### PR TITLE
fix(gateway): scope channels page gateway status reads to profile (#71211)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -134,7 +134,9 @@ def _parse_branch_flag(value: Optional[str]) -> Optional[str]:
     return branch
 
 
-def _check_dispatcher_presence() -> tuple[bool, str]:
+def _check_dispatcher_presence(
+    hermes_home: Optional[Path] = None,
+) -> tuple[bool, str]:
     """Return ``(running, message)``.
 
     - ``running=True``: a gateway is alive for this HERMES_HOME and its
@@ -155,7 +157,9 @@ def _check_dispatcher_presence() -> tuple[bool, str]:
     except Exception:
         return (True, "")  # can't probe — silent
     try:
-        pid = get_running_pid()
+        pid = get_running_pid(
+            pid_path=hermes_home / "gateway.pid" if hermes_home else None
+        )
     except Exception:
         return (True, "")  # probe errored — silent
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8592,6 +8592,7 @@ def _messaging_platform_payload(
     env_on_disk: dict[str, str],
     runtime: dict | None,
     scoped: bool = False,
+    scoped_home: Path | None = None,
 ) -> dict[str, Any]:
     platform_id = entry["id"]
     runtime_platforms = runtime.get("platforms") if runtime else {}
@@ -8600,8 +8601,9 @@ def _messaging_platform_payload(
         if isinstance(runtime_platforms, dict)
         else {}
     )
+    pid_path = scoped_home / "gateway.pid" if scoped_home else None
     gateway_running = (
-        get_running_pid() is not None
+        get_running_pid(pid_path=pid_path) is not None
         or get_runtime_status_running_pid(runtime) is not None
     )
     env_vars = []
@@ -9609,13 +9611,16 @@ async def get_messaging_platforms(profile: Optional[str] = None):
     # all resolve against the requested profile's HERMES_HOME.
     with _profile_scope(profile) as scoped_dir:
         env_on_disk = load_env()
-        runtime = read_runtime_status()
+        runtime = read_runtime_status(
+            path=scoped_dir / "gateway_state.json" if scoped_dir else None
+        )
         return {
             "env_path": str(get_env_path()),
             "gateway_start_command": _gateway_display_command(profile, "start"),
             "platforms": [
                 _messaging_platform_payload(
-                    entry, env_on_disk, runtime, scoped=scoped_dir is not None
+                    entry, env_on_disk, runtime, scoped=scoped_dir is not None,
+                    scoped_home=scoped_dir,
                 )
                 for entry in _messaging_platform_catalog()
             ]
@@ -9751,7 +9756,9 @@ async def test_messaging_platform(platform_id: str, profile: Optional[str] = Non
     with _profile_scope(profile) as scoped_dir:
         env_on_disk = load_env()
         payload = _messaging_platform_payload(
-            entry, env_on_disk, read_runtime_status(), scoped=scoped_dir is not None
+            entry, env_on_disk, read_runtime_status(
+                path=scoped_dir / "gateway_state.json" if scoped_dir else None
+            ), scoped=scoped_dir is not None, scoped_home=scoped_dir,
         )
     if not payload["enabled"]:
         message = f"{entry['name']} is disabled. Enable it, then restart the gateway."


### PR DESCRIPTION
## Summary

Inside `_profile_scope`, `read_runtime_status()` and `get_running_pid()` in `_messaging_platform_payload` now resolve against the profile's HERMES_HOME via explicit path parameters, rather than defaulting to the process root which ignores the context-local override from `set_hermes_home_override`.

## Changes
- **`hermes_cli/web_server.py`**: `get_messaging_platforms` and `test_messaging_platform` now pass the scoped_dir path to `read_runtime_status()`; `_messaging_platform_payload` accepts `scoped_home` parameter and passes `pid_path` to `get_running_pid()`
- **`hermes_cli/kanban.py`**: `_check_dispatcher_presence` now accepts optional `hermes_home` parameter to resolve the correct PID file

## Test Plan
- ✅ All 126 gateway status tests pass
- ✅ All 516 web server tests pass
- ✅ Syntax checks pass on all modified files

Closes #71211