### PR TITLE
docs(tools-reference): fix stale feishu_comment.py path in zh-Hans locale

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/tools-reference.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/tools-reference.md
@@ -64,7 +64,7 @@ description: "Hermes 内置工具权威参考，按工具集分组"
 
 ## `feishu_doc` 工具集
 
-仅限飞书文档评论智能回复处理器（`gateway/platforms/feishu_comment.py`）使用。不在 `hermes-cli` 或常规飞书聊天适配器中暴露。
+仅限飞书文档评论智能回复处理器（`plugins/platforms/feishu/feishu_comment.py`）使用。不在 `hermes-cli` 或常规飞书聊天适配器中暴露。
 
 | 工具 | 描述 | 所需环境 |
 |------|------|----------|


### PR DESCRIPTION
## Problem

The Chinese (zh-Hans) locale mirror of `website/docs/reference/tools-reference.md` (line 67) still references `gateway/platforms/feishu_comment.py` — a path that no longer exists. The feishu platform was migrated from `gateway/platforms/` to `plugins/platforms/feishu/`, so the correct path is `plugins/platforms/feishu/feishu_comment.py`.

This is the same stale path that was already fixed in the English version of this doc page.

## Triage / Root cause

The zh-Hans locale mirror was not updated when the English `tools-reference.md` was edited to reflect the feishu platform migration to the plugins directory.

## Fix

Changed `gateway/platforms/feishu_comment.py` → `plugins/platforms/feishu/feishu_comment.py` on line 67 of the zh-Hans tools-reference locale mirror.

## Verification

- Confirmed `plugins/platforms/feishu/feishu_comment.py` exists on `upstream/main` (e0dfcf275)
- Confirmed `gateway/platforms/` has no feishu files
- Confirmed no other stale `gateway/platforms/feishu_comment.py` references remain in any docs locale