### PR TITLE
feat(federated): K-way aggregation, health checks, and re-rank prompt

### DIFF
--- a/plugins/web/federated/__init__.py
+++ b/plugins/web/federated/__init__.py
@@ -1,0 +1,15 @@
+"""Federated search plugin — bundled, auto-loaded.
+
+Aggregates search results from multiple configured sub-backends and uses an
+LLM to rank them by relevance. Configuration lives under ``web.federated``
+in config.yaml.
+"""
+
+from __future__ import annotations
+
+from plugins.web.federated.provider import FederatedSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the federated search provider with the plugin context."""
+    ctx.register_web_search_provider(FederatedSearchProvider())

--- a/plugins/web/federated/plugin.yaml
+++ b/plugins/web/federated/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-federated
+version: 1.0.0
+description: "Federated search — aggregate results from multiple search backends (Tavily, SearXNG, custom HTTP endpoints, etc.) with LLM-based relevance ranking. Configure sub-backends under web.federated.backends."
+author: Hermes Agent Contributors
+kind: backend
+provides_web_providers:
+  - federated

--- a/plugins/web/federated/provider.py
+++ b/plugins/web/federated/provider.py
@@ -1,0 +1,468 @@
+"""
+Federated search provider — aggregate results from multiple search backends
+with LLM-based relevance ranking.
+
+Configuration in config.yaml::
+
+    web:
+      search_backend: federated
+      federated:
+        timeout: 10                  # seconds to wait for all backends (config item 1)
+        max_results: 8               # top N results after ranking (config item 3)
+        ranker:                      # LLM for relevance ranking (config item 2)
+                                     # Note: LLM providers may have concurrency limits.
+                                     # When the ranking LLM fails (timeout, rate limit, etc.)
+                                     # the plugin automatically falls back to NONE mode
+                                     # (keyword-based scoring, no LLM call).
+                                     # For best results, use a non-main-model provider
+                                     # or one with higher concurrency limits.
+          provider: opencode-go
+          model: deepseek-v4-flash
+        backends:
+          - name: tavily             # use an existing registered provider
+          - name: minimax            # custom HTTP backend
+            type: custom
+            base_url: "https://api.minimaxi.com"
+            api_key_env: MINIMAX_CN_API_KEY
+            search_path: /v1/coding_plan/search
+            query_param: "q"
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DEFAULT_TIMEOUT = 10
+_DEFAULT_MAX_RESULTS = 8
+_CUSTOM_BACKEND_TIMEOUT = 15
+_CUSTOM_BACKEND_MAX_RESULTS = 10
+_SKIP_RANK_IF = 3
+_MAX_RANK_INPUT = 10
+_RANK_TIMEOUT = 20
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_config() -> Optional[Dict[str, Any]]:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        web = cfg.get("web", {})
+        if not isinstance(web, dict):
+            return None
+        return web.get("federated")
+    except Exception:
+        return None
+
+
+def _get_registered_provider(name: str) -> Optional[WebSearchProvider]:
+    try:
+        from agent.web_search_registry import get_provider
+        return get_provider(name)
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# LLM ranking & keyword ranking
+# ---------------------------------------------------------------------------
+
+
+def _keyword_rank(
+    query: str,
+    results: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Rank results by keyword match frequency in title + description.
+
+    Fast, no LLM needed. De-duplicates by URL.
+    """
+    seen_urls = set()
+    deduped = []
+    for r in results:
+        url = r.get("url", "")
+        if url and url not in seen_urls:
+            seen_urls.add(url)
+            deduped.append(r)
+
+    terms = query.lower().split()
+    def _score(r):
+        title = (r.get("title", "") or "").lower()
+        desc = (r.get("description", "") or "").lower()
+        return sum(1 for t in terms if t in title or t in desc)
+
+    deduped.sort(key=_score, reverse=True)
+    return deduped
+
+
+def _rank_results(
+    query: str,
+    results: List[Dict[str, Any]],
+    ranker_config: Optional[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Rank search results by relevance to *query*.
+
+    Ranking mode is selected by the ``provider`` field in *ranker_config*:
+
+    - ``"none"`` / unset / empty → keyword match scoring (fast, no LLM).
+    - ``"auto"`` or a real provider name → LLM-based ranking.
+      On LLM failure (timeout, rate limit, concurrency limit) the function
+      automatically falls back to keyword (``none``) ranking.
+      **Recommendation**: use a non-main-model provider or one with higher
+      concurrency limits to avoid ranking failures degrading search quality.
+
+    Optimizations:
+    - Skip LLM ranking when <= _SKIP_RANK_IF results.
+    - Truncate titles to 60 chars, descriptions to 80 chars.
+    - Hard timeout via _RANK_TIMEOUT.
+    """
+    if not results or len(results) <= _SKIP_RANK_IF:
+        return results
+
+    provider = (ranker_config or {}).get("provider") or ""
+    model = (ranker_config or {}).get("model") or ""
+
+    # "none" → keyword ranking, no LLM
+    if not provider or provider == "none":
+        return _keyword_rank(query, results)
+
+    # ── LLM-based ranking ──
+    try:
+        from agent.auxiliary_client import call_llm
+
+        lines = []
+        for i, r in enumerate(results):
+            title = (r.get("title", "") or "")[:60]
+            desc = (r.get("description", "") or "")[:80]
+            lines.append(f"[{i + 1}] {title}\n{desc}")
+        results_text = "\n".join(lines)
+
+        sys = (
+            "You rank search results by relevance. Rules:\n"
+            "- Return ONLY a JSON array of result indices ranked by relevance, e.g. [3,1,5,2,4]\n"
+            "- Include ALL results. Most relevant first.\n"
+            "- No other text."
+        )
+        user = f"Query: {query}\n\nResults:\n{results_text}\n\nRanked indices:"
+
+        logger.info(
+            "LLM ranking %d results (provider=%s, model=%s)",
+            len(results), provider or "auto", model or "auto",
+        )
+
+        response = call_llm(
+            task="web_extract",
+            provider=provider or None,
+            model=model or None,
+            messages=[{"role": "system", "content": sys}, {"role": "user", "content": user}],
+            temperature=0,
+            max_tokens=128,
+            timeout=_RANK_TIMEOUT,
+        )
+
+        raw = (response.choices[0].message.content or "").strip()
+        import json, re
+
+        match = re.search(r"\[[\d\s,,\]]+\]", raw)
+        if match:
+            indices = json.loads(match.group())
+            if isinstance(indices, list):
+                ranked, seen = [], set()
+                for idx in indices:
+                    pos = int(idx) - 1
+                    if 0 <= pos < len(results) and pos not in seen:
+                        ranked.append(results[pos])
+                        seen.add(pos)
+                for i, r in enumerate(results):
+                    if i not in seen:
+                        ranked.append(r)
+                return ranked
+
+        logger.warning("LLM ranking unparseable, falling back to keyword ranking")
+    except Exception as exc:
+        logger.warning("LLM ranking failed (%s), falling back to keyword ranking", exc)
+
+    return _keyword_rank(query, results)
+
+
+# ---------------------------------------------------------------------------
+# Custom HTTP backend search
+# ---------------------------------------------------------------------------
+
+
+def _search_custom_backend(
+    backend_config: Dict[str, Any],
+    query: str,
+    limit: int,
+) -> List[Dict[str, Any]]:
+    """Execute a search against a custom HTTP endpoint.
+
+    Config keys: base_url, api_key_env, search_path, query_param (default ``q``),
+    auth_style (``bearer`` or ``x-api-key``, default ``bearer``).
+    """
+    import httpx
+
+    base_url = (backend_config.get("base_url") or "").rstrip("/")
+    api_key_env = backend_config.get("api_key_env", "")
+    search_path = backend_config.get("search_path", "/v1/coding_plan/search")
+    query_param = backend_config.get("query_param", "q")
+    auth_style = backend_config.get("auth_style", "bearer")
+    api_key = os.environ.get(api_key_env, "") if api_key_env else ""
+
+    if not base_url or not api_key:
+        return []
+
+    url = f"{base_url}{search_path}"
+    if auth_style == "x-api-key":
+        headers = {"Content-Type": "application/json", "x-api-key": api_key}
+    else:
+        headers = {"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"}
+
+    payload = {query_param: query, "max_results": min(limit, _CUSTOM_BACKEND_MAX_RESULTS)}
+
+    try:
+        resp = httpx.post(url, json=payload, headers=headers, timeout=_CUSTOM_BACKEND_TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+        results = _extract_custom_results(data)
+        if not results:
+            logger.warning("Custom backend returned no parseable results")
+        return results
+    except httpx.TimeoutException:
+        logger.warning("Custom backend timed out: %s", url)
+    except httpx.HTTPStatusError as exc:
+        logger.warning("Custom backend HTTP error: %s (%s)", exc, exc.response.text[:200])
+    except Exception as exc:
+        logger.warning("Custom backend failed: %s", exc)
+    return []
+
+
+def _extract_custom_results(data: Any) -> List[Dict[str, Any]]:
+    """Extract search results from various API response shapes."""
+    if not isinstance(data, dict):
+        return []
+
+    results: List[Dict[str, Any]] = []
+
+    # {organic: [{title, link, snippet, date}, ...]}
+    organic = data.get("organic")
+    if isinstance(organic, list):
+        for item in organic:
+            if isinstance(item, dict):
+                results.append({
+                    "title": str(item.get("title", "") or ""),
+                    "url": str(item.get("link", "") or item.get("url", "") or ""),
+                    "description": str(item.get("snippet", "") or item.get("content", "") or ""),
+                    "position": len(results) + 1,
+                })
+        if results:
+            return results
+
+    # {data: {web: [...]}}
+    web_data = data.get("data")
+    if isinstance(web_data, dict):
+        web_list = web_data.get("web")
+        if isinstance(web_list, list):
+            for item in web_list:
+                if isinstance(item, dict):
+                    results.append({
+                        "title": str(item.get("title", "") or ""),
+                        "url": str(item.get("url", "") or ""),
+                        "description": str(item.get("description", "") or item.get("content", "") or ""),
+                        "position": len(results) + 1,
+                    })
+            if results:
+                return results
+
+    # {results: [{...}]}
+    raw = data.get("results")
+    if isinstance(raw, list):
+        for item in raw:
+            if isinstance(item, dict):
+                results.append({
+                    "title": str(item.get("title", "") or ""),
+                    "url": str(item.get("url", "") or item.get("link", "") or ""),
+                    "description": str(item.get("content", "") or item.get("snippet", "") or ""),
+                    "position": len(results) + 1,
+                })
+        if results:
+            return results
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Per-backend worker (used by ThreadPoolExecutor)
+# ---------------------------------------------------------------------------
+
+
+def _search_one_backend(backend: Dict[str, Any], query: str, limit: int) -> List[Dict[str, Any]]:
+    """Single-backend search worker for thread-pool execution."""
+    name = str(backend.get("name", "?"))
+    typ = str(backend.get("type", "") or "")
+
+    try:
+        if typ == "custom":
+            results = _search_custom_backend(backend, query, limit)
+        else:
+            provider = _get_registered_provider(name)
+            if provider is None:
+                logger.warning("Backend '%s' not registered, skipping", name)
+                return []
+            resp = provider.search(query, limit=limit)
+            if isinstance(resp, dict) and resp.get("success"):
+                data = resp.get("data", {})
+                items = data.get("web", []) if isinstance(data, dict) else []
+                results = [
+                    {"title": str(r.get("title", "") or ""),
+                     "url": str(r.get("url", "") or ""),
+                     "description": str(r.get("description", "") or ""),
+                     "position": i + 1}
+                    for i, r in enumerate(items) if isinstance(r, dict)
+                ]
+            else:
+                err = resp.get("error", "unknown") if isinstance(resp, dict) else "unknown"
+                logger.warning("Backend '%s' failed: %s", name, err)
+                return []
+        logger.info("Backend '%s' returned %d results", name, len(results))
+        return results
+    except Exception as exc:
+        logger.warning("Backend '%s' error: %s", name, exc)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class FederatedSearchProvider(WebSearchProvider):
+    """Aggregated search provider that fans out to multiple sub-backends."""
+
+    @property
+    def name(self) -> str:
+        return "federated"
+
+    @property
+    def display_name(self) -> str:
+        return "Federated Search"
+
+    def is_available(self) -> bool:
+        config = _read_config()
+        if not config:
+            return False
+        backends = config.get("backends")
+        return isinstance(backends, list) and len(backends) > 0
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        try:
+            from tools.interrupt import is_interrupted
+            if is_interrupted():
+                return {"success": False, "error": "Interrupted"}
+
+            config = _read_config()
+            if not config:
+                return {"success": False, "error": "federated search not configured"}
+
+            backends = config.get("backends", [])
+            if not isinstance(backends, list) or not backends:
+                return {"success": False, "error": "no search backends configured"}
+
+            timeout = int(config.get("timeout", _DEFAULT_TIMEOUT))
+            max_results = int(config.get("max_results", _DEFAULT_MAX_RESULTS))
+            ranker_config = config.get("ranker")
+
+            logger.info(
+                "Federated search: '%s' (%d backends, timeout=%ds, max_results=%d)",
+                query, len(backends), timeout, max_results,
+            )
+
+            # ---------- parallel backend execution ----------
+            all_results: List[Dict[str, Any]] = []
+            errors: List[str] = []
+            deadline = time.time() + timeout
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=len(backends)) as pool:
+                futures = {pool.submit(_search_one_backend, b, query, limit): b for b in backends}
+
+                for future in concurrent.futures.as_completed(futures, timeout=timeout):
+                    if time.time() >= deadline or is_interrupted():
+                        # Cancel remaining futures
+                        for f in futures:
+                            f.cancel()
+                        break
+                    try:
+                        results = future.result(timeout=2)
+                        all_results.extend(results)
+                    except concurrent.futures.TimeoutError:
+                        b = futures[future]
+                        errors.append(f"backend '{b.get('name','?')}' timed out")
+                    except Exception as exc:
+                        b = futures[future]
+                        errors.append(f"backend '{b.get('name','?')}' failed: {exc}")
+
+            if not all_results:
+                if errors:
+                    return {"success": False, "error": "All backends failed: " + "; ".join(errors)}
+                return {"success": True, "data": {"web": []}}
+
+            # ---------- ranking ----------
+            # _rank_results handles all modes internally:
+            # - provider: none / empty → keyword scoring (fast)
+            # - provider: <real>      → LLM, falls back to keyword on failure
+            rank_input = all_results[:_MAX_RANK_INPUT]
+            ranked = _rank_results(query, rank_input, ranker_config)
+
+            # Top N
+            top = ranked[:max_results]
+            for i, r in enumerate(top):
+                r["position"] = i + 1
+
+            logger.info(
+                "Federated search: %d raw -> %d ranked (total %.1fs)",
+                len(all_results), len(top), time.time() - (time.time() - 20),
+            )
+
+            return {
+                "success": True,
+                "data": {
+                    "web": [
+                        {"title": r.get("title", ""), "url": r.get("url", ""),
+                         "description": r.get("description", ""), "position": r.get("position", i + 1)}
+                        for i, r in enumerate(top)
+                    ],
+                },
+            }
+
+        except Exception as exc:
+            logger.error("Federated search error: %s", exc)
+            return {"success": False, "error": f"Federated search failed: {exc}"}
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Federated Search",
+            "badge": "advanced",
+            "tag": (
+                "Aggregate multiple search backends with LLM-based ranking. "
+                "Configure backends under web.federated.backends in config.yaml."
+            ),
+            "env_vars": [],
+        }

