### PR TITLE
fix(agent): preserve Anthropic auxiliary cache usage

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1479,13 +1479,29 @@ class _AnthropicCompletionsAdapter:
 
         usage = None
         if hasattr(response, "usage") and response.usage:
-            prompt_tokens = getattr(response.usage, "input_tokens", 0) or 0
+            fresh_input_tokens = getattr(response.usage, "input_tokens", 0) or 0
+            cache_read_tokens = (
+                getattr(response.usage, "cache_read_input_tokens", 0) or 0
+            )
+            cache_write_tokens = (
+                getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+            )
+            # OpenAI's prompt_tokens total includes cached input. Preserve that
+            # contract in the shim so normalize_usage can recover the native
+            # Anthropic fresh/read/write buckets without losing spend.
+            prompt_tokens = (
+                fresh_input_tokens + cache_read_tokens + cache_write_tokens
+            )
             completion_tokens = getattr(response.usage, "output_tokens", 0) or 0
             total_tokens = getattr(response.usage, "total_tokens", 0) or (prompt_tokens + completion_tokens)
             usage = SimpleNamespace(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
                 total_tokens=total_tokens,
+                prompt_tokens_details=SimpleNamespace(
+                    cached_tokens=cache_read_tokens,
+                ),
+                cache_creation_input_tokens=cache_write_tokens,
             )
 
         choice = SimpleNamespace(

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1486,9 +1486,10 @@ class _AnthropicCompletionsAdapter:
             cache_write_tokens = (
                 getattr(response.usage, "cache_creation_input_tokens", 0) or 0
             )
-            # OpenAI's prompt_tokens total includes cached input. Preserve that
-            # contract in the shim so normalize_usage can recover the native
-            # Anthropic fresh/read/write buckets without losing spend.
+            # Keep both usage shapes because this adapter feeds two normalizers:
+            # native Anthropic accounting reads input/output/cache_* fields,
+            # while MoA's OpenAI-compatible path reads an inclusive
+            # prompt_tokens total and subtracts prompt_tokens_details.
             prompt_tokens = (
                 fresh_input_tokens + cache_read_tokens + cache_write_tokens
             )
@@ -1501,6 +1502,9 @@ class _AnthropicCompletionsAdapter:
                 prompt_tokens_details=SimpleNamespace(
                     cached_tokens=cache_read_tokens,
                 ),
+                input_tokens=fresh_input_tokens,
+                output_tokens=completion_tokens,
+                cache_read_input_tokens=cache_read_tokens,
                 cache_creation_input_tokens=cache_write_tokens,
             )
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4579,6 +4579,63 @@ class TestAnthropicAuxiliaryReasoningTranslation:
         assert captured["output_config"] == {"effort": "medium"}
         assert "extra_body" not in captured
 
+    def test_usage_preserves_anthropic_cache_buckets(self):
+        """The OpenAI-shaped shim must normalize like the native response."""
+        from agent.auxiliary_client import _AnthropicCompletionsAdapter
+        from agent.usage_pricing import normalize_usage
+
+        raw_usage = SimpleNamespace(
+            input_tokens=597,
+            output_tokens=17,
+            cache_read_input_tokens=57_335,
+            cache_creation_input_tokens=194,
+        )
+        adapter = _AnthropicCompletionsAdapter(
+            MagicMock(), "claude-fable-5", is_oauth=False
+        )
+
+        with (
+            patch(
+                "agent.anthropic_adapter.build_anthropic_kwargs",
+                return_value={
+                    "model": "claude-fable-5",
+                    "messages": [],
+                    "max_tokens": 64,
+                },
+            ),
+            patch(
+                "agent.anthropic_adapter.create_anthropic_message",
+                return_value=SimpleNamespace(usage=raw_usage),
+            ),
+            patch("agent.transports.get_transport") as mock_get_transport,
+        ):
+            mock_get_transport.return_value.normalize_response.return_value = (
+                SimpleNamespace(
+                    content="ok",
+                    tool_calls=None,
+                    reasoning=None,
+                    finish_reason="stop",
+                )
+            )
+            response = adapter.create(
+                model="claude-fable-5",
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=64,
+            )
+
+        native = normalize_usage(
+            raw_usage,
+            provider="anthropic",
+            api_mode="anthropic_messages",
+        )
+        adapted = normalize_usage(
+            response.usage,
+            provider="moa",
+            api_mode="chat_completions",
+        )
+
+        assert adapted == native
+
     def test_build_call_kwargs_private_reasoning_only_for_anthropic_messages(self):
         anthropic_kwargs = _build_call_kwargs(
             "anthropic",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4579,16 +4579,27 @@ class TestAnthropicAuxiliaryReasoningTranslation:
         assert captured["output_config"] == {"effort": "medium"}
         assert "extra_body" not in captured
 
-    def test_usage_preserves_anthropic_cache_buckets(self):
-        """The OpenAI-shaped shim must normalize like the native response."""
+    @pytest.mark.parametrize(
+        ("cache_read_tokens", "cache_write_tokens"),
+        [
+            (57_335, 194),
+            (0, 4_211),
+        ],
+    )
+    def test_usage_preserves_anthropic_cache_buckets(
+        self,
+        cache_read_tokens,
+        cache_write_tokens,
+    ):
+        """The dual-shaped shim must normalize like the native response."""
         from agent.auxiliary_client import _AnthropicCompletionsAdapter
         from agent.usage_pricing import normalize_usage
 
         raw_usage = SimpleNamespace(
             input_tokens=597,
             output_tokens=17,
-            cache_read_input_tokens=57_335,
-            cache_creation_input_tokens=194,
+            cache_read_input_tokens=cache_read_tokens,
+            cache_creation_input_tokens=cache_write_tokens,
         )
         adapter = _AnthropicCompletionsAdapter(
             MagicMock(), "claude-fable-5", is_oauth=False
@@ -4628,13 +4639,18 @@ class TestAnthropicAuxiliaryReasoningTranslation:
             provider="anthropic",
             api_mode="anthropic_messages",
         )
-        adapted = normalize_usage(
+        adapted_chat = normalize_usage(
             response.usage,
             provider="moa",
             api_mode="chat_completions",
         )
+        adapted_native = normalize_usage(
+            response.usage,
+            provider="anthropic",
+        )
 
-        assert adapted == native
+        assert adapted_chat == native
+        assert adapted_native == native
 
     def test_build_call_kwargs_private_reasoning_only_for_anthropic_messages(self):
         anthropic_kwargs = _build_call_kwargs(


### PR DESCRIPTION
## Summary
- preserve Anthropic cache-read and cache-write usage through both native and OpenAI-compatible auxiliary accounting
- keep canonical usage and cost accounting identical to the native Anthropic response

## Root cause
`_AnthropicCompletionsAdapter` feeds both OpenAI-compatible MoA accounting and native Anthropic auxiliary accounting. The old shim dropped cache buckets entirely; the first correction exposed the OpenAI fields but still omitted the native `input_tokens`, `output_tokens`, and `cache_read_input_tokens` fields, so the native path normalized to zero and skipped recording the row.

## Validation
- `python -m pytest tests/agent/test_auxiliary_client.py -q` — 364 passed
- `python -m pytest tests/agent/test_moa_aggregator_cost_slot.py tests/agent/test_moa_aggregator_cache_control.py -q` — 4 passed
- `python -m ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py` — passed
- `git diff --check` — passed

Tested on Windows with Python 3.

Fixes #71242