### PR TITLE
fix(windows): hide the console windows the desktop's SSH spawns flash on screen

### DIFF
--- a/apps/desktop/electron/ssh-connection.test.ts
+++ b/apps/desktop/electron/ssh-connection.test.ts
@@ -841,6 +841,61 @@ test('failed ControlMaster close disowns the master instead of retrying it', asy
   assert.equal(spawnFn.calls.length, 1)
 })
 
+test('runSsh hides the console window of the ssh child on Windows', async () => {
+  // Electron's main process is GUI-subsystem, so a console-subsystem child gets
+  // its own visible console on Windows. runSsh is the funnel for every one-shot
+  // ssh invocation (open/isAlive/exec/forward/cancelForward), so without
+  // windowsHide the remote-backend readiness poll flashes a console repeatedly.
+  let captured: any = null
+
+  const spawnFn: any = (_cmd, _args, opts) => {
+    captured = opts
+    const child: any = new EventEmitter()
+    child.stdout = new EventEmitter()
+    child.stderr = new EventEmitter()
+
+    child.kill = () => {}
+    process.nextTick(() => child.emit('close', 0))
+
+    return child
+  }
+
+  await runSsh(['host', 'true'], { timeoutMs: 5000, spawnFn })
+  assert.equal(captured?.windowsHide, true, 'every ssh child must be spawned with windowsHide')
+})
+
+test('no-mux: the persistent -N -L tunnel child hides its console window on Windows', async () => {
+  // mux defaults to false on Windows, so this branch IS the Windows path. The
+  // tunnel child outlives the whole remote session — an unhidden console would
+  // sit in the taskbar, and closing it would drop the port forward.
+  const localPort = 5111
+  let tunnelOpts: any = null
+
+  const spawnFn: any = (_cmd, args, opts) => {
+    const child: any = new EventEmitter()
+    child.stdout = new EventEmitter()
+    child.stderr = new EventEmitter()
+    child.exitCode = null
+
+    child.kill = () => true
+
+    if (args.includes('-N')) {
+      tunnelOpts = opts
+      process.nextTick(() =>
+        child.stderr.emit('data', Buffer.from(`Local forwarding listening on 127.0.0.1 port ${localPort}.`))
+      )
+    } else {
+      process.nextTick(() => child.emit('close', 0))
+    }
+
+    return child
+  }
+
+  const conn = new SshConnection({ host: 'box', user: 'me' }, { spawnFn, mux: false })
+  await conn.forward(localPort, 9119)
+  assert.equal(tunnelOpts?.windowsHide, true, 'the persistent tunnel child must be spawned with windowsHide')
+})
+
 test('stopTunnelChild waits for process exit', async () => {
   const child: any = new EventEmitter()
   child.exitCode = null

--- a/apps/desktop/electron/ssh-connection.ts
+++ b/apps/desktop/electron/ssh-connection.ts
@@ -357,7 +357,10 @@ function runSsh(args, { timeoutMs, spawnFn = spawn, stdin = 'ignore', stdinData 
     let child
 
     try {
-      child = spawnFn('ssh', args, { stdio: [useStdinPipe ? 'pipe' : 'ignore', 'pipe', 'pipe'] })
+      child = spawnFn('ssh', args, {
+        stdio: [useStdinPipe ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+        windowsHide: true
+      })
     } catch (error) {
       reject(error)
 
@@ -720,7 +723,7 @@ class SshConnection {
         target(this.user, this.host)
       ]
 
-      const child = this._spawnFn('ssh', args, { stdio: ['ignore', 'ignore', 'pipe'] })
+      const child = this._spawnFn('ssh', args, { stdio: ['ignore', 'ignore', 'pipe'], windowsHide: true })
       const tunnel = { child, alive: true }
       this._tunnels.set(spec, tunnel)
       let stderr = ''


### PR DESCRIPTION
## What does this PR do?

Electron's main process is GUI-subsystem, so every console-subsystem child it spawns allocates its own **visible** console window on Windows. That is why 15 child-process sites under `apps/desktop/electron/` already pass `windowsHide: true`. `apps/desktop/electron/ssh-connection.ts` is the one module that never did — and since `45acb62c6` ("route Desktop SSH to the Windows lifecycle") both of its spawn sites are on the Windows path.

Two spawn sites, both user-visible in Desktop remote/SSH mode:

- **`runSsh` (`ssh-connection.ts:360`)** is the single funnel for every one-shot `ssh` invocation — `open()`, `isAlive()`, `exec()`, `_verifyMuxChannel()`, `_evictStaleMaster()`, `cancelForward()`. `windows-remote-lifecycle.ts` `waitReady()` issues two `ssh.exec` calls per tick at `READY_POLL_INTERVAL_MS = 750`, so a console window flashes roughly every 0.4s for the entire remote-backend startup. Settings → **Test connection** (`createSshProbeConnection`, forced `mux: false`) flashes on every test.
- **The persistent `ssh -N -L` tunnel child (`ssh-connection.ts:723`)** is the Windows forward path — `this._mux = opts.mux ?? process.platform !== 'win32'`, so `mux` is `false` on Windows. That child is long-lived: its console window stays on screen and in the taskbar for the **entire remote session**, and closing that stray window kills the port forward and drops the gateway connection.

The fix adds `windowsHide: true` to both options literals, mirroring the existing `execFileSync(ssh, args, { …, windowsHide: true })` at `main.ts:6996`. Node ignores the flag on POSIX, so there is no behavior change off Windows.

I used the plain literal rather than the `hiddenWindowsChildOptions(...)` helper here: both sites are static option objects, and the helper's `isWindows` default would make the regression assertions platform-dependent on CI. The in-tree contract in `windows-child-options.ts:4-8` is the same one being satisfied either way.

**Coverage — this is the complete set for this root cause.** `grep -n 'spawn\|execFile' apps/desktop/electron/ssh-connection.ts` returns exactly two child-process sites (`:360`, `:723`); every other `ssh` call in the module routes through `runSsh`. `grep -rn windowsHide apps/desktop/electron/*.ts` confirms every other module's Windows-reachable site already has it (`bootstrap-runner.ts` reaches Windows only via `spawnPowerShell`, which already uses `hiddenWindowsChildOptions`; its `spawnBash` sibling is the POSIX branch).

Prior art for the same class of fix: #43449, #54236, #54492, #66040. This is the same "the sweep missed one module" follow-up shape as #54492.

## Related Issue

No filed issue — found by sweeping the desktop's Windows child-process sites against `apps/desktop/electron/windows-child-options.ts`, which the previous sweeps did not cover for this module.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/ssh-connection.ts` — add `windowsHide: true` to the `runSsh` spawn options (`:360`) and to the no-mux persistent `ssh -N -L` tunnel spawn options (`:723`).
- `apps/desktop/electron/ssh-connection.test.ts` — two regression tests asserting the third `opts` argument the injected `spawnFn` receives carries `windowsHide === true`, one per site.

## How to Test

```
npm ci
npm --prefix apps/desktop run test:desktop:platforms -- ssh-connection
```

Red-before / green-after, verified on this branch:

- With only the test file applied on top of clean `main`:
  `Tests  2 failed | 58 passed (60)` — both new tests report `+ undefined  - true`, i.e. no `windowsHide` reached the spawn.
- With the `ssh-connection.ts` change applied: `Tests  60 passed (60)`.
- Whole electron project after the change: `Test Files  65 passed | 1 skipped (66)`, `Tests  727 passed | 2 skipped (729)`.
- `tsc -p tsconfig.electron.json --noEmit`, `eslint electron/ssh-connection*.ts`, and `prettier --check` on both files are clean.

Deleting either production hunk turns the corresponding test red, so neither assertion is vacuous.

Manual (Windows 11, Desktop remote mode): connect to a remote host. Before, console windows flash throughout backend startup and one `ssh -N -L` console remains in the taskbar for the session. After, none appear.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is a TypeScript-only change; ran the desktop vitest suites instead (above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (the vitest suites are platform-independent — they assert the spawn options, not OS behavior)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the flag is a no-op on POSIX; the fix is Windows-only in effect
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A