### PR TITLE
feat(desktop+web): fuzzy session/skills search with match-field UI

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -27,7 +27,13 @@ import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/he
 import { useI18n } from '@/i18n'
 import { comboTokens } from '@/lib/keybinds/combo'
 import { profileColor } from '@/lib/profile-color'
-import { sessionMatchesSearch } from '@/lib/session-search'
+import {
+  SEARCH_FIELD_LABEL_EN,
+  SEARCH_FIELD_LABEL_ZH,
+  stripHighlightMarkers,
+  type SearchField
+} from '@/lib/search-match'
+import { rankSession } from '@/lib/session-search'
 import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
 import { $cronJobs } from '@/store/cron'
@@ -115,6 +121,10 @@ import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } 
 import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
 import {
+  SessionSearchMetaContext,
+  type SessionSearchMeta
+} from './search-meta-context'
+import {
   overlayLiveLanes,
   overlayLivePreviews,
   PROJECT_PREVIEW_COUNT,
@@ -197,9 +207,11 @@ const HEADER_NAV_BTN =
 
 // FTS results cover sessions that aren't in the loaded page; synthesize a
 // minimal SessionInfo so they render in the same row component (resume works
-// by id; the snippet stands in for the preview).
+// by id; the snippet stands in for the preview when title is missing).
 function searchResultToSession(result: SessionSearchResult): SessionInfo {
   const ts = result.session_started ?? Date.now() / 1000
+  const marked = result.snippet?.trim() || ''
+  const cleanPreview = marked ? stripHighlightMarkers(marked) : null
 
   return {
     archived: false,
@@ -213,11 +225,31 @@ function searchResultToSession(result: SessionSearchResult): SessionInfo {
     message_count: 0,
     model: result.model ?? null,
     output_tokens: 0,
-    preview: result.snippet?.trim() || null,
+    preview: cleanPreview,
     source: result.source ?? null,
     started_at: ts,
-    title: null,
+    title: result.title?.trim() || null,
     tool_call_count: 0
+  }
+}
+
+function matchFieldLabel(field: SearchField, locale: string): string {
+  return (locale.startsWith('zh') ? SEARCH_FIELD_LABEL_ZH : SEARCH_FIELD_LABEL_EN)[field]
+}
+
+function matchedOnToField(matchedOn: SessionSearchResult['matched_on'] | undefined): SearchField {
+  switch (matchedOn) {
+    case 'id':
+      return 'id'
+    case 'title':
+      return 'title'
+    case 'preview':
+      return 'preview'
+    case 'meta':
+      return 'title'
+    case 'message':
+    default:
+      return 'body'
   }
 }
 
@@ -253,7 +285,7 @@ export function ChatSidebar({
   onManageCronJob,
   onTriggerCronJob
 }: ChatSidebarProps) {
-  const { t } = useI18n()
+  const { t, locale } = useI18n()
   const s = t.sidebar
   const { pathname } = useLocation()
   // Contributed nav rows (plugins pairing a page with a sidebar entry) render
@@ -468,30 +500,78 @@ export function ChatSidebar({
     }
   }, [trimmedQuery])
 
-  const searchResults = useMemo(() => {
+  const searchBundle = useMemo(() => {
+    const empty = { sessions: [] as SessionInfo[], meta: new Map<string, SessionSearchMeta>() }
+
     if (!trimmedQuery) {
-      return []
+      return empty
     }
 
     const out = new Map<string, SessionInfo>()
+    const meta = new Map<string, SessionSearchMeta>()
 
     for (const s of sortedSessions) {
-      if (sessionMatchesSearch(s, trimmedQuery)) {
-        out.set(s.id, s)
+      const ranked = rankSession(s, trimmedQuery, { fuzzy: true, itemCount: sortedSessions.length })
+
+      if (!ranked) {
+        continue
+      }
+
+      out.set(s.id, s)
+      const best = ranked.matches[0]
+
+      if (best) {
+        meta.set(s.id, {
+          field: best.field,
+          fieldLabel: matchFieldLabel(best.field, locale),
+          titleRanges: best.field === 'title' ? best.ranges : undefined,
+          tooltip: best.value
+        })
       }
     }
 
     for (const match of serverMatches) {
+      const field = matchedOnToField(match.matched_on)
+      const fieldLabel = matchFieldLabel(field, locale)
+
       if (out.has(match.session_id)) {
+        // Keep local meta; upgrade tooltip when server has a body snippet.
+        if (match.matched_on === 'message' && match.snippet) {
+          const prev = meta.get(match.session_id)
+          meta.set(match.session_id, {
+            field: 'body',
+            fieldLabel: matchFieldLabel('body', locale),
+            titleRanges: prev?.titleRanges,
+            markedSnippet: match.snippet,
+            tooltip: match.snippet
+          })
+        }
+
         continue
       }
 
       const loaded = sessionByAnyId.get(match.session_id)
-      out.set(match.session_id, loaded ?? searchResultToSession(match))
+      const session = loaded
+        ? {
+            ...loaded,
+            title: loaded.title ?? match.title ?? null,
+            preview: loaded.preview ?? (match.snippet ? stripHighlightMarkers(match.snippet) : null)
+          }
+        : searchResultToSession(match)
+      out.set(match.session_id, session)
+      meta.set(match.session_id, {
+        field,
+        fieldLabel,
+        markedSnippet: field === 'body' ? match.snippet : undefined,
+        tooltip: match.snippet || match.title || undefined
+      })
     }
 
-    return [...out.values()]
-  }, [trimmedQuery, sortedSessions, serverMatches, sessionByAnyId])
+    return { sessions: [...out.values()], meta }
+  }, [trimmedQuery, sortedSessions, serverMatches, sessionByAnyId, locale])
+
+  const searchResults = searchBundle.sessions
+  const searchMetaMap = searchBundle.meta
 
   const unpinnedAgentSessions = useMemo(
     () => sortedSessions.filter(s => !pinnedRealIdSet.has(s.id)),
@@ -1207,33 +1287,35 @@ export function ChatSidebar({
         {showSessionSections && (
           <div className={cn('flex min-h-0 flex-1 flex-col pb-1.75', SCROLL_Y)}>
             {trimmedQuery && (
-              <SidebarSessionsSection
-                activeSessionId={activeSidebarSessionId}
-                contentClassName={cn('flex min-h-0 flex-1 flex-col gap-px pb-1.75', SCROLL_Y)}
-                emptyState={
-                  searchPending ? (
-                    <SidebarSessionSkeletons />
-                  ) : (
-                    <div className="wrap-anywhere grid min-h-24 place-items-center rounded-lg px-2 text-center text-xs text-(--ui-text-tertiary)">
-                      {s.noMatch(trimmedQuery)}
-                    </div>
-                  )
-                }
-                label={s.results}
-                labelMeta={String(searchResults.length)}
-                onArchiveSession={onArchiveSession}
-                onBranchSession={onBranchSession}
-                onDeleteSession={onDeleteSession}
-                onResumeSession={onResumeSession}
-                onToggle={() => undefined}
-                onTogglePin={pinSession}
-                open
-                pinned={false}
-                rootClassName="min-h-32 flex-1 overflow-hidden p-0"
-                sessions={searchResults}
-                showProfileTags={showAllProfiles}
-                workingSessionIdSet={workingSessionIdSet}
-              />
+              <SessionSearchMetaContext.Provider value={searchMetaMap}>
+                <SidebarSessionsSection
+                  activeSessionId={activeSidebarSessionId}
+                  contentClassName={cn('flex min-h-0 flex-1 flex-col gap-px pb-1.75', SCROLL_Y)}
+                  emptyState={
+                    searchPending ? (
+                      <SidebarSessionSkeletons />
+                    ) : (
+                      <div className="wrap-anywhere grid min-h-24 place-items-center rounded-lg px-2 text-center text-xs text-(--ui-text-tertiary)">
+                        {s.noMatch(trimmedQuery)}
+                      </div>
+                    )
+                  }
+                  label={s.results}
+                  labelMeta={String(searchResults.length)}
+                  onArchiveSession={onArchiveSession}
+                  onBranchSession={onBranchSession}
+                  onDeleteSession={onDeleteSession}
+                  onResumeSession={onResumeSession}
+                  onToggle={() => undefined}
+                  onTogglePin={pinSession}
+                  open
+                  pinned={false}
+                  rootClassName="min-h-32 flex-1 overflow-hidden p-0"
+                  sessions={searchResults}
+                  showProfileTags={showAllProfiles}
+                  workingSessionIdSet={workingSessionIdSet}
+                />
+              </SessionSearchMetaContext.Provider>
             )}
 
             {!trimmedQuery && (

--- a/apps/desktop/src/app/chat/sidebar/search-meta-context.tsx
+++ b/apps/desktop/src/app/chat/sidebar/search-meta-context.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react'
+
+import type { SearchField } from '@/lib/search-match'
+
+/** Per-session search UI metadata for sidebar results. */
+export interface SessionSearchMeta {
+  /** Best-matching field id. */
+  field: SearchField
+  /** Localized short label for the chip (标题 / 正文 / …). */
+  fieldLabel: string
+  /** Optional ranges into the displayed title string. */
+  titleRanges?: Array<[number, number]>
+  /** Full tooltip: marked snippet or field value. */
+  tooltip?: string
+  /** Raw snippet with FTS markers when match is body text. */
+  markedSnippet?: string
+}
+
+export const SessionSearchMetaContext = createContext<Map<string, SessionSearchMeta>>(new Map())
+
+export function useSessionSearchMeta(sessionId: string): SessionSearchMeta | undefined {
+  return useContext(SessionSearchMetaContext).get(sessionId)
+}

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -6,12 +6,14 @@ import { startSessionDrag } from '@/app/chat/session-drag'
 import { PlatformAvatar } from '@/app/messaging/platform-icon'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
+import { HighlightMarked, HighlightText, MatchFieldChip } from '@/components/ui/search-highlight'
 import { Tip } from '@/components/ui/tooltip'
 import type { SessionInfo } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
+import { stripHighlightMarkers } from '@/lib/search-match'
 import { coarseElapsed } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { $attentionSessionIds, openSessionTile } from '@/store/session-states'
@@ -20,6 +22,7 @@ import { canOpenSessionWindow, openSessionInNewWindow } from '@/store/windows'
 import { SessionStatusDot } from '../session-status-dot'
 
 import { SidebarRowBody, SidebarRowGrab, SidebarRowLabel, SidebarRowLead, SidebarRowShell } from './chrome'
+import { useSessionSearchMeta } from './search-meta-context'
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
 import { sessionShowsRunningArc } from './session-row-state'
 import { useProfilePrewarm } from './use-profile-prewarm'
@@ -77,6 +80,7 @@ export function SidebarSessionRow({
   const { t } = useI18n()
   const r = t.sidebar.row
   const { cancelPrewarm, startPrewarm } = useProfilePrewarm(session.profile)
+  const searchMeta = useSessionSearchMeta(session.id)
   const title = sessionTitle(session)
   const age = formatAge(session.last_active || session.started_at, r)
   const handleLabel = `Reorder ${title}`
@@ -87,6 +91,16 @@ export function SidebarSessionRow({
   const handoffLabel = handoffSource ? (sessionSourceLabel(handoffSource) ?? handoffSource) : null
   // True when a clarify prompt in this session is waiting on the user.
   const needsInput = useStore($attentionSessionIds).includes(session.id)
+  const titleNode = searchMeta?.titleRanges?.length ? (
+    <HighlightText ranges={searchMeta.titleRanges} text={title} />
+  ) : searchMeta?.markedSnippet && !session.title?.trim() ? (
+    <HighlightMarked text={searchMeta.markedSnippet} />
+  ) : (
+    title
+  )
+  const rowTitleAttr = searchMeta?.tooltip
+    ? `${title} · ${searchMeta.fieldLabel}: ${stripHighlightMarkers(searchMeta.tooltip)}`
+    : title
 
   return (
     <SessionContextMenu
@@ -241,8 +255,14 @@ export function SidebarSessionRow({
               />
             </Tip>
           ) : null}
-          <SidebarRowLabel className="flex-1 font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90">
-            {title}
+          <SidebarRowLabel
+            className="flex-1 font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90"
+            title={rowTitleAttr}
+          >
+            <span className="flex min-w-0 items-center gap-1">
+              <span className="min-w-0 truncate">{titleNode}</span>
+              {searchMeta ? <MatchFieldChip label={searchMeta.fieldLabel} /> : null}
+            </span>
           </SidebarRowLabel>
           {showProfile && <ProfileTag profile={session.profile} />}
         </SidebarRowBody>

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -46,6 +46,7 @@ import {
   Wrench,
   Zap
 } from '@/lib/icons'
+import { scoreLabeledItem } from '@/lib/search-match'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { $repoWorktrees } from '@/store/coding-status'
@@ -137,48 +138,11 @@ interface SessionEntry {
 // cmdk still auto-selects the first DOM item whenever the search changes, so
 // rendering best-match-first is what puts the highlight on the best match.
 //
-// AND semantics: every typed word must appear in the label or keywords. The
-// grade rewards matches on the visible label — exact > prefix > whole word >
-// word prefix > substring > scattered terms > keyword-only — so typing "tools"
-// selects the row that says Tools, not a row that hides it in keywords.
-const scoreItem = (item: PaletteItem, needle: string): number => {
-  const label = item.label.toLowerCase()
-  const keys = (item.keywords ?? []).join(' ').toLowerCase()
-  const terms = needle.split(/\s+/).filter(Boolean)
-
-  if (terms.some(term => !label.includes(term) && !keys.includes(term))) {
-    return 0
-  }
-
-  if (label === needle) {
-    return 1
-  }
-
-  if (label.startsWith(needle)) {
-    return 0.9
-  }
-
-  const words = label.split(/[^\p{L}\p{N}]+/u).filter(Boolean)
-
-  if (words.includes(needle)) {
-    return 0.85
-  }
-
-  if (words.some(word => word.startsWith(needle))) {
-    return 0.8
-  }
-
-  if (label.includes(needle)) {
-    return 0.7
-  }
-
-  if (terms.every(term => label.includes(term))) {
-    return 0.6
-  }
-
-  // Matched only via keywords — the weakest, generic-row signal.
-  return 0.4
-}
+// Scoring is shared with skills/session lists (`lib/search-match`): exact >
+// prefix > whole word > word prefix > substring > fuzzy > keyword-only. Query
+// supports AND (whitespace), OR / `|`, quoted phrases, and light typo tolerance.
+const scoreItem = (item: PaletteItem, needle: string): number =>
+  scoreLabeledItem(item.label, item.keywords, needle, { fuzzy: true })
 
 // Order items within each group by score, order groups by their best item, and
 // drop everything that doesn't match. Ties keep their original order (stable

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -21,9 +21,18 @@ import {
   toggleToolset
 } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { MatchFieldChip } from '@/components/ui/search-highlight'
 import { isDesktopToolsetVisible } from '@/lib/desktop-toolsets'
 import { compactNumber } from '@/lib/format'
 import { queryClient, writeCache } from '@/lib/query-client'
+import {
+  bestMatch,
+  rankItems,
+  SEARCH_FIELD_LABEL_EN,
+  SEARCH_FIELD_LABEL_ZH,
+  type FieldMatch,
+  type SearchField
+} from '@/lib/search-match'
 import { normalize } from '@/lib/text'
 import { $gateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
@@ -127,17 +136,44 @@ function skillSubtitle(skill: SkillInfo): React.ReactNode {
   )
 }
 
-function filteredSkills(skills: SkillInfo[], query: string, desc: boolean): SkillInfo[] {
+function fieldLabel(field: SearchField, locale: string): string {
+  return (locale.startsWith('zh') ? SEARCH_FIELD_LABEL_ZH : SEARCH_FIELD_LABEL_EN)[field]
+}
+
+type RankedSkill = { skill: SkillInfo; match?: FieldMatch }
+
+function filteredSkills(skills: SkillInfo[], query: string, desc: boolean): RankedSkill[] {
   const q = normalize(query)
   const sign = desc ? 1 : -1
 
-  return skills
-    .filter(
-      skill =>
-        !q || includesQuery(skill.name, q) || includesQuery(skill.description, q) || includesQuery(skill.category, q)
+  if (!q) {
+    return [...skills]
+      .sort((a, b) => sign * (usageOf(b) - usageOf(a)) || asText(a.name).localeCompare(asText(b.name)))
+      .map(skill => ({ skill }))
+  }
+
+  const ranked = rankItems(
+    skills,
+    skill => [
+      { field: 'name', value: skill.name },
+      { field: 'description', value: skill.description },
+      { field: 'category', value: skill.category }
+    ],
+    q,
+    { fuzzy: true }
+  )
+
+  return ranked
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        sign * (usageOf(b.item) - usageOf(a.item)) ||
+        asText(a.item.name).localeCompare(asText(b.item.name))
     )
-    .sort((a, b) => sign * (usageOf(b) - usageOf(a)) || asText(a.name).localeCompare(asText(b.name)))
+    .map(hit => ({ skill: hit.item, match: bestMatch(hit.matches) }))
 }
+
+type RankedToolset = { toolset: ToolsetInfo; match?: FieldMatch }
 
 const toolsetCalls = (toolset: ToolsetInfo, toolCalls: Record<string, number>): number =>
   toolNames(toolset).reduce((sum, name) => sum + (toolCalls[name] ?? 0), 0)
@@ -147,32 +183,41 @@ function filteredToolsets(
   query: string,
   toolCalls: Record<string, number>,
   desc: boolean
-): ToolsetInfo[] {
+): RankedToolset[] {
   const q = normalize(query)
   const sign = desc ? 1 : -1
+  const visible = toolsets.filter(toolset => isDesktopToolsetVisible(toolset.name))
 
-  return toolsets
-    .filter(toolset => {
-      if (!isDesktopToolsetVisible(toolset.name)) {
-        return false
-      }
-
-      if (!q) {
-        return true
-      }
-
-      return (
-        includesQuery(toolset.name, q) ||
-        includesQuery(toolsetDisplayLabel(toolset), q) ||
-        includesQuery(toolset.description, q) ||
-        toolNames(toolset).some(name => includesQuery(name, q))
+  if (!q) {
+    return [...visible]
+      .sort(
+        (a, b) =>
+          sign * (toolsetCalls(b, toolCalls) - toolsetCalls(a, toolCalls)) ||
+          toolsetDisplayLabel(a).localeCompare(toolsetDisplayLabel(b))
       )
-    })
+      .map(toolset => ({ toolset }))
+  }
+
+  const ranked = rankItems(
+    visible,
+    toolset => [
+      { field: 'name', value: toolset.name },
+      { field: 'label', value: toolsetDisplayLabel(toolset) },
+      { field: 'description', value: toolset.description },
+      { field: 'tool', value: toolNames(toolset).join(' ') }
+    ],
+    q,
+    { fuzzy: true }
+  )
+
+  return ranked
     .sort(
       (a, b) =>
-        sign * (toolsetCalls(b, toolCalls) - toolsetCalls(a, toolCalls)) ||
-        toolsetDisplayLabel(a).localeCompare(toolsetDisplayLabel(b))
+        b.score - a.score ||
+        sign * (toolsetCalls(b.item, toolCalls) - toolsetCalls(a.item, toolCalls)) ||
+        toolsetDisplayLabel(a.item).localeCompare(toolsetDisplayLabel(b.item))
     )
+    .map(hit => ({ toolset: hit.item, match: bestMatch(hit.matches) }))
 }
 
 const visibleToolsetCount = (toolsets: ToolsetInfo[]) => toolsets.filter(ts => isDesktopToolsetVisible(ts.name)).length
@@ -182,7 +227,7 @@ interface SkillsViewProps extends React.ComponentProps<'section'> {
 }
 
 export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...props }: SkillsViewProps) {
-  const { t } = useI18n()
+  const { t, locale } = useI18n()
   const gateway = useStore($gateway) as HermesGateway | null
   const [mode, setMode] = useRouteEnumParam('tab', SKILLS_MODES, 'skills')
 
@@ -319,12 +364,13 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
   // Keep a valid selection: fall back to the first visible row when the
   // current selection is filtered out (or nothing is selected yet).
   const activeSkill = useMemo(
-    () => visibleSkills.find(s => s.name === selectedSkill) ?? visibleSkills[0] ?? null,
+    () => visibleSkills.find(row => row.skill.name === selectedSkill)?.skill ?? visibleSkills[0]?.skill ?? null,
     [selectedSkill, visibleSkills]
   )
 
   const activeToolset = useMemo(
-    () => visibleToolsets.find(ts => ts.name === selectedToolset) ?? visibleToolsets[0] ?? null,
+    () =>
+      visibleToolsets.find(row => row.toolset.name === selectedToolset)?.toolset ?? visibleToolsets[0]?.toolset ?? null,
     [selectedToolset, visibleToolsets]
   )
 
@@ -594,7 +640,7 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
                 />
               }
             >
-              {visibleSkills.map(skill => (
+              {visibleSkills.map(({ skill, match }) => (
                 <CapRow
                   active={activeSkill?.name === skill.name}
                   busy={bulkBusy}
@@ -603,7 +649,16 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
                   meta={usageOf(skill) > 0 ? `×${compactNumber(usageOf(skill))}` : undefined}
                   onSelect={() => setSelectedSkill(skill.name)}
                   onToggle={enabled => void handleToggleSkill(skill, enabled)}
-                  subtitle={skillSubtitle(skill)}
+                  subtitle={
+                    match && normalize(query) ? (
+                      <>
+                        <MatchFieldChip label={fieldLabel(match.field, locale)} />
+                        <span className="truncate">{skillSubtitle(skill)}</span>
+                      </>
+                    ) : (
+                      skillSubtitle(skill)
+                    )
+                  }
                   title={skill.name}
                   toggleLabel={skill.name}
                 />
@@ -632,7 +687,7 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
               />
             }
           >
-            {visibleToolsets.map(toolset => {
+            {visibleToolsets.map(({ toolset, match }) => {
               const label = toolsetDisplayLabel(toolset)
               const calls = toolCalls ? toolsetCalls(toolset, toolCalls) : null
 
@@ -653,7 +708,16 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
                   }
                   onSelect={() => setSelectedToolset(toolset.name)}
                   onToggle={checked => void handleToggleToolset(toolset, checked)}
-                  subtitle={asText(toolset.description)}
+                  subtitle={
+                    match && normalize(query) ? (
+                      <>
+                        <MatchFieldChip label={fieldLabel(match.field, locale)} />
+                        <span className="truncate">{asText(toolset.description)}</span>
+                      </>
+                    ) : (
+                      asText(toolset.description)
+                    )
+                  }
                   title={label}
                   toggleLabel={t.skills.toggleToolset(label)}
                 />

--- a/apps/desktop/src/components/ui/search-highlight.tsx
+++ b/apps/desktop/src/components/ui/search-highlight.tsx
@@ -1,0 +1,68 @@
+import type * as React from 'react'
+
+import { parseHighlightSegments, wrapRanges } from '@/lib/search-match'
+import { cn } from '@/lib/utils'
+
+/** Inline mark styling shared by search surfaces. */
+const MARK_CLASS = 'rounded-[2px] bg-(--ui-accent)/25 px-px font-medium text-foreground'
+
+export function HighlightText({
+  text,
+  ranges,
+  className
+}: {
+  text: string
+  ranges?: Array<[number, number]>
+  className?: string
+}): React.ReactNode {
+  if (!text) {
+    return null
+  }
+
+  if (!ranges?.length) {
+    return <span className={className}>{text}</span>
+  }
+
+  return <HighlightMarked className={className} text={wrapRanges(text, ranges)} />
+}
+
+/** Render text that already contains FTS `>>>/<<<` or client `[[m]]` markers. */
+export function HighlightMarked({ text, className }: { text: string; className?: string }): React.ReactNode {
+  const segments = parseHighlightSegments(text)
+
+  if (segments.length === 1 && !segments[0].hit) {
+    return <span className={className}>{segments[0].text}</span>
+  }
+
+  return (
+    <span className={className}>
+      {segments.map((seg, i) =>
+        seg.hit ? (
+          <mark className={MARK_CLASS} key={i}>
+            {seg.text}
+          </mark>
+        ) : (
+          <span key={i}>{seg.text}</span>
+        )
+      )}
+    </span>
+  )
+}
+
+/** Tiny in-row field chip (fits locked sidebar row height). */
+export function MatchFieldChip({ label, className }: { label: string; className?: string }): React.ReactNode {
+  if (!label) {
+    return null
+  }
+
+  return (
+    <span
+      className={cn(
+        'shrink-0 rounded px-1 py-px text-[0.55rem] leading-none text-(--ui-text-tertiary) bg-(--ui-bg-quinary)',
+        className
+      )}
+    >
+      {label}
+    </span>
+  )
+}

--- a/apps/desktop/src/lib/search-match.test.ts
+++ b/apps/desktop/src/lib/search-match.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  excerptAround,
+  levenshtein,
+  parseHighlightSegments,
+  parseQuery,
+  rankFields,
+  rankItems,
+  scoreLabeledItem,
+  stripHighlightMarkers,
+  wrapRanges
+} from './search-match'
+
+describe('parseQuery', () => {
+  it('parses AND by whitespace', () => {
+    expect(parseQuery('foo bar').alternatives).toEqual([['foo', 'bar']])
+  })
+
+  it('parses OR and pipe', () => {
+    expect(parseQuery('foo OR bar').alternatives).toEqual([['foo'], ['bar']])
+    expect(parseQuery('a | b').alternatives).toEqual([['a'], ['b']])
+  })
+
+  it('keeps quoted phrases', () => {
+    expect(parseQuery('"exact phrase" other').alternatives).toEqual([['exact phrase', 'other']])
+  })
+})
+
+describe('rankFields', () => {
+  const fields = [
+    { field: 'title' as const, value: 'Desktop session search' },
+    { field: 'preview' as const, value: 'fuzzy match and highlight' },
+    { field: 'cwd' as const, value: 'C:/Users/me/hermes-agent' }
+  ]
+
+  it('matches substring (infix) not only prefix', () => {
+    const hit = rankFields(fields, 'sess')
+    expect(hit).not.toBeNull()
+    expect(hit!.matches[0].field).toBe('title')
+    // "sess" is a word-prefix of "session"
+    expect(['word-prefix', 'substring']).toContain(hit!.matches[0].kind)
+
+    const mid = rankFields([{ field: 'title', value: 'xxfoobarxx' }], 'bar')
+    expect(mid!.matches[0].kind).toBe('substring')
+  })
+
+  it('prefers title over preview', () => {
+    const hit = rankFields(fields, 'search')
+    expect(hit!.matches[0].field).toBe('title')
+  })
+
+  it('supports OR alternatives', () => {
+    const hit = rankFields(fields, 'zzzz OR fuzzy')
+    expect(hit).not.toBeNull()
+    expect(hit!.matches.some(m => m.field === 'preview')).toBe(true)
+  })
+
+  it('fuzzy-matches small typos on long enough words', () => {
+    const hit = rankFields([{ field: 'name', value: 'docker-compose' }], 'dokcer', { fuzzy: true })
+    expect(hit).not.toBeNull()
+    expect(hit!.matches[0].kind).toBe('fuzzy')
+  })
+
+  it('does not fuzzy short needles', () => {
+    const hit = rankFields([{ field: 'name', value: 'cat' }], 'ca', { fuzzy: true })
+    // "ca" is prefix of cat
+    expect(hit!.matches[0].kind).toBe('prefix')
+  })
+})
+
+describe('rankItems + scoreLabeledItem', () => {
+  it('ranks and filters a list', () => {
+    const items = [
+      { name: 'alpha', description: 'first' },
+      { name: 'beta-tools', description: 'second alpha mention' },
+      { name: 'gamma', description: 'nope' }
+    ]
+    const hits = rankItems(
+      items,
+      i => [
+        { field: 'name', value: i.name },
+        { field: 'description', value: i.description }
+      ],
+      'alpha'
+    )
+    expect(hits.map(h => h.item.name)).toEqual(['alpha', 'beta-tools'])
+    expect(hits[0].score).toBeGreaterThan(hits[1].score)
+  })
+
+  it('scores palette labels with keywords', () => {
+    const s = scoreLabeledItem('Open settings', ['prefs', 'config'], 'prefs')
+    expect(s).toBeGreaterThan(0)
+    expect(scoreLabeledItem('Open settings', ['prefs'], 'zzzz')).toBe(0)
+  })
+})
+
+describe('levenshtein', () => {
+  it('bounds distance', () => {
+    expect(levenshtein('kitten', 'sitten', 1)).toBe(1)
+    expect(levenshtein('kitten', 'sittin', 1)).toBeNull()
+  })
+})
+
+describe('highlight helpers', () => {
+  it('wraps and strips ranges', () => {
+    const wrapped = wrapRanges('hello world', [[6, 11]])
+    expect(wrapped).toContain('[[m]]world[[/m]]')
+    expect(stripHighlightMarkers(wrapped)).toBe('hello world')
+  })
+
+  it('parses FTS markers', () => {
+    const segs = parseHighlightSegments('before >>>hit<<< after')
+    expect(segs).toEqual([
+      { text: 'before ', hit: false },
+      { text: 'hit', hit: true },
+      { text: ' after', hit: false }
+    ])
+  })
+
+  it('excerpts around a hit', () => {
+    const long = 'x'.repeat(40) + 'NEEDLE' + 'y'.repeat(40)
+    const { text, ranges } = excerptAround(long, [[40, 46]], 5)
+    expect(text).toContain('NEEDLE')
+    expect(text.startsWith('…')).toBe(true)
+    expect(ranges[0][1] - ranges[0][0]).toBe(6)
+  })
+})

--- a/apps/desktop/src/lib/search-match.ts
+++ b/apps/desktop/src/lib/search-match.ts
@@ -1,0 +1,704 @@
+/**
+ * Shared multi-field search ranking for Desktop lists (command palette, skills,
+ * session metadata). Ranking happens in React — cmdk stays keyboard-only.
+ *
+ * Features:
+ * - Multi-field weighted scoring + match-field reporting
+ * - Grades: exact > prefix > whole word > word prefix > substring > fuzzy
+ * - Query syntax: whitespace = AND; `OR` / `|` between alternatives; quoted
+ *   phrases; trailing `*` keeps prefix-only for that term
+ * - Light edit-distance fuzzy (≤1–2) for short lists / long-enough terms
+ */
+
+import { asText, normalize } from '@/lib/text'
+
+export type SearchField =
+  | 'title'
+  | 'name'
+  | 'label'
+  | 'preview'
+  | 'description'
+  | 'category'
+  | 'cwd'
+  | 'branch'
+  | 'id'
+  | 'source'
+  | 'keywords'
+  | 'body'
+  | 'tool'
+
+export type MatchKind = 'exact' | 'prefix' | 'word' | 'word-prefix' | 'substring' | 'fuzzy' | 'keyword'
+
+export interface FieldMatch {
+  field: SearchField
+  kind: MatchKind
+  score: number
+  value: string
+  /** Inclusive-exclusive UTF-16 code unit ranges into `value`. */
+  ranges: Array<[number, number]>
+}
+
+export interface RankedHit<T> {
+  item: T
+  score: number
+  matches: FieldMatch[]
+}
+
+export interface FieldSpec {
+  field: SearchField
+  value: unknown
+  /** Relative weight; default 1. Keywords default lower via field. */
+  weight?: number
+}
+
+export interface RankOptions {
+  /** Enable edit-distance fuzzy (default true for small lists). */
+  fuzzy?: boolean
+  /** Soft cap for enabling fuzzy when not set explicitly (default 2000). */
+  fuzzyMaxItems?: number
+  /** Candidate count — used with fuzzyMaxItems. */
+  itemCount?: number
+}
+
+const DEFAULT_FIELD_WEIGHT: Partial<Record<SearchField, number>> = {
+  title: 1,
+  name: 1,
+  label: 1,
+  preview: 0.85,
+  description: 0.85,
+  category: 0.7,
+  branch: 0.75,
+  cwd: 0.65,
+  id: 0.55,
+  source: 0.5,
+  keywords: 0.4,
+  body: 0.7,
+  tool: 0.8
+}
+
+const GRADE: Record<MatchKind, number> = {
+  exact: 1,
+  prefix: 0.9,
+  word: 0.85,
+  'word-prefix': 0.8,
+  substring: 0.7,
+  fuzzy: 0.55,
+  keyword: 0.4
+}
+
+/** FTS5 snippet markers from the backend. */
+export const FTS_MARK_OPEN = '>>>'
+export const FTS_MARK_CLOSE = '<<<'
+
+/** Client highlight markers when we re-wrap ranges. */
+export const HL_OPEN = '[[m]]'
+export const HL_CLOSE = '[[/m]]'
+
+// ── Query parsing ──────────────────────────────────────────────────────────
+
+export interface ParsedQuery {
+  /** OR of AND-groups. Empty → match-all. */
+  alternatives: string[][]
+  /** Raw normalized query (trim+lower). */
+  raw: string
+}
+
+/**
+ * Parse user query into OR-of-AND groups.
+ * - `foo bar` → [[foo, bar]] (AND)
+ * - `foo OR bar` / `foo | bar` → [[foo], [bar]]
+ * - `"exact phrase"` kept as one term
+ * - trailing `*` retained on the term (prefix-only signal)
+ */
+export function parseQuery(query: string): ParsedQuery {
+  const raw = normalize(query)
+
+  if (!raw) {
+    return { alternatives: [], raw: '' }
+  }
+
+  // Split on OR / | outside quotes
+  const groups: string[] = []
+  let buf = ''
+  let inQuote = false
+
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i]
+
+    if (ch === '"') {
+      inQuote = !inQuote
+      buf += ch
+      continue
+    }
+
+    if (!inQuote) {
+      if (ch === '|') {
+        if (buf.trim()) {
+          groups.push(buf.trim())
+        }
+
+        buf = ''
+        continue
+      }
+
+      // word-boundary "or"
+      if (
+        (ch === 'o' || ch === 'O') &&
+        raw.slice(i, i + 2).toLowerCase() === 'or' &&
+        isBoundary(raw, i - 1) &&
+        isBoundary(raw, i + 2)
+      ) {
+        if (buf.trim()) {
+          groups.push(buf.trim())
+        }
+
+        buf = ''
+        i += 1
+        continue
+      }
+    }
+
+    buf += ch
+  }
+
+  if (buf.trim()) {
+    groups.push(buf.trim())
+  }
+
+  const alternatives = groups.map(group => tokenizeGroup(group)).filter(terms => terms.length > 0)
+
+  return { alternatives: alternatives.length ? alternatives : [], raw }
+}
+
+function isBoundary(s: string, idx: number): boolean {
+  if (idx < 0 || idx >= s.length) {
+    return true
+  }
+
+  return /\s/.test(s[idx])
+}
+
+function tokenizeGroup(group: string): string[] {
+  const terms: string[] = []
+  const re = /"([^"]+)"|(\S+)/g
+  let m: RegExpExecArray | null
+
+  while ((m = re.exec(group))) {
+    const term = (m[1] ?? m[2] ?? '').trim()
+
+    if (term && term.toLowerCase() !== 'or' && term !== '|') {
+      terms.push(term)
+    }
+  }
+
+  return terms
+}
+
+// ── Core scoring ───────────────────────────────────────────────────────────
+
+interface TermHit {
+  kind: MatchKind
+  score: number
+  ranges: Array<[number, number]>
+}
+
+function wordsOf(text: string): Array<{ word: string; start: number }> {
+  const out: Array<{ word: string; start: number }> = []
+  const re = /[\p{L}\p{N}]+/gu
+  let m: RegExpExecArray | null
+
+  while ((m = re.exec(text))) {
+    out.push({ word: m[0], start: m.index })
+  }
+
+  return out
+}
+
+function scoreTermInText(haystackLower: string, term: string, allowFuzzy: boolean): TermHit | null {
+  if (!term) {
+    return null
+  }
+
+  const prefixOnly = term.endsWith('*')
+  const needle = prefixOnly ? term.slice(0, -1) : term
+
+  if (!needle) {
+    return null
+  }
+
+  if (haystackLower === needle) {
+    return { kind: 'exact', score: GRADE.exact, ranges: [[0, haystackLower.length]] }
+  }
+
+  if (haystackLower.startsWith(needle)) {
+    return { kind: 'prefix', score: GRADE.prefix, ranges: [[0, needle.length]] }
+  }
+
+  const words = wordsOf(haystackLower)
+
+  for (const { word, start } of words) {
+    if (word === needle) {
+      return { kind: 'word', score: GRADE.word, ranges: [[start, start + word.length]] }
+    }
+  }
+
+  for (const { word, start } of words) {
+    if (word.startsWith(needle)) {
+      return { kind: 'word-prefix', score: GRADE['word-prefix'], ranges: [[start, start + needle.length]] }
+    }
+  }
+
+  if (!prefixOnly) {
+    const idx = haystackLower.indexOf(needle)
+
+    if (idx >= 0) {
+      return { kind: 'substring', score: GRADE.substring, ranges: [[idx, idx + needle.length]] }
+    }
+  }
+
+  if (!allowFuzzy || prefixOnly) {
+    return null
+  }
+
+  // Light fuzzy: only against individual words, bounded edit distance.
+  const maxDist = needle.length >= 6 ? 2 : needle.length >= 4 ? 1 : 0
+
+  if (maxDist <= 0) {
+    return null
+  }
+
+  let best: TermHit | null = null
+
+  for (const { word, start } of words) {
+    if (Math.abs(word.length - needle.length) > maxDist) {
+      continue
+    }
+
+    const d = levenshtein(word, needle, maxDist)
+
+    if (d === null || d <= 0) {
+      continue
+    }
+
+    const score = GRADE.fuzzy * (1 - d / (maxDist + 1))
+
+    if (!best || score > best.score) {
+      best = { kind: 'fuzzy', score, ranges: [[start, start + word.length]] }
+    }
+  }
+
+  return best
+}
+
+/** Bounded Levenshtein; returns null if distance would exceed maxDist. */
+export function levenshtein(a: string, b: string, maxDist: number): number | null {
+  if (a === b) {
+    return 0
+  }
+
+  const n = a.length
+  const m = b.length
+
+  if (Math.abs(n - m) > maxDist) {
+    return null
+  }
+
+  if (n === 0) {
+    return m <= maxDist ? m : null
+  }
+
+  if (m === 0) {
+    return n <= maxDist ? n : null
+  }
+
+  let prev = new Array<number>(m + 1)
+  let curr = new Array<number>(m + 1)
+
+  for (let j = 0; j <= m; j++) {
+    prev[j] = j
+  }
+
+  for (let i = 1; i <= n; i++) {
+    curr[0] = i
+    let rowMin = curr[0]
+
+    for (let j = 1; j <= m; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost)
+      rowMin = Math.min(rowMin, curr[j])
+    }
+
+    if (rowMin > maxDist) {
+      return null
+    }
+
+    ;[prev, curr] = [curr, prev]
+  }
+
+  const dist = prev[m]
+
+  return dist <= maxDist ? dist : null
+}
+
+function fieldWeight(field: SearchField, explicit?: number): number {
+  return explicit ?? DEFAULT_FIELD_WEIGHT[field] ?? 1
+}
+
+function scoreFieldsAgainstTerms(
+  fields: FieldSpec[],
+  terms: string[],
+  allowFuzzy: boolean
+): { score: number; matches: FieldMatch[] } | null {
+  if (!terms.length) {
+    return { score: 1, matches: [] }
+  }
+
+  const prepared = fields
+    .map(f => ({
+      field: f.field,
+      weight: fieldWeight(f.field, f.weight),
+      raw: asText(f.value),
+      lower: asText(f.value).toLowerCase()
+    }))
+    .filter(f => f.lower.length > 0)
+
+  if (!prepared.length) {
+    return null
+  }
+
+  const matches: FieldMatch[] = []
+  let total = 0
+
+  for (const term of terms) {
+    let best: FieldMatch | null = null
+
+    for (const f of prepared) {
+      const hit = scoreTermInText(f.lower, term, allowFuzzy && f.field !== 'id')
+
+      if (!hit) {
+        continue
+      }
+
+      // Keywords field never outranks a visible-label hit of the same grade.
+      const kind = f.field === 'keywords' && hit.kind !== 'exact' ? 'keyword' : hit.kind
+      const score = (kind === 'keyword' ? GRADE.keyword : hit.score) * f.weight
+
+      if (!best || score > best.score) {
+        best = {
+          field: f.field,
+          kind,
+          score,
+          value: f.raw,
+          ranges: hit.ranges
+        }
+      }
+    }
+
+    if (!best) {
+      return null
+    }
+
+    matches.push(best)
+    total += best.score
+  }
+
+  // Prefer fewer, stronger field hits; average keeps multi-term fair.
+  const score = total / terms.length
+
+  // Deduplicate matches by field keeping best + merge ranges.
+  const byField = new Map<SearchField, FieldMatch>()
+
+  for (const m of matches) {
+    const prev = byField.get(m.field)
+
+    if (!prev || m.score > prev.score) {
+      const ranges = prev ? mergeRanges([...prev.ranges, ...m.ranges]) : m.ranges
+      byField.set(m.field, { ...m, ranges })
+    } else if (prev) {
+      byField.set(m.field, { ...prev, ranges: mergeRanges([...prev.ranges, ...m.ranges]) })
+    }
+  }
+
+  return { score, matches: [...byField.values()].sort((a, b) => b.score - a.score) }
+}
+
+function mergeRanges(ranges: Array<[number, number]>): Array<[number, number]> {
+  if (ranges.length <= 1) {
+    return ranges
+  }
+
+  const sorted = [...ranges].sort((a, b) => a[0] - b[0] || a[1] - b[1])
+  const out: Array<[number, number]> = [[sorted[0][0], sorted[0][1]]]
+
+  for (let i = 1; i < sorted.length; i++) {
+    const last = out[out.length - 1]
+    const cur = sorted[i]
+
+    if (cur[0] <= last[1]) {
+      last[1] = Math.max(last[1], cur[1])
+    } else {
+      out.push([cur[0], cur[1]])
+    }
+  }
+
+  return out
+}
+
+function fuzzyEnabled(opts?: RankOptions): boolean {
+  if (opts?.fuzzy === false) {
+    return false
+  }
+
+  if (opts?.fuzzy === true) {
+    return true
+  }
+
+  const max = opts?.fuzzyMaxItems ?? 2000
+  const count = opts?.itemCount
+
+  return count == null || count <= max
+}
+
+/**
+ * Rank one item's fields against a query. Returns null when no alternative matches.
+ */
+export function rankFields(
+  fields: FieldSpec[],
+  query: string,
+  opts?: RankOptions
+): { score: number; matches: FieldMatch[] } | null {
+  const parsed = parseQuery(query)
+
+  if (!parsed.alternatives.length) {
+    return { score: 1, matches: [] }
+  }
+
+  const allowFuzzy = fuzzyEnabled(opts)
+  let best: { score: number; matches: FieldMatch[] } | null = null
+
+  for (const terms of parsed.alternatives) {
+    const hit = scoreFieldsAgainstTerms(fields, terms, allowFuzzy)
+
+    if (hit && (!best || hit.score > best.score)) {
+      best = hit
+    }
+  }
+
+  return best
+}
+
+/** Filter + sort a list by multi-field rank. Stable for equal scores. */
+export function rankItems<T>(
+  items: readonly T[],
+  getFields: (item: T) => FieldSpec[],
+  query: string,
+  opts?: RankOptions
+): Array<RankedHit<T>> {
+  const needle = normalize(query)
+
+  if (!needle) {
+    return items.map(item => ({ item, score: 1, matches: [] }))
+  }
+
+  const baseOpts: RankOptions = { ...opts, itemCount: opts?.itemCount ?? items.length }
+  const hits: Array<RankedHit<T> & { idx: number }> = []
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    const ranked = rankFields(getFields(item), needle, baseOpts)
+
+    if (ranked && ranked.score > 0) {
+      hits.push({ item, score: ranked.score, matches: ranked.matches, idx: i })
+    }
+  }
+
+  hits.sort((a, b) => b.score - a.score || a.idx - b.idx)
+
+  return hits.map(({ item, score, matches }) => ({ item, score, matches }))
+}
+
+/** Palette-compatible scorer: label + keywords, returns numeric score (0 = no match). */
+export function scoreLabeledItem(
+  label: string,
+  keywords: string[] | undefined,
+  query: string,
+  opts?: RankOptions
+): number {
+  const ranked = rankFields(
+    [
+      { field: 'label', value: label, weight: 1 },
+      { field: 'keywords', value: (keywords ?? []).join(' '), weight: 0.4 }
+    ],
+    query,
+    opts
+  )
+
+  return ranked?.score ?? 0
+}
+
+export function bestMatch(matches: FieldMatch[]): FieldMatch | undefined {
+  return matches[0]
+}
+
+// ── Highlight helpers ──────────────────────────────────────────────────────
+
+export function wrapRanges(
+  text: string,
+  ranges: Array<[number, number]>,
+  open = HL_OPEN,
+  close = HL_CLOSE
+): string {
+  if (!ranges.length || !text) {
+    return text
+  }
+
+  const merged = mergeRanges(ranges)
+  let out = ''
+  let cursor = 0
+
+  for (const [start, end] of merged) {
+    const s = Math.max(0, Math.min(text.length, start))
+    const e = Math.max(s, Math.min(text.length, end))
+
+    out += text.slice(cursor, s)
+    out += open + text.slice(s, e) + close
+    cursor = e
+  }
+
+  out += text.slice(cursor)
+
+  return out
+}
+
+/** Strip FTS or client highlight markers. */
+export function stripHighlightMarkers(text: string): string {
+  return text
+    .replaceAll(FTS_MARK_OPEN, '')
+    .replaceAll(FTS_MARK_CLOSE, '')
+    .replaceAll(HL_OPEN, '')
+    .replaceAll(HL_CLOSE, '')
+}
+
+export interface HighlightSegment {
+  text: string
+  hit: boolean
+}
+
+/** Parse text with either FTS `>>>/<<<` or client `[[m]]` markers into segments. */
+export function parseHighlightSegments(text: string): HighlightSegment[] {
+  if (!text) {
+    return []
+  }
+
+  const hasFts = text.includes(FTS_MARK_OPEN)
+  const hasHl = text.includes(HL_OPEN)
+
+  if (!hasFts && !hasHl) {
+    return [{ text, hit: false }]
+  }
+
+  const open = hasFts ? FTS_MARK_OPEN : HL_OPEN
+  const close = hasFts ? FTS_MARK_CLOSE : HL_CLOSE
+  const segments: HighlightSegment[] = []
+  let rest = text
+
+  while (rest.length) {
+    const i = rest.indexOf(open)
+
+    if (i < 0) {
+      segments.push({ text: rest, hit: false })
+      break
+    }
+
+    if (i > 0) {
+      segments.push({ text: rest.slice(0, i), hit: false })
+    }
+
+    rest = rest.slice(i + open.length)
+    const j = rest.indexOf(close)
+
+    if (j < 0) {
+      segments.push({ text: rest, hit: true })
+      break
+    }
+
+    segments.push({ text: rest.slice(0, j), hit: true })
+    rest = rest.slice(j + close.length)
+  }
+
+  return segments.filter(s => s.text.length > 0)
+}
+
+/** Build a short snippet around the first highlight / range. */
+export function excerptAround(
+  text: string,
+  ranges: Array<[number, number]>,
+  radius = 28
+): { text: string; ranges: Array<[number, number]> } {
+  if (!text) {
+    return { text: '', ranges: [] }
+  }
+
+  if (!ranges.length) {
+    const clipped = text.length > radius * 2 ? `${text.slice(0, radius * 2)}…` : text
+
+    return { text: clipped, ranges: [] }
+  }
+
+  const [start, end] = ranges[0]
+  const from = Math.max(0, start - radius)
+  const to = Math.min(text.length, end + radius)
+  let snippet = text.slice(from, to)
+  const adj: Array<[number, number]> = ranges
+    .map(([s, e]) => [s - from, e - from] as [number, number])
+    .filter(([s, e]) => e > 0 && s < snippet.length)
+    .map(([s, e]) => [Math.max(0, s), Math.min(snippet.length, e)] as [number, number])
+
+  if (from > 0) {
+    snippet = `…${snippet}`
+
+    for (const r of adj) {
+      r[0] += 1
+      r[1] += 1
+    }
+  }
+
+  if (to < text.length) {
+    snippet = `${snippet}…`
+  }
+
+  return { text: snippet, ranges: adj }
+}
+
+/** Human-readable default field labels (EN). UI may override via i18n. */
+export const SEARCH_FIELD_LABEL_EN: Record<SearchField, string> = {
+  title: 'Title',
+  name: 'Name',
+  label: 'Label',
+  preview: 'Preview',
+  description: 'Description',
+  category: 'Category',
+  cwd: 'Path',
+  branch: 'Branch',
+  id: 'ID',
+  source: 'Source',
+  keywords: 'Keywords',
+  body: 'Message',
+  tool: 'Tool'
+}
+
+export const SEARCH_FIELD_LABEL_ZH: Record<SearchField, string> = {
+  title: '标题',
+  name: '名称',
+  label: '标签',
+  preview: '预览',
+  description: '描述',
+  category: '分类',
+  cwd: '路径',
+  branch: '分支',
+  id: '编号',
+  source: '来源',
+  keywords: '关键词',
+  body: '正文',
+  tool: '工具'
+}

--- a/apps/desktop/src/lib/session-search.test.ts
+++ b/apps/desktop/src/lib/session-search.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { SessionInfo } from '@/types/hermes'
 
-import { sessionMatchesSearch } from './session-search'
+import { rankSession, sessionMatchesSearch } from './session-search'
 
 function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -68,5 +68,18 @@ describe('sessionMatchesSearch', () => {
 
   it('does not match unrelated queries', () => {
     expect(sessionMatchesSearch(makeSession(), 'totally-unrelated')).toBe(false)
+  })
+
+  it('supports OR alternatives and light fuzzy on long tokens', () => {
+    expect(sessionMatchesSearch(makeSession(), 'zzzz OR desktop')).toBe(true)
+    const ranked = rankSession(makeSession({ title: 'docker-compose setup' }), 'dokcer', { fuzzy: true })
+    expect(ranked).not.toBeNull()
+    expect(ranked!.matches[0].kind).toBe('fuzzy')
+  })
+
+  it('reports the best matching field', () => {
+    const ranked = rankSession(makeSession(), 'hermes-agent')
+    expect(ranked).not.toBeNull()
+    expect(ranked!.matches[0].field).toBe('cwd')
   })
 })

--- a/apps/desktop/src/lib/session-search.ts
+++ b/apps/desktop/src/lib/session-search.ts
@@ -2,7 +2,47 @@ import { normalize } from '@/lib/text'
 import type { SessionInfo } from '@/types/hermes'
 
 import { sessionTitle } from './chat-runtime'
+import {
+  bestMatch,
+  rankFields,
+  type FieldMatch,
+  type FieldSpec,
+  type RankedHit,
+  type RankOptions
+} from './search-match'
 import { sessionSourceSearchTerms } from './session-source'
+
+export function sessionSearchFields(session: SessionInfo): FieldSpec[] {
+  return [
+    { field: 'id', value: session.id },
+    { field: 'id', value: session._lineage_root_id ?? '' },
+    { field: 'title', value: session.title?.trim() || sessionTitle(session) },
+    { field: 'preview', value: session.preview ?? '' },
+    { field: 'cwd', value: session.cwd ?? '' },
+    { field: 'branch', value: session.git_branch ?? '' },
+    { field: 'source', value: sessionSourceSearchTerms(session.source).join(' ') }
+  ]
+}
+
+export function rankSession(
+  session: SessionInfo,
+  query: string,
+  opts?: RankOptions
+): RankedHit<SessionInfo> | null {
+  const needle = normalize(query)
+
+  if (!needle) {
+    return { item: session, score: 1, matches: [] }
+  }
+
+  const ranked = rankFields(sessionSearchFields(session), needle, opts)
+
+  if (!ranked || ranked.score <= 0) {
+    return null
+  }
+
+  return { item: session, score: ranked.score, matches: ranked.matches }
+}
 
 export function sessionMatchesSearch(session: SessionInfo, query: string): boolean {
   const needle = normalize(query)
@@ -11,13 +51,9 @@ export function sessionMatchesSearch(session: SessionInfo, query: string): boole
     return true
   }
 
-  return [
-    session.id,
-    session._lineage_root_id ?? '',
-    sessionTitle(session),
-    session.preview ?? '',
-    session.cwd ?? '',
-    session.git_branch ?? '',
-    ...sessionSourceSearchTerms(session.source)
-  ].some(value => value.toLowerCase().includes(needle))
+  return rankSession(session, query) != null
+}
+
+export function sessionBestMatch(session: SessionInfo, query: string): FieldMatch | undefined {
+  return bestMatch(rankSession(session, query)?.matches ?? [])
 }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1020,6 +1020,10 @@ export interface SessionSearchResult {
   session_started: number | null
   snippet: string
   source: string | null
+  /** Session title when known (id/meta hits and message hits that resolve a row). */
+  title?: string | null
+  /** Which surface produced the hit — drives the match-field chip. */
+  matched_on?: 'id' | 'title' | 'preview' | 'message' | 'meta' | null
 }
 
 export interface SessionSearchResponse {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5280,16 +5280,68 @@ async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] =
             # SQL-bounded, so this stays cheap even with thousands of sessions.
             for row in db.search_sessions_by_id(q, limit=safe_limit, include_archived=True):
                 sid = row.get("id")
+                title = (row.get("title") or "").strip() or None
                 preview = (row.get("preview") or "").strip()
-                snippet = preview or f"Session ID: {sid}"
+                snippet = preview or (f"Session ID: {sid}" if sid else "")
                 add_lineage_result(
                     sid,
                     {
                         "snippet": snippet,
+                        "title": title,
+                        "matched_on": "id",
                         "role": None,
                         "source": row.get("source"),
                         "model": row.get("model"),
                         "session_started": row.get("started_at"),
+                    },
+                )
+
+            # P1 latin/title infix: session metadata (title + id substring) via
+            # list_sessions_rich.search_query — sessions table is small; avoids
+            # full messages LIKE scans while catching mid-title hits FTS prefix
+            # wildcards miss on the id path alone.
+            try:
+                meta_rows = db.list_sessions_rich(
+                    limit=max(safe_limit * 3, 30),
+                    offset=0,
+                    include_archived=True,
+                    order_by_last_active=True,
+                    search_query=q.strip(),
+                    compact_rows=True,
+                )
+            except Exception:
+                meta_rows = []
+            for row in meta_rows:
+                if len(seen) >= safe_limit:
+                    break
+                sid = row.get("id")
+                if not sid:
+                    continue
+                title = (row.get("title") or "").strip() or None
+                preview = (row.get("preview") or "").strip()
+                # Prefer title as the human surface; fall back to preview.
+                needle = q.strip().lower()
+                title_l = (title or "").lower()
+                preview_l = preview.lower()
+                if title and needle in title_l:
+                    matched_on = "title"
+                    snippet = title
+                elif preview and needle in preview_l:
+                    matched_on = "preview"
+                    snippet = preview
+                else:
+                    matched_on = "meta"
+                    snippet = title or preview or f"Session ID: {sid}"
+                add_lineage_result(
+                    sid,
+                    {
+                        "snippet": snippet,
+                        "title": title,
+                        "matched_on": matched_on,
+                        "role": None,
+                        "source": row.get("source"),
+                        "model": row.get("model"),
+                        "session_started": row.get("started_at") or row.get("last_active"),
                     },
                 )
 
@@ -5312,10 +5364,20 @@ async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] =
             for m in matches:
                 if len(seen) >= safe_limit:
                     break
+                sid = m["session_id"]
+                title = None
+                try:
+                    sess = db.get_session(sid)
+                    if isinstance(sess, dict):
+                        title = (sess.get("title") or "").strip() or None
+                except Exception:
+                    title = None
                 add_lineage_result(
-                    m["session_id"],
+                    sid,
                     {
                         "snippet": m.get("snippet", ""),
+                        "title": title,
+                        "matched_on": "message",
                         "role": m.get("role"),
                         "source": m.get("source"),
                         "model": m.get("model"),

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -6,10 +6,10 @@ from hermes_cli import web_server
 class _FakeSessionDB:
     """Fake backing the /api/sessions/search endpoint.
 
-    The endpoint surfaces direct session-id matches first, then FTS message
-    matches, deduping both by compression lineage root. This fake has no
-    compression chains (get_session returns no parent), so each session is its
-    own lineage root.
+    The endpoint surfaces direct session-id matches first, then metadata
+    (title/id) infix hits, then FTS message matches, deduping by compression
+    lineage root. This fake has no compression chains (get_session returns no
+    parent), so each session is its own lineage root.
     """
 
     closed = False
@@ -20,12 +20,19 @@ class _FakeSessionDB:
         return [
             {
                 "id": "20260603_090200_exact",
+                "title": "Exact ID Session",
                 "preview": "ID match preview",
                 "source": "cli",
                 "model": "claude",
                 "started_at": 100,
             }
         ]
+
+    def list_sessions_rich(self, **kwargs):
+        # Metadata infix path — return empty so ID + FTS paths stay primary in
+        # this fixture (title search is covered by the ID row's title field).
+        assert kwargs.get("search_query") == "20260603"
+        return []
 
     def search_messages(self, query, limit=20):
         assert query == "20260603*"
@@ -50,7 +57,17 @@ class _FakeSessionDB:
 
     def get_session(self, session_id):
         # No compression chains in this fixture — every session is its own root.
-        return {"id": session_id, "parent_session_id": None}
+        if session_id == "content_session":
+            return {
+                "id": session_id,
+                "parent_session_id": None,
+                "title": "Content Title",
+            }
+        return {
+            "id": session_id,
+            "parent_session_id": None,
+            "title": "Exact ID Session",
+        }
 
     def get_compression_tip(self, session_id):
         return session_id
@@ -72,6 +89,8 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
                 "session_id": "20260603_090200_exact",
                 "lineage_root": "20260603_090200_exact",
                 "snippet": "ID match preview",
+                "title": "Exact ID Session",
+                "matched_on": "id",
                 "role": None,
                 "source": "cli",
                 "model": "claude",
@@ -81,6 +100,8 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
                 "session_id": "content_session",
                 "lineage_root": "content_session",
                 "snippet": "content hit",
+                "title": "Content Title",
+                "matched_on": "message",
                 "role": "assistant",
                 "source": "desktop",
                 "model": "gpt",


### PR DESCRIPTION
## Summary

- Shared lightweight rank kernel (`apps/desktop/src/lib/search-match.ts`): tiered exact/prefix/word/substring/fuzzy scores, multi-field weights, `OR`/`|` and quoted phrases, light typo tolerance on small lists.
- Wire skills page, command palette, and session sidebar; show **match-field chips** and FTS `>>>`/`<<<` snippet highlights.
- API: `/api/sessions/search` returns `title` + `matched_on`; after id hits, also scan session metadata via `list_sessions_rich` so title mid-string (Latin infix) works beyond FTS prefix wildcards.

## Scope / non-goals

- **No** local desk/ops scripts (`desk.mjs`, promote helpers) — those stay private carry.
- Content body search remains FTS (prefix for Latin; CJK tokenizer path unchanged). Metadata infix is the cheap dual channel.

## Test plan

- [x] `vitest` `search-match.test.ts` + `session-search.test.ts` (22 passed on desktop worktree)
- [x] `pytest tests/hermes_cli/test_web_server_session_search.py` (passed on PR branch)
- [ ] Manual: sidebar search shows field chip + title highlight; skills page chip on description hits; palette OR/typo
- [ ] Manual: API response includes `title` / `matched_on` after backend restart

## Notes

Depends on nothing else. Frontend degrades gracefully if an older backend omits the new fields (local rank still fills chips for in-list sessions).