### PR TITLE
fix(deps): patch high-severity npm advisories in lockfiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7747,16 +7747,16 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7134,9 +7134,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -14537,9 +14537,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -15247,9 +15247,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -15266,7 +15266,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

Targeted, lockfile-only bumps that clear two open high-severity Dependabot advisories without disturbing any application code.

- **postcss 8.5.15 → 8.5.23** (`website/package-lock.json`) — clears the source-map path-traversal disclosure, [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) (patched from 8.5.18). `nanoid` moves 3.3.12 → 3.3.16 as postcss's raised floor. The root lockfile's postcss is deliberately left to the open Dependabot PR #70861 to avoid duplication.
- **brace-expansion 5.0.7 → 5.0.8** (root `package-lock.json`) — clears the unbounded-expansion OOM DoS, CVE-2026-14257 / [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg). An in-range `^5` bump; dev-scoped.
- **brace-expansion 1.1.15 → 1.1.16** (`website/package-lock.json`) — the latest release on the 1.x line, which backports an opt-in `max` expansion limit.

## Why the website's brace-expansion cannot be fully cleared here

The advisory's only patched release is 5.0.8, and 5.x ships named exports only (`{ expand }`); it is no longer a callable default export. The website's 1.x copy is required by CommonJS consumers in the Docusaurus toolchain (e.g. `minimatch@3` calls `require("brace-expansion")(pattern)` directly), so forcing 5.0.8 via an override would break the site build — verified empirically. 1.1.16 is the best available mitigation on that line until the toolchain's dependents move to brace-expansion@5-compatible majors. The residual exposure is a build-time DoS in a static-site toolchain, not a runtime surface.

## Not included, and why

- **httplib2 < 0.32.0** (`uv.lock`) — already covered by open Dependabot PR #70862.
- **postcss in the root lockfile** — already covered by open Dependabot PR #70861.
- **react-router ≥ 7.12.0 RSC CSRF ([GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2))** — the only patched release is 8.3.0, which requires migrating `web/` to React Router v8 (an earlier attempt, #70958, was withdrawn by its author). That is an application migration, not a lockfile refresh, and deserves its own reviewed PR.

## Test plan

- [x] `npm ci && npm run build` in `website/` succeeds with the bumped lockfile (Docusaurus production build, exit 0).
- [x] `npm audit` in `website/` no longer flags postcss.
- [x] Root lockfile change verified as the single in-range `brace-expansion` entry bump (dev scope), produced with `npm update brace-expansion --package-lock-only`.
- [x] Diff audited by hand: 2 files, 14 insertions, 14 deletions — versions, integrity hashes, and postcss's `nanoid` floor only.
