### PR TITLE
docs(tools-reference): fix stale feishu_comment.py path

### DIFF
--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -64,7 +64,7 @@ These two tools live in the `browser` toolset but only register when a Chrome De
 
 ## `feishu_doc` toolset
 
-Scoped to the Feishu document-comment intelligent-reply handler (`gateway/platforms/feishu_comment.py`). Not exposed on `hermes-cli` or the regular Feishu chat adapter.
+Scoped to the Feishu document-comment intelligent-reply handler (`plugins/platforms/feishu/feishu_comment.py`). Not exposed on `hermes-cli` or the regular Feishu chat adapter.
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|


### PR DESCRIPTION
## Problem

website/docs/reference/tools-reference.md line 67 references the Feishu document-comment handler as gateway/platforms/feishu_comment.py. That path no longer exists — the feishu platform was migrated to plugins/platforms/feishu/, so the actual file is plugins/platforms/feishu/feishu_comment.py.

## Triage / Root cause

Path drift after the platforms were moved from gateway/platforms/ to plugins/platforms/<name>/. The migration caught most references but missed this one in the tools reference doc.

## Fix

One-line path correction: gateway/platforms/feishu_comment.py → plugins/platforms/feishu/feishu_comment.py.

## Verification

- Confirmed plugins/platforms/feishu/feishu_comment.py exists on upstream/main (e0dfcf275).
- Confirmed gateway/platforms/feishu_comment.py does not exist.
- No other stale gateway/platforms/feishu_comment references remain in the file.