### PR TITLE
fix(gateway): stop API session fork from accepting path-traversal session ids

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1918,6 +1918,27 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return raw, None
 
+    def _reject_unsafe_session_id(self, session_id: str) -> Optional["web.Response"]:
+        """Reject caller-supplied session ids that are empty, control-laden,
+        path-unsafe, or over-long.
+
+        Shared by create, fork, and ``X-Hermes-Session-Id`` continuation so
+        the same bounds apply before an id becomes a SessionDB key / agent
+        ``task_id`` (Docker/Singularity sandboxes join ``task_id`` under the
+        sandbox root). Returns a 400 response on failure, else ``None``.
+        """
+        from gateway.session import _is_path_unsafe
+
+        if not session_id or re.search(r'[\r\n\x00]', session_id) or _is_path_unsafe(session_id):
+            return web.json_response(
+                _openai_error("Invalid session ID", code="invalid_session_id"), status=400
+            )
+        if len(session_id) > self._MAX_SESSION_HEADER_LEN:
+            return web.json_response(
+                _openai_error("Session ID too long", code="invalid_session_id"), status=400
+            )
+        return None
+
     # ------------------------------------------------------------------
     # Session DB helper
     # ------------------------------------------------------------------
@@ -3127,11 +3148,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         raw_id = body.get("id") or body.get("session_id")
         session_id = str(raw_id).strip() if raw_id else f"api_{int(time.time())}_{uuid.uuid4().hex[:8]}"
-        from gateway.session import _is_path_unsafe
-        if not session_id or re.search(r'[\r\n\x00]', session_id) or _is_path_unsafe(session_id):
-            return web.json_response(_openai_error("Invalid session ID", code="invalid_session_id"), status=400)
-        if len(session_id) > self._MAX_SESSION_HEADER_LEN:
-            return web.json_response(_openai_error("Session ID too long", code="invalid_session_id"), status=400)
+        id_err = self._reject_unsafe_session_id(session_id)
+        if id_err:
+            return id_err
 
         model = body.get("model") or self._model_name
         system_prompt = body.get("system_prompt")
@@ -3299,8 +3318,9 @@ class APIServerAdapter(BasePlatformAdapter):
             return err
         db = await self._ensure_session_db_async()
         fork_id = str(body.get("id") or body.get("session_id") or f"api_{int(time.time())}_{uuid.uuid4().hex[:8]}").strip()
-        if not fork_id or re.search(r'[\r\n\x00]', fork_id):
-            return web.json_response(_openai_error("Invalid session ID", code="invalid_session_id"), status=400)
+        id_err = self._reject_unsafe_session_id(fork_id)
+        if id_err:
+            return id_err
         if await asyncio.to_thread(db.get_session, fork_id):
             return web.json_response(_openai_error(f"Session already exists: {fork_id}", code="session_exists"), status=409)
 
@@ -3793,22 +3813,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     ),
                     status=403,
                 )
