### PR TITLE
fix(gateway): dedupe shutdown notifications across rapid restart cycles (#71180)

### DIFF
--- a/gateway/restart_loop_guard.py
+++ b/gateway/restart_loop_guard.py
@@ -119,6 +119,77 @@ def clear() -> None:
         pass
 
 
+DEFAULT_NOTIFICATION_COOLDOWN_SECONDS = 60
+
+
+def _notification_state_path():
+    return get_hermes_home() / "gateway" / "shutdown_notifications.json"
+
+
+def _load_notification_timestamps() -> dict:
+    try:
+        raw = _notification_state_path().read_text(encoding="utf-8")
+        data = json.loads(raw)
+        last_notified = data.get("last_notified", {})
+        return {str(k): float(v) for k, v in last_notified.items() if isinstance(v, (int, float))}
+    except (OSError, ValueError, TypeError):
+        return {}
+
+
+def _save_notification_timestamps(timestamps: dict) -> None:
+    try:
+        path = _notification_state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"last_notified": timestamps}), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def should_suppress_shutdown_notification(
+    destination_key: str,
+    cooldown_seconds: float = DEFAULT_NOTIFICATION_COOLDOWN_SECONDS,
+    *,
+    now: Optional[float] = None,
+) -> bool:
+    """Return True when a shutdown notification for ``destination_key`` was
+    already sent within ``cooldown_seconds`` (#71180).
+
+    ``_notify_active_sessions_of_shutdown`` in ``gateway/run.py`` dedupes
+    sends within a *single* shutdown via a local in-memory set, but that set
+    starts empty on every fresh gateway process. When something outside
+    Hermes repeatedly cycles the host (OS suspend/resume tearing a WSL
+    distro down and back up, a flapping supervisor, ...), each new process
+    is free to announce a "first" shutdown again seconds after the previous
+    process already announced one, flooding the destination.
+
+    This persists the last-notified timestamp per destination across
+    process restarts (mirroring the restart-loop breaker's own persistence
+    model) so a genuinely rapid re-cycle is suppressed while an isolated
+    shutdown still notifies normally.
+
+    When NOT suppressing, this call also records the current attempt as the
+    new "last notified" timestamp — callers should call this immediately
+    before sending, not after, so a failed send doesn't leave the window
+    unrecorded and re-flood on retry.
+
+    Best-effort / fails OPEN: any read/write error never suppresses a
+    legitimate notification (``cooldown_seconds <= 0`` also disables it).
+    """
+    if cooldown_seconds <= 0:
+        return False
+    ts = time.time() if now is None else now
+    try:
+        timestamps = _load_notification_timestamps()
+    except Exception:  # pragma: no cover — _load_notification_timestamps already guards
+        return False
+    last = timestamps.get(destination_key)
+    if last is not None and (ts - last) < cooldown_seconds:
+        return True
+    timestamps[destination_key] = ts
+    _save_notification_timestamps(timestamps)
+    return False
+
+
 def check_and_record(
     max_restarts: int = DEFAULT_MAX_RESTARTS,
     window_seconds: int = DEFAULT_WINDOW_SECONDS,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4912,6 +4912,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pass
         return max_restarts, window_seconds
 
+    def _shutdown_notification_cooldown_seconds(self) -> float:
+        """Return the cooldown (seconds) that suppresses re-sending the same
+        home/session shutdown notification across rapid gateway restart
+        cycles (#71180), read from
+        ``gateway.shutdown_notification_cooldown_seconds`` in config.yaml
+        with the module default as fallback. ``<= 0`` disables the cooldown
+        (every process announces its own shutdown, matching legacy
+        behavior).
+        """
+        from gateway import restart_loop_guard as _rlg
+
+        cooldown = _rlg.DEFAULT_NOTIFICATION_COOLDOWN_SECONDS
+        try:
+            user_cfg = _load_gateway_config()
+            gw = user_cfg.get("gateway") if isinstance(user_cfg, dict) else None
+            raw = gw.get("shutdown_notification_cooldown_seconds") if isinstance(gw, dict) else None
+            if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+                cooldown = raw
+        except Exception:  # noqa: BLE001
+            pass
+        return cooldown
+
     def _scale_to_zero_should_arm(self) -> bool:
         """Whether to start the idle watcher (D1/D11/§3.4(1))."""
         from gateway.relay import relay_wake_url
@@ -6649,6 +6671,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "Shutdown notification suppressed for active session: %s has gateway_restart_notification=false",
                         platform_str,
                     )
