### PR TITLE
fix(desktop): retain Webhooks backend ownership across switches

### DIFF
--- a/apps/desktop/src/api/messaging.ts
+++ b/apps/desktop/src/api/messaging.ts
@@ -13,7 +13,7 @@ import type {
   WebhooksResponse
 } from '@/types/hermes'
 
-import { hermesApi, profileScoped } from './client'
+import { capabilityScoped, hermesApi, type ProfileScope, profileScoped } from './client'
 
 export function getMessagingPlatforms(profile?: null | string): Promise<MessagingPlatformsResponse> {
   return hermesApi<MessagingPlatformsResponse>({
@@ -137,33 +137,33 @@ export function revokePairing(platform: string, userId: string, profile?: null |
 // shared JSON store the CLI/dashboard also drive. Enable mutates config and
 // best-effort restarts the gateway; subscription changes hot-reload.
 
-export function getWebhooks(): Promise<WebhooksResponse> {
-  return hermesApi<WebhooksResponse>({
-    ...profileScoped(),
+export function getWebhooks(scope?: ProfileScope): Promise<WebhooksResponse> {
+  return window.hermesDesktop.api<WebhooksResponse>({
+    ...capabilityScoped(scope),
     path: '/api/webhooks'
   })
 }
 
-export function enableWebhooks(): Promise<WebhookEnableResponse> {
-  return hermesApi<WebhookEnableResponse>({
-    ...profileScoped(),
+export function enableWebhooks(scope?: ProfileScope): Promise<WebhookEnableResponse> {
+  return window.hermesDesktop.api<WebhookEnableResponse>({
+    ...capabilityScoped(scope),
     path: '/api/webhooks/enable',
     method: 'POST'
   })
 }
 
-export function createWebhook(body: WebhookCreatePayload): Promise<WebhookCreateResponse> {
-  return hermesApi<WebhookCreateResponse>({
-    ...profileScoped(),
+export function createWebhook(body: WebhookCreatePayload, scope?: ProfileScope): Promise<WebhookCreateResponse> {
+  return window.hermesDesktop.api<WebhookCreateResponse>({
+    ...capabilityScoped(scope),
     path: '/api/webhooks',
     method: 'POST',
     body
   })
 }
 
-export function deleteWebhook(name: string): Promise<{ ok: boolean }> {
-  return hermesApi<{ ok: boolean }>({
-    ...profileScoped(),
+export function deleteWebhook(name: string, scope?: ProfileScope): Promise<{ ok: boolean }> {
+  return window.hermesDesktop.api<{ ok: boolean }>({
+    ...capabilityScoped(scope),
     path: `/api/webhooks/${encodeURIComponent(name)}`,
     method: 'DELETE'
   })
@@ -171,10 +171,11 @@ export function deleteWebhook(name: string): Promise<{ ok: boolean }> {
 
 export function setWebhookEnabled(
   name: string,
-  enabled: boolean
+  enabled: boolean,
+  scope?: ProfileScope
 ): Promise<{ enabled: boolean; name: string; ok: boolean }> {
-  return hermesApi<{ enabled: boolean; name: string; ok: boolean }>({
-    ...profileScoped(),
+  return window.hermesDesktop.api<{ enabled: boolean; name: string; ok: boolean }>({
+    ...capabilityScoped(scope),
     path: `/api/webhooks/${encodeURIComponent(name)}/enabled`,
     method: 'PUT',
     body: { enabled }

--- a/apps/desktop/src/api/system.ts
+++ b/apps/desktop/src/api/system.ts
@@ -135,9 +135,9 @@ export function runCurator(): Promise<ActionResponse> {
   })
 }
 
-export function restartGateway(): Promise<ActionResponse> {
-  return hermesApi<ActionResponse>({
-    ...profileScoped(),
+export function restartGateway(scope?: ProfileScope): Promise<ActionResponse> {
+  return window.hermesDesktop.api<ActionResponse>({
+    ...capabilityScoped(scope),
     path: '/api/gateway/restart',
     method: 'POST'
   })

--- a/apps/desktop/src/app/webhooks/index.test.tsx
+++ b/apps/desktop/src/app/webhooks/index.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeGatewayProfile, $showAllProfiles } from '@/store/profile'
+
+import { WebhooksView } from './index'
+
+const createWebhook = vi.fn()
+const deleteWebhook = vi.fn()
+const enableWebhooks = vi.fn()
+const getWebhooks = vi.fn()
+const notify = vi.fn()
+const notifyError = vi.fn()
+const setWebhookEnabled = vi.fn()
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.mock('@/hermes', () => ({
+  createWebhook: (body: unknown, profile?: string) => createWebhook(body, profile),
+  deleteWebhook: (name: string, profile?: string) => deleteWebhook(name, profile),
+  enableWebhooks: (profile?: string) => enableWebhooks(profile),
+  getProfiles: vi.fn(),
+  getWebhooks: (profile?: string) => getWebhooks(profile),
+  setApiRequestProfile: vi.fn(),
+  setWebhookEnabled: (name: string, enabled: boolean, profile?: string) => setWebhookEnabled(name, enabled, profile)
+}))
+
+vi.mock('@/store/system-actions', () => ({
+  runGatewayRestart: vi.fn()
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: (...args: unknown[]) => notify(...args),
+  notifyError: (...args: unknown[]) => notifyError(...args)
+}))
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+})
+
+function renderWebhooks() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false }
+    }
+  })
+
+  return render(
+    <QueryClientProvider client={client}>
+      <WebhooksView onClose={vi.fn()} />
+    </QueryClientProvider>
+  )
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  $showAllProfiles.set(false)
+  $activeGatewayProfile.set('default')
+  getWebhooks.mockResolvedValue({ enabled: true, subscriptions: [] })
+})
+
+afterEach(() => {
+  cleanup()
+  $showAllProfiles.set(false)
+  $activeGatewayProfile.set('default')
+  vi.clearAllMocks()
+})
+
+describe('WebhooksView profile switching', () => {
+  it('closes and clears an open create draft before re-homing to another profile', async () => {
+    renderWebhooks()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'New subscription' }))
+    const name = screen.getByLabelText('Name')
+    fireEvent.change(name, { target: { value: 'default-profile-hook' } })
+    expect((name as HTMLInputElement).value).toBe('default-profile-hook')
+
+    act(() => {
+      $activeGatewayProfile.set('worker')
+    })
+
+    await waitFor(() => expect(getWebhooks).toHaveBeenCalledWith('worker'))
+    expect(screen.queryByRole('dialog')).toBeNull()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'New subscription' }))
+    expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('')
+  })
+
+  it('re-homes when the active backend changes while the All profiles view stays selected', async () => {
+    $showAllProfiles.set(true)
+    renderWebhooks()
+
+    await waitFor(() => expect(getWebhooks).toHaveBeenCalledWith('default'))
+    fireEvent.click(await screen.findByRole('button', { name: 'New subscription' }))
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'default-profile-hook' } })
+
+    act(() => {
+      $activeGatewayProfile.set('worker')
+    })
+
+    await waitFor(() => expect(getWebhooks).toHaveBeenCalledWith('worker'))
+    expect($showAllProfiles.get()).toBe(true)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('does not reveal a prior profile webhook secret when create completes after a switch', async () => {
+    const pending = deferred<{ secret: string; url: string }>()
+    createWebhook.mockReturnValueOnce(pending.promise)
+    renderWebhooks()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'New subscription' }))
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'default-profile-hook' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+    await waitFor(() =>
+      expect(createWebhook).toHaveBeenCalledWith(expect.objectContaining({ name: 'default-profile-hook' }), 'default')
+    )
+
+    act(() => {
+      $activeGatewayProfile.set('worker')
+    })
+
+    await act(async () => {
+      pending.resolve({ secret: 'default-profile-secret', url: 'https://example.test/hooks/default' })
+      await pending.promise
+    })
+
+    expect(screen.queryByText('default-profile-secret')).toBeNull()
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(notify).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/webhooks/index.test.tsx
+++ b/apps/desktop/src/app/webhooks/index.test.tsx
@@ -1,0 +1,287 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { StrictMode } from 'react'
+import { afterEach, beforeAll, beforeEach, expect, it, vi } from 'vitest'
+
+import { HermesGateway } from '@/api/client'
+import type { HermesConnection } from '@/global'
+import { queryClient } from '@/lib/query-client'
+import {
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  ensureGatewayForAgent,
+  ensureGatewayForProfile,
+  setPrimaryGateway,
+  setPrimaryGatewayConnectionId
+} from '@/store/gateway'
+import { $notifications, clearNotifications } from '@/store/notifications'
+import { $activeGatewayProfile, $showAllProfiles } from '@/store/profile'
+import { $connection } from '@/store/session'
+import { $gatewayRestarting, watchGatewayRestartOutcome } from '@/store/system-actions'
+
+import { WebhooksView } from './index'
+
+interface Request {
+  body?: unknown
+  connectionId?: string
+  method?: string
+  path: string
+  profile?: string
+}
+
+const api = vi.fn<(request: Request) => Promise<unknown>>()
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+})
+
+beforeEach(async () => {
+  api.mockReset()
+  queryClient.clear()
+  queryClient.setDefaultOptions({ queries: { retry: false } })
+  clearNotifications()
+  $showAllProfiles.set(false)
+  $activeGatewayProfile.set('default')
+  // Only socket transport and the Electron bridge are replaced. Registry
+  // activation, scope stores, REST helpers and restart polling stay real.
+  const connected = new WeakSet<HermesGateway>()
+  vi.spyOn(HermesGateway.prototype, 'connect').mockImplementation(async function (this: HermesGateway) {
+    connected.add(this)
+  })
+  vi.spyOn(HermesGateway.prototype, 'connectionState', 'get').mockImplementation(function (this: HermesGateway) {
+    return connected.has(this) ? 'open' : 'closed'
+  })
+  vi.spyOn(HermesGateway.prototype, 'close').mockImplementation(function (this: HermesGateway) {
+    connected.delete(this)
+  })
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: {
+      api,
+      getConnection: async () => connection(null, 'default'),
+      getConnectionFor: async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+        connection(connectionId, profile),
+      touchBackend: async () => undefined
+    }
+  })
+  configureGatewayRegistry({
+    activeConnectionId: () => $connection.get()?.connectionId ?? null,
+    onEvent: vi.fn(),
+    onActiveRouteChanged: profile => {
+      if ($activeGatewayProfile.get() !== profile) {
+        $activeGatewayProfile.set(profile)
+      }
+    }
+  })
+  await activatePrimary(null)
+})
+
+afterEach(() => {
+  cleanup()
+  queryClient.clear()
+  clearNotifications()
+  $showAllProfiles.set(false)
+  $activeGatewayProfile.set('default')
+  closeSecondaryGateways()
+  setPrimaryGateway(null)
+  $connection.set(null)
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+  Reflect.deleteProperty(window, 'hermesDesktop')
+})
+
+function renderWebhooks() {
+  return render(
+    <StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <WebhooksView onClose={vi.fn()} />
+      </QueryClientProvider>
+    </StrictMode>
+  )
+}
+
+function connection(connectionId: null | string, profile: string): HermesConnection {
+  return {
+    baseUrl: 'https://example.test',
+    ...(connectionId ? { connectionId } : {}),
+    isFullscreen: false,
+    logs: [],
+    nativeOverlayWidth: 0,
+    profile,
+    registryScoped: Boolean(connectionId),
+    token: '',
+    windowButtonPosition: null,
+    wsUrl: 'wss://example.test'
+  }
+}
+
+async function activatePrimary(connectionId: null | string) {
+  await ensureGatewayForProfile('default')
+  const gateway = new HermesGateway()
+  await gateway.connect('wss://example.test')
+  setPrimaryGateway(gateway, 'default')
+  setPrimaryGatewayConnectionId(connectionId)
+  $connection.set(connection(connectionId, 'default'))
+  await ensureGatewayForProfile('default')
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+it('keeps drafts and one-time secrets with their backend profile under StrictMode', async () => {
+  const pending = deferred<{ secret: string; url: string }>()
+  let creates = 0
+  api.mockImplementation(async request => {
+    if (request.path === '/api/webhooks' && request.method === 'POST') {
+      creates += 1
+
+      return creates === 2 ? pending.promise : { secret: `secret-${creates}`, url: 'https://example.test/created' }
+    }
+
+    return { enabled: true, subscriptions: [] }
+  })
+  await activatePrimary('host-a')
+  $showAllProfiles.set(true)
+  renderWebhooks()
+
+  fireEvent.click(await screen.findByRole('button', { name: 'New subscription' }))
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'first' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+  expect(await screen.findByText('secret-1')).toBeTruthy()
+  fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+  fireEvent.click(screen.getByRole('button', { name: 'New subscription' }))
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'pending-draft' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+  await waitFor(() => expect(creates).toBe(2))
+  clearNotifications()
+
+  await act(async () => {
+    expect(await ensureGatewayForAgent('host-b', 'default')).toBe(true)
+  })
+  await act(async () => {
+    pending.resolve({ secret: 'previous-profile-secret', url: 'https://example.test/previous' })
+    await pending.promise
+  })
+
+  await waitFor(() => expect(api).toHaveBeenCalledWith(expect.objectContaining({ connectionId: 'host-b' })))
+  expect(screen.queryByText('previous-profile-secret')).toBeNull()
+  expect(screen.queryByRole('dialog')).toBeNull()
+  expect($notifications.get()).toEqual([])
+  expect($showAllProfiles.get()).toBe(true)
+  expect(queryClient.getQueryData(['webhooks', 'host-b::default'])).toEqual({ enabled: true, subscriptions: [] })
+  fireEvent.click(screen.getByRole('button', { name: 'New subscription' }))
+  expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('')
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'new-host-draft' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+  expect(await screen.findByText('secret-3')).toBeTruthy()
+  const secondaryDescriptor = $connection.get()
+  await act(async () => {
+    await ensureGatewayForProfile('default')
+  })
+  // The primary fast path changes the socket, but publishes neither a new
+  // descriptor nor a different profile name. Its old secret must still clear.
+  expect($connection.get()).toBe(secondaryDescriptor)
+  expect($activeGatewayProfile.get()).toBe('default')
+  expect(screen.queryByText('secret-3')).toBeNull()
+  expect(screen.queryByRole('dialog')).toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'New subscription' }))
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'primary-draft' } })
+  await act(async () => {
+    expect(await ensureGatewayForAgent('host-b', 'worker')).toBe(true)
+  })
+  await waitFor(() => expect(api).toHaveBeenCalledWith(expect.objectContaining({ profile: 'worker' })))
+  expect(screen.queryByRole('dialog')).toBeNull()
+  expect(queryClient.getQueryData(['webhooks', 'host-b::worker'])).toEqual({ enabled: true, subscriptions: [] })
+})
+
+it('keeps restart polls with their legacy or registry owner across a same-profile host switch', async () => {
+  let polls = 0
+  api.mockImplementation(async request => {
+    if (request.path === '/api/webhooks/enable') {
+      return { restart_started: false, restart_error: 'manual restart required' }
+    }
+
+    if (request.path === '/api/gateway/restart') {
+      return { name: 'gateway-restart' }
+    }
+
+    if (request.path.startsWith('/api/actions/')) {
+      polls += 1
+
+      return { running: polls === 1, exit_code: polls === 1 ? null : 1 }
+    }
+
+    return { enabled: false, subscriptions: [] }
+  })
+
+  for (const connectionId of [null, 'host-a']) {
+    polls = 0
+    api.mockClear()
+    await activatePrimary(connectionId)
+    const view = renderWebhooks()
+    fireEvent.click(await screen.findByRole('button', { name: 'Enable webhooks' }))
+    const restart = await screen.findByRole('button', { name: 'Restart gateway' })
+    clearNotifications()
+    vi.useFakeTimers()
+
+    await act(async () => {
+      fireEvent.click(restart)
+      await vi.advanceTimersByTimeAsync(1200)
+    })
+    expect(polls).toBe(1)
+    expect($gatewayRestarting.get()).toBe(true)
+    await act(async () => {
+      expect(await ensureGatewayForAgent('host-b', 'default')).toBe(true)
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1200)
+    })
+
+    expect(polls).toBe(2)
+
+    const restartRequests = api.mock.calls
+      .map(([request]) => request)
+      .filter(request => request.path === '/api/gateway/restart' || request.path.startsWith('/api/actions/'))
+
+    for (const request of restartRequests) {
+      expect(request.profile).toBe('default')
+      // Untagged legacy requests must stay untagged, preserving remote overrides.
+      expect(request.connectionId).toBe(connectionId ?? undefined)
+    }
+
+    expect($gatewayRestarting.get()).toBe(false)
+    expect($notifications.get()).toEqual([])
+    expect(screen.queryByRole('button', { name: 'Restart gateway' })).toBeNull()
+    view.unmount()
+    queryClient.clear()
+    vi.useRealTimers()
+  }
+
+  // The same ownership applies when the backend started the restart itself.
+  vi.useFakeTimers()
+  const watching = watchGatewayRestartOutcome()
+  await act(async () => {
+    await ensureGatewayForProfile('default')
+  })
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(1200)
+    expect(await watching).toBe(false)
+  })
+  expect(api.mock.calls.at(-1)?.[0]).toEqual(expect.objectContaining({ connectionId: 'host-b', profile: 'default' }))
+  expect($gatewayRestarting.get()).toBe(false)
+  expect($notifications.get()).toEqual([])
+})

