### PR TITLE
fix(gateway): block restart helper scripts from gateway terminal

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1315,7 +1315,11 @@ def create_job(
     # `cronjob` model tool — which calls create_job directly — is also
     # covered, not just `hermes cron create`.
     from cron.lifecycle_guard import check_gateway_lifecycle
-    check_gateway_lifecycle(prompt_text, normalized_script)
+    check_gateway_lifecycle(
+        prompt_text,
+        normalized_script,
+        cwd=normalized_workdir,
+    )
 
     label_source = (prompt_text or (normalized_skills[0] if normalized_skills else None) or (normalized_script if normalized_no_agent else None)) or "cron job"
 
@@ -1550,6 +1554,20 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                         f"(grace window: {ONESHOT_GRACE_SECONDS}s) and cannot be scheduled."
                     )
                 updated["next_run_at"] = next_run
+
+            # Validate the complete effective definition before persisting any
+            # active update. This closes the create-only bypass and also makes
+            # resume/trigger fail closed after a script was changed on disk.
+            # Pausing remains possible so operators can disable an unsafe
+            # legacy or hand-edited job without first making it executable.
+            if updated.get("enabled", True) and updated.get("state") != "paused":
+                from cron.lifecycle_guard import check_gateway_lifecycle
+
+                check_gateway_lifecycle(
+                    _coerce_job_text(updated.get("prompt")),
+                    updated.get("script"),
+                    cwd=updated.get("workdir"),
+                )
 
             jobs[i] = updated
             save_jobs(jobs)

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -131,7 +131,10 @@ _SHELL_SOURCE_REF_PATTERN = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 _SHELL_COMMAND_STRING_PATTERN = re.compile(
-    r"\b(?:bash|sh|zsh|dash|ksh)\s+"
+    _SHELL_COMMAND_START
+    + _SHELL_CONTROL_PREFIX
+    + _SHELL_LAUNCH_PREFIX
+    + r"(?:bash|sh|zsh|dash|ksh)\s+"
     r"(?:-\S+\s+)*?-[A-Za-z]*c[A-Za-z]*\s+"
     r"(?P<quote>[\"'])(?P<body>.*?)(?P=quote)",
     re.IGNORECASE | re.DOTALL,

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -33,7 +33,9 @@ only fail (silently) when it fires.
 
 from __future__ import annotations
 
+import os
 import re
+import stat
 from pathlib import Path
 from typing import Optional
 
@@ -66,12 +68,56 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
 )
 
 
