### PR TITLE
fix(tests): assert the current failed-build turn contract in the TUI gateway

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8311,9 +8311,23 @@ def test_agent_build_failure_surfaces_error_and_drops_turn(monkeypatch):
 
         assert calls["run_prompt"] == 0
         assert session["running"] is False
-        error_events = [e for e in emitted if e and e[0] == "error" and e[1] == "sid"]
-        assert len(error_events) == 1, f"expected one error event, got: {emitted}"
-        assert "No LLM provider configured" in error_events[0][2].get("message", "")
+        # A failed build closes the turn with a TERMINAL message.complete frame
+        # (status="error"), not a bare "error" event: the frame shape matches the
+        # returned-error path in _run_prompt_submit, and _fail_inflight_turn
+        # retains the failure so a client that was disconnected during this
+        # window can still recover it from session.resume's inflight payload.
+        complete_events = [
+            e
+            for e in emitted
+            if e and e[0] == "message.complete" and e[1] == "sid"
+        ]
+        assert len(complete_events) == 1, (
+            f"expected one terminal message.complete, got: {emitted}"
+        )
+        payload = complete_events[0][2]
+        assert payload.get("status") == "error"
+        assert "No LLM provider configured" in payload.get("error", "")
+        assert "No LLM provider configured" in payload.get("text", "")
     finally:
         server._sessions.pop("sid", None)
 


### PR DESCRIPTION
## Summary

Unblocks CI: `tests/test_tui_gateway_server.py::test_agent_build_failure_surfaces_error_and_drops_turn` has been failing **deterministically on `main`** since 60c8fc6290 ("deliver the first message when the deferred agent build outlives 30s", #63078).

This is a stale assertion, not a flake, and not a code bug — the shipped behavior is correct and the test was left behind.

## Root cause

60c8fc6290 deliberately changed the failed-build path from emitting a bare `"error"` event to `_emit_terminal_turn_error()`, which:

- closes the turn with a terminal `message.complete` frame (`status: "error"`) — the same frame shape the returned-error path in `_run_prompt_submit` already produces, so TUI/desktop handling is uniform; and
- retains the failure via `_fail_inflight_turn()` so a client that was disconnected during that window can still recover it from `session.resume`'s `inflight` payload.

The test still asserted exactly one bare `"error"` event for the session, so it failed against the intended behavior.

## Changes

- `tests/test_tui_gateway_server.py` — assert the shipped contract: one terminal `message.complete` for the session, `status == "error"`, and the build error surfaced in **both** the `error` and `text` fields (the frame the TUI/desktop actually renders).

No production code changed.

## Validation

Bisected to confirm it is deterministic rather than timing-sensitive:

| Commit | Result |
|---|---|
| `60c8fc6290~1` (parent) | 456 passed, **0 failed** |
| `60c8fc6290` | **1 failed** |
| `origin/main` + this fix | **463 passed, 0 failed** |

Verified on a clean detached worktree at `origin/main` with no other changes in the tree, so the failure and the fix are both attributable to this file alone.

Split out of #71200 (session-store size reporting), which this failure was blocking — per policy an unrelated CI fix ships as its own PR.

## Infographic

![A red test that was never a flake — the assertion aged out, the behavior was correct](https://v3b.fal.media/files/b/0aa3a07f/snIj4c0d2WC_t9_5XpJ7G_ZYwOkYiI.png)
