### PR TITLE
fix(hermes_cli): stop full uninstall from wiping named profiles after user declines

### DIFF
--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -492,6 +492,29 @@ def _uninstall_profile(profile) -> None:
         log_warn(f"  Could not remove {profile_home}: {e}")
 
 
+def _remove_hermes_home(hermes_home: Path, *, preserve_profiles: bool) -> None:
+    """Delete ``hermes_home``, optionally keeping the named-profiles subtree.
+
+    Named profiles live under ``<default>/profiles/<name>/``. Full uninstall
+    always clears default-root data (config, sessions, .env, …), but when the
+    user declined removing other profiles — or the non-interactive ``--yes``
+    path keeps them — the ``profiles/`` directory must survive. A blanket
+    ``shutil.rmtree(hermes_home)`` would wipe those homes anyway.
+    """
+    profiles_dir = hermes_home / "profiles"
+    if not preserve_profiles or not profiles_dir.is_dir():
+        shutil.rmtree(hermes_home)
+        return
+
+    for child in list(hermes_home.iterdir()):
+        if child.name == "profiles":
+            continue
+        if child.is_symlink() or child.is_file():
+            child.unlink()
+        else:
+            shutil.rmtree(child)
+
+
 def run_gui_uninstall(args):
     """GUI-only uninstall: remove the Chat GUI, leave the agent + data intact.
 
@@ -865,12 +888,13 @@ def _perform_uninstall(
             log_info("No Windows installer artifacts to remove")
     
     # 5. Optionally remove ~/.hermes/ data directory (and named profiles)
+    preserved_profiles = False
     if full_uninstall:
         # 5a. Stop and remove each named profile's gateway service and
-        #     alias wrapper. The profile HERMES_HOME dirs live under
-        #     ``<default>/profiles/<name>/`` and will be swept away by the
-        #     rmtree below, but services + alias scripts live OUTSIDE the
-        #     default root and have to be cleaned up explicitly.
+        #     alias wrapper. Services + alias scripts live OUTSIDE the
+        #     default root and must be cleaned explicitly. Profile data
+        #     under ``profiles/`` is removed here too when requested;
+        #     otherwise step 5b preserves that subtree.
         if remove_profiles and named_profiles:
             for prof in named_profiles:
                 _uninstall_profile(prof)
@@ -878,8 +902,18 @@ def _perform_uninstall(
         log_info("Removing configuration and data...")
         try:
             if hermes_home.exists():
-                shutil.rmtree(hermes_home)
-                log_success(f"Removed {hermes_home}")
+                preserve_profiles = not remove_profiles
+                _remove_hermes_home(hermes_home, preserve_profiles=preserve_profiles)
+                preserved_profiles = (
+                    preserve_profiles and (hermes_home / "profiles").is_dir()
+                )
+                if preserved_profiles:
+                    log_success(
+                        f"Removed default data under {hermes_home} "
+                        "(kept named profiles)"
+                    )
+                else:
+                    log_success(f"Removed {hermes_home}")
         except Exception as e:
             log_warn(f"Could not fully remove {hermes_home}: {e}")
             log_info("You may need to manually remove it")
@@ -902,6 +936,10 @@ def _perform_uninstall(
             print(color("  iex (irm https://hermes-agent.nousresearch.com/install.ps1)", Colors.DIM))
         else:
             print(color("  curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash", Colors.DIM))
+        print()
+    elif preserved_profiles:
+        print(color("Named profiles were preserved:", Colors.CYAN))
+        print(f"  {hermes_home / 'profiles'}/")
         print()
 
     if _is_windows():

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -509,10 +509,10 @@ def _remove_hermes_home(hermes_home: Path, *, preserve_profiles: bool) -> None:
     for child in list(hermes_home.iterdir()):
         if child.name == "profiles":
             continue
-        if child.is_symlink() or child.is_file():
-            child.unlink()
-        else:
+        if child.is_dir() and not child.is_symlink():
             shutil.rmtree(child)
+        else:
+            child.unlink()
 
 
 def run_gui_uninstall(args):
@@ -751,7 +751,10 @@ def _print_uninstall_dry_run(*, project_root: Path, hermes_home: Path, full_unin
         if _is_default_hermes_home(hermes_home):
             profiles = _discover_named_profiles()
             if profiles:
-                print("  • Named profiles (interactive uninstall asks before removing):")
+                print(
+                    "  • Named profiles (kept by default on --yes; "
+                    "interactive uninstall asks before removing):"
+                )
                 for prof in profiles:
                     print(f"    - {prof.name}: {prof.path}")
     else:
@@ -840,10 +843,10 @@ def _perform_uninstall(
     #     dir). Both the "keep data" and "full" CLI flows remove the agent
     #     code, so the GUI — which is just another consumer of the same
     #     checkout — should go with it. uninstall_gui() never touches config /
-    #     sessions / .env, so it's safe in keep-data mode; on full uninstall the
-    #     step-5 rmtree(hermes_home) would sweep the in-tree artifacts anyway,
-    #     but the packaged app + Electron userData live OUTSIDE HERMES_HOME and
-    #     must be cleaned explicitly here.
+    #     sessions / .env, so it's safe in keep-data mode; on full uninstall
+    #     step 5 ``_remove_hermes_home`` sweeps in-tree artifacts (full wipe
+    #     when profiles are removed), but the packaged app + Electron userData
+    #     live OUTSIDE HERMES_HOME and must be cleaned explicitly here.
     log_info("Removing desktop Chat GUI artifacts...")
     try:
         from hermes_cli.gui_uninstall import uninstall_gui
@@ -875,9 +878,9 @@ def _perform_uninstall(
     # 4b. Remove Windows-only installer artifacts that are NOT user data:
     #     PortableGit, bundled Node, gateway-service dir.  Installer put them
     #     under HERMES_HOME but they're install tooling, not config — safe to
-    #     remove even in "keep data" mode.  If we're doing a full uninstall
-    #     the step-5 rmtree(hermes_home) would sweep them anyway; calling
-    #     this helper there is a no-op since they'll already be gone.
+    #     remove even in "keep data" mode.  On full uninstall step 5
+    #     ``_remove_hermes_home`` sweeps them when the default root is wiped;
+    #     calling this helper first is still useful in keep-data mode.
     if _is_windows():
         log_info("Removing Windows installer artifacts (PortableGit, Node, gateway-service)...")
         removed_artifacts = remove_portable_tooling_windows(hermes_home)

--- a/tests/hermes_cli/test_uninstall_preserve_profiles.py
+++ b/tests/hermes_cli/test_uninstall_preserve_profiles.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -77,6 +78,44 @@ def test_perform_uninstall_full_without_remove_profiles_keeps_data(
     assert profile_home.is_dir()
     assert (profile_home / "config.yaml").read_text(encoding="utf-8") == "profile: coder\n"
     assert not (hermes_home / "config.yaml").exists()
+
+
+def test_perform_uninstall_full_with_remove_profiles_wipes_home(
+    monkeypatch, tmp_path
+):
+    project_root = tmp_path / "repo"
+    hermes_home = tmp_path / ".hermes"
+    project_root.mkdir()
+    profile_home = _seed_default_home(hermes_home)
+    removed_profiles: list[str] = []
+
+    monkeypatch.setattr(uninstall, "uninstall_gateway_service", lambda: False)
+    monkeypatch.setattr(uninstall, "remove_path_from_shell_configs", lambda: [])
+    monkeypatch.setattr(uninstall, "remove_wrapper_script", lambda: [])
+    monkeypatch.setattr(uninstall, "remove_node_symlinks", lambda _home: [])
+    monkeypatch.setattr(uninstall, "_is_windows", lambda: False)
+
+    def _fake_uninstall_profile(profile):
+        removed_profiles.append(profile.name)
+        # Mirror production: wipe the profile home before step 5b.
+        if profile.path.exists():
+            shutil.rmtree(profile.path)
+
+    monkeypatch.setattr(uninstall, "_uninstall_profile", _fake_uninstall_profile)
+
+    uninstall._perform_uninstall(
+        project_root=project_root,
+        hermes_home=hermes_home,
+        full_uninstall=True,
+        remove_profiles=True,
+        named_profiles=[
+            SimpleNamespace(name="coder", path=profile_home, alias_path=None)
+        ],
+    )
+
+    assert removed_profiles == ["coder"]
+    assert not project_root.exists()
+    assert not hermes_home.exists()
 
 
 def test_yes_full_uninstall_does_not_wipe_named_profiles(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_uninstall_preserve_profiles.py
+++ b/tests/hermes_cli/test_uninstall_preserve_profiles.py
@@ -1,0 +1,107 @@
+"""Full uninstall must honor remove_profiles when wiping HERMES_HOME."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_cli import uninstall
+
+
+def _seed_default_home(hermes_home: Path) -> Path:
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+    (hermes_home / "sessions").mkdir()
+    (hermes_home / ".env").write_text("KEY=secret\n", encoding="utf-8")
+    profile_home = hermes_home / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text("profile: coder\n", encoding="utf-8")
+    return profile_home
+
+
+def test_remove_hermes_home_preserves_profiles_subtree(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    profile_home = _seed_default_home(hermes_home)
+
+    uninstall._remove_hermes_home(hermes_home, preserve_profiles=True)
+
+    assert hermes_home.is_dir()
+    assert profile_home.is_dir()
+    assert (profile_home / "config.yaml").read_text(encoding="utf-8") == "profile: coder\n"
+    assert not (hermes_home / "config.yaml").exists()
+    assert not (hermes_home / "sessions").exists()
+    assert not (hermes_home / ".env").exists()
+
+
+def test_remove_hermes_home_wipes_everything_when_not_preserving(tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    _seed_default_home(hermes_home)
+
+    uninstall._remove_hermes_home(hermes_home, preserve_profiles=False)
+
+    assert not hermes_home.exists()
+
+
+def test_perform_uninstall_full_without_remove_profiles_keeps_data(
+    monkeypatch, tmp_path
+):
+    project_root = tmp_path / "repo"
+    hermes_home = tmp_path / ".hermes"
+    project_root.mkdir()
+    profile_home = _seed_default_home(hermes_home)
+    removed_profiles: list[str] = []
+
+    monkeypatch.setattr(uninstall, "uninstall_gateway_service", lambda: False)
+    monkeypatch.setattr(uninstall, "remove_path_from_shell_configs", lambda: [])
+    monkeypatch.setattr(uninstall, "remove_wrapper_script", lambda: [])
+    monkeypatch.setattr(uninstall, "remove_node_symlinks", lambda _home: [])
+    monkeypatch.setattr(uninstall, "_is_windows", lambda: False)
+    monkeypatch.setattr(
+        uninstall,
+        "_uninstall_profile",
+        lambda profile: removed_profiles.append(profile.name),
+    )
+
+    uninstall._perform_uninstall(
+        project_root=project_root,
+        hermes_home=hermes_home,
+        full_uninstall=True,
+        remove_profiles=False,
+        named_profiles=[
+            SimpleNamespace(name="coder", path=profile_home, alias_path=None)
+        ],
+    )
+
+    assert removed_profiles == []
+    assert not project_root.exists()
+    assert profile_home.is_dir()
+    assert (profile_home / "config.yaml").read_text(encoding="utf-8") == "profile: coder\n"
+    assert not (hermes_home / "config.yaml").exists()
+
+
+def test_yes_full_uninstall_does_not_wipe_named_profiles(monkeypatch, tmp_path):
+    """Non-interactive --yes --full claims not to remove named profiles."""
+    project_root = tmp_path / "repo"
+    hermes_home = tmp_path / ".hermes"
+    project_root.mkdir()
+    profile_home = _seed_default_home(hermes_home)
+
+    monkeypatch.setattr(uninstall, "get_project_root", lambda: project_root)
+    monkeypatch.setattr(uninstall, "get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr(uninstall, "_is_default_hermes_home", lambda _home: True)
+    monkeypatch.setattr(
+        uninstall,
+        "_discover_named_profiles",
+        lambda: [SimpleNamespace(name="coder", path=profile_home, alias_path=None)],
+    )
+    monkeypatch.setattr(uninstall, "uninstall_gateway_service", lambda: False)
+    monkeypatch.setattr(uninstall, "remove_path_from_shell_configs", lambda: [])
+    monkeypatch.setattr(uninstall, "remove_wrapper_script", lambda: [])
+    monkeypatch.setattr(uninstall, "remove_node_symlinks", lambda _home: [])
+    monkeypatch.setattr(uninstall, "_is_windows", lambda: False)
+
+    uninstall.run_uninstall(SimpleNamespace(yes=True, full=True, dry_run=False, gui=False))
+
+    assert profile_home.is_dir()
+    assert (profile_home / "config.yaml").read_text(encoding="utf-8") == "profile: coder\n"
+    assert not (hermes_home / "config.yaml").exists()


### PR DESCRIPTION
## What does this PR do?

Full uninstall from the default Hermes home asked whether to remove named profiles, but then always deleted the entire default root, which also deleted `profiles/<name>/`. This PR keeps the `profiles/` subtree when the user declines (and on non-interactive `--yes --full`, which already sets `remove_profiles=False`).

### Bug Cause

`_perform_uninstall` only skipped per-profile gateway/alias cleanup when `remove_profiles` was false. Step 5 still called `shutil.rmtree(hermes_home)`. Named profiles live under `<default>/profiles/<name>/`, so that rmtree wiped their data anyway and could leave zombie gateway units/aliases behind.

### Reproduction Steps

1. Create a named profile under `~/.hermes/profiles/coder` (with config / `.env`).
2. Run interactive `hermes uninstall`, choose option `2` (full).
3. Answer `N` to "Also stop and remove these profile(s)?".
4. Type `yes` to confirm.

Expected: default-root data removed; `~/.hermes/profiles/coder/` kept.
Before fix: entire `~/.hermes` (including `profiles/coder`) deleted.

### Fix

- Add `_remove_hermes_home(..., preserve_profiles=)` to delete default-root contents while keeping `profiles/` when requested.
- Wire it into `_perform_uninstall` so `remove_profiles=False` preserves the subtree and `remove_profiles=True` still fully wipes.
- Clarify dry-run wording for `--yes` vs interactive ask.
- Regression tests cover preserve, wipe, `--yes --full`, and `remove_profiles=True` through `_perform_uninstall`.

## Related Issue

No issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/uninstall.py` - preserve `profiles/` on declined / `--yes` full uninstall; update dry-run copy and step-5 comments
- `tests/hermes_cli/test_uninstall_preserve_profiles.py` - regression coverage for preserve and wipe paths

## How to Test

1. Manual: follow Reproduction Steps and confirm `profiles/coder` remains after answering `N`.
2. Automated (already run locally, 32 passed):

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_uninstall_preserve_profiles.py \
  tests/hermes_cli/test_uninstall_dry_run.py \
  tests/hermes_cli/test_uninstall_node_symlinks.py \
  tests/hermes_cli/test_gui_uninstall.py \
  -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact - N/A (path wipe uses pathlib/shutil)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
