### PR TITLE
fix(tests): stop the suite writing into the operator's real Hermes logs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,9 +20,12 @@ test runner at ``scripts/run_tests.sh``.
 """
 
 import asyncio
+import atexit
 import os
+import shutil
 import sqlite3
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -31,6 +34,35 @@ import pytest
 PROJECT_ROOT = Path(__file__).parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+
+# ── Sandbox HERMES_HOME before ANY test module is imported ──────────────────
+# `hermes_cli/main.py` calls `setup_logging()` at MODULE level, which resolves
+# `get_hermes_home()` and attaches rotating file handlers to the ROOT logger.
+# So merely importing it - which many test modules do, directly or
+# transitively - points the whole pytest session's logging at the operator's
+# real `~/.hermes/logs/agent.log` and `errors.log`.
+#
+# The `_isolate_env` fixture below also sandboxes HERMES_HOME, but fixtures run
+# AFTER collection imports test modules, by which point the handler already
+# holds an absolute path to the real log. Measured on a live install: 126
+# warnings in the operator's agent.log came from test runs, not the gateway -
+# enough noise to make genuine warnings hard to find.
+#
+# conftest is imported before any test module, so setting it here closes that
+# window. The per-test fixture still applies for everything after import.
+if not os.environ.get("HERMES_HOME"):
+    _SESSION_HERMES_HOME = tempfile.mkdtemp(prefix="hermes-test-home-")
+    os.environ["HERMES_HOME"] = _SESSION_HERMES_HOME
+    atexit.register(shutil.rmtree, _SESSION_HERMES_HOME, True)
+
+#: HERMES_HOME as it stood when conftest was imported - i.e. before any test
+#: module could import code that configures logging. Recorded so the guard in
+#: tests/test_log_isolation.py can assert the sandbox existed AT THAT MOMENT.
+#: Reading os.environ from inside a test is useless here: the per-test
+#: `_isolate_env` fixture has sandboxed it by then, so the check would pass
+#: even with this block removed.
+HERMES_HOME_AT_CONFTEST_IMPORT = os.environ.get("HERMES_HOME", "")
 
 
 # ── Per-file process isolation ──────────────────────────────────────────────

--- a/tests/test_log_isolation.py
+++ b/tests/test_log_isolation.py
@@ -1,0 +1,88 @@
+"""The test suite must never write into the operator's real Hermes logs.
+
+`hermes_cli/main.py` calls `setup_logging()` at module scope, which resolves
+`get_hermes_home()` and attaches rotating file handlers to the ROOT logger.
+Importing it - which many test modules do, directly or transitively - wires
+the whole pytest session's logging to `<HERMES_HOME>/logs/agent.log`.
+
+If HERMES_HOME is not already sandboxed at that moment, that is the
+operator's real log. Measured on a live install, 126 warnings in a personal
+`agent.log` came from test runs rather than the running gateway: phantom
+`FakeTree` Discord failures and `rejected invalid API key` entries from
+`test_api_server_runs.py`. Noise like that makes genuine warnings hard to
+find precisely when someone is debugging.
+
+The per-test env fixture cannot close this: fixtures run after collection has
+imported the test modules, and by then the handler holds an absolute path.
+`tests/conftest.py` sets HERMES_HOME at module scope for that reason - this
+guards the property so a refactor cannot quietly undo it.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _real_hermes_home() -> Path:
+    """Where the operator's logs live, ignoring any test sandboxing."""
+    return Path.home() / ".hermes"
+
+
+def _all_file_destinations() -> list[str]:
+    """Every file path the root logger can reach, including via a QueueHandler.
+
+    Logging is routed through a queue, so the file handlers hang off the
+    listener rather than the root logger - checking `root.handlers` alone
+    reports nothing and looks falsely clean.
+    """
+    seen: list[str] = []
+
+    def collect(handlers) -> None:
+        for handler in handlers or ():
+            path = getattr(handler, "baseFilename", None)
+            if path:
+                seen.append(str(path))
+            listener = getattr(handler, "listener", None)
+            if listener is not None:
+                collect(getattr(listener, "handlers", ()))
+
+    collect(logging.getLogger().handlers)
+
+    try:
+        import hermes_logging
+
+        listener = getattr(hermes_logging, "_queue_listener", None)
+        if listener is not None:
+            collect(getattr(listener, "handlers", ()))
+    except Exception:
+        pass
+
+    return seen
+
+
+class TestLogIsolation:
+    def test_hermes_home_is_sandboxed_before_imports(self):
+        # Deliberately NOT os.environ: by test time the per-test `_isolate_env`
+        # fixture has sandboxed HERMES_HOME, so reading it here would pass even
+        # with the conftest block deleted. Assert the value captured at conftest
+        # import, which is the moment that actually matters.
+        from tests.conftest import HERMES_HOME_AT_CONFTEST_IMPORT as home
+
+        assert home, "conftest must set HERMES_HOME before test modules import"
+        assert Path(home).resolve() != _real_hermes_home().resolve(), (
+            f"HERMES_HOME pointed at the operator's real home ({home}) when "
+            "conftest loaded; import-time setup_logging() writes to their agent.log"
+        )
+
+    def test_importing_the_cli_does_not_target_the_real_logs(self):
+        pytest.importorskip("hermes_cli.main")
+
+        real_logs = str(_real_hermes_home() / "logs")
+        offenders = [p for p in _all_file_destinations() if p.startswith(real_logs)]
+
+        assert offenders == [], (
+            "the test session is writing into the operator's real Hermes logs:\n  "
+            + "\n  ".join(offenders)
+        )


