### PR TITLE
fix(skills): normalize path separators and sort order for cross-platform hash parity

### DIFF
--- a/tests/tools/test_skills_hash_parity.py
+++ b/tests/tools/test_skills_hash_parity.py
@@ -1,0 +1,81 @@
+"""Regression tests for #71237: disk vs bundle hash parity across platforms.
+
+``tools.skills_guard.content_hash`` (disk) and
+``tools.skills_hub.bundle_content_hash`` (in-memory bundle) must produce the
+same digest for the same skill content, regardless of platform path-separator
+conventions or filesystem iteration order. When they diverge, every
+``hermes skills check`` reports ``update_available`` for an up-to-date skill
+and ``hermes skills update`` never converges (the perpetual-update loop on
+Windows for skills with subdirectories).
+"""
+
+from tools.skills_guard import content_hash
+from tools.skills_hub import SkillBundle, bundle_content_hash
+
+
+def _make_skill_dir(tmp_path):
+    """Skill layout with subdirectories, mirroring a real hub skill."""
+    (tmp_path / "SKILL.md").write_bytes(b"---\nname: parity\n---\n\n# Parity\n")
+    (tmp_path / "references").mkdir()
+    (tmp_path / "references" / "cli.md").write_bytes(b"cli reference\n")
+    (tmp_path / "references" / "composition.md").write_bytes(b"composition\n")
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "setup.sh").write_bytes(b"#!/bin/sh\n")
+    return tmp_path
+
+
+def _bundle_from(files):
+    return SkillBundle(
+        name="parity",
+        files=files,
+        source="official",
+        identifier="official/parity",
+        trust_level="builtin",
+    )
+
+
+def test_disk_hash_matches_bundle_hash_with_subdirectories(tmp_path):
+    """The disk digest and the bundle digest must agree on every platform.
+
+    Regression for the sort-order half of #71237: ``_content_digest`` used to
+    iterate ``sorted(Path.rglob(...))`` (component-wise Path ordering) while
+    ``bundle_content_hash`` sorts the posix strings alphabetically, so skills
+    with subdirectories hashed their files in a different order on disk than
+    in the bundle.
+    """
+    skill_dir = _make_skill_dir(tmp_path)
+    files = {
+        f.relative_to(skill_dir).as_posix(): f.read_bytes()
+        for f in skill_dir.rglob("*")
+        if f.is_file()
+    }
+    assert content_hash(skill_dir) == bundle_content_hash(_bundle_from(files))
+
+
+def test_bundle_hash_normalizes_backslash_keys(tmp_path):
+    """Backslash-keyed bundles must hash identically to posix-keyed ones.
+
+    Regression for the separator half of #71237: bundles built on Windows can
+    carry ``references\\cli.md``-style keys; the digest must be computed on
+    the posix form so it matches the disk-side ``content_hash``.
+    """
+    skill_dir = _make_skill_dir(tmp_path)
+    posix_files = {
+        f.relative_to(skill_dir).as_posix(): f.read_bytes()
+        for f in skill_dir.rglob("*")
+        if f.is_file()
+    }
+    windows_files = {k.replace("/", "\\"): v for k, v in posix_files.items()}
+
+    posix_hash = bundle_content_hash(_bundle_from(posix_files))
+    windows_hash = bundle_content_hash(_bundle_from(windows_files))
+
+    assert posix_hash == windows_hash
+    assert posix_hash == content_hash(skill_dir)
+
+
+def test_flat_skill_still_matches(tmp_path):
+    """Flat skills (a single SKILL.md) never regressed; keep it that way."""
+    (tmp_path / "SKILL.md").write_bytes(b"---\nname: flat\n---\n")
+    files = {"SKILL.md": (tmp_path / "SKILL.md").read_bytes()}
+    assert content_hash(tmp_path) == bundle_content_hash(_bundle_from(files))

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -692,11 +692,18 @@ def _content_digest(skill_path: Path) -> str:
     """Canonical SHA-256 over relative paths and exact file bytes."""
     h = hashlib.sha256()
     if skill_path.is_dir():
-        for file_path in sorted(skill_path.rglob("*")):
+        # Collect all files, convert to posix relative strings, then sort as
+        # strings. Path.rglob + sorted(Path) orders by Path components which on
+        # some filesystems/OS puts subdirectory files before root-level files.
+        # bundle_content_hash sorts the posix strings alphabetically, so this
+        # must do the same to produce matching hashes on all platforms.
+        rel_files = []
+        for file_path in skill_path.rglob("*"):
             if file_path.is_file():
-                rel = file_path.relative_to(skill_path).as_posix()
-                h.update(rel.encode("utf-8") + b"\x00")
-                h.update(file_path.read_bytes())
+                rel_files.append(file_path.relative_to(skill_path).as_posix())
+        for rel in sorted(rel_files):
+            h.update(rel.encode("utf-8") + b"\x00")
+            h.update((skill_path / rel).read_bytes())
     else:
         h.update(skill_path.read_bytes())
     return h.hexdigest()

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3239,7 +3239,7 @@ class OptionalSkillSource(SkillSource):
                 and "__pycache__" not in f.parts
                 and f.suffix != ".pyc"
             ):
-                rel_path = str(f.relative_to(skill_dir))
+                rel_path = f.relative_to(skill_dir).as_posix()
                 try:
                     files[rel_path] = f.read_bytes()
                 except OSError:
@@ -3704,7 +3704,12 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     for rel_path in sorted(bundle.files):
         # Include the path so swapping file contents between two paths
         # changes the hash (avoids filename-swap evading update detection).
-        h.update(rel_path.encode("utf-8"))
+        # Normalize backslashes to forward slashes so the hash matches the
+        # disk-based ``content_hash`` (which uses ``Path.as_posix()``) on all
+        # platforms. Without this, Windows bundles produce a different digest
+        # than the installed files, causing a perpetual "update_available".
+        norm_path = rel_path.replace("\\", "/")
+        h.update(norm_path.encode("utf-8"))
         h.update(b"\x00")
         content = bundle.files[rel_path]
         if isinstance(content, bytes):


### PR DESCRIPTION
## Problem

Follow-up to #71246 — that PR fixes one of the three path/hash mismatches that cause the perpetual `update_available` loop on Windows (#71237). This PR fixes the remaining two so the loop is fully resolved.

Even with #71246 applied (backslash → posix in `OptionalSkillSource.fetch`), skills with subdirectories still loop on Windows because of two additional inconsistencies between `bundle_content_hash` and `_content_digest`:

1. **`bundle_content_hash` does not normalize separators.** Any bundle whose file keys still carry backslashes (from a Windows-built bundle, a GitHub source on Windows, or a stale lock entry) diverges from the posix-normalized disk digest.
2. **`_content_digest` sorts `Path` objects, not strings.** `sorted(skill_path.rglob("*"))` orders by path components — on NTFS this places subdirectory files before root-level files (e.g. `references/cli.md` before `SKILL.md`). `bundle_content_hash` sorts the posix *strings* alphabetically, where `SKILL.md` comes first. Different iteration order → different SHA-256 → permanent mismatch, even with identical separators and identical file content.

## Reproduction (Windows, even with #71246 applied)

```
hermes skills install hyperframes   # skill has references/ and scripts/ subdirs
hermes skills check                 # → update_available
hermes skills update                # → "Updated 1 skill(s)"
hermes skills check                 # → update_available (still!)
```

Observed hashes on the same skill, same content:

| Hash source | Value | Why it differs |
|---|---|---|
| `_content_digest` (disk, sorted by `Path`) | `sha256:1f1c139f07f16489` | Subdir files first |
| `bundle_content_hash` (bundle, backslash keys) | `sha256:0ae3a5fa4ec70721` | `\` instead of `/` |
| Both fixed (this PR) | `sha256:f6d7c9ac8e6a55a0` | Posix + string sort = match ✓ |

## Fix

Three changes (two files). Change 1 is identical to #71246 and is included so this PR is self-contained and can merge independently.

**1. `tools/skills_hub.py` — `OptionalSkillSource.fetch()`: posix keys**

```diff
-                rel_path = str(f.relative_to(skill_dir))
+                rel_path = f.relative_to(skill_dir).as_posix()
```

**2. `tools/skills_hub.py` — `bundle_content_hash()`: normalize backslashes**

```diff
     for rel_path in sorted(bundle.files):
-        h.update(rel_path.encode("utf-8"))
+        norm_path = rel_path.replace("\\", "/")
+        h.update(norm_path.encode("utf-8"))
         h.update(b"\x00")
```

Defense-in-depth normalization: even if a bundle's file keys arrive with backslashes (GitHub source on Windows, hand-crafted bundles, or future sources), the hash is computed on the posix form, matching what `_content_digest` produces on disk.

**3. `tools/skills_guard.py` — `_content_digest()`: sort as posix strings**

```diff
     if skill_path.is_dir():
-        for file_path in sorted(skill_path.rglob("*")):
+        rel_files = []
+        for file_path in skill_path.rglob("*"):
             if file_path.is_file():
-                rel = file_path.relative_to(skill_path).as_posix()
-                h.update(rel.encode("utf-8") + b"\x00")
-                h.update(file_path.read_bytes())
+                rel_files.append(file_path.relative_to(skill_path).as_posix())
+        for rel in sorted(rel_files):
+            h.update(rel.encode("utf-8") + b"\x00")
+            h.update((skill_path / rel).read_bytes())
```

`sorted(Path)` compares `Path` objects component-by-component; combined with `rglob` traversal this yields a different file order than `sorted(str)` on posix-joined paths. Collecting to strings first and then sorting makes `_content_digest` and `bundle_content_hash` iterate in the same deterministic order on every platform. The docstring of `content_hash` already requires the two functions to stay symmetric — this restores that invariant on Windows.

## Tests

Adds `tests/tools/test_skills_hash_parity.py` with three regression tests:

- `test_disk_hash_matches_bundle_hash_with_subdirectories` — builds a skill with `references/` and `scripts/` subdirs on disk, asserts `content_hash(dir) == bundle_content_hash(bundle)` on all platforms (catches the sort-order bug).
- `test_bundle_hash_normalizes_backslash_keys` — asserts a backslash-keyed bundle hashes identically to the posix-keyed equivalent and to the disk hash (catches the separator bug).
- `test_flat_skill_still_matches` — flat single-file skills never regressed; keeps it that way.

## After the fix (verified on Windows 11, v0.19.0)

```
hyperframes: up_to_date  (lock=sha256:f6d7c9ac…, bundle=sha256:f6d7c9ac…)
0 update(s) available across 1 checked skill(s)
```

## Relationship to #71246

- #71246 fixes only change 1 (the `str()` → `.as_posix()` in `fetch()`).
- This PR fixes 1 plus 2 and 3, so it fully resolves #71237 on its own.
- If #71246 merges first, change 1 here becomes a no-op (no conflict).

Fixes #71237

🤖 Generated with [Claude Code](https://claude.com/claude-code)
