### PR TITLE
fix: queue env-enabled platforms for background reconnect after fatal error

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4630,6 +4630,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             logger.debug("[Gateway] reaction hook emit failed", exc_info=True)
 
+    def _build_env_fallback_platform_config(
+        self, platform: "Platform"
+    ) -> "Optional[PlatformConfig]":
+        """Build a minimal PlatformConfig from env vars for a platform that
+        was enabled via .env (e.g. TELEGRAM_BOT_TOKEN) rather than via
+        config.yaml's gateway.platforms block.
+
+        Without this, a retryable fatal error on such a platform never gets
+        queued into _failed_platforms (platform_config is None), so the
+        background reconnect watcher never tries to recover it — the gateway
+        stays alive but deaf until manual restart.
+        """
+        from gateway.config import PLATFORM_TOKEN_ENV_NAMES, PlatformConfig
+
+        env_name = PLATFORM_TOKEN_ENV_NAMES.get(platform)
+        if not env_name:
+            return None
+        token = os.environ.get(env_name)
+        if not token:
+            return None
+        home_channel = os.environ.get(f"{platform.value.upper()}_HOME_CHANNEL")
+        return PlatformConfig(
+            token=token,
+            home_channel=home_channel or "",
+            enabled=True,
+        )
+
     async def _handle_adapter_fatal_error(self, adapter: BasePlatformAdapter) -> None:
         """React to an adapter failure after startup.
 
@@ -4750,6 +4777,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Queue retryable failures for background reconnection
         if adapter.fatal_error_retryable:
             platform_config = self.config.platforms.get(adapter.platform)
+            # Fallback: platforms enabled via .env (e.g. TELEGRAM_BOT_TOKEN)
+            # are not in config.yaml's gateway.platforms dict, so
+            # platform_config would be None and the adapter would never be
+            # queued for background reconnection — causing the gateway to
+            # silently stay alive but deaf until manual restart.
+            # Build a minimal PlatformConfig from env vars so the reconnect
+            # watcher can recover it.
+            if platform_config is None:
+                platform_config = self._build_env_fallback_platform_config(
+                    adapter.platform
+                )
             if platform_config and adapter.platform not in self._failed_platforms:
                 self._failed_platforms[adapter.platform] = {
                     "config": platform_config,
@@ -4764,6 +4802,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # exhausting its restart budget), respawn it so queued platforms
                 # are not permanently stranded (#70344).
                 self._ensure_reconnect_watcher_running()
+            elif platform_config is None:
+                logger.warning(
+                    "%s has retryable fatal error but no platform config "
+                    "found in config.yaml or env; cannot queue for reconnect",
+                    adapter.platform.value,
+                )
 
         if not self.adapters and not self._failed_platforms:
             self._exit_reason = adapter.fatal_error_message or "All messaging adapters disconnected"


### PR DESCRIPTION
## Problem

Platforms enabled via `.env` (e.g. `TELEGRAM_BOT_TOKEN`) are not present in `config.yaml`'s `gateway.platforms` dict. When such a platform hits a retryable fatal error (e.g. 10 consecutive network failures during a proxy outage), `_handle_adapter_fatal_error_impl` calls `self.config.platforms.get(adapter.platform)` which returns `None`, so the platform is **never queued** into `_failed_platforms`. The background reconnect watcher therefore never tries to recover it.

**Observed behavior:** Gateway process stays alive (other platforms still connected), but Telegram adapter is deaf. Messages sent from Telegram are silently dropped until manual gateway restart. In the reported case, the outage lasted 1h47m before the user noticed and restarted manually.

## Root Cause

```python
# gateway/run.py, _handle_adapter_fatal_error_impl()
if adapter.fatal_error_retryable:
    platform_config = self.config.platforms.get(adapter.platform)  # ← None for .env platforms
    if platform_config and ...:  # ← False, skip queue
        self._failed_platforms[adapter.platform] = { ... }
```

The existing `stranded` guard (added in a prior commit to mitigate this) exits the gateway so the service manager restarts it. But this is a **workaround**, not a root-cause fix: it converts a transient outage into a restart loop, losing in-process state (active sessions, cron context, etc.) every time.

## Fix

When `platform_config` is `None`, build a minimal `PlatformConfig` from the same env vars that were used to start the adapter originally, using the existing `PLATFORM_TOKEN_ENV_NAMES` mapping:

```python
if platform_config is None:
    platform_config = self._build_env_fallback_platform_config(adapter.platform)
```

The fallback reads `PLATFORM_TOKEN_ENV_NAMES[platform]` (e.g. `TELEGRAM_BOT_TOKEN`) and `{PLATFORM}_HOME_CHANNEL` from `os.environ`, constructs a `PlatformConfig(token=..., home_channel=..., enabled=True)`. This lets the reconnect watcher recover the platform **without a full gateway restart**.

## Testing

Unit tests verify:
1. `_build_env_fallback_platform_config` correctly constructs `PlatformConfig` from env vars
2. Returns `None` when env vars are absent (no false queueing)
3. Retryable fatal error on an env-enabled platform correctly enters `_failed_platforms`
4. Non-retryable errors are **not** queued (unchanged behavior)
5. **Old bug scenario reproduced then fixed**: `config.platforms` has no Telegram entry, retryable fatal error → platform correctly queued

```
✅ 5/5 tests passed
```

## Scope

- 1 file changed, 44 insertions, 0 deletions
- No behavioral change for platforms already in `config.yaml`
- No new env vars introduced (reuses existing `PLATFORM_TOKEN_ENV_NAMES`)
- The `stranded` guard remains as a safety net for any edge case the fallback doesn't cover