+                    continue
+
+                from gateway import restart_loop_guard as _rlg
+
+                cooldown = self._shutdown_notification_cooldown_seconds()
+                if _rlg.should_suppress_shutdown_notification(
+                    f"{platform_str}:{chat_id}:{thread_id or ''}",
+                    cooldown,
+                ):
+                    logger.info(
+                        "Shutdown notification suppressed for %s:%s — already notified within the last %ss "
+                        "(#71180 rapid-restart flood guard)",
+                        platform_str,
+                        chat_id,
+                        cooldown,
+                    )
+                    notified.add(dedup_key)
                     continue
 
                 reply_to_message_id = getattr(source, "message_id", None) if source is not None else None

--- a/tests/gateway/test_71180_shutdown_notification_flood.py
+++ b/tests/gateway/test_71180_shutdown_notification_flood.py
@@ -1,0 +1,96 @@
+"""Regression test for #71180: gateway re-broadcasts the shutdown
+notification to the same destination on every process start/stop cycle.
+
+``_notify_active_sessions_of_shutdown`` dedupes sends within a *single*
+shutdown via a local in-memory set, but that set is reset on every fresh
+gateway process, so rapid host-driven restart cycling (WSL suspend/resume
+tearing the distro down and back up, a flapping supervisor, ...) causes each
+new process to re-announce a "first" shutdown seconds after the previous
+process already announced one. ``restart_loop_guard.should_suppress_shutdown_notification``
+persists the last-notified timestamp per destination across process
+restarts so rapid re-cycling is suppressed while a genuine isolated
+shutdown still notifies normally.
+"""
+
+import gateway.restart_loop_guard as restart_loop_guard
+from gateway.session import build_session_key
+from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_notification_state(tmp_path, monkeypatch):
+    monkeypatch.setattr(restart_loop_guard, "get_hermes_home", lambda: tmp_path)
+
+
+async def _fresh_process_notifies(now: float, monkeypatch):
+    """Simulate a brand-new gateway process (fresh in-memory dedup set)
+    experiencing its own first shutdown and calling the shared
+    notification path."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="active-42")
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = type("E", (), {"origin": source})()
+
+    from unittest.mock import AsyncMock
+    from gateway.platforms.base import SendResult
+
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m"))
+
+    import gateway.run as gateway_run  # noqa: F401
+    monkeypatch.setattr(restart_loop_guard.time, "time", lambda: now)
+    await runner._notify_active_sessions_of_shutdown()
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_rapid_restart_cycling_suppresses_repeat_notifications(monkeypatch):
+    """Simulates ~10 process cycles inside a 60s cooldown window (mirroring
+    the WSL suspend/resume flap from the issue) — only the FIRST process's
+    notification should actually send.
+    """
+    base = 1_000_000.0
+    sends = []
+    for i in range(10):
+        adapter = await _fresh_process_notifies(base + i * 3, monkeypatch)  # every 3s, like a fast flap
+        sends.append(adapter.send.await_count)
+
+    assert sends[0] == 1, "first (genuine) shutdown must notify"
+    assert sum(sends[1:]) == 0, (
+        f"repeat process cycles inside the cooldown window must be suppressed, got per-cycle sends={sends}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_isolated_shutdown_after_cooldown_still_notifies(monkeypatch):
+    """A genuine, isolated shutdown that happens well outside the cooldown
+    window (not part of a rapid restart loop) must still notify normally.
+    """
+    base = 2_000_000.0
+    first = await _fresh_process_notifies(base, monkeypatch)
+    assert first.send.await_count == 1
+
+    later = await _fresh_process_notifies(base + restart_loop_guard.DEFAULT_NOTIFICATION_COOLDOWN_SECONDS + 5, monkeypatch)
+    assert later.send.await_count == 1, "shutdown outside the cooldown window must notify again"
+
+
+def test_should_suppress_shutdown_notification_unit(tmp_path, monkeypatch):
+    monkeypatch.setattr(restart_loop_guard, "get_hermes_home", lambda: tmp_path)
+
+    assert restart_loop_guard.should_suppress_shutdown_notification(
+        "telegram:42:None", cooldown_seconds=60, now=1000.0
+    ) is False
+    # Immediately repeating within the cooldown is suppressed.
+    assert restart_loop_guard.should_suppress_shutdown_notification(
+        "telegram:42:None", cooldown_seconds=60, now=1005.0
+    ) is True
+    # Past the cooldown, it notifies again.
+    assert restart_loop_guard.should_suppress_shutdown_notification(
+        "telegram:42:None", cooldown_seconds=60, now=1065.0
+    ) is False
+    # A cooldown of 0 disables suppression entirely (legacy behavior).
+    assert restart_loop_guard.should_suppress_shutdown_notification(
+        "telegram:42:None", cooldown_seconds=0, now=1065.1
+    ) is False


### PR DESCRIPTION
Fixes #71180

## Root cause

`GatewayRunner._notify_active_sessions_of_shutdown` in `gateway/run.py` dedupes sends via a **local in-memory set** (`notified: set[...]`), which correctly prevents double-sending within a *single* shutdown. But that set starts empty on every fresh gateway process, so nothing prevents a brand-new process from announcing another "first" shutdown seconds after the previous process already announced one — no state was persisted across process restarts. On a WSL host where Windows Modern Standby cycled the distro every ~33s for ~10 minutes, this produced 240 duplicate shutdown messages to the reporter's Telegram home channel.

No component was actually crashing — each process is genuinely experiencing its own first shutdown from its own point of view. The defect is notification **volume/flooding** under rapid restart cycling, not a functional break.

## Fix

Extended `gateway/restart_loop_guard.py` (rather than inventing a new persistence mechanism) — it already has the exact pattern needed: a small JSON state file under `<HERMES_HOME>/gateway/`, profile-scoped, best-effort/fail-open on read/write errors. Added:

- `should_suppress_shutdown_notification(destination_key, cooldown_seconds, now=None)` — persists a `last_notified` timestamp per destination (`platform:chat_id:thread_id`) to `<HERMES_HOME>/gateway/shutdown_notifications.json`. Returns `True` (suppress) if the same destination was already notified within `cooldown_seconds`; otherwise records the attempt and returns `False`.

`gateway/run.py`:

- `_shutdown_notification_cooldown_seconds()` — reads `gateway.shutdown_notification_cooldown_seconds` from `config.yaml` (default 60s), matching the project's config.yaml-not-env-var convention (AGENTS.md).
- `_notify_active_sessions_of_shutdown` now calls `should_suppress_shutdown_notification` per destination, right after the existing `gateway_restart_notification` opt-out check and before sending, so a suppressed destination never hits the adapter at all. Suppression is logged at INFO for observability.

This is purely additive on top of the existing in-process dedup — a **genuine, isolated shutdown still notifies normally** (nothing changes for the common single-restart case, since the cooldown default is short relative to normal operator gaps between restarts, and the very first notification for any destination is never suppressed).

## Tests

Added `tests/gateway/test_71180_shutdown_notification_flood.py`:

- `test_rapid_restart_cycling_suppresses_repeat_notifications` — simulates 10 fresh-process shutdown cycles 3s apart (mirroring the WSL flap) and asserts only the first actually sends.
- `test_isolated_shutdown_after_cooldown_still_notifies` — asserts a shutdown *outside* the cooldown window still notifies normally.
- `test_should_suppress_shutdown_notification_unit` — direct unit coverage of the new guard function, including the `cooldown_seconds<=0` disable path.

Ran targeted suite locally:

```
python -m pytest tests/gateway/test_71180_shutdown_notification_flood.py tests/gateway/test_gateway_shutdown.py tests/gateway/test_restart_notification.py tests/gateway/test_restart_drain.py -q
81 passed in 19.72s
```