### PR TITLE
fix(api_server): say which auth failure happened, not always "invalid API key"

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1583,8 +1583,23 @@ class APIServerAdapter(BasePlatformAdapter):
             if hmac.compare_digest(token.encode(), expected_key.encode()):
                 return None  # Auth OK
 
+        # Name which of the three rejections this was. They have different
+        # remedies: no header means the caller never authenticated (fix the
+        # client), a non-Bearer scheme means it authenticated the wrong way,
+        # and only a mismatched Bearer token is actually a bad key. Logging
+        # all three as "invalid API key" sends the operator to check a key
+        # that was never sent. Deliberately classifies without echoing any
+        # part of the supplied credential.
+        if not auth_header:
+            reason = "no Authorization header"
+        elif not auth_header.startswith("Bearer "):
+            reason = "unsupported Authorization scheme (expected Bearer)"
+        else:
+            reason = "invalid API key"
+
         logger.warning(
-            "API server rejected invalid API key: %s",
+            "API server rejected request — %s: %s",
+            reason,
             self._request_audit_log_suffix(request),
         )
         return web.json_response(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -266,11 +266,13 @@ class TestAuth:
             return " ".join(r.getMessage() for r in caplog.records)
 
         missing = reject({})
+        assert "no Authorization header" in missing
         assert "invalid API key" not in missing, (
             f"no credentials were sent, so this must not blame the key: {missing}"
         )
 
         scheme = reject({"Authorization": "Basic dXNlcjpwYXNz"})
+        assert "unsupported Authorization scheme (expected Bearer)" in scheme
         assert "invalid API key" not in scheme, (
             f"a non-Bearer scheme is not a bad key: {scheme}"
         )
@@ -284,15 +286,20 @@ class TestAuth:
         """Classifying the failure must not leak what the client sent."""
         config = PlatformConfig(enabled=True, extra={"key": "sk-test123"})
         adapter = APIServerAdapter(config)
-        request = MagicMock()
-        request.headers = {"Authorization": "Bearer super-secret-wrong-token"}
 
-        with caplog.at_level("WARNING"):
-            adapter._check_auth(request)
+        for authorization in (
+            "Bearer super-secret-wrong-token",
+            "Basic dXNlcjpwYXNz",
+        ):
+            request = MagicMock()
+            request.headers = {"Authorization": authorization}
 
-        logged = " ".join(r.getMessage() for r in caplog.records)
-        assert "super-secret-wrong-token" not in logged
-        assert "dXNlcjpwYXNz" not in logged
+            with caplog.at_level("WARNING"):
+                caplog.clear()
+                adapter._check_auth(request)
+
+            logged = " ".join(r.getMessage() for r in caplog.records)
+            assert authorization.split(" ", 1)[1] not in logged
 
     def test_non_ascii_bearer_token_returns_401_not_500(self):
         """A non-ASCII byte in the bearer token must be rejected with 401, not
@@ -2669,5 +2676,4 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -241,6 +241,59 @@ class TestAuth:
         assert adapter._check_auth(mock_request) is None
 
 
+    def test_rejection_log_names_the_actual_cause(self, caplog):
+        """The 401 log must say WHICH auth failure happened.
+
+        `_check_auth` rejects three distinct situations - no Authorization
+        header, a non-Bearer scheme, and a Bearer token that does not match -
+        but logged all three as "rejected invalid API key". An operator
+        reading that goes and checks whether their key is wrong, when the
+        common case is a client sending no credentials at all, which is a
+        different fix entirely (client config, not key mismatch).
+
+        Observed on a live install: 57 such warnings, every one of them a
+        caller sending no Authorization header.
+        """
+        config = PlatformConfig(enabled=True, extra={"key": "sk-test123"})
+        adapter = APIServerAdapter(config)
+
+        def reject(headers):
+            request = MagicMock()
+            request.headers = headers
+            with caplog.at_level("WARNING"):
+                caplog.clear()
+                assert adapter._check_auth(request) is not None
+            return " ".join(r.getMessage() for r in caplog.records)
+
+        missing = reject({})
+        assert "invalid API key" not in missing, (
+            f"no credentials were sent, so this must not blame the key: {missing}"
+        )
+
+        scheme = reject({"Authorization": "Basic dXNlcjpwYXNz"})
+        assert "invalid API key" not in scheme, (
+            f"a non-Bearer scheme is not a bad key: {scheme}"
+        )
+
+        wrong = reject({"Authorization": "Bearer wrong-key"})
+        assert "invalid API key" in wrong, (
+            f"a mismatched Bearer token IS an invalid key: {wrong}"
+        )
+
+    def test_rejection_log_never_echoes_the_supplied_credential(self, caplog):
+        """Classifying the failure must not leak what the client sent."""
+        config = PlatformConfig(enabled=True, extra={"key": "sk-test123"})
+        adapter = APIServerAdapter(config)
+        request = MagicMock()
+        request.headers = {"Authorization": "Bearer super-secret-wrong-token"}
+
+        with caplog.at_level("WARNING"):
+            adapter._check_auth(request)
+
+        logged = " ".join(r.getMessage() for r in caplog.records)
+        assert "super-secret-wrong-token" not in logged
+        assert "dXNlcjpwYXNz" not in logged
+
     def test_non_ascii_bearer_token_returns_401_not_500(self):
         """A non-ASCII byte in the bearer token must be rejected with 401, not
         crash the handler: hmac.compare_digest raises TypeError on a str with


### PR DESCRIPTION
## The problem

`_check_auth` rejects three distinct situations and logs all of them identically:

```python
auth_header = request.headers.get("Authorization", "")
if auth_header.startswith("Bearer "):
    token = auth_header[7:].strip()
    if hmac.compare_digest(token.encode(), self._api_key.encode()):
        return None                      # auth OK

logger.warning("API server rejected invalid API key: %s", ...)
```

Falling through to that line means any of:

1. **No `Authorization` header** — the caller never authenticated
2. **A non-Bearer scheme** — it authenticated the wrong way
3. **A `Bearer` token that doesn't match** — an actually invalid key

Only (3) is an invalid API key.

## Why it matters

The three have different remedies. An operator reading "invalid API key" goes and checks whether their key is wrong — reissues it, compares it against `API_SERVER_KEY`, restarts things — when the common case is a client sending no credentials at all, which is a client-config fix and has nothing to do with the key's value.

Observed on a live install: **57 of these warnings, every one a caller sending no `Authorization` header.** The log said the key was invalid 57 times while the key was never in question.

The existing tests already cover all three cases returning 401, so the behaviour is right — it's only the diagnosis that misleads.

## The fix

Classify the rejection:

```
no Authorization header
unsupported Authorization scheme (expected Bearer)
invalid API key
```

Deliberately classifies **without echoing any part of the supplied credential**, and the 401 response body is left unchanged since clients may match on it. Behaviour is identical; only the log line differs.

## Tests

- the log names the actual cause for each of the three rejections, and specifically does **not** say "invalid API key" when no credentials were sent
- the supplied credential never reaches the log (checked for both a wrong bearer token and a Basic blob)

256 passed in `tests/gateway/test_api_server.py`, 495 across the api_server and session_api suites.
