### PR TITLE
fix(agent): narrow should_use_direct_api_call to providers with #62151 deadlock (#71268)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -436,15 +436,29 @@ def should_use_direct_api_call(agent) -> bool:
     """Whether a cron OpenAI-wire request should skip the interrupt worker.
 
     Issue #62151 is specific to OpenRouter's chat-completions path inside the
-    gateway cron thread stack. Keep native/Codex/Bedrock/MoA transports on their
-    established workers: their cancellation and client ownership differ, and
+    gateway cron thread stack. Keep native/Codex/Bedrock/MoA transports on
+    their established workers: their cancellation and client ownership differ, and
     the report provides no evidence that those paths share the pre-HTTP wedge.
+
+    Apply the same narrow scope to *which providers* the workaround targets: only
+    providers with documented evidence of the nested-ThreadPool wedge force the
+    non-streaming direct path. ``custom`` / named-custom / ``openai`` /
+    ``deepseek`` / etc. providers are kept on the normal streaming path so
+    long-reasoning models do not stall against short response-header timeouts
+    on reverse proxies (#71268).
     """
-    return (
-        getattr(agent, "platform", None) == "cron"
-        and getattr(agent, "api_mode", None) == "chat_completions"
-        and getattr(agent, "provider", None) != "moa"
-    )
+    if (
+        getattr(agent, "platform", None) != "cron"
+        or getattr(agent, "api_mode", None) != "chat_completions"
+    ):
+        return False
+    provider = getattr(agent, "provider", None) or ""
+    if provider == "moa":
+        return False
+    # Only providers that actually exhibit the #62151 deadlock. New providers
+    # must NOT be added here without a repro on the openrouter-style path —
+    # the direct/non-streaming call is an LRO-blocking fallback, not a default.
+    return provider in {"openrouter", "nous"}
 
 
 def direct_api_call(agent, api_kwargs: dict):

--- a/tests/cron/test_cron_direct_api_call_62151.py
+++ b/tests/cron/test_cron_direct_api_call_62151.py
@@ -45,6 +45,38 @@ def test_should_use_direct_api_call_only_for_cron_openai_wire():
     assert should_use_direct_api_call(moa) is False
 
 
+def test_should_use_direct_api_call_only_for_openrouter_and_nous_providers():
+    """Regression guard for #71268.
+
+    The non-streaming direct path must only apply to providers documented
+    to exhibit the #62151 deadlock. Custom / named-custom / openai / deepseek
+    providers stay on the streaming path so long-reasoning models do not
+    stall against short response-header timeouts on reverse proxies.
+    """
+    for provider in ("openrouter", "nous"):
+        agent = _make_agent(platform="cron")
+        agent.provider = provider
+        assert should_use_direct_api_call(agent) is True, provider
+
+    for provider in (
+        "custom",
+        "custom:newapi2",
+        "openai",
+        "deepseek",
+        "anthropic",
+        "unknown-provider",
+    ):
+        agent = _make_agent(platform="cron")
+        agent.provider = provider
+        assert should_use_direct_api_call(agent) is False, provider
+
+    # No provider at all must also take the streaming path, not the legacy
+    # "match-anything-but-moa" fallback that #71268 removed.
+    empty = _make_agent(platform="cron")
+    empty.provider = None
+    assert should_use_direct_api_call(empty) is False
+
+
 def test_direct_api_call_runs_two_sequential_requests_on_same_thread():
     """Mirror the 2nd+ call failure mode: two back-to-back completions.create."""
     agent = _make_agent()


### PR DESCRIPTION
## Summary

`should_use_direct_api_call()` forced the non-streaming `direct_api_call()` path on **every** OpenAI-wire cron provider except `moa`. That over-broad guard caught `custom`, named-custom (`custom:newapi2`), `openai`, `deepseek`, etc. — long-reasoning models on those providers had to wait the full reasoning+response to materialize before the first byte of the HTTP response, which fails any reverse-proxy with a `ResponseHeaderTimeout` of 15-30s (a recommended value for streaming endpoints). The 600s cron inactivity watchdog would then kill the job with `all accounts failed`. The same model worked fine in interactive (gateway-streaming) sessions because those use SSE.

Scopes the workaround to providers documented to exhibit the #62151 nested-ThreadPool deadlock — `{"openrouter", "nous"}`. All other chat-completions cron providers now use the streaming path so SSE headers return immediately and tokens flow through with the inactivity watchdog satisfied.

## Changes

- `agent/chat_completion_helpers.py` — rewrite `should_use_direct_api_call()` to early-return False unless `provider in {"openrouter", "nous"}`, preserving the core cron+chat_completions gate from #62151 while narrowing the provider scope. Docstring expanded to spell out the rationale and warn future contributors that adding to the set requires a documented repro.
- `tests/cron/test_cron_direct_api_call_62151.py` — new test `test_should_use_direct_api_call_only_for_openrouter_and_nous_providers` covering `openrouter`/`nous` (True), `custom`/`custom:newapi2`/`openai`/`deepseek`/`anthropic`/unknown/`None` (all False). Existing legacy test unaffected because `_make_agent` defaults provider to `openrouter`.

## How to Test

```
python -m pytest tests/cron/test_cron_direct_api_call_62151.py tests/agent/test_cron_inline_api_call_62151.py -v
# → 8 passed (1 new assertion + 7 prior)
```

## Checklist

- [x] Tests pass — 8/8 in the two targeted files
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact: neutral — provider-name string comparison
- [x] profile-safe paths — N/A
- [x] .env not used — no config touched

## Risk & Impact

Low. The two providers documented to hit #62151 (openrouter, nous) keep the exact same behavior. Every other provider gains streaming on cron for the first time, which is a strict improvement for long-reasoning models and a neutral change for short-prompt cron jobs.

Type: Bug fix
Closes: #71268