### PR TITLE
fix(scripts): accept legacy consecutive-hyphen GitHub logins in add_contributor

### DIFF
--- a/scripts/add_contributor.py
+++ b/scripts/add_contributor.py
@@ -25,7 +25,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 EMAILS_DIR = REPO_ROOT / "contributors" / "emails"
 
 _EMAIL_RE = re.compile(r"^[^/\\\s]+@[^/\\\s]+$")
-_LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$")
+# GitHub's *current* signup rules forbid consecutive hyphens, but legacy
+# accounts with them exist and are valid (e.g. Roger--Han, verified via the
+# users API July 2026). Accept any alphanumeric/hyphen login that doesn't
+# start or end with a hyphen, max 39 chars.
+_LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
 
 
 def read_mapping_file(path: Path) -> str | None:

--- a/tests/scripts/test_contributor_map.py
+++ b/tests/scripts/test_contributor_map.py
@@ -114,6 +114,15 @@ def test_add_rejects_invalid_email_and_login(emails_dir):
     )
 
 
+def test_add_accepts_legacy_consecutive_hyphen_login(emails_dir):
+    # Legacy GitHub accounts with consecutive hyphens are real (Roger--Han);
+    # current signup rules forbid them but existing logins remain valid.
+    assert add_contributor("roger.hanhong@gmail.com", "Roger--Han") == 0
+    assert (emails_dir / "roger.hanhong@gmail.com").read_text(
+        encoding="utf-8"
+    ).strip().endswith("Roger--Han")
+
+
 def test_add_strips_at_prefix(emails_dir):
     assert add_contributor("z@z.com", "@zeta") == 0
     assert read_mapping_file(emails_dir / "z@z.com") == "zeta"


### PR DESCRIPTION
## Summary
`scripts/add_contributor.py` now accepts legacy GitHub logins containing consecutive hyphens — the old regex rejected the real account `Roger--Han` during the July 24 sweep, forcing a hand-written mapping file.

## Changes
- scripts/add_contributor.py: `_LOGIN_RE` accepts any alphanumeric/hyphen login without leading/trailing hyphen (39-char cap kept). GitHub's *signup* rules forbid `--` but legacy accounts keep them (verified live via the users API).
- tests/scripts/test_contributor_map.py: regression test for the legacy login; all existing rejects (leading/trailing hyphen, spaces, over-length) still pinned.

## Validation
| | Before | After |
|---|---|---|
| `add_contributor roger.hanhong@gmail.com Roger--Han` | exit 2 (rejected) | mapping file written |
| tests/scripts/test_contributor_map.py | — | 13 passed, 0 failed |

## Infographic

![add-contributor-hyphen](https://v3b.fal.media/files/b/0aa3a00f/cgwBA0xXZV13Y8dfzwoRQ_F0fG19P6.png)
