### PR TITLE
fix(hermes_cli): stop bare managed model pin from bypassing config set write guard

### DIFF
--- a/hermes_cli/managed_scope.py
+++ b/hermes_cli/managed_scope.py
@@ -168,9 +168,7 @@ def apply_managed_overlay(config: dict) -> dict:
         # read. _normalize_root_model_keys only promotes the string when there
         # are root provider/base_url keys to migrate, so handle the bare case
         # here (matches cli.py's own string-model handling).
-        if isinstance(managed_expanded.get("model"), str):
-            managed_expanded = dict(managed_expanded)
-            managed_expanded["model"] = {"default": managed_expanded["model"]}
+        managed_expanded = _promote_bare_model_string(managed_expanded)
         return _deep_merge(config, managed_expanded)
     except Exception:  # noqa: BLE001 — overlay must never break a caller
         logger.warning("managed scope: failed to apply config overlay", exc_info=True)
@@ -188,6 +186,18 @@ def _parse_env(f) -> Dict[str, str]:
     return out
 
 
+def _promote_bare_model_string(config: dict) -> dict:
+    """Promote root ``model: <str>`` to ``{"default": <str>}`` (copy-on-write).
+
+    Kept in sync with apply_managed_overlay and managed_config_keys so write
+    guards see the same leaf (``model.default``) that runtime merge pins.
+    """
+    if isinstance(config.get("model"), str):
+        config = dict(config)
+        config["model"] = {"default": config["model"]}
+    return config
+
+
 def _flatten_keys(d: dict, prefix: str = "") -> set:
     keys: set = set()
     for k, v in d.items():
@@ -201,7 +211,9 @@ def _flatten_keys(d: dict, prefix: str = "") -> set:
 
 def managed_config_keys() -> set:
     """Dotted leaf keys pinned by the managed config (e.g. {'model.default'})."""
-    return _flatten_keys(load_managed_config())
+    # Promote bare ``model: x/y`` before flattening so is_key_managed("model.default")
+    # matches apply_managed_overlay's effective pin.
+    return _flatten_keys(_promote_bare_model_string(load_managed_config()))
 
 
 def is_key_managed(dotted_key: str) -> bool:

--- a/tests/hermes_cli/test_managed_scope.py
+++ b/tests/hermes_cli/test_managed_scope.py
@@ -115,6 +115,16 @@ def test_is_key_managed(tmp_path, monkeypatch):
     assert managed_scope.is_key_managed("model.fallback") is False
 
 
+def test_bare_string_model_pins_model_default(tmp_path, monkeypatch):
+    """Bare ``model: org/locked`` must expose model.default to write guards."""
+    from hermes_cli import managed_scope
+
+    _write_managed(tmp_path, monkeypatch, config="model: org/locked\n")
+    assert managed_scope.managed_config_keys() == {"model.default"}
+    assert managed_scope.is_key_managed("model.default") is True
+    assert managed_scope.is_key_managed("model") is False
+
+
 def test_load_managed_env_and_is_env_managed(tmp_path, monkeypatch):
     from hermes_cli import managed_scope
 

--- a/tests/hermes_cli/test_managed_scope_writeguard.py
+++ b/tests/hermes_cli/test_managed_scope_writeguard.py
@@ -51,6 +51,30 @@ def test_config_set_unmanaged_key_still_works(homes):
     assert read_raw_config().get("model", {}).get("fallback") == "user/fb"
 
 
+def test_config_set_rejects_bare_string_managed_model(tmp_path, monkeypatch, capsys):
+    """Admin bare ``model: org/locked`` must block ``hermes config set model.default``."""
+    home = tmp_path / "home"
+    home.mkdir()
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    import hermes_cli.config as cfg
+    from hermes_cli import managed_scope
+
+    cfg._LOAD_CONFIG_CACHE.clear()
+    cfg._RAW_CONFIG_CACHE.clear()
+    (managed / "config.yaml").write_text("model: org/locked\n", encoding="utf-8")
+    managed_scope.invalidate_managed_cache()
+
+    with pytest.raises(SystemExit) as exc:
+        cfg.set_config_value("model.default", "user/override")
+    assert exc.value.code != 0
+    captured = capsys.readouterr()
+    assert "managed" in (captured.out + captured.err).lower()
+    assert cfg.read_raw_config().get("model", {}).get("default") != "user/override"
+
+
 # ── env write guards ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

When an administrator pins a bare string `model: org/locked` in managed config, runtime overlay correctly locks `model.default`, but write guards treated only the leaf key `model` as managed. Users could run `hermes config set model.default ...` successfully and write a useless override into their config. This aligns key flattening with the same bare-string promotion used by the overlay.

### Bug Cause

`apply_managed_overlay` promotes root `model: <str>` to `model.default` before merge. `managed_config_keys()` / `is_key_managed()` flattened the raw managed YAML without that promotion, so `is_key_managed("model.default")` returned false while the effective runtime pin was `model.default`. `set_config_value` / `unset_config_value` gate only on `is_key_managed(key)`.

### Reproduction Steps

1. Point `HERMES_MANAGED_DIR` at a directory whose `config.yaml` contains only `model: org/locked`.
2. Set a temp `HERMES_HOME` for the user config.
3. Run `hermes config set model.default user/override` (or call `set_config_value("model.default", "user/override")`).

Expected: rejected with SystemExit and a managed-admin message; user config not written.
Before fix: command succeeds and writes `model.default: user/override` into user `config.yaml` (runtime still uses managed value on next load).

### Fix

Extract `_promote_bare_model_string` and use it in both `apply_managed_overlay` and `managed_config_keys`, so write guards see `model.default`. Tests cover key listing and `set_config_value` rejection for the bare-string shape.

## Related Issue

No issue - discovered via internal bug hunt (BUG-1 / managed_scope write-guard mismatch).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Changes Made

- `hermes_cli/managed_scope.py` - shared bare-model promotion for overlay and managed key listing
- `tests/hermes_cli/test_managed_scope.py` - bare string pins `model.default` in `managed_config_keys`
- `tests/hermes_cli/test_managed_scope_writeguard.py` - `set_config_value` rejects bare managed model

## How to Test

1. Manual: reproduce steps above; after the fix, set must exit non-zero and leave user config without the override.
2. Automated (already run locally, 32 passed):

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_managed_scope.py \
  tests/hermes_cli/test_managed_scope_writeguard.py \
  tests/hermes_cli/test_managed_scope_overlay.py \
  tests/hermes_cli/test_managed_scope_config.py \
  -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (WSL test runner)

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact - N/A (pure config key logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
