### PR TITLE
feat: BackSearch plugin — point-in-time web search/fetch (General Reasoning)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4193,6 +4193,14 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "OPENREWARD_API_KEY": {
+        "description": "OpenReward API key for BackSearch point-in-time web search/fetch (backsearch, backfetch)",
+        "prompt": "OpenReward API key (or_...)",
+        "url": "https://openreward.ai/",
+        "tools": ["backsearch", "backfetch"],
+        "password": True,
+        "category": "tool",
+    },
     "SEARXNG_URL": {
         "description": "URL of your SearXNG instance for free self-hosted web search",
         "prompt": "SearXNG URL (e.g. http://localhost:8080)",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -114,6 +114,7 @@ CONFIGURABLE_TOOLSETS = [
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
     ("spotify",          "🎵 Spotify",                  "playback, search, playlists, library"),
+    ("backsearch",       "🕰️  BackSearch (point-in-time web)", "backsearch/backfetch — the web as it was on a date (requires OPENREWARD_API_KEY)"),
     ("discord",         "💬 Discord (read/participate)", "fetch messages, search members, create thread"),
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
     ("yuanbao",          "🤖 Yuanbao",                  "group info, member queries, DM"),
@@ -150,7 +151,10 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+#
+# BackSearch follows the same pattern: off by default, auto-enables when
+# OPENREWARD_API_KEY is set (see the inject block in _get_platform_tools).
+_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "backsearch", "discord", "discord_admin", "video", "video_gen", "x_search"}
 
 
 def _xai_credentials_present() -> bool:
@@ -179,6 +183,23 @@ def _xai_credentials_present() -> bool:
     except Exception:
         pass
     return bool(str(os.environ.get("XAI_API_KEY") or "").strip())
+
+
+def _backsearch_credentials_present() -> bool:
+    """Cheap, side-effect-free check for a usable OpenReward API key.
+
+    Used to auto-enable the ``backsearch`` toolset when the user has set
+    ``OPENREWARD_API_KEY`` — mirroring the xAI → ``x_search`` auto-enable
+    above. Does NOT hit the network. The tools' runtime ``check_fn`` still
+    gates schema registration if the key later disappears.
+    """
+    try:
+        from plugins.backsearch.tools import check_backsearch_available
+
+        return check_backsearch_available()
+    except Exception:
+        pass
+    return bool(str(os.environ.get("OPENREWARD_API_KEY") or "").strip())
 
 # Platform-scoped toolsets: only appear in the `hermes tools` checklist for
 # these platforms, and only resolve/save for these platforms.  A toolset
@@ -578,6 +599,20 @@ TOOL_CATEGORIES = {
                 "tag": "PKCE OAuth — opens the setup wizard",
                 "env_vars": [],
                 "post_setup": "spotify",
+            },
+        ],
+    },
+    "backsearch": {
+        "name": "BackSearch (point-in-time web)",
+        "icon": "🕰️",
+        "providers": [
+            {
+                "name": "BackSearch (General Reasoning)",
+                "badge": "paid",
+                "tag": "Search & fetch the web as it was on a date — uses your OpenReward key",
+                "env_vars": [
+                    {"key": "OPENREWARD_API_KEY", "prompt": "OpenReward API key (or_...)", "url": "https://openreward.ai/"},
+                ],
             },
         ],
     },
