### PR TITLE
feat(google-workspace): add Gmail filter management

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: google-workspace
 description: "Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python."
-version: 1.1.0
+version: 1.2.0
 author: Nous Research
 license: MIT
 platforms: [linux, macos, windows]
@@ -196,7 +196,22 @@ $GAPI gmail reply MESSAGE_ID --from '"Support Bot" <user@example.com>' --body "T
 $GAPI gmail labels
 $GAPI gmail modify MESSAGE_ID --add-labels LABEL_ID
 $GAPI gmail modify MESSAGE_ID --remove-labels UNREAD
+
+# Filters
+$GAPI gmail filter-list
+$GAPI gmail filter-get FILTER_ID
+$GAPI gmail filter-create --from alerts@example.com --add-labels LABEL_ID --remove-labels INBOX
+$GAPI gmail filter-create --query 'list:team@example.com has:attachment' --add-labels LABEL_ID
+$GAPI gmail filter-delete FILTER_ID
 ```
+
+If `$GSETUP --check` reports `AUTHENTICATED (partial)`, the existing token
+predates the Gmail settings scope. Run `$GSETUP --revoke`, then repeat Steps
+3–5 above to authorize the updated scope before using filters.
+
+Before creating a filter, run the same criteria through `gmail search` and show
+the matching messages to the user. Filter creation and deletion require
+confirmation. Forwarding actions are intentionally unsupported by this wrapper.
 
 ### Calendar
 
@@ -293,6 +308,8 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 - **Gmail search**: `[{id, threadId, from, to, subject, date, snippet, labels}]`
 - **Gmail get**: `{id, threadId, from, to, subject, date, labels, body}`
 - **Gmail send/reply**: `{status: "sent", id, threadId}`
+- **Gmail filter list/get**: Filter objects with `id`, `criteria`, and `action`
+- **Gmail filter create/delete**: `{status: "created" | "deleted", ...}`
 - **Calendar list**: `[{id, summary, start, end, location, description, htmlLink}]`
 - **Calendar create**: `{status: "created", id, summary, htmlLink}`
 - **Drive search**: `[{id, name, mimeType, modifiedTime, webViewLink}]`
@@ -310,7 +327,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 
 ## Rules
 
-1. **Never send email, create/delete calendar events, delete Drive files, share files, or modify Docs/Sheets without confirming with the user first.** Show what will be done (recipients, file IDs, content, share role) and ask for approval. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
+1. **Never send email, create/delete Gmail filters or calendar events, delete Drive files, share files, or modify Docs/Sheets without confirming with the user first.** Show what will be done (recipients, filter criteria/actions, file IDs, content, share role) and ask for approval. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
 2. **Check auth before first use** — run `setup.py --check`. If it fails, guide the user through setup.
 3. **Use the Gmail search syntax reference** for complex queries — load it with `skill_view("google-workspace", file_path="references/gmail-search-syntax.md")`.
 4. **Calendar times must include timezone** — always use ISO 8601 with offset (e.g., `2026-03-01T10:00:00-06:00`) or UTC (`Z`).

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -10,6 +10,8 @@ Usage:
   python google_api.py gmail get MESSAGE_ID
   python google_api.py gmail send --to user@example.com --subject "Hi" --body "Hello"
   python google_api.py gmail reply MESSAGE_ID --body "Thanks"
+  python google_api.py gmail filter-list
+  python google_api.py gmail filter-create --from sender@example.com --add-labels LABEL_ID
   python google_api.py calendar list [--from DATE] [--to DATE] [--calendar primary]
   python google_api.py calendar create --summary "Meeting" --start DATETIME --end DATETIME
   python google_api.py drive search "budget report" [--max 10]
@@ -46,6 +48,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.send",
     "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.settings.basic",
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/contacts.readonly",
@@ -454,6 +457,87 @@ def gmail_modify(args):
     service = build_service("gmail", "v1")
     result = service.users().messages().modify(userId="me", id=args.message_id, body=body).execute()
     print(json.dumps({"id": result["id"], "labels": result.get("labelIds", [])}, indent=2))
+
+
+def gmail_filter_list(args):
+    if _gws_binary():
+        result = _run_gws(
+            ["gmail", "users", "settings", "filters", "list"],
+            params={"userId": "me"},
+        )
+    else:
+        service = build_service("gmail", "v1")
+        result = service.users().settings().filters().list(userId="me").execute()
+    print(json.dumps(result.get("filter", []), indent=2, ensure_ascii=False))
+
+
+def gmail_filter_get(args):
+    params = {"userId": "me", "id": args.filter_id}
+    if _gws_binary():
+        result = _run_gws(
+            ["gmail", "users", "settings", "filters", "get"],
+            params=params,
+        )
+    else:
+        service = build_service("gmail", "v1")
+        result = service.users().settings().filters().get(**params).execute()
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+def gmail_filter_create(args):
+    criteria = {
+        key: value
+        for key, value in {
+            "from": args.from_address,
+            "to": args.to,
+            "subject": args.subject,
+            "query": args.query,
+            "negatedQuery": args.negated_query,
+            "hasAttachment": args.has_attachment,
+            "excludeChats": args.exclude_chats,
+        }.items()
+        if value
+    }
+    action = {}
+    if args.add_labels:
+        action["addLabelIds"] = [
+            label.strip() for label in args.add_labels.split(",") if label.strip()
+        ]
+    if args.remove_labels:
+        action["removeLabelIds"] = [
+            label.strip() for label in args.remove_labels.split(",") if label.strip()
+        ]
+    if not criteria:
+        raise SystemExit("ERROR: filter-create requires at least one matching criterion")
+    if not action:
+        raise SystemExit("ERROR: filter-create requires --add-labels or --remove-labels")
+
+    body = {"criteria": criteria, "action": action}
+    if _gws_binary():
+        result = _run_gws(
+            ["gmail", "users", "settings", "filters", "create"],
+            params={"userId": "me"},
+            body=body,
+        )
+    else:
+        service = build_service("gmail", "v1")
+        result = (
+            service.users().settings().filters().create(userId="me", body=body).execute()
+        )
+    print(json.dumps({"status": "created", "filter": result}, indent=2, ensure_ascii=False))
+
+
+def gmail_filter_delete(args):
+    params = {"userId": "me", "id": args.filter_id}
+    if _gws_binary():
+        _run_gws(
+            ["gmail", "users", "settings", "filters", "delete"],
+            params=params,
+        )
+    else:
+        service = build_service("gmail", "v1")
+        service.users().settings().filters().delete(**params).execute()
+    print(json.dumps({"status": "deleted", "filterId": args.filter_id}, indent=2))
 
 
 # =========================================================================
@@ -1092,6 +1176,35 @@ def main():
     p.add_argument("--add-labels", default="", help="Comma-separated label IDs to add")
     p.add_argument("--remove-labels", default="", help="Comma-separated label IDs to remove")
     p.set_defaults(func=gmail_modify)
+
+    p = gmail_sub.add_parser("filter-list")
+    p.set_defaults(func=gmail_filter_list)
+
+    p = gmail_sub.add_parser("filter-get")
+    p.add_argument("filter_id")
+    p.set_defaults(func=gmail_filter_get)
+
+    p = gmail_sub.add_parser("filter-create")
+    p.add_argument(
+        "--from", dest="from_address", default="", help="Sender address or expression"
+    )
+    p.add_argument("--to", default="", help="Recipient address or expression")
+    p.add_argument("--subject", default="", help="Subject expression")
+    p.add_argument("--query", default="", help="Gmail search expression that must match")
+    p.add_argument(
+        "--negated-query",
+        default="",
+        help="Gmail search expression that must not match",
+    )
+    p.add_argument("--has-attachment", action="store_true")
+    p.add_argument("--exclude-chats", action="store_true")
+    p.add_argument("--add-labels", default="", help="Comma-separated label IDs to add")
+    p.add_argument("--remove-labels", default="", help="Comma-separated label IDs to remove")
+    p.set_defaults(func=gmail_filter_create)
+
+    p = gmail_sub.add_parser("filter-delete")
+    p.add_argument("filter_id")
+    p.set_defaults(func=gmail_filter_delete)
 
     # --- Calendar ---
     cal = sub.add_parser("calendar")

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -48,6 +48,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.send",
     "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.settings.basic",
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/contacts.readonly",

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -144,6 +144,126 @@ def test_api_calendar_list_uses_events_list(api_module):
 
 
 
+def test_api_gmail_filter_create_uses_settings_api(api_module, capsys):
+    captured = {}
+
+    def fake_run_gws(parts, *, params=None, body=None):
+        captured.update(parts=parts, params=params, body=body)
+        return {"id": "filter-1", **body}
+
+    api_module._run_gws = fake_run_gws
+    args = api_module.argparse.Namespace(
+        from_address="alerts@example.com",
+        to="",
+        subject="",
+        query="has:attachment",
+        negated_query="",
+        has_attachment=False,
+        exclude_chats=True,
+        add_labels="Label_1, STARRED",
+        remove_labels="INBOX",
+        func=api_module.gmail_filter_create,
+    )
+
+    api_module.gmail_filter_create(args)
+
+    assert captured == {
+        "parts": ["gmail", "users", "settings", "filters", "create"],
+        "params": {"userId": "me"},
+        "body": {
+            "criteria": {
+                "from": "alerts@example.com",
+                "query": "has:attachment",
+                "excludeChats": True,
+            },
+            "action": {
+                "addLabelIds": ["Label_1", "STARRED"],
+                "removeLabelIds": ["INBOX"],
+            },
+        },
+    }
+    assert json.loads(capsys.readouterr().out)["filter"]["id"] == "filter-1"
+
+
+def test_api_gmail_filter_list_get_delete_use_settings_api(api_module, capsys):
+    calls = []
+
+    def fake_run_gws(parts, *, params=None, body=None):
+        calls.append({"parts": parts, "params": params, "body": body})
+        if parts[-1] == "list":
+            return {"filter": [{"id": "filter-1"}]}
+        return {"id": params["id"]}
+
+    api_module._run_gws = fake_run_gws
+    api_module.gmail_filter_list(api_module.argparse.Namespace())
+    api_module.gmail_filter_get(api_module.argparse.Namespace(filter_id="filter-1"))
+    api_module.gmail_filter_delete(api_module.argparse.Namespace(filter_id="filter-1"))
+
+    assert calls == [
+        {
+            "parts": ["gmail", "users", "settings", "filters", "list"],
+            "params": {"userId": "me"},
+            "body": None,
+        },
+        {
+            "parts": ["gmail", "users", "settings", "filters", "get"],
+            "params": {"userId": "me", "id": "filter-1"},
+            "body": None,
+        },
+        {
+            "parts": ["gmail", "users", "settings", "filters", "delete"],
+            "params": {"userId": "me", "id": "filter-1"},
+            "body": None,
+        },
+    ]
+    output = capsys.readouterr().out
+    assert '"id": "filter-1"' in output
+    assert '"status": "deleted"' in output
+
+
+def test_api_gmail_filter_get_uses_python_fallback(api_module, capsys):
+    request = MagicMock()
+    request.execute.return_value = {"id": "filter-1"}
+    service = MagicMock()
+    service.users().settings().filters().get.return_value = request
+    api_module._gws_binary = lambda: None
+    api_module.build_service = MagicMock(return_value=service)
+
+    api_module.gmail_filter_get(api_module.argparse.Namespace(filter_id="filter-1"))
+
+    api_module.build_service.assert_called_once_with("gmail", "v1")
+    service.users().settings().filters().get.assert_called_once_with(
+        userId="me", id="filter-1"
+    )
+    assert json.loads(capsys.readouterr().out) == {"id": "filter-1"}
+
+
+@pytest.mark.parametrize(
+    ("criteria", "actions", "message"),
+    [
+        ({}, {"add_labels": "Label_1"}, "matching criterion"),
+        ({"from_address": "alerts@example.com"}, {}, "--add-labels or --remove-labels"),
+    ],
+)
+def test_api_gmail_filter_create_rejects_incomplete_filter(
+    api_module, criteria, actions, message
+):
+    values = {
+        "from_address": "",
+        "to": "",
+        "subject": "",
+        "query": "",
+        "negated_query": "",
+        "has_attachment": False,
+        "exclude_chats": False,
+        "add_labels": "",
+        "remove_labels": "",
+        **criteria,
+        **actions,
+    }
+
+    with pytest.raises(SystemExit, match=message):
+        api_module.gmail_filter_create(api_module.argparse.Namespace(**values))
 
 
 def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Adds Gmail filter management to the bundled Google Workspace CLI wrapper. Agents can list, inspect, create, and delete filters through the existing `gws` backend or Python API fallback.

Filter creation accepts Gmail criteria and label actions, rejects empty criteria/actions, and intentionally does not expose forwarding. The skill requires previewing matching messages and user confirmation before create/delete.

## Related Issue

No existing issue or PR covers Gmail filter management. I searched open and closed issues/PRs before implementation.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `gmail filter-list`, `filter-get`, `filter-create`, and `filter-delete` commands.
- Add the `gmail.settings.basic` OAuth scope required for filter writes.
- Document preview, confirmation, output, and forwarding guardrails.
- Test request construction and incomplete-filter validation.

## How to Test

1. Run `scripts/run_tests.sh tests/skills/test_google_workspace_api.py -q`.
2. Run `python skills/productivity/google-workspace/scripts/google_api.py gmail filter-create --help`.
3. With authorized test credentials, list filters and create/delete a temporary label-only filter after previewing its Gmail search criteria.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this feature.
- [x] The focused test file passes: 19 tests.
- [x] I've added tests for my changes.
- [x] I've tested on macOS.

### Documentation & Housekeeping

- [x] I've updated relevant skill documentation.
- [x] `cli-config.yaml.example` update: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A.
- [x] Cross-platform impact considered: argparse, JSON, and existing API clients are platform-neutral.
- [x] Tool descriptions/schemas update: N/A.
