### PR TITLE
fix(models): accept live Nous Portal recommendations in /model validation

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5058,6 +5058,42 @@ def validate_requested_model(
                     ),
                 }
 
+            # Nous provider: also check the Portal's live
+            # /api/nous/recommended-models feed. That feed can list a model
+            # (e.g. a newly-promoted free/paid recommendation) before it's
+            # been added to the hardcoded _PROVIDER_MODELS["nous"] curated
+            # list or the docs-hosted catalog manifest has been rebuilt.
+            # `hermes chat` already accepts these models via
+            # union_with_portal_free/paid_recommendations() at model-list
+            # build time; this mirrors that same source of truth for the
+            # per-message /model validation path (messaging platform
+            # pickers, /model command), which previously only checked the
+            # curated catalog and rejected valid Portal-recommended models.
+            if normalized == "nous":
+                try:
+                    portal_payload = fetch_nous_recommended_models(
+                        _resolve_nous_portal_url()
+                    )
+                    portal_model_names = {
+                        str(entry.get("modelName", "")).strip().lower()
+                        for tier in ("freeRecommendedModels", "paidRecommendedModels")
+                        for entry in (portal_payload.get(tier) or [])
+                        if isinstance(entry, dict)
+                    }
+                    portal_model_names.discard("")
+                except Exception:
+                    portal_model_names = set()
+                if requested_for_lookup.lower() in portal_model_names:
+                    return {
+                        "accepted": True,
+                        "persist": True,
+                        "recognized": True,
+                        "message": (
+                            f"Note: `{requested}` was not found in the live /v1/models "
+                            f"listing but is a current Nous Portal recommendation — accepted."
+                        ),
+                    }
+
         return {
             "accepted": False,
             "persist": False,

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -520,31 +520,6 @@ class TestProbeApiModelsUserAgent:
         assert req.get_header("Authorization") is None
 
 
-        body = b'{"data":[]}'
-        with patch(
-            "hermes_cli.models._urlopen_model_catalog_request",
-            return_value=self._make_mock_response(body),
-        ) as mock_urlopen:
-            probe_api_models(
-                "gemini-key",
-                "https://generativelanguage.googleapis.com/v1beta/openai",
-            )
-
-        req = mock_urlopen.call_args[0][0]
-        assert req.get_header("X-goog-api-client") == f"hermes-agent/{_HERMES_VERSION}"
-
-    def test_probe_omits_gemini_client_context_for_other_providers(self):
-        from unittest.mock import patch
-
-        body = b'{"data":[]}'
-        with patch(
-            "hermes_cli.models._urlopen_model_catalog_request",
-            return_value=self._make_mock_response(body),
-        ) as mock_urlopen:
-            probe_api_models("provider-key", "https://api.example.com/v1")
-
-        req = mock_urlopen.call_args[0][0]
-        assert req.get_header("X-goog-api-client") is None
 
 
 class TestValidateRequestedModelNousPortalRecommendations:

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -520,3 +520,136 @@ class TestProbeApiModelsUserAgent:
         assert req.get_header("Authorization") is None
 
 
+        body = b'{"data":[]}'
+        with patch(
+            "hermes_cli.models._urlopen_model_catalog_request",
+            return_value=self._make_mock_response(body),
+        ) as mock_urlopen:
+            probe_api_models(
+                "gemini-key",
+                "https://generativelanguage.googleapis.com/v1beta/openai",
+            )
+
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("X-goog-api-client") == f"hermes-agent/{_HERMES_VERSION}"
+
+    def test_probe_omits_gemini_client_context_for_other_providers(self):
+        from unittest.mock import patch
+
+        body = b'{"data":[]}'
+        with patch(
+            "hermes_cli.models._urlopen_model_catalog_request",
+            return_value=self._make_mock_response(body),
+        ) as mock_urlopen:
+            probe_api_models("provider-key", "https://api.example.com/v1")
+
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("X-goog-api-client") is None
+
+
+class TestValidateRequestedModelNousPortalRecommendations:
+    """Regression tests for issue #71312: the Nous Telegram picker (and any
+    other messaging-platform /model validation, since they all share
+    validate_requested_model()) rejected models that are live Nous Portal
+    recommendations (/api/nous/recommended-models) but not yet in the
+    hardcoded curated catalog -- even though `hermes chat` already accepts
+    these via union_with_portal_free/paid_recommendations() at model-list
+    build time. The per-message validation path now checks the same Portal
+    feed as a fallback tier before rejecting, so Telegram/CLI agree.
+    """
+
+    PORTAL_PAYLOAD = {
+        "freeRecommendedModels": [
+            {"modelName": "inclusionai/ling-3.0-flash:free"},
+        ],
+        "paidRecommendedModels": [
+            {"modelName": "inclusionai/ling-3.0-pro"},
+        ],
+    }
+
+    def _validate_nous(self, model, api_models=None, portal_payload=None, portal_raises=False):
+        api_models = api_models if api_models is not None else ["inclusionai/ling-2.6-flash"]
+        probe_payload = {
+            "models": api_models,
+            "probed_url": "https://portal.nousresearch.com/v1/models",
+            "resolved_base_url": "https://portal.nousresearch.com/v1",
+            "suggested_base_url": None,
+            "used_fallback": False,
+        }
+
+        def _fetch_portal(*a, **kw):
+            if portal_raises:
+                raise RuntimeError("portal unreachable")
+            return portal_payload if portal_payload is not None else self.PORTAL_PAYLOAD
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=api_models), \
+             patch("hermes_cli.models.probe_api_models", return_value=probe_payload), \
+             patch("hermes_cli.models.fetch_nous_recommended_models", side_effect=_fetch_portal), \
+             patch("hermes_cli.models._resolve_nous_portal_url", return_value="https://portal.nousresearch.com"), \
+             patch("hermes_cli.models._model_in_provider_catalog", return_value=False):
+            return validate_requested_model(model, "nous")
+
+    def test_free_portal_recommendation_accepted(self):
+        """The exact scenario from #71312: a free-tier Portal recommendation
+        missing from the curated catalog and the live /v1/models listing
+        must be accepted, not rejected."""
+        result = self._validate_nous("inclusionai/ling-3.0-flash:free")
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert "Portal recommendation" in (result["message"] or "")
+
+    def test_paid_portal_recommendation_accepted(self):
+        result = self._validate_nous("inclusionai/ling-3.0-pro")
+        assert result["accepted"] is True
+
+    def test_model_absent_from_portal_and_catalog_still_rejected(self):
+        """A model that's genuinely nowhere (not live, not curated, not a
+        Portal recommendation) must still be rejected -- this fallback
+        tier must not make validation permissive for everything."""
+        result = self._validate_nous("totally-made-up-model-xyz")
+        assert result["accepted"] is False
+        assert result["recognized"] is False
+
+    def test_portal_fetch_failure_falls_through_to_rejection_not_crash(self):
+        """A network/parse failure fetching the Portal feed must not crash
+        validation -- it degrades to the existing rejection path."""
+        result = self._validate_nous(
+            "inclusionai/ling-3.0-flash:free", portal_raises=True
+        )
+        assert result["accepted"] is False  # fails closed, doesn't crash
+
+    def test_non_nous_provider_does_not_consult_portal_feed(self):
+        """This fallback tier is Nous-specific; a non-Nous provider must
+        not have its rejection changed by (or trigger a call to) the Nous
+        Portal feed."""
+        probe_payload = {
+            "models": ["some/other-model"],
+            "probed_url": "https://api.example.com/v1/models",
+            "resolved_base_url": "https://api.example.com/v1",
+            "suggested_base_url": None,
+            "used_fallback": False,
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=["some/other-model"]), \
+             patch("hermes_cli.models.probe_api_models", return_value=probe_payload), \
+             patch("hermes_cli.models.fetch_nous_recommended_models") as mock_portal, \
+             patch("hermes_cli.models._model_in_provider_catalog", return_value=False):
+            result = validate_requested_model("inclusionai/ling-3.0-flash:free", "openrouter")
+        mock_portal.assert_not_called()
+        assert result["accepted"] is False
+
+    def test_curated_catalog_hit_short_circuits_before_portal_check(self):
+        """When the curated-catalog fallback already accepts the model, the
+        Portal feed should not need to be consulted at all (cheaper, and
+        avoids an unnecessary network call on the common path)."""
+        api_models = ["inclusionai/ling-2.6-flash"]
+        probe_payload = {
+            "models": api_models, "probed_url": "x", "resolved_base_url": "x",
+            "suggested_base_url": None, "used_fallback": False,
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=api_models), \
+             patch("hermes_cli.models.probe_api_models", return_value=probe_payload), \
+             patch("hermes_cli.models._model_in_provider_catalog", return_value=True), \
+             patch("hermes_cli.models.fetch_nous_recommended_models") as mock_portal:
+            result = validate_requested_model("inclusionai/ling-2.6-flash", "nous")
+        mock_portal.assert_not_called()
+        assert result["accepted"] is True


