### PR TITLE
fix(desktop): render a repo's lone main lane without its branch header

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.test.tsx
@@ -1,0 +1,200 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+import { $sidebarWorkspaceNodeOpen } from '@/store/layout'
+
+import { EnteredProjectContent } from './entered-content'
+import type { SidebarProjectTree, SidebarSessionGroup, SidebarWorkspaceTree } from './workspace-groups'
+
+afterEach(cleanup)
+
+beforeEach(() => {
+  // Collapse state is persisted per node; reset it so one test's collapse can't
+  // leak into the next.
+  $sidebarWorkspaceNodeOpen.set({})
+})
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: { cancel: 'Cancel' },
+      sidebar: {
+        newSessionIn: (label: string) => `New session in ${label}`,
+        noSessions: 'No sessions yet',
+        projects: {
+          forceRemove: 'Force remove',
+          removeFromSidebar: 'Hide from sidebar',
+          removeWorktree: 'Remove worktree',
+          removeWorktreeConfirm: 'confirm',
+          removeWorktreeDirty: 'dirty',
+          removeWorktreeFailed: 'failed'
+        },
+        showMoreIn: (n: number, label: string) => `Show ${n} more in ${label}`
+      },
+      statusStack: { coding: { switchFailed: (branch: string) => `switch ${branch}` } }
+    }
+  })
+}))
+
+let nextId = 0
+
+const session = (overrides: Partial<SessionInfo> = {}): SessionInfo =>
+  ({
+    archived: false,
+    cwd: '/repo',
+    id: `s${nextId++}`,
+    is_active: false,
+    last_active: 1_000,
+    message_count: 1,
+    started_at: 1_000,
+    title: null,
+    ...overrides
+  }) as unknown as SessionInfo
+
+const lane = (over: Partial<SidebarSessionGroup> & Pick<SidebarSessionGroup, 'id' | 'label'>): SidebarSessionGroup => ({
+  path: '/repo',
+  sessions: [],
+  ...over
+})
+
+const project = (
+  groups: SidebarSessionGroup[],
+  repoOverrides: Partial<SidebarWorkspaceTree> = {}
+): SidebarProjectTree => {
+  const sessionCount = groups.reduce((sum, group) => sum + group.sessions.length, 0)
+
+  return {
+    id: 'p1',
+    label: 'hermes-agent',
+    path: '/repo',
+    repos: [{ groups, id: '/repo', label: 'repo', path: '/repo', sessionCount, ...repoOverrides }],
+    sessionCount
+  } as unknown as SidebarProjectTree
+}
+
+// Rows are rendered by the caller (the real sidebar renders SessionRow); a plain
+// title list is enough to assert what the user can see without expanding.
+const renderRows = (sessions: SessionInfo[]) => (
+  <div>
+    {sessions.map(s => (
+      <div key={s.id}>{s.title}</div>
+    ))}
+  </div>
+)
+
+// The lane header splits its label across two spans (head + tail, for truncation),
+// so the label is only queryable via the header's title attribute.
+const laneHeaderLabels = (container: HTMLElement): string[] =>
+  [...container.querySelectorAll('span[title]')].map(el => (el.getAttribute('title') ?? '').split('\n')[0])
+
+describe('EnteredProjectContent', () => {
+  it('renders main-checkout sessions with no branch header when it is the repo\u2019s only lane', () => {
+    const { container } = render(
+      <EnteredProjectContent
+        project={project([
+          lane({
+            id: '/repo::branch::main',
+            label: 'main',
+            isHome: true,
+            isMain: true,
+            sessions: [session({ title: 'ship the fix' }), session({ title: 'read the docs' })]
+          })
+        ])}
+        renderRows={renderRows}
+      />
+    )
+
+    expect(laneHeaderLabels(container)).toEqual([])
+    expect(screen.getByText('ship the fix')).toBeTruthy()
+    expect(screen.getByText('read the docs')).toBeTruthy()
+  })
+
+  it('shows those sessions even when the lane was collapsed before the header went away', () => {
+    // The reported symptom: a persisted collapse left a body of nothing but
+    // `main (N)`. A headerless lane has no toggle, so it must ignore that state.
+    $sidebarWorkspaceNodeOpen.set({ '/repo::branch::main': false })
+
+    render(
+      <EnteredProjectContent
+        project={project([
+          lane({
+            id: '/repo::branch::main',
+            label: 'main',
+            isHome: true,
+            isMain: true,
+            sessions: [session({ title: 'ship the fix' })]
+          })
+        ])}
+        renderRows={renderRows}
+      />
+    )
+
+    expect(screen.getByText('ship the fix')).toBeTruthy()
+  })
+
+  it('keeps every lane header once a linked worktree exists', () => {
+    const { container } = render(
+      <EnteredProjectContent
+        project={project([
+          lane({
+            id: '/repo::branch::main',
+            label: 'main',
+            isHome: true,
+            isMain: true,
+            sessions: [session({ title: 'on trunk' })]
+          }),
+          lane({
+            id: '/repo-wt-feature',
+            label: 'feature',
+            path: '/repo-wt-feature',
+            sessions: [session({ cwd: '/repo-wt-feature', title: 'on feature' })]
+          })
+        ])}
+        renderRows={renderRows}
+      />
+    )
+
+    expect(laneHeaderLabels(container)).toEqual(['main', 'feature'])
+    expect(screen.getByText('on trunk')).toBeTruthy()
+    expect(screen.getByText('on feature')).toBeTruthy()
+  })
+
+  it('keeps per-repo headers for a multi-folder project', () => {
+    const multi = {
+      id: 'p1',
+      label: 'monorepo',
+      path: '/repo',
+      sessionCount: 2,
+      repos: [
+        {
+          groups: [lane({ id: '/repo::branch::main', label: 'main', isMain: true, sessions: [session()] })],
+          id: '/repo',
+          label: 'repo',
+          path: '/repo',
+          sessionCount: 1
+        },
+        {
+          groups: [
+            lane({
+              id: '/other::branch::main',
+              label: 'main',
+              isMain: true,
+              path: '/other',
+              sessions: [session({ cwd: '/other' })]
+            })
+          ],
+          id: '/other',
+          label: 'other',
+          path: '/other',
+          sessionCount: 1
+        }
+      ]
+    } as unknown as SidebarProjectTree
+
+    const { container } = render(<EnteredProjectContent project={multi} renderRows={renderRows} />)
+
+    // Both repo headers stay; their lone main lanes still flatten inside them.
+    expect(laneHeaderLabels(container)).toEqual(['repo', 'other'])
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -24,6 +24,7 @@ import { SidebarRowStack } from '../chrome'
 import { useWorkspaceNodeOpen } from './model'
 import { SidebarWorkspaceGroup } from './workspace-group'
 import {
+  isFlatHomeLane,
   mergeRepoWorktreeGroups,
   overlayRepoLanes,
   type SidebarProjectTree,
@@ -32,10 +33,14 @@ import {
 } from './workspace-groups'
 import { WorkspaceAddButton, WorkspaceHeader } from './workspace-header'
 
-// The entered project's body. Main-checkout sessions render directly — no
-// redundant repo/branch header (the breadcrumb already names the project). Only
-// linked worktrees nest, shown by branch. Multi-folder projects keep per-repo
-// headers so the folders stay distinguishable.
+// The entered project's body. When the repo's ONLY lane is its main checkout,
+// those sessions render directly — the breadcrumb already names the project, so
+// a lone branch header is chrome the user has to click through (and a collapse
+// they can accidentally persist, leaving a body of nothing but `main (N)`).
+// As soon as a second lane exists the branch label is load-bearing — it's the
+// only thing telling the lanes apart — so every lane keeps its header. Linked
+// worktrees nest, shown by branch. Multi-folder projects keep per-repo headers
+// so the folders stay distinguishable.
 export function EnteredProjectContent({
   project,
   renderRows,
@@ -160,10 +165,17 @@ function RepoFlatSection({
     }
   }
 
+  // A repo whose only lane is its main checkout renders that lane headerless —
+  // the project breadcrumb already names it and there's no sibling lane to tell
+  // apart. Any second lane (worktree, another branch, kanban) restores headers
+  // on all of them, branch labels included.
+  const flatHome = isFlatHomeLane(ordered)
+
   const body = (
     <>
       {ordered.map(group => (
         <SidebarWorkspaceGroup
+          flat={flatHome}
           group={group}
           key={group.id}
           // The kanban bucket is read-only: it aggregates many task worktrees, so

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -23,9 +23,22 @@ interface SidebarWorkspaceGroupProps {
   // When set (linked worktree rows), shows a remove affordance that runs a real
   // `git worktree remove`.
   onRemove?: () => void
+  // Headerless mode: render the lane's rows directly, always expanded. Used by
+  // the entered project when the repo's only lane is its main checkout, where a
+  // lone branch header adds no information and can persist a collapse that hides
+  // every session. Paging and the empty placeholder are unchanged — only the
+  // header (and with it the toggle and the lane-level "+") goes away; the
+  // project header already owns "new session" there.
+  flat?: boolean
 }
 
-export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemove }: SidebarWorkspaceGroupProps) {
+export function SidebarWorkspaceGroup({
+  group,
+  renderRows,
+  onNewSession,
+  onRemove,
+  flat = false
+}: SidebarWorkspaceGroupProps) {
   const { t } = useI18n()
   const s = t.sidebar
   const isProfileGroup = group.mode === 'profile'
@@ -33,7 +46,11 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
   // yet" placeholder, so defaulting them open just adds noise. Profile lanes and
   // lanes that already hold sessions default open.
   const defaultOpen = isProfileGroup || group.sessions.length > 0
-  const [open, toggleOpen] = useWorkspaceNodeOpen(group.id, defaultOpen)
+  const [storedOpen, toggleOpen] = useWorkspaceNodeOpen(group.id, defaultOpen)
+  // A headerless lane has no toggle, so it must never read as collapsed —
+  // otherwise a collapse persisted while the lane still had a header would leave
+  // the body permanently empty with nothing to click.
+  const open = flat || storedOpen
   const [visibleCount, setVisibleCount] = useState(SIDEBAR_GROUP_PAGE)
 
   const loadedCount = group.sessions.length
@@ -102,30 +119,32 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
 
   return (
     <SidebarRowStack>
-      <WorkspaceHeader
-        action={
-          (onNewSession || isProfileGroup || onRemove) && (
-            <div className="flex items-center">
-              {(onNewSession || isProfileGroup) && (
-                <WorkspaceAddButton
-                  label={s.newSessionIn(group.label)}
-                  // Profile groups start a fresh session in that profile but keep
-                  // the all-profiles browse view; workspace groups seed the new
-                  // session's cwd. Main checkout lanes are branch-targeted.
-                  onClick={() => void handleNewSession()}
-                />
-              )}
-              {onRemove && <WorkspaceMenu onRemove={onRemove} path={group.path} />}
-            </div>
-          )
-        }
-        count={isProfileGroup ? countLabel(visibleSessions.length, totalCount) : group.sessions.length}
-        icon={leadingIcon}
-        label={group.label}
-        onToggle={toggleOpen}
-        open={open}
-        title={group.path ?? undefined}
-      />
+      {!flat && (
+        <WorkspaceHeader
+          action={
+            (onNewSession || isProfileGroup || onRemove) && (
+              <div className="flex items-center">
+                {(onNewSession || isProfileGroup) && (
+                  <WorkspaceAddButton
+                    label={s.newSessionIn(group.label)}
+                    // Profile groups start a fresh session in that profile but keep
+                    // the all-profiles browse view; workspace groups seed the new
+                    // session's cwd. Main checkout lanes are branch-targeted.
+                    onClick={() => void handleNewSession()}
+                  />
+                )}
+                {onRemove && <WorkspaceMenu onRemove={onRemove} path={group.path} />}
+              </div>
+            )
+          }
+          count={isProfileGroup ? countLabel(visibleSessions.length, totalCount) : group.sessions.length}
+          icon={leadingIcon}
+          label={group.label}
+          onToggle={toggleOpen}
+          open={storedOpen}
+          title={group.path ?? undefined}
+        />
+      )}
       {open && (
         <>
           {visibleSessions.length === 0 ? (

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -5,6 +5,7 @@ import type { ProjectInfo, SessionInfo } from '@/types/hermes'
 
 import {
   baseName,
+  isFlatHomeLane,
   kanbanWorktreeDir,
   liveSessionProjectId,
   mergeRepoWorktreeGroups,
@@ -101,6 +102,30 @@ describe('sortWorktreeGroups', () => {
     const groups = [lane({ id: 'b', label: 'beta', isMain: false }), lane({ id: 'a', label: 'alpha', isMain: false })]
 
     expect(sortWorktreeGroups(groups).map(g => g.label)).toEqual(['alpha', 'beta'])
+  })
+})
+
+describe('isFlatHomeLane', () => {
+  it('flattens a repo whose only lane is its main checkout', () => {
+    expect(isFlatHomeLane([lane({ id: 'home', label: 'main', isMain: true, isHome: true })])).toBe(true)
+  })
+
+  it('keeps headers as soon as a second lane exists — the labels are what tell them apart', () => {
+    const groups = [
+      lane({ id: 'home', label: 'main', isMain: true, isHome: true }),
+      lane({ id: '/repo-wt-feature', label: 'feature', isMain: false, path: '/repo-wt-feature' })
+    ]
+
+    expect(isFlatHomeLane(groups)).toBe(false)
+  })
+
+  it('keeps the header for a lone linked-worktree or kanban lane (not the main checkout)', () => {
+    expect(isFlatHomeLane([lane({ id: 'wt', label: 'feature', isMain: false })])).toBe(false)
+    expect(isFlatHomeLane([lane({ id: 'k', label: 'kanban', isMain: true, isKanban: true })])).toBe(false)
+  })
+
+  it('is false for an empty lane set (nothing to flatten)', () => {
+    expect(isFlatHomeLane([])).toBe(false)
   })
 })
 

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -154,6 +154,22 @@ export function sortWorktreeGroups(groups: SidebarSessionGroup[]): SidebarSessio
 }
 
 /**
+ * True when a repo's lane set is JUST its main checkout, so the entered-project
+ * body can render those sessions directly instead of behind a lone branch
+ * header. The breadcrumb already names the project and there is no sibling lane
+ * to tell apart, so the header carries no information — and being collapsible,
+ * it can persist a collapse that leaves the project looking empty except for a
+ * `main (N)` row (the reported symptom).
+ *
+ * Deliberately narrow: with two or more lanes every branch label is the only
+ * thing distinguishing them, so all lanes keep their headers. A kanban bucket
+ * counts as a lane — it is never the flattened one.
+ */
+export function isFlatHomeLane(groups: SidebarSessionGroup[]): boolean {
+  return groups.length === 1 && Boolean(groups[0].isMain) && !groups[0].isKanban
+}
+
+/**
  * VISUAL enhancer only: inject empty lanes from a live `git worktree list` so a
  * repo shows its branches/worktrees even when they have no Hermes sessions yet.
  * The repo's real session lanes already come fully built from the backend

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -114,8 +114,10 @@ interface SidebarSessionsSectionProps {
   // True while the backend project tree is loading (overview skeleton).
   projectsLoading?: boolean
   onEnterProject?: (id: string) => void
-  // The entered project's flattened content: main-checkout sessions render
-  // directly (no redundant repo/branch header); only linked worktrees nest.
+  // The entered project's content. A repo whose only lane is its main checkout
+  // renders those sessions directly (no redundant branch header); once a second
+  // lane exists — linked worktrees, another branch, kanban — every lane nests
+  // under its own header so the labels stay distinguishable.
   projectContent?: SidebarProjectTree
   // Live git lanes (`git worktree list`) for repos in the entered project —
   // a VISUAL enhancer only (empty lanes), never session membership.


### PR DESCRIPTION
## What does this PR do?

Entering a single-repo project in the Desktop Projects sidebar showed a collapsible `main (N)` lane header above the session rows. That header carries no information in the entered view — the breadcrumb already names the project, and there is no sibling lane to tell apart — and because it is collapsible, a persisted collapse leaves the project body as nothing but `main (N)`, which reads as "my project chats are gone".

One correction to the issue's premise, since it changes the right fix: **the session titles were never hidden by default.** `defaultOpen` in `workspace-group.tsx` is `isProfileGroup || group.sessions.length > 0`, so a lane holding sessions renders expanded. I confirmed this with a throwaway render test on current `main` (a lone `main` lane with two sessions renders the `main` header *and* both titles). So the reported "titles hidden until you expand each lane" happens only after the user has collapsed the lane themselves — that state is persisted in `$sidebarWorkspaceNodeOpen`. This PR fixes the redundant chrome *and* that collapse trap; it is not restoring rows that were unreachable on first paint.

I also deliberately did **not** take the issue's `mergeIsMainSessions(ordered)` approach of flattening every `isMain` lane unconditionally. That would drop live behavior the design depends on:

- `isHome` lane ordering + the home glyph (`laneRank` in `workspace-groups.ts`, `leadingIcon` in `workspace-group.tsx`)
- the lane-level `+`, which calls `switchBranchInRepo` first so "new session on `main`" actually lands on `main` rather than whatever branch the root currently sits on
- `WorkspaceShowMoreButton` paging (5/page) within the lane

And the lane label is **not** always the trunk name: with a local git probe the home lane is labeled by the repo's *live* branch (e.g. `bb/live`), which the breadcrumb does not carry. Hiding that whenever a worktree lane is also present would lose the "where am I" signal.

So the gate is narrow: `isFlatHomeLane()` flattens only when the repo has **exactly one** lane and it is the main checkout. The moment a second lane exists (linked worktree, another branch, kanban) every lane keeps its header, because the branch label is then the only thing distinguishing them.

On the issue's "two identical `main` headers" item: that is already handled upstream of this file and I left it alone. The backend folds an unrecorded branch into the one trunk lane (`_place` in `tui_gateway/project_tree.py`), and with a git probe the frontend folds all main lanes into a single home lane (`mergeRepoWorktreeGroups`, covered by an existing test). The residual double-lane case I could construct needs *different* labels (`main` + `master`) and no git probe — that is the phantom-membership class tracked in #59228 / #53329 / #52811 / #70790, not this presentation bug.

## Related Issue

Fixes #71232

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts` — new `isFlatHomeLane(groups)` predicate: exactly one lane, `isMain`, not `isKanban`.
- `apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx` — new `flat` prop. Skips `WorkspaceHeader` and forces the body open (`open = flat || storedOpen`), so a headerless lane can't read as collapsed from previously stored state. The header still receives `storedOpen`, so nothing changes when a header is present. Paging, the empty placeholder, and every other branch are untouched.
- `apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx` — computes `flatHome` from the post-overlay, post-dismissal `ordered` lane set and passes it down. Comment corrected to describe actual behavior.
- `apps/desktop/src/app/chat/sidebar/sessions-section.tsx` — same comment correction on `projectContent`.
- `apps/desktop/src/app/chat/sidebar/projects/entered-content.test.tsx` (new) — render-level coverage.
- `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts` — unit coverage for `isFlatHomeLane`.

Display-only: no session is deleted, archived, or moved off the project, and lane membership is still entirely backend-owned.

## How to Test

Automated, from `apps/desktop`:

```bash
npx vitest run src/app/chat/sidebar/projects/entered-content.test.tsx \
               src/app/chat/sidebar/projects/workspace-groups.test.ts --project ui
# 56 passed
npm run typecheck   # clean
npx eslint src/app/chat/sidebar/projects src/app/chat/sidebar/sessions-section.tsx  # clean
```

New tests cover: lone main lane renders titles with **zero** lane headers; a *previously collapsed* lone main lane still renders its sessions (the reported symptom); a linked worktree restores headers on both lanes; a multi-folder project keeps both per-repo headers.

Proof the tests catch the bug: with the two source files reverted (`git stash push -- entered-content.tsx workspace-group.tsx`) 3 of the 4 render tests fail; restored, all pass.

Manually:

1. `hermes` Desktop → Sessions header → "Show projects".
2. Enter a project whose folder is a normal git checkout with a few sessions. Session titles appear directly under the project name, no `main (N)` row.
3. `git worktree add ../repo-wt-feature -b feature`, reopen the project: both lanes now show their headers (`main`, `feature`) with rows nested, as before.
4. Regression check for the collapse trap: on `main`, collapse the `main` lane, then apply this branch — the sessions are visible again instead of stranded behind a header that no longer exists.

Backend `project_tree` unchanged; ran `pytest tests/tui_gateway/test_project_tree.py -q` anyway → 26 passed.

Tested on: macOS 15 (Apple silicon), Electron desktop app.

Note on the full suite: `npx vitest run --project ui` reports 142 pre-existing failures on my machine (`TypeError: Cannot read properties of undefined (reading 'clear')` — `window.localStorage` unavailable without `--localstorage-file` on my Node build). Identical count on a clean `upstream/main` checkout, so unrelated to this change; my files add +9 passing, 0 failing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass (desktop is a TS surface — `vitest` + `typecheck` + `eslint`; also ran `pytest tests/tui_gateway/test_project_tree.py`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Apple silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (corrected the two stale in-file comments that claimed this flattening already existed) — the behavior is not described in `docs/`
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change (`apps/desktop/AGENTS.md` unaffected)
- [x] Cross-platform: pure React render logic, no path or process handling. `isFlatHomeLane` reads existing lane flags only; the Windows path-identity folding in `mergeRepoWorktreeGroups` is upstream of it and untouched.
- [x] N/A — no tool descriptions or schemas touched

## Screenshots / Logs

No screenshots (I don't have the reporter's project set up to capture a like-for-like before/after). The render tests assert the same thing the screenshots would show — header count 0 vs. session titles present.

### Overlap note

#65871 (open) also touches `entered-content.tsx` / `workspace-group.tsx`, adding an archive action to the lane menu. No functional conflict — that PR works on the lane *menu*, this one on whether the header renders at all — but whichever lands second will want a trivial rebase, and its new lane action should stay reachable in the multi-lane (headered) case, which this PR preserves.
