### PR TITLE
feat(telegram): send native stickers from a persistent, agent-curated collection

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16494,7 +16494,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _pb_err,
                 )
                 turn_sidecar_notes.append(_intro_note)
-        
+
+        # Telegram sticker collection -- injected on the session's FIRST turn
+        # only (empty transcript == brand-new session, the same first-turn
+        # detection the home-channel prompt below uses).  The note rides the
+        # first user message via the sidecar channel and is persisted through
+        # api_content, so it replays verbatim on later turns: mid-session
+        # collection changes never re-inject and the prompt cache stays
+        # intact.  Lazy, guarded import -- the telegram platform plugin may
+        # be absent, and a rendering failure must never break message
+        # processing.
+        if not history and source.platform == Platform.TELEGRAM:
+            try:
+                from plugins.platforms.telegram.sticker_collection import (
+                    build_sticker_collection_note,
+                )
+
+                _sticker_note = build_sticker_collection_note()
+                if _sticker_note:
+                    turn_sidecar_notes.append(_sticker_note)
+            except Exception as _sticker_err:
+                logger.warning(
+                    "Telegram sticker collection note injection failed "
+                    "(non-fatal): %s",
+                    _sticker_err,
+                )
+
         # One-time prompt if no home channel is set for this platform
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1897,6 +1897,7 @@ DEFAULT_CONFIG = {
         "reactions": False,            # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
         "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
+        "sticker_sets": [],            # Sticker pack short names (e.g. ["HotCherry"]) imported into the sticker collection at startup
         "extra": {
             "rich_messages": False,     # Bot API 10.1 rich messages (tables/task lists/details/math) render natively; set True to opt in. Default stays legacy MarkdownV2 because rich messages can be hard to copy as plain text in Telegram clients.
             "rich_drafts": False,       # Experimental Bot API 10.1 rich draft previews during Telegram DM streaming. Default off because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws.

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -119,6 +119,7 @@ CONFIGURABLE_TOOLSETS = [
     ("discord",         "💬 Discord (read/participate)", "fetch messages, search members, create thread"),
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
     ("yuanbao",          "🤖 Yuanbao",                  "group info, member queries, DM"),
+    ("telegram",         "📱 Telegram",                 "send stickers, manage sticker collection"),
     ("computer_use",     "🖱️  Computer Use (macOS/Windows/Linux)", "background desktop control via cua-driver"),
 ]
 
@@ -201,6 +202,7 @@ def _xai_credentials_present() -> bool:
 _TOOLSET_PLATFORM_RESTRICTIONS: Dict[str, Set[str]] = {
     "discord": {"discord"},
     "discord_admin": {"discord"},
+    "telegram": {"telegram"},
 }
 
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3574,11 +3574,57 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[%s] DM topics setup failed (non-fatal): %s",
                     self.name, topics_err, exc_info=True,
                 )
+
+            # Seed the sticker collection from configured packs
+            # (telegram.sticker_sets → PlatformConfig.extra). Deferred here,
+            # off the connect path, so slow/failing getStickerSet calls can
+            # never block or crash connect(). Empty config is a no-op.
+            try:
+                await self._seed_sticker_collection_from_config()
+            except Exception as seed_err:
+                logger.warning(
+                    "[%s] Sticker collection seed failed (non-fatal): %s",
+                    self.name, seed_err, exc_info=True,
+                )
         except asyncio.CancelledError:
             raise
         finally:
             if self._post_connect_task is asyncio.current_task():
                 self._post_connect_task = None
+
+    async def _seed_sticker_collection_from_config(self) -> None:
+        """Import configured sticker packs into the persistent collection.
+
+        Reads ``telegram.sticker_sets`` from config.yaml (bridged into
+        ``PlatformConfig.extra`` by :func:`_apply_yaml_config`) and bulk-imports
+        each pack via the Bot API. An empty or missing list is a no-op. The
+        caller treats every failure as non-fatal; per-set failures are logged
+        and skipped inside ``refresh_from_sets``.
+        """
+        extra = getattr(self.config, "extra", None) or {}
+        sticker_sets = extra.get("sticker_sets")
+        if isinstance(sticker_sets, str):
+            # Tolerate a comma-separated string in user config.
+            sticker_sets = [s.strip() for s in sticker_sets.split(",")]
+        if not isinstance(sticker_sets, (list, tuple)):
+            return
+        names = [str(n).strip() for n in sticker_sets if str(n or "").strip()]
+        if not names:
+            return
+        bot = self._bot
+        if bot is None:
+            return
+        from plugins.platforms.telegram import sticker_collection
+        summary = await sticker_collection.refresh_from_sets(bot, names)
+        logger.info(
+            "[%s] Sticker collection seeded from config: %d set(s), %d sticker(s) "
+            "(%d new, %d set(s) failed)",
+            self.name,
+            summary["sets"],
+            summary["stickers"],
+            summary["new"],
+            summary["sets_failed"],
+        )
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to Telegram via polling or webhook.
@@ -9309,6 +9355,11 @@ class TelegramAdapter(BasePlatformAdapter):
         For static stickers (WEBP), we download, analyze with vision, and cache
         the description by file_unique_id. For animated/video stickers, we inject
         a placeholder noting the emoji.
+
+        Every received sticker is also recorded into the persistent sticker
+        collection so the agent can later send it back with tg_send_sticker.
+        New entries append a mid-session note to the injected text (current
+        user message only — prompt-cache safe); known stickers get no note.
         """
         from gateway.sticker_cache import (
             get_cached_description,
@@ -9317,6 +9368,7 @@ class TelegramAdapter(BasePlatformAdapter):
             build_animated_sticker_injection,
             STICKER_VISION_PROMPT,
         )
+        from plugins.platforms.telegram import sticker_collection
 
         sticker = msg.sticker
         emoji = sticker.emoji or ""
@@ -9325,6 +9377,9 @@ class TelegramAdapter(BasePlatformAdapter):
         # Animated and video stickers can't be analyzed as static images
         if sticker.is_animated or sticker.is_video:
             event.text = build_animated_sticker_injection(emoji)
+            self._record_sticker_into_collection(
+                sticker_collection, sticker, event, emoji, set_name
+            )
             return
 
         # Check the cache first
@@ -9334,6 +9389,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 cached["description"], cached.get("emoji", emoji), cached.get("set_name", set_name)
             )
             logger.info("[Telegram] Sticker cache hit: %s", sticker.file_unique_id)
+            # Also refreshes file_id for entries the collection already knows.
+            self._record_sticker_into_collection(
+                sticker_collection, sticker, event, emoji, set_name
+            )
             return
 
         # Cache miss -- download and analyze
@@ -9366,6 +9425,58 @@ class TelegramAdapter(BasePlatformAdapter):
                 f"a sticker with emoji {emoji}" if emoji else "a sticker",
                 emoji, set_name,
             )
+
+        # Record AFTER any cache_sticker_description() call above so the
+        # collection's best-effort vision-cache backfill can pick up the fresh
+        # description (see record_sticker's description merge rule).
+        self._record_sticker_into_collection(
+            sticker_collection, sticker, event, emoji, set_name
+        )
+
+    def _record_sticker_into_collection(
+        self,
+        sticker_collection: Any,
+        sticker: Any,
+        event: "MessageEvent",
+        emoji: str,
+        set_name: str,
+    ) -> None:
+        """Upsert an inbound sticker into the persistent sticker collection.
+
+        When the sticker is new to the collection, append a mid-session note
+        to the injected ``event.text`` telling the model it can send the
+        sticker back with ``tg_send_sticker``. The note rides the current user
+        message only, so no prior context is touched (prompt-cache safe).
+        Known stickers silently refresh ``file_id``/``last_seen``. Never
+        raises — collection failures must not break sticker handling.
+        """
+        try:
+            is_new = sticker_collection.record_sticker(
+                file_unique_id=sticker.file_unique_id,
+                file_id=sticker.file_id,
+                emoji=emoji,
+                set_name=set_name,
+                kind=sticker_collection.sticker_kind(sticker),
+            )
+        except Exception as e:
+            logger.warning(
+                "[Telegram] Failed to record sticker %s into collection: %s",
+                getattr(sticker, "file_unique_id", "?"),
+                _redact_telegram_error_text(e),
+            )
+            return
+        if not is_new:
+            return
+        details = []
+        if emoji:
+            details.append(f"emoji {emoji}")
+        if set_name:
+            details.append(f'set "{set_name}"')
+        suffix = f": {', '.join(details)}" if details else ""
+        event.text = (event.text or "") + (
+            "\n(New sticker saved to your collection — you can send it back "
+            f"later with tg_send_sticker{suffix})"
+        )
 
     def _reload_dm_topics_from_config(self) -> None:
         """Re-read dm_topics from config.yaml and load any new thread_ids into cache.
@@ -9909,6 +10020,12 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
 
     if "disable_topic_auto_rename" in telegram_cfg:
         extras.setdefault("disable_topic_auto_rename", telegram_cfg["disable_topic_auto_rename"])
+
+    # Sticker collection seed (plan §6): pack short names imported via
+    # refresh_from_sets() during post-connect housekeeping. Flows through
+    # PlatformConfig.extra; the adapter skips empty/missing lists.
+    if "sticker_sets" in telegram_cfg:
+        extras.setdefault("sticker_sets", telegram_cfg["sticker_sets"])
 
     _effective_rm = telegram_cfg.get("require_mention", yaml_cfg.get("require_mention"))
     if _effective_rm is not None and not os.getenv("TELEGRAM_REQUIRE_MENTION"):

--- a/plugins/platforms/telegram/sticker_collection.py
+++ b/plugins/platforms/telegram/sticker_collection.py
@@ -1,0 +1,385 @@
+"""
+Persistent Telegram sticker collection.
+
+When users send the bot stickers (or the agent imports a pack via
+``refresh_from_sets``), we record each sticker's ``file_id`` here so the
+agent can later send *native* Telegram stickers back with
+``tg_send_sticker``. The collection is keyed by ``file_unique_id``
+(Telegram's globally stable sticker identifier) and persisted as JSON at
+``~/.hermes/telegram_stickers.json`` (profile-aware via
+``get_hermes_home()``).
+
+This module is intentionally separate from ``gateway/sticker_cache.py``:
+that file is a vision-description cache keyed the same way, and we only
+*read* from it (best-effort description backfill). We never trigger
+vision calls ourselves.
+
+Invariants:
+- Missing or corrupt JSON is treated as an empty collection (never raises).
+- Writes are atomic: ``tempfile.mkstemp`` + ``os.replace`` (mirrors
+  ``gateway/sticker_cache.py``).
+- Entries missing required fields ("dirty" entries) are skipped on read
+  paths and dropped the next time ``record_sticker`` saves (self-heal).
+- Capacity is capped at ``MAX_STICKERS``; overflow evicts the oldest
+  entries by ``last_seen``.
+"""
+
+import json
+import logging
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_cli.config import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+COLLECTION_VERSION = 1
+MAX_STICKERS = 500
+
+_VALID_KINDS = ("static", "animated", "video")
+
+
+def _now() -> float:
+    """Current epoch seconds (seam for tests)."""
+    return time.time()
+
+
+def _collection_path() -> Path:
+    """Resolve the collection file lazily so HERMES_HOME isolation works."""
+    return get_hermes_home() / "telegram_stickers.json"
+
+
+def _empty_collection() -> Dict[str, Any]:
+    return {"version": COLLECTION_VERSION, "stickers": {}}
+
+
+def _valid_entry(entry: Any) -> bool:
+    """True when an entry has every required field with a sane type."""
+    if not isinstance(entry, dict):
+        return False
+    if not isinstance(entry.get("file_id"), str) or not entry["file_id"]:
+        return False
+    for key in ("emoji", "set_name", "kind", "description"):
+        if not isinstance(entry.get(key), str):
+            return False
+    for key in ("first_seen", "last_seen"):
+        if not isinstance(entry.get(key), (int, float)):
+            return False
+    return True
+
+
+def _load_collection() -> Dict[str, Any]:
+    """Load the collection from disk; corrupt/missing data reads as empty."""
+    path = _collection_path()
+    if not path.exists():
+        return _empty_collection()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        logger.warning("[Telegram] Sticker collection unreadable; treating as empty: %s", path)
+        return _empty_collection()
+    if not isinstance(data, dict) or not isinstance(data.get("stickers"), dict):
+        return _empty_collection()
+    return data
+
+
+def _save_collection(collection: Dict[str, Any]) -> None:
+    """Persist the collection atomically (mkstemp + os.replace)."""
+    path = _collection_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(collection, f, indent=2, ensure_ascii=False)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _lookup_cached_description(file_unique_id: str) -> str:
+    """
+    Best-effort description from the vision cache (gateway/sticker_cache.py).
+
+    Never raises, never triggers a vision call — a miss just returns "".
+    """
+    try:
+        from gateway.sticker_cache import get_cached_description
+
+        cached = get_cached_description(file_unique_id)
+    except Exception:
+        return ""
+    if isinstance(cached, dict):
+        description = cached.get("description")
+        if isinstance(description, str):
+            return description
+    return ""
+
+
+def sticker_kind(sticker: Any) -> str:
+    """Derive the collection "kind" label from a Telegram Sticker object."""
+    if getattr(sticker, "is_video", False):
+        return "video"
+    if getattr(sticker, "is_animated", False):
+        return "animated"
+    return "static"
+
+
+def record_sticker(
+    file_unique_id: str,
+    file_id: str,
+    emoji: str = "",
+    set_name: str = "",
+    kind: str = "static",
+    description: str = "",
+) -> bool:
+    """
+    Upsert a sticker into the collection and refresh its ``last_seen``.
+
+    Returns True iff this call created a *new* entry (callers use this to
+    decide whether to tell the model a sticker was just added).
+
+    Description merge rule: a non-empty stored description is never
+    overwritten here — explicit curation (``update_description``) is the
+    only overwrite channel. When the stored description is empty and the
+    caller passes "", we best-effort backfill from the vision cache.
+    """
+    if not file_unique_id or not file_id:
+        logger.warning("[Telegram] record_sticker called without stable identity; skipping")
+        return False
+
+    collection = _load_collection()
+    # Self-heal: drop dirty entries on every record save.
+    stickers = {
+        key: entry
+        for key, entry in collection["stickers"].items()
+        if _valid_entry(entry)
+    }
+    collection["stickers"] = stickers
+
+    now = _now()
+    existing = stickers.get(file_unique_id)
+    is_new = existing is None
+
+    if is_new:
+        entry: Dict[str, Any] = {
+            "file_id": file_id,
+            "emoji": emoji or "",
+            "set_name": set_name or "",
+            "kind": kind if kind in _VALID_KINDS else "static",
+            "description": "",
+            "first_seen": now,
+            "last_seen": now,
+        }
+        stickers[file_unique_id] = entry
+    else:
+        entry = existing
+        entry["file_id"] = file_id
+        if emoji:
+            entry["emoji"] = emoji
+        if set_name:
+            entry["set_name"] = set_name
+        if kind in _VALID_KINDS:
+            entry["kind"] = kind
+        entry["last_seen"] = now
+
+    # Description merge: fill only when the stored value is empty.
+    if not entry["description"]:
+        new_description = description or _lookup_cached_description(file_unique_id)
+        if new_description:
+            entry["description"] = new_description
+
+    # Capacity: evict oldest by last_seen, never the just-recorded entry.
+    while len(stickers) > MAX_STICKERS:
+        oldest_key = min(
+            (key for key in stickers if key != file_unique_id),
+            key=lambda key: (stickers[key]["last_seen"], key),
+            default=None,
+        )
+        if oldest_key is None:
+            break
+        del stickers[oldest_key]
+
+    _save_collection(collection)
+    return is_new
+
+
+def update_description(file_unique_id: str, description: str) -> bool:
+    """
+    Agent curation channel: unconditionally overwrite an entry's description.
+
+    Passing "" clears the annotation. Returns False when the entry is
+    unknown (or dirty).
+    """
+    collection = _load_collection()
+    entry = collection["stickers"].get(file_unique_id)
+    if not _valid_entry(entry):
+        return False
+    entry["description"] = description or ""
+    _save_collection(collection)
+    return True
+
+
+def remove_sticker(file_unique_id: str) -> bool:
+    """Delete an entry. Returns False when it wasn't in the collection."""
+    collection = _load_collection()
+    if file_unique_id not in collection["stickers"]:
+        return False
+    del collection["stickers"][file_unique_id]
+    _save_collection(collection)
+    return True
+
+
+def _sorted_entries(collection: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Valid entries as dicts (with file_unique_id), newest last_seen first."""
+    entries = []
+    for key, entry in collection["stickers"].items():
+        if not _valid_entry(entry):
+            continue
+        entries.append({"file_unique_id": key, **entry})
+    entries.sort(key=lambda e: e["last_seen"], reverse=True)
+    return entries
+
+
+def list_stickers(set_name: str = "", limit: int = 100) -> List[Dict[str, Any]]:
+    """
+    Read-only listing of the local collection (never touches the Bot API).
+
+    Each dict includes ``file_unique_id`` for use as the selector in
+    ``update_description`` / ``remove_sticker``.
+    """
+    entries = _sorted_entries(_load_collection())
+    if set_name:
+        entries = [e for e in entries if e["set_name"] == set_name]
+    return entries[: max(limit, 0)]
+
+
+def resolve(query: str, set_name: str = "") -> Optional[Dict[str, Any]]:
+    """
+    Resolve a user/agent query string to a collection entry.
+
+    Priority: exact ``file_id`` passthrough → exact ``file_unique_id`` →
+    "set_name:emoji" → bare emoji. Ties on emoji matches break toward the
+    most recent ``last_seen``. Returns None when nothing matches.
+    """
+    query = (query or "").strip()
+    if not query:
+        return None
+
+    collection = _load_collection()
+    stickers = collection["stickers"]
+
+    for key, entry in stickers.items():
+        if _valid_entry(entry) and entry["file_id"] == query:
+            return {"file_unique_id": key, **entry}
+
+    entry = stickers.get(query)
+    if _valid_entry(entry):
+        return {"file_unique_id": query, **entry}
+
+    entries = _sorted_entries(collection)
+
+    if ":" in query:
+        set_part, _, emoji_part = query.partition(":")
+        for candidate in entries:
+            if candidate["set_name"] == set_part and candidate["emoji"] == emoji_part:
+                return candidate
+
+    for candidate in entries:
+        if candidate["emoji"] != query:
+            continue
+        if set_name and candidate["set_name"] != set_name:
+            continue
+        return candidate
+
+    return None
+
+
+def format_for_prompt(limit: int = 100) -> str:
+    """
+    Compact one-line-per-sticker listing for prompt injection.
+
+    Lines look like:  - 😀 "a cat waving" (set: MyPack, kind: static)
+    Sorted by last_seen, newest first. Empty collection returns "".
+    """
+    entries = _sorted_entries(_load_collection())
+    if not entries:
+        return ""
+    lines = []
+    for entry in entries[: max(limit, 0)]:
+        description = f' "{entry["description"]}"' if entry["description"] else ""
+        details = []
+        if entry["set_name"]:
+            details.append(f"set: {entry['set_name']}")
+        details.append(f"kind: {entry['kind']}")
+        lines.append(f"- {entry['emoji']}{description} ({', '.join(details)})")
+    return "\n".join(lines)
+
+
+async def refresh_from_sets(bot: Any, set_names: List[str]) -> Dict[str, int]:
+    """
+    Bulk-import sticker packs via the Bot API (``bot.get_sticker_set``).
+
+    Used as a startup seed (config ``telegram.sticker_sets``) and by the
+    ``tg_manage_stickers`` add_set action. Per-set failures are logged and
+    skipped. Recording goes through ``record_sticker``, so descriptions
+    enjoy the same best-effort vision-cache backfill.
+
+    Returns summary counts: {"sets", "sets_failed", "stickers", "new"}.
+    """
+    summary = {"sets": 0, "sets_failed": 0, "stickers": 0, "new": 0}
+    for raw_name in set_names or []:
+        name = (raw_name or "").strip()
+        if not name:
+            continue
+        try:
+            sticker_set = await bot.get_sticker_set(name)
+        except Exception as e:
+            logger.warning("[Telegram] Failed to fetch sticker set %r: %s", name, e)
+            summary["sets_failed"] += 1
+            continue
+        summary["sets"] += 1
+        for sticker in getattr(sticker_set, "stickers", None) or []:
+            try:
+                is_new = record_sticker(
+                    file_unique_id=sticker.file_unique_id,
+                    file_id=sticker.file_id,
+                    emoji=getattr(sticker, "emoji", None) or "",
+                    set_name=getattr(sticker, "set_name", None) or name,
+                    kind=sticker_kind(sticker),
+                )
+            except Exception as e:
+                logger.warning("[Telegram] Failed to record sticker from set %r: %s", name, e)
+                continue
+            summary["stickers"] += 1
+            if is_new:
+                summary["new"] += 1
+    return summary
+
+
+def build_sticker_collection_note() -> str:
+    """
+    Render the first-turn context note describing the sticker collection.
+
+    Injected once per session through the gateway turn-note channel (see
+    plan §3); "" when the collection is empty so callers skip injection.
+    """
+    listing = format_for_prompt()
+    if not listing:
+        return ""
+    return (
+        "## Your Telegram Sticker Collection\n"
+        f"{listing}\n"
+        "To send one, call tg_send_sticker with its emoji (and set name). "
+        "You may curate this collection with tg_manage_stickers (annotate "
+        "descriptions, remove entries, import a set). Never draw sticker-like "
+        "PNGs — that is the wrong path."
+    )

--- a/tests/gateway/test_telegram_sticker_collection_note.py
+++ b/tests/gateway/test_telegram_sticker_collection_note.py
@@ -1,0 +1,320 @@
+"""First-turn Telegram sticker-collection note (plan §3).
+
+The gateway injects the rendered ``## Your Telegram Sticker Collection``
+block into the FIRST user message of a brand-new telegram session through
+the per-turn must-deliver sidecar channel (``turn_sidecar_notes`` →
+``_set_pending_turn_sidecar_notes`` → ``agent._gateway_turn_context_notes``
+→ ``api_content`` sidecar).  Because the note is persisted with the first
+user row and replayed verbatim, it must be staged only when the session
+transcript is empty (``not history`` — the same first-turn detection the
+first-contact intro and home-channel prompt use); continuation sessions
+with DB history, later turns, non-telegram platforms, and empty
+collections must stage nothing.
+"""
+
+import sys
+import types
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource
+from plugins.platforms.telegram import sticker_collection
+
+_MARKER = "Your Telegram Sticker Collection"
+
+
+@pytest.fixture(autouse=True)
+def _no_vision_cache(monkeypatch: pytest.MonkeyPatch):
+    """Keep the vision-description cache out of the picture entirely."""
+    import gateway.sticker_cache as sticker_cache
+
+    monkeypatch.setattr(
+        sticker_cache, "get_cached_description", lambda file_unique_id: None
+    )
+
+
+def _bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    *,
+    platform: Platform = Platform.TELEGRAM,
+    history=None,
+    continued: bool = False,
+):
+    """Minimal GatewayRunner setup; mirrors test_42039_duplicate_user_message."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    config = GatewayConfig()
+    runner = gateway_run.GatewayRunner(config)
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner._session_db = MagicMock()
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._get_guild_id = lambda _event: None
+    runner._should_send_voice_reply = lambda *_a, **_kw: False
+    # Tests call _handle_message_with_agent directly (not via _handle_message,
+    # whose finally releases the turn lease), so a second turn on the same
+    # runner would block on the unreleased lease.  The lease is orthogonal to
+    # note staging — disable it.
+    runner._turn_leases = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    session_key = f"agent:main:{platform.value}:dm:12345"
+    created = datetime.now() - timedelta(days=1) if continued else datetime.now()
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key=session_key,
+        session_id="sess-sticker-note",
+        created_at=created,
+        updated_at=datetime.now() if continued else created,
+        platform=platform,
+        chat_type="dm",
+    )
+    runner.session_store.load_transcript.return_value = (
+        list(history) if history else []
+    )
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.has_platform_message_id.return_value = False
+    runner.session_store.update_session = MagicMock()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Hello!",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "Hello!"},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+    return runner, session_key
+
+
+def _event(platform: Platform) -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=platform,
+            chat_id="12345",
+            chat_type="dm",
+            user_id="12345",
+        ),
+        message_id="msg-1",
+    )
+
+
+def _source(platform: Platform) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="12345",
+    )
+
+
+def _stage_spy(runner) -> MagicMock:
+    spy = MagicMock(wraps=runner._set_pending_turn_sidecar_notes)  # noqa: SLF001
+    runner._set_pending_turn_sidecar_notes = spy  # noqa: SLF001
+    return spy
+
+
+def _staged_note_lists(spy: MagicMock):
+    return [call.args[1] for call in spy.call_args_list]
+
+
+def _stages_sticker_note(spy: MagicMock) -> bool:
+    return any(
+        _MARKER in note
+        for notes in _staged_note_lists(spy)
+        for note in notes
+    )
+
+
+def _record_one_sticker(uid: str = "uid1") -> None:
+    assert sticker_collection.record_sticker(
+        uid,
+        f"fid-{uid}",
+        emoji="😀",
+        set_name="MyPack",
+        kind="static",
+        description="a cat waving",
+    ) is True
+
+
+# ---------------------------------------------------------------------------
+# First turn of a telegram session with a non-empty collection → note staged
+
+
+@pytest.mark.asyncio
+async def test_first_turn_non_empty_collection_stages_note(monkeypatch, tmp_path):
+    runner, session_key = _bootstrap(monkeypatch, tmp_path, history=[])
+    _record_one_sticker()
+    spy = _stage_spy(runner)
+
+    await runner._handle_message_with_agent(
+        _event(Platform.TELEGRAM), _source(Platform.TELEGRAM), session_key, 1
+    )
+
+    assert _stages_sticker_note(spy), (
+        f"expected the collection note in staged notes, got "
+        f"{_staged_note_lists(spy)}"
+    )
+    # The note must land in the per-session staging dict consumed by run_sync
+    # (mocked _run_agent never consumes it, so it is still observable here).
+    pending = runner._pending_turn_sidecar_notes.get(session_key, [])  # noqa: SLF001
+    assert any(_MARKER in note for note in pending)
+
+
+# ---------------------------------------------------------------------------
+# Second turn (transcript now has history) → no re-injection, even when the
+# collection changed mid-session
+
+
+@pytest.mark.asyncio
+async def test_second_turn_does_not_reinject_even_after_collection_change(
+    monkeypatch, tmp_path
+):
+    runner, session_key = _bootstrap(monkeypatch, tmp_path, history=[])
+    _record_one_sticker("uid1")
+    spy = _stage_spy(runner)
+
+    await runner._handle_message_with_agent(
+        _event(Platform.TELEGRAM), _source(Platform.TELEGRAM), session_key, 1
+    )
+    assert _stages_sticker_note(spy)
+
+    # Turn 2: the transcript now has history, and the collection changed
+    # mid-session (a new sticker arrived).  No note may be staged again.
+    spy.reset_mock()
+    _record_one_sticker("uid2")
+    runner.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "Hello!"},
+    ]
+
+    await runner._handle_message_with_agent(
+        _event(Platform.TELEGRAM), _source(Platform.TELEGRAM), session_key, 2
+    )
+
+    assert not _stages_sticker_note(spy)
+
+
+# ---------------------------------------------------------------------------
+# Continuation session (pre-existing entry + DB history) → no injection
+
+
+@pytest.mark.asyncio
+async def test_continuation_session_with_history_stages_no_note(
+    monkeypatch, tmp_path
+):
+    runner, session_key = _bootstrap(
+        monkeypatch,
+        tmp_path,
+        history=[
+            {"role": "user", "content": "earlier"},
+            {"role": "assistant", "content": "earlier reply"},
+        ],
+        continued=True,
+    )
+    _record_one_sticker()
+    spy = _stage_spy(runner)
+
+    await runner._handle_message_with_agent(
+        _event(Platform.TELEGRAM), _source(Platform.TELEGRAM), session_key, 1
+    )
+
+    assert not _stages_sticker_note(spy)
+
+
+# ---------------------------------------------------------------------------
+# Non-telegram platform → no injection even on a first turn with a
+# non-empty collection
+
+
+@pytest.mark.asyncio
+async def test_non_telegram_platform_stages_no_note(monkeypatch, tmp_path):
+    runner, session_key = _bootstrap(
+        monkeypatch, tmp_path, platform=Platform.DISCORD, history=[]
+    )
+    _record_one_sticker()
+    spy = _stage_spy(runner)
+
+    await runner._handle_message_with_agent(
+        _event(Platform.DISCORD), _source(Platform.DISCORD), session_key, 1
+    )
+
+    assert not _stages_sticker_note(spy)
+
+
+# ---------------------------------------------------------------------------
+# Empty collection → nothing staged
+
+
+@pytest.mark.asyncio
+async def test_empty_collection_stages_no_note(monkeypatch, tmp_path):
+    runner, session_key = _bootstrap(monkeypatch, tmp_path, history=[])
+    spy = _stage_spy(runner)
+
+    await runner._handle_message_with_agent(
+        _event(Platform.TELEGRAM), _source(Platform.TELEGRAM), session_key, 1
+    )
+
+    assert not _stages_sticker_note(spy)
+
+
+# ---------------------------------------------------------------------------
+# Collection module import failure → message processing still succeeds
+
+
+@pytest.mark.asyncio
+async def test_import_failure_does_not_break_message_processing(
+    monkeypatch, tmp_path, caplog
+):
+    runner, session_key = _bootstrap(monkeypatch, tmp_path, history=[])
+    # ``None`` in sys.modules makes the guarded ``from ... import`` raise
+    # ImportError, simulating an absent/broken telegram platform plugin.
+    monkeypatch.setitem(
+        sys.modules, "plugins.platforms.telegram.sticker_collection", None
+    )
+    spy = _stage_spy(runner)
+
+    with caplog.at_level("WARNING", logger="gateway.run"):
+        await runner._handle_message_with_agent(
+            _event(Platform.TELEGRAM), _source(Platform.TELEGRAM), session_key, 1
+        )
+
+    assert runner._run_agent.await_count == 1  # noqa: SLF001
+    assert not _stages_sticker_note(spy)
+    assert any(
+        "sticker collection note" in record.getMessage().lower()
+        for record in caplog.records
+    )

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -414,6 +414,52 @@ class TestImagegenModelPicker:
 
 
 