--- a/plugins/web/federated/provider.py
+++ b/plugins/web/federated/provider.py
@@ -399,25 +399,36 @@ class FederatedSearchProvider(WebSearchProvider):
             all_results: List[Dict[str, Any]] = []
             errors: List[str] = []
             deadline = time.time() + timeout
+            start_time = time.time()
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=len(backends)) as pool:
                 futures = {pool.submit(_search_one_backend, b, query, limit): b for b in backends}
 
-                for future in concurrent.futures.as_completed(futures, timeout=timeout):
-                    if time.time() >= deadline or is_interrupted():
-                        # Cancel remaining futures
-                        for f in futures:
-                            f.cancel()
-                        break
-                    try:
-                        results = future.result(timeout=2)
-                        all_results.extend(results)
-                    except concurrent.futures.TimeoutError:
-                        b = futures[future]
-                        errors.append(f"backend '{b.get('name','?')}' timed out")
-                    except Exception as exc:
-                        b = futures[future]
-                        errors.append(f"backend '{b.get('name','?')}' failed: {exc}")
+                try:
+                    for future in concurrent.futures.as_completed(futures, timeout=timeout):
+                        if time.time() >= deadline or is_interrupted():
+                            for f in futures:
+                                f.cancel()
+                            break
+                        try:
+                            results = future.result(timeout=2)
+                            all_results.extend(results)
+                        except concurrent.futures.TimeoutError:
+                            b = futures[future]
+                            errors.append(f"backend '{b.get('name','?')}' timed out")
+                        except Exception as exc:
+                            b = futures[future]
+                            errors.append(f"backend '{b.get('name','?')}' failed: {exc}")
+                except concurrent.futures.TimeoutError:
+                    logger.warning(
+                        "Federated search timed out after %ds, collecting partial "
+                        "results from %d/%d backends",
+                        timeout,
+                        sum(1 for f in futures if f.done()),
+                        len(futures),
+                    )
+                    for f in futures:
+                        f.cancel()
 
             if not all_results:
                 if errors:
@@ -428,7 +439,8 @@ class FederatedSearchProvider(WebSearchProvider):
             # _rank_results handles all modes internally:
             # - provider: none / empty → keyword scoring (fast)
             # - provider: <real>      → LLM, falls back to keyword on failure
-            rank_input = all_results[:_MAX_RANK_INPUT]
+            rank_input_count = max(max_results + 5, _MAX_RANK_INPUT)
+            rank_input = all_results[:rank_input_count]
             ranked = _rank_results(query, rank_input, ranker_config)
 
             # Top N
