### PR TITLE
fix(install): reap Windows cua installer process tree

### DIFF
--- a/contributors/emails/xiongyue_hnu@163.com
+++ b/contributors/emails/xiongyue_hnu@163.com
@@ -1,0 +1,1 @@
+yuexiongHNU

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -958,27 +958,116 @@ _CUA_INSTALLER_TIMEOUT = 660
 _CUA_LOCK_STALE_AFTER = 600
 
 
+def _cua_install_home() -> "Path":
+    """Package home shared by the upstream POSIX and Windows installers."""
+    return Path(
+        os.environ.get("CUA_DRIVER_RS_HOME")
+        or str(Path.home() / ".cua-driver")
+    )
+
+
 def _cua_install_lock_dir() -> "Path":
     """Path of the upstream installer's concurrent-install lock dir."""
-    home = os.environ.get("CUA_DRIVER_RS_HOME") or str(Path.home() / ".cua-driver")
-    return Path(home) / "packages" / ".install.lock.d"
+    return _cua_install_home() / "packages" / ".install.lock.d"
+
+
+def _cua_windows_install_lock_file() -> "Path":
+    """Path of install.ps1's FileShare::None lock file."""
+    return _cua_install_home() / "install.lock"
+
+
+def _clear_stale_windows_cua_install_lock() -> None:
+    """Delete install.ps1's lock file only when no process still holds it.
+
+    ``install.ps1`` serializes installs with a ``FileStream`` opened using
+    ``FileShare::None``. Mirror that primitive with a zero-share
+    ``CreateFileW`` probe. ``FILE_FLAG_DELETE_ON_CLOSE`` removes an unlocked
+    leftover atomically when the probe handle closes, avoiding a gap where a
+    new installer could acquire the file between our probe and deletion.
+    """
+    lock_file = _cua_windows_install_lock_file()
+    try:
+        if not lock_file.is_file():
+            return
+
+        import ctypes as _ctypes
+        from ctypes import wintypes as _wintypes
+
+        # Win32 constants used by install.ps1's FileShare::None equivalent.
+        delete_access = 0x00010000
+        generic_read = 0x80000000
+        generic_write = 0x40000000
+        open_existing = 3
+        file_attribute_normal = 0x00000080
+        file_flag_delete_on_close = 0x04000000
+
+        kernel32 = _ctypes.WinDLL("kernel32", use_last_error=True)
+        create_file = kernel32.CreateFileW
+        create_file.argtypes = [
+            _wintypes.LPCWSTR,
+            _wintypes.DWORD,
+            _wintypes.DWORD,
+            _wintypes.LPVOID,
+            _wintypes.DWORD,
+            _wintypes.DWORD,
+            _wintypes.HANDLE,
+        ]
+        create_file.restype = _wintypes.HANDLE
+        close_handle = kernel32.CloseHandle
+        close_handle.argtypes = [_wintypes.HANDLE]
+        close_handle.restype = _wintypes.BOOL
+
+        handle = create_file(
+            str(lock_file),
+            generic_read | generic_write | delete_access,
+            0,  # FileShare::None
+            None,
+            open_existing,
+            file_attribute_normal | file_flag_delete_on_close,
+            None,
+        )
+        invalid_handle = _wintypes.HANDLE(-1).value
+        if handle == invalid_handle:
+            logger.debug(
+                "Windows cua install lock at %s is still held or cannot be "
+                "removed (winerror %s)",
+                lock_file,
+                _ctypes.get_last_error(),
+            )
+            return
+
+        if not close_handle(handle):
+            logger.debug(
+                "could not close Windows cua install lock probe at %s "
+                "(winerror %s)",
+                lock_file,
+                _ctypes.get_last_error(),
+            )
+            return
+        if lock_file.exists():
+            logger.debug(
+                "Windows cua install lock probe succeeded but %s remains",
+                lock_file,
+            )
+            return
+
+        logger.info("Cleared stale Windows cua-driver install lock at %s", lock_file)
+        _print_info(f"    Cleared stale cua-driver install lock ({lock_file}).")
+    except Exception as e:
+        logger.debug("stale Windows cua install lock check failed: %s", e)
 
 
 def _clear_stale_cua_install_lock() -> None:
     """Best-effort: remove a stale installer lock left by a dead holder.
 
-    A previous timed-out/killed install can orphan
-    ``~/.cua-driver/packages/.install.lock.d`` (the holder's pid is stamped
-    into its ``info`` file). The upstream installer only reclaims it after
-    waiting 600s — longer than our old subprocess timeout — so an orphaned
-    lock wedged every subsequent refresh. Clear it up front when the holder
-    is provably dead; leave it alone when the holder is alive (a slow
-    concurrent install) or liveness can't be determined.
-
-    POSIX-only: the lock protocol lives in the bash installer; install.ps1
-    does not use it.
+    The POSIX installer stamps its holder pid into
+    ``~/.cua-driver/packages/.install.lock.d/info``. The Windows installer
+    instead holds ``~/.cua-driver/install.lock`` open with
+    ``FileShare::None``. Clear either artifact up front only when its
+    platform-specific liveness check proves that no install still holds it.
     """
     if sys.platform == "win32":
