### PR TITLE
docs(tools-reference): fix stale feishu_comment.py path

### DIFF
--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -64,7 +64,7 @@ These two tools live in the `browser` toolset but only register when a Chrome De
 
 ## `feishu_doc` toolset
 
-Scoped to the Feishu document-comment intelligent-reply handler (`gateway/platforms/feishu_comment.py`). Not exposed on `hermes-cli` or the regular Feishu chat adapter.
+Scoped to the Feishu document-comment intelligent-reply handler (`plugins/platforms/feishu/feishu_comment.py`). Not exposed on `hermes-cli` or the regular Feishu chat adapter.
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/tools-reference.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/tools-reference.md
@@ -64,7 +64,7 @@ description: "Hermes 内置工具权威参考，按工具集分组"
 
 ## `feishu_doc` 工具集
 
-仅限飞书文档评论智能回复处理器（`gateway/platforms/feishu_comment.py`）使用。不在 `hermes-cli` 或常规飞书聊天适配器中暴露。
+仅限飞书文档评论智能回复处理器（`plugins/platforms/feishu/feishu_comment.py`）使用。不在 `hermes-cli` 或常规飞书聊天适配器中暴露。
 
 | 工具 | 描述 | 所需环境 |
 |------|------|----------|


### PR DESCRIPTION
## What does this PR do?

Fixes a stale file path in the tools-reference documentation (English and Chinese locale mirrors).

The `feishu_doc` toolset description references `gateway/platforms/feishu_comment.py`, which no longer exists. The Feishu platform was migrated from `gateway/platforms/` to `plugins/platforms/` in PR #49408, so the correct path is `plugins/platforms/feishu/feishu_comment.py`.

## Related Issue

Self-sourced docs drift found by path verification against the current `main` branch.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/reference/tools-reference.md` (line 67): updated `gateway/platforms/feishu_comment.py` → `plugins/platforms/feishu/feishu_comment.py`
- `website/i18n/zh-Hans/.../reference/tools-reference.md` (line 67): same fix in the Chinese locale mirror

## How to Test

1. `git show plugins/platforms/feishu/feishu_comment.py` — confirms the file exists at the new path
2. `ls gateway/platforms/feishu_comment.py` — confirms the old path does not exist
3. `grep -r "gateway/platforms/feishu_comment" website/` — confirms no remaining stale references

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (docs-only)
- [ ] I've added tests for my changes — N/A (docs-only)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A