### PR TITLE
fix(desktop): flatten main sessions in entered projects

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -114,6 +114,7 @@ import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } 
 import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
 import {
+  EnteredMainSessionButton,
   excludeProjectSessions,
   orderProjectsByIds,
   overlayLiveLanes,
@@ -1335,6 +1336,11 @@ export function ChatSidebar({
                 headerAction={
                   inProject && enteredProject ? (
                     <div className="group/workspace flex shrink-0 items-center gap-0.5">
+                      <EnteredMainSessionButton
+                        onNewSession={onNewSessionInWorkspace}
+                        project={enteredProjectContent ?? enteredProject}
+                        repoWorktrees={scopedRepoWorktrees}
+                      />
                       {enteredProject.path && <StartWorkButton repoPath={enteredProject.path} />}
                       {/* Home has no folder and no record to rename, theme, or delete. */}
                       {!enteredProject.isNoProject && (

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.test.tsx
@@ -1,0 +1,188 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+import * as notifications from '@/store/notifications'
+import * as projectStore from '@/store/projects'
+
+import { EnteredMainSessionButton, EnteredProjectContent } from './entered-content'
+import type { SidebarProjectTree, SidebarSessionGroup } from './workspace-groups'
+
+const switchBranchInRepoMock = vi.spyOn(projectStore, 'switchBranchInRepo')
+const notifyErrorMock = vi.spyOn(notifications, 'notifyError')
+
+afterEach(() => {
+  cleanup()
+  notifyErrorMock.mockReset()
+  switchBranchInRepoMock.mockReset()
+})
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: { cancel: 'Cancel' },
+      sidebar: {
+        newSessionIn: (label: string) => `New session in ${label}`,
+        showMoreIn: (count: number, label: string) => `Show ${count} more in ${label}`,
+        projects: {
+          forceRemove: 'Force remove',
+          removeFromSidebar: 'Remove from sidebar',
+          removeWorktree: 'Remove worktree',
+          removeWorktreeConfirm: 'Remove this worktree?',
+          removeWorktreeDirty: 'This worktree has changes.',
+          removeWorktreeFailed: 'Could not remove worktree'
+        }
+      },
+      statusStack: { coding: { switchFailed: (label: string) => `Could not switch to ${label}` } }
+    }
+  })
+}))
+
+vi.mock('./model', () => ({
+  SIDEBAR_GROUP_PAGE: 5,
+  useWorkspaceNodeOpen: () => [true, vi.fn()]
+}))
+
+vi.mock('./workspace-group', () => ({
+  SidebarWorkspaceGroup: ({ group }: { group: SidebarSessionGroup }) => (
+    <div data-testid={`workspace-group-${group.id}`}>{group.label}</div>
+  )
+}))
+
+const session = (id: string, lastActive: number): SessionInfo =>
+  ({ id, last_active: lastActive, started_at: lastActive }) as SessionInfo
+
+const projectWithMain = (): SidebarProjectTree => ({
+  id: 'project',
+  label: 'Project',
+  path: '/repo',
+  repos: [
+    {
+      id: '/repo',
+      label: 'repo',
+      path: '/repo',
+      sessionCount: 0,
+      groups: [
+        {
+          id: 'main',
+          isMain: true,
+          label: 'main',
+          path: '/repo',
+          sessions: []
+        }
+      ]
+    }
+  ],
+  sessionCount: 0
+})
+
+describe('EnteredProjectContent', () => {
+  it('renders deduplicated main-checkout sessions directly and keeps linked worktrees grouped', () => {
+    const staleDuplicate = session('duplicate', 2)
+    const freshDuplicate = session('duplicate', 5)
+    const recent = session('recent', 4)
+    const oldest = session('oldest', 1)
+    const linked = session('linked-session', 3)
+
+    const project: SidebarProjectTree = {
+      id: 'project',
+      label: 'Project',
+      path: '/repo',
+      repos: [
+        {
+          id: '/repo',
+          label: 'repo',
+          path: '/repo',
+          sessionCount: 5,
+          groups: [
+            {
+              id: 'main',
+              isMain: true,
+              label: 'main',
+              path: '/repo',
+              sessions: [oldest, staleDuplicate]
+            },
+            {
+              id: 'old-main',
+              isMain: true,
+              label: 'old-main',
+              path: '/repo',
+              sessions: [recent, freshDuplicate]
+            },
+            {
+              id: 'linked',
+              label: 'feature',
+              path: '/repo-feature',
+              sessions: [linked]
+            }
+          ]
+        }
+      ],
+      sessionCount: 5
+    }
+
+    const renderRows = vi.fn((_sessions: SessionInfo[]) => null)
+
+    render(<EnteredProjectContent project={project} renderRows={renderRows} />)
+
+    expect(renderRows).toHaveBeenCalledOnce()
+    expect(renderRows.mock.calls[0][0]).toEqual([freshDuplicate, recent, oldest])
+    expect(screen.queryByTestId('workspace-group-main')).toBeNull()
+    expect(screen.queryByTestId('workspace-group-old-main')).toBeNull()
+    expect(screen.getByTestId('workspace-group-linked').textContent).toBe('feature')
+  })
+
+  it('pages flattened main-checkout sessions without restoring the branch header', () => {
+    const sessions = Array.from({ length: 7 }, (_, index) => session(`session-${index}`, 7 - index))
+    const project = projectWithMain()
+    const repo = project.repos[0]
+    const mainGroup = repo?.groups[0]
+
+    if (!repo || !mainGroup) {
+      throw new Error('expected main checkout fixture')
+    }
+
+    mainGroup.sessions = sessions
+    repo.sessionCount = sessions.length
+    project.sessionCount = sessions.length
+
+    const renderRows = vi.fn((_sessions: SessionInfo[]) => null)
+
+    render(<EnteredProjectContent project={project} renderRows={renderRows} />)
+
+    expect(renderRows).toHaveBeenCalledOnce()
+    expect(renderRows).toHaveBeenLastCalledWith(sessions.slice(0, 5))
+    expect(screen.queryByTestId('workspace-group-main')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show 2 more in main' }))
+
+    expect(renderRows).toHaveBeenCalledTimes(2)
+    expect(renderRows).toHaveBeenLastCalledWith(sessions)
+    expect(screen.queryByRole('button', { name: 'Show 2 more in main' })).toBeNull()
+  })
+
+  it('switches to the visible main lane before creating a session from the entered-project header', async () => {
+    switchBranchInRepoMock.mockResolvedValue(undefined)
+    const onNewSession = vi.fn()
+
+    render(<EnteredMainSessionButton onNewSession={onNewSession} project={projectWithMain()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'New session in main' }))
+
+    await waitFor(() => expect(switchBranchInRepoMock).toHaveBeenCalledWith('/repo', 'main'))
+    expect(onNewSession).toHaveBeenCalledWith('/repo')
+    expect(switchBranchInRepoMock.mock.invocationCallOrder[0]).toBeLessThan(onNewSession.mock.invocationCallOrder[0])
+  })
+
+  it('does not create a session when switching the main lane fails', async () => {
+    const error = new Error('switch failed')
+    switchBranchInRepoMock.mockRejectedValue(error)
+    notifyErrorMock.mockReturnValue('notification')
+    const onNewSession = vi.fn()
+
+    render(<EnteredMainSessionButton onNewSession={onNewSession} project={projectWithMain()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'New session in main' }))
+
+    await waitFor(() => expect(notifyErrorMock).toHaveBeenCalledWith(error, 'Could not switch to main'))
+    expect(onNewSession).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -18,20 +18,115 @@ import { useI18n } from '@/i18n'
 import { displayPath } from '@/lib/display-path'
 import { $dismissedWorktreeIds, dismissWorktree, setWorkspaceNodeOpen } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
-import { removeWorktreePath } from '@/store/projects'
+import { removeWorktreePath, switchBranchInRepo } from '@/store/projects'
 
 import { SidebarRowStack } from '../chrome'
 
-import { useWorkspaceNodeOpen } from './model'
+import { SIDEBAR_GROUP_PAGE, useWorkspaceNodeOpen } from './model'
 import { SidebarWorkspaceGroup } from './workspace-group'
 import {
   mergeRepoWorktreeGroups,
   overlayRepoLanes,
+  sessionRecency,
   type SidebarProjectTree,
   type SidebarSessionGroup,
   type SidebarWorkspaceTree
 } from './workspace-groups'
-import { WorkspaceAddButton, WorkspaceHeader } from './workspace-header'
+import { WorkspaceAddButton, WorkspaceHeader, WorkspaceShowMoreButton } from './workspace-header'
+
+const mainCheckoutSessions = (groups: SidebarSessionGroup[]): SessionInfo[] => {
+  const byId = new Map<string, SessionInfo>()
+
+  for (const group of groups) {
+    if (!group.isMain) {
+      continue
+    }
+
+    for (const session of group.sessions) {
+      const existing = byId.get(session.id)
+
+      if (!existing || sessionRecency(session) > sessionRecency(existing)) {
+        byId.set(session.id, session)
+      }
+    }
+  }
+
+  return [...byId.values()].sort((a, b) => sessionRecency(b) - sessionRecency(a) || a.id.localeCompare(b.id))
+}
+
+function EnteredMainSessionRows({
+  groups,
+  renderRows
+}: {
+  groups: SidebarSessionGroup[]
+  renderRows: (sessions: SessionInfo[]) => React.ReactNode
+}) {
+  const [visibleCount, setVisibleCount] = useState(SIDEBAR_GROUP_PAGE)
+  const sessions = mainCheckoutSessions(groups)
+  const mainGroup = groups.find(group => group.isMain && group.isHome) ?? groups.find(group => group.isMain)
+
+  if (!sessions.length || !mainGroup) {
+    return null
+  }
+
+  const visibleSessions = sessions.slice(0, visibleCount)
+  const hiddenCount = sessions.length - visibleSessions.length
+  const nextCount = Math.min(SIDEBAR_GROUP_PAGE, hiddenCount)
+
+  return (
+    <>
+      {renderRows(visibleSessions)}
+      {hiddenCount > 0 && (
+        <WorkspaceShowMoreButton
+          count={nextCount}
+          label={mainGroup.label}
+          onClick={() => setVisibleCount(count => count + SIDEBAR_GROUP_PAGE)}
+        />
+      )}
+    </>
+  )
+}
+
+interface EnteredMainSessionButtonProps {
+  project: SidebarProjectTree
+  onNewSession: (path: null | string) => void
+  repoWorktrees?: Record<string, HermesGitWorktree[]>
+}
+
+export function EnteredMainSessionButton({ project, onNewSession, repoWorktrees }: EnteredMainSessionButtonProps) {
+  const { t } = useI18n()
+  const repo = project.path ? project.repos.find(candidate => candidate.path === project.path) : undefined
+
+  const mainGroup = useMemo(() => {
+    if (!repo) {
+      return undefined
+    }
+
+    const groups = mergeRepoWorktreeGroups(repo, repo.path ? repoWorktrees?.[repo.path] : undefined)
+
+    return groups.find(group => group.isMain && group.isHome) ?? groups.find(group => group.isMain)
+  }, [repo, repoWorktrees])
+
+  if (!mainGroup?.path) {
+    return null
+  }
+
+  const path = mainGroup.path
+
+  const handleNewSession = async () => {
+    try {
+      await switchBranchInRepo(path, mainGroup.label)
+    } catch (err) {
+      notifyError(err, t.statusStack.coding.switchFailed(mainGroup.label))
+
+      return
+    }
+
+    onNewSession(path)
+  }
+
+  return <WorkspaceAddButton label={t.sidebar.newSessionIn(mainGroup.label)} onClick={() => void handleNewSession()} />
+}
 
 // The entered project's body. Main-checkout sessions render directly — no
 // redundant repo/branch header (the breadcrumb already names the project). Only
@@ -140,6 +235,8 @@ function RepoFlatSection({
       group.isMain || !dismissedWorktrees.includes(group.id) || (group.path && discoveredWorktreePaths.has(group.path))
   )
 
+  const nestedGroups = ordered.filter(group => !group.isMain)
+
   // Removal asks how: actually `git worktree remove` it, or just hide the lane
   // and leave the worktree on disk. A dirty worktree escalates to a force prompt
   // instead of erroring (those changes are usually throwaway).
@@ -167,14 +264,15 @@ function RepoFlatSection({
 
   const body = (
     <>
-      {ordered.map(group => (
+      <EnteredMainSessionRows groups={ordered} renderRows={renderRows} />
+      {nestedGroups.map(group => (
         <SidebarWorkspaceGroup
           group={group}
           key={group.id}
           // The kanban bucket is read-only: it aggregates many task worktrees, so
           // "new session here" and "remove worktree" have no single target.
           onNewSession={group.isKanban ? undefined : onNewSession}
-          onRemove={group.isMain || group.isKanban ? undefined : () => setRemoveTarget(group)}
+          onRemove={group.isKanban ? undefined : () => setRemoveTarget(group)}
           renderRows={renderRows}
         />
       ))}

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -1,5 +1,5 @@
 // Public surface of the project/worktree sidebar, consumed by the sidebar root.
-export { EnteredProjectContent } from './entered-content'
+export { EnteredMainSessionButton, EnteredProjectContent } from './entered-content'
 export {
   orderProjectsByIds,
   PROJECT_PREVIEW_COUNT,


### PR DESCRIPTION
## Summary

- render main-checkout sessions directly in the entered-project view instead of behind redundant branch headers
- keep the existing five-row paging and shared Show more control for large histories
- preserve linked-worktree grouping and the switch-before-create behavior for new sessions on main

## Root cause

`RepoFlatSection` sent every lane, including `isMain` lanes, through `SidebarWorkspaceGroup`. That gave the main checkout a redundant collapsible header whose persisted closed state could leave the entered project showing only `main (N)` instead of chat titles.

Flattened main lanes are now deduplicated by session id, sorted, and rendered directly. They still reveal only `SIDEBAR_GROUP_PAGE` rows at a time, while linked worktrees remain grouped.

The rebase also preserves current main's `StartWorkButton` and global `WorktreeDialog` behavior.

## Validation

- `npm run test:ui --workspace apps/desktop -- src/app/chat/sidebar/projects/entered-content.test.tsx` — 4 passed
- Desktop typecheck, targeted ESLint, and Prettier — passed
- Desktop production build and `git diff --check` — passed
- GitHub required CI on `87ba8e2fbe` — passed; merge state `CLEAN`

Tested on Windows with Node 22.23.1.

Fixes #71232
