### PR TITLE
fix(lm-studio): recognize wrapped HTTP 400 grammar parse failures

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -736,9 +736,16 @@ def classify_api_error(
     # ``self.tools`` in the retry loop and retry once. Cloud providers are
     # unaffected — they accept these keywords and we never hit this branch.
     if (
-        status_code == 400
+        (
+            status_code == 400
+            or (
+                status_code is None
+                and "predict request returned 400" in error_msg
+            )
+        )
         and (
             "error parsing grammar" in error_msg
+            or "failed to parse grammar" in error_msg
             or "json-schema-to-grammar" in error_msg
             or (
                 "unable to generate parser" in error_msg

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -932,6 +932,37 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_compress is False
 
+    def test_lm_studio_failed_to_parse_grammar(self):
+        """LM Studio wraps llama.cpp grammar failures in a sampler error."""
+        e = MockAPIError(
+            "Failed to initialize samplers: failed to parse grammar",
+            status_code=400,
+        )
+        result = classify_api_error(
+            e,
+            provider="custom",
+            model="qwen3.6-35b-a3b",
+        )
+        assert result.reason == FailoverReason.llama_cpp_grammar_pattern
+        assert result.retryable is True
+        assert result.should_compress is False
+
+    def test_lm_studio_embedded_400_failed_to_parse_grammar(self):
+        """LM Studio's SDK wrapper may expose HTTP 400 only in the message."""
+        e = Exception(
+            'Engine protocol predict request returned 400: '
+            '{"error":{"code":400,"message":"Failed to initialize samplers: '
+            'failed to parse grammar","type":"invalid_request_error"}}'
+        )
+        result = classify_api_error(
+            e,
+            provider="custom",
+            model="qwen3.6-35b-a3b",
+        )
+        assert result.reason == FailoverReason.llama_cpp_grammar_pattern
+        assert result.retryable is True
+        assert result.should_compress is False
+
     def test_llama_cpp_unable_to_generate_parser(self):
         """Older llama.cpp builds surface the error as 'unable to generate parser'."""
         e = MockAPIError(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4205,6 +4205,73 @@ class TestRunConversation:
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
 
+    def test_lm_studio_grammar_error_strips_schema_and_retries_once(self, agent):
+        """LM Studio's wrapped 400 triggers the full llama.cpp recovery chain."""
+        self._setup_agent(agent)
+        agent.provider = "custom"
+        agent.model = "qwen3.6-35b-a3b"
+        agent.base_url = "http://localhost:1234/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "periodic_note",
+                    "description": "Read a dated note",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "date": {
+                                "type": "string",
+                                "pattern": r"^\d{4}-\d{2}-\d{2}$",
+                                "format": "date",
+                            }
+                        },
+                    },
+                },
+            }
+        ]
+        recovered = _mock_response(
+            content="HERMES_LM_GRAMMAR_RECOVERY_OK",
+            finish_reason="stop",
+        )
+        request_tools = []
+
+        def _lm_studio_then_recover(api_kwargs):
+            request_tools.append(json.loads(json.dumps(api_kwargs["tools"])))
+            if len(request_tools) == 1:
+                raise Exception(
+                    'Engine protocol predict request returned 400: '
+                    '{"error":{"code":400,"message":"Failed to initialize '
+                    'samplers: failed to parse grammar","type":"invalid_request_error"}}'
+                )
+            return recovered
+
+        with (
+            patch.object(
+                agent,
+                "_interruptible_api_call",
+                side_effect=_lm_studio_then_recover,
+            ) as mock_api_call,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("reply with the recovery sentinel")
+
+        assert result["final_response"] == "HERMES_LM_GRAMMAR_RECOVERY_OK"
+        assert result["completed"] is True
+        assert mock_api_call.call_count == 2
+        assert request_tools[0][0]["function"]["parameters"]["properties"]["date"] == {
+            "type": "string",
+            "pattern": r"^\d{4}-\d{2}-\d{2}$",
+            "format": "date",
+        }
+        assert request_tools[1][0]["function"]["parameters"]["properties"]["date"] == {
+            "type": "string",
+        }
+        assert agent.tools == request_tools[1]
+
     def test_prompt_cache_marks_static_system_prefix_on_wire(self, agent):
         self._setup_agent(agent)
         agent._cached_system_prompt = "stable instructions\n\nsession context"


### PR DESCRIPTION
## Summary

- recognize LM Studio / llama.cpp sampler failures containing `failed to parse grammar`
- handle SDK wrappers that expose HTTP 400 only inside the exception message as `predict request returned 400`
- route both forms through the existing `llama_cpp_grammar_pattern` recovery path
- verify the complete recovery flow strips unsupported JSON Schema `pattern` / `format` keys and retries once

## Problem

LM Studio can surface llama.cpp JSON-schema-to-grammar failures in either of these forms:

```text
Failed to initialize samplers: failed to parse grammar
```

or, after SDK wrapping:

```text
Engine protocol predict request returned 400:
{"error":{"code":400,"message":"Failed to initialize samplers: failed to parse grammar","type":"invalid_request_error"}}
```

The second form has no structured `status_code`, so Hermes currently classifies it as `unknown`. The first form has HTTP 400 but does not match the phrases recognized by the existing llama.cpp grammar recovery classifier. As a result, Hermes performs a generic retry without removing unsupported schema constraints, and the same request can fail again.

## Root cause

The existing classifier recognizes:

- `error parsing grammar`
- `json-schema-to-grammar`
- `unable to generate parser ... template`

It does not recognize LM Studio's `failed to parse grammar` wording. It also requires a structured HTTP 400 status, while LM Studio's SDK wrapper may expose 400 only in the exception text.

## Fix

Extend the existing llama.cpp grammar condition to accept:

1. structured `status_code == 400`, or
2. `status_code is None` when the normalized message contains `predict request returned 400`

and recognize `failed to parse grammar` as another llama.cpp grammar failure phrase.

The condition still requires a recognized grammar-specific phrase, so unrelated wrapped HTTP 400 errors are not routed into schema recovery.

## Test plan

RED was observed before changing production code:

- the structured LM Studio sampler error was classified as `format_error`
- the SDK-wrapped error was classified as `unknown`
- the end-to-end retry did not strip `pattern` and `format`

GREEN after rebasing onto the latest `origin/main` and rerunning the combined relevant suites:

```text
python -m pytest \
  tests/agent/test_error_classifier.py \
  tests/run_agent/test_run_agent.py \
  -q -n 0
647 passed in 108.38s

python -m compileall -q \
  agent/error_classifier.py \
  tests/agent/test_error_classifier.py \
  tests/run_agent/test_run_agent.py
```

Additional checks:

- rebased/fast-forwarded to current `origin/main` (`95a566b1e769cca26dfa441c1ff963ec03bdc7d6`) before final verification
- `git diff --check` passed
- static added-line security scan found no concerns
- independent code review: **PASS**, with no blocking security, logic, or compatibility issues
- no credentials, configuration, or provider-specific secrets are added

## Scope and risk

The production change is limited to one existing error-classification branch. Cloud-provider behavior is unchanged unless an error simultaneously contains a recognized llama.cpp grammar phrase and either a structured HTTP 400 or LM Studio's wrapped `predict request returned 400` marker.
