### PR TITLE
fix(desktop): one-shot clarify choices (Claude Code / Perplexity style)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -9,7 +9,7 @@ import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
 import { $activeSessionId } from '@/store/session'
 
-import { ClarifyTool, readClarifyResult } from './clarify-tool'
+import { ClarifyTool, isRecommendedChoice, readClarifyResult } from './clarify-tool'
 
 // The live pending card only renders while its message is running. Force that so
 // keyboard-navigation tests can exercise ClarifyToolPending directly.
@@ -86,6 +86,15 @@ function renderLiveClarify() {
 
   return request
 }
+
+describe('isRecommendedChoice', () => {
+  it('detects explicit recommended / default markers', () => {
+    expect(isRecommendedChoice('A. 推荐：走 staging')).toBe(true)
+    expect(isRecommendedChoice('Use production (recommended)')).toBe(true)
+    expect(isRecommendedChoice('default path')).toBe(true)
+    expect(isRecommendedChoice('plain option')).toBe(false)
+  })
+})
 
 describe('readClarifyResult', () => {
   it('reads question + user_response from the tool JSON payload', () => {
@@ -234,8 +243,8 @@ describe('ClarifyTool keyboard navigation', () => {
   it('cycles through choices and Other with the arrow keys', () => {
     renderLiveClarify()
 
-    const staging = screen.getByRole('button', { name: /staging/ })
-    const production = screen.getByRole('button', { name: /production/ })
+    const staging = screen.getByRole('option', { name: /staging/ })
+    const production = screen.getByRole('option', { name: /production/ })
     const other = screen.getByPlaceholderText(/Other/)
 
     expect(staging.getAttribute('data-highlighted')).toBe('true')
@@ -257,11 +266,10 @@ describe('ClarifyTool keyboard navigation', () => {
     expect(other.closest('label')?.getAttribute('data-highlighted')).toBe('true')
   })
 
-  it('selects by number and confirms the answer with Enter', async () => {
+  it('submits immediately when a number key is pressed (one-shot, Claude/Perplexity style)', async () => {
     const request = renderLiveClarify()
 
     fireEvent.keyDown(window, { key: '2' })
-    fireEvent.keyDown(window, { key: 'Enter' })
 
     await waitFor(() => {
       expect(request).toHaveBeenCalledWith('clarify.respond', {
@@ -269,6 +277,41 @@ describe('ClarifyTool keyboard navigation', () => {
         request_id: 'request-1'
       })
     })
+  })
+
+  it('submits immediately when a choice row is clicked', async () => {
+    const request = renderLiveClarify()
+
+    fireEvent.click(screen.getByRole('option', { name: /production/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'production',
+        request_id: 'request-1'
+      })
+    })
+  })
+
+  it('marks recommended choices and keeps choice labels selectable', () => {
+    $activeSessionId.set('session-1')
+    $gateway.set({ request: vi.fn().mockResolvedValue({ ok: true }) } as never)
+    setClarifyRequest({
+      choices: ['staging (recommended)', 'production'],
+      question: 'Which deployment target?',
+      requestId: 'request-1',
+      sessionId: 'session-1'
+    })
+    renderClarify(
+      <ClarifyTool
+        {...liveClarifyProps(['staging (recommended)', 'production'])}
+      />
+    )
+
+    const recommended = screen.getByRole('option', { name: /staging \(recommended\)/ })
+    expect(recommended.getAttribute('data-recommended')).toBe('true')
+    expect(screen.getByText('Recommended')).toBeTruthy()
+    expect(recommended.querySelector('span.select-text')).toBeTruthy()
+    expect(document.querySelector('[data-clarify-choice-hint]')).toBeTruthy()
   })
 
   it('focuses Other when its number is pressed and leaves typing keys alone', () => {

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -86,14 +86,20 @@ export function readClarifyResult(result: unknown): ClarifyResult {
 
 const letterFor = (index: number): string => String.fromCharCode(65 + index)
 
+/** Detect an explicit recommended / default marker in choice text (Claude-style). */
+export function isRecommendedChoice(choice: string): boolean {
+  return /推荐|建議|建议|recommended|\bdefault\b|★|⭐|（推荐）|\(推荐\)|【推荐】|\[recommended\]/i.test(choice)
+}
+
+// Card-like rows (Perplexity / Claude Code): border + padding, not bare text lines.
 const OPTION_ROW_CLASS =
-  'flex w-full items-start gap-2 rounded-[0.25rem] px-1.5 py-1 text-left disabled:cursor-not-allowed disabled:opacity-50'
+  'flex w-full items-start gap-2.5 rounded-md border border-transparent px-2 py-1.5 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50'
 
 // field-sizing on top of Textarea's shared chrome; kill min-h-16 for one-liners.
 const CLARIFY_TEXTAREA_CLASS = 'field-sizing-content max-h-40 min-h-0 resize-none'
 
 const CLARIFY_SHELL_CLASS =
-  'my-1.5 rounded-md border border-primary/20 bg-(--ui-chat-surface-background) text-[length:var(--conversation-text-font-size)] text-(--ui-text-primary)'
+  'my-1.5 rounded-lg border border-primary/25 bg-(--ui-chat-surface-background) text-[length:var(--conversation-text-font-size)] text-(--ui-text-primary) shadow-sm'
 
 const CLARIFY_ICON_CLASS = 'mt-px size-4 shrink-0 text-(--ui-text-tertiary)'
 
@@ -123,7 +129,7 @@ function KeyBadge({ char, preview, selected }: { char: string; preview?: boolean
   return (
     <Kbd
       className={cn(
-        'mt-px',
+        'mt-px shrink-0',
         selected && 'border-primary bg-primary text-white shadow-none',
         !selected && preview && 'border-primary text-primary shadow-none'
       )}
@@ -134,8 +140,22 @@ function KeyBadge({ char, preview, selected }: { char: string; preview?: boolean
   )
 }
 
-/** A letter-badged option row. Shared by the live pending card (where a click
- * selects an answer) and the settled skip card (where a click drafts a
+/** True when the user was drag-selecting text inside the control — don't treat as a pick. */
+function clickWasTextSelection(target: EventTarget | null): boolean {
+  const selection = typeof window !== 'undefined' ? window.getSelection() : null
+
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return false
+  }
+
+  const node = selection.anchorNode
+  const el = target instanceof Element ? target : null
+
+  return Boolean(el && node && el.contains(node))
+}
+
+/** A letter-badged option row. Shared by the live pending card (one-click submit,
+ * Claude Code / Perplexity style) and the settled skip card (click drafts a
  * follow-up), so both stay visually identical. */
 function ChoiceButton({
   active = false,
@@ -144,6 +164,8 @@ function ChoiceButton({
   disabled,
   keyShortcuts,
   onClick,
+  recommended = false,
+  recommendedLabel,
   selected = false,
   title
 }: {
@@ -153,6 +175,8 @@ function ChoiceButton({
   disabled?: boolean
   keyShortcuts?: string
   onClick: () => void
+  recommended?: boolean
+  recommendedLabel?: string
   selected?: boolean
   title?: string
 }) {
@@ -171,18 +195,33 @@ function ChoiceButton({
         aria-keyshortcuts={keyShortcuts}
         className={cn(
           OPTION_ROW_CLASS,
-          'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary)',
-          active && 'bg-(--chrome-action-hover) text-(--ui-text-primary)',
-          selected && 'text-(--ui-text-primary)'
+          'text-(--ui-text-secondary) hover:border-(--ui-border) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary)',
+          active && 'border-primary/35 bg-(--chrome-action-hover) text-(--ui-text-primary)',
+          selected && 'border-primary/55 bg-primary/10 text-(--ui-text-primary)',
+          recommended && !selected && !active && 'border-primary/20 bg-primary/5'
         )}
         data-choice
         data-highlighted={active || undefined}
+        data-recommended={recommended || undefined}
         disabled={disabled}
-        onClick={onClick}
+        onClick={event => {
+          // Keep Ctrl+C / drag-select usable on the label without accidental submit.
+          if (clickWasTextSelection(event.currentTarget)) {
+            return
+          }
+
+          onClick()
+        }}
+        role="option"
         type="button"
       >
         <KeyBadge char={char} preview={active} selected={selected} />
-        <span className="flex-1 wrap-anywhere">{choice}</span>
+        <span className="min-w-0 flex-1 select-text wrap-anywhere leading-(--conversation-line-height)">{choice}</span>
+        {recommended && recommendedLabel ? (
+          <span className="mt-px shrink-0 rounded-sm bg-primary/15 px-1 py-px text-[0.625rem] font-medium leading-4 text-primary">
+            {recommendedLabel}
+          </span>
+        ) : null}
       </button>
     </Tip>
   )
@@ -258,13 +297,15 @@ function ClarifyToolSettled({ args, result }: ToolCallMessagePartProps) {
         </ClarifyLine>
       ) : null}
       {skipped && choices.length > 0 ? (
-        <div className="grid gap-px" data-clarify-late-choices="" role="group">
+        <div className="grid gap-1" data-clarify-late-choices="" role="listbox">
           {choices.map((choice, index) => (
             <ChoiceButton
               char={letterFor(index)}
               choice={choice}
               key={`${index}-${choice}`}
               onClick={() => followUp(choice)}
+              recommended={isRecommendedChoice(choice)}
+              recommendedLabel={copy.recommended}
               title={copy.lateAnswerTip}
             />
           ))}
@@ -356,17 +397,24 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   )
 
   const trimmedDraft = draft.trim()
-  // The answer is whichever input is active: a picked choice, or typed text.
-  // Picking a choice no longer fires immediately — it selects, then the user
-  // confirms with Continue (or Enter from the field).
+  // Free-text "Other" still uses Continue / Enter. Predefined choices submit on
+  // the first click or letter/number key (Claude Code / Perplexity one-shot).
   const pendingAnswer = selectedChoice ?? (trimmedDraft || null)
 
-  const selectChoice = useCallback((choice: string, index: number) => {
-    // Picking a choice and typing are mutually exclusive answers.
-    setDraft('')
-    setSelectedChoice(choice)
-    setActiveIndex(index)
-  }, [])
+  /** One-shot pick: stage for visual feedback, then resolve immediately. */
+  const pickChoice = useCallback(
+    (choice: string, index: number) => {
+      if (submitting) {
+        return
+      }
+
+      setDraft('')
+      setSelectedChoice(choice)
+      setActiveIndex(index)
+      void respond(choice)
+    },
+    [respond, submitting]
+  )
 
   // Keep the cursor in range when the choice set changes (never past "Other").
   useEffect(() => {
@@ -399,25 +447,30 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   }, [respond, selectedChoice, trimmedDraft])
 
   const activateActive = useCallback(() => {
-    // A staged answer (picked choice or typed text) wins — confirm it.
-    if (pendingAnswer) {
-      submitAnswer()
+    // Typed free-text or a mid-submit staged choice wins.
+    if (trimmedDraft) {
+      void respond(trimmedDraft)
 
       return
     }
 
-    // Otherwise act on the highlighted row: a choice responds immediately, and
-    // the trailing "Other" row focuses the free-text field.
+    if (selectedChoice !== null) {
+      void respond(selectedChoice)
+
+      return
+    }
+
+    // Highlighted predefined row → one-shot submit; "Other" focuses the field.
     const choice = choices[activeIndex]
 
     if (choice) {
-      void respond(choice)
+      pickChoice(choice, activeIndex)
 
       return
     }
 
     textareaRef.current?.focus()
-  }, [activeIndex, choices, pendingAnswer, respond, submitAnswer])
+  }, [activeIndex, choices, pickChoice, respond, selectedChoice, trimmedDraft])
 
   const handleTextareaKey = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -441,11 +494,9 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
     [submitAnswer]
   )
 
-  // Arrow keys move a visual cursor, 1-9 and A/B/C… pick directly, and Enter
-  // confirms the current answer (or acts on the highlighted row). Stands down
-  // whenever a focusable control (a field, a choice button, the action bar) is
-  // focused, so it never eats keystrokes meant for the composer, the Other box,
-  // or a button the user tabbed to.
+  // Arrow keys move a visual cursor; 1-9 and A/B/C… one-shot submit (Claude Code);
+  // Enter confirms free-text or the highlighted row. Stands down whenever a
+  // focusable control is focused so it never eats composer / Other / button keys.
   useEffect(() => {
     if (!ready || !hasChoices || submitting) {
       return
@@ -477,7 +528,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
         if (index < choices.length) {
           event.preventDefault()
-          selectChoice(choices[index], index)
+          pickChoice(choices[index], index)
         } else if (index === choices.length) {
           event.preventDefault()
           setActiveIndex(index)
@@ -494,7 +545,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
         if (index < choices.length) {
           event.preventDefault()
-          selectChoice(choices[index], index)
+          pickChoice(choices[index], index)
         } else if (index === choices.length) {
           event.preventDefault()
           setActiveIndex(index)
@@ -513,7 +564,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
     window.addEventListener('keydown', onKeyDown)
 
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [activateActive, choices, hasChoices, moveActive, ready, selectChoice, submitting])
+  }, [activateActive, choices, hasChoices, moveActive, pickChoice, ready, submitting])
 
   if (loading) {
     return (
@@ -550,7 +601,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
       <form className="grid gap-2" onSubmit={handleSubmit}>
         {hasChoices ? (
-          <div className="grid gap-px" role="group">
+          <div className="grid gap-1" role="listbox" aria-label={question || copy.loadingQuestion}>
             {choices.map((choice, index) => (
               <ChoiceButton
                 active={activeIndex === index}
@@ -559,15 +610,17 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
                 disabled={submitting}
                 key={`${index}-${choice}`}
                 keyShortcuts={`${letterFor(index)} ${index + 1}`}
-                onClick={() => selectChoice(choice, index)}
+                onClick={() => pickChoice(choice, index)}
+                recommended={isRecommendedChoice(choice)}
+                recommendedLabel={copy.recommended}
                 selected={selectedChoice === choice}
               />
             ))}
             <label
               className={cn(
                 OPTION_ROW_CLASS,
-                'items-center',
-                activeIndex === choices.length && 'bg-(--chrome-action-hover)'
+                'items-center border-(--ui-border)/40',
+                activeIndex === choices.length && 'border-primary/35 bg-(--chrome-action-hover)'
               )}
               data-highlighted={activeIndex === choices.length || undefined}
             >
@@ -596,6 +649,9 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
                 value={draft}
               />
             </label>
+            <p className="px-1 pt-0.5 text-[0.6875rem] leading-4 text-(--ui-text-tertiary)" data-clarify-choice-hint="">
+              {copy.choiceHint}
+            </p>
           </div>
         ) : (
           <Textarea
@@ -615,6 +671,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
           <Button disabled={submitting} onClick={() => void respond('')} size="xs" type="button" variant="text">
             {copy.skip}
           </Button>
+          {/* Continue is for free-text / Other; predefined choices one-shot on click. */}
           <Button disabled={submitting || !pendingAnswer} size="xs" type="submit">
             {submitting ? (
               <Loader2 className="size-3 animate-spin" />

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2290,7 +2290,9 @@ export const ar = defineLocale({
       other: 'غير ذلك',
       placeholder: 'اكتب إجابتك...',
       skip: 'تخطي',
-      continueLabel: 'متابعة'
+      continueLabel: 'متابعة',
+      recommended: 'موصى به',
+      choiceHint: 'انقر للاختيار · A/B أو 1/2 · ↑↓ ثم ⏎'
     },
     tool: {
       code: 'الكود',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2667,6 +2667,8 @@ export const en: Translations = {
       skip: 'Skip',
       skipped: 'Skipped',
       continueLabel: 'Continue',
+      recommended: 'Recommended',
+      choiceHint: 'Click an option to choose · A/B or 1/2 · ↑↓ then ⏎',
       lateAnswer: (question, choice) => `Re: "${question}" — my answer: ${choice}`,
       lateAnswerTip: 'Draft this answer as a follow-up message',
       lateAnswerHint: 'This prompt is no longer waiting. Pick an option to draft it as a follow-up message.'

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2531,6 +2531,8 @@ export const ja = defineLocale({
       skip: 'スキップ',
       skipped: 'スキップ済み',
       continueLabel: '続行',
+      recommended: 'おすすめ',
+      choiceHint: 'クリックで選択 · A/B または 1/2 · ↑↓ のあと ⏎',
       lateAnswer: (question, choice) => `「${question}」について — 私の回答: ${choice}`,
       lateAnswerTip: 'この回答をフォローアップメッセージとして下書きします',
       lateAnswerHint: 'この質問はもう回答を待っていません。選択肢を選ぶとフォローアップメッセージとして下書きされます。'

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2266,6 +2266,10 @@ export interface Translations {
       skip: string
       skipped: string
       continueLabel: string
+      /** Short chip when choice text marks itself recommended / default. */
+      recommended: string
+      /** Keyboard / click affordance under the option list. */
+      choiceHint: string
       lateAnswer: (question: string, choice: string) => string
       lateAnswerTip: string
       lateAnswerHint: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2453,6 +2453,8 @@ export const zhHant = defineLocale({
       skip: '略過',
       skipped: '已略過',
       continueLabel: '繼續',
+      recommended: '推薦',
+      choiceHint: '點擊選項即選定 · A/B 或 1/2 · ↑↓ 後 ⏎',
       lateAnswer: (question, choice) => `關於「${question}」 — 我的回答: ${choice}`,
       lateAnswerTip: '將此回答起草為後續訊息',
       lateAnswerHint: '此問題已不再等待回答。選擇一個選項會將其起草為後續訊息。'

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2838,6 +2838,8 @@ export const zh: Translations = {
       skip: '跳过',
       skipped: '已跳过',
       continueLabel: '继续',
+      recommended: '推荐',
+      choiceHint: '点击选项即选定 · A/B 或 1/2 · ↑↓ 后 ⏎',
       lateAnswer: (question, choice) => `关于"${question}" — 我的回答: ${choice}`,
       lateAnswerTip: '将此回答起草为后续消息',
       lateAnswerHint: '此问题已不再等待回答。选择一个选项会将其起草为后续消息。'


### PR DESCRIPTION
## Summary

- Predefined clarify options **submit on first click** (and on A/B/1/2), matching Claude Code / Perplexity one-shot selection instead of select-then-Continue.
- Card-style option rows, optional **Recommended** chip when choice text marks itself (推荐 / recommended / default / ★), restore `select-text` so labels stay copyable, short keyboard hint under the list.
- Free-text **Other** still uses Continue / Enter; Skip unchanged.
- Drag-select on a label does not accidental-submit.

## Test plan

- [x] `vitest run src/components/assistant-ui/clarify-tool.test.tsx` — 17/17
- [ ] Manual: launch Desktop, trigger `clarify` with ≥2 choices → click option → agent continues without Continue
- [ ] Manual: press `2` / `B` → same one-shot submit
- [ ] Manual: type in Other + Continue still works
- [ ] Manual: option text drag-select + Ctrl+C

## Notes

Local staging stamp `f7950cdcf` / PR head `490fd2a38` (cherry-pick onto latest main).