### PR TITLE
fix(hermes_cli): stop custom model listing from sending OpenRouter keys to arbitrary hosts

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2059,6 +2059,11 @@ def _api_key_for_custom_model_catalog(base_url: str, model_cfg: dict[str, Any]) 
         openrouter_key = os.getenv("OPENROUTER_API_KEY", "").strip()
         if openrouter_key:
             return openrouter_key
+        # Parity with runtime_provider openrouter context (#289):
+        # OpenRouter accepts OPENAI_API_KEY when OPENROUTER_API_KEY is unset.
+        openai_key = os.getenv("OPENAI_API_KEY", "").strip()
+        if openai_key:
+            return openai_key
 
     return ""
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -20,6 +20,7 @@ from typing import Any, NamedTuple, Optional
 
 from hermes_cli import __version__ as _HERMES_VERSION
 from hermes_cli.urllib_security import open_credentialed_url
+from utils import base_url_host_matches
 
 # Identify ourselves so endpoints fronted by Cloudflare's Browser Integrity
 # Check (error 1010) don't reject the default ``Python-urllib/*`` signature.
@@ -2026,6 +2027,42 @@ def _get_custom_base_url() -> str:
     return str(model_cfg.get("base_url", "")).strip()
 
 
+def _api_key_for_custom_model_catalog(base_url: str, model_cfg: dict[str, Any]) -> str:
+    """Resolve a /models probe key without leaking unrelated provider secrets.
+
+    Explicit ``model.api_key`` / ``CUSTOM_API_KEY`` always win. Env-backed
+    OpenAI / OpenRouter / Ollama keys are host-gated the same way
+    ``runtime_provider`` does for chat (GHSA-76xc-57q6-vm5m / #28660) so a
+    custom ``base_url`` cannot siphon those credentials onto an unrelated host.
+    """
+    cfg_key = str(model_cfg.get("api_key", "") or "").strip()
+    if cfg_key:
+        return cfg_key
+
+    custom_key = os.getenv("CUSTOM_API_KEY", "").strip()
+    if custom_key:
+        return custom_key
+
+    if base_url_host_matches(base_url, "ollama.com"):
+        ollama_key = os.getenv("OLLAMA_API_KEY", "").strip()
+        if ollama_key:
+            return ollama_key
+
+    if base_url_host_matches(base_url, "openai.com") or base_url_host_matches(
+        base_url, "openai.azure.com"
+    ):
+        openai_key = os.getenv("OPENAI_API_KEY", "").strip()
+        if openai_key:
+            return openai_key
+
+    if base_url_host_matches(base_url, "openrouter.ai"):
+        openrouter_key = os.getenv("OPENROUTER_API_KEY", "").strip()
+        if openrouter_key:
+            return openrouter_key
+
+    return ""
+
+
 def _get_model_config_dict() -> dict[str, Any]:
     """Return the main model config mapping, or an empty dict."""
     try:
@@ -2721,13 +2758,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         base_url = _get_custom_base_url()
         if base_url:
             model_cfg = _get_model_config_dict()
-            # Try common API key env vars for custom endpoints
-            api_key = (
-                str(model_cfg.get("api_key", "") or "").strip()
-                or os.getenv("CUSTOM_API_KEY", "")
-                or os.getenv("OPENAI_API_KEY", "")
-                or os.getenv("OPENROUTER_API_KEY", "")
-            )
+            api_key = _api_key_for_custom_model_catalog(base_url, model_cfg)
             api_mode = "anthropic_messages" if _base_url_looks_like_anthropic_messages(base_url) else None
             live = fetch_api_models(api_key, base_url, api_mode=api_mode)
             if live:

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -267,6 +267,125 @@ class TestProviderModelIds:
             api_mode="anthropic_messages",
         )
 
+    def test_custom_catalog_does_not_leak_openrouter_key_to_unrelated_host(
+        self, monkeypatch,
+    ):
+        """OPENROUTER_API_KEY must not ride /models probes to unrelated hosts.
+
+        Mirrors runtime_provider host-gating (GHSA-76xc / #28660): listing
+        models for provider=custom with an attacker-controlled base_url must
+        not attach OpenRouter/OpenAI secrets from the environment.
+        """
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-leaked")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-leaked")
+        monkeypatch.delenv("CUSTOM_API_KEY", raising=False)
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "model": {
+                    "provider": "custom",
+                    "base_url": "https://attacker.example/v1",
+                }
+            },
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["attacker-model"],
+        ) as mock_fetch:
+            assert provider_model_ids("custom") == ["attacker-model"]
+
+        mock_fetch.assert_called_once()
+        api_key, base_url = mock_fetch.call_args.args[:2]
+        assert base_url == "https://attacker.example/v1"
+        assert api_key == ""
+
+    def test_custom_catalog_uses_openrouter_key_only_on_openrouter_host(
+        self, monkeypatch,
+    ):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-ok")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("CUSTOM_API_KEY", raising=False)
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "model": {
+                    "provider": "custom",
+                    "base_url": "https://openrouter.ai/api/v1",
+                }
+            },
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["or-model"],
+        ) as mock_fetch:
+            assert provider_model_ids("custom") == ["or-model"]
+
+        mock_fetch.assert_called_once()
+        assert mock_fetch.call_args.args[0] == "sk-or-ok"
+
+    def test_custom_catalog_prefers_explicit_config_api_key(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-should-not-win")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-should-not-win")
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "model": {
+                    "provider": "custom",
+                    "base_url": "https://attacker.example/v1",
+                    "api_key": "explicit-custom-key",
+                }
+            },
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["m"],
+        ) as mock_fetch:
+            assert provider_model_ids("custom") == ["m"]
+
+        assert mock_fetch.call_args.args[0] == "explicit-custom-key"
+
+    def test_custom_catalog_uses_custom_api_key_on_unrelated_host(self, monkeypatch):
+        monkeypatch.setenv("CUSTOM_API_KEY", "custom-endpoint-key")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-should-not-win")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "model": {
+                    "provider": "custom",
+                    "base_url": "https://attacker.example/v1",
+                }
+            },
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["m"],
+        ) as mock_fetch:
+            assert provider_model_ids("custom") == ["m"]
+
+        assert mock_fetch.call_args.args[0] == "custom-endpoint-key"
+
+    def test_custom_catalog_uses_openai_key_only_on_openai_host(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-ok")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-should-not-win")
+        monkeypatch.delenv("CUSTOM_API_KEY", raising=False)
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "model": {
+                    "provider": "custom",
+                    "base_url": "https://api.openai.com/v1",
+                }
+            },
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["gpt"],
+        ) as mock_fetch:
+            assert provider_model_ids("custom") == ["gpt"]
+
+        assert mock_fetch.call_args.args[0] == "sk-openai-ok"
+
 
 # -- fetch_api_models --------------------------------------------------------
 

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -323,6 +323,74 @@ class TestProviderModelIds:
         mock_fetch.assert_called_once()
         assert mock_fetch.call_args.args[0] == "sk-or-ok"
 
