### PR TITLE
fix(cli): hand off terminal for /prompt editor

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2620,13 +2620,67 @@ class CLICommandsMixin:
         lines = [ln for ln in raw.splitlines() if not ln.startswith("#!")]
         return "\n".join(lines).strip()
 
+    def _schedule_prompt_compose_in_terminal(self, initial_text: str) -> bool:
+        """Schedule the editor through prompt_toolkit's terminal handoff.
+
+        Slash commands run on ``process_loop`` rather than the application
+        event loop. Launching an editor directly from that thread leaves
+        prompt_toolkit attached to stdin and free to repaint over the editor.
+        """
+        app = getattr(self, "_app", None)
+        app_loop = getattr(app, "loop", None)
+        app_context = getattr(app, "context", None)
+        if (
+            app is None
+            or not getattr(app, "is_running", False)
+            or app_loop is None
+            or not app_loop.is_running()
+            or app_context is None
+        ):
+            return False
+
+        from cli import _DIM, _RST, _cprint
+        from prompt_toolkit.application import run_in_terminal
+
+        def _finished(task) -> None:
+            try:
+                composed = task.result()
+            except Exception as exc:
+                _cprint(f"  {_DIM}(>_<) Could not open editor: {exc}{_RST}")
+                return
+
+            if composed:
+                getattr(self, "_pending_input").put(composed)
+            else:
+                _cprint(f"  {_DIM}(._.) Empty prompt — nothing sent.{_RST}")
+
+        def _start() -> None:
+            try:
+                task = run_in_terminal(
+                    lambda: self._compose_in_editor(initial_text),
+                    in_executor=True,
+                )
+                task.add_done_callback(_finished)
+            except Exception as exc:
+                _cprint(f"  {_DIM}(>_<) Could not open editor: {exc}{_RST}")
+
+        def _schedule() -> None:
+            app_context.copy().run(_start)
+
+        try:
+            app_loop.call_soon_threadsafe(_schedule)
+        except Exception:
+            return False
+        return True
+
     def _handle_prompt_compose_command(self, cmd_original: str) -> None:
         """Handle /prompt — compose the next prompt in $EDITOR and send it.
 
         Opens the user's editor on a temporary markdown file (optionally
         seeded with text passed after the command), then queues the saved
-        buffer as the next agent turn via the one-shot ``_pending_agent_seed``
-        the interactive loop already consumes (same path as /blueprint).
+        buffer as the next agent turn. The interactive CLI schedules a managed
+        terminal handoff; non-interactive callers retain the one-shot
+        ``_pending_agent_seed`` fallback used by /blueprint.
         """
         from cli import _DIM, _RST, _cprint
 
@@ -2634,6 +2688,9 @@ class CLICommandsMixin:
         parts = (cmd_original or "").strip().split(None, 1)
         if len(parts) > 1:
             initial = parts[1]
+
+        if self._schedule_prompt_compose_in_terminal(initial):
+            return
 
         try:
             composed = self._compose_in_editor(initial)

--- a/tests/hermes_cli/test_prompt_compose_command.py
+++ b/tests/hermes_cli/test_prompt_compose_command.py
@@ -1,13 +1,15 @@
 """Tests for the CLI `/prompt` editor-compose command.
 
 `/prompt` opens `$VISUAL`/`$EDITOR` on a temp markdown file so the user can
-hand-edit a multi-line prompt, then queues the saved buffer as the next
-agent turn via the one-shot `_pending_agent_seed` (same path `/blueprint`
-uses). These drive a fake editor subprocess to verify read-back, header
-stripping, seeding, and the empty-buffer cancel path.
+hand-edit a multi-line prompt, then queues the saved buffer as the next agent
+turn. These drive fake app/editor boundaries to verify the managed terminal
+handoff, read-back, header stripping, seeding, and the empty-buffer cancel
+path.
 """
 
+import contextvars
 import os
+import queue
 import stat
 import tempfile
 
@@ -20,6 +22,53 @@ from hermes_cli.commands import resolve_command
 class _Stub(CLICommandsMixin):
     def __init__(self):
         self._pending_agent_seed = None
+
+
+class _FakeLoop:
+    def __init__(self):
+        self.callbacks = []
+
+    def is_running(self):
+        return True
+
+    def call_soon_threadsafe(self, callback):
+        self.callbacks.append(callback)
+
+
+class _FakeApp:
+    def __init__(self):
+        self.context = contextvars.copy_context()
+        self.is_running = True
+        self.loop = _FakeLoop()
+
+
+class _FakeTask:
+    def __init__(self):
+        self.callback = None
+        self.editor_call = None
+        self.editor_result = None
+
+    def add_done_callback(self, callback):
+        self.callback = callback
+
+    def result(self):
+        return self.editor_result
+
+    def finish(self):
+        assert self.callback is not None
+        self.callback(self)
+
+
+class _InteractiveStub(_Stub):
+    def __init__(self):
+        super().__init__()
+        self._app = _FakeApp()
+        self._pending_input = queue.Queue()
+        self.compose_calls = []
+
+    def _compose_in_editor(self, initial_text=""):
+        self.compose_calls.append(initial_text)
+        return "Composed in managed editor"
 
 
 def _fake_editor(body: str, mode: str = "append") -> str:
@@ -52,6 +101,49 @@ def test_compose_reads_and_strips_header(monkeypatch):
     assert "Refactor the auth module." in out
     assert "Use pytest." in out
     assert "#!" not in out  # the instructional header is stripped