+        _clear_stale_windows_cua_install_lock()
         return
     lock_dir = _cua_install_lock_dir()
     try:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1122,7 +1122,48 @@ def _run_cua_driver_installer(label: str = "Installing", verbose: bool = True) -
             if not is_windows:
                 os.killpg(os.getpgid(proc.pid), _signal.SIGKILL)  # windows-footgun: ok — POSIX branch only
             else:
-                proc.kill()
+                # PowerShell may leave download/install helpers alive after its
+                # direct process is killed. Those descendants inherit stdout
+                # and can keep both communicate() and install.lock wedged, so
+                # collect the tree first and kill it leaf-up.
+                import psutil as _psutil
+
+                try:
+                    parent = _psutil.Process(proc.pid)
+                    descendants = parent.children(recursive=True)
+                except _psutil.NoSuchProcess:
+                    return
+                except _psutil.Error as e:
+                    logger.debug(
+                        "could not enumerate cua-driver installer tree for pid %s: %s",
+                        proc.pid,
+                        e,
+                    )
+                    proc.kill()
+                    return
+
+                for child in reversed(descendants):
+                    try:
+                        child.kill()
+                    except _psutil.NoSuchProcess:
+                        pass
+                    except _psutil.Error as e:
+                        logger.debug(
+                            "could not kill cua-driver installer child pid %s: %s",
+                            child.pid,
+                            e,
+                        )
+                try:
+                    parent.kill()
+                except _psutil.NoSuchProcess:
+                    pass
+                except _psutil.Error as e:
+                    logger.debug(
+                        "could not kill cua-driver installer parent pid %s: %s",
+                        proc.pid,
+                        e,
+                    )
+                    proc.kill()
         except (OSError, ProcessLookupError):
             proc.kill()
 

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -329,6 +329,69 @@ class TestInstallerTimeoutKillsProcessGroup:
 
         assert captured.get("start_new_session") is True
 
+    def test_windows_timeout_kills_descendants_and_parent(self):
+        import subprocess
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        child = MagicMock()
+        parent = MagicMock()
+        parent.children.return_value = [child]
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 12345
+        fake_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="powershell", timeout=1),
+            ("", None),
+        ]
+
+        with patch("platform.system", return_value="Windows"), \
+             patch("subprocess.Popen", return_value=fake_proc), \
+             patch("psutil.Process", return_value=parent), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info"):
+            ok = tools_config._run_cua_driver_installer(
+                label="Refreshing", verbose=False
+            )
+
+        assert ok is False
+        parent.children.assert_called_once_with(recursive=True)
+        child.kill.assert_called_once_with()
+        parent.kill.assert_called_once_with()
+        fake_proc.kill.assert_not_called()
+        assert fake_proc.communicate.call_count == 2
+
+    def test_windows_tree_enumeration_failure_falls_back_to_direct_kill(self):
+        import psutil
+        import subprocess
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        parent = MagicMock()
+        parent.children.side_effect = psutil.AccessDenied(pid=12345)
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 12345
+        fake_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="powershell", timeout=1),
+            ("", None),
+        ]
+
+        with patch("platform.system", return_value="Windows"), \
+             patch("subprocess.Popen", return_value=fake_proc), \
+             patch("psutil.Process", return_value=parent), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info"):
+            ok = tools_config._run_cua_driver_installer(
+                label="Refreshing", verbose=False
+            )
+
+        assert ok is False
+        fake_proc.kill.assert_called_once_with()
+        assert fake_proc.communicate.call_count == 2
+
 
 class TestInstallerNoShell:
     """The POSIX installer path must not use shell=True or command

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -21,7 +21,10 @@ cleanly on missing-arch assets, and the upgrade path uses
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import patch
+
+import pytest
 
 
 class TestInstallCuaDriverUpgrade:
@@ -194,7 +197,11 @@ class TestArchProbeRemoval:
             urlopen.assert_not_called()
 
 
-class TestStaleInstallLockClear:
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX installer uses the .install.lock.d directory protocol",
+)
+class TestPosixStaleInstallLockClear:
     """_clear_stale_cua_install_lock: pre-clears the upstream installer's
     concurrent-install lock only when the holder is provably dead (or the
     lock is old and pid-less). Issue #58762."""
