### PR TITLE
fix(anthropic): match Claude Agent SDK OAuth requests

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -345,6 +345,15 @@ _FAST_MODE_BETA = "fast-mode-2026-02-01"
 _OAUTH_ONLY_BETAS = [
     "claude-code-20250219",
     "oauth-2025-04-20",
+    "thinking-token-count-2026-05-13",
+    "context-management-2025-06-27",
+    "prompt-caching-scope-2026-01-05",
+    "mid-conversation-system-2026-04-07",
+    "advisor-tool-2026-03-01",
+    "advanced-tool-use-2025-11-20",
+    "effort-2025-11-24",
+    "extended-cache-ttl-2025-04-11",
+    "cache-diagnosis-2026-04-07",
 ]
 
 # Claude Code identity — required for OAuth requests to be routed correctly.
@@ -380,7 +389,7 @@ def _detect_claude_code_version() -> str:
     return _CLAUDE_CODE_VERSION_FALLBACK
 
 
-_CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
+_CLAUDE_CODE_SYSTEM_PREFIX = "You are a Claude agent, built on Anthropic's Claude Agent SDK."
 _MCP_TOOL_PREFIX = "mcp__"
 
 
@@ -762,6 +771,45 @@ def _build_anthropic_client_with_bearer_hook(
     return client
 
 
+def _build_oauth_impersonation_http_client(
+    api_key: str,
+    *,
+    timeout,
+    anthropic_beta: str = "",
+) -> Any:
+    """Build an httpx client that rewrites headers to Claude Code's JS SDK shape."""
+    from httpx import Client, Limits, Timeout
+
+    cc_version = _get_claude_code_version()
+
+    def _rewrite_headers(request):
+        request.headers["user-agent"] = f"claude-cli/{cc_version} (external, sdk-cli)"
+        request.headers["x-stainless-lang"] = "js"
+        request.headers["x-stainless-runtime"] = "node"
+        request.headers["x-stainless-runtime-version"] = "v26.3.0"
+        request.headers["x-stainless-package-version"] = "0.94.0"
+        request.headers["x-stainless-timeout"] = "600"
+        request.headers["x-stainless-async"] = "false"
+        request.headers["x-stainless-helper-method"] = "stream"
+        request.headers["x-stainless-stream-helper"] = "messages"
+        request.headers["x-app"] = "cli"
+        request.headers["x-anthropic-billing-header"] = (
+            f"cc_version={cc_version}; cc_entrypoint=sdk-cli; cch=00000;"
+        )
+        request.headers["anthropic-dangerous-direct-browser-access"] = "true"
+        if anthropic_beta:
+            request.headers["anthropic-beta"] = anthropic_beta
+        request.headers["authorization"] = f"Bearer {api_key}"
+        request.headers.pop("x-api-key", None)
+
+    http_timeout = timeout if isinstance(timeout, Timeout) else Timeout(timeout=900.0, connect=10.0)
+    return Client(
+        timeout=http_timeout,
+        limits=Limits(max_keepalive_connections=5, max_connections=10),
+        event_hooks={"request": [_rewrite_headers]},
+    )
+
+
 def build_anthropic_client(
     api_key,
     base_url: str = None,
@@ -872,15 +920,25 @@ def build_anthropic_client(
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
     elif _is_oauth_token(api_key):
-        # OAuth access token / setup-token → Bearer auth + Claude Code identity.
-        # Anthropic routes OAuth requests based on user-agent and headers;
-        # without Claude Code's fingerprint, requests get intermittent 500s.
+        # OAuth access token / setup-token -> Bearer auth + Claude Code identity.
+        # The Python SDK fingerprints itself in headers, so use a request hook
+        # to rewrite the wire request to Claude Code's JS SDK shape.
         all_betas = common_betas + _OAUTH_ONLY_BETAS
+        all_betas = [b for b in all_betas if b != _TOOL_STREAMING_BETA]
+        beta_header = ",".join(all_betas)
         kwargs["auth_token"] = api_key
+        kwargs["http_client"] = _build_oauth_impersonation_http_client(
+            api_key,
+            timeout=kwargs.get("timeout"),
+            anthropic_beta=beta_header,
+        )
         kwargs["default_headers"] = {
-            "anthropic-beta": ",".join(all_betas),
-            "user-agent": f"claude-code/{_get_claude_code_version()} (external, cli)",
+            "anthropic-beta": beta_header,
+            "user-agent": f"claude-cli/{_get_claude_code_version()} (external, sdk-cli)",
             "x-app": "cli",
+            "x-anthropic-billing-header": (
+                f"cc_version={_get_claude_code_version()}; cc_entrypoint=sdk-cli; cch=00000;"
+            ),
         }
     else:
         # Regular API key → x-api-key header + common betas
@@ -2759,14 +2817,21 @@ def build_anthropic_kwargs(
 
     # ── OAuth: Claude Code identity ──────────────────────────────────
     if is_oauth:
-        # 1. Prepend Claude Code system prompt identity
+        # 1. Prepend billing attribution, then Claude Code/SDK identity.
+        billing_block = {
+            "type": "text",
+            "text": (
+                f"x-anthropic-billing-header: cc_version={_get_claude_code_version()}; "
+                "cc_entrypoint=sdk-cli; cch=00000;"
+            ),
+        }
         cc_block = {"type": "text", "text": _CLAUDE_CODE_SYSTEM_PREFIX}
         if isinstance(system, list):
-            system = [cc_block] + system
+            system = [billing_block, cc_block] + system
         elif isinstance(system, str) and system:
-            system = [cc_block, {"type": "text", "text": system}]
+            system = [billing_block, cc_block, {"type": "text", "text": system}]
         else:
-            system = [cc_block]
+            system = [billing_block, cc_block]
 
         # 2. Sanitize system prompt — replace product name references
         #    to avoid Anthropic's server-side content filters.
@@ -2833,17 +2898,19 @@ def build_anthropic_kwargs(
 
     if anthropic_tools:
         kwargs["tools"] = anthropic_tools
-        # Map OpenAI tool_choice to Anthropic format
-        if tool_choice == "auto" or tool_choice is None:
-            kwargs["tool_choice"] = {"type": "auto"}
-        elif tool_choice == "required":
-            kwargs["tool_choice"] = {"type": "any"}
-        elif tool_choice == "none":
+        # Claude Code's native SDK omits tool_choice for OAuth requests, but
+        # caller intent to disable tools must still remove them from the body.
+        if tool_choice == "none":
             # Anthropic has no tool_choice "none" — omit tools entirely to prevent use
             kwargs.pop("tools", None)
-        elif isinstance(tool_choice, str):
-            # Specific tool name
-            kwargs["tool_choice"] = {"type": "tool", "name": tool_choice}
+        elif not is_oauth:
+            if tool_choice == "auto" or tool_choice is None:
+                kwargs["tool_choice"] = {"type": "auto"}
+            elif tool_choice == "required":
+                kwargs["tool_choice"] = {"type": "any"}
+            elif isinstance(tool_choice, str):
+                # Specific tool name
+                kwargs["tool_choice"] = {"type": "tool", "name": tool_choice}
 
     # Map reasoning_config to Anthropic's thinking parameter.
     # Claude 4.6+ models use adaptive thinking + output_config.effort.
@@ -2917,6 +2984,24 @@ def build_anthropic_kwargs(
             betas.extend(_OAUTH_ONLY_BETAS)
         betas.append(_FAST_MODE_BETA)
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
+
+    # ── OAuth: body fields matching Claude Code's JS SDK ─────────────
+    if is_oauth:
+        kwargs.setdefault("extra_body", {})
+        if kwargs.get("thinking"):
+            kwargs["extra_body"]["context_management"] = {
+                "edits": [
+                    {"type": "clear_thinking_20251015", "keep": "all"},
+                ],
+            }
+        kwargs["extra_body"]["metadata"] = {
+            "user_id": json.dumps({
+                "device_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                "account_uuid": "00000000-0000-0000-0000-000000000000",
+                "session_id": "00000000-0000-0000-0000-000000000000",
+            }),
+        }
+        kwargs["extra_body"]["diagnostics"] = {"previous_message_id": None}
 
     return kwargs
 

--- a/tests/agent/test_anthropic_oauth_ua_prefix.py
+++ b/tests/agent/test_anthropic_oauth_ua_prefix.py
@@ -1,10 +1,9 @@
 """Regression tests for the OAuth User-Agent header in anthropic_adapter.py.
 
-Two DIFFERENT Anthropic endpoints impose OPPOSITE User-Agent requirements:
+Two DIFFERENT Anthropic endpoints impose distinct User-Agent requirements:
 
-- Inference (``/v1/messages`` via build_anthropic_client): requires the
-  ``claude-code/`` UA + ``x-app: cli`` fingerprint, or requests get
-  intermittent 500s. (issue #48534: ``claude-cli/`` is 404'd here.)
+- Inference (``/v1/messages`` via build_anthropic_client) matches the current
+  Claude Agent SDK fingerprint: ``claude-cli/... (external, sdk-cli)``.
 - OAuth token endpoint (``/v1/oauth/token`` login exchange + refresh):
   Anthropic now RATE-LIMITS (HTTP 429) any UA whose prefix is ``claude-code/``
   (or ``Mozilla/``). Verified empirically against platform.claude.com:
@@ -15,17 +14,19 @@ Two DIFFERENT Anthropic endpoints impose OPPOSITE User-Agent requirements:
 
 from __future__ import annotations
 
+import json
 import re
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 
 class TestOAuthUserAgentPrefix:
-    """Inference uses ``claude-code/``; the OAuth token endpoint must NOT."""
+    """Inference uses the SDK CLI UA; the OAuth token endpoint must not."""
 
     def test_build_anthropic_client_oauth_ua(self):
-        """build_anthropic_client (INFERENCE) with OAuth token must use claude-code UA."""
+        """OAuth inference must match the current Claude Agent SDK UA."""
         from agent.anthropic_adapter import build_anthropic_client
 
         mock_sdk = MagicMock()
@@ -37,10 +38,97 @@ class TestOAuthUserAgentPrefix:
         headers = call_kwargs.get("default_headers", {})
         ua = headers.get("user-agent", "") or headers.get("User-Agent", "")
 
-        assert "claude-code/" in ua, f"Expected claude-code/ in UA, got: {ua}"
-        assert "claude-cli/" not in ua, f"Must not use claude-cli/ prefix: {ua}"
+        assert "claude-cli/" in ua, f"Expected claude-cli/ in UA, got: {ua}"
+        assert "(external, sdk-cli)" in ua
+        betas = headers["anthropic-beta"]
+        assert "oauth-2025-04-20" in betas
+        assert "claude-code-20250219" in betas
+        assert "fine-grained-tool-streaming-2025-05-14" not in betas
 
+    def test_oauth_request_hook_rewrites_final_wire_headers(self):
+        """The request hook must replace Python-SDK headers on the wire."""
+        from agent.anthropic_adapter import _build_oauth_impersonation_http_client
 
+        client = _build_oauth_impersonation_http_client(
+            "oauth-token",
+            timeout=30,
+            anthropic_beta="beta-one,beta-two",
+        )
+        try:
+            hook = client.event_hooks["request"][0]
+            request = httpx.Request(
+                "POST",
+                "https://api.anthropic.com/v1/messages",
+                headers={
+                    "user-agent": "anthropic-python/1.0",
+                    "x-stainless-lang": "python",
+                    "x-api-key": "must-be-removed",
+                },
+                json={"model": "claude-sonnet-4-6"},
+            )
+
+            hook(request)
+
+            assert request.headers["user-agent"].startswith("claude-cli/")
+            assert "(external, sdk-cli)" in request.headers["user-agent"]
+            assert request.headers["x-stainless-lang"] == "js"
+            assert request.headers["x-stainless-runtime"] == "node"
+            assert request.headers["x-app"] == "cli"
+            assert request.headers["anthropic-beta"] == "beta-one,beta-two"
+            assert request.headers["authorization"] == "Bearer oauth-token"
+            assert "x-api-key" not in request.headers
+        finally:
+            client.close()
+
+    def test_oauth_tool_choice_none_omits_tools_and_tool_choice(self):
+        """Disabling tools must remain effective when OAuth omits tool_choice."""
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[{
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "description": "Read a file",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }],
+            max_tokens=128,
+            reasoning_config=None,
+            tool_choice="none",
+            is_oauth=True,
+        )
+
+        assert "tool_choice" not in kwargs
+        assert "tools" not in kwargs
+
+    def test_oauth_body_fields_are_built_at_runtime(self):
+        """OAuth body metadata is present and thinking edits are conditional."""
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        common = {
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "hello"}],
+            "tools": None,
+            "max_tokens": 128,
+            "is_oauth": True,
+        }
+        without_thinking = build_anthropic_kwargs(reasoning_config=None, **common)
+        with_thinking = build_anthropic_kwargs(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            **common,
+        )
+
+        body = without_thinking["extra_body"]
+        identity = json.loads(body["metadata"]["user_id"])
+        assert set(identity) == {"device_id", "account_uuid", "session_id"}
+        assert body["diagnostics"] == {"previous_message_id": None}
+        assert "context_management" not in body
+        assert with_thinking["extra_body"]["context_management"] == {
+            "edits": [{"type": "clear_thinking_20251015", "keep": "all"}],
+        }
 
     def test_token_refresh_ua_not_throttled(self):
         """refresh_anthropic_oauth_pure must NOT send a throttled token-endpoint UA."""


### PR DESCRIPTION
## Summary

- rewrite Anthropic OAuth wire headers to the current Claude Agent SDK CLI fingerprint
- align OAuth beta and request-body fields, with `clear_thinking_20251015` gated on active thinking
- omit OAuth `tool_choice` while preserving `tool_choice="none"` semantics by removing tools
- add runtime coverage for the final request-hook headers and OAuth request body

## Remaining failure shape

The original PR base (`760112adb6`) already contained the OAuth `mcp__` tool-name normalization from `b70a4e7533dce506a41f847b3fc082d6b6fe4a9b`. The remaining request shape was therefore an OAuth inference request with normalized tool names but the Anthropic Python SDK fingerprint still present on the final wire request: the SDK adds its Python `User-Agent` / `x-stainless-*` headers after client defaults are constructed. Static `default_headers` cannot reliably replace that final fingerprint.

This change uses an `httpx` request hook at the wire boundary. The regression test now invokes that hook against deliberately conflicting Python-SDK headers and verifies the final JS SDK headers, Bearer authorization, beta header, and `x-api-key` removal.

## Verification

- rebased onto current `NousResearch/main` (`8defb9fd60`)
- canonical focused suite: 89 passed, 0 failed
- `compileall`: passed
- `git diff --check`: passed

## Scope

One commit; only the Anthropic adapter and its focused OAuth regression-test file are changed.