### PR TITLE
fix(skills): pin text-mode file I/O to UTF-8 in comfyui and pdf skill scripts

### DIFF
--- a/skills/creative/comfyui/scripts/hardware_check.py
+++ b/skills/creative/comfyui/scripts/hardware_check.py
@@ -68,7 +68,7 @@ def is_wsl() -> bool:
     if "microsoft" in platform.release().lower() or "wsl" in platform.release().lower():
         return True
     try:
-        with open("/proc/version", "r") as fh:
+        with open("/proc/version", "r", encoding="utf-8") as fh:
             return "microsoft" in fh.read().lower()
     except OSError:
         return False
@@ -227,7 +227,7 @@ def total_system_ram_gb() -> float:
             return 0.0
     if sysname == "Linux":
         try:
-            with open("/proc/meminfo", "r") as fh:
+            with open("/proc/meminfo", "r", encoding="utf-8") as fh:
                 for line in fh:
                     if line.startswith("MemTotal:"):
                         kb = int(line.split()[1])

--- a/skills/creative/comfyui/scripts/run_workflow.py
+++ b/skills/creative/comfyui/scripts/run_workflow.py
@@ -450,7 +450,7 @@ def _inline_schema(workflow: dict) -> dict:
 
 def load_schema(schema_path: str | None, workflow: dict) -> dict:
     if schema_path:
-        with open(schema_path) as f:
+        with open(schema_path, encoding="utf-8-sig") as f:
             return json.load(f)
     return _inline_schema(workflow)
 
@@ -606,7 +606,7 @@ def main(argv: list[str] | None = None) -> int:
         emit_json({"error": f"Workflow file not found: {args.workflow}"})
         return 1
     try:
-        with wf_path.open() as f:
+        with wf_path.open(encoding="utf-8-sig") as f:
             workflow_raw = json.load(f)
         workflow = unwrap_workflow(workflow_raw)
     except ValueError as e:

--- a/skills/productivity/pdf/scripts/extract_form_field_info.py
+++ b/skills/productivity/pdf/scripts/extract_form_field_info.py
@@ -110,7 +110,7 @@ def get_field_info(reader: PdfReader):
 def write_field_info(pdf_path: str, json_output_path: str):
     reader = PdfReader(pdf_path)
     field_info = get_field_info(reader)
-    with open(json_output_path, "w") as f:
+    with open(json_output_path, "w", encoding="utf-8") as f:
         json.dump(field_info, f, indent=2)
     print(f"Wrote {len(field_info)} fields to {json_output_path}")
 

--- a/skills/productivity/pdf/scripts/extract_form_structure.py
+++ b/skills/productivity/pdf/scripts/extract_form_structure.py
@@ -99,7 +99,7 @@ def main():
     print(f"Extracting structure from {pdf_path}...")
     structure = extract_form_structure(pdf_path)
 
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         json.dump(structure, f, indent=2)
 
     print(f"Found:")

