### PR TITLE
fix(feishu): recognize @all slash commands

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1263,6 +1263,39 @@ def _build_mention_hint(mentions: Sequence[FeishuMentionRef]) -> str:
     return f"[Mentioned: {', '.join(parts)}]" if parts else ""
 
 
+def _strip_edge_all_mentions_for_command(
+    text: str,
+    mentions: Sequence[FeishuMentionRef],
+) -> str:
+    # Feishu @_all normalizes to @all. Keep this aligned with
+    # _strip_edge_self_mentions: strip leading all-mentions only when
+    # token-bounded, and strip trailing all-mentions only at terminal edges.
+    # Mid-sentence references ("don't @all again") stay intact.
+    if not text or not any(ref.is_all for ref in mentions):
+        return text
+
+    all_name = "@all"
+    remaining = text.lstrip()
+    while True:
+        if not remaining.startswith(all_name):
+            break
+        after = remaining[len(all_name):]
+        if after and after[0] not in _MENTION_BOUNDARY_CHARS:
+            break
+        remaining = after.lstrip()
+
+    while True:
+        i = len(remaining)
+        while i > 0 and remaining[i - 1] in _TRAILING_TERMINAL_PUNCT:
+            i -= 1
+        body = remaining[:i]
+        tail = remaining[i:]
+        if body.endswith(all_name):
+            remaining = body[: -len(all_name)].rstrip() + tail
+        else:
+            return remaining
+
+
 def _strip_edge_self_mentions(
     text: str,
     mentions: Sequence[FeishuMentionRef],
@@ -3285,6 +3318,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         if inbound_type == MessageType.TEXT:
             text = _strip_edge_self_mentions(text, mentions)
+            text = _strip_edge_all_mentions_for_command(text, mentions)
             if text.startswith("/"):
                 inbound_type = MessageType.COMMAND
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2301,6 +2301,58 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         self.assertNotIn("[Mentioned:", event.text)
         self.assertTrue(event.text.startswith("/model"))
 
+    def test_at_all_slash_message_becomes_command(self):
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "@_all /new"}),
+            message_type="text",
+            message_id="m_at_all_command",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="m_at_all_command",
+            )
+        )
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.message_type.value, "command")
+        self.assertEqual(event.text, "/new")
+
+    def test_at_all_prose_strips_edge_mention_but_stays_text(self):
+        from gateway.platforms.base import MessageType
+
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "@_all please /new"}),
+            message_type="text",
+            message_id="m_at_all_prose",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="m_at_all_prose",
+            )
+        )
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.message_type, MessageType.TEXT)
+        self.assertEqual(event.text, "[Mentioned: @all]\n\nplease /new")
+
 
 class TestFeishuFetchMessageText(unittest.TestCase):
     def _build_adapter(self):


### PR DESCRIPTION
## What does this PR do?

Fixes Feishu group slash-command detection for all-mention commands such as `@all /new`.

Feishu all-mentions arrive as `@_all` and Hermes normalizes them to `@all`. Before this change, the Feishu adapter only stripped the bot's own edge mentions before checking whether text starts with `/`, so `@all /new` was routed as normal text instead of entering the slash-command path.

This change adds edge `@all` stripping with the same style and semantics as `_strip_edge_self_mentions`, then runs slash-command detection on the cleaned text.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/feishu/adapter.py`: strip edge `@all` mentions before slash-command detection.
- `tests/gateway/test_feishu.py`: add regression coverage for `@_all /new` becoming a command and edge `@_all` prose staying text.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_feishu.py -q
.venv/bin/python -m ruff check plugins/platforms/feishu/adapter.py tests/gateway/test_feishu.py
```

Local result:

```text
216 tests passed, 0 failed
All checks passed!
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
running per-file parallel test suite via run_tests_parallel.py
Discovered 1 test files (~216 tests) under ['tests/gateway/test_feishu.py']; running with -j 20
[100.0% |   216/~216 | 216 passed | 0 failed] tests/gateway/test_feishu.py

Summary: 1 files, 216 tests passed, 0 failed in 5.9s
```
