### PR TITLE
fix(gateway): stabilize FNM Node paths in service definitions

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3565,6 +3565,24 @@ def _stable_service_working_dir() -> str:
     return str(PROJECT_ROOT)
 
 
+def _stable_node_bin_dir(node: str) -> str:
+    """Return a stable bin directory for a Node executable found on PATH.
+
+    Preserve ordinary symlink parents (notably ``~/.local/bin`` profile
+    shims), but resolve fnm's per-shell ``fnm_multishells`` symlink.  The
+    latter lives below ``/run/user`` and changes between shells, which would
+    otherwise make service definitions perpetually stale and eventually leave
+    them pointing at a removed directory.
+    """
+    node_path = Path(node)
+    if "fnm_multishells" in node_path.parts:
+        try:
+            node_path = node_path.resolve(strict=True)
+        except OSError:
+            pass
+    return str(node_path.parent)
+
+
 def _systemd_watchdog_seconds(hermes_home: str | Path | None = None) -> int:
     """Resolve the managed-overlay-aware watchdog setting for a service home."""
     override_token = None
@@ -3650,15 +3668,10 @@ def _append_node_dir_for_service(
     if not resolved_node:
         return
 
-    # Use the directory where ``node`` is *found on PATH*, NOT the symlink's
-    # resolved target. ``~/.local/bin/node`` is often a symlink into a
-    # specific profile's node install (e.g. profiles/jarvis/node/bin/node);
-    # calling .resolve() here would chase that symlink and bake one profile's
-    # node path into *every* profile's service unit. That cross-profile leak
-    # makes systemd_unit_is_current() perpetually false, so each gateway
-    # rewrites its unit + daemon-reload on every boot. Using the symlink's own
-    # parent keeps the generated unit profile-agnostic.
-    resolved_node_dir = str(Path(resolved_node).parent)
+    # Preserve the directory where ordinary PATH symlinks are found (notably
+    # ~/.local/bin profile shims), but resolve fnm's ephemeral multishell shim
+    # to its stable installation directory. See _stable_node_bin_dir().
+    resolved_node_dir = _stable_node_bin_dir(resolved_node)
     if resolved_node_dir not in path_entries:
         path_entries.append(resolved_node_dir)
 
@@ -4977,11 +4990,19 @@ def generate_launchd_plist() -> str:
     # so it's explicitly in PATH even if the user's shell PATH changes later.
     priority_dirs = _build_service_path_dirs()
     _append_node_dir_for_service(priority_dirs)
-    sane_path = ":".join(
-        dict.fromkeys(
-            priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p]
-        )
-    )
+    shell_path_dirs = [p for p in os.environ.get("PATH", "").split(":") if p]
+    resolved_node = shutil.which("node")
+    if resolved_node:
+        # The helper above already adds the stable Node directory. Remove any
+        # stale fnm multishell entries captured from the interactive shell.
+        found_node_dir = Path(resolved_node).parent
+        if Path(_stable_node_bin_dir(resolved_node)) != found_node_dir:
+            shell_path_dirs = [
+                path
+                for path in shell_path_dirs
+                if "fnm_multishells" not in Path(path).parts
+            ]
+    sane_path = ":".join(dict.fromkeys(priority_dirs + shell_path_dirs))
 
     err_path = log_dir / "gateway.error.log"
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2712,6 +2712,24 @@ def _stable_service_working_dir() -> str:
     return str(PROJECT_ROOT)
 
 
+def _stable_node_bin_dir(node: str) -> str:
+    """Return a stable bin directory for a Node executable found on PATH.
+
+    Preserve ordinary symlink parents (notably ``~/.local/bin`` profile
+    shims), but resolve fnm's per-shell ``fnm_multishells`` symlink.  The
+    latter lives below ``/run/user`` and changes between shells, which would
+    otherwise make service definitions perpetually stale and eventually leave
+    them pointing at a removed directory.
+    """
+    node_path = Path(node)
+    if "fnm_multishells" in node_path.parts:
+        try:
+            node_path = node_path.resolve(strict=True)
+        except OSError:
+            pass
+    return str(node_path.parent)
+
+
 def _systemd_watchdog_seconds(hermes_home: str | Path | None = None) -> int:
     """Resolve the managed-overlay-aware watchdog setting for a service home."""
     override_token = None
