### PR TITLE
fix(kanban): launch workers in verified systemd user scopes

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -83,6 +83,7 @@ import subprocess
 import sys
 import threading
 import logging
+import stat
 import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
@@ -7890,7 +7891,17 @@ def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
                 "UPDATE task_runs SET worker_pid = ? WHERE id = ?",
                 (int(pid), run_id),
             )
-        _append_event(conn, task_id, "spawned", {"pid": int(pid)}, run_id=run_id)
+        payload = {"pid": int(pid)}
+        launch_mode = getattr(pid, "launch_mode", None)
+        scope_unit = getattr(pid, "scope_unit", None)
+        verification_status = getattr(pid, "verification_status", None)
+        if launch_mode is not None:
+            payload["launch_mode"] = launch_mode
+        if scope_unit is not None:
+            payload["scope_unit"] = scope_unit
+        if verification_status is not None:
+            payload["verification_status"] = verification_status
+        _append_event(conn, task_id, "spawned", payload, run_id=run_id)
 
 
 def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
@@ -8471,7 +8482,7 @@ def _dispatch_once_locked(
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
             if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+                _set_worker_pid(conn, claimed.id, pid)
             # NOTE: we intentionally do NOT reset consecutive_failures
             # here. A successful spawn proves the worker can start but
             # doesn't prove the run will succeed. Under unified
@@ -8566,7 +8577,7 @@ def _dispatch_once_locked(
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
             if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+                _set_worker_pid(conn, claimed.id, pid)
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
         except Exception as exc:
@@ -8865,8 +8876,338 @@ def _retag_legacy_worker_sessions(workspaces_root_path: str) -> None:
         _retagged_workspace_roots.add(workspaces_root_path)
     except Exception as exc:
         _log.debug("kanban worker: legacy session retag skipped (%s)", exc)
+_SYSTEMD_WORKER_SCOPE_PREFIX = "hermes-kanban-worker-"
+_SYSTEMD_SCOPE_MIN_VERSION = 236
+_SYSTEMD_SCOPE_PROBE_TIMEOUT = 2.0
+_SYSTEMD_SCOPE_VERIFY_TIMEOUT = 2.0
+_SYSTEMD_SCOPE_CLEANUP_TIMEOUT = 2.0
+_SYSTEMD_WORKER_SCOPE_RE = re.compile(
+    rf"^{re.escape(_SYSTEMD_WORKER_SCOPE_PREFIX)}[0-9a-f]{{32}}\.scope$"
+)
 
 
+@dataclass(frozen=True)
+class _SystemdUserManagerTarget:
+    """Authenticated identity of the current process's user manager."""
+
+    uid: int
+    runtime_dir: Path = field(repr=False)
+    bus_path: Path = field(repr=False)
+
+
+class _WorkerLaunchPid(int):
+    """Integer-compatible PID with a verified launch receipt."""
+
+    def __new__(
+        cls,
+        pid: int,
+        *,
+        launch_mode: str = "direct",
+        scope_unit: Optional[str] = None,
+        verification_status: str = "not-applicable",
+    ):
+        value = int.__new__(cls, int(pid))
+        value.launch_mode = launch_mode
+        value.scope_unit = scope_unit
+        value.verification_status = verification_status
+        return value
+
+
+def _systemd_user_manager_environment(
+    target: _SystemdUserManagerTarget,
+) -> dict[str, str]:
+    return {
+        "XDG_RUNTIME_DIR": str(target.runtime_dir),
+        "DBUS_SESSION_BUS_ADDRESS": f"unix:path={target.bus_path}",
+    }
+
+
+def _systemd_user_manager_target_for_cgroup(
+    cgroup_path: Optional[str],
+) -> Optional[_SystemdUserManagerTarget]:
+    """Return a trusted same-UID user bus only for a user-service cgroup."""
+    if not sys.platform.startswith("linux") or not cgroup_path:
+        return None
+    path = cgroup_path.rstrip("/")
+    match = re.search(r"/user@(\d+)\.service(?:/|$)", path)
+    if (
+        not match
+        or not path.rsplit("/", 1)[-1].endswith(".service")
+        or not re.search(r"/user@\d+\.service/.+\.service$", path)
+    ):
+        return None
+    getuid = getattr(os, "getuid", None)
+    geteuid = getattr(os, "geteuid", None)
+    if getuid is None or geteuid is None:
+        return None
+    uid = int(match.group(1))
+    if uid != int(getuid()) or uid != int(geteuid()):
+        return None
+    runtime_dir = Path("/run/user") / str(uid)
+    bus_path = runtime_dir / "bus"
+    try:
+        runtime_stat = os.lstat(runtime_dir)
+        bus_stat = os.lstat(bus_path)
+    except OSError:
+        return None
+    if (
+        not stat.S_ISDIR(runtime_stat.st_mode)
+        or runtime_stat.st_uid != uid
+        or stat.S_IMODE(runtime_stat.st_mode) & 0o077
+        or not stat.S_ISSOCK(bus_stat.st_mode)
+        or bus_stat.st_uid != uid
+    ):
+        return None
+    return _SystemdUserManagerTarget(uid, runtime_dir, bus_path)
+
+
+def _current_cgroup_path() -> Optional[str]:
+    if not sys.platform.startswith("linux"):
+        return None
+    try:
+        for line in Path("/proc/self/cgroup").read_text(encoding="utf-8").splitlines():
+            hierarchy, controllers, path = line.split(":", 2)
+            if hierarchy == "0" and not controllers:
+                return path
+            if "name=systemd" in controllers.split(","):
+                return path
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def _systemd_run_version(
+    runner: str,
+    *,
+    run_fn=None,
+) -> Optional[int]:
+    run = run_fn or subprocess.run
+    try:
+        result = run(
+            [runner, "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=_SYSTEMD_SCOPE_PROBE_TIMEOUT,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError, TimeoutError):
+        return None
+    match = re.search(r"\bsystemd\s+(\d+)\b", result.stdout or "")
+    return int(match.group(1)) if result.returncode == 0 and match else None
+
+
+def _systemd_user_manager_reachable(
+    target: _SystemdUserManagerTarget,
+    *,
+    systemctl: Optional[str] = None,
+    run_fn=None,
+) -> bool:
+    controller = systemctl or shutil.which("systemctl")
+    if not controller:
+        return False
+    run = run_fn or subprocess.run
+    try:
+        result = run(
+            [controller, "--user", "show", "--property=Version", "--value"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=_SYSTEMD_SCOPE_PROBE_TIMEOUT,
+            check=False,
+            env=_systemd_user_manager_environment(target),
+        )
+    except (OSError, subprocess.SubprocessError, TimeoutError):
+        return False
+    return result.returncode == 0 and bool((result.stdout or "").strip())
+
+
+def _systemd_scope_unit_name(
+    task_id: str,
+    run_id: int,
+    *,
+    board: Optional[str] = None,
+) -> str:
+    """Derive a bounded unit name from canonical board DB, task, and run."""
+    db_identity = os.path.normcase(
+        str(kanban_db_path(board=board).expanduser().resolve(strict=False))
+    )
+    digest = hashlib.blake2s(
+        f"v1\0{db_identity}\0{task_id}\0{int(run_id)}".encode("utf-8"),
+        digest_size=16,
+    ).hexdigest()
+    return f"{_SYSTEMD_WORKER_SCOPE_PREFIX}{digest}.scope"
+
+
+def _systemd_scope_argv(
+    cmd: list[str],
+    task: Task,
+    *,
+    board: Optional[str] = None,
+    cgroup_path: Optional[str] = None,
+    manager_target: Optional[_SystemdUserManagerTarget] = None,
+    systemd_run: Optional[str] = None,
+    user_manager_ready: Optional[bool] = None,
+) -> tuple[list[str], Optional[str], Optional[_SystemdUserManagerTarget]]:
+    """Return a scoped argv only when the dispatcher identity is trusted."""
+    if not sys.platform.startswith("linux") or task.current_run_id is None:
+        return cmd, None, None
+    current = cgroup_path if cgroup_path is not None else _current_cgroup_path()
+    target = manager_target or _systemd_user_manager_target_for_cgroup(current)
+    runner = systemd_run or shutil.which("systemd-run")
+    if target is None or runner is None:
+        return cmd, None, None
+    if user_manager_ready is None:
+        version = _systemd_run_version(runner)
+        ready = (
+            version is not None
+            and version >= _SYSTEMD_SCOPE_MIN_VERSION
+            and _systemd_user_manager_reachable(target)
+        )
+    else:
+        ready = bool(user_manager_ready)
+    if not ready:
+        return cmd, None, None
+    try:
+        unit = _systemd_scope_unit_name(task.id, int(task.current_run_id), board=board)
+    except (OSError, TypeError, ValueError):
+        return cmd, None, None
+    return (
+        [runner, "--user", "--scope", "--quiet", "--collect", f"--unit={unit}", "--", *cmd],
+        unit,
+        target,
+    )
+
+
+def _systemd_scope_properties(
+    unit: str,
+    target: _SystemdUserManagerTarget,
+    *,
+    systemctl: Optional[str] = None,
+    run_fn=None,
+) -> Optional[dict[str, str]]:
+    if not _SYSTEMD_WORKER_SCOPE_RE.fullmatch(unit):
+        return None
+    controller = systemctl or shutil.which("systemctl")
+    if not controller:
+        return None
+    run = run_fn or subprocess.run
+    try:
+        result = run(
+            [
+                controller,
+                "--user",
+                "show",
+                unit,
+                "--property=LoadState",
+                "--property=ActiveState",
+                "--property=ControlGroup",
+                "--no-pager",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=_SYSTEMD_SCOPE_PROBE_TIMEOUT,
+            check=False,
+            env=_systemd_user_manager_environment(target),
+        )
+    except (OSError, subprocess.SubprocessError, TimeoutError):
+        return None
+    if result.returncode != 0:
+        return None
+    return {
+        key: value
+        for key, value in (
+            line.split("=", 1)
+            for line in (result.stdout or "").splitlines()
+            if "=" in line
+        )
+    }
+
+
+def _process_cgroup_path(pid: int) -> Optional[str]:
+    try:
+        for line in Path(f"/proc/{int(pid)}/cgroup").read_text(encoding="utf-8").splitlines():
+            hierarchy, controllers, path = line.split(":", 2)
+            if hierarchy == "0" and not controllers:
+                return path
+            if "name=systemd" in controllers.split(","):
+                return path
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def _verify_systemd_scope_pid(
+    proc: subprocess.Popen,
+    unit: str,
+    target: _SystemdUserManagerTarget,
+) -> None:
+    """Require this exact Popen PID to be in this manager-owned scope."""
+    deadline = time.monotonic() + _SYSTEMD_SCOPE_VERIFY_TIMEOUT
+    last_reason = "scope identity was not observable"
+    while time.monotonic() < deadline:
+        if getattr(proc, "poll", lambda: None)() is not None:
+            raise RuntimeError(f"systemd scope launcher exited before verification: {unit}")
+        props = _systemd_scope_properties(unit, target)
+        if props is not None:
+            load_state = props.get("LoadState")
+            active_state = props.get("ActiveState")
+            control_group = (props.get("ControlGroup") or "").rstrip("/")
+            process_group = (_process_cgroup_path(proc.pid) or "").rstrip("/")
+            if load_state != "loaded":
+                last_reason = f"scope unit load state was {load_state!r}"
+            elif active_state not in {"active", "activating"}:
+                last_reason = f"scope unit state was {active_state!r}"
+            elif not control_group:
+                last_reason = "scope has no control group"
+            elif process_group != control_group:
+                last_reason = (
+                    f"Popen PID {proc.pid} was in {process_group!r}, "
+                    f"expected {control_group!r}"
+                )
+            else:
+                return
+        time.sleep(0.05)
+    raise RuntimeError(f"could not verify systemd scope {unit}: {last_reason}")
+
+
+def _cleanup_systemd_scope_launch(
+    proc: subprocess.Popen,
+    unit: str,
+    target: _SystemdUserManagerTarget,
+) -> None:
+    """Stop exactly the transient unit and reap exactly its Popen wrapper."""
+    controller = shutil.which("systemctl")
+    if controller:
+        try:
+            subprocess.run(
+                [controller, "--user", "stop", unit],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=_SYSTEMD_SCOPE_CLEANUP_TIMEOUT,
+                check=False,
+                env=_systemd_user_manager_environment(target),
+            )
+        except (OSError, subprocess.SubprocessError, TimeoutError):
+            pass
+    try:
+        proc.wait(timeout=_SYSTEMD_SCOPE_CLEANUP_TIMEOUT)
+        return
+    except (subprocess.TimeoutExpired, AttributeError):
+        pass
+    try:
+        proc.terminate()
+        proc.wait(timeout=_SYSTEMD_SCOPE_CLEANUP_TIMEOUT)
+    except (ProcessLookupError, OSError, subprocess.TimeoutExpired, AttributeError):
+        try:
+            proc.kill()
+        except (ProcessLookupError, OSError, AttributeError):
+            return
+        try:
+            proc.wait(timeout=_SYSTEMD_SCOPE_CLEANUP_TIMEOUT)
+        except (OSError, subprocess.TimeoutExpired, AttributeError):
+            pass
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -9040,6 +9381,19 @@ def _default_spawn(
         # turn, prints text, exits rc=0, and the dispatcher records a
         # protocol violation (incident 2026-06-09 t_d9cbe312).
         cmd.append("-Q")
+    worker_cmd = cmd
+    direct_env = dict(env)
+    cmd, scope_unit, scope_target = _systemd_scope_argv(
+        worker_cmd,
+        task,
+        board=board,
+    )
+    if scope_unit is not None and scope_target is not None:
+        # Use the same authenticated user manager for the launcher and its
+        # verification queries; do not inherit a different session bus.
+        for key in ("DBUS_STARTER_ADDRESS", "DBUS_STARTER_BUS_TYPE"):
+            env.pop(key, None)
+        env.update(_systemd_user_manager_environment(scope_target))
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and
@@ -9052,28 +9406,63 @@ def _default_spawn(
 
     # Use 'a' so a re-run on unblock appends rather than overwrites.
     log_f = open(log_path, "ab")
+    popen_kwargs = {
+        "cwd": workspace if os.path.isdir(workspace) else None,
+        "stdin": subprocess.DEVNULL,
+        "stdout": log_f,
+        "stderr": subprocess.STDOUT,
+        "env": env,
+        "start_new_session": True,
+        "creationflags": subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+    }
     try:
         proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
             cmd,
-            cwd=workspace if os.path.isdir(workspace) else None,
-            stdin=subprocess.DEVNULL,
-            stdout=log_f,
-            stderr=subprocess.STDOUT,
-            env=env,
-            start_new_session=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            **popen_kwargs,
         )
     except FileNotFoundError:
-        log_f.close()
-        raise RuntimeError(
-            "`hermes` executable not found on PATH. "
-            "Install Hermes Agent or activate its venv before running the kanban dispatcher."
-        )
+        if scope_unit is None:
+            log_f.close()
+            raise RuntimeError(
+                "`hermes` executable not found on PATH. "
+                "Install Hermes Agent or activate its venv before running the kanban dispatcher."
+            )
+        # A PATH race can remove systemd-run after the capability probe. Treat
+        # that as the unavailable-runtime case and retain direct launching.
+        scope_unit = None
+        scope_target = None
+        cmd = worker_cmd
+        popen_kwargs["env"] = direct_env
+        try:
+            proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
+                cmd,
+                **popen_kwargs,
+            )
+        except FileNotFoundError:
+            log_f.close()
+            raise RuntimeError(
+                "`hermes` executable not found on PATH. "
+                "Install Hermes Agent or activate its venv before running the kanban dispatcher."
+            )
+    if scope_unit is not None and scope_target is not None:
+        try:
+            _verify_systemd_scope_pid(proc, scope_unit, scope_target)
+        except Exception:
+            _cleanup_systemd_scope_launch(proc, scope_unit, scope_target)
+            log_f.close()
+            raise
     # NOTE: we intentionally do NOT close log_f here — we want Popen's
     # child process to keep writing after this function returns.  The
     # handle is kept alive by the child's inheritance.  The parent's
     # reference goes out of scope and is GC'd, but the OS-level FD stays
     # open in the child until the child exits.
+    if scope_unit is not None:
+        return _WorkerLaunchPid(
+            proc.pid,
+            launch_mode="systemd-user-scope",
+            scope_unit=scope_unit,
+            verification_status="verified",
+        )
     return proc.pid
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8876,6 +8876,8 @@ def _retag_legacy_worker_sessions(workspaces_root_path: str) -> None:
         _retagged_workspace_roots.add(workspaces_root_path)
     except Exception as exc:
         _log.debug("kanban worker: legacy session retag skipped (%s)", exc)
+
+
 _SYSTEMD_WORKER_SCOPE_PREFIX = "hermes-kanban-worker-"
 _SYSTEMD_SCOPE_MIN_VERSION = 236
 _SYSTEMD_SCOPE_PROBE_TIMEOUT = 2.0
@@ -9138,36 +9140,85 @@ def _process_cgroup_path(pid: int) -> Optional[str]:
     return None
 
 
-def _verify_systemd_scope_pid(
-    proc: subprocess.Popen,
+def _systemd_scope_process_ids(control_group: str) -> tuple[int, ...]:
+    """Return the PIDs the manager currently reports in ``control_group``."""
+    relative = control_group.strip().lstrip("/")
+    if not relative or ".." in Path(relative).parts:
+        return ()
+    roots = [Path("/sys/fs/cgroup")]
+    if not (roots[0] / "cgroup.controllers").exists():
+        roots.insert(0, roots[0] / "systemd")
+    for root in roots:
+        procs = root / relative / "cgroup.procs"
+        try:
+            return tuple(
+                int(line)
+                for line in procs.read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            )
+        except (OSError, ValueError):
+            continue
+    return ()
+
+
+def _process_command_argv(pid: int) -> tuple[str, ...]:
+    try:
+        raw = Path(f"/proc/{int(pid)}/cmdline").read_bytes()
+    except OSError:
+        return ()
+    return tuple(
+        part.decode("utf-8", errors="surrogateescape")
+        for part in raw.rstrip(b"\0").split(b"\0")
+        if part
+    )
+
+
+def _process_command_matches(pid: int, worker_cmd: list[str]) -> bool:
+    """Match a direct exec or a shebang interpreter followed by worker argv."""
+    observed = _process_command_argv(pid)
+    expected = tuple(worker_cmd)
+    return bool(expected) and (
+        observed == expected
+        or (len(observed) > len(expected) and observed[-len(expected):] == expected)
+    )
+
+
+def _verify_systemd_scope_worker_pid(
+    proc: Any,
     unit: str,
     target: _SystemdUserManagerTarget,
-) -> None:
-    """Require this exact Popen PID to be in this manager-owned scope."""
+    worker_cmd: list[str],
+) -> int:
+    """Return the actual worker PID after the manager has attached and exec'd it."""
     deadline = time.monotonic() + _SYSTEMD_SCOPE_VERIFY_TIMEOUT
     last_reason = "scope identity was not observable"
     while time.monotonic() < deadline:
-        if getattr(proc, "poll", lambda: None)() is not None:
-            raise RuntimeError(f"systemd scope launcher exited before verification: {unit}")
         props = _systemd_scope_properties(unit, target)
         if props is not None:
             load_state = props.get("LoadState")
             active_state = props.get("ActiveState")
             control_group = (props.get("ControlGroup") or "").rstrip("/")
-            process_group = (_process_cgroup_path(proc.pid) or "").rstrip("/")
             if load_state != "loaded":
                 last_reason = f"scope unit load state was {load_state!r}"
             elif active_state not in {"active", "activating"}:
                 last_reason = f"scope unit state was {active_state!r}"
             elif not control_group:
                 last_reason = "scope has no control group"
-            elif process_group != control_group:
-                last_reason = (
-                    f"Popen PID {proc.pid} was in {process_group!r}, "
-                    f"expected {control_group!r}"
-                )
             else:
-                return
+                scope_pids = _systemd_scope_process_ids(control_group)
+                for pid in scope_pids:
+                    process_group = (_process_cgroup_path(pid) or "").rstrip("/")
+                    if (
+                        process_group == control_group
+                        and _process_command_matches(pid, worker_cmd)
+                    ):
+                        return pid
+                last_reason = (
+                    f"scope PIDs {scope_pids!r} did not expose worker argv "
+                    f"{tuple(worker_cmd)!r}"
+                )
+        if getattr(proc, "poll", lambda: None)() is not None:
+            raise RuntimeError(f"systemd scope launcher exited before verification: {unit}")
         time.sleep(0.05)
     raise RuntimeError(f"could not verify systemd scope {unit}: {last_reason}")
 
@@ -9208,6 +9259,8 @@ def _cleanup_systemd_scope_launch(
             proc.wait(timeout=_SYSTEMD_SCOPE_CLEANUP_TIMEOUT)
         except (OSError, subprocess.TimeoutExpired, AttributeError):
             pass
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -9388,6 +9441,7 @@ def _default_spawn(
         task,
         board=board,
     )
+    worker_pid: Optional[int] = None
     if scope_unit is not None and scope_target is not None:
         # Use the same authenticated user manager for the launcher and its
         # verification queries; do not inherit a different session bus.
@@ -9446,7 +9500,12 @@ def _default_spawn(
             )
     if scope_unit is not None and scope_target is not None:
         try:
-            _verify_systemd_scope_pid(proc, scope_unit, scope_target)
+            worker_pid = _verify_systemd_scope_worker_pid(
+                proc,
+                scope_unit,
+                scope_target,
+                worker_cmd,
+            )
         except Exception:
             _cleanup_systemd_scope_launch(proc, scope_unit, scope_target)
             log_f.close()
@@ -9457,8 +9516,10 @@ def _default_spawn(
     # reference goes out of scope and is GC'd, but the OS-level FD stays
     # open in the child until the child exits.
     if scope_unit is not None:
+        if worker_pid is None:
+            raise RuntimeError(f"systemd scope {scope_unit} has no verified worker PID")
         return _WorkerLaunchPid(
-            proc.pid,
+            worker_pid,
             launch_mode="systemd-user-scope",
             scope_unit=scope_unit,
             verification_status="verified",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -79,6 +79,7 @@ import random
 import secrets
 import shutil
 import sqlite3
+import stat
 import subprocess
 import sys
 import threading
@@ -9233,7 +9234,17 @@ def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
                 "UPDATE task_runs SET worker_pid = ? WHERE id = ?",
                 (int(pid), run_id),
             )
-        _append_event(conn, task_id, "spawned", {"pid": int(pid)}, run_id=run_id)
+        payload = {"pid": int(pid)}
+        launch_mode = getattr(pid, "launch_mode", None)
+        scope_unit = getattr(pid, "scope_unit", None)
+        verification_status = getattr(pid, "verification_status", None)
+        if launch_mode is not None:
+            payload["launch_mode"] = launch_mode
+        if scope_unit is not None:
+            payload["scope_unit"] = scope_unit
+        if verification_status is not None:
+            payload["verification_status"] = verification_status
+        _append_event(conn, task_id, "spawned", payload, run_id=run_id)
 
 
 def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
@@ -9859,7 +9870,7 @@ def _dispatch_once_locked(
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
             if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+                _set_worker_pid(conn, claimed.id, pid)
             # Worker-lifecycle observer (RFC #58548): fires AFTER spawn_fn
             # returned and the PID (when reported) is durably persisted,
             # per the RFC timing contract. Best-effort — can never break
@@ -9991,7 +10002,7 @@ def _dispatch_once_locked(
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
             if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+                _set_worker_pid(conn, claimed.id, pid)
             # Worker-lifecycle observer (RFC #58548): same contract as the
             # ready-lane fire above — after spawn + PID persistence.
             _fire_worker_spawned_hook(
@@ -10301,6 +10312,396 @@ def _retag_legacy_worker_sessions(workspaces_root_path: str) -> None:
         _log.debug("kanban worker: legacy session retag skipped (%s)", exc)
 
 
+_SYSTEMD_WORKER_SCOPE_PREFIX = "hermes-kanban-worker-"
+_SYSTEMD_SCOPE_MIN_VERSION = 236
+_SYSTEMD_SCOPE_PROBE_TIMEOUT = 2.0
+_SYSTEMD_SCOPE_VERIFY_TIMEOUT = 2.0
+_SYSTEMD_SCOPE_CLEANUP_TIMEOUT = 2.0
+_SYSTEMD_WORKER_SCOPE_RE = re.compile(
+    rf"^{re.escape(_SYSTEMD_WORKER_SCOPE_PREFIX)}[0-9a-f]{{32}}\.scope$"
+)
+
+
+@dataclass(frozen=True)
+class _SystemdUserManagerTarget:
+    """Authenticated identity of the current process's user manager."""
+
+    uid: int
+    runtime_dir: Path = field(repr=False)
+    bus_path: Path = field(repr=False)
+
+
+class _WorkerLaunchPid(int):
+    """Integer-compatible PID with a verified launch receipt."""
+
+    def __new__(
+        cls,
+        pid: int,
+        *,
+        launch_mode: str = "direct",
+        scope_unit: Optional[str] = None,
+        verification_status: str = "not-applicable",
+    ):
+        value = int.__new__(cls, int(pid))
+        value.launch_mode = launch_mode
+        value.scope_unit = scope_unit
+        value.verification_status = verification_status
+        return value
+
+
+def _systemd_user_manager_environment(
+    target: _SystemdUserManagerTarget,
+) -> dict[str, str]:
+    return {
+        "XDG_RUNTIME_DIR": str(target.runtime_dir),
+        "DBUS_SESSION_BUS_ADDRESS": f"unix:path={target.bus_path}",
+    }
+
+
+def _systemd_user_manager_target_for_cgroup(
+    cgroup_path: Optional[str],
+) -> Optional[_SystemdUserManagerTarget]:
+    """Return a trusted same-UID user bus only for a user-service cgroup."""
+    if not sys.platform.startswith("linux") or not cgroup_path:
+        return None
+    path = cgroup_path.rstrip("/")
+    match = re.search(r"/user@(\d+)\.service(?:/|$)", path)
+    if (
+        not match
+        or not path.rsplit("/", 1)[-1].endswith(".service")
+        or not re.search(r"/user@\d+\.service/.+\.service$", path)
+    ):
+        return None
+    getuid = getattr(os, "getuid", None)
+    geteuid = getattr(os, "geteuid", None)
+    if getuid is None or geteuid is None:
+        return None
+    uid = int(match.group(1))
+    if uid != int(getuid()) or uid != int(geteuid()):
+        return None
+    runtime_dir = Path("/run/user") / str(uid)
+    bus_path = runtime_dir / "bus"
+    try:
+        runtime_stat = os.lstat(runtime_dir)
+        bus_stat = os.lstat(bus_path)
+    except OSError:
+        return None
+    if (
+        not stat.S_ISDIR(runtime_stat.st_mode)
+        or runtime_stat.st_uid != uid
+        or stat.S_IMODE(runtime_stat.st_mode) & 0o077
+        or not stat.S_ISSOCK(bus_stat.st_mode)
+        or bus_stat.st_uid != uid
+    ):
+        return None
+    return _SystemdUserManagerTarget(uid, runtime_dir, bus_path)
+
+
+def _current_cgroup_path() -> Optional[str]:
+    if not sys.platform.startswith("linux"):
+        return None
+    try:
+        for line in Path("/proc/self/cgroup").read_text(encoding="utf-8").splitlines():
+            hierarchy, controllers, path = line.split(":", 2)
+            if hierarchy == "0" and not controllers:
+                return path
+            if "name=systemd" in controllers.split(","):
+                return path
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def _systemd_run_version(runner: str, *, run_fn=None) -> Optional[int]:
+    run = run_fn or subprocess.run
+    try:
+        result = run(
+            [runner, "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=_SYSTEMD_SCOPE_PROBE_TIMEOUT,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError, TimeoutError):
+        return None
+    match = re.search(r"\bsystemd\s+(\d+)\b", result.stdout or "")
+    return int(match.group(1)) if result.returncode == 0 and match else None
+
+
+def _systemd_user_manager_reachable(
+    target: _SystemdUserManagerTarget,
+    *,
+    systemctl: Optional[str] = None,
+    run_fn=None,
+) -> bool:
+    controller = systemctl or shutil.which("systemctl")
+    if not controller:
+        return False
+    run = run_fn or subprocess.run
+    try:
+        result = run(
+            [controller, "--user", "show", "--property=Version", "--value"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=_SYSTEMD_SCOPE_PROBE_TIMEOUT,
+            check=False,
+            env=_systemd_user_manager_environment(target),
+        )
+    except (OSError, subprocess.SubprocessError, TimeoutError):
+        return False
+    return result.returncode == 0 and bool((result.stdout or "").strip())
+
+
+def _systemd_scope_unit_name(
+    task_id: str,
+    run_id: int,
+    *,
+    board: Optional[str] = None,
+) -> str:
+    """Derive a bounded unit name from canonical board DB, task, and run."""
+    db_identity = os.path.normcase(
+        str(kanban_db_path(board=board).expanduser().resolve(strict=False))
+    )
+    digest = hashlib.blake2s(
+        f"v1\0{db_identity}\0{task_id}\0{int(run_id)}".encode(), digest_size=16
+    ).hexdigest()
+    return f"{_SYSTEMD_WORKER_SCOPE_PREFIX}{digest}.scope"
+
+
+def _systemd_scope_argv(
+    cmd: list[str],
+    task: Task,
+    *,
+    board: Optional[str] = None,
+    cgroup_path: Optional[str] = None,
+    manager_target: Optional[_SystemdUserManagerTarget] = None,
+    systemd_run: Optional[str] = None,
+    user_manager_ready: Optional[bool] = None,
+) -> tuple[list[str], Optional[str], Optional[_SystemdUserManagerTarget]]:
+    """Return a scoped argv only when the dispatcher identity is trusted."""
+    if not sys.platform.startswith("linux") or task.current_run_id is None:
+        return cmd, None, None
+    current = cgroup_path if cgroup_path is not None else _current_cgroup_path()
+    target = manager_target or _systemd_user_manager_target_for_cgroup(current)
+    runner = systemd_run or shutil.which("systemd-run")
+    if target is None or runner is None:
+        return cmd, None, None
+    if user_manager_ready is None:
+        version = _systemd_run_version(runner)
+        ready = (
+            version is not None
+            and version >= _SYSTEMD_SCOPE_MIN_VERSION
+            and _systemd_user_manager_reachable(target)
+        )
+    else:
+        ready = bool(user_manager_ready)
+    if not ready:
+        return cmd, None, None
+    try:
+        unit = _systemd_scope_unit_name(task.id, int(task.current_run_id), board=board)
+    except (OSError, TypeError, ValueError):
+        return cmd, None, None
+    return (
+        [
+            runner,
+            "--user",
+            "--scope",
+            "--quiet",
+            "--collect",
+            f"--unit={unit}",
+            "--",
+            *cmd,
+        ],
+        unit,
+        target,
+    )
+
+
+def _systemd_scope_properties(
+    unit: str,
+    target: _SystemdUserManagerTarget,
+    *,
+    systemctl: Optional[str] = None,
+    run_fn=None,
+) -> Optional[dict[str, str]]:
+    if not _SYSTEMD_WORKER_SCOPE_RE.fullmatch(unit):
+        return None
+    controller = systemctl or shutil.which("systemctl")
+    if not controller:
+        return None
+    run = run_fn or subprocess.run
+    try:
+        result = run(
+            [
+                controller,
+                "--user",
+                "show",
+                unit,
+                "--property=LoadState",
+                "--property=ActiveState",
+                "--property=ControlGroup",
+                "--no-pager",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=_SYSTEMD_SCOPE_PROBE_TIMEOUT,
+            check=False,
+            env=_systemd_user_manager_environment(target),
+        )
+    except (OSError, subprocess.SubprocessError, TimeoutError):
+        return None
+    if result.returncode != 0:
+        return None
+    return {
+        key: value
+        for key, value in (
+            line.split("=", 1)
+            for line in (result.stdout or "").splitlines()
+            if "=" in line
+        )
+    }
+
+
+def _process_cgroup_path(pid: int) -> Optional[str]:
+    try:
+        lines = Path(f"/proc/{int(pid)}/cgroup").read_text(encoding="utf-8").splitlines()
+        for line in lines:
+            hierarchy, controllers, path = line.split(":", 2)
+            if hierarchy == "0" and not controllers:
+                return path
+            if "name=systemd" in controllers.split(","):
+                return path
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def _systemd_scope_process_ids(control_group: str) -> tuple[int, ...]:
+    """Return the PIDs the manager currently reports in ``control_group``."""
+    relative = control_group.strip().lstrip("/")
+    if not relative or ".." in Path(relative).parts:
+        return ()
+    roots = [Path("/sys/fs/cgroup")]
+    if not (roots[0] / "cgroup.controllers").exists():
+        roots.insert(0, roots[0] / "systemd")
+    for root in roots:
+        try:
+            return tuple(
+                int(line)
+                for line in (root / relative / "cgroup.procs")
+                .read_text(encoding="utf-8")
+                .splitlines()
+                if line.strip()
+            )
+        except (OSError, ValueError):
+            continue
+    return ()
+
+
+def _process_command_argv(pid: int) -> tuple[str, ...]:
+    try:
+        raw = Path(f"/proc/{int(pid)}/cmdline").read_bytes()
+    except OSError:
+        return ()
+    return tuple(
+        part.decode("utf-8", errors="surrogateescape")
+        for part in raw.rstrip(b"\0").split(b"\0")
+        if part
+    )
+
+
+def _process_command_matches(pid: int, worker_cmd: list[str]) -> bool:
+    """Match a direct exec or a shebang interpreter followed by worker argv."""
+    observed = _process_command_argv(pid)
+    expected = tuple(worker_cmd)
+    return bool(expected) and (
+        observed == expected
+        or (len(observed) > len(expected) and observed[-len(expected) :] == expected)
+    )
+
+
+def _verify_systemd_scope_worker_pid(
+    proc: Any,
+    unit: str,
+    target: _SystemdUserManagerTarget,
+    worker_cmd: list[str],
+) -> int:
+    """Return the actual worker PID after the manager has attached and exec'd it."""
+    deadline = time.monotonic() + _SYSTEMD_SCOPE_VERIFY_TIMEOUT
+    last_reason = "scope identity was not observable"
+    while time.monotonic() < deadline:
+        props = _systemd_scope_properties(unit, target)
+        if props is not None:
+            load_state = props.get("LoadState")
+            active_state = props.get("ActiveState")
+            control_group = (props.get("ControlGroup") or "").rstrip("/")
+            if load_state != "loaded":
+                last_reason = f"scope unit load state was {load_state!r}"
+            elif active_state not in {"active", "activating"}:
+                last_reason = f"scope unit state was {active_state!r}"
+            elif not control_group:
+                last_reason = "scope has no control group"
+            else:
+                scope_pids = _systemd_scope_process_ids(control_group)
+                for pid in scope_pids:
+                    process_group = (_process_cgroup_path(pid) or "").rstrip("/")
+                    if process_group == control_group and _process_command_matches(
+                        pid, worker_cmd
+                    ):
+                        return pid
+                last_reason = (
+                    f"scope PIDs {scope_pids!r} did not expose worker argv "
+                    f"{tuple(worker_cmd)!r}"
+                )
+        if getattr(proc, "poll", lambda: None)() is not None:
+            raise RuntimeError(
+                f"systemd scope launcher exited before verification: {unit}"
+            )
+        time.sleep(0.05)
+    raise RuntimeError(f"could not verify systemd scope {unit}: {last_reason}")
+
+
+def _cleanup_systemd_scope_launch(
+    proc: subprocess.Popen,
+    unit: str,
+    target: _SystemdUserManagerTarget,
+) -> None:
+    """Stop exactly the transient unit and reap exactly its Popen wrapper."""
+    controller = shutil.which("systemctl")
+    if controller:
+        try:
+            subprocess.run(
+                [controller, "--user", "stop", unit],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=_SYSTEMD_SCOPE_CLEANUP_TIMEOUT,
+                check=False,
+                env=_systemd_user_manager_environment(target),
+            )
+        except (OSError, subprocess.SubprocessError, TimeoutError):
+            pass
+    try:
+        proc.wait(timeout=_SYSTEMD_SCOPE_CLEANUP_TIMEOUT)
+        return
+    except (subprocess.TimeoutExpired, AttributeError):
+        pass
+    try:
+        proc.terminate()
+        proc.wait(timeout=_SYSTEMD_SCOPE_CLEANUP_TIMEOUT)
+    except (ProcessLookupError, OSError, subprocess.TimeoutExpired, AttributeError):
+        try:
+            proc.kill()
+        except (ProcessLookupError, OSError, AttributeError):
+            return
+        try:
+            proc.wait(timeout=_SYSTEMD_SCOPE_CLEANUP_TIMEOUT)
+        except (OSError, subprocess.TimeoutExpired, AttributeError):
+            pass
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -10479,6 +10880,19 @@ def _default_spawn(
         # turn, prints text, exits rc=0, and the dispatcher records a
         # protocol violation (incident 2026-06-09 t_d9cbe312).
         cmd.append("-Q")
+    worker_cmd = cmd
+    direct_env = dict(env)
+    cmd, scope_unit, scope_target = _systemd_scope_argv(
+        worker_cmd,
+        task,
+        board=board,
+    )
+    worker_pid: Optional[int] = None
+    if scope_unit is not None and scope_target is not None:
+        # Pin every manager operation to the authenticated same-UID bus.
+        for key in ("DBUS_STARTER_ADDRESS", "DBUS_STARTER_BUS_TYPE"):
+            env.pop(key, None)
+        env.update(_systemd_user_manager_environment(scope_target))
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and
@@ -10491,28 +10905,68 @@ def _default_spawn(
 
     # Use 'a' so a re-run on unblock appends rather than overwrites.
     log_f = open(log_path, "ab")
+    popen_kwargs = {
+        "cwd": workspace if os.path.isdir(workspace) else None,
+        "stdin": subprocess.DEVNULL,
+        "stdout": log_f,
+        "stderr": subprocess.STDOUT,
+        "env": env,
+        "start_new_session": True,
+        "creationflags": subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+    }
     try:
         proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
             cmd,
-            cwd=workspace if os.path.isdir(workspace) else None,
-            stdin=subprocess.DEVNULL,
-            stdout=log_f,
-            stderr=subprocess.STDOUT,
-            env=env,
-            start_new_session=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            **popen_kwargs,
         )
     except FileNotFoundError:
-        log_f.close()
-        raise RuntimeError(
-            "`hermes` executable not found on PATH. "
-            "Install Hermes Agent or activate its venv before running the kanban dispatcher."
-        )
+        if scope_unit is None:
+            log_f.close()
+            raise RuntimeError(
+                "`hermes` executable not found on PATH. "
+                "Install Hermes Agent or activate its venv before running the kanban dispatcher."
+            )
+        # A PATH race can remove systemd-run after the capability probe.
+        scope_unit = None
+        scope_target = None
+        popen_kwargs["env"] = direct_env
+        try:
+            proc = subprocess.Popen(  # noqa: S603 -- fixed argv
+                worker_cmd,
+                **popen_kwargs,
+            )
+        except FileNotFoundError:
+            log_f.close()
+            raise RuntimeError(
+                "`hermes` executable not found on PATH. "
+                "Install Hermes Agent or activate its venv before running the kanban dispatcher."
+            )
+    if scope_unit is not None and scope_target is not None:
+        try:
+            worker_pid = _verify_systemd_scope_worker_pid(
+                proc,
+                scope_unit,
+                scope_target,
+                worker_cmd,
+            )
+        except Exception:
+            _cleanup_systemd_scope_launch(proc, scope_unit, scope_target)
+            log_f.close()
+            raise
     # NOTE: we intentionally do NOT close log_f here — we want Popen's
     # child process to keep writing after this function returns.  The
     # handle is kept alive by the child's inheritance.  The parent's
     # reference goes out of scope and is GC'd, but the OS-level FD stays
     # open in the child until the child exits.
+    if scope_unit is not None:
+        if worker_pid is None:
+            raise RuntimeError(f"systemd scope {scope_unit} has no verified worker PID")
+        return _WorkerLaunchPid(
+            worker_pid,
+            launch_mode="systemd-user-scope",
+            scope_unit=scope_unit,
+            verification_status="verified",
+        )
     return proc.pid
 
 

--- a/tests/hermes_cli/test_kanban_worker_systemd_scope.py
+++ b/tests/hermes_cli/test_kanban_worker_systemd_scope.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 
@@ -121,9 +122,11 @@ def test_scope_verification_failure_stops_exact_unit(monkeypatch):
             "ControlGroup": "/expected.scope",
         },
     )
-    monkeypatch.setattr(kb, "_process_cgroup_path", lambda pid: "/wrong.scope")
+    monkeypatch.setattr(kb, "_systemd_scope_process_ids", lambda path: (4242,))
+    monkeypatch.setattr(kb, "_process_cgroup_path", lambda pid: "/expected.scope")
+    monkeypatch.setattr(kb, "_process_command_argv", lambda pid: ("/wrong",))
     with pytest.raises(RuntimeError, match="could not verify systemd scope"):
-        kb._verify_systemd_scope_pid(proc, unit, target)
+        kb._verify_systemd_scope_worker_pid(proc, unit, target, ["/bin/sleep", "30"])
 
     stop_calls = []
     monkeypatch.setattr(kb.shutil, "which", lambda name: "/usr/bin/systemctl")
@@ -135,6 +138,55 @@ def test_scope_verification_failure_stops_exact_unit(monkeypatch):
     kb._cleanup_systemd_scope_launch(proc, unit, target)
     assert stop_calls[0][0] == ["/usr/bin/systemctl", "--user", "stop", unit]
     assert getattr(proc, "terminated", False)
+
+
+def test_scope_verification_returns_matching_worker_not_launcher(monkeypatch):
+    unit = "hermes-kanban-worker-0123456789abcdef0123456789abcdef.scope"
+    target = kb._SystemdUserManagerTarget(
+        os.getuid(),
+        Path("/run/user") / str(os.getuid()),
+        Path("/run/user") / str(os.getuid()) / "bus",
+    )
+    proc = SimpleNamespace(pid=111, poll=lambda: None)
+    monkeypatch.setattr(
+        kb,
+        "_systemd_scope_properties",
+        lambda *args, **kwargs: {
+            "LoadState": "loaded",
+            "ActiveState": "active",
+            "ControlGroup": "/expected.scope",
+        },
+    )
+    monkeypatch.setattr(kb, "_systemd_scope_process_ids", lambda path: (111, 222))
+    monkeypatch.setattr(kb, "_process_cgroup_path", lambda pid: "/expected.scope")
+    monkeypatch.setattr(
+        kb,
+        "_process_command_argv",
+        lambda pid: ("/usr/bin/systemd-run",) if pid == 111 else ("/bin/sleep", "30"),
+    )
+
+    assert (
+        kb._verify_systemd_scope_worker_pid(
+            cast(subprocess.Popen, proc),
+            unit,
+            target,
+            ["/bin/sleep", "30"],
+        )
+        == 222
+    )
+
+
+def test_process_command_matches_shebang_interpreter(monkeypatch):
+    monkeypatch.setattr(
+        kb,
+        "_process_command_argv",
+        lambda pid: ("/usr/bin/python3", "/usr/local/bin/hermes", "chat", "-q", "work"),
+    )
+
+    assert getattr(kb, "_process_command_matches")(
+        222,
+        ["/usr/local/bin/hermes", "chat", "-q", "work"],
+    )
 
 
 def test_default_spawn_receipt_reaches_spawned_event(
@@ -159,7 +211,7 @@ def test_default_spawn_receipt_reaches_spawned_event(
         return ["/usr/bin/systemd-run", "--user", "--scope", "--unit=" + unit, "--", *cmd], unit, target
 
     monkeypatch.setattr(kb, "_systemd_scope_argv", fake_scope_argv)
-    monkeypatch.setattr(kb, "_verify_systemd_scope_pid", lambda *args: None)
+    monkeypatch.setattr(kb, "_verify_systemd_scope_worker_pid", lambda *args: 2468)
     monkeypatch.setattr(kb.subprocess, "Popen", fake_popen)
 
     with kb.connect() as conn:
@@ -169,7 +221,7 @@ def test_default_spawn_receipt_reaches_spawned_event(
 
     assert result.spawned and result.spawned[0][0] == task_id
     assert event.payload == {
-        "pid": 6789,
+        "pid": 2468,
         "launch_mode": "systemd-user-scope",
         "scope_unit": captured["unit"],
         "verification_status": "verified",
@@ -203,7 +255,9 @@ def test_native_systemd_scope_lifecycle_when_user_manager_is_available(kanban_ho
         systemd_run=runner,
         user_manager_ready=True,
     )
-    assert unit is not None and manager is target
+    assert unit is not None
+    assert manager is target
+    assert manager is not None
     native_env = dict(os.environ)
     native_env.update(kb._systemd_user_manager_environment(target))
     proc = subprocess.Popen(
@@ -214,7 +268,38 @@ def test_native_systemd_scope_lifecycle_when_user_manager_is_available(kanban_ho
         env=native_env,
     )
     try:
-        kb._verify_systemd_scope_pid(proc, unit, manager)
+        worker_pid = kb._verify_systemd_scope_worker_pid(
+            proc,
+            unit,
+            manager,
+            ["/bin/sleep", "30"],
+        )
+        props = kb._systemd_scope_properties(unit, manager)
+        assert props is not None
+        control_group = props["ControlGroup"]
+        assert worker_pid in kb._systemd_scope_process_ids(control_group)
+        assert kb._process_cgroup_path(worker_pid) == control_group
+
+        with kb.connect() as conn:
+            task_id = kb.create_task(
+                conn,
+                title="native scope timeout",
+                assignee="worker",
+                max_runtime_seconds=1,
+            )
+            claimed = kb.claim_task(conn, task_id)
+            assert claimed is not None
+            kb._set_worker_pid(conn, task_id, worker_pid)
+            conn.execute(
+                "UPDATE task_runs SET started_at = ? WHERE id = ?",
+                (int(kb.time.time()) - 2, claimed.current_run_id),
+            )
+            conn.commit()
+            assert kb.enforce_max_runtime(conn) == [task_id]
+            timed_out_task = kb.get_task(conn, task_id)
+            assert timed_out_task is not None
+            assert timed_out_task.status == "ready"
+        proc.wait(timeout=kb._SYSTEMD_SCOPE_CLEANUP_TIMEOUT)
     finally:
         kb._cleanup_systemd_scope_launch(proc, unit, manager)
     assert proc.poll() is not None

--- a/tests/hermes_cli/test_kanban_worker_systemd_scope.py
+++ b/tests/hermes_cli/test_kanban_worker_systemd_scope.py
@@ -1,0 +1,222 @@
+"""Focused lifecycle and fallback coverage for Kanban worker scopes."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _task(task_id="task-1", run_id=7):
+    return SimpleNamespace(id=task_id, current_run_id=run_id)
+
+
+def test_scope_unit_identity_is_canonical_board_and_run_bound(monkeypatch):
+    monkeypatch.setattr(
+        kb,
+        "kanban_db_path",
+        lambda board=None: Path("/srv/hermes") / (board or "default") / "kanban.db",
+    )
+
+    first = kb._systemd_scope_unit_name("task with text", 11, board="alpha")
+    same = kb._systemd_scope_unit_name("task with text", 11, board="alpha")
+    other_run = kb._systemd_scope_unit_name("task with text", 12, board="alpha")
+    other_board = kb._systemd_scope_unit_name("task with text", 11, board="beta")
+
+    assert first == same
+    assert first != other_run
+    assert first != other_board
+    assert kb._SYSTEMD_WORKER_SCOPE_RE.fullmatch(first)
+    assert "task with text" not in first
+
+
+@pytest.mark.parametrize(
+    ("platform", "cgroup", "run_id", "runner", "ready"),
+    [
+        ("darwin", "/user.slice/user-1000.slice/user@1000.service/hermes.service", 1, "/usr/bin/systemd-run", True),
+        ("linux", "/system.slice/hermes.service", 1, "/usr/bin/systemd-run", True),
+        ("linux", "/user.slice/user-1000.slice/user@1000.service", 1, "/usr/bin/systemd-run", True),
+        ("linux", "/user.slice/user-1000.slice/user@1000.service/app.slice/app.scope", 1, "/usr/bin/systemd-run", True),
+        ("linux", "/user.slice/user-1000.slice/user@1000.service/hermes.service", None, "/usr/bin/systemd-run", True),
+        ("linux", "/user.slice/user-1000.slice/user@1000.service/hermes.service", 1, None, True),
+        ("linux", "/user.slice/user-1000.slice/user@1000.service/hermes.service", 1, "/usr/bin/systemd-run", False),
+    ],
+)
+def test_scope_capability_fail_open(
+    monkeypatch, platform, cgroup, run_id, runner, ready
+):
+    monkeypatch.setattr(kb.sys, "platform", platform)
+    target = kb._SystemdUserManagerTarget(
+        os.getuid(), Path("/run/user") / str(os.getuid()), Path("/run/user") / str(os.getuid()) / "bus"
+    )
+    monkeypatch.setattr(
+        kb,
+        "_systemd_user_manager_target_for_cgroup",
+        lambda _: target
+        if cgroup.endswith("hermes.service") and "/system.slice/" not in cgroup
+        else None,
+    )
+    monkeypatch.setattr(kb.shutil, "which", lambda name: runner if name == "systemd-run" else "/usr/bin/systemctl")
+
+    original = ["/usr/bin/hermes", "chat", "-q", "work"]
+    scoped, unit, manager = kb._systemd_scope_argv(
+        original,
+        _task(run_id=run_id),
+        cgroup_path=cgroup,
+        user_manager_ready=ready,
+    )
+
+    assert scoped is original
+    assert unit is None
+    assert manager is None
+
+
+def test_scope_verification_failure_stops_exact_unit(monkeypatch):
+    unit = "hermes-kanban-worker-0123456789abcdef0123456789abcdef.scope"
+    target = kb._SystemdUserManagerTarget(
+        os.getuid(), Path("/run/user") / str(os.getuid()), Path("/run/user") / str(os.getuid()) / "bus"
+    )
+
+    class FakeProc:
+        pid = 4242
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            if timeout is not None:
+                raise subprocess.TimeoutExpired("systemd-run", timeout)
+            return 0
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            self.killed = True
+
+    proc = FakeProc()
+    monkeypatch.setattr(kb, "_SYSTEMD_SCOPE_VERIFY_TIMEOUT", 0.01)
+    monkeypatch.setattr(
+        kb,
+        "_systemd_scope_properties",
+        lambda *args, **kwargs: {
+            "LoadState": "loaded",
+            "ActiveState": "active",
+            "ControlGroup": "/expected.scope",
+        },
+    )
+    monkeypatch.setattr(kb, "_process_cgroup_path", lambda pid: "/wrong.scope")
+    with pytest.raises(RuntimeError, match="could not verify systemd scope"):
+        kb._verify_systemd_scope_pid(proc, unit, target)
+
+    stop_calls = []
+    monkeypatch.setattr(kb.shutil, "which", lambda name: "/usr/bin/systemctl")
+    monkeypatch.setattr(
+        kb.subprocess,
+        "run",
+        lambda argv, **kwargs: stop_calls.append((argv, kwargs)) or SimpleNamespace(returncode=0, stdout=""),
+    )
+    kb._cleanup_systemd_scope_launch(proc, unit, target)
+    assert stop_calls[0][0] == ["/usr/bin/systemctl", "--user", "stop", unit]
+    assert getattr(proc, "terminated", False)
+
+
+def test_default_spawn_receipt_reaches_spawned_event(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    target = kb._SystemdUserManagerTarget(
+        os.getuid(), Path("/run/user") / str(os.getuid()), Path("/run/user") / str(os.getuid()) / "bus"
+    )
+    captured = {}
+
+    class FakeProc:
+        pid = 6789
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return FakeProc()
+
+    def fake_scope_argv(cmd, task, **kwargs):
+        unit = kb._systemd_scope_unit_name(task.id, task.current_run_id)
+        captured["unit"] = unit
+        return ["/usr/bin/systemd-run", "--user", "--scope", "--unit=" + unit, "--", *cmd], unit, target
+
+    monkeypatch.setattr(kb, "_systemd_scope_argv", fake_scope_argv)
+    monkeypatch.setattr(kb, "_verify_systemd_scope_pid", lambda *args: None)
+    monkeypatch.setattr(kb.subprocess, "Popen", fake_popen)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="scoped", assignee="worker")
+        result = kb.dispatch_once(conn, spawn_fn=kb._default_spawn)
+        event = next(event for event in kb.list_events(conn, task_id) if event.kind == "spawned")
+
+    assert result.spawned and result.spawned[0][0] == task_id
+    assert event.payload == {
+        "pid": 6789,
+        "launch_mode": "systemd-user-scope",
+        "scope_unit": captured["unit"],
+        "verification_status": "verified",
+    }
+    assert isinstance(kb._WorkerLaunchPid(6789), int)
+    assert captured["cmd"][0] == "/usr/bin/systemd-run"
+
+
+def test_native_systemd_scope_lifecycle_when_user_manager_is_available(kanban_home):
+    """Exercise the real unit/control-group boundary, not just argv shape."""
+    if not sys.platform.startswith("linux"):
+        pytest.skip("native systemd user scopes require Linux")
+    cgroup = kb._current_cgroup_path()
+    target = kb._systemd_user_manager_target_for_cgroup(cgroup)
+    if target is None:
+        pytest.skip("dispatcher is not hosted in its own authenticated user-service cgroup")
+    runner = kb.shutil.which("systemd-run")
+    if runner is None:
+        pytest.skip("systemd-run is unavailable")
+    version = kb._systemd_run_version(runner)
+    if version is None or version < kb._SYSTEMD_SCOPE_MIN_VERSION:
+        pytest.skip("systemd-run lacks the required transient-scope support")
+    if not kb._systemd_user_manager_reachable(target):
+        pytest.skip("authenticated systemd user manager is unreachable")
+
+    scoped, unit, manager = kb._systemd_scope_argv(
+        ["/bin/sleep", "30"],
+        _task("native-lifecycle", 1),
+        cgroup_path=cgroup,
+        manager_target=target,
+        systemd_run=runner,
+        user_manager_ready=True,
+    )
+    assert unit is not None and manager is target
+    native_env = dict(os.environ)
+    native_env.update(kb._systemd_user_manager_environment(target))
+    proc = subprocess.Popen(
+        scoped,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=native_env,
+    )
+    try:
+        kb._verify_systemd_scope_pid(proc, unit, manager)
+    finally:
+        kb._cleanup_systemd_scope_launch(proc, unit, manager)
+    assert proc.poll() is not None
+    props = kb._systemd_scope_properties(unit, manager)
+    assert props is None or props.get("LoadState") == "not-found"

--- a/tests/hermes_cli/test_kanban_worker_systemd_scope.py
+++ b/tests/hermes_cli/test_kanban_worker_systemd_scope.py
@@ -1,0 +1,315 @@
+"""Focused lifecycle and fallback coverage for Kanban worker scopes."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _task(task_id="task-1", run_id=7):
+    return SimpleNamespace(id=task_id, current_run_id=run_id)
+
+
+def _target():
+    runtime = Path("/run/user") / str(os.getuid())
+    return kb._SystemdUserManagerTarget(os.getuid(), runtime, runtime / "bus")
+
+
+def test_scope_unit_identity_is_canonical_board_and_run_bound(monkeypatch):
+    monkeypatch.setattr(
+        kb,
+        "kanban_db_path",
+        lambda board=None: Path("/srv/hermes") / (board or "default") / "kanban.db",
+    )
+
+    first = kb._systemd_scope_unit_name("task with text", 11, board="alpha")
+    same = kb._systemd_scope_unit_name("task with text", 11, board="alpha")
+    other_run = kb._systemd_scope_unit_name("task with text", 12, board="alpha")
+    other_board = kb._systemd_scope_unit_name("task with text", 11, board="beta")
+
+    assert first == same
+    assert first != other_run
+    assert first != other_board
+    assert kb._SYSTEMD_WORKER_SCOPE_RE.fullmatch(first)
+    assert "task with text" not in first
+
+
+@pytest.mark.parametrize(
+    ("platform", "cgroup", "run_id", "runner", "ready"),
+    [
+        ("darwin", "/user.slice/user-1000.slice/user@1000.service/hermes.service", 1, "/usr/bin/systemd-run", True),
+        ("linux", "/system.slice/hermes.service", 1, "/usr/bin/systemd-run", True),
+        ("linux", "/user.slice/user-1000.slice/user@1000.service", 1, "/usr/bin/systemd-run", True),
+        ("linux", "/user.slice/user-1000.slice/user@1000.service/app.slice/app.scope", 1, "/usr/bin/systemd-run", True),
+        ("linux", "/user.slice/user-1000.slice/user@1000.service/hermes.service", None, "/usr/bin/systemd-run", True),
+        ("linux", "/user.slice/user-1000.slice/user@1000.service/hermes.service", 1, None, True),
+        ("linux", "/user.slice/user-1000.slice/user@1000.service/hermes.service", 1, "/usr/bin/systemd-run", False),
+    ],
+)
+def test_scope_capability_fail_open(
+    monkeypatch, platform, cgroup, run_id, runner, ready
+):
+    monkeypatch.setattr(kb.sys, "platform", platform)
+    monkeypatch.setattr(
+        kb,
+        "_systemd_user_manager_target_for_cgroup",
+        lambda value: _target()
+        if value.endswith("hermes.service") and "/system.slice/" not in value
+        else None,
+    )
+    monkeypatch.setattr(
+        kb.shutil,
+        "which",
+        lambda name: runner if name == "systemd-run" else "/usr/bin/systemctl",
+    )
+
+    original = ["/usr/bin/hermes", "chat", "-q", "work"]
+    scoped, unit, manager = kb._systemd_scope_argv(
+        original,
+        _task(run_id=run_id),
+        cgroup_path=cgroup,
+        user_manager_ready=ready,
+    )
+
+    assert scoped is original
+    assert unit is None
+    assert manager is None
+
+
+def test_scope_verification_failure_stops_exact_unit(monkeypatch):
+    unit = "hermes-kanban-worker-0123456789abcdef0123456789abcdef.scope"
+
+    class FakeProc:
+        pid = 4242
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            if timeout is not None:
+                raise subprocess.TimeoutExpired("systemd-run", timeout)
+            return 0
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            self.killed = True
+
+    proc = FakeProc()
+    monkeypatch.setattr(kb, "_SYSTEMD_SCOPE_VERIFY_TIMEOUT", 0.01)
+    monkeypatch.setattr(
+        kb,
+        "_systemd_scope_properties",
+        lambda *args, **kwargs: {
+            "LoadState": "loaded",
+            "ActiveState": "active",
+            "ControlGroup": "/expected.scope",
+        },
+    )
+    monkeypatch.setattr(kb, "_systemd_scope_process_ids", lambda path: (4242,))
+    monkeypatch.setattr(kb, "_process_cgroup_path", lambda pid: "/expected.scope")
+    monkeypatch.setattr(kb, "_process_command_argv", lambda pid: ("/wrong",))
+    with pytest.raises(RuntimeError, match="could not verify systemd scope"):
+        kb._verify_systemd_scope_worker_pid(
+            proc, unit, _target(), ["/bin/sleep", "30"]
+        )
+
+    stop_calls = []
+    monkeypatch.setattr(kb.shutil, "which", lambda name: "/usr/bin/systemctl")
+    monkeypatch.setattr(
+        kb.subprocess,
+        "run",
+        lambda argv, **kwargs: stop_calls.append((argv, kwargs))
+        or SimpleNamespace(returncode=0, stdout=""),
+    )
+    kb._cleanup_systemd_scope_launch(proc, unit, _target())
+    assert stop_calls[0][0] == ["/usr/bin/systemctl", "--user", "stop", unit]
+    assert getattr(proc, "terminated", False)
+
+
+def test_scope_verification_returns_matching_worker_not_launcher(monkeypatch):
+    unit = "hermes-kanban-worker-0123456789abcdef0123456789abcdef.scope"
+    proc = SimpleNamespace(pid=111, poll=lambda: None)
+    monkeypatch.setattr(
+        kb,
+        "_systemd_scope_properties",
+        lambda *args, **kwargs: {
+            "LoadState": "loaded",
+            "ActiveState": "active",
+            "ControlGroup": "/expected.scope",
+        },
+    )
+    monkeypatch.setattr(kb, "_systemd_scope_process_ids", lambda path: (111, 222))
+    monkeypatch.setattr(kb, "_process_cgroup_path", lambda pid: "/expected.scope")
+    monkeypatch.setattr(
+        kb,
+        "_process_command_argv",
+        lambda pid: ("/usr/bin/systemd-run",)
+        if pid == 111
+        else ("/bin/sleep", "30"),
+    )
+
+    assert (
+        kb._verify_systemd_scope_worker_pid(
+            cast(subprocess.Popen, proc),
+            unit,
+            _target(),
+            ["/bin/sleep", "30"],
+        )
+        == 222
+    )
+
+
+def test_process_command_matches_shebang_interpreter(monkeypatch):
+    monkeypatch.setattr(
+        kb,
+        "_process_command_argv",
+        lambda pid: (
+            "/usr/bin/python3",
+            "/usr/local/bin/hermes",
+            "chat",
+            "-q",
+            "work",
+        ),
+    )
+
+    assert kb._process_command_matches(
+        222, ["/usr/local/bin/hermes", "chat", "-q", "work"]
+    )
+
+
+def test_default_spawn_receipt_reaches_spawned_event(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    captured = {}
+
+    class FakeProc:
+        pid = 6789
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return FakeProc()
+
+    def fake_scope_argv(cmd, task, **kwargs):
+        unit = kb._systemd_scope_unit_name(task.id, task.current_run_id)
+        captured["unit"] = unit
+        return [
+            "/usr/bin/systemd-run",
+            "--user",
+            "--scope",
+            "--unit=" + unit,
+            "--",
+            *cmd,
+        ], unit, _target()
+
+    monkeypatch.setattr(kb, "_systemd_scope_argv", fake_scope_argv)
+    monkeypatch.setattr(kb, "_verify_systemd_scope_worker_pid", lambda *args: 2468)
+    monkeypatch.setattr(kb.subprocess, "Popen", fake_popen)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="scoped", assignee="worker")
+        result = kb.dispatch_once(conn, spawn_fn=kb._default_spawn)
+        event = next(
+            event for event in kb.list_events(conn, task_id) if event.kind == "spawned"
+        )
+
+    assert result.spawned and result.spawned[0][0] == task_id
+    assert event.payload == {
+        "pid": 2468,
+        "launch_mode": "systemd-user-scope",
+        "scope_unit": captured["unit"],
+        "verification_status": "verified",
+    }
+    assert isinstance(kb._WorkerLaunchPid(6789), int)
+    assert captured["cmd"][0] == "/usr/bin/systemd-run"
+
+
+def test_native_systemd_scope_lifecycle_when_user_manager_is_available(kanban_home):
+    """Exercise the real unit/control-group boundary, not just argv shape."""
+    if not sys.platform.startswith("linux"):
+        pytest.skip("native systemd user scopes require Linux")
+    cgroup = kb._current_cgroup_path()
+    target = kb._systemd_user_manager_target_for_cgroup(cgroup)
+    if target is None:
+        pytest.skip("dispatcher is not in an authenticated user-service cgroup")
+    runner = kb.shutil.which("systemd-run")
+    if runner is None:
+        pytest.skip("systemd-run is unavailable")
+    version = kb._systemd_run_version(runner)
+    if version is None or version < kb._SYSTEMD_SCOPE_MIN_VERSION:
+        pytest.skip("systemd-run lacks required transient-scope support")
+    if not kb._systemd_user_manager_reachable(target):
+        pytest.skip("authenticated systemd user manager is unreachable")
+
+    scoped, unit, manager = kb._systemd_scope_argv(
+        ["/bin/sleep", "30"],
+        _task("native-lifecycle", 1),
+        cgroup_path=cgroup,
+        manager_target=target,
+        systemd_run=runner,
+        user_manager_ready=True,
+    )
+    assert unit is not None and manager is target
+    native_env = dict(os.environ)
+    native_env.update(kb._systemd_user_manager_environment(target))
+    proc = subprocess.Popen(
+        scoped,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=native_env,
+    )
+    try:
+        worker_pid = kb._verify_systemd_scope_worker_pid(
+            proc, unit, manager, ["/bin/sleep", "30"]
+        )
+        props = kb._systemd_scope_properties(unit, manager)
+        assert props is not None
+        control_group = props["ControlGroup"]
+        assert worker_pid in kb._systemd_scope_process_ids(control_group)
+        assert kb._process_cgroup_path(worker_pid) == control_group
+
+        with kb.connect() as conn:
+            task_id = kb.create_task(
+                conn,
+                title="native scope timeout",
+                assignee="worker",
+                max_runtime_seconds=1,
+            )
+            claimed = kb.claim_task(conn, task_id)
+            assert claimed is not None
+            kb._set_worker_pid(conn, task_id, worker_pid)
+            conn.execute(
+                "UPDATE task_runs SET started_at = ? WHERE id = ?",
+                (int(kb.time.time()) - 2, claimed.current_run_id),
+            )
+            conn.commit()
+            assert kb.enforce_max_runtime(conn) == [task_id]
+            task = kb.get_task(conn, task_id)
+            assert task is not None and task.status == "ready"
+        proc.wait(timeout=kb._SYSTEMD_SCOPE_CLEANUP_TIMEOUT)
+    finally:
+        kb._cleanup_systemd_scope_launch(proc, unit, manager)
+    assert proc.poll() is not None
+    props = kb._systemd_scope_properties(unit, manager)
+    assert props is None or props.get("LoadState") == "not-found"


### PR DESCRIPTION
## Summary

- launch Kanban workers through transient `systemd --user` scopes when the dispatcher is itself running under a same-UID user service
- verify the exact launched PID, scope unit, control group, manager UID, and active state before accepting the launch
- fail open to the existing direct spawn path when the host cannot prove that boundary, and route failed verification through the existing spawn-failure cleanup
- preserve the existing integer `worker_pid` and direct-launch event contract while adding truthful scope receipt fields

This is a current-main successor to the verified per-worker systemd-scope portion of #63073. It intentionally does not include the fleet-cap portion, which overlaps later scheduler work in #69942. Thanks to the original #63073 contributor for identifying and implementing the systemd-scope direction.

## Why

A worker launched directly by a long-lived dispatcher remains in the dispatcher's service cgroup. If the worker or one of its descendants survives the Python task lifecycle, process ownership and cleanup become ambiguous. A verified transient user scope gives each worker run a manager-owned cgroup boundary without changing behavior on unsupported or unverified hosts.

The scope path is deliberately gated: Linux only, same-UID user manager, dispatcher hosted by its own `.service`, and exact post-launch PID/cgroup verification. Any inability to prove those conditions preserves the direct launch behavior.

## Verification

- rebased onto upstream `main` at `d5e135a51353c2dbc489d5c2583158b22d8efd7b`; exact head `b3b692dab6f2f41790ef9783d655f73c0f27ec03`
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_worker_systemd_scope.py tests/hermes_cli/test_kanban_worker_spawn_toolsets.py tests/hermes_cli/test_kanban_worker_terminal_cwd.py tests/hermes_cli/test_kanban_worker_session_source.py tests/hermes_cli/test_kanban_boards.py` — 42 passed
- the native scope lifecycle ran under a real systemd user scope and verified that timeout/requeue terminates the persisted scoped worker PID
- `ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_worker_systemd_scope.py` — clean
- `python -m py_compile hermes_cli/kanban_db.py` — clean
- `git diff --check` — clean

## Boundaries

No deploy, service restart, live-runtime mutation, release-ref movement, merge, or auto-merge is included or implied.

