### PR TITLE
fix(tools): stop hermes doctor from executing poisoned SSH ProxyCommand hosts

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -26,6 +26,7 @@ load_hermes_dotenv(hermes_home=_env_path.parent, project_env=PROJECT_ROOT / ".en
 from hermes_cli.colors import Colors, color
 from hermes_cli.models import _HERMES_USER_AGENT
 from hermes_constants import OPENROUTER_MODELS_URL
+from tools.environments.ssh_destination import build_ssh_probe_command
 from utils import base_url_host_matches
 
 
@@ -199,6 +200,26 @@ def _fail_and_issue(text: str, detail: str, fix: str, issues: list[str]) -> None
     """Emit a check_fail and append the corresponding fix instruction."""
     check_fail(text, detail)
     issues.append(fix)
+
+
+def _doctor_ssh_probe_command(
+    ssh_host: str,
+    ssh_user: str | None = None,
+    ssh_port: str | None = None,
+    ssh_key: str | None = None,
+) -> list[str]:
+    """Build argv for the doctor SSH connectivity probe.
+
+    Raises ValueError when host/user would be parsed as OpenSSH options.
+    Always inserts ``--`` before the destination (defense in depth).
+    """
+    return build_ssh_probe_command(
+        ssh_host,
+        ssh_user,
+        port=ssh_port or None,
+        key=ssh_key,
+        connect_timeout=5,
+    )
 
 
 # Deprecated / legacy config keys still read for back-compat. Doctor surfaces
@@ -1731,27 +1752,31 @@ def run_doctor(args):
             ssh_user = os.getenv("TERMINAL_SSH_USER")
             ssh_port = os.getenv("TERMINAL_SSH_PORT")
             ssh_key = os.getenv("TERMINAL_SSH_KEY")
-            target = f"{ssh_user}@{ssh_host}" if ssh_user else ssh_host
-            cmd = ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes"]
-            if ssh_port:
-                cmd += ["-p", ssh_port]
-            if ssh_key:
-                cmd += ["-i", os.path.expanduser(ssh_key)]
-            cmd += [target, "echo ok"]
-            # Try to connect
             try:
-                result = subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    text=True, encoding='utf-8', errors='replace',
-                    timeout=15
+                cmd = _doctor_ssh_probe_command(ssh_host, ssh_user, ssh_port, ssh_key)
+            except ValueError as exc:
+                _fail_and_issue(
+                    "invalid SSH destination",
+                    f"({exc})",
+                    "Set TERMINAL_SSH_HOST / TERMINAL_SSH_USER to a real hostname/user "
+                    "(values must not start with '-')",
+                    issues,
                 )
-            except subprocess.TimeoutExpired:
-                result = None
-            if result is not None and result.returncode == 0:
-                check_ok(f"SSH connection to {ssh_host}")
             else:
-                _fail_and_issue(f"SSH connection to {ssh_host}", "", f"Check SSH configuration for {ssh_host}", issues)
+                # Try to connect
+                try:
+                    result = subprocess.run(
+                        cmd,
+                        capture_output=True,
+                        text=True, encoding='utf-8', errors='replace',
+                        timeout=15
+                    )
+                except subprocess.TimeoutExpired:
+                    result = None
+                if result is not None and result.returncode == 0:
+                    check_ok(f"SSH connection to {ssh_host}")
+                else:
+                    _fail_and_issue(f"SSH connection to {ssh_host}", "", f"Check SSH configuration for {ssh_host}", issues)
         else:
             _fail_and_issue(
                 "TERMINAL_SSH_HOST not set",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -22,6 +22,10 @@ from pathlib import Path
 from typing import Optional, Dict, Any
 
 from hermes_cli.nous_subscription import get_nous_subscription_features
+from tools.environments.ssh_destination import (
+    build_ssh_probe_command,
+    validate_ssh_identity,
+)
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 from utils import base_url_hostname
 from hermes_constants import get_optional_skills_dir
@@ -1416,46 +1420,68 @@ def setup_terminal_backend(config: dict):
         # SSH host
         current_host = get_env_value("TERMINAL_SSH_HOST") or ""
         host = prompt("  SSH host (hostname or IP)", current_host)
-        if host:
-            save_env_value("TERMINAL_SSH_HOST", host)
 
         # SSH user
         current_user = get_env_value("TERMINAL_SSH_USER") or ""
         user = prompt("  SSH user", current_user or os.getenv("USER", ""))
-        if user:
-            save_env_value("TERMINAL_SSH_USER", user)
 
         # SSH port
         current_port = get_env_value("TERMINAL_SSH_PORT") or "22"
         port = prompt("  SSH port", current_port)
-        if port and port != "22":
-            save_env_value("TERMINAL_SSH_PORT", port)
 
         # SSH key
         current_key = get_env_value("TERMINAL_SSH_KEY") or ""
         default_key = str(Path.home() / ".ssh" / "id_rsa")
         ssh_key = prompt("  SSH private key path", current_key or default_key)
-        if ssh_key:
-            save_env_value("TERMINAL_SSH_KEY", ssh_key)
 
-        # Test connection
-        if host and prompt_yes_no("  Test SSH connection?", True):
-            print_info("  Testing connection...")
-            import subprocess
+        # Validate destination before persisting — a leading-dash host/user
+        # would be treated as OpenSSH options (CWE-88) by doctor / runtime.
+        ssh_ok = True
+        probe_cmd = None
+        try:
+            dest = validate_ssh_identity(host, user)
+            if dest is not None:
+                probe_cmd = build_ssh_probe_command(
+                    host,
+                    user,
+                    port=port if port and port != "22" else None,
+                    key=ssh_key or None,
+                )
+        except ValueError as exc:
+            print_error(f"  Invalid SSH destination: {exc}")
+            print_info("  Not saved. Host/user must not start with '-'.")
+            ssh_ok = False
+            config.setdefault("terminal", {})["backend"] = current_backend
+            selected_backend = current_backend
 
-            ssh_cmd = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=5"]
-            if ssh_key:
-                ssh_cmd.extend(["-i", ssh_key])
+        if ssh_ok:
+            if host:
+                save_env_value("TERMINAL_SSH_HOST", host)
+            if user:
+                save_env_value("TERMINAL_SSH_USER", user)
             if port and port != "22":
-                ssh_cmd.extend(["-p", port])
-            ssh_cmd.append(f"{user}@{host}" if user else host)
-            ssh_cmd.append("echo ok")
-            result = subprocess.run(ssh_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10)
-            if result.returncode == 0:
-                print_success("  SSH connection successful!")
-            else:
-                print_warning(f"  SSH connection failed: {result.stderr.strip()}")
-                print_info("  Check your SSH key and host settings.")
+                save_env_value("TERMINAL_SSH_PORT", port)
+            if ssh_key:
+                save_env_value("TERMINAL_SSH_KEY", ssh_key)
+
+            # Test connection
+            if host and probe_cmd and prompt_yes_no("  Test SSH connection?", True):
+                print_info("  Testing connection...")
+                import subprocess
+
+                result = subprocess.run(
+                    probe_cmd,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=10,
+                )
+                if result.returncode == 0:
+                    print_success("  SSH connection successful!")
+                else:
+                    print_warning(f"  SSH connection failed: {result.stderr.strip()}")
+                    print_info("  Check your SSH key and host settings.")
 
     # Sync terminal backend to .env so terminal_tool picks it up directly.
     # config.yaml is the source of truth, but terminal_tool reads TERMINAL_ENV.

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1681,3 +1681,25 @@ terminal:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+class TestDoctorSshProbeArgv:
+    """CWE-88: leading-dash SSH destinations must not become OpenSSH options."""
+
+    def test_probe_command_inserts_double_dash_before_destination(self):
+        cmd = doctor_mod._doctor_ssh_probe_command(
+            "example.com", "alice", "2222", "~/.ssh/id_ed25519"
+        )
+        assert cmd[0] == "ssh"
+        dash = cmd.index("--")
+        assert cmd[dash + 1] == "alice@example.com"
+        assert cmd[dash + 2] == "echo ok"
+        assert "-p" in cmd and "2222" in cmd
+
+    def test_probe_command_rejects_leading_dash_host(self):
+        with pytest.raises(ValueError, match="must not start with"):
+            doctor_mod._doctor_ssh_probe_command("-oProxyCommand=evil")
+
+    def test_probe_command_rejects_leading_dash_user(self):
+        with pytest.raises(ValueError, match="must not start with"):
+            doctor_mod._doctor_ssh_probe_command("example.com", "-oProxyCommand=evil")

--- a/tests/hermes_cli/test_setup_ssh_destination.py
+++ b/tests/hermes_cli/test_setup_ssh_destination.py
@@ -1,0 +1,67 @@
+"""Setup terminal SSH identity persistence (CWE-88 option smuggling)."""
+
+from pathlib import Path
+
+import hermes_cli.setup as setup_mod
+
+
+def _select_ssh_backend(question, choices, default=0):
+    for i, choice in enumerate(choices):
+        if choice.startswith("SSH"):
+            return i
+    raise AssertionError(f"SSH choice missing from {choices!r}")
+
+
+def test_ssh_setup_rejects_leading_dash_host_without_persisting(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = {"terminal": {"backend": "local"}}
+    prompts = iter(
+        [
+            "-oProxyCommand=evil",  # host
+            "alice",  # user
+            "22",  # port
+            str(tmp_path / "id"),  # key
+        ]
+    )
+    saved = {}
+    monkeypatch.setattr(setup_mod, "prompt_choice", _select_ssh_backend)
+    monkeypatch.setattr(setup_mod, "prompt", lambda *a, **k: next(prompts))
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *a, **k: False)
+    monkeypatch.setattr(setup_mod, "save_config", lambda cfg: None)
+    monkeypatch.setattr(setup_mod, "save_env_value", lambda k, v: saved.__setitem__(k, v))
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda k: "")
+
+    setup_mod.setup_terminal_backend(config)
+
+    assert config["terminal"]["backend"] == "local"
+    assert "TERMINAL_SSH_HOST" not in saved
+    assert "TERMINAL_SSH_USER" not in saved
+    assert saved.get("TERMINAL_ENV") == "local"
+    assert "Invalid SSH destination" in capsys.readouterr().out
+
+
+def test_ssh_setup_rejects_leading_dash_user_even_when_host_blank(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = {"terminal": {"backend": "local"}}
+    prompts = iter(
+        [
+            "",  # host blank
+            "-oProxyCommand=evil",  # user
+            "22",
+            str(tmp_path / "id"),
+        ]
+    )
+    saved = {}
+    monkeypatch.setattr(setup_mod, "prompt_choice", _select_ssh_backend)
+    monkeypatch.setattr(setup_mod, "prompt", lambda *a, **k: next(prompts))
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *a, **k: False)
+    monkeypatch.setattr(setup_mod, "save_config", lambda cfg: None)
+    monkeypatch.setattr(setup_mod, "save_env_value", lambda k, v: saved.__setitem__(k, v))
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda k: "")
+
+    setup_mod.setup_terminal_backend(config)
+
+    assert config["terminal"]["backend"] == "local"
+    assert "TERMINAL_SSH_USER" not in saved
+    assert saved.get("TERMINAL_ENV") == "local"
+    assert "Invalid SSH destination" in capsys.readouterr().out

