### PR TITLE
fix(gateway): detach-on-timeout for adapter connect so swallowed cancel can't wedge reconnect

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4037,18 +4037,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         server-side queue) from a watcher reconnect after a prolonged outage
         (preserve the queue so messages sent during the outage are delivered
         rather than silently dropped — #46621).
+
+        The connect is run detach-on-timeout, mirroring
+        ``_await_adapter_cleanup_with_timeout``: ``asyncio.wait_for`` cancels an
+        overdue child but then *awaits* it, so a ``connect()`` that swallows
+        ``CancelledError`` would block the reconnect watcher forever. Instead we
+        release the runner at the deadline and raise ``TimeoutError`` — the
+        watcher then disposes the unowned adapter and backs off exactly as it
+        already does for this exception. The detached connect task is cancelled
+        and drained; a timed-out connect is never installed on ``self.adapters``,
+        so a late-completing swallowed-cancel connect stays unowned and is
+        disposed rather than leaving a half-registered adapter (#55992).
         """
         timeout = self._platform_connect_timeout_secs()
         if timeout <= 0:
             return await adapter.connect(is_reconnect=is_reconnect)
+
+        task = asyncio.ensure_future(adapter.connect(is_reconnect=is_reconnect))
         try:
-            return await asyncio.wait_for(
-                adapter.connect(is_reconnect=is_reconnect), timeout=timeout
-            )
-        except asyncio.TimeoutError as exc:
-            raise TimeoutError(
-                f"{platform.value} connect timed out after {timeout:g}s"
-            ) from exc
+            done, _pending = await asyncio.wait({task}, timeout=timeout)
+        except asyncio.CancelledError:
+            task.cancel()
+            task.add_done_callback(consume_detached_task_result)
+            raise
+        if task in done:
+            # Propagates the connect result, or re-raises whatever connect raised
+            # (same surface as the previous ``await asyncio.wait_for``).
+            return task.result()
+
+        task.cancel()
+        task.add_done_callback(consume_detached_task_result)
+        raise TimeoutError(
+            f"{platform.value} connect timed out after {timeout:g}s"
+        )
 
     async def _connect_initial_adapter_with_timeout(self, adapter, platform) -> bool:
         """Connect one cold-start adapter with tightly scoped replace intent.

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -154,6 +154,55 @@ class TestStartupPlatformIsolation:
         with pytest.raises(TimeoutError, match="telegram connect timed out"):
             await runner._connect_adapter_with_timeout(adapter, Platform.TELEGRAM)
 
+    @pytest.mark.asyncio
+    async def test_connect_timeout_releases_when_connect_swallows_cancel(self, monkeypatch):
+        """A connect() that traps CancelledError must not wedge the caller.
+
+        ``asyncio.wait_for`` cancels an overdue child and then *awaits* it, so a
+        connect() whose teardown swallows CancelledError (a broad ``except``)
+        keeps the reconnect watcher blocked forever — the gateway stays alive
+        but never rebuilds the deaf adapter. ``_connect_adapter_with_timeout``
+        runs connect detach-on-timeout instead, so it releases the runner at the
+        deadline and raises ``TimeoutError`` regardless of the child's behavior.
+
+        On the unhardened plain-``wait_for`` implementation the inner call hangs;
+        the 2s outer bound then trips with a bare ``asyncio.TimeoutError`` whose
+        message does NOT match, so this test fails. With the detach fix the inner
+        call raises the bounded ``"... connect timed out"`` error promptly.
+        """
+        runner = _make_runner()
+        adapter = StubAdapter()
+        release = asyncio.Event()
+
+        async def swallow(*, is_reconnect: bool = False):
+            adapter.connect_calls.append(is_reconnect)
+            try:
+                await asyncio.Event().wait()  # never completes on its own
+            except asyncio.CancelledError:
+                # Trap the cancellation and keep "connecting" — reproduces a
+                # connect() that does not propagate CancelledError. ``release``
+                # only lets the detached task finish during test teardown.
+                await release.wait()
+                return False
+
+        adapter.connect = swallow
+        monkeypatch.setenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "0.001")
+
+        try:
+            with pytest.raises(TimeoutError, match="telegram connect timed out"):
+                await asyncio.wait_for(
+                    runner._connect_adapter_with_timeout(adapter, Platform.TELEGRAM),
+                    timeout=2,
+                )
+            # connect was attempted, but the timed-out adapter is left unowned
+            # for the caller's failure path to dispose (never half-registered).
+            assert adapter.connect_calls == [False]
+            assert Platform.TELEGRAM not in runner.adapters
+        finally:
+            # Let the detached connect task complete so no task lingers.
+            release.set()
+            await asyncio.sleep(0)
+
 
 class TestStartupFailureQueuing:
     """Verify that failed platforms are queued during startup."""


### PR DESCRIPTION
## Summary
Switches `_connect_adapter_with_timeout` from `asyncio.wait_for()` to the detach-on-timeout pattern, preventing a `connect()` that swallows `CancelledError` from wedging the reconnect watcher indefinitely.

Root cause: `asyncio.wait_for` cancels an overdue child task but then *awaits* it — a `connect()` whose teardown traps `CancelledError` blocks the caller forever, leaving the gateway alive but never rebuilding a deaf adapter.

## Changes
- `gateway/run.py`: `_connect_adapter_with_timeout` now uses `asyncio.wait({task}, timeout=...)` + `consume_detached_task_result` (same pattern as `_await_adapter_cleanup_with_timeout`)
- `tests/gateway/test_platform_reconnect.py`: regression test `test_connect_timeout_releases_when_connect_swallows_cancel` — a `connect()` that traps `CancelledError` and keeps running

Credit: @VaitaR's original commit cherry-picked with authorship preserved.

## Validation
| | Before | After |
|---|---|---|
| connect() swallows CancelledError | watcher wedged forever | TimeoutError raised, watcher freed |
| Normal connect() | works | works |
| Targeted tests | — | 39 passed |

Closes #70344 (detach-on-timeout concern). The reconnect watcher respawn concern is addressed in a separate PR.

## Infographic

Image generation is unavailable in this environment (no FAL_KEY / portal credits). The infographic will be attached once available.
