### PR TITLE
fix(gateway): forward max_tokens on provider-pinned routes (#59763)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2315,6 +2315,46 @@ def _resolve_runtime_agent_kwargs() -> dict:
     }
 
 
+def _resolve_runtime_max_tokens(runtime: dict) -> object:
+    """Compute the effective ``max_tokens`` output cap with global precedence.
+
+    Shared by both runtime resolvers so provider-pinned routes don't silently
+    drop the cap. Precedence (config.yaml is authoritative for behavioral
+    config; env vars only act as an override when no config value is set):
+
+        1. ``HERMES_MAX_TOKENS`` env var
+        2. ``model.max_tokens`` from config.yaml
+        3. per-provider ``max_output_tokens`` (custom_providers fallback)
+
+    Returns ``None`` when nothing is configured, preserving existing behavior.
+    """
+    max_tokens = None
+    _env_mt = os.environ.get("HERMES_MAX_TOKENS")
+    if _env_mt:
+        try:
+            max_tokens = int(_env_mt)
+        except (ValueError, TypeError):
+            max_tokens = None
+    if max_tokens is None:
+        try:
+            from hermes_cli.runtime_provider import _get_model_config
+
+            model_cfg = _get_model_config()
+        except Exception:
+            model_cfg = None
+        if isinstance(model_cfg, dict):
+            mt = model_cfg.get("max_tokens")
+            if isinstance(mt, int):
+                max_tokens = mt
+    # Only fall back to the per-provider cap when the documented global
+    # model.max_tokens isn't set, so the global key always wins.
+    if max_tokens is None:
+        _runtime_mot = runtime.get("max_output_tokens")
+        if isinstance(_runtime_mot, int) and _runtime_mot > 0:
+            max_tokens = _runtime_mot
+    return max_tokens
+
+
 def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
     """Resolve runtime credentials for a specific provider (e.g. from channel override)."""
     from hermes_cli.runtime_provider import (
@@ -2334,6 +2374,11 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        # Previously omitted — see #59763: provider-pinned routes (channel
+        # overrides, rehydrated /model session overrides) built agents with
+        # max_tokens=None, so the documented output cap never reached the API
+        # request. Mirror the sibling resolver's precedence.
+        "max_tokens": _resolve_runtime_max_tokens(runtime),
     }
 
 

--- a/tests/gateway/test_channel_overrides.py
+++ b/tests/gateway/test_channel_overrides.py
@@ -10,8 +10,70 @@ from gateway.config import (
     Platform,
     PlatformConfig,
 )
-from gateway.run import _get_channel_override, GatewayRunner
+from gateway.run import (
+    _get_channel_override,
+    _resolve_runtime_agent_kwargs_for_provider,
+    GatewayRunner,
+)
 from gateway.session import SessionSource
+
+
+class TestRuntimeMaxTokensResolution:
+    """Regression for #59763: provider-pinned routes must forward max_tokens."""
+
+    def test_provider_resolver_includes_max_tokens_from_model_config(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {
+                "provider": "openrouter",
+                "api_key": "k",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+                "max_output_tokens": 8000,
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_model_config",
+            lambda: {"max_tokens": 4096},
+        )
+
+        result = _resolve_runtime_agent_kwargs_for_provider("openrouter")
+        assert result["max_tokens"] == 4096
+
+    def test_provider_resolver_falls_back_to_max_output_tokens(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {
+                "provider": "openrouter",
+                "api_key": "k",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+                "max_output_tokens": 8000,
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_model_config", lambda: {}
+        )
+
+        result = _resolve_runtime_agent_kwargs_for_provider("openrouter")
+        assert result["max_tokens"] == 8000
+
+    def test_provider_resolver_returns_none_when_unconfigured(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {
+                "provider": "openrouter",
+                "api_key": "k",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_model_config", lambda: {}
+        )
+
+        result = _resolve_runtime_agent_kwargs_for_provider("openrouter")
+        assert result["max_tokens"] is None
 
 
 class TestGetChannelOverride:


### PR DESCRIPTION
Fixes #59763 — _resolve_runtime_agent_kwargs_for_provider() omitted max_tokens from its return dict, while its sibling _resolve_runtime_agent_kwargs() included it. Every provider-pinned route (channel overrides, rehydrated /model session overrides) built agents with max_tokens=None, so the documented output cap (model.max_tokens / HERMES_MAX_TOKENS / per-provider max_output_tokens) never reached the API request — output was silently capped at the internal default.

Root cause
gateway/run.py has two sibling runtime resolvers:

_resolve_runtime_agent_kwargs() (line 2247) — resolves and returns max_tokens with precedence env > model.max_tokens > per-provider max_output_tokens.
_resolve_runtime_agent_kwargs_for_provider(provider) (line 2318) — returns credentials but drops max_tokens.
The channel-override route (_resolve_session_agent_runtime, line 4464) calls the provider-specific resolver, so its runtime dict carries max_tokens=None. Downstream _resolve_turn_agent_config() reads runtime_kwargs["max_tokens"] (line 4541), so the cap is lost for every provider-pinned session.

Fix
Extract a shared helper _resolve_runtime_max_tokens(runtime) with the same precedence as the sibling resolver, and call it from _resolve_runtime_agent_kwargs_for_provider. The downstream consumer already forwards the value, so the cap now flows through unchanged for all other routes.

Verification
tests/gateway/test_channel_overrides.py — 18 passed (15 existing + 3 new):

test_provider_resolver_includes_max_tokens_from_model_config — model.max_tokens wins
test_provider_resolver_falls_back_to_max_output_tokens — per-provider cap applies when global unset
test_provider_resolver_returns_none_when_unconfigured — preserves prior None behavior
Refs #59763, #28046 (same chokepoint).