### PR TITLE
fix(registry): stop warning when an optional capability is simply off

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -583,3 +583,69 @@ class TestDeregisterAuthorization:
             evil_handler = eval("lambda *a, **k: 'hijacked'", {"__name__": "hermes_plugins.evil"})
             reg.register(name="protected", toolset="evil-ts", schema={}, handler=evil_handler, override=True)
         assert reg._tools["protected"].handler({}) == "built-in"
+
+
+class TestCheckFnLogLevels:
+    """A check_fn returning False is a capability being OFF, not a failure.
+
+    `check_fn` gates optional toolsets on runtime prerequisites: is a terminal
+    open, is kanban mode enabled, is a browser attached, is Home Assistant
+    configured. On any normal install most of those are simply not in use, and
+    every one of them logged at WARNING once per turn.
+
+    Measured on a live install: 420 of 1869 WARNING lines - 22% of every
+    warning emitted - were `check_fn ... returned False` for features that had
+    never been enabled, and zero were the `raised` case. Real warnings drown in
+    that, which is the actual cost.
+
+    An exception from a check_fn IS a defect and stays at WARNING. The registry
+    already distinguishes the two.
+    """
+
+    @staticmethod
+    def _registry_with(check_fn):
+        reg = ToolRegistry()
+        reg.register(
+            name="t",
+            toolset="gated",
+            schema=_make_schema(),
+            handler=_dummy_handler,
+            check_fn=check_fn,
+        )
+        return reg
+
+    def test_returning_false_is_not_a_warning(self, caplog):
+        reg = self._registry_with(lambda: False)
+
+        with caplog.at_level("DEBUG", logger="tools.registry"):
+            assert reg.is_toolset_available("gated") is False
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert warnings == [], (
+            "a disabled capability must not warn: "
+            f"{[r.getMessage() for r in warnings]}"
+        )
+
+    def test_returning_false_is_still_logged_for_diagnosis(self, caplog):
+        """Quiet-mode subagents lose tools silently, so the signal must survive
+        the level change - just below WARNING."""
+        reg = self._registry_with(lambda: False)
+
+        with caplog.at_level("DEBUG", logger="tools.registry"):
+            reg.is_toolset_available("gated")
+
+        assert any("returned False" in r.getMessage() for r in caplog.records)
+
+    def test_raising_check_fn_still_warns(self, caplog):
+        def boom():
+            raise RuntimeError("probe blew up")
+
+        reg = self._registry_with(boom)
+
+        with caplog.at_level("DEBUG", logger="tools.registry"):
+            assert reg.is_toolset_available("gated") is False
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any("raised" in m for m in warnings), (
+            f"an exception from check_fn is a real defect and must warn: {warnings}"
+        )

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -631,10 +631,12 @@ class TestCheckFnLogLevels:
         the level change - just below WARNING."""
         reg = self._registry_with(lambda: False)
 
-        with caplog.at_level("DEBUG", logger="tools.registry"):
+        with caplog.at_level("INFO", logger="tools.registry"):
             reg.is_toolset_available("gated")
 
-        assert any("returned False" in r.getMessage() for r in caplog.records)
+        records = [r for r in caplog.records if "returned False" in r.getMessage()]
+        assert len(records) == 1
+        assert records[0].levelname == "INFO"
 
     def test_raising_check_fn_still_warns(self, caplog):
         def boom():

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -270,7 +270,17 @@ def _check_fn_cached(fn: Callable) -> bool:
 
         # No recent success (or grace expired) — honor the failure. Log it so
         # silent tool loss in quiet mode (subagents) is diagnosable.
-        logger.warning(
+        #
+        # Level split: a check_fn that RAISED is a defect and warrants a
+        # warning. One that simply returned False is an optional capability
+        # being off (no terminal open, kanban disabled, no browser attached,
+        # Home Assistant not configured) — the normal state on most installs,
+        # re-logged every turn. Warning on that buried the real signal: on a
+        # live install 420 of 1869 warnings (22%) were this line, none of them
+        # the raised case. Keep it at info so quiet-mode tool loss stays
+        # diagnosable without drowning genuine warnings.
+        log = logger.warning if raised else logger.info
+        log(
             "check_fn %s %s; dependent tools will be unavailable this turn",
             getattr(fn, "__qualname__", fn),
             "raised" if raised else "returned False",


### PR DESCRIPTION
## The problem

`check_fn` gates optional toolsets on runtime prerequisites — is a terminal open, is kanban mode enabled, is a browser attached, is Home Assistant configured, is video generation set up. On a normal install most of those are simply not in use.

Every one of them logged at **WARNING**, once per turn.

Measured on a live install over two log files:

```
all WARNING lines                      1869
check_fn "returned False"               420   (22%)
check_fn "raised"                         0
```

Top offenders, none of which are failures:

```
41  check_read_terminal_requirements     (no terminal open)
41  check_close_terminal_requirements    (no terminal open)
34  _check_kanban_mode                   (kanban not enabled)
34  _browser_cdp_check                   (no browser attached)
31  _check_xai_video_requirements        (video gen not configured)
18  _check_ha_available                  (no Home Assistant)
```

## Why it matters

Nearly a quarter of all warnings are a capability being switched off. That's not a cosmetic complaint — it buries the warnings that mean something. Diagnosing a genuine auxiliary-provider failure in the same log was materially harder because of the surrounding noise, and "grep the warnings" is the first thing anyone does when a gateway misbehaves.

## The fix

The registry already distinguishes the two cases (`raised` vs `returned False`), so split the level rather than the message:

- **`raised`** — a check_fn threw. That's a defect. Stays at `WARNING`.
- **`returned False`** — the capability is off. Drops to `INFO`.

The line still lands in `agent.log`, so the original intent in the surrounding comment — keeping silent tool loss in quiet-mode subagents diagnosable — is preserved. Only the severity changes.

## Tests

Three, pinning each property independently:

- returning False does not emit a warning
- returning False is *still logged* (the diagnostic signal survives the level change)
- a raising check_fn still warns

47 passed in `tests/tools/test_registry.py`.

Note: `tests/tools/test_file_state_registry.py` has 2 failures on this branch, both reproduced on a clean `origin/main` checkout — pre-existing and unrelated to this change.
