### PR TITLE
fix(tools): keep empty required[] instead of dropping the key (#59386)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -445,7 +445,9 @@ class TestSchemaConversion:
 
         assert schema["required"] == ["a"]
 
-    def test_required_removed_when_all_names_dangle(self):
+    def test_required_kept_as_empty_array_when_all_names_dangle(self):
+        # Regression for #59386: a missing ``required`` key is rejected as
+        # ``null`` by strict OpenAI-compatible backends. Keep an empty array.
         from tools.mcp_tool import _normalize_mcp_input_schema
 
         schema = _normalize_mcp_input_schema({
@@ -454,7 +456,7 @@ class TestSchemaConversion:
             "required": ["ghost"],
         })
 
-        assert "required" not in schema
+        assert schema["required"] == []
 
     def test_required_pruning_applies_recursively_inside_nested_objects(self):
         """Nested object schemas also get required pruning."""

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -179,11 +179,25 @@ def test_required_pruned_to_existing_properties():
     assert out[0]["function"]["parameters"]["required"] == ["name"]
 
 
-def test_required_all_missing_is_dropped():
+def test_required_all_missing_keeps_empty_array():
+    # Regression for #59386: a *missing* ``required`` key is materialized as
+    # ``null`` by strict OpenAI-compatible proxies during schema validation,
+    # causing a non-retryable HTTP 400 ("null is not of type 'array'"). We must
+    # keep an explicit empty array instead of dropping the key.
     tools = [_tool("t", {
         "type": "object",
         "properties": {},
         "required": ["x", "y"],
+    })]
+    out = sanitize_tool_schemas(tools)
+    assert out[0]["function"]["parameters"]["required"] == []
+
+
+def test_no_required_key_is_not_injected():
+    # Schemas that genuinely never declared ``required`` should stay clean.
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {"a": {"type": "string"}},
     })]
     out = sanitize_tool_schemas(tools)
     assert "required" not in out[0]["function"]["parameters"]

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5166,7 +5166,13 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
                     if valid:
                         repaired["required"] = valid
                     else:
-                        repaired.pop("required", None)
+                        # Keep an explicit empty ``required`` array instead of
+                        # dropping the key. Strict OpenAI-compatible backends
+                        # materialize a missing ``required`` as ``null`` during
+                        # validation, which violates the JSON Schema spec and
+                        # triggers a non-retryable HTTP 400. An empty array is
+                        # always valid (see tools/schema_sanitizer.py).
+                        repaired["required"] = []
 
         return repaired
 

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -347,7 +347,13 @@ def _sanitize_node(node: Any, path: str) -> Any:
         props = out.get("properties") or {}
         valid = [r for r in out["required"] if isinstance(r, str) and r in props]
         if not valid:
-            out.pop("required", None)
+            # Keep an explicit empty ``required`` array instead of dropping the
+            # key. Strict OpenAI-compatible backends (and several API proxies)
+            # treat a *missing* ``required`` key as ``null`` during validation,
+            # which violates the JSON Schema spec ("required" must be an array)
+            # and triggers a non-retryable HTTP 400 ("null is not of type
+            # 'array'"). An empty array is always valid and preserves intent.
+            out["required"] = []
         elif len(valid) != len(out["required"]):
             out["required"] = valid
 


### PR DESCRIPTION
Fixes #59386 — delegate_task schema (and any built-in/plugin tool with an empty required) triggered a non-retryable HTTP 400 on strict OpenAI-compatible backends/proxies:

Code
Invalid schema for function 'delegate_task': null is not of type "array"
Root cause
Both schema prune sites dropped a required key whose entries didn't all exist in properties:

tools/schema_sanitizer.py _sanitize_node (line 350)
tools/mcp_tool.py _normalize_mcp_input_schema reconstruction (line 5169)
Strict OpenAI-compatible proxies treat a missing required key as null during validation, which violates JSON Schema (required must be an array) → BadRequestError → the conversation loop can't recover and the session dies. This hit CLI, gateway, and cron jobs inheriting default tools (the full default toolset includes delegate_task).

Fix
Set required: [] instead of popping the key. An empty array is always spec-valid and preserves intent. Partial required lists are still pruned; schemas that never declared required remain clean.

Verification
tests/tools/test_schema_sanitizer.py: 48 passed (added test_required_all_missing_keeps_empty_array and test_no_required_key_is_not_injected; updated the old "dropped" assertion).
tools/mcp_tool._normalize_mcp_input_schema verified directly: all-dangle → [], partial → pruned, no-required → key absent.
Note: tests/tools/test_mcp_tool.py cannot be collected in this environment due to a pre-existing, unrelated import of CreateMessageResultWithTools from mcp.types (symbol version mismatch), which fails at collection before any test runs — not introduced by this change.
Scope note
This is the minimal root-cause fix matching the cross-PR triage in #59386 (PR #59459). It is intentionally not the broader null-keyword hardening from #59421 — that can land separately as standalone hardening.