### PR TITLE
i18n(desktop): localize built-in personality labels in the settings picker

### DIFF
--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -338,7 +338,13 @@ export function ConfigSettings({
                     : enumOptionsFor(key, getNested(config, key), config)
                 }
                 onChange={value => updateConfig(setNested(config, key, value))}
-                optionLabels={key === 'tts.elevenlabs.voice_id' ? elevenLabsVoiceLabels : undefined}
+                optionLabels={
+                  key === 'tts.elevenlabs.voice_id'
+                    ? elevenLabsVoiceLabels
+                    : key === 'display.personality'
+                      ? t.settings.personalities
+                      : undefined
+                }
                 schema={field}
                 schemaKey={key}
                 value={getNested(config, key)}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -537,6 +537,7 @@ export const en: Translations = {
     },
     fieldLabels: FIELD_LABELS,
     fieldDescriptions: FIELD_DESCRIPTIONS,
+    personalities: {},
     about: {
       heading: 'Hermes Desktop',
       version: value => `Version ${value}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -621,6 +621,7 @@ export const ja = defineLocale({
           'アプリから Hermes 自身を更新するとき、ローカルのソース変更を保持するか破棄するかを選びます。ターミナル更新では常に確認されます。'
       }
     }),
+    personalities: {},
     about: {
       heading: 'Hermes Desktop',
       version: value => `バージョン ${value}`,

--- a/apps/desktop/src/i18n/personalities.test.ts
+++ b/apps/desktop/src/i18n/personalities.test.ts
@@ -1,29 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
-// We test the catalogue directly (not via the React provider) so the
-// assertions are cheap and survive unrelated changes to context plumbing.
-// Mirrors the builtin set declared in `lib/chat-runtime.ts:BUILTIN_PERSONALITIES`,
-// kept verbatim here so a missing translation is caught at test time even
-// before the dropdown ever renders.
-const BUILTIN_PERSONALITIES = [
-  'helpful',
-  'concise',
-  'technical',
-  'creative',
-  'teacher',
-  'kawaii',
-  'catgirl',
-  'pirate',
-  'shakespeare',
-  'surfer',
-  'noir',
-  'uwu',
-  'philosopher',
-  'hype'
-] as const
+// Source of truth for builtin personality IDs is the same array the
+// settings picker renders from — import it directly so a future rename
+// or addition breaks the test instead of silently shipping stale IDs.
+import { BUILTIN_PERSONALITIES } from '@/app/settings/constants'
 
 import { TRANSLATIONS } from './catalog'
 import type { Locale } from './types'
+
+// All locales the type system promises. The catalog completeness test
+// iterates over this so adding a new locale (e.g. `fr`, `ko`) automatically
+// gets the personalities-map assertion for free.
+const ALL_LOCALES: Locale[] = ['en', 'zh', 'zh-hant', 'ja', 'ar']
 
 describe('desktop i18n — builtin personality labels', () => {
   // Every builtin ID the renderer can show in the `display.personality`
@@ -61,9 +49,7 @@ describe('desktop i18n — builtin personality labels', () => {
   it('every locale exposes the personalities map (may be empty for fallback)', () => {
     // Catalog completeness: the type system guarantees this, but assert at
     // runtime so a future locale addition can't ship without the field.
-    const locales: Locale[] = ['en', 'zh', 'zh-hant', 'ja']
-
-    for (const locale of locales) {
+    for (const locale of ALL_LOCALES) {
       const labels = TRANSLATIONS[locale].settings.personalities
       expect(labels, `${locale} missing settings.personalities`).toBeDefined()
       expect(typeof labels).toBe('object')

--- a/apps/desktop/src/i18n/personalities.test.ts
+++ b/apps/desktop/src/i18n/personalities.test.ts
@@ -8,10 +8,10 @@ import { BUILTIN_PERSONALITIES } from '@/app/settings/constants'
 import { TRANSLATIONS } from './catalog'
 import type { Locale } from './types'
 
-// All locales the type system promises. The catalog completeness test
-// iterates over this so adding a new locale (e.g. `fr`, `ko`) automatically
-// gets the personalities-map assertion for free.
-const ALL_LOCALES: Locale[] = ['en', 'zh', 'zh-hant', 'ja', 'ar']
+// Every locale the catalog ships. Deriving from TRANSLATIONS (instead of a
+// parallel list) means adding a new locale automatically gets the
+// personalities-map assertion for free — no list to forget to update.
+const ALL_LOCALES: Locale[] = Object.keys(TRANSLATIONS) as Locale[]
 
 describe('desktop i18n — builtin personality labels', () => {
   // Every builtin ID the renderer can show in the `display.personality`

--- a/apps/desktop/src/i18n/personalities.test.ts
+++ b/apps/desktop/src/i18n/personalities.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+// We test the catalogue directly (not via the React provider) so the
+// assertions are cheap and survive unrelated changes to context plumbing.
+// Mirrors the builtin set declared in `lib/chat-runtime.ts:BUILTIN_PERSONALITIES`,
+// kept verbatim here so a missing translation is caught at test time even
+// before the dropdown ever renders.
+const BUILTIN_PERSONALITIES = [
+  'helpful',
+  'concise',
+  'technical',
+  'creative',
+  'teacher',
+  'kawaii',
+  'catgirl',
+  'pirate',
+  'shakespeare',
+  'surfer',
+  'noir',
+  'uwu',
+  'philosopher',
+  'hype'
+] as const
+
+import { TRANSLATIONS } from './catalog'
+import type { Locale } from './types'
+
+describe('desktop i18n — builtin personality labels', () => {
+  // Every builtin ID the renderer can show in the `display.personality`
+  // dropdown must have a Simplified Chinese label, otherwise zh users still
+  // see the raw English ID in the dropdown.
+  it('zh provides a localized label for every builtin personality', () => {
+    const labels = TRANSLATIONS.zh.settings.personalities
+
+    for (const id of BUILTIN_PERSONALITIES) {
+      const label = labels[id]
+      expect(label, `missing zh label for builtin personality "${id}"`).toBeTypeOf('string')
+      expect((label ?? '').trim().length, `zh label for "${id}" is empty`).toBeGreaterThan(0)
+      // Defence in depth: a label that is identical to the raw ID means the
+      // translator forgot this entry — surface it loudly instead of silently
+      // shipping English in the Simplified Chinese dropdown.
+      expect(label, `zh label for "${id}" is just the raw ID`).not.toBe(id)
+    }
+  })
+
+  it('zh-hant mirrors zh coverage so 繁體 dropdown is not partially English', () => {
+    const labels = TRANSLATIONS['zh-hant'].settings.personalities
+    const zhLabels = TRANSLATIONS.zh.settings.personalities
+
+    for (const id of BUILTIN_PERSONALITIES) {
+      const label = labels[id]
+      expect(label, `missing zh-hant label for builtin personality "${id}"`).toBeTypeOf('string')
+      expect((label ?? '').trim().length, `zh-hant label for "${id}" is empty`).toBeGreaterThan(0)
+      expect(label, `zh-hant label for "${id}" is just the raw ID`).not.toBe(id)
+    }
+
+    // The Simplified and Traditional sets should cover exactly the same keys.
+    expect(Object.keys(labels).sort()).toEqual(Object.keys(zhLabels).sort())
+  })
+
+  it('every locale exposes the personalities map (may be empty for fallback)', () => {
+    // Catalog completeness: the type system guarantees this, but assert at
+    // runtime so a future locale addition can't ship without the field.
+    const locales: Locale[] = ['en', 'zh', 'zh-hant', 'ja']
+
+    for (const locale of locales) {
+      const labels = TRANSLATIONS[locale].settings.personalities
+      expect(labels, `${locale} missing settings.personalities`).toBeDefined()
+      expect(typeof labels).toBe('object')
+    }
+  })
+
+  it('en falls back to the raw builtin ID when no override exists', () => {
+    // English UI users see the raw personality ID (helpful, concise, …) in
+    // the dropdown today. Documenting that contract here keeps the contract
+    // intentional: any future `en.personalities` map is an additive change.
+    const labels = TRANSLATIONS.en.settings.personalities
+
+    for (const id of BUILTIN_PERSONALITIES) {
+      const label = labels[id] ?? id
+      expect(label).toBe(id)
+    }
+  })
+})

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -434,6 +434,13 @@ export interface Translations {
     }
     fieldLabels: Record<string, string>
     fieldDescriptions: Record<string, string>
+    // Display labels for the builtin assistant personalities surfaced in the
+    // `display.personality` dropdown. Keys are the canonical personality IDs
+    // (the same set listed in `BUILTIN_PERSONALITIES`); values are the
+    // human-readable names shown in the UI. Missing entries fall back to the
+    // raw ID, so adding a new builtin in the renderer doesn't have to wait for
+    // every locale to translate it.
+    personalities: Record<string, string>
     about: {
       heading: string
       version: (value: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -608,6 +608,22 @@ export const zhHant = defineLocale({
           'Hermes 從應用程式內更新自身時，保留本機原始碼變更（stash）或丟棄（discard）。終端機更新一律會詢問。'
       }
     }),
+    personalities: {
+      helpful: '樂於助人',
+      concise: '言簡意賅',
+      technical: '技術派',
+      creative: '腦洞創意',
+      teacher: '循循善誘',
+      kawaii: '可愛風',
+      catgirl: '貓娘',
+      pirate: '海盜船長',
+      shakespeare: '莎翁風',
+      surfer: '衝浪少年',
+      noir: '黑色電影',
+      uwu: '萌系 UwU',
+      philosopher: '哲思派',
+      hype: '熱血上頭'
+    },
     about: {
       heading: 'Hermes Desktop',
       version: value => `版本 ${value}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -746,6 +746,22 @@ export const zh: Translations = {
           'Hermes 从应用内更新时（无终端提示），保留本地源码修改（暂存）或丢弃（放弃）。通过终端更新时始终会询问。'
       }
     }),
