### PR TITLE
fix(desktop): fall back when gated backends 401 /api/health

### DIFF
--- a/apps/desktop/electron/backend-health.test.ts
+++ b/apps/desktop/electron/backend-health.test.ts
@@ -52,6 +52,34 @@ test('falls back to /api/status only for old backends without /api/health', asyn
   ])
 })
 
+test('falls back to /api/status when gated 0.19 backends 401 /api/health', async () => {
+  const calls: string[][] = []
+
+  await waitForHermesReady('http://192.168.1.132:9119', {
+    token: null,
+    fetchPublicJson: async url => {
+      calls.push(['public', url])
+
+      throw new Error(
+        '401: {"error":"unauthenticated","detail":"Unauthorized","reason":"no_cookie","login_url":"/login"}'
+      )
+    },
+    fetchJson: async (url, token) => {
+      calls.push(['token', url, token == null ? 'null' : token])
+
+      return { version: '0.19.0', auth_required: true }
+    },
+    sleep: async () => {},
+    timeoutMs: 100,
+    pollMs: 1
+  })
+
+  assert.deepEqual(calls, [
+    ['public', 'http://192.168.1.132:9119/api/health'],
+    ['token', 'http://192.168.1.132:9119/api/status', 'null']
+  ])
+})
+
 test('does not fall back to heavyweight /api/status for transient health failures', async () => {
   const calls: string[][] = []
   let currentTime = 0
@@ -75,6 +103,35 @@ test('does not fall back to heavyweight /api/status for transient health failure
       pollMs: 1
     }),
     /Timed out connecting/
+  )
+
+  assert.ok(calls.length > 0)
+  assert.ok(calls.every(call => call[0] === 'public' && call[1].endsWith('/api/health')))
+})
+
+test('does not fall back on generic 401 without the gated no_cookie shape', async () => {
+  const calls: string[][] = []
+  let currentTime = 0
+
+  await assert.rejects(
+    waitForHermesReady('http://127.0.0.1:9000', {
+      fetchPublicJson: async url => {
+        calls.push(['public', url])
+        throw new Error('401: {"detail":"Unauthorized"}')
+      },
+      fetchJson: async url => {
+        calls.push(['token', url])
+      },
+      sleep: async () => {},
+      now: () => {
+        currentTime += 20
+
+        return currentTime
+      },
+      timeoutMs: 50,
+      pollMs: 1
+    }),
+    /401: \{"detail":"Unauthorized"\}/
   )
 
   assert.ok(calls.length > 0)
@@ -123,7 +180,7 @@ test('aborts as superseded when the bootstrap signal fires', async () => {
   )
 })
 
-test('recognizes missing-route shapes only', () => {
+test('recognizes missing-route and gated-health shapes', () => {
   assert.equal(isMissingHealthEndpointError(new Error('404: {"detail":"Not Found"}')), true)
   assert.equal(
     isMissingHealthEndpointError(
@@ -131,6 +188,13 @@ test('recognizes missing-route shapes only', () => {
     ),
     true
   )
+  assert.equal(
+    isMissingHealthEndpointError(
+      new Error('401: {"error":"unauthenticated","detail":"Unauthorized","reason":"no_cookie","login_url":"/login"}')
+    ),
+    true
+  )
+  assert.equal(isMissingHealthEndpointError(new Error('401: {"detail":"Unauthorized"}')), false)
   assert.equal(isMissingHealthEndpointError(new Error('Timed out connecting to Hermes backend after 15000ms')), false)
   assert.equal(isMissingHealthEndpointError(new Error('500: boom')), false)
 })

--- a/apps/desktop/electron/backend-health.ts
+++ b/apps/desktop/electron/backend-health.ts
@@ -25,7 +25,19 @@ export interface HermesReadyOptions {
 export function isMissingHealthEndpointError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error ?? '')
 
-  return /^404:/.test(message) || message.includes('endpoint is likely missing')
+  // 404 / HTML: route genuinely absent (SPA returns JSON 404 for unknown /api/*).
+  // Gated 401 no_cookie: pre-/api/health backends (e.g. release 0.19.0) run the
+  // auth gate before the SPA catch-all, so an unknown /api/health is rejected as
+  // unauthenticated instead of 404. Only that gate shape falls back — a generic
+  // 401 must not skip a real (misconfigured) health endpoint.
+  const gatedMissingHealth =
+    /^401:/.test(message) && (message.includes('"reason":"no_cookie"') || message.includes('no_cookie'))
+
+  return (
+    /^404:/.test(message) ||
+    gatedMissingHealth ||
+    message.includes('endpoint is likely missing')
+  )
 }
 
 function supersededError() {
@@ -78,8 +90,9 @@ export async function waitForHermesReady(baseUrl: string, options: HermesReadyOp
     } catch (error) {
       lastError = error
 
-      // Only an explicitly missing route means the backend predates
-      // /api/health; timeouts and server errors keep polling health.
+      // Missing or gate-rejected /api/health means the backend predates the
+      // public health probe (404, or gated 401 no_cookie on older builds).
+      // Timeouts, 5xx, and other 401s keep polling health.
       if (!useStatusFallback && isMissingHealthEndpointError(error)) {
         useStatusFallback = true
 


### PR DESCRIPTION
## Summary
- Newer Desktop readiness probes `/api/health` first. On release `0.19.0` remote dashboards, that path is unknown and the auth gate returns `401 no_cookie` *before* a 404, so boot never falls back to public `/api/status`.
- That matches the stuck "connecting" loop: **Test remote** (hits `/api/status`) passes, **Save & connect** fails with `Hermes backend did not become ready: 401 … reason: no_cookie`.
- Treat `401` on the health probe like a missing health route and fall back to `/api/status`.

## Test plan
- [x] `cd apps/desktop && npx vitest run --project electron electron/backend-health.test.ts`
- [ ] Point Desktop (build with this change) at a LAN `0.19.0` docker/dashboard with basic auth; confirm Save & connect gets past readiness instead of looping on `no_cookie`
- [ ] Confirm a current-main backend still uses `/api/health` successfully (no unnecessary status fallback)