### PR TITLE
fix(deepseek): remap retired chat/reasoner aliases after 2026-07-24 cut-off

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -12,9 +12,11 @@ Different LLM providers expect model identifiers in different formats:
   model IDs, but Claude still uses hyphenated native names like
   ``claude-sonnet-4-6``.
 - **OpenCode Go** preserves dots in model names: ``minimax-m2.7``.
-- **DeepSeek** accepts ``deepseek-chat`` (V3), ``deepseek-reasoner``
-  (R1-family), and the first-class V-series IDs (``deepseek-v4-pro``,
-  ``deepseek-v4-flash``, and any future ``deepseek-v<N>-*``).  Older
+- **DeepSeek** accepts only the first-class V-series IDs
+  (``deepseek-v4-pro``, ``deepseek-v4-flash``, and any future
+  ``deepseek-v<N>-*``).  The legacy aliases ``deepseek-chat`` and
+  ``deepseek-reasoner`` were retired on 2026-07-24 and are remapped to
+  ``deepseek-v4-flash`` (official non-thinking / thinking shims).  Older
   Hermes revisions folded every non-reasoner input into
   ``deepseek-chat``, which on aggregators routes to V3 — so a user
   picking V4 Pro was silently downgraded.
@@ -118,8 +120,9 @@ _LOWERCASE_MODEL_PROVIDERS: frozenset[str] = frozenset({
 # ---------------------------------------------------------------------------
 # DeepSeek special handling
 # ---------------------------------------------------------------------------
-# DeepSeek's API only recognises exactly two model identifiers.  We map
-# common aliases and patterns to the canonical names.
+# DeepSeek's direct API only accepts first-class V-series IDs after the
+# 2026-07-24 cut-off.  Legacy aliases and fuzzy names are remapped here so
+# saved configs / picker leftovers cannot keep sending retired IDs.
 
 _DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset({
     "reasoner",
@@ -129,9 +132,15 @@ _DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset({
     "cot",
 })
 
+# Retired on 2026-07-24 15:59 UTC. Official docs: both aliases mapped to
+# deepseek-v4-flash (chat = non-thinking, reasoner = thinking). Thinking
+# mode itself is controlled by extra_body.thinking on the DeepSeek profile.
+_DEEPSEEK_RETIRED_ALIASES: frozenset[str] = frozenset({
+    "deepseek-chat",
+    "deepseek-reasoner",
+})
+
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-chat",       # V3 on DeepSeek direct and most aggregators
-    "deepseek-reasoner",   # R1-family reasoning model
     "deepseek-v4-pro",     # V4 Pro — first-class model ID
     "deepseek-v4-flash",   # V4 Flash — first-class model ID
 })
@@ -149,13 +158,15 @@ def _normalize_for_deepseek(model_name: str) -> str:
     """Map a model input to a DeepSeek-accepted identifier.
 
     Rules:
-    - Already a known canonical (``deepseek-chat``/``deepseek-reasoner``/
-      ``deepseek-v4-pro``/``deepseek-v4-flash``) -> pass through.
+    - Retired aliases ``deepseek-chat`` / ``deepseek-reasoner`` (cut off
+      2026-07-24) -> ``deepseek-v4-flash``.
+    - Already a known canonical (``deepseek-v4-pro``/``deepseek-v4-flash``)
+      -> pass through.
     - Matches the V-series pattern ``deepseek-v<digit>...`` -> pass through
       (covers future ``deepseek-v5-*`` and dated variants without a release).
     - Contains a reasoner keyword (r1, think, reasoning, cot, reasoner)
-      -> ``deepseek-reasoner``.
-    - Everything else -> ``deepseek-chat``.
+      -> ``deepseek-v4-flash``.
+    - Everything else -> ``deepseek-v4-flash``.
 
     Args:
         model_name: The bare model name (vendor prefix already stripped).
@@ -164,6 +175,11 @@ def _normalize_for_deepseek(model_name: str) -> str:
         A DeepSeek-accepted model identifier.
     """
     bare = _strip_vendor_prefix(model_name).lower()
+
+    # Retired aliases must rewrite — DeepSeek returns HTTP 400 after the
+    # 2026-07-24 cut-off if these IDs are sent on the wire.
+    if bare in _DEEPSEEK_RETIRED_ALIASES:
+        return "deepseek-v4-flash"
 
     if bare in _DEEPSEEK_CANONICAL_MODELS:
         return bare
@@ -175,9 +191,9 @@ def _normalize_for_deepseek(model_name: str) -> str:
     # Check for reasoner-like keywords anywhere in the name
     for keyword in _DEEPSEEK_REASONER_KEYWORDS:
         if keyword in bare:
-            return "deepseek-reasoner"
+            return "deepseek-v4-flash"
 
-    return "deepseek-chat"
+    return "deepseek-v4-flash"
 
 
 # ---------------------------------------------------------------------------
@@ -369,10 +385,13 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
         'minimax-m2.5-free'
 
         >>> normalize_model_for_provider("deepseek-v3", "deepseek")
-        'deepseek-chat'
+        'deepseek-v4-flash'
 
         >>> normalize_model_for_provider("deepseek-r1", "deepseek")
-        'deepseek-reasoner'
+        'deepseek-v4-flash'
+
+        >>> normalize_model_for_provider("deepseek-reasoner", "deepseek")
+        'deepseek-v4-flash'
 
         >>> normalize_model_for_provider("my-model", "custom")
         'my-model'

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -390,8 +390,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "deepseek": [
         "deepseek-v4-pro",
         "deepseek-v4-flash",
-        "deepseek-chat",
-        "deepseek-reasoner",
     ],
     "xiaomi": [
         "mimo-v2.5-pro",
@@ -2085,11 +2083,25 @@ def _provider_keys(provider: str) -> set[str]:
     return {k for k in (key, normalized) if k}
 
 
+# Retired model IDs kept for /model auto-detect only — not shown in pickers.
+# DeepSeek cut these off on 2026-07-24; model_normalize remaps them on the wire.
+_PROVIDER_RETIRED_ALIASES: dict[str, tuple[str, ...]] = {
+    "deepseek": ("deepseek-chat", "deepseek-reasoner"),
+}
+
+
+def _provider_catalog_names(provider: str) -> tuple[str, ...]:
+    """Active picker models plus retired aliases recognized for detection."""
+    active = tuple(_PROVIDER_MODELS.get(provider, []))
+    retired = _PROVIDER_RETIRED_ALIASES.get(provider, ())
+    return active + retired
+
+
 def _model_in_provider_catalog(name_lower: str, providers: set[str]) -> bool:
     return any(
         name_lower == model.lower()
         for provider in providers
-        for model in _PROVIDER_MODELS.get(provider, [])
+        for model in _provider_catalog_names(provider)
     )
 
 
@@ -2235,7 +2247,7 @@ def detect_static_provider_for_model(
         current_provider == "custom"
         or current_provider.startswith("custom:")
     )
-    for pid, models in _PROVIDER_MODELS.items():
+    for pid in _PROVIDER_MODELS:
         if (
             pid in current_keys
             or pid in _AGGREGATOR_PROVIDERS
@@ -2244,7 +2256,7 @@ def detect_static_provider_for_model(
             continue
         if _is_custom_current:
             continue
-        if any(name_lower == m.lower() for m in models):
+        if any(name_lower == m.lower() for m in _provider_catalog_names(pid)):
             return (pid, name)
 
     # Borrow-list providers (re-expose other vendors' models) only after every
@@ -2252,7 +2264,7 @@ def detect_static_provider_for_model(
     for pid in _BORROWED_MODEL_PROVIDERS:
         if pid in current_keys:
             continue
-        if any(name_lower == m.lower() for m in _PROVIDER_MODELS.get(pid, [])):
+        if any(name_lower == m.lower() for m in _provider_catalog_names(pid)):
             return (pid, name)
 
     return None

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -1,11 +1,11 @@
 """DeepSeek provider profile.
 
-DeepSeek's V4 family (and the legacy ``deepseek-reasoner``) defaults to
-thinking-mode ON when ``extra_body.thinking`` is unset.  The API then returns
-``reasoning_content`` and starts enforcing the contract that subsequent turns
-echo it back; combined with how Hermes replays history this lands on the
-notorious HTTP 400 ``reasoning_content must be passed back`` error after the
-first tool call (#15700, #17212, #17825).
+DeepSeek's V4 family defaults to thinking-mode ON when ``extra_body.thinking``
+is unset.  The API then returns ``reasoning_content`` and starts enforcing
+the contract that subsequent turns echo it back; combined with how Hermes
+replays history this lands on the notorious HTTP 400
+``reasoning_content must be passed back`` error after the first tool call
+(#15700, #17212, #17825).
 
 This profile overrides :meth:`build_api_kwargs_extras` to mirror the Kimi /
 Moonshot wire shape that DeepSeek's OpenAI-compat endpoint expects:
@@ -13,8 +13,12 @@ Moonshot wire shape that DeepSeek's OpenAI-compat endpoint expects:
     {"reasoning_effort": "<low|medium|high|max>",
      "extra_body": {"thinking": {"type": "enabled" | "disabled"}}}
 
-Non-thinking models (only ``deepseek-chat`` today, which is V3) are left as
-no-ops so we don't perturb the V3 wire format.
+Non-thinking models (``deepseek-v3-*`` variants) are left as no-ops so we
+don't perturb the V3 wire format.
+
+The legacy aliases ``deepseek-chat`` / ``deepseek-reasoner`` were retired on
+2026-07-24.  Use ``deepseek-v4-flash`` or ``deepseek-v4-pro``; Hermes remaps
+the retired IDs in ``hermes_cli.model_normalize``.
 """
 
 from __future__ import annotations
@@ -29,8 +33,8 @@ def _model_supports_thinking(model: str | None) -> bool:
     """DeepSeek thinking-capable model families.
 
     Currently covers the V4 family (``deepseek-v4-pro``, ``deepseek-v4-flash``,
-    and any future ``deepseek-v4-*`` variants) and the legacy
-    ``deepseek-reasoner`` (R1).  ``deepseek-chat`` is V3 with no thinking mode.
+    and any future ``deepseek-v4-*`` variants).  Retired aliases are remapped
+    before requests leave Hermes, so they are not listed here.
     """
     m = (model or "").strip().lower()
     if not m:
@@ -38,8 +42,6 @@ def _model_supports_thinking(model: str | None) -> bool:
     if m.startswith("deepseek-v") and not m.startswith("deepseek-v3"):
         # deepseek-v4-*, deepseek-v5-*, etc. — every V4+ generation has
         # thinking. v3 explicitly excluded.
-        return True
-    if m == "deepseek-reasoner":
         return True
     return False
 
@@ -90,11 +92,11 @@ deepseek = DeepSeekProfile(
     description="DeepSeek — native DeepSeek API",
     signup_url="https://platform.deepseek.com/",
     fallback_models=(
-        "deepseek-chat",
-        "deepseek-reasoner",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
     ),
     base_url="https://api.deepseek.com/v1",
-    default_aux_model="deepseek-chat",
+    default_aux_model="deepseek-v4-flash",
 )
 
 register_provider(deepseek)

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -232,18 +232,32 @@ class TestDeepseekVSeriesPassThrough:
         assert result == "deepseek-v4-flash"
 
 
-# ── DeepSeek regressions (existing behaviour still holds) ──────────────
+# ── DeepSeek post-2026-07-24 alias remapping ───────────────────────────
 
 class TestDeepseekCanonicalAndReasonerMapping:
-    """Canonical pass-through and reasoner-keyword folding stay intact."""
+    """Retired aliases and fuzzy names rewrite to deepseek-v4-flash.
+
+    DeepSeek cut off ``deepseek-chat`` / ``deepseek-reasoner`` on
+    2026-07-24; sending them on the wire returns HTTP 400.
+    """
 
     @pytest.mark.parametrize("model,expected", [
-        ("deepseek-chat", "deepseek-chat"),
-        ("deepseek-reasoner", "deepseek-reasoner"),
-        ("DEEPSEEK-CHAT", "deepseek-chat"),
+        ("deepseek-chat", "deepseek-v4-flash"),
+        ("deepseek-reasoner", "deepseek-v4-flash"),
+        ("DEEPSEEK-CHAT", "deepseek-v4-flash"),
+        ("DEEPSEEK-REASONER", "deepseek-v4-flash"),
+        ("deepseek/deepseek-reasoner", "deepseek-v4-flash"),
+        ("deepseek-v4-pro", "deepseek-v4-pro"),
+        ("deepseek-v4-flash", "deepseek-v4-flash"),
     ])
-    def test_canonical_models_pass_through(self, model, expected):
+    def test_retired_aliases_and_canonicals(self, model, expected):
         assert _normalize_for_deepseek(model) == expected
+
+    def test_provider_path_rewrites_reasoner(self):
+        assert (
+            normalize_model_for_provider("deepseek-reasoner", "deepseek")
+            == "deepseek-v4-flash"
+        )
 
     @pytest.mark.parametrize("model", [
         "deepseek-r1",
@@ -252,8 +266,8 @@ class TestDeepseekCanonicalAndReasonerMapping:
         "deepseek-reasoning-preview",
         "deepseek-cot-experimental",
     ])
-    def test_reasoner_keywords_map_to_reasoner(self, model):
-        assert _normalize_for_deepseek(model) == "deepseek-reasoner"
+    def test_reasoner_keywords_map_to_v4_flash(self, model):
+        assert _normalize_for_deepseek(model) == "deepseek-v4-flash"
 
     @pytest.mark.parametrize("model", [
         "deepseek-chat-v3.1",    # 'chat' prefix, not V-series pattern
@@ -261,5 +275,5 @@ class TestDeepseekCanonicalAndReasonerMapping:
         "something-random",
         "gpt-5",                 # non-DeepSeek names still fall through
     ])
-    def test_unknown_names_fall_back_to_chat(self, model):
-        assert _normalize_for_deepseek(model) == "deepseek-chat"
+    def test_unknown_names_fall_back_to_v4_flash(self, model):
+        assert _normalize_for_deepseek(model) == "deepseek-v4-flash"

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -252,10 +252,16 @@ class TestDetectProviderForModel:
         assert result[0] == "anthropic"
 
     def test_deepseek_model_detected(self):
-        """deepseek-chat should resolve to deepseek provider."""
+        """Retired deepseek-chat alias still resolves to deepseek for /model."""
         result = detect_provider_for_model("deepseek-chat", "openai-codex")
         assert result is not None
         # Provider is deepseek (direct) or openrouter (fallback) depending on creds
+        assert result[0] in {"deepseek", "openrouter"}
+
+    def test_deepseek_v4_model_detected(self):
+        """Current DeepSeek V4 IDs resolve to the deepseek provider."""
+        result = detect_provider_for_model("deepseek-v4-flash", "openai-codex")
+        assert result is not None
         assert result[0] in {"deepseek", "openrouter"}
 
     def test_current_provider_model_returns_none(self):

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -1,10 +1,10 @@
 """Unit tests for the DeepSeek provider profile's thinking-mode wiring.
 
-DeepSeek V4 (and the legacy ``deepseek-reasoner``) expects every request to
-carry an explicit ``extra_body.thinking`` parameter.  Omitting it makes the
-server default to thinking-mode ON, which then enforces the
-``reasoning_content``-must-be-echoed-back contract on subsequent turns and
-breaks the conversation with HTTP 400 (#15700, #17212, #17825).
+DeepSeek V4 expects every request to carry an explicit ``extra_body.thinking``
+parameter.  Omitting it makes the server default to thinking-mode ON, which
+then enforces the ``reasoning_content``-must-be-echoed-back contract on
+subsequent turns and breaks the conversation with HTTP 400 (#15700, #17212,
+#17825).
 
 These tests pin the profile's wire-shape contract so DeepSeek requests stay
 correctly shaped without going live.
@@ -106,7 +106,7 @@ class TestDeepSeekThinkingWireShape:
 
 
 class TestDeepSeekModelGating:
-    """V4 family + ``deepseek-reasoner`` get thinking; V3 stays untouched."""
+    """V4 family gets thinking; V3 / unknown stay untouched."""
 
     @pytest.mark.parametrize(
         "model",
@@ -114,7 +114,6 @@ class TestDeepSeekModelGating:
             "deepseek-v4-pro",
             "deepseek-v4-flash",
             "deepseek-v4-future-variant",
-            "deepseek-reasoner",
             "DEEPSEEK-V4-PRO",  # case-insensitive
         ],
     )
@@ -127,7 +126,6 @@ class TestDeepSeekModelGating:
     @pytest.mark.parametrize(
         "model",
         [
-            "deepseek-chat",         # V3 alias
             "deepseek-v3-0324",      # explicit V3
             "deepseek-v3.1",         # V3 minor revisions
             "",                       # bare/unknown
@@ -168,11 +166,11 @@ class TestDeepSeekFullKwargsIntegration:
         assert kwargs["reasoning_effort"] == "high"
         assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
 
-    def test_v3_chat_full_kwargs_omit_thinking(self, deepseek_profile):
+    def test_v3_full_kwargs_omit_thinking(self, deepseek_profile):
         from agent.transports.chat_completions import ChatCompletionsTransport
 
         kwargs = ChatCompletionsTransport().build_kwargs(
-            model="deepseek-chat",
+            model="deepseek-v3-0324",
             messages=[{"role": "user", "content": "ping"}],
             tools=None,
             provider_profile=deepseek_profile,
@@ -195,12 +193,18 @@ class TestDeepSeekAuxModel:
     system.
     """
 
-    def test_profile_advertises_deepseek_chat(self, deepseek_profile):
-        assert deepseek_profile.default_aux_model == "deepseek-chat"
+    def test_profile_advertises_deepseek_v4_flash(self, deepseek_profile):
+        assert deepseek_profile.default_aux_model == "deepseek-v4-flash"
 
-    def test_consumer_api_returns_deepseek_chat(self):
+    def test_fallback_models_are_v4_only(self, deepseek_profile):
+        assert deepseek_profile.fallback_models == (
+            "deepseek-v4-pro",
+            "deepseek-v4-flash",
+        )
+
+    def test_consumer_api_returns_deepseek_v4_flash(self):
         from agent.auxiliary_client import _get_aux_model_for_provider
-        assert _get_aux_model_for_provider("deepseek") == "deepseek-chat"
+        assert _get_aux_model_for_provider("deepseek") == "deepseek-v4-flash"
 
     def test_consumer_api_returns_non_empty(self):
         from agent.auxiliary_client import _get_aux_model_for_provider


### PR DESCRIPTION
## Summary
- DeepSeek retired `deepseek-chat` and `deepseek-reasoner` on 2026-07-24; API calls with those IDs now return HTTP 400.
- Remap the retired aliases (and fuzzy reasoner-like names) to `deepseek-v4-flash` in model normalization so existing configs keep working.
- Remove the retired IDs from the static DeepSeek picker list and provider fallback/aux defaults.

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_model_normalize.py tests/plugins/model_providers/test_deepseek_profile.py -q`
- [ ] With `provider: deepseek` and `model: deepseek-reasoner` in config, confirm a chat request succeeds (model rewritten to `deepseek-v4-flash`)
- [ ] Confirm `/model` DeepSeek list only shows `deepseek-v4-pro` and `deepseek-v4-flash`