@@ -1849,6 +1884,18 @@ def _get_platform_tools(
         if x_search_auto_enabled:
             enabled_toolsets.add("x_search")
 
+        # Same deal for ``backsearch`` (point-in-time web search): its two
+        # tools are plugin-registered and absent from platform composites,
+        # so the subset loop can't pick it up. Auto-enable when the user
+        # has an OpenReward key configured — the check_fn still gates the
+        # schema at runtime if the key later disappears.
+        backsearch_auto_enabled = (
+            _toolset_allowed_for_platform("backsearch", platform)
+            and _backsearch_credentials_present()
+        )
+        if backsearch_auto_enabled:
+            enabled_toolsets.add("backsearch")
+
         default_off = set(_DEFAULT_OFF_TOOLSETS)
         # Legacy safety: if the platform's own name matches a default-off
         # toolset (e.g. `homeassistant` platform + `homeassistant` toolset),
@@ -1871,6 +1918,9 @@ def _get_platform_tools(
         # strip the entry we just added.
         if x_search_auto_enabled and "x_search" in default_off:
             default_off.remove("x_search")
+        # And for backsearch (see the inject block above).
+        if backsearch_auto_enabled and "backsearch" in default_off:
+            default_off.remove("backsearch")
         _exempt_explicit_platform_native(
             default_off, platform, explicitly_configured=explicitly_configured
         )

--- a/plugins/backsearch/__init__.py
+++ b/plugins/backsearch/__init__.py
@@ -1,0 +1,48 @@
+"""BackSearch plugin — point-in-time web search + fetch (bundled, auto-loaded).
+
+Registers two tools into the ``backsearch`` toolset:
+
+- ``backsearch`` — search a frozen news archive as of a date
+- ``backfetch``  — fetch a page's text as archived on or before a date
+
+Backed by BackSearch from General Reasoning (https://www.gr.inc), served at
+https://search.openreward.ai and billed against an OpenReward prepaid
+balance. Both tools gate on ``OPENREWARD_API_KEY`` via ``check_fn`` — when
+the key is absent the tools stay registered (so they appear in ``hermes
+tools``) but never reach the model schema.
+
+Why a plugin instead of a core tool: point-in-time search is a niche,
+paid capability (forecasting backtests, quant research, RL environments).
+Bundled ``kind: backend`` plugins auto-load at startup like the spotify /
+image_gen backends, and the check_fn keeps the model-tool footprint at
+zero for everyone without the credential.
+"""
+
+from __future__ import annotations
+
+from plugins.backsearch.tools import (
+    BACKFETCH_SCHEMA,
+    BACKSEARCH_SCHEMA,
+    check_backsearch_available,
+    handle_backfetch,
+    handle_backsearch,
+)
+
+_TOOLS = (
+    ("backsearch", BACKSEARCH_SCHEMA, handle_backsearch, "🕰️"),
+    ("backfetch", BACKFETCH_SCHEMA, handle_backfetch, "📰"),
+)
+
+
+def register(ctx) -> None:
+    """Register the BackSearch tools. Called once by the plugin loader."""
+    for name, schema, handler, emoji in _TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="backsearch",
+            schema=schema,
+            handler=handler,
+            check_fn=check_backsearch_available,
+            requires_env=["OPENREWARD_API_KEY"],
+            emoji=emoji,
+        )

--- a/plugins/backsearch/plugin.yaml
+++ b/plugins/backsearch/plugin.yaml
@@ -1,0 +1,10 @@
+name: backsearch
+version: 1.0.0
+description: "BackSearch by General Reasoning — search and fetch the web as it was on a particular date. Two tools (backsearch, backfetch) over a frozen news archive: every request carries an as_of date, search returns only documents crawled on or before it, and fetch returns the article text as archived at that time. Great for forecasting backtests, quant finance research loops, RL environments, and reproducible benchmarks. Gates on OPENREWARD_API_KEY."
+author: NousResearch
+kind: backend
+requires_env:
+  - OPENREWARD_API_KEY
+provides_tools:
+  - backsearch
+  - backfetch

--- a/plugins/backsearch/tools.py
+++ b/plugins/backsearch/tools.py
@@ -1,0 +1,386 @@
+"""BackSearch tools — search and fetch the web as it was on a given date.
+
+BackSearch (by General Reasoning, https://www.gr.inc) is a point-in-time
+web archive with two endpoints:
+
+- ``POST /search`` — hybrid search over a frozen news corpus. Every request
+  carries an ``as_of`` date; only documents *crawled* on or before that date
+  are returned. The corpus never moves, so the same query with the same
+  ``as_of`` returns the same results forever.
+- ``POST /fetch`` — point-in-time page fetch. Returns the extracted article
+  text from the latest capture on or before the cutoff, not today's bytes.
+
+Both authenticate with an OpenReward API key (``or_...``) in the
+``x-api-key`` header — the same credential used for openreward.ai; there is
+no separate BackSearch key. Base URL: ``https://search.openreward.ai``
+(override with ``OPENREWARD_SEARCH_URL`` for testing/self-routing).
+
+Important semantics baked into the tool descriptions:
+
+- ``as_of`` gates on **crawl_date**, not the article's self-reported publish
+  date. A page first archived after the cutoff will not be returned even if
+  it claims an earlier publish date. This is what guarantees no post-cutoff
+  leakage into a backtest.
+- The current preview archive covers **news domains, December 2025 to
+  July 2026**. An ``as_of`` outside the archive window returns an empty hit
+  list rather than an error, so "no results" on a far-past/future date
+  usually means the date is off the edge of the archive.
+- Billing is per successful request; a fetch with no capture on or before
+  the cutoff returns 404 and costs nothing. An exhausted OpenReward balance
+  returns 402.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+from tools.registry import tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://search.openreward.ai"
+
+# Preview-archive window (see module docstring). Used only to append a
+# helpful hint on empty results — never to reject a request, since the
+# archive is expected to widen over time.
+_PREVIEW_WINDOW_HINT = (
+    "The current BackSearch preview archive covers news domains from "
+    "December 2025 to July 2026. An as_of outside that window returns "
+    "no hits rather than an error."
+)
+
+_AS_OF_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+# Cap the article text returned by backfetch so a long feature piece can't
+# blow out the model context. The full text stays server-side; the model can
+# re-fetch with a summarize prompt if it needs the gist of a long article.
+_FETCH_TEXT_CAP = 15000
+
+
+def _get_env(name: str) -> str:
+    """Config-aware env lookup (os.environ, then ~/.hermes/.env)."""
+    try:
+        from hermes_cli.config import get_env_value
+
+        val = get_env_value(name)
+    except Exception:
+        import os
+
+        val = os.getenv(name)
+    return (val or "").strip()
+
+
+def check_backsearch_available() -> bool:
+    """Tools are only exposed when an OpenReward API key is configured."""
+    return bool(_get_env("OPENREWARD_API_KEY"))
+
+
+def _base_url() -> str:
+    return (_get_env("OPENREWARD_SEARCH_URL") or DEFAULT_BASE_URL).rstrip("/")
+
+
+def _request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """POST to the BackSearch API and return the parsed JSON response.
+
+    Raises ``ValueError`` with a user-actionable message on missing key,
+    payment/auth failures, and no-capture 404s so handlers can surface a
+    typed error the model can recover from.
+    """
+    import httpx
+
+    api_key = _get_env("OPENREWARD_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "OPENREWARD_API_KEY is not set. BackSearch uses your OpenReward "
+            "key (or_...) — get one at https://openreward.ai/"
+        )
+
+    url = f"{_base_url()}/{endpoint.lstrip('/')}"
+    body = {k: v for k, v in payload.items() if v is not None}
+    logger.info("BackSearch %s request (as_of=%s)", endpoint, body.get("as_of"))
+
+    response = httpx.post(
+        url,
+        headers={"x-api-key": api_key, "Content-Type": "application/json"},
+        json=body,
+        timeout=60,
+    )
+    if response.status_code == 402:
+        raise ValueError(
+            "OpenReward balance exhausted (HTTP 402). Top up your prepaid "
+            "balance at https://openreward.ai/ to keep using BackSearch."
+        )
+    if response.status_code in (401, 403):
+        raise ValueError(
+            "BackSearch rejected the API key (HTTP "
+            f"{response.status_code}). Check OPENREWARD_API_KEY."
+        )
+    if response.status_code == 404 and endpoint.lstrip("/") == "fetch":
+        raise ValueError(
+            "No capture of this URL exists on or before the as_of date. "
+            "Try a later as_of, or a different URL from the search hits."
+        )
+    response.raise_for_status()
+    return response.json()
+
+
+def _validate_as_of(raw: Any) -> str:
+    as_of = str(raw or "").strip()
+    if not as_of:
+        raise ValueError("as_of is required (YYYY-MM-DD), e.g. '2026-01-15'.")
+    if not _AS_OF_RE.match(as_of):
+        raise ValueError(
+            f"as_of must be an ISO date (YYYY-MM-DD), got: {as_of!r}"
+        )
+    return as_of
+
+
+def _as_domain_list(raw: Any) -> Optional[List[str]]:
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        items = [p.strip() for p in raw.split(",")]
+    elif isinstance(raw, list):
+        items = [str(p).strip() for p in raw]
+    else:
+        return None
+    items = [p for p in items if p]
+    return items or None
+
+
+def _coerce_k(raw: Any, *, default: int = 5, maximum: int = 20) -> int:
+    try:
+        value = int(raw)
+    except Exception:
+        value = default
+    return max(1, min(maximum, value))
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+def handle_backsearch(args: dict, **kw) -> str:
+    """Search the frozen archive as of a date."""
+    try:
+        from tools.interrupt import is_interrupted
+
+        if is_interrupted():
+            return tool_error("Interrupted")
+    except Exception:
+        pass
+
+    try:
+        as_of = _validate_as_of(args.get("as_of"))
+    except ValueError as exc:
+        return tool_error(str(exc))
+
+    query = str(args.get("query") or "").strip()
+    if not query:
+        return tool_error("query is required.")
+
+    allowed = _as_domain_list(args.get("allowed_domains"))
+    blocked = _as_domain_list(args.get("blocked_domains"))
+    if allowed and blocked:
+        return tool_error(
+            "Pass allowed_domains OR blocked_domains, never both."
+        )
+
+    try:
+        raw = _request(
+            "search",
+            {
+                "query": query,
+                "as_of": as_of,
+                "k": _coerce_k(args.get("k")),
+                "allowed_domains": allowed,
+                "blocked_domains": blocked,
+            },
+        )
+    except ValueError as exc:
+        return tool_error(str(exc))
+    except Exception as exc:  # noqa: BLE001 — httpx errors included
+        logger.warning("BackSearch search error: %s", exc)
+        return tool_error(f"BackSearch search failed: {exc}")
+
+    hits = raw.get("hits") or []
+    results: Dict[str, Any] = {
+        "success": True,
+        "as_of": as_of,
+        "hits": [
+            {
+                "url": h.get("url", ""),
+                "title": h.get("title", ""),
+                "snippet": h.get("snippet", ""),
+                "host": h.get("host", ""),
+                "crawl_date": h.get("crawl_date", ""),
+                "publish_date": h.get("publish_date", ""),
+            }
+            for h in hits
+        ],
+    }
+    if not hits:
+        results["note"] = _PREVIEW_WINDOW_HINT
+    return tool_result(results)
+
+
+def handle_backfetch(args: dict, **kw) -> str:
+    """Fetch a page as it was archived on or before a date."""
+    try:
+        from tools.interrupt import is_interrupted
+
+        if is_interrupted():
+            return tool_error("Interrupted")
+    except Exception:
+        pass
+
+    try:
+        as_of = _validate_as_of(args.get("as_of"))
+    except ValueError as exc:
+        return tool_error(str(exc))
+
+    url = str(args.get("url") or "").strip()
+    if not url:
+        return tool_error("url is required.")
+
+    prompt = str(args.get("prompt") or "").strip() or None
+
+    try:
+        raw = _request(
+            "fetch",
+            {
+                "url": url,
+                "as_of": as_of,
+                "prompt": prompt,
+                "summarize": bool(prompt) or None,
+            },
+        )
+    except ValueError as exc:
+        return tool_error(str(exc))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("BackSearch fetch error: %s", exc)
+        return tool_error(f"BackSearch fetch failed: {exc}")
+
+    text = str(raw.get("text") or "")
+    truncated = len(text) > _FETCH_TEXT_CAP
+    result: Dict[str, Any] = {
+        "success": True,
+        "as_of": as_of,
+        "url": url,
+        "text": text[:_FETCH_TEXT_CAP],
+    }
+    for key in ("title", "crawl_date", "publish_date", "host"):
+        if raw.get(key):
+            result[key] = raw[key]
+    if truncated:
+        result["truncated"] = True
+        result["note"] = (
+            f"Article text truncated to {_FETCH_TEXT_CAP} chars. Re-fetch "
+            "with a 'prompt' describing what to extract for a focused summary."
+        )
+    if not text:
+        result["success"] = False
+        result["error"] = "No text returned for this capture."
+    return json.dumps(result, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+BACKSEARCH_SCHEMA = {
+    "name": "backsearch",
+    "description": (
+        "Search the web as it was on a particular date (BackSearch by "
+        "General Reasoning). Runs against a FROZEN archive: only documents "
+        "crawled on or before as_of are returned, and the same query + "
+        "as_of always returns the same results. Use for forecasting "
+        "backtests, point-in-time financial research, and any task where "
+        "evidence after a cutoff date must not leak in. The cutoff gates "
+        "on crawl_date, not the article's self-reported publish date. "
+        "Current preview archive: news domains, December 2025 – July 2026; "
+        "an as_of outside that window returns zero hits (not an error)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "The search query.",
+            },
+            "as_of": {
+                "type": "string",
+                "description": (
+                    "Point-in-time cutoff date, ISO format YYYY-MM-DD "
+                    "(e.g. '2026-01-15'). Only pages crawled on or before "
+                    "this date are searched."
+                ),
+            },
+            "k": {
+                "type": "integer",
+                "description": "Number of hits to return (1-20, default 5).",
+            },
+            "allowed_domains": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Restrict the search to these hosts. Mutually exclusive "
+                    "with blocked_domains."
+                ),
+            },
+            "blocked_domains": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Exclude these hosts from the search. Mutually exclusive "
+                    "with allowed_domains."
+                ),
+            },
+        },
+        "required": ["query", "as_of"],
+    },
+}
+
+BACKFETCH_SCHEMA = {
+    "name": "backfetch",
+    "description": (
+        "Fetch a web page as it was archived on or before a date "
+        "(BackSearch by General Reasoning). Returns the extracted article "
+        "text from the latest capture on or before as_of — NOT today's "
+        "version of the page. Use it to read pages returned by the "
+        "backsearch tool. If no capture exists on or before the cutoff, "
+        "returns a soft error (try a later as_of or another URL). Pass a "
+        "'prompt' to get a focused summary of a long article instead of "
+        "the full text."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "The URL to fetch from the archive.",
+            },
+            "as_of": {
+                "type": "string",
+                "description": (
+                    "Point-in-time cutoff date, ISO format YYYY-MM-DD. The "
+                    "latest capture on or before this date is returned."
+                ),
+            },
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "Optional: what to extract from the page. When set, the "
+                    "archive summarizes the capture against this prompt "
+                    "instead of returning the full text."
+                ),
+            },
+        },
+        "required": ["url", "as_of"],
+    },
+}

--- a/tests/plugins/test_backsearch_plugin.py
+++ b/tests/plugins/test_backsearch_plugin.py
@@ -1,0 +1,367 @@
+"""Tests for the bundled BackSearch plugin (point-in-time web search/fetch).
+
+Real imports from the plugin module — no mocking of the handlers
+themselves. HTTP is stubbed at the httpx layer; no live network calls.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugins.backsearch.tools import (
+    BACKFETCH_SCHEMA,
+    BACKSEARCH_SCHEMA,
+    DEFAULT_BASE_URL,
+    _validate_as_of,
+    check_backsearch_available,
+    handle_backfetch,
+    handle_backsearch,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(status_code: int = 200, payload: dict | None = None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload or {}
+    if status_code >= 400:
+        import httpx
+
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"HTTP {status_code}", request=MagicMock(), response=resp
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+SEARCH_HIT = {
+    "url": "https://www.example.com/article",
+    "title": "UAE Central Bank cuts interest rates",
+    "snippet": "The UAE Central Bank on Wednesday lowered...",
+    "crawl_date": "2025-12-10T20:24:28Z",
+    "publish_date": "2025-12-10T00:00:00Z",
+    "host": "www.example.com",
+}
+
+
+@pytest.fixture(autouse=True)
+def _key_set(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("OPENREWARD_API_KEY", "or_test_key")
+    monkeypatch.delenv("OPENREWARD_SEARCH_URL", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Availability gating
+# ---------------------------------------------------------------------------
+
+
+class TestAvailability:
+    def test_available_with_key(self):
+        assert check_backsearch_available() is True
+
+    def test_unavailable_without_key(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("OPENREWARD_API_KEY", raising=False)
+        # get_env_value may read ~/.hermes/.env; force the plain-os path
+        with patch(
+            "plugins.backsearch.tools._get_env", return_value=""
+        ):
+            assert check_backsearch_available() is False
+
+    def test_search_without_key_returns_actionable_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        with patch("plugins.backsearch.tools._get_env", return_value=""):
+            out = json.loads(
+                handle_backsearch({"query": "rates", "as_of": "2026-01-15"})
+            )
+        assert "OPENREWARD_API_KEY" in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# as_of validation
+# ---------------------------------------------------------------------------
+
+
+class TestAsOfValidation:
+    def test_valid(self):
+        assert _validate_as_of("2026-01-15") == "2026-01-15"
+
+    @pytest.mark.parametrize("bad", ["", None, "01/15/2026", "2026-1-5", "jan 15"])
+    def test_invalid(self, bad):
+        with pytest.raises(ValueError):
+            _validate_as_of(bad)
+
+    def test_handler_surfaces_as_of_error(self):
+        out = json.loads(handle_backsearch({"query": "x", "as_of": "not-a-date"}))
+        assert "as_of" in out["error"]
+
+    def test_missing_query(self):
+        out = json.loads(handle_backsearch({"as_of": "2026-01-15"}))
+        assert "query" in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# Search behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSearch:
+    def test_search_success_shape(self):
+        with patch(
+            "httpx.post",
+            return_value=_mock_response(200, {"mode": "hybrid", "hits": [SEARCH_HIT]}),
+        ) as post:
+            out = json.loads(
+                handle_backsearch({"query": "central bank", "as_of": "2026-01-15"})
+            )
+        assert out["success"] is True
+        assert out["as_of"] == "2026-01-15"
+        hit = out["hits"][0]
+        assert hit["url"] == SEARCH_HIT["url"]
+        assert hit["crawl_date"] == SEARCH_HIT["crawl_date"]
+        assert hit["publish_date"] == SEARCH_HIT["publish_date"]
+        # request went to the right endpoint with the auth header
+        url = post.call_args.args[0] if post.call_args.args else post.call_args.kwargs["url"]
+        assert url == f"{DEFAULT_BASE_URL}/search"
+        assert post.call_args.kwargs["headers"]["x-api-key"] == "or_test_key"
+        body = post.call_args.kwargs["json"]
+        assert body["as_of"] == "2026-01-15"
+        assert body["query"] == "central bank"
+
+    def test_empty_hits_appends_archive_window_hint(self):
+        with patch("httpx.post", return_value=_mock_response(200, {"hits": []})):
+            out = json.loads(
+                handle_backsearch({"query": "anything", "as_of": "2026-01-15"})
+            )
+        assert out["success"] is True
+        assert out["hits"] == []
+        assert "preview archive" in out["note"]
+
+    def test_allowed_and_blocked_domains_mutually_exclusive(self):
+        out = json.loads(
+            handle_backsearch(
+                {
+                    "query": "x",
+                    "as_of": "2026-01-15",
+                    "allowed_domains": ["a.com"],
+                    "blocked_domains": ["b.com"],
+                }
+            )
+        )
+        assert "never both" in out["error"]
+
+    def test_k_is_clamped(self):
+        with patch(
+            "httpx.post", return_value=_mock_response(200, {"hits": []})
+        ) as post:
+            handle_backsearch({"query": "x", "as_of": "2026-01-15", "k": 500})
+        assert post.call_args.kwargs["json"]["k"] == 20
+
+    def test_domain_list_accepts_comma_string(self):
+        with patch(
+            "httpx.post", return_value=_mock_response(200, {"hits": []})
+        ) as post:
+            handle_backsearch(
+                {
+                    "query": "x",
+                    "as_of": "2026-01-15",
+                    "allowed_domains": "a.com, b.com",
+                }
+            )
+        assert post.call_args.kwargs["json"]["allowed_domains"] == ["a.com", "b.com"]
+
+    def test_402_returns_balance_error(self):
+        with patch("httpx.post", return_value=_mock_response(402)):
+            out = json.loads(
+                handle_backsearch({"query": "x", "as_of": "2026-01-15"})
+            )
+        assert "balance" in out["error"].lower()
+
+    def test_401_returns_key_error(self):
+        with patch("httpx.post", return_value=_mock_response(401)):
+            out = json.loads(
+                handle_backsearch({"query": "x", "as_of": "2026-01-15"})
+            )
+        assert "OPENREWARD_API_KEY" in out["error"]
+
+    def test_network_error_is_soft(self):
+        with patch("httpx.post", side_effect=OSError("boom")):
+            out = json.loads(
+                handle_backsearch({"query": "x", "as_of": "2026-01-15"})
+            )
+        assert "failed" in out["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Fetch behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestFetch:
+    def test_fetch_success(self):
+        with patch(
+            "httpx.post",
+            return_value=_mock_response(
+                200,
+                {
+                    "text": "The article body.",
+                    "title": "Headline",
+                    "crawl_date": "2025-12-10T20:24:28Z",
+                },
+            ),
+        ) as post:
+            out = json.loads(
+                handle_backfetch(
+                    {"url": "https://example.com/a", "as_of": "2026-01-15"}
+                )
+            )
+        assert out["success"] is True
+        assert out["text"] == "The article body."
+        assert out["title"] == "Headline"
+        url = post.call_args.args[0] if post.call_args.args else post.call_args.kwargs["url"]
+        assert url == f"{DEFAULT_BASE_URL}/fetch"
+
+    def test_fetch_404_no_capture_is_soft_error(self):
+        with patch("httpx.post", return_value=_mock_response(404)):
+            out = json.loads(
+                handle_backfetch(
+                    {"url": "https://example.com/a", "as_of": "2026-01-15"}
+                )
+            )
+        assert "capture" in out["error"].lower()
+
+    def test_fetch_missing_url(self):
+        out = json.loads(handle_backfetch({"as_of": "2026-01-15"}))
+        assert "url" in out["error"]
+
+    def test_fetch_prompt_sets_summarize(self):
+        with patch(
+            "httpx.post", return_value=_mock_response(200, {"text": "summary"})
+        ) as post:
+            handle_backfetch(
+                {
+                    "url": "https://example.com/a",
+                    "as_of": "2026-01-15",
+                    "prompt": "what rate?",
+                }
+            )
+        body = post.call_args.kwargs["json"]
+        assert body["prompt"] == "what rate?"
+        assert body["summarize"] is True
+
+    def test_fetch_no_prompt_omits_summarize(self):
+        with patch(
+            "httpx.post", return_value=_mock_response(200, {"text": "t"})
+        ) as post:
+            handle_backfetch(
+                {"url": "https://example.com/a", "as_of": "2026-01-15"}
+            )
+        body = post.call_args.kwargs["json"]
+        assert "summarize" not in body
+        assert "prompt" not in body
+
+    def test_fetch_long_text_truncated_with_note(self):
+        from plugins.backsearch.tools import _FETCH_TEXT_CAP
+
+        with patch(
+            "httpx.post",
+            return_value=_mock_response(200, {"text": "x" * (_FETCH_TEXT_CAP + 100)}),
+        ):
+            out = json.loads(
+                handle_backfetch(
+                    {"url": "https://example.com/a", "as_of": "2026-01-15"}
+                )
+            )
+        assert out["truncated"] is True
+        assert len(out["text"]) == _FETCH_TEXT_CAP
+
+    def test_base_url_override(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("OPENREWARD_SEARCH_URL", "http://localhost:9999/")
+        with patch(
+            "httpx.post", return_value=_mock_response(200, {"text": "t"})
+        ) as post:
+            handle_backfetch(
+                {"url": "https://example.com/a", "as_of": "2026-01-15"}
+            )
+        url = post.call_args.args[0] if post.call_args.args else post.call_args.kwargs["url"]
+        assert url == "http://localhost:9999/fetch"
+
+
+# ---------------------------------------------------------------------------
+# Registration + toolset wiring (behavioural contracts, not snapshots)
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_plugin_registers_both_tools(self):
+        import plugins.backsearch as plugin_mod
+
+        registered = []
+
+        class _Ctx:
+            def register_tool(self, **kwargs):
+                registered.append(kwargs)
+
+        plugin_mod.register(_Ctx())
+        names = {r["name"] for r in registered}
+        assert names == {"backsearch", "backfetch"}
+        for r in registered:
+            assert r["toolset"] == "backsearch"
+            assert r["check_fn"] is check_backsearch_available
+            assert r["requires_env"] == ["OPENREWARD_API_KEY"]
+            assert callable(r["handler"])
+
+    def test_toolset_defined_with_plugin_tools(self):
+        from toolsets import TOOLSETS
+
+        ts = TOOLSETS["backsearch"]
+        assert set(ts["tools"]) == {"backsearch", "backfetch"}
+
+    def test_schemas_declare_required_params(self):
+        assert set(BACKSEARCH_SCHEMA["parameters"]["required"]) == {"query", "as_of"}
+        assert set(BACKFETCH_SCHEMA["parameters"]["required"]) == {"url", "as_of"}
+        # schema names match the registered tool names
+        assert BACKSEARCH_SCHEMA["name"] == "backsearch"
+        assert BACKFETCH_SCHEMA["name"] == "backfetch"
+
+    def test_configurable_in_hermes_tools_and_default_off(self):
+        from hermes_cli.tools_config import (
+            _DEFAULT_OFF_TOOLSETS,
+            CONFIGURABLE_TOOLSETS,
+            TOOL_CATEGORIES,
+        )
+
+        keys = {ts for ts, _, _ in CONFIGURABLE_TOOLSETS}
+        assert "backsearch" in keys
+        assert "backsearch" in _DEFAULT_OFF_TOOLSETS
+        env_keys = [
+            ev["key"]
+            for prov in TOOL_CATEGORIES["backsearch"]["providers"]
+            for ev in prov["env_vars"]
+        ]
+        assert "OPENREWARD_API_KEY" in env_keys
+
+    def test_env_var_documented_in_optional_env_vars(self):
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        meta = OPTIONAL_ENV_VARS["OPENREWARD_API_KEY"]
+        assert meta["password"] is True
+        assert meta["category"] == "tool"
+
+    def test_auto_enable_helper_reflects_key_presence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from hermes_cli.tools_config import _backsearch_credentials_present
+
+        assert _backsearch_credentials_present() is True
+        monkeypatch.delenv("OPENREWARD_API_KEY", raising=False)
+        with patch("plugins.backsearch.tools._get_env", return_value=""):
+            assert _backsearch_credentials_present() is False

--- a/toolsets.py
+++ b/toolsets.py
@@ -328,6 +328,17 @@ TOOLSETS = {
         "includes": []
     },
 
+    "backsearch": {
+        "description": (
+            "Point-in-time web search and fetch over a frozen archive "
+            "(BackSearch by General Reasoning). Search/read the web as it "
+            "was on a given date — forecasting backtests, quant research, "
+            "reproducible benchmarks. Requires OPENREWARD_API_KEY."
+        ),
+        "tools": ["backsearch", "backfetch"],
+        "includes": []
+    },
+
 
     # Scenario-specific toolsets
     

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -218,6 +218,15 @@ The single `video_generate` tool covers both modalities — pass `image_url` to 
 |------|-------------|----------------------|
 | `x_search` | Search X (Twitter) posts, profiles, and threads using xAI's built-in `x_search` Responses tool. Read-only public X discovery for current discussion, reactions, or claims on public X (not general web pages). Does not post, reply, like, DM, upload media, delete, or inspect the authenticated X account — those need a separate authenticated X API surface (e.g. the `xurl` skill). Off by default — opt in via `hermes tools` → 🐦 X (Twitter) Search. Schema is only registered when xAI credentials are configured (check_fn-gated). | XAI_API_KEY **or** xAI Grok OAuth (SuperGrok / Premium+) login |
 
+## `backsearch` toolset
+
+Point-in-time web search over a frozen archive — [BackSearch by General Reasoning](https://www.gr.inc/releases/introducing-backsearch). Every request carries an `as_of` date; search returns only documents crawled on or before it, and fetch returns the article text as archived at that time. The same query with the same `as_of` returns the same results forever, which makes it suited to forecasting backtests, quant-finance research loops, RL environments, and reproducible benchmarks. Billed against your prepaid [OpenReward](https://openreward.ai/) balance. Registered by the bundled `backsearch` plugin; auto-enables when `OPENREWARD_API_KEY` is set (or opt in via `hermes tools` → 🕰️ BackSearch).
+
+| Tool | Description | Requires environment |
+|------|-------------|----------------------|
+| `backsearch` | Search the web as it was on a particular date. Takes `query` + `as_of` (YYYY-MM-DD), optional `k` (1-20) and `allowed_domains`/`blocked_domains` (mutually exclusive). The cutoff gates on crawl date, not the article's self-reported publish date, so nothing post-cutoff leaks in. Current preview archive: news domains, December 2025 – July 2026. | `OPENREWARD_API_KEY` |
+| `backfetch` | Fetch a page's text as archived on or before `as_of` — not today's version. Pass an optional `prompt` to get a focused summary of a long article. Returns a soft error when no capture exists on or before the cutoff. | `OPENREWARD_API_KEY` |
+
 ## `tts` toolset
 
 | Tool | Description | Requires environment |

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -77,6 +77,7 @@ Or in-session:
 | `session_search` | `session_search` | Search past conversation sessions. |
 | `skills` | `skill_manage`, `skill_view`, `skills_list` | Skill CRUD and browsing. |
 | `spotify` | `spotify_albums`, `spotify_devices`, `spotify_library`, `spotify_playback`, `spotify_playlists`, `spotify_queue`, `spotify_search` | Native Spotify control (playback, queue, search, playlists, albums, library). Registered by the bundled `spotify` plugin. |
+| `backsearch` | `backsearch`, `backfetch` | Point-in-time web search and fetch over a frozen archive ([BackSearch](https://www.gr.inc/releases/introducing-backsearch) by General Reasoning) — search/read the web as it was on a given date. Registered by the bundled `backsearch` plugin; requires `OPENREWARD_API_KEY` (auto-enables when set). |
 | `terminal` | `process`, `terminal` | Shell command execution and background process management. |
 | `todo` | `todo` | Task list management within a session. |
 | `tts` | `text_to_speech` | Text-to-speech audio generation. |

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -61,6 +61,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `observability/nemo_relay` | hooks | Relay observability events (turns / LLM calls / tools) to an NVIDIA NeMo endpoint |
 | `teams_pipeline` | standalone | Microsoft Teams meeting pipeline — Graph-backed, transcript-first meeting summaries |
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
+| `backsearch` | backend (2 tools) | Point-in-time web search/fetch over a frozen archive ([BackSearch](https://www.gr.inc/releases/introducing-backsearch) by General Reasoning) — gates on `OPENREWARD_API_KEY` |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
 | `image_gen/openai` | image backend | OpenAI `gpt-image-2` image generation backend (alternative to FAL) |
 | `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth |


### PR DESCRIPTION
## Summary
Hermes can now search and read the web **as it was on a particular date** — a bundled `backsearch` plugin wraps [BackSearch by General Reasoning](https://www.gr.inc/releases/introducing-backsearch) (two tools: `backsearch`, `backfetch`), gated on `OPENREWARD_API_KEY` so it costs zero model-tool schema for everyone without the key.

BackSearch is a frozen news archive: every request carries an `as_of` date, search returns only documents *crawled* on or before it, and fetch returns the article text as archived at that time. Same query + same `as_of` = same results forever — built for forecasting backtests, quant research loops, RL environments, and reproducible benchmarks.

## Changes
- `plugins/backsearch/` — bundled `kind: backend` plugin (auto-loads like spotify/image_gen). `tools.py` has the two handlers + schemas: `as_of` validation (YYYY-MM-DD), `allowed_domains`/`blocked_domains` mutual exclusion, typed errors for 402 (balance exhausted), 401/403 (bad key), fetch-404 (no capture on or before cutoff — soft, recoverable), 15K-char fetch text cap with a re-fetch-with-prompt hint, and an archive-window hint on empty hits.
- `toolsets.py` — `backsearch` toolset entry.
- `hermes_cli/tools_config.py` — `hermes tools` checklist row + `TOOL_CATEGORIES` setup flow (prompts for the OpenReward key). Default-off, auto-enables when `OPENREWARD_API_KEY` is set — mirrors the `x_search`/`HASS_TOKEN` pattern exactly (inject + symmetric default-off carve-out).
- `hermes_cli/config.py` — `OPENREWARD_API_KEY` in `OPTIONAL_ENV_VARS` (secret, category `tool`).
- Docs — `tools-reference.md` (new toolset section), `toolsets-reference.md`, `built-in-plugins.md`.
- `tests/plugins/test_backsearch_plugin.py` — 32 tests, real plugin imports, httpx stubbed.

## Footprint
Follows the plugin rung of the ladder: no core files touched beyond the standard 4 wiring points every backend integrates (toolset entry, tools UI, env-var metadata, docs). check_fn keeps the schema empty without the credential.

## Validation
| Check | Result |
|---|---|
| `tests/plugins/test_backsearch_plugin.py` | 32/32 ✓ |
| `tests/hermes_cli/test_tools_config.py` + web provider plugin tests | 181/181 ✓ |
| `tests/test_toolsets.py`, `test_toolset_distributions.py`, `tests/tools/test_registry.py` | 92/92 ✓ |
| E2E (temp HERMES_HOME, real imports) | discovery → registry → check_fn off/on with key → `resolve_toolset` → `get_tool_definitions` → `handle_function_call` dispatch → `_get_platform_tools` auto-enable, all green |
| ruff | clean |

## Infographic

![backsearch-plugin](https://v3b.fal.media/files/b/0aa3a0c7/0oTMQ_Biweasy6GeJ1q4j_VZinUDTh.png)