+def test_telegram_toolset_in_configurable_toolsets():
+    keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
+    assert "telegram" in keys
+
+
+def test_telegram_toolset_not_default_off():
+    """Unlike discord/discord_admin, the telegram toolset is NOT opt-in:
+    subset inference auto-enables it for telegram sessions."""
+    assert "telegram" not in _DEFAULT_OFF_TOOLSETS
+
+
+def test_telegram_toolset_not_available_on_other_platforms():
+    """Platform-scoping mirrors discord: `telegram` should not appear on
+    CLI, Discord, Slack, etc. — not even as an opt-in."""
+    from hermes_cli.tools_config import _toolset_allowed_for_platform
+    for plat in ["cli", "discord", "slack", "whatsapp", "signal"]:
+        assert not _toolset_allowed_for_platform("telegram", plat), (
+            f"`telegram` toolset leaked onto {plat}"
+        )
+    assert _toolset_allowed_for_platform("telegram", "telegram")
+
+
+def test_get_platform_tools_telegram_auto_enabled_on_telegram():
+    """No saved config: the hermes-telegram composite carries the tg_* tools,
+    so subset inference resolves the `telegram` toolset as enabled."""
+    enabled = _get_platform_tools({}, "telegram")
+    assert "telegram" in enabled
+
+
+def test_get_platform_tools_telegram_toolset_hidden_on_other_platforms():
+    for plat in ["cli", "discord", "slack"]:
+        enabled = _get_platform_tools({}, plat)
+        assert "telegram" not in enabled, f"telegram toolset leaked onto {plat}"
+
+
+def test_save_platform_tools_strips_telegram_toolset_elsewhere():
+    """Hand-edited or all-platforms checklist with `telegram` selected for
+    Discord must be stripped at save time (mirrors the discord case)."""
+    config = {}
+    _save_platform_tools(config, "discord", {"web", "terminal", "telegram"})
+    saved = config["platform_toolsets"]["discord"]
+    assert "telegram" not in saved
+    assert "web" in saved
+    assert "terminal" in saved
+
+
 def test_get_effective_configurable_toolsets_dedupes_bundled_plugins():
     """Bundled plugins (plugins/spotify) share their toolset key with the
     built-in CONFIGURABLE_TOOLSETS entry. The effective list must not list

--- a/tests/plugins/platforms/telegram/test_adapter_sticker_hooks.py
+++ b/tests/plugins/platforms/telegram/test_adapter_sticker_hooks.py
@@ -1,0 +1,374 @@
+"""Adapter-side tests for the Telegram sticker collection hooks.
+
+Covers ``_handle_sticker`` recording (plan §2): every inbound sticker —
+static (vision path and cache-hit path), animated, video — is upserted into
+the persistent collection, and entries new to the collection append a
+mid-session "saved to your collection" note to the injected ``event.text``.
+Also covers the config-driven seed refresh (plan §6):
+``telegram.sticker_sets`` → ``PlatformConfig.extra`` →
+``refresh_from_sets`` during post-connect housekeeping.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from plugins.platforms.telegram import sticker_collection
+import plugins.platforms.telegram.adapter as telegram_adapter_mod
+from plugins.platforms.telegram.adapter import TelegramAdapter, _apply_yaml_config
+
+
+@pytest.fixture(autouse=True)
+def _sticker_cache_tmp(monkeypatch: pytest.MonkeyPatch):
+    """Re-point the vision-description cache at the per-test HERMES_HOME.
+
+    ``gateway.sticker_cache.CACHE_PATH`` is a module-level constant computed
+    at import time, so patch it explicitly to keep the real cache functions
+    hermetic (conftest already isolates HERMES_HOME per test).
+    """
+    import gateway.sticker_cache as sticker_cache
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.setattr(
+        sticker_cache, "CACHE_PATH", get_hermes_home() / "sticker_cache.json"
+    )
+    return sticker_cache
+
+
+def _make_adapter(extra: Dict[str, Any] | None = None) -> TelegramAdapter:
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="fake-token", extra=extra or {})
+    adapter._bot = None
+    adapter._post_connect_task = None
+    return adapter
+
+
+def _make_sticker(
+    uid: str = "uid-1",
+    fid: str = "fid-1",
+    *,
+    emoji: str = "😀",
+    set_name: str = "MyPack",
+    animated: bool = False,
+    video: bool = False,
+    with_file: bool = False,
+) -> Any:
+    sticker = SimpleNamespace(
+        file_unique_id=uid,
+        file_id=fid,
+        emoji=emoji,
+        set_name=set_name,
+        is_animated=animated,
+        is_video=video,
+    )
+    if with_file:
+        file_obj = SimpleNamespace(
+            download_as_bytearray=AsyncMock(return_value=bytearray(b"webp-bytes"))
+        )
+        sticker.get_file = AsyncMock(return_value=file_obj)
+    return sticker
+
+
+def _event() -> Any:
+    return SimpleNamespace(text=None)
+
+
+# ---------------------------------------------------------------------------
+# _handle_sticker: animated / video early-return branch
+
+
+@pytest.mark.asyncio
+async def test_animated_sticker_recorded_with_note() -> None:
+    adapter = _make_adapter()
+    sticker = _make_sticker("uid-anim", "fid-anim", animated=True)
+    event = _event()
+
+    await adapter._handle_sticker(SimpleNamespace(sticker=sticker), event)
+
+    # Existing injection behavior is intact...
+    assert event.text.startswith("[The user sent an animated sticker 😀~")
+    # ...and the new sticker gained the mid-session collection note.
+    assert "saved to your collection" in event.text
+    assert "tg_send_sticker" in event.text
+    assert "emoji 😀" in event.text
+    assert 'set "MyPack"' in event.text
+
+    entry = sticker_collection.resolve("uid-anim")
+    assert entry is not None
+    assert entry["file_id"] == "fid-anim"
+    assert entry["kind"] == "animated"
+    assert entry["set_name"] == "MyPack"
+
+
+@pytest.mark.asyncio
+async def test_video_sticker_recorded_with_note() -> None:
+    adapter = _make_adapter()
+    sticker = _make_sticker("uid-vid", "fid-vid", video=True, emoji="🚀")
+    event = _event()
+
+    await adapter._handle_sticker(SimpleNamespace(sticker=sticker), event)
+
+    assert "saved to your collection" in event.text
+    entry = sticker_collection.resolve("uid-vid")
+    assert entry is not None
+    assert entry["kind"] == "video"
+
+
+# ---------------------------------------------------------------------------
+# _handle_sticker: static cache-hit branch
+
+
+@pytest.mark.asyncio
+async def test_static_cache_hit_records_file_id_and_note(
+    _sticker_cache_tmp,
+) -> None:
+    # Seed the vision cache so the static branch hits it (no vision call).
+    _sticker_cache_tmp.cache_sticker_description(
+        "uid-static", "a cat waving its paw", "😀", "MyPack"
+    )
+    adapter = _make_adapter()
+    # No get_file on the sticker: a vision download would blow up.
+    sticker = _make_sticker("uid-static", "fid-static")
+    event = _event()
+
+    await adapter._handle_sticker(SimpleNamespace(sticker=sticker), event)
+
+    assert event.text.startswith('[The user sent a sticker 😀 from "MyPack"~')
+    assert "a cat waving its paw" in event.text
+    assert "saved to your collection" in event.text
+
+    entry = sticker_collection.resolve("uid-static")
+    assert entry is not None
+    assert entry["file_id"] == "fid-static"  # file_id recorded on cache hit
+    assert entry["kind"] == "static"
+    # Description backfilled from the vision cache.
+    assert entry["description"] == "a cat waving its paw"
+
+
+@pytest.mark.asyncio
+async def test_known_sticker_gets_no_note_and_refreshes_file_id(
+    _sticker_cache_tmp,
+) -> None:
+    # The collection already knows this sticker (with a stale file_id).
+    assert sticker_collection.record_sticker(
+        "uid-known", "fid-old", emoji="😀", set_name="MyPack", kind="static"
+    ) is True
+    _sticker_cache_tmp.cache_sticker_description(
+        "uid-known", "a cat waving its paw", "😀", "MyPack"
+    )
+    adapter = _make_adapter()
+    sticker = _make_sticker("uid-known", "fid-new")
+    event = _event()
+
+    await adapter._handle_sticker(SimpleNamespace(sticker=sticker), event)
+
+    # Injection still happens, but no mid-session note for known stickers.
+    assert "a cat waving its paw" in event.text
+    assert "saved to your collection" not in event.text
+    # file_id refreshes silently (per-bot validity).
+    assert sticker_collection.resolve("uid-known")["file_id"] == "fid-new"
+
+
+# ---------------------------------------------------------------------------
+# _handle_sticker: static vision path
+
+
+@pytest.mark.asyncio
+async def test_static_vision_path_records_after_cache_write(
+    _sticker_cache_tmp, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        telegram_adapter_mod,
+        "cache_image_from_bytes",
+        lambda data, ext=".webp": "/tmp/fake-sticker.webp",
+    )
+    monkeypatch.setattr(
+        "tools.vision_tools.vision_analyze_tool",
+        AsyncMock(
+            return_value=json.dumps(
+                {"success": True, "analysis": "a cat waving its paw"}
+            )
+        ),
+    )
+    adapter = _make_adapter()
+    sticker = _make_sticker("uid-vision", "fid-vision", with_file=True)
+    event = _event()
+
+    await adapter._handle_sticker(SimpleNamespace(sticker=sticker), event)
+
+    assert "a cat waving its paw" in event.text
+    assert "saved to your collection" in event.text
+
+    entry = sticker_collection.resolve("uid-vision")
+    assert entry is not None
+    assert entry["file_id"] == "fid-vision"
+    # The record ran AFTER cache_sticker_description(), so the collection's
+    # best-effort cache backfill picked up the fresh vision description.
+    assert entry["description"] == "a cat waving its paw"
+
+
+@pytest.mark.asyncio
+async def test_static_vision_failure_still_records_with_fallback(
+    _sticker_cache_tmp, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        telegram_adapter_mod,
+        "cache_image_from_bytes",
+        lambda data, ext=".webp": "/tmp/fake-sticker.webp",
+    )
+    monkeypatch.setattr(
+        "tools.vision_tools.vision_analyze_tool",
+        AsyncMock(return_value=json.dumps({"success": False, "error": "boom"})),
+    )
+    adapter = _make_adapter()
+    sticker = _make_sticker("uid-fail", "fid-fail")
+    event = _event()
+
+    await adapter._handle_sticker(SimpleNamespace(sticker=sticker), event)
+
+    assert "a sticker with emoji 😀" in event.text  # existing fallback text
+    assert "saved to your collection" in event.text
+    entry = sticker_collection.resolve("uid-fail")
+    assert entry is not None
+    assert entry["description"] == ""  # nothing in the vision cache to backfill
+
+
+@pytest.mark.asyncio
+async def test_collection_failure_does_not_break_sticker_handling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _explode(*args: Any, **kwargs: Any) -> bool:
+        raise RuntimeError("disk on fire")
+
+    monkeypatch.setattr(sticker_collection, "record_sticker", _explode)
+    adapter = _make_adapter()
+    sticker = _make_sticker("uid-anim", "fid-anim", animated=True)
+    event = _event()
+
+    await adapter._handle_sticker(SimpleNamespace(sticker=sticker), event)
+
+    # Injection still happened; the collection error was swallowed.
+    assert event.text.startswith("[The user sent an animated sticker 😀~")
+    assert "saved to your collection" not in event.text
+
+
+# ---------------------------------------------------------------------------
+# Seed refresh (plan §6)
+
+
+class _FakeBot:
+    """Duck-typed stand-in for telegram.Bot (only get_sticker_set is used)."""
+
+    def __init__(self, sets: Dict[str, List[Any]], failing: List[str] | None = None):
+        self._sets = sets
+        self._failing = set(failing or [])
+        self.requested: List[str] = []
+
+    async def get_sticker_set(self, name: str) -> Any:
+        self.requested.append(name)
+        if name in self._failing:
+            raise RuntimeError(f"telegram exploded for {name}")
+        return SimpleNamespace(name=name, stickers=self._sets[name])
+
+
+def _pack_sticker(uid: str, emoji: str) -> Any:
+    return SimpleNamespace(
+        file_id=f"fid-{uid}", file_unique_id=uid, emoji=emoji,
+        is_animated=False, is_video=False, set_name="",
+    )
+
+
+@pytest.mark.asyncio
+async def test_seed_imports_configured_sets_and_swallows_failures() -> None:
+    bot = _FakeBot(
+        {"PackOne": [_pack_sticker("uid1", "😀"), _pack_sticker("uid2", "😂")]},
+        failing=["BadPack"],
+    )
+    adapter = _make_adapter(extra={"sticker_sets": ["PackOne", "BadPack"]})
+    adapter._bot = bot
+
+    await adapter._seed_sticker_collection_from_config()
+
+    assert bot.requested == ["PackOne", "BadPack"]
+    entries = {e["file_unique_id"] for e in sticker_collection.list_stickers()}
+    assert entries == {"uid1", "uid2"}
+
+
+@pytest.mark.asyncio
+async def test_seed_accepts_comma_separated_string() -> None:
+    bot = _FakeBot({"PackOne": [], "PackTwo": []})
+    adapter = _make_adapter(extra={"sticker_sets": "PackOne, PackTwo"})
+    adapter._bot = bot
+
+    await adapter._seed_sticker_collection_from_config()
+
+    assert bot.requested == ["PackOne", "PackTwo"]
+
+
+@pytest.mark.asyncio
+async def test_seed_noop_when_unconfigured() -> None:
+    bot = _FakeBot({})
+    for extra in ({}, {"sticker_sets": []}, {"sticker_sets": None}, {"sticker_sets": 42}):
+        adapter = _make_adapter(extra=extra)
+        adapter._bot = bot
+        await adapter._seed_sticker_collection_from_config()
+    assert bot.requested == []
+
+
+@pytest.mark.asyncio
+async def test_post_connect_housekeeping_invokes_seed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter()
+    adapter._bot = AsyncMock()
+    monkeypatch.setattr(adapter, "_setup_dm_topics", AsyncMock())
+    seed = AsyncMock()
+    monkeypatch.setattr(adapter, "_seed_sticker_collection_from_config", seed)
+
+    await adapter._run_post_connect_housekeeping()
+
+    seed.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Config flow: telegram.sticker_sets → PlatformConfig.extra
+
+
+def test_apply_yaml_config_bridges_sticker_sets() -> None:
+    extras = _apply_yaml_config({}, {"sticker_sets": ["HotCherry", "CatsPack"]})
+    assert extras is not None
+    assert extras["sticker_sets"] == ["HotCherry", "CatsPack"]
+
+
+def test_apply_yaml_config_without_sticker_sets_returns_none() -> None:
+    assert _apply_yaml_config({}, {}) is None
+
+
+def test_sticker_sets_flow_from_config_yaml_to_platform_extra(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "telegram:\n"
+        "  enabled: true\n"
+        "  token: test-token\n"
+        "  sticker_sets:\n"
+        "    - HotCherry\n"
+        "    - CatsPack\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from gateway.config import load_gateway_config
+
+    config = load_gateway_config()
+
+    telegram = config.platforms[Platform.TELEGRAM]
+    assert telegram.extra["sticker_sets"] == ["HotCherry", "CatsPack"]

--- a/tests/plugins/platforms/telegram/test_sticker_collection.py
+++ b/tests/plugins/platforms/telegram/test_sticker_collection.py
@@ -1,0 +1,447 @@
+"""Behavior tests for the Telegram sticker collection store.
+
+Covers record/dedup/last_seen, description merge rules (vision-cache
+backfill vs agent curation), eviction at capacity, resolve priority,
+prompt formatting, refresh_from_sets with a mock bot, and the
+first-turn collection note renderer.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+
+from plugins.platforms.telegram import sticker_collection
+
+
+@pytest.fixture(autouse=True)
+def _no_vision_cache(monkeypatch: pytest.MonkeyPatch):
+    """Default: the vision-description cache misses for every lookup.
+
+    Individual tests re-patch ``get_cached_description`` when they want a
+    hit. Keeping this autouse means no test can accidentally read the
+    developer's real ~/.hermes/sticker_cache.json.
+    """
+    import gateway.sticker_cache as sticker_cache
+
+    monkeypatch.setattr(
+        sticker_cache, "get_cached_description", lambda file_unique_id: None
+    )
+    return sticker_cache
+
+
+def _collection_file() -> Any:
+    from hermes_cli.config import get_hermes_home
+
+    return get_hermes_home() / "telegram_stickers.json"
+
+
+def _read_raw() -> Dict[str, Any]:
+    return json.loads(_collection_file().read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# record_sticker: dedup, last_seen refresh, new-vs-known return
+
+
+def test_record_new_sticker_returns_true_and_persists() -> None:
+    assert sticker_collection.record_sticker(
+        "uid1", "fid1", emoji="😀", set_name="MyPack", kind="static",
+        description="a cat waving",
+    ) is True
+
+    raw = _read_raw()
+    assert raw["version"] == 1
+    entry = raw["stickers"]["uid1"]
+    assert entry["file_id"] == "fid1"
+    assert entry["emoji"] == "😀"
+    assert entry["set_name"] == "MyPack"
+    assert entry["kind"] == "static"
+    assert entry["description"] == "a cat waving"
+    assert entry["first_seen"] == entry["last_seen"]
+
+
+def test_record_known_sticker_returns_false_and_refreshes_last_seen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    times = iter([1000.0, 2000.0])
+    monkeypatch.setattr(sticker_collection, "_now", lambda: next(times))
+
+    assert sticker_collection.record_sticker("uid1", "fid1") is True
+    assert sticker_collection.record_sticker("uid1", "fid1-new") is False
+
+    entries = sticker_collection.list_stickers()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["file_unique_id"] == "uid1"
+    assert entry["file_id"] == "fid1-new"  # file_id refreshes (per-bot validity)
+    assert entry["first_seen"] == 1000.0
+    assert entry["last_seen"] == 2000.0
+
+
+def test_record_without_identity_is_a_noop() -> None:
+    assert sticker_collection.record_sticker("", "fid1") is False
+    assert sticker_collection.record_sticker("uid1", "") is False
+    assert sticker_collection.list_stickers() == []
+
+
+# ---------------------------------------------------------------------------
+# Description merge rules
+
+
+def test_record_backfills_description_from_vision_cache_when_empty(
+    _no_vision_cache, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        _no_vision_cache,
+        "get_cached_description",
+        lambda fuid: {"description": "a cat waving its paw", "emoji": "😀"},
+    )
+    assert sticker_collection.record_sticker("uid1", "fid1", emoji="😀") is True
+    entry = sticker_collection.resolve("uid1")
+    assert entry["description"] == "a cat waving its paw"
+
+
+def test_record_never_clobbers_existing_description(
+    _no_vision_cache, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sticker_collection.record_sticker("uid1", "fid1", description="agent note")
+
+    # Caller-supplied non-empty description does not overwrite either.
+    assert sticker_collection.record_sticker("uid1", "fid1", description="new attempt") is False
+    # ... and neither does a cache backfill.
+    monkeypatch.setattr(
+        _no_vision_cache,
+        "get_cached_description",
+        lambda fuid: {"description": "cache attempt"},
+    )
+    assert sticker_collection.record_sticker("uid1", "fid1") is False
+
+    assert sticker_collection.resolve("uid1")["description"] == "agent note"
+
+
+def test_update_description_overwrites_and_clears() -> None:
+    sticker_collection.record_sticker("uid1", "fid1", description="first")
+
+    assert sticker_collection.update_description("uid1", "second") is True
+    assert sticker_collection.resolve("uid1")["description"] == "second"
+
+    # "" clears the annotation.
+    assert sticker_collection.update_description("uid1", "") is True
+    assert sticker_collection.resolve("uid1")["description"] == ""
+
+    # Unknown id -> False, no crash.
+    assert sticker_collection.update_description("nope", "x") is False
+
+
+def test_update_description_beats_later_cache_backfill(
+    _no_vision_cache, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sticker_collection.record_sticker("uid1", "fid1")
+    assert sticker_collection.update_description("uid1", "use when user is sarcastic") is True
+
+    monkeypatch.setattr(
+        _no_vision_cache,
+        "get_cached_description",
+        lambda fuid: {"description": "cache attempt"},
+    )
+    sticker_collection.record_sticker("uid1", "fid1")
+    assert sticker_collection.resolve("uid1")["description"] == "use when user is sarcastic"
+
+
+# ---------------------------------------------------------------------------
+# Capacity / eviction
+
+
+def test_eviction_at_capacity_removes_oldest_by_last_seen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sticker_collection, "MAX_STICKERS", 3)
+    clock = {"t": 0.0}
+
+    def tick() -> float:
+        clock["t"] += 1.0
+        return clock["t"]
+
+    monkeypatch.setattr(sticker_collection, "_now", tick)
+
+    for i in range(4):
+        sticker_collection.record_sticker(f"uid{i}", f"fid{i}")
+
+    entries = sticker_collection.list_stickers()
+    assert len(entries) == 3
+    surviving = {e["file_unique_id"] for e in entries}
+    assert surviving == {"uid1", "uid2", "uid3"}  # uid0 (oldest) evicted
+    # Newest first.
+    assert [e["file_unique_id"] for e in entries] == ["uid3", "uid2", "uid1"]
+
+
+def test_re_record_refreshes_last_seen_and_avoids_eviction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sticker_collection, "MAX_STICKERS", 2)
+    clock = {"t": 0.0}
+    monkeypatch.setattr(
+        sticker_collection, "_now", lambda: clock.__setitem__("t", clock["t"] + 1.0) or clock["t"]
+    )
+
+    sticker_collection.record_sticker("old", "fid-old")
+    sticker_collection.record_sticker("keep", "fid-keep")
+    sticker_collection.record_sticker("old", "fid-old")  # refresh: now newest
+    sticker_collection.record_sticker("new", "fid-new")  # evicts "keep"
+
+    surviving = {e["file_unique_id"] for e in sticker_collection.list_stickers()}
+    assert surviving == {"old", "new"}
+
+
+# ---------------------------------------------------------------------------
+# resolve priority
+
+
+@pytest.fixture()
+def _packed() -> None:
+    """Two same-emoji stickers in different packs + one distinct sticker."""
+    sticker_collection.record_sticker(
+        "uid-a", "fid-a", emoji="😀", set_name="PackOne", kind="static",
+        description="first cat",
+    )
+    sticker_collection.record_sticker(
+        "uid-b", "fid-b", emoji="😀", set_name="PackTwo", kind="animated",
+        description="second cat",
+    )
+    sticker_collection.record_sticker(
+        "uid-c", "CAAC-x9", emoji="🚀", set_name="PackTwo", kind="video",
+    )
+
+
+def test_resolve_file_id_passthrough_wins(_packed) -> None:
+    entry = sticker_collection.resolve("CAAC-x9")
+    assert entry["file_unique_id"] == "uid-c"
+    assert entry["kind"] == "video"
+
+
+def test_resolve_file_id_beats_file_unique_id_collision(_packed) -> None:
+    # A query that is both some entry's file_id and another's file_unique_id
+    # resolves as the file_id (priority order).
+    sticker_collection.record_sticker("fid-a", "fid-other", emoji="🐶")
+    entry = sticker_collection.resolve("fid-a")
+    assert entry["file_unique_id"] == "uid-a"
+
+
+def test_resolve_file_unique_id_exact(_packed) -> None:
+    assert sticker_collection.resolve("uid-a")["file_id"] == "fid-a"
+
+
+def test_resolve_set_name_emoji_exact(_packed) -> None:
+    entry = sticker_collection.resolve("PackOne:😀")
+    assert entry["file_unique_id"] == "uid-a"
+
+
+def test_resolve_bare_emoji_picks_most_recent(_packed) -> None:
+    entry = sticker_collection.resolve("😀")
+    assert entry["file_unique_id"] == "uid-b"  # recorded after uid-a
+
+
+def test_resolve_bare_emoji_with_set_name_disambiguation(_packed) -> None:
+    entry = sticker_collection.resolve("😀", set_name="PackOne")
+    assert entry["file_unique_id"] == "uid-a"
+
+
+def test_resolve_unknown_returns_none(_packed) -> None:
+    assert sticker_collection.resolve("🦄") is None
+    assert sticker_collection.resolve("NoSuchPack:😀") is None
+    assert sticker_collection.resolve("") is None
+
+
+# ---------------------------------------------------------------------------
+# list / remove
+
+
+def test_list_stickers_filter_limit_and_shape() -> None:
+    sticker_collection.record_sticker("uid1", "fid1", emoji="😀", set_name="A")
+    sticker_collection.record_sticker("uid2", "fid2", emoji="😂", set_name="B")
+    sticker_collection.record_sticker("uid3", "fid3", emoji="🚀", set_name="B")
+
+    all_entries = sticker_collection.list_stickers()
+    assert [e["file_unique_id"] for e in all_entries] == ["uid3", "uid2", "uid1"]
+
+    only_b = sticker_collection.list_stickers(set_name="B")
+    assert {e["file_unique_id"] for e in only_b} == {"uid2", "uid3"}
+
+    capped = sticker_collection.list_stickers(limit=2)
+    assert len(capped) == 2
+
+    entry = all_entries[0]
+    for key in ("file_unique_id", "file_id", "emoji", "set_name", "kind",
+                "description", "first_seen", "last_seen"):
+        assert key in entry
+
+
+def test_remove_sticker() -> None:
+    sticker_collection.record_sticker("uid1", "fid1")
+    assert sticker_collection.remove_sticker("uid1") is True
+    assert sticker_collection.remove_sticker("uid1") is False
+    assert sticker_collection.list_stickers() == []
+    # Deletion is persisted, not just in-memory.
+    assert "uid1" not in _read_raw()["stickers"]
+
+
+# ---------------------------------------------------------------------------
+# Corrupt / dirty data tolerance
+
+
+def test_corrupt_json_reads_as_empty_collection() -> None:
+    _collection_file().write_text("not json {{{", encoding="utf-8")
+    assert sticker_collection.list_stickers() == []
+    assert sticker_collection.resolve("😀") is None
+    assert sticker_collection.format_for_prompt() == ""
+    # ... and the store still works afterwards.
+    assert sticker_collection.record_sticker("uid1", "fid1") is True
+    assert sticker_collection.resolve("uid1") is not None
+
+
+def test_dirty_entries_skipped_on_read_and_self_heal_on_record() -> None:
+    _collection_file().write_text(json.dumps({
+        "version": 1,
+        "stickers": {
+            "dirty-no-file-id": {"emoji": "😀"},
+            "dirty-wrong-types": {"file_id": "fid", "emoji": 3},
+            "good": {
+                "file_id": "fid-good", "emoji": "😀", "set_name": "Pack",
+                "kind": "static", "description": "",
+                "first_seen": 1.0, "last_seen": 1.0,
+            },
+        },
+    }), encoding="utf-8")
+
+    # Read paths skip dirty entries.
+    assert [e["file_unique_id"] for e in sticker_collection.list_stickers()] == ["good"]
+    assert sticker_collection.update_description("dirty-no-file-id", "x") is False
+
+    # record_sticker drops them from the persisted file (self-heal).
+    sticker_collection.record_sticker("uid-new", "fid-new")
+    raw = _read_raw()
+    assert set(raw["stickers"]) == {"good", "uid-new"}
+
+
+# ---------------------------------------------------------------------------
+# format_for_prompt
+
+
+def test_format_for_prompt_empty_collection() -> None:
+    assert sticker_collection.format_for_prompt() == ""
+
+
+def test_format_for_prompt_lines_sorted_and_truncated() -> None:
+    sticker_collection.record_sticker(
+        "uid1", "fid1", emoji="😀", set_name="MyPack", kind="static",
+        description="a cat waving",
+    )
+    sticker_collection.record_sticker(
+        "uid2", "fid2", emoji="🚀", set_name="MyPack", kind="video",
+    )
+
+    listing = sticker_collection.format_for_prompt()
+    lines = listing.split("\n")
+    # Newest (uid2) first; empty description renders without quotes.
+    assert lines[0] == '- 🚀 (set: MyPack, kind: video)'
+    assert lines[1] == '- 😀 "a cat waving" (set: MyPack, kind: static)'
+
+    capped = sticker_collection.format_for_prompt(limit=1)
+    assert capped.split("\n") == [lines[0]]
+
+
+# ---------------------------------------------------------------------------
+# refresh_from_sets
+
+
+class _FakeBot:
+    """Duck-typed stand-in for telegram.Bot (only get_sticker_set is used)."""
+
+    def __init__(self, sets: Dict[str, List[Any]], failing: List[str] | None = None):
+        self._sets = sets
+        self._failing = set(failing or [])
+        self.requested: List[str] = []
+
+    async def get_sticker_set(self, name: str) -> Any:
+        self.requested.append(name)
+        if name in self._failing:
+            raise RuntimeError(f"telegram exploded for {name}")
+        return SimpleNamespace(name=name, stickers=self._sets[name])
+
+
+def _sticker(uid: str, emoji: str, *, animated: bool = False, video: bool = False,
+             set_name: str = "") -> Any:
+    return SimpleNamespace(
+        file_id=f"fid-{uid}", file_unique_id=uid, emoji=emoji,
+        is_animated=animated, is_video=video, set_name=set_name,
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_from_sets_records_and_summarizes() -> None:
+    bot = _FakeBot(
+        {
+            "PackOne": [_sticker("uid1", "😀"), _sticker("uid2", "😂", animated=True)],
+            "PackTwo": [_sticker("uid3", "🚀", video=True)],
+        },
+        failing=["BadPack"],
+    )
+
+    summary = await sticker_collection.refresh_from_sets(
+        bot, ["PackOne", "BadPack", "PackTwo", "  "]
+    )
+
+    assert summary == {"sets": 2, "sets_failed": 1, "stickers": 3, "new": 3}
+    assert bot.requested == ["PackOne", "BadPack", "PackTwo"]  # blanks skipped
+
+    entries = {e["file_unique_id"]: e for e in sticker_collection.list_stickers()}
+    assert set(entries) == {"uid1", "uid2", "uid3"}
+    assert entries["uid1"]["kind"] == "static"
+    assert entries["uid2"]["kind"] == "animated"
+    assert entries["uid3"]["kind"] == "video"
+    # Set name comes from the pack being imported when the sticker lacks one.
+    assert entries["uid1"]["set_name"] == "PackOne"
+
+
+@pytest.mark.asyncio
+async def test_refresh_from_sets_is_idempotent_and_backfills(
+    _no_vision_cache, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        _no_vision_cache,
+        "get_cached_description",
+        lambda fuid: {"description": "previously visioned"} if fuid == "uid1" else None,
+    )
+    bot = _FakeBot({"Pack": [_sticker("uid1", "😀"), _sticker("uid2", "😂")]})
+
+    first = await sticker_collection.refresh_from_sets(bot, ["Pack"])
+    assert first["new"] == 2
+    assert sticker_collection.resolve("uid1")["description"] == "previously visioned"
+
+    second = await sticker_collection.refresh_from_sets(bot, ["Pack"])
+    assert second == {"sets": 1, "sets_failed": 0, "stickers": 2, "new": 0}
+
+
+# ---------------------------------------------------------------------------
+# build_sticker_collection_note
+
+
+def test_build_note_empty_collection() -> None:
+    assert sticker_collection.build_sticker_collection_note() == ""
+
+
+def test_build_note_renders_header_listing_and_guidance() -> None:
+    sticker_collection.record_sticker(
+        "uid1", "fid1", emoji="😀", set_name="MyPack", kind="static",
+        description="a cat waving",
+    )
+
+    note = sticker_collection.build_sticker_collection_note()
+    assert note.startswith("## Your Telegram Sticker Collection\n")
+    assert '- 😀 "a cat waving" (set: MyPack, kind: static)' in note
+    assert "tg_send_sticker" in note
+    assert "tg_manage_stickers" in note
+    assert "PNG" in note  # "never draw sticker PNGs" guidance

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -104,6 +104,35 @@ class TestResolveToolset:
 
 
 
+class TestTelegramToolset:
+    """Invariant tests for the telegram sticker toolset wiring.
+
+    These assert relationships (composite carries its platform tools;
+    unrelated composites do not), not snapshots of tool lists.
+    """
+
+    def test_hermes_telegram_includes_sticker_tools(self):
+        tools = resolve_toolset("hermes-telegram")
+        assert "tg_send_sticker" in tools
+        assert "tg_manage_stickers" in tools
+
+    def test_telegram_leaf_toolset_static_membership(self):
+        ts = get_toolset("telegram", include_registry=False)
+        assert ts is not None
+        assert set(ts["tools"]) == {"tg_send_sticker", "tg_manage_stickers"}
+        assert ts["includes"] == []
+
+    def test_sticker_tools_not_in_unrelated_composites(self):
+        for composite in ("hermes-cli", "hermes-slack"):
+            tools = resolve_toolset(composite)
+            assert "tg_send_sticker" not in tools, (
+                f"tg_send_sticker leaked into {composite}"
+            )
+            assert "tg_manage_stickers" not in tools, (
+                f"tg_manage_stickers leaked into {composite}"
+            )
+
+
 class TestResolveMultipleToolsets:
     def test_combines_and_deduplicates(self):
         tools = resolve_multiple_toolsets(["web", "terminal"])

--- a/tests/tools/test_telegram_tool.py
+++ b/tests/tools/test_telegram_tool.py
@@ -1,0 +1,515 @@
+"""Behavior tests for tools/telegram_tool.py (tg_send_sticker / tg_manage_stickers).
+
+Covers check_fn gating (send: active Telegram session only; manage: session or
+bot token), the session-scoped delivery contract (no model-facing chat_id),
+the send happy path against a mocked ``telegram.Bot`` (normalized chat_id from
+session env, file_id, forum-thread mapping incl. General-topic "1" → None),
+resolve-failure wording, the TELEGRAM_PROXY branch, and all four
+tg_manage_stickers actions against the real collection store in the isolated
+temp HERMES_HOME.
+
+Mocking conventions mirror tests/tools/test_send_message_tool.py and
+test_send_message_telegram_proxy.py: a stub ``telegram`` package is installed
+into ``sys.modules`` whose ``Bot`` is a factory mock.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import tools.telegram_tool as telegram_tool
+from plugins.platforms.telegram import sticker_collection
+from tools.registry import registry
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch):
+    """Deterministic environment: no ambient proxy/session/token state.
+
+    Proxy vars are wiped so the no-proxy assertions can't flip with the host
+    machine's proxy settings, and sys.platform is pinned to linux so macOS
+    system-proxy auto-detection (scutil) can't kick in.
+    """
+    for var in (
+        "TELEGRAM_PROXY",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "NO_PROXY",
+        "no_proxy",
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_CHAT_ID",
+        "HERMES_SESSION_THREAD_ID",
+        "TELEGRAM_BOT_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(sys, "platform", "linux")
+
+
+def _make_bot(message_id: int = 42) -> MagicMock:
+    bot = MagicMock()
+    bot.send_sticker = AsyncMock(return_value=SimpleNamespace(message_id=message_id))
+    return bot
+
+
+def _install_telegram_mock(
+    monkeypatch: pytest.MonkeyPatch,
+    bot_factory: MagicMock,
+    httpx_request_factory: Any = None,
+) -> None:
+    """Install a stub ``telegram`` package whose ``Bot`` is the supplied factory."""
+    request_mod = SimpleNamespace(HTTPXRequest=httpx_request_factory or MagicMock())
+    telegram_mod = SimpleNamespace(Bot=bot_factory, request=request_mod)
+    monkeypatch.setitem(sys.modules, "telegram", telegram_mod)
+    monkeypatch.setitem(sys.modules, "telegram.request", request_mod)
+
+
+def _sticker_obj(uid: str, emoji: str, set_name: str = "") -> Any:
+    """Duck-typed telegram.Sticker for get_sticker_set responses."""
+    return SimpleNamespace(
+        file_id=f"fid-{uid}",
+        file_unique_id=uid,
+        emoji=emoji,
+        is_animated=False,
+        is_video=False,
+        set_name=set_name,
+    )
+
+
+def _record(uid: str = "uid1", emoji: str = "😀", set_name: str = "MyPack", **kw) -> None:
+    sticker_collection.record_sticker(
+        uid, f"fid-{uid}", emoji=emoji, set_name=set_name, kind="static", **kw
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration + check_fn gating
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_both_tools_registered_under_telegram_toolset(self) -> None:
+        for name in ("tg_send_sticker", "tg_manage_stickers"):
+            entry = registry._tools.get(name)
+            assert entry is not None, f"{name} not registered"
+            assert entry.toolset == "telegram"
+            assert entry.is_async is True
+
+    def test_send_sticker_gated_on_active_session_manage_on_token_or_session(self) -> None:
+        assert registry._tools["tg_send_sticker"].check_fn is telegram_tool._check_telegram_session
+        assert registry._tools["tg_manage_stickers"].check_fn is telegram_tool._check_telegram
+
+    def test_send_sticker_schema_has_no_arbitrary_target(self) -> None:
+        """Review contract: delivery is scoped to the active session, so the
+        model-facing schema must not offer a chat_id-style outbound target."""
+        props = registry._tools["tg_send_sticker"].schema["parameters"]["properties"]
+        assert "chat_id" not in props
+
+
+class TestCheckFnGating:
+    def test_visible_in_telegram_session(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        assert telegram_tool._check_telegram() is True
+        assert telegram_tool._check_telegram_session() is True
+
+    def test_send_hidden_with_bot_token_alone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A bot token without an active Telegram session is enough to MANAGE
+        the collection (add_set works from the CLI) but not to SEND — there is
+        no session chat to deliver to."""
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok123")
+        assert telegram_tool._check_telegram() is True
+        assert telegram_tool._check_telegram_session() is False
+
+    def test_hidden_in_other_platform_without_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+        assert telegram_tool._check_telegram() is False
+        assert telegram_tool._check_telegram_session() is False
+
+    def test_hidden_with_neither(self) -> None:
+        assert telegram_tool._check_telegram() is False
+        assert telegram_tool._check_telegram_session() is False
+
+
+# ---------------------------------------------------------------------------
+# tg_send_sticker
+# ---------------------------------------------------------------------------
+
+
+class TestSendSticker:
+    @pytest.mark.asyncio
+    async def test_happy_path_uses_session_defaults(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _record(description="a cat waving")
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok123")
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "-1001234567890")
+        monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "17585")
+        bot = _make_bot()
+        bot_factory = MagicMock(return_value=bot)
+        _install_telegram_mock(monkeypatch, bot_factory)
+
+        result = await telegram_tool.tg_send_sticker("😀")
+
+        assert result["success"] is True
+        assert result["message_id"] == 42
+        assert result["chat_id"] == "-1001234567890"
+        assert result["sticker"] == {
+            "file_unique_id": "uid1",
+            "emoji": "😀",
+            "set_name": "MyPack",
+        }
+        assert "end your turn" in result["note"]
+        # No proxy configured → plain one-shot Bot construction.
+        bot_factory.assert_called_once_with(token="tok123")
+        bot.send_sticker.assert_awaited_once()
+        kwargs = bot.send_sticker.await_args.kwargs
+        assert kwargs["chat_id"] == -1001234567890  # normalized to int
+        assert kwargs["sticker"] == "fid-uid1"
+        assert kwargs["message_thread_id"] == 17585  # forum thread id → int
+
+    @pytest.mark.asyncio
+    async def test_general_topic_thread_id_maps_to_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Forum General topic arrives as thread id "1" but the Bot API rejects
+        message_thread_id=1 — the kwarg must be omitted entirely."""
+        _record()
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok123")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "-1001234567890")
+        monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "1")
+        bot = _make_bot()
+        _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+
+        result = await telegram_tool.tg_send_sticker("😀")
+
+        assert result["success"] is True
+        kwargs = bot.send_sticker.await_args.kwargs
+        assert "message_thread_id" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_no_thread_id_no_kwarg(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _record()
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok123")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "123")
+        bot = _make_bot()
+        _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+
+        result = await telegram_tool.tg_send_sticker("😀")
+
+        assert result["success"] is True
+        kwargs = bot.send_sticker.await_args.kwargs
+        assert kwargs["chat_id"] == 123
+        assert "message_thread_id" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_set_name_disambiguates_shared_emoji(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _record("uid-a", emoji="😀", set_name="PackOne")
+        _record("uid-b", emoji="😀", set_name="PackTwo")
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok123")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "123")
+        bot = _make_bot()
+        _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+
+        result = await telegram_tool.tg_send_sticker("😀", set_name="PackOne")
+
+        assert result["success"] is True
+        assert result["sticker"]["file_unique_id"] == "uid-a"
+        assert bot.send_sticker.await_args.kwargs["sticker"] == "fid-uid-a"
+
+    @pytest.mark.asyncio
+    async def test_resolve_failure_message_points_to_add_set(self) -> None:
+        result = await telegram_tool.tg_send_sticker("🦄")
+
+        assert result["success"] is False
+        assert "not in your collection" in result["error"]
+        assert "add_set" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_no_active_session_chat_errors(self) -> None:
+        _record()
+        result = await telegram_tool.tg_send_sticker("😀")
+
+        assert result["success"] is False
+        assert "No active Telegram chat" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_bot_token_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _record()
+        monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "123")
+        result = await telegram_tool.tg_send_sticker("😀")
+
+        assert result["success"] is False
+        assert "TELEGRAM_BOT_TOKEN" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_api_error_is_returned_with_token_redacted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _record()
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok123")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "123")
+        bot = _make_bot()
+        bot.send_sticker = AsyncMock(
+            side_effect=Exception("Bad Request: wrong file_id for bot tok123")
+        )
+        _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+
+        result = await telegram_tool.tg_send_sticker("😀")
+
+        assert result["success"] is False
+        assert "wrong file_id" in result["error"]
+        assert "tok123" not in result["error"]
+        assert "***" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_proxy_routes_bot_through_httpx_request(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _record()
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok123")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "123")
+        monkeypatch.setenv("TELEGRAM_PROXY", "socks5://127.0.0.1:1080")
+        bot = _make_bot()
+        bot_factory = MagicMock(return_value=bot)
+        httpx_request_factory = MagicMock(side_effect=lambda **kw: MagicMock(_kw=kw))
+        _install_telegram_mock(monkeypatch, bot_factory, httpx_request_factory)
+
+        result = await telegram_tool.tg_send_sticker("😀")
+
+        assert result["success"] is True
+        bot_factory.assert_called_once()
+        call_kwargs = bot_factory.call_args.kwargs
+        assert call_kwargs["token"] == "tok123"
+        assert "request" in call_kwargs, "request= kwarg missing — proxy not wired"
+        assert "get_updates_request" in call_kwargs
+        assert httpx_request_factory.call_count == 2
+        for call in httpx_request_factory.call_args_list:
+            assert call.kwargs.get("proxy") == "socks5://127.0.0.1:1080"
+        bot.send_sticker.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# tg_manage_stickers — list / update / remove (local store, no bot needed)
+# ---------------------------------------------------------------------------
+
+
+class TestManageList:
+    @pytest.mark.asyncio
+    async def test_list_returns_summaries_without_file_id(self) -> None:
+        _record("uid1", emoji="😀", set_name="A", description="cat")
+        _record("uid2", emoji="😂", set_name="B")
+        _record("uid3", emoji="🚀", set_name="B")
+
+        result = await telegram_tool.tg_manage_stickers("list")
+
+        assert result["success"] is True
+        assert result["total"] == 3
+        assert result["returned"] == 3
+        by_uid = {e["file_unique_id"]: e for e in result["stickers"]}
+        assert set(by_uid) == {"uid1", "uid2", "uid3"}
+        for entry in result["stickers"]:
+            assert set(entry) == {"file_unique_id", "emoji", "set_name", "kind", "description"}
+        assert by_uid["uid1"]["description"] == "cat"
+
+    @pytest.mark.asyncio
+    async def test_list_set_name_filter_and_limit(self) -> None:
+        _record("uid1", emoji="😀", set_name="A")
+        _record("uid2", emoji="😂", set_name="B")
+        _record("uid3", emoji="🚀", set_name="B")
+
+        filtered = await telegram_tool.tg_manage_stickers("list", set_name="B")
+        assert filtered["total"] == 2
+        assert filtered["set_name"] == "B"
+        assert {e["file_unique_id"] for e in filtered["stickers"]} == {"uid2", "uid3"}
+
+        capped = await telegram_tool.tg_manage_stickers("list", limit=2)
+        assert capped["returned"] == 2
+        assert capped["total"] == 3
+        assert "note" in capped  # truncation hint
+
+    @pytest.mark.asyncio
+    async def test_handler_wrapper_returns_json_string(self) -> None:
+        raw = await telegram_tool._handle_tg_manage_stickers({"action": "list"})
+        parsed = json.loads(raw)
+        assert parsed["success"] is True
+        assert parsed["total"] == 0
+
+
+class TestManageUpdate:
+    @pytest.mark.asyncio
+    async def test_update_by_file_unique_id(self) -> None:
+        _record("uid1")
+
+        result = await telegram_tool.tg_manage_stickers(
+            "update", file_unique_id="uid1", description="use when the user is sarcastic"
+        )
+
+        assert result["success"] is True
+        assert result["updated"] == 1
+        assert result["entry"]["description"] == "use when the user is sarcastic"
+        assert sticker_collection.resolve("uid1")["description"] == "use when the user is sarcastic"
+
+    @pytest.mark.asyncio
+    async def test_update_by_sticker_query_and_clear(self) -> None:
+        _record("uid1", emoji="😀", description="first")
+
+        result = await telegram_tool.tg_manage_stickers(
+            "update", sticker="😀", description="second"
+        )
+        assert result["success"] is True
+        assert sticker_collection.resolve("uid1")["description"] == "second"
+
+        cleared = await telegram_tool.tg_manage_stickers(
+            "update", sticker="😀", description=""
+        )
+        assert cleared["success"] is True
+        assert cleared["entry"]["description"] == ""
+        assert sticker_collection.resolve("uid1")["description"] == ""
+
+    @pytest.mark.asyncio
+    async def test_update_requires_a_selector(self) -> None:
+        result = await telegram_tool.tg_manage_stickers("update", description="x")
+
+        assert result["success"] is False
+        assert "file_unique_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_unknown_selector_errors(self) -> None:
+        result = await telegram_tool.tg_manage_stickers(
+            "update", file_unique_id="nope", description="x"
+        )
+
+        assert result["success"] is False
+        assert "nope" in result["error"]
+        assert "list" in result["error"]
+
+
+class TestManageRemove:
+    @pytest.mark.asyncio
+    async def test_remove_by_file_unique_id(self) -> None:
+        _record("uid1", emoji="😀")
+
+        result = await telegram_tool.tg_manage_stickers("remove", file_unique_id="uid1")
+
+        assert result["success"] is True
+        assert result["removed"] == 1
+        assert result["entry"]["file_unique_id"] == "uid1"
+        assert sticker_collection.list_stickers() == []
+
+    @pytest.mark.asyncio
+    async def test_remove_by_sticker_query(self) -> None:
+        _record("uid1", emoji="😀")
+
+        result = await telegram_tool.tg_manage_stickers("remove", sticker="😀")
+
+        assert result["success"] is True
+        assert sticker_collection.resolve("😀") is None
+
+    @pytest.mark.asyncio
+    async def test_remove_unknown_selector_errors(self) -> None:
+        result = await telegram_tool.tg_manage_stickers("remove", file_unique_id="nope")
+
+        assert result["success"] is False
+        assert "nope" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# tg_manage_stickers — add_set (one-shot bot + refresh_from_sets)
+# ---------------------------------------------------------------------------
+
+
+class TestManageAddSet:
+    def _bot_with_set(self, monkeypatch: pytest.MonkeyPatch, stickers: list) -> MagicMock:
+        bot = MagicMock()
+        bot.get_sticker_set = AsyncMock(
+            return_value=SimpleNamespace(name="HotCherry", stickers=stickers)
+        )
+        _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+        return bot
+
+    @pytest.mark.asyncio
+    async def test_add_set_imports_pack(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok123")
+        bot = self._bot_with_set(
+            monkeypatch, [_sticker_obj("uid1", "😀"), _sticker_obj("uid2", "😂")]
+        )
+
+        result = await telegram_tool.tg_manage_stickers("add_set", set_name="HotCherry")
+
+        assert result["success"] is True
+        assert result["set_name"] == "HotCherry"
+        assert result["sets"] == 1
+        assert result["stickers"] == 2
+        assert result["new"] == 2
+        bot.get_sticker_set.assert_awaited_once_with("HotCherry")
+        entries = {e["file_unique_id"] for e in sticker_collection.list_stickers()}
+        assert entries == {"uid1", "uid2"}
+
+    @pytest.mark.asyncio
+    async def test_add_set_parses_tme_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok123")
+        bot = self._bot_with_set(monkeypatch, [_sticker_obj("uid1", "😀")])
+
+        result = await telegram_tool.tg_manage_stickers(
+            "add_set", set_name="https://t.me/addstickers/HotCherry"
+        )
+
+        assert result["success"] is True
+        assert result["set_name"] == "HotCherry"
+        bot.get_sticker_set.assert_awaited_once_with("HotCherry")
+
+    @pytest.mark.asyncio
+    async def test_add_set_fetch_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok123")
+        bot = MagicMock()
+        bot.get_sticker_set = AsyncMock(side_effect=Exception("Bad Request: STICKERSET_INVALID"))
+        _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+
+        result = await telegram_tool.tg_manage_stickers("add_set", set_name="NoSuchPack")
+
+        assert result["success"] is False
+        assert "NoSuchPack" in result["error"]
+        assert sticker_collection.list_stickers() == []
+
+    @pytest.mark.asyncio
+    async def test_add_set_requires_name(self) -> None:
+        result = await telegram_tool.tg_manage_stickers("add_set")
+
+        assert result["success"] is False
+        assert "set_name" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_errors(self) -> None:
+        result = await telegram_tool.tg_manage_stickers("search")
+
+        assert result["success"] is False
+        assert "list" in result["error"] and "add_set" in result["error"]
+
+
+class TestSetNameParsing:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("HotCherry", "HotCherry"),
+            ("https://t.me/addstickers/HotCherry", "HotCherry"),
+            ("http://t.me/addstickers/HotCherry", "HotCherry"),
+            ("t.me/addstickers/HotCherry", "HotCherry"),
+            ("  HotCherry  ", "HotCherry"),
+            ("", ""),
+        ],
+    )
+    def test_parse_set_short_name(self, raw: str, expected: str) -> None:
+        assert telegram_tool._parse_set_short_name(raw) == expected

--- a/tools/telegram_tool.py
+++ b/tools/telegram_tool.py
@@ -1,0 +1,563 @@
+"""Telegram platform tools — native sticker send + collection management.
+
+Two service-gated tools (Footprint Ladder rung 3):
+
+- ``tg_send_sticker`` — send a *native* Telegram sticker (Bot API ``file_id``
+  semantics) from the persistent collection in
+  ``plugins/platforms/telegram/sticker_collection.py``. Exposed only inside
+  Telegram gateway sessions, and delivery is scoped to the active session's
+  chat (derived from session context, never a model-supplied target) — the
+  same no-arbitrary-outbound rule that keeps ``send_message`` out of the
+  agent-callable registry.
+- ``tg_manage_stickers`` — curate that collection (list / update / remove /
+  add_set). Exposed in Telegram gateway sessions or when
+  ``TELEGRAM_BOT_TOKEN`` is configured (``add_set`` works from the CLI too).
+  Management surface only; NOT a global Telegram sticker search.
+
+Mirrors the registration style of ``tools/yuanbao_tools.py`` and the
+one-shot Bot + proxy pattern of ``tools/send_message_tool.py::_send_telegram``.
+``telegram.Bot`` (python-telegram-bot) is imported lazily inside functions so
+minimal installs without PTB can still load this module and evaluate
+``check_fn`` without crashing.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, Optional
+
+from agent.redact import redact_sensitive_text
+from tools.registry import registry, tool_result
+
+logger = logging.getLogger(__name__)
+
+_TOOLSET = "telegram"
+
+
+def _sticker_collection():
+    """Lazy access to the sticker-collection store.
+
+    ``plugins.platforms.telegram``'s package ``__init__`` imports the adapter,
+    which pulls in python-telegram-bot — an optional dependency and a heavy
+    import. Importing it here at module top would make every CLI startup (and
+    every PTB-less install) pay that cost at tool-discovery time, so we import
+    only when a tool actually runs.
+    """
+    from plugins.platforms.telegram import sticker_collection
+
+    return sticker_collection
+
+# https://t.me/addstickers/<short_name> (optionally without the scheme).
+_ADDSTICKERS_URL_RE = re.compile(r"(?:https?://)?t\.me/addstickers/([A-Za-z0-9_]+)")
+
+
+# ---------------------------------------------------------------------------
+# Availability gate + one-shot Bot construction
+# ---------------------------------------------------------------------------
+
+
+def _check_telegram_session() -> bool:
+    """Availability check for tools that act on the ACTIVE Telegram session.
+
+    True only inside a Telegram gateway session (session env is task-local).
+    Used for tg_send_sticker, whose delivery target is derived from session
+    context — outside a Telegram session the tool could not send anywhere, so
+    it stays hidden rather than erroring at call time.
+    """
+    try:
+        from gateway.session_context import get_session_env
+
+        return get_session_env("HERMES_SESSION_PLATFORM", "") == "telegram"
+    except Exception:
+        return False
+
+
+def _check_telegram() -> bool:
+    """Toolset availability check.
+
+    True when running inside a Telegram gateway session, or when a bot token
+    is configured (CLI / cron one-shot usage). Must never crash when the
+    gateway or python-telegram-bot is absent.
+    """
+    try:
+        from gateway.session_context import get_session_env
+
+        if get_session_env("HERMES_SESSION_PLATFORM", "") == "telegram":
+            return True
+    except Exception:
+        pass
+    try:
+        from agent.secret_scope import get_secret
+
+        if (get_secret("TELEGRAM_BOT_TOKEN", "") or "").strip():
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _resolve_bot_token() -> str:
+    """Resolve the Telegram bot token (profile-scoped secret → env fallback)."""
+    try:
+        from agent.secret_scope import get_secret
+
+        token = get_secret("TELEGRAM_BOT_TOKEN", "")
+    except Exception:
+        token = ""
+    return (token or "").strip()
+
+
+def _build_bot(token: str):
+    """Construct a one-shot ``telegram.Bot`` honouring the configured proxy.
+
+    Mirrors ``tools/send_message_tool.py::_send_telegram``: ``TELEGRAM_PROXY``
+    (resolved via ``resolve_proxy_url``) routes the Bot through
+    ``HTTPXRequest``; a failure to attach the proxy falls back to a direct
+    connection. Raises ImportError when python-telegram-bot is absent.
+    """
+    from telegram import Bot  # lazy: PTB may be absent in minimal installs
+
+    try:
+        from gateway.platforms.base import resolve_proxy_url
+
+        proxy = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
+    except Exception:
+        proxy = None
+
+    if proxy:
+        try:
+            from telegram.request import HTTPXRequest
+
+            logger.info("telegram_tool: one-shot Bot routed through proxy %s", proxy)
+            return Bot(
+                token=token,
+                request=HTTPXRequest(proxy=proxy),
+                get_updates_request=HTTPXRequest(proxy=proxy),
+            )
+        except Exception as exc:
+            logger.warning(
+                "telegram_tool: failed to attach Telegram proxy (%s); using direct connection",
+                exc,
+            )
+    return Bot(token=token)
+
+
+# ---------------------------------------------------------------------------
+# Session-context defaults + Telegram id mapping
+# ---------------------------------------------------------------------------
+
+
+def _session_env(name: str) -> str:
+    """Read a HERMES_SESSION_* value; "" when the gateway context is absent."""
+    try:
+        from gateway.session_context import get_session_env
+
+        return (get_session_env(name, "") or "").strip()
+    except Exception:
+        return ""
+
+
+def _map_thread_id_for_send(thread_id: str) -> Optional[int]:
+    """Map a session thread id through the adapter's General-topic rule.
+
+    Telegram forum supergroups address the General topic as thread id "1" on
+    incoming updates, but Bot API sends reject ``message_thread_id=1`` with
+    "Message thread not found" — the adapter's
+    ``_message_thread_id_for_send`` maps "1" → None so the send lands in
+    General. Falls back to the explicit mapping when the adapter import
+    fails (e.g. python-telegram-bot missing in this venv).
+    """
+    if not thread_id:
+        return None
+    try:
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        return TelegramAdapter._message_thread_id_for_send(str(thread_id))
+    except Exception:
+        return None if str(thread_id) == "1" else int(thread_id)
+
+
+def _redact_token(text: str, token: str) -> str:
+    """Strip the bot token (and other secrets) from API error text."""
+    if token:
+        text = text.replace(token, "***")
+    return redact_sensitive_text(text)
+
+
+def _entry_summary(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Selector-facing view of a collection entry (no per-bot file_id)."""
+    return {
+        "file_unique_id": entry["file_unique_id"],
+        "emoji": entry["emoji"],
+        "set_name": entry["set_name"],
+        "kind": entry["kind"],
+        "description": entry["description"],
+    }
+
+
+def _resolve_selector(file_unique_id: str, sticker: str) -> Optional[Dict[str, Any]]:
+    """Locate a collection entry by exact file_unique_id, else a resolve query."""
+    store = _sticker_collection()
+    fuid = (file_unique_id or "").strip()
+    if fuid:
+        return store.resolve(fuid)
+    query = (sticker or "").strip()
+    if query:
+        return store.resolve(query)
+    return None
+
+
+def _parse_set_short_name(raw: str) -> str:
+    """Extract a sticker-pack short name, accepting t.me/addstickers URLs."""
+    raw = (raw or "").strip()
+    if not raw:
+        return ""
+    match = _ADDSTICKERS_URL_RE.search(raw)
+    if match:
+        return match.group(1)
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Tool 1: tg_send_sticker
+# ---------------------------------------------------------------------------
+
+
+async def tg_send_sticker(sticker: str, set_name: str = "") -> dict:
+    """Send a native Telegram sticker from the collection to the current chat."""
+    query = (sticker or "").strip()
+    if not query:
+        return {
+            "success": False,
+            "error": "sticker is required (emoji, set_name:emoji, file_unique_id, or file_id).",
+        }
+
+    entry = _sticker_collection().resolve(query, set_name=(set_name or "").strip())
+    if entry is None:
+        return {
+            "success": False,
+            "error": (
+                f"Sticker {query!r} is not in your collection. You can only send stickers "
+                "that are already in the collection — stickers users have sent you (recorded "
+                "automatically), or packs you imported with tg_manage_stickers action='add_set'."
+            ),
+        }
+
+    # Delivery is scoped to the ACTIVE Telegram session only. Mirroring the
+    # send_message precedent (tools/send_message_tool.py), the model must not
+    # get an arbitrary outbound target, so there is deliberately no chat_id
+    # parameter — the destination is derived from session context.
+    target = _session_env("HERMES_SESSION_CHAT_ID")
+    if not target:
+        return {
+            "success": False,
+            "error": "No active Telegram chat in this session — tg_send_sticker only works inside a Telegram conversation.",
+        }
+
+    token = _resolve_bot_token()
+    if not token:
+        return {
+            "success": False,
+            "error": "Telegram bot token is not configured (TELEGRAM_BOT_TOKEN).",
+        }
+
+    from plugins.platforms.telegram.telegram_ids import normalize_telegram_chat_id
+
+    # Numeric ids pass through as ints; @username targets stay strings —
+    # both are valid Bot API chat identifiers.
+    normalized_chat_id = normalize_telegram_chat_id(target)
+    thread_id = _map_thread_id_for_send(_session_env("HERMES_SESSION_THREAD_ID"))
+
+    try:
+        bot = _build_bot(token)
+    except ImportError:
+        return {
+            "success": False,
+            "error": "python-telegram-bot is not installed in this environment.",
+        }
+
+    send_kwargs: Dict[str, Any] = {"chat_id": normalized_chat_id, "sticker": entry["file_id"]}
+    if thread_id is not None:
+        send_kwargs["message_thread_id"] = thread_id
+
+    try:
+        message = await bot.send_sticker(**send_kwargs)
+    except Exception as exc:
+        logger.exception("[telegram_tool] tg_send_sticker error")
+        return {"success": False, "error": _redact_token(str(exc), token)}
+
+    return {
+        "success": True,
+        "chat_id": str(normalized_chat_id),
+        "sticker": {
+            "file_unique_id": entry["file_unique_id"],
+            "emoji": entry["emoji"],
+            "set_name": entry["set_name"],
+        },
+        "message_id": getattr(message, "message_id", None),
+        "note": "Sticker delivered to the chat. If you have additional text to say, reply now; otherwise end your turn without generating text.",
+    }
+
+
+async def _handle_tg_send_sticker(args, **kw):
+    return tool_result(await tg_send_sticker(
+        sticker=args.get("sticker", ""),
+        set_name=args.get("set_name", ""),
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Tool 2: tg_manage_stickers
+# ---------------------------------------------------------------------------
+
+
+async def tg_manage_stickers(
+    action: str,
+    sticker: str = "",
+    file_unique_id: str = "",
+    description: str = "",
+    set_name: str = "",
+    limit: int = 100,
+) -> dict:
+    """Curate the local Telegram sticker collection (list/update/remove/add_set)."""
+    action = (action or "").strip().lower()
+    store = _sticker_collection()
+
+    if action == "list":
+        set_filter = (set_name or "").strip()
+        # The collection is capped at MAX_STICKERS entries, so one unbounded
+        # listing gives both the page and the true total.
+        entries = store.list_stickers(set_name=set_filter, limit=store.MAX_STICKERS)
+        total = len(entries)
+        try:
+            cap = max(int(limit), 0)
+        except (TypeError, ValueError):
+            cap = 100
+        shown = entries[:cap]
+        result: Dict[str, Any] = {
+            "success": True,
+            "action": "list",
+            "total": total,
+            "returned": len(shown),
+            "stickers": [_entry_summary(e) for e in shown],
+        }
+        if set_filter:
+            result["set_name"] = set_filter
+        if len(shown) < total:
+            result["note"] = f"Showing {len(shown)} of {total} entries; raise limit to see more."
+        return result
+
+    if action in ("update", "remove"):
+        if not (file_unique_id or "").strip() and not (sticker or "").strip():
+            return {
+                "success": False,
+                "error": f"action={action!r} requires file_unique_id (preferred) or a sticker query (emoji / set_name:emoji).",
+            }
+        entry = _resolve_selector(file_unique_id, sticker)
+        if entry is None:
+            selector = (file_unique_id or "").strip() or (sticker or "").strip()
+            return {
+                "success": False,
+                "error": f"No collection entry matches {selector!r}. Call tg_manage_stickers action='list' to see current file_unique_ids.",
+            }
+        if action == "update":
+            if not store.update_description(entry["file_unique_id"], description or ""):
+                return {
+                    "success": False,
+                    "error": f"Could not update {entry['file_unique_id']!r} (entry missing or corrupt).",
+                }
+            updated = dict(_entry_summary(entry))
+            updated["description"] = description or ""
+            return {"success": True, "action": "update", "updated": 1, "entry": updated}
+        if not store.remove_sticker(entry["file_unique_id"]):
+            return {
+                "success": False,
+                "error": f"Could not remove {entry['file_unique_id']!r} (entry already gone).",
+            }
+        return {"success": True, "action": "remove", "removed": 1, "entry": _entry_summary(entry)}
+
+    if action == "add_set":
+        name = _parse_set_short_name(set_name)
+        if not name:
+            return {
+                "success": False,
+                "error": "action='add_set' requires set_name — a pack short name or a https://t.me/addstickers/<name> link.",
+            }
+        token = _resolve_bot_token()
+        if not token:
+            return {
+                "success": False,
+                "error": "Telegram bot token is not configured (TELEGRAM_BOT_TOKEN).",
+            }
+        try:
+            bot = _build_bot(token)
+        except ImportError:
+            return {
+                "success": False,
+                "error": "python-telegram-bot is not installed in this environment.",
+            }
+        try:
+            summary = await store.refresh_from_sets(bot, [name])
+        except Exception as exc:
+            logger.exception("[telegram_tool] tg_manage_stickers add_set error")
+            return {"success": False, "error": _redact_token(str(exc), token)}
+        if summary.get("sets", 0) == 0:
+            return {
+                "success": False,
+                "error": (
+                    f"Could not import sticker set {name!r} — the Bot API fetch failed. "
+                    "Check the short name (it must be exact) and the bot token."
+                ),
+                "summary": summary,
+            }
+        return {
+            "success": True,
+            "action": "add_set",
+            "set_name": name,
+            "sets": summary["sets"],
+            "stickers": summary["stickers"],
+            "new": summary["new"],
+            "note": (
+                f"Imported set {name!r}: {summary['stickers']} stickers "
+                f"({summary['new']} new). They are now in your collection and "
+                "sendable with tg_send_sticker."
+            ),
+        }
+
+    return {
+        "success": False,
+        "error": f"Unknown action {action!r}. Valid actions: list, update, remove, add_set.",
+    }
+
+
+async def _handle_tg_manage_stickers(args, **kw):
+    return tool_result(await tg_manage_stickers(
+        action=args.get("action", ""),
+        sticker=args.get("sticker", ""),
+        file_unique_id=args.get("file_unique_id", ""),
+        description=args.get("description", ""),
+        set_name=args.get("set_name", ""),
+        limit=args.get("limit", 100),
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Registry registration
+# ---------------------------------------------------------------------------
+
+
+registry.register(
+    name="tg_send_sticker",
+    toolset=_TOOLSET,
+    schema={
+        "name": "tg_send_sticker",
+        "description": (
+            "Send a native Telegram sticker to the current Telegram chat. Stickers are "
+            "resolved from your sticker collection — stickers users have sent you, plus "
+            "packs you imported with tg_manage_stickers action='add_set'. The collection "
+            "listing is injected into your context at session start; pick from it by emoji "
+            "(optionally disambiguated with set_name) instead of guessing. "
+            "CRITICAL: Whenever the user asks you to send a sticker, you MUST use this "
+            "tool. DO NOT draw or generate a sticker image yourself and send it as a "
+            "photo — that produces a fake 'sticker' picture instead of a real "
+            "Telegram sticker and is the WRONG path. You can only send stickers that are "
+            "already in your collection; if none fits, say so, or ask the user to send you "
+            "one (or a https://t.me/addstickers/<name> link you can import)."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "sticker": {
+                    "type": "string",
+                    "description": (
+                        "Which sticker to send: its emoji (e.g. '😀'), 'set_name:emoji' "
+                        "for an exact pack match, or a file_unique_id / file_id from the "
+                        "collection."
+                    ),
+                },
+                "set_name": {
+                    "type": "string",
+                    "description": (
+                        "Optional pack short name to disambiguate when several stickers "
+                        "share the same emoji."
+                    ),
+                },
+            },
+            "required": ["sticker"],
+        },
+    },
+    handler=_handle_tg_send_sticker,
+    check_fn=_check_telegram_session,
+    is_async=True,
+    emoji="🎨",
+)
+
+
+registry.register(
+    name="tg_manage_stickers",
+    toolset=_TOOLSET,
+    schema={
+        "name": "tg_manage_stickers",
+        "description": (
+            "Manage your Telegram sticker collection (the stickers tg_send_sticker can "
+            "send). Actions: 'update' annotates a sticker's description in your own words "
+            "(e.g. 'use when the user is being sarcastic') so future picks are more "
+            "accurate; 'remove' deletes an entry (also the cleanup path for stickers "
+            "whose file_id went stale); 'add_set' imports a whole sticker pack by short "
+            "name or https://t.me/addstickers/<name> link; 'list' shows the local "
+            "collection. "
+            "IMPORTANT about 'list': the collection listing is already injected into your "
+            "context at session start — rely on that injected listing to pick stickers. "
+            "Call 'list' ONLY to verify the result of a manage action you just performed "
+            "(update/remove/add_set), or when you have a concrete reason to believe the "
+            "collection changed mid-session. Never call it just to browse. This is a "
+            "local collection, not a global Telegram sticker search."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "update", "remove", "add_set"],
+                    "description": "Which management operation to perform.",
+                },
+                "sticker": {
+                    "type": "string",
+                    "description": (
+                        "Selector for update/remove when you don't know the "
+                        "file_unique_id: emoji or set_name:emoji, resolved against the "
+                        "collection."
+                    ),
+                },
+                "file_unique_id": {
+                    "type": "string",
+                    "description": (
+                        "Selector for update/remove: the entry's file_unique_id "
+                        "(exact match, preferred over sticker)."
+                    ),
+                },
+                "description": {
+                    "type": "string",
+                    "description": "New description for action='update' (\"\" clears the annotation).",
+                },
+                "set_name": {
+                    "type": "string",
+                    "description": (
+                        "Pack short name: filter for 'list', pack to import for 'add_set' "
+                        "(https://t.me/addstickers/<name> links accepted)."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max entries returned by 'list' (default 100).",
+                },
+            },
+            "required": ["action"],
+        },
+    },
+    handler=_handle_tg_manage_stickers,
+    check_fn=_check_telegram,
+    is_async=True,
+    emoji="🗂️",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -328,6 +328,15 @@ TOOLSETS = {
         "includes": []
     },
 
+    "telegram": {
+        "description": "Telegram platform tools - send and manage stickers",
+        "tools": [
+            "tg_send_sticker",
+            "tg_manage_stickers",
+        ],
+        "includes": []
+    },
+
     "feishu_doc": {
         "description": "Read Feishu/Lark document content",
         "tools": ["feishu_doc_read"],
@@ -478,7 +487,11 @@ TOOLSETS = {
 
     "hermes-telegram": {
         "description": "Telegram bot toolset - full access for personal use (terminal has safety checks)",
-        "tools": _HERMES_CORE_TOOLS,
+        "tools": _HERMES_CORE_TOOLS + [
+            "tg_send_sticker",
+            "tg_manage_stickers",
+        ],
+        "module": "tools.telegram_tool",
         "includes": []
     },
     

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1246,6 +1246,40 @@ Keys are chat IDs (groups/supergroups) or forum topic IDs. For forum groups, top
 
 Numeric YAML keys are automatically normalized to strings.
 
+## Stickers
+
+The agent can send **native Telegram stickers** (real stickers, not sticker-like images) from a personal sticker collection it builds over time:
+
+- Every sticker you send the bot is **recorded automatically**. Static stickers also get a short vision-generated description (e.g. "a cat waving its paw") so the agent knows when each one fits; animated and video stickers are recorded by emoji and pack.
+- When a **new session starts**, the collection listing is injected into the agent's context, so it knows which stickers it can send from the first message on.
+
+Just ask in chat — "send me the 😂 sticker" — and the bot replies with a native Telegram sticker.
+
+### Seeding packs from config
+
+To give the agent stickers before anyone has sent it any, list pack short names under `telegram.sticker_sets` in `~/.hermes/config.yaml`:
+
+```yaml
+telegram:
+  sticker_sets:
+    - HotCherry
+    - AnimatedEmojies
+```
+
+The packs are imported in the background when the gateway connects (a failing pack is logged and skipped). The short name is the last part of a pack's `https://t.me/addstickers/<name>` link.
+
+### Managing the collection
+
+The agent has two Telegram-only tools: `tg_send_sticker` picks a sticker from the collection by emoji (optionally disambiguated by pack name) and delivers it natively, and `tg_manage_stickers` curates the collection — annotate descriptions, remove entries, or import a whole pack. You never call these yourself: send the agent a `https://t.me/addstickers/<name>` link to have it import that pack, or ask it to forget a sticker ("forget the 😂 sticker").
+
+### Where the data lives
+
+The collection persists at `~/.hermes/telegram_stickers.json` (per-[profile](/user-guide/profiles) — each profile has its own file) and holds up to 500 stickers, evicting the least recently seen when full.
+
+:::note
+Sticker `file_id`s are issued **per bot**. If you switch to a new bot token, existing entries may stop working — re-import your packs (restart with `telegram.sticker_sets` set, or send the agent the pack links again) and ask the agent to remove any stale entries.
+:::
+
 ## Troubleshooting
 
 | Problem | Solution |


### PR DESCRIPTION
## What does this PR do?

The agent can now send **native Telegram stickers** (Bot API `file_id` semantics — real stickers, not sticker-like PNG images).

The design centers on a **persistent sticker collection** (`~/.hermes/telegram_stickers.json`, per-profile, 500-entry cap, atomic writes):

- Every sticker a user sends the bot is **recorded automatically** — including animated/video stickers — keyed by `file_unique_id`. Static stickers reuse the existing vision-description cache (`gateway/sticker_cache.py`) as a best-effort description source; the collection never triggers vision calls itself.
- On the **first turn of a brand-new telegram session**, the collection listing is injected into the first user message via the gateway's sidecar-note channel. This is strictly append-only: mid-session collection changes never edit prior context, so per-conversation prompt caching stays intact. Newly received stickers announce themselves inline on the current user message.
- Two **service-gated tools** (visible only in telegram sessions or when `TELEGRAM_BOT_TOKEN` is set — zero schema footprint otherwise):
  - `tg_send_sticker` — resolve by emoji / `set_name:emoji` / `file_unique_id` and send via a one-shot Bot (proxy-aware, forum General-topic mapping), with schema prose steering the model away from drawing fake sticker PNGs.
  - `tg_manage_stickers` — curate the collection: `update` (annotate descriptions in the agent's own words; agent annotations are never overwritten by cache backfill), `remove` (also the stale-`file_id` cleanup path), `add_set` (import a pack by short name or `t.me/addstickers/<name>` link), `list` (schema description actively discourages casual use — the injected listing is the primary channel).
- `telegram.sticker_sets` in config.yaml seeds packs at gateway connect (deferred post-connect housekeeping, non-fatal).

Footprint: wired into the `hermes-telegram` composite so it auto-enables for telegram sessions and is hidden on every other platform. `python-telegram-bot` and the adapter are imported lazily throughout, so CLI startup and minimal installs without PTB are unaffected (verified: importing `tools.telegram_tool` pulls no heavy modules).

## Related Issue

Fixes #16168

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/telegram/sticker_collection.py` — new persistent collection store (record/resolve/list/update/remove, `refresh_from_sets`, prompt-note renderer)
- `tools/telegram_tool.py` — new `tg_send_sticker` + `tg_manage_stickers` tools (lazy PTB import, proxy-aware one-shot Bot, thread mapping)
- `plugins/platforms/telegram/adapter.py` — record all inbound stickers into the collection + inline "saved to your collection" note; `sticker_sets` yaml bridging + post-connect seed
- `gateway/run.py` — first-turn collection-note injection for telegram sessions (guarded, non-fatal)
- `toolsets.py`, `hermes_cli/tools_config.py` — `telegram` toolset + composite wiring + platform restriction (auto-on for telegram only)
- `hermes_cli/config.py` — `telegram.sticker_sets: []` (no config-version bump; deep-merge covers it)
- `website/docs/user-guide/messaging/telegram.md` — new "Stickers" section
- Tests: `tests/plugins/platforms/telegram/test_sticker_collection.py` (26), `tests/plugins/platforms/telegram/test_adapter_sticker_hooks.py` (14), `tests/tools/test_telegram_tool.py` (36), `tests/gateway/test_telegram_sticker_collection_note.py` (6), plus toolset/tools-config invariant tests

## How to Test

1. `scripts/run_tests.sh tests/plugins/platforms/telegram/ tests/tools/test_telegram_tool.py tests/gateway/test_telegram_sticker_collection_note.py tests/test_toolsets.py tests/hermes_cli/test_tools_config.py -q` → all pass
2. Live: add `telegram.sticker_sets: ["HotCherry"]` to config.yaml, start the gateway, send the bot a sticker from another pack, then ask it to send a sticker back — it sends a native sticker from the seeded pack or the one you just sent
3. Ask the agent to import `https://t.me/addstickers/<name>` or to forget a sticker — collection updates accordingly

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the test suite — 482/482 tests pass across all 11 touched/relevant files; full `tests/gateway/` sweep: 11081 passed, 26 failed in 6 files, all confirmed pre-existing environment issues on this machine (macOS `/tmp` symlink, VPN DNS resolving CDN hosts to SSRF-blocked ranges, no systemd) and unrelated to this diff
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (live-verified end-to-end against a real Telegram bot)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/messaging/telegram.md`, docstrings)
- [x] `cli-config.yaml.example` — N/A (the example file has no per-platform telegram section; the key is documented in the website docs)
- [x] `AGENTS.md` — N/A (no architecture/workflow change; the feature follows existing toolset/plugin patterns)
- [x] Cross-platform impact — N/A (pure Python, stdlib + existing PTB dependency; no POSIX-only primitives)
- [x] Tool descriptions/schemas updated — new tools follow the anti-wrong-path schema prose conventions

