### PR TITLE
fix(tui_gateway): persist crash-recovery attempts before agent initialization to enforce the auto-continue loop limit

### DIFF
--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -28,6 +28,7 @@ from tui_gateway import server
 from tui_gateway.turn_marker import (
     clear_turn_marker,
     read_turn_marker,
+    record_auto_continue_attempt,
     record_turn_start,
 )
 
@@ -145,6 +146,26 @@ def test_marker_survives_corrupt_sidecar(tmp_path):
     assert read_turn_marker(tmp_path, "abc") is None
     record_turn_start(tmp_path, "abc", "prompt")
     assert read_turn_marker(tmp_path, "abc")["prompt"] == "prompt"
+
+
+def test_attempt_update_does_not_overwrite_a_newer_turn(tmp_path):
+    record_turn_start(tmp_path, "abc", "interrupted prompt")
+    interrupted = read_turn_marker(tmp_path, "abc")
+    assert interrupted is not None
+    record_turn_start(tmp_path, "abc", "new user prompt")
+
+    updated = record_auto_continue_attempt(
+        tmp_path,
+        "abc",
+        prompt=interrupted["prompt"],
+        started_at=interrupted["started_at"],
+        attempts=1,
+    )
+
+    assert updated is False
+    marker = read_turn_marker(tmp_path, "abc")
+    assert marker["prompt"] == "new user prompt"
+    assert marker["attempts"] == 0
 
 
 # ── Turn lifecycle owns the marker ─────────────────────────────────────
@@ -369,7 +390,7 @@ def test_double_schedule_is_guarded(emits, schedule_env, marker_home):
     assert len(schedule_env) == 1
 
 