--- a/tests/skills/test_comfyui_skill.py
+++ b/tests/skills/test_comfyui_skill.py
@@ -1,0 +1,125 @@
+"""Invariant tests for the bundled comfyui skill.
+
+Covers skills/creative/comfyui — the diffusion workflow runner. Tests assert
+contracts (locale-independent file reads), not snapshots of skill content.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+SCRIPTS = REPO / "skills" / "creative" / "comfyui" / "scripts"
+
+# Text reads that must not depend on the host locale. The workflow and schema
+# JSON are user-authored files (exported by ComfyUI or hand-edited), so they
+# are read BOM-tolerantly: Notepad prepends U+FEFF, which makes json.load
+# raise JSONDecodeError. See the jobs.json regression in #66607. The /proc
+# reads are Linux-gated and never carry a BOM, so they pin plain utf-8.
+_ENCODING_SENSITIVE_READS = [
+    ("hardware_check.py", 'with open("/proc/version", "r", encoding="utf-8") as fh:'),
+    ("hardware_check.py", 'with open("/proc/meminfo", "r", encoding="utf-8") as fh:'),
+    ("run_workflow.py", 'with open(schema_path, encoding="utf-8-sig") as f:'),
+    ("run_workflow.py", 'with wf_path.open(encoding="utf-8-sig") as f:'),
+]
+
+
+@pytest.mark.parametrize("rel_path,expected", _ENCODING_SENSITIVE_READS)
+def test_readers_are_locale_independent(rel_path, expected):
+    """Every text read of a user-supplied or system file pins its codec."""
+    source = (SCRIPTS / rel_path).read_text(encoding="utf-8")
+    assert expected in source, f"{rel_path}: locale-dependent read of a UTF-8 payload"
+
+
+def _run_under_c_locale(snippet: str) -> subprocess.CompletedProcess:
+    """Execute a snippet in a child interpreter forced to a non-UTF-8 locale.
+
+    The default text codec is resolved at interpreter startup, so the locale
+    has to be set on the child's environment. Patching os.environ in-process
+    would not change locale.getpreferredencoding(). PYTHONUTF8=0 disables
+    PEP 540 UTF-8 mode, which would otherwise mask the bug entirely.
+    """
+    env = dict(os.environ)
+    env.update({
+        "LC_ALL": "C",
+        "LANG": "C",
+        "PYTHONUTF8": "0",
+        "PYTHONIOENCODING": "utf-8",
+    })
+    return subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+def test_load_schema_reads_non_ascii_under_non_utf8_locale(tmp_path):
+    """A schema with non-ASCII labels loads under the C locale.
+
+    Without the explicit encoding the C-locale default codec is ASCII, so
+    json.load crashes with UnicodeDecodeError on any CJK/Cyrillic label.
+    """
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_bytes(
+        json.dumps(
+            {"prompt": {"label": "プロンプト", "type": "string"}},
+            ensure_ascii=False,
+        ).encode("utf-8")
+    )
+
+    result = _run_under_c_locale(
+        textwrap.dedent(
+            f"""
+            import sys
+            sys.path.insert(0, {str(SCRIPTS)!r})
+            from run_workflow import load_schema
+
+            schema = load_schema({str(schema_path)!r}, {{}})
+            assert schema["prompt"]["label"] == "\\u30d7\\u30ed\\u30f3\\u30d7\\u30c8", schema
+            print("SUCCESS")
+            """
+        )
+    )
+    assert result.returncode == 0, (
+        f"load_schema failed under non-UTF-8 locale:\n{result.stderr}"
+    )
+    assert "SUCCESS" in result.stdout
+
+
+def test_load_schema_tolerates_utf8_bom(tmp_path):
+    """A schema saved by a Windows GUI editor (UTF-8 BOM) still parses.
+
+    json.load rejects a leading U+FEFF with JSONDecodeError, so a BOM-blind
+    read turns "user edited the file in Notepad" into a hard failure.
+    """
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_bytes(
+        b"\xef\xbb\xbf" + json.dumps({"prompt": {"type": "string"}}).encode("utf-8")
+    )
+
+    result = _run_under_c_locale(
+        textwrap.dedent(
+            f"""
+            import sys
+            sys.path.insert(0, {str(SCRIPTS)!r})
+            from run_workflow import load_schema
+
+            schema = load_schema({str(schema_path)!r}, {{}})
+            assert schema["prompt"]["type"] == "string", schema
+            print("SUCCESS")
+            """
+        )
+    )
+    assert result.returncode == 0, (
+        f"load_schema rejected a BOM-prefixed schema:\n{result.stderr}"
+    )
+    assert "SUCCESS" in result.stdout

--- a/tests/skills/test_office_document_skills.py
+++ b/tests/skills/test_office_document_skills.py
@@ -209,3 +209,30 @@ def test_check_bounding_boxes_reads_utf8_fields_json(tmp_path):
         f"script failed under non-UTF-8 locale:\n{result.stderr}"
     )
     assert "SUCCESS" in result.stdout
+
+
+# The extraction scripts write their JSON payload with json.dump, whose
+# default ensure_ascii=True keeps the bytes on disk pure ASCII — so these
+# writers are not broken today. They are pinned anyway: the codec is the
+# writer's contract, not a property of whatever the caller happens to dump,
+# and a later ensure_ascii=False would otherwise turn into silent mojibake
+# on any non-UTF-8 host.
+_ENCODING_SENSITIVE_WRITES = [
+    (
+        "pdf/scripts/extract_form_structure.py",
+        'with open(output_path, "w", encoding="utf-8") as f:',
+    ),
+    (
+        "pdf/scripts/extract_form_field_info.py",
+        'with open(json_output_path, "w", encoding="utf-8") as f:',
+    ),
+]
+
+
+@pytest.mark.parametrize("rel_path,expected", _ENCODING_SENSITIVE_WRITES)
+def test_document_writers_are_locale_independent(rel_path, expected):
+    """JSON payloads are written as UTF-8, never with the locale codec."""
+    source = (SKILLS / "productivity" / rel_path).read_text(encoding="utf-8")
+    assert expected in source, (
+        f"{rel_path}: locale-dependent write of a JSON payload"
+    )


### PR DESCRIPTION
## Summary

Six text-mode file operations in the bundled `comfyui` and `pdf` skills used the
locale-default codec instead of an explicit one. Both skills declare
`platforms: [linux, macos, windows]`.

## Problem

`run_workflow.py` parses two user-authored JSON files, the schema and the
workflow itself. Under a non-UTF-8 locale (cp1252 on US Windows, cp936 on Chinese
Windows, ASCII under `LC_ALL=C`) a non-ASCII label raises `UnicodeDecodeError`
from `json.load`. Separately, a workflow saved from a Windows GUI editor carries a
UTF-8 BOM that `json.load` rejects with `JSONDecodeError`, the same failure as the
`jobs.json` regression in #66607.

`hardware_check.py` reads `/proc/version` and `/proc/meminfo`. Both are
Linux-gated so Windows never reaches them, but the C locale defaults to ASCII.

The two `extract_form_*.py` writers are **not** broken today: `json.dump` defaults
to `ensure_ascii=True`, so the bytes on disk are pure ASCII. I pinned them anyway
because the codec is the writer's contract rather than a property of whatever the
caller happens to dump. Happy to drop them if you would rather keep the diff to
demonstrable bugs.

## Changes

- `run_workflow.py:453,609`: schema and workflow read as `utf-8-sig`, which strips
  a BOM when present and is identical to `utf-8` when absent.
- `hardware_check.py:71,230`: `/proc` reads pin plain `utf-8`; no BOM is possible
  there.
- `extract_form_structure.py`, `extract_form_field_info.py`: JSON written as
  `utf-8`.
- `tests/skills/test_comfyui_skill.py` (new): contract assertions plus two live
  regressions that run `load_schema` in a child interpreter under `LC_ALL=C` with
  `PYTHONUTF8=0`, one with a non-ASCII schema and one BOM-prefixed. The child
  process is required because the default codec is resolved at interpreter
  startup; `PYTHONUTF8=0` stops PEP 540 mode from masking the bug.
- `tests/skills/test_office_document_skills.py`: writer contract assertions,
  following the reader pattern adecb0d1a added to this file.

## Validation

| | Before | After |
|---|---|---|
| Non-ASCII schema under `LC_ALL=C` | `UnicodeDecodeError` | loads |
| BOM-prefixed workflow JSON | `JSONDecodeError` | loads |
| `check-windows-footguns.py skills optional-skills` | 5 findings | 0 |
| The 8 new tests | fail | pass |
| `tests/skills/` | — | 374 passed, 0 failed |
| `ruff check .` | — | clean |

Arch Linux, Python 3.11.11. I have no Windows or macOS host, so the Windows
behavior is reproduced under a forced C locale rather than observed on real
hardware.

The full `scripts/run_tests.sh` run has 5 failures in `tests/agent/` and
`tests/hermes_cli/` (SQLite WAL checkpointing, `HOME` resolution, credential-pool
routing). They reproduce identically on a clean `origin/main` worktree at
760112adb with none of these changes applied, so they are pre-existing on my
machine and unrelated to this PR.

## Notes

Two calls I would take a second opinion on:

1. **`utf-8-sig` differs from adecb0d1a**, which used plain `utf-8` for the pdf
   form JSON. Deliberate: those payloads are agent-authored and BOM-free by
   construction, while a ComfyUI workflow is exported or hand-edited by the user.
   Happy to make the two consistent.
2. **`wf_path.open()` (line 609) is not linter-flagged.** It is a `Path.open()`
   site that `check-windows-footguns.py` deliberately skips ("can be audited
   separately", per its rule comment). Fixed because it is the same bug 156 lines
   from a site the checker does flag, and line 623 of that file already uses
   `read_text(encoding="utf-8")`. Easy to drop if you want this kept to flagged
   sites only.