-            # Sanitize: reject control characters that could enable header
-            # injection, and path-traversal-shaped IDs that would escape the
-            # sessions directory when interpolated into on-disk artifact
-            # filenames (session snapshots, request dumps). Mirrors the native
-            # gateway's entry-boundary guard (gateway.session._is_path_unsafe).
-            from gateway.session import _is_path_unsafe
-            if re.search(r'[\r\n\x00]', provided_session_id) or _is_path_unsafe(provided_session_id):
-                return web.json_response(
-                    {"error": {"message": "Invalid session ID", "type": "invalid_request_error"}},
-                    status=400,
-                )
-            if len(provided_session_id) > self._MAX_SESSION_HEADER_LEN:
-                return web.json_response(
-                    {"error": {"message": "Session ID too long", "type": "invalid_request_error"}},
-                    status=400,
-                )
+            # Sanitize: control chars, path-unsafe ids, and length - same
+            # bounds as create/fork (see _reject_unsafe_session_id).
+            id_err = self._reject_unsafe_session_id(provided_session_id)
+            if id_err:
+                return id_err
             session_id = provided_session_id
             try:
                 db = await self._ensure_session_db_async()

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -127,6 +127,32 @@ async def test_run_agent_binds_api_session_context_for_tool_env(adapter, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_session_fork_rejects_path_unsafe_and_oversized_session_id(adapter, session_db):
+    """Fork body id must match create: reject path-unsafe / control / over-long
+    ids before branching the source or creating a child session.
+
+    Path-shaped ids later become agent task_id and are joined under Docker /
+    Singularity sandbox roots - without this guard they escape the sandbox.
+    """
+    source_id = session_db.create_session("source-session", "api_server", model="test-model")
+    session_db.append_message(source_id, "user", "first path")
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        for bad_id in ("../../evil-sandbox", "..\\evil", "x" * 1000, "bad\nid"):
+            resp = await cli.post(
+                f"/api/sessions/{source_id}/fork",
+                json={"id": bad_id, "title": "Should fail"},
+            )
+            assert resp.status == 400, f"{bad_id!r} should be rejected"
+            payload = await resp.json()
+            assert payload["error"]["code"] == "invalid_session_id"
+            assert session_db.get_session(bad_id) is None
+
+    assert session_db.get_session(source_id).get("end_reason") != "branched"
+
+
+@pytest.mark.asyncio
 async def test_session_chat_stream_run_completed_carries_turn_transcript(adapter, session_db):
     """run.completed must include the full interleaved turn transcript so a
     client that lost intermediate (pre-tool-call) assistant text from the live


### PR DESCRIPTION
## What does this PR do?

Reject path-unsafe, control-character, and oversized client-chosen session ids on `POST /api/sessions/{id}/fork`. Without this guard, a forked id can become an agent `task_id` and Docker/Singularity persistent sandboxes join it under the sandbox root, allowing directory creation outside the intended sandbox.

### Bug Cause

`POST /api/sessions` already rejects empty/control/path-unsafe/oversized ids via `gateway.session._is_path_unsafe` and `_MAX_SESSION_HEADER_LEN`. Fork only rejected CR/LF/NUL, then called `create_session(fork_id, ...)`. Session chat later sets `effective_task_id = session_id`, and Docker does `get_sandbox_dir()/docker/task_id` then `os.makedirs`.

### Reproduction Steps

1. Enable the API Server with authentication.
2. Create a source session via `POST /api/sessions`.
3. Authenticated `POST /api/sessions/{source}/fork` with JSON `{"id": "../../evil-sandbox"}`.
4. Optionally chat on that session with Docker persistent sandboxes enabled.

Expected: HTTP 400 `invalid_session_id`; source session not branched; no fork row created.
Before fix: HTTP 201; fork id stored; later agent runs can create host dirs outside the sandbox root.

### Fix

- Add shared `APIServerAdapter._reject_unsafe_session_id` (control chars + `_is_path_unsafe` + length).
- Route session create, session fork, and `X-Hermes-Session-Id` continuation through the helper so the guard cannot drift.
- Regression test: path-unsafe / Windows-separator / oversized / control-char fork ids return 400 and do not branch the source.

Out of scope: `POST /v1/runs` session_id path traversal is covered by #71120.

## Related Issue

No issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Changes Made

- `gateway/platforms/api_server.py` - shared `_reject_unsafe_session_id`; wire create, fork, and chat session-id header
- `tests/gateway/test_session_api.py` - reject path-unsafe / oversized / control-char fork ids before branch

## How to Test

1. Manual: authenticated `POST /api/sessions/{id}/fork` with `{"id": "../../evil-sandbox"}` should return 400 and leave the source unbranched.
2. Automated (already run locally):

```bash
scripts/run_tests.sh tests/gateway/test_session_api.py -q
scripts/run_tests.sh tests/gateway/test_api_server.py -k "fork or traversal_session_id or provided_session_id" -q
```

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I have run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: Windows 11

### Documentation and Housekeeping

- [x] I have updated relevant documentation - or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I have considered cross-platform impact (Windows path separators covered by `_is_path_unsafe`)
- [x] I have updated tool descriptions/schemas if I changed tool behavior - or N/A
