### PR TITLE
fix(wecom): omit body from heartbeat ping (#71337)

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -415,7 +415,6 @@ class WeComAdapter(BasePlatformAdapter):
                         {
                             "cmd": APP_CMD_PING,
                             "headers": {"req_id": self._new_req_id("ping")},
-                            "body": {},
                         }
                     )
                 except Exception as exc:

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -62,6 +62,30 @@ class TestWeComConnect:
         assert "invalid secret" in (adapter.fatal_error_message or "")
 
 
+class TestWeComHeartbeat:
+    @pytest.mark.asyncio
+    async def test_ping_omits_body_field(self, monkeypatch):
+        import plugins.platforms.wecom.adapter as wecom_module
+        from plugins.platforms.wecom.adapter import APP_CMD_PING, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=False)
+
+        async def capture_once(_payload):
+            adapter._running = False
+
+        adapter._send_json = AsyncMock(side_effect=capture_once)
+        monkeypatch.setattr(wecom_module.asyncio, "sleep", AsyncMock())
+
+        await adapter._heartbeat_loop()
+
+        payload = adapter._send_json.await_args.args[0]
+        assert payload["cmd"] == APP_CMD_PING
+        assert payload["headers"]["req_id"].startswith("ping-")
+        assert "body" not in payload
+
+
 class TestWeComQrScan:
     @patch("plugins.platforms.wecom.adapter.time")
     @patch("plugins.platforms.wecom.adapter.json.loads")


### PR DESCRIPTION
## Summary

Fixes #71337 by aligning Hermes' application-level heartbeat payload with
the WeComTeam reference SDK implementations.

Hermes currently sends:

```json
{
  "cmd": "ping",
  "headers": {"req_id": "..."},
  "body": {}
}
```

The WeComTeam reference SDKs send the heartbeat with only `cmd` and
`headers`:

- Node.js SDK: the documented format and implementation omit `body`
  ([source, lines 337-363](https://github.com/WecomTeam/aibot-node-sdk/blob/80615b987ef69c6028ad764924609247c0725955/src/ws.ts#L337-L363)).
- Python SDK: the independent implementation uses the same two-field
  payload
  ([source, lines 304-328](https://github.com/WecomTeam/wecom-aibot-python-sdk/blob/6bcb59a9a636c566f4c6ea5268b228e3def1611a/aibot/ws.py#L304-L328)).

This change removes the extra empty `body` field and adds a regression test
for the emitted payload shape.

## Change

- omit the empty `body` field from application-level ping frames
- add a focused regression test that verifies:
  - `cmd == APP_CMD_PING`
  - the generated `headers.req_id` uses the `ping-` prefix
  - the emitted wire payload does not contain `body`

## Verification boundary

The linked issue reports that connections carrying the extra empty `body`
are disconnected after approximately 300 seconds. That timing has not been
independently reproduced against a live WeCom tenant as part of this PR.

The automated coverage in this PR verifies the narrower, deterministic
claim: Hermes now emits the same heartbeat field set as the WeComTeam
Node.js and Python reference SDKs. The approximately 300-second operational
observation remains report-derived.

## Testing

- `scripts/run_tests.sh tests/gateway/test_wecom.py` — 50 passed
- `.venv/bin/ruff check plugins/platforms/wecom/adapter.py tests/gateway/test_wecom.py`
- GitHub Actions on the current head — all required checks passed