+_MAX_HELPER_SCAN_BYTES = 256 * 1024
+_MAX_HELPER_SCAN_DEPTH = 3
+_MAX_HELPERS_SCANNED = 16
+
+# Terminal execution may hide the lifecycle command in a literal helper file.
+# Keep extraction deliberately narrow: static ``*.sh`` references, literal
+# path commands (``./helper`` / ``/tmp/helper``), shell source builtins, and
+# literal script arguments to common shell interpreters. Shell control-flow
+# keywords and simple execution wrappers are accepted before those command
+# shapes. Dynamic expansion and arbitrary PATH-only executable lookup remain
+# outside this bounded inspection layer.
+_SHELL_COMMAND_START = r"(?:^|[;&|]\s*|\$\(\s*|\{\s*)"
+_SHELL_CONTROL_PREFIX = r"(?:(?:(?:if|then|elif|while|until|do|else)|!)\s+)*"
+_SHELL_WRAPPER_PREFIX = r"(?:(?:command|exec|builtin|nohup|time)\s+)*"
+_SHELL_ENV_PREFIX = r"(?:env\s+(?:(?:-\S+|[A-Za-z_]\w*=\S+)\s+)*)?"
+_LITERAL_HELPER_TOKEN = r"[A-Za-z0-9_./:@%+=,~\-]+"
 _SHELL_SCRIPT_REF_PATTERN = re.compile(
     r"(?<![\w./~-])"
     r"("
     r"(?:~|/|\./|\../)?"
     r"[A-Za-z0-9_./:@%+=,\-]+\.sh"
     r")"
+)
+_LITERAL_COMMAND_PATH_PATTERN = re.compile(
+    _SHELL_COMMAND_START
+    + _SHELL_CONTROL_PREFIX
+    + _SHELL_WRAPPER_PREFIX
+    + _SHELL_ENV_PREFIX
+    + r"[\"']?"
+    r"((?:~|/|\./|\../)[A-Za-z0-9_./:@%+=,\-]+)"
+    r"[\"']?",
+    re.MULTILINE,
+)
+_SHELL_INTERPRETER_REF_PATTERN = re.compile(
+    _SHELL_COMMAND_START
+    + _SHELL_CONTROL_PREFIX
+    + _SHELL_WRAPPER_PREFIX
+    + _SHELL_ENV_PREFIX
+    + r"(?:bash|sh|zsh|dash|ksh)\s+"
+    r"(?:-[A-Za-z]+\s+)*"
+    r"[\"']?([A-Za-z0-9_./:@%+=,~\-]+)[\"']?",
+    re.IGNORECASE | re.MULTILINE,
+)
+_SHELL_SOURCE_REF_PATTERN = re.compile(
+    _SHELL_COMMAND_START
+    + _SHELL_CONTROL_PREFIX
+    + _SHELL_WRAPPER_PREFIX
+    + r"(?:source|\.)\s+(?:--\s+)?"
+    + rf"[\"']?({_LITERAL_HELPER_TOKEN})[\"']?",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 
@@ -90,22 +136,112 @@ def _resolve_terminal_script_path(script_path: str, cwd: Optional[Path | str]) -
     return base / raw
 
 
-def _read_file_for_scanning(path: Path) -> str:
+def _read_file_for_scanning(path: Path) -> tuple[str, bool]:
+    """Return ``(text, unsafe)`` without blocking on special or huge files.
+
+    Missing literal paths are ignored because the shell will fail to execute
+    them. Existing helpers fail closed when they cannot be resolved/read as a
+    bounded regular file. Resolving first still permits normal symlinks to
+    regular files while rejecting symlinks to FIFOs/devices/directories.
+    """
     try:
-        return path.read_bytes().decode("utf-8", errors="replace")
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError:
+        return "", False
+    except (OSError, RuntimeError):
+        return "", True
+
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(resolved, flags)
+        with os.fdopen(descriptor, "rb") as handle:
+            file_stat = os.fstat(handle.fileno())
+            if not stat.S_ISREG(file_stat.st_mode):
+                return "", True
+            if file_stat.st_size > _MAX_HELPER_SCAN_BYTES:
+                return "", True
+            data = handle.read(_MAX_HELPER_SCAN_BYTES + 1)
     except OSError:
-        return ""
+        return "", True
+
+    if len(data) > _MAX_HELPER_SCAN_BYTES:
+        return "", True
+    return data.decode("utf-8", errors="replace"), False
 
 
-def _iter_shell_script_refs(text: str) -> list[str]:
+def _collect_literal_helper_refs(text: str) -> tuple[list[str], bool]:
+    """Collect at most the scan budget of distinct literal helper references."""
     seen: set[str] = set()
     refs: list[str] = []
-    for match in _SHELL_SCRIPT_REF_PATTERN.finditer(text or ""):
-        ref = match.group(1)
-        if ref not in seen:
+    for pattern in (
+        _SHELL_SCRIPT_REF_PATTERN,
+        _LITERAL_COMMAND_PATH_PATTERN,
+        _SHELL_INTERPRETER_REF_PATTERN,
+        _SHELL_SOURCE_REF_PATTERN,
+    ):
+        for match in pattern.finditer(text or ""):
+            ref = match.group(1)
+            if ref in seen:
+                continue
+            if len(refs) >= _MAX_HELPERS_SCANNED:
+                return refs, True
             seen.add(ref)
             refs.append(ref)
-    return refs
+    return refs, False
+
+
+def _scan_literal_helpers(
+    text: str,
+    *,
+    cwd: Optional[Path | str],
+    depth: int,
+    seen_paths: set[Path],
+    files_scanned: list[int],
+) -> bool:
+    refs, reference_overflow = _collect_literal_helper_refs(text)
+    if reference_overflow:
+        return True
+
+    for ref in refs:
+        path = _resolve_terminal_script_path(ref, cwd)
+        try:
+            path_key = path.resolve(strict=False)
+        except (OSError, RuntimeError):
+            return True
+        if path_key in seen_paths:
+            continue
+        seen_paths.add(path_key)
+
+        files_scanned[0] += 1
+        if files_scanned[0] > _MAX_HELPERS_SCANNED:
+            return True
+
+        helper_text, unsafe = _read_file_for_scanning(path)
+        if unsafe:
+            return True
+        if not helper_text:
+            continue
+        if contains_gateway_lifecycle_command(helper_text):
+            return True
+
+        nested_refs, nested_reference_overflow = _collect_literal_helper_refs(helper_text)
+        if nested_reference_overflow:
+            return True
+        if not nested_refs:
+            continue
+        if depth >= _MAX_HELPER_SCAN_DEPTH:
+            return True
+        if _scan_literal_helpers(
+            helper_text,
+            cwd=cwd,
+            depth=depth + 1,
+            seen_paths=seen_paths,
+            files_scanned=files_scanned,
+        ):
+            return True
+
+    return False
 
 
 def contains_gateway_lifecycle_invocation(
@@ -113,26 +249,25 @@ def contains_gateway_lifecycle_invocation(
     *,
     cwd: Optional[Path | str] = None,
 ) -> bool:
-    """Return True if a shell command directly or indirectly targets the gateway.
+    """Return True for a direct command or bounded literal-helper invocation.
 
-    ``contains_gateway_lifecycle_command`` intentionally scans only the supplied
-    text.  Terminal execution needs one more layer: a command can invoke a
-    helper script, e.g. ``sleep 75; /tmp/restart.sh``, whose contents contain
-    the actual ``launchctl``/``hermes gateway restart`` foot-gun.  This helper
-    scans readable ``*.sh`` references as they would be resolved from the
-    command cwd.
+    Terminal commands can invoke a helper whose contents contain the actual
+    lifecycle operation. This scans a bounded set of readable regular helper
+    files as resolved from the exact execution cwd, including nested literal
+    helper references. Existing helpers that are special, unreadable, too
+    large, too deep, or too numerous fail closed rather than hanging or
+    exhausting the gateway process.
     """
     if contains_gateway_lifecycle_command(text):
         return True
 
-    for ref in _iter_shell_script_refs(text):
-        script_text = _read_file_for_scanning(
-            _resolve_terminal_script_path(ref, cwd)
-        )
-        if script_text and contains_gateway_lifecycle_command(script_text):
-            return True
-
-    return False
+    return _scan_literal_helpers(
+        text,
+        cwd=cwd,
+        depth=0,
+        seen_paths=set(),
+        files_scanned=[0],
+    )
 
 
 def _resolve_script_path(script_path: str) -> Path:
@@ -155,15 +290,19 @@ def _resolve_script_path(script_path: str) -> Path:
 
 
 def _read_script_for_scanning(script_path: str) -> str:
-    """Read a script file for lifecycle-pattern scanning.
+    """Read a bounded regular cron script for lifecycle-pattern scanning.
 
-    Decodes with ``errors="replace"`` so binary or non-UTF-8 content does not
-    silently bypass the check — a plain text-mode read raises
-    ``UnicodeDecodeError`` on such files, and swallowing that error would let
-    an attacker hide the command in binary noise.  Returns an empty string
-    only when the file cannot be read at all.
+    Decodes with ``errors="replace"`` so non-UTF-8 bytes cannot hide a plain
+    command. Existing scripts that are special, unreadable, or oversized fail
+    closed; missing scripts remain a downstream scheduler validation concern.
     """
-    return _read_file_for_scanning(_resolve_script_path(script_path))
+    script_text, unsafe = _read_file_for_scanning(_resolve_script_path(script_path))
+    if unsafe:
+        raise GatewayLifecycleBlocked(
+            "Blocked: cron script could not be safely inspected as a bounded "
+            "regular file (#30719)."
+        )
+    return script_text
 
 
 def check_gateway_lifecycle(

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -73,39 +73,50 @@ _MAX_HELPER_SCAN_DEPTH = 3
 _MAX_HELPERS_SCANNED = 16
 
 # Terminal execution may hide the lifecycle command in a literal helper file.
-# Keep extraction deliberately narrow: static ``*.sh`` references, literal
-# path commands (``./helper`` / ``/tmp/helper``), shell source builtins, and
-# literal script arguments to common shell interpreters. Shell control-flow
-# keywords and simple execution wrappers are accepted before those command
-# shapes. Dynamic expansion and arbitrary PATH-only executable lookup remain
-# outside this bounded inspection layer.
+# Keep extraction deliberately narrow: literal path commands
+# (``./helper`` / ``scripts/helper`` / ``/tmp/helper``), shell source builtins,
+# and literal script arguments to common shell interpreters. Shell control-flow
+# keywords, variable assignments, and simple execution/privilege/environment
+# wrappers are accepted before those command shapes. Quoted ``sh -c`` payloads
+# are scanned recursively. Dynamic expansion and arbitrary PATH-only executable
+# lookup remain outside this bounded inspection layer.
 _SHELL_COMMAND_START = r"(?:^|[;&|]\s*|\$\(\s*|\{\s*)"
 _SHELL_CONTROL_PREFIX = r"(?:(?:(?:if|then|elif|while|until|do|else)|!)\s+)*"
-_SHELL_WRAPPER_PREFIX = r"(?:(?:command|exec|builtin|nohup|time)\s+)*"
-_SHELL_ENV_PREFIX = r"(?:env\s+(?:(?:-\S+|[A-Za-z_]\w*=\S+)\s+)*)?"
-_LITERAL_HELPER_TOKEN = r"[A-Za-z0-9_./:@%+=,~\-]+"
-_SHELL_SCRIPT_REF_PATTERN = re.compile(
-    r"(?<![\w./~-])"
-    r"("
-    r"(?:~|/|\./|\../)?"
-    r"[A-Za-z0-9_./:@%+=,\-]+\.sh"
-    r")"
+_SHELL_ASSIGNMENT = (
+    r"[A-Za-z_]\w*=(?:[^\s;&|]+|\"[^\"]*\"|'[^']*')"
 )
+_SUDO_OPTION_WITH_ARG = (
+    r"(?:-u|--user|-g|--group|-h|--host|-C|--chdir|-R|--chroot|"
+    r"-r|--role|-t|--type|-T|--command-timeout)"
+)
+_SUDO_PREFIX = (
+    rf"sudo(?:\s+(?:{_SUDO_OPTION_WITH_ARG}\s+\S+|-\S+))*"
+)
+_SHELL_LAUNCH_PREFIX = (
+    r"(?:"
+    + _SHELL_ASSIGNMENT
+    + r"|(?:command|exec|builtin|nohup|time)"
+    + r"|"
+    + _SUDO_PREFIX
+    + r"|env(?:\s+-\S+)*"
+    + r")\s+"
+)
+_SHELL_LAUNCH_PREFIX = rf"(?:{_SHELL_LAUNCH_PREFIX})*"
+_LITERAL_HELPER_TOKEN = r"[A-Za-z0-9_./:@%+=,~\-]+"
 _LITERAL_COMMAND_PATH_PATTERN = re.compile(
     _SHELL_COMMAND_START
     + _SHELL_CONTROL_PREFIX
-    + _SHELL_WRAPPER_PREFIX
-    + _SHELL_ENV_PREFIX
+    + _SHELL_LAUNCH_PREFIX
     + r"[\"']?"
-    r"((?:~|/|\./|\../)[A-Za-z0-9_./:@%+=,\-]+)"
+    r"((?:(?:~|/|\./|\../)[A-Za-z0-9_./:@%+=,\-]+|"
+    r"[A-Za-z0-9_.:@%+=,~\-]+/[A-Za-z0-9_./:@%+=,~\-]+))"
     r"[\"']?",
     re.MULTILINE,
 )
 _SHELL_INTERPRETER_REF_PATTERN = re.compile(
     _SHELL_COMMAND_START
     + _SHELL_CONTROL_PREFIX
-    + _SHELL_WRAPPER_PREFIX
-    + _SHELL_ENV_PREFIX
+    + _SHELL_LAUNCH_PREFIX
     + r"(?:bash|sh|zsh|dash|ksh)\s+"
     r"(?:-[A-Za-z]+\s+)*"
     r"[\"']?([A-Za-z0-9_./:@%+=,~\-]+)[\"']?",
@@ -114,10 +125,16 @@ _SHELL_INTERPRETER_REF_PATTERN = re.compile(
 _SHELL_SOURCE_REF_PATTERN = re.compile(
     _SHELL_COMMAND_START
     + _SHELL_CONTROL_PREFIX
-    + _SHELL_WRAPPER_PREFIX
+    + _SHELL_LAUNCH_PREFIX
     + r"(?:source|\.)\s+(?:--\s+)?"
     + rf"[\"']?({_LITERAL_HELPER_TOKEN})[\"']?",
     re.IGNORECASE | re.MULTILINE,
+)
+_SHELL_COMMAND_STRING_PATTERN = re.compile(
+    r"\b(?:bash|sh|zsh|dash|ksh)\s+"
+    r"(?:-\S+\s+)*?-[A-Za-z]*c[A-Za-z]*\s+"
+    r"(?P<quote>[\"'])(?P<body>.*?)(?P=quote)",
+    re.IGNORECASE | re.DOTALL,
 )
 
 
@@ -171,23 +188,39 @@ def _read_file_for_scanning(path: Path) -> tuple[str, bool]:
 
 
 def _collect_literal_helper_refs(text: str) -> tuple[list[str], bool]:
-    """Collect at most the scan budget of distinct literal helper references."""
-    seen: set[str] = set()
+    """Collect bounded helper refs, including quoted shell-command payloads."""
+    seen_refs: set[str] = set()
     refs: list[str] = []
-    for pattern in (
-        _SHELL_SCRIPT_REF_PATTERN,
-        _LITERAL_COMMAND_PATH_PATTERN,
-        _SHELL_INTERPRETER_REF_PATTERN,
-        _SHELL_SOURCE_REF_PATTERN,
-    ):
-        for match in pattern.finditer(text or ""):
-            ref = match.group(1)
-            if ref in seen:
+    pending: list[tuple[str, int]] = [(text or "", 0)]
+    seen_payloads: set[str] = {text or ""}
+
+    while pending:
+        chunk, shell_depth = pending.pop(0)
+        for pattern in (
+            _LITERAL_COMMAND_PATH_PATTERN,
+            _SHELL_INTERPRETER_REF_PATTERN,
+            _SHELL_SOURCE_REF_PATTERN,
+        ):
+            for match in pattern.finditer(chunk):
+                ref = match.group(1)
+                if ref in seen_refs:
+                    continue
+                if len(refs) >= _MAX_HELPERS_SCANNED:
+                    return refs, True
+                seen_refs.add(ref)
+                refs.append(ref)
+
+        for match in _SHELL_COMMAND_STRING_PATTERN.finditer(chunk):
+            payload = match.group("body")
+            if payload in seen_payloads:
                 continue
-            if len(refs) >= _MAX_HELPERS_SCANNED:
+            if shell_depth >= _MAX_HELPER_SCAN_DEPTH:
                 return refs, True
-            seen.add(ref)
-            refs.append(ref)
+            if len(seen_payloads) >= _MAX_HELPERS_SCANNED:
+                return refs, True
+            seen_payloads.add(payload)
+            pending.append((payload, shell_depth + 1))
+
     return refs, False
 
 
@@ -248,18 +281,28 @@ def contains_gateway_lifecycle_invocation(
     text: str,
     *,
     cwd: Optional[Path | str] = None,
+    inspect_helpers: bool = True,
 ) -> bool:
     """Return True for a direct command or bounded literal-helper invocation.
 
     Terminal commands can invoke a helper whose contents contain the actual
-    lifecycle operation. This scans a bounded set of readable regular helper
-    files as resolved from the exact execution cwd, including nested literal
-    helper references. Existing helpers that are special, unreadable, too
-    large, too deep, or too numerous fail closed rather than hanging or
-    exhausting the gateway process.
+    lifecycle operation. On a local backend this scans a bounded set of
+    readable regular helper files as resolved from the exact execution cwd,
+    including nested literal references. Existing helpers that are special,
+    unreadable, too large, too deep, or too numerous fail closed rather than
+    hanging or exhausting the gateway process.
+
+    A non-local backend cannot truthfully inspect its helper bytes from the
+    local gateway. Callers therefore pass ``inspect_helpers=False``; any
+    literal helper invocation then fails closed instead of trusting an
+    unrelated local path with the same spelling.
     """
     if contains_gateway_lifecycle_command(text):
         return True
+
+    if not inspect_helpers:
+        refs, reference_overflow = _collect_literal_helper_refs(text)
+        return reference_overflow or bool(refs)
 
     return _scan_literal_helpers(
         text,
@@ -308,30 +351,46 @@ def _read_script_for_scanning(script_path: str) -> str:
 def check_gateway_lifecycle(
     prompt: Optional[str],
     script: Optional[str] = None,
+    *,
+    cwd: Optional[Path | str] = None,
 ) -> None:
-    """Raise ``GatewayLifecycleBlocked`` if *prompt* or *script* contains a
-    gateway-lifecycle command pattern.
+    """Fail closed when an effective cron definition can invoke lifecycle.
 
-    ``prompt`` is scanned directly.  ``script``, when supplied, is read from
-    disk and concatenated for the scan.  Both are considered together so a
-    job cannot slip through by splitting the command across the prompt and
-    the script.
-
-    Callers should let the exception propagate when they want the create to
-    fail with a ``ValueError``-shaped error (the agent's ``cronjob`` tool
-    surfaces this as a tool error; the CLI prints it in red and exits 1).
+    ``prompt`` and the top-level ``script`` bytes are scanned directly. Literal
+    helpers referenced by either are inspected recursively from the effective
+    execution cwd. When no explicit cwd is configured, script helpers resolve
+    from the top-level script directory, matching scheduler execution.
     """
-    combined = prompt or ""
+    prompt_text = prompt or ""
+    script_text = ""
+    script_cwd: Optional[Path | str] = cwd
     if script:
+        script_path = _resolve_script_path(script)
         script_text = _read_script_for_scanning(script)
-        if script_text:
-            combined = f"{combined}\n{script_text}"
+        if script_cwd is None:
+            script_cwd = script_path.parent
 
-    if contains_gateway_lifecycle_command(combined):
+    combined = prompt_text
+    if script_text:
+        combined = f"{combined}\n{script_text}"
+
+    blocked = contains_gateway_lifecycle_command(combined)
+    if not blocked and prompt_text:
+        blocked = contains_gateway_lifecycle_invocation(
+            prompt_text,
+            cwd=cwd,
+        )
+    if not blocked and script_text:
+        blocked = contains_gateway_lifecycle_invocation(
+            script_text,
+            cwd=script_cwd,
+        )
+
+    if blocked:
         raise GatewayLifecycleBlocked(
             "Blocked: cron job contains a gateway lifecycle command "
-            "(restart/stop/kill). This is blocked to prevent agent-driven "
-            "SIGTERM-respawn loops under launchd/systemd supervision "
-            "(#30719). Run `hermes gateway restart` from a shell outside "
-            "the running gateway instead."
+            "(restart/stop/kill), directly or through a literal helper. "
+            "This is blocked to prevent agent-driven SIGTERM-respawn loops "
+            "under launchd/systemd supervision (#30719). Run `hermes gateway "
+            "restart` from a shell outside the running gateway instead."
         )

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -66,11 +66,73 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
 )
 
 
+_SHELL_SCRIPT_REF_PATTERN = re.compile(
+    r"(?<![\w./~-])"
+    r"("
+    r"(?:~|/|\./|\../)?"
+    r"[A-Za-z0-9_./:@%+=,\-]+\.sh"
+    r")"
+)
+
+
 def contains_gateway_lifecycle_command(text: str) -> bool:
     """Return True if *text* contains a gateway lifecycle command pattern."""
     if not text:
         return False
     return bool(_GATEWAY_LIFECYCLE_PATTERN.search(text))
+
+
+def _resolve_terminal_script_path(script_path: str, cwd: Optional[Path | str]) -> Path:
+    raw = Path(script_path).expanduser()
+    if raw.is_absolute():
+        return raw
+    base = Path(cwd).expanduser() if cwd else Path.cwd()
+    return base / raw
+
+
+def _read_file_for_scanning(path: Path) -> str:
+    try:
+        return path.read_bytes().decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _iter_shell_script_refs(text: str) -> list[str]:
+    seen: set[str] = set()
+    refs: list[str] = []
+    for match in _SHELL_SCRIPT_REF_PATTERN.finditer(text or ""):
+        ref = match.group(1)
+        if ref not in seen:
+            seen.add(ref)
+            refs.append(ref)
+    return refs
+
+
+def contains_gateway_lifecycle_invocation(
+    text: str,
+    *,
+    cwd: Optional[Path | str] = None,
+) -> bool:
+    """Return True if a shell command directly or indirectly targets the gateway.
+
+    ``contains_gateway_lifecycle_command`` intentionally scans only the supplied
+    text.  Terminal execution needs one more layer: a command can invoke a
+    helper script, e.g. ``sleep 75; /tmp/restart.sh``, whose contents contain
+    the actual ``launchctl``/``hermes gateway restart`` foot-gun.  This helper
+    scans readable ``*.sh`` references as they would be resolved from the
+    command cwd.
+    """
+    if contains_gateway_lifecycle_command(text):
+        return True
+
+    for ref in _iter_shell_script_refs(text):
+        script_text = _read_file_for_scanning(
+            _resolve_terminal_script_path(ref, cwd)
+        )
+        if script_text and contains_gateway_lifecycle_command(script_text):
+            return True
+
+    return False
 
 
 def _resolve_script_path(script_path: str) -> Path:
@@ -101,12 +163,7 @@ def _read_script_for_scanning(script_path: str) -> str:
     an attacker hide the command in binary noise.  Returns an empty string
     only when the file cannot be read at all.
     """
-    try:
-        return _resolve_script_path(script_path).read_bytes().decode(
-            "utf-8", errors="replace"
-        )
-    except OSError:
-        return ""
+    return _read_file_for_scanning(_resolve_script_path(script_path))
 
 
 def check_gateway_lifecycle(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2267,6 +2267,17 @@ def _run_job_script(
     if not path.is_file():
         return False, f"Script path is not a file: {path}"
 
+    # Revalidate the bytes and any bounded literal helpers immediately before
+    # every scheduler execution. Creation/update validation is not sufficient:
+    # scripts can be replaced or jobs can be hand-edited while persisted.
+    _script_cwd = workdir or str(path.parent)
+    from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
+
+    try:
+        check_gateway_lifecycle(None, str(path), cwd=_script_cwd)
+    except GatewayLifecycleBlocked as exc:
+        return False, str(exc)
+
     script_timeout = _get_script_timeout()
 
     # Pick an interpreter by extension.  Bash for .sh/.bash, Python for
@@ -2307,11 +2318,17 @@ def _run_job_script(
             }
         env = _sanitize_subprocess_env(os.environ.copy())
         env.update(env_overlay)
+        # Environment/interpreter preparation can be separated from execution
+        # by hooks or monkeypatchable seams. Re-read the script/helper graph at
+        # the final subprocess boundary to minimize scan/execute mutation races.
+        try:
+            check_gateway_lifecycle(None, str(path), cwd=_script_cwd)
+        except GatewayLifecycleBlocked as exc:
+            return False, str(exc)
         # Use the job's workdir as the subprocess cwd when configured,
         # otherwise default to the scripts-dir parent (back-compat).
         # NEVER mutate the Python process cwd — that would leak into
         # concurrent gateway sessions (#69396).
-        _script_cwd = workdir or str(path.parent)
         result = subprocess.run(
             argv,
             capture_output=True,
@@ -2784,6 +2801,34 @@ def run_job(
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
 
+    # Resolve workdir once so scheduler validation and every script execution
+    # share the same effective cwd. Missing workdirs preserve existing fallback
+    # behavior while still scanning from the path that will actually execute.
+    _job_workdir = str(job.get("workdir") or "").strip() or None
+    if _job_workdir and not Path(_job_workdir).is_dir():
+        logger.warning(
+            "Job '%s': configured workdir %r no longer exists — running without it",
+            job_id,
+            _job_workdir,
+        )
+        _job_workdir = None
+
+    # Persisted definitions are not trusted solely because they passed create
+    # or update. Revalidate prompt, top-level script, and bounded literal helper
+    # graph immediately before dispatch so hand-edited or replaced jobs cannot
+    # bypass the lifecycle guard through the scheduler.
+    from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
+
+    try:
+        check_gateway_lifecycle(
+            str(job.get("prompt") or ""),
+            job.get("script"),
+            cwd=_job_workdir,
+        )
+    except GatewayLifecycleBlocked as exc:
+        logger.error("Job '%s' blocked before dispatch: %s", job_id, exc)
+        return False, "", "", str(exc)
+
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
     # ---------------------------------------------------------------
@@ -2809,18 +2854,8 @@ def run_job(
             logger.error("Job '%s': %s", job_id, err)
             return False, "", "", err
 
-        # Apply workdir if configured — lets scripts use predictable relative
-        # paths. For no_agent jobs this is passed as the subprocess cwd so the
-        # Python process cwd is NEVER mutated — avoiding the global-side-effect
-        # bug where os.chdir() leaks into concurrent gateway sessions (#69396).
-        _job_workdir = (job.get("workdir") or "").strip() or None
-        if _job_workdir and not Path(_job_workdir).is_dir():
-            logger.warning(
-                "Job '%s': configured workdir %r no longer exists — running without it",
-                job_id, _job_workdir,
-            )
-            _job_workdir = None
-
+        # The effective workdir was resolved before lifecycle revalidation and
+        # is passed through without mutating the gateway process cwd.
         try:
             ok, output = _run_job_script_with_claim_heartbeat(
                 job, script_path, workdir=_job_workdir,
@@ -2970,7 +3005,11 @@ def run_job(
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path)
+        prerun_script = _run_job_script_with_claim_heartbeat(
+            job,
+            script_path,
+            workdir=_job_workdir,
+        )
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -23,6 +23,7 @@ from hermes_cli.colors import Colors, color
 # commands at execution time when ``_HERMES_GATEWAY=1``.
 from cron.lifecycle_guard import (  # noqa: F401  (re-exported for terminal_tool)
     contains_gateway_lifecycle_command as _contains_gateway_lifecycle_command,
+    contains_gateway_lifecycle_invocation as _contains_gateway_lifecycle_invocation,
 )
 
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -677,16 +677,20 @@ class TestLifecycleGuardModule:
 
         assert contains_gateway_lifecycle_invocation(command, cwd=tmp_path)
 
-    def test_shell_suffix_mentioned_as_data_is_not_scanned(self, tmp_path):
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo helper.sh",
+            "echo bash -c './helper.sh'",
+            "printf '%s\\n' \"bash -c './helper.sh'\"",
+        ],
+    )
+    def test_shell_helper_mentioned_as_data_is_not_scanned(self, tmp_path, command):
         from cron.lifecycle_guard import contains_gateway_lifecycle_invocation
 
-        (tmp_path / "helper.sh").write_text(
-            "#!/bin/sh\nhermes gateway restart\n"
-        )
+        (tmp_path / "helper.sh").write_text("#!/bin/sh\nhermes gateway restart\n")
 
-        assert not contains_gateway_lifecycle_invocation(
-            "echo helper.sh", cwd=tmp_path
-        )
+        assert not contains_gateway_lifecycle_invocation(command, cwd=tmp_path)
 
     def test_literal_nested_helpers_are_scanned_recursively(self, tmp_path):
         from cron.lifecycle_guard import contains_gateway_lifecycle_invocation

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -338,6 +338,35 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]
 
+    def test_blocks_lifecycle_command_hidden_in_script_inside_gateway(
+        self, monkeypatch, tmp_path
+    ):
+        import tools.terminal_tool as tt
+
+        script = tmp_path / "delayed_restart.sh"
+        script.write_text(
+            "#!/bin/bash\n"
+            "launchctl kickstart -k user/501/ai.hermes.gateway-mission-control\n"
+        )
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+        monkeypatch.setattr(
+            tt,
+            "_get_env_config",
+            lambda: {
+                "env_type": "local",
+                "cwd": str(tmp_path),
+                "timeout": 60,
+                "lifetime_seconds": 3600,
+            },
+        )
+
+        result = json.loads(tt.terminal_tool(
+            command="sleep 75; ./delayed_restart.sh"
+        ))
+
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+
     def test_safe_systemctl_commands_pass_through(self, monkeypatch):
         """Non-hermes systemctl commands must not be blocked by this guard."""
         import tools.terminal_tool as tt

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -304,6 +304,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         monkeypatch.setattr(tt, "_active_environments", {eid: fake_env})
         monkeypatch.setattr(tt, "_last_activity", {eid: 0.0})
         monkeypatch.setattr(tt, "_task_env_overrides", {})
+        monkeypatch.setattr(tt, "get_session_cwd", lambda key=None: None)
         monkeypatch.setattr(tt, "_get_env_config", self._minimal_config)
         if inside_gateway:
             monkeypatch.setenv("_HERMES_GATEWAY", "1")
@@ -363,6 +364,42 @@ class TestTerminalToolGatewayLifecycleGuard:
         result = json.loads(tt.terminal_tool(
             command="sleep 75; ./delayed_restart.sh"
         ))
+
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+
+    @pytest.mark.parametrize("background", [False, True])
+    def test_revalidates_helper_after_approval_before_execution(
+        self, monkeypatch, tmp_path, background
+    ):
+        import tools.terminal_tool as tt
+
+        script = tmp_path / "delayed_restart.sh"
+        script.write_text("#!/bin/sh\nprintf safe\\n\n")
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+        monkeypatch.setattr(
+            tt,
+            "_get_env_config",
+            lambda: {
+                "env_type": "local",
+                "cwd": str(tmp_path),
+                "timeout": 60,
+                "lifetime_seconds": 3600,
+            },
+        )
+
+        def _approve_after_mutation(*args, **kwargs):
+            script.write_text("#!/bin/sh\nhermes gateway restart\n")
+            return {"approved": True}
+
+        monkeypatch.setattr(tt, "_check_all_guards", _approve_after_mutation)
+
+        result = json.loads(
+            tt.terminal_tool(
+                command="./delayed_restart.sh",
+                background=background,
+            )
+        )
 
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]
@@ -439,7 +476,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]
 
-    def test_nonlocal_background_guard_and_spawn_share_effective_cwd(
+    def test_nonlocal_background_helper_fails_closed_without_backend_inspection(
         self, monkeypatch, tmp_path
     ):
         from types import SimpleNamespace
@@ -493,9 +530,9 @@ class TestTerminalToolGatewayLifecycleGuard:
             )
         )
 
-        assert result["exit_code"] == 0
-        assert len(spawn_calls) == 1
-        assert spawn_calls[0]["cwd"] == str(execution)
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+        assert spawn_calls == []
 
     def test_safe_systemctl_commands_pass_through(self, monkeypatch):
         """Non-hermes systemctl commands must not be blocked by this guard."""
@@ -618,6 +655,14 @@ class TestLifecycleGuardModule:
             ". helper",
             "exec ./helper",
             "command bash helper",
+            "DELAY=1 ./helper",
+            "sudo ./helper",
+            "sudo -u root ./helper",
+            "sudo -n bash helper",
+            "sudo -n env DELAY=1 ./helper",
+            "bash -c './helper'",
+            "bash -c 'sudo -u root ./helper'",
+            'bash -c "source helper"',
             "if ./helper; then printf safe; fi",
             "while ./helper; do :; done",
             "! ./helper",
@@ -631,6 +676,17 @@ class TestLifecycleGuardModule:
         (tmp_path / "helper").write_text("#!/bin/sh\nhermes gateway restart\n")
 
         assert contains_gateway_lifecycle_invocation(command, cwd=tmp_path)
+
+    def test_shell_suffix_mentioned_as_data_is_not_scanned(self, tmp_path):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_invocation
+
+        (tmp_path / "helper.sh").write_text(
+            "#!/bin/sh\nhermes gateway restart\n"
+        )
+
+        assert not contains_gateway_lifecycle_invocation(
+            "echo helper.sh", cwd=tmp_path
+        )
 
     def test_literal_nested_helpers_are_scanned_recursively(self, tmp_path):
         from cron.lifecycle_guard import contains_gateway_lifecycle_invocation
@@ -719,6 +775,119 @@ class TestCreateJobBlocksLifecycleCommands:
                          schedule="30m")
         assert job["id"]
 
+    def test_create_job_blocks_nested_script_helper(self, tmp_path, monkeypatch):
+        from cron.jobs import create_job
+        from cron.lifecycle_guard import GatewayLifecycleBlocked
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        scripts = tmp_path / ".hermes" / "scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "outer.sh").write_text("#!/bin/sh\n./helper\n")
+        (scripts / "helper").write_text(
+            "#!/bin/sh\nhermes gateway restart\n"
+        )
+
+        with pytest.raises(GatewayLifecycleBlocked):
+            create_job(
+                prompt="collect status",
+                schedule="30m",
+                script="outer.sh",
+            )
+
+    def test_create_job_scans_helpers_from_configured_workdir(
+        self, tmp_path, monkeypatch
+    ):
+        from cron.jobs import create_job
+        from cron.lifecycle_guard import GatewayLifecycleBlocked
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        scripts = tmp_path / ".hermes" / "scripts"
+        scripts.mkdir(parents=True)
+        workdir = tmp_path / "job-workdir"
+        workdir.mkdir()
+        (scripts / "outer.sh").write_text("#!/bin/sh\n./helper\n")
+        (workdir / "helper").write_text(
+            "#!/bin/sh\nhermes gateway restart\n"
+        )
+
+        with pytest.raises(GatewayLifecycleBlocked):
+            create_job(
+                prompt="collect status",
+                schedule="30m",
+                script="outer.sh",
+                workdir=str(workdir),
+            )
+
+    def test_update_job_blocks_unsafe_effective_prompt_and_preserves_job(self):
+        from cron.jobs import create_job, get_job, update_job
+        from cron.lifecycle_guard import GatewayLifecycleBlocked
+
+        job = create_job(prompt="collect status", schedule="30m")
+
+        with pytest.raises(GatewayLifecycleBlocked):
+            update_job(
+                job["id"],
+                {"prompt": "then run hermes gateway restart"},
+            )
+
+        stored = get_job(job["id"])
+        assert stored is not None
+        assert stored["prompt"] == "collect status"
+
+    def test_update_job_revalidates_active_script_after_helper_mutation(
+        self, tmp_path, monkeypatch
+    ):
+        from cron.jobs import create_job, get_job, update_job
+        from cron.lifecycle_guard import GatewayLifecycleBlocked
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        scripts = tmp_path / ".hermes" / "scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "outer.sh").write_text("#!/bin/sh\n./helper\n")
+        helper = scripts / "helper"
+        helper.write_text("#!/bin/sh\nprintf safe\\n\n")
+        job = create_job(
+            prompt="collect status",
+            schedule="30m",
+            script="outer.sh",
+        )
+        assert job is not None
+        helper.write_text("#!/bin/sh\nhermes gateway restart\n")
+
+        with pytest.raises(GatewayLifecycleBlocked):
+            update_job(job["id"], {"name": "still active"})
+
+        stored = get_job(job["id"])
+        assert stored is not None
+        assert stored["name"] == job["name"]
+
+    def test_update_job_can_pause_an_unsafe_legacy_job(
+        self, tmp_path, monkeypatch
+    ):
+        from cron.jobs import create_job, update_job
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        scripts = tmp_path / ".hermes" / "scripts"
+        scripts.mkdir(parents=True)
+        script = scripts / "legacy.sh"
+        script.write_text("#!/bin/sh\nprintf safe\\n\n")
+        job = create_job(
+            prompt="collect status",
+            schedule="30m",
+            script="legacy.sh",
+        )
+        assert job is not None
+        script.write_text("#!/bin/sh\nhermes gateway restart\n")
+
+        paused = update_job(
+            job["id"],
+            {"enabled": False, "state": "paused"},
+        )
+
+        assert paused is not None
+        assert paused["enabled"] is False
+        assert paused["state"] == "paused"
+
     def test_cronjob_tool_surfaces_block_as_error(self, tmp_path, monkeypatch):
         """End-to-end through the model tool: the block comes back as
         result['error'] with the #30719 hint, not an unhandled exception."""
@@ -731,6 +900,115 @@ class TestCreateJobBlocksLifecycleCommands:
         ))
         assert result.get("success") is False
         assert "#30719" in result.get("error", "")
+
+
+class TestSchedulerLifecycleRevalidation:
+    """Persisted or changed scripts must fail closed immediately before run."""
+
+    def test_run_job_script_blocks_nested_helper_without_subprocess(
+        self, tmp_path, monkeypatch
+    ):
+        from cron import scheduler
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        scripts = tmp_path / ".hermes" / "scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "outer.sh").write_text("#!/bin/sh\n./helper\n")
+        (scripts / "helper").write_text(
+            "#!/bin/sh\nhermes gateway restart\n"
+        )
+        calls = []
+
+        def _must_not_run(*args, **kwargs):
+            calls.append((args, kwargs))
+            raise AssertionError("subprocess.run must not be reached")
+
+        monkeypatch.setattr(scheduler.subprocess, "run", _must_not_run)
+
+        ok, output = scheduler._run_job_script("outer.sh")
+
+        assert ok is False
+        assert "#30719" in output
+        assert calls == []
+
+    def test_run_job_script_scans_configured_workdir_before_subprocess(
+        self, tmp_path, monkeypatch
+    ):
+        from cron import scheduler
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        scripts = tmp_path / ".hermes" / "scripts"
+        scripts.mkdir(parents=True)
+        workdir = tmp_path / "job-workdir"
+        workdir.mkdir()
+        (scripts / "outer.sh").write_text("#!/bin/sh\n./helper\n")
+        (scripts / "helper").write_text("#!/bin/sh\nprintf safe\\n\n")
+        (workdir / "helper").write_text(
+            "#!/bin/sh\nhermes gateway restart\n"
+        )
+        calls = []
+
+        def _must_not_run(*args, **kwargs):
+            calls.append((args, kwargs))
+            raise AssertionError("subprocess.run must not be reached")
+
+        monkeypatch.setattr(scheduler.subprocess, "run", _must_not_run)
+
+        ok, output = scheduler._run_job_script(
+            "outer.sh",
+            workdir=str(workdir),
+        )
+
+        assert ok is False
+        assert "#30719" in output
+        assert calls == []
+
+    def test_run_job_script_revalidates_after_environment_setup(
+        self, tmp_path, monkeypatch
+    ):
+        from cron import scheduler
+        from tools.environments import local
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        scripts = tmp_path / ".hermes" / "scripts"
+        scripts.mkdir(parents=True)
+        script = scripts / "mutable.sh"
+        script.write_text("#!/bin/sh\nprintf safe\\n\n")
+        calls = []
+
+        def _mutating_sanitizer(env):
+            script.write_text("#!/bin/sh\nhermes gateway restart\n")
+            return env
+
+        def _must_not_run(*args, **kwargs):
+            calls.append((args, kwargs))
+            raise AssertionError("subprocess.run must not be reached")
+
+        monkeypatch.setattr(local, "_sanitize_subprocess_env", _mutating_sanitizer)
+        monkeypatch.setattr(scheduler.subprocess, "run", _must_not_run)
+
+        ok, output = scheduler._run_job_script("mutable.sh")
+
+        assert ok is False
+        assert "#30719" in output
+        assert calls == []
+
+    def test_run_job_blocks_hand_edited_prompt_before_agent_setup(self):
+        from cron import scheduler
+
+        success, _doc, _response, error = scheduler.run_job(
+            {
+                "id": "legacy-unsafe",
+                "name": "legacy unsafe",
+                "prompt": "run hermes gateway restart",
+                "script": None,
+                "no_agent": False,
+            }
+        )
+
+        assert success is False
+        assert error is not None
+        assert "#30719" in error
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -367,6 +367,136 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]
 
+    @pytest.mark.parametrize("background", [False, True])
+    def test_guard_uses_explicit_workdir_for_foreground_and_background(
+        self, monkeypatch, tmp_path, background
+    ):
+        import tools.terminal_tool as tt
+
+        configured = tmp_path / "configured"
+        execution = tmp_path / "execution"
+        configured.mkdir()
+        execution.mkdir()
+        (execution / "delayed_restart.sh").write_text(
+            "#!/bin/bash\nhermes gateway restart\n"
+        )
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+        monkeypatch.setattr(
+            tt,
+            "_get_env_config",
+            lambda: {
+                "env_type": "local",
+                "cwd": str(configured),
+                "timeout": 60,
+                "lifetime_seconds": 3600,
+            },
+        )
+
+        result = json.loads(tt.terminal_tool(
+            command="./delayed_restart.sh",
+            workdir=str(execution),
+            background=background,
+        ))
+
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+
+    def test_guard_uses_persistent_session_cwd(self, monkeypatch, tmp_path):
+        import tools.approval as approval
+        import tools.terminal_tool as tt
+
+        configured = tmp_path / "configured"
+        execution = tmp_path / "execution"
+        configured.mkdir()
+        execution.mkdir()
+        (execution / "delayed_restart.sh").write_text(
+            "#!/bin/bash\nhermes gateway restart\n"
+        )
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+        monkeypatch.setattr(
+            tt,
+            "_get_env_config",
+            lambda: {
+                "env_type": "local",
+                "cwd": str(configured),
+                "timeout": 60,
+                "lifetime_seconds": 3600,
+            },
+        )
+        monkeypatch.setattr(
+            tt,
+            "get_session_cwd",
+            lambda key=None: str(execution) if key == "live-session" else None,
+        )
+        monkeypatch.setattr(
+            approval,
+            "get_current_session_key",
+            lambda default="": "live-session",
+        )
+
+        result = json.loads(tt.terminal_tool(command="./delayed_restart.sh"))
+
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+
+    def test_nonlocal_background_guard_and_spawn_share_effective_cwd(
+        self, monkeypatch, tmp_path
+    ):
+        from types import SimpleNamespace
+
+        import tools.process_registry as process_registry_module
+        import tools.terminal_tool as tt
+
+        configured = tmp_path / "configured"
+        execution = tmp_path / "execution"
+        configured.mkdir()
+        execution.mkdir()
+        (configured / "helper.sh").write_text(
+            "#!/bin/sh\nhermes gateway restart\n"
+        )
+        (execution / "helper.sh").write_text("#!/bin/sh\nprintf safe\\n\n")
+
+        fake_env = self._make_fake_env()
+        self._patch_env(monkeypatch, fake_env, inside_gateway=True)
+        monkeypatch.setattr(
+            tt,
+            "_get_env_config",
+            lambda: {
+                "env_type": "ssh",
+                "cwd": str(configured),
+                "timeout": 60,
+                "lifetime_seconds": 3600,
+            },
+        )
+        monkeypatch.setattr(
+            tt,
+            "_check_all_guards",
+            lambda cmd, env, **kwargs: {"approved": True},
+        )
+        spawn_calls = []
+
+        def _fake_spawn_via_env(**kwargs):
+            spawn_calls.append(kwargs)
+            return SimpleNamespace(id="proc_fake", pid=1234)
+
+        monkeypatch.setattr(
+            process_registry_module.process_registry,
+            "spawn_via_env",
+            _fake_spawn_via_env,
+        )
+
+        result = json.loads(
+            tt.terminal_tool(
+                command="./helper.sh",
+                workdir=str(execution),
+                background=True,
+            )
+        )
+
+        assert result["exit_code"] == 0
+        assert len(spawn_calls) == 1
+        assert spawn_calls[0]["cwd"] == str(execution)
+
     def test_safe_systemctl_commands_pass_through(self, monkeypatch):
         """Non-hermes systemctl commands must not be blocked by this guard."""
         import tools.terminal_tool as tt
@@ -470,6 +600,96 @@ class TestLifecycleGuardModule:
         )
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily", "restart.sh")
+
+    def test_extensionless_interpreter_helper_is_scanned(self, tmp_path):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_invocation
+
+        helper = tmp_path / "restart-helper"
+        helper.write_text("#!/bin/sh\nhermes gateway restart\n")
+
+        assert contains_gateway_lifecycle_invocation(
+            "bash restart-helper", cwd=tmp_path
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "source helper",
+            ". helper",
+            "exec ./helper",
+            "command bash helper",
+            "if ./helper; then printf safe; fi",
+            "while ./helper; do :; done",
+            "! ./helper",
+        ],
+    )
+    def test_literal_shell_wrappers_and_control_flow_helpers_are_scanned(
+        self, tmp_path, command
+    ):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_invocation
+
+        (tmp_path / "helper").write_text("#!/bin/sh\nhermes gateway restart\n")
+
+        assert contains_gateway_lifecycle_invocation(command, cwd=tmp_path)
+
+    def test_literal_nested_helpers_are_scanned_recursively(self, tmp_path):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_invocation
+
+        (tmp_path / "outer").write_text("#!/bin/sh\n./inner\n")
+        (tmp_path / "inner").write_text("#!/bin/sh\nhermes gateway restart\n")
+
+        assert contains_gateway_lifecycle_invocation("./outer", cwd=tmp_path)
+
+    @pytest.mark.skipif(os.name == "nt", reason="symlink creation is not reliable on Windows")
+    def test_symlink_loop_fails_closed(self, tmp_path):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_invocation
+
+        (tmp_path / "loop").symlink_to("loop")
+
+        assert contains_gateway_lifecycle_invocation("./loop", cwd=tmp_path)
+
+    def test_literal_helper_reference_collection_is_bounded(self):
+        from cron.lifecycle_guard import (
+            _MAX_HELPERS_SCANNED,
+            _collect_literal_helper_refs,
+        )
+
+        command = "; ".join(
+            f"./helper-{index}" for index in range(_MAX_HELPERS_SCANNED + 100)
+        )
+        refs, overflow = _collect_literal_helper_refs(command)
+
+        assert overflow is True
+        assert len(refs) == _MAX_HELPERS_SCANNED
+
+    def test_safe_extensionless_helper_is_allowed(self, tmp_path):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_invocation
+
+        (tmp_path / "health-helper").write_text("#!/bin/sh\nprintf ok\\n\n")
+
+        assert not contains_gateway_lifecycle_invocation(
+            "sh health-helper", cwd=tmp_path
+        )
+
+    def test_special_helper_file_fails_closed_without_reading(self, tmp_path):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_invocation
+
+        fifo = tmp_path / "blocking-helper"
+        os.mkfifo(fifo)
+
+        assert contains_gateway_lifecycle_invocation(
+            "bash blocking-helper", cwd=tmp_path
+        )
+
+    def test_oversized_helper_fails_closed(self, tmp_path):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_invocation
+
+        helper = tmp_path / "large-helper"
+        helper.write_bytes(b"#" * (257 * 1024))
+
+        assert contains_gateway_lifecycle_invocation(
+            "bash large-helper", cwd=tmp_path
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -773,6 +773,33 @@ class TestSpawnEnvSanitization:
         args, kwargs = env.commands[0]
         assert kwargs.get("rewrite_compound_background") is False
 
+    def test_spawn_via_env_propagates_effective_cwd_to_backend(self, registry):
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+
+            def get_temp_dir(self):
+                return "/tmp"
+
+            def execute(self, command, **kwargs):
+                self.commands.append((command, kwargs))
+                return {"output": "4321\n", "returncode": 0}
+
+        env = FakeEnv()
+        fake_thread = MagicMock()
+
+        with patch("tools.process_registry.threading.Thread", return_value=fake_thread), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_via_env(
+                env,
+                "./helper",
+                cwd="/workspace/effective",
+            )
+
+        _, kwargs = env.commands[0]
+        assert session.cwd == "/workspace/effective"
+        assert kwargs["cwd"] == "/workspace/effective"
+
     def test_env_poller_quotes_temp_paths_with_spaces(self, registry):
         session = _make_session(sid="proc_space")
         session.exited = False

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -885,6 +885,7 @@ class ProcessRegistry:
         try:
             result = env.execute(
                 bg_command,
+                cwd=cwd or "",
                 timeout=timeout,
                 rewrite_compound_background=False,
             )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2356,8 +2356,8 @@ def terminal_tool(
         # hermes_cli/gateway.py and the cron-path guard in hermes_cli/cron.py,
         # but applies unconditionally (force=True cannot help here).
         if os.environ.get("_HERMES_GATEWAY") == "1":
-            from hermes_cli.cron import _contains_gateway_lifecycle_command
-            if _contains_gateway_lifecycle_command(command):
+            from hermes_cli.cron import _contains_gateway_lifecycle_invocation
+            if _contains_gateway_lifecycle_invocation(command, cwd=cwd):
                 return json.dumps({
                     "output": "",
                     "exit_code": 1,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2348,6 +2348,36 @@ def terminal_tool(
                 "error": "Terminal environment unavailable (creation raced cleanup)",
             }, ensure_ascii=False)
 
+        # Resolve the exact directory that will be supplied to execution before
+        # scanning any literal helper files. Explicit ``workdir`` and the live
+        # per-session cwd must not let the guard inspect one directory and run
+        # the command in another.
+        if workdir:
+            workdir_error = _validate_workdir(workdir)
+            if workdir_error:
+                logger.warning(
+                    "Blocked dangerous workdir: %s (command: %s)",
+                    workdir[:200],
+                    _safe_command_preview(command),
+                )
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": workdir_error,
+                    "status": "blocked",
+                }, ensure_ascii=False)
+
+        # get_current_session_key()'s contextvar doesn't cross tool-worker
+        # threads, so fall back to the raw task_id (the top-level session key).
+        from tools.approval import get_current_session_key
+
+        session_key = get_current_session_key(default="") or (task_id or "")
+        effective_command_cwd = _resolve_command_cwd(
+            workdir=workdir,
+            default_cwd=cwd,
+            session_key=session_key,
+        )
+
         # Hard-block: gateway lifecycle commands (systemctl/launchctl/hermes
         # restart|stop targeting hermes-gateway) must never run inside the
         # gateway process itself. The restart would SIGTERM the gateway, which
@@ -2357,7 +2387,10 @@ def terminal_tool(
         # but applies unconditionally (force=True cannot help here).
         if os.environ.get("_HERMES_GATEWAY") == "1":
             from hermes_cli.cron import _contains_gateway_lifecycle_invocation
-            if _contains_gateway_lifecycle_invocation(command, cwd=cwd):
+            if _contains_gateway_lifecycle_invocation(
+                command,
+                cwd=effective_command_cwd,
+            ):
                 return json.dumps({
                     "output": "",
                     "exit_code": 1,
@@ -2420,19 +2453,6 @@ def terminal_tool(
                 desc = approval.get("description", "flagged as dangerous")
                 approval_note = f"Command was flagged ({desc}) and auto-approved by smart approval."
 
-        # Validate workdir against shell injection
-        if workdir:
-            workdir_error = _validate_workdir(workdir)
-            if workdir_error:
-                logger.warning("Blocked dangerous workdir: %s (command: %s)",
-                               workdir[:200], _safe_command_preview(command))
-                return json.dumps({
-                    "output": "",
-                    "exit_code": -1,
-                    "error": workdir_error,
-                    "status": "blocked"
-                }, ensure_ascii=False)
-
         # Prepare command for execution
         pty_disabled_reason = None
         effective_pty = pty
@@ -2445,25 +2465,13 @@ def terminal_tool(
                 "EOF."
             )
 
-        # The session key that drives cwd records: get_current_session_key()'s
-        # contextvar doesn't cross tool-worker threads, so fall back to the raw
-        # task_id (which IS the session_key for the top-level agent) — a
-        # stable, thread-safe anchor.
-        from tools.approval import get_current_session_key
-
-        session_key = get_current_session_key(default="") or (task_id or "")
-
         if background:
             # Spawn a tracked background process via the process registry.
             # For local backends: uses subprocess.Popen with output buffering.
             # For non-local backends: runs inside the sandbox via env.execute().
             from tools.process_registry import process_registry
 
-            effective_cwd = _resolve_command_cwd(
-                workdir=workdir,
-                default_cwd=cwd,
-                session_key=session_key,
-            )
+            effective_cwd = effective_command_cwd
             try:
                 if env_type == "local":
                     proc_session = process_registry.spawn_local(
@@ -2719,11 +2727,7 @@ def terminal_tool(
 
             while retry_count <= max_retries:
                 try:
-                    command_cwd = _resolve_command_cwd(
-                        workdir=workdir,
-                        default_cwd=cwd,
-                        session_key=session_key,
-                    )
+                    command_cwd = effective_command_cwd
                     execute_kwargs = {
                         "timeout": effective_timeout,
                         "cwd": command_cwd,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2385,24 +2385,36 @@ def terminal_tool(
         # never restart. This mirrors the `hermes gateway restart` guard in
         # hermes_cli/gateway.py and the cron-path guard in hermes_cli/cron.py,
         # but applies unconditionally (force=True cannot help here).
-        if os.environ.get("_HERMES_GATEWAY") == "1":
+        def _gateway_lifecycle_block_response() -> Optional[str]:
+            """Revalidate lifecycle safety against the execution-time backend/cwd."""
+            if os.environ.get("_HERMES_GATEWAY") != "1":
+                return None
+
             from hermes_cli.cron import _contains_gateway_lifecycle_invocation
-            if _contains_gateway_lifecycle_invocation(
+
+            if not _contains_gateway_lifecycle_invocation(
                 command,
                 cwd=effective_command_cwd,
+                inspect_helpers=env_type == "local",
             ):
-                return json.dumps({
-                    "output": "",
-                    "exit_code": 1,
-                    "error": (
-                        "Blocked: cannot restart or stop the gateway from inside the "
-                        "gateway process. The gateway would kill this command before "
-                        "it could complete (SIGTERM propagates to child processes). "
-                        "Run `hermes gateway restart` from a separate shell outside "
-                        "the running gateway."
-                    ),
-                    "status": "error",
-                }, ensure_ascii=False)
+                return None
+
+            return json.dumps({
+                "output": "",
+                "exit_code": 1,
+                "error": (
+                    "Blocked: cannot restart or stop the gateway from inside the "
+                    "gateway process. The gateway would kill this command before "
+                    "it could complete (SIGTERM propagates to child processes). "
+                    "Run `hermes gateway restart` from a separate shell outside "
+                    "the running gateway."
+                ),
+                "status": "error",
+            }, ensure_ascii=False)
+
+        blocked_response = _gateway_lifecycle_block_response()
+        if blocked_response is not None:
+            return blocked_response
 
         # Pre-exec security checks (tirith + dangerous command detection)
         # Skip check if force=True (user has confirmed they want to run it)
@@ -2472,6 +2484,9 @@ def terminal_tool(
             from tools.process_registry import process_registry
 
             effective_cwd = effective_command_cwd
+            blocked_response = _gateway_lifecycle_block_response()
+            if blocked_response is not None:
+                return blocked_response
             try:
                 if env_type == "local":
                     proc_session = process_registry.spawn_local(
@@ -2738,6 +2753,9 @@ def terminal_tool(
                         # reads, RPC reads) intentionally stay unbounded.
                         "bounded_capture": True,
                     }
+                    blocked_response = _gateway_lifecycle_block_response()
+                    if blocked_response is not None:
+                        return blocked_response
                     result = env.execute(command, **execute_kwargs)
                 except Exception as e:
                     error_str = str(e).lower()


### PR DESCRIPTION
## Summary
- Blocks gateway lifecycle commands hidden behind shell helper scripts invoked from the gateway terminal tool.
- Resolves the IN-708 restart-loop failure class where delayed helper scripts repeatedly terminated the Mission Control gateway after resume replay.
- Keeps the existing direct command guard and extends terminal execution to scan readable `*.sh` references from the command working directory before running them.

## Verification
- `/Users/nms/.hermes/hermes-agent/venv/bin/python -m py_compile cron/lifecycle_guard.py hermes_cli/cron.py tools/terminal_tool.py tests/hermes_cli/test_gateway_restart_loop.py`
- `uv run --with pytest --with pyyaml python -m pytest tests/hermes_cli/test_gateway_restart_loop.py -q` → `66 passed in 16.38s`

## Safety
- No gateway lifecycle command executed for this PR packaging pass.
- Clean worktree from current upstream `origin/main`.
- Intended files only: lifecycle guard, CLI re-export, terminal tool call site, regression test.
