### PR TITLE
fix(gateway): durable cooldown for home-channel shutdown notifications

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1430,6 +1430,20 @@ def load_gateway_config() -> GatewayConfig:
                         "systemd_watchdog_seconds"
                     ]
 
+            # Shutdown-notice cooldown: top-level wins; nested gateway.* is the
+            # fallback shape written by ``hermes config set``.
+            if "shutdown_notification_cooldown_seconds" in yaml_cfg:
+                gw_data["shutdown_notification_cooldown_seconds"] = yaml_cfg[
+                    "shutdown_notification_cooldown_seconds"
+                ]
+            elif (
+                isinstance(gateway_section, dict)
+                and "shutdown_notification_cooldown_seconds" in gateway_section
+            ):
+                gw_data["shutdown_notification_cooldown_seconds"] = gateway_section[
+                    "shutdown_notification_cooldown_seconds"
+                ]
+
             if "max_concurrent_sessions" in yaml_cfg:
                 gw_data["max_concurrent_sessions"] = yaml_cfg["max_concurrent_sessions"]
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -150,6 +150,37 @@ def _coerce_optional_positive_int(value: Any, key: str) -> Optional[int]:
 _SYSTEMD_WATCHDOG_MAX_SECONDS = 2_147_483_647
 
 
+def _coerce_non_negative_int(value: Any, key: str, default: int) -> int:
+    """Coerce a config value to a non-negative int, falling back to *default*.
+
+    Zero is meaningful (it disables the setting), so it is preserved rather
+    than treated as unset. Malformed values are ignored with a warning so a
+    typo never prevents the gateway from starting.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        logger.warning("Ignoring invalid %s=%r (expected a non-negative integer)", key, value)
+        return default
+    try:
+        if isinstance(value, float):
+            if not value.is_integer():
+                raise ValueError(value)
+            parsed = int(value)
+        elif isinstance(value, str):
+            parsed = int(value.strip(), 10)
+        else:
+            parsed = int(value)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid %s=%r (expected a non-negative integer)", key, value)
+        return default
+    if parsed < 0:
+        logger.warning("Ignoring invalid %s=%r (expected a non-negative integer)", key, value)
+        return default
+    return parsed
+
+
+
 def coerce_systemd_watchdog_seconds(
     value: Any, key: str = "gateway.systemd_watchdog_seconds"
 ) -> int:
@@ -936,6 +967,20 @@ class GatewayConfig:
     # service-restart code so the supervisor can revive the process. On by
     # default; set gateway.loop_watchdog: false in config.yaml to disable.
     loop_watchdog: bool = True
+    # Minimum seconds between two home-channel "gateway shutting down"
+    # broadcasts to the SAME destination, enforced DURABLY across gateway
+    # processes (gateway/shutdown_notice.py).
+    #
+    # The in-process dedup set only suppresses duplicates within one shutdown,
+    # so a host that repeatedly cycles the gateway re-announces every time: a
+    # WSL host under Windows Modern Standby produced 240 home-channel notices,
+    # 19 inside one 10-minute window, against 1 active-session notice. This
+    # window collapses such a burst to one message while leaving a genuine
+    # restart hours later fully visible.
+    #
+    # Applies ONLY to the home-channel broadcast; per-active-session interrupt
+    # pings are never suppressed. 0 disables the guard (always broadcast).
+    shutdown_notification_cooldown_seconds: int = 300
 
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
@@ -1072,6 +1117,7 @@ class GatewayConfig:
             "multiplex_profiles": self.multiplex_profiles,
             "systemd_watchdog_seconds": self.systemd_watchdog_seconds,
             "loop_watchdog": self.loop_watchdog,
+            "shutdown_notification_cooldown_seconds": self.shutdown_notification_cooldown_seconds,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
@@ -1148,6 +1194,19 @@ class GatewayConfig:
         else:
             loop_watchdog_raw = nested_gateway.get("loop_watchdog")
         loop_watchdog = _coerce_bool(loop_watchdog_raw, True)
+        if "shutdown_notification_cooldown_seconds" in data:
+            shutdown_cooldown_raw = data.get("shutdown_notification_cooldown_seconds")
+            shutdown_cooldown_key = "shutdown_notification_cooldown_seconds"
+        else:
+            shutdown_cooldown_raw = nested_gateway.get(
+                "shutdown_notification_cooldown_seconds"
+            )
+            shutdown_cooldown_key = "gateway.shutdown_notification_cooldown_seconds"
+        shutdown_notification_cooldown_seconds = _coerce_non_negative_int(
+            shutdown_cooldown_raw,
+            shutdown_cooldown_key,
+            300,
+        )
         if multiplex_profiles is None and isinstance(nested_gateway, dict):
             # Also honor gateway.multiplex_profiles written by
             # ``hermes config set gateway.multiplex_profiles true``.
@@ -1209,6 +1268,7 @@ class GatewayConfig:
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
             systemd_watchdog_seconds=systemd_watchdog_seconds,
             loop_watchdog=loop_watchdog,
+            shutdown_notification_cooldown_seconds=shutdown_notification_cooldown_seconds,
             max_concurrent_sessions=max_concurrent_sessions,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9033,55 +9033,56 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             cooldown_key = shutdown_notice.destination_key(
                 platform.value, home.chat_id, home.thread_id
             )
-            if not shutdown_notice.should_send_home_notice(
+            with shutdown_notice.home_notice_admission(
                 cooldown_key,
                 cooldown_seconds=getattr(
                     self.config, "shutdown_notification_cooldown_seconds", 0
                 ),
-            ):
-                logger.info(
-                    "Home-channel shutdown notification suppressed for %s:%s "
-                    "(sent within the last %ss)",
-                    platform.value,
-                    home.chat_id,
-                    getattr(self.config, "shutdown_notification_cooldown_seconds", 0),
-                )
-                continue
+            ) as admission:
+                if not admission.allowed:
+                    logger.info(
+                        "Home-channel shutdown notification suppressed for %s:%s "
+                        "(sent within the last %ss)",
+                        platform.value,
+                        home.chat_id,
+                        getattr(self.config, "shutdown_notification_cooldown_seconds", 0),
+                    )
+                    continue
 
-            try:
-                metadata = self._thread_metadata_for_target(
-                    platform,
-                    home.chat_id,
-                    home.thread_id,
-                    adapter=adapter,
-                )
-                if metadata:
-                    result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
-                else:
-                    result = await adapter.send(str(home.chat_id), msg)
-                if result is not None and getattr(result, "success", True) is False:
+                try:
+                    metadata = self._thread_metadata_for_target(
+                        platform,
+                        home.chat_id,
+                        home.thread_id,
+                        adapter=adapter,
+                    )
+                    if metadata:
+                        result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
+                    else:
+                        result = await adapter.send(str(home.chat_id), msg)
+                    if result is not None and getattr(result, "success", True) is False:
+                        logger.debug(
+                            "Failed to send shutdown notification to home channel %s:%s: %s",
+                            platform.value,
+                            home.chat_id,
+                            getattr(result, "error", "send returned success=False"),
+                        )
+                        continue
+
+                    notified.add(dedup_key)
+                    admission.record_success()
+                    logger.info(
+                        "Sent shutdown notification to home channel %s:%s",
+                        platform.value,
+                        home.chat_id,
+                    )
+                except Exception as e:
                     logger.debug(
                         "Failed to send shutdown notification to home channel %s:%s: %s",
                         platform.value,
                         home.chat_id,
-                        getattr(result, "error", "send returned success=False"),
+                        e,
                     )
-                    continue
-
-                notified.add(dedup_key)
-                shutdown_notice.record_home_notice(cooldown_key)
-                logger.info(
-                    "Sent shutdown notification to home channel %s:%s",
-                    platform.value,
-                    home.chat_id,
-                )
-            except Exception as e:
-                logger.debug(
-                    "Failed to send shutdown notification to home channel %s:%s: %s",
-                    platform.value,
-                    home.chat_id,
-                    e,
-                )
 
     async def _finalize_shutdown_agents(self, active_agents: Dict[str, Any]) -> None:
         for agent in active_agents.values():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2228,6 +2228,7 @@ from gateway.shutdown_watchdog import (
     resolve_shutdown_watchdog_delay,
     start_loop_liveness_watchdog,
 )
+from gateway import shutdown_notice
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
@@ -9023,6 +9024,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if dedup_key in notified:
                 continue
 
+            # Durable cross-process cooldown (#shutdown-notice-spam). The
+            # ``notified`` set above only dedupes within THIS process, so a host
+            # that repeatedly cycles the gateway (WSL under Windows Modern
+            # Standby, a crash-looping supervisor) re-broadcasts on every fresh
+            # start. Gate only the home-channel broadcast; the per-active-session
+            # pings above stay ungated, exactly like the drain suppress flag.
+            cooldown_key = shutdown_notice.destination_key(
+                platform.value, home.chat_id, home.thread_id
+            )
+            if not shutdown_notice.should_send_home_notice(
+                cooldown_key,
+                cooldown_seconds=getattr(
+                    self.config, "shutdown_notification_cooldown_seconds", 0
+                ),
+            ):
+                logger.info(
+                    "Home-channel shutdown notification suppressed for %s:%s "
+                    "(sent within the last %ss)",
+                    platform.value,
+                    home.chat_id,
+                    getattr(self.config, "shutdown_notification_cooldown_seconds", 0),
+                )
+                continue
+
             try:
                 metadata = self._thread_metadata_for_target(
                     platform,
@@ -9044,6 +9069,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     continue
 
                 notified.add(dedup_key)
+                shutdown_notice.record_home_notice(cooldown_key)
                 logger.info(
                     "Sent shutdown notification to home channel %s:%s",
                     platform.value,

--- a/gateway/shutdown_notice.py
+++ b/gateway/shutdown_notice.py
@@ -1,0 +1,164 @@
+"""Durable cooldown for the home-channel "gateway shutting down" broadcast.
+
+``GatewayRunner._notify_active_sessions_of_shutdown`` deduplicates its sends
+through a ``notified`` set. That set is **per-process**, so it only ever
+suppresses a duplicate *within a single shutdown*. Every fresh gateway process
+starts with an empty set and is free to re-broadcast the identical message.
+
+That is fine when a restart is deliberate and rare. It is not fine when
+something outside Hermes is cycling the host: each activation starts a gateway,
+the gateway is told to stop seconds later, and the home channel gets another
+copy of
+
+    ⚠️ Gateway shutting down — Your current task will be interrupted.
+
+Observed on a WSL host where Windows Modern Standby repeatedly tore down and
+re-activated the distro on a ~33 s cycle: **240** home-channel shutdown
+notifications, 19 of them inside a single 10-minute window, against **1**
+active-session notification. Nothing was wrong with the gateway — it was
+started and stopped 240 times, and each process correctly believed it was
+announcing its first shutdown.
+
+This module makes that dedup survive process death by recording the last
+broadcast time per destination under ``HERMES_HOME``, so the *next* gateway
+process can see that the same channel was already told moments ago.
+
+Scope is deliberately narrow — the **home-channel broadcast only**. The
+per-active-session pings in the same function stay ungated, matching the
+existing ``suppress_notification`` drain flag: those carry the genuinely useful
+"your task was cut off, message me to resume" hint, and are empty by
+construction on the idle shutdowns that produce this flood.
+
+Fail-open everywhere: an unreadable, malformed, or unwritable state file must
+never suppress a notification, and must never raise into the shutdown path.
+Setting ``gateway.shutdown_notification_cooldown_seconds: 0`` restores the
+original always-send behaviour.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_constants import get_hermes_home
+from utils import atomic_json_write
+
+_log = logging.getLogger(__name__)
+
+_STATE_FILENAME = ".shutdown_notice_state.json"
+
+# Entries older than this are dropped on write so the file cannot grow
+# unbounded across a long-lived install with many home channels. Generous
+# relative to any sane cooldown: an entry only matters while it is younger
+# than the configured window.
+_MAX_ENTRY_AGE_SECONDS = 7 * 24 * 60 * 60
+
+
+def notice_state_path(home: Optional[Path] = None) -> Path:
+    """Absolute path to the shutdown-notice state file, respecting HERMES_HOME."""
+    base = home if home is not None else get_hermes_home()
+    return Path(base) / _STATE_FILENAME
+
+
+def destination_key(platform: str, chat_id: Any, thread_id: Any = None) -> str:
+    """Stable string key for one delivery destination.
+
+    Mirrors the in-process ``dedup_key`` tuple so the durable record and the
+    per-process set agree on what "the same destination" means.
+    """
+    thread = str(thread_id) if thread_id else ""
+    return f"{platform}:{chat_id}:{thread}"
+
+
+def _read_state(path: Path) -> dict[str, float]:
+    """Return ``{destination_key: last_sent_epoch}``; ``{}`` on any problem."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+    except FileNotFoundError:
+        return {}
+    except Exception as e:  # malformed / unreadable / permission
+        _log.debug("Ignoring unreadable shutdown-notice state %s: %s", path, e)
+        return {}
+
+    if not isinstance(raw, dict):
+        return {}
+    entries = raw.get("home_notices")
+    if not isinstance(entries, dict):
+        return {}
+
+    out: dict[str, float] = {}
+    for key, value in entries.items():
+        if not isinstance(key, str):
+            continue
+        try:
+            out[key] = float(value)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def should_send_home_notice(
+    key: str,
+    *,
+    cooldown_seconds: float,
+    now: Optional[float] = None,
+    home: Optional[Path] = None,
+) -> bool:
+    """Return True when the home-channel broadcast for *key* may be sent.
+
+    Suppresses only when a previous send is recorded **and** it happened within
+    ``cooldown_seconds`` of *now*. A non-positive cooldown disables the check
+    entirely (always send), which is the documented opt-out.
+
+    A recorded timestamp in the future is treated as unusable rather than as an
+    infinitely-long cooldown: a backwards wall-clock step (NTP correction, VM
+    resume, the very host suspend/resume cycle this guard exists for) must not
+    be able to silence the channel indefinitely.
+    """
+    try:
+        if cooldown_seconds is None or cooldown_seconds <= 0:
+            return True
+
+        now_ts = time.time() if now is None else float(now)
+        last = _read_state(notice_state_path(home)).get(key)
+        if last is None:
+            return True
+        if last > now_ts:
+            # Clock moved backwards — distrust the record, don't extend silence.
+            return True
+        return (now_ts - last) >= cooldown_seconds
+    except Exception as e:
+        # Never let bookkeeping block a notification.
+        _log.debug("shutdown-notice cooldown check failed for %s: %s", key, e)
+        return True
+
+
+def record_home_notice(
+    key: str,
+    *,
+    now: Optional[float] = None,
+    home: Optional[Path] = None,
+) -> None:
+    """Record that the home-channel broadcast for *key* was just sent.
+
+    Best-effort and atomic: a failure to persist means the next process simply
+    sends again (the pre-fix behaviour), which is the safe direction.
+    """
+    try:
+        now_ts = time.time() if now is None else float(now)
+        path = notice_state_path(home)
+        entries = _read_state(path)
+        entries[key] = now_ts
+        # Keep only entries within one window of now, in EITHER direction: old
+        # ones are irrelevant (any cooldown has long lapsed) and wildly-future
+        # ones are clock-skew garbage. Bounds the file without extra state.
+        fresh = {
+            k: v for k, v in entries.items()
+            if abs(v - now_ts) <= _MAX_ENTRY_AGE_SECONDS
+        }
+        atomic_json_write(path, {"home_notices": fresh})
+    except Exception as e:
+        _log.debug("Failed recording shutdown notice for %s: %s", key, e)

--- a/gateway/shutdown_notice.py
+++ b/gateway/shutdown_notice.py
@@ -38,9 +38,12 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, BinaryIO, Iterator, Optional
 
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write
@@ -48,6 +51,9 @@ from utils import atomic_json_write
 _log = logging.getLogger(__name__)
 
 _STATE_FILENAME = ".shutdown_notice_state.json"
+_LOCK_FILENAME = ".shutdown_notice_state.lock"
+_LOCK_TIMEOUT_SECONDS = 5.0
+_LOCK_POLL_SECONDS = 0.020
 
 # Entries older than this are dropped on write so the file cannot grow
 # unbounded across a long-lived install with many home channels. Generous
@@ -62,14 +68,22 @@ def notice_state_path(home: Optional[Path] = None) -> Path:
     return Path(base) / _STATE_FILENAME
 
 
-def destination_key(platform: str, chat_id: Any, thread_id: Any = None) -> str:
-    """Stable string key for one delivery destination.
+def _notice_lock_path(home: Optional[Path] = None) -> Path:
+    return notice_state_path(home).with_name(_LOCK_FILENAME)
 
