### PR TITLE
Keep custom provider picker tests offline

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2864,6 +2864,7 @@ def list_picker_providers(
     current_model: str = "",
     include_moa: bool = False,
     excluded_providers: list | None = None,
+    probe_custom_providers: bool = True,
 ) -> List[dict]:
     """Interactive-picker variant of :func:`list_authenticated_providers`.
 
@@ -2883,6 +2884,11 @@ def list_picker_providers(
     All other providers and metadata fields are passed through unchanged.
     The typed ``/model <name>`` path is unaffected -- only the interactive
     picker payload is narrowed.
+
+    ``probe_custom_providers`` is forwarded to the base provider lister. Set
+    it false for deterministic/offline callers that must preserve the supplied
+    custom model list without querying a live ``/models`` endpoint. The default
+    remains true for existing interactive-picker behavior.
     """
     from hermes_cli.models import fetch_openrouter_models
 
@@ -2895,6 +2901,7 @@ def list_picker_providers(
         current_model=current_model,
         for_picker=True,
         excluded_providers=excluded_providers,
+        probe_custom_providers=probe_custom_providers,
     )
     if include_moa:
         providers = _prepend_moa_picker_provider(providers, current_provider=current_provider)

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -270,6 +270,10 @@ def test_current_custom_endpoint_passthrough_marks_current_row(monkeypatch):
     monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
     monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
                         lambda *a, **kw: [])
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda *args, **kwargs: ["unexpected-live-model"],
+    )
 
     result = model_switch.list_picker_providers(
         current_provider="custom:ollama",
@@ -291,6 +295,7 @@ def test_current_custom_endpoint_passthrough_marks_current_row(monkeypatch):
             },
         ],
         max_models=50,
+        probe_custom_providers=False,
     )
 
     custom_rows = [p for p in result if p.get("is_user_defined")]

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -699,6 +699,10 @@ def test_list_authenticated_providers_groups_same_endpoint(monkeypatch):
     returned as a single picker row with all their models merged."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda *args, **kwargs: ["unexpected-live-model"],
+    )
 
     providers = list_authenticated_providers(
         current_provider="custom",
@@ -786,6 +790,10 @@ def test_list_authenticated_providers_distinct_endpoints_stay_separate(monkeypat
     even if some display names happen to be similar."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda *args, **kwargs: ["unexpected-live-model"],
+    )
 
     providers = list_authenticated_providers(
         user_providers={},
@@ -882,6 +890,10 @@ def test_list_authenticated_providers_total_models_reflects_grouped_count(monkey
     the full count, and every grouped model appears in the list."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda *args, **kwargs: ["unexpected-live-model"],
+    )
 
     entries = [
         {"name": f"Ollama \u2014 Model {i}", "base_url": "http://localhost:11434/v1",


### PR DESCRIPTION
## Summary
- let picker callers disable live custom-provider model probes
- preserve the new upstream provider-exclusion picker option
- harden custom-provider tests against accidental network discovery

## Verification
- four focused regression tests passed
