### PR TITLE
feat(memory): per-chat memory isolation via optional entry-level `scope` (#28279)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -407,6 +407,34 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
     agent.request_overrides = overrides
 
 
+def _build_memory_session_scopes(agent) -> Optional[List[str]]:
+    """Build this session's scope identity for scoped memory (issue #28279).
+
+    Returns e.g. ["telegram", "telegram:123456789", "profile:work"], or None
+    when the session has no platform identity at all (scope filtering then
+    stays off, preserving pre-scope behaviour for exotic embedding setups).
+    """
+    scopes: List[str] = []
+    platform = (getattr(agent, "platform", None) or "").strip().lower()
+    if platform:
+        scopes.append(platform)
+        chat_id = str(getattr(agent, "_chat_id", None) or "").strip()
+        if chat_id:
+            scopes.append(f"{platform}:{chat_id}")
+    else:
+        # Interactive/local sessions have no gateway platform — they are the
+        # trusted home base and match "cli"-scoped entries.
+        scopes.append("cli")
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        profile = (get_active_profile_name() or "").strip()
+        if profile:
+            scopes.append(f"profile:{profile}")
+    except Exception:
+        pass
+    return scopes
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -1579,6 +1607,7 @@ def init_agent(
                 agent._memory_store = MemoryStore(
                     memory_char_limit=mem_config.get("memory_char_limit", 2200),
                     user_char_limit=mem_config.get("user_char_limit", 1375),
+                    session_scopes=_build_memory_session_scopes(agent),
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -456,6 +456,34 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
     agent.request_overrides = overrides
 
 
+def _build_memory_session_scopes(agent) -> Optional[List[str]]:
+    """Build this session's scope identity for scoped memory (issue #28279).
+
+    Returns e.g. ["telegram", "telegram:123456789", "profile:work"], or None
+    when the session has no platform identity at all (scope filtering then
+    stays off, preserving pre-scope behaviour for exotic embedding setups).
+    """
+    scopes: List[str] = []
+    platform = (getattr(agent, "platform", None) or "").strip().lower()
+    if platform:
+        scopes.append(platform)
+        chat_id = str(getattr(agent, "_chat_id", None) or "").strip()
+        if chat_id:
+            scopes.append(f"{platform}:{chat_id}")
+    else:
+        # Interactive/local sessions have no gateway platform — they are the
+        # trusted home base and match "cli"-scoped entries.
+        scopes.append("cli")
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        profile = (get_active_profile_name() or "").strip()
+        if profile:
+            scopes.append(f"profile:{profile}")
+    except Exception:
+        pass
+    return scopes
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -1716,6 +1744,7 @@ def init_agent(
                 agent._memory_store = MemoryStore(
                     memory_char_limit=mem_config.get("memory_char_limit", 2200),
                     user_char_limit=mem_config.get("user_char_limit", 1375),
+                    session_scopes=_build_memory_session_scopes(agent),
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/tests/gateway/test_scoped_memory_isolation_28279.py
+++ b/tests/gateway/test_scoped_memory_isolation_28279.py
@@ -1,0 +1,170 @@
+"""End-to-end gateway isolation test for scoped memory (issue #28279, PR #71224).
+
+Simulates the exact scenario from the issue: one Hermes instance serving a
+private Telegram DM and a public Telegram group. A secret saved from the DM
+with scope='current' must be invisible to the group session through BOTH
+disclosure surfaces:
+
+  1. the system-prompt memory block (snapshot filtering), and
+  2. every memory-tool result path (access-boundary filtering) — error
+     inventories and replace/remove targeting.
+
+Agents are constructed the same way ``gateway/run.py`` builds them (real
+``AIAgent`` with ``platform`` + ``chat_id`` from the message source, memory
+enabled via ``$HERMES_HOME/config.yaml``), so this exercises the full chain:
+gateway identity → agent_init._build_memory_session_scopes → MemoryStore.
+"""
+
+import json
+
+import pytest
+
+from run_agent import AIAgent
+
+
+class _FakeOpenAI:
+    def __init__(self, **kw):
+        self.api_key = kw.get("api_key", "test")
+        self.base_url = kw.get("base_url", "http://test")
+
+    def close(self):
+        pass
+
+
+DM_CHAT_ID = "555000111"
+GROUP_CHAT_ID = "999888777"
+SECRET = "prod DB password hunter2-XYZZY"
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with memory enabled, as a gateway deploy has."""
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "memory:\n  memory_enabled: true\n  user_profile_enabled: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _gateway_agent(monkeypatch, chat_id: str) -> AIAgent:
+    """Build an agent the way GatewayRunner does for a Telegram message."""
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: [])
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
+    return AIAgent(
+        api_key="test-key",
+        base_url="http://test",
+        provider="openrouter",
+        api_mode="chat_completions",
+        max_iterations=1,
+        quiet_mode=True,
+        skip_context_files=True,
+        platform="telegram",
+        user_id="42",
+        chat_id=chat_id,
+        enabled_toolsets=["memory"],
+    )
+
+
+def _memory_tool_call(agent: AIAgent, **args) -> dict:
+    """Invoke the memory tool exactly as the tool registry dispatches it."""
+    from tools.memory_tool import memory_tool
+
+    return json.loads(memory_tool(store=agent._memory_store, **args))
+
+
+class TestGatewayScopedMemoryIsolation:
+    def test_dm_secret_isolated_from_group_session(self, hermes_home, monkeypatch):
+        # ── 1. DM session saves a secret scoped to the current chat ──
+        dm = _gateway_agent(monkeypatch, chat_id=DM_CHAT_ID)
+        assert dm._memory_store is not None
+        assert f"telegram:{DM_CHAT_ID}" in dm._memory_store.session_scopes
+
+        result = _memory_tool_call(
+            dm, action="add", target="memory",
+            content=SECRET, scope="current",
+        )
+        assert result["success"] is True
+        # Server-side resolution pinned it to the DM chat, no model-invented ID.
+        on_disk = (hermes_home / "memories" / "MEMORY.md").read_text(encoding="utf-8")
+        assert f"[scope: telegram:{DM_CHAT_ID}] {SECRET}" in on_disk
+
+        # An unscoped (global) entry for contrast.
+        assert _memory_tool_call(
+            dm, action="add", target="memory",
+            content="team stand-up is at 10am",
+        )["success"] is True
+
+        # ── 2. Group session on the SAME instance loads the same store ──
+        group = _gateway_agent(monkeypatch, chat_id=GROUP_CHAT_ID)
+        assert f"telegram:{GROUP_CHAT_ID}" in group._memory_store.session_scopes
+
+        # Surface 1: system-prompt snapshot must not contain the secret.
+        snap = group._memory_store.format_for_system_prompt("memory") or ""
+        assert SECRET not in snap
+        assert "team stand-up is at 10am" in snap  # global entry still shared
+
+        # Surface 2a: error inventories must not leak it.
+        err = _memory_tool_call(group, action="remove", target="memory")
+        assert err["success"] is False
+        assert SECRET not in json.dumps(err, ensure_ascii=False)
+        assert any("stand-up" in e for e in err["current_entries"])
+
+        # Surface 2b: the group session cannot target the entry by substring.
+        steal = _memory_tool_call(
+            group, action="replace", target="memory",
+            old_text="XYZZY", content="stolen",
+        )
+        assert steal["success"] is False
+        assert SECRET not in json.dumps(steal, ensure_ascii=False)
+
+        # And the secret is still intact on disk for the DM session.
+        on_disk = (hermes_home / "memories" / "MEMORY.md").read_text(encoding="utf-8")
+        assert SECRET in on_disk
+
+    def test_dm_session_keeps_full_access_to_its_secret(self, hermes_home, monkeypatch):
+        dm = _gateway_agent(monkeypatch, chat_id=DM_CHAT_ID)
+        _memory_tool_call(dm, action="add", target="memory",
+                          content=SECRET, scope="current")
+
+        # A NEW session of the same DM chat (fresh agent, same chat_id) sees
+        # the secret in its snapshot (marker stripped)…
+        dm2 = _gateway_agent(monkeypatch, chat_id=DM_CHAT_ID)
+        snap = dm2._memory_store.format_for_system_prompt("memory") or ""
+        assert SECRET in snap
+        assert "[scope:" not in snap
+
+        # …and can consolidate (replace) and delete it.
+        assert _memory_tool_call(
+            dm2, action="replace", target="memory",
+            old_text="hunter2-XYZZY", content=f"[scope: telegram:{DM_CHAT_ID}] rotated",
+        )["success"] is True
+        assert _memory_tool_call(
+            dm2, action="remove", target="memory", old_text="rotated",
+        )["success"] is True
+        on_disk = (hermes_home / "memories" / "MEMORY.md").read_text(encoding="utf-8")
+        assert SECRET not in on_disk
+
+    def test_cli_session_isolated_from_chat_scoped_entries(self, hermes_home, monkeypatch):
+        """A local CLI session (no gateway platform) must not see chat-scoped
+        secrets either — its identity is ['cli', ...], not a telegram scope."""
+        dm = _gateway_agent(monkeypatch, chat_id=DM_CHAT_ID)
+        _memory_tool_call(dm, action="add", target="memory",
+                          content=SECRET, scope="current")
+
+        monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: [])
+        monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+        monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
+        cli = AIAgent(
+            api_key="test-key", base_url="http://test",
+            provider="openrouter", api_mode="chat_completions",
+            max_iterations=1, quiet_mode=True, skip_context_files=True,
+            enabled_toolsets=["memory"],
+        )
+        snap = cli._memory_store.format_for_system_prompt("memory") or ""
+        assert SECRET not in snap
+        err = _memory_tool_call(cli, action="remove", target="memory")
+        assert SECRET not in json.dumps(err, ensure_ascii=False)

--- a/tests/tools/test_memory_scope.py
+++ b/tests/tools/test_memory_scope.py
@@ -15,6 +15,7 @@ from tools.memory_tool import (
     validate_scope,
     scope_matches,
     apply_scope_marker,
+    resolve_scope,
     MEMORY_SCHEMA,
     ENTRY_DELIMITER,
 )
@@ -178,10 +179,27 @@ class TestSnapshotScopeFiltering:
         store.load_from_disk()
         assert len(store.memory_entries) == len(self.ENTRIES)
 
-    def test_remove_scoped_entry_from_other_session(self, mem_dir):
-        """A session that doesn't match the scope can still manage the entry."""
+    def test_scoped_entry_not_removable_from_non_matching_session(self, mem_dir):
+        """Scope is an access boundary: a non-matching session can't target
+        the entry, and the no-match error must not leak it either."""
         _write_entries(mem_dir / "MEMORY.md", self.ENTRIES)
         store = MemoryStore(session_scopes=["cli"])
+        store.load_from_disk()
+        result = json.loads(memory_tool(
+            action="remove", target="memory",
+            old_text="private DM secret", store=store,
+        ))
+        assert result["success"] is False
+        # The error may echo the caller's own old_text, but the store
+        # inventory it returns must not contain the scoped entry.
+        assert not any("private DM secret" in e
+                       for e in result.get("current_entries", []))
+        # Entry untouched on disk.
+        assert any("private DM secret" in e for e in store.memory_entries)
+
+    def test_owning_session_can_remove_scoped_entry(self, mem_dir):
+        _write_entries(mem_dir / "MEMORY.md", self.ENTRIES)
+        store = MemoryStore(session_scopes=["telegram", "telegram:123"])
         store.load_from_disk()
         result = json.loads(memory_tool(
             action="remove", target="memory",
@@ -270,3 +288,178 @@ class TestMemoryToolScope:
         assert "scope" in MEMORY_SCHEMA["parameters"]["properties"]
         batch_props = MEMORY_SCHEMA["parameters"]["properties"]["operations"]["items"]["properties"]
         assert "scope" in batch_props
+
+    def test_schema_recommends_current_not_raw_ids(self):
+        """The model is never shown raw chat IDs, so the schema must steer it
+        to the server-resolved 'current' token (review feedback on #71224)."""
+        desc = MEMORY_SCHEMA["parameters"]["properties"]["scope"]["description"]
+        assert "current" in desc
+        assert "server-side" in desc
+
+
+# =========================================================================
+# 'current' scope resolution (server-side, review feedback on #71224)
+# =========================================================================
+
+class TestResolveScope:
+    def test_explicit_scope_passthrough(self):
+        assert resolve_scope("telegram:99", ["cli"]) == ("telegram:99", None)
+
+    def test_explicit_invalid_scope_errors(self):
+        scope, err = resolve_scope("bad scope]", ["cli"])
+        assert err is not None
+
+    def test_current_resolves_to_chat_scope(self):
+        scope, err = resolve_scope(
+            "current", ["telegram", "telegram:123456789", "profile:work"])
+        assert err is None
+        assert scope == "telegram:123456789"
+
+    def test_current_without_chat_id_falls_back_to_platform_wildcard(self):
+        scope, err = resolve_scope("current", ["telegram", "profile:work"])
+        assert err is None
+        assert scope == "telegram:*"
+
+    def test_current_with_no_identity_errors(self):
+        scope, err = resolve_scope("current", None)
+        assert err is not None
+        scope, err = resolve_scope("current", [])
+        assert err is not None
+
+    def test_current_ignores_profile_scopes(self):
+        scope, err = resolve_scope("current", ["profile:work"])
+        assert err is not None
+
+
+class TestCurrentScopeEndToEnd:
+    def test_add_with_current_scope(self, mem_dir):
+        store = MemoryStore(session_scopes=["telegram", "telegram:123"])
+        store.load_from_disk()
+        result = json.loads(memory_tool(
+            action="add", target="memory",
+            content="DB host: 10.0.1.50", scope="current", store=store,
+        ))
+        assert result["success"] is True
+        assert "[scope: telegram:123] DB host: 10.0.1.50" in store.memory_entries
+
+    def test_add_current_in_cli_session_errors_cleanly(self, mem_dir):
+        store = MemoryStore(session_scopes=["cli"])
+        store.load_from_disk()
+        result = json.loads(memory_tool(
+            action="add", target="memory",
+            content="x", scope="current", store=store,
+        ))
+        # cli has no chat_id → falls back to cli:* wildcard
+        assert result["success"] is True
+        assert "[scope: cli:*] x" in store.memory_entries
+
+    def test_batch_current_scope(self, mem_dir):
+        store = MemoryStore(session_scopes=["discord", "discord:777"])
+        store.load_from_disk()
+        result = json.loads(memory_tool(
+            target="memory",
+            operations=[{"action": "add", "content": "secret", "scope": "current"}],
+            store=store,
+        ))
+        assert result["success"] is True
+        assert "[scope: discord:777] secret" in store.memory_entries
+
+
+# =========================================================================
+# Error-path leak prevention (review feedback on #71224)
+# =========================================================================
+
+class TestErrorPathsDoNotLeakScopedEntries:
+    """Scope is an ACCESS BOUNDARY: no tool result reaching a non-matching
+    session may contain a scoped entry's text — including every error path
+    that returns current_entries or match previews."""
+
+    SECRET = "private DM secret token XYZZY"
+    ENTRIES = [
+        "global fact",
+        f"[scope: telegram:123] {SECRET}",
+    ]
+
+    @pytest.fixture
+    def other_chat_store(self, mem_dir):
+        _write_entries(mem_dir / "MEMORY.md", self.ENTRIES)
+        store = MemoryStore(session_scopes=["telegram", "telegram:999"])
+        store.load_from_disk()
+        return store
+
+    def _assert_no_leak(self, result):
+        assert self.SECRET not in json.dumps(result, ensure_ascii=False)
+
+    def test_missing_old_text_error(self, other_chat_store):
+        result = json.loads(memory_tool(
+            action="remove", target="memory", store=other_chat_store,
+        ))
+        assert result["success"] is False
+        self._assert_no_leak(result)
+        assert "global fact" in result["current_entries"]
+
+    def test_replace_no_match_error(self, other_chat_store):
+        result = json.loads(memory_tool(
+            action="replace", target="memory",
+            old_text="nonexistent", content="new", store=other_chat_store,
+        ))
+        assert result["success"] is False
+        self._assert_no_leak(result)
+
+    def test_remove_no_match_error(self, other_chat_store):
+        result = json.loads(memory_tool(
+            action="remove", target="memory",
+            old_text="nonexistent", store=other_chat_store,
+        ))
+        assert result["success"] is False
+        self._assert_no_leak(result)
+
+    def test_replace_cannot_target_invisible_entry(self, other_chat_store):
+        """Substring-matching an invisible entry must behave as no-match."""
+        result = json.loads(memory_tool(
+            action="replace", target="memory",
+            old_text="XYZZY", content="stolen", store=other_chat_store,
+        ))
+        assert result["success"] is False
+        self._assert_no_leak(result)
+
+    def test_add_capacity_error(self, mem_dir):
+        _write_entries(mem_dir / "MEMORY.md", self.ENTRIES)
+        store = MemoryStore(memory_char_limit=80,
+                            session_scopes=["telegram", "telegram:999"])
+        store.load_from_disk()
+        result = json.loads(memory_tool(
+            action="add", target="memory",
+            content="y" * 100, store=store,
+        ))
+        assert result["success"] is False
+        self._assert_no_leak(result)
+
+    def test_batch_error_inventory(self, other_chat_store):
+        result = json.loads(memory_tool(
+            target="memory",
+            operations=[{"action": "remove", "old_text": "nonexistent"}],
+            store=other_chat_store,
+        ))
+        assert result["success"] is False
+        self._assert_no_leak(result)
+
+    def test_batch_cannot_target_invisible_entry(self, other_chat_store):
+        result = json.loads(memory_tool(
+            target="memory",
+            operations=[{"action": "remove", "old_text": "XYZZY"}],
+            store=other_chat_store,
+        ))
+        assert result["success"] is False
+        self._assert_no_leak(result)
+
+    def test_owning_chat_still_sees_its_entry_in_errors(self, mem_dir):
+        """The boundary must not break the owning session's consolidation flow."""
+        _write_entries(mem_dir / "MEMORY.md", self.ENTRIES)
+        store = MemoryStore(session_scopes=["telegram", "telegram:123"])
+        store.load_from_disk()
+        result = json.loads(memory_tool(
+            action="remove", target="memory", store=store,
+        ))
+        assert result["success"] is False
+        assert self.SECRET in json.dumps(result, ensure_ascii=False)

--- a/tests/tools/test_memory_scope.py
+++ b/tests/tools/test_memory_scope.py
@@ -1,0 +1,272 @@
+"""Tests for scoped memory entries (issue #28279).
+
+Scope markers ("[scope: telegram:123] content") restrict which sessions an
+entry is injected into. Filtering is snapshot-side only: live state keeps all
+entries so replace/remove work across scopes.
+"""
+
+import json
+import pytest
+
+from tools.memory_tool import (
+    MemoryStore,
+    memory_tool,
+    parse_entry_scope,
+    validate_scope,
+    scope_matches,
+    apply_scope_marker,
+    MEMORY_SCHEMA,
+    ENTRY_DELIMITER,
+)
+
+
+# =========================================================================
+# Scope primitives
+# =========================================================================
+
+class TestParseEntryScope:
+    def test_unscoped_entry(self):
+        assert parse_entry_scope("plain fact") == ("", "plain fact")
+
+    def test_scoped_entry(self):
+        scope, content = parse_entry_scope("[scope: telegram:123] DB host: 10.0.1.50")
+        assert scope == "telegram:123"
+        assert content == "DB host: 10.0.1.50"
+
+    def test_wildcard_scope(self):
+        scope, content = parse_entry_scope("[scope: discord:*] server rules apply")
+        assert scope == "discord:*"
+        assert content == "server rules apply"
+
+    def test_profile_scope(self):
+        scope, _ = parse_entry_scope("[scope: profile:work] VPN config at ~/vpn")
+        assert scope == "profile:work"
+
+    def test_scope_marker_mid_entry_is_not_a_marker(self):
+        scope, content = parse_entry_scope("note about [scope: telegram:1] syntax")
+        assert scope == ""
+        assert content == "note about [scope: telegram:1] syntax"
+
+    def test_multiline_entry(self):
+        entry = "[scope: telegram:99] line one\nline two"
+        scope, content = parse_entry_scope(entry)
+        assert scope == "telegram:99"
+        assert content == "line one\nline two"
+
+
+class TestValidateScope:
+    @pytest.mark.parametrize("scope", [
+        "telegram:123456789", "discord:999", "telegram:*",
+        "profile:work", "cli", "matrix:room-1.example_a",
+    ])
+    def test_valid(self, scope):
+        assert validate_scope(scope) is None
+
+    @pytest.mark.parametrize("scope", [
+        "telegram:123]extra", "has space:1", "a:b:c:d]", "[nested]", "",
+    ])
+    def test_invalid(self, scope):
+        assert validate_scope(scope) is not None
+
+
+class TestScopeMatches:
+    SESSION = ["telegram", "telegram:123", "profile:work"]
+
+    def test_global_matches_everywhere(self):
+        assert scope_matches("", self.SESSION)
+        assert scope_matches("", [])
+
+    def test_exact_chat_match(self):
+        assert scope_matches("telegram:123", self.SESSION)
+
+    def test_other_chat_no_match(self):
+        assert not scope_matches("telegram:456", self.SESSION)
+
+    def test_other_platform_no_match(self):
+        assert not scope_matches("discord:123", self.SESSION)
+
+    def test_platform_wildcard(self):
+        assert scope_matches("telegram:*", self.SESSION)
+        assert not scope_matches("discord:*", self.SESSION)
+
+    def test_profile_match(self):
+        assert scope_matches("profile:work", self.SESSION)
+        assert not scope_matches("profile:home", self.SESSION)
+
+    def test_none_session_scopes_disables_filtering(self):
+        assert scope_matches("telegram:123", None)
+        assert scope_matches("discord:456", None)
+
+
+class TestApplyScopeMarker:
+    def test_prepends(self):
+        assert apply_scope_marker("fact", "telegram:1") == "[scope: telegram:1] fact"
+
+    def test_no_scope_is_identity(self):
+        assert apply_scope_marker("fact", None) == "fact"
+        assert apply_scope_marker("fact", "") == "fact"
+
+    def test_idempotent_same_scope(self):
+        once = apply_scope_marker("fact", "telegram:1")
+        assert apply_scope_marker(once, "telegram:1") == once
+
+    def test_rescope_replaces_marker(self):
+        once = apply_scope_marker("fact", "telegram:1")
+        assert apply_scope_marker(once, "discord:2") == "[scope: discord:2] fact"
+
+
+# =========================================================================
+# Snapshot filtering
+# =========================================================================
+
+@pytest.fixture
+def mem_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+    return tmp_path
+
+
+def _write_entries(path, entries):
+    path.write_text(ENTRY_DELIMITER.join(entries), encoding="utf-8")
+
+
+class TestSnapshotScopeFiltering:
+    ENTRIES = [
+        "global fact",
+        "[scope: telegram:123] private DM secret",
+        "[scope: telegram:*] telegram-wide note",
+        "[scope: discord:9] discord channel note",
+        "[scope: profile:work] work-only fact",
+    ]
+
+    def _snapshot(self, store):
+        return store.format_for_system_prompt("memory") or ""
+
+    def test_matching_session_sees_scoped_entries_without_marker(self, mem_dir):
+        _write_entries(mem_dir / "MEMORY.md", self.ENTRIES)
+        store = MemoryStore(session_scopes=["telegram", "telegram:123", "profile:work"])
+        store.load_from_disk()
+        snap = self._snapshot(store)
+        assert "global fact" in snap
+        assert "private DM secret" in snap
+        assert "telegram-wide note" in snap
+        assert "work-only fact" in snap
+        assert "discord channel note" not in snap
+        assert "[scope:" not in snap  # markers stripped from prompt
+
+    def test_other_chat_does_not_see_dm_secret(self, mem_dir):
+        _write_entries(mem_dir / "MEMORY.md", self.ENTRIES)
+        store = MemoryStore(session_scopes=["telegram", "telegram:999"])
+        store.load_from_disk()
+        snap = self._snapshot(store)
+        assert "private DM secret" not in snap      # the issue's core scenario
+        assert "telegram-wide note" in snap          # wildcard still matches
+        assert "global fact" in snap
+
+    def test_none_session_scopes_keeps_pre_scope_behaviour(self, mem_dir):
+        _write_entries(mem_dir / "MEMORY.md", self.ENTRIES)
+        store = MemoryStore(session_scopes=None)
+        store.load_from_disk()
+        snap = self._snapshot(store)
+        # No filtering: every entry injected verbatim, markers intact.
+        assert "private DM secret" in snap
+        assert "discord channel note" in snap
+        assert "[scope: telegram:123]" in snap
+
+    def test_live_state_keeps_all_entries(self, mem_dir):
+        _write_entries(mem_dir / "MEMORY.md", self.ENTRIES)
+        store = MemoryStore(session_scopes=["cli"])
+        store.load_from_disk()
+        assert len(store.memory_entries) == len(self.ENTRIES)
+
+    def test_remove_scoped_entry_from_other_session(self, mem_dir):
+        """A session that doesn't match the scope can still manage the entry."""
+        _write_entries(mem_dir / "MEMORY.md", self.ENTRIES)
+        store = MemoryStore(session_scopes=["cli"])
+        store.load_from_disk()
+        result = json.loads(memory_tool(
+            action="remove", target="memory",
+            old_text="private DM secret", store=store,
+        ))
+        assert result["success"] is True
+        assert not any("private DM secret" in e for e in store.memory_entries)
+
+    def test_user_target_also_filtered(self, mem_dir):
+        _write_entries(mem_dir / "USER.md", [
+            "likes short answers",
+            "[scope: telegram:123] shares personal health details here",
+        ])
+        store = MemoryStore(session_scopes=["telegram", "telegram:999"])
+        store.load_from_disk()
+        snap = store.format_for_system_prompt("user") or ""
+        assert "likes short answers" in snap
+        assert "health details" not in snap
+
+
+# =========================================================================
+# Tool entry point
+# =========================================================================
+
+class TestMemoryToolScope:
+    def test_add_with_scope_stores_marker(self, mem_dir):
+        store = MemoryStore(session_scopes=["telegram", "telegram:123"])
+        store.load_from_disk()
+        result = json.loads(memory_tool(
+            action="add", target="memory",
+            content="DB host: 10.0.1.50", scope="telegram:123", store=store,
+        ))
+        assert result["success"] is True
+        assert "[scope: telegram:123] DB host: 10.0.1.50" in store.memory_entries
+
+    def test_add_with_invalid_scope_rejected(self, mem_dir):
+        store = MemoryStore()
+        store.load_from_disk()
+        result = json.loads(memory_tool(
+            action="add", target="memory",
+            content="x", scope="bad scope]", store=store,
+        ))
+        assert result["success"] is False
+        assert "Invalid scope" in result["error"]
+        assert store.memory_entries == []
+
+    def test_add_without_scope_unchanged(self, mem_dir):
+        store = MemoryStore()
+        store.load_from_disk()
+        result = json.loads(memory_tool(
+            action="add", target="memory", content="plain fact", store=store,
+        ))
+        assert result["success"] is True
+        assert store.memory_entries == ["plain fact"]
+
+    def test_batch_op_scope(self, mem_dir):
+        store = MemoryStore()
+        store.load_from_disk()
+        result = json.loads(memory_tool(
+            target="memory",
+            operations=[
+                {"action": "add", "content": "global note"},
+                {"action": "add", "content": "chat secret", "scope": "telegram:42"},
+            ],
+            store=store,
+        ))
+        assert result["success"] is True
+        assert "global note" in store.memory_entries
+        assert "[scope: telegram:42] chat secret" in store.memory_entries
+
+    def test_batch_invalid_scope_rejects_whole_batch(self, mem_dir):
+        store = MemoryStore()
+        store.load_from_disk()
+        result = json.loads(memory_tool(
+            target="memory",
+            operations=[
+                {"action": "add", "content": "ok"},
+                {"action": "add", "content": "bad", "scope": "no way]"},
+            ],
+            store=store,
+        ))
+        assert result["success"] is False
+        assert store.memory_entries == []
+
+    def test_schema_documents_scope(self):
+        assert "scope" in MEMORY_SCHEMA["parameters"]["properties"]
+        batch_props = MEMORY_SCHEMA["parameters"]["properties"]["operations"]["items"]["properties"]
+        assert "scope" in batch_props

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -147,6 +147,43 @@ def apply_scope_marker(content: str, scope: Optional[str]) -> str:
     return f"[scope: {scope}] {bare if existing else content}"
 
 
+# Sentinel scope value resolved server-side to the running session's own
+# chat scope. The model never sees raw chat IDs in its system prompt, so it
+# cannot construct 'telegram:123456789' itself — it says 'current' and the
+# store resolves it from trusted session context (issue #28279 review).
+CURRENT_SCOPE_SENTINEL = "current"
+
+
+def resolve_scope(scope: str, session_scopes: Optional[List[str]]) -> tuple:
+    """Resolve a model-supplied scope value to a concrete stored scope.
+
+    Returns (resolved_scope, error). 'current' resolves to the session's most
+    specific chat scope ('platform:chat_id' when the session has one, else the
+    bare platform). Any other value is validated and passed through.
+    """
+    scope = (scope or "").strip()
+    if scope != CURRENT_SCOPE_SENTINEL:
+        err = validate_scope(scope)
+        return (scope, err) if not err else ("", err)
+    if not session_scopes:
+        return "", (
+            "Cannot resolve scope 'current': this session has no platform "
+            "identity. Omit scope, or pass an explicit one."
+        )
+    chat_scopes = [s for s in session_scopes
+                   if ":" in s and not s.startswith("profile:")]
+    if chat_scopes:
+        # Most specific chat scope (e.g. 'telegram:123456789').
+        return max(chat_scopes, key=len), None
+    platforms = [s for s in session_scopes if ":" not in s]
+    if platforms:
+        return f"{platforms[0]}:*", None
+    return "", (
+        "Cannot resolve scope 'current': session identity has no platform "
+        "component. Omit scope, or pass an explicit one."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Memory content scanning — lightweight check for injection/exfiltration
 # in content that gets injected into the system prompt.
@@ -323,6 +360,25 @@ class MemoryStore:
                 kept.append(bare)
         return kept
 
+    def _entry_visible(self, entry: str) -> bool:
+        """True when this session may see/mutate the entry.
+
+        Scope is an ACCESS BOUNDARY, not just prompt routing: sessions that
+        don't match an entry's scope must not receive it through any tool
+        result either — error inventories (``current_entries``), match
+        previews, and replace/remove targeting all go through this check.
+        Markers are kept on visible entries here (unlike the snapshot) so the
+        owning session can manage and re-scope them.
+        """
+        if self.session_scopes is None:
+            return True
+        scope, _ = parse_entry_scope(entry)
+        return scope_matches(scope, self.session_scopes)
+
+    def _visible_entries(self, entries: List[str]) -> List[str]:
+        """Filter an entry list down to what this session may see."""
+        return [e for e in entries if self._entry_visible(e)]
+
     @staticmethod
     def _sanitize_entries_for_snapshot(entries: List[str], filename: str) -> List[str]:
         """Return ``entries`` with any threat-matching entry replaced by a placeholder.
@@ -494,7 +550,7 @@ class MemoryStore:
                         f"shorter ones or 'remove' stale or less important entries (see "
                         f"current_entries below), then retry this add — all in this turn."
                     ),
-                    "current_entries": entries,
+                    "current_entries": self._visible_entries(entries),
                     "usage": f"{current:,}/{limit:,}",
                 })
 
@@ -524,13 +580,16 @@ class MemoryStore:
                 return _drift_error(self._path_for(target), bak)
 
             entries = self._entries_for(target)
-            matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
+            # Scoped entries invisible to this session are not valid targets:
+            # matching them would leak their text via error/preview paths.
+            matches = [(i, e) for i, e in enumerate(entries)
+                       if old_text in e and self._entry_visible(e)]
 
             if not matches:
                 return self._consolidation_failure({
                     "success": False,
                     "error": f"No entry matched '{old_text}'. Check current_entries below and retry with the exact text of the entry you want to replace.",
-                    "current_entries": entries,
+                    "current_entries": self._visible_entries(entries),
                 })
 
             if len(matches) > 1:
@@ -563,7 +622,7 @@ class MemoryStore:
                         f"entries to make room (see current_entries below), then retry — all "
                         f"in this turn."
                     ),
-                    "current_entries": entries,
+                    "current_entries": self._visible_entries(entries),
                     "usage": f"{current:,}/{limit:,}",
                 })
 
@@ -585,13 +644,15 @@ class MemoryStore:
                 return _drift_error(self._path_for(target), bak)
 
             entries = self._entries_for(target)
-            matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
+            # Same visibility rule as replace: invisible entries can't be hit.
+            matches = [(i, e) for i, e in enumerate(entries)
+                       if old_text in e and self._entry_visible(e)]
 
             if not matches:
                 return self._consolidation_failure({
                     "success": False,
                     "error": f"No entry matched '{old_text}'. Check current_entries below and retry with the exact text of the entry you want to remove.",
-                    "current_entries": entries,
+                    "current_entries": self._visible_entries(entries),
                 })
 
             if len(matches) > 1:
@@ -670,7 +731,8 @@ class MemoryStore:
                             target,
                             f"{pos}: content is required (use action='remove' to delete).",
                         )
-                    matches = [j for j, e in enumerate(working) if old_text in e]
+                    matches = [j for j, e in enumerate(working)
+                               if old_text in e and self._entry_visible(e)]
                     if not matches:
                         return self._batch_error(target, f"{pos}: no entry matched '{old_text}'.")
                     if len({working[j] for j in matches}) > 1:
@@ -683,7 +745,8 @@ class MemoryStore:
                 elif act == "remove":
                     if not old_text:
                         return self._batch_error(target, f"{pos}: old_text is required.")
-                    matches = [j for j, e in enumerate(working) if old_text in e]
+                    matches = [j for j, e in enumerate(working)
+                               if old_text in e and self._entry_visible(e)]
                     if not matches:
                         return self._batch_error(target, f"{pos}: no entry matched '{old_text}'.")
                     if len({working[j] for j in matches}) > 1:
@@ -710,7 +773,7 @@ class MemoryStore:
                         f"{new_total:,}/{limit:,} chars -- over the limit. Remove or shorten more "
                         f"entries in the same batch (see current_entries below), then retry."
                     ),
-                    "current_entries": self._entries_for(target),
+                    "current_entries": self._visible_entries(self._entries_for(target)),
                     "usage": f"{current:,}/{limit:,}",
                 })
 
@@ -727,7 +790,7 @@ class MemoryStore:
         return self._consolidation_failure({
             "success": False,
             "error": message + " No operations were applied (batch is all-or-nothing).",
-            "current_entries": self._entries_for(target),
+            "current_entries": self._visible_entries(self._entries_for(target)),
             "usage": f"{current:,}/{limit:,}",
         })
 
@@ -1057,7 +1120,9 @@ def _missing_old_text_error(store: "MemoryStore", target: str, action: str) -> s
     the call with ``old_text`` set to a unique substring of the entry it means.
     Mirrors the batch path's ``_batch_error`` shape. (issues #43412, #49466)
     """
-    entries = store._entries_for(target)
+    # Only entries visible to this session — the raw store may hold entries
+    # scoped to other chats, which must not leak through error inventories.
+    entries = store._visible_entries(store._entries_for(target))
     current = store._char_count(target)
     limit = store._char_limit(target)
     return json.dumps(
@@ -1122,10 +1187,10 @@ def memory_tool(
             op = dict(op or {})
             op_scope = (op.pop("scope", None) or "").strip()
             if op_scope and op.get("action") == "add" and op.get("content"):
-                err = validate_scope(op_scope)
+                resolved, err = resolve_scope(op_scope, store.session_scopes)
                 if err:
                     return tool_error(err, success=False)
-                op["content"] = apply_scope_marker(op["content"], op_scope)
+                op["content"] = apply_scope_marker(op["content"], resolved)
             folded.append(op)
         operations = folded
         gate_result = _apply_batch_write_gate(target, operations)
@@ -1144,10 +1209,10 @@ def memory_tool(
     # which already works against the stored "[scope: ...] content" text.
     scope = (scope or "").strip()
     if scope and action == "add":
-        err = validate_scope(scope)
+        resolved, err = resolve_scope(scope, store.session_scopes)
         if err:
             return tool_error(err, success=False)
-        content = apply_scope_marker(content, scope)
+        content = apply_scope_marker(content, resolved)
     if action == "replace" and (not old_text or not content):
         missing = "old_text" if not old_text else "content"
         if not old_text:
@@ -1257,11 +1322,13 @@ MEMORY_SCHEMA = {
                 "type": "string",
                 "description": (
                     "Optional, 'add' only: restrict where this entry is injected. "
-                    "Formats: 'platform:chat_id' (e.g. 'telegram:123456789') for one "
-                    "chat, 'platform:*' for all chats on a platform, 'profile:name' "
-                    "for a Hermes profile. Omit for global (injected everywhere). "
-                    "Use a scope whenever the fact is private to the current chat "
-                    "(credentials, personal details shared in a DM)."
+                    "Use 'current' to pin the entry to THIS chat — it is resolved "
+                    "server-side from the session, so you never need a chat ID. "
+                    "Explicit forms also work: 'platform:*' (all chats on a "
+                    "platform), 'profile:name' (a Hermes profile). Omit for global "
+                    "(injected everywhere). Use scope='current' whenever the fact "
+                    "is private to this conversation (credentials, personal "
+                    "details shared in a DM)."
                 )
             },
             "operations": {
@@ -1277,7 +1344,7 @@ MEMORY_SCHEMA = {
                         "action": {"type": "string", "enum": ["add", "replace", "remove"]},
                         "content": {"type": "string", "description": "Entry content for add/replace."},
                         "old_text": {"type": "string", "description": "Substring identifying the entry for replace/remove."},
-                        "scope": {"type": "string", "description": "Optional, add only: injection scope ('platform:chat_id', 'platform:*', or 'profile:name')."},
+                        "scope": {"type": "string", "description": "Optional, add only: injection scope. 'current' pins to this chat (resolved server-side); also 'platform:*' or 'profile:name'."},
                     },
                     "required": ["action"],
                 },

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -68,6 +68,84 @@ MEMORY_BLOCK_HEADERS = {
 
 ENTRY_DELIMITER = "\n§\n"
 
+# ---------------------------------------------------------------------------
+# Scoped memory (issue #28279)
+#
+# An entry may carry an optional scope marker as a text prefix:
+#     [scope: telegram:123456789] Production DB host: 10.0.1.50
+#
+# Scope encodes WHERE the entry may be injected. At snapshot-build time
+# (load_from_disk) entries whose scope does not match the current session are
+# excluded from the system prompt. Live state keeps ALL entries so
+# replace/remove/dedup keep working across scopes, and so the agent that owns
+# a scope can still manage its entries from any session via the memory tool.
+#
+# Supported scope forms (mirrors the issue proposal):
+#     telegram:123456789   exact chat/channel on a platform
+#     telegram:*           any chat on that platform
+#     profile:work         a Hermes profile
+#     (no marker)          global — injected everywhere (backward compatible)
+#
+# The marker is plain entry text: it round-trips through the existing
+# file format, char limits, substring-based replace/remove, and the staged
+# write-approval path without any storage migration.
+# ---------------------------------------------------------------------------
+
+import re
+
+_SCOPE_MARKER_RE = re.compile(r"^\[scope:\s*([^\]]+)\]\s*", re.DOTALL)
+
+# platform | platform:id | platform:* | profile:name — conservative charset,
+# no whitespace/brackets so the marker regex can never be confused.
+_VALID_SCOPE_RE = re.compile(r"^[A-Za-z0-9_.-]+(?::[A-Za-z0-9_.*-]+)?$")
+
+
+def parse_entry_scope(entry: str) -> tuple:
+    """Split an entry into (scope, content). scope is '' when unscoped."""
+    m = _SCOPE_MARKER_RE.match(entry)
+    if not m:
+        return "", entry
+    return m.group(1).strip(), entry[m.end():]
+
+
+def validate_scope(scope: str) -> Optional[str]:
+    """Return an error string if the scope value is malformed, else None."""
+    if not _VALID_SCOPE_RE.match(scope):
+        return (
+            f"Invalid scope '{scope}'. Use 'platform:chat_id' (e.g. "
+            f"'telegram:123456789'), 'platform:*', or 'profile:name'."
+        )
+    return None
+
+
+def scope_matches(scope: str, session_scopes: Optional[List[str]]) -> bool:
+    """True when an entry with ``scope`` may be injected into this session.
+
+    ``session_scopes`` is the identity list of the running session, e.g.
+    ``["telegram", "telegram:123456789", "profile:work"]``. ``None`` means
+    "no filtering" (write-only stores, or callers predating scope support).
+    """
+    scope = (scope or "").strip()
+    if not scope:
+        return True  # global entry
+    if session_scopes is None:
+        return True
+    if scope.endswith(":*"):
+        base = scope[:-2]        # "telegram"
+        prefix = scope[:-1]      # "telegram:"
+        return any(s == base or s.startswith(prefix) for s in session_scopes)
+    return scope in session_scopes
+
+
+def apply_scope_marker(content: str, scope: Optional[str]) -> str:
+    """Prepend the scope marker to entry content (idempotent for same scope)."""
+    if not scope:
+        return content
+    existing, bare = parse_entry_scope(content)
+    if existing == scope:
+        return content
+    return f"[scope: {scope}] {bare if existing else content}"
+
 
 # ---------------------------------------------------------------------------
 # Memory content scanning — lightweight check for injection/exfiltration
@@ -137,11 +215,16 @@ class MemoryStore:
     # turn to budget exhaustion and suppress the user's reply (issue #42405).
     _MAX_CONSOLIDATION_FAILURES_PER_TURN = 3
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375,
+                 session_scopes: Optional[List[str]] = None):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
+        # Session identity for scoped-entry filtering (issue #28279), e.g.
+        # ["telegram", "telegram:123456789", "profile:work"]. None disables
+        # filtering entirely (all entries injected — pre-scope behaviour).
+        self.session_scopes = session_scopes
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
         # Per-turn counter of failed at-capacity consolidation attempts; reset
@@ -202,17 +285,43 @@ class MemoryStore:
         self.memory_entries = list(dict.fromkeys(self.memory_entries))
         self.user_entries = list(dict.fromkeys(self.user_entries))
 
+        # Scope filtering happens BEFORE sanitization, snapshot-side only
+        # (issue #28279): entries scoped to another chat/platform/profile are
+        # dropped from the system prompt but stay in live state, so the memory
+        # tool can still list/replace/remove them from any session.
+        snapshot_memory = self._filter_entries_for_scope(self.memory_entries)
+        snapshot_user = self._filter_entries_for_scope(self.user_entries)
+
         # Sanitize entries for the system-prompt snapshot only.  Live state
         # (memory_entries / user_entries) keeps the raw text so the user
         # can see + remove poisoned entries via the memory tool.
-        sanitized_memory = self._sanitize_entries_for_snapshot(self.memory_entries, "MEMORY.md")
-        sanitized_user = self._sanitize_entries_for_snapshot(self.user_entries, "USER.md")
+        sanitized_memory = self._sanitize_entries_for_snapshot(snapshot_memory, "MEMORY.md")
+        sanitized_user = self._sanitize_entries_for_snapshot(snapshot_user, "USER.md")
 
         # Capture frozen snapshot for system prompt injection
         self._system_prompt_snapshot = {
             "memory": self._render_block("memory", sanitized_memory),
             "user": self._render_block("user", sanitized_user),
         }
+
+    def _filter_entries_for_scope(self, entries: List[str]) -> List[str]:
+        """Return entries whose scope matches this session (issue #28279).
+
+        Matching entries are returned WITH their scope marker stripped — the
+        marker is routing metadata, not content the model needs to see.
+        Unscoped entries pass through unchanged. ``session_scopes is None``
+        disables filtering (backward compatible).
+        """
+        if self.session_scopes is None:
+            return list(entries)
+        kept: List[str] = []
+        for entry in entries:
+            scope, bare = parse_entry_scope(entry)
+            if not scope:
+                kept.append(entry)
+            elif scope_matches(scope, self.session_scopes):
+                kept.append(bare)
+        return kept
 
     @staticmethod
     def _sanitize_entries_for_snapshot(entries: List[str], filename: str) -> List[str]:
@@ -973,14 +1082,19 @@ def memory_tool(
     old_text: str = None,
     operations: Optional[List[Dict[str, Any]]] = None,
     store: Optional[MemoryStore] = None,
+    scope: str = None,
 ) -> str:
     """
     Single entry point for the memory tool. Dispatches to MemoryStore methods.
 
     Two shapes:
-      - Single op: action + (content / old_text).
-      - Batch:     operations=[{action, content?, old_text?}, ...] applied
-                   atomically against the final char budget in ONE call.
+      - Single op: action + (content / old_text), optionally scope.
+      - Batch:     operations=[{action, content?, old_text?, scope?}, ...]
+                   applied atomically against the final char budget in ONE call.
+
+    ``scope`` (issue #28279) restricts where an added entry is injected:
+    'platform:chat_id', 'platform:*', or 'profile:name'. Unscoped entries
+    remain global.
 
     Returns JSON string with results.
     """
@@ -1000,6 +1114,20 @@ def memory_tool(
     if operations:
         if not isinstance(operations, list):
             return tool_error("operations must be a list of {action, content?, old_text?} objects.", success=False)
+        # Fold per-op scope into content up front so the gate preview, the
+        # atomic char-budget check, and the staged-approval replay all see
+        # the final stored text (issue #28279).
+        folded: List[Dict[str, Any]] = []
+        for op in operations:
+            op = dict(op or {})
+            op_scope = (op.pop("scope", None) or "").strip()
+            if op_scope and op.get("action") == "add" and op.get("content"):
+                err = validate_scope(op_scope)
+                if err:
+                    return tool_error(err, success=False)
+                op["content"] = apply_scope_marker(op["content"], op_scope)
+            folded.append(op)
+        operations = folded
         gate_result = _apply_batch_write_gate(target, operations)
         if gate_result is not None:
             return gate_result
@@ -1011,6 +1139,15 @@ def memory_tool(
     # immediately instead of being staged and only failing at approve time.
     if action == "add" and not content:
         return tool_error("Content is required for 'add' action.", success=False)
+
+    # Scope only applies to add: replace/remove locate entries by substring,
+    # which already works against the stored "[scope: ...] content" text.
+    scope = (scope or "").strip()
+    if scope and action == "add":
+        err = validate_scope(scope)
+        if err:
+            return tool_error(err, success=False)
+        content = apply_scope_marker(content, scope)
     if action == "replace" and (not old_text or not content):
         missing = "old_text" if not old_text else "content"
         if not old_text:
@@ -1116,6 +1253,17 @@ MEMORY_SCHEMA = {
                 "type": "string",
                 "description": "REQUIRED for 'replace' and 'remove' (single-op shape): a short unique substring identifying the existing entry to modify. Omit only for 'add'."
             },
+            "scope": {
+                "type": "string",
+                "description": (
+                    "Optional, 'add' only: restrict where this entry is injected. "
+                    "Formats: 'platform:chat_id' (e.g. 'telegram:123456789') for one "
+                    "chat, 'platform:*' for all chats on a platform, 'profile:name' "
+                    "for a Hermes profile. Omit for global (injected everywhere). "
+                    "Use a scope whenever the fact is private to the current chat "
+                    "(credentials, personal details shared in a DM)."
+                )
+            },
             "operations": {
                 "type": "array",
                 "description": (
@@ -1129,6 +1277,7 @@ MEMORY_SCHEMA = {
                         "action": {"type": "string", "enum": ["add", "replace", "remove"]},
                         "content": {"type": "string", "description": "Entry content for add/replace."},
                         "old_text": {"type": "string", "description": "Substring identifying the entry for replace/remove."},
+                        "scope": {"type": "string", "description": "Optional, add only: injection scope ('platform:chat_id', 'platform:*', or 'profile:name')."},
                     },
                     "required": ["action"],
                 },
@@ -1152,7 +1301,8 @@ registry.register(
         content=args.get("content"),
         old_text=args.get("old_text"),
         operations=args.get("operations"),
-        store=kw.get("store")),
+        store=kw.get("store"),
+        scope=args.get("scope")),
     check_fn=check_memory_requirements,
     emoji="🧠",
 )

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -66,6 +66,84 @@ MEMORY_BLOCK_HEADERS = {
 
 ENTRY_DELIMITER = "\n§\n"
 
+# ---------------------------------------------------------------------------
+# Scoped memory (issue #28279)
+#
+# An entry may carry an optional scope marker as a text prefix:
+#     [scope: telegram:123456789] Production DB host: 10.0.1.50
+#
+# Scope encodes WHERE the entry may be injected. At snapshot-build time
+# (load_from_disk) entries whose scope does not match the current session are
+# excluded from the system prompt. Live state keeps ALL entries so
+# replace/remove/dedup keep working across scopes, and so the agent that owns
+# a scope can still manage its entries from any session via the memory tool.
+#
+# Supported scope forms (mirrors the issue proposal):
+#     telegram:123456789   exact chat/channel on a platform
+#     telegram:*           any chat on that platform
+#     profile:work         a Hermes profile
+#     (no marker)          global — injected everywhere (backward compatible)
+#
+# The marker is plain entry text: it round-trips through the existing
+# file format, char limits, substring-based replace/remove, and the staged
+# write-approval path without any storage migration.
+# ---------------------------------------------------------------------------
+
+import re
+
+_SCOPE_MARKER_RE = re.compile(r"^\[scope:\s*([^\]]+)\]\s*", re.DOTALL)
+
+# platform | platform:id | platform:* | profile:name — conservative charset,
+# no whitespace/brackets so the marker regex can never be confused.
+_VALID_SCOPE_RE = re.compile(r"^[A-Za-z0-9_.-]+(?::[A-Za-z0-9_.*-]+)?$")
+
+
+def parse_entry_scope(entry: str) -> tuple:
+    """Split an entry into (scope, content). scope is '' when unscoped."""
+    m = _SCOPE_MARKER_RE.match(entry)
+    if not m:
+        return "", entry
+    return m.group(1).strip(), entry[m.end():]
+
+
+def validate_scope(scope: str) -> Optional[str]:
+    """Return an error string if the scope value is malformed, else None."""
+    if not _VALID_SCOPE_RE.match(scope):
+        return (
+            f"Invalid scope '{scope}'. Use 'platform:chat_id' (e.g. "
+            f"'telegram:123456789'), 'platform:*', or 'profile:name'."
+        )
+    return None
+
+
+def scope_matches(scope: str, session_scopes: Optional[List[str]]) -> bool:
+    """True when an entry with ``scope`` may be injected into this session.
+
+    ``session_scopes`` is the identity list of the running session, e.g.
+    ``["telegram", "telegram:123456789", "profile:work"]``. ``None`` means
+    "no filtering" (write-only stores, or callers predating scope support).
+    """
+    scope = (scope or "").strip()
+    if not scope:
+        return True  # global entry
+    if session_scopes is None:
+        return True
+    if scope.endswith(":*"):
+        base = scope[:-2]        # "telegram"
+        prefix = scope[:-1]      # "telegram:"
+        return any(s == base or s.startswith(prefix) for s in session_scopes)
+    return scope in session_scopes
+
+
+def apply_scope_marker(content: str, scope: Optional[str]) -> str:
+    """Prepend the scope marker to entry content (idempotent for same scope)."""
+    if not scope:
+        return content
+    existing, bare = parse_entry_scope(content)
+    if existing == scope:
+        return content
+    return f"[scope: {scope}] {bare if existing else content}"
+
 
 # ---------------------------------------------------------------------------
 # Memory content scanning — lightweight check for injection/exfiltration
@@ -162,11 +240,16 @@ class MemoryStore:
     # turn to budget exhaustion and suppress the user's reply (issue #42405).
     _MAX_CONSOLIDATION_FAILURES_PER_TURN = 3
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375,
+                 session_scopes: Optional[List[str]] = None):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
+        # Session identity for scoped-entry filtering (issue #28279), e.g.
+        # ["telegram", "telegram:123456789", "profile:work"]. None disables
+        # filtering entirely (all entries injected — pre-scope behaviour).
+        self.session_scopes = session_scopes
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
         # Per-turn counter of failed at-capacity consolidation attempts; reset
@@ -227,17 +310,43 @@ class MemoryStore:
         self.memory_entries = list(dict.fromkeys(self.memory_entries))
         self.user_entries = list(dict.fromkeys(self.user_entries))
 
+        # Scope filtering happens BEFORE sanitization, snapshot-side only
+        # (issue #28279): entries scoped to another chat/platform/profile are
+        # dropped from the system prompt but stay in live state, so the memory
+        # tool can still list/replace/remove them from any session.
+        snapshot_memory = self._filter_entries_for_scope(self.memory_entries)
+        snapshot_user = self._filter_entries_for_scope(self.user_entries)
+
         # Sanitize entries for the system-prompt snapshot only.  Live state
         # (memory_entries / user_entries) keeps the raw text so the user
         # can see + remove poisoned entries via the memory tool.
-        sanitized_memory = self._sanitize_entries_for_snapshot(self.memory_entries, "MEMORY.md")
-        sanitized_user = self._sanitize_entries_for_snapshot(self.user_entries, "USER.md")
+        sanitized_memory = self._sanitize_entries_for_snapshot(snapshot_memory, "MEMORY.md")
+        sanitized_user = self._sanitize_entries_for_snapshot(snapshot_user, "USER.md")
 
         # Capture frozen snapshot for system prompt injection
         self._system_prompt_snapshot = {
             "memory": self._render_block("memory", sanitized_memory),
             "user": self._render_block("user", sanitized_user),
         }
+
+    def _filter_entries_for_scope(self, entries: List[str]) -> List[str]:
+        """Return entries whose scope matches this session (issue #28279).
+
+        Matching entries are returned WITH their scope marker stripped — the
+        marker is routing metadata, not content the model needs to see.
+        Unscoped entries pass through unchanged. ``session_scopes is None``
+        disables filtering (backward compatible).
+        """
+        if self.session_scopes is None:
+            return list(entries)
+        kept: List[str] = []
+        for entry in entries:
+            scope, bare = parse_entry_scope(entry)
+            if not scope:
+                kept.append(entry)
+            elif scope_matches(scope, self.session_scopes):
+                kept.append(bare)
+        return kept
 
     @staticmethod
     def _sanitize_entries_for_snapshot(entries: List[str], filename: str) -> List[str]:
@@ -1059,14 +1168,19 @@ def memory_tool(
     old_text: str = None,
     operations: Optional[List[Dict[str, Any]]] = None,
     store: Optional[MemoryStore] = None,
+    scope: str = None,
 ) -> str:
     """
     Single entry point for the memory tool. Dispatches to MemoryStore methods.
 
     Two shapes:
-      - Single op: action + (content / old_text).
-      - Batch:     operations=[{action, content?, old_text?}, ...] applied
-                   atomically against the final char budget in ONE call.
+      - Single op: action + (content / old_text), optionally scope.
+      - Batch:     operations=[{action, content?, old_text?, scope?}, ...]
+                   applied atomically against the final char budget in ONE call.
+
+    ``scope`` (issue #28279) restricts where an added entry is injected:
+    'platform:chat_id', 'platform:*', or 'profile:name'. Unscoped entries
+    remain global.
 
     Returns JSON string with results.
     """
@@ -1086,6 +1200,20 @@ def memory_tool(
     if operations:
         if not isinstance(operations, list):
             return tool_error("operations must be a list of {action, content?, old_text?} objects.", success=False)
+        # Fold per-op scope into content up front so the gate preview, the
+        # atomic char-budget check, and the staged-approval replay all see
+        # the final stored text (issue #28279).
+        folded: List[Dict[str, Any]] = []
+        for op in operations:
+            op = dict(op or {})
+            op_scope = (op.pop("scope", None) or "").strip()
+            if op_scope and op.get("action") == "add" and op.get("content"):
+                err = validate_scope(op_scope)
+                if err:
+                    return tool_error(err, success=False)
+                op["content"] = apply_scope_marker(op["content"], op_scope)
+            folded.append(op)
+        operations = folded
         gate_result = _apply_batch_write_gate(target, operations)
         if gate_result is not None:
             return gate_result
@@ -1097,6 +1225,15 @@ def memory_tool(
     # immediately instead of being staged and only failing at approve time.
     if action == "add" and not content:
         return tool_error("Content is required for 'add' action.", success=False)
+
+    # Scope only applies to add: replace/remove locate entries by substring,
+    # which already works against the stored "[scope: ...] content" text.
+    scope = (scope or "").strip()
+    if scope and action == "add":
+        err = validate_scope(scope)
+        if err:
+            return tool_error(err, success=False)
+        content = apply_scope_marker(content, scope)
     if action == "replace" and (not old_text or not content):
         missing = "old_text" if not old_text else "content"
         if not old_text:
@@ -1202,6 +1339,17 @@ MEMORY_SCHEMA = {
                 "type": "string",
                 "description": "REQUIRED for 'replace' and 'remove' (single-op shape): a short unique substring identifying the existing entry to modify. Omit only for 'add'."
             },
+            "scope": {
+                "type": "string",
+                "description": (
+                    "Optional, 'add' only: restrict where this entry is injected. "
+                    "Formats: 'platform:chat_id' (e.g. 'telegram:123456789') for one "
+                    "chat, 'platform:*' for all chats on a platform, 'profile:name' "
+                    "for a Hermes profile. Omit for global (injected everywhere). "
+                    "Use a scope whenever the fact is private to the current chat "
+                    "(credentials, personal details shared in a DM)."
+                )
+            },
             "operations": {
                 "type": "array",
                 "description": (
@@ -1215,6 +1363,7 @@ MEMORY_SCHEMA = {
                         "action": {"type": "string", "enum": ["add", "replace", "remove"]},
                         "content": {"type": "string", "description": "Entry content for add/replace."},
                         "old_text": {"type": "string", "description": "Substring identifying the entry for replace/remove."},
+                        "scope": {"type": "string", "description": "Optional, add only: injection scope ('platform:chat_id', 'platform:*', or 'profile:name')."},
                     },
                     "required": ["action"],
                 },
@@ -1238,7 +1387,8 @@ registry.register(
         content=args.get("content"),
         old_text=args.get("old_text"),
         operations=args.get("operations"),
-        store=kw.get("store")),
+        store=kw.get("store"),
+        scope=args.get("scope")),
     check_fn=check_memory_requirements,
     emoji="🧠",
 )

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -145,6 +145,43 @@ def apply_scope_marker(content: str, scope: Optional[str]) -> str:
     return f"[scope: {scope}] {bare if existing else content}"
 
 
+# Sentinel scope value resolved server-side to the running session's own
+# chat scope. The model never sees raw chat IDs in its system prompt, so it
+# cannot construct 'telegram:123456789' itself — it says 'current' and the
+# store resolves it from trusted session context (issue #28279 review).
+CURRENT_SCOPE_SENTINEL = "current"
+
+
+def resolve_scope(scope: str, session_scopes: Optional[List[str]]) -> tuple:
+    """Resolve a model-supplied scope value to a concrete stored scope.
+
+    Returns (resolved_scope, error). 'current' resolves to the session's most
+    specific chat scope ('platform:chat_id' when the session has one, else the
+    bare platform). Any other value is validated and passed through.
+    """
+    scope = (scope or "").strip()
+    if scope != CURRENT_SCOPE_SENTINEL:
+        err = validate_scope(scope)
+        return (scope, err) if not err else ("", err)
+    if not session_scopes:
+        return "", (
+            "Cannot resolve scope 'current': this session has no platform "
+            "identity. Omit scope, or pass an explicit one."
+        )
+    chat_scopes = [s for s in session_scopes
+                   if ":" in s and not s.startswith("profile:")]
+    if chat_scopes:
+        # Most specific chat scope (e.g. 'telegram:123456789').
+        return max(chat_scopes, key=len), None
+    platforms = [s for s in session_scopes if ":" not in s]
+    if platforms:
+        return f"{platforms[0]}:*", None
+    return "", (
+        "Cannot resolve scope 'current': session identity has no platform "
+        "component. Omit scope, or pass an explicit one."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Memory content scanning — lightweight check for injection/exfiltration
 # in content that gets injected into the system prompt.
@@ -348,6 +385,25 @@ class MemoryStore:
                 kept.append(bare)
         return kept
 
+    def _entry_visible(self, entry: str) -> bool:
+        """True when this session may see/mutate the entry.
+
+        Scope is an ACCESS BOUNDARY, not just prompt routing: sessions that
+        don't match an entry's scope must not receive it through any tool
+        result either — error inventories (``current_entries``), match
+        previews, and replace/remove targeting all go through this check.
+        Markers are kept on visible entries here (unlike the snapshot) so the
+        owning session can manage and re-scope them.
+        """
+        if self.session_scopes is None:
+            return True
+        scope, _ = parse_entry_scope(entry)
+        return scope_matches(scope, self.session_scopes)
+
+    def _visible_entries(self, entries: List[str]) -> List[str]:
+        """Filter an entry list down to what this session may see."""
+        return [e for e in entries if self._entry_visible(e)]
+
     @staticmethod
     def _sanitize_entries_for_snapshot(entries: List[str], filename: str) -> List[str]:
         """Return ``entries`` with any threat-matching entry replaced by a placeholder.
@@ -545,7 +601,7 @@ class MemoryStore:
                         f"shorter ones or 'remove' stale or less important entries (see "
                         f"current_entries below), then retry this add — all in this turn."
                     ),
-                    "current_entries": entries,
+                    "current_entries": self._visible_entries(entries),
                     "usage": f"{current:,}/{limit:,}",
                 })
 
@@ -577,13 +633,16 @@ class MemoryStore:
                 return _drift_error(self._path_for(target), bak)
 
             entries = self._entries_for(target)
-            matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
+            # Scoped entries invisible to this session are not valid targets:
+            # matching them would leak their text via error/preview paths.
+            matches = [(i, e) for i, e in enumerate(entries)
+                       if old_text in e and self._entry_visible(e)]
 
             if not matches:
                 return self._consolidation_failure({
                     "success": False,
                     "error": f"No entry matched '{old_text}'. Check current_entries below and retry with the exact text of the entry you want to replace.",
-                    "current_entries": entries,
+                    "current_entries": self._visible_entries(entries),
                 })
 
             if len(matches) > 1:
@@ -616,7 +675,7 @@ class MemoryStore:
                         f"entries to make room (see current_entries below), then retry — all "
                         f"in this turn."
                     ),
-                    "current_entries": entries,
+                    "current_entries": self._visible_entries(entries),
                     "usage": f"{current:,}/{limit:,}",
                 })
 
@@ -640,13 +699,15 @@ class MemoryStore:
                 return _drift_error(self._path_for(target), bak)
 
             entries = self._entries_for(target)
-            matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
+            # Same visibility rule as replace: invisible entries can't be hit.
+            matches = [(i, e) for i, e in enumerate(entries)
+                       if old_text in e and self._entry_visible(e)]
 
             if not matches:
                 return self._consolidation_failure({
                     "success": False,
                     "error": f"No entry matched '{old_text}'. Check current_entries below and retry with the exact text of the entry you want to remove.",
-                    "current_entries": entries,
+                    "current_entries": self._visible_entries(entries),
                 })
 
             if len(matches) > 1:
@@ -727,7 +788,8 @@ class MemoryStore:
                             target,
                             f"{pos}: content is required (use action='remove' to delete).",
                         )
-                    matches = [j for j, e in enumerate(working) if old_text in e]
+                    matches = [j for j, e in enumerate(working)
+                               if old_text in e and self._entry_visible(e)]
                     if not matches:
                         return self._batch_error(target, f"{pos}: no entry matched '{old_text}'.")
                     if len({working[j] for j in matches}) > 1:
@@ -740,7 +802,8 @@ class MemoryStore:
                 elif act == "remove":
                     if not old_text:
                         return self._batch_error(target, f"{pos}: old_text is required.")
-                    matches = [j for j, e in enumerate(working) if old_text in e]
+                    matches = [j for j, e in enumerate(working)
+                               if old_text in e and self._entry_visible(e)]
                     if not matches:
                         return self._batch_error(target, f"{pos}: no entry matched '{old_text}'.")
                     if len({working[j] for j in matches}) > 1:
@@ -767,7 +830,7 @@ class MemoryStore:
                         f"{new_total:,}/{limit:,} chars -- over the limit. Remove or shorten more "
                         f"entries in the same batch (see current_entries below), then retry."
                     ),
-                    "current_entries": self._entries_for(target),
+                    "current_entries": self._visible_entries(self._entries_for(target)),
                     "usage": f"{current:,}/{limit:,}",
                 })
 
@@ -784,7 +847,7 @@ class MemoryStore:
         return self._consolidation_failure({
             "success": False,
             "error": message + " No operations were applied (batch is all-or-nothing).",
-            "current_entries": self._entries_for(target),
+            "current_entries": self._visible_entries(self._entries_for(target)),
             "usage": f"{current:,}/{limit:,}",
         })
 
@@ -1143,7 +1206,9 @@ def _missing_old_text_error(store: "MemoryStore", target: str, action: str) -> s
     the call with ``old_text`` set to a unique substring of the entry it means.
     Mirrors the batch path's ``_batch_error`` shape. (issues #43412, #49466)
     """
-    entries = store._entries_for(target)
+    # Only entries visible to this session — the raw store may hold entries
+    # scoped to other chats, which must not leak through error inventories.
+    entries = store._visible_entries(store._entries_for(target))
     current = store._char_count(target)
     limit = store._char_limit(target)
     return json.dumps(
@@ -1208,10 +1273,10 @@ def memory_tool(
             op = dict(op or {})
             op_scope = (op.pop("scope", None) or "").strip()
             if op_scope and op.get("action") == "add" and op.get("content"):
-                err = validate_scope(op_scope)
+                resolved, err = resolve_scope(op_scope, store.session_scopes)
                 if err:
                     return tool_error(err, success=False)
-                op["content"] = apply_scope_marker(op["content"], op_scope)
+                op["content"] = apply_scope_marker(op["content"], resolved)
             folded.append(op)
         operations = folded
         gate_result = _apply_batch_write_gate(target, operations)
@@ -1230,10 +1295,10 @@ def memory_tool(
     # which already works against the stored "[scope: ...] content" text.
     scope = (scope or "").strip()
     if scope and action == "add":
-        err = validate_scope(scope)
+        resolved, err = resolve_scope(scope, store.session_scopes)
         if err:
             return tool_error(err, success=False)
-        content = apply_scope_marker(content, scope)
+        content = apply_scope_marker(content, resolved)
     if action == "replace" and (not old_text or not content):
         missing = "old_text" if not old_text else "content"
         if not old_text:
@@ -1343,11 +1408,13 @@ MEMORY_SCHEMA = {
                 "type": "string",
                 "description": (
                     "Optional, 'add' only: restrict where this entry is injected. "
-                    "Formats: 'platform:chat_id' (e.g. 'telegram:123456789') for one "
-                    "chat, 'platform:*' for all chats on a platform, 'profile:name' "
-                    "for a Hermes profile. Omit for global (injected everywhere). "
-                    "Use a scope whenever the fact is private to the current chat "
-                    "(credentials, personal details shared in a DM)."
+                    "Use 'current' to pin the entry to THIS chat — it is resolved "
+                    "server-side from the session, so you never need a chat ID. "
+                    "Explicit forms also work: 'platform:*' (all chats on a "
+                    "platform), 'profile:name' (a Hermes profile). Omit for global "
+                    "(injected everywhere). Use scope='current' whenever the fact "
+                    "is private to this conversation (credentials, personal "
+                    "details shared in a DM)."
                 )
             },
             "operations": {
@@ -1363,7 +1430,7 @@ MEMORY_SCHEMA = {
                         "action": {"type": "string", "enum": ["add", "replace", "remove"]},
                         "content": {"type": "string", "description": "Entry content for add/replace."},
                         "old_text": {"type": "string", "description": "Substring identifying the entry for replace/remove."},
-                        "scope": {"type": "string", "description": "Optional, add only: injection scope ('platform:chat_id', 'platform:*', or 'profile:name')."},
+                        "scope": {"type": "string", "description": "Optional, add only: injection scope. 'current' pins to this chat (resolved server-side); also 'platform:*' or 'profile:name'."},
                     },
                     "required": ["action"],
                 },


### PR DESCRIPTION
> Per the `needs-decision` label on #28279, opening as a **draft** for direction feedback — happy to adjust the contract (marker syntax, scope grammar, or a different storage representation) once maintainers pick a direction. Context: [design summary](https://github.com/NousResearch/hermes-agent/issues/28279#issuecomment-5055551466) and [comparison with the adjacent scope PRs #62841 / #47552](https://github.com/NousResearch/hermes-agent/issues/28279#issuecomment-5059188357).

## Summary

Implements #28279 — memory entries can now carry an optional scope restricting which sessions they are injected into:

```json
{
  "action": "add",
  "target": "memory",
  "content": "Production DB host: 10.0.1.50",
  "scope": "telegram:123456789"
}
```

Supported scopes, as proposed in the issue:

| Scope | Meaning |
|-------|---------|
| `telegram:123456789` | one specific chat |
| `telegram:*` | all chats on a platform |
| `profile:work` | a Hermes profile |
| *(unset)* | global — current behaviour, unchanged |

This closes the privacy foot-gun where secrets saved from a private DM get injected into every public group session on the same instance.

## Design

**Scope is stored as an entry-text prefix** (`[scope: telegram:123] content`), not a storage schema change. This round-trips through the existing file format, `ENTRY_DELIMITER` splitting, char limits, substring-based replace/remove, threat scanning, and the staged write-approval path with zero migration.

**Filtering is snapshot-side only.** At `load_from_disk()`, entries whose scope doesn't match the session are excluded from the system-prompt snapshot (and matching entries enter it with the marker stripped — routing metadata, not content). Live state keeps ALL entries, so:
- any session can still list/replace/remove scoped entries via the memory tool
- dedup-on-load and drift detection behave exactly as before
- the prefix-cache invariant holds (snapshot is still frozen per session)

**Session identity** is built in `agent_init` from `platform` + `chat_id` + active profile, e.g. `["telegram", "telegram:123456789", "profile:work"]`. Interactive/local sessions get `["cli", ...]`. Sessions with no identity at all get `session_scopes=None`, which disables filtering entirely (pre-scope behaviour).

**Batch ops** accept a per-op `scope` field; it's folded into content before the write gate, so the approval preview and the atomic char-budget check both see the final stored text.

## Relation to adjacent PRs

Orthogonal to both open scope PRs — this is **entry-level, selective** isolation (most memory stays shared; individual sensitive entries are pinned), while #62841 is a whole-deployment `memory.scope` config policy and #47552 routes writes into per-`context_id` directories. No storage layout change here, so it can land independently or compose with either. It also gives a path to #11430: per-user profile entries are expressible as scoped entries (e.g. `[scope: telegram:<user_id>]`) without a separate per-user store.

## Backward compatibility

- Unscoped entries behave exactly as today (injected everywhere)
- No storage migration; existing MEMORY.md/USER.md files load unchanged
- `MemoryStore(...)` signature change is additive (`session_scopes` keyword, default `None`)
- Callers that construct MemoryStore without scopes (prompt_size, context_breakdown, compression) keep pre-scope behaviour

## Tests

- 40 new tests in `tests/tools/test_memory_scope.py`: marker parsing, scope validation, wildcard/profile matching, snapshot filtering (incl. the issue's DM-secret-in-group scenario), cross-scope entry management, batch ops, schema coverage
- Existing suites pass unchanged: `test_memory_tool.py` + `test_memory_tool_schema.py` (88), `test_memory_provider.py` + `test_skip_memory_store_65429.py` + `test_memory_tool_import_fallback.py` (106)

Fixes #28279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
