### PR TITLE
fix(kanban): keep worker heartbeat alive during background process waits

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -254,6 +254,33 @@ def test_reader_loop_streams_incremental_chunks_from_read1(registry, monkeypatch
 
 
 # =========================================================================
+# Blocking wait activity
+# =========================================================================
+
+
+def test_wait_reports_activity_while_process_is_running(registry, monkeypatch):
+    """A blocking process wait must keep the agent/kanban heartbeat alive."""
+    session = _make_session(sid="proc_wait_activity")
+    registry._running[session.id] = session
+    touches = []
+
+    def record_touch(state, label):
+        touches.append((state, label))
+
+    monkeypatch.setattr(
+        "tools.environments.base.touch_activity_if_due",
+        record_touch,
+    )
+
+    result = registry.wait(session.id, timeout=0.05)
+
+    assert result["status"] == "timeout"
+    assert touches
+    assert {label for _, label in touches} == {"background process wait"}
+    assert all("start" in state and "last_touch" in state for state, _ in touches)
+
+
+# =========================================================================
 # Orphaned-pipe reconciliation (issue #17327)
 # =========================================================================
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1492,6 +1492,7 @@ class ProcessRegistry:
             and output snapshot.
         """
         from tools.ansi_strip import strip_ansi
+        from tools.environments.base import touch_activity_if_due
         from tools.interrupt import is_interrupted as _is_interrupted
 
         try:
@@ -1515,7 +1516,9 @@ class ProcessRegistry:
         if session is None:
             return {"status": "not_found", "error": f"No process with ID {session_id}"}
 
-        deadline = time.monotonic() + effective_timeout
+        now = time.monotonic()
+        deadline = now + effective_timeout
+        activity_state = {"last_touch": now, "start": now}
 
         while time.monotonic() < deadline:
             session = self._refresh_detached_session(session)
@@ -1553,6 +1556,7 @@ class ProcessRegistry:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 break
+            touch_activity_if_due(activity_state, "background process wait")
             session._completion_event.wait(timeout=min(1.0, remaining))
 
         result = {


### PR DESCRIPTION
ProcessRegistry's wait loop blocks in `Event.wait` without invoking the thread-local activity callback, so a live kanban worker waiting on a long background process stops emitting its heartbeat and gets reaped/reclaimed as stale (we observed ~200 spurious heartbeat-lost reclaims per day on a busy deployment before this patch).

Fix: call `touch_activity_if_due` on each iteration of the bounded wait loop so genuine liveness is reported while waiting, without changing timeout semantics. Includes unit tests covering the activity-touch behavior.

Running in production on our fleet since 2026-07-25; heartbeat-loss reclaim churn stopped.