+
+
+def test_prompt_sets_pending_seed(monkeypatch):
+    monkeypatch.setenv("EDITOR", _fake_editor("Write a haiku about caching."))
+    s = _Stub()
+    s._handle_prompt_compose_command("/prompt")
+    assert s._pending_agent_seed
+    assert "haiku about caching" in s._pending_agent_seed
+
+
+def test_interactive_prompt_suspends_app_while_editor_runs(monkeypatch):
+    task = _FakeTask()
+
+    def fake_run_in_terminal(editor_call, *, in_executor):
+        task.editor_call = editor_call
+        assert in_executor is True
+        return task
+
+    monkeypatch.setattr(
+        "prompt_toolkit.application.run_in_terminal", fake_run_in_terminal
+    )
+    s = _InteractiveStub()
+
+    s._handle_prompt_compose_command("/prompt Initial draft")
+
+    assert s.compose_calls == []
+    assert s._pending_agent_seed is None
+    assert len(s._app.loop.callbacks) == 1
+
+    s._app.loop.callbacks[0]()
+    assert task.editor_call is not None
+    task.editor_result = task.editor_call()
+    task.finish()
+
+    assert s.compose_calls == ["Initial draft"]
+    assert s._pending_input.get_nowait() == "Composed in managed editor"
+
+
+def test_initial_text_is_seeded(monkeypatch):
+    # The fake editor appends, so the initial text leads the buffer.
+    monkeypatch.setenv("EDITOR", _fake_editor("rest of prompt"))
+    out = _Stub()._compose_in_editor("DRAFT: ")
+    assert out.startswith("DRAFT:")
 
 
 def test_empty_buffer_does_not_seed(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes terminal corruption when the classic CLI's `/prompt` command opens a full-screen external editor such as Neovim.

`/prompt` is dispatched from Hermes's background `process_loop`. It currently invokes the editor directly with `subprocess.call()` while prompt_toolkit still owns stdin and continues rendering. The editor and prompt_toolkit can therefore contend for terminal state, causing overwritten characters, corrupted screen contents, and unusable editor input.

This change schedules editor composition on the active prompt_toolkit application loop, restores the application's context, and runs the blocking editor through `prompt_toolkit.application.run_in_terminal(..., in_executor=True)`. prompt_toolkit can then suspend rendering, detach input, let the editor own the terminal, and redraw cleanly when the editor exits.

The non-interactive fallback remains unchanged.

## Related Issue

Addresses the terminal-state restoration gap called out in #7262.

Follow-up to #15821, which fixed the analogous Ctrl+G / Alt+G external-editor handoff but did not cover the separate `/prompt` command path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Schedule `/prompt` editor composition onto the live prompt_toolkit event loop with `call_soon_threadsafe()`.
- Re-enter the prompt_toolkit application context before invoking `run_in_terminal()`.
- Run the blocking editor call in an executor while prompt_toolkit suspends terminal ownership.
- Queue the saved prompt through `_pending_input` after the editor exits.
- Preserve the existing synchronous `_pending_agent_seed` behavior for non-interactive callers.
- Add regression coverage for the cross-thread scheduling, terminal handoff, executor use, initial prompt text, and queued result.

## How to Test

Automated tests in a Hermes development environment:

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_prompt_compose_command.py \
  tests/cli/test_cli_external_editor.py
ruff check .
```

Manual reproduction:

1. Set `EDITOR=nvim` and start the classic Hermes CLI.
2. Run `/prompt`.
3. Enter a line containing letters and digits, then leave the editor idle for several seconds.
4. Confirm Hermes does not repaint over Neovim and the entered text remains unchanged.
5. Exit Neovim and confirm the Hermes prompt redraws cleanly.

Observed locally on Arch Linux with tmux and Neovim:

- Before the fix, prompt_toolkit repainted while Neovim was active and visibly changed text such as `starting` to `st8rti7g`.
- After the fix, complete alphabet-and-digit input remained intact.
- Two editor-screen captures taken three seconds apart were byte-identical.
- Hermes redrew correctly after the editor exited.

## Checklist

### Code

- [x] I've read the contributing guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing open and merged issues/PRs for duplicates.
- [x] This change contains only the terminal-handoff fix and its regression test.
- [x] I completed a pre-rebase full-suite regression check. `scripts/run_tests.sh -j 8` reported 42,892 passed and 8 failed across 2,094 files; pristine upstream reproduced the same eight failures and two collection errors in the same environment, so the change introduced no failures there. After replaying the patch onto current `origin/main`, the 16 focused affected tests pass; the full suite has not been rerun on the new base.
- [x] I've added a regression test for the bug.
- [x] I've tested on Arch Linux with tmux and Neovim.

### Documentation & Housekeeping

- [x] Relevant implementation docstrings were updated; user-facing documentation is N/A because command behavior is unchanged.
- [x] `cli-config.yaml.example` update is N/A; no configuration changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no architecture or workflow changed.
- [x] Cross-platform impact was considered: the fix uses prompt_toolkit's supported application and executor APIs, while retaining the existing platform-specific editor invocation. Manual validation is Linux-only.
- [x] Tool schemas/descriptions are N/A.

## Screenshots / Logs

Focused verification:

```text
16 passed on current origin/main base
pre-rebase full canonical suite: 42,892 passed, 8 baseline failures across 2,094 files
pre-rebase pristine-upstream comparison: same 8 failures and 2 collection errors
ruff check .: All checks passed
python compilation: passed
git diff --check: passed
independent review: passed; no security concerns or logic errors
```