@@ -256,6 +263,87 @@ class TestStaleInstallLockClear:
         tools_config._clear_stale_cua_install_lock()  # must not raise
 
 
+class TestWindowsStaleInstallLockClearDispatch:
+    def test_windows_branch_uses_file_lock_probe(self):
+        from hermes_cli import tools_config
+
+        with patch.object(tools_config.sys, "platform", "win32"), \
+             patch.object(
+                 tools_config, "_clear_stale_windows_cua_install_lock"
+             ) as clear_windows:
+            tools_config._clear_stale_cua_install_lock()
+
+        clear_windows.assert_called_once_with()
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="requires native Win32 FileShare semantics",
+)
+class TestWindowsStaleInstallLockClear:
+    def _make_lock(self, tmp_path):
+        import os
+
+        home = tmp_path / ".cua-driver"
+        home.mkdir()
+        lock = home / "install.lock"
+        lock.write_text("pid=stale\n", encoding="utf-8")
+        os.environ["CUA_DRIVER_RS_HOME"] = str(home)
+        return lock
+
+    def teardown_method(self):
+        import os
+
+        os.environ.pop("CUA_DRIVER_RS_HOME", None)
+
+    def test_unlocked_lock_file_is_cleared(self, tmp_path):
+        from hermes_cli import tools_config
+
+        lock = self._make_lock(tmp_path)
+        with patch.object(tools_config, "_print_info"):
+            tools_config._clear_stale_cua_install_lock()
+
+        assert not lock.exists()
+
+    def test_lock_held_with_file_share_none_is_kept(self, tmp_path):
+        import ctypes
+        from ctypes import wintypes
+        from hermes_cli import tools_config
+
+        lock = self._make_lock(tmp_path)
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        create_file = kernel32.CreateFileW
+        create_file.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.HANDLE,
+        ]
+        create_file.restype = wintypes.HANDLE
+        close_handle = kernel32.CloseHandle
+        close_handle.argtypes = [wintypes.HANDLE]
+        close_handle.restype = wintypes.BOOL
+        handle = create_file(
+            str(lock),
+            0x80000000 | 0x40000000,  # GENERIC_READ | GENERIC_WRITE
+            0,  # FileShare::None, matching install.ps1
+            None,
+            3,  # OPEN_EXISTING
+            0x00000080,  # FILE_ATTRIBUTE_NORMAL
+            None,
+        )
+        assert handle != wintypes.HANDLE(-1).value
+
+        try:
+            tools_config._clear_stale_cua_install_lock()
+            assert lock.exists()
+        finally:
+            assert close_handle(handle)
+
+
 class TestInstallerTimeoutKillsProcessGroup:
     """On timeout the whole installer process group must be killed, so the
     `curl | bash` grandchildren can't survive holding the install lock."""
@@ -264,11 +352,11 @@ class TestInstallerTimeoutKillsProcessGroup:
         import os
         import signal
         import subprocess
-        import sys as _sys
         from unittest.mock import MagicMock
         from hermes_cli import tools_config
 
         killed = {}
+        sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
 
         fake_proc = MagicMock()
         fake_proc.pid = 12345
