### PR TITLE
fix(environments): reap subprocesses on every _wait_for_process exit path (#71253)

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -512,6 +512,120 @@ class TestInitSessionFailure:
         assert calls[0]["login"] is False
 
 
+class TestProcessReaping:
+    """Regression tests for issue #71253.
+
+    _wait_for_process must reap its subprocess on every return path
+    (natural exit, KeyboardInterrupt, timeout) by calling ``proc.wait()``,
+    so that Popen objects do not leak zombie entries to the OS.
+    """
+
+    @staticmethod
+    def _make_proc(rc=0):
+        proc = MagicMock()
+        proc.poll.return_value = rc
+        proc.returncode = rc
+        proc.stdout = iter([])
+        return proc
+
+    def test_natural_exit_reaps_subprocess(self):
+        env = _TestableEnv()
+        proc = self._make_proc(rc=0)
+
+        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+            return proc
+
+        env._run_bash = mock_run_bash
+        result = env.execute("echo natural")
+
+        assert result["returncode"] == 0
+        # proc.wait() MUST be called exactly once on the natural exit path
+        # so the kernel can release the PID entry.
+        proc.wait.assert_called_once()
+
+    def test_interrupt_exit_reaps_subprocess(self):
+        """KeyboardInterrupt-equivalent path: _wait_for_process returns 130
+        and must still call proc.wait() to avoid leaking a zombie."""
+        env = _TestableEnv()
+        proc_holder = {}
+
+        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+            p = MagicMock()
+            # Stay running for the first poll so the loop sees the interrupt
+            # branch; then return 130 via _wait_for_process.
+            poll_calls = {"n": 0}
+
+            def _poll():
+                poll_calls["n"] += 1
+                return None if poll_calls["n"] == 1 else 130
+
+            p.poll.side_effect = _poll
+            p.returncode = 130
+            p.stdout = iter([])
+            proc_holder["p"] = p
+            return p
+
+        env._run_bash = mock_run_bash
+
+        # Stub ``is_interrupted`` so the loop takes the interrupt branch on
+        # the first poll, then returns cleanly on the second tick.
+        from tools.environments import base as base_mod
+
+        state = {"hit": False}
+
+        def mixed_is_interrupted():
+            if not state["hit"]:
+                state["hit"] = True
+                return True
+            return False
+
+        original = base_mod.is_interrupted
+        base_mod.is_interrupted = mixed_is_interrupted
+        try:
+            result = env.execute("echo interrupt")
+        finally:
+            base_mod.is_interrupted = original
+
+        assert result["returncode"] == 130
+        proc_holder["p"].wait.assert_called()
+
+    def test_timeout_exit_reaps_subprocess(self):
+        """Timeout path: _wait_for_process returns 124 and must still reap."""
+        env = _TestableEnv()
+        proc = MagicMock()
+        poll_calls = {"n": 0}
+
+        def _poll():
+            poll_calls["n"] += 1
+            return None if poll_calls["n"] <= 1 else None  # never exits naturally
+
+        proc.poll.side_effect = _poll
+        proc.stdout = iter([])
+
+        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+            return proc
+
+        env._run_bash = mock_run_bash
+        env._kill_process = lambda p: None  # avoid touching real kill in mock
+        # Tight timeout to trigger the timeout branch quickly.
+        result = env.execute("sleep 999", timeout=0.05)
+
+        assert result["returncode"] == 124
+        proc.wait.assert_called()
+
+    def test_base_kill_process_waits_for_reap(self):
+        """BaseEnvironment._kill_process must wait() after kill() so a
+        killed but unreaped subprocess does not become a zombie."""
+        env = _TestableEnv()
+        proc = MagicMock()
+
+        env._kill_process(proc)
+
+        proc.kill.assert_called_once()
+        # Critical reaping assertion — currently absent in base class.
+        proc.wait.assert_called()
+
+
 class TestCwdMarker:
     def test_marker_contains_session_id(self):
         env = _TestableEnv()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -933,6 +933,13 @@ class BaseEnvironment(ABC):
                         )
                     self._kill_process(proc)
                     drain_thread.join(timeout=2)
+                    # Reap is best-effort: _kill_process waits on the
+                    # subprocess but a defensive sync here is harmless if a
+                    # subclass overrides kill without a wait.
+                    try:
+                        proc.wait(timeout=2.0)
+                    except (ProcessLookupError, subprocess.TimeoutExpired, OSError):
+                        pass
                     return {
                         "output": output.render(suffix="\n[Command interrupted]"),
                         "returncode": 130,
@@ -946,6 +953,10 @@ class BaseEnvironment(ABC):
                         )
                     self._kill_process(proc)
                     drain_thread.join(timeout=2)
