### PR TITLE
fix(web): prevent URL userinfo credentials from leaking to third-party extraction providers

### DIFF
--- a/tests/tools/test_browser_secret_exfil.py
+++ b/tests/tools/test_browser_secret_exfil.py
@@ -94,6 +94,66 @@ class TestWebExtractSecretExfil:
     """Verify web_extract_tool blocks URLs containing secrets."""
 
     @pytest.mark.asyncio
+    async def test_blocks_url_userinfo_before_extract_provider(self, monkeypatch):
+        """Third-party readers must never receive Basic-auth or token userinfo."""
+        from agent.web_search_provider import WebSearchProvider
+        from agent import web_search_registry
+        from tools import web_tools
+
+        received_urls = []
+
+        class RecordingExtractProvider(WebSearchProvider):
+            @property
+            def name(self) -> str:
+                return "recording-extract"
+
+            def is_available(self) -> bool:
+                return True
+
+            def supports_search(self) -> bool:
+                return False
+
+            def supports_extract(self) -> bool:
+                return True
+
+            def extract(self, urls, **_kwargs):
+                received_urls.extend(urls)
+                return []
+
+        web_search_registry._reset_for_tests()
+        web_search_registry.register_provider(RecordingExtractProvider())
+        monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+        monkeypatch.setattr(
+            web_tools, "_get_extract_backend", lambda: "recording-extract"
+        )
+
+        try:
+            result = await web_tools.web_extract_tool(
+                urls=["https://alice:DEMO_PASSWORD_123@example.com/private"],
+            )
+        finally:
+            web_search_registry._reset_for_tests()
+
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "embedded userinfo credentials" in parsed["error"]
+        assert "DEMO_PASSWORD_123" not in result
+        assert received_urls == []
+
+    @pytest.mark.asyncio
+    async def test_blocks_bare_token_url_userinfo(self):
+        from tools.web_tools import web_extract_tool
+
+        result = await web_extract_tool(
+            urls=["https://opaque-bearer-value@example.com/private"],
+        )
+
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "embedded userinfo credentials" in parsed["error"]
+        assert "opaque-bearer-value" not in result
+
+    @pytest.mark.asyncio
     async def test_blocks_api_key_in_url(self):
         from tools.web_tools import web_extract_tool
         result = await web_extract_tool(

--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -8,6 +8,7 @@ import httpx
 from tools.url_safety import (
     is_safe_url,
     async_is_safe_url,
+    has_url_userinfo,
     is_always_blocked_url,
     normalize_url_for_request,
     redirect_target_from_response,
@@ -73,6 +74,33 @@ class TestNormalizeUrlForRequest:
             normalize_url_for_request("https://example.com/r?next=https:// evil.example")
             == "https://example.com/r?next=https://%20evil.example"
         )
+
+
+class TestHasUrlUserinfo:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://alice:password@example.com/private",
+            "https://opaque-token@example.com/private",
+            "https://alice:p%40ssword@example.com/private",
+            "http://user:@example.com/",
+        ],
+    )
+    def test_detects_http_userinfo(self, url):
+        assert has_url_userinfo(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/path?email=user@example.com",
+            "https://example.com/user@example.com",
+            "mailto:user@example.com",
+            "not a url",
+            "",
+        ],
+    )
+    def test_ignores_at_signs_outside_http_authority(self, url):
+        assert has_url_userinfo(url) is False
 
 
 class TestIsSafeUrl:

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -159,6 +159,26 @@ def has_sensitive_query_params(url: str) -> bool:
     """Return True when ``url`` carries likely credential-bearing query params."""
     return sensitive_query_param_name(url) is not None
 
+
+def has_url_userinfo(url: str) -> bool:
+    """Return True when an HTTP(S) URL embeds credentials in its authority.
+
+    URL userinfo (``user:password@host`` or ``token@host``) is sent verbatim
+    to third-party extract/browser providers when they receive the full URL.
+    Treat any userinfo as credential-bearing rather than trying to recognize
+    particular password or token formats.
+    """
+    if not isinstance(url, str):
+        return False
+    try:
+        parsed = urlsplit(url.strip())
+    except ValueError:
+        return False
+    return (
+        parsed.scheme.lower() in {"http", "https"}
+        and parsed.username is not None
+    )
+
 # Hostnames that should always be blocked regardless of IP resolution
 # or any config toggle.  These are cloud metadata endpoints that an
 # attacker could use to steal instance credentials.

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -97,7 +97,12 @@ from tools.tool_backend_helpers import (  # noqa: F401
     nous_tool_gateway_unavailable_message,
     prefers_gateway,
 )
-from tools.url_safety import async_is_safe_url, normalize_url_for_request, sensitive_query_param_name
+from tools.url_safety import (
+    async_is_safe_url,
+    has_url_userinfo,
+    normalize_url_for_request,
+    sensitive_query_param_name,
+)
 import sys
 
 logger = logging.getLogger(__name__)
@@ -794,6 +799,16 @@ async def web_extract_tool(
             }
             continue
         normalized_url = normalize_url_for_request(_url)
+        if has_url_userinfo(normalized_url):
+            return json.dumps({
+                "success": False,
+                "error": (
+                    "Blocked: URL contains embedded userinfo credentials. "
+                    "Web extract backends are third-party readers; remove the "
+                    "userinfo or use a local browser session when authenticated "
+                    "access is explicitly required."
+                ),
+            })
         if (
             _PREFIX_RE.search(_url)
             or _PREFIX_RE.search(unquote(_url))


### PR DESCRIPTION
## What does this PR do?

Prevents `web_extract` from sending credentials embedded in HTTP(S) URL userinfo, such as `https://user:password@host/`, to third-party extraction providers.

On current main, a real local Firecrawl endpoint received the password verbatim in its `/v2/scrape` request body.

## Related Issue

No issue filed.

Related but non-duplicate work:

- #56366 blocks credential-like query parameters before cloud web/browser dispatch.
- #6454 and #54475 redact URL userinfo from surfaced output.
- #59658 removes URL userinfo from tool progress display.

None prevents the original credential-bearing URL from being transmitted to an extraction provider.

## Changes Made

- Added a shared HTTP(S) userinfo detector in `tools/url_safety.py`.
- Blocked Basic-auth and bare-token userinfo before any extract provider is called.
- Ensured rejection responses never echo the credential.
- Added provider-boundary and URL parsing regression coverage.

## How to Test

1. Configure a local Firecrawl endpoint.
2. Call `web_extract` with `https://alice:password@example.com/private`.
3. Confirm the request is rejected and Firecrawl receives no HTTP request.

Validation:

```text
449 passed
ruff: passed
compileall: passed
Windows footgun scan: passed
git diff --check: passed