@@ -2759,15 +2777,13 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     path_entries = _build_service_path_dirs()
     resolved_node = shutil.which("node")
     if resolved_node:
-        # Use the directory where ``node`` is *found on PATH*, NOT the
-        # symlink's resolved target. ``~/.local/bin/node`` is often a symlink
-        # into a specific profile's node install (e.g. profiles/jarvis/node/
-        # bin/node); calling .resolve() here would chase that symlink and bake
-        # one profile's node path into *every* profile's service unit. That
-        # cross-profile leak makes systemd_unit_is_current() perpetually false,
-        # so each gateway rewrites its unit + daemon-reload on every boot. Using
-        # the symlink's own parent keeps the generated unit profile-agnostic.
-        resolved_node_dir = str(Path(resolved_node).parent)
+        # Usually use the directory where ``node`` is found on PATH, NOT the
+        # symlink's resolved target. ``~/.local/bin/node`` can point into one
+        # profile, so resolving it would leak that profile into every unit.
+        # The helper resolves only fnm's ephemeral ``fnm_multishells`` shim,
+        # whose per-shell parent would otherwise make this unit perpetually
+        # stale and eventually disappear.
+        resolved_node_dir = _stable_node_bin_dir(resolved_node)
         if resolved_node_dir not in path_entries:
             path_entries.append(resolved_node_dir)
 
@@ -3962,22 +3978,23 @@ def generate_launchd_plist() -> str:
     # Resolve the directory containing the node binary (e.g. Homebrew, nvm)
     # so it's explicitly in PATH even if the user's shell PATH changes later.
     priority_dirs = _build_service_path_dirs()
+    shell_path_dirs = [p for p in os.environ.get("PATH", "").split(":") if p]
     resolved_node = shutil.which("node")
     if resolved_node:
-        # Use the directory where ``node`` is *found on PATH*, NOT the symlink's
-        # resolved target. ``~/.local/bin/node`` is often a symlink into a
-        # specific profile's node install; calling .resolve() would chase it and
-        # bake one profile's path into every profile's service definition,
-        # breaking profile isolation and causing perpetual unit rewrites. See
-        # the matching fix in generate_systemd_unit().
-        resolved_node_dir = str(Path(resolved_node).parent)
+        # Preserve ordinary symlink parents for profile isolation, but resolve
+        # fnm's ephemeral ``fnm_multishells`` shim to its stable installation
+        # directory. See the matching logic in generate_systemd_unit().
+        found_node_dir = Path(resolved_node).parent
+        resolved_node_dir = _stable_node_bin_dir(resolved_node)
         if resolved_node_dir not in priority_dirs:
             priority_dirs.append(resolved_node_dir)
