### PR TITLE
fix(kanban): hold claim on iteration-budget exhaustion (#71175)

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -151,6 +151,10 @@ def finalize_turn(
         # We route through ``_record_task_failure(outcome="timed_out")``
         # rather than ``kanban_block`` so this counts toward the dispatcher's
         # consecutive-failure circuit breaker (#29747 gap 2).
+        # Hold the claim (release_claim=False) so the dispatcher cannot
+        # spawn a second worker into the same worktree while this process
+        # is still alive — the goal loop will continue with a fresh
+        # iteration budget until goal_max_turns is exhausted (#71175).
         _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
         if _kanban_task:
             try:
@@ -167,7 +171,7 @@ def finalize_turn(
                             "iterations"
                         ),
                         outcome="timed_out",
-                        release_claim=True,
+                        release_claim=False,
                         end_run=True,
                         event_payload_extra={
                             "budget_used": api_call_count,

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -292,7 +292,7 @@ def test_pending_response_records_kanban_timeout(monkeypatch):
             "within the allowed iterations"
         ),
         outcome="timed_out",
-        release_claim=True,
+        release_claim=False,
         end_run=True,
         event_payload_extra={"budget_used": 60, "budget_max": 60},
     )

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5994,7 +5994,7 @@ class TestRunConversation:
         # Positional: (conn, task_id, ...)
         assert call.args[1] == "t_test_task_123"
         assert call.kwargs.get("outcome") == "timed_out"
-        assert call.kwargs.get("release_claim") is True
+        assert call.kwargs.get("release_claim") is False
         assert call.kwargs.get("end_run") is True
         assert "Iteration budget exhausted" in call.kwargs.get("error", "")
 


### PR DESCRIPTION
## Problem

When a goal-mode Kanban worker exhausts its per-turn iteration budget, `_record_task_failure` is called with `release_claim=True`. This releases the claim and closes the run while the worker process is still alive. The dispatcher then sees an unclaimed `ready` card and spawns a second worker into the same worktree — two workers edit the same files with no coordination.

## Fix

Change `release_claim=True` to `release_claim=False` in `agent/turn_finalizer.py:169`. The claim stays held so the dispatcher cannot spawn a duplicate worker. The goal loop continues with a fresh iteration budget until `goal_max_turns` is exhausted.

## Test update

Updated `test_pending_response_records_kanban_timeout` to expect `release_claim=False` instead of `True`.

Fixes #71175
