### PR TITLE
feat(discord): add opt-in voice auto-join routes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3668,10 +3668,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Per-chat voice reply mode: "off" | "voice_only" | "all"
         self._voice_mode: Dict[str, str] = self._load_voice_modes()
-        # Recent voice transcripts per (guild,user) for duplicate suppression.
+        # Recent voice transcripts per (profile,guild,user) for duplicate suppression.
         # Protects against the same utterance being emitted twice by the voice
         # capture / STT pipeline, which otherwise produces a second delayed reply.
-        self._recent_voice_transcripts: Dict[tuple[int, int], List[tuple[float, str]]] = {}
+        self._recent_voice_transcripts: Dict[
+            tuple[Optional[str], int, int], List[tuple[float, str]]
+        ] = {}
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
@@ -15522,13 +15524,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter = adapter or self.adapters.get(Platform.DISCORD)
         self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
 
-    def _is_duplicate_voice_transcript(self, guild_id: int, user_id: int, transcript: str) -> bool:
+    def _is_duplicate_voice_transcript(
+        self,
+        guild_id: int,
+        user_id: int,
+        transcript: str,
+        *,
+        profile: Optional[str] = None,
+    ) -> bool:
         """Suppress repeated STT outputs for the same recent utterance.
 
         Voice capture can occasionally emit the same utterance twice a few
         seconds apart, which creates a second queued agent run and overlapping
-        spoken replies. Dedup exact and near-exact repeats per guild/user over a
-        short window while allowing genuinely new turns through.
+        spoken replies. Dedup exact and near-exact repeats per profile/guild/user
+        over a short window while allowing genuinely new turns through.
         """
         from difflib import SequenceMatcher
 
@@ -15539,7 +15548,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         now = time.monotonic()
         window_seconds = 12.0
-        key = (guild_id, user_id)
+        key = (profile, guild_id, user_id)
         recent_store = getattr(self, "_recent_voice_transcripts", None)
         if not isinstance(recent_store, dict):
             recent_store = {}
@@ -15600,7 +15609,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Unauthorized voice input from user %d, ignoring", user_id)
             return
 