--- a/tests/tools/test_ssh_destination.py
+++ b/tests/tools/test_ssh_destination.py
@@ -1,0 +1,59 @@
+"""Tests for OpenSSH destination formatting (CWE-88 option smuggling)."""
+
+import pytest
+
+from tools.environments.ssh_destination import (
+    build_ssh_probe_command,
+    format_ssh_destination,
+)
+
+
+class TestFormatSshDestination:
+    def test_host_only(self):
+        assert format_ssh_destination("example.com") == "example.com"
+
+    def test_user_and_host(self):
+        assert format_ssh_destination("example.com", "alice") == "alice@example.com"
+
+    def test_blank_user_treated_as_host_only(self):
+        assert format_ssh_destination("example.com", "  ") == "example.com"
+
+    def test_rejects_empty_host(self):
+        with pytest.raises(ValueError, match="empty"):
+            format_ssh_destination("")
+
+    def test_rejects_leading_dash_host(self):
+        with pytest.raises(ValueError, match="must not start with"):
+            format_ssh_destination("-oProxyCommand=evil")
+
+    def test_rejects_leading_dash_user(self):
+        with pytest.raises(ValueError, match="must not start with"):
+            format_ssh_destination("example.com", "-oProxyCommand=evil")
+
+
+class TestBuildSshProbeCommand:
+    def test_includes_double_dash_and_echo(self):
+        cmd = build_ssh_probe_command("example.com", "alice", port="2222", key="~/.ssh/id")
+        assert cmd[0] == "ssh"
+        dash = cmd.index("--")
+        assert cmd[dash + 1] == "alice@example.com"
+        assert cmd[dash + 2] == "echo ok"
+        assert "-p" in cmd and "2222" in cmd
+
+
+class TestValidateSshIdentity:
+    def test_returns_destination_when_host_set(self):
+        from tools.environments.ssh_destination import validate_ssh_identity
+
+        assert validate_ssh_identity("h", "u") == "u@h"
+
+    def test_blank_host_ok_with_safe_user(self):
+        from tools.environments.ssh_destination import validate_ssh_identity
+
+        assert validate_ssh_identity("", "alice") is None
+
+    def test_blank_host_rejects_leading_dash_user(self):
+        from tools.environments.ssh_destination import validate_ssh_identity
+
+        with pytest.raises(ValueError, match="must not start with"):
+            validate_ssh_identity("", "-oProxyCommand=evil")

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -64,7 +64,7 @@ class TestBuildSSHCommand:
 
     def test_user_host_suffix(self):
         env = SSHEnvironment(host="h", user="u")
