### PR TITLE
fix(update): allow `hermes update` for Docker backends with a legacy .install-method file

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -404,8 +404,10 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
     1. Code-scoped stamp ``<install tree>/.install_method`` (next to the
        running code) — the authoritative marker.
     2. Legacy home-scoped stamp ``$HERMES_HOME/.install_method`` — read for
-       backward compatibility, but a ``docker`` value is IGNORED when we are
-       not actually running inside a container (see below).
+       backward compatibility, but a ``docker`` value is IGNORED when it
+       cannot describe this install: either we are not actually running
+       inside a container, or the running code is a git checkout (``.git``
+       present, which the published image never ships). See below.
     3. HERMES_MANAGED env / .managed marker (NixOS managed mode)
     4. /nix/store/ path detection -> 'nix' (nix run / nix profile install)
     5. .git directory presence -> 'git'
@@ -426,10 +428,13 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
     its own truthful marker.
 
     Self-healing for already-poisoned homes: a legacy ``docker`` value in the
-    home-scoped stamp is only honoured when we are genuinely in a container.
-    On a host install that read a contaminating ``docker`` stamp, we fall
-    through to managed/.git detection instead — so existing shared-home
-    setups recover without the user touching anything.
+    home-scoped stamp is only honoured when it could plausibly be this
+    install — i.e. we are genuinely in a container AND the running code is
+    not a git checkout. On a host install that read a contaminating ``docker``
+    stamp, we fall through to managed/nix/.git detection instead — so
+    existing shared-home setups recover without the user touching anything.
+    (The published image excludes ``.git`` and carries a code-scoped stamp,
+    so a working tree with ``.git`` is never that image.)
 
     Note: running inside a container is NOT treated as "docker" on its own.
     The supported installs self-identify via the code-scoped stamp:
@@ -452,10 +457,8 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
     except OSError:
         pass
 
-    # 2. Legacy home-scoped stamp — back-compat. Ignore a ``docker`` value
-    #    when we are not actually containerised: that is the signature of a
-    #    host install whose shared $HERMES_HOME was stamped by a co-located
-    #    container, and honouring it wrongly blocks ``hermes update``.
+    # 2. Legacy home-scoped stamp — back-compat, with the ``docker`` value
+    #    filtered as described below.
     try:
         method = (
             (get_hermes_home() / ".install_method")
@@ -463,7 +466,16 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
             .strip()
             .lower()
         )
-        if method in supported_methods and not (method == "docker" and not _running_in_container()):
+        # A ``docker`` stamp is untrustworthy — and must not block
+        # ``hermes update`` — when it cannot describe this install: either
+        # we are not containerised, or the running code is a git checkout
+        # (the published image ships no ``.git`` and stamps code-scoped).
+        # Both are the signature of a shared $HERMES_HOME stamped by a
+        # co-located container rather than by the running install.
+        docker_stamp_untrustworthy = method == "docker" and (
+            not _running_in_container() or _is_git_checkout(root)
+        )
+        if method in supported_methods and not docker_stamp_untrustworthy:
             return method
     except OSError:
         pass
@@ -483,20 +495,29 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
     except OSError:
         pass
 
-    # detect git repo installs (normal installer, development env)
+    # detect git repo installs (normal installer, development env, worktrees)
+    if _is_git_checkout(root):
+        return "git"
+    return "unknown"
+
+
+def _is_git_checkout(root: Path) -> bool:
+    """Return True when ``root`` is a git checkout.
+
+    Recognises both a normal ``.git`` directory and a worktree/submodule
+    ``.git`` file (a text pointer beginning ``gitdir:``). The published
+    Docker image excludes ``.git`` entirely, so this doubles as "not the
+    published image" — see ``detect_install_method``.
+    """
     git_path = root / ".git"
     if git_path.is_dir():
-        return "git"
-
-    # detect git repo installs from worktrees
+        return True
     if git_path.is_file():
         try:
-            content = git_path.read_text(encoding="utf-8").strip()
-            if content.startswith("gitdir:"):
-                return "git"
+            return git_path.read_text(encoding="utf-8").strip().startswith("gitdir:")
         except OSError:
             pass
-    return "unknown"
+    return False
 
 
 def _running_in_container() -> bool:

--- a/tests/hermes_cli/test_pip_install_detection.py
+++ b/tests/hermes_cli/test_pip_install_detection.py
@@ -124,6 +124,45 @@ def test_home_docker_stamp_honored_inside_container(tmp_path):
         assert detect_install_method(project_root=code) == "docker"
 
 
+def test_home_docker_stamp_ignored_for_git_checkout_in_container(tmp_path):
+    """A 'docker' home stamp is ignored for a git checkout, even in a container.
+
+    Regression: Hermes installed as a git checkout but run inside an unrelated
+    sandbox container (a "terminal sandbox"), whose shared $HERMES_HOME was
+    poisoned with a 'docker' stamp by a co-located published image. Being
+    containerized is not enough to honour the stamp — the published image
+    excludes ``.git`` and carries a code-scoped stamp, so a working tree with
+    ``.git`` is provably not that image and must resolve to 'git' so
+    ``hermes update`` is allowed.
+    """
+    code = tmp_path / "code"
+    home = tmp_path / "home"
+    code.mkdir()
+    home.mkdir()
+    (code / ".git").mkdir()
+    (home / ".install_method").write_text("docker\n")
+    with patch("hermes_cli.config.get_managed_system", return_value=None), \
+         patch("hermes_cli.config.get_hermes_home", return_value=home), \
+         patch("hermes_cli.config._running_in_container", return_value=True):
+        from hermes_cli.config import detect_install_method
+        assert detect_install_method(project_root=code) == "git"
+
+
+def test_home_docker_stamp_ignored_for_git_worktree_in_container(tmp_path):
+    """Same as above but the checkout is a git worktree (``.git`` is a file)."""
+    code = tmp_path / "code"
+    home = tmp_path / "home"
+    code.mkdir()
+    home.mkdir()
+    (code / ".git").write_text("gitdir: /elsewhere/.git/worktrees/hermes\n")
+    (home / ".install_method").write_text("docker\n")
+    with patch("hermes_cli.config.get_managed_system", return_value=None), \
+         patch("hermes_cli.config.get_hermes_home", return_value=home), \
+         patch("hermes_cli.config._running_in_container", return_value=True):
+        from hermes_cli.config import detect_install_method
+        assert detect_install_method(project_root=code) == "git"
+
+
 def test_home_non_docker_stamp_still_honored_for_backcompat(tmp_path):
     """Legacy non-'docker' home stamps (e.g. 'git') are still respected.
 


### PR DESCRIPTION
## What does this PR do?

Allows `hermes update` for Git installations that have a Docker backend and a legacy .install_method file that contains "docker".  

## Related Issue

Fixes #71153 

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Updates the `hermes-cli/config.py` `detect_install_method` to check for a .git directory before deciding that it's a Docker install, because the git directory isn't present in the standard Docker image.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Configure Hermes to use a Docker backend
2. echo "docker" > .install_method
3. hermes update

After making the code changes, my Hermes successfully updated to the latest version.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

