### PR TITLE
fix(cli): don't auto-switch away from proxy providers with a base_url (#71324)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1335,6 +1335,86 @@ def switch_model(
                     if isinstance(user_providers, dict) and target_provider in user_providers:
                         explicit_provider = target_provider
 
+        # --- Step d2: Configured provider catalog check ---
+        # When the user's config.yaml specifies a default provider (e.g.
+        # ``model.provider: opencode-go``) and the current session is on a
+        # different provider, the configured provider's live catalog may
+        # contain the bare model name.  Check it before falling to static
+        # catalog detection, which would pick the native provider instead.
+        # See #48731.
+        #
+        # Also checks the current provider's own live catalog when it has
+        # a ``base_url`` (proxy/custom endpoint like litellm), so a model
+        # served by the proxy isn't hijacked by static native-provider
+        # catalogs.  See #71324.
+        if (
+            not resolved_in_current_catalog
+            and not resolved_alias
+            and target_provider == current_provider
+        ):
+            try:
+                from hermes_cli.config import load_config as _load_cfg
+                _cfg = _load_cfg()
+                _model_cfg = _cfg.get("model")
+                _configured_prov = (
+                    _model_cfg.get("provider", "")
+                    if isinstance(_model_cfg, dict)
+                    else ""
+                )
+
+                # Case A: configured provider differs from current and is
+                # an aggregator — switch to it if it has the model.
+                if (
+                    _configured_prov
+                    and _configured_prov != current_provider
+                    and is_aggregator(_configured_prov)
+                ):
+                    _cat = list_provider_models(_configured_prov)
+                    if _cat:
+                        _nl = new_model.lower()
+                        for _mid in _cat:
+                            if _mid.lower() == _nl:
+                                new_model = _mid
+                                target_provider = _configured_prov
+                                resolved_in_current_catalog = True
+                                break
+                        if not resolved_in_current_catalog:
+                            for _mid in _cat:
+                                if "/" in _mid:
+                                    _, _bare = _mid.split("/", 1)
+                                    if _bare.lower() == _nl:
+                                        new_model = _mid
+                                        target_provider = _configured_prov
+                                        resolved_in_current_catalog = True
+                                        break
+
+                # Case B: current provider has a custom base_url (proxy
+                # like litellm) — check its own live /v1/models catalog
+                # before falling through to static detection.
+                if (
+                    not resolved_in_current_catalog
+                    and isinstance(_model_cfg, dict)
+                    and _model_cfg.get("base_url", "")
+                ):
+                    _cat = list_provider_models(current_provider)
+                    if _cat:
+                        _nl = new_model.lower()
+                        for _mid in _cat:
+                            if _mid.lower() == _nl:
+                                new_model = _mid
+                                resolved_in_current_catalog = True
+                                break
+                        if not resolved_in_current_catalog:
+                            for _mid in _cat:
+                                if "/" in _mid:
+                                    _, _bare = _mid.split("/", 1)
+                                    if _bare.lower() == _nl:
+                                        new_model = _mid
+                                        resolved_in_current_catalog = True
+                                        break
+            except Exception:
+                pass  # config unavailable — fall through to static detection
+
         # --- Step e: detect_provider_for_model() as last resort ---
         _base = current_base_url or ""
         is_custom = (

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1335,18 +1335,9 @@ def switch_model(
                     if isinstance(user_providers, dict) and target_provider in user_providers:
                         explicit_provider = target_provider
 
-        # --- Step d2: Configured provider catalog check ---
-        # When the user's config.yaml specifies a default provider (e.g.
-        # ``model.provider: opencode-go``) and the current session is on a
-        # different provider, the configured provider's live catalog may
-        # contain the bare model name.  Check it before falling to static
-        # catalog detection, which would pick the native provider instead.
-        # See #48731.
-        #
-        # Also checks the current provider's own live catalog when it has
-        # a ``base_url`` (proxy/custom endpoint like litellm), so a model
-        # served by the proxy isn't hijacked by static native-provider
-        # catalogs.  See #71324.
+        # --- Step d2: Configured aggregator fallback (#48731) ---
+        # When config.yaml specifies a different aggregator provider, check
+        # its live catalog before static detection.
         if (
             not resolved_in_current_catalog
             and not resolved_alias
@@ -1361,9 +1352,6 @@ def switch_model(
                     if isinstance(_model_cfg, dict)
                     else ""
                 )
-
-                # Case A: configured provider differs from current and is
-                # an aggregator — switch to it if it has the model.
                 if (
                     _configured_prov
                     and _configured_prov != current_provider
@@ -1387,40 +1375,17 @@ def switch_model(
                                         target_provider = _configured_prov
                                         resolved_in_current_catalog = True
                                         break
-
-                # Case B: current provider has a custom base_url (proxy
-                # like litellm) — check its own live /v1/models catalog
-                # before falling through to static detection.
-                if (
-                    not resolved_in_current_catalog
-                    and isinstance(_model_cfg, dict)
-                    and _model_cfg.get("base_url", "")
-                ):
-                    _cat = list_provider_models(current_provider)
-                    if _cat:
-                        _nl = new_model.lower()
-                        for _mid in _cat:
-                            if _mid.lower() == _nl:
-                                new_model = _mid
-                                resolved_in_current_catalog = True
-                                break
-                        if not resolved_in_current_catalog:
-                            for _mid in _cat:
-                                if "/" in _mid:
-                                    _, _bare = _mid.split("/", 1)
-                                    if _bare.lower() == _nl:
-                                        new_model = _mid
-                                        resolved_in_current_catalog = True
-                                        break
             except Exception:
-                pass  # config unavailable — fall through to static detection
+                pass
 
         # --- Step e: detect_provider_for_model() as last resort ---
         _base = current_base_url or ""
+        _unknown_proxy = bool(_base) and not list_provider_models(current_provider)
         is_custom = (
             current_provider in {"custom", "local"}
             or current_provider.startswith("custom:")
             or ("localhost" in _base or "127.0.0.1" in _base)
+            or _unknown_proxy  # ponytail: base_url + unknown to models.dev = proxy, don't auto-switch
         )
 
         if (

--- a/tests/hermes_cli/test_model_switch_configured_provider.py
+++ b/tests/hermes_cli/test_model_switch_configured_provider.py
@@ -1,0 +1,269 @@
+"""Tests for configured-provider catalog fallback in switch_model (#48731, #71324).
+
+When the user's config.yaml specifies ``model.provider: opencode-go`` and
+the current session is on a different provider (e.g. minimax), typing
+``/model deepseek-v4-pro`` should switch to opencode-go (which has the
+model in its live catalog) rather than falling to
+``detect_provider_for_model`` which picks native ``deepseek``.
+
+Also covers proxy providers with a custom ``base_url`` (e.g. litellm)
+where the model is served by the proxy's endpoint — the provider should
+not be switched away based on static catalog matches.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+# Live catalog opencode-go currently returns from /v1/models (snapshot).
+_OPENCODE_GO_LIVE = [
+    "minimax-m2.7", "minimax-m2.5",
+    "kimi-k2.6", "kimi-k2.5",
+    "glm-5.1", "glm-5",
+    "deepseek-v4-pro", "deepseek-v4-flash",
+    "qwen3.6-plus", "qwen3.5-plus",
+    "mimo-v2-pro", "mimo-v2-omni", "mimo-v2.5-pro", "mimo-v2.5",
+]
+
+
+def _run_switch_from_minimax(
+    raw_input: str,
+    configured_provider: str = "opencode-go",
+    **extra,
+):
+    """Call switch_model with minimax as current provider, mocking the live
+    catalog and config so the test doesn't hit the network."""
+    defaults = dict(
+        current_provider="minimax",
+        current_model="minimax-m2.7",
+        current_base_url="https://api.minimax.com/v1",
+        current_api_key="«redacted:sk-…»",
+        is_global=False,
+        explicit_provider="",
+    )
+    defaults.update(extra)
+
+    def fake_list_provider_models(provider: str):
+        if provider == "opencode-go":
+            return list(_OPENCODE_GO_LIVE)
+        if provider == "minimax":
+            return ["minimax-m2.7", "minimax-m2.5"]
+        return []
+
+    fake_config = {
+        "model": {
+            "provider": configured_provider,
+            "default": "minimax-m2.7",
+        }
+    }
+
+    with (
+        patch(
+            "hermes_cli.model_switch.list_provider_models",
+            side_effect=fake_list_provider_models,
+        ),
+        patch(
+            "hermes_cli.config.load_config",
+            return_value=fake_config,
+        ),
+    ):
+        return switch_model(raw_input=raw_input, **defaults)
+
+
+def test_configured_provider_fallback_deepseek_v4_pro():
+    """#48731: /model deepseek-v4-pro on minimax with configured opencode-go
+    should switch to opencode-go, not native deepseek."""
+    result = _run_switch_from_minimax("deepseek-v4-pro")
+    assert result.target_provider == "opencode-go", (
+        f"Expected opencode-go, got {result.target_provider}. "
+        f"Configured provider's live catalog was not checked."
+    )
+    assert result.new_model == "deepseek-v4-pro"
+
+
+def test_configured_provider_fallback_deepseek_v4_flash():
+    """Same bug class — flash variant."""
+    result = _run_switch_from_minimax("deepseek-v4-flash")
+    assert result.target_provider == "opencode-go"
+    assert result.new_model == "deepseek-v4-flash"
+
+
+def test_configured_provider_same_as_current_no_switch():
+    """When configured provider == current provider, no extra check needed."""
+    result = _run_switch_from_minimax(
+        "deepseek-v4-pro",
+        configured_provider="minimax",
+    )
+    # minimax doesn't have deepseek-v4-pro in its catalog, so
+    # detect_provider_for_model kicks in → returns native deepseek
+    assert result.target_provider == "deepseek"
+
+
+def test_configured_provider_not_aggregator_no_switch():
+    """When configured provider is not an aggregator, skip the check."""
+    result = _run_switch_from_minimax(
+        "deepseek-v4-pro",
+        configured_provider="minimax",  # minimax is not an aggregator
+    )
+    assert result.target_provider == "deepseek"
+
+
+def test_configured_provider_model_not_in_catalog_falls_through():
+    """When the configured provider's catalog doesn't have the model,
+    fall through to detect_provider_for_model."""
+    result = _run_switch_from_minimax(
+        "gpt-5.3-codex-spark",  # not in opencode-go's catalog
+        configured_provider="opencode-go",
+    )
+    # Should fall through to static detection
+    assert result.target_provider != "opencode-go"
+
+
+def test_configured_provider_config_unavailable_falls_through():
+    """When config loading fails, fall through gracefully."""
+    defaults = dict(
+        current_provider="minimax",
+        current_model="minimax-m2.7",
+        current_base_url="https://api.minimax.com/v1",
+        current_api_key="«redacted:sk-…»",
+        is_global=False,
+    )
+
+    def fake_list_provider_models(provider: str):
+        if provider == "minimax":
+            return ["minimax-m2.7", "minimax-m2.5"]
+        return []
+
+    with (
+        patch(
+            "hermes_cli.model_switch.list_provider_models",
+            side_effect=fake_list_provider_models,
+        ),
+        patch(
+            "hermes_cli.config.load_config",
+            side_effect=Exception("config unavailable"),
+        ),
+    ):
+        result = switch_model(raw_input="deepseek-v4-pro", **defaults)
+
+    # Should fall through to static detection → native deepseek
+    assert result.target_provider == "deepseek"
+
+
+def test_explicit_provider_bypasses_configured_check():
+    """When --provider is given, the configured provider check is skipped."""
+    result = _run_switch_from_minimax(
+        "deepseek-v4-pro",
+        explicit_provider="minimax",
+    )
+    # With explicit_provider="minimax", the model goes through Path A,
+    # not the configured provider fallback
+    assert result.target_provider == "minimax"
+
+
+# ── Case B: proxy provider with base_url (litellm, etc.) ──────────────
+
+
+_LITELLM_LIVE = [
+    "deepseek-v4-pro", "deepseek-v4-flash",
+    "gemma4-unsloth", "moonshot/kimi-k2.6",
+]
+
+
+def _run_switch_on_litellm(raw_input: str, **extra):
+    """Call switch_model with litellm as the current provider, mocking a
+    proxy endpoint whose /v1/models returns models like deepseek-v4-pro."""
+    defaults = dict(
+        current_provider="litellm",
+        current_model="deepseek-v4-flash",
+        current_base_url="https://litellm-proxy.example.com/v1",
+        current_api_key="sk-litellm-key",
+        is_global=False,
+        explicit_provider="",
+    )
+    defaults.update(extra)
+
+    def fake_list_provider_models(provider: str):
+        if provider == "litellm":
+            return list(_LITELLM_LIVE)
+        return []
+
+    fake_config = {
+        "model": {
+            "provider": "litellm",
+            "base_url": "https://litellm-proxy.example.com/v1",
+            "default": "deepseek-v4-flash",
+        }
+    }
+
+    with (
+        patch(
+            "hermes_cli.model_switch.list_provider_models",
+            side_effect=fake_list_provider_models,
+        ),
+        patch(
+            "hermes_cli.config.load_config",
+            return_value=fake_config,
+        ),
+    ):
+        return switch_model(raw_input=raw_input, **defaults)
+
+
+def test_proxy_provider_keeps_current_when_model_in_catalog():
+    """#71324: /model deepseek-v4-pro on litellm with base_url should
+    stay on litellm, not switch to native deepseek."""
+    result = _run_switch_on_litellm("deepseek-v4-pro")
+    assert result.target_provider == "litellm", (
+        f"Expected litellm, got {result.target_provider}. "
+        f"Proxy provider's live catalog was not checked."
+    )
+    assert result.new_model == "deepseek-v4-pro"
+
+
+def test_proxy_provider_falls_through_when_model_not_in_catalog():
+    """When the proxy's catalog doesn't have the model, fall through to
+    static detection."""
+    result = _run_switch_on_litellm("claude-opus-4-5-20251101")
+    # Falls through to detect_provider_for_model
+    assert result.target_provider != "litellm"
+
+
+def test_proxy_provider_without_base_url_falls_through():
+    """When configured provider has no base_url, Case B is skipped."""
+    defaults = dict(
+        current_provider="litellm",
+        current_model="deepseek-v4-flash",
+        current_base_url="https://litellm-proxy.example.com/v1",
+        current_api_key="sk-litellm-key",
+        is_global=False,
+        explicit_provider="",
+    )
+
+    def fake_list_provider_models(provider: str):
+        if provider == "litellm":
+            return list(_LITELLM_LIVE)
+        return []
+
+    fake_config = {
+        "model": {
+            "provider": "litellm",
+            # no base_url — Case B not triggered
+            "default": "deepseek-v4-flash",
+        }
+    }
+
+    with (
+        patch(
+            "hermes_cli.model_switch.list_provider_models",
+            side_effect=fake_list_provider_models,
+        ),
+        patch(
+            "hermes_cli.config.load_config",
+            return_value=fake_config,
+        ),
+    ):
+        result = switch_model(raw_input="deepseek-v4-pro", **defaults)
+
+    # Falls through to static detection → native deepseek
+    assert result.target_provider == "deepseek"

--- a/tests/hermes_cli/test_model_switch_configured_provider.py
+++ b/tests/hermes_cli/test_model_switch_configured_provider.py
@@ -165,37 +165,31 @@ def test_explicit_provider_bypasses_configured_check():
 # ── Case B: proxy provider with base_url (litellm, etc.) ──────────────
 
 
-_LITELLM_LIVE = [
-    "deepseek-v4-pro", "deepseek-v4-flash",
-    "gemma4-unsloth", "moonshot/kimi-k2.6",
-]
-
-
-def _run_switch_on_litellm(raw_input: str, **extra):
-    """Call switch_model with litellm as the current provider, mocking a
-    proxy endpoint whose /v1/models returns models like deepseek-v4-pro."""
+def _run_switch_on_litellm(raw_input: str, with_base_url: bool = True, **extra):
+    """Call switch_model with litellm as current provider, mocking
+    list_provider_models to return [] (litellm is unknown to models.dev)
+    so _unknown_proxy = True → is_custom = True → Step e skipped."""
     defaults = dict(
         current_provider="litellm",
         current_model="deepseek-v4-flash",
         current_base_url="https://litellm-proxy.example.com/v1",
-        current_api_key="sk-litellm-key",
+        current_api_key="***",
         is_global=False,
         explicit_provider="",
     )
     defaults.update(extra)
 
     def fake_list_provider_models(provider: str):
-        if provider == "litellm":
-            return list(_LITELLM_LIVE)
-        return []
+        return []  # litellm unknown to models.dev
 
     fake_config = {
         "model": {
             "provider": "litellm",
-            "base_url": "https://litellm-proxy.example.com/v1",
             "default": "deepseek-v4-flash",
         }
     }
+    if with_base_url:
+        fake_config["model"]["base_url"] = "https://litellm-proxy.example.com/v1"
 
     with (
         patch(
@@ -210,60 +204,19 @@ def _run_switch_on_litellm(raw_input: str, **extra):
         return switch_model(raw_input=raw_input, **defaults)
 
 
-def test_proxy_provider_keeps_current_when_model_in_catalog():
-    """#71324: /model deepseek-v4-pro on litellm with base_url should
-    stay on litellm, not switch to native deepseek."""
-    result = _run_switch_on_litellm("deepseek-v4-pro")
+def test_proxy_provider_keeps_current_when_base_url_set():
+    """#71324: litellm with base_url → _unknown_proxy=True → is_custom=True
+    → Step e skipped → provider stays on litellm."""
+    result = _run_switch_on_litellm("deepseek-v4-pro", with_base_url=True)
     assert result.target_provider == "litellm", (
         f"Expected litellm, got {result.target_provider}. "
-        f"Proxy provider's live catalog was not checked."
+        f"Proxy with base_url was not treated as custom."
     )
     assert result.new_model == "deepseek-v4-pro"
 
 
-def test_proxy_provider_falls_through_when_model_not_in_catalog():
-    """When the proxy's catalog doesn't have the model, fall through to
-    static detection."""
-    result = _run_switch_on_litellm("claude-opus-4-5-20251101")
-    # Falls through to detect_provider_for_model
-    assert result.target_provider != "litellm"
-
-
-def test_proxy_provider_without_base_url_falls_through():
-    """When configured provider has no base_url, Case B is skipped."""
-    defaults = dict(
-        current_provider="litellm",
-        current_model="deepseek-v4-flash",
-        current_base_url="https://litellm-proxy.example.com/v1",
-        current_api_key="sk-litellm-key",
-        is_global=False,
-        explicit_provider="",
-    )
-
-    def fake_list_provider_models(provider: str):
-        if provider == "litellm":
-            return list(_LITELLM_LIVE)
-        return []
-
-    fake_config = {
-        "model": {
-            "provider": "litellm",
-            # no base_url — Case B not triggered
-            "default": "deepseek-v4-flash",
-        }
-    }
-
-    with (
-        patch(
-            "hermes_cli.model_switch.list_provider_models",
-            side_effect=fake_list_provider_models,
-        ),
-        patch(
-            "hermes_cli.config.load_config",
-            return_value=fake_config,
-        ),
-    ):
-        result = switch_model(raw_input="deepseek-v4-pro", **defaults)
-
-    # Falls through to static detection → native deepseek
+def test_proxy_provider_without_base_url_switches():
+    """litellm without base_url → _unknown_proxy=False → falls through
+    to detect_provider_for_model → native deepseek."""
+    result = _run_switch_on_litellm("deepseek-v4-pro", with_base_url=False)
     assert result.target_provider == "deepseek"


### PR DESCRIPTION
## What does this PR do?

Two changes in `switch_model()` to prevent model names from being hijacked by static native-provider catalogs:

### 1. Step d2: Configured aggregator fallback (#48731, @alt-glitch)
When `config.yaml` specifies a different aggregator as the default provider (e.g. `model.provider: opencode-go`) but the current session is on a different provider, check the configured aggregator's live catalog before falling to static detection.

### 2. Step e: Proxy provider guard (#71324)
When the current provider has a `base_url` configured but is **unknown to models.dev** (no static catalog entry — i.e. a proxy like litellm), treat it as a custom provider. This prevents `detect_provider_for_model()` from switching to the native provider based on static catalog matches.

**ponytail:** 2 lines (`_unknown_proxy` + `is_custom` guard) instead of an 80-line catalog check. Also avoids the broken assumption that `list_provider_models()` returns anything for unknown providers.

## Related Issues
- #71324 (proxy-only gap)
- #48731 (aggregator fallback)

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `hermes_cli/model_switch.py`: +2 lines in `is_custom` check, keep Step d2 from #48744
- `tests/hermes_cli/test_model_switch_configured_provider.py`: 2 tests for proxy provider behavior