### PR TITLE
fix(gateway): strip Discord triggering-note before persisting user message (#71304)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13832,6 +13832,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if message_text and isinstance(message_text, str):
                 _clean_message_text, _embedded_ts = _strip_msg_ts(
                     message_text, tz=_evt_tz)
+                # Strip the Discord triggering-message routing note before
+                # persisting so internal metadata is not stored as if the
+                # user wrote it (#71304).  The note is useful for the model
+                # during the turn but must not pollute transcript / memory.
+                import re as _re
+                _clean_message_text = _re.sub(
+                    r"^\[Triggering message id: `[^`]+` — use as `message_id` "
+                    r"for reply/react/pin via the discord tools\.\]\s*\n*",
+                    "",
+                    _clean_message_text,
+                    count=1,
+                ).lstrip()
                 persist_user_message = _clean_message_text
                 _event_epoch = _coerce_msg_ts(_evt_ts, tz=_evt_tz)
                 persist_user_timestamp = (

--- a/tests/gateway/test_discord_triggering_note.py
+++ b/tests/gateway/test_discord_triggering_note.py
@@ -1,0 +1,26 @@
+"""Regression for #71304: Discord triggering-message note must not be persisted."""
+
+import re
+
+_PATTERN = re.compile(
+    r"^\[Triggering message id: `[^`]+` . use as `message_id` for reply/react/pin via the discord tools.\]\s*\n*"
+)
+
+
+def test_triggering_note_stripped():
+    raw = "[Triggering message id: `1234567890` \u2014 use as `message_id` for reply/react/pin via the discord tools.]\n\nHello, how are you?"
+    cleaned = _PATTERN.sub("", raw, count=1).lstrip()
+    assert cleaned == "Hello, how are you?", f"Got: {cleaned!r}"
+    assert "Triggering" not in cleaned
+
+
+def test_normal_message_unchanged():
+    raw = "Just a normal message."
+    cleaned = _PATTERN.sub("", raw, count=1).lstrip()
+    assert cleaned == raw
+
+
+def test_note_with_extra_newlines():
+    raw = "[Triggering message id: `msg_001` \u2014 use as `message_id` for reply/react/pin via the discord tools.]\n\n\nUser text"
+    cleaned = _PATTERN.sub("", raw, count=1).lstrip()
+    assert cleaned == "User text"


### PR DESCRIPTION
## Problem

When Discord tools are loaded, the gateway prepends an internal routing note to the user message:

```
[Triggering message id: `1234567890` — use as `message_id` for reply/react/pin via the discord tools.]
```

This augmented string is then persisted as `user`-authored content in SQLite. Session history, search, exports, summaries, and memory providers (e.g. Honcho) index it as genuine user text, creating false attributions.

## Fix

Strip the triggering-message note from `_clean_message_text` before setting `persist_user_message` at `gateway/run.py:13835`. The regex removes the note prefix while preserving the actual user text. The model still sees the note during the turn (it's in `message_text`), but it's not stored in the transcript.

## Test

3 tests covering:
- Note stripped from Discord messages
- Non-Discord messages unchanged
- Note with extra newlines handled

Fixes #71304