-        assert env._build_ssh_command()[-1] == "u@h"
+        assert env._build_ssh_command()[-2:] == ["--", "u@h"]
 
 
 class TestControlSocketPath:

--- a/tests/tools/test_ssh_environment_destination.py
+++ b/tests/tools/test_ssh_environment_destination.py
@@ -1,0 +1,62 @@
+"""SSHEnvironment argv safety for OpenSSH destination option smuggling."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tools.environments.ssh import SSHEnvironment
+from tools.environments.ssh_destination import format_ssh_destination
+
+
+def test_ssh_environment_rejects_leading_dash_host_before_connect(monkeypatch):
+    monkeypatch.setattr("tools.environments.ssh._ensure_ssh_available", lambda: None)
+    called = {"connect": False}
+
+    def _boom(self):
+        called["connect"] = True
+        raise AssertionError("must not connect with poisoned destination")
+
+    monkeypatch.setattr(SSHEnvironment, "_establish_connection", _boom)
+    with pytest.raises(ValueError, match="must not start with"):
+        SSHEnvironment(host="-oProxyCommand=evil", user="alice")
+    assert called["connect"] is False
+
+
+def test_build_ssh_command_places_double_dash_before_destination():
+    env = object.__new__(SSHEnvironment)
+    env.port = 22
+    env.key_path = ""
+    env.control_socket = Path("/tmp/hermes-ssh-test.sock")
+    env._destination = format_ssh_destination("example.com", "alice")
+    cmd = SSHEnvironment._build_ssh_command(env)
+    dash = cmd.index("--")
+    assert cmd[dash + 1] == "alice@example.com"
+    assert all(not arg.startswith("-oProxy") for arg in cmd)
+
+
+def test_scp_upload_places_double_dash_before_paths(monkeypatch):
+    env = object.__new__(SSHEnvironment)
+    env.port = 22
+    env.key_path = ""
+    env.control_socket = Path("/tmp/hermes-ssh-test.sock")
+    env._destination = format_ssh_destination("example.com", "alice")
+    monkeypatch.setattr(
+        SSHEnvironment,
+        "_build_ssh_command",
+        lambda self, extra_args=None: ["ssh", "--", "alice@example.com"],
+    )
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.setdefault("cmds", []).append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("tools.environments.ssh.subprocess.run", fake_run)
+    SSHEnvironment._scp_upload(env, "/local/file", "/home/alice/remote")
+    scp_cmds = [c for c in captured["cmds"] if c and c[0] == "scp"]
+    assert scp_cmds, "expected an scp subprocess"
+    cmd = scp_cmds[-1]
+    dash = cmd.index("--")
+    assert cmd[dash + 1] == "/local/file"
+    assert cmd[dash + 2] == "alice@example.com:/home/alice/remote"

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -17,6 +17,7 @@ from tools.environments.file_sync import (
     quoted_rm_command,
     unique_parent_dirs,
 )
+from tools.environments.ssh_destination import format_ssh_destination
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,9 @@ class SSHEnvironment(BaseEnvironment):
     def __init__(self, host: str, user: str, cwd: str = "~",
                  timeout: int = 60, port: int = 22, key_path: str = ""):
         super().__init__(cwd=cwd, timeout=timeout)
+        # Reject leading-dash host/user before any ssh/scp subprocess
+        # (OpenSSH option smuggling / CWE-88).
+        self._destination = format_ssh_destination(host, user)
         self.host = host
         self.user = user
         self.port = port
@@ -94,7 +98,7 @@ class SSHEnvironment(BaseEnvironment):
             cmd.extend(["-i", self.key_path])
         if extra_args:
             cmd.extend(extra_args)
-        cmd.append(f"{self.user}@{self.host}")
+        cmd.extend(["--", self._destination])
         return cmd
 
     def _establish_connection(self):
@@ -174,7 +178,7 @@ class SSHEnvironment(BaseEnvironment):
             scp_cmd.extend(["-P", str(self.port)])
         if self.key_path:
             scp_cmd.extend(["-i", self.key_path])
-        scp_cmd.extend([host_path, f"{self.user}@{self.host}:{remote_path}"])
+        scp_cmd.extend(["--", host_path, f"{self._destination}:{remote_path}"])
         result = subprocess.run(
             scp_cmd,
             capture_output=True,
@@ -360,7 +364,7 @@ class SSHEnvironment(BaseEnvironment):
         if self.control_socket.exists():
             try:
                 cmd = ["ssh", "-o", f"ControlPath={self.control_socket}",
-                       "-O", "exit", f"{self.user}@{self.host}"]
+                       "-O", "exit", "--", self._destination]
                 subprocess.run(
                     cmd,
                     capture_output=True,

--- a/tools/environments/ssh_destination.py
+++ b/tools/environments/ssh_destination.py
@@ -1,0 +1,84 @@
+"""Safe OpenSSH destination formatting.
+
+OpenSSH treats a destination that begins with ``-`` as an option (classic
+ProxyCommand / argv smuggling, CWE-88). Callers that build ``ssh``/``scp``
+argv from user config must use :func:`format_ssh_destination` and place
+``--`` before the destination.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def format_ssh_destination(host: str, user: str | None = None) -> str:
+    """Return ``user@host`` or ``host`` for an OpenSSH destination argument.
+
+    Raises:
+        ValueError: if host is empty or host/user starts with ``-``.
+    """
+    host_s = str(host or "").strip()
+    if not host_s:
+        raise ValueError("SSH host is empty")
+    if host_s.startswith("-"):
+        raise ValueError(
+            "SSH host must not start with '-' "
+            "(OpenSSH would parse it as an option)"
+        )
+    _reject_leading_dash_ssh_user(user)
+    user_s = str(user or "").strip()
+    if user_s:
+        return f"{user_s}@{host_s}"
+    return host_s
+
+
+def _reject_leading_dash_ssh_user(user: str | None) -> None:
+    user_s = str(user or "").strip()
+    if user_s.startswith("-"):
+        raise ValueError(
+            "SSH user must not start with '-' "
+            "(OpenSSH would parse it as an option)"
+        )
+
+
+def validate_ssh_identity(host: str | None, user: str | None = None) -> str | None:
+    """Validate SSH host/user from config.
+
+    Returns the OpenSSH destination when host is non-empty, else ``None``.
+    Always rejects a leading-dash user (even when host is blank) so setup
+    cannot persist ``TERMINAL_SSH_USER=-o...`` under ``TERMINAL_ENV=ssh``.
+    """
+    _reject_leading_dash_ssh_user(user)
+    host_s = str(host or "").strip()
+    if not host_s:
+        return None
+    return format_ssh_destination(host_s, user)
+
+
+def build_ssh_probe_command(
+    host: str,
+    user: str | None = None,
+    *,
+    port: str | None = None,
+    key: str | None = None,
+    connect_timeout: int = 5,
+) -> list[str]:
+    """Build argv for a BatchMode SSH connectivity probe (``echo ok``).
+
+    Raises ValueError when host/user would be parsed as OpenSSH options.
+    Always inserts ``--`` before the destination.
+    """
+    target = format_ssh_destination(host, user)
+    cmd = [
+        "ssh",
+        "-o",
+        f"ConnectTimeout={connect_timeout}",
+        "-o",
+        "BatchMode=yes",
+    ]
+    if port:
+        cmd += ["-p", str(port)]
+    if key:
+        cmd += ["-i", os.path.expanduser(key)]
+    cmd += ["--", target, "echo ok"]
+    return cmd


