### PR TITLE
fix(desktop): preserve prompts during warm activation

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1472,7 +1472,13 @@ describe('resumeSession warm-cache mapping integrity', () => {
       return {} as never
     })
 
-    vi.mocked(getSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-A' } as never)
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [
+        { content: 'old prompt', role: 'user', timestamp: 1 },
+        { content: 'old answer', role: 'assistant', timestamp: 2 }
+      ],
+      session_id: 'stored-A'
+    } as never)
 
     let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
     render(
@@ -1520,7 +1526,9 @@ describe('resumeSession warm-cache mapping integrity', () => {
         { content: 'old prompt', role: 'user', timestamp: 1 },
         { content: 'old answer', role: 'assistant', timestamp: 2 }
       ],
-      running: true,
+      // The backend captured this before the prompt was submitted, so the
+      // explicit false is stale by the time activation reaches the renderer.
+      running: false,
       info: {}
     })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1543,6 +1543,187 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(finalMessages.map(chatMessageText)).toEqual(['old prompt', 'old answer', 'new prompt'])
     expect(finalState).toMatchObject({ awaitingResponse: true, busy: true })
   })
+
+  it('accepts an idle activation when the warm turn state did not change', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const state = clientState('stored-A')
+    state.messages = [
+      {
+        id: 'old-user',
+        role: 'user',
+        parts: [{ type: 'text', text: 'old prompt' }]
+      },
+      {
+        id: 'old-assistant',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'old answer' }]
+      }
+    ]
+    state.busy = true
+    state.awaitingResponse = true
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', state]])
+    }
+
+    const persistedMessages = [
+      { content: 'old prompt', role: 'user' as const, timestamp: 1 },
+      { content: 'old answer', role: 'assistant' as const, timestamp: 2 }
+    ]
+
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: persistedMessages,
+      session_id: 'stored-A'
+    })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return {
+          session_id: 'rt-A',
+          session_key: 'stored-A',
+          resumed: 'stored-A',
+          message_count: persistedMessages.length,
+          messages: persistedMessages,
+          running: false,
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={r => (resume = r)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    expect(sessionStateByRuntimeIdRef.current.get('rt-A')).toMatchObject({
+      awaitingResponse: false,
+      busy: false
+    })
+  })
+
+  it('does not resurrect a turn completed while warm activation is still pending', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const state = clientState('stored-A')
+    state.messages = [
+      {
+        id: 'old-user',
+        role: 'user',
+        parts: [{ type: 'text', text: 'old prompt' }]
+      },
+      {
+        id: 'old-assistant',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'old answer' }]
+      },
+      {
+        id: 'user-new-prompt',
+        role: 'user',
+        parts: [{ type: 'text', text: 'new prompt' }]
+      }
+    ]
+    state.busy = true
+    state.awaitingResponse = true
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', state]])
+    }
+
+    const activation = deferred<SessionResumeResponse>()
+
+    let activationStarted!: () => void
+
+    const activationStartedPromise = new Promise<void>(resolve => {
+      activationStarted = resolve
+    })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        activationStarted()
+
+        return activation.promise as never
+      }
+
+      return {} as never
+    })
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={r => (resume = r)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    let resumePromise!: Promise<unknown>
+    act(() => {
+      resumePromise = resume!('stored-A', true)
+    })
+    await activationStartedPromise
+
+    act(() => {
+      const current = sessionStateByRuntimeIdRef.current.get('rt-A')!
+
+      const completedState = {
+        ...current,
+        messages: [
+          ...current.messages,
+          {
+            id: 'assistant-completed',
+            role: 'assistant' as const,
+            parts: [{ type: 'text' as const, text: 'new answer' }]
+          }
+        ],
+        busy: false,
+        awaitingResponse: false,
+        sawAssistantPayload: true
+      }
+
+      sessionStateByRuntimeIdRef.current.set('rt-A', completedState)
+    })
+
+    activation.resolve({
+      session_id: 'rt-A',
+      session_key: 'stored-A',
+      resumed: 'stored-A',
+      message_count: 2,
+      messages: [
+        { content: 'old prompt', role: 'user', timestamp: 1 },
+        { content: 'old answer', role: 'assistant', timestamp: 2 }
+      ],
+      inflight: {
+        user: 'new prompt',
+        streaming: true
+      },
+      running: true,
+      info: {}
+    })
+
+    await act(async () => {
+      await resumePromise
+    })
+
+    const finalState = sessionStateByRuntimeIdRef.current.get('rt-A')!
+    expect(finalState.messages.map(chatMessageText)).toEqual(['old prompt', 'old answer', 'new prompt', 'new answer'])
+    expect(finalState).toMatchObject({ awaitingResponse: false, busy: false })
+  })
 })
 
 describe('createBackendSessionForSend workspace target', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getSession, getSessionMessages, type SessionInfo } from '@/hermes'
