### PR TITLE
fix(agent): preserve Anthropic cache token fields in auxiliary usage (#71242)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1210,6 +1210,11 @@ class _CodexCompletionsAdapter:
 
             resp_usage = getattr(final, "usage", None)
             if resp_usage:
+                # Pass through input_tokens_details so usage_pricing.py
+                # can extract cache tokens for codex_responses mode (#71242).
+                _details = getattr(resp_usage, "input_tokens_details", None)
+                if _details is None and isinstance(resp_usage, dict):
+                    _details = resp_usage.get("input_tokens_details")
                 usage = SimpleNamespace(
                     prompt_tokens=getattr(resp_usage, "input_tokens", 0)
                         or (resp_usage.get("input_tokens", 0) if isinstance(resp_usage, dict) else 0),
@@ -1217,6 +1222,7 @@ class _CodexCompletionsAdapter:
                         or (resp_usage.get("output_tokens", 0) if isinstance(resp_usage, dict) else 0),
                     total_tokens=getattr(resp_usage, "total_tokens", 0)
                         or (resp_usage.get("total_tokens", 0) if isinstance(resp_usage, dict) else 0),
+                    input_tokens_details=_details,
                 )
         except Exception as exc:
             if timed_out.is_set():
@@ -1423,10 +1429,16 @@ class _AnthropicCompletionsAdapter:
             prompt_tokens = getattr(response.usage, "input_tokens", 0) or 0
             completion_tokens = getattr(response.usage, "output_tokens", 0) or 0
             total_tokens = getattr(response.usage, "total_tokens", 0) or (prompt_tokens + completion_tokens)
+            # Preserve Anthropic cache token fields so that usage_pricing.py
+            # can calculate MoA / auxiliary cost correctly (issue #71242).
+            cache_read = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+            cache_creation = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
             usage = SimpleNamespace(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
                 total_tokens=total_tokens,
+                cache_read_input_tokens=cache_read,
+                cache_creation_input_tokens=cache_creation,
             )
 
         choice = SimpleNamespace(


### PR DESCRIPTION
## Problem

The auxiliary client's Anthropic and Codex adapters rebuild response usage into a SimpleNamespace with only `prompt_tokens` / `completion_tokens` / `total_tokens`, **dropping** cache-related fields. Downstream, `usage_pricing.py` reads `cache_read_input_tokens` and `cache_creation_input_tokens` from the usage object to calculate MoA aggregator costs — but those fields are absent on the reconstructed SimpleNamespace, so cache tokens are always 0.

**Impact**: MoA cost under-reported ~7x for Anthropic models; Codex Responses API cache data also lost.

## Fix

### Anthropic adapter (`_AnthropicCompletionsAdapter.create`)
Pass through `cache_read_input_tokens` and `cache_creation_input_tokens` from `response.usage`.

### Codex adapter (`_CodexResponsesAdapter.create`)
Pass through `input_tokens_details` (which contains `cached_tokens` / `cache_creation_tokens`) from `response.usage`.

## Testing

- Verified `ruff` lint passes
- Both fields default to `0` when the upstream object lacks them (backward compatible)
- No existing tests broken (usage fields are additive)

Fixes #71242