### PR TITLE
fix(desktop): route messaging API calls through active profile backend

### DIFF
--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1114,6 +1114,7 @@ export function grantComputerUsePermissions(): Promise<ActionResponse> {
 
 export function getMessagingPlatforms(): Promise<MessagingPlatformsResponse> {
   return window.hermesDesktop.api<MessagingPlatformsResponse>({
+    ...profileScoped(),
     path: '/api/messaging/platforms'
   })
 }
@@ -1123,6 +1124,7 @@ export function updateMessagingPlatform(
   body: MessagingPlatformUpdate
 ): Promise<{ ok: boolean; platform: string }> {
   return window.hermesDesktop.api<{ ok: boolean; platform: string }>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}`,
     method: 'PUT',
     body
@@ -1131,6 +1133,7 @@ export function updateMessagingPlatform(
 
 export function testMessagingPlatform(platformId: string): Promise<MessagingPlatformTestResponse> {
   return window.hermesDesktop.api<MessagingPlatformTestResponse>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}/test`,
     method: 'POST'
   })


### PR DESCRIPTION
## Summary

- `getMessagingPlatforms`, `updateMessagingPlatform`, and `testMessagingPlatform` in `apps/desktop/src/hermes.ts` were missing `...profileScoped()`, unlike the equivalent webhook functions which already have it
- Without the profile field, the Electron `hermes:api` IPC handler (main.ts line 9514) routes every Messaging settings request to the primary (default-profile) backend
- The default backend has no named-profile gateway running → returns `gateway_running: false` → Messaging panel shows **"Messaging gateway stopped"** even when the named-profile gateway is fully connected and responding

## Reproduction

1. Create a named profile (e.g. `agent_touchdesigner`) with Telegram configured
2. Start the Telegram gateway for that profile — confirm the bot responds to messages
3. In the Desktop UI, switch to that profile's tab
4. Navigate to **Messaging** settings
5. ❌ Shows "Messaging gateway stopped" despite the bot working

## Fix

Add `...profileScoped()` to the three affected functions so the IPC request carries `profile: "<name>"` and Electron routes it to the correct pool backend.

```diff
 export function getMessagingPlatforms(): Promise<MessagingPlatformsResponse> {
   return window.hermesDesktop.api<MessagingPlatformsResponse>({
+    ...profileScoped(),
     path: '/api/messaging/platforms'
   })
 }

 export function updateMessagingPlatform(...) {
   return window.hermesDesktop.api<...>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}`,
     ...
   })
 }

 export function testMessagingPlatform(platformId: string) {
   return window.hermesDesktop.api<MessagingPlatformTestResponse>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}/test`,
     ...
   })
 }
```

## Test plan

- [ ] Named profile with Telegram gateway running → Messaging settings shows "Connected" ✅
- [ ] Default profile (no gateway) → Messaging settings shows gateway not running ✅
- [ ] `updateMessagingPlatform` saves env vars to the correct profile backend ✅
- [ ] `testMessagingPlatform` tests against the correct profile backend ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)