### PR DESCRIPTION
## What does this PR do?

Rejects OpenSSH destination option smuggling (CWE-88) when Hermes builds `ssh`/`scp` argv from `TERMINAL_SSH_HOST` / `TERMINAL_SSH_USER`. Without this fix, a poisoned host that starts with `-` (for example `-oProxyCommand=...`) is executed locally on every `hermes doctor` run when the SSH terminal backend is configured, with no confirmation prompt.

### Bug Cause

`hermes doctor` built `ssh` argv as a list ending with `user@host` (or bare host) and `echo ok`, but never inserted `--` before the destination and never rejected values starting with `-`. OpenSSH then parsed the "destination" as options. The same pattern existed in `hermes setup` SSH connectivity tests and `SSHEnvironment` ssh/scp/cleanup argv builders. Setup also persisted poisoned values before any validation.

### Reproduction Steps

1. Set `TERMINAL_ENV=ssh` and `TERMINAL_SSH_HOST=-oProxyCommand=cmd.exe /c echo PWNED` (or equivalent).
2. Run `hermes doctor` (or build the same argv and run `ssh -vvv ...`).
3. Observe OpenSSH debug output such as `Executing proxy command: exec cmd.exe /c echo PWNED`.

Expected: reject the destination (or at least treat it as a host after `--`), and never execute a local ProxyCommand from config.
Before fix: local ProxyCommand runs during the External Tools SSH check.