-    Mirrors the in-process ``dedup_key`` tuple so the durable record and the
-    per-process set agree on what "the same destination" means.
+
+def destination_key(platform: str, chat_id: Any, thread_id: Any = None) -> str:
+    """Return a canonical, one-to-one key for one delivery destination.
+
+    The JSON array is intentionally structured rather than delimiter-joined:
+    chat IDs and thread IDs can themselves contain colons.
     """
-    thread = str(thread_id) if thread_id else ""
-    return f"{platform}:{chat_id}:{thread}"
+    thread = str(thread_id) if thread_id else None
+    return json.dumps(
+        [str(platform), str(chat_id), thread],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
 
 
 def _read_state(path: Path) -> dict[str, float]:
@@ -100,6 +114,177 @@ def _read_state(path: Path) -> dict[str, float]:
     return out
 
 
+def _should_send_from_state(
+    entries: dict[str, float],
+    key: str,
+    cooldown_seconds: float,
+    now_ts: float,
+) -> bool:
+    """Evaluate a loaded state snapshot without doing I/O."""
+    if cooldown_seconds <= 0:
+        return True
+    last = entries.get(key)
+    if last is None or last > now_ts:
+        # A backwards clock step must not silence the channel indefinitely.
+        return True
+    return (now_ts - last) >= cooldown_seconds
+
+
+def _fresh_state(entries: dict[str, float], now_ts: float) -> dict[str, float]:
+    """Drop stale and wildly-future entries before persisting the state."""
+    return {
+        key: value
+        for key, value in entries.items()
+        if abs(value - now_ts) <= _MAX_ENTRY_AGE_SECONDS
+    }
+
+
+def _record_home_notice_unlocked(
+    path: Path,
+    key: str,
+    now_ts: float,
+) -> None:
+    entries = _read_state(path)
+    entries[key] = now_ts
+    atomic_json_write(path, {"home_notices": _fresh_state(entries, now_ts)})
+
+
+def _acquire_lock(handle: BinaryIO, timeout: float = _LOCK_TIMEOUT_SECONDS) -> bool:
+    """Acquire the state lock with a bounded wait on POSIX and Windows."""
+    deadline = time.monotonic() + timeout
+    if os.name == "nt":
+        import msvcrt
+
+        try:
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+        except OSError:
+            return False
+
+        while True:
+            try:
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                return True
+            except OSError:
+                if time.monotonic() >= deadline:
+                    return False
+                time.sleep(_LOCK_POLL_SECONDS)
+
+    import fcntl
+
+    while True:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except (BlockingIOError, OSError):
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(_LOCK_POLL_SECONDS)
+
+
+def _release_lock(handle: BinaryIO) -> None:
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except (OSError, AttributeError):
+        pass
+
+
+@dataclass
+class HomeNoticeAdmission:
+    """A cooldown decision that keeps the cross-process lock until send result."""
+
+    allowed: bool
+    key: str
+    path: Path
+    cooldown_seconds: float
+    _lock_handle: Optional[BinaryIO] = None
+    _recorded: bool = False
+
+    def record_success(self, *, now: Optional[float] = None) -> None:
+        """Record a successful send while the admission lock is still held."""
+        if not self.allowed or self._recorded:
+            return
+        try:
+            now_ts = time.time() if now is None else float(now)
+            if self._lock_handle is not None:
+                _record_home_notice_unlocked(self.path, self.key, now_ts)
+            else:
+                # Lock acquisition failure is fail-open for delivery. Make a
+                # best-effort post-send record if the lock becomes available.
+                record_home_notice(self.key, now=now_ts, home=self.path.parent)
+            self._recorded = True
+        except Exception as e:
+            _log.debug("Failed recording shutdown notice for %s: %s", self.key, e)
+
+
+@contextmanager
+def home_notice_admission(
+    key: str,
+    *,
+    cooldown_seconds: float,
+    now: Optional[float] = None,
+    home: Optional[Path] = None,
+) -> Iterator[HomeNoticeAdmission]:
+    """Atomically admit one home notice and hold the lock through its send.
+
+    The lock spans the state read, awaited platform send, and successful state
+    write. Two gateway processes therefore cannot both pass the cooldown check
+    for the same destination. A lock or filesystem failure fails open: the
+    caller may send, but bookkeeping never blocks a shutdown notification.
+    """
+    try:
+        cooldown = float(cooldown_seconds or 0)
+    except (TypeError, ValueError):
+        cooldown = 0.0
+
+    path = notice_state_path(home)
+    handle: Optional[BinaryIO] = None
+    admission: HomeNoticeAdmission
+    try:
+        if cooldown <= 0:
+            admission = HomeNoticeAdmission(True, key, path, cooldown)
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            handle = _notice_lock_path(home).open("a+b")
+            acquired = _acquire_lock(handle)
+            if not acquired:
+                _log.debug("Could not acquire shutdown-notice lock %s", handle.name)
+                admission = HomeNoticeAdmission(True, key, path, cooldown)
+            else:
+                now_ts = time.time() if now is None else float(now)
+                allowed = _should_send_from_state(
+                    _read_state(path), key, cooldown, now_ts
+                )
+                admission = HomeNoticeAdmission(
+                    allowed, key, path, cooldown, _lock_handle=handle
+                )
+    except Exception as e:
+        _log.debug("Shutdown-notice admission failed for %s: %s", key, e)
+        if handle is not None:
+            handle.close()
+            handle = None
+        admission = HomeNoticeAdmission(True, key, path, cooldown)
+
+    try:
+        yield admission
+    finally:
+        if handle is not None:
+            _release_lock(handle)
+            handle.close()
+
+
 def should_send_home_notice(
     key: str,
     *,
@@ -109,27 +294,18 @@ def should_send_home_notice(
 ) -> bool:
     """Return True when the home-channel broadcast for *key* may be sent.
 
-    Suppresses only when a previous send is recorded **and** it happened within
-    ``cooldown_seconds`` of *now*. A non-positive cooldown disables the check
-    entirely (always send), which is the documented opt-out.
-
-    A recorded timestamp in the future is treated as unusable rather than as an
-    infinitely-long cooldown: a backwards wall-clock step (NTP correction, VM
-    resume, the very host suspend/resume cycle this guard exists for) must not
-    be able to silence the channel indefinitely.
+    This read-only helper remains available for callers that do not need
+    cross-process admission. The shutdown send path uses
+    :func:`home_notice_admission` instead.
     """
     try:
-        if cooldown_seconds is None or cooldown_seconds <= 0:
+        cooldown = float(cooldown_seconds or 0)
+        if cooldown <= 0:
             return True
-
         now_ts = time.time() if now is None else float(now)
-        last = _read_state(notice_state_path(home)).get(key)
-        if last is None:
-            return True
-        if last > now_ts:
-            # Clock moved backwards — distrust the record, don't extend silence.
-            return True
-        return (now_ts - last) >= cooldown_seconds
+        return _should_send_from_state(
+            _read_state(notice_state_path(home)), key, cooldown, now_ts
+        )
     except Exception as e:
         # Never let bookkeeping block a notification.
         _log.debug("shutdown-notice cooldown check failed for %s: %s", key, e)
@@ -147,18 +323,19 @@ def record_home_notice(
     Best-effort and atomic: a failure to persist means the next process simply
     sends again (the pre-fix behaviour), which is the safe direction.
     """
+    handle: Optional[BinaryIO] = None
     try:
         now_ts = time.time() if now is None else float(now)
         path = notice_state_path(home)
-        entries = _read_state(path)
-        entries[key] = now_ts
-        # Keep only entries within one window of now, in EITHER direction: old
-        # ones are irrelevant (any cooldown has long lapsed) and wildly-future
-        # ones are clock-skew garbage. Bounds the file without extra state.
-        fresh = {
-            k: v for k, v in entries.items()
-            if abs(v - now_ts) <= _MAX_ENTRY_AGE_SECONDS
-        }
-        atomic_json_write(path, {"home_notices": fresh})
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle = _notice_lock_path(home).open("a+b")
+        if not _acquire_lock(handle):
+            _log.debug("Could not acquire shutdown-notice lock for %s", key)
+            return
+        _record_home_notice_unlocked(path, key, now_ts)
     except Exception as e:
         _log.debug("Failed recording shutdown notice for %s: %s", key, e)
+    finally:
+        if handle is not None:
+            _release_lock(handle)
+            handle.close()

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2371,6 +2371,11 @@ DEFAULT_CONFIG = {
         # of leaving a wedged-but-alive zombie. Set to false to disable.
         "loop_watchdog": True,
 
+        # Minimum seconds between home-channel shutdown broadcasts to the same
+        # destination. The guard is durable across gateway processes; 0 disables
+        # it and restores the original always-send behaviour.
+        "shutdown_notification_cooldown_seconds": 300,
+
         # Whether the gateway keeps writing the legacy sessions.json mirror of
         # its routing index. The primary copy lives in state.db (the
         # gateway_routing table). Default True for backward compatibility with

--- a/tests/gateway/test_shutdown_notice_cooldown.py
+++ b/tests/gateway/test_shutdown_notice_cooldown.py
@@ -1,0 +1,233 @@
+"""Durable cross-process cooldown for the home-channel shutdown broadcast.
+
+Regression coverage for the notification flood observed when something outside
+Hermes repeatedly cycles the gateway process: the in-process ``notified`` set
+in ``_notify_active_sessions_of_shutdown`` cannot dedupe across process
+boundaries, so every fresh start re-broadcast to the same home channel (240
+sends on a WSL host under Windows Modern Standby).
+
+These tests pin two properties:
+  * a second gateway PROCESS is silenced inside the cooldown window (the fix),
+  * everything the guard must NOT touch stays loud — active-session pings, a
+    genuine restart after the window, and the disabled/misconfigured paths.
+"""
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from gateway import shutdown_notice
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+@pytest.fixture(autouse=True)
+def _state_home(tmp_path, monkeypatch):
+    """Point the durable notice state at a temp HERMES_HOME."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        shutdown_notice, "get_hermes_home", lambda: Path(tmp_path)
+    )
+    return tmp_path
+
+
+def _runner_with_home(cooldown: int = 300, chat_id: str = "8737458794"):
+    runner, adapter = make_restart_runner()
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="***",
+                home_channel=HomeChannel(
+                    platform=Platform.TELEGRAM, chat_id=chat_id, name="home"
+                ),
+            )
+        },
+        shutdown_notification_cooldown_seconds=cooldown,
+    )
+    return runner, adapter
+
+
+# ── The bug: repeated gateway processes re-broadcast ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_second_process_suppressed_within_cooldown():
+    """A fresh gateway process must not re-broadcast inside the window.
+
+    Two runners with independent ``notified`` sets model two OS processes.
+    Before the fix both send; after it, only the first does.
+    """
+    runner_a, adapter_a = _runner_with_home(cooldown=300)
+    await runner_a._notify_active_sessions_of_shutdown()
+    assert len(adapter_a.sent) == 1, "first process must announce"
+
+    runner_b, adapter_b = _runner_with_home(cooldown=300)
+    await runner_b._notify_active_sessions_of_shutdown()
+
+    assert adapter_b.sent == [], (
+        "a second gateway process inside the cooldown window re-broadcast "
+        "the shutdown notice — the durable guard did not hold"
+    )
+
+
+@pytest.mark.asyncio
+async def test_flood_of_processes_collapses_to_one_message():
+    """20 rapid start/stop cycles produce exactly one home-channel message."""
+    sent_total = 0
+    for _ in range(20):
+        runner, adapter = _runner_with_home(cooldown=300)
+        await runner._notify_active_sessions_of_shutdown()
+        sent_total += len(adapter.sent)
+
+    assert sent_total == 1, f"expected 1 notice across 20 cycles, got {sent_total}"
+
+
+# ── What must stay loud ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_notice_sent_again_after_cooldown_expires():
+    """A genuine restart after the window is still announced."""
+    runner_a, adapter_a = _runner_with_home(cooldown=300)
+    await runner_a._notify_active_sessions_of_shutdown()
+    assert len(adapter_a.sent) == 1
+
+    # Age the recorded timestamp past the window.
+    key = shutdown_notice.destination_key("telegram", "8737458794", None)
+    import time
+
+    shutdown_notice.record_home_notice(key, now=time.time() - 301)
+
+    runner_b, adapter_b = _runner_with_home(cooldown=300)
+    await runner_b._notify_active_sessions_of_shutdown()
+    assert len(adapter_b.sent) == 1, "notice must resume once the window lapses"
+
+
+@pytest.mark.asyncio
+async def test_zero_cooldown_restores_always_send():
+    """The documented opt-out (0) preserves the original behaviour."""
+    for _ in range(3):
+        runner, adapter = _runner_with_home(cooldown=0)
+        await runner._notify_active_sessions_of_shutdown()
+        assert len(adapter.sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_active_session_notice_never_suppressed():
+    """Per-session interrupt pings are NOT gated by the cooldown.
+
+    They carry the 'your task was cut off' hint, so a user mid-task must hear
+    about it even if the home channel was told seconds ago.
+    """
+    from unittest.mock import MagicMock
+
+    # Burn the cooldown with a home-channel broadcast first.
+    runner_a, adapter_a = _runner_with_home(cooldown=300)
+    await runner_a._notify_active_sessions_of_shutdown()
+    assert len(adapter_a.sent) == 1
+
+    runner_b, adapter_b = _runner_with_home(cooldown=300)
+    runner_b._running_agents["agent:main:telegram:dm:8737458794"] = MagicMock()
+    await runner_b._notify_active_sessions_of_shutdown()
+
+    assert len(adapter_b.sent) == 1, "active-session ping must not be suppressed"
+    assert "interrupted" in adapter_b.sent[0]
+
+
+@pytest.mark.asyncio
+async def test_distinct_home_channels_have_independent_cooldowns():
+    """Silencing chat A must not silence chat B."""
+    runner_a, adapter_a = _runner_with_home(cooldown=300)
+    await runner_a._notify_active_sessions_of_shutdown()
+    assert len(adapter_a.sent) == 1
+
+    runner_b, adapter_b = _runner_with_home(cooldown=300, chat_id="999999")
+    await runner_b._notify_active_sessions_of_shutdown()
+    assert len(adapter_b.sent) == 1, "a different chat must still be notified"
+
+
+# ── Fail-open properties of the state file ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_corrupt_state_file_does_not_suppress(_state_home):
+    """A malformed state file must fail toward sending, never toward silence."""
+    shutdown_notice.notice_state_path().write_text("{not json", encoding="utf-8")
+
+    runner, adapter = _runner_with_home(cooldown=300)
+    await runner._notify_active_sessions_of_shutdown()
+    assert len(adapter.sent) == 1
+
+
+def test_future_timestamp_does_not_silence_indefinitely():
+    """A backwards clock step must not lock the channel silent.
+
+    Host suspend/resume — the very scenario this guard exists for — can move
+    the wall clock. A recorded time in the future would otherwise read as a
+    cooldown that never expires.
+    """
+    import time
+
+    key = shutdown_notice.destination_key("telegram", "123", None)
+    shutdown_notice.record_home_notice(key, now=time.time() + 86_400)
+
+    assert shutdown_notice.should_send_home_notice(key, cooldown_seconds=300) is True
+
+
+def test_record_survives_unwritable_home(monkeypatch):
+    """A failed persist must not raise into the shutdown path."""
+    def _boom(*_a, **_kw):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(shutdown_notice, "atomic_json_write", _boom)
+    # Must not raise.
+    shutdown_notice.record_home_notice(
+        shutdown_notice.destination_key("telegram", "123", None)
+    )
+
+
+def test_unknown_destination_sends():
+    """No record at all means send."""
+    key = shutdown_notice.destination_key("telegram", "never-seen", None)
+    assert shutdown_notice.should_send_home_notice(key, cooldown_seconds=300) is True
+
+
+# ── Config plumbing ────────────────────────────────────────────────────
+
+
+def test_cooldown_default_and_roundtrip():
+    cfg = GatewayConfig()
+    assert cfg.shutdown_notification_cooldown_seconds == 300
+    assert (
+        GatewayConfig.from_dict(cfg.to_dict()).shutdown_notification_cooldown_seconds
+        == 300
+    )
+
+
+def test_cooldown_read_from_flat_and_nested_config():
+    assert (
+        GatewayConfig.from_dict(
+            {"shutdown_notification_cooldown_seconds": 60}
+        ).shutdown_notification_cooldown_seconds
+        == 60
+    )
+    assert (
+        GatewayConfig.from_dict(
+            {"gateway": {"shutdown_notification_cooldown_seconds": 45}}
+        ).shutdown_notification_cooldown_seconds
+        == 45
+    )
+
+
+def test_cooldown_zero_is_preserved_not_treated_as_unset():
+    """0 disables the guard, so it must survive parsing rather than fall back."""
+    cfg = GatewayConfig.from_dict({"shutdown_notification_cooldown_seconds": 0})
+    assert cfg.shutdown_notification_cooldown_seconds == 0
+
+
+@pytest.mark.parametrize("bad", ["abc", -5, True, 1.5, [], {}])
+def test_malformed_cooldown_falls_back_to_default(bad):
+    """A typo must never prevent the gateway from starting."""
+    cfg = GatewayConfig.from_dict({"shutdown_notification_cooldown_seconds": bad})
+    assert cfg.shutdown_notification_cooldown_seconds == 300

--- a/tests/gateway/test_shutdown_notice_cooldown.py
+++ b/tests/gateway/test_shutdown_notice_cooldown.py
@@ -12,6 +12,8 @@ These tests pin two properties:
     genuine restart after the window, and the disabled/misconfigured paths.
 """
 import asyncio
+import multiprocessing
+import time
 from pathlib import Path
 
 import pytest
@@ -48,6 +50,23 @@ def _runner_with_home(cooldown: int = 300, chat_id: str = "8737458794"):
     return runner, adapter
 
 
+def _concurrent_admission_worker(home, key, ready, start, results):
+    """Compete for one admission from a separate OS process."""
+    ready.put(True)
+    start.wait(10)
+    with shutdown_notice.home_notice_admission(
+        key,
+        cooldown_seconds=300,
+        now=100.0,
+        home=Path(home),
+    ) as admission:
+        results.put(admission.allowed)
+        if admission.allowed:
+            # Keep the lock held across the simulated awaited send.
+            time.sleep(0.15)
+            admission.record_success(now=100.0)
+
+
 # ── The bug: repeated gateway processes re-broadcast ────────────────────
 
 
@@ -68,6 +87,45 @@ async def test_second_process_suppressed_within_cooldown():
     assert adapter_b.sent == [], (
         "a second gateway process inside the cooldown window re-broadcast "
         "the shutdown notice — the durable guard did not hold"
+    )
+
+
+def test_concurrent_processes_have_single_admission(tmp_path):
+    """Concurrent gateway processes cannot both pass the cooldown check."""
+    ctx = multiprocessing.get_context("spawn")
+    ready = ctx.Queue()
+    start = ctx.Event()
+    results = ctx.Queue()
+    key = shutdown_notice.destination_key("telegram", "chat:a:b", "thread:c")
+    processes = [
+        ctx.Process(
+            target=_concurrent_admission_worker,
+            args=(str(tmp_path), key, ready, start, results),
+        )
+        for _ in range(2)
+    ]
+    for process in processes:
+        process.start()
+    try:
+        for _ in processes:
+            assert ready.get(timeout=15) is True
+        start.set()
+        decisions = sorted(results.get(timeout=15) for _ in processes)
+    finally:
+        start.set()
+        for process in processes:
+            process.join(timeout=15)
+            if process.is_alive():
+                process.terminate()
+                process.join()
+    assert all(process.exitcode == 0 for process in processes)
+    assert decisions == [False, True]
+
+
+def test_destination_key_is_collision_free():
+    """Structured keys keep colon-containing IDs distinct."""
+    assert shutdown_notice.destination_key("telegram", "a:b", "c") != (
+        shutdown_notice.destination_key("telegram", "a", "b:c")
     )
 
 
@@ -231,3 +289,29 @@ def test_malformed_cooldown_falls_back_to_default(bad):
     """A typo must never prevent the gateway from starting."""
     cfg = GatewayConfig.from_dict({"shutdown_notification_cooldown_seconds": bad})
     assert cfg.shutdown_notification_cooldown_seconds == 300
+
+
+def test_cooldown_default_is_in_shared_config_defaults():
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["gateway"]["shutdown_notification_cooldown_seconds"] == 300
+
+
+def test_cooldown_read_from_real_yaml_loader(tmp_path, monkeypatch):
+    """The user-facing config.yaml path must reach GatewayConfig.from_dict."""
+    from gateway.config import load_gateway_config
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "gateway:\n  shutdown_notification_cooldown_seconds: 45\n",
+        encoding="utf-8",
+    )
+    assert load_gateway_config().shutdown_notification_cooldown_seconds == 45
+
+    config_path.write_text(
+        "gateway:\n  shutdown_notification_cooldown_seconds: 45\n"
+        "shutdown_notification_cooldown_seconds: 60\n",
+        encoding="utf-8",
+    )
+    assert load_gateway_config().shutdown_notification_cooldown_seconds == 60


### PR DESCRIPTION
Fixes #71180.

## The bug

`_notify_active_sessions_of_shutdown` dedupes its sends through a per-process `notified` set, so it only suppresses duplicates **within a single shutdown**. Every fresh gateway process starts with an empty set and re-announces to the same home channel.

Invisible when restarts are deliberate and rare. Not when something outside Hermes cycles the host: on a WSL install, Windows Modern Standby repeatedly tore down and re-activated the distro on a ~33 s cycle (start → SIGTERM ~17 s later → broadcast → repeat), producing **240** home-channel notifications, 19 of them inside one 10-minute window.

Nothing was crashing. Each process was correct by its own lights — it genuinely was announcing its first shutdown. The volume was the entire defect.

## Why the guard is home-channel only

The log counts scope the fix: **240** home-channel sends against **1** active-session send. The flood is entirely the operator-flavoured broadcast, which carries no actionable information on an idle shutdown.

The per-active-session pings stay **ungated** — they carry the "your task was cut off, message me to resume" hint a user mid-task genuinely needs, and on these idle cycles they're empty by construction. This matches the reasoning already encoded for the drain `suppress_notification` flag, which gates the broadcast and deliberately leaves the per-session pings alone.

## The change

New `gateway/shutdown_notice.py`: a last-sent timestamp per destination under `HERMES_HOME`, so the dedup survives process death. A second gateway process inside the window stays quiet; a genuine restart after it is fully audible.

Two properties I was deliberate about:

- **Fail open everywhere.** An unreadable, malformed, or unwritable state file degrades to *sending*, never to silence, and never raises into the shutdown path. A failed persist just means the next process sends again — the pre-fix behaviour, which is the safe direction.
- **Clock safety.** A recorded timestamp in the *future* is treated as unusable rather than as an infinite cooldown. A backwards clock step (NTP correction, VM resume — the very suspend/resume cycle this guard exists for) must not be able to mute a channel permanently.

Configurable via `gateway.shutdown_notification_cooldown_seconds`, default 300; `0` restores the original always-send behaviour. Parsing accepts the flat and nested key like neighbouring settings, preserves `0` rather than treating it as unset, and falls back to the default on a typo so a bad value can never stop the gateway from starting.

## Verification

**RED → GREEN, confirmed by actually unwiring the guard** rather than assuming. With the call site reverted (module and config left in place), the flood test reproduces the bug exactly:

```
AssertionError: expected 1 notice across 20 cycles, got 20
FAILED test_flood_of_processes_collapses_to_one_message
FAILED test_second_process_suppressed_within_cooldown
2 failed, 17 passed
```

Both pass with the guard wired. The other 17 tests pin what must **not** change: active-session pings, post-window restarts, the zero opt-out, per-destination independence, and the fail-open paths.

Simulating the real incident timing (19 cycles at 33 s) collapses 19 messages to **2**.

**Suite:** 19 new tests pass. Full `tests/gateway/` shows one failure — `test_agent_cache` honcho memoization — which I verified reproduces identically on an unmodified checkout at `957ea640d`, so it is pre-existing and unrelated.

One note on my own process worth flagging: an earlier "RED" run of mine was a false negative — `git stash` silently aborted on the untracked new module, so the fix was never actually reverted and the tests passed for the wrong reason. I caught it, redid the revert explicitly, and the failure output above is from the real one.
