### PR TITLE
fix(desktop): sync composer DOM to draft before saving queued edit

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1022,7 +1022,17 @@ export function ChatBar({
                       </Button>
                       <Button
                         className="h-6 rounded-md px-2 text-[0.68rem]"
-                        onClick={() => exitQueuedEdit('save')}
+                        onClick={() => {
+                          const editor = editorRef.current
+                          if (editor) {
+                            const domText = composerPlainText(editor)
+                            if (domText !== draftRef.current) {
+                              draftRef.current = domText
+                              setComposerText(domText)
+                            }
+                          }
+                          exitQueuedEdit('save')
+                        }}
                         type="button"
                       >
                         {t.common.save}


### PR DESCRIPTION
Fixes #57945

## Steps to Reproduce

1. Open any Desktop session and start a turn (the agent must be working)
2. While the agent is streaming, type a prompt in the composer and queue it (`Cmd+Shift+Enter`)
3. Open the queued prompt for editing (click it in the status stack)
4. Type additional characters — **do NOT press Enter**
5. Click **Save**

→ The saved text is missing the last keystrokes.

## Expected Behavior

Clicking Save should persist the complete text as visible in the editor, including characters typed immediately before clicking.

## Defect

`exitQueuedEdit('save')` reads `draftRef.current` directly. That ref is updated by a `requestAnimationFrame`-coalesced flush from the `contentEditable` DOM. If the flush hasn't fired yet (because rAF hasn't ticked), `draftRef` still holds the value from *before* the last keystrokes. The user loses their most recent input.

The `submitDraft` path (Enter key) already handles this correctly by syncing `editor → composerPlainText → draftRef` before acting — the Save button was missing that sync.

## Root Cause

In `apps/desktop/src/app/chat/composer/index.tsx`, the Save button's `onClick` handler at the queued-edit bar:

```tsx
onClick={() => exitQueuedEdit('save')}
```

No DOM sync before reading `draftRef`. Compare with the Enter-key path (lines ~598–602, ~620) which correctly syncs first:

```tsx
const domText = composerPlainText(editor)
if (domText !== draftRef.current) {
  draftRef.current = domText
  setComposerText(domText)
}
```

This is a **timing-sensitive but deterministic** bug — it depends on whether `requestAnimationFrame` fires between the last keystroke and the click. On fast machines it may not reproduce; on slower ones it's consistent.

## Fix

Add the identical DOM → draft sync pattern before `exitQueuedEdit('save')`:

```tsx
onClick={() => {
  const editor = editorRef.current
  if (editor) {
    const domText = composerPlainText(editor)
    if (domText !== draftRef.current) {
      draftRef.current = domText
      setComposerText(domText)
    }
  }
  exitQueuedEdit('save')
}}
```

This reuses the exact same pattern already established at lines 598–602 and 620 of the same file. No new abstraction, no behaviour change for any other code path.

## Verification

- [x] Fix applied to current `main` (37a27664)
- [x] Single file changed (`composer/index.tsx`), 11 lines added, 1 removed
- [x] No new dependencies, no config changes
- [x] Existing Enter-key save path untouched — this only adds the sync to the button path
- [x] Manual test: queue prompt → edit → add text → Save → text is complete
