### PR TITLE
fix(moa): default reference_timeout to 180s instead of inheriting 900s (#71243)

### DIFF
--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -21,7 +21,7 @@ DEFAULT_MOA_AGGREGATOR: dict[str, str] = {
     "model": "anthropic/claude-opus-4.8",
 }
 
-DEFAULT_MOA_REFERENCE_TIMEOUT: float | None = None
+DEFAULT_MOA_REFERENCE_TIMEOUT: float | None = 180.0
 
 
 def _default_reference_models() -> list[dict[str, Any]]:
@@ -47,12 +47,14 @@ def _coerce_float_or_none(value: Any) -> float | None:
 def _coerce_reference_timeout(value: Any) -> float | None:
     """Return a finite positive advisor timeout, or None to inherit.
 
-    ``None`` (the default) means "no per-preset override": the reference
-    fan-out inherits the ``auxiliary.moa_reference.timeout`` config value
-    (900s by default) via ``call_llm``'s own resolution, exactly like every
-    other auxiliary task. An explicit finite positive per-preset value is
-    honored as-is — no artificial cap, since long-thinking advisor models
-    legitimately run far beyond five minutes.
+    ``None`` means "no per-preset override": the reference fan-out inherits
+    the ``auxiliary.moa_reference.timeout`` config value via ``call_llm``'s
+    own resolution, exactly like every other auxiliary task.  The module
+    default is **180 s** (down from the inherited 900 s) so that a stuck
+    advisor degrades in a bounded window instead of hanging for 15 minutes
+    (#71243).  An explicit finite positive per-preset value is honored
+    as-is — no artificial cap, since long-thinking advisor models
+    legitimately run far beyond three minutes.
     """
     if value is None or value == "" or isinstance(value, bool):
         return DEFAULT_MOA_REFERENCE_TIMEOUT

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -761,8 +761,8 @@ def test_reference_failure_controls_are_normalized_per_preset_and_flattened():
 
 @pytest.mark.parametrize("value", [None, "", 0, -1, "bad"])
 def test_reference_timeout_invalid_values_fall_back_to_default(value):
-    # None = inherit auxiliary.moa_reference.timeout (no per-preset override).
-    assert resolve_moa_preset(_preset(reference_timeout=value), "p")["reference_timeout"] is None
+    # Invalid/blank values fall back to DEFAULT_MOA_REFERENCE_TIMEOUT (180 s).
+    assert resolve_moa_preset(_preset(reference_timeout=value), "p")["reference_timeout"] == 180.0
 
 
 def test_reference_timeout_is_uncapped_and_unknown_policy_is_loud():


### PR DESCRIPTION
## Problem

MoA reference fan-out inherited `auxiliary.moa_reference.timeout` (900 s) when no per-preset `reference_timeout` was set. A stuck advisor — e.g. a reasoning model with no `reasoning_effort` pin — would hang for **15 minutes** with zero UI feedback before degrading. The user's only signal was a blank screen, leading them to Ctrl+C and lose the turn.

## Fix

Change `DEFAULT_MOA_REFERENCE_TIMEOUT` from `None` (inherit 900 s) to `180.0` (3 minutes). A stuck advisor now degrades in a bounded window instead of hanging for 15 minutes.

- Users who need longer can still set `reference_timeout` explicitly on their preset
- The `_coerce_reference_timeout` docstring is updated to reflect the new default
- Test updated to match new default value

## Testing

```
uv run python -m pytest tests/hermes_cli/test_moa_config.py::test_reference_timeout_invalid_values_fall_back_to_default -x
# 5 passed
```

Fixes #71243