### PR TITLE
fix(tools): pass ~ through to the ssh remote instead of expanding against gateway HOME (#71201)

### DIFF
--- a/tests/tools/test_resolve_path.py
+++ b/tests/tools/test_resolve_path.py
@@ -72,3 +72,30 @@ class TestResolvePath:
             terminal_tool.clear_session_cwd(task_id)
 
         assert result == live_dir / "nested" / "file.txt"
+
+    def test_ssh_tilde_not_expanded_on_host(self, monkeypatch):
+        """#71201: on the ssh backend a leading ~ must NOT be expanded against
+        the gateway HOME — it must pass through for remote-side expansion."""
+        from tools import file_tools
+
+        monkeypatch.setattr(
+            file_tools, "_terminal_env_type_for_task",
+            lambda task_id="default": "ssh",
+        )
+
+        assert str(file_tools._resolve_path("~/notes.txt")) == "~/notes.txt"
+        assert str(file_tools._resolve_path("~")) == "~"
+        assert str(file_tools._resolve_path("~user/file.txt")) == "~user/file.txt"
+
+    def test_local_tilde_still_expanded(self, monkeypatch):
+        """On the local backend ~ is still expanded (regression guard)."""
+        from tools import file_tools
+
+        monkeypatch.setattr(
+            file_tools, "_terminal_env_type_for_task",
+            lambda task_id="default": "local",
+        )
+
+        result = file_tools._resolve_path("~/notes.txt")
+        assert "~" not in str(result)
+        assert result.is_absolute()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -379,6 +379,15 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
         resolved = _resolve_base_dir(task_id, container_paths=True) / expanded
         return _normalize_without_host_deref(resolved)
 
+    # SSH backend: a leading ``~`` must reach the remote unexpanded.
+    # Expanding it here resolves against the GATEWAY process's HOME, but the
+    # path is executed on the ssh remote where that directory may not exist
+    # (#71201). Leave it intact so ShellFileOperations._expand_path() resolves
+    # it against the remote $HOME at execution time (it runs ``echo $HOME``
+    # through the live environment for every file op).
+    if filepath.startswith("~") and _terminal_env_type_for_task(task_id) == "ssh":
+        return PurePosixPath(filepath)
+
     # Host paths only — never rewrite Linux paths inside a container/WSL env.
     from tools.environments.local import _msys_to_windows_path
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -371,6 +371,21 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
     translated to ``C:\\Users\\...`` before resolution so file tools don't
     treat them as relative ``\\c\\Users\\...`` under the process cwd.
     """
+    # SSH backend: a leading ``~`` must reach the remote unexpanded.
+    # Expanding it here resolves against the GATEWAY process's HOME, but the
+    # path is executed on the ssh remote where that directory may not exist
+    # (#71201). Leave it intact so ShellFileOperations._expand_path() resolves
+    # it against the remote $HOME at execution time (it runs ``echo $HOME``
+    # through the live environment for every file op).
+    #
+    # This guard sits ABOVE the container-paths branch on purpose: if ssh is
+    # ever folded into the POSIX/container path set (e.g. #57998), that branch
+    # would call _expand_tilde() and return before this guard is reached,
+    # silently reverting the fix. Hoisting keeps the two changes composable
+    # regardless of merge order.
+    if filepath.startswith("~") and _terminal_env_type_for_task(task_id) == "ssh":
+        return PurePosixPath(filepath)
+
     container_paths = _uses_container_paths(task_id)
     if container_paths:
         expanded = _expand_tilde(filepath)
@@ -378,15 +393,6 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
             return _normalize_without_host_deref(expanded)
         resolved = _resolve_base_dir(task_id, container_paths=True) / expanded
         return _normalize_without_host_deref(resolved)
-
-    # SSH backend: a leading ``~`` must reach the remote unexpanded.
-    # Expanding it here resolves against the GATEWAY process's HOME, but the
-    # path is executed on the ssh remote where that directory may not exist
-    # (#71201). Leave it intact so ShellFileOperations._expand_path() resolves
-    # it against the remote $HOME at execution time (it runs ``echo $HOME``
-    # through the live environment for every file op).
-    if filepath.startswith("~") and _terminal_env_type_for_task(task_id) == "ssh":
-        return PurePosixPath(filepath)
 
     # Host paths only — never rewrite Linux paths inside a container/WSL env.
     from tools.environments.local import _msys_to_windows_path


### PR DESCRIPTION
## What does this PR do?

On the `ssh` terminal backend, file tools (`write_file`, `patch`, `read_file`) expanded a leading `~` against the **gateway process's HOME** instead of the ssh remote's HOME, because `_resolve_path_for_task()` ran `_expand_tilde()` on the host before the path reached the remote. The pre-expanded local path was then executed on the remote, where it doesn't exist — every tilde-path write failed with `No such file or directory` (or silently landed at the wrong location if the gateway-home path happened to exist on the remote).

The fix leaves a leading-`~` path unexpanded for the ssh backend so `ShellFileOperations._expand_path()` — which is already backend-aware and runs `echo $HOME` through the live environment — resolves it against the remote `$HOME`.

The guard is placed **above** the container-paths branch on purpose, so the fix survives regardless of whether #57998 (or any future change) folds ssh into the POSIX/container path set (that branch also calls `_expand_tilde()` and would otherwise return first, silently reverting the fix).

## Related Issue

Fixes #71201

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/file_tools.py`: in `_resolve_path_for_task()`, return a leading-`~` path as-is (`PurePosixPath(filepath)`) when the backend is `ssh`, hoisted above the container-paths branch for composability with #57998. Comment explains why the ordering is load-bearing.
- `tests/tools/test_resolve_path.py`: 2 new regression tests — ssh tilde paths pass through unexpanded (`~`, `~/...`, `~user/...`); local backend still expands tilde.

## How to Test

1. Configure the `ssh` backend with a remote whose home differs from the gateway's (e.g. gateway user `hermes`, remote user `sandbox`).
2. `write_file` to `~/notes.txt`.
3. Verify it lands at the remote's `$HOME/notes.txt` (before fix: failed with the gateway-home path).

The issue author independently verified this end-to-end on the production topology (Fedora gateway → Fedora libvirt VM): pre-fix the write failed against the gateway home; post-fix it lands on the remote (`bytes_written: 13`, remote `cat` confirms).

Unit tests: `pytest tests/tools/test_resolve_path.py -v` → 8 passed (6 existing + 2 new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tools): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (affected module run locally: 8 passed; ruff + windows-footgun checker clean; full suite via CI)
- [x] I've added tests for my changes (2 new regression tests)
- [x] I've tested on my platform: Windows 11 (native, Python 3.11); issue author verified E2E on Fedora

### Documentation & Housekeeping

- [x] I've updated relevant documentation (inline comment explaining the guard ordering)
- [x] N/A — no config key changes (`cli-config.yaml.example`)
- [x] N/A — no architecture/workflow changes (CONTRIBUTING.md / AGENTS.md)
- [x] I've considered cross-platform impact — ssh remote paths are POSIX; the guard only affects the ssh backend
- [x] N/A — no tool description/schema changes

## Screenshots / Logs

Note: for ssh tilde paths, `resolved_path` in the tool result now reports the `~`-form (e.g. `~/notes.txt`) rather than a host-expanded absolute path — the previous value was the *wrong* (gateway) home, so the tilde form is the truthful representation. Surfacing the expanded remote absolute path back through `WriteResult` is a follow-up.