### PR DESCRIPTION
## Context

Fixes #71312 (duplicate: #71313).

## Problem

Selecting a model via the Telegram `/model` picker (or any messaging-platform slash command, since they all share `validate_requested_model()`) rejects a model that's available via Nous Portal's live `/api/nous/recommended-models` endpoint but not yet in the hardcoded curated catalog -- even though the same model works fine via `hermes chat -m <model> --provider nous`.

## Root Cause

`hermes chat` merges Portal recommendations into its model list via `union_with_portal_free_recommendations()` / `union_with_portal_paid_recommendations()` at model-list build time. `validate_requested_model()` -- which every per-message `/model` command goes through -- never checked that same feed, only the live `/v1/models` listing and the curated catalog.

## Fix

Added a Nous-specific fallback tier in `validate_requested_model()`, checked after the curated-catalog fallback and before the final rejection, reading the same `fetch_nous_recommended_models()` feed the CLI union helpers already use. Scoped to `provider == "nous"` only; short-circuits before any network call when an earlier tier already accepted the model; fails closed if the Portal feed is unreachable.

Also: #71312 and #71313 were filed 3 minutes apart by the same author with identical content. Commented on #71313 marking it a duplicate (could not close it directly -- no admin rights on the repo from this token).

## Verification

6/6 new tests pass; 95/95 in the full `tests/hermes_cli/test_model_validation.py` file; 87/87 in `tests/hermes_cli/test_models.py` (unaffected, confirmed).