-def test_failed_agent_build_leaves_marker_for_retry(
+def test_failed_agent_build_counts_toward_crash_loop_limit(
     emits, schedule_env, marker_home, monkeypatch
 ):
     record_turn_start(marker_home, "session-key", "prompt")
@@ -378,14 +399,34 @@ def test_failed_agent_build_leaves_marker_for_retry(
         "_wait_agent",
         lambda session, rid, timeout=30.0: {"error": {"message": "boom"}},
     )
-    session = _session()
 
-    result = server._maybe_schedule_auto_continue("sid", session, "session-key")
+    first_session = _session()
+    first = server._maybe_schedule_auto_continue("sid-1", first_session, "session-key")
 
-    assert result is not None
+    assert first is not None
     assert not schedule_env
-    assert session["_auto_continue_scheduled"] is False
-    assert read_turn_marker(marker_home, "session-key") is not None
+    assert first_session["_auto_continue_scheduled"] is False
+    marker = read_turn_marker(marker_home, "session-key")
+    assert marker is not None
+    assert marker["attempts"] == 1
+
+    second = server._maybe_schedule_auto_continue(
+        "sid-2", _session(), "session-key"
+    )
+
+    assert second is not None
+    marker = read_turn_marker(marker_home, "session-key")
+    assert marker is not None
+    assert marker["attempts"] == 2
+
+    # A fresh backend process/session must now honor max_attempts instead of
+    # retrying agent initialization forever with the original zero count.
+    third = server._maybe_schedule_auto_continue(
+        "sid-3", _session(), "session-key"
+    )
+
+    assert third is None
+    assert read_turn_marker(marker_home, "session-key") is None
 
 
 # ── End to end: continuation runs a real turn and clears the marker ────

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -32,6 +32,7 @@ from tui_gateway import git_probe
 from tui_gateway.turn_marker import (
     clear_turn_marker,
     read_turn_marker,
+    record_auto_continue_attempt,
     record_turn_start,
 )
 from tui_gateway.transport import (
@@ -6386,6 +6387,27 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
 
     def kickoff() -> None:
         rid = f"__auto_continue__{int(time.time() * 1000)}"
+        with session["history_lock"]:
+            if (
+                session.get("running")
+                or session.get("_turn_cancel_requested")
+                or session.get("_finalized")
+            ):
+                session["_auto_continue_scheduled"] = False
+                return
+        # Agent construction is part of the recovery attempt and may itself
+        # fail or kill the process. Count it before entering that fallible
+        # stage so repeated cold resumes cannot bypass max_attempts forever.
+        # The compare-and-set guard refuses to overwrite a newer user turn.
+        if not record_auto_continue_attempt(
+            home,
+            session_key,
+            prompt=marker["prompt"],
+            started_at=marker["started_at"],
+            attempts=attempt,
+        ):
+            session["_auto_continue_scheduled"] = False
+            return
         try:
             _start_agent_build(sid, session)
             err = _wait_agent(session, rid, timeout=120.0)
@@ -6393,7 +6415,8 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
             logger.warning("auto-continue agent build failed for %s", sid, exc_info=True)
             err = {"error": {"message": "agent build failed"}}
         if err:
-            # Leave the marker: the next resume retries (bounded by attempts).
+            # Leave the advanced marker: the next resume may retry, bounded by
+            # the persisted attempt count.
             session["_auto_continue_scheduled"] = False
             return
         with session["history_lock"]:

--- a/tui_gateway/turn_marker.py
+++ b/tui_gateway/turn_marker.py
@@ -121,6 +121,58 @@ def record_turn_start(
         logger.debug("failed to record turn marker for %s", session_key, exc_info=True)
 
 
+def record_auto_continue_attempt(
+    home: Path | str,
+    session_key: str,
+    *,
+    prompt: str,
+    started_at: float,
+    attempts: int,
+) -> bool:
+    """Persist an auto-continue attempt before fallible agent initialization.
+
+    The prompt and timestamp form a compare-and-set guard: a user turn may
+    replace the interrupted marker while the continuation thread starts, and
+    that newer marker must never be overwritten. Returns whether the original
+    marker was still current and the attempt was durably recorded.
+    """
+    if not session_key or not prompt:
+        return False
+    try:
+        expected_started_at = float(started_at)
+        next_attempts = max(0, int(attempts))
+    except (TypeError, ValueError):
+        return False
+    try:
+        with _lock:
+            path = _marker_path(home)
+            entries = _load(path)
+            current = entries.get(session_key)
+            if not isinstance(current, dict):
+                return False
+            try:
+                current_started_at = float(current.get("started_at") or 0)
+            except (TypeError, ValueError):
+                return False
+            if (
+                str(current.get("prompt") or "") != prompt
+                or current_started_at != expected_started_at
+            ):
+                return False
+            updated = dict(current)
+            updated["attempts"] = next_attempts
+            entries[session_key] = updated
+            _store(path, entries)
+            return True
+    except Exception:
+        logger.debug(
+            "failed to record auto-continue attempt for %s",
+            session_key,
+            exc_info=True,
+        )
+        return False
+
+
 def clear_turn_marker(home: Path | str, session_key: str) -> None:
     """Remove the marker once its turn concluded (any outcome the client saw)."""
     if not session_key:


### PR DESCRIPTION
## What does this PR do?

Prevents Desktop/TUI crash recovery from retrying forever when agent initialization fails.

The recovery attempt counter was previously persisted only after the agent finished initializing. If initialization failed or killed the gateway, the marker remained at `attempts: 0`, allowing every cold resume to bypass `max_attempts` and keep the session trapped in a recovery loop.

## Fix

- Persist the recovery attempt before agent initialization.
- Use a compare-and-set guard so a newer user turn cannot be overwritten.
- Stop scheduling recovery after the configured attempt limit.

## Related Work

- #71184 introduced interrupted-turn recovery and the auto-continue attempt limit.
- #35893 added automatic gateway respawn and session recovery.
- #49201 documented the restart-loop failure mode.

## Tests

- Reproduced on current `main`: repeated build failures kept `attempts: 0`.
- After the fix: attempts progress `1 → 2`, and the third resume is rejected.
- `27 passed, 904 deselected`
- Ruff, compileall, and `git diff --check` passed.