--- a/apps/desktop/src/app/webhooks/index.tsx
+++ b/apps/desktop/src/app/webhooks/index.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { PageLoader } from '@/components/page-loader'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -33,7 +33,7 @@ import { useI18n } from '@/i18n'
 import { AlertTriangle, Globe, Plus, RefreshCw } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
-import { $profileScope } from '@/store/profile'
+import { $activeGatewayProfile } from '@/store/profile'
 import { runGatewayRestart } from '@/store/system-actions'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
@@ -79,12 +79,24 @@ interface WebhooksViewProps {
 }
 
 export function WebhooksView({ onClose }: WebhooksViewProps) {
+  const profile = useStore($activeGatewayProfile)
+
+  return <ProfileWebhooksView key={profile} onClose={onClose} profile={profile} />
+}
+
+interface ProfileWebhooksViewProps extends WebhooksViewProps {
+  profile: string
+}
+
+function ProfileWebhooksView({ onClose, profile }: ProfileWebhooksViewProps) {
   const { t } = useI18n()
   const w = t.webhooks
-  // Re-load when the active profile changes so REST routes to the right backend.
-  const profileScope = useStore($profileScope)
   const queryClient = useQueryClient()
-  const queryKey = useMemo(() => ['webhooks', profileScope] as const, [profileScope])
+  const queryKey = useMemo(() => ['webhooks', profile] as const, [profile])
+  const active = useRef(true)
+  const reloadTimer = useRef<null | number>(null)
+
+  const isActiveProfile = useCallback(() => active.current && $activeGatewayProfile.get() === profile, [profile])
 
   const [query, setQuery] = useState('')
   const [enabling, setEnabling] = useState(false)
@@ -107,6 +119,18 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
 
   const [pendingDelete, setPendingDelete] = useState<null | string>(null)
 
+  useEffect(() => {
+    active.current = true
+
+    return () => {
+      active.current = false
+
+      if (reloadTimer.current !== null) {
+        window.clearTimeout(reloadTimer.current)
+      }
+    }
+  }, [])
+
   const {
     data,
     error,
@@ -114,7 +138,7 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
     refetch
   } = useQuery({
     queryKey,
-    queryFn: getWebhooks
+    queryFn: () => getWebhooks(profile)
   })
 
   // React Query v5 dropped useQuery onError; surface a load failure toast once
@@ -135,46 +159,81 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
       try {
         await queryClient.invalidateQueries({ queryKey })
       } catch (err) {
-        if (!silent) {
+        if (!silent && isActiveProfile()) {
           notifyError(err, w.loadFailed)
         }
       }
     },
-    [queryClient, queryKey, w.loadFailed]
+    [isActiveProfile, queryClient, queryKey, w.loadFailed]
   )