### Fix

- Add shared `tools/environments/ssh_destination.py` helpers: `format_ssh_destination`, `validate_ssh_identity`, `build_ssh_probe_command` (reject leading-dash host/user; always insert `--` before destination).
- Wire doctor, setup, and `SSHEnvironment` (ssh/scp/cleanup) through those helpers.
- Setup validates before `save_env_value` and rolls back the terminal backend on invalid identity (including blank host + dash-prefixed user).
- Regression tests cover helper behavior, doctor probe argv, setup persist/rollback, and SSHEnvironment/`scp` `--` placement.

## Related Issue

No issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tools/environments/ssh_destination.py` - shared safe destination + probe argv helpers
- `tools/environments/ssh.py` - validate on init; `--` before destination for ssh/scp/cleanup
- `hermes_cli/doctor.py` - fail closed on unsafe destination; probe via shared helper
- `hermes_cli/setup.py` - validate before persist; rollback backend on invalid identity
- `tests/tools/test_ssh_destination.py` - helper unit tests
- `tests/tools/test_ssh_environment_destination.py` - SSHEnvironment/`scp` argv tests
- `tests/tools/test_ssh_environment.py` - assert destination is preceded by `--`
- `tests/hermes_cli/test_doctor.py` - doctor probe argv regression
- `tests/hermes_cli/test_setup_ssh_destination.py` - setup persist/rollback regression

## How to Test

1. Manual: set a leading-dash `TERMINAL_SSH_HOST` and run `hermes doctor` - expect an invalid SSH destination failure and no local ProxyCommand execution.
2. Automated (already run locally, 32 passed in related files):

```bash
scripts/run_tests.sh \
  tests/tools/test_ssh_destination.py \
  tests/tools/test_ssh_environment_destination.py \
  tests/tools/test_ssh_environment.py \
  tests/hermes_cli/test_setup_ssh_destination.py \
  tests/hermes_cli/test_doctor.py -k SshProbe \
  -q
```

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I have updated relevant documentation - N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I have considered cross-platform impact - OpenSSH `--` and leading-dash rejection apply on Windows and POSIX
- [x] I have updated tool descriptions/schemas if I changed tool behavior - N/A