### PR DESCRIPTION
## The problem

Running the test suite writes into the developer's **real** `~/.hermes/logs/agent.log` and `errors.log`.

`hermes_cli/main.py` calls `setup_logging()` at module scope. That resolves `get_hermes_home()` and attaches rotating file handlers to the ROOT logger through a `QueueHandler`. So merely *importing* it — which many test modules do, directly or transitively — points the entire pytest session's logging at the operator's real files.

Verified by importing it in a clean interpreter and walking the queue listener:

```
queue listener targets:
   _ManagedRotatingFileHandler -> /Users/<me>/.hermes/logs/agent.log
   _ManagedRotatingFileHandler -> /Users/<me>/.hermes/logs/errors.log
```

(Checking `root.handlers` alone shows nothing useful — the file handlers hang off the listener, so a naive look reports a falsely clean result.)

The `_isolate_env` fixture already sandboxes `HERMES_HOME`, but **fixtures run after collection has imported the test modules**, and by then the handler holds an absolute path.

## Why it matters

Measured on a live install: **126 warnings in a personal `agent.log` came from test runs, not the running gateway.**

- 69 × `[Discord] Failed to register /skill command: 'FakeTree' object has no attribute 'add_command'` — `FakeTree` exists only in `tests/gateway/`
- 57 × `API server rejected invalid API key` — the paths use a literal `run_any` id that exists only in `tests/gateway/test_api_server_runs.py`

Phantom failures in an operator's log make genuine warnings hard to find precisely when someone is debugging a real problem. It also silently interleaves test output into a file people attach to bug reports.

## The fix

`conftest.py` is imported before any test module, so sandboxing `HERMES_HOME` there closes the window. The per-test fixture still applies for everything after import.

Four lines, guarded so an explicitly-set `HERMES_HOME` (CI, deliberate runs) is respected, with the tempdir cleaned up at exit.

## Bonus: fixes 4 pre-existing failures

`tests/gateway/test_channel_directory.py::TestBuildFromSessions` (4 tests) was reading the operator's **real** sessions data for the same reason. They pass with this change.

## Verification

Full `tests/gateway` + `tests/tools`, both directions:

| | failures |
| --- | --- |
| clean `origin/main` | 66 |
| with this change | **62** |
| **new failures introduced** | **0** |

## The guard

`tests/test_log_isolation.py` asserts the value captured **at conftest import**, not `os.environ` at test time.

That distinction is the whole test: my first version read `os.environ` inside the test and **passed even with the fix deleted**, because the per-test fixture has sandboxed it by then. Confirmed the current version fails with the conftest block disabled and passes with it restored.
