### PR TITLE
fix(cli): resolve bare MoA selections consistently

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4154,19 +4154,29 @@ def save_config_value(key_path: str, value: any) -> bool:
 
 
 def _normalize_moa_model(model: Optional[str]) -> tuple[Optional[str], Optional[str]]:
-    """Map a ``moa:<preset>`` model string to ``(provider, preset)``.
+    """Map ``moa`` or ``moa:<preset>`` to ``(provider, preset)``.
 
-    Returns ``("moa", "<preset>")`` when *model* selects the MoA virtual
-    provider, otherwise ``(None, model)`` unchanged. This gives non-interactive
-    ``hermes chat -Q -m moa:<preset>`` the same routing the interactive
-    ``/moa`` command and the model picker already use: ``resolve_runtime_provider``
-    handles ``requested_provider == "moa"`` and ``agent_init`` builds the
-    MoAClient off ``provider == "moa"``. Without this the raw ``moa:<preset>``
-    string is sent to the real provider and rejected with a 401/400 "model not
-    supported" (#56828).
+    A bare ``moa`` selects the configured default preset. Otherwise returns
+    ``(None, model)`` unchanged. This gives non-interactive
+    ``hermes chat -Q -m moa[:<preset>]`` the same routing the model picker uses:
+    ``resolve_runtime_provider`` handles ``requested_provider == "moa"`` and
+    ``agent_init`` builds the MoAClient off ``provider == "moa"``. Without this
+    the raw value is sent to the real provider and rejected as an unknown model.
     """
     if isinstance(model, str):
         stripped = model.strip()
+        if stripped.lower() == "moa":
+            try:
+                from hermes_cli.config import load_config
+                from hermes_cli.moa_config import normalize_moa_config
+
+                preset = normalize_moa_config(
+                    load_config().get("moa") or {}
+                )["default_preset"]
+            except Exception:
+                preset = "default"
+
+            return "moa", preset
         if stripped.lower().startswith("moa:"):
             preset = stripped.split(":", 1)[1].strip()
             if preset:
@@ -4356,11 +4366,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _config_model = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
         _DEFAULT_CONFIG_MODEL = ""
         self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
-        # A ``moa:<preset>`` model string selects the MoA virtual provider in
+        # A ``moa`` or ``moa:<preset>`` model string selects the MoA virtual provider in
         # one shot (parity with interactive ``/moa`` and the model picker). Do
         # this before provider resolution so ``-Q -m moa:<preset>`` routes
         # through MoA instead of hitting the real provider with an unknown
-        # model (#56828). A ``moa:`` prefix wins over an explicit ``--provider``.
+        # model (#56828). An MoA selection wins over an explicit ``--provider``.
         _moa_provider_override, self.model = _normalize_moa_model(self.model)
         # Read max_tokens from config (env var override: HERMES_MAX_TOKENS)
         _env_mt = os.environ.get("HERMES_MAX_TOKENS")

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1353,11 +1353,18 @@ def switch_model(
             from hermes_cli.moa_config import exact_moa_preset_name, normalize_moa_config
 
             _moa_cfg = normalize_moa_config(load_config().get("moa") or {})
-            _moa_match = (
-                _moa_cfg["default_preset"]
-                if raw_input.strip().lower() == "moa"
-                else exact_moa_preset_name(_moa_cfg, raw_input)
-            )
+            _moa_selector = raw_input.strip()
+            if _moa_selector.lower() == "moa":
+                _moa_match = _moa_cfg["default_preset"]
+            elif _moa_selector.lower().startswith("moa:"):
+                _prefixed_preset = _moa_selector.split(":", 1)[1].strip()
+                _moa_match = (
+                    _prefixed_preset
+                    if _prefixed_preset in _moa_cfg["presets"]
+                    else None
+                )
+            else:
+                _moa_match = exact_moa_preset_name(_moa_cfg, _moa_selector)
             if _moa_match:
                 target_provider = "moa"
                 new_model = _moa_match

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1353,7 +1353,11 @@ def switch_model(
             from hermes_cli.moa_config import exact_moa_preset_name, normalize_moa_config
 
             _moa_cfg = normalize_moa_config(load_config().get("moa") or {})
-            _moa_match = exact_moa_preset_name(_moa_cfg, raw_input)
+            _moa_match = (
+                _moa_cfg["default_preset"]
+                if raw_input.strip().lower() == "moa"
+                else exact_moa_preset_name(_moa_cfg, raw_input)
+            )
             if _moa_match:
                 target_provider = "moa"
                 new_model = _moa_match

--- a/tests/cli/test_moa_command.py
+++ b/tests/cli/test_moa_command.py
@@ -88,6 +88,16 @@ class TestNormalizeMoaModel:
         assert _normalize_moa_model("moa:strategy") == ("moa", "strategy")
 
 
+    def test_bare_moa_maps_to_default_preset(self):
+        from cli import _normalize_moa_model
+
+        with patch("hermes_cli.config.load_config", return_value=_make_cli().config):
+            assert _normalize_moa_model("  MOA  ") == ("moa", "default")
+
+    def test_empty_moa_prefix_is_not_treated_as_virtual(self):
+        from cli import _normalize_moa_model
+        # No preset after the colon → leave untouched (no provider override).
+        assert _normalize_moa_model("moa:") == (None, "moa:")
 
 
     def test_none_model_unchanged(self):
@@ -113,3 +123,34 @@ class TestNormalizeMoaModel:
         assert requested_provider == "moa"
         assert model == "strategy"
 
+
+class TestBareMoaModelSwitch:
+    def test_bare_moa_reuses_default_preset_when_already_on_moa(self):
+        from hermes_cli.model_switch import switch_model
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=_make_cli().config),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "moa-virtual-provider",
+                    "base_url": "moa://local",
+                    "api_mode": "chat_completions",
+                },
+            ),
+            patch("hermes_cli.model_switch.get_model_info", return_value=None),
+            patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        ):
+            result = switch_model(
+                "moa",
+                "moa",
+                "review",
+                current_base_url="moa://local",
+                current_api_key="moa-virtual-provider",
+                is_global=True,
+            )
+
+        assert result.success is True, result.error_message
+        assert result.target_provider == "moa"
+        assert result.new_model == "default"
+        assert result.is_global is True

--- a/tests/cli/test_moa_command.py
+++ b/tests/cli/test_moa_command.py
@@ -5,11 +5,11 @@ from cli import HermesCLI
 from hermes_cli.moa_config import decode_moa_turn
 
 
-def _make_cli():
+def _make_cli(default_preset="default"):
     cli = HermesCLI.__new__(HermesCLI)
     cli.config = {
         "moa": {
-            "default_preset": "default",
+            "default_preset": default_preset,
             "presets": {
                 "default": {
                     "reference_models": [{"provider": "openai-codex", "model": "gpt-5.5"}],
@@ -91,8 +91,9 @@ class TestNormalizeMoaModel:
     def test_bare_moa_maps_to_default_preset(self):
         from cli import _normalize_moa_model
 
-        with patch("hermes_cli.config.load_config", return_value=_make_cli().config):
-            assert _normalize_moa_model("  MOA  ") == ("moa", "default")
+        config = _make_cli(default_preset="review").config
+        with patch("hermes_cli.config.load_config", return_value=config):
+            assert _normalize_moa_model("  MOA  ") == ("moa", "review")
 
     def test_empty_moa_prefix_is_not_treated_as_virtual(self):
         from cli import _normalize_moa_model
@@ -128,8 +129,9 @@ class TestBareMoaModelSwitch:
     def test_bare_moa_reuses_default_preset_when_already_on_moa(self):
         from hermes_cli.model_switch import switch_model
 
+        config = _make_cli(default_preset="review").config
         with (
-            patch("hermes_cli.config.load_config", return_value=_make_cli().config),
+            patch("hermes_cli.config.load_config", return_value=config),
             patch(
                 "hermes_cli.runtime_provider.resolve_runtime_provider",
                 return_value={
@@ -144,7 +146,7 @@ class TestBareMoaModelSwitch:
             result = switch_model(
                 "moa",
                 "moa",
-                "review",
+                "default",
                 current_base_url="moa://local",
                 current_api_key="moa-virtual-provider",
                 is_global=True,
@@ -152,5 +154,5 @@ class TestBareMoaModelSwitch:
 
         assert result.success is True, result.error_message
         assert result.target_provider == "moa"
-        assert result.new_model == "default"
+        assert result.new_model == "review"
         assert result.is_global is True

--- a/tests/cli/test_moa_command.py
+++ b/tests/cli/test_moa_command.py
@@ -156,3 +156,32 @@ class TestBareMoaModelSwitch:
         assert result.target_provider == "moa"
         assert result.new_model == "review"
         assert result.is_global is True
+
+    def test_prefixed_moa_preset_uses_virtual_provider_in_session(self):
+        from hermes_cli.model_switch import switch_model
+
+        config = _make_cli(default_preset="review").config
+        with (
+            patch("hermes_cli.config.load_config", return_value=config),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "moa-virtual-provider",
+                    "base_url": "moa://local",
+                    "api_mode": "chat_completions",
+                },
+            ),
+            patch("hermes_cli.model_switch.get_model_info", return_value=None),
+            patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        ):
+            result = switch_model(
+                "moa:review",
+                "openrouter",
+                "anthropic/claude-opus-4.8",
+                current_base_url="https://openrouter.ai/api/v1",
+                current_api_key="test-key",
+            )
+
+        assert result.success is True, result.error_message
+        assert result.target_provider == "moa"
+        assert result.new_model == "review"


### PR DESCRIPTION
## Summary
- make bare `-m moa` select the configured default MoA preset
- make repeated `/model moa --global` resolve the same way when the current provider is already MoA
- accept explicit `/model moa:<preset>` selections in-session

## Root cause
CLI startup only recognized the `moa:<preset>` form, while the in-session switch path tried preset-name resolution before treating bare `moa` as the virtual provider and treated `moa:<preset>` as a literal model. That left startup calls on the previous provider, rejected repeated global selection, and made the two surfaces accept different MoA syntax.

## Validation
- `python -m pytest tests/cli/test_moa_command.py -q` — 14 passed
- MoA config/CLI routing selection — 77 passed, 34 deselected
- model-switch variant and configured-provider routing — 17 passed
- Ruff check for touched files — passed
- Python compile check — passed
- `git diff --check` — passed

Tested on Windows with Python 3.

Fixes #71244