### PR TITLE
fix(lazy_deps): normalize cwd to project root for uv/pip subprocesses (#71165)

### DIFF
--- a/tests/tools/test_lazy_deps_cwd.py
+++ b/tests/tools/test_lazy_deps_cwd.py
@@ -1,0 +1,41 @@
+"""Regression for #71165: lazy-deps subprocesses must not inherit an
+inaccessible cwd from su/sudo invocations."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+def test_venv_pip_install_uses_project_root_as_cwd(monkeypatch, tmp_path):
+    """_venv_pip_install must pass cwd=project_root to subprocess.run so uv
+    doesn't try to read uv.toml from an inaccessible inherited cwd."""
+    from tools.lazy_deps import _venv_pip_install
+
+    _captured_kwargs = {}
+
+    def _fake_run(*args, **kwargs):
+        _captured_kwargs.update(kwargs)
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/uv")
+    monkeypatch.setattr("tools.lazy_deps.windows_hide_flags", lambda: 0)
+
+    _venv_pip_install(("requests",))
+
+    expected_cwd = Path(__file__).parent.parent.parent.parent.resolve() / "tools" / "lazy_deps.py"
+    # The actual project root is 2 levels up from tools/lazy_deps.py
+    project_root = (Path(__file__).parent.parent.parent.parent / "tools" / "lazy_deps.py").parent.parent.resolve()
+
+    assert "cwd" in _captured_kwargs, "subprocess.run was not passed cwd"
+    cwd = _captured_kwargs["cwd"]
+    # Must be an existing directory
+    assert cwd.is_dir(), f"cwd={cwd} is not a directory"
+    # Must contain pyproject.toml (project root marker)
+    assert (cwd / "pyproject.toml").exists() or (cwd / "tools").exists(), (
+        f"cwd={cwd} doesn't look like the project root"
+    )

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -656,6 +656,13 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
     if constraints is not None:
         constraint_args = ["--constraint", str(constraints)]
 
+    # Normalize cwd to the project checkout so subprocesses (uv, pip)
+    # don't inherit an inaccessible directory from su/sudo invocations
+    # (e.g. root's home when launched via `su -c 'hermes update'`).
+    # uv reads uv.toml from cwd and fails with "Permission denied" when
+    # cwd is unreadable (#71165).
+    _project_root = Path(__file__).parent.parent.resolve()
+
     try:
         venv_root = Path(sys.executable).parent.parent
         from tools.environments.local import hermes_subprocess_env
@@ -670,6 +677,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                     [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
                     capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout, env=uv_env,
                     stdin=subprocess.DEVNULL,
+                    cwd=_project_root,
                     creationflags=windows_hide_flags(),
                 )
                 if r.returncode == 0:
@@ -687,6 +695,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 pip_cmd + ["--version"],
                 capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=15,
                 stdin=subprocess.DEVNULL,
+                cwd=_project_root,
                 creationflags=windows_hide_flags(),
             )
             if probe.returncode != 0:
@@ -697,6 +706,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                     [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
                     capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120, check=True,
                     stdin=subprocess.DEVNULL,
+                    cwd=_project_root,
                     creationflags=windows_hide_flags(),
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
@@ -708,6 +718,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 pip_cmd + ["install", *target_args, *constraint_args, *specs],
                 capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout,
                 stdin=subprocess.DEVNULL,
+                cwd=_project_root,
                 creationflags=windows_hide_flags(),
             )
             if r.returncode == 0 and target is not None:


### PR DESCRIPTION
## Problem

When `hermes update` is launched via `su`/`sudo` from an inaccessible cwd (e.g. root's home directory), `uv` inherits that cwd and fails with `Permission denied` when trying to read `uv.toml`. The lazy backend refresh then fails, and the updater restarts gateways with missing adapters.

## Fix

Compute `_project_root = Path(__file__).parent.parent.resolve()` at the start of `_venv_pip_install()` and pass `cwd=_project_root` to all four `subprocess.run` calls (uv pip install, pip --version, ensurepip, pip install). This ensures subprocesses always run from the project checkout, regardless of the caller's inherited cwd.

## Regression test

`test_venv_pip_install_uses_project_root_as_cwd` — monkeypatches `subprocess.run` and `shutil.which`, calls `_venv_pip_install`, verifies `cwd` was passed and points to a valid project directory.

Fixes #71165