-        if self._is_duplicate_voice_transcript(guild_id, user_id, transcript):
+        if self._is_duplicate_voice_transcript(
+            guild_id,
+            user_id,
+            transcript,
+            profile=self._adapter_profile_name(adapter),
+        ):
             logger.info(
                 "Suppressing duplicate voice transcript for guild=%s user=%s: %s",
                 guild_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3790,9 +3790,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     _VOICE_MODE_PATH = _hermes_home / "gateway_voice_mode.json"
 
-    def _voice_key(self, platform: Platform, chat_id: str) -> str:
-        """Return a platform-namespaced key for voice mode state."""
+    def _voice_key(
+        self,
+        platform: Platform,
+        chat_id: str,
+        profile: Optional[str] = None,
+    ) -> str:
+        """Return a platform/profile-namespaced key for voice mode state."""
+        if profile:
+            return f"profile:{profile}:{platform.value}:{chat_id}"
         return f"{platform.value}:{chat_id}"
+
+    @staticmethod
+    def _adapter_profile_name(adapter) -> Optional[str]:
+        """Return a real named-profile binding, ignoring mock/foreign attributes."""
+        profile = getattr(adapter, "_profile_name", None)
+        if isinstance(profile, str) and profile.strip():
+            return profile
+        return None
 
     def _load_voice_modes(self) -> Dict[str, str]:
         try:
@@ -3891,7 +3906,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if hasattr(adapter, "_auto_tts_default"):
             adapter._auto_tts_default = _auto_tts_default
 
-        prefix = f"{platform.value}:"
+        profile = self._adapter_profile_name(adapter)
+        prefix = (
+            f"profile:{profile}:{platform.value}:"
+            if profile
+            else f"{platform.value}:"
+        )
         if isinstance(disabled_chats, set):
             disabled_chats.clear()
             disabled_chats.update(
@@ -10103,8 +10123,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 if success:
                     profile_map[platform] = adapter
-                    self._sync_voice_mode_state_to_adapter(adapter)
-                    await self._configure_voice_auto_join_adapter(adapter)
+                    with _profile_runtime_scope(profile_home):
+                        self._sync_voice_mode_state_to_adapter(adapter)
+                        await self._configure_voice_auto_join_adapter(adapter)
                     connected += 1
                     logger.info("✓ %s connected (profile: %s)", platform.value, profile_name)
                 else:
@@ -10135,6 +10156,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter.set_authorization_check(
             self._make_adapter_auth_check(platform, profile_name=profile_name)
         )
+        setattr(adapter, "_profile_name", profile_name)
         adapter._busy_text_mode = self._busy_text_mode
 
     async def _run_secondary_profile_reconnect(
@@ -10174,8 +10196,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         profile_map = self._profile_adapters.setdefault(profile_name, {})
                         if platform not in profile_map:
                             profile_map[platform] = adapter
-                            self._sync_voice_mode_state_to_adapter(adapter)
-                            await self._configure_voice_auto_join_adapter(adapter)
+                            with _profile_runtime_scope(profile_home):
+                                self._sync_voice_mode_state_to_adapter(adapter)
+                                await self._configure_voice_auto_join_adapter(adapter)
                             logger.info(
                                 "✓ %s reconnected (profile: %s)",
                                 platform.value,
@@ -15225,6 +15248,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _wire_discord_voice_callbacks(self, adapter) -> None:
         """Wire one Discord adapter into the shared voice pipeline."""
+        profile = self._adapter_profile_name(adapter)
         if hasattr(adapter, "_voice_input_callback"):
             adapter._voice_input_callback = (
                 lambda guild_id, user_id, transcript: self._handle_voice_channel_input(
@@ -15232,10 +15256,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             )
         if hasattr(adapter, "_on_voice_disconnect"):
-            adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
+            adapter._on_voice_disconnect = lambda chat_id: self._handle_voice_timeout_cleanup(
+                chat_id, adapter=adapter
+            )
         if hasattr(adapter, "_voice_mode_getter"):
             adapter._voice_mode_getter = lambda chat_id: self._voice_mode.get(
-                self._voice_key(Platform.DISCORD, str(chat_id)), "off"
+                self._voice_key(Platform.DISCORD, str(chat_id), profile), "off"
             )
 
     async def _join_discord_voice_channel(
@@ -15258,7 +15284,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not success:
             return False
 
-        voice_key = self._voice_key(source.platform, source.chat_id)
+        voice_key = self._voice_key(
+            source.platform, source.chat_id, source.profile
+        )
         previous_mode = self._voice_mode.get(voice_key)
         had_previous_mode = voice_key in self._voice_mode
         try:
@@ -15283,8 +15311,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._save_voice_modes()
             except Exception:
                 logger.warning(
-                    "Failed to persist Discord voice-mode rollback for guild %s",
-                    guild_id,
+                    "Failed to persist Discord voice-mode rollback",
                     exc_info=True,
                 )
             try:
@@ -15293,16 +15320,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             except Exception:
                 logger.warning(
-                    "Failed to roll back Discord auto-TTS for guild %s",
-                    guild_id,
+                    "Failed to roll back Discord auto-TTS",
                     exc_info=True,
                 )
             try:
                 await adapter.leave_voice_channel(guild_id)
             except Exception:
                 logger.warning(
-                    "Failed to roll back Discord voice join for guild %s",
-                    guild_id,
+                    "Failed to roll back Discord voice join",
                     exc_info=True,
                 )
             raise
@@ -15318,12 +15343,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 await adapter.leave_voice_channel(route.guild_id)
             except Exception:
                 logger.warning(
-                    "Failed to auto-leave Discord voice channel for guild %s",
-                    route.guild_id,
+                    "Failed to auto-leave Discord voice channel",
                     exc_info=True,
                 )
                 return False
-            self._voice_mode[self._voice_key(Platform.DISCORD, chat_id)] = "off"
+            profile = self._adapter_profile_name(adapter)
+            self._voice_mode[
+                self._voice_key(Platform.DISCORD, chat_id, profile)
+            ] = "off"
             self._save_voice_modes()
             self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
             voice_clients = getattr(adapter, "_voice_clients", None)
@@ -15337,14 +15364,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         text_guild_id = getattr(getattr(text_channel, "guild", None), "id", None)
         if text_channel is None or text_guild_id != route.guild_id:
             logger.warning(
-                "Discord voice auto-join text channel not found in configured guild: "
-                "guild=%s channel=%s",
-                route.guild_id,
-                route.text_channel_id,
+                "Discord voice auto-join text channel was not found in the configured guild",
             )
             return False
 
-        profile = getattr(adapter, "_profile_name", None)
+        profile = self._adapter_profile_name(adapter)
         source = SessionSource(
             platform=Platform.DISCORD,
             chat_id=chat_id,
@@ -15357,9 +15381,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         if not self._is_user_authorized(source):
             logger.warning(
-                "Discord voice auto-join trigger user %s is not authorized by "
-                "the gateway access policy",
-                member.id,
+                "Discord voice auto-join trigger is not authorized by the gateway access policy",
             )
             return False
         try:
@@ -15372,8 +15394,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         except Exception:
             logger.warning(
-                "Failed to auto-join Discord voice channel for guild %s",
-                route.guild_id,
+                "Failed to auto-join Discord voice channel",
                 exc_info=True,
             )
             return False
@@ -15384,11 +15405,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
         routes = getattr(adapter, "_voice_auto_join_routes", ())
         if routes:
-            adapter._voice_auto_join_callback = (
-                lambda action, route, channel, member: self._handle_voice_auto_join(
+            async def _callback(action, route, channel, member):
+                profile = self._adapter_profile_name(adapter)
+                if profile:
+                    from hermes_cli.profiles import get_profile_dir
+
+                    with _profile_runtime_scope(get_profile_dir(profile)):
+                        return await self._handle_voice_auto_join(
+                            adapter, action, route, channel, member
+                        )
+                return await self._handle_voice_auto_join(
                     adapter, action, route, channel, member
                 )
-            )
+
+            adapter._voice_auto_join_callback = _callback
         reconcile = getattr(adapter, "reconcile_voice_auto_join", None)
         if callable(reconcile) and routes:
             try:
@@ -15466,21 +15496,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.warning("Error leaving voice channel: %s", e)
         # Always clean up state even if leave raised an exception
-        self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "off"
+        self._voice_mode[
+            self._voice_key(
+                event.source.platform,
+                event.source.chat_id,
+                event.source.profile,
+            )
+        ] = "off"
         self._save_voice_modes()
         self._set_adapter_auto_tts_disabled(adapter, event.source.chat_id, disabled=True)
         if hasattr(adapter, "_voice_input_callback"):
             adapter._voice_input_callback = None
         return "Left voice channel."
 
-    def _handle_voice_timeout_cleanup(self, chat_id: str) -> None:
+    def _handle_voice_timeout_cleanup(self, chat_id: str, *, adapter=None) -> None:
         """Called by the adapter when a voice channel times out.
 
         Cleans up runner-side voice_mode state that the adapter cannot reach.
         """
-        self._voice_mode[self._voice_key(Platform.DISCORD, chat_id)] = "off"
+        profile = self._adapter_profile_name(adapter) if adapter is not None else None
+        self._voice_mode[
+            self._voice_key(Platform.DISCORD, chat_id, profile)
+        ] = "off"
         self._save_voice_modes()
-        adapter = self.adapters.get(Platform.DISCORD)
+        adapter = adapter or self.adapters.get(Platform.DISCORD)
         self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
 
     def _is_duplicate_voice_transcript(self, guild_id: int, user_id: int, transcript: str) -> bool:
@@ -15614,7 +15653,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
 
         chat_id = event.source.chat_id
-        voice_mode = self._voice_mode.get(self._voice_key(event.source.platform, chat_id), "off")
+        voice_mode = self._voice_mode.get(
+            self._voice_key(
+                event.source.platform, chat_id, event.source.profile
+            ),
+            "off",
+        )
         is_voice_input = (event.message_type == MessageType.VOICE)
 
         should = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8234,6 +8234,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if success:
                     self.adapters[platform] = adapter
                     self._sync_voice_mode_state_to_adapter(adapter)
+                    await self._configure_voice_auto_join_adapter(adapter)
                     connected_count += 1
                     self._update_platform_runtime_status(
                         platform.value,
@@ -9259,6 +9260,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         self.adapters[platform] = adapter
                         self._sync_voice_mode_state_to_adapter(adapter)
                         self.delivery_router.adapters = self.adapters
+                        await self._configure_voice_auto_join_adapter(adapter)
                         del self._failed_platforms[platform]
                         self._update_platform_runtime_status(
                             platform.value,
@@ -10101,6 +10103,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 if success:
                     profile_map[platform] = adapter
+                    self._sync_voice_mode_state_to_adapter(adapter)
+                    await self._configure_voice_auto_join_adapter(adapter)
                     connected += 1
                     logger.info("✓ %s connected (profile: %s)", platform.value, profile_name)
                 else:
@@ -10171,6 +10175,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if platform not in profile_map:
                             profile_map[platform] = adapter
                             self._sync_voice_mode_state_to_adapter(adapter)
+                            await self._configure_voice_auto_join_adapter(adapter)
                             logger.info(
                                 "✓ %s reconnected (profile: %s)",
                                 platform.value,
@@ -15218,6 +15223,179 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return None
 
 
+    def _wire_discord_voice_callbacks(self, adapter) -> None:
+        """Wire one Discord adapter into the shared voice pipeline."""
+        if hasattr(adapter, "_voice_input_callback"):
+            adapter._voice_input_callback = (
+                lambda guild_id, user_id, transcript: self._handle_voice_channel_input(
+                    guild_id, user_id, transcript, adapter=adapter
+                )
+            )
+        if hasattr(adapter, "_on_voice_disconnect"):
+            adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
+        if hasattr(adapter, "_voice_mode_getter"):
+            adapter._voice_mode_getter = lambda chat_id: self._voice_mode.get(
+                self._voice_key(Platform.DISCORD, str(chat_id)), "off"
+            )
+
+    async def _join_discord_voice_channel(
+        self,
+        adapter,
+        voice_channel,
+        source: SessionSource,
+        guild_id: int,
+        *,
+        move_existing: bool = True,
+    ) -> bool:
+        """Join and bind a Discord VC to the normal Hermes voice session path."""
+        self._wire_discord_voice_callbacks(adapter)
+        if move_existing:
+            success = await adapter.join_voice_channel(voice_channel)
+        else:
+            success = await adapter.join_voice_channel(
+                voice_channel, move_existing=False
+            )
+        if not success:
+            return False
+
+        voice_key = self._voice_key(source.platform, source.chat_id)
+        previous_mode = self._voice_mode.get(voice_key)
+        had_previous_mode = voice_key in self._voice_mode
+        try:
+            adapter._voice_text_channels[guild_id] = int(source.chat_id)
+            if hasattr(adapter, "_voice_sources"):
+                adapter._voice_sources[guild_id] = source.to_dict()
+            self._voice_mode[voice_key] = "all"
+            self._save_voice_modes()
+            self._set_adapter_auto_tts_enabled(adapter, source.chat_id, enabled=True)
+        except Exception:
+            # A connected VC without its linked session route would receive
+            # audio with nowhere safe to send transcripts. Roll back instead.
+            adapter._voice_text_channels.pop(guild_id, None)
+            if hasattr(adapter, "_voice_sources"):
+                adapter._voice_sources.pop(guild_id, None)
+            if had_previous_mode:
+                assert previous_mode is not None
+                self._voice_mode[voice_key] = previous_mode
+            else:
+                self._voice_mode.pop(voice_key, None)
+            try:
+                self._save_voice_modes()
+            except Exception:
+                logger.warning(
+                    "Failed to persist Discord voice-mode rollback for guild %s",
+                    guild_id,
+                    exc_info=True,
+                )
+            try:
+                self._set_adapter_auto_tts_disabled(
+                    adapter, source.chat_id, disabled=True
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to roll back Discord auto-TTS for guild %s",
+                    guild_id,
+                    exc_info=True,
+                )
+            try:
+                await adapter.leave_voice_channel(guild_id)
+            except Exception:
+                logger.warning(
+                    "Failed to roll back Discord voice join for guild %s",
+                    guild_id,
+                    exc_info=True,
+                )
+            raise
+        return True
+
+    async def _handle_voice_auto_join(
+        self, adapter, action: str, route, voice_channel, member
+    ) -> bool:
+        """Apply adapter-detected auto-join lifecycle through runner-owned state."""
+        chat_id = str(route.text_channel_id)
+        if action == "leave":
+            try:
+                await adapter.leave_voice_channel(route.guild_id)
+            except Exception:
+                logger.warning(
+                    "Failed to auto-leave Discord voice channel for guild %s",
+                    route.guild_id,
+                    exc_info=True,
+                )
+                return False
+            self._voice_mode[self._voice_key(Platform.DISCORD, chat_id)] = "off"
+            self._save_voice_modes()
+            self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
+            voice_clients = getattr(adapter, "_voice_clients", None)
+            if not isinstance(voice_clients, dict) or not voice_clients:
+                adapter._voice_input_callback = None
+            return True
+
+        if action != "join" or member is None:
+            return False
+        text_channel = adapter._client.get_channel(route.text_channel_id)
+        text_guild_id = getattr(getattr(text_channel, "guild", None), "id", None)
+        if text_channel is None or text_guild_id != route.guild_id:
+            logger.warning(
+                "Discord voice auto-join text channel not found in configured guild: "
+                "guild=%s channel=%s",
+                route.guild_id,
+                route.text_channel_id,
+            )
+            return False
+
+        profile = getattr(adapter, "_profile_name", None)
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id=chat_id,
+            chat_name=getattr(text_channel, "name", None),
+            chat_type="channel",
+            user_id=str(member.id),
+            user_name=getattr(member, "display_name", str(member.id)),
+            scope_id=str(route.guild_id),
+            profile=profile,
+        )
+        if not self._is_user_authorized(source):
+            logger.warning(
+                "Discord voice auto-join trigger user %s is not authorized by "
+                "the gateway access policy",
+                member.id,
+            )
+            return False
+        try:
+            return await self._join_discord_voice_channel(
+                adapter,
+                voice_channel,
+                source,
+                route.guild_id,
+                move_existing=False,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to auto-join Discord voice channel for guild %s",
+                route.guild_id,
+                exc_info=True,
+            )
+            return False
+
+    async def _configure_voice_auto_join_adapter(self, adapter) -> None:
+        """Attach the runner callback and reconcile one connected adapter."""
+        if getattr(adapter, "platform", None) != Platform.DISCORD:
+            return
+        routes = getattr(adapter, "_voice_auto_join_routes", ())
+        if routes:
+            adapter._voice_auto_join_callback = (
+                lambda action, route, channel, member: self._handle_voice_auto_join(
+                    adapter, action, route, channel, member
+                )
+            )
+        reconcile = getattr(adapter, "reconcile_voice_auto_join", None)
+        if callable(reconcile) and routes:
+            try:
+                await reconcile()
+            except Exception:
+                logger.warning("Discord voice auto-join reconciliation failed", exc_info=True)
+
     async def _handle_voice_channel_join(self, event: MessageEvent) -> str:
         """Join the user's current Discord voice channel."""
         adapter = self._adapter_for_source(event.source)
@@ -15234,21 +15412,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not voice_channel:
             return "You need to be in a voice channel first."
 
-        # Wire callbacks BEFORE join so voice input arriving immediately
-        # after connection is not lost.
-        if hasattr(adapter, "_voice_input_callback"):
-            adapter._voice_input_callback = self._handle_voice_channel_input
-        if hasattr(adapter, "_on_voice_disconnect"):
-            adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
-        # Let the adapter's inactivity timer see the live voice-reply mode so it
-        # doesn't disconnect a deliberately text-only (/voice off) session.
-        if hasattr(adapter, "_voice_mode_getter"):
-            adapter._voice_mode_getter = lambda chat_id: self._voice_mode.get(
-                self._voice_key(Platform.DISCORD, str(chat_id)), "off"
-            )
-
+        manual_claimed = False
         try:
-            success = await adapter.join_voice_channel(voice_channel)
+            begin_manual_join = getattr(
+                type(adapter), "_begin_manual_voice_join", None
+            )
+            if callable(begin_manual_join):
+                begin_manual_join(adapter, guild_id)
+                manual_claimed = True
+            success = await self._join_discord_voice_channel(
+                adapter, voice_channel, event.source, guild_id
+            )
         except Exception as e:
             logger.warning("Failed to join voice channel: %s", e)
             adapter._voice_input_callback = None
@@ -15259,14 +15433,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"Install with: `{sys.executable} -m pip install PyNaCl`"
                 )
             return f"Failed to join voice channel: {e}"
+        finally:
+            if manual_claimed:
+                end_manual_join = getattr(
+                    type(adapter), "_end_manual_voice_join", None
+                )
+                if callable(end_manual_join):
+                    end_manual_join(adapter, guild_id)
 
         if success:
-            adapter._voice_text_channels[guild_id] = int(event.source.chat_id)
-            if hasattr(adapter, "_voice_sources"):
-                adapter._voice_sources[guild_id] = event.source.to_dict()
-            self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
-            self._save_voice_modes()
-            self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
             return (
                 f"Joined voice channel **{voice_channel.name}**.\n"
                 f"I'll speak my replies and listen to you. Use /voice leave to disconnect."
@@ -15350,14 +15525,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return False
 
     async def _handle_voice_channel_input(
-        self, guild_id: int, user_id: int, transcript: str
+        self, guild_id: int, user_id: int, transcript: str, *, adapter: Any = None
     ):
         """Handle transcribed voice from a user in a voice channel.
 
         Creates a synthetic MessageEvent and processes it through the
         adapter's full message pipeline (session, typing, agent, TTS reply).
         """
-        adapter = self.adapters.get(Platform.DISCORD)
+        adapter = cast(Any, adapter or self.adapters.get(Platform.DISCORD))
         if not adapter:
             return
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2676,7 +2676,7 @@ class GatewaySlashCommandsMixin:
         args = event.get_command_args().strip().lower()
         chat_id = event.source.chat_id
         platform = event.source.platform
-        voice_key = self._voice_key(platform, chat_id)
+        voice_key = self._voice_key(platform, chat_id, event.source.profile)
 
         adapter = self.adapters.get(platform)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2678,7 +2678,7 @@ class GatewaySlashCommandsMixin:
         platform = event.source.platform
         voice_key = self._voice_key(platform, chat_id, event.source.profile)
 
-        adapter = self.adapters.get(platform)
+        adapter = getattr(self, "_adapter_for_source")(event.source)
 
         if args in {"on", "enable"}:
             self._voice_mode[voice_key] = "voice_only"
@@ -2710,7 +2710,7 @@ class GatewaySlashCommandsMixin:
                 "all": t("gateway.voice.label_all"),
             }
             # Append voice channel info if connected
-            adapter = self.adapters.get(event.source.platform)
+            adapter = getattr(self, "_adapter_for_source")(event.source)
             guild_id = self._get_guild_id(event)
             if guild_id and hasattr(adapter, "get_voice_channel_info"):
                 info = adapter.get_voice_channel_info(guild_id)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2647,6 +2647,24 @@ DEFAULT_CONFIG = {
         # override: DISCORD_APPROVAL_MENTIONS. Default false avoids surprise
         # pings.
         "approval_mentions": False,
+        # Optional hands-free Discord VC lifecycle. Disabled by default. Each
+        # route binds one guild/voice channel to an explicit text channel and
+        # only the listed user IDs may trigger a join. Trigger users must also
+        # pass the normal Discord access policy. One route per guild.
+        "voice_auto_join": {
+            "enabled": False,
+            "reconnect_on_startup": True,
+            "routes": [
+                # {
+                #     "guild_id": "123456789012345678",
+                #     "voice_channel_id": "123456789012345679",
+                #     "text_channel_id": "123456789012345680",
+                #     "trigger_user_ids": ["123456789012345681"],
+                #     "leave_when_no_trigger_users": True,
+                #     "leave_grace_seconds": 10,
+                # }
+            ],
+        },
         # Voice-channel audio effects (the continuous mixer). OFF by default.
         # When enabled, the bot installs a software mixer on the outgoing voice
         # stream so a low ambient "thinking" bed, verbal acknowledgements, and

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -949,6 +949,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_auto_join_active: Dict[int, int] = {}
         self._voice_auto_join_locks: Dict[int, asyncio.Lock] = {}
         self._voice_auto_join_leave_tasks: Dict[int, asyncio.Task] = {}
+        self._voice_auto_join_leaving: set[int] = set()
         self._voice_manual_join_pending: set[int] = set()
         self._voice_manual_join_generation: Dict[int, int] = {}
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
@@ -1754,6 +1755,9 @@ class DiscordAdapter(BasePlatformAdapter):
         active_routes = getattr(self, "_voice_auto_join_active", None)
         if isinstance(active_routes, dict):
             active_routes.clear()
+        leaving_routes = getattr(self, "_voice_auto_join_leaving", None)
+        if isinstance(leaving_routes, set):
+            leaving_routes.clear()
         manual_pending = getattr(self, "_voice_manual_join_pending", None)
         if isinstance(manual_pending, set):
             manual_pending.clear()
@@ -3884,6 +3888,8 @@ class DiscordAdapter(BasePlatformAdapter):
         leave_tasks = getattr(self, "_voice_auto_join_leave_tasks", None)
         if not isinstance(leave_tasks, dict):
             return
+        if guild_id in getattr(self, "_voice_auto_join_leaving", set()):
+            return
         task = leave_tasks.pop(guild_id, None)
         if task and task is not asyncio.current_task():
             task.cancel()
@@ -3906,13 +3912,27 @@ class DiscordAdapter(BasePlatformAdapter):
         callback = self._voice_auto_join_callback
         if callback is None:
             logger.warning(
-                "Discord voice auto-join route matched guild %d, but the gateway "
-                "lifecycle callback is unavailable",
-                route.guild_id,
+                "Discord voice auto-join route matched, but the gateway lifecycle "
+                "callback is unavailable",
             )
             return False
         if route.guild_id in self._voice_manual_join_pending:
             return False
+        leave_task = self._voice_auto_join_leave_tasks.get(route.guild_id)
+        if (
+            route.guild_id in self._voice_auto_join_leaving
+            and leave_task is not None
+            and leave_task is not asyncio.current_task()
+        ):
+            try:
+                await asyncio.shield(leave_task)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "Discord voice auto-leave completion failed before rejoin",
+                    exc_info=True,
+                )
         self._cancel_voice_auto_leave(route.guild_id)
         existing_client = self._voice_clients.get(route.guild_id)
         if existing_client is not None and existing_client.is_connected():
@@ -3921,16 +3941,27 @@ class DiscordAdapter(BasePlatformAdapter):
         async with self._voice_auto_join_locks.setdefault(route.guild_id, asyncio.Lock()):
             if route.guild_id in self._voice_manual_join_pending:
                 return False
-            if self._voice_auto_join_active.get(route.guild_id) == route.voice_channel_id:
+            existing_client = self._voice_clients.get(route.guild_id)
+            active_matches = (
+                self._voice_auto_join_active.get(route.guild_id)
+                == route.voice_channel_id
+            )
+            connected_matches = bool(
+                existing_client is not None
+                and existing_client.is_connected()
+                and getattr(getattr(existing_client, "channel", None), "id", None)
+                == route.voice_channel_id
+            )
+            if active_matches and connected_matches:
                 return True
+            if active_matches:
+                self._voice_auto_join_active.pop(route.guild_id, None)
             manual_generation = self._voice_manual_join_generation.get(route.guild_id, 0)
             try:
                 joined = bool(await callback("join", route, channel, member))
             except Exception:
                 logger.warning(
-                    "Discord voice auto-join failed for guild %d channel %d",
-                    route.guild_id,
-                    route.voice_channel_id,
+                    "Discord voice auto-join failed",
                     exc_info=True,
                 )
                 return False
@@ -3960,26 +3991,23 @@ class DiscordAdapter(BasePlatformAdapter):
                 callback = self._voice_auto_join_callback
                 if callback is None:
                     return
+                self._voice_auto_join_leaving.add(route.guild_id)
                 left = bool(await callback("leave", route, channel, None))
                 if left:
                     self._voice_auto_join_active.pop(route.guild_id, None)
                 else:
                     logger.warning(
-                        "Discord voice auto-leave was not completed for guild %d "
-                        "channel %d",
-                        route.guild_id,
-                        route.voice_channel_id,
+                        "Discord voice auto-leave was not completed",
                     )
             except asyncio.CancelledError:
                 return
             except Exception:
                 logger.warning(
-                    "Discord voice auto-leave failed for guild %d channel %d",
-                    route.guild_id,
-                    route.voice_channel_id,
+                    "Discord voice auto-leave failed",
                     exc_info=True,
                 )
             finally:
+                self._voice_auto_join_leaving.discard(route.guild_id)
                 current = asyncio.current_task()
                 if self._voice_auto_join_leave_tasks.get(route.guild_id) is current:
                     self._voice_auto_join_leave_tasks.pop(route.guild_id, None)
@@ -4006,22 +4034,7 @@ class DiscordAdapter(BasePlatformAdapter):
             and before_channel != after_channel
         )
         if (joined or left or switched) and guild_id in self._voice_clients:
-            if joined:
-                state_change = f"joined {getattr(after_channel, 'name', 'unknown')}"
-            elif left:
-                state_change = f"left {getattr(before_channel, 'name', 'unknown')}"
-            else:
-                state_change = (
-                    f"moved {getattr(before_channel, 'name', 'unknown')} -> "
-                    f"{getattr(after_channel, 'name', 'unknown')}"
-                )
-            logger.info(
-                "Voice state: %s (%d) %s (guild %d)",
-                member.display_name,
-                member.id,
-                state_change,
-                guild_id,
-            )
+            logger.info("Voice state changed for a connected Discord session")
 
         if getattr(member, "bot", False):
             return
@@ -4058,22 +4071,18 @@ class DiscordAdapter(BasePlatformAdapter):
             channel = guild.get_channel(route.voice_channel_id) if guild else None
             if channel is None:
                 logger.warning(
-                    "Discord voice_auto_join route not found: guild=%d channel=%d",
-                    route.guild_id,
-                    route.voice_channel_id,
+                    "Discord voice_auto_join route target was not found",
                 )
                 continue
-            member = next(
-                (
-                    item
-                    for item in (getattr(channel, "members", None) or [])
-                    if not getattr(item, "bot", False)
-                    and getattr(item, "id", None) in route.trigger_user_ids
-                ),
-                None,
-            )
-            if member is not None:
-                await self._request_voice_auto_join(route, channel, member)
+            members = [
+                item
+                for item in (getattr(channel, "members", None) or [])
+                if not getattr(item, "bot", False)
+                and getattr(item, "id", None) in route.trigger_user_ids
+            ]
+            for member in members:
+                if await self._request_voice_auto_join(route, channel, member):
+                    break
 
     async def join_voice_channel(self, channel, *, move_existing: bool = True) -> bool:
         """Join a Discord voice channel. Returns True on success."""

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -25,6 +25,7 @@ import threading
 import time
 from collections import defaultdict
 from contextlib import suppress
+from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Any, Tuple
 from urllib.parse import urljoin
 
@@ -70,6 +71,40 @@ _DISCORD_NONCONVERSATIONAL_METADATA_KEYS = frozenset({
 })
 _DISCORD_IMAGE_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
 _DISCORD_IMAGE_MAX_REDIRECTS = 10
+
+
+@dataclass(frozen=True)
+class VoiceAutoJoinRoute:
+    """One fail-closed Discord voice auto-join route."""
+
+    guild_id: int
+    voice_channel_id: int
+    text_channel_id: int
+    trigger_user_ids: frozenset[int]
+    leave_when_no_trigger_users: bool = True
+    leave_grace_seconds: float = 10.0
+
+
+def _config_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    return default
+
+
+def _positive_snowflake(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    try:
+        snowflake = int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    return snowflake if snowflake > 0 else None
 # Upgrade-bridge fallback only. The primary mechanism is the persisted
 # non-conversational message-ID set populated from explicitly marked sends
 # (metadata["non_conversational"]). These regexes exist solely to recognize
@@ -904,6 +939,18 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
         self._voice_input_callback: Optional[Callable] = None  # set by run.py
         self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
+        # Optional, config-gated voice lifecycle. The gateway supplies the
+        # callback so auto-joined audio uses the same session/state path as
+        # manual /voice join. No callback means fail closed (never connect).
+        self._voice_auto_join_callback: Optional[Callable] = None
+        self._voice_auto_join_routes, self._voice_auto_join_reconnect = (
+            self._load_voice_auto_join_config()
+        )
+        self._voice_auto_join_active: Dict[int, int] = {}
+        self._voice_auto_join_locks: Dict[int, asyncio.Lock] = {}
+        self._voice_auto_join_leave_tasks: Dict[int, asyncio.Task] = {}
+        self._voice_manual_join_pending: set[int] = set()
+        self._voice_manual_join_generation: Dict[int, int] = {}
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
         # linked text-channel id; set by run.py. Lets the inactivity timer leave
         # the bot in the channel when the user deliberately picked text-only
@@ -1013,6 +1060,77 @@ class DiscordAdapter(BasePlatformAdapter):
             return int(value)
         except (TypeError, ValueError):
             return 0
+
+    def _load_voice_auto_join_config(
+        self,
+    ) -> tuple[tuple[VoiceAutoJoinRoute, ...], bool]:
+        """Parse explicit Discord auto-join config, dropping unsafe routes."""
+        extra = self.config.extra if isinstance(getattr(self.config, "extra", None), dict) else {}
+        raw = extra.get("voice_auto_join")
+        if not isinstance(raw, dict) or not _config_bool(raw.get("enabled"), False):
+            return (), False
+
+        routes_raw = raw.get("routes")
+        if not isinstance(routes_raw, list):
+            logger.warning("Discord voice_auto_join.routes must be a list; auto-join disabled")
+            return (), False
+
+        routes: list[VoiceAutoJoinRoute] = []
+        seen_guilds: set[int] = set()
+        for index, item in enumerate(routes_raw):
+            if not isinstance(item, dict):
+                logger.warning("Ignoring Discord voice_auto_join route %d: expected a mapping", index)
+                continue
+            guild_id = _positive_snowflake(item.get("guild_id"))
+            voice_channel_id = _positive_snowflake(item.get("voice_channel_id"))
+            text_channel_id = _positive_snowflake(item.get("text_channel_id"))
+            trigger_values = item.get("trigger_user_ids")
+            trigger_user_ids: set[int] = set()
+            if isinstance(trigger_values, list):
+                for value in trigger_values:
+                    parsed = _positive_snowflake(value)
+                    if parsed is not None:
+                        trigger_user_ids.add(parsed)
+
+            if guild_id is None or voice_channel_id is None or text_channel_id is None or not trigger_user_ids:
+                logger.warning(
+                    "Ignoring Discord voice_auto_join route %d: guild_id, "
+                    "voice_channel_id, text_channel_id, and a non-empty "
+                    "trigger_user_ids list are required",
+                    index,
+                )
+                continue
+            if guild_id in seen_guilds:
+                logger.warning(
+                    "Ignoring Discord voice_auto_join route %d: only one route "
+                    "per guild is supported",
+                    index,
+                )
+                continue
+
+            try:
+                grace = float(item.get("leave_grace_seconds", 10.0))
+            except (TypeError, ValueError):
+                grace = 10.0
+            if not math.isfinite(grace):
+                grace = 10.0
+            grace = min(300.0, max(0.0, grace))
+
+            seen_guilds.add(guild_id)
+            routes.append(
+                VoiceAutoJoinRoute(
+                    guild_id=guild_id,
+                    voice_channel_id=voice_channel_id,
+                    text_channel_id=text_channel_id,
+                    trigger_user_ids=frozenset(trigger_user_ids),
+                    leave_when_no_trigger_users=_config_bool(
+                        item.get("leave_when_no_trigger_users"), True
+                    ),
+                    leave_grace_seconds=grace,
+                )
+            )
+
+        return tuple(routes), _config_bool(raw.get("reconnect_on_startup"), True)
 
     def _handle_bot_task_done(self, task: asyncio.Task) -> None:
         """Surface post-startup discord.py task exits to the gateway supervisor.
@@ -1217,36 +1335,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
             @self._client.event
             async def on_voice_state_update(member, before, after):
-                """Track voice channel join/leave events."""
-                # Only track channels where the bot is connected
-                bot_guild_ids = set(adapter_self._voice_clients.keys())
-                if not bot_guild_ids:
-                    return
-                guild_id = member.guild.id
-                if guild_id not in bot_guild_ids:
-                    return
-                # Ignore the bot itself
-                if member == adapter_self._client.user:
-                    return
-
-                joined = before.channel is None and after.channel is not None
-                left = before.channel is not None and after.channel is None
-                switched = (
-                    before.channel is not None
-                    and after.channel is not None
-                    and before.channel != after.channel
-                )
-
-                if joined or left or switched:
-                    logger.info(
-                        "Voice state: %s (%d) %s (guild %d)",
-                        member.display_name,
-                        member.id,
-                        "joined " + after.channel.name if joined
-                        else "left " + before.channel.name if left
-                        else f"moved {before.channel.name} -> {after.channel.name}",
-                        guild_id,
-                    )
+                await adapter_self._handle_voice_state_update(member, before, after)
 
             # Register slash commands
             if self._slash_commands:
@@ -1657,6 +1746,20 @@ class DiscordAdapter(BasePlatformAdapter):
                 await self.leave_voice_channel(guild_id)
             except Exception as e:  # pragma: no cover - defensive logging
                 logger.debug("[%s] Error leaving voice channel %s: %s", self.name, guild_id, e)
+        leave_tasks = getattr(self, "_voice_auto_join_leave_tasks", None)
+        if isinstance(leave_tasks, dict):
+            for task in list(leave_tasks.values()):
+                task.cancel()
+            leave_tasks.clear()
+        active_routes = getattr(self, "_voice_auto_join_active", None)
+        if isinstance(active_routes, dict):
+            active_routes.clear()
+        manual_pending = getattr(self, "_voice_manual_join_pending", None)
+        if isinstance(manual_pending, set):
+            manual_pending.clear()
+        manual_generations = getattr(self, "_voice_manual_join_generation", None)
+        if isinstance(manual_generations, dict):
+            manual_generations.clear()
 
         if self._client:
             try:
@@ -3756,7 +3859,223 @@ class DiscordAdapter(BasePlatformAdapter):
         mixers = getattr(self, "_voice_mixers", None)
         return bool(mixers) and mixers.get(guild_id) is not None
 
-    async def join_voice_channel(self, channel) -> bool:
+    def _voice_auto_join_route(
+        self, guild_id: int, channel_id: int
+    ) -> Optional[VoiceAutoJoinRoute]:
+        return next(
+            (
+                route
+                for route in self._voice_auto_join_routes
+                if route.guild_id == guild_id
+                and route.voice_channel_id == channel_id
+            ),
+            None,
+        )
+
+    @staticmethod
+    def _voice_route_has_trigger(channel: Any, route: VoiceAutoJoinRoute) -> bool:
+        return any(
+            not getattr(member, "bot", False)
+            and getattr(member, "id", None) in route.trigger_user_ids
+            for member in (getattr(channel, "members", None) or [])
+        )
+
+    def _cancel_voice_auto_leave(self, guild_id: int) -> None:
+        leave_tasks = getattr(self, "_voice_auto_join_leave_tasks", None)
+        if not isinstance(leave_tasks, dict):
+            return
+        task = leave_tasks.pop(guild_id, None)
+        if task and task is not asyncio.current_task():
+            task.cancel()
+
+    def _begin_manual_voice_join(self, guild_id: int) -> None:
+        """Prevent auto-join ownership from racing an explicit join command."""
+        self._voice_manual_join_pending.add(guild_id)
+        self._voice_manual_join_generation[guild_id] = (
+            self._voice_manual_join_generation.get(guild_id, 0) + 1
+        )
+        self._voice_auto_join_active.pop(guild_id, None)
+        self._cancel_voice_auto_leave(guild_id)
+
+    def _end_manual_voice_join(self, guild_id: int) -> None:
+        self._voice_manual_join_pending.discard(guild_id)
+
+    async def _request_voice_auto_join(
+        self, route: VoiceAutoJoinRoute, channel: Any, member: Any
+    ) -> bool:
+        callback = self._voice_auto_join_callback
+        if callback is None:
+            logger.warning(
+                "Discord voice auto-join route matched guild %d, but the gateway "
+                "lifecycle callback is unavailable",
+                route.guild_id,
+            )
+            return False
+        if route.guild_id in self._voice_manual_join_pending:
+            return False
+        self._cancel_voice_auto_leave(route.guild_id)
+        existing_client = self._voice_clients.get(route.guild_id)
+        if existing_client is not None and existing_client.is_connected():
+            # Never move or take ownership of a manual /voice join session.
+            return False
+        async with self._voice_auto_join_locks.setdefault(route.guild_id, asyncio.Lock()):
+            if route.guild_id in self._voice_manual_join_pending:
+                return False
+            if self._voice_auto_join_active.get(route.guild_id) == route.voice_channel_id:
+                return True
+            manual_generation = self._voice_manual_join_generation.get(route.guild_id, 0)
+            try:
+                joined = bool(await callback("join", route, channel, member))
+            except Exception:
+                logger.warning(
+                    "Discord voice auto-join failed for guild %d channel %d",
+                    route.guild_id,
+                    route.voice_channel_id,
+                    exc_info=True,
+                )
+                return False
+            manual_took_over = (
+                route.guild_id in self._voice_manual_join_pending
+                or self._voice_manual_join_generation.get(route.guild_id, 0)
+                != manual_generation
+            )
+            if joined and not manual_took_over:
+                self._voice_auto_join_active[route.guild_id] = route.voice_channel_id
+            return joined and not manual_took_over
+
+    def _schedule_voice_auto_leave(
+        self, route: VoiceAutoJoinRoute, channel: Any
+    ) -> None:
+        if not route.leave_when_no_trigger_users:
+            return
+        self._cancel_voice_auto_leave(route.guild_id)
+
+        async def _leave_after_grace() -> None:
+            try:
+                await asyncio.sleep(route.leave_grace_seconds)
+                if self._voice_auto_join_active.get(route.guild_id) != route.voice_channel_id:
+                    return
+                if self._voice_route_has_trigger(channel, route):
+                    return
+                callback = self._voice_auto_join_callback
+                if callback is None:
+                    return
+                left = bool(await callback("leave", route, channel, None))
+                if left:
+                    self._voice_auto_join_active.pop(route.guild_id, None)
+                else:
+                    logger.warning(
+                        "Discord voice auto-leave was not completed for guild %d "
+                        "channel %d",
+                        route.guild_id,
+                        route.voice_channel_id,
+                    )
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                logger.warning(
+                    "Discord voice auto-leave failed for guild %d channel %d",
+                    route.guild_id,
+                    route.voice_channel_id,
+                    exc_info=True,
+                )
+            finally:
+                current = asyncio.current_task()
+                if self._voice_auto_join_leave_tasks.get(route.guild_id) is current:
+                    self._voice_auto_join_leave_tasks.pop(route.guild_id, None)
+
+        self._voice_auto_join_leave_tasks[route.guild_id] = asyncio.create_task(
+            _leave_after_grace()
+        )
+
+    async def _handle_voice_state_update(self, member: Any, before: Any, after: Any) -> None:
+        """Track voice state and apply explicitly configured auto-join routes."""
+        if not self._client or member == self._client.user:
+            return
+        guild_id = getattr(getattr(member, "guild", None), "id", None)
+        if guild_id is None:
+            return
+        before_channel = getattr(before, "channel", None)
+        after_channel = getattr(after, "channel", None)
+
+        joined = before_channel is None and after_channel is not None
+        left = before_channel is not None and after_channel is None
+        switched = (
+            before_channel is not None
+            and after_channel is not None
+            and before_channel != after_channel
+        )
+        if (joined or left or switched) and guild_id in self._voice_clients:
+            if joined:
+                state_change = f"joined {getattr(after_channel, 'name', 'unknown')}"
+            elif left:
+                state_change = f"left {getattr(before_channel, 'name', 'unknown')}"
+            else:
+                state_change = (
+                    f"moved {getattr(before_channel, 'name', 'unknown')} -> "
+                    f"{getattr(after_channel, 'name', 'unknown')}"
+                )
+            logger.info(
+                "Voice state: %s (%d) %s (guild %d)",
+                member.display_name,
+                member.id,
+                state_change,
+                guild_id,
+            )
+
+        if getattr(member, "bot", False):
+            return
+        member_id = getattr(member, "id", None)
+        if after_channel is not None:
+            route = self._voice_auto_join_route(guild_id, getattr(after_channel, "id", 0))
+            if route and member_id in route.trigger_user_ids:
+                await self._request_voice_auto_join(route, after_channel, member)
+
+        if before_channel is not None:
+            route = self._voice_auto_join_route(guild_id, getattr(before_channel, "id", 0))
+            moved_away = bool(
+                route
+                and (
+                    after_channel is None
+                    or getattr(after_channel, "id", None) != route.voice_channel_id
+                )
+            )
+            if (
+                route
+                and moved_away
+                and member_id in route.trigger_user_ids
+                and self._voice_auto_join_active.get(guild_id) == route.voice_channel_id
+                and not self._voice_route_has_trigger(before_channel, route)
+            ):
+                self._schedule_voice_auto_leave(route, before_channel)
+
+    async def reconcile_voice_auto_join(self) -> None:
+        """Join configured routes whose trigger user is already present."""
+        if not self._voice_auto_join_reconnect or not self._client:
+            return
+        for route in self._voice_auto_join_routes:
+            guild = self._client.get_guild(route.guild_id)
+            channel = guild.get_channel(route.voice_channel_id) if guild else None
+            if channel is None:
+                logger.warning(
+                    "Discord voice_auto_join route not found: guild=%d channel=%d",
+                    route.guild_id,
+                    route.voice_channel_id,
+                )
+                continue
+            member = next(
+                (
+                    item
+                    for item in (getattr(channel, "members", None) or [])
+                    if not getattr(item, "bot", False)
+                    and getattr(item, "id", None) in route.trigger_user_ids
+                ),
+                None,
+            )
+            if member is not None:
+                await self._request_voice_auto_join(route, channel, member)
+
+    async def join_voice_channel(self, channel, *, move_existing: bool = True) -> bool:
         """Join a Discord voice channel. Returns True on success."""
         if not self._client or not DISCORD_AVAILABLE:
             return False
@@ -3766,6 +4085,11 @@ class DiscordAdapter(BasePlatformAdapter):
             # Already connected in this guild?
             existing = self._voice_clients.get(guild_id)
             if existing and existing.is_connected():
+                if not move_existing:
+                    # Auto-join must never claim or move a manual session. This
+                    # check is inside the shared voice lock so a simultaneous
+                    # manual join cannot race the earlier adapter-level guard.
+                    return False
                 if existing.channel.id == channel.id:
                     self._reset_voice_timeout(guild_id)
                     return True
@@ -3827,6 +4151,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 task.cancel()
             self._voice_text_channels.pop(guild_id, None)
             self._voice_sources.pop(guild_id, None)
+            active_routes = getattr(self, "_voice_auto_join_active", None)
+            if isinstance(active_routes, dict):
+                active_routes.pop(guild_id, None)
+            self._cancel_voice_auto_leave(guild_id)
 
     # Maximum seconds to wait for voice playback before giving up
     PLAYBACK_TIMEOUT = 120
@@ -3934,6 +4262,20 @@ class DiscordAdapter(BasePlatformAdapter):
         except asyncio.CancelledError:
             return
         text_ch_id = self._voice_text_channels.get(guild_id)
+        active_channel_id = getattr(self, "_voice_auto_join_active", {}).get(guild_id)
+        if active_channel_id is not None:
+            voice_client = self._voice_clients.get(guild_id)
+            active_channel = getattr(voice_client, "channel", None)
+            route = self._voice_auto_join_route(guild_id, active_channel_id)
+            if (
+                route is not None
+                and getattr(active_channel, "id", None) == active_channel_id
+                and self._voice_route_has_trigger(active_channel, route)
+            ):
+                # Auto-join ownership is presence-based. A silent but present
+                # trigger user must not be disconnected by the legacy audio
+                # inactivity timer; their eventual leave event owns teardown.
+                return
         # ``/voice off`` mutes spoken replies but deliberately keeps the bot in
         # the channel (leaving is ``/voice leave``). The inactivity timer only
         # counts the bot's OWN audio as activity, so under voice-off mode it
@@ -9408,6 +9750,11 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
         os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
     seeded_extra = {}
+    voice_auto_join_cfg = discord_cfg.get("voice_auto_join")
+    if isinstance(voice_auto_join_cfg, dict):
+        # Behavioral lifecycle config stays in PlatformConfig.extra rather than
+        # a process-global env var, preserving multiplexed profile isolation.
+        seeded_extra["voice_auto_join"] = dict(voice_auto_join_cfg)
     backfill_cfg = discord_cfg.get("missed_message_backfill")
     if isinstance(backfill_cfg, dict):
         seeded_extra["missed_message_backfill"] = dict(backfill_cfg)

--- a/tests/gateway/test_discord_voice_auto_join.py
+++ b/tests/gateway/test_discord_voice_auto_join.py
@@ -1,0 +1,356 @@
+"""Behavioral tests for opt-in Discord voice-channel auto-join."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter, _apply_yaml_config
+
+
+def _route_config(**overrides):
+    route = {
+        "guild_id": "100",
+        "voice_channel_id": "200",
+        "text_channel_id": "300",
+        "trigger_user_ids": ["42"],
+        "leave_when_no_trigger_users": True,
+        "leave_grace_seconds": 0,
+    }
+    route.update(overrides)
+    return {
+        "voice_auto_join": {
+            "enabled": True,
+            "reconnect_on_startup": True,
+            "routes": [route],
+        }
+    }
+
+
+def _adapter(extra=None):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test", extra=extra or {}))
+    adapter._voice_auto_join_callback = AsyncMock(return_value=True)
+    adapter._client = MagicMock()
+    adapter._client.user = SimpleNamespace(id=999)
+    return adapter
+
+
+def _channel(*, guild_id=100, channel_id=200, members=None, name="Voice"):
+    guild = SimpleNamespace(id=guild_id, name="Guild")
+    return SimpleNamespace(
+        id=channel_id,
+        name=name,
+        guild=guild,
+        members=list(members or []),
+    )
+
+
+def _member(*, user_id=42, guild_id=100, channel=None, bot=False):
+    return SimpleNamespace(
+        id=user_id,
+        display_name=f"user-{user_id}",
+        bot=bot,
+        guild=SimpleNamespace(id=guild_id),
+        voice=SimpleNamespace(channel=channel) if channel is not None else None,
+    )
+
+
+def _state(channel):
+    return SimpleNamespace(channel=channel)
+
+
+def test_auto_join_is_disabled_by_default():
+    adapter = _adapter()
+
+    assert adapter._voice_auto_join_routes == ()
+
+
+def test_enabled_config_parses_explicit_route_options():
+    adapter = _adapter(
+        _route_config(
+            leave_when_no_trigger_users=False,
+            leave_grace_seconds=12.5,
+        )
+    )
+
+    assert adapter._voice_auto_join_reconnect is True
+    assert len(adapter._voice_auto_join_routes) == 1
+    route = adapter._voice_auto_join_routes[0]
+    assert route.guild_id == 100
+    assert route.voice_channel_id == 200
+    assert route.text_channel_id == 300
+    assert route.trigger_user_ids == frozenset({42})
+    assert route.leave_when_no_trigger_users is False
+    assert route.leave_grace_seconds == 12.5
+
+
+def test_invalid_route_fails_closed():
+    adapter = _adapter(
+        {
+            "voice_auto_join": {
+                "enabled": True,
+                "routes": [
+                    {
+                        "guild_id": "100",
+                        "voice_channel_id": "200",
+                        "text_channel_id": "300",
+                        "trigger_user_ids": [],
+                    }
+                ],
+            }
+        }
+    )
+
+    assert adapter._voice_auto_join_routes == ()
+
+
+def test_duplicate_routes_for_one_guild_fail_closed_to_first_route():
+    config = _route_config()
+    config["voice_auto_join"]["routes"].append(
+        {
+            "guild_id": "100",
+            "voice_channel_id": "201",
+            "text_channel_id": "301",
+            "trigger_user_ids": ["43"],
+        }
+    )
+
+    adapter = _adapter(config)
+
+    assert [route.voice_channel_id for route in adapter._voice_auto_join_routes] == [200]
+
+
+@pytest.mark.asyncio
+async def test_wrong_channel_and_unauthorized_user_do_not_join():
+    adapter = _adapter(_route_config())
+    wrong_channel = _channel(channel_id=201)
+    right_channel = _channel(channel_id=200)
+
+    wrong_channel_member = _member(channel=wrong_channel)
+    unauthorized_member = _member(user_id=43, channel=right_channel)
+
+    await adapter._handle_voice_state_update(
+        wrong_channel_member, _state(None), _state(wrong_channel)
+    )
+    await adapter._handle_voice_state_update(
+        unauthorized_member, _state(None), _state(right_channel)
+    )
+
+    adapter._voice_auto_join_callback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_authorized_user_joins_exactly_once_on_duplicate_events():
+    adapter = _adapter(_route_config())
+    channel = _channel()
+    member = _member(channel=channel)
+    channel.members[:] = [member]
+
+    await adapter._handle_voice_state_update(member, _state(None), _state(channel))
+    await adapter._handle_voice_state_update(member, _state(None), _state(channel))
+
+    adapter._voice_auto_join_callback.assert_awaited_once()
+    action, route, actual_channel, actual_member = (
+        adapter._voice_auto_join_callback.await_args.args
+    )
+    assert action == "join"
+    assert route.guild_id == 100
+    assert actual_channel is channel
+    assert actual_member is member
+
+
+@pytest.mark.asyncio
+async def test_concurrent_duplicate_join_events_start_one_session():
+    adapter = _adapter(_route_config())
+    channel = _channel()
+    member = _member(channel=channel)
+    channel.members[:] = [member]
+
+    async def delayed_join(*_args):
+        await asyncio.sleep(0)
+        return True
+
+    adapter._voice_auto_join_callback = AsyncMock(side_effect=delayed_join)
+    await asyncio.gather(
+        adapter._handle_voice_state_update(member, _state(None), _state(channel)),
+        adapter._handle_voice_state_update(member, _state(None), _state(channel)),
+    )
+
+    adapter._voice_auto_join_callback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_callback_error_is_contained_and_can_retry():
+    adapter = _adapter(_route_config())
+    channel = _channel()
+    member = _member(channel=channel)
+    channel.members[:] = [member]
+    adapter._voice_auto_join_callback = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await adapter._handle_voice_state_update(member, _state(None), _state(channel))
+
+    assert adapter._voice_auto_join_active == {}
+    adapter._voice_auto_join_callback = AsyncMock(return_value=True)
+    await adapter._handle_voice_state_update(member, _state(None), _state(channel))
+    adapter._voice_auto_join_callback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_auto_join_does_not_take_over_a_manual_voice_connection():
+    adapter = _adapter(_route_config())
+    voice_client = MagicMock()
+    voice_client.is_connected.return_value = True
+    adapter._voice_clients[100] = voice_client
+    channel = _channel()
+    member = _member(channel=channel)
+    channel.members[:] = [member]
+
+    await adapter._handle_voice_state_update(member, _state(None), _state(channel))
+
+    adapter._voice_auto_join_callback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_atomic_auto_join_guard_does_not_claim_manual_connection():
+    adapter = _adapter(_route_config())
+    existing = MagicMock()
+    existing.is_connected.return_value = True
+    existing.channel = SimpleNamespace(id=201)
+    existing.move_to = AsyncMock()
+    adapter._voice_clients[100] = existing
+
+    joined = await adapter.join_voice_channel(
+        _channel(channel_id=200), move_existing=False
+    )
+
+    assert joined is False
+    existing.move_to.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_manual_join_claim_wins_over_in_flight_auto_join():
+    adapter = _adapter(_route_config())
+    channel = _channel()
+    member = _member(channel=channel)
+    channel.members[:] = [member]
+    callback_started = asyncio.Event()
+    release_callback = asyncio.Event()
+
+    async def delayed_join(*_args):
+        callback_started.set()
+        await release_callback.wait()
+        return True
+
+    adapter._voice_auto_join_callback = AsyncMock(side_effect=delayed_join)
+    auto_join = asyncio.create_task(
+        adapter._handle_voice_state_update(member, _state(None), _state(channel))
+    )
+    await callback_started.wait()
+
+    adapter._begin_manual_voice_join(100)
+    release_callback.set()
+    await auto_join
+    adapter._end_manual_voice_join(100)
+
+    assert adapter._voice_auto_join_active == {}
+
+
+@pytest.mark.asyncio
+async def test_inactivity_timeout_keeps_present_auto_join_trigger_connected(monkeypatch):
+    adapter = _adapter(_route_config())
+    channel = _channel()
+    member = _member(channel=channel)
+    channel.members[:] = [member]
+    voice_client = MagicMock()
+    voice_client.channel = channel
+    adapter._voice_clients[100] = voice_client
+    adapter._voice_auto_join_active[100] = 200
+    adapter._voice_text_channels[100] = 300
+    monkeypatch.setattr(adapter, "VOICE_TIMEOUT", 0)
+    adapter.leave_voice_channel = AsyncMock()
+
+    await adapter._voice_timeout_handler(100)
+
+    adapter.leave_voice_channel.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_last_trigger_user_leaving_disconnects_after_grace_period():
+    adapter = _adapter(_route_config())
+    channel = _channel()
+    member = _member(channel=channel)
+    channel.members[:] = [member]
+
+    await adapter._handle_voice_state_update(member, _state(None), _state(channel))
+    channel.members.clear()
+    await adapter._handle_voice_state_update(member, _state(channel), _state(None))
+    await asyncio_sleep_until_tasks_run()
+
+    assert [call.args[0] for call in adapter._voice_auto_join_callback.await_args_list] == [
+        "join",
+        "leave",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_other_trigger_user_keeps_auto_join_session_connected():
+    config = _route_config(trigger_user_ids=["42", "43"])
+    adapter = _adapter(config)
+    channel = _channel()
+    leaving = _member(user_id=42, channel=channel)
+    staying = _member(user_id=43, channel=channel)
+    channel.members[:] = [leaving, staying]
+
+    await adapter._handle_voice_state_update(leaving, _state(None), _state(channel))
+    channel.members[:] = [staying]
+    await adapter._handle_voice_state_update(leaving, _state(channel), _state(None))
+    await asyncio_sleep_until_tasks_run()
+
+    assert [call.args[0] for call in adapter._voice_auto_join_callback.await_args_list] == [
+        "join"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_startup_reconciliation_joins_when_trigger_is_already_present():
+    adapter = _adapter(_route_config())
+    channel = _channel()
+    member = _member(channel=channel)
+    channel.members[:] = [member]
+    guild = SimpleNamespace(id=100, get_channel=lambda channel_id: channel if channel_id == 200 else None)
+    adapter._client.get_guild.return_value = guild
+
+    await adapter.reconcile_voice_auto_join()
+
+    adapter._voice_auto_join_callback.assert_awaited_once_with(
+        "join", adapter._voice_auto_join_routes[0], channel, member
+    )
+
+
+@pytest.mark.asyncio
+async def test_startup_reconciliation_can_be_disabled_per_config():
+    config = _route_config()
+    config["voice_auto_join"]["reconnect_on_startup"] = False
+    adapter = _adapter(config)
+
+    await adapter.reconcile_voice_auto_join()
+
+    adapter._voice_auto_join_callback.assert_not_awaited()
+
+
+def test_yaml_bridge_preserves_voice_auto_join_as_adapter_config():
+    voice_auto_join = _route_config()["voice_auto_join"]
+
+    seeded = _apply_yaml_config({}, {"voice_auto_join": voice_auto_join})
+
+    assert seeded is not None
+    assert seeded["voice_auto_join"] == voice_auto_join
+    assert seeded["voice_auto_join"] is not voice_auto_join
+
+
+async def asyncio_sleep_until_tasks_run():
+    """Allow zero-grace leave tasks to run without timing-sensitive sleeps."""
+    for _ in range(3):
+        await asyncio.sleep(0)

--- a/tests/gateway/test_discord_voice_auto_join.py
+++ b/tests/gateway/test_discord_voice_auto_join.py
@@ -149,6 +149,10 @@ async def test_authorized_user_joins_exactly_once_on_duplicate_events():
     channel.members[:] = [member]
 
     await adapter._handle_voice_state_update(member, _state(None), _state(channel))
+    voice_client = MagicMock()
+    voice_client.is_connected.return_value = True
+    voice_client.channel = channel
+    adapter._voice_clients[100] = voice_client
     await adapter._handle_voice_state_update(member, _state(None), _state(channel))
 
     adapter._voice_auto_join_callback.assert_awaited_once()
@@ -170,6 +174,10 @@ async def test_concurrent_duplicate_join_events_start_one_session():
 
     async def delayed_join(*_args):
         await asyncio.sleep(0)
+        voice_client = MagicMock()
+        voice_client.is_connected.return_value = True
+        voice_client.channel = channel
+        adapter._voice_clients[100] = voice_client
         return True
 
     adapter._voice_auto_join_callback = AsyncMock(side_effect=delayed_join)
@@ -182,7 +190,7 @@ async def test_concurrent_duplicate_join_events_start_one_session():
 
 
 @pytest.mark.asyncio
-async def test_callback_error_is_contained_and_can_retry():
+async def test_callback_error_is_contained_and_can_retry(caplog):
     adapter = _adapter(_route_config())
     channel = _channel()
     member = _member(channel=channel)
@@ -192,6 +200,9 @@ async def test_callback_error_is_contained_and_can_retry():
     await adapter._handle_voice_state_update(member, _state(None), _state(channel))
 
     assert adapter._voice_auto_join_active == {}
+    assert "100" not in caplog.text
+    assert "200" not in caplog.text
+    assert "42" not in caplog.text
     adapter._voice_auto_join_callback = AsyncMock(return_value=True)
     await adapter._handle_voice_state_update(member, _state(None), _state(channel))
     adapter._voice_auto_join_callback.assert_awaited_once()
@@ -258,6 +269,52 @@ async def test_manual_join_claim_wins_over_in_flight_auto_join():
 
 
 @pytest.mark.asyncio
+async def test_reentry_waits_for_committed_auto_leave_then_reconnects():
+    adapter = _adapter(_route_config())
+    channel = _channel()
+    member = _member(channel=channel)
+    channel.members[:] = [member]
+    leave_started = asyncio.Event()
+    finish_leave = asyncio.Event()
+    join_count = 0
+
+    async def lifecycle(action, _route, actual_channel, _member):
+        nonlocal join_count
+        if action == "join":
+            join_count += 1
+            voice_client = MagicMock()
+            voice_client.is_connected.return_value = True
+            voice_client.channel = actual_channel
+            adapter._voice_clients[100] = voice_client
+            return True
+        adapter._voice_clients.pop(100, None)
+        leave_started.set()
+        await finish_leave.wait()
+        return True
+
+    adapter._voice_auto_join_callback = AsyncMock(side_effect=lifecycle)
+    await adapter._handle_voice_state_update(member, _state(None), _state(channel))
+
+    channel.members.clear()
+    await adapter._handle_voice_state_update(member, _state(channel), _state(None))
+    await leave_started.wait()
+
+    channel.members[:] = [member]
+    reentry = asyncio.create_task(
+        adapter._handle_voice_state_update(member, _state(None), _state(channel))
+    )
+    await asyncio.sleep(0)
+    assert reentry.done() is False
+
+    finish_leave.set()
+    await reentry
+
+    assert join_count == 2
+    assert adapter._voice_auto_join_active == {100: 200}
+    assert adapter._voice_clients[100].is_connected()
+
+
+@pytest.mark.asyncio
 async def test_inactivity_timeout_keeps_present_auto_join_trigger_connected(monkeypatch):
     adapter = _adapter(_route_config())
     channel = _channel()
@@ -320,13 +377,38 @@ async def test_startup_reconciliation_joins_when_trigger_is_already_present():
     member = _member(channel=channel)
     channel.members[:] = [member]
     guild = SimpleNamespace(id=100, get_channel=lambda channel_id: channel if channel_id == 200 else None)
-    adapter._client.get_guild.return_value = guild
+    client = MagicMock()
+    adapter._client = client
+    client.get_guild.return_value = guild
 
     await adapter.reconcile_voice_auto_join()
 
     adapter._voice_auto_join_callback.assert_awaited_once_with(
         "join", adapter._voice_auto_join_routes[0], channel, member
     )
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_tries_later_trigger_when_first_is_rejected():
+    config = _route_config(trigger_user_ids=["42", "43"])
+    adapter = _adapter(config)
+    channel = _channel()
+    first = _member(user_id=42, channel=channel)
+    second = _member(user_id=43, channel=channel)
+    channel.members[:] = [first, second]
+    guild = SimpleNamespace(
+        id=100,
+        get_channel=lambda channel_id: channel if channel_id == 200 else None,
+    )
+    client = MagicMock()
+    adapter._client = client
+    client.get_guild.return_value = guild
+    adapter._voice_auto_join_callback = AsyncMock(side_effect=[False, True])
+
+    await adapter.reconcile_voice_auto_join()
+
+    assert adapter._voice_auto_join_callback.await_count == 2
+    assert adapter._voice_auto_join_active == {100: 200}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -262,6 +262,49 @@ class TestHandleVoiceCommand:
         assert runner._voice_mode["telegram:999"] == "voice_only"
         assert runner._voice_mode["slack:999"] == "off"
 
+    @pytest.mark.asyncio
+    async def test_profile_voice_commands_use_source_profile_adapter(self, runner):
+        from gateway.config import Platform
+
+        default_adapter = SimpleNamespace(
+            _auto_tts_disabled_chats=set(),
+            _auto_tts_enabled_chats=set(),
+            get_voice_channel_info=MagicMock(return_value=None),
+        )
+        profile_adapter = SimpleNamespace(
+            _auto_tts_disabled_chats=set(),
+            _auto_tts_enabled_chats=set(),
+            get_voice_channel_info=MagicMock(return_value=None),
+        )
+        runner.adapters = {Platform.DISCORD: default_adapter}
+        runner._profile_adapters = {
+            "voice": {Platform.DISCORD: profile_adapter},
+        }
+
+        event = _make_event("/voice on")
+        event.source.platform = Platform.DISCORD
+        event.source.profile = "voice"
+        event.raw_message = SimpleNamespace(guild_id=111, guild=None)
+
+        await runner._handle_voice_command(event)
+        assert profile_adapter._auto_tts_enabled_chats == {"123"}
+        assert default_adapter._auto_tts_enabled_chats == set()
+
+        event.text = "/voice off"
+        await runner._handle_voice_command(event)
+        assert profile_adapter._auto_tts_disabled_chats == {"123"}
+        assert default_adapter._auto_tts_disabled_chats == set()
+
+        event.text = "/voice tts"
+        await runner._handle_voice_command(event)
+        assert profile_adapter._auto_tts_enabled_chats == {"123"}
+        assert default_adapter._auto_tts_enabled_chats == set()
+
+        event.text = "/voice status"
+        await runner._handle_voice_command(event)
+        profile_adapter.get_voice_channel_info.assert_called_once_with(111)
+        default_adapter.get_voice_channel_info.assert_not_called()
+
 
 # =====================================================================
 # Auto voice reply decision logic
@@ -1271,6 +1314,45 @@ class TestVoiceChannelCommands:
 
         mock_adapter.handle_message.assert_called_once()
         mock_channel.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_input_duplicate_suppression_is_profile_scoped(self, runner):
+        from gateway.config import Platform
+
+        default_source = SessionSource(
+            chat_id="123",
+            user_id="42",
+            platform=Platform.DISCORD,
+        )
+        profile_source = SessionSource(
+            chat_id="123",
+            user_id="42",
+            platform=Platform.DISCORD,
+            profile="voice",
+        )
+
+        default_adapter = AsyncMock()
+        default_adapter._voice_text_channels = {111: 123}
+        default_adapter._voice_sources = {111: default_source.to_dict()}
+        default_adapter._client.get_channel.return_value = AsyncMock()
+        default_adapter.handle_message = AsyncMock()
+
+        profile_adapter = AsyncMock()
+        profile_adapter._profile_name = "voice"
+        profile_adapter._voice_text_channels = {111: 123}
+        profile_adapter._voice_sources = {111: profile_source.to_dict()}
+        profile_adapter._client.get_channel.return_value = AsyncMock()
+        profile_adapter.handle_message = AsyncMock()
+
+        await runner._handle_voice_channel_input(
+            111, 42, "Hello from VC", adapter=default_adapter
+        )
+        await runner._handle_voice_channel_input(
+            111, 42, "Hello from VC", adapter=profile_adapter
+        )
+
+        default_adapter.handle_message.assert_awaited_once()
+        profile_adapter.handle_message.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_input_suppresses_near_duplicate_transcript(self, runner):

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -890,6 +890,183 @@ class TestVoiceChannelCommands:
         assert "voice dependencies are missing" in result.lower()
         assert "PyNaCl" in result
 
+    @pytest.mark.asyncio
+    async def test_configure_auto_join_attaches_runner_callback_and_reconciles(self, runner):
+        from gateway.config import Platform
+
+        adapter = SimpleNamespace(
+            platform=Platform.DISCORD,
+            _voice_auto_join_routes=(SimpleNamespace(guild_id=111),),
+            _voice_auto_join_callback=None,
+            reconcile_voice_auto_join=AsyncMock(),
+        )
+
+        await runner._configure_voice_auto_join_adapter(adapter)
+
+        assert callable(adapter._voice_auto_join_callback)
+        adapter.reconcile_voice_auto_join.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_auto_join_uses_configured_text_channel_and_normal_voice_pipeline(self, runner):
+        from gateway.config import Platform
+
+        route = SimpleNamespace(
+            guild_id=111,
+            voice_channel_id=222,
+            text_channel_id=333,
+            trigger_user_ids=frozenset({42}),
+        )
+        voice_channel = SimpleNamespace(id=222, name="Voice")
+        member = SimpleNamespace(id=42, display_name="Maikel")
+        text_channel = SimpleNamespace(
+            id=333,
+            name="general",
+            guild=SimpleNamespace(id=111),
+        )
+        mock_adapter = MagicMock()
+        mock_adapter.platform = Platform.DISCORD
+        mock_adapter._profile_name = None
+        mock_adapter._client.get_channel.return_value = text_channel
+        mock_adapter.join_voice_channel = AsyncMock(return_value=True)
+        mock_adapter._voice_text_channels = {}
+        mock_adapter._voice_sources = {}
+        mock_adapter._voice_input_callback = None
+        mock_adapter._on_voice_disconnect = None
+        mock_adapter._voice_mode_getter = None
+
+        success = await runner._handle_voice_auto_join(
+            mock_adapter, "join", route, voice_channel, member
+        )
+
+        assert success is True
+        mock_adapter.join_voice_channel.assert_awaited_once_with(
+            voice_channel, move_existing=False
+        )
+        assert mock_adapter._voice_text_channels[111] == 333
+        assert mock_adapter._voice_sources[111]["chat_id"] == "333"
+        assert mock_adapter._voice_sources[111]["scope_id"] == "111"
+        assert runner._voice_mode["discord:333"] == "all"
+
+    @pytest.mark.asyncio
+    async def test_auto_join_rejects_trigger_not_authorized_by_gateway(self, runner):
+        route = SimpleNamespace(
+            guild_id=111,
+            voice_channel_id=222,
+            text_channel_id=333,
+            trigger_user_ids=frozenset({42}),
+        )
+        mock_adapter = MagicMock()
+        mock_adapter._client.get_channel.return_value = SimpleNamespace(
+            id=333,
+            name="general",
+            guild=SimpleNamespace(id=111),
+        )
+        mock_adapter.join_voice_channel = AsyncMock(return_value=True)
+        runner._is_user_authorized = lambda source: False
+
+        success = await runner._handle_voice_auto_join(
+            mock_adapter,
+            "join",
+            route,
+            SimpleNamespace(id=222, name="Voice"),
+            SimpleNamespace(id=42, display_name="user-42"),
+        )
+
+        assert success is False
+        mock_adapter.join_voice_channel.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_join_rejects_text_channel_from_another_guild(self, runner):
+        route = SimpleNamespace(
+            guild_id=111,
+            voice_channel_id=222,
+            text_channel_id=333,
+            trigger_user_ids=frozenset({42}),
+        )
+        mock_adapter = MagicMock()
+        mock_adapter._client.get_channel.return_value = SimpleNamespace(
+            id=333,
+            name="other-server",
+            guild=SimpleNamespace(id=999),
+        )
+        mock_adapter.join_voice_channel = AsyncMock(return_value=True)
+
+        success = await runner._handle_voice_auto_join(
+            mock_adapter,
+            "join",
+            route,
+            SimpleNamespace(id=222, name="Voice"),
+            SimpleNamespace(id=42, display_name="user-42"),
+        )
+
+        assert success is False
+        mock_adapter.join_voice_channel.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_join_rolls_back_when_session_binding_fails(self, runner):
+        route = SimpleNamespace(
+            guild_id=111,
+            voice_channel_id=222,
+            text_channel_id=333,
+            trigger_user_ids=frozenset({42}),
+        )
+        voice_channel = SimpleNamespace(id=222, name="Voice")
+        mock_adapter = MagicMock()
+        mock_adapter._client.get_channel.return_value = SimpleNamespace(
+            id=333,
+            name="general",
+            guild=SimpleNamespace(id=111),
+        )
+        mock_adapter.join_voice_channel = AsyncMock(return_value=True)
+        mock_adapter.leave_voice_channel = AsyncMock()
+        mock_adapter._voice_text_channels = {}
+        mock_adapter._voice_sources = {}
+        mock_adapter._voice_input_callback = None
+        mock_adapter._on_voice_disconnect = None
+        mock_adapter._voice_mode_getter = None
+        runner._save_voice_modes = MagicMock(side_effect=OSError("disk full"))
+
+        success = await runner._handle_voice_auto_join(
+            mock_adapter,
+            "join",
+            route,
+            voice_channel,
+            SimpleNamespace(id=42, display_name="user-42"),
+        )
+
+        assert success is False
+        mock_adapter.join_voice_channel.assert_awaited_once_with(
+            voice_channel, move_existing=False
+        )
+        mock_adapter.leave_voice_channel.assert_awaited_once_with(111)
+        assert "discord:333" not in runner._voice_mode
+        assert mock_adapter._voice_text_channels == {}
+        assert mock_adapter._voice_sources == {}
+
+    @pytest.mark.asyncio
+    async def test_auto_leave_cleans_up_runner_voice_mode(self, runner):
+        from gateway.config import Platform
+
+        route = SimpleNamespace(
+            guild_id=111,
+            voice_channel_id=222,
+            text_channel_id=333,
+            trigger_user_ids=frozenset({42}),
+        )
+        mock_adapter = MagicMock()
+        mock_adapter.leave_voice_channel = AsyncMock()
+        mock_adapter._voice_input_callback = AsyncMock()
+        runner._voice_mode["discord:333"] = "all"
+
+        success = await runner._handle_voice_auto_join(
+            mock_adapter, "leave", route, SimpleNamespace(id=222), None
+        )
+
+        assert success is True
+        mock_adapter.leave_voice_channel.assert_awaited_once_with(111)
+        assert runner._voice_mode["discord:333"] == "off"
+        assert mock_adapter._voice_input_callback is None
+
     # -- _handle_voice_channel_leave --
 
     @pytest.mark.asyncio
@@ -1405,24 +1582,16 @@ class TestCallbackWiringOrder:
     """Verify callback is wired BEFORE join, not after."""
 
     def test_callback_set_before_join(self):
-        """_handle_voice_channel_join wires callback before calling join."""
+        """Shared manual/auto join path wires callback before connecting."""
         import inspect
         from gateway.run import GatewayRunner
-        source = inspect.getsource(GatewayRunner._handle_voice_channel_join)
-        lines = source.split("\n")
-        callback_line = None
-        join_line = None
-        for i, line in enumerate(lines):
-            if "_voice_input_callback" in line and "=" in line and "None" not in line:
-                if callback_line is None:
-                    callback_line = i
-            if "join_voice_channel" in line and "await" in line:
-                join_line = i
-        assert callback_line is not None, "callback wiring not found"
-        assert join_line is not None, "join_voice_channel call not found"
-        assert callback_line < join_line, (
-            f"callback must be wired (line {callback_line}) BEFORE "
-            f"join_voice_channel (line {join_line})"
+
+        wiring = inspect.getsource(GatewayRunner._wire_discord_voice_callbacks)
+        source = inspect.getsource(GatewayRunner._join_discord_voice_channel)
+
+        assert "_voice_input_callback =" in wiring
+        assert source.index("self._wire_discord_voice_callbacks") < source.index(
+            "await adapter.join_voice_channel"
         )
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -907,6 +907,67 @@ class TestVoiceChannelCommands:
         adapter.reconcile_voice_auto_join.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_secondary_auto_join_uses_own_profile_authorization(
+        self, runner, tmp_path, monkeypatch
+    ):
+        from gateway.config import Platform
+        from hermes_cli import profiles
+
+        profile_home = tmp_path / "profiles" / "voice"
+        profile_home.mkdir(parents=True)
+        (profile_home / ".env").write_text("DISCORD_ALLOWED_USERS=42\n")
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", "99")
+        monkeypatch.setattr(profiles, "get_profile_dir", lambda _name: profile_home)
+
+        route = SimpleNamespace(
+            guild_id=111,
+            voice_channel_id=222,
+            text_channel_id=333,
+            trigger_user_ids=frozenset({42, 99}),
+        )
+        text_channel = SimpleNamespace(
+            id=333,
+            name="general",
+            guild=SimpleNamespace(id=111),
+        )
+        adapter = MagicMock()
+        adapter.platform = Platform.DISCORD
+        adapter._voice_auto_join_routes = (route,)
+        adapter._voice_auto_join_callback = None
+        adapter.reconcile_voice_auto_join = AsyncMock()
+        adapter._client.get_channel.return_value = text_channel
+        runner._configure_profile_adapter(adapter, "voice", Platform.DISCORD)
+        from gateway.authz_mixin import GatewayAuthorizationMixin
+
+        runner._is_user_authorized = GatewayAuthorizationMixin._is_user_authorized.__get__(
+            runner, type(runner)
+        )
+        runner.pairing_store = None
+        runner.pairing_stores = {}
+        runner._multiplex_adapters = {"voice": {Platform.DISCORD: adapter}}
+        runner._join_discord_voice_channel = AsyncMock(return_value=True)
+
+        await runner._configure_voice_auto_join_adapter(adapter)
+
+        profile_member = SimpleNamespace(id=42, display_name="profile-user")
+        default_member = SimpleNamespace(id=99, display_name="default-user")
+        voice_channel = SimpleNamespace(id=222, name="Voice")
+        profile_allowed = await adapter._voice_auto_join_callback(
+            "join", route, voice_channel, profile_member
+        )
+        default_rejected = await adapter._voice_auto_join_callback(
+            "join", route, voice_channel, default_member
+        )
+
+        assert adapter._profile_name == "voice"
+        assert profile_allowed is True
+        assert default_rejected is False
+        runner._join_discord_voice_channel.assert_awaited_once()
+        source = runner._join_discord_voice_channel.await_args_list[0].args[2]
+        assert source.profile == "voice"
+        assert source.user_id == "42"
+
+    @pytest.mark.asyncio
     async def test_auto_join_uses_configured_text_channel_and_normal_voice_pipeline(self, runner):
         from gateway.config import Platform
 
@@ -1581,18 +1642,39 @@ class TestVoiceReceiverThreadSafety:
 class TestCallbackWiringOrder:
     """Verify callback is wired BEFORE join, not after."""
 
-    def test_callback_set_before_join(self):
+    @pytest.mark.asyncio
+    async def test_callback_set_before_join(self, tmp_path):
         """Shared manual/auto join path wires callback before connecting."""
-        import inspect
-        from gateway.run import GatewayRunner
+        from gateway.config import Platform
 
-        wiring = inspect.getsource(GatewayRunner._wire_discord_voice_callbacks)
-        source = inspect.getsource(GatewayRunner._join_discord_voice_channel)
-
-        assert "_voice_input_callback =" in wiring
-        assert source.index("self._wire_discord_voice_callbacks") < source.index(
-            "await adapter.join_voice_channel"
+        runner = _make_runner(tmp_path)
+        adapter = MagicMock()
+        adapter._voice_input_callback = None
+        adapter._on_voice_disconnect = None
+        adapter._voice_mode_getter = None
+        adapter._voice_text_channels = {}
+        adapter._voice_sources = {}
+        channel = SimpleNamespace(name="Voice")
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="333",
+            user_id="42",
         )
+
+        async def assert_wired_before_join(actual_channel):
+            assert actual_channel is channel
+            assert callable(adapter._voice_input_callback)
+            assert callable(adapter._on_voice_disconnect)
+            assert callable(adapter._voice_mode_getter)
+            return True
+
+        adapter.join_voice_channel = AsyncMock(side_effect=assert_wired_before_join)
+
+        joined = await runner._join_discord_voice_channel(
+            adapter, channel, source, 111
+        )
+
+        assert joined is True
 
     @pytest.mark.asyncio
     async def test_join_failure_clears_callback(self, tmp_path):
@@ -2132,6 +2214,18 @@ class TestVoiceTimeoutCleansRunnerState:
 
         assert runner._voice_mode["discord:999"] == "off", \
             "voice_mode must persist explicit off state after timeout cleanup"
+
+    def test_runner_cleanup_is_profile_scoped(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        runner._voice_mode["discord:999"] = "all"
+        runner._voice_mode["profile:voice:discord:999"] = "all"
+
+        profile_adapter = MagicMock()
+        profile_adapter._profile_name = "voice"
+        runner._handle_voice_timeout_cleanup("999", adapter=profile_adapter)
+
+        assert runner._voice_mode["discord:999"] == "all"
+        assert runner._voice_mode["profile:voice:discord:999"] == "off"
 
     @pytest.mark.asyncio
     async def test_timeout_without_callback_does_not_crash(self, adapter):

--- a/tests/gateway/test_voice_mode_platform_isolation.py
+++ b/tests/gateway/test_voice_mode_platform_isolation.py
@@ -38,6 +38,16 @@ class TestVoiceKeyHelper:
         assert key_slack == "slack:123"
         assert key_discord == "discord:123"
 
+    def test_voice_key_isolates_same_discord_chat_across_profiles(self):
+        runner = _make_runner()
+
+        default_key = runner._voice_key(Platform.DISCORD, "123")
+        profile_key = runner._voice_key(Platform.DISCORD, "123", "voice")
+
+        assert default_key == "discord:123"
+        assert profile_key == "profile:voice:discord:123"
+        assert default_key != profile_key
+
 
 class TestVoiceModePlatformIsolation:
     """Test that voice mode state is isolated by platform."""
@@ -178,6 +188,21 @@ class TestSyncVoiceModeStateToAdapter:
 
         # Old entries should be cleared
         assert mock_adapter._auto_tts_disabled_chats == {"123"}
+
+    def test_sync_secondary_profile_does_not_read_default_voice_state(self):
+        runner = _make_runner()
+        runner._voice_mode = {
+            "discord:123": "off",
+            "profile:voice:discord:456": "off",
+        }
+        mock_adapter = MagicMock()
+        mock_adapter.platform = Platform.DISCORD
+        mock_adapter._profile_name = "voice"
+        mock_adapter._auto_tts_disabled_chats = set()
+
+        runner._sync_voice_mode_state_to_adapter(mock_adapter)
+
+        assert mock_adapter._auto_tts_disabled_chats == {"456"}
 
     def test_sync_returns_early_without_platform(self):
         """_sync_voice_mode_state_to_adapter returns early if adapter has no platform."""

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -373,6 +373,29 @@ In a Discord text channel where the bot is present:
 /voice status
 ```
 
+### Optional auto-join
+
+Auto-join is opt-in and disabled by default. It lets an authorized user enter one configured VC and have Hermes join without running `/voice join`:
+
+```yaml
+discord:
+  voice_auto_join:
+    enabled: true
+    reconnect_on_startup: true
+    routes:
+      - guild_id: "123456789012345678"
+        voice_channel_id: "123456789012345679"
+        text_channel_id: "123456789012345680"
+        trigger_user_ids:
+          - "123456789012345681"
+        leave_when_no_trigger_users: true
+        leave_grace_seconds: 10
+```
+
+The IDs in `trigger_user_ids` must also pass your normal Discord user access policy through `DISCORD_ALLOWED_USERS` or `DISCORD_ALLOW_ALL_USERS`. Role-only admission does not authorize a voice-state trigger. Hermes only reacts in the configured voice channel, uses the configured text channel for transcripts and responses, and leaves after the final trigger user departs when `leave_when_no_trigger_users` is enabled. A manual `/voice join` session is never moved or taken over by auto-join.
+
+Use one route per guild. Invalid or incomplete routes are ignored rather than falling back to a broader channel or user match.
+
 ### What happens when joined
 
 - users speak in the VC

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -402,7 +402,8 @@ Use one route per guild. Invalid or incomplete routes are ignored rather than fa
 - Hermes detects speech boundaries
 - transcripts are posted in the associated text channel
 - Hermes responds in text and audio
-- the text channel is the one where `/voice join` was issued
+- manual sessions use the text channel where `/voice join` was issued
+- auto-joined sessions use the route's configured `text_channel_id`
 
 ### Best practices for Discord VC use
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -395,7 +395,8 @@ When the bot is in a voice channel:
 
 - Transcripts appear in the text channel: `[Voice] @user: what you said`
 - Agent responses are sent as text in the channel AND spoken in the VC
-- The text channel is the one where `/voice join` was issued
+- Manual sessions use the text channel where `/voice join` was issued
+- Auto-joined sessions use the route's configured `text_channel_id`
 
 ### Echo Prevention
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -357,6 +357,28 @@ Use these in the Discord text channel where the bot is present:
 You must be in a voice channel before running `/voice join`. The bot joins the same VC you're in.
 :::
 
+### Optional Auto-Join
+
+You can opt into a narrowly scoped hands-free lifecycle. Auto-join is off by default and does not replace the manual commands:
+
+```yaml
+discord:
+  voice_auto_join:
+    enabled: true
+    reconnect_on_startup: true
+    routes:
+      - guild_id: "123456789012345678"
+        voice_channel_id: "123456789012345679"
+        text_channel_id: "123456789012345680"
+        trigger_user_ids: ["123456789012345681"]
+        leave_when_no_trigger_users: true
+        leave_grace_seconds: 10
+```
+
+Each route is fail-closed and binds one guild to one VC and one text channel. Only listed trigger users who also pass `DISCORD_ALLOWED_USERS` or `DISCORD_ALLOW_ALL_USERS` can start the connection; role-only admission does not authorize voice-state triggers. If `reconnect_on_startup` is enabled and a trigger user is already present after a gateway reconnect, Hermes rejoins. When `leave_when_no_trigger_users` is enabled and the last trigger user leaves, Hermes waits for `leave_grace_seconds` and disconnects. Manual voice connections are not moved or claimed by auto-join.
+
+Only one route per guild is supported because a Discord bot can have one voice connection per guild.
+
 ### How It Works
 
 When the bot joins a voice channel, it:


### PR DESCRIPTION
## What does this PR do?

Adds a disabled-by-default, fixed-route Discord voice auto-join lifecycle on top of the existing classic voice pipeline.

An operator can bind one guild, one voice channel, one text channel, and an explicit list of trigger user IDs. When a directly authorized trigger enters that exact VC, Hermes joins and uses the configured text channel for transcript/session routing. It can reconcile after startup/reconnect and leave after the last trigger departs.

This is deliberately separate from realtime/Codex Live provider work. It reuses the existing Discord receiver, mixer, STT, agent, TTS, voice-mode persistence, and manual `/voice` commands.

There are overlapping implementations in #59885, #62499, and #67225. This PR is the narrower fixed-route alternative: no VAD/provider work, no follow-anywhere mode, explicit fail-closed routing, and bounded lifecycle coverage. Credit to @marcelomediagroup for the original follow-mode work in #53747 and its hardening successor #67225.

## Related Issue

Alternative to #67225. Related overlap: #53747, #59885, #62499.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add `discord.voice_auto_join` route configuration, disabled by default
- detect configured trigger joins/moves in the Discord adapter and reconcile after reconnect
- route auto-join through the same runner-owned session, authorization, mode, and TTS path as manual `/voice join`
- preserve manual-session ownership across duplicate/concurrent join and delayed-leave races
- isolate voice authorization, commands, persistence, and transcript deduplication across named Discord profiles
- validate explicit guild/voice/text/user bindings and fail closed on malformed or cross-guild routes
- add grace-period teardown, inactivity behavior, cleanup, rollback, and profile/multi-guild lifecycle coverage
- document the configuration and its authorization/ownership semantics

## How to Test

1. Run the focused canonical gate:
   ```bash
   scripts/run_tests.sh -j 2 \
     tests/gateway/test_discord_voice_auto_join.py \
     tests/gateway/test_voice_command.py \
     tests/gateway/test_voice_mode_platform_isolation.py \
     tests/gateway/test_config_env_bridge_authority.py \
     tests/gateway/test_config_driven_access_policy.py \
     tests/gateway/test_discord_prompt_timeout_config.py \
     tests/gateway/test_discord_voice_mixer.py \
     tests/gateway/test_discord_race_polish.py \
     tests/gateway/test_platform_reconnect.py \
     tests/gateway/test_multiplex_lifecycle.py \
     tests/gateway/test_profile_resolution.py -q
   ```
   Result: **420 passed**.
2. Run `scripts/run_tests.sh -j 6 tests/gateway -q`.
   Result: **11,160 passed**.
3. Run `ruff check .`.
   Result: passed.
4. Run the docs production build with `cd website && npm run build`.
   Result: passed for English and zh-Hans; only pre-existing site-wide broken-link/anchor warnings remain.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and documented the overlap above
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A; this is gateway/Discord config and the canonical generated defaults plus voice docs are updated
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A; no contributor workflow or core architecture changed
- [x] I've considered cross-platform impact; the feature uses existing discord.py gateway/voice lifecycle and adds no OS-specific path
- [x] Tool descriptions/schemas are N/A

## Screenshots / Logs

No UI change. Validation summary is included above.
