### PR TITLE
fix(tools): config.yaml terminal.backend overrides stale .env TERMINAL_ENV (#71137)

### DIFF
--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -8,9 +8,11 @@ back silently to the local backend even when config.yaml selected
 ``terminal.backend: docker`` — commands the user intended to sandbox ran on
 the host (#63141 / #54449 / #61115 / #65696).
 
-``_ensure_terminal_env_bridged()`` closes that hole at the chokepoint: when
-TERMINAL_ENV is unset, backfill TERMINAL_* from config.yaml before the
-local default applies. An explicitly-set TERMINAL_ENV always wins.
+``_ensure_terminal_env_bridged()`` closes that hole at the chokepoint:
+when config.yaml has a ``terminal`` section, its values are authoritative
+and override any existing TERMINAL_* env vars (including stale .env values).
+When config.yaml has NO terminal section, only missing env vars are
+backfilled so explicit shell exports and .env values keep working (#71137).
 """
 
 import os
@@ -36,7 +38,7 @@ def _reset_bridge_state(monkeypatch):
 def _write_config(text: str) -> None:
     home = get_hermes_home()
     home.mkdir(parents=True, exist_ok=True)
-    (home / "config.yaml").write_text(text)
+    (home / "config.yaml").write_text(text, encoding="utf-8")
 
 
 def test_unset_terminal_env_backfills_backend_from_config():
@@ -55,20 +57,20 @@ def test_unset_terminal_env_backfills_backend_from_config():
     assert os.environ.get("TERMINAL_ENV") == "docker"
 
 
-def test_explicit_terminal_env_wins_over_config(monkeypatch):
-    """An explicit env choice (launcher bridge or .env) is never overridden —
-    honor explicit choice vs accidental fallback."""
+def test_config_terminal_section_overrides_env(monkeypatch):
+    """config.yaml terminal section is authoritative over env/.env values
+    (aligned with CLI _file_has_terminal_config and gateway bridge)."""
     _write_config("terminal:\n  backend: docker\n")
     monkeypatch.setenv("TERMINAL_ENV", "local")
 
     config = terminal_tool._get_env_config()
 
-    assert config["env_type"] == "local"
+    assert config["env_type"] == "docker"
 
 
-def test_preset_terminal_vars_survive_backfill(monkeypatch):
-    """override=False: already-set sibling TERMINAL_* values stay
-    authoritative; only missing ones are backfilled."""
+def test_config_terminal_section_overrides_sibling_vars(monkeypatch):
+    """When config.yaml has a terminal section, its values override
+    already-set sibling TERMINAL_* env vars (consistent with CLI path)."""
     _write_config(
         "terminal:\n"
         "  backend: docker\n"
@@ -79,7 +81,7 @@ def test_preset_terminal_vars_survive_backfill(monkeypatch):
     config = terminal_tool._get_env_config()
 
     assert config["env_type"] == "docker"
-    assert config["docker_image"] == "env/image:2"
+    assert config["docker_image"] == "config/image:1"
 
 
 def test_bridge_failure_falls_back_to_local(monkeypatch):
@@ -117,3 +119,26 @@ def test_bridge_only_attempted_once(monkeypatch):
     terminal_tool._get_env_config()
 
     assert len(calls) == 1
+
+
+def test_stale_env_overridden_by_config_backend(monkeypatch):
+    """#71137: .env TERMINAL_ENV=ssh must not override config.yaml
+    terminal.backend=local on the fallback bridge path."""
+    _write_config("terminal:\n  backend: local\n")
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_SSH_HOST", "1.2.3.4")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "local"
+
+
+def test_no_terminal_section_env_wins(monkeypatch):
+    """Without a terminal section in config.yaml, env values are kept
+    (backfill-only mode preserves explicit shell exports and .env)."""
+    _write_config("model:\n  default: some-model\n")
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "ssh"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1306,14 +1306,14 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
 
 
 # One-shot guard for the config-fallback bridge below.  Purely an
-# optimization: after the first attempt either TERMINAL_ENV is set (bridge
-# succeeded — merged config always carries terminal.backend) or the import
-# failed and retrying every call would be wasted work.
+# optimization: after the first attempt the bridge has either applied
+# config.yaml values (or backfilled defaults) or the import failed —
+# retrying every call would be wasted work.
 _terminal_config_bridge_attempted = False
 
 
 def _ensure_terminal_env_bridged() -> None:
-    """Backfill TERMINAL_* env vars from config.yaml when no launcher did.
+    """Bridge TERMINAL_* env vars from config.yaml for launcher-less paths.
 
     terminal_tool reads ALL terminal settings from os.environ (TERMINAL_*).
     The CLI (cli.py ``env_mappings``), the gateway (gateway/run.py
@@ -1325,21 +1325,32 @@ def _ensure_terminal_env_bridged() -> None:
     config.yaml selects ``terminal.backend: docker``, running commands on the
     host the user intended to sandbox (#63141, #54449, #61115, #65696).
 
-    Explicit env always wins: when TERMINAL_ENV is already set (a launcher's
-    bridge or the user's .env made a deliberate choice) this is a no-op.  The
-    config bridge only fills the unset case, so it changes an accidental
-    default — never an explicit selection.
+    Precedence (aligned with CLI and gateway bridges):
+    - config.yaml has a ``terminal`` section → config is authoritative and
+      overrides any existing TERMINAL_* env vars (including stale .env values
+      loaded by ``load_dotenv``).  Fixes #71137.
+    - config.yaml has NO ``terminal`` section → only backfill missing env
+      vars so explicit shell exports and .env values keep working.
     """
     global _terminal_config_bridge_attempted
-    if "TERMINAL_ENV" in os.environ or _terminal_config_bridge_attempted:
+    if _terminal_config_bridge_attempted:
         return
     _terminal_config_bridge_attempted = True
     try:
         from hermes_cli.config import apply_terminal_config_to_env
 
-        # env=None targets os.environ inside the helper; override=False keeps
-        # any already-set TERMINAL_* values (e.g. from .env) authoritative.
-        apply_terminal_config_to_env(env=None, override=False)
+        # env=None targets os.environ; override=None (default) lets the
+        # helper decide: config.yaml terminal section present → override;
+        # absent → backfill only.
+        prev = os.environ.get("TERMINAL_ENV")
+        apply_terminal_config_to_env()
+        new = os.environ.get("TERMINAL_ENV")
+        if prev and new and prev != new:
+            logger.warning(
+                "terminal backend: config.yaml '%s' overrode .env/env '%s' "
+                "(config.yaml is authoritative for behavioral settings)",
+                new, prev,
+            )
     except Exception:
         # Never let a config problem take the terminal tool down — the
         # historical local default still applies.


### PR DESCRIPTION
## What changed

Fixed `_ensure_terminal_env_bridged()` in `tools/terminal_tool.py` so that config.yaml's `terminal` section is authoritative over stale `.env` values, aligning the fallback bridge with the existing CLI and gateway behavior.

## Why

When `hermes setup` writes `TERMINAL_ENV=ssh` to `.env` and the user later switches to local via `hermes config set terminal.backend local` (writes config.yaml), the fallback bridge path (serve / Desktop / cron / ACP) still used SSH because:

1. `load_dotenv` loads `.env` into `os.environ` at startup
2. The bridge guard `"TERMINAL_ENV" in os.environ` treated the stale `.env` value as an "explicit choice" and skipped the config bridge entirely

This bricked sessions when the SSH host became unreachable — all tools timed out with no way to recover.

## How

- Removed `"TERMINAL_ENV" in os.environ` from the early-return guard (kept the one-shot `_terminal_config_bridge_attempted` optimization)
- Removed `override=False` so `apply_terminal_config_to_env()` uses its default logic: config.yaml has `terminal` section → override env; no section → backfill only
- Added a `logger.warning` when config.yaml overrides a conflicting env value

## How to test

1. Write `TERMINAL_ENV=ssh` to `~/.hermes/.env`
2. Set `terminal.backend: local` in `~/.hermes/config.yaml`
3. Start a session via Desktop / `hermes serve` / cron
4. Verify the session uses `local` (before fix: used `ssh`)

Unit tests: `pytest tests/tools/test_terminal_env_bridge.py -v` (7 tests, all pass)

## Platforms tested

- Windows 11 (native, Python 3.11)

Closes #71137
