### PR TITLE
fix(nix): read manifests from the repo root, not the filtered source copy

### DIFF
--- a/contributors/emails/tomoya.otabi@gmail.com
+++ b/contributors/emails/tomoya.otabi@gmail.com
@@ -1,0 +1,1 @@
+natsukium

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -207,8 +207,18 @@ let
   # resolves each package from the lockfile's own `integrity` hashes, so the
   # lockfile is the single source of truth — no separate dependency hash to
   # keep in sync with it.
+  #
+  # package/packageLock come from repoRoot, not npmDepsSrc: left to itself
+  # importNpmLock would importJSON them out of the fileset copy, which only
+  # materialises when nix may write to the store.  Reading one during
+  # evaluation therefore breaks read-only eval (`nix flake check --no-build`,
+  # which downstream flakes run in CI) with "path '…-source' is not valid".
+  # repoRoot is the flake's own source, so it is always a valid store path.
+  # npmRoot stays npmDepsSrc, keeping the derivation's rebuild scope as is.
   npmDeps = importNpmLock.importNpmLock {
     npmRoot = npmDepsSrc;
+    package = rootPackageJson;
+    packageLock = builtins.fromJSON (builtins.readFile (repoRoot + "/package-lock.json"));
   };
 
   # Build a per-package npm source: workspace resolution files + the

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -13,7 +13,12 @@
   dependency-groups ? [ "all" ],
 }:
 let
-  workspace = uv2nix.lib.workspace.loadWorkspace { workspaceRoot = pythonSrc; };
+  # Not pythonSrc: loadWorkspace reads pyproject.toml / uv.lock at evaluation
+  # time, and reading a cleanSourceWith copy breaks read-only eval (see the
+  # npmDeps comment in lib.nix).  hermes-agent's src is set back to pythonSrc
+  # below, so the venv's rebuild scope is unaffected.
+  workspaceRoot = ./..;
+  workspace = uv2nix.lib.workspace.loadWorkspace { inherit workspaceRoot; };
   hacks = callPackage pyproject-nix.build.hacks { };
 
   overlay = workspace.mkPyprojectOverlay {
@@ -114,21 +119,24 @@ let
           # Hermes derivation. This is deliberately a derivation environment
           # variable, not a devShell variable: ``nix develop -c uv build``
           # must remain blocked.
+          #
+          # src is the filtered pythonSrc, not the workspace root the
+          # workspace was loaded from, so .tsx/doc/skill edits still don't
+          # rebuild the venv.
           (final: prev: {
             hermes-agent = prev.hermes-agent.overrideAttrs (_old: {
+              src = pythonSrc;
               HERMES_NIX_BUILD = "1";
             });
           })
         ]
       );
 