+
+  const scheduleReload = useCallback(() => {
+    if (reloadTimer.current !== null) {
+      window.clearTimeout(reloadTimer.current)
+    }
+
+    reloadTimer.current = window.setTimeout(() => {
+      if (isActiveProfile()) {
+        void reload(true)
+      }
+    }, 4000)
+  }, [isActiveProfile, reload])
 
   useRefreshHotkey(() => void refetch())
 
   const restartGatewayNow = useCallback(async () => {
+    if (!isActiveProfile()) {
+      return
+    }
+
     setRestarting(true)
 
     try {
       await runGatewayRestart()
+
+      if (!isActiveProfile()) {
+        return
+      }
+
       setRestartNeeded(false)
       setRestartError(null)
       // Give the receiver a moment to bind before re-reading state.
-      window.setTimeout(() => void reload(true), 4000)
+      scheduleReload()
     } catch (err) {
+      if (!isActiveProfile()) {
+        return
+      }
+
       setRestartNeeded(true)
       setRestartError(String(err))
       notifyError(err, w.restartFailed(''))
     } finally {
-      setRestarting(false)
+      if (isActiveProfile()) {
+        setRestarting(false)
+      }
     }
-  }, [reload, w])
+  }, [isActiveProfile, scheduleReload, w])
 
   const handleEnable = useCallback(async () => {
+    if (!isActiveProfile()) {
+      return
+    }
+
     setEnabling(true)
     setRestartNeeded(false)
     setRestartError(null)
 
     try {
-      const result = await enableWebhooks()
+      const result = await enableWebhooks(profile)
       await reload(true)
+
+      if (!isActiveProfile()) {
+        return
+      }
 
       if (result.restart_started) {
         notify({ kind: 'success', message: w.enabledRestarting })
-        window.setTimeout(() => void reload(true), 4000)
+        scheduleReload()
       } else {
         const detail = result.restart_error ? `: ${result.restart_error}` : '.'
         setRestartNeeded(true)
@@ -182,11 +241,15 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
         notify({ kind: 'error', message: w.restartFailed(detail) })
       }
     } catch (err) {
-      notifyError(err, w.restartFailed(''))
+      if (isActiveProfile()) {
+        notifyError(err, w.restartFailed(''))
+      }
     } finally {
-      setEnabling(false)
+      if (isActiveProfile()) {
+        setEnabling(false)
+      }
     }
-  }, [reload, w])
+  }, [isActiveProfile, profile, reload, scheduleReload, w])
 
   const resetForm = useCallback(() => {
     setName('')
@@ -208,6 +271,10 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
   }, [creating])
 
   const handleCreate = useCallback(async () => {
+    if (!isActiveProfile()) {
+      return
+    }
+
     if (!name.trim()) {
       notify({ kind: 'error', message: w.nameRequired })
 
@@ -227,29 +294,45 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
         .map(s => s.trim())
         .filter(Boolean)
 
-      const res = await createWebhook({
-        deliver,
-        deliver_only: deliverOnly,
-        description: description.trim() || undefined,
-        events: eventsList.length ? eventsList : undefined,
-        name: name.trim(),
-        prompt: prompt.trim() || undefined,
-        skills: skillsList.length ? skillsList : undefined
-      })
+      const res = await createWebhook(
+        {
+          deliver,
+          deliver_only: deliverOnly,
+          description: description.trim() || undefined,
+          events: eventsList.length ? eventsList : undefined,
+          name: name.trim(),
+          prompt: prompt.trim() || undefined,
+          skills: skillsList.length ? skillsList : undefined
+        },
+        profile
+      )
+
+      void reload(true)
+
+      if (!isActiveProfile()) {
+        return
+      }
 
       notify({ kind: 'success', message: w.created })
       setCreated({ secret: res.secret, url: res.url })
       resetForm()
-      void reload(true)
     } catch (err) {
-      notifyError(err, w.createFailed(''))
+      if (isActiveProfile()) {
+        notifyError(err, w.createFailed(''))
+      }
     } finally {
-      setCreating(false)
+      if (isActiveProfile()) {
+        setCreating(false)
+      }
     }
-  }, [deliver, deliverOnly, description, events, name, prompt, reload, resetForm, skills, w])
+  }, [deliver, deliverOnly, description, events, isActiveProfile, name, profile, prompt, reload, resetForm, skills, w])
 
   const handleToggle = useCallback(
     async (subName: string, nextEnabled: boolean) => {
+      if (!isActiveProfile()) {
+        return
+      }
+
       // Optimistic cache paint; the invalidate below lets backend truth win.
       queryClient.setQueryData<WebhooksResponse>(queryKey, current =>
         current
@@ -261,34 +344,47 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
       )
 
       try {
-        await setWebhookEnabled(subName, nextEnabled)
-        notify({ kind: 'success', message: nextEnabled ? w.enabled(subName) : w.disabled(subName) })
+        await setWebhookEnabled(subName, nextEnabled, profile)
         void reload(true)
+
+        if (isActiveProfile()) {
+          notify({ kind: 'success', message: nextEnabled ? w.enabled(subName) : w.disabled(subName) })
+        }
       } catch (err) {
         await reload(true)
-        notifyError(err, w.toggleFailed(subName))
+
+        if (isActiveProfile()) {
+          notifyError(err, w.toggleFailed(subName))
+        }
       }
     },
-    [queryClient, queryKey, reload, w]
+    [isActiveProfile, profile, queryClient, queryKey, reload, w]
   )
 
   // ConfirmDialog owns the pending→done→close beat; throw to surface its inline
   // error and keep the dialog open. Success toast matches the cron delete idiom
   // (title + name).
   const handleDelete = useCallback(async () => {
-    if (!pendingDelete) {
+    if (!pendingDelete || !isActiveProfile()) {
       return
     }
 
     try {
-      await deleteWebhook(pendingDelete)
-      notify({ kind: 'success', title: w.deleted, message: pendingDelete })
+      await deleteWebhook(pendingDelete, profile)
       void reload(true)
+
+      if (isActiveProfile()) {
+        notify({ kind: 'success', title: w.deleted, message: pendingDelete })
+      }
     } catch (err) {
+      if (!isActiveProfile()) {
+        return
+      }
+
       notifyError(err, w.deleteFailed(pendingDelete))
       throw err
     }
-  }, [pendingDelete, reload, w])
+  }, [isActiveProfile, pendingDelete, profile, reload, w])
 
   const visible = useMemo(() => {
     const q = query.trim().toLowerCase()

--- a/apps/desktop/src/app/webhooks/index.tsx
+++ b/apps/desktop/src/app/webhooks/index.tsx
@@ -1,6 +1,7 @@
 import { useStore } from '@nanostores/react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { computed } from 'nanostores'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { PageLoader } from '@/components/page-loader'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -24,7 +25,9 @@ import {
   createWebhook,
   deleteWebhook,
   enableWebhooks,
+  getApiRequestConnection,
   getWebhooks,
+  profileScopeKey,
   setWebhookEnabled,
   type WebhookRoute,
   type WebhooksResponse
@@ -32,8 +35,10 @@ import {
 import { useI18n } from '@/i18n'
 import { AlertTriangle, Globe, Plus, RefreshCw } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { $gateway, activeGatewayConnectionId } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
-import { $profileScope } from '@/store/profile'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $connection } from '@/store/session'
 import { runGatewayRestart } from '@/store/system-actions'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
@@ -77,13 +82,45 @@ interface WebhooksViewProps {
   onClose: () => void
 }
 
+// Returning to the primary socket may leave the descriptor and profile name
+// unchanged. Read its registry owner when the socket changes, before the
+// ambient REST connection is published later in the same activation.
+const $webhooksScope = computed([$gateway, $connection, $activeGatewayProfile], (_gateway, _connection, profile) => ({
+  connectionId: activeGatewayConnectionId(),
+  profile
+}))
+
 export function WebhooksView({ onClose }: WebhooksViewProps) {
+  const scope = useStore($webhooksScope)
+
+  return (
+    <ProfileWebhooksView
+      connectionId={scope.connectionId}
+      key={profileScopeKey(scope)}
+      onClose={onClose}
+      profile={scope.profile}
+    />
+  )
+}
+
+interface ProfileWebhooksViewProps extends WebhooksViewProps {
+  connectionId: null | string
+  profile: string
+}
+
+function ProfileWebhooksView({ connectionId, onClose, profile }: ProfileWebhooksViewProps) {
   const { t } = useI18n()
   const w = t.webhooks
-  // Re-load when the active profile changes so REST routes to the right backend.
-  const profileScope = useStore($profileScope)
   const queryClient = useQueryClient()
-  const queryKey = useMemo(() => ['webhooks', profileScope] as const, [profileScope])
+  const scope = useMemo(() => ({ connectionId, profile }), [connectionId, profile])
+  const queryKey = useMemo(() => ['webhooks', profileScopeKey(scope)] as const, [scope])
+  const active = useRef(true)
+  const reloadTimer = useRef<null | number>(null)
+
+  const isActiveScope = useCallback(
+    () => active.current && $activeGatewayProfile.get() === profile && getApiRequestConnection() === connectionId,
+    [connectionId, profile]
+  )
 
   const [query, setQuery] = useState('')
   const [enabling, setEnabling] = useState(false)
@@ -106,6 +143,19 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
 
   const [pendingDelete, setPendingDelete] = useState<null | string>(null)
 
+  // eslint-disable-next-line no-restricted-syntax -- mount lifetime, not an atom mirror
+  useEffect(() => {
+    active.current = true
+
+    return () => {
+      active.current = false
+
+      if (reloadTimer.current !== null) {
+        window.clearTimeout(reloadTimer.current)
+      }
+    }
+  }, [])
+
   const {
     data,
     error,
@@ -113,7 +163,7 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
     refetch
   } = useQuery({
     queryKey,
-    queryFn: getWebhooks
+    queryFn: () => getWebhooks(scope)
   })
 
   // React Query v5 dropped useQuery onError; surface a load failure toast once
@@ -134,48 +184,76 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
       try {
         await queryClient.invalidateQueries({ queryKey })
       } catch (err) {
-        if (!silent) {
+        if (!silent && isActiveScope()) {
           notifyError(err, w.loadFailed)
         }
       }
     },
-    [queryClient, queryKey, w.loadFailed]
+    [isActiveScope, queryClient, queryKey, w.loadFailed]
   )
+
+  const scheduleReload = useCallback(() => {
+    if (reloadTimer.current !== null) {
+      window.clearTimeout(reloadTimer.current)
+    }
+
+    reloadTimer.current = window.setTimeout(() => {
+      if (isActiveScope()) {
+        void reload(true)
+      }
+    }, 4000)
+  }, [isActiveScope, reload])
 
   useRefreshHotkey(() => void refetch())
 
   const restartGatewayNow = useCallback(async () => {
+    if (!isActiveScope()) {
+      return
+    }
+
     setRestarting(true)
 
     // runGatewayRestart never rejects (it toasts its own failure); the boolean
     // is the only signal that the receiver actually came back.
-    const ok = await runGatewayRestart()
+    const ok = await runGatewayRestart(scope)
+
+    if (!isActiveScope()) {
+      return
+    }
 
     if (ok) {
       setRestartNeeded(false)
       setRestartError(null)
       // Give the receiver a moment to bind before re-reading state.
-      window.setTimeout(() => void reload(true), 4000)
+      scheduleReload()
     } else {
       setRestartNeeded(true)
       setRestartError(w.restartFailed(''))
     }
 
     setRestarting(false)
-  }, [reload, w])
+  }, [isActiveScope, scope, scheduleReload, w])
 
   const handleEnable = useCallback(async () => {
+    if (!isActiveScope()) {
+      return
+    }
+
     setEnabling(true)
     setRestartNeeded(false)
     setRestartError(null)
 
     try {
-      const result = await enableWebhooks()
+      const result = await enableWebhooks(scope)
       await reload(true)
+
+      if (!isActiveScope()) {
+        return
+      }
 
       if (result.restart_started) {
         notify({ kind: 'success', message: w.enabledRestarting })
-        window.setTimeout(() => void reload(true), 4000)
+        scheduleReload()
       } else {
         const detail = result.restart_error ? `: ${result.restart_error}` : '.'
         setRestartNeeded(true)
@@ -183,11 +261,15 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
         notify({ kind: 'error', message: w.restartFailed(detail) })
       }
     } catch (err) {
-      notifyError(err, w.restartFailed(''))
+      if (isActiveScope()) {
+        notifyError(err, w.restartFailed(''))
+      }
     } finally {
-      setEnabling(false)
+      if (isActiveScope()) {
+        setEnabling(false)
+      }
     }
-  }, [reload, w])
+  }, [isActiveScope, scope, reload, scheduleReload, w])
 
   const resetForm = useCallback(() => {
     setName('')
@@ -209,6 +291,10 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
   }, [creating])
 
   const handleCreate = useCallback(async () => {
+    if (!isActiveScope()) {
+      return
+    }
+
     if (!name.trim()) {
       notify({ kind: 'error', message: w.nameRequired })
 
@@ -228,29 +314,45 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
         .map(s => s.trim())
         .filter(Boolean)
 
-      const res = await createWebhook({
-        deliver,
-        deliver_only: deliverOnly,
-        description: description.trim() || undefined,
-        events: eventsList.length ? eventsList : undefined,
-        name: name.trim(),
-        prompt: prompt.trim() || undefined,
-        skills: skillsList.length ? skillsList : undefined
-      })
+      const res = await createWebhook(
+        {
+          deliver,
+          deliver_only: deliverOnly,
+          description: description.trim() || undefined,
+          events: eventsList.length ? eventsList : undefined,
+          name: name.trim(),
+          prompt: prompt.trim() || undefined,
+          skills: skillsList.length ? skillsList : undefined
+        },
+        scope
+      )
+
+      void reload(true)
+
+      if (!isActiveScope()) {
+        return
+      }
 
       notify({ kind: 'success', message: w.created })
       setCreated({ secret: res.secret, url: res.url })
       resetForm()
-      void reload(true)
     } catch (err) {
-      notifyError(err, w.createFailed(''))
+      if (isActiveScope()) {
+        notifyError(err, w.createFailed(''))
+      }
     } finally {
-      setCreating(false)
+      if (isActiveScope()) {
+        setCreating(false)
+      }
     }
-  }, [deliver, deliverOnly, description, events, name, prompt, reload, resetForm, skills, w])
+  }, [deliver, deliverOnly, description, events, isActiveScope, name, scope, prompt, reload, resetForm, skills, w])
 
   const handleToggle = useCallback(
     async (subName: string, nextEnabled: boolean) => {
+      if (!isActiveScope()) {
+        return
+      }
+
       // Optimistic cache paint; the invalidate below lets backend truth win.
       queryClient.setQueryData<WebhooksResponse>(queryKey, current =>
         current
@@ -262,34 +364,47 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
       )
 
       try {
-        await setWebhookEnabled(subName, nextEnabled)
-        notify({ kind: 'success', message: nextEnabled ? w.enabled(subName) : w.disabled(subName) })
+        await setWebhookEnabled(subName, nextEnabled, scope)
         void reload(true)
+
+        if (isActiveScope()) {
+          notify({ kind: 'success', message: nextEnabled ? w.enabled(subName) : w.disabled(subName) })
+        }
       } catch (err) {
         await reload(true)
-        notifyError(err, w.toggleFailed(subName, nextEnabled))
+
+        if (isActiveScope()) {
+          notifyError(err, w.toggleFailed(subName, nextEnabled))
+        }
       }
     },
-    [queryClient, queryKey, reload, w]
+    [isActiveScope, scope, queryClient, queryKey, reload, w]
   )
 
   // ConfirmDialog owns the pending→done→close beat; throw to surface its inline
   // error and keep the dialog open. Success toast matches the cron delete idiom
   // (title + name).
   const handleDelete = useCallback(async () => {
-    if (!pendingDelete) {
+    if (!pendingDelete || !isActiveScope()) {
       return
     }
 
     try {
-      await deleteWebhook(pendingDelete)
-      notify({ kind: 'success', title: w.deleted, message: pendingDelete })
+      await deleteWebhook(pendingDelete, scope)
       void reload(true)
+
+      if (isActiveScope()) {
+        notify({ kind: 'success', title: w.deleted, message: pendingDelete })
+      }
     } catch (err) {
+      if (!isActiveScope()) {
+        return
+      }
+
       notifyError(err, w.deleteFailed(pendingDelete))
       throw err
     }
-  }, [pendingDelete, reload, w])
+  }, [isActiveScope, pendingDelete, scope, reload, w])
 
   const visible = useMemo(() => {
     const q = query.trim().toLowerCase()

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1141,33 +1141,33 @@ export function testMessagingPlatform(platformId: string): Promise<MessagingPlat
 // shared JSON store the CLI/dashboard also drive. Enable mutates config and
 // best-effort restarts the gateway; subscription changes hot-reload.
 
-export function getWebhooks(): Promise<WebhooksResponse> {
+export function getWebhooks(profile?: string): Promise<WebhooksResponse> {
   return window.hermesDesktop.api<WebhooksResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/webhooks'
   })
 }
 
-export function enableWebhooks(): Promise<WebhookEnableResponse> {
+export function enableWebhooks(profile?: string): Promise<WebhookEnableResponse> {
   return window.hermesDesktop.api<WebhookEnableResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/webhooks/enable',
     method: 'POST'
   })
 }
 