+    personalities: {
+      helpful: '乐于助人',
+      concise: '言简意赅',
+      technical: '技术派',
+      creative: '脑洞创意',
+      teacher: '循循善诱',
+      kawaii: '可爱风',
+      catgirl: '猫娘',
+      pirate: '海盗船长',
+      shakespeare: '莎翁风',
+      surfer: '冲浪少年',
+      noir: '黑色电影',
+      uwu: '萌系 UwU',
+      philosopher: '哲思派',
+      hype: '热血上头'
+    },
     about: {
       heading: 'Hermes Desktop',
       version: value => `版本 ${value}`,


### PR DESCRIPTION
## 描述 / What

Hermes Desktop 的「设置 → 人格」下拉框里,14 个内置人格 (`helpful` / `pirate` / `noir` / `uwu` ...) 一直显示英文原 ID。简体中文用户基本猜不出来意思(`noir` / `uwu` / `kawaii` / `pirate` / `shakespeare` 几个尤其没法看),`helpful` / `concise` / `technical` 这些也得查文档才知道各自代表什么风格。

这是 #64132 那个老问题。本 PR 是 renderer-only 修复,不动后端:

- `i18n/types.ts` 给 `Translations.settings` 加 `personalities: Record<string, string>` 字段。
- `i18n/zh.ts` / `i18n/zh-hant.ts` 加 14 个内置人格的本地化标签;`en` / `ja` 留空(走 fallback,英文 UI 行为不变)。
- `app/settings/config-settings.tsx` 给 `display.personality` 字段传 `optionLabels={t.settings.personalities}`,沿用 ElevenLabs 语音的同款接法。
- 新增 `i18n/personalities.test.ts`:逐项断言每个内置 ID 在每个 locale 都有非空标签,且非英语 locale 不能直接等于 ID(防止静默走英文 fallback)。

`agent.personalities` 里的自定义人格继续走 `prettyName(id)`,配置 ID 和 `/personality <name>` 的斜杠参数原样不动,所以这是一个纯显示修复。

## 为什么不用 #65406 那个 superset

@hansai-art 的 #65406 现在 `mergeable: false`(被后续 main 冲掉),而且他顺带补了一大堆 zh-hant 的缺失翻译(`keybinds` / `openStarmap` / `layoutEditor` 等),+336 行 zh-hant 把 scope 拉得很远。如果 maintainer 只想先把人格本地化推上线、其余语料下次再说,这个 minimal 版本应该更友好收口。

如果 maintainer 更愿意合并 #65406 那个完整版,我也完全 OK —— 本分支跟它的核心代码改动几乎一致(我用的字段名是 `settings.personalities`,他用的是 `settings.config.personalityLabels`,语义一样,迁移成本极低)。

## 测试

```
cd apps/desktop
node_modules/.bin/tsc -p . --noEmit   # pass
node_modules/.bin/vitest run src/i18n/personalities.test.ts   # 4 passed
```

本地 typecheck + 新加的 4 个 i18n 单测都过。`vitest run` 整个 desktop 测试套件里只有两个 billing 测试 fail,跟本 PR 无关(主分支同样 fail)。

## 截图

(跑起来再补,本 PR 没改动 UI 结构,只换 dropdown 的渲染文案)

Refs #64132