+import { chatMessageText } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile } from '@/store/profile'
@@ -34,6 +35,7 @@ import {
   setSessions
 } from '@/store/session'
 import { $sessionTiles } from '@/store/session-states'
+import type { SessionResumeResponse } from '@/types/hermes'
 
 import { sessionRoute } from '../../routes'
 import type { ClientSessionState } from '../../types'
@@ -597,7 +599,11 @@ function ResumeHarness({
     sessionStateByRuntimeIdRef: sessionStateByRuntimeIdRef ?? ref(new Map<string, ClientSessionState>()),
     syncSessionStateToView: vi.fn(),
     updateSessionState: (sessionId, updater) => {
-      const next = updater({} as ClientSessionState)
+      const stateByRuntimeId = sessionStateByRuntimeIdRef?.current
+      const current = stateByRuntimeId?.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+
+      stateByRuntimeId?.set(sessionId, next)
       onStateUpdate?.(sessionId, next)
 
       return next
@@ -1423,6 +1429,111 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(requestGateway.mock.calls.map(([method]) => method)).not.toContain('session.resume')
     expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A')
     expect(sessionStateByRuntimeIdRef.current.get('rt-A')?.messages[0]?.id).toBe('user-optimistic')
+  })
+
+  it('preserves a prompt submitted while warm session activation is still pending', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const state = clientState('stored-A')
+    state.messages = [
+      {
+        id: 'old-user',
+        role: 'user',
+        parts: [{ type: 'text', text: 'old prompt' }]
+      },
+      {
+        id: 'old-assistant',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'old answer' }]
+      }
+    ]
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', state]])
+    }
+
+    const activation = deferred<SessionResumeResponse>()
+
+    let activationStarted!: () => void
+
+    const activationStartedPromise = new Promise<void>(resolve => {
+      activationStarted = resolve
+    })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        activationStarted()
+
+        return activation.promise as never
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(getSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-A' } as never)
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={r => (resume = r)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    let resumePromise!: Promise<unknown>
+    act(() => {
+      resumePromise = resume!('stored-A', true)
+    })
+    await activationStartedPromise
+
+    const optimisticPrompt = {
+      id: 'user-new-prompt',
+      role: 'user' as const,
+      parts: [{ type: 'text' as const, text: 'new prompt' }]
+    }
+
+    act(() => {
+      const current = sessionStateByRuntimeIdRef.current.get('rt-A')!
+
+      const next = {
+        ...current,
+        messages: [...current.messages, optimisticPrompt],
+        busy: true,
+        awaitingResponse: true
+      }
+
+      sessionStateByRuntimeIdRef.current.set('rt-A', next)
+      setMessages(next.messages)
+    })
+
+    activation.resolve({
+      session_id: 'rt-A',
+      session_key: 'stored-A',
+      resumed: 'stored-A',
+      message_count: 2,
+      messages: [
+        { content: 'old prompt', role: 'user', timestamp: 1 },
+        { content: 'old answer', role: 'assistant', timestamp: 2 }
+      ],
+      running: true,
+      info: {}
+    })
+
+    await act(async () => {
+      await resumePromise
+    })
+
+    const finalState = sessionStateByRuntimeIdRef.current.get('rt-A')!
+    const finalMessages = finalState.messages
+
+    expect(finalMessages.filter(message => chatMessageText(message) === 'new prompt')).toHaveLength(1)
+    expect(finalMessages.map(chatMessageText)).toEqual(['old prompt', 'old answer', 'new prompt'])
+    expect(finalState).toMatchObject({ awaitingResponse: true, busy: true })
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -150,6 +150,21 @@ function reconcileProjectedMessages(projectedMessages: ChatMessage[], previousMe
   return preserveLocalAssistantErrors(withPendingTurn, previousMessages)
 }
 
+function liveTurnStateChanged(current: ClientSessionState, snapshot: ClientSessionState): boolean {
+  return (
+    current.messages !== snapshot.messages ||
+    current.busy !== snapshot.busy ||
+    current.awaitingResponse !== snapshot.awaitingResponse ||
+    current.streamId !== snapshot.streamId ||
+    current.sawAssistantPayload !== snapshot.sawAssistantPayload ||
+    current.pendingBranchGroup !== snapshot.pendingBranchGroup ||
+    current.interrupted !== snapshot.interrupted ||
+    current.interimBoundaryPending !== snapshot.interimBoundaryPending ||
+    current.needsInput !== snapshot.needsInput ||
+    current.turnStartedAt !== snapshot.turnStartedAt
+  )
+}
+
 // `session.create` params from the current profile + sticky-UI model/effort/fast,
 // ensuring the gateway is on that profile first. Shared by the primary send path
 // and the "open in split" tile path; `cwd` is the one thing that differs (the
@@ -754,24 +769,22 @@ export function useSessionActions({
               const activatedState = updateSessionState(
                 cachedRuntimeId,
                 state => {
-                  // session.activate may have been pending while prompt.submit
-                  // appended a newer optimistic row to the live cache. Re-read
-                  // that cache at the atomic update boundary so this stale
-                  // activation projection cannot clobber accepted user intent.
-                  const messages = reconcileProjectedMessages(activatedMessages, state.messages)
-                  // The activation payload snapshots `running` before this
-                  // response is delivered. A prompt accepted during that gap
-                  // has already armed the live cache, so a stale explicit
-                  // `false` must not clear either pending-turn indicator.
-                  const busy = Boolean(activated.running || state.busy)
-                  const awaitingResponse = Boolean(activated.running || state.awaitingResponse)
+                  // session.activate snapshots its turn projection before the
+                  // response is delivered. If submit/stream/complete/interrupt
+                  // changed that projection during the await, the live cache is
+                  // newer and wins as a unit. Otherwise activation remains
+                  // authoritative and may legitimately clear a stale busy cache.
+                  const turnAdvanced = liveTurnStateChanged(state, cachedViewState)
+                  const activatedRunning = Boolean(activated.running ?? state.busy)
 
                   return {
                     ...state,
                     ...(runtimeInfo ?? {}),
-                    messages,
-                    busy,
-                    awaitingResponse
+                    messages: turnAdvanced
+                      ? state.messages
+                      : reconcileProjectedMessages(activatedMessages, state.messages),
+                    busy: turnAdvanced ? state.busy : activatedRunning,
+                    awaitingResponse: turnAdvanced ? state.awaitingResponse : activatedRunning
                   }
                 },
                 storedSessionId

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -759,14 +759,19 @@ export function useSessionActions({
                   // that cache at the atomic update boundary so this stale
                   // activation projection cannot clobber accepted user intent.
                   const messages = reconcileProjectedMessages(activatedMessages, state.messages)
-                  const currentRunning = Boolean(activated.running ?? state.busy)
+                  // The activation payload snapshots `running` before this
+                  // response is delivered. A prompt accepted during that gap
+                  // has already armed the live cache, so a stale explicit
+                  // `false` must not clear either pending-turn indicator.
+                  const busy = Boolean(activated.running || state.busy)
+                  const awaitingResponse = Boolean(activated.running || state.awaitingResponse)
 
                   return {
                     ...state,
                     ...(runtimeInfo ?? {}),
                     messages,
-                    busy: currentRunning,
-                    awaitingResponse: currentRunning
+                    busy,
+                    awaitingResponse
                   }
                 },
                 storedSessionId

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -139,7 +139,12 @@ function reconcileAuthoritativeMessages(
 ): ChatMessage[] {
   const authoritative = toChatMessages(authoritativeMessages)
   const withLiveProjection = liveProjection ? appendLiveSessionProjection(authoritative, liveProjection) : authoritative
-  const reconciled = reconcileResumeMessages(withLiveProjection, previousMessages)
+
+  return reconcileProjectedMessages(withLiveProjection, previousMessages)
+}
+
+function reconcileProjectedMessages(projectedMessages: ChatMessage[], previousMessages: ChatMessage[]): ChatMessage[] {
+  const reconciled = reconcileResumeMessages(projectedMessages, previousMessages)
   const withPendingTurn = preserveLocalPendingTurnMessages(reconciled, previousMessages)
 
   return preserveLocalAssistantErrors(withPendingTurn, previousMessages)
@@ -748,19 +753,28 @@ export function useSessionActions({
 
               const activatedState = updateSessionState(
                 cachedRuntimeId,
-                state => ({
-                  ...state,
-                  ...(runtimeInfo ?? {}),
-                  messages: activatedMessages,
-                  busy: running,
-                  awaitingResponse: running
-                }),
+                state => {
+                  // session.activate may have been pending while prompt.submit
+                  // appended a newer optimistic row to the live cache. Re-read
+                  // that cache at the atomic update boundary so this stale
+                  // activation projection cannot clobber accepted user intent.
+                  const messages = reconcileProjectedMessages(activatedMessages, state.messages)
+                  const currentRunning = Boolean(activated.running ?? state.busy)
+
+                  return {
+                    ...state,
+                    ...(runtimeInfo ?? {}),
+                    messages,
+                    busy: currentRunning,
+                    awaitingResponse: currentRunning
+                  }
+                },
                 storedSessionId
               )
 
-              busyRef.current = running
-              setBusy(running)
-              setAwaitingResponse(running)
+              busyRef.current = activatedState.busy
+              setBusy(activatedState.busy)
+              setAwaitingResponse(activatedState.awaitingResponse)
               syncSessionStateToView(cachedRuntimeId, activatedState)
 
               return


### PR DESCRIPTION
## What does this PR do?

Preserves a user prompt submitted while a warm Desktop session is still waiting for `session.activate`.

The activation payload snapshots the runtime before its response is delivered. If `prompt.submit` appends an optimistic row during that delay, applying the older activation projection can erase the visible prompt and regress `busy` / `awaitingResponse` even though the backend accepted the turn.

At the atomic `updateSessionState` boundary, this change compares the current turn-owned state with the pre-activation snapshot. If submit, streaming, completion, interruption, or another turn transition advanced the live state, that newer message/indicator projection wins as a unit. If the turn state did not change, activation remains authoritative, including allowing a genuine `running: false` response to clear a stale busy cache. The shared view is synchronized from the state that was actually committed.

## Related Issue

Fixes #70785

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts`
  - Detect whether turn-owned live state advanced while warm activation was pending.
  - Preserve the newer live messages and busy/awaiting flags when the activation snapshot is stale.
  - Keep activation authoritative when no newer turn transition occurred.
  - Publish busy/awaiting state from the committed session state.
- `apps/desktop/src/app/session/hooks/use-session-actions.test.tsx`
  - Make the resume harness update the supplied live runtime cache, matching the production updater contract.
  - Hold `session.activate`, submit an optimistic prompt, resolve with stale `running: false`, and assert one prompt bubble plus both active-turn flags.
  - Assert a genuine idle activation still clears an unchanged stale busy cache.
  - Assert delayed `running: true` activation cannot resurrect a turn or erase an answer completed during the wait.

## How to Test

```bash
cd apps/desktop
npx vitest run --project ui \
  src/app/session/hooks/use-session-actions.test.tsx \
  src/app/session/hooks/use-session-actions/utils.test.ts
npm run typecheck
npx eslint \
  src/app/session/hooks/use-session-actions/index.ts \
  src/app/session/hooks/use-session-actions.test.tsx
npm run test:ui
```

For the reported race, hold a completed `session.activate` response at the renderer transport boundary, submit a prompt while it is pending, and release the older response with `running: false`. The prompt must remain exactly once and both pending-turn indicators must remain true.

## Scope

This is renderer-only state reconciliation. It changes no gateway protocol, persistence, configuration, tool schema, platform adapter, or unrelated Desktop surface. The two additional ordering regressions constrain the same warm-activation race rather than adding behavior.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this bug
- [x] I've added behavior-contract tests for the reported race and its ordering boundaries
- [x] I've tested on macOS 26.5

### Documentation & Housekeeping

- [x] No user-facing documentation or configuration changes are required
- [x] No `cli-config.yaml.example`, tool description, or schema changes are required
- [x] The renderer-only change is platform-neutral

## Validation

Latest branch validation:

- Focused session-action/reconciliation suite: 70 passed
- Full Desktop UI suite: 2,141 passed, 1 skipped
- TypeScript typecheck: passed
- Affected-file ESLint: passed with zero warnings
- `git diff --check`: passed

Integration audit against current `origin/main`:

- Merge: clean, limited to the same two files
- Focused session-action/reconciliation suite: 85 passed
- Affected-file ESLint: passed

The current-main activation path remains vulnerable without this patch; no competing fix has landed there.