@@ -283,10 +371,15 @@ class TestInstallerTimeoutKillsProcessGroup:
             killed["sig"] = sig
 
         with patch("platform.system", return_value="Linux"), \
+             patch.object(signal, "SIGKILL", sigkill, create=True), \
              patch("subprocess.run", return_value=MagicMock(returncode=0, stderr="")), \
              patch("subprocess.Popen", return_value=fake_proc), \
-             patch.object(tools_config.os, "getpgid", return_value=99999), \
-             patch.object(tools_config.os, "killpg", side_effect=fake_killpg), \
+             patch.object(
+                 tools_config.os, "getpgid", return_value=99999, create=True
+             ), \
+             patch.object(
+                 tools_config.os, "killpg", side_effect=fake_killpg, create=True
+             ), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
              patch.object(tools_config, "_print_warning"), \
              patch.object(tools_config, "_print_info"):
@@ -294,7 +387,7 @@ class TestInstallerTimeoutKillsProcessGroup:
 
         assert ok is False
         assert killed.get("pgid") == 99999
-        assert killed.get("sig") == signal.SIGKILL
+        assert killed.get("sig") == sigkill
         # Post-kill reap happened.
         assert fake_proc.communicate.call_count == 2
 


### PR DESCRIPTION
## What does this PR do?

This PR closes both Windows recovery gaps from #71319:

1. A timed-out cua-driver install now terminates the full PowerShell process tree instead of only the direct process.
2. Before starting an install, Hermes probes `install.ps1`'s `%USERPROFILE%\.cua-driver\install.lock` using the same zero-share Win32 file semantics. An unlocked leftover is deleted atomically; a lock held by an active installer is preserved.

The POSIX process-group and `.install.lock.d` paths are unchanged. The Windows process-tree fix uses the existing core `psutil` dependency and falls back to the previous direct `proc.kill()` behavior if the process tree cannot be inspected.

## Related Issue

Fixes #71319

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [x] Tests
- [ ] Refactor

## Changes Made

- Updated `hermes_cli/tools_config.py` to enumerate Windows installer descendants recursively, kill them leaf-first, then kill the parent.
- Added a Windows stale-lock preflight using `CreateFileW` with `FileShare::None` semantics and `FILE_FLAG_DELETE_ON_CLOSE`, so probe and cleanup are atomic.
- Preserved active Windows locks: sharing violations or inaccessible lock files are left untouched.
- Preserved direct-process fallback when process inspection is denied.
- Added native Windows regressions for unlocked-lock cleanup, active-lock preservation, descendant cleanup, and fallback behavior.
- Made the installer test file platform-correct: POSIX lock-directory cases skip on native Windows, while mocked POSIX process-group coverage remains runnable there.
- Added the contributor email mapping required by repository CI.

## How to Test

1. Run `pytest tests/hermes_cli/test_install_cua_driver.py -q` on native Windows.
2. Run `pytest tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_mcp_tools_config.py -q`.
3. Run the repository Windows-footgun and Ruff checks.
4. For a live tree-kill check, start a parent process with a sleeping child, route it through installer timeout cleanup, and verify both PIDs exit.

## Validation

- Native Windows installer test file: `22 passed, 5 skipped` (the skips are POSIX-only lock-directory cases).
- Focused Windows regressions: `5 passed`.
- Adjacent tools configuration suites: `145 passed`.
- Local CI `Smart -Quick`: passed (`uv lock --check`, all-file Windows-footgun scan, repository Ruff, targeted pytest).
- `ruff check hermes_cli/tools_config.py tests/hermes_cli/test_install_cua_driver.py`: passed.
- `compileall` on both touched Python files: passed.
- Native Windows process-tree exercise: `result=False`, parent exited, `child_alive=False`.
- `git diff --check`: passed.

GitHub Linux CI remains the authoritative POSIX run.

## Checklist

- [x] I read the contributing guide.
- [x] Commit messages follow Conventional Commits.
- [x] I searched for existing PRs.
- [x] The PR contains only issue-related changes.
- [x] I added regression tests.
- [x] Tested on Windows 10 Pro 19045.
- [x] Cross-platform impact considered; the POSIX runtime path is unchanged.
- [x] Documentation/config/schema updates are N/A.