### PR TITLE
fix(desktop): resolve unpacked spawn-helper before chmod

### DIFF
--- a/apps/desktop/electron/spawn-helper-perms.test.ts
+++ b/apps/desktop/electron/spawn-helper-perms.test.ts
@@ -8,7 +8,8 @@ import {
   needsExecBit,
   spawnHelperCandidates,
   type SpawnHelperFs,
-  withExecBits
+  withExecBits,
+  writableNodePtyRoot
 } from './spawn-helper-perms'
 
 interface FakeFile {
@@ -55,6 +56,30 @@ function fakeFs(
     }
   }
 }
+
+test('rewrites an archived node-pty root to the matching unpacked tree exactly once', () => {
+  assert.equal(
+    writableNodePtyRoot('/Hermes.app/Contents/Resources/app.asar/dist/node_modules/node-pty'),
+    '/Hermes.app/Contents/Resources/app.asar.unpacked/dist/node_modules/node-pty'
+  )
+  assert.equal(
+    writableNodePtyRoot('/Hermes.app/Contents/Resources/app.asar.unpacked/dist/node_modules/node-pty'),
+    '/Hermes.app/Contents/Resources/app.asar.unpacked/dist/node_modules/node-pty'
+  )
+})
+
+test('uses the unpacked helper when resolution reports an app.asar node-pty root', () => {
+  const archivedRoot = '/Hermes.app/Contents/Resources/app.asar/dist/node_modules/node-pty'
+  const unpackedRoot = writableNodePtyRoot(archivedRoot)
+  const helper = join(unpackedRoot, 'prebuilds', 'darwin-arm64', 'spawn-helper')
+  const fs = fakeFs({ [helper]: { mode: 0o644 } }, { [join(unpackedRoot, 'prebuilds')]: ['darwin-arm64'] })
+
+  const result = ensureSpawnHelperExecutable(archivedRoot, fs)
+
+  assert.deepEqual(result.fixed, [helper])
+  assert.deepEqual(result.errors, [])
+  assert.deepEqual(fs.chmods, [{ path: helper, mode: 0o755 }])
+})
 
 test('needsExecBit / withExecBits treat any missing exec bit as non-executable', () => {
   assert.equal(needsExecBit(0o644), true)

--- a/apps/desktop/electron/spawn-helper-perms.ts
+++ b/apps/desktop/electron/spawn-helper-perms.ts
@@ -18,6 +18,14 @@ import { join } from 'node:path'
 
 const EXEC_BITS = 0o111
 
+// Electron exposes module paths inside app.asar even when electron-builder has
+// unpacked the native payload beside it. `stat` can read an archived path, but
+// chmod cannot mutate it (ENOTDIR). Native node-pty helpers belong in the
+// writable app.asar.unpacked tree; leave an already-unpacked path unchanged.
+export function writableNodePtyRoot(nodePtyRoot: string): string {
+  return nodePtyRoot.replace(/app\.asar(?!\.unpacked)/, 'app.asar.unpacked')
+}
+
 export interface SpawnHelperFs {
   existsSync(path: string): boolean
   readdirSync(path: string): string[]
@@ -81,8 +89,9 @@ export function ensureSpawnHelperExecutable(
   fs: SpawnHelperFs = defaultFs
 ): EnsureSpawnHelperResult {
   const result: EnsureSpawnHelperResult = { fixed: [], errors: [] }
+  const writableRoot = writableNodePtyRoot(nodePtyRoot)
 
-  for (const path of spawnHelperCandidates(nodePtyRoot, fs)) {
+  for (const path of spawnHelperCandidates(writableRoot, fs)) {
     if (!fs.existsSync(path)) {
       continue
     }


### PR DESCRIPTION
## Summary

Fixes the macOS Desktop runtime path that attempts to `chmod` node-pty's `spawn-helper` inside `app.asar`.

Electron module resolution can report:

```text
.../Hermes.app/Contents/Resources/app.asar/dist/node_modules/node-pty
```

while electron-builder has staged the mutable native payload under the matching `app.asar.unpacked` directory. `stat` can read the archived path, but `chmod` cannot mutate it and returns `ENOTDIR`.

This normalizes the node-pty package root to the writable unpacked tree before helper candidate discovery. The normalization is idempotent, so an already-unpacked root is preserved.

## Test plan

- `npm run test:desktop:platforms -- --run electron/spawn-helper-perms.test.ts`
  - 8 tests passed
- `npm run typecheck -- --pretty false`
- `git diff --check`

## Issue

Fixes #71167

Related: #61389, #61396