@@ -438,7 +450,7 @@ class FederatedSearchProvider(WebSearchProvider):
 
             logger.info(
                 "Federated search: %d raw -> %d ranked (total %.1fs)",
-                len(all_results), len(top), time.time() - (time.time() - 20),
+                len(all_results), len(top), time.time() - start_time,
             )
 
             return {

--- a/plugins/web/federated/provider.py
+++ b/plugins/web/federated/provider.py
@@ -58,10 +58,20 @@ _RANK_TIMEOUT = 20
 
 
 def _read_config() -> Optional[Dict[str, Any]]:
+    """Read the ``web.federated`` section from the raw config file.
+
+    Uses raw-YAML access rather than ``load_config()`` because the schema
+    validator strips unknown keys from the ``web`` section during loading.
+    """
     try:
-        from hermes_cli.config import load_config
-        cfg = load_config()
-        web = cfg.get("web", {})
+        from hermes_cli.config import get_config_path
+        import yaml
+        config_path = get_config_path()
+        if not config_path.exists():
+            return None
+        with open(config_path, encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+        web = cfg.get("web")
         if not isinstance(web, dict):
             return None
         return web.get("federated")
@@ -398,37 +408,41 @@ class FederatedSearchProvider(WebSearchProvider):
             # ---------- parallel backend execution ----------
             all_results: List[Dict[str, Any]] = []
             errors: List[str] = []
-            deadline = time.time() + timeout
             start_time = time.time()
 
-            with concurrent.futures.ThreadPoolExecutor(max_workers=len(backends)) as pool:
+            pool = concurrent.futures.ThreadPoolExecutor(max_workers=len(backends))
+            try:
                 futures = {pool.submit(_search_one_backend, b, query, limit): b for b in backends}
 
-                try:
-                    for future in concurrent.futures.as_completed(futures, timeout=timeout):
-                        if time.time() >= deadline or is_interrupted():
-                            for f in futures:
-                                f.cancel()
-                            break
-                        try:
-                            results = future.result(timeout=2)
-                            all_results.extend(results)
-                        except concurrent.futures.TimeoutError:
-                            b = futures[future]
-                            errors.append(f"backend '{b.get('name','?')}' timed out")
-                        except Exception as exc:
-                            b = futures[future]
-                            errors.append(f"backend '{b.get('name','?')}' failed: {exc}")
-                except concurrent.futures.TimeoutError:
+                done, not_done = concurrent.futures.wait(
+                    futures, timeout=timeout,
+                )
+
+                for f in not_done:
+                    b = futures[f]
+                    errors.append(f"backend '{b.get('name','?')}' timed out")
+                    f.cancel()
+
+                for f in done:
+                    if is_interrupted():
+                        break
+                    try:
+                        results = f.result(timeout=2)
+                        all_results.extend(results)
+                    except Exception as exc:
+                        b = futures[f]
+                        errors.append(f"backend '{b.get('name','?')}' failed: {exc}")
+
+                if not_done:
                     logger.warning(
-                        "Federated search timed out after %ds, collecting partial "
+                        "Federated search timed out after %ds, collected partial "
                         "results from %d/%d backends",
                         timeout,
-                        sum(1 for f in futures if f.done()),
+                        len(done),
                         len(futures),
                     )
-                    for f in futures:
-                        f.cancel()
+            finally:
+                pool.shutdown(wait=False)
 
             if not all_results:
                 if errors:
@@ -443,8 +457,10 @@ class FederatedSearchProvider(WebSearchProvider):
             rank_input = all_results[:rank_input_count]
             ranked = _rank_results(query, rank_input, ranker_config)
 
-            # Top N
-            top = ranked[:max_results]
+            # Top N — honour the caller's requested limit while respecting
+            # the configured max_results cap.
+            output_count = min(limit, max_results)
+            top = ranked[:output_count]
             for i, r in enumerate(top):
                 r["position"] = i + 1
 

--- a/plugins/web/federated/provider.py
+++ b/plugins/web/federated/provider.py
@@ -53,11 +53,10 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
-import os
 import time
 from typing import Any, Dict, List, Optional
 
-from agent.web_search_provider import WebSearchProvider
+from agent.web_search_provider import WebSearchProvider, get_provider_env
 
 logger = logging.getLogger(__name__)
 
@@ -389,11 +388,15 @@ def _search_custom_backend(
     backend_config: Dict[str, Any],
     query: str,
     limit: int,
-) -> List[Dict[str, Any]]:
+) -> tuple[List[Dict[str, Any]], Optional[int]]:
     """Execute a search against a custom HTTP endpoint.
 
     Config keys: base_url, api_key_env, search_path, query_param (default ``q``),
     auth_style (``bearer`` or ``x-api-key``, default ``bearer``).
+
+    Returns ``(results, status_code)`` where *status_code* is ``None`` on
+    success or non-HTTP errors, and the response status code on HTTP errors
+    so the caller can invoke health-cache cooldowns.
     """
     import httpx
 
@@ -402,10 +405,10 @@ def _search_custom_backend(
     search_path = backend_config.get("search_path", "/v1/coding_plan/search")
     query_param = backend_config.get("query_param", "q")
     auth_style = backend_config.get("auth_style", "bearer")
-    api_key = os.environ.get(api_key_env, "") if api_key_env else ""
+    api_key = get_provider_env(api_key_env) if api_key_env else ""
 
     if not base_url or not api_key:
-        return []
+        return [], None
 
     url = f"{base_url}{search_path}"
     if auth_style == "x-api-key":
@@ -422,14 +425,15 @@ def _search_custom_backend(
         results = _extract_custom_results(data)
         if not results:
             logger.warning("Custom backend returned no parseable results")
-        return results
+        return results, None
     except httpx.TimeoutException:
         logger.warning("Custom backend timed out: %s", url)
     except httpx.HTTPStatusError as exc:
         logger.warning("Custom backend HTTP error: %s (%s)", exc, exc.response.text[:200])
+        return [], exc.response.status_code
     except Exception as exc:
         logger.warning("Custom backend failed: %s", exc)
-    return []
+    return [], None
 
 
 def _extract_custom_results(data: Any) -> List[Dict[str, Any]]:
@@ -490,19 +494,24 @@ def _extract_custom_results(data: Any) -> List[Dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def _search_one_backend(backend: Dict[str, Any], query: str, limit: int) -> List[Dict[str, Any]]:
-    """Single-backend search worker for thread-pool execution."""
+def _search_one_backend(backend: Dict[str, Any], query: str, limit: int) -> tuple[List[Dict[str, Any]], Optional[int]]:
+    """Single-backend search worker for thread-pool execution.
+
+    Returns ``(results, status_code)``. *status_code* carries the HTTP status
+    for custom backends that fail with HTTP errors so the caller can invoke
+    health-cache cooldowns.
+    """
     name = str(backend.get("name", "?"))
     typ = str(backend.get("type", "") or "")
 
     try:
         if typ == "custom":
-            results = _search_custom_backend(backend, query, limit)
+            results, status_code = _search_custom_backend(backend, query, limit)
         else:
             provider = _get_registered_provider(name)
             if provider is None:
                 logger.warning("Backend '%s' not registered, skipping", name)
-                return []
+                return [], None
             resp = provider.search(query, limit=limit)
             if isinstance(resp, dict) and resp.get("success"):
                 data = resp.get("data", {})
@@ -517,12 +526,13 @@ def _search_one_backend(backend: Dict[str, Any], query: str, limit: int) -> List
             else:
                 err = resp.get("error", "unknown") if isinstance(resp, dict) else "unknown"
                 logger.warning("Backend '%s' failed: %s", name, err)
-                return []
+                return [], None
+            status_code = None
         logger.info("Backend '%s' returned %d results", name, len(results))
-        return results
+        return results, status_code
     except Exception as exc:
         logger.warning("Backend '%s' error: %s", name, exc)
-        return []
+        return [], None
 
 
 # ---------------------------------------------------------------------------
@@ -659,9 +669,13 @@ class FederatedSearchProvider(WebSearchProvider):
                     b = futures[f]
                     name = str(b.get("name", "?"))
                     try:
-                        results = f.result(timeout=2)
+                        results, status_code = f.result(timeout=2)
                         all_results.extend(results)
-                        backend_results[name] = (results, None)
+                        backend_results[name] = (results, status_code)
+                        # Wire real search failures into the health cache so
+                        # the documented 401/403/429 cooldown actually fires.
+                        if health_cache is not None and status_code is not None:
+                            health_cache.mark_failed(name, status_code)
                     except Exception as exc:
                         errors.append(f"backend '{name}' failed: {exc}")
                         backend_results[name] = ([], None)
@@ -681,7 +695,7 @@ class FederatedSearchProvider(WebSearchProvider):
                 if results
             ]
             required_failed = []
-            for b in active_backends:
+            for b in backends:
                 name = str(b.get("name", "?"))
                 if b.get("required", False) and name not in successful:
                     required_failed.append(name)

--- a/plugins/web/federated/provider.py
+++ b/plugins/web/federated/provider.py
@@ -7,25 +7,46 @@ Configuration in config.yaml::
     web:
       search_backend: federated
       federated:
-        timeout: 10                  # seconds to wait for all backends (config item 1)
-        max_results: 8               # top N results after ranking (config item 3)
-        ranker:                      # LLM for relevance ranking (config item 2)
+        timeout: 10                  # seconds to wait for all backends
+        max_results: 8               # top N results after ranking
+
+        # ── K-way aggregation ──
+        k: 3                         # exactly K backends required (max 32)
+        min_backends: 2              # at least N backends must succeed
+
+        # ── ranking ──
+        ranker:                      # LLM for relevance ranking
                                      # Note: LLM providers may have concurrency limits.
                                      # When the ranking LLM fails (timeout, rate limit, etc.)
-                                     # the plugin automatically falls back to NONE mode
-                                     # (keyword-based scoring, no LLM call).
+                                     # the plugin automatically falls back to keyword scoring.
                                      # For best results, use a non-main-model provider
                                      # or one with higher concurrency limits.
           provider: opencode-go
           model: deepseek-v4-flash
+          prompt: |                  # optional: custom ranking preferences
+            优先中文来源，优先官方文档
+
+        # ── health checks (cached, avoids per-search quota consumption) ──
+        health_check:
+          ttl_seconds: 300           # cache probe results for N seconds
+          timeout: 5                 # per-probe timeout
+
+        # ── K backends (exactly K) ──
         backends:
           - name: tavily             # use an existing registered provider
+            required: false
           - name: minimax            # custom HTTP backend
             type: custom
             base_url: "https://api.minimaxi.com"
             api_key_env: MINIMAX_CN_API_KEY
             search_path: /v1/coding_plan/search
             query_param: "q"
+            required: false
+          - name: searxng
+            type: custom
+            base_url: "https://search.example.com"
+            api_key_env: SEARXNG_API_KEY
+            required: true
 """
 
 from __future__ import annotations
@@ -51,6 +72,14 @@ _CUSTOM_BACKEND_MAX_RESULTS = 10
 _SKIP_RANK_IF = 3
 _MAX_RANK_INPUT = 10
 _RANK_TIMEOUT = 20
+
+# K-way aggregation
+_MAX_K = 32
+
+# Health check defaults
+_DEFAULT_HEALTH_TTL = 300
+_DEFAULT_HEALTH_TIMEOUT = 5
+
 
 # ---------------------------------------------------------------------------
 # Config helpers
@@ -85,6 +114,138 @@ def _get_registered_provider(name: str) -> Optional[WebSearchProvider]:
         return get_provider(name)
     except Exception:
         return None
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_config(config: Dict[str, Any]) -> Optional[str]:
+    """Validate federated search configuration. Returns error message or None.
+
+    Checks:
+    - k ≤ _MAX_K
+    - len(backends) == k
+    - 1 ≤ min_backends ≤ k
+    """
+    backends = config.get("backends", [])
+    if not isinstance(backends, list) or not backends:
+        return "no search backends configured"
+
+    k = int(config.get("k", len(backends)))
+    if k > _MAX_K:
+        return f"k={k} exceeds maximum {_MAX_K}"
+    if k < 1:
+        return f"k={k} must be at least 1"
+
+    if len(backends) != k:
+        return (
+            f"k={k} but {len(backends)} backend(s) configured — "
+            f"exactly {k} required"
+        )
+
+    min_backends = int(config.get("min_backends", 1))
+    if min_backends < 1:
+        return f"min_backends={min_backends} must be at least 1"
+    if min_backends > k:
+        return f"min_backends={min_backends} cannot exceed k={k}"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Health check cache
+# ---------------------------------------------------------------------------
+
+
+class _HealthCache:
+    """TTL-based cache for backend health probe results.
+
+    Avoids consuming provider quota on every search by caching HEAD probe
+    results for ``ttl_seconds``.  A real search failure (HTTP 401/403/429)
+    bypasses the cache and marks the backend unavailable for the configured
+    cooldown period.
+    """
+
+    def __init__(self, ttl_seconds: int = _DEFAULT_HEALTH_TTL):
+        self._ttl = ttl_seconds
+        self._cache: Dict[str, tuple[bool, float]] = {}
+        # Cooldown after real search failure: status_code → seconds
+        self._failure_cooldown: Dict[int, int] = {
+            401: 300,
+            403: 300,
+            429: 3600,
+        }
+
+    def is_available(self, backend_name: str) -> Optional[bool]:
+        """Return cached availability or None if cache miss."""
+        entry = self._cache.get(backend_name)
+        if entry is None:
+            return None
+        available, timestamp = entry
+        if time.time() - timestamp < self._ttl:
+            return available
+        # Expired — remove and return miss
+        del self._cache[backend_name]
+        return None
+
+    def set_available(self, backend_name: str, available: bool) -> None:
+        self._cache[backend_name] = (available, time.time())
+
+    def mark_failed(self, backend_name: str, status_code: int) -> None:
+        """Mark backend unavailable after a real search failure.
+
+        Uses a longer cooldown than the probe TTL — quota/billing failures
+        don't resolve in seconds.
+        """
+        cooldown = self._failure_cooldown.get(status_code, 300)
+        # Store with an artificial timestamp so the entry expires after
+        # cooldown seconds regardless of normal TTL.
+        self._cache[backend_name] = (False, time.time() - self._ttl + cooldown)
+
+
+# ---------------------------------------------------------------------------
+# Backend health probe
+# ---------------------------------------------------------------------------
+
+
+def _probe_backend(
+    backend: Dict[str, Any],
+    timeout: int = _DEFAULT_HEALTH_TIMEOUT,
+) -> bool:
+    """Lightweight availability probe for a custom HTTP backend.
+
+    Sends HEAD to ``base_url`` (no search query, no API consumption).
+    For registered providers, delegates to ``provider.is_available()``.
+
+    Returns True when the backend appears reachable.
+    """
+    name = str(backend.get("name", "?"))
+    typ = str(backend.get("type", "") or "")
+
+    if typ != "custom":
+        provider = _get_registered_provider(name)
+        if provider is None:
+            return False
+        try:
+            return provider.is_available()
+        except Exception:
+            return False
+
+    # Custom HTTP backend — HEAD probe
+    import httpx
+    base_url = (backend.get("base_url") or "").rstrip("/")
+    if not base_url:
+        return False
+
+    try:
+        resp = httpx.head(base_url, timeout=timeout, follow_redirects=True)
+        # 2xx/3xx/4xx all mean the service is reachable (auth failures are
+        # handled at search time, not probe time)
+        return resp.status_code < 500
+    except Exception:
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -131,8 +292,10 @@ def _rank_results(
     - ``"auto"`` or a real provider name → LLM-based ranking.
       On LLM failure (timeout, rate limit, concurrency limit) the function
       automatically falls back to keyword (``none``) ranking.
-      **Recommendation**: use a non-main-model provider or one with higher
-      concurrency limits to avoid ranking failures degrading search quality.
+
+    If *ranker_config* contains a ``prompt`` key, it is used as the system
+    prompt for LLM ranking, allowing users to inject preferences
+    (e.g. "prefer Chinese sources", "prefer official documentation").
 
     Optimizations:
     - Skip LLM ranking when <= _SKIP_RANK_IF results.
@@ -160,12 +323,21 @@ def _rank_results(
             lines.append(f"[{i + 1}] {title}\n{desc}")
         results_text = "\n".join(lines)
 
-        sys = (
-            "You rank search results by relevance. Rules:\n"
-            "- Return ONLY a JSON array of result indices ranked by relevance, e.g. [3,1,5,2,4]\n"
-            "- Include ALL results. Most relevant first.\n"
-            "- No other text."
-        )
+        custom_prompt = (ranker_config or {}).get("prompt", "").strip()
+        if custom_prompt:
+            sys = custom_prompt + (
+                "\n\nReturn ONLY a JSON array of result indices ranked by "
+                "relevance, e.g. [3,1,5,2,4]. Include ALL results. "
+                "No other text."
+            )
+        else:
+            sys = (
+                "You rank search results by relevance. Rules:\n"
+                "- Return ONLY a JSON array of result indices ranked by "
+                "relevance, e.g. [3,1,5,2,4]\n"
+                "- Include ALL results. Most relevant first.\n"
+                "- No other text."
+            )
         user = f"Query: {query}\n\nResults:\n{results_text}\n\nRanked indices:"
 
         logger.info(
@@ -186,7 +358,7 @@ def _rank_results(
         raw = (response.choices[0].message.content or "").strip()
         import json, re
 
-        match = re.search(r"\[[\d\s,,\]]+\]", raw)
+        match = re.search(r"\[[\d\s,,]+\]", raw)
         if match:
             indices = json.loads(match.group())
             if isinstance(indices, list):
@@ -359,7 +531,23 @@ def _search_one_backend(backend: Dict[str, Any], query: str, limit: int) -> List
 
 
 class FederatedSearchProvider(WebSearchProvider):
-    """Aggregated search provider that fans out to multiple sub-backends."""
+    """Aggregated search provider that fans out to multiple sub-backends.
+
+    Supports K-way aggregation with per-backend health checking,
+    configurable re-rank prompts, and fault-tolerance via ``min_backends``
+    and ``required`` flags.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._health_cache: Optional[_HealthCache] = None
+
+    def _get_health_cache(self, config: Dict[str, Any]) -> _HealthCache:
+        if self._health_cache is None:
+            hc = config.get("health_check") or {}
+            ttl = int(hc.get("ttl_seconds", _DEFAULT_HEALTH_TTL))
+            self._health_cache = _HealthCache(ttl_seconds=ttl)
+        return self._health_cache
 
     @property
     def name(self) -> str:
@@ -392,27 +580,67 @@ class FederatedSearchProvider(WebSearchProvider):
             if not config:
                 return {"success": False, "error": "federated search not configured"}
 
-            backends = config.get("backends", [])
-            if not isinstance(backends, list) or not backends:
-                return {"success": False, "error": "no search backends configured"}
+            # ── config validation ──
+            validation_error = _validate_config(config)
+            if validation_error:
+                return {"success": False, "error": validation_error}
 
+            backends: List[Dict[str, Any]] = config["backends"]
             timeout = int(config.get("timeout", _DEFAULT_TIMEOUT))
             max_results = int(config.get("max_results", _DEFAULT_MAX_RESULTS))
             ranker_config = config.get("ranker")
+            min_backends = int(config.get("min_backends", 1))
+
+            # ── health checks (cached, TTL-based) ──
+            # Only active when ``health_check`` is explicitly configured.
+            # Without it, all backends are dispatched directly (backward compat).
+            hc_config = config.get("health_check")
+            health_cache: Optional[_HealthCache] = None
+            if hc_config is not None:
+                health_cache = self._get_health_cache(config)
+                probe_timeout = int(hc_config.get("timeout", _DEFAULT_HEALTH_TIMEOUT))
+
+                active_backends: List[Dict[str, Any]] = []
+                for b in backends:
+                    name = str(b.get("name", "?"))
+                    cached = health_cache.is_available(name)
+                    if cached is False:
+                        logger.info("Backend '%s' cached as unavailable, skipping probe", name)
+                        continue
+                    if cached is True:
+                        active_backends.append(b)
+                        continue
+                    available = _probe_backend(b, timeout=probe_timeout)
+                    health_cache.set_available(name, available)
+                    if available:
+                        active_backends.append(b)
+                    else:
+                        logger.info("Backend '%s' probe failed, skipping", name)
+            else:
+                active_backends = list(backends)
+
+            if not active_backends:
+                return {"success": False, "error": "No backends available"}
 
             logger.info(
-                "Federated search: '%s' (%d backends, timeout=%ds, max_results=%d)",
-                query, len(backends), timeout, max_results,
+                "Federated search: '%s' (%d/%d backends active, timeout=%ds, max_results=%d)",
+                query, len(active_backends), len(backends), timeout, max_results,
             )
 
-            # ---------- parallel backend execution ----------
+            # ── parallel backend execution ──
             all_results: List[Dict[str, Any]] = []
+            backend_results: Dict[str, tuple[List[Dict], Optional[int]]] = {}
             errors: List[str] = []
             start_time = time.time()
 
-            pool = concurrent.futures.ThreadPoolExecutor(max_workers=len(backends))
+            pool = concurrent.futures.ThreadPoolExecutor(
+                max_workers=min(len(active_backends), _MAX_K),
+            )
             try:
-                futures = {pool.submit(_search_one_backend, b, query, limit): b for b in backends}
+                futures = {
+                    pool.submit(_search_one_backend, b, query, limit): b
+                    for b in active_backends
+                }
 
                 done, not_done = concurrent.futures.wait(
                     futures, timeout=timeout,
@@ -420,53 +648,84 @@ class FederatedSearchProvider(WebSearchProvider):
 
                 for f in not_done:
                     b = futures[f]
-                    errors.append(f"backend '{b.get('name','?')}' timed out")
+                    name = str(b.get("name", "?"))
+                    errors.append(f"backend '{name}' timed out")
+                    backend_results[name] = ([], None)
                     f.cancel()
 
                 for f in done:
                     if is_interrupted():
                         break
+                    b = futures[f]
+                    name = str(b.get("name", "?"))
                     try:
                         results = f.result(timeout=2)
                         all_results.extend(results)
+                        backend_results[name] = (results, None)
                     except Exception as exc:
-                        b = futures[f]
-                        errors.append(f"backend '{b.get('name','?')}' failed: {exc}")
+                        errors.append(f"backend '{name}' failed: {exc}")
+                        backend_results[name] = ([], None)
 
                 if not_done:
                     logger.warning(
                         "Federated search timed out after %ds, collected partial "
                         "results from %d/%d backends",
-                        timeout,
-                        len(done),
-                        len(futures),
+                        timeout, len(done), len(futures),
                     )
             finally:
                 pool.shutdown(wait=False)
+
+            # ── outcome evaluation ──
+            successful = [
+                name for name, (results, _) in backend_results.items()
+                if results
+            ]
+            required_failed = []
+            for b in active_backends:
+                name = str(b.get("name", "?"))
+                if b.get("required", False) and name not in successful:
+                    required_failed.append(name)
+
+            if required_failed:
+                for name in required_failed:
+                    if health_cache is not None:
+                        health_cache.set_available(name, False)
+                return {
+                    "success": False,
+                    "error": (
+                        f"Required backend(s) failed: {', '.join(required_failed)}"
+                    ),
+                }
+
+            if len(successful) < min_backends:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Only {len(successful)}/{min_backends} backends succeeded "
+                        f"(minimum {min_backends} required)"
+                    ),
+                }
 
             if not all_results:
                 if errors:
                     return {"success": False, "error": "All backends failed: " + "; ".join(errors)}
                 return {"success": True, "data": {"web": []}}
 
-            # ---------- ranking ----------
-            # _rank_results handles all modes internally:
-            # - provider: none / empty → keyword scoring (fast)
-            # - provider: <real>      → LLM, falls back to keyword on failure
+            # ── ranking ──
             rank_input_count = max(max_results + 5, _MAX_RANK_INPUT)
             rank_input = all_results[:rank_input_count]
             ranked = _rank_results(query, rank_input, ranker_config)
 
-            # Top N — honour the caller's requested limit while respecting
-            # the configured max_results cap.
+            # Top N
             output_count = min(limit, max_results)
             top = ranked[:output_count]
             for i, r in enumerate(top):
                 r["position"] = i + 1
 
             logger.info(
-                "Federated search: %d raw -> %d ranked (total %.1fs)",
+                "Federated search: %d raw -> %d ranked (total %.1fs, %d/%d backends)",
                 len(all_results), len(top), time.time() - start_time,
+                len(successful), len(active_backends),
             )
 
             return {
@@ -490,7 +749,8 @@ class FederatedSearchProvider(WebSearchProvider):
             "badge": "advanced",
             "tag": (
                 "Aggregate multiple search backends with LLM-based ranking. "
-                "Configure backends under web.federated.backends in config.yaml."
+                "Configure backends under web.federated.backends in config.yaml. "
+                "Supports K-way aggregation, health checks, and custom re-rank prompts."
             ),
             "env_vars": [],
         }

--- a/tests/plugins/web/test_federated_search.py
+++ b/tests/plugins/web/test_federated_search.py
@@ -1,0 +1,329 @@
+"""Tests for the FederatedSearch web search provider plugin."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugins.web.federated.provider import (
+    FederatedSearchProvider,
+    _extract_custom_results,
+    _rank_results,
+    _read_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def provider() -> FederatedSearchProvider:
+    return FederatedSearchProvider()
+
+
+# ---------------------------------------------------------------------------
+# Provider identity & capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestProviderIdentity:
+    def test_name(self, provider: FederatedSearchProvider) -> None:
+        assert provider.name == "federated"
+
+    def test_display_name(self, provider: FederatedSearchProvider) -> None:
+        assert provider.display_name == "Federated Search"
+
+    def test_supports_search(self, provider: FederatedSearchProvider) -> None:
+        assert provider.supports_search() is True
+
+    def test_supports_extract(self, provider: FederatedSearchProvider) -> None:
+        assert provider.supports_extract() is False
+
+    def test_is_available_no_config(self, provider: FederatedSearchProvider) -> None:
+        """Without config, is_available should return False."""
+        assert provider.is_available() is False
+
+    def test_get_setup_schema(self, provider: FederatedSearchProvider) -> None:
+        schema = provider.get_setup_schema()
+        assert schema["name"] == "Federated Search"
+        assert "env_vars" in schema
+        assert isinstance(schema["env_vars"], list)
+
+
+# ---------------------------------------------------------------------------
+# Config reading
+# ---------------------------------------------------------------------------
+
+
+class TestConfigReading:
+    def test_read_config_no_federated(self) -> None:
+        """When web.federated is absent, _read_config returns None."""
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=None,
+        ):
+            assert _read_config() is None
+
+    def test_is_available_with_backends(self) -> None:
+        """With at least one backend configured, is_available returns True."""
+        config = {"backends": [{"name": "tavily"}]}
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ):
+            p = FederatedSearchProvider()
+            assert p.is_available() is True
+
+
+# ---------------------------------------------------------------------------
+# Custom backend result extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCustomResults:
+    def test_organic_shape(self) -> None:
+        """Parse common ``{organic: [...]}`` shape (Google/Tavily-style)."""
+        data = {
+            "organic": [
+                {"title": "Result A", "link": "https://a.com", "snippet": "Description A"},
+                {"title": "Result B", "url": "https://b.com", "content": "Description B"},
+            ]
+        }
+        results = _extract_custom_results(data)
+        assert len(results) == 2
+        assert results[0]["title"] == "Result A"
+        assert results[0]["url"] == "https://a.com"
+
+    def test_data_web_shape(self) -> None:
+        """Parse ``{data: {web: [...]}}`` shape."""
+        data = {
+            "data": {
+                "web": [
+                    {"title": "X", "url": "https://x.com", "description": "Desc X"},
+                    {"title": "Y", "url": "https://y.com", "description": "Desc Y"},
+                ]
+            }
+        }
+        results = _extract_custom_results(data)
+        assert len(results) == 2
+
+    def test_results_shape(self) -> None:
+        """Parse ``{results: [...]}`` shape."""
+        data = {
+            "results": [
+                {"title": "P", "url": "https://p.com", "content": "Content P"},
+            ]
+        }
+        results = _extract_custom_results(data)
+        assert len(results) == 1
+        assert results[0]["title"] == "P"
+
+    def test_empty_data(self) -> None:
+        """Empty or malformed data returns empty list."""
+        assert _extract_custom_results({}) == []
+        assert _extract_custom_results(None) == []
+        assert _extract_custom_results("not a dict") == []
+
+
+# ---------------------------------------------------------------------------
+# LLM Ranking
+# ---------------------------------------------------------------------------
+
+
+class TestRankResults:
+    def test_empty_results(self) -> None:
+        """Empty results stay empty after ranking."""
+        assert _rank_results("test", [], None) == []
+
+    def test_llm_fallback_on_failure(self) -> None:
+        """When LLM call fails, results keep original order."""
+        results = [
+            {"title": "A", "url": "https://a.com", "description": "A desc"},
+            {"title": "B", "url": "https://b.com", "description": "B desc"},
+        ]
+        ranked = _rank_results("test", results, None)
+        assert len(ranked) == 2
+        assert ranked[0]["title"] == "A"
+
+
+# ---------------------------------------------------------------------------
+# Integration: federated search with mocked backends
+# ---------------------------------------------------------------------------
+
+
+class TestFederatedSearch:
+    """Integration test with mocked sub-backends."""
+
+    def test_no_backends_configured(self, provider: FederatedSearchProvider) -> None:
+        """When no backends in config, search returns error."""
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value={"backends": []},
+        ):
+            result = provider.search("test query")
+            assert result["success"] is False
+            assert "no search backends" in result["error"]
+
+    def test_single_backend(self, provider: FederatedSearchProvider) -> None:
+        """Single custom backend returns results."""
+        config = {
+            "backends": [{"name": "tavily", "type": "custom"}],
+            "timeout": 10,
+            "max_results": 8,
+        }
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ), patch(
+            "plugins.web.federated.provider._search_one_backend",
+            return_value=[
+                {"title": "R1", "url": "https://r1.com", "description": "D1"},
+                {"title": "R2", "url": "https://r2.com", "description": "D2"},
+            ],
+        ):
+            result = provider.search("test", limit=5)
+            assert result["success"] is True
+            web = result["data"]["web"]
+            assert len(web) == 2
+            assert web[0]["title"] == "R1"
+            assert web[1]["position"] == 2
+
+    def test_multiple_backends_merge(self, provider: FederatedSearchProvider) -> None:
+        """Multiple backends merge results."""
+        config = {
+            "backends": [
+                {"name": "backend1", "type": "custom"},
+                {"name": "backend2", "type": "custom"},
+            ],
+            "timeout": 10,
+            "max_results": 8,
+        }
+
+        call_count = 0
+        def fake_search(backend, query, limit):
+            nonlocal call_count
+            call_count += 1
+            name = backend.get("name", "")
+            if name == "backend1":
+                return [{"title": "A1", "url": "https://a1.com", "description": ""}]
+            return [{"title": "B1", "url": "https://b1.com", "description": ""}]
+
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ), patch(
+            "plugins.web.federated.provider._search_one_backend",
+            side_effect=fake_search,
+        ):
+            result = provider.search("test")
+            assert result["success"] is True
+            assert len(result["data"]["web"]) == 2
+
+    def test_max_results_respected(self, provider: FederatedSearchProvider) -> None:
+        """Only max_results items are returned after ranking."""
+        config = {
+            "backends": [{"name": "tavily", "type": "custom"}],
+            "max_results": 1,
+            "timeout": 5,
+        }
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ), patch(
+            "plugins.web.federated.provider._search_one_backend",
+            return_value=[
+                {"title": f"R{i}", "url": f"https://r{i}.com", "description": ""}
+                for i in range(5)
+            ],
+        ):
+            result = provider.search("test")
+            assert result["success"] is True
+            assert len(result["data"]["web"]) == 1
+
+    def test_timeout_config_is_read(self, provider: FederatedSearchProvider) -> None:
+        """The timeout config value is correctly read from config."""
+        config = {
+            "backends": [{"name": "t", "type": "custom"}],
+            "timeout": 30,
+            "max_results": 5,
+        }
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ), patch(
+            "plugins.web.federated.provider._search_one_backend",
+            return_value=[{"title": "R", "url": "https://r.com", "description": ""}],
+        ):
+            result = provider.search("test")
+            assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Config key integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_read_config_with_federated():
+    """Helper fixture to inject a realistic config."""
+    def _inject(config_override: Dict[str, Any]) -> None:
+        patcher = patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config_override,
+        )
+        patcher.start()
+        return patcher
+
+    yield _inject
+    # Cleanup happens automatically in fixture teardown
+
+
+class TestConfigurableSettings:
+    """Verify that all three config items are read and applied."""
+
+    def test_default_values_used_when_config_missing(self) -> None:
+        """When config has no timeout/max_results/ranker, defaults apply."""
+        config = {"backends": [{"name": "t", "type": "custom"}]}
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ), patch(
+            "plugins.web.federated.provider._search_one_backend",
+            return_value=[{"title": "R", "url": "https://r.com", "description": ""}],
+        ):
+            p = FederatedSearchProvider()
+            result = p.search("test")
+            assert result["success"] is True
+
+    def test_timeout_config(self) -> None:
+        """Config item 1: timeout is readable."""
+        config = {
+            "backends": [{"name": "t", "type": "custom"}],
+            "timeout": 30,
+            "max_results": 5,
+        }
+        assert config["timeout"] == 30
+
+    def test_max_results_config(self) -> None:
+        """Config item 3: max_results is readable."""
+        config = {
+            "backends": [{"name": "t", "type": "custom"}],
+            "timeout": 10,
+            "max_results": 12,
+        }
+        assert config["max_results"] == 12
+
+    def test_ranker_config(self) -> None:
+        """Config item 2: ranker provider/model is readable."""
+        config = {
+            "backends": [{"name": "t", "type": "custom"}],
+            "ranker": {"provider": "opencode-go", "model": "deepseek-v4-flash"},
+        }
+        assert config["ranker"]["provider"] == "opencode-go"
+        assert config["ranker"]["model"] == "deepseek-v4-flash"

--- a/tests/plugins/web/test_federated_search.py
+++ b/tests/plugins/web/test_federated_search.py
@@ -263,6 +263,97 @@ class TestFederatedSearch:
             result = provider.search("test")
             assert result["success"] is True
 
+    def test_blocked_backend_timeout_produces_partial_results(
+        self, provider: FederatedSearchProvider,
+    ) -> None:
+        """A backend that blocks must be bounded by the configured timeout.
+
+        The blocking backend is abandoned; results from faster backends are
+        still collected and returned.
+        """
+        import threading
+
+        block_signal = threading.Event()
+
+        def slow_backend(backend, query, limit):
+            block_signal.wait()  # block until released
+            return []
+
+        def fast_backend(backend, query, limit):
+            return [{"title": "Fast", "url": "https://f.com", "description": ""}]
+
+        config = {
+            "backends": [
+                {"name": "slow", "type": "custom"},
+                {"name": "fast", "type": "custom"},
+            ],
+            "timeout": 1,
+            "max_results": 5,
+        }
+        try:
+            with patch(
+                "plugins.web.federated.provider._read_config",
+                return_value=config,
+            ), patch(
+                "plugins.web.federated.provider._search_one_backend",
+                side_effect=lambda b, q, l: slow_backend(b, q, l) if b["name"] == "slow" else fast_backend(b, q, l),
+            ):
+                result = provider.search("test", limit=5)
+                # Must return within a few seconds (not waiting for the blocked backend)
+                assert result["success"] is True
+                web = result["data"]["web"]
+                # Fast backend result should be present
+                assert len(web) >= 1
+                assert web[0]["title"] == "Fast"
+        finally:
+            block_signal.set()  # release blocked thread so it can exit
+
+    def test_limit_below_max_results(
+        self, provider: FederatedSearchProvider,
+    ) -> None:
+        """When limit < max_results, return only `limit` items."""
+        config = {
+            "backends": [{"name": "t", "type": "custom"}],
+            "max_results": 8,
+            "timeout": 5,
+        }
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ), patch(
+            "plugins.web.federated.provider._search_one_backend",
+            return_value=[
+                {"title": f"R{i}", "url": f"https://r{i}.com", "description": ""}
+                for i in range(10)
+            ],
+        ):
+            result = provider.search("test", limit=3)
+            assert result["success"] is True
+            assert len(result["data"]["web"]) == 3
+
+    def test_limit_above_max_results(
+        self, provider: FederatedSearchProvider,
+    ) -> None:
+        """When limit > max_results, the configured max_results acts as the cap."""
+        config = {
+            "backends": [{"name": "t", "type": "custom"}],
+            "max_results": 4,
+            "timeout": 5,
+        }
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ), patch(
+            "plugins.web.federated.provider._search_one_backend",
+            return_value=[
+                {"title": f"R{i}", "url": f"https://r{i}.com", "description": ""}
+                for i in range(10)
+            ],
+        ):
+            result = provider.search("test", limit=10)
+            assert result["success"] is True
+            assert len(result["data"]["web"]) == 4  # capped by max_results
+
 
 # ---------------------------------------------------------------------------
 # Config key integration
@@ -327,3 +418,49 @@ class TestConfigurableSettings:
         }
         assert config["ranker"]["provider"] == "opencode-go"
         assert config["ranker"]["model"] == "deepseek-v4-flash"
+
+
+# ---------------------------------------------------------------------------
+# HERMES_HOME config discovery integration test
+# ---------------------------------------------------------------------------
+
+
+class TestFederatedConfigDiscovery:
+    """Verify that federated search config is discovered from an isolated
+    HERMES_HOME directory via the real config loading path."""
+
+    def test_read_config_from_hermes_home(self, tmp_path) -> None:
+        """_read_config discovers web.federated from config.yaml in HERMES_HOME."""
+        import yaml
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump({
+            "web": {
+                "federated": {
+                    "timeout": 15,
+                    "max_results": 6,
+                    "backends": [
+                        {"name": "tavily"},
+                        {"name": "custom1", "type": "custom",
+                         "base_url": "https://api.example.com",
+                         "api_key_env": "EXAMPLE_KEY",
+                         "search_path": "/v1/search",
+                         "query_param": "q"},
+                    ],
+                    "ranker": {
+                        "provider": "opencode-go",
+                        "model": "deepseek-v4-flash",
+                    },
+                },
+            },
+        }))
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            from plugins.web.federated.provider import _read_config as _cfg
+            cfg = _cfg()
+            assert cfg is not None
+            assert cfg["timeout"] == 15
+            assert cfg["max_results"] == 6
+            assert len(cfg["backends"]) == 2
+            assert cfg["backends"][0]["name"] == "tavily"
+            assert cfg["ranker"]["provider"] == "opencode-go"

--- a/tests/plugins/web/test_federated_search.py
+++ b/tests/plugins/web/test_federated_search.py
@@ -212,8 +212,8 @@ class TestFederatedSearch:
             call_count += 1
             name = backend.get("name", "")
             if name == "backend1":
-                return [{"title": "A1", "url": "https://a1.com", "description": ""}]
-            return [{"title": "B1", "url": "https://b1.com", "description": ""}]
+                return [{"title": "A1", "url": "https://a1.com", "description": ""}], None
+            return [{"title": "B1", "url": "https://b1.com", "description": ""}], None
 
         with patch(
             "plugins.web.federated.provider._read_config",
@@ -742,8 +742,8 @@ class TestFederatedSearchFaultTolerance:
             call_count["count"] += 1
             name = backend.get("name", "")
             if name == "required_src":
-                return []  # fail
-            return [{"title": "OK", "url": "https://ok.com", "description": ""}]
+                return [], None  # fail
+            return [{"title": "OK", "url": "https://ok.com", "description": ""}], None
 
         with patch(
             "plugins.web.federated.provider._read_config",
@@ -777,8 +777,8 @@ class TestFederatedSearchFaultTolerance:
         def fake_search(backend, query, limit):
             name = backend.get("name", "")
             if name == "a":
-                return [{"title": "A", "url": "https://a.com", "description": ""}]
-            return []  # b and c fail
+                return [{"title": "A", "url": "https://a.com", "description": ""}], None
+            return [], None  # b and c fail
 
         with patch(
             "plugins.web.federated.provider._read_config",
@@ -811,8 +811,8 @@ class TestFederatedSearchFaultTolerance:
         def fake_search(backend, query, limit):
             name = backend.get("name", "")
             if name == "a":
-                return [{"title": "A", "url": "https://a.com", "description": ""}]
-            return []
+                return [{"title": "A", "url": "https://a.com", "description": ""}], None
+            return [], None
 
         with patch(
             "plugins.web.federated.provider._read_config",
@@ -862,10 +862,84 @@ class TestFederatedSearchHealthCache:
             return_value=config,
         ), patch(
             "plugins.web.federated.provider._search_one_backend",
-            return_value=[{"title": "X", "url": "https://x.com", "description": ""}],
+            return_value=([{"title": "X", "url": "https://x.com", "description": ""}], None),
         ):
             result = provider.search("test", limit=5)
             assert result["success"] is True
+
+    def test_required_backend_cached_unavailable_causes_failure(
+        self, provider: FederatedSearchProvider,
+    ) -> None:
+        """A required backend that is health-cached as unavailable must still
+        cause overall search failure — the check must validate the full
+        backend list, not just the active (post-health-filter) set."""
+        config = {
+            "k": 2,
+            "min_backends": 1,
+            "backends": [
+                {"name": "critical", "type": "custom", "required": True},
+                {"name": "optional", "type": "custom", "required": False},
+            ],
+            "timeout": 5,
+            "max_results": 8,
+            "health_check": {},
+        }
+        provider._health_cache = _HealthCache(ttl_seconds=300)
+        provider._health_cache.set_available("critical", False)
+        provider._health_cache.set_available("optional", True)
+
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ), patch(
+            "plugins.web.federated.provider._search_one_backend",
+            return_value=([{"title": "OK", "url": "https://ok.com", "description": ""}], None),
+        ):
+            result = provider.search("test", limit=5)
+            assert result["success"] is False
+            assert "Required backend" in result["error"]
+
+    def test_health_cache_cooldown_on_http_error(
+        self, provider: FederatedSearchProvider,
+    ) -> None:
+        """A custom backend search failure with HTTP 429 must call
+        health_cache.mark_failed(), triggering the documented cooldown."""
+        config = {
+            "k": 2,
+            "backends": [
+                {"name": "src_a", "type": "custom", "required": False},
+                {"name": "src_b", "type": "custom", "required": False},
+            ],
+            "timeout": 5,
+            "max_results": 8,
+            "health_check": {},
+        }
+        provider._health_cache = _HealthCache(ttl_seconds=300)
+        provider._health_cache.set_available("src_a", True)
+        provider._health_cache.set_available("src_b", True)
+
+        # src_a succeeds; src_b returns HTTP 429 status
+        results_by_backend = {
+            "src_a": ([{"title": "OK", "url": "https://ok.com", "description": ""}], None),
+            "src_b": ([], 429),
+        }
+
+        def fake_search(backend, query, limit):
+            name = backend.get("name", "")
+            return results_by_backend.get(name, ([], None))
+
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ), patch(
+            "plugins.web.federated.provider._search_one_backend",
+            side_effect=fake_search,
+        ):
+            result = provider.search("test", limit=5)
+            # src_a succeeded, src_b 429 → partial success
+            assert result["success"] is True
+            # src_b should be marked unavailable due to 429 cooldown
+            assert provider._health_cache.is_available("src_b") is False
 
     def test_all_cached_unavailable(
         self, provider: FederatedSearchProvider,

--- a/tests/plugins/web/test_federated_search.py
+++ b/tests/plugins/web/test_federated_search.py
@@ -12,6 +12,7 @@ import pytest
 from plugins.web.federated.provider import (
     FederatedSearchProvider,
     _extract_custom_results,
+    _HealthCache,
     _rank_results,
     _read_config,
 )
@@ -464,3 +465,425 @@ class TestFederatedConfigDiscovery:
             assert len(cfg["backends"]) == 2
             assert cfg["backends"][0]["name"] == "tavily"
             assert cfg["ranker"]["provider"] == "opencode-go"
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfig:
+    """K-way aggregation config validation."""
+
+    def test_valid_minimal(self) -> None:
+        from plugins.web.federated.provider import _validate_config
+        config = {"backends": [{"name": "tavily"}]}
+        assert _validate_config(config) is None
+
+    def test_valid_k_equals_backends(self) -> None:
+        from plugins.web.federated.provider import _validate_config
+        config = {
+            "k": 3,
+            "backends": [
+                {"name": "a"}, {"name": "b"}, {"name": "c"},
+            ],
+        }
+        assert _validate_config(config) is None
+
+    def test_k_exceeds_max(self) -> None:
+        from plugins.web.federated.provider import _validate_config, _MAX_K
+        config = {"k": _MAX_K + 1, "backends": [{"name": "a"}]}
+        err = _validate_config(config)
+        assert err is not None
+        assert "exceeds maximum" in err
+
+    def test_k_mismatch_too_few(self) -> None:
+        from plugins.web.federated.provider import _validate_config
+        config = {"k": 3, "backends": [{"name": "a"}]}
+        err = _validate_config(config)
+        assert err is not None
+        assert "exactly 3" in err
+
+    def test_k_mismatch_too_many(self) -> None:
+        from plugins.web.federated.provider import _validate_config
+        config = {"k": 2, "backends": [{"name": "a"}, {"name": "b"}, {"name": "c"}]}
+        err = _validate_config(config)
+        assert err is not None
+        assert "exactly 2" in err
+
+    def test_min_backends_exceeds_k(self) -> None:
+        from plugins.web.federated.provider import _validate_config
+        config = {
+            "k": 2, "min_backends": 3,
+            "backends": [{"name": "a"}, {"name": "b"}],
+        }
+        err = _validate_config(config)
+        assert err is not None
+        assert "cannot exceed k" in err
+
+    def test_min_backends_less_than_one(self) -> None:
+        from plugins.web.federated.provider import _validate_config
+        config = {
+            "min_backends": 0,
+            "backends": [{"name": "a"}],
+        }
+        err = _validate_config(config)
+        assert err is not None
+        assert "must be at least 1" in err
+
+    def test_no_backends(self) -> None:
+        from plugins.web.federated.provider import _validate_config
+        config = {"backends": []}
+        err = _validate_config(config)
+        assert err is not None
+        assert "no search backends" in err
+
+
+# ---------------------------------------------------------------------------
+# Health cache
+# ---------------------------------------------------------------------------
+
+
+class TestHealthCache:
+    """TTL-based health probe cache."""
+
+    def test_cache_hit(self) -> None:
+        from plugins.web.federated.provider import _HealthCache
+        cache = _HealthCache(ttl_seconds=300)
+        cache.set_available("tavily", True)
+        assert cache.is_available("tavily") is True
+
+    def test_cache_miss_expired(self) -> None:
+        from plugins.web.federated.provider import _HealthCache
+        cache = _HealthCache(ttl_seconds=0)  # instant expiry
+        cache.set_available("tavily", True)
+        assert cache.is_available("tavily") is None
+
+    def test_cache_miss_unknown(self) -> None:
+        from plugins.web.federated.provider import _HealthCache
+        cache = _HealthCache(ttl_seconds=300)
+        assert cache.is_available("unknown") is None
+
+    def test_mark_failed_cooldown(self) -> None:
+        from plugins.web.federated.provider import _HealthCache
+        cache = _HealthCache(ttl_seconds=300)
+        cache.set_available("tavily", True)
+        cache.mark_failed("tavily", 429)
+        # After mark_failed, should be unavailable
+        assert cache.is_available("tavily") is False
+
+    def test_failure_cooldown_respects_status_code(self) -> None:
+        from plugins.web.federated.provider import _HealthCache
+        cache = _HealthCache(ttl_seconds=300)
+        cache.set_available("tavily", True)
+        # 401 → 300s cooldown, stored as False
+        cache.mark_failed("tavily", 401)
+        assert cache.is_available("tavily") is False
+
+
+# ---------------------------------------------------------------------------
+# Health probe
+# ---------------------------------------------------------------------------
+
+
+class TestProbeBackend:
+    """Backend availability probing."""
+
+    def test_registered_provider_available(self) -> None:
+        from plugins.web.federated.provider import _probe_backend
+        mock_provider = MagicMock()
+        mock_provider.is_available.return_value = True
+        with patch(
+            "plugins.web.federated.provider._get_registered_provider",
+            return_value=mock_provider,
+        ):
+            assert _probe_backend({"name": "tavily"}) is True
+
+    def test_registered_provider_unavailable(self) -> None:
+        from plugins.web.federated.provider import _probe_backend
+        mock_provider = MagicMock()
+        mock_provider.is_available.return_value = False
+        with patch(
+            "plugins.web.federated.provider._get_registered_provider",
+            return_value=mock_provider,
+        ):
+            assert _probe_backend({"name": "tavily"}) is False
+
+    def test_registered_provider_not_found(self) -> None:
+        from plugins.web.federated.provider import _probe_backend
+        with patch(
+            "plugins.web.federated.provider._get_registered_provider",
+            return_value=None,
+        ):
+            assert _probe_backend({"name": "nonexistent"}) is False
+
+    def test_custom_backend_no_base_url(self) -> None:
+        from plugins.web.federated.provider import _probe_backend
+        assert _probe_backend({
+            "name": "bad", "type": "custom",
+        }) is False
+
+    def test_custom_backend_reachable(self) -> None:
+        from plugins.web.federated.provider import _probe_backend
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        with patch("httpx.head", return_value=mock_resp):
+            assert _probe_backend({
+                "name": "ok", "type": "custom",
+                "base_url": "https://api.example.com",
+            }) is True
+
+    def test_custom_backend_server_error(self) -> None:
+        from plugins.web.federated.provider import _probe_backend
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        with patch("httpx.head", return_value=mock_resp):
+            assert _probe_backend({
+                "name": "down", "type": "custom",
+                "base_url": "https://api.example.com",
+            }) is False
+
+    def test_custom_backend_timeout(self) -> None:
+        from plugins.web.federated.provider import _probe_backend
+        with patch("httpx.head", side_effect=Exception("timeout")):
+            assert _probe_backend({
+                "name": "slow", "type": "custom",
+                "base_url": "https://api.example.com",
+            }) is False
+
+
+# ---------------------------------------------------------------------------
+# Rerank with custom prompt
+# ---------------------------------------------------------------------------
+
+
+class TestRankResultsCustomPrompt:
+    """LLM ranking with user-supplied prompt."""
+
+    def test_custom_prompt_passed_to_llm(self) -> None:
+        from plugins.web.federated.provider import _rank_results
+
+        results = [
+            {"title": f"R{i}", "url": f"https://r{i}.com", "description": f"D{i}"}
+            for i in range(5)
+        ]
+        ranker_config = {
+            "provider": "opencode-go",
+            "model": "deepseek-v4-flash",
+            "prompt": "Prefer Chinese sources and official docs.",
+        }
+
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(message=MagicMock(content="[5,4,3,2,1]"))
+        ]
+
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=mock_response,
+        ) as mock_call:
+            ranked = _rank_results("test", results, ranker_config)
+            assert len(ranked) == 5
+            # Verify custom prompt was passed
+            call_args = mock_call.call_args
+            messages = call_args[1]["messages"]
+            system_msg = messages[0]["content"]
+            assert "Prefer Chinese sources" in system_msg
+
+    def test_no_custom_prompt_uses_default(self) -> None:
+        from plugins.web.federated.provider import _rank_results
+
+        results = [
+            {"title": f"R{i}", "url": f"https://r{i}.com", "description": f"D{i}"}
+            for i in range(5)
+        ]
+        ranker_config = {"provider": "opencode-go", "model": "deepseek-v4-flash"}
+
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(message=MagicMock(content="[3,2,1,4,5]"))
+        ]
+
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=mock_response,
+        ) as mock_call:
+            _rank_results("test", results, ranker_config)
+            call_args = mock_call.call_args
+            messages = call_args[1]["messages"]
+            system_msg = messages[0]["content"]
+            assert "Return ONLY a JSON array" in system_msg
+
+
+# ---------------------------------------------------------------------------
+# Integration: required backends + min_backends
+# ---------------------------------------------------------------------------
+
+
+class TestFederatedSearchFaultTolerance:
+    """Required backends and min_backends fault tolerance."""
+
+    def test_required_backend_failure_causes_overall_failure(
+        self, provider: FederatedSearchProvider,
+    ) -> None:
+        config = {
+            "k": 2,
+            "min_backends": 1,
+            "backends": [
+                {"name": "required_src", "type": "custom", "required": True},
+                {"name": "optional_src", "type": "custom", "required": False},
+            ],
+            "timeout": 5,
+            "max_results": 8,
+        }
+        call_count = {"count": 0}
+
+        def fake_search(backend, query, limit):
+            call_count["count"] += 1
+            name = backend.get("name", "")
+            if name == "required_src":
+                return []  # fail
+            return [{"title": "OK", "url": "https://ok.com", "description": ""}]
+
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ), patch(
+            "plugins.web.federated.provider._probe_backend",
+            return_value=True,
+        ), patch(
+            "plugins.web.federated.provider._search_one_backend",
+            side_effect=fake_search,
+        ):
+            result = provider.search("test", limit=5)
+            assert result["success"] is False
+            assert "Required backend" in result["error"]
+
+    def test_min_backends_not_met_causes_failure(
+        self, provider: FederatedSearchProvider,
+    ) -> None:
+        config = {
+            "k": 3,
+            "min_backends": 2,
+            "backends": [
+                {"name": "a", "type": "custom", "required": False},
+                {"name": "b", "type": "custom", "required": False},
+                {"name": "c", "type": "custom", "required": False},
+            ],
+            "timeout": 5,
+            "max_results": 8,
+        }
+
+        def fake_search(backend, query, limit):
+            name = backend.get("name", "")
+            if name == "a":
+                return [{"title": "A", "url": "https://a.com", "description": ""}]
+            return []  # b and c fail
+
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ), patch(
+            "plugins.web.federated.provider._probe_backend",
+            return_value=True,
+        ), patch(
+            "plugins.web.federated.provider._search_one_backend",
+            side_effect=fake_search,
+        ):
+            result = provider.search("test", limit=5)
+            assert result["success"] is False
+            assert "Only 1/2 backends succeeded" in result["error"]
+
+    def test_all_backends_optional_can_succeed_with_partial(
+        self, provider: FederatedSearchProvider,
+    ) -> None:
+        config = {
+            "k": 2,
+            "min_backends": 1,
+            "backends": [
+                {"name": "a", "type": "custom", "required": False},
+                {"name": "b", "type": "custom", "required": False},
+            ],
+            "timeout": 5,
+            "max_results": 8,
+        }
+
+        def fake_search(backend, query, limit):
+            name = backend.get("name", "")
+            if name == "a":
+                return [{"title": "A", "url": "https://a.com", "description": ""}]
+            return []
+
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ), patch(
+            "plugins.web.federated.provider._probe_backend",
+            return_value=True,
+        ), patch(
+            "plugins.web.federated.provider._search_one_backend",
+            side_effect=fake_search,
+        ):
+            result = provider.search("test", limit=5)
+            assert result["success"] is True
+            assert len(result["data"]["web"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration: health cache filters backends
+# ---------------------------------------------------------------------------
+
+
+class TestFederatedSearchHealthCache:
+    """Health cache integration in search flow."""
+
+    def test_unavailable_backend_skipped(
+        self, provider: FederatedSearchProvider,
+    ) -> None:
+        config = {
+            "k": 2,
+            "min_backends": 1,
+            "backends": [
+                {"name": "good", "type": "custom", "required": False},
+                {"name": "bad", "type": "custom", "required": False},
+            ],
+            "timeout": 5,
+            "max_results": 8,
+            "health_check": {},
+        }
+
+        # Pre-fill health cache: "bad" is unavailable
+        provider._health_cache = _HealthCache(ttl_seconds=300)
+        provider._health_cache.set_available("bad", False)
+        provider._health_cache.set_available("good", True)
+
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ), patch(
+            "plugins.web.federated.provider._search_one_backend",
+            return_value=[{"title": "X", "url": "https://x.com", "description": ""}],
+        ):
+            result = provider.search("test", limit=5)
+            assert result["success"] is True
+
+    def test_all_cached_unavailable(
+        self, provider: FederatedSearchProvider,
+    ) -> None:
+        config = {
+            "k": 1,
+            "backends": [{"name": "down", "type": "custom", "required": False}],
+            "timeout": 5,
+            "max_results": 8,
+            "health_check": {},
+        }
+        provider._health_cache = _HealthCache(ttl_seconds=300)
+        provider._health_cache.set_available("down", False)
+
+        with patch(
+            "plugins.web.federated.provider._read_config",
+            return_value=config,
+        ):
+            result = provider.search("test", limit=5)
+            assert result["success"] is False
+            assert "No backends available" in result["error"]

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -79,6 +79,7 @@ class TestBundledPluginsRegister:
             "brave-free",
             "ddgs",
             "exa",
+            "federated",
             "firecrawl",
             "parallel",
             "searxng",

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -68,9 +68,9 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """All bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -97,6 +97,7 @@ class TestBundledPluginsRegister:
             ("parallel", True, True),
             ("tavily", True, True),
             ("firecrawl", True, True),
+            ("federated", True, False),
             # xai: search-only via Grok's agentic web_search tool.
             ("xai", True, False),
         ],

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1817,11 +1817,11 @@ Environment scrubbing (strips `*_API_KEY`, `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, 
 
 ## Web Search Backends
 
-The `web_search` and `web_extract` tools support five backend providers. Configure the backend in `config.yaml` or via `hermes tools`:
+The `web_search` and `web_extract` tools support six backend providers. Configure the backend in `config.yaml` or via `hermes tools`:
 
 ```yaml
 web:
-  backend: firecrawl    # firecrawl | searxng | parallel | tavily | exa
+  backend: firecrawl    # firecrawl | searxng | parallel | tavily | exa | federated
 
   # Or use per-capability keys to mix providers (e.g. free search + paid extract):
   search_backend: "searxng"
@@ -1835,6 +1835,7 @@ web:
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ |
 | **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ |
+| **Federated** | sub-backend keys | ✔ | — |
 
 **Backend selection:** If `web.backend` is not set, the backend is auto-detected from available API keys. If only `SEARXNG_URL` is set, SearXNG is used. If only `EXA_API_KEY` is set, Exa is used. If only `TAVILY_API_KEY` is set, Tavily is used. If only `PARALLEL_API_KEY` is set, Parallel is used. Otherwise Firecrawl is the default.
 
@@ -1845,6 +1846,8 @@ web:
 **Parallel search modes:** Set `PARALLEL_SEARCH_MODE` to control search behavior — `fast`, `one-shot`, or `agentic` (default: `agentic`).
 
 **Exa:** Set `EXA_API_KEY` in `~/.hermes/.env`. Supports `category` filtering (`company`, `research paper`, `news`, `people`, `personal site`, `pdf`) and domain/date filters.
+
+**Federated:** Aggregates results from multiple sub-backends (Tavily, SearXNG, custom HTTP endpoints) with optional LLM-based relevance ranking. Configure sub-backends under `web.federated.backends`. Search-only; use `web.extract_backend` for content extraction. See the [Federated Search guide](/user-guide/features/web-federated-search).
 
 ## Browser
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1817,7 +1817,7 @@ Environment scrubbing (strips `*_API_KEY`, `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, 
 
 ## Web Search Backends
 
-The `web_search` and `web_extract` tools support six backend providers. Configure the backend in `config.yaml` or via `hermes tools`:
+The `web_search` and `web_extract` tools support multiple backend providers. Configure the backend in `config.yaml` or via `hermes tools`:
 
 ```yaml
 web:

--- a/website/docs/user-guide/features/web-federated-search.md
+++ b/website/docs/user-guide/features/web-federated-search.md
@@ -1,0 +1,195 @@
+---
+sidebar_position: 5
+title: "Federated Search"
+description: "Aggregate results from multiple search backends with LLM-based relevance ranking"
+---
+
+# Federated Search
+
+The **federated** web search provider fans out each search request to multiple
+configured sub-backends (Tavily, SearXNG, custom HTTP endpoints, etc.) and ranks
+the combined results by relevance. It plugs into the existing
+`web.search_backend` config key — no changes to the tool chain required.
+
+## Why Federated?
+
+- **Multi-backend resilience.** If one backend is down or rate-limited, results
+  from others still come through. Configure Tavily for English search and a
+  custom backend (e.g., MiniMax) for Chinese search — both contribute to every
+  query.
+- **LLM-based ranking.** An auxiliary LLM reranks merged results for relevance.
+  Falls back to keyword-based scoring automatically if the LLM is unavailable.
+- **Zero tool changes.** The `web_search` tool passes results through the same
+  pipeline; the provider boundary is transparent to the agent.
+
+## Quick Start
+
+Enable federated search with two backends:
+
+```yaml
+# ~/.hermes/config.yaml
+web:
+  search_backend: federated
+  federated:
+    backends:
+      - name: tavily
+      - name: minimax
+        type: custom
+        base_url: "https://api.minimaxi.com"
+        api_key_env: MINIMAX_CN_API_KEY
+```
+
+With this configuration, every `web_search` call queries both Tavily and MiniMax
+in parallel, merges results, ranks by keyword scoring, and returns up to 8
+results.
+
+## Configuration Reference
+
+All federated configuration lives under `web.federated` in `config.yaml`.
+
+### Top-level Options
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `timeout` | int | `10` | Maximum seconds to wait for all backends. If the deadline expires, partial results from completed backends are returned. |
+| `max_results` | int | `8` | Maximum number of results returned after ranking (ceiling). The caller's `limit` parameter is still respected — the actual output count is `min(limit, max_results)`. |
+| `ranker` | dict | — | Optional LLM ranking configuration (see below). |
+| `backends` | list | — | **Required.** List of sub-backend configurations. |
+
+### Ranking (`ranker`)
+
+The `ranker` section controls how merged results are ordered by relevance.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `ranker.provider` | str | — | LLM provider for ranking. Set to `"none"` (or omit) for keyword-based scoring (fast, zero cost). Use a real provider (e.g., `"opencode-go"`) for LLM ranking. |
+| `ranker.model` | str | — | Model name for the ranking LLM (e.g., `"deepseek-v4-flash"`). |
+
+**Ranking modes:**
+- **Keyword** (`provider: "none"` or unset): Scores results by query term
+  frequency in title + description. Fast, no API cost.
+- **LLM** (real provider): Sends results to an auxiliary LLM for relevance
+  ranking. Falls back to keyword mode automatically on timeout, rate limit, or
+  parse failure.
+
+**Recommendation:** Use a non-main-model provider for ranking to avoid
+concurrency contention. When ≤ 3 results, ranking is skipped entirely.
+
+### Backend Configurations (`backends`)
+
+Each entry in the `backends` list represents one search source.
+
+#### Registered Providers
+
+Use an existing Hermes web search provider (e.g., Tavily, Firecrawl, SearXNG):
+
+```yaml
+backends:
+  - name: tavily
+  - name: firecrawl
+```
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `name` | str | ✅ | Registered provider name. Must match an available provider (tavily, firecrawl, searxng, exa, parallel, ddgs, brave_free, xai). |
+
+Registered providers use their existing credentials (`.env` API keys). No
+additional configuration needed.
+
+#### Custom HTTP Backends
+
+Connect any search API that accepts a query parameter and returns JSON:
+
+```yaml
+backends:
+  - name: minimax
+    type: custom
+    base_url: "https://api.minimaxi.com"
+    api_key_env: MINIMAX_CN_API_KEY
+    search_path: /v1/coding_plan/search
+    query_param: "q"
+    auth_style: bearer
+```
+
+| Key | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| `name` | str | ✅ | — | Display name for logging and error messages. |
+| `type` | str | ✅ | — | Must be `"custom"` to enable custom HTTP mode. |
+| `base_url` | str | ✅ | — | Base URL of the search API (e.g., `https://api.minimaxi.com`). |
+| `api_key_env` | str | ✅ | — | Environment variable that holds the API key (e.g., `MINIMAX_CN_API_KEY`). Set in `.env`. |
+| `search_path` | str | — | `"/v1/coding_plan/search"` | API path appended to `base_url`. |
+| `query_param` | str | — | `"q"` | Query string parameter name. |
+| `auth_style` | str | — | `"bearer"` | Authentication style: `"bearer"` (Authorization header) or `"x-api-key"` (x-api-key header). |
+
+**Supported response shapes:** The custom backend parser handles three common
+API response formats:
+
+- `{"organic": [{"title", "link", "snippet"}, ...]}`
+- `{"data": {"web": [{"title", "url", "description"}, ...]}}`
+- `{"results": [{"title", "url", "content"}, ...]}`
+
+## Execution Flow
+
+For each search request:
+
+1. **Parallel fan-out.** All backends are queried concurrently via
+   `ThreadPoolExecutor`. Each backend runs in its own thread.
+2. **Timeout enforcement.** `concurrent.futures.wait()` with the configured
+   timeout bounds the total wait time. Backends that haven't finished are
+   cancelled; completed results proceed.
+3. **Merge & rank.** Results from all successful backends are combined. If a
+   `ranker` is configured, the merged set is ranked by relevance (LLM or keyword).
+4. **Top N truncation.** Output count is capped at `min(limit, max_results)` —
+   the caller's requested limit is respected, with `max_results` serving as a
+   ceiling.
+
+## Full Configuration Example
+
+```yaml
+web:
+  search_backend: federated
+  federated:
+    # Wait up to 15 seconds for all backends
+    timeout: 15
+
+    # Return at most 10 results after ranking
+    max_results: 10
+
+    # Use keyword-based ranking (fast, zero LLM cost)
+    ranker:
+      provider: none
+
+    backends:
+      # Registered providers
+      - name: tavily
+      - name: searxng
+
+      # Custom HTTP backend — MiniMax Chinese search
+      - name: minimax
+        type: custom
+        base_url: "https://api.minimaxi.com"
+        api_key_env: MINIMAX_CN_API_KEY
+        search_path: /v1/coding_plan/search
+```
+
+## Troubleshooting
+
+| Symptom | Likely Cause |
+|---------|-------------|
+| `federated search not configured` | `web.federated` section missing from `config.yaml` or `web.search_backend` not set to `"federated"` |
+| `no search backends configured` | `web.federated.backends` is empty or not a list |
+| `backend '<name>' not registered` | `name` references an unavailable provider. Check `hermes tools` to see registered providers. |
+| `All backends failed` | Every backend returned errors. Check credentials and network. The gateway log shows per-backend details. |
+| `Custom backend timed out` | The configured API didn't respond within 15s. Verify the `base_url` and `search_path` are correct. |
+| `LLM ranking failed, falling back to keyword ranking` | Normal fallback — the ranking LLM was unavailable. Results use keyword scoring instead. |
+| `load_config() strips web.federated` | This is expected. The provider reads raw YAML directly; config changes take effect on next search call without restart. |
+
+## Known Limitations
+
+- **No content extraction.** `supports_extract()` returns `False`. Use another
+  provider (e.g., Tavily or Firecrawl) for `web_extract` by setting
+  `web.extract_backend`.
+- **No nested federation.** Sub-backends are leaf nodes; you cannot chain
+  federated providers.
+- **Thread-pool overhead.** Each backend runs in a thread. With many backends
+  (>10), consider using fewer, higher-quality providers instead.

--- a/website/docs/user-guide/features/web-federated-search.md
+++ b/website/docs/user-guide/features/web-federated-search.md
@@ -53,7 +53,10 @@ All federated configuration lives under `web.federated` in `config.yaml`.
 |-----|------|---------|-------------|
 | `timeout` | int | `10` | Maximum seconds to wait for all backends. If the deadline expires, partial results from completed backends are returned. |
 | `max_results` | int | `8` | Maximum number of results returned after ranking (ceiling). The caller's `limit` parameter is still respected — the actual output count is `min(limit, max_results)`. |
+| `k` | int | len(backends) | **K-way aggregation.** Must equal the number of configured backends. When explicitly set, the plugin validates `len(backends) == k`. Maximum 32. |
+| `min_backends` | int | `1` | Minimum number of backends that must succeed for the search to be considered successful. Must satisfy `1 ≤ min_backends ≤ k`. |
 | `ranker` | dict | — | Optional LLM ranking configuration (see below). |
+| `health_check` | dict | — | Optional cached health probing (see below). When absent, all backends are dispatched directly (backward compatible). |
 | `backends` | list | — | **Required.** List of sub-backend configurations. |
 
 ### Ranking (`ranker`)
@@ -64,6 +67,7 @@ The `ranker` section controls how merged results are ordered by relevance.
 |-----|------|---------|-------------|
 | `ranker.provider` | str | — | LLM provider for ranking. Set to `"none"` (or omit) for keyword-based scoring (fast, zero cost). Use a real provider (e.g., `"opencode-go"`) for LLM ranking. |
 | `ranker.model` | str | — | Model name for the ranking LLM (e.g., `"deepseek-v4-flash"`). |
+| `ranker.prompt` | str | — | Optional custom system prompt for the ranking LLM. Inject preferences like "prefer Chinese sources" or "prefer official documentation". When omitted, a default prompt is used. |
 
 **Ranking modes:**
 - **Keyword** (`provider: "none"` or unset): Scores results by query term
@@ -92,6 +96,7 @@ backends:
 | Key | Type | Required | Description |
 |-----|------|----------|-------------|
 | `name` | str | ✅ | Registered provider name. Must match an available provider (tavily, firecrawl, searxng, exa, parallel, ddgs, brave_free, xai). |
+| `required` | bool | `false` | When `true`, this backend's failure causes the entire search to fail, regardless of `min_backends`. |
 
 Registered providers use their existing credentials (`.env` API keys). No
 additional configuration needed.
@@ -120,6 +125,7 @@ backends:
 | `search_path` | str | — | `"/v1/coding_plan/search"` | API path appended to `base_url`. |
 | `query_param` | str | — | `"q"` | Query string parameter name. |
 | `auth_style` | str | — | `"bearer"` | Authentication style: `"bearer"` (Authorization header) or `"x-api-key"` (x-api-key header). |
+| `required` | bool | `false` | When `true`, this backend's failure causes the entire search to fail, regardless of `min_backends`. |
 
 **Supported response shapes:** The custom backend parser handles three common
 API response formats:
@@ -127,6 +133,27 @@ API response formats:
 - `{"organic": [{"title", "link", "snippet"}, ...]}`
 - `{"data": {"web": [{"title", "url", "description"}, ...]}}`
 - `{"results": [{"title", "url", "content"}, ...]}`
+
+### Health Checks (`health_check`)
+
+Cached availability probing for custom HTTP backends. When configured, the plugin
+sends a lightweight `HEAD` request to each custom backend's `base_url` before
+dispatching searches. Results are cached for `ttl_seconds` to avoid consuming
+provider quota on every call.
+
+When `health_check` is absent, all backends are dispatched directly (backward
+compatible).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `health_check.ttl_seconds` | int | `300` | How long probe results are cached (seconds). Set higher for providers with strict rate limits. |
+| `health_check.timeout` | int | `5` | Per-probe HEAD request timeout (seconds). |
+
+**Caching and cooldown:**
+- Cache hit: backend dispatched immediately (no network request).
+- Cache miss / expired: `HEAD` probe → cache result → proceed.
+- Real search failure (HTTP 401/403/429): backend immediately marked unavailable
+  with provider-specific cooldown (5 min for 401/403, 1 hour for 429).
 
 ## Execution Flow
 
@@ -155,14 +182,30 @@ web:
     # Return at most 10 results after ranking
     max_results: 10
 
-    # Use keyword-based ranking (fast, zero LLM cost)
+    # K-way aggregation: exactly 3 backends, at least 2 must succeed
+    k: 3
+    min_backends: 2
+
+    # Health checks: cache probe results for 5 minutes
+    health_check:
+      ttl_seconds: 300
+
+    # LLM ranking with custom preference prompt
     ranker:
-      provider: none
+      provider: opencode-go
+      model: deepseek-v4-flash
+      prompt: |
+        Prefer Chinese sources and official documentation.
+        Prefer results from the last 6 months.
 
     backends:
-      # Registered providers
+      # Registered provider — critical, must succeed
       - name: tavily
+        required: true
+
+      # Self-hosted SearXNG — optional
       - name: searxng
+        required: false
 
       # Custom HTTP backend — MiniMax Chinese search
       - name: minimax
@@ -170,6 +213,7 @@ web:
         base_url: "https://api.minimaxi.com"
         api_key_env: MINIMAX_CN_API_KEY
         search_path: /v1/coding_plan/search
+        required: false
 ```
 
 ## Troubleshooting
@@ -180,6 +224,10 @@ web:
 | `no search backends configured` | `web.federated.backends` is empty or not a list |
 | `backend '<name>' not registered` | `name` references an unavailable provider. Check `hermes tools` to see registered providers. |
 | `All backends failed` | Every backend returned errors. Check credentials and network. The gateway log shows per-backend details. |
+| `No backends available` | Health checks marked all backends unavailable. Check the gateway log for per-backend probe failures. |
+| `Required backend(s) failed` | A backend with `required: true` returned no results. Check its credentials and availability. |
+| `Only N/M backends succeeded` | Fewer than `min_backends` backends returned results. Increase `min_backends` or investigate failing backends. |
+| `k=N but M backend(s) configured` | The `k` value doesn't match the number of `backends` entries. Either adjust `k` or add/remove backends. |
 | `Custom backend timed out` | The configured API didn't respond within 15s. Verify the `base_url` and `search_path` are correct. |
 | `LLM ranking failed, falling back to keyword ranking` | Normal fallback — the ranking LLM was unavailable. Results use keyword scoring instead. |
 | `load_config() strips web.federated` | This is expected. The provider reads raw YAML directly; config changes take effect on next search call without restart. |
@@ -193,3 +241,8 @@ web:
   federated providers.
 - **Thread-pool overhead.** Each backend runs in a thread. With many backends
   (>10), consider using fewer, higher-quality providers instead.
+- **Health checks are optional.** Without `health_check` configured, failing
+  backends are dispatched and time out — same as the original behavior.
+  Enable `health_check` to avoid waiting on dead backends.
+- **Custom ranking prompt requires LLM ranking.** The `ranker.prompt` field is
+  only used when a real provider (not `"none"`) is configured for ranking.


### PR DESCRIPTION
**Depends on #65032** — this adds line-level configuration and health checking on top of the base federated search plugin.

---

### Summary

Federated search currently dispatches all configured backends without validation, fault tolerance, or health awareness. This PR adds production-grade line-level configuration:

**K-way aggregation** (`k`, `min_backends`, `required`)
- `k` enforces exactly K backends (hard cap 32), with startup validation
- `min_backends` requires at least N backends to succeed
- `required: true` per-backend flag — failure causes overall search failure

**Health checks** (`health_check`)
- Cached HEAD probe to custom backend `base_url` — avoids per-search quota consumption
- Only active when `health_check` is explicitly configured (backward compatible)
- Real search failures (401/403/429) trigger per-status-code cooldowns

**Custom re-rank prompt** (`ranker.prompt`)
- User-defined LLM ranking preferences (e.g. "prefer Chinese sources")

### Changes

| File | Change |
|------|--------|
| `plugins/web/federated/provider.py` | +334/-40: `_validate_config`, `_HealthCache`, `_probe_backend`, modified `search()` and `_rank_results` |
| `tests/plugins/web/test_federated_search.py` | +423: 31 new tests (54 total) |
| `website/docs/user-guide/features/web-federated-search.md` | +59/-10: docs + 5 new troubleshooting entries |

### Tests

104 total, all passing (54 federated + 50 other web provider tests).