-  # The editable venv points at the live checkout, so it uses an
-  # UNFILTERED workspace rooted at a real path — mkEditablePyprojectOverlay
-  # computes relative paths via lib.path.splitRoot, which rejects the
-  # filtered pythonSrc (a cleanSourceWith set, not a path).  Filtering
-  # buys nothing here anyway: the editable install reads from
-  # $HERMES_PYTHON_SRC_ROOT at runtime.
-  workspaceRoot = ./..;
+  # The editable venv points at the live checkout, so it reuses the same
+  # UNFILTERED workspaceRoot — mkEditablePyprojectOverlay computes relative
+  # paths via lib.path.splitRoot, which rejects the filtered pythonSrc (a
+  # cleanSourceWith set, not a path).  Filtering buys nothing here anyway:
+  # the editable install reads from $HERMES_PYTHON_SRC_ROOT at runtime.
   editableWorkspace = uv2nix.lib.workspace.loadWorkspace { inherit workspaceRoot; };
   editableOverlay = editableWorkspace.mkEditablePyprojectOverlay {
     root = "$HERMES_PYTHON_SRC_ROOT"; # resolved at shellHook time


### PR DESCRIPTION
## What does this PR do?

Fixes read-only Nix evaluation, which #65237 broke.

The filtered derivation sources introduced in f8b6d38 are built with `lib.fileset.toSource` / `lib.cleanSourceWith`. Such a source only materialises its copy in the store when Nix is allowed to write to it. But two call sites read *out of those copies during evaluation*:

- `importNpmLock` reads `package.json` / `package-lock.json` out of `npmDepsSrc`
- uv2nix's `loadWorkspace` reads `pyproject.toml` / `uv.lock` out of `pythonSrc`

So `nix flake check --no-build` — which downstream flakes run in CI — fails during evaluation with `path '…-source' is not valid`, before anything is built.

The fix routes both **evaluation-time** reads through the repo root, which is the flake's own source and therefore always a valid store path. The filtered sources are left untouched and stay in use as **derivation inputs**: `npmDeps` keeps `npmDepsSrc` as its `npmRoot`, and `hermes-agent`'s `src` is set back to `pythonSrc`. The rebuild scoping #65237 added is therefore unaffected — verified below.

## Related Issue

No PR or issue addresses read-only evaluation. This is a follow-up fix to #65237, which introduced the filtered sources.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `nix/lib.nix`: pass `package` / `packageLock` to `importNpmLock` explicitly, sourced from `repoRoot`, instead of letting it `importJSON` them out of `npmDepsSrc`. `npmRoot` still points at `npmDepsSrc`, so the `npmDeps` derivation is unchanged. `package` reuses the already-parsed `rootPackageJson`.
- `nix/python.nix`: `loadWorkspace` now takes the unfiltered `workspaceRoot` (`./..`), and `pythonSrc` is re-applied as `hermes-agent`'s `src` in the existing `HERMES_NIX_BUILD` overlay, so the venv's rebuild scope is unchanged. `workspaceRoot` was already defined further down for the editable overlay; it just moves up and is now shared by both workspaces.

Second commit adds the contributor email mapping that the attribution check requires.

## How to Test

> **One caveat worth knowing:** the bug only shows when the filtered `-source` copy is **not already in your store**. That is the normal state for downstream CI and fresh checkouts, but if you have built or evaluated this repo locally the path is already valid and the failure hides — note that a plain `nix build` / `nix eval` is enough to materialise it, since those evaluate with the store writable. The `--store <dir>` below points Nix at a throwaway store, so the repro is deterministic either way.

**1. Reproduce on `main`** (`226b095a5`):

```console
$ nix --store /tmp/ro-a flake check --no-build
checking derivation checks.aarch64-darwin.cross-eval...
error:
       … while checking the derivation 'checks.aarch64-darwin.cross-eval'
       error: path '1h0lzhn784i5m852hqswf2bpcsi25qfj-source' is not valid
```

**2. Same check on this branch**, against its own throwaway store — `cross-eval` now evaluates, and the run proceeds past it:

```console
$ nix --store /tmp/ro-b flake check --no-build
checking derivation checks.aarch64-darwin.build-devshell...
```

> The run does not reach "all checks passed" **on aarch64-darwin**, but for an unrelated pre-existing reason: `nix/sandbox.nix` pulls `bubblewrap` into the devShell unconditionally, and that package is Linux-only, so `checks.aarch64-darwin.build-devshell` refuses to evaluate. That is independent of this PR — this branch touches neither the devShell nor the sandbox — and it is why the failure only appears once the `is not valid` error before it is gone.

**3. Confirm rebuild scoping is unaffected.** `tui` and `web` derivations are byte-identical across the two revisions:

```console
$ for a in tui web; do nix path-info --derivation .#$a; done
/nix/store/jmf9yyn7nb4169lnnskh4ms0473627kv-hermes-tui-0.0.1.drv   # base
/nix/store/jmf9yyn7nb4169lnnskh4ms0473627kv-hermes-tui-0.0.1.drv   # fix  ← identical
/nix/store/fs74gkc4490ya11p3cfivkq9sa37wlac-web-0.0.0.drv          # base
/nix/store/fs74gkc4490ya11p3cfivkq9sa37wlac-web-0.0.0.drv          # fix  ← identical
```

And the sealed venv is untouched. Comparing the **full recursive derivation closure** of `.#default` between `main` and the `nix/` commit, exactly one derivation out of 4848 differs:

```console
$ nix derivation show -r .#default > closure.json     # on each revision
$ comm -3 <(jq -r '.derivations|keys[]' base.json | sort) \
          <(jq -r '.derivations|keys[]' fix.json  | sort)
skm1fp6s38cwc4910r0l4klk18gqchjd-hermes-agent-0.20.0.drv        # base only
        k2kjvw64wb28swcn99fhqcgyyfqvl9h7-hermes-agent-0.20.0.drv        # fix only
```

The other 4847 derivation paths are identical — and a `.drv` path is a content hash, so identical paths mean identical contents. That includes the sealed venv (`kwy5ac3670r8wr330rbmnc12z4fb5ly0-hermes-agent-env.drv` on both sides), which is the one this PR's `python.nix` change could plausibly have moved.

The single differing derivation is the top-level wrapper, which embeds the git rev in its `installPhase` (from #65237) and therefore differs between *any* two commits. Normalising the two revs away, the wrappers are identical apart from the output path the rev determines:

```console
$ diff <(jq -S '.derivations["skm1…-hermes-agent-0.20.0.drv"]' base.json | sed "s/$BASE_REV/REV/g") \
       <(jq -S '.derivations["k2kj…-hermes-agent-0.20.0.drv"]' fix.json  | sed "s/$FIX_REV/REV/g")
36c36
<     "out": "/nix/store/sbyabx4f6kqzw71lqrlcib4xyhxcj4xf-hermes-agent-0.20.0"
---
>     "out": "/nix/store/55f5fc9fln7kxh7nwixsa3nn462kyvn1-hermes-agent-0.20.0"
```

The remaining `out` difference is not an independent change: the rev is embedded in the wrapper's `installPhase`, so the output path it hashes to necessarily moves with it.

> Measured against the `nix/` commit alone. The contributor-mapping commit *does* move the venv hash, because `contributors/` is not in `pythonSrc`'s excluded-dirs list, so any mapping file added anywhere in the repo invalidates the Python venv. That is pre-existing filter behaviour, not something this PR introduces — but it may be worth adding `contributors` to that list in a separate change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — open and closed/merged PRs plus issues; see the Related Issue section
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — the `nix/` fix plus the contributor mapping the attribution check demands
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A, Nix evaluation isn't covered by the pytest suite; `nix flake check --no-build` is the regression check
- [x] I've tested on my platform: macOS 26.4 (aarch64-darwin)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, the reasoning lives in the `nix/lib.nix` and `nix/python.nix` comments
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Nix-only; no platform-specific logic added or changed
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

cc @ethernet8023
