### PR TITLE
feat(gateway): render full terminal command in non-verbose code blocks when it fits tool_preview_length

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20520,16 +20520,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "" if last_was_terminal_block[0] else f"{emoji} {tool_name}\n"
                 )
                 _code_block_full = f"{_block_header}```\n{_cmd_full}\n```"
-                # Single-line, capped preview for non-verbose modes.
+                # Capped preview for non-verbose modes.  Treat
+                # tool_preview_length as a TOTAL-length budget: when the whole
+                # command (all lines) fits the budget, render it in full — so a
+                # multi-line command a user opted into (by raising
+                # tool_preview_length) shows completely.  When it exceeds the
+                # budget, preserve the existing collapse-to-first-line behaviour
+                # exactly, so a long/multiline command never becomes a huge
+                # persistent block (the #42634 / commit 8d99b5bc size policy).
                 _pl = get_tool_preview_max_len()
                 _cap = _pl if _pl > 0 else 40
-                _lines = _cmd_full.splitlines()
-                _cmd_short = _lines[0] if _lines else _cmd_full
-                _multiline = len(_lines) > 1
-                if len(_cmd_short) > _cap:
-                    _cmd_short = _cmd_short[:_cap - 3] + "..."
-                elif _multiline:
-                    _cmd_short = _cmd_short + " ..."
+                if len(_cmd_full) <= _cap:
+                    _cmd_short = _cmd_full
+                else:
+                    _lines = _cmd_full.splitlines()
+                    _first = _lines[0] if _lines else _cmd_full
+                    _multiline = len(_lines) > 1
+                    if len(_first) > _cap:
+                        _cmd_short = _first[:_cap - 3] + "..."
+                    elif _multiline:
+                        _cmd_short = _first + " ..."
+                    else:
+                        _cmd_short = _first
                 _code_block_short = f"{_block_header}```\n{_cmd_short}\n```"
 
             # Verbose mode: show detailed arguments, respects tool_preview_length

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1711,6 +1711,62 @@ async def test_terminal_progress_renders_fenced_code_block(monkeypatch, tmp_path
 
 
 @pytest.mark.asyncio
+async def test_terminal_progress_all_mode_full_command_when_within_budget(monkeypatch, tmp_path):
+    """Non-verbose ("all") mode renders the FULL multi-line command in a fenced
+    block when the whole command fits within tool_preview_length.  The default
+    cap still collapses over-budget commands to the first line
+    (test_terminal_progress_renders_fenced_code_block) — this covers the opt-in
+    path where an operator widened the budget."""
+    import yaml
+
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = TerminalCommandAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji
+
+    # Raise the budget above the command length so the whole thing fits.
+    config = {"display": {"tool_preview_length": 2000}}
+    (tmp_path / "config.yaml").write_text(yaml.dump(config), encoding="utf-8")
+
+    adapter = CodeBlockProgressAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-terminal-code-block-all-full",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    all_content = " ".join(call["content"] for call in adapter.sent)
+    all_content += " ".join(call["content"] for call in adapter.edits)
+    assert "```" in all_content
+    assert "```bash" not in all_content
+    # Whole multi-line command is present because it fits the raised budget.
+    assert "npm install -g hyperframes@latest" in all_content
+    assert "node --version" in all_content
+
+
+@pytest.mark.asyncio
 async def test_terminal_progress_verbose_shows_full_command(monkeypatch, tmp_path):
     """Verbose mode on a markdown-capable gateway renders the FULL multi-line
     command in a bare fenced block (no truncation, no 'bash' tag).  This is the


### PR DESCRIPTION
## Summary

In non-verbose progress modes (`all` / `new`), terminal commands rendered as fenced
code blocks are collapsed to the first line, capped at `tool_preview_length`
(default 40). This PR keeps that collapse **for anything over the budget** but
renders the command **in full when the whole command fits within
`tool_preview_length`** — turning the setting into a *total-length budget* rather
than a first-line-only cap. Full multi-line output is therefore strictly opt-in:
it only appears once an operator raises `tool_preview_length`.

## Prior art & why this isn't a duplicate

I read the existing thread before opening this and want to be explicit about it:

- **#46941** (issue) — reports the confusing partial-command UX.
- **#46962** (open PR) — fixes it by switching non-verbose modes to
  `_code_block_full`, i.e. *always* full. The maintainer review on that PR
  (`hermes-sweeper`, verdict `keep_open salvageability=none`) pushed back:

  > *"This reverses an explicit gateway UX decision … maintainer commit
  > `8d99b5bc4f3f` introduced that cap specifically to prevent long or multiline
  > terminal commands from producing huge persistent progress blocks … Please
  > retain the non-verbose capped path unless maintainers decide to change the
  > gateway progress-size policy."*

This PR is deliberately **not** that change. It **retains the cap and the
size policy**. The difference from #46962:

|                          | #46962 (always full) | this PR (budget-gated)                    |
| ------------------------ | -------------------- | ----------------------------------------- |
| Command **over** budget  | full → huge block    | **unchanged** — first line + `…` collapse |
| Command **under** budget | full                 | full                                      |
| Default (`40`) behaviour | changes              | **preserved** (over-budget still collapses) |
| Full multi-line output   | unconditional        | **opt-in** via `tool_preview_length`      |

So the "huge persistent block" the cap was designed to prevent still cannot
happen at the default setting. An operator only gets full multi-line commands
after explicitly widening the budget.

## Behaviour

`display.tool_preview_length` now bounds the **whole** command string (all lines),
not just the first line:

- `len(command) <= cap` → render the command in full (all lines).
- `len(command) > cap` → **exactly the previous behaviour**: collapse to the
  first line, truncated to `cap` with `…` (single-line) or `first line …`
  (multi-line).

Default (`tool_preview_length: 0` → 40): a long/multiline command still collapses
to its first line — no change. Verbose mode is untouched (already full).

## Changes

- `gateway/run.py`: budget-gated rendering for the non-verbose terminal code
  block (over-budget path unchanged).
- `tests/gateway/test_run_progress_topics.py`: existing default-cap contract test
  is untouched and still green; adds a test that a raised `tool_preview_length`
  renders the full multi-line command in the fenced block.

## Note for maintainers

I read #46962 and the `hermes-sweeper` review first: this keeps the size cap
(default unchanged, over-budget still collapses) and makes full output opt-in, so
it shouldn't reverse the policy from commit `8d99b5bc`. Since that review framed
the area as a policy call, happy to adjust the default, close in favour of
#46962, or drop it if the first-line cap is meant to be absolute.

Relates to #46941. Alternative approach to #46962.
