### PR TITLE
fix(telegram): detect stalled local update dispatch

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -766,6 +766,17 @@ class TelegramAdapter(BasePlatformAdapter):
         # error_callback ever fires and the gateway silently stops receiving
         # messages with the process still alive (#55769).
         self._polling_not_running_count: int = 0
+        # Telegram removes updates from its server-side queue as soon as
+        # getUpdates succeeds, before PTB's Application dispatcher invokes our
+        # handlers. A dead Application consumer therefore looks healthy to both
+        # the getUpdates progress marker and pending_update_count (which returns
+        # zero) while messages pile up in the local update_queue. Track two
+        # consecutive no-progress probes and force a full retryable adapter
+        # rebuild instead of merely restarting the Updater (#71239).
+        self._dispatch_app_ref = None
+        self._dispatch_queue_stuck_count: int = 0
+        self._dispatch_queue_last_size: Optional[int] = None
+        self._application_not_running_count: int = 0
         # A polling generation stays degraded until the dedicated getUpdates
         # request makes successful progress. start_polling() return and getMe()
         # success on the general request path are not polling-health signals.
@@ -2718,6 +2729,12 @@ class TelegramAdapter(BasePlatformAdapter):
         task is gone rather than wedged, so even ``get_webhook_info`` can't
         report a queue against a live consumer. We detect the stopped updater
         directly and feed the same ladder (#55769).
+
+        Finally, getUpdates can successfully remove updates from Telegram's
+        server queue while PTB's Application dispatcher is stopped or its local
+        ``update_queue`` is no longer draining. In that state both the transport
+        progress marker and ``pending_update_count`` look healthy, so two
+        no-progress local probes force a full retryable adapter rebuild.
         """
         if getattr(self, "_polling_teardown_started", False):
             return
@@ -2769,6 +2786,86 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return
         self._polling_not_running_count = 0
+
+        app = self._app
+        if app is not self._dispatch_app_ref:
+            self._dispatch_app_ref = app
+            self._dispatch_queue_stuck_count = 0
+            self._dispatch_queue_last_size = None
+            self._application_not_running_count = 0
+
+        if not getattr(app, "running", False):
+            self._dispatch_queue_stuck_count = 0
+            self._dispatch_queue_last_size = None
+            self._application_not_running_count += 1
+            logger.warning(
+                "[%s] Telegram polling heartbeat: PTB Application dispatcher "
+                "stopped while Updater remains active (stuck probe %d/2)",
+                self.name,
+                self._application_not_running_count,
+            )
+            if self._application_not_running_count >= 2:
+                self._application_not_running_count = 0
+                message = (
+                    "Telegram Application dispatcher stopped while polling "
+                    "remained active; rebuilding adapter"
+                )
+                logger.error("[%s] %s", self.name, message)
+                self._set_fatal_error(
+                    "telegram_update_dispatch_stalled", message, retryable=True
+                )
+                await self._handoff_polling_fatal_error()
+            return
+        self._application_not_running_count = 0
+
+        update_queue = getattr(app, "update_queue", None)
+        queue_size = getattr(update_queue, "qsize", None)
+        local_pending: Optional[int] = None
+        if callable(queue_size):
+            try:
+                raw_local_pending = queue_size()
+                if isinstance(raw_local_pending, int):
+                    local_pending = raw_local_pending
+            except Exception:
+                logger.debug(
+                    "[%s] Could not inspect Telegram Application update queue",
+                    self.name,
+                    exc_info=True,
+                )
+
+        if local_pending is None or local_pending <= 0:
+            self._dispatch_queue_stuck_count = 0
+            self._dispatch_queue_last_size = None
+        else:
+            previous_size = self._dispatch_queue_last_size
+            if previous_size is None or local_pending < previous_size:
+                # The queue shrank since the last probe, so the dispatcher made
+                # progress. Start a fresh debounce window for the remaining item.
+                self._dispatch_queue_stuck_count = 1
+            else:
+                self._dispatch_queue_stuck_count += 1
+            self._dispatch_queue_last_size = local_pending
+            logger.warning(
+                "[%s] Telegram polling heartbeat: %d update(s) stuck in PTB's "
+                "local dispatch queue (stuck probe %d/2)",
+                self.name,
+                local_pending,
+                self._dispatch_queue_stuck_count,
+            )
+            if self._dispatch_queue_stuck_count >= 2:
+                self._dispatch_queue_stuck_count = 0
+                self._dispatch_queue_last_size = None
+                message = (
+                    "Telegram Application update queue stopped draining after "
+                    "getUpdates succeeded; rebuilding adapter"
+                )
+                logger.error("[%s] %s", self.name, message)
+                self._set_fatal_error(
+                    "telegram_update_dispatch_stalled", message, retryable=True
+                )
+                await self._handoff_polling_fatal_error()
+                return
+
         get_webhook_info = getattr(bot, "get_webhook_info", None)
         if not callable(get_webhook_info):
             return

--- a/tests/gateway/test_telegram_pending_update_probe.py
+++ b/tests/gateway/test_telegram_pending_update_probe.py
@@ -7,8 +7,15 @@ CLOSE-WAIT heartbeat is blind to it. ``_probe_pending_updates`` watches
 ``get_webhook_info().pending_update_count`` and escalates to the existing
 network-error recovery ladder after two consecutive stuck probes.
 
-The same probe also covers the harsher case where the updater has stopped
-entirely (``running=False``) with no reconnect in flight — the long-poll task
+The same probe also covers two failures after Telegram has already removed an
+update from its server-side queue: a stopped PTB ``Application`` dispatcher and
+a local ``Application.update_queue`` that is no longer draining. Those cases
+report ``pending_update_count == 0`` even though the gateway is alive-but-deaf,
+so they require a full retryable adapter rebuild rather than merely restarting
+the Updater.
+
+The probe also covers the harsher case where the updater has stopped entirely
+(``running=False``) with no reconnect in flight — the long-poll task
 is gone, so the gateway silently stops receiving messages while the process
 stays alive (#55769) — and feeds it into the same recovery ladder.
 """
@@ -37,11 +44,14 @@ _ensure_telegram_mock()
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 
 
-def _make_adapter(*, pending: int) -> TelegramAdapter:
+def _make_adapter(*, pending: int, local_pending: int = 0) -> TelegramAdapter:
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
     adapter._webhook_mode = False
-    adapter._app = MagicMock()
-    adapter._app.updater.running = True
+    app = MagicMock()
+    app.running = True
+    app.updater.running = True
+    app.update_queue.qsize.return_value = local_pending
+    adapter._app = app
     bot = MagicMock()
     bot.get_webhook_info = AsyncMock(
         return_value=MagicMock(pending_update_count=pending)
@@ -88,6 +98,61 @@ async def test_zero_pending_resets_counter():
         await adapter._probe_pending_updates(adapter._app.bot, 5)
     assert adapter._polling_pending_stuck_count == 0
     rec.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_local_update_queue_stall_forces_retryable_adapter_rebuild():
+    """Updates pulled off Telegram but stuck locally must rebuild Application."""
+    adapter = _make_adapter(pending=0, local_pending=1)
+    with patch.object(
+        adapter, "_handoff_polling_fatal_error", new=AsyncMock()
+    ) as handoff:
+        await adapter._probe_pending_updates(adapter._app.bot, 5)
+        assert adapter._dispatch_queue_stuck_count == 1
+        handoff.assert_not_called()
+
+        await adapter._probe_pending_updates(adapter._app.bot, 5)
+
+    assert adapter.fatal_error_code == "telegram_update_dispatch_stalled"
+    assert adapter.fatal_error_retryable is True
+    handoff.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_local_update_queue_progress_resets_stall_debounce():
+    """A shrinking local queue is forward progress, not a dispatcher wedge."""
+    adapter = _make_adapter(pending=0)
+    adapter._app.update_queue.qsize.side_effect = [2, 1]
+    with patch.object(
+        adapter, "_handoff_polling_fatal_error", new=AsyncMock()
+    ) as handoff:
+        await adapter._probe_pending_updates(adapter._app.bot, 5)
+        await adapter._probe_pending_updates(adapter._app.bot, 5)
+
+    assert adapter._dispatch_queue_stuck_count == 1
+    assert adapter._dispatch_queue_last_size == 1
+    assert not adapter.has_fatal_error
+    handoff.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stopped_application_dispatcher_forces_retryable_rebuild():
+    """Updater health cannot mask a stopped PTB Application dispatcher."""
+    adapter = _make_adapter(pending=0)
+    adapter._app.running = False
+    with patch.object(
+        adapter, "_handoff_polling_fatal_error", new=AsyncMock()
+    ) as handoff:
+        await adapter._probe_pending_updates(adapter._app.bot, 5)
+        assert adapter._application_not_running_count == 1
+        handoff.assert_not_called()
+
+        await adapter._probe_pending_updates(adapter._app.bot, 5)
+
+    assert adapter.fatal_error_code == "telegram_update_dispatch_stalled"
+    assert adapter.fatal_error_retryable is True
+    handoff.assert_awaited_once()
+    adapter._app.bot.get_webhook_info.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #71239.

Telegram's `getUpdates` call removes updates from the Bot API's server-side queue before python-telegram-bot's `Application` dispatcher invokes Hermes handlers. The existing health checks can therefore all report healthy while the gateway is alive-but-deaf:

- successful `getUpdates` marks polling progress
- `Updater.running` remains true
- `getWebhookInfo.pending_update_count` returns zero

This change extends the existing 90-second heartbeat to cover that downstream dispatch boundary.

## Changes

- Detect `Application.running == false` while the Updater remains active.
- Inspect the public `Application.update_queue.qsize()`.
- Debounce dispatch stalls across two heartbeat probes.
- Treat a shrinking local queue as forward progress.
- On a persistent local stall, emit retryable `telegram_update_dispatch_stalled` and use the existing fatal handoff so the gateway rebuilds the full adapter/Application.
- Keep the existing Updater-only reconnect ladder for transport/server-queue stalls; a local dispatcher failure requires a full Application rebuild.
- Fence counters to the current Application object so reconnects cannot inherit stale observations.

## Live evidence

A macOS launchd-managed gateway remained reported connected and alive for roughly four days while fresh Telegram DMs no longer reached inbound handlers. During the incident:

- `getMe` returned HTTP 200
- `pending_update_count` was zero
- Telegram TCP connections were established
- no agent was active
- a direct model smoke test succeeded
- only a supervised gateway adapter rebuild restored ingress

No credentials or user message contents are included.

## Tests

RED before production code: 3 new failures.

GREEN after the fix:

```text
scripts/run_tests.sh \
  tests/gateway/test_telegram_pending_update_probe.py \
  tests/gateway/test_telegram_network_reconnect.py \
  tests/gateway/test_telegram_polling_progress.py \
  tests/test_telegram_polling_progress_ptb.py \
  tests/gateway/test_telegram_start_polling_timeout.py \
  tests/gateway/test_telegram_conflict.py -- -q

111 passed, 0 failed
```

Also passed:

- Ruff on both changed files
- `compileall` on both changed files
- `git diff --check`
- `scripts/check-windows-footguns.py` on both changed files

## Risk and rollback

The deliberate tradeoff is a full retryable adapter rebuild when the local queue does not shrink for two consecutive 90-second probes. A continuously busy bot whose queue remains exactly the same size for three minutes could theoretically trigger a conservative reconnect; Hermes handlers normally hand updates into the gateway quickly, so a non-draining local queue at that horizon is already unhealthy.

Rollback is a normal revert. No config or schema migration.