+    def test_custom_catalog_falls_back_to_openai_key_on_openrouter_host(
+        self, monkeypatch,
+    ):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-for-or")
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("CUSTOM_API_KEY", raising=False)
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "model": {
+                    "provider": "custom",
+                    "base_url": "https://openrouter.ai/api/v1",
+                }
+            },
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["or-model"],
+        ) as mock_fetch:
+            assert provider_model_ids("custom") == ["or-model"]
+
+        assert mock_fetch.call_args.args[0] == "sk-openai-for-or"
+
+    def test_custom_catalog_does_not_leak_ollama_key_to_unrelated_host(
+        self, monkeypatch,
+    ):
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama-leaked")
+        monkeypatch.delenv("CUSTOM_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "model": {
+                    "provider": "custom",
+                    "base_url": "https://attacker.example/v1",
+                }
+            },
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["m"],
+        ) as mock_fetch:
+            assert provider_model_ids("custom") == ["m"]
+
+        assert mock_fetch.call_args.args[0] == ""
+
+    def test_custom_catalog_rejects_openrouter_lookalike_host(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-leaked")
+        monkeypatch.delenv("CUSTOM_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "model": {
+                    "provider": "custom",
+                    "base_url": "https://openrouter.ai.evil.test/v1",
+                }
+            },
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["m"],
+        ) as mock_fetch:
+            assert provider_model_ids("custom") == ["m"]
+
+        assert mock_fetch.call_args.args[0] == ""
+
     def test_custom_catalog_prefers_explicit_config_api_key(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-should-not-win")
         monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-should-not-win")


### PR DESCRIPTION
## What does this PR do?

Stops `provider_model_ids("custom")` from attaching `OPENROUTER_API_KEY` / `OPENAI_API_KEY` to unrelated custom `base_url` hosts when probing `/models` (for example from the `/model` picker). Catalog key selection now host-gates those env vars the same way chat-time `runtime_provider` already does for GHSA-76xc / #28660.

### Bug Cause

The custom branch in `hermes_cli/models.py` built the catalog probe key as `model.api_key` or `CUSTOM_API_KEY` or `OPENAI_API_KEY` or `OPENROUTER_API_KEY` with no host check, then called `fetch_api_models(api_key, base_url)`, which sends `Authorization: Bearer ...`. Chat resolution already refused to send those keys to non-matching hosts; the model-list path did not.

### Reproduction Steps

1. Set `model.provider: custom` and `model.base_url: https://attacker.example/v1` (no `model.api_key` / `CUSTOM_API_KEY`).
2. Export only `OPENROUTER_API_KEY=sk-or-secret` (no custom key).
3. Trigger `provider_model_ids("custom")` (or open the model picker for the custom provider).

Expected: the `/models` request to `attacker.example` has no OpenRouter Bearer token (empty key / no Authorization).
Before fix: request includes `Authorization: Bearer sk-or-secret`.

### Fix

Add `_api_key_for_custom_model_catalog()` that keeps explicit `model.api_key` / `CUSTOM_API_KEY`, then host-gates `OLLAMA_API_KEY` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` via `base_url_host_matches`. On `openrouter.ai`, fall back to `OPENAI_API_KEY` when `OPENROUTER_API_KEY` is unset (parity with runtime #289). Tests cover leak denial, lookalike hosts, OpenRouter/OpenAI allow paths, and explicit/`CUSTOM_API_KEY` preference.

## Related Issue

No issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Changes Made

- `hermes_cli/models.py` - host-gate custom model-catalog API key selection
- `tests/hermes_cli/test_model_validation.py` - leak, lookalike, allow-path, and preference coverage

## How to Test

1. Manual: configure custom `base_url` to a non-OpenRouter host with only `OPENROUTER_API_KEY` set; confirm catalog probe does not send that Bearer token. Point `base_url` at `https://openrouter.ai/api/v1` and confirm OpenRouter (or OPENAI fallback) key is still used.
2. Automated (already run locally, 97 passed):

```bash
scripts/run_tests.sh tests/hermes_cli/test_model_validation.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact - N/A (pure key-selection logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
