### PR TITLE
fix(desktop): avoid transcript content-visibility memory growth

### DIFF
--- a/apps/desktop/scripts/perf/lib/cdp.mjs
+++ b/apps/desktop/scripts/perf/lib/cdp.mjs
@@ -13,6 +13,7 @@ export const SELECTORS = {
   composer: '[data-slot="composer-rich-input"]',
   threadViewport: '[data-slot="aui_thread-viewport"]',
   threadContent: '[data-slot="aui_thread-content"]',
+  threadGroup: '[data-slot="aui_thread-group"]',
   assistantMessage: '[data-slot="aui_assistant-message-root"]',
   turnPair: '[data-slot="aui_turn-pair"]',
   profileRail: '[data-slot="profile-rail"]',

--- a/apps/desktop/scripts/perf/scenarios/transcript.mjs
+++ b/apps/desktop/scripts/perf/scenarios/transcript.mjs
@@ -3,7 +3,7 @@
 // mount→paint time plus any longtasks the mount blocks the main thread with.
 // This is the "open a long session" path — a first-impression latency.
 
-import { sleep } from '../lib/cdp.mjs'
+import { SELECTORS, sleep } from '../lib/cdp.mjs'
 
 const OBSERVE = `
   (() => {
@@ -27,24 +27,57 @@ export default {
     const turns = Number(opts.turns ?? 200)
 
     await cdp.send('Runtime.enable')
-    await cdp.eval(OBSERVE)
 
-    const mountMs = await cdp.eval(`window.__PERF_DRIVE__.loadTranscript(${turns})`)
+    let mountMs
+    let longtasks
+    let groupVisibility
 
-    // Let post-mount longtasks (content-visibility passes, virtualizer) settle.
-    await sleep(1500)
+    try {
+      await cdp.eval(OBSERVE)
+      mountMs = await cdp.eval(`window.__PERF_DRIVE__.loadTranscript(${turns})`)
 
-    const longtasks = await cdp.eval('window.__TM__.longtasks')
-    await cdp.eval('try { window.__TM__.po && window.__TM__.po.disconnect() } catch {}')
-    await cdp.eval('window.__PERF_DRIVE__.reset()')
+      // Let post-mount work settle before checking the rendered transcript.
+      await sleep(1500)
 
-    return {
-      metrics: {
-        transcript_mount_ms: Math.round(mountMs * 10) / 10,
-        transcript_longtask_ms: Math.round(longtasks.reduce((a, b) => a + b, 0) * 10) / 10,
-        transcript_longtask_max_ms: Math.round((longtasks.length ? Math.max(...longtasks) : 0) * 10) / 10
-      },
-      detail: { turns, messages: turns * 2, longtasks: longtasks.length }
+      longtasks = await cdp.eval('window.__TM__.longtasks')
+      groupVisibility = await cdp.eval(`(() => {
+        const groups = [...document.querySelectorAll(${JSON.stringify(SELECTORS.threadGroup)})]
+        return {
+          count: groups.length,
+          nonVisible: groups.filter(group => getComputedStyle(group).contentVisibility !== 'visible').length
+        }
+      })()`)
+
+      if (!groupVisibility.count) {
+        throw new Error('transcript scenario rendered no thread groups')
+      }
+
+      if (groupVisibility.nonVisible) {
+        throw new Error(
+          `transcript rendered ${groupVisibility.nonVisible}/${groupVisibility.count} groups without content-visibility:visible`
+        )
+      }
+
+      return {
+        metrics: {
+          transcript_mount_ms: Math.round(mountMs * 10) / 10,
+          transcript_longtask_ms: Math.round(longtasks.reduce((a, b) => a + b, 0) * 10) / 10,
+          transcript_longtask_max_ms: Math.round((longtasks.length ? Math.max(...longtasks) : 0) * 10) / 10
+        },
+        detail: {
+          turns,
+          messages: turns * 2,
+          longtasks: longtasks.length,
+          renderedGroups: groupVisibility.count,
+          contentVisibilityNonVisibleGroups: groupVisibility.nonVisible
+        }
+      }
+    } finally {
+      try {
+        await cdp.eval('try { window.__TM__?.po?.disconnect() } catch {}')
+      } finally {
+        await cdp.eval('window.__PERF_DRIVE__?.reset()')
+      }
     }
   }
 }

--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildGroups, firstVisibleGroupIndex, isVirtualizedGroup, LIVE_TAIL_GROUPS, type MessageGroup } from './list'
+import { buildGroups, firstVisibleGroupIndex, type MessageGroup } from './list'
 
 // Signature rows are `${index}:${id}:${role}:${weight}` (see the useAuiState
 // selector in list.tsx).
@@ -78,35 +78,5 @@ describe('firstVisibleGroupIndex', () => {
 
   it('returns groups.length for an empty list', () => {
     expect(firstVisibleGroupIndex([], 60)).toBe(0)
-  })
-})
-
-describe('isVirtualizedGroup', () => {
-  it('never virtualizes the newest turns (the live tail)', () => {
-    const count = 20
-
-    for (let i = count - LIVE_TAIL_GROUPS; i < count; i++) {
-      expect(isVirtualizedGroup(i, count)).toBe(false)
-    }
-  })
-
-  it('virtualizes older turns that sit before the live tail', () => {
-    const count = 20
-
-    expect(isVirtualizedGroup(0, count)).toBe(true)
-    expect(isVirtualizedGroup(count - LIVE_TAIL_GROUPS - 1, count)).toBe(true)
-  })
-
-  it('keeps every turn rendered when the whole transcript fits in the tail', () => {
-    const count = LIVE_TAIL_GROUPS
-
-    for (let i = 0; i < count; i++) {
-      expect(isVirtualizedGroup(i, count)).toBe(false)
-    }
-  })
-
-  it('honors a custom tail size', () => {
-    expect(isVirtualizedGroup(5, 10, 3)).toBe(true)
-    expect(isVirtualizedGroup(7, 10, 3)).toBe(false)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -113,27 +113,6 @@ export function firstVisibleGroupIndex(groups: readonly MessageGroup[], budget: 
   return firstVisible
 }
 
-// content-visibility:auto skips off-screen turns for perf, but with
-// contain-intrinsic-size:auto the browser only remembers a turn's size AFTER
-// it has rendered. A turn that finishes streaming near the bottom may have had
-// its (smaller) mid-stream size remembered; when it scrolls just off the top
-// edge and gets skipped, it snaps back to that stale height, shifting content
-// down. With overflow-anchor:none (the viewport can't self-correct) the
-// stick-to-bottom lock drifts and the view creeps up over older turns — the
-// "long session eventually shows old responses" glitch.
-//
-// Keep the newest N turns always-rendered so a turn is only ever virtualized
-// once its layout has settled at its final size (remembered == real → skipping
-// it changes no height). Off-screen OLDER turns still skip, so the dialog/popover
-// recalc win on long transcripts is preserved (that scales with the hundreds of
-// old turns, not this small live tail).
-export const LIVE_TAIL_GROUPS = 6
-
-/** True when a visible group is old enough to virtualize (outside the live tail). */
-export function isVirtualizedGroup(indexInVisible: number, visibleCount: number, liveTail = LIVE_TAIL_GROUPS): boolean {
-  return indexInVisible < visibleCount - liveTail
-}
-
 const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   clampToComposer,
   components,
@@ -380,28 +359,15 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
                 {t.assistant.thread.showEarlier}
               </button>
             )}
-            {visibleGroups.map((group, indexInVisible) => (
-              // content-visibility:auto — off-screen turns skip style recalc,
-              // layout, and paint. On a long transcript this is what keeps
-              // UNRELATED UI fast: any dialog/popover mount (Radix Presence
-              // reads getComputedStyle) forces a whole-document style recalc,
-              // measured ~650-730ms per open on a 1300-message session and
-              // ~100-200ms with this on. contain-intrinsic-size keeps a
-              // placeholder height for never-rendered turns (auto: remembered
-              // real size once rendered), so scrollbar/anchoring stay stable.
-              // Sticky human bubbles are unaffected — their turn is rendered
-              // whenever any part of it intersects the viewport.
-              //
-              // The live tail (newest turns) is exempt: virtualizing a turn
-              // whose final size hasn't been remembered yet snaps it to a stale
-              // height when it scrolls off, drifting stick-to-bottom up over old
-              // turns. See isVirtualizedGroup.
+            {visibleGroups.map(group => (
+              // Keep every budgeted group in normal Chromium layout.
+              // content-visibility:auto can trigger unbounded native renderer memory
+              // growth on long transcripts (#69180); exempting only the live tail
+              // still leaves older groups on that path. The part budget above limits initial
+              // DOM work without relying on Chromium's content-visibility machinery.
               <div
-                className={cn(
-                  'flex min-w-0 flex-col gap-(--conversation-turn-gap) pb-(--conversation-turn-gap)',
-                  isVirtualizedGroup(indexInVisible, visibleGroups.length) &&
-                    '[contain-intrinsic-size:auto_37.5rem] [content-visibility:auto]'
-                )}
+                className="flex min-w-0 flex-col gap-(--conversation-turn-gap) pb-(--conversation-turn-gap)"
+                data-slot="aui_thread-group"
                 key={group.id}
               >
                 <MessageRenderBoundary resetKey={messageSignature}>


### PR DESCRIPTION
## Summary

- stop applying Chromium `content-visibility:auto` / `contain-intrinsic-size` to desktop transcript groups
- keep the existing 300-part render-budget behavior, first-paint budget, and “Show earlier” paging unchanged
- remove the now-obsolete live-tail virtualization policy and its unit tests
- extend the real Electron transcript perf scenario with a computed-style invariant that requires every rendered group to use normal `content-visibility:visible` layout

## Related issue

Related to #69180. This draft addresses the transcript `content-visibility` path discussed there; it does not yet claim to reproduce or fully resolve that report's distinct empty-chat case.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (improves runtime regression coverage)

## Changes made

- `apps/desktop/src/components/assistant-ui/thread/list.tsx`: remove transcript-group content visibility while retaining the existing part-budget/paging behavior
- `apps/desktop/src/components/assistant-ui/thread/list.test.ts`: remove obsolete live-tail policy tests
- `apps/desktop/scripts/perf/lib/cdp.mjs`: centralize the stable thread-group selector
- `apps/desktop/scripts/perf/scenarios/transcript.mjs`: assert real computed styles and guarantee cleanup on failure

## Why the existing live-tail mitigation is insufficient

#69019 exempted the newest six groups while retaining `content-visibility:auto` for older rendered groups. On the affected Windows system, those older groups still exercise the Chromium path associated with unbounded native renderer memory growth. The partial live-tail mitigation also did not stop Electron main-process growth during the same run.

The existing part-based render budget still limits the initial transcript work without relying on Chromium content visibility. “Show earlier” can intentionally reveal additional groups, so this is not a strict permanent DOM cap. This change deliberately prefers normal rendering with the existing paging behavior over a CSS optimization that can make the desktop unusable on long sessions.

## Related open work

#69275 independently limits initial long-session rendering to at most 20 semantic groups and substantially improves long tool-session responsiveness, but explicitly retains #69019's live-tail `content-visibility` behavior. This draft has not yet been rebased or benchmarked on top of #69275. If that PR lands first, this change should be retested on its smaller rendered group set; that combination may reduce the responsiveness cost observed here.

## Reproduction and measured result

Affected system:

- Windows 11 Pro, build 26200
- Hermes Desktop 0.17.0
- Electron 40.10.2 / Chromium 144
- Intel UHD Graphics 770 + NVIDIA GeForce RTX 4070
- 64 GiB RAM; 35–39 GiB remained free during the failures
- long real session: 653 messages and approximately 1.6 million transcript characters

Private-memory samples from controlled restarts of the same long session:

| Build | Duration | Main final | Renderer final | Result |
|---|---:|---:|---:|---|
| unpatched | ~5 min | 3.40 GiB | 2.10 GiB | ~5.5 GiB combined and still growing |
| heartbeat guards + #69019 live-tail mitigation | 3 min | 1,890.3 MiB | 2,050.9 MiB | still growing |
| same build with transcript `content-visibility` fully disabled | 3 min | 87.0 MiB | 224.6 MiB | stabilized after warm-up |

Final renderer series after the change:

```text
145.1 → 246.3 → 234.0 → 225.4 → 224.8 → 224.6 → 224.6 MiB
```

This is an 89.0% lower renderer final value and a 95.4% lower main final value than the partial live-tail run. Windows also recorded `RADAR_PRE_LEAK_64` for `Hermes.exe` during the original failure; no system-wide memory exhaustion was present.

### User-visible failure mode

On the affected Windows machine, the user observed that allowing the growth to continue eventually made the desktop unresponsive and led to a crash/termination. Windows recorded `RADAR_PRE_LEAK_64` for `Hermes.exe`, which is consistent with runaway process-memory growth. The retained Windows logs do not identify a specific stack overflow, buffer overflow, or V8 OOM exception for that event, so this draft does not claim one of those exact termination mechanisms.

## Regression coverage

The transcript perf scenario now inspects the computed style of real rendered thread groups in Electron:

- before the production change: **RED**, `24/30` rendered groups used `content-visibility:auto`
- after the production change: **GREEN**, every rendered group computes to `content-visibility:visible`

The check uses computed browser behavior rather than reading source text or testing a dead policy helper.

## How to test

From `apps/desktop`:

```bash
npm run typecheck
npx eslint scripts/perf/lib/cdp.mjs scripts/perf/scenarios/transcript.mjs src/components/assistant-ui/thread/list.tsx src/components/assistant-ui/thread/list.test.ts
npm run test:ui -- --run src/components/assistant-ui/thread/list.test.ts
node --check scripts/perf/lib/cdp.mjs
node --check scripts/perf/scenarios/transcript.mjs
npm run build
npm run perf -- transcript --spawn --prod --turns 200
```

The focused unit test should report 8/8 passing. The Electron transcript scenario should reach metric evaluation with `contentVisibilityNonVisibleGroups: 0`; on machines compared with the committed `darwin-arm64` baseline it may still exit non-zero on the documented longtask thresholds.

For manual verification, open a long real transcript, switch sessions, scroll to the bottom, use “Show earlier”, and open dialogs/popovers while sampling Electron main/renderer private memory. The Windows evidence below used controlled restarts of the same 653-message session.

## Validation performed

Passed:

- focused `list.test.ts`: 8/8
- TypeScript (`tsc` for renderer, Electron, and E2E configs)
- focused ESLint and Prettier
- `git diff --check`
- full production build and `assert-dist-built`
- real three-minute installed-app Windows memory trace shown above

Not fully green on this Windows environment:

- UI suite with valid local-storage backing: 2,187 passed, 6 failed, 1 skipped. The same command on unchanged `origin/main` produced 2,189 passed, 8 failed, 1 skipped. The PR has four fewer tests because the obsolete live-tail policy tests are removed, and it introduces no new failing UI test. The remaining failures are locale/fixture/timing expectations outside this diff (notably `de-DE` number/month formatting).
- Electron suite: 699 passed, 26 failed, 2 skipped. The failures are Windows/POSIX path, permission, SSH, and concurrent Git-fixture issues outside the four files in this diff; this suite is not claimed as green.

### Known performance trade-off / draft blocker

The production transcript perf run confirmed the invariant but exceeded the committed macOS longtask baseline:

| Metric | This Windows run | committed macOS baseline | Result |
|---|---:|---:|---|
| transcript mount | 285.5 ms | 145 ms | within configured tolerance |
| total transcript longtasks | 737 ms | 82 ms | regression |
| max transcript longtask | 214 ms | 82 ms | regression |

The committed baseline is `darwin-arm64`, so this is not a controlled same-machine before/after benchmark. It nevertheless shows that removing the optimization has a real responsiveness cost and is why this PR is intentionally a **Draft**. A production-quality merge decision should compare before/after on the same Windows, Linux, and macOS machines and may ultimately require replacing CSS content visibility with a real transcript virtualizer.

## Platform and client scope

- **Windows desktop:** memory fix reproduced and verified on real hardware
- **Linux desktop:** #69180 reports the same failure class, but this patch has not yet been run there
- **macOS desktop:** not yet validated
- **CLI, TUI, gateway, Telegram/Discord/Slack, and other non-Electron clients:** unaffected; this diff is confined to four desktop React/perf-harness files

The code change itself is OS-neutral and removes a Chromium CSS optimization rather than adding platform branches. That supports cross-platform applicability, but this draft does **not** claim universal validation yet.

## Follow-up validation requested

- same-machine production transcript perf comparison before/after on Windows
- Linux Electron memory soak and interaction benchmark
- macOS arm64/x64 memory soak and interaction benchmark
- 30-minute idle and active-stream long-session traces
- session switching, scroll-to-bottom, “Show earlier”, dialogs, and popovers
- CI results and maintainer review of the performance trade-off

## Checklist

### Code

- [x] I've read the Contributing Guide and the root/Desktop `AGENTS.md` files
- [x] My commit message follows Conventional Commits: `fix(desktop): avoid transcript content-visibility memory growth`
- [x] I searched open and merged issues/PRs and documented #69019, #69180, #69275, and #69376
- [x] The PR contains only the four desktop files related to this fix
- [ ] `pytest tests/ -q` passes — not run because this is a JS-only desktop diff; the repository change classifier places `.ts`/`.tsx`/`.mjs` behavior coverage in the JS suite
- [x] I've added a real Electron computed-style regression invariant
- [x] I've tested on Windows 11 Pro build 26200
- [ ] The complete desktop `npm run check` passes — it remains non-green on this Windows environment for documented local-storage, locale, path, permission, and fixture failures outside this diff

### Documentation & housekeeping

- [x] Documentation update: N/A; no user-facing configuration or documented behavior changes
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow rules changed
- [x] Cross-platform impact considered and explicitly scoped above
- [x] Tool descriptions/schemas: N/A; no model tool behavior changed

## AI-assisted investigation disclosure

Reproduction, diagnosis, patch development, and runtime verification were performed interactively with **Hermes Agent using OpenAI GPT-5.6 Sol at high reasoning effort**. All measurements above come from real executions on the affected Windows machine and were reviewed by the human submitter, **@Puma7**. No conversation contents, credentials, tokens, or raw private logs are included.