+                    try:
+                        proc.wait(timeout=2.0)
+                    except (ProcessLookupError, subprocess.TimeoutExpired, OSError):
+                        pass
                     timeout_msg = f"\n[Command timed out after {timeout}s]"
                     return {
                         "output": output.render(suffix=timeout_msg).lstrip()
@@ -1017,6 +1028,26 @@ class BaseEnvironment(ABC):
         except Exception:
             pass
 
+        # Reap the subprocess on the natural exit path.
+        #
+        # CPython's ``subprocess.Popen.__del__`` is *not* guaranteed to call
+        # ``wait()``, and the ``_ThreadedProcessHandle`` adapter used by SDK
+        # backends can keep its worker thread alive on a long-tail ``exec_fn``
+        # after the underlying process has exited (its ``wait()`` blocks on a
+        # ``threading.Event`` set inside that worker).  Returning without an
+        # explicit ``wait()`` leaks a zombie to the kernel PID table for the
+        # lifetime of the parent Hermes process — every ``terminal()`` /
+        # ``read_file`` / search invocation accumulates one (#71253).
+        try:
+            proc.wait(timeout=2.0)
+        except (ProcessLookupError, subprocess.TimeoutExpired, OSError):
+            # ProcessLookupError: a stranger (e.g. timeout path) already reaped
+            # this PID; nothing more to do.
+            # TimeoutExpired / OSError: the worker is still flushing; the
+            # next caller's execute() will encounter a finished handle and
+            # wait() in its own path, completing cleanup.
+            pass
+
         if _DEBUG_INTERRUPT:
             logger.info(
                 "[interrupt-debug] _wait_for_process EXIT (natural) "
@@ -1029,10 +1060,33 @@ class BaseEnvironment(ABC):
         return {"output": output.render(), "returncode": proc.returncode}
 
     def _kill_process(self, proc: ProcessHandle):
-        """Terminate a process. Subclasses may override for process-group kill."""
+        """Terminate a process and reap it.
+
+        Subclasses may override for process-group kill; they are responsible
+        for reap support (``proc.wait()`` or equivalent) themselves and need
+        not route through here.  Subclasses that *do* delegate back into this
+        implementation (e.g. when no process-group semantics are required)
+        inherit the wait/reap contract below.
+
+        The wait protects the kernel's process table from zombies:
+        ``subprocess.Popen.__del__`` is documented NOT to call ``wait()``,
+        and the other ``ProcessHandle`` adapters in this module can keep their
+        worker thread alive on a long-tail ``exec_fn()`` unless we
+        synchronously block on their completion here (#71253).
+        """
         try:
             proc.kill()
         except (ProcessLookupError, PermissionError, OSError):
+            pass
+        # Reap regardless of whether kill() found the process — the previous
+        # owner may already have reaped it, in which case wait() is a no-op.
+        try:
+            proc.wait(timeout=5.0)
+        except (ProcessLookupError, subprocess.TimeoutExpired, OSError):
+            # ProcessLookupError: already reaped (or never existed) — fine.
+            # TimeoutExpired: still won't go; the next poll cycle / a manual
+            # ``kill -9`` can finish cleanup.  We deliberately do not block the
+            # tool forever — the process is going away, just slowly.
             pass
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`_wait_for_process` in `tools/environments/base.py` polled with `proc.poll()` but never called `proc.wait()`, and the base `_kill_process` only killed without waiting. Every `terminal()`, `read_file`, and `search_files` invocation left a zombie entry in the kernel PID table (#71253).

Adds an explicit `proc.wait()` on the natural exit, interrupt (130), and timeout (124) return paths of `_wait_for_process`, and adds `proc.wait()` inside the base `_kill_process` so subclasses that delegate back to it inherit the reap contract. Subclasses with their own process-group kill semantics (`local.py`) already invoke `proc.wait()` — this fix does not change their behavior, only brings the base implementation up to the same contract.

## Changes

- `tools/environments/base.py`: add `proc.wait(timeout=2.0)` on all three exit branches of `_wait_for_process` (natural, interrupt, timeout); add `proc.wait(timeout=5.0)` inside `_kill_process` after `proc.kill()`. Each waits defensively under `try/except (ProcessLookupError, subprocess.TimeoutExpired, OSError)` so a concurrent reap or slow worker does not break the tool contract.
- `tests/tools/test_base_environment.py` — `TestProcessReaping` (4 new tests): natural exit calls `wait()` exactly once; interrupt (130) path calls `wait()`; timeout (124) path calls `wait()`; `_kill_process` calls `wait()` after `kill()`. Uses `MagicMock` per-instance handles so each test asserts the exact invariant against the right handle.

## How to Test

```
python -m pytest tests/tools/test_base_environment.py -q
# → 37 passed (including 4 new TestProcessReaping cases)
```

Pre-existing Termux live-system failures in `test_local_interrupt_cleanup.py` / `test_local_background_child_hang.py` / `test_terminal_timeout_output.py` are blocked by `tests/conftest.py:_live_system_guard` and fire unrelated to this change (confirmed by stashing the diff and re-running).

## Checklist

- [x] Tests pass — 37/37 in test_base_environment.py
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact: neutral. Popen.wait() is POSIX+Windows.
- [x] profile-safe paths — N/A, no path code touched
- [x] .env not used — no config touched

## Risk & Impact

Low. Adds explicit `wait()` calls inside the only paths that previously abandoned the subprocess. The `ProcessHandle` protocol already declared `wait()`; this fix only starts calling it.

Type: Bug fix
Closes: #71253