### PR TITLE
fix(install): avoid realpath dependency in macOS venv launcher (#71320)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1654,12 +1654,33 @@ setup_path() {
     # the rm, `cat >` follows the symlink and overwrites the venv pip entry
     # point with this shim — making `exec "$HERMES_BIN"` self-recurse. (#21454)
     rm -f "$command_link_dir/hermes"
-    cat > "$command_link_dir/hermes" <<EOF
+    if [ "$USE_VENV" = true ]; then
+        # For venv installs, exec the venv's python interpreter directly
+        # against the checked-in `hermes` launcher script instead of the
+        # uv-generated console-script wrapper at $HERMES_BIN. uv's generated
+        # wrapper resolves its own location via the external `realpath`
+        # binary at runtime on some platforms; stock macOS (no Homebrew/
+        # coreutils) does not ship `realpath`, so that wrapper fails with
+        # `realpath: command not found` — followed by a misleading
+        # `ModuleNotFoundError` because the launcher never reaches the venv
+        # interpreter to report the real error. Invoking the interpreter and
+        # entrypoint script directly avoids that dependency entirely, and
+        # this shim gets regenerated on every `hermes update` regardless of
+        # what uv does to venv/bin/hermes. (#71320)
+        cat > "$command_link_dir/hermes" <<EOF
+#!/usr/bin/env bash
+unset PYTHONPATH
+unset PYTHONHOME
+exec "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/hermes" "\$@"
+EOF
+    else
+        cat > "$command_link_dir/hermes" <<EOF
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
 exec "$HERMES_BIN" "\$@"
 EOF
+    fi
     chmod +x "$command_link_dir/hermes"
     log_success "Installed hermes launcher → $command_link_display_dir/hermes"
 

--- a/tests/test_install_sh_macos_no_realpath_launcher.py
+++ b/tests/test_install_sh_macos_no_realpath_launcher.py
@@ -1,0 +1,111 @@
+"""Regression for #71320: `hermes update` breaks stock macOS when the
+uv-generated venv console-script wrapper needs an external `realpath` binary.
+
+Stock macOS (no Homebrew/coreutils) does not ship `realpath` on PATH. The
+uv-generated console-script at `venv/bin/hermes` resolves its own location
+via `realpath` at runtime on some uv/Python versions; when that lookup fails,
+the launcher errors out with `realpath: command not found` and then a
+misleading `ModuleNotFoundError: No module named 'yaml'` (PyYAML is actually
+present in the venv — the launcher just never reaches that interpreter).
+
+Fix: for venv installs, the user-facing shim written by `setup_path()` must
+exec the venv's python interpreter directly against the checked-in `hermes`
+entrypoint script, bypassing the uv wrapper (and its `realpath` dependency)
+entirely. This also means the shim gets recreated correctly on every
+`hermes update`, since it no longer depends on what uv regenerates at
+`venv/bin/hermes`.
+"""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_venv_launcher_shim_does_not_exec_hermes_bin_directly() -> None:
+    """Static guard: for USE_VENV, the shim must not shell out via $HERMES_BIN."""
+    text = INSTALL_SH.read_text()
+    assert 'exec "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/hermes"' in text, (
+        "setup_path() must, for venv installs, write a shim that execs the "
+        "venv python interpreter directly against the checked-in `hermes` "
+        "entrypoint script instead of the uv console-script wrapper at "
+        "$HERMES_BIN. See #71320."
+    )
+
+
+def test_venv_launcher_shim_runs_without_realpath_on_path(tmp_path: Path) -> None:
+    """Behavioral repro: simulate the venv-branch shim with no `realpath` on PATH.
+
+    Builds a fake INSTALL_DIR with a venv python and a checked-in `hermes`
+    entrypoint script, drives the exact shim body used for USE_VENV=true, and
+    runs it with a PATH stripped of `realpath` (simulating stock macOS) to
+    confirm the launcher does not depend on that binary.
+    """
+    install_dir = tmp_path / "install"
+    venv_bin = install_dir / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+
+    # Fake venv python: just execs the real interpreter's binary via a shell
+    # wrapper so this stays a tiny, fast, dependency-free stand-in.
+    import sys
+
+    python_stub = venv_bin / "python"
+    python_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f'exec "{sys.executable}" "$@"\n'
+    )
+    python_stub.chmod(python_stub.stat().st_mode | stat.S_IXUSR)
+
+    hermes_entry = install_dir / "hermes"
+    hermes_entry.write_text(
+        "import sys\n"
+        "print('LAUNCHED:' + ','.join(sys.argv[1:]))\n"
+    )
+
+    command_link_dir = tmp_path / "local_bin"
+    command_link_dir.mkdir()
+    shim_path = command_link_dir / "hermes"
+    shim_path.write_text(
+        "#!/usr/bin/env bash\n"
+        "unset PYTHONPATH\n"
+        "unset PYTHONHOME\n"
+        f'exec "{install_dir}/venv/bin/python" "{install_dir}/hermes" "$@"\n'
+    )
+    shim_path.chmod(shim_path.stat().st_mode | stat.S_IXUSR)
+
+    # PATH with no `realpath` on it — a minimal directory of symlinks to the
+    # binaries actually needed (bash, python), excluding realpath, so this
+    # simulates stock macOS regardless of what else lives alongside bash on
+    # the host running the test.
+    import os
+    import shutil
+
+    bash_path = shutil.which("bash")
+    assert bash_path is not None, "test setup invalid: bash not found on PATH"
+
+    fake_bin = tmp_path / "fake_bin"
+    fake_bin.mkdir()
+    os.symlink(bash_path, fake_bin / "bash")
+    os.symlink(sys.executable, fake_bin / Path(sys.executable).name)
+    minimal_path = str(fake_bin)
+
+    result = subprocess.run(
+        ["bash", str(shim_path), "foo", "bar"],
+        capture_output=True,
+        text=True,
+        env={"PATH": minimal_path, "HOME": str(tmp_path)},
+    )
+
+    assert shutil.which("realpath", path=minimal_path) is None, (
+        "test setup invalid: `realpath` must be absent from the minimal PATH "
+        "used to simulate stock macOS"
+    )
+    assert result.returncode == 0, (
+        f"launcher shim failed without `realpath` on PATH:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "LAUNCHED:foo,bar" in result.stdout


### PR DESCRIPTION
Fixes #71320

## Root cause

On stock macOS (no Homebrew/coreutils installed), `realpath` is not on
`PATH`. The venv-branch shim written by `setup_path()` in `scripts/install.sh`
previously invoked `$HERMES_BIN` (`$INSTALL_DIR/venv/bin/hermes`), the
uv/pip-generated console-script wrapper. That wrapper resolves its own
location via the external `realpath` binary at runtime on some
uv/Python versions. Without `realpath` on `PATH`, the wrapper fails with
`realpath: command not found`, and the launcher never reaches the venv's
Python interpreter — surfacing as a misleading
`ModuleNotFoundError: No module named 'yaml'` even though PyYAML is present
in the venv. `hermes update` regenerates this broken wrapper every time,
so the failure persists across updates.

## Changes

- `scripts/install.sh`, `setup_path()`: for venv installs (`USE_VENV=true`),
  the user-facing shim at `$command_link_dir/hermes` now execs the venv's
  python interpreter directly against the checked-in `hermes` entrypoint
  script (`exec "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/hermes" "$@"`)
  instead of shelling out to the uv-generated console script at
  `$HERMES_BIN`. This removes the runtime dependency on an external
  `realpath` binary entirely for venv installs, and since the shim is
  written fresh by `setup_path()` on every `hermes update`, it stays correct
  regardless of what uv does to `venv/bin/hermes`.
- Non-venv installs (`--no-venv`, `USE_VENV=false`) are unchanged — they
  still resolve and exec `$HERMES_BIN` from `PATH` as before.
- Added `tests/test_install_sh_macos_no_realpath_launcher.py`:
  - a static guard asserting the venv-branch shim body execs the venv
    python + checked-in `hermes` script rather than `$HERMES_BIN`
  - a behavioral test that builds a fake venv + `hermes` entrypoint,
    writes the exact shim body used by `setup_path()`, and runs it with a
    minimal `PATH` that excludes `realpath` (simulating stock macOS),
    confirming the launcher runs successfully and forwards argv correctly.

## Verification

This environment is Linux (aarch64), not macOS, so I could not reproduce or
verify the fix on real stock macOS — I want to be explicit about that
limitation rather than claim untested macOS behavior.

What I did verify:
- `bash -n scripts/install.sh` — script is syntactically valid after the edit.
- Ran the full existing install-related regression suite plus the new test
  file locally via `uv run pytest`:
  `tests/test_install_sh_symlink_stomp.py`,
  `tests/test_install_sh_pythonpath_sanitization.py`,
  `tests/test_install_sh_root_fhs_uv_python_path.py`,
  `tests/test_install_sh_macos_no_realpath_launcher.py` — all 8 tests pass,
  including the pre-existing #21454 symlink-stomp regression test (the
  venv-branch change doesn't touch the non-venv `rm -f` / symlink-safety
  logic those tests pin).
- Manually simulated the generated shim on Linux with a `PATH` stripped of
  `realpath` (asserted via `shutil.which("realpath", path=minimal_path) is
  None` in the new test) to confirm the venv-python + entrypoint-script
  invocation succeeds without ever needing `realpath`, unlike the old
  `$HERMES_BIN` wrapper path.
- Did not test on an actual macOS machine; a maintainer or the original
  reporter with macOS access should confirm `hermes update` followed by
  `hermes` now works end-to-end on stock macOS.
