### PR TITLE
fix(skills): use posix paths in bundle hash for Windows parity (#71237)

### DIFF
--- a/tests/tools/test_skills_hash_posix.py
+++ b/tests/tools/test_skills_hash_posix.py
@@ -1,0 +1,35 @@
+"""Regression for #71237: skill hash must use posix paths on all platforms."""
+
+import hashlib
+from pathlib import Path, PurePosixPath
+
+
+def test_bundle_content_hash_uses_posix_paths(monkeypatch, tmp_path):
+    """bundle_content_hash must produce the same hash regardless of OS
+    path separator. The disk-side _content_digest uses .as_posix(), so
+    the bundle-side hash must too."""
+    from tools.skills_hub import bundle_content_hash, SkillBundle
+
+    # Simulate a skill with subdirectory (the case that breaks on Windows)
+    files = {
+        "references/cli.md": b"# CLI ref",
+        "SKILL.md": b"# Skill",
+    }
+    bundle = SkillBundle(
+        name="test",
+        source="hub",
+        identifier="test-skill",
+        files=files,
+        metadata={},
+        trust_level="trusted",
+    )
+    h1 = bundle_content_hash(bundle)
+
+    # Now simulate what _content_digest produces (posix paths, sorted)
+    h2 = hashlib.sha256()
+    for rel_path in sorted(files.keys()):
+        h2.update(rel_path.encode("utf-8") + b"\x00")
+        h2.update(files[rel_path])
+    expected = f"sha256:{h2.hexdigest()[:16]}"
+
+    assert h1 == expected, f"Hash mismatch: {h1} != {expected}"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3239,7 +3239,7 @@ class OptionalSkillSource(SkillSource):
                 and "__pycache__" not in f.parts
                 and f.suffix != ".pyc"
             ):
-                rel_path = str(f.relative_to(skill_dir))
+                rel_path = f.relative_to(skill_dir).as_posix()
                 try:
                     files[rel_path] = f.read_bytes()
                 except OSError:


### PR DESCRIPTION
## Problem

On Windows, hub-installed skills with subdirectories are stuck in a perpetual `update_available` loop. The bundle-side hash uses `str(f.relative_to(skill_dir))` which produces backslash-separated paths on Windows, while the disk-side `_content_digest` uses `.as_posix()` (forward slashes). The two hashes never match.

## Fix

Change `str(f.relative_to(skill_dir))` to `f.relative_to(skill_dir).as_posix()` in `tools/skills_hub.py:3242` so both hash computations use the same path format.

Fixes #71237
