### PR TITLE
docs(cron): fix stale cron provider discovery path

### DIFF
--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -114,7 +114,7 @@ The active provider is chosen by the `cron.provider` config key:
   historical in-process loop calling `scheduler.tick()` every 60 seconds. This
   is byte-identical to the pre-provider behavior.
 - **a named provider** (e.g. `chronos`, a managed-cron provider for
-  scale-to-zero deployments) → discovered from `plugins/cron/<name>/` or
+  scale-to-zero deployments) → discovered from `plugins/cron_providers/<name>/` or
   `$HERMES_HOME/plugins/<name>/`.
 
 If a named provider is missing, fails to load, or reports `is_available() ==

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -560,7 +560,7 @@ The cron **trigger** is pluggable via the `cron.provider` config key. Empty
 (the default) uses the built-in in-process ticker. Set it to `chronos` (the
 NAS-managed provider for scale-to-zero hosted gateways) — configured via the
 `cron.chronos.*` keys (`portal_url`, `callback_url`, `expected_audience`,
-`nas_jwks_url`) — or name a custom provider under `plugins/cron/<name>/` or
+`nas_jwks_url`) — or name a custom provider under `plugins/cron_providers/<name>/` or
 `$HERMES_HOME/plugins/<name>/`. An unknown or unavailable provider falls back to
 the built-in, so cron is never left without a trigger. See the
 [cron internals](../developer-guide/cron-internals.md#gateway-integration) doc.


### PR DESCRIPTION
## What does this PR do?

Fixes stale file paths in two documentation files that reference the wrong directory for custom cron provider discovery.

Both `cli-commands.md` and `cron-internals.md` reference `plugins/cron/<name>/` as the location for custom cron providers, but the actual directory was renamed to `plugins/cron_providers/` during the cron provider refactor. The code in `plugins/cron_providers/__init__.py` confirms this: `"1. Bundled providers: plugins/cron_providers/<name>/ (shipped with hermes-agent)"`.

## Related Issue

Self-sourced docs drift found by path verification against the current `main` branch.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/reference/cli-commands.md` (line 563): updated `plugins/cron/<name>/` → `plugins/cron_providers/<name>/`
- `website/docs/developer-guide/cron-internals.md` (line 117): updated `plugins/cron/<name>/` → `plugins/cron_providers/<name>/`

## How to Test

1. `ls plugins/cron_providers/` — confirms the directory exists at the correct path
2. `ls plugins/cron/` — confirms the old path does not exist
3. `grep -rn "plugins/cron/<name>" website/docs/` — confirms no remaining stale references
4. `grep "cron_providers" plugins/cron_providers/__init__.py` — confirms the code documents the correct path

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (docs-only)
- [ ] I've added tests for my changes — N/A (docs-only)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A