### PR TITLE
fix(web): scope messaging/kanban gateway probes to profile home

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -134,7 +134,9 @@ def _parse_branch_flag(value: Optional[str]) -> Optional[str]:
     return branch
 
 
-def _check_dispatcher_presence() -> tuple[bool, str]:
+def _check_dispatcher_presence(
+    hermes_home: Path | str | None = None,
+) -> tuple[bool, str]:
     """Return ``(running, message)``.
 
     - ``running=True``: a gateway is alive for this HERMES_HOME and its
@@ -143,6 +145,10 @@ def _check_dispatcher_presence() -> tuple[bool, str]:
     - ``running=False``: either no gateway is running, or the gateway
       is running but the config flag is off. Message is human guidance
       explaining the next step.
+
+    ``hermes_home`` scopes the PID probe to a named profile directory when
+    the dashboard backend process HERMES_HOME is the machine root (#71211).
+    The CLI path leaves it ``None`` (unchanged behavior).
 
     Used by ``hermes kanban create`` (and callers) to warn when a task
     will sit in ``ready`` because nothing is there to pick it up.
@@ -155,7 +161,13 @@ def _check_dispatcher_presence() -> tuple[bool, str]:
     except Exception:
         return (True, "")  # can't probe — silent
     try:
-        pid = get_running_pid()
+        if hermes_home is not None:
+            from pathlib import Path as _Path
+
+            home = _Path(hermes_home)
+            pid = get_running_pid(pid_path=home / "gateway.pid")
+        else:
+            pid = get_running_pid()
     except Exception:
         return (True, "")  # probe errored — silent
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8592,6 +8592,7 @@ def _messaging_platform_payload(
     env_on_disk: dict[str, str],
     runtime: dict | None,
     scoped: bool = False,
+    profile_home: Optional[Path] = None,
 ) -> dict[str, Any]:
     platform_id = entry["id"]
     runtime_platforms = runtime.get("platforms") if runtime else {}
@@ -8600,10 +8601,22 @@ def _messaging_platform_payload(
         if isinstance(runtime_platforms, dict)
         else {}
     )
-    gateway_running = (
-        get_running_pid() is not None
-        or get_runtime_status_running_pid(runtime) is not None
-    )
+    # gateway/status readers intentionally ignore HERMES_HOME contextvar
+    # overrides (see #56986 / #69143). When the dashboard scopes to a named
+    # profile, pass explicit paths so we don't read the process-root state.
+    if profile_home is not None:
+        gateway_running = (
+            get_running_pid(pid_path=profile_home / "gateway.pid") is not None
+            or get_runtime_status_running_pid(
+                runtime, expected_home=profile_home
+            )
+            is not None
+        )
+    else:
+        gateway_running = (
+            get_running_pid() is not None
+            or get_runtime_status_running_pid(runtime) is not None
+        )
     env_vars = []
 
     for key in entry["env_vars"]:
@@ -9605,17 +9618,28 @@ async def cancel_telegram_onboarding(pairing_id: str):
 async def get_messaging_platforms(profile: Optional[str] = None):
     # Profile-scoped so the dashboard's global profile switcher shows the
     # TARGET profile's channel credentials/state, not the root install's.
-    # Inside _profile_scope, load_env()/read_runtime_status()/get_running_pid()
-    # all resolve against the requested profile's HERMES_HOME.
+    # load_env() honors the HERMES_HOME override; gateway status readers do
+    # not (process-level home only) — pass explicit paths for those.
     with _profile_scope(profile) as scoped_dir:
         env_on_disk = load_env()
-        runtime = read_runtime_status()
+        # Explicit state path: read_runtime_status() ignores contextvar HERMES_HOME
+        # overrides and would otherwise read the machine-root gateway_state.json
+        # while env_path/start command are correctly profile-scoped (#71211).
+        runtime = (
+            read_runtime_status(path=scoped_dir / "gateway_state.json")
+            if scoped_dir is not None
+            else read_runtime_status()
+        )
         return {
             "env_path": str(get_env_path()),
             "gateway_start_command": _gateway_display_command(profile, "start"),
             "platforms": [
                 _messaging_platform_payload(
-                    entry, env_on_disk, runtime, scoped=scoped_dir is not None
+                    entry,
+                    env_on_disk,
+                    runtime,
+                    scoped=scoped_dir is not None,
+                    profile_home=scoped_dir,
                 )
                 for entry in _messaging_platform_catalog()
             ]
@@ -9750,8 +9774,17 @@ async def test_messaging_platform(platform_id: str, profile: Optional[str] = Non
 
     with _profile_scope(profile) as scoped_dir:
         env_on_disk = load_env()
+        runtime = (
+            read_runtime_status(path=scoped_dir / "gateway_state.json")
+            if scoped_dir is not None
+            else read_runtime_status()
+        )
         payload = _messaging_platform_payload(
-            entry, env_on_disk, read_runtime_status(), scoped=scoped_dir is not None
+            entry,
+            env_on_disk,
+            runtime,
+            scoped=scoped_dir is not None,
+            profile_home=scoped_dir,
         )
     if not payload["enabled"]:
         message = f"{entry['name']} is disabled. Enable it, then restart the gateway."

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -647,7 +647,13 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
         if task and task.status == "ready" and task.assignee:
             try:
                 from hermes_cli.kanban import _check_dispatcher_presence
-                running, message = _check_dispatcher_presence()
+                from hermes_constants import get_hermes_home
+
+                # Prefer the active request/profile home so a machine-root
+                # dashboard backend still probes named-profile gateways (#71211).
+                running, message = _check_dispatcher_presence(
+                    hermes_home=get_hermes_home()
+                )
                 if not running and message:
                     body["warning"] = message
             except Exception:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -397,6 +397,91 @@ class TestWebServerEndpoints:
         assert data["gateway_pid"] == 4321
         assert data["gateway_state"] == "running"
 
+    def test_messaging_platforms_profile_scopes_gateway_state_reads(self, monkeypatch, tmp_path):
+        """?profile=<name> messaging endpoints must read profile gateway_state (#71211)."""
+        from pathlib import Path
+        import json
+
+        worker_home = tmp_path / "profiles" / "worker"
+        worker_home.mkdir(parents=True)
+        (worker_home / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "gateway_state": "running",
+                    "pid": 424242,
+                    "updated_at": "2026-07-25T00:00:00+00:00",
+                    "platforms": {
+                        "telegram": {
+                            "state": "connected",
+                            "updated_at": "2026-07-25T00:00:00+00:00",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        (worker_home / ".env").write_text("", encoding="utf-8")
+        (worker_home / "config.yaml").write_text(
+            "platforms:\n  telegram:\n    enabled: true\n",
+            encoding="utf-8",
+        )
+
+        seen = {"runtime_path": None, "pid_path": None}
+
+        def _resolve(name: str):
+            assert name == "worker"
+            return worker_home
+
+        def _read_runtime(path=None):
+            seen["runtime_path"] = path
+            if path is None:
+                return {
+                    "gateway_state": "stopped",
+                    "platforms": {},
+                }
+            import json as _json
+            return _json.loads(Path(path).read_text(encoding="utf-8"))
+
+        def _running_pid(pid_path=None, cleanup_stale=True, **kwargs):
+            seen["pid_path"] = pid_path
+            if pid_path is not None and Path(pid_path).parent == worker_home:
+                return 424242
+            return None
+
+        def _runtime_pid(runtime=None, *, expected_home=None):
+            if expected_home is not None and Path(expected_home) == worker_home:
+                return 424242
+            return None
+
+        monkeypatch.setattr(
+            "hermes_cli.web_server._resolve_profile_dir", _resolve
+        )
+        monkeypatch.setattr(
+            "hermes_cli.web_server.read_runtime_status", _read_runtime
+        )
+        monkeypatch.setattr(
+            "hermes_cli.web_server.get_running_pid", _running_pid
+        )
+        monkeypatch.setattr(
+            "hermes_cli.web_server.get_runtime_status_running_pid", _runtime_pid
+        )
+        monkeypatch.setattr(
+            "hermes_cli.web_server.load_env", lambda: {"TELEGRAM_BOT_TOKEN": "1:abc"}
+        )
+        monkeypatch.setattr(
+            "hermes_cli.web_server.load_config",
+            lambda: {"platforms": {"telegram": {"enabled": True}}},
+        )
+
+        resp = self.client.get("/api/messaging/platforms?profile=worker")
+        assert resp.status_code == 200, resp.text
+        assert seen["runtime_path"] == worker_home / "gateway_state.json"
+        assert seen["pid_path"] == worker_home / "gateway.pid"
+        platforms = {p["id"]: p for p in resp.json()["platforms"]}
+        assert platforms["telegram"]["gateway_running"] is True
+        assert platforms["telegram"]["state"] == "connected"
+
+
     def test_get_status_unknown_profile_404s(self):
         resp = self.client.get("/api/status?profile=no-such-profile")
         assert resp.status_code == 404

--- a/tests/hermes_cli/test_web_server_messaging_profiles.py
+++ b/tests/hermes_cli/test_web_server_messaging_profiles.py
@@ -108,11 +108,13 @@ class TestProfileScopedMessagingReads:
             yaml.safe_dump({"platforms": {"telegram": {"enabled": True}}}),
             encoding="utf-8",
         )
-        monkeypatch.setattr(web_server, "get_running_pid", lambda: None)
+        monkeypatch.setattr(
+            web_server, "get_running_pid", lambda *a, **k: None
+        )
         monkeypatch.setattr(
             web_server,
             "read_runtime_status",
-            lambda: {
+            lambda *a, **k: {
                 "gateway_state": "startup_failed",
                 "exit_reason": "all configured messaging platforms failed to connect",
                 "platforms": {},

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1576,7 +1576,10 @@ def test_create_task_includes_warning_when_no_dispatcher(client, monkeypatch):
     # Force the dispatcher probe to report "not running".
     monkeypatch.setattr(
         "hermes_cli.kanban._check_dispatcher_presence",
-        lambda: (False, "No gateway is running — start `hermes gateway start`."),
+        lambda *a, **k: (
+            False,
+            "No gateway is running — start `hermes gateway start`.",
+        ),
     )
     r = client.post(
         "/api/plugins/kanban/tasks",
@@ -1592,7 +1595,7 @@ def test_create_task_no_warning_when_dispatcher_up(client, monkeypatch):
     """Dispatcher running -> no `warning` field in the response."""
     monkeypatch.setattr(
         "hermes_cli.kanban._check_dispatcher_presence",
-        lambda: (True, ""),
+        lambda *a, **k: (True, ""),
     )
     r = client.post(
         "/api/plugins/kanban/tasks",
@@ -1607,7 +1610,7 @@ def test_create_task_no_warning_on_triage(client, monkeypatch):
     anyway until promoted)."""
     monkeypatch.setattr(
         "hermes_cli.kanban._check_dispatcher_presence",
-        lambda: (False, "oh no"),
+        lambda *a, **k: (False, "oh no"),
     )
     r = client.post(
         "/api/plugins/kanban/tasks",
@@ -1700,7 +1703,7 @@ def test_single_task_endpoint_survives_task_age_exception(client, monkeypatch):
 
 def test_create_task_probe_error_does_not_break_create(client, monkeypatch):
     """Probe failure must never break task creation."""
-    def _raise():
+    def _raise(*a, **k):
         raise RuntimeError("probe crashed")
     monkeypatch.setattr(
         "hermes_cli.kanban._check_dispatcher_presence", _raise,


### PR DESCRIPTION
## Summary
Closes #71211. Channels + Kanban still read process-root `gateway_state.json` under `?profile=` after #70498 fixed `/api/status`.

## Problem
Named-profile gateways look disconnected on Channels and Kanban while `/api/status?profile=` is correct.

## Root cause
`gateway/status` ignores HERMES_HOME contextvar overrides; bare `read_runtime_status()` / `get_running_pid()` stay on machine root.

## Fix
Pass explicit profile `gateway.pid` / `gateway_state.json` into messaging payloads; optional `hermes_home` on kanban dispatcher probe.

## Verification
`pytest tests/hermes_cli/test_web_server.py -k messaging_platforms_profile_scopes -q` (pass)