-    sane_path = ":".join(
-        dict.fromkeys(
-            priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p]
-        )
-    )
+        if Path(resolved_node_dir) != found_node_dir:
+            shell_path_dirs = [
+                path
+                for path in shell_path_dirs
+                if "fnm_multishells" not in Path(path).parts
+            ]
+    sane_path = ":".join(dict.fromkeys(priority_dirs + shell_path_dirs))
 
     # Build ProgramArguments array, including --profile when using a named profile
     prog_args = [

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -215,6 +215,38 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in unit
         assert str(profile_node_bin) not in unit
 
+    def test_user_unit_resolves_ephemeral_fnm_multishell_node_path(self, tmp_path, monkeypatch):
+        stable_bin = (
+            tmp_path
+            / ".local"
+            / "share"
+            / "fnm"
+            / "node-versions"
+            / "v22.22.1"
+            / "installation"
+            / "bin"
+        )
+        stable_bin.mkdir(parents=True)
+        real_node = stable_bin / "node"
+        real_node.write_text("#!/bin/sh\n")
+
+        ephemeral_bin = (
+            tmp_path / "run" / "user" / "1000" / "fnm_multishells" / "12345" / "bin"
+        )
+        ephemeral_bin.mkdir(parents=True)
+        ephemeral_node = ephemeral_bin / "node"
+        ephemeral_node.symlink_to(real_node)
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda cmd: str(ephemeral_node) if cmd == "node" else None,
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert str(stable_bin) in unit
+        assert str(ephemeral_bin) not in unit
+
     def test_launchd_plist_does_not_leak_profile_node_symlink_target(self, tmp_path, monkeypatch):
         # Same #48700 regression for the macOS twin generate_launchd_plist().
         local_bin = tmp_path / ".local" / "bin"
@@ -232,6 +264,48 @@ class TestGeneratedSystemdUnits:
 
         assert str(local_bin) in plist
         assert str(profile_node_bin) not in plist
+
+    def test_launchd_plist_resolves_ephemeral_fnm_multishell_node_path(
+        self, tmp_path, monkeypatch
+    ):
+        stable_bin = (
+            tmp_path
+            / ".local"
+            / "share"
+            / "fnm"
+            / "node-versions"
+            / "v22.22.1"
+            / "installation"
+            / "bin"
+        )
+        stable_bin.mkdir(parents=True)
+        real_node = stable_bin / "node"
+        real_node.write_text("#!/bin/sh\n")
+
+        ephemeral_bin = (
+            tmp_path / "run" / "user" / "1000" / "fnm_multishells" / "12345" / "bin"
+        )
+        ephemeral_bin.mkdir(parents=True)
+        ephemeral_node = ephemeral_bin / "node"
+        ephemeral_node.symlink_to(real_node)
+        stale_ephemeral_bin = (
+            tmp_path / "run" / "user" / "1000" / "fnm_multishells" / "67890" / "bin"
+        )
+        stale_ephemeral_bin.mkdir(parents=True)
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda cmd: str(ephemeral_node) if cmd == "node" else None,
+        )
+        monkeypatch.setenv(
+            "PATH", f"{ephemeral_bin}:{stale_ephemeral_bin}:/usr/bin"
+        )
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert str(stable_bin) in plist
+        assert str(ephemeral_bin) not in plist
+        assert str(stale_ephemeral_bin) not in plist
 
     def test_launchd_plist_persists_configured_nofile_soft_limit(self, monkeypatch):
         """The generated plist must carry SoftResourceLimits/NumberOfFiles so a

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -487,6 +487,38 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in unit
         assert str(profile_node_bin) not in unit
 
+    def test_user_unit_resolves_ephemeral_fnm_multishell_node_path(self, tmp_path, monkeypatch):
+        stable_bin = (
+            tmp_path
+            / ".local"
+            / "share"
+            / "fnm"
+            / "node-versions"
+            / "v22.22.1"
+            / "installation"
+            / "bin"
+        )
+        stable_bin.mkdir(parents=True)
+        real_node = stable_bin / "node"
+        real_node.write_text("#!/bin/sh\n")
+
+        ephemeral_bin = (
+            tmp_path / "run" / "user" / "1000" / "fnm_multishells" / "12345" / "bin"
+        )
+        ephemeral_bin.mkdir(parents=True)
+        ephemeral_node = ephemeral_bin / "node"
+        ephemeral_node.symlink_to(real_node)
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda cmd: str(ephemeral_node) if cmd == "node" else None,
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert str(stable_bin) in unit
+        assert str(ephemeral_bin) not in unit
+
     def test_launchd_plist_does_not_leak_profile_node_symlink_target(self, tmp_path, monkeypatch):
         # Same #48700 regression for the macOS twin generate_launchd_plist().
         local_bin = tmp_path / ".local" / "bin"
@@ -504,6 +536,48 @@ class TestGeneratedSystemdUnits:
 
         assert str(local_bin) in plist
         assert str(profile_node_bin) not in plist
+
+    def test_launchd_plist_resolves_ephemeral_fnm_multishell_node_path(
+        self, tmp_path, monkeypatch
+    ):
+        stable_bin = (
+            tmp_path
+            / ".local"
+            / "share"
+            / "fnm"
+            / "node-versions"
+            / "v22.22.1"
+            / "installation"
+            / "bin"
+        )
+        stable_bin.mkdir(parents=True)
+        real_node = stable_bin / "node"
+        real_node.write_text("#!/bin/sh\n")
+
+        ephemeral_bin = (
+            tmp_path / "run" / "user" / "1000" / "fnm_multishells" / "12345" / "bin"
+        )
+        ephemeral_bin.mkdir(parents=True)
+        ephemeral_node = ephemeral_bin / "node"
+        ephemeral_node.symlink_to(real_node)
+        stale_ephemeral_bin = (
+            tmp_path / "run" / "user" / "1000" / "fnm_multishells" / "67890" / "bin"
+        )
+        stale_ephemeral_bin.mkdir(parents=True)
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda cmd: str(ephemeral_node) if cmd == "node" else None,
+        )
+        monkeypatch.setenv(
+            "PATH", f"{ephemeral_bin}:{stale_ephemeral_bin}:/usr/bin"
+        )
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert str(stable_bin) in plist
+        assert str(ephemeral_bin) not in plist
+        assert str(stale_ephemeral_bin) not in plist
 
     def test_user_unit_includes_wsl_windows_interop_paths(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_wsl", lambda: True)


### PR DESCRIPTION
## Summary

- resolve FNM's per-shell `fnm_multishells` Node symlink to its stable installation directory when generating gateway service definitions
- preserve ordinary symlink parents such as `~/.local/bin` so profile-specific Node targets do not leak across Hermes profiles
- remove current and stale `fnm_multishells` entries from launchd's captured shell PATH after the active FNM Node resolves successfully

## Problem

`fnm env` adds a per-shell path such as:

```text
/run/user/1000/fnm_multishells/<shell-id>/bin
```

The shell ID changes between invocations. Persisting that directory in a systemd unit or launchd plist makes the generated service definition differ between shells, so `hermes gateway status` can report the unit as outdated immediately after a restart. The directory can also disappear after the originating shell exits, leaving the gateway with a stale Node path.

This surfaced as an FNM-specific edge case around the profile-isolation fix in #56364. That fix correctly preserves ordinary symlink parents; FNM is unusual because its parent directory is itself per-shell. In a live reproduction, restart and status ran under different shells and produced different `fnm_multishells/<shell-id>` paths that resolved to the same Node installation. This PR preserves #56364's behavior and resolves only the exact `fnm_multishells` component.

## Fix

The new helper resolves a Node path only when it contains an exact `fnm_multishells` path component. Other symlinks retain their own parent directory, preserving the profile-isolation behavior introduced by #56364.

For launchd, the stable FNM directory is added to the priority PATH and ephemeral FNM entries are removed from the captured shell PATH only after resolution succeeds. If resolution fails, the original path remains as a fallback.

This is intentionally scoped to observed FNM paths. It does not generalize symlink resolution or normalize paths from nodenv, nvm, mise, asdf, or Volta.

## Tests

- `uv run --isolated --extra dev pytest tests/hermes_cli/test_gateway_service.py::TestGeneratedSystemdUnits -q` — 11 passed
- `uv run --isolated --extra dev ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py` — passed
- `git diff --check` — passed
- live generation probe with multiple FNM multishell entries — neither the systemd unit nor launchd plist retained `fnm_multishells`

## Related

- #56364 established the ordinary-symlink/profile-isolation behavior preserved here
- #62210 and #46276 cover other sources of volatile gateway PATH differences; this PR addresses the distinct FNM per-shell symlink case