-export function createWebhook(body: WebhookCreatePayload): Promise<WebhookCreateResponse> {
+export function createWebhook(body: WebhookCreatePayload, profile?: string): Promise<WebhookCreateResponse> {
   return window.hermesDesktop.api<WebhookCreateResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/webhooks',
     method: 'POST',
     body
   })
 }
 
-export function deleteWebhook(name: string): Promise<{ ok: boolean }> {
+export function deleteWebhook(name: string, profile?: string): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/webhooks/${encodeURIComponent(name)}`,
     method: 'DELETE'
   })
@@ -1175,10 +1175,11 @@ export function deleteWebhook(name: string): Promise<{ ok: boolean }> {
 
 export function setWebhookEnabled(
   name: string,
-  enabled: boolean
+  enabled: boolean,
+  profile?: string
 ): Promise<{ enabled: boolean; name: string; ok: boolean }> {
   return window.hermesDesktop.api<{ enabled: boolean; name: string; ok: boolean }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/webhooks/${encodeURIComponent(name)}/enabled`,
     method: 'PUT',
     body: { enabled }

--- a/apps/desktop/src/store/system-actions.ts
+++ b/apps/desktop/src/store/system-actions.ts
@@ -1,6 +1,12 @@
 import { atom } from 'nanostores'
 
-import { getActionStatus, restartGateway } from '@/hermes'
+import {
+  getActionStatus,
+  getApiRequestConnection,
+  getApiRequestProfile,
+  type ProfileScope,
+  restartGateway
+} from '@/hermes'
 import { translateNow } from '@/i18n'
 import { notifyError } from '@/store/notifications'
 import type { ActionResponse } from '@/types/hermes'
@@ -19,10 +25,10 @@ export const $gatewayRestarting = atom(false)
 // non-zero exit so the caller can surface the failure. In no-service installs
 // the child becomes the foreground gateway and never exits, so "still running
 // when the window closes" counts as success.
-async function awaitAction(name: string): Promise<void> {
+async function awaitAction(name: string, scope: ProfileScope): Promise<void> {
   for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt += 1) {
     await new Promise(resolve => window.setTimeout(resolve, POLL_INTERVAL_MS))
-    const status = await getActionStatus(name, POLL_TIMEOUT_S)
+    const status = await getActionStatus(name, POLL_TIMEOUT_S, scope)
 
     if (!status.running) {
       if (status.exit_code != null && status.exit_code !== 0) {
@@ -40,16 +46,20 @@ async function awaitAction(name: string): Promise<void> {
 // `void runGatewayRestart()`, and a failure is the only thing that toasts.
 // Resolves `true` when the restart child completed cleanly (callers that keep
 // a "restart needed" banner clear it on that signal only).
-export async function runGatewayRestart(): Promise<boolean> {
+export async function runGatewayRestart(
+  scope = { connectionId: getApiRequestConnection(), profile: getApiRequestProfile() }
+): Promise<boolean> {
   $gatewayRestarting.set(true)
 
   try {
-    const started: ActionResponse = await restartGateway()
-    await awaitAction(started.name)
+    const started: ActionResponse = await restartGateway(scope)
+    await awaitAction(started.name, scope)
 
     return true
   } catch (err) {
-    notifyError(err, translateNow('commandCenter.gatewayRestartFailed'))
+    if (getApiRequestProfile() === scope.profile && getApiRequestConnection() === scope.connectionId) {
+      notifyError(err, translateNow('commandCenter.gatewayRestartFailed'))
+    }
 
     return false
   } finally {
@@ -61,10 +71,11 @@ export async function runGatewayRestart(): Promise<boolean> {
 // credentials) instead of one this app requested. Same indicator, same bounded
 // poll; resolves `false` on a non-zero exit so the caller can re-arm its banner.
 export async function watchGatewayRestartOutcome(): Promise<boolean> {
+  const scope = { connectionId: getApiRequestConnection(), profile: getApiRequestProfile() }
   $gatewayRestarting.set(true)
 
   try {
-    await awaitAction(GATEWAY_RESTART_ACTION)
+    await awaitAction(GATEWAY_RESTART_ACTION, scope)
 
     return true
   } catch {

--- a/apps/desktop/src/webhooks-rest.test.ts
+++ b/apps/desktop/src/webhooks-rest.test.ts
@@ -19,15 +19,17 @@ describe('Webhook REST parity helpers', () => {
   })
 
   it('lists webhooks from the admin endpoint', async () => {
-    await getWebhooks()
+    await getWebhooks('worker')
 
-    expect(api).toHaveBeenCalledWith(expect.objectContaining({ path: '/api/webhooks' }))
+    expect(api).toHaveBeenCalledWith(expect.objectContaining({ path: '/api/webhooks', profile: 'worker' }))
   })
 
   it('enables the webhook platform with POST', async () => {
-    await enableWebhooks()
+    await enableWebhooks('worker')
 
-    expect(api).toHaveBeenCalledWith(expect.objectContaining({ method: 'POST', path: '/api/webhooks/enable' }))
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'POST', path: '/api/webhooks/enable', profile: 'worker' })
+    )
   })
 
   it('creates a subscription with the full payload', async () => {
@@ -40,25 +42,30 @@ describe('Webhook REST parity helpers', () => {
       prompt: 'summarize the push'
     }
 
-    await createWebhook(body)
+    await createWebhook(body, 'worker')
 
-    expect(api).toHaveBeenCalledWith(expect.objectContaining({ body, method: 'POST', path: '/api/webhooks' }))
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({ body, method: 'POST', path: '/api/webhooks', profile: 'worker' })
+    )
   })
 
   it('encodes the name when deleting a subscription', async () => {
-    await deleteWebhook('my hook')
+    await deleteWebhook('my hook', 'worker')
 
-    expect(api).toHaveBeenCalledWith(expect.objectContaining({ method: 'DELETE', path: '/api/webhooks/my%20hook' }))
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'DELETE', path: '/api/webhooks/my%20hook', profile: 'worker' })
+    )
   })
 
   it('toggles a subscription enabled state via PUT', async () => {
-    await setWebhookEnabled('github-push', false)
+    await setWebhookEnabled('github-push', false, 'worker')
 
     expect(api).toHaveBeenCalledWith(
       expect.objectContaining({
         body: { enabled: false },
         method: 'PUT',
-        path: '/api/webhooks/github-push/enabled'
+        path: '/api/webhooks/github-push/enabled',
+        profile: 'worker'
       })
     )
   })


### PR DESCRIPTION
## What does this PR do?

Keep Webhooks tied to the backend that the page is showing. If you switch profiles while a subscription is being created, the previous profile's one-time secret and draft should not appear in the new one. The same applies when two registered servers both use a profile named `default`.

Webhooks now captures its connection and profile together, uses that owner for requests and cached data, and resets transient state when the active gateway changes. Restart requests and every subsequent status poll also retain their original owner, so a failed restart cannot show an error in the backend you switched to. Untagged legacy requests keep their existing per-profile routing.

## Related Issue

Fixes #71352. Addresses the unresolved restart-polling review on this PR.

#71538 is an open alternative for the original profile-scoping issue; this revision brings this existing PR forward to the current API modules and gateway registry.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/webhooks/index.tsx`: bind query data, drafts, dialogs and one-time secrets to the active backend; discard stale completions and delayed reloads.
- `apps/desktop/src/api/messaging.ts`, `apps/desktop/src/api/system.ts`: accept the existing explicit backend scope for Webhooks and restart requests.
- `apps/desktop/src/store/system-actions.ts`: retain that scope throughout restart polling and only report failures to the owning backend.
- `apps/desktop/src/app/webhooks/index.test.tsx`, `apps/desktop/src/webhooks-rest.test.ts`: exercise real gateway activation and API helpers, including StrictMode and legacy routing.

## How to Test

1. On backend A, open Webhooks and create a subscription. Switch to backend B before creation resolves. The old secret, draft and notifications must not appear on B. Repeat with two servers whose profile names are both `default`, then return to the primary server.
2. Enable Webhooks, start a gateway restart, and switch backends while it is being polled. Every status request must still target A; a failed result must not display an error on B.
3. Run the two regression invariants and existing endpoint tests from `apps/desktop`: `npx vitest run --project ui src/app/webhooks/index.test.tsx src/webhooks-rest.test.ts`.

On macOS arm64 with Node 26.3.1, both new invariants fail on current main and pass with this change. The targeted UI/REST tests pass (7), the existing Electron connection-routing tests pass (216), and the complete desktop typecheck passes. The full UI run passed 797 files / 7,577 tests; one existing test file needed two backend source files missing from the sparse checkout. After restoring those unchanged files, its 4 tests passed on a focused rerun. Lint and formatting checks passed for the changed files.

The automated tests retain the real UI, query client, stores, gateway registry and REST helpers; only WebSocket transport and the Electron boundary are stubbed. I have not run a packaged Electron app or restarted a real gateway.

## Checklist

- [x] Read the Contributing Guide.
- [x] Searched existing PRs; the overlapping alternative is linked above.
- [x] Kept the change focused on Webhooks and restart ownership.
- [x] Added regression tests and proved them failing on the base branch.
- [x] Tested on macOS arm64.
- [ ] Full Python test suite — not run; this change is in the desktop renderer and its API helpers.
- [x] Documentation, config keys and tool schemas — no changes needed.
- [x] Considered cross-platform impact; no platform-specific filesystem/process behavior was changed.
