### PR TITLE
feat(voice): add Codex realtime Discord speech route

### DIFF
--- a/agent/transports/codex_realtime_voice.py
+++ b/agent/transports/codex_realtime_voice.py
@@ -302,7 +302,9 @@ class AiortcRealtimePeer:
         except Exception as exc:
             # MediaStreamError is the normal remote-track EOF during teardown.
             # Outside teardown it means speech output is gone, so fail over.
-            logger.debug("Codex realtime remote audio ended: %s", exc)
+            logger.debug(
+                "Codex realtime remote audio ended: %s", safe_realtime_error(exc)
+            )
             if not self._closing:
                 self._notify_failure("WebRTC remote audio ended")
 
@@ -722,15 +724,13 @@ class CodexRealtimeSession:
             )
         self._speech_generation += 1
         generation = self._speech_generation
-        self._speech_gate = True
-        self._speech_started_at = time.monotonic()
-        self._speech_last_pcm_at = None
-        # Fail closed if WebRTC output never starts or never becomes idle.
-        gate_timeout = min(180.0, max(10.0, len(cleaned) / 8.0))
+        # Do not trust any remote PCM until app-server has accepted this exact
+        # Hermes-authored speech request. Opening the gate before the JSON-RPC
+        # acknowledgement can expose delayed or unsolicited provider audio.
+        self._speech_gate = False
         self._cancel_speech_watchdog()
-        self._speech_watchdog_task = asyncio.create_task(
-            self._watch_speech_gate(generation, gate_timeout)
-        )
+        self._speech_started_at = None
+        self._speech_last_pcm_at = None
         try:
             await asyncio.to_thread(
                 self._client.request,
@@ -739,10 +739,23 @@ class CodexRealtimeSession:
                 15,
             )
         except Exception as exc:
-            self._speech_gate = False
-            self._fail(f"Codex realtime speech failed: {exc}")
+            safe_reason = safe_realtime_error(f"Codex realtime speech failed: {exc}")
+            self._fail(safe_reason)
             self._schedule_stop()
-            raise
+            raise CodexRealtimeUnavailable(safe_reason) from None
+        if not self._active:
+            return False
+        if generation != self._speech_generation:
+            raise CodexRealtimeStaleSpeech(
+                "Hermes reply was superseded while realtime speech was starting"
+            )
+        self._speech_gate = True
+        self._speech_started_at = time.monotonic()
+        # Fail closed if WebRTC output never starts or never becomes idle.
+        gate_timeout = min(180.0, max(10.0, len(cleaned) / 8.0))
+        self._speech_watchdog_task = asyncio.create_task(
+            self._watch_speech_gate(generation, gate_timeout)
+        )
         return True
 
     async def stop(self) -> None:
@@ -770,8 +783,11 @@ class CodexRealtimeSession:
                         {"threadId": self._thread_id},
                         10,
                     )
-                except Exception:
-                    logger.debug("Codex realtime stop request failed", exc_info=True)
+                except Exception as exc:
+                    logger.debug(
+                        "Codex realtime stop request failed: %s",
+                        safe_realtime_error(exc),
+                    )
             await self._close_resources()
 
     async def _close_resources(self) -> None:
@@ -783,10 +799,16 @@ class CodexRealtimeSession:
         if peer is not None:
             try:
                 await peer.close()
-            except Exception:
-                logger.debug("Codex realtime WebRTC close failed", exc_info=True)
+            except Exception as exc:
+                logger.debug(
+                    "Codex realtime WebRTC close failed: %s",
+                    safe_realtime_error(exc),
+                )
         if client is not None:
             try:
                 await asyncio.to_thread(client.close)
-            except Exception:
-                logger.debug("Codex realtime app-server close failed", exc_info=True)
+            except Exception as exc:
+                logger.debug(
+                    "Codex realtime app-server close failed: %s",
+                    safe_realtime_error(exc),
+                )

--- a/agent/transports/codex_realtime_voice.py
+++ b/agent/transports/codex_realtime_voice.py
@@ -379,6 +379,7 @@ class CodexRealtimeSession:
         self._speech_generation = 0
         self._speech_started_at: Optional[float] = None
         self._speech_last_pcm_at: Optional[float] = None
+        self._speech_first_pcm_event: Optional[asyncio.Event] = None
         self._speech_watchdog_task: Optional[asyncio.Task] = None
         self._peer_failure_reason: Optional[str] = None
         self._failure_notified = False
@@ -570,6 +571,7 @@ class CodexRealtimeSession:
                     # can trigger independent remote-model audio.
                     self._speech_generation += 1
                     self._speech_gate = False
+                    self._wake_speech_start_waiter()
                     self._cancel_speech_watchdog()
                     continue
                 if method == "thread/realtime/transcript/done":
@@ -577,6 +579,7 @@ class CodexRealtimeSession:
                     if role == "user":
                         self._speech_generation += 1
                         self._speech_gate = False
+                        self._wake_speech_start_waiter()
                         self._cancel_speech_watchdog()
                         text = str(params.get("text") or "").strip()
                         if text:
@@ -620,8 +623,21 @@ class CodexRealtimeSession:
 
     def _handle_peer_pcm(self, pcm: bytes) -> None:
         if self._speech_gate:
-            self._speech_last_pcm_at = time.monotonic()
+            now = time.monotonic()
+            first_pcm = self._speech_last_pcm_at is None
+            self._speech_last_pcm_at = now
+            if first_pcm and self._speech_started_at is not None:
+                logger.info(
+                    "Codex realtime speech audio started after %.3fs",
+                    now - self._speech_started_at,
+                )
+            self._wake_speech_start_waiter()
             self._emit_output_pcm(pcm)
+
+    def _wake_speech_start_waiter(self) -> None:
+        event = self._speech_first_pcm_event
+        if event is not None:
+            event.set()
 
     def _handle_peer_failure(self, reason: str) -> None:
         safe_reason = safe_realtime_error(reason)
@@ -680,6 +696,7 @@ class CodexRealtimeSession:
         self._active = False
         self._speech_generation += 1
         self._speech_gate = False
+        self._wake_speech_start_waiter()
         self._cancel_speech_watchdog()
         self._speech_started_at = None
         self._speech_last_pcm_at = None
@@ -751,11 +768,35 @@ class CodexRealtimeSession:
             )
         self._speech_gate = True
         self._speech_started_at = time.monotonic()
+        self._speech_last_pcm_at = None
+        first_pcm_event = asyncio.Event()
+        self._speech_first_pcm_event = first_pcm_event
         # Fail closed if WebRTC output never starts or never becomes idle.
         gate_timeout = min(180.0, max(10.0, len(cleaned) / 8.0))
         self._speech_watchdog_task = asyncio.create_task(
             self._watch_speech_gate(generation, gate_timeout)
         )
+        try:
+            await asyncio.wait_for(
+                first_pcm_event.wait(),
+                timeout=SPEECH_FIRST_AUDIO_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            safe_reason = "Codex realtime speech produced no audio"
+            self._fail(safe_reason)
+            self._schedule_stop()
+            raise CodexRealtimeUnavailable(safe_reason) from None
+        finally:
+            if self._speech_first_pcm_event is first_pcm_event:
+                self._speech_first_pcm_event = None
+        if generation != self._speech_generation:
+            raise CodexRealtimeStaleSpeech(
+                "Hermes reply was superseded before realtime audio started"
+            )
+        if not self._active or self._speech_last_pcm_at is None:
+            raise CodexRealtimeUnavailable(
+                "Codex realtime speech ended before audio started"
+            )
         return True
 
     async def stop(self) -> None:
@@ -764,6 +805,7 @@ class CodexRealtimeSession:
             self._active = False
             self._speech_generation += 1
             self._speech_gate = False
+            self._wake_speech_start_waiter()
             watchdog = self._speech_watchdog_task
             self._cancel_speech_watchdog()
             self._speech_started_at = None

--- a/agent/transports/codex_realtime_voice.py
+++ b/agent/transports/codex_realtime_voice.py
@@ -1,0 +1,692 @@
+"""Experimental Codex GPT-Live realtime voice transport.
+
+This module owns only the Codex app-server/WebRTC boundary. Discord capture,
+agent routing, and playback stay in the gateway/platform edge. The realtime
+model is deliberately used as a speech interface: Hermes remains responsible
+for the actual assistant turn and tool execution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from agent.transports.codex_app_server import (
+    CodexAppServerClient,
+    check_codex_binary,
+)
+
+logger = logging.getLogger(__name__)
+
+MIN_CODEX_REALTIME_VERSION = (0, 145, 0)
+REALTIME_SAMPLE_RATE = 24_000
+REALTIME_CHANNELS = 1
+REALTIME_FRAME_SAMPLES = 480  # 20 ms at 24 kHz
+
+_SPEECH_INTERFACE_PROMPT = (
+    "You are a low-latency speech interface for another assistant. "
+    "Transcribe the user's speech accurately. Do not answer the user, "
+    "do not call tools, and do not delegate work. Stay silent until "
+    "the client supplies text to speak."
+)
+
+
+class CodexRealtimeUnavailable(RuntimeError):
+    """Raised when the optional Codex realtime route cannot be started."""
+
+
+def safe_realtime_error(message: Any) -> str:
+    """Return an actionable error without backend URLs or request metadata."""
+    text = str(message or "Codex realtime voice failed").strip()
+    lowered = text.lower()
+    if "voice session access denied" in lowered or "realtime access denied" in lowered:
+        return "Codex account is not entitled to realtime voice"
+    if "realtime conversation requires api key auth" in lowered:
+        return "Codex realtime route requires API-key authentication"
+    from agent.redact import redact_sensitive_text
+
+    text = redact_sensitive_text(text, force=True, redact_url_credentials=True)
+    text = re.sub(r"https?://\S+", "<backend-url>", text)
+    text = re.sub(r"(?i)(request id|cf-ray):\s*[^,\s]+", r"\1: <redacted>", text)
+    return text[:300]
+
+
+@dataclass(frozen=True)
+class CodexRealtimeCapabilities:
+    """Capabilities Hermes may safely expose for this experimental route."""
+
+    protocol_version: str
+    voices: tuple[str, ...]
+    language_selection: bool = False
+    reasoning_effort: bool = False
+
+
+def _require_numpy():
+    try:
+        import numpy as np
+    except ImportError as exc:  # pragma: no cover - dependency gate exercises this
+        raise CodexRealtimeUnavailable(
+            "Codex realtime voice requires the optional voice dependencies"
+        ) from exc
+    return np
+
+
+def discord_pcm_to_realtime(pcm: bytes) -> bytes:
+    """Convert Discord 48 kHz stereo s16le PCM to 24 kHz mono s16le."""
+
+    if not pcm:
+        return b""
+    np = _require_numpy()
+    samples = np.frombuffer(pcm, dtype=np.int16)
+    usable = samples.size - (samples.size % 4)
+    if usable <= 0:
+        return b""
+    stereo = samples[:usable].reshape(-1, 2).astype(np.int32)
+    mono_48k = (stereo[:, 0] + stereo[:, 1]) // 2
+    mono_24k = (mono_48k[0::2] + mono_48k[1::2]) // 2
+    return np.clip(mono_24k, -32768, 32767).astype(np.int16).tobytes()
+
+
+class _AiortcOutgoingAudioTrack:
+    """Small wrapper around a lazily-created aiortc MediaStreamTrack."""
+
+    def __init__(self) -> None:
+        from aiortc import MediaStreamTrack
+        from av import AudioFrame
+
+        queue: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=100)
+
+        class QueuedTrack(MediaStreamTrack):
+            kind = "audio"
+
+            def __init__(track_self) -> None:
+                super().__init__()
+                track_self._pts = 0
+                track_self._started_at: Optional[float] = None
+
+            async def recv(track_self):
+                loop = asyncio.get_running_loop()
+                if track_self._started_at is None:
+                    track_self._started_at = loop.time()
+                target = track_self._started_at + (
+                    track_self._pts / REALTIME_SAMPLE_RATE
+                )
+                delay = target - loop.time()
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                try:
+                    pcm = queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pcm = b"\x00" * (REALTIME_FRAME_SAMPLES * 2)
+                if pcm is None:
+                    track_self.stop()
+                    raise asyncio.CancelledError
+                sample_count = len(pcm) // 2
+                frame = AudioFrame(format="s16", layout="mono", samples=sample_count)
+                frame.planes[0].update(pcm)
+                frame.sample_rate = REALTIME_SAMPLE_RATE
+                frame.pts = track_self._pts
+                frame.time_base = Fraction(1, REALTIME_SAMPLE_RATE)
+                track_self._pts += sample_count
+                return frame
+
+        self.track = QueuedTrack()
+        self._queue = queue
+
+    def push(self, pcm: bytes) -> None:
+        if not pcm:
+            return
+        try:
+            self._queue.put_nowait(pcm)
+        except asyncio.QueueFull:
+            try:
+                self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+            try:
+                self._queue.put_nowait(pcm)
+            except asyncio.QueueFull:  # pragma: no cover - defensive race
+                pass
+
+    def close(self) -> None:
+        try:
+            self._queue.put_nowait(None)
+        except asyncio.QueueFull:
+            try:
+                self._queue.get_nowait()
+                self._queue.put_nowait(None)
+            except (asyncio.QueueEmpty, asyncio.QueueFull):
+                pass
+        self.track.stop()
+
+
+class AiortcRealtimePeer:
+    """OAuth-compatible WebRTC media peer for Codex app-server realtime."""
+
+    def __init__(self) -> None:
+        self._pc = None
+        self._outgoing: Optional[_AiortcOutgoingAudioTrack] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._remote_tasks: set[asyncio.Task] = set()
+        self._on_pcm: Optional[Callable[[bytes], None]] = None
+        self._on_failure: Optional[Callable[[str], None]] = None
+        self._closing = False
+        self._failure_reported = False
+
+    async def create_offer(
+        self,
+        on_pcm: Callable[[bytes], None],
+        on_failure: Optional[Callable[[str], None]] = None,
+    ) -> str:
+        try:
+            from aiortc import RTCPeerConnection
+        except ImportError as exc:
+            raise CodexRealtimeUnavailable(
+                "Codex realtime voice requires aiortc; install the realtime voice extra"
+            ) from exc
+
+        self._loop = asyncio.get_running_loop()
+        self._on_pcm = on_pcm
+        self._on_failure = on_failure
+        self._pc = RTCPeerConnection()
+        self._outgoing = _AiortcOutgoingAudioTrack()
+        self._pc.addTrack(self._outgoing.track)
+        # The OpenAI realtime WebRTC contract expects this channel in the SDP,
+        # even though Codex app-server consumes events through its sideband WS.
+        self._pc.createDataChannel("oai-events")
+
+        @self._pc.on("track")
+        def _on_track(track) -> None:
+            if getattr(track, "kind", None) != "audio":
+                return
+            task = asyncio.create_task(self._consume_remote_audio(track))
+            self._remote_tasks.add(task)
+            task.add_done_callback(self._remote_tasks.discard)
+
+        @self._pc.on("connectionstatechange")
+        def _on_connection_state() -> None:
+            if (
+                self._pc is not None
+                and self._pc.connectionState in {"failed", "closed"}
+                and not self._closing
+            ):
+                self._notify_failure(f"WebRTC connection {self._pc.connectionState}")
+
+        offer = await self._pc.createOffer()
+        await self._pc.setLocalDescription(offer)
+        await self._wait_for_ice_gathering()
+        local = self._pc.localDescription
+        if local is None or not local.sdp:
+            raise CodexRealtimeUnavailable("WebRTC produced no local SDP offer")
+        return local.sdp
+
+    async def _wait_for_ice_gathering(self, timeout: float = 10.0) -> None:
+        if self._pc is None or self._pc.iceGatheringState == "complete":
+            return
+        complete = asyncio.Event()
+
+        @self._pc.on("icegatheringstatechange")
+        def _on_ice_state() -> None:
+            if self._pc is not None and self._pc.iceGatheringState == "complete":
+                complete.set()
+
+        try:
+            await asyncio.wait_for(complete.wait(), timeout=timeout)
+        except asyncio.TimeoutError as exc:
+            raise CodexRealtimeUnavailable("WebRTC ICE gathering timed out") from exc
+
+    async def accept_answer(self, sdp: str) -> None:
+        if self._pc is None:
+            raise CodexRealtimeUnavailable("WebRTC peer has not created an offer")
+        from aiortc import RTCSessionDescription
+
+        await self._pc.setRemoteDescription(
+            RTCSessionDescription(sdp=sdp, type="answer")
+        )
+
+    def push_input(self, pcm: bytes) -> bool:
+        outgoing = self._outgoing
+        loop = self._loop
+        if outgoing is None or loop is None or loop.is_closed():
+            return False
+        converted = discord_pcm_to_realtime(pcm)
+        if not converted:
+            return False
+        loop.call_soon_threadsafe(outgoing.push, converted)
+        return True
+
+    async def _consume_remote_audio(self, track) -> None:
+        from av import AudioResampler
+
+        resampler = AudioResampler(format="s16", layout="stereo", rate=48_000)
+        try:
+            while True:
+                frame = await track.recv()
+                for output in resampler.resample(frame):
+                    pcm = output.to_ndarray().tobytes()
+                    if pcm and self._on_pcm is not None:
+                        self._on_pcm(pcm)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # MediaStreamError is the normal remote-track EOF during teardown.
+            # Outside teardown it means speech output is gone, so fail over.
+            logger.debug("Codex realtime remote audio ended: %s", exc)
+            if not self._closing:
+                self._notify_failure("WebRTC remote audio ended")
+
+    def _notify_failure(self, reason: str) -> None:
+        if self._failure_reported or self._closing:
+            return
+        self._failure_reported = True
+        if self._on_failure is not None:
+            self._on_failure(reason)
+
+    async def close(self) -> None:
+        self._closing = True
+        if self._outgoing is not None:
+            self._outgoing.close()
+        for task in list(self._remote_tasks):
+            task.cancel()
+        if self._remote_tasks:
+            await asyncio.gather(*self._remote_tasks, return_exceptions=True)
+        self._remote_tasks.clear()
+        if self._pc is not None:
+            await self._pc.close()
+        self._pc = None
+        self._outgoing = None
+        self._on_failure = None
+
+
+class CodexRealtimeSession:
+    """One isolated Codex app-server thread plus one WebRTC voice session."""
+
+    def __init__(
+        self,
+        *,
+        cwd: str | Path,
+        codex_bin: str = "codex",
+        codex_home: Optional[str] = None,
+        client_factory: Callable[..., Any] = CodexAppServerClient,
+        peer_factory: Callable[[], Any] = AiortcRealtimePeer,
+        binary_checker: Callable[..., tuple[bool, str]] = check_codex_binary,
+        on_user_transcript: Optional[Callable[[str], Any]] = None,
+        on_output_pcm: Optional[Callable[[bytes], Any]] = None,
+        on_error: Optional[Callable[[str], Any]] = None,
+    ) -> None:
+        self._cwd = str(cwd)
+        self._codex_bin = codex_bin
+        self._codex_home = codex_home
+        self._client_factory = client_factory
+        self._peer_factory = peer_factory
+        self._binary_checker = binary_checker
+        self._on_user_transcript = on_user_transcript
+        self._on_output_pcm = on_output_pcm
+        self._on_error = on_error
+        self._client = None
+        self._peer = None
+        self._thread_id: Optional[str] = None
+        self._notification_task: Optional[asyncio.Task] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._active = False
+        # Remote model audio is dropped until Hermes explicitly appends the
+        # final response text. This keeps GPT-Live as speech I/O instead of a
+        # second assistant that can answer independently of Hermes.
+        self._speech_gate = False
+        self._speech_generation = 0
+        self._peer_failure_reason: Optional[str] = None
+        self._failure_notified = False
+        self._stop_lock = asyncio.Lock()
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    async def start(self, *, voice: Optional[str] = None) -> CodexRealtimeCapabilities:
+        if self._active:
+            raise RuntimeError("Codex realtime session is already active")
+        self._loop = asyncio.get_running_loop()
+        self._peer_failure_reason = None
+        self._failure_notified = False
+        ok, detail = await asyncio.to_thread(
+            self._binary_checker,
+            self._codex_bin,
+            MIN_CODEX_REALTIME_VERSION,
+        )
+        if not ok:
+            raise CodexRealtimeUnavailable(detail)
+
+        self._client = self._client_factory(
+            codex_bin=self._codex_bin,
+            codex_home=self._codex_home,
+            extra_args=[
+                "-c",
+                "features.realtime_conversation=true",
+                "-c",
+                'sandbox_mode="read-only"',
+                "-c",
+                'approval_policy="never"',
+            ],
+        )
+        self._peer = self._peer_factory()
+        try:
+            capabilities = await asyncio.to_thread(self._initialize_client, voice)
+            offer_sdp = await self._peer.create_offer(
+                self._handle_peer_pcm,
+                self._handle_peer_failure,
+            )
+            await asyncio.to_thread(self._request_start, offer_sdp, voice)
+            answer_sdp = await self._wait_for_startup_notifications()
+            await self._peer.accept_answer(answer_sdp)
+            if self._peer_failure_reason:
+                raise CodexRealtimeUnavailable(self._peer_failure_reason)
+        except Exception:
+            await self._close_resources()
+            raise
+
+        self._active = True
+        self._notification_task = asyncio.create_task(
+            self._notification_loop(), name="codex-realtime-notifications"
+        )
+        return capabilities
+
+    def _initialize_client(
+        self, requested_voice: Optional[str]
+    ) -> CodexRealtimeCapabilities:
+        assert self._client is not None
+        self._client.initialize(
+            client_name="hermes-realtime-voice",
+            client_title="Hermes Realtime Voice",
+            client_version="1",
+            capabilities={
+                "experimentalApi": True,
+                # WebRTC output is played from the negotiated remote audio
+                # track. Suppress sideband PCM to avoid duplicate playback and
+                # unnecessary base64 traffic over app-server stdio.
+                "optOutNotificationMethods": ["thread/realtime/outputAudio/delta"],
+            },
+        )
+        thread_result = self._client.request(
+            "thread/start",
+            {"cwd": self._cwd, "ephemeral": True},
+            timeout=15,
+        )
+        thread = thread_result.get("thread") or {}
+        self._thread_id = (
+            thread.get("id")
+            or thread.get("sessionId")
+            or thread_result.get("threadId")
+            or thread_result.get("sessionId")
+        )
+        if not self._thread_id:
+            raise CodexRealtimeUnavailable("Codex thread/start returned no thread id")
+        voices_result = self._client.request(
+            "thread/realtime/listVoices", {}, timeout=10
+        )
+        raw_voices = voices_result.get("voices") or {}
+        if isinstance(raw_voices, dict):
+            voices = tuple(str(value) for value in raw_voices.get("v1", []) if value)
+        else:
+            voices = ()
+        if requested_voice and voices and requested_voice not in voices:
+            raise CodexRealtimeUnavailable(
+                f"Codex realtime voice {requested_voice!r} is not supported for v1; "
+                f"choose one of: {', '.join(voices)}"
+            )
+        return CodexRealtimeCapabilities(protocol_version="v1", voices=voices)
+
+    def _request_start(self, offer_sdp: str, voice: Optional[str]) -> None:
+        assert self._client is not None and self._thread_id is not None
+        params: dict[str, Any] = {
+            "threadId": self._thread_id,
+            "clientManagedHandoffs": True,
+            "includeStartupContext": False,
+            "outputModality": "audio",
+            "prompt": _SPEECH_INTERFACE_PROMPT,
+            "transport": {"type": "webrtc", "sdp": offer_sdp},
+            "version": "v1",
+        }
+        if voice:
+            params["voice"] = voice
+        self._client.request("thread/realtime/start", params, timeout=30)
+
+    async def _wait_for_startup_notifications(self, timeout: float = 30.0) -> str:
+        assert self._client is not None
+        deadline = time.monotonic() + timeout
+        started = False
+        answer_sdp: Optional[str] = None
+        while time.monotonic() < deadline and (not started or answer_sdp is None):
+            notification = await asyncio.to_thread(self._client.take_notification, 0.2)
+            if notification is None:
+                continue
+            method = notification.get("method")
+            params = notification.get("params") or {}
+            if (
+                str(method or "").startswith("thread/realtime/")
+                and params.get("threadId") != self._thread_id
+            ):
+                continue
+            if method == "thread/realtime/started":
+                version = str(params.get("version") or "")
+                if version and version != "v1":
+                    raise CodexRealtimeUnavailable(
+                        f"Codex realtime started unsupported protocol {version!r}"
+                    )
+                started = True
+            elif method == "thread/realtime/sdp":
+                answer_sdp = str(params.get("sdp") or "") or None
+            elif method == "thread/realtime/error":
+                raise CodexRealtimeUnavailable(
+                    safe_realtime_error(
+                        params.get("message") or "Codex realtime startup failed"
+                    )
+                )
+            elif method == "thread/realtime/closed":
+                raise CodexRealtimeUnavailable("Codex realtime closed during startup")
+        if not started or answer_sdp is None:
+            raise CodexRealtimeUnavailable("Codex realtime startup timed out")
+        return answer_sdp
+
+    async def _notification_loop(self) -> None:
+        assert self._client is not None
+        try:
+            while self._active:
+                notification = await asyncio.to_thread(
+                    self._client.take_notification, 0.2
+                )
+                if notification is None:
+                    client_alive = (
+                        self._client.is_alive()
+                        if hasattr(self._client, "is_alive")
+                        else True
+                    )
+                    if not client_alive:
+                        self._fail("Codex app-server exited")
+                        await self.stop()
+                        return
+                    continue
+                method = notification.get("method")
+                params = notification.get("params") or {}
+                if (
+                    str(method or "").startswith("thread/realtime/")
+                    and params.get("threadId") != self._thread_id
+                ):
+                    continue
+                if (
+                    method == "thread/realtime/transcript/delta"
+                    and params.get("role") == "user"
+                ):
+                    # Barge-in closes the speech gate before a new user utterance
+                    # can trigger independent remote-model audio.
+                    self._speech_generation += 1
+                    self._speech_gate = False
+                    continue
+                if method == "thread/realtime/transcript/done":
+                    role = params.get("role")
+                    if role == "user":
+                        self._speech_generation += 1
+                        self._speech_gate = False
+                        text = str(params.get("text") or "").strip()
+                        if text:
+                            self._emit(self._on_user_transcript, text)
+                    elif role == "assistant":
+                        generation = self._speech_generation
+                        asyncio.create_task(
+                            self._close_speech_gate_after(generation, 0.3)
+                        )
+                elif method == "thread/realtime/outputAudio/delta":
+                    # WebRTC audio arrives on the negotiated remote media
+                    # track. Ignore defensive sideband copies so one response
+                    # cannot be played twice.
+                    continue
+                elif method == "thread/realtime/error":
+                    self._fail(
+                        safe_realtime_error(
+                            params.get("message") or "Codex realtime error"
+                        )
+                    )
+                    await self.stop()
+                    return
+                elif method == "thread/realtime/closed":
+                    self._fail(
+                        str(params.get("reason") or "Codex realtime session closed")
+                    )
+                    await self.stop()
+                    return
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._fail(f"Codex realtime protocol error: {exc}")
+            await self.stop()
+
+    def _emit_output_pcm(self, pcm: bytes) -> None:
+        if pcm:
+            self._emit(self._on_output_pcm, pcm)
+
+    def _handle_peer_pcm(self, pcm: bytes) -> None:
+        if self._speech_gate:
+            self._emit_output_pcm(pcm)
+
+    def _handle_peer_failure(self, reason: str) -> None:
+        safe_reason = safe_realtime_error(reason)
+        self._peer_failure_reason = safe_reason
+        if self._active:
+            self._fail(f"Codex realtime WebRTC failed: {safe_reason}")
+            self._schedule_stop()
+
+    async def _close_speech_gate_after(self, generation: int, delay: float) -> None:
+        # Transcript completion can precede the last WebRTC audio packets.
+        await asyncio.sleep(delay)
+        if generation == self._speech_generation:
+            self._speech_gate = False
+
+    @staticmethod
+    def _emit(callback: Optional[Callable[[Any], Any]], value: Any) -> None:
+        if callback is None:
+            return
+        try:
+            result = callback(value)
+            if asyncio.iscoroutine(result):
+                asyncio.create_task(result)
+        except Exception:
+            logger.exception("Codex realtime callback failed")
+
+    def _fail(self, reason: str) -> None:
+        if self._failure_notified:
+            return
+        self._failure_notified = True
+        self._active = False
+        self._speech_generation += 1
+        self._speech_gate = False
+        self._emit(self._on_error, safe_realtime_error(reason))
+
+    def _schedule_stop(self) -> None:
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return
+        loop.call_soon_threadsafe(lambda: asyncio.create_task(self.stop()))
+
+    def push_discord_pcm(self, pcm: bytes) -> bool:
+        if not self._active or self._peer is None:
+            return False
+        try:
+            return bool(self._peer.push_input(pcm))
+        except Exception as exc:
+            self._fail(f"Codex realtime input failed: {exc}")
+            self._schedule_stop()
+            return False
+
+    async def append_speech(self, text: str) -> bool:
+        cleaned = str(text or "").strip()
+        if (
+            not cleaned
+            or not self._active
+            or self._client is None
+            or not self._thread_id
+        ):
+            return False
+        self._speech_generation += 1
+        generation = self._speech_generation
+        self._speech_gate = True
+        # Fail closed if a backend revision never emits assistant completion.
+        gate_timeout = min(180.0, max(10.0, len(cleaned) / 8.0))
+        asyncio.create_task(self._close_speech_gate_after(generation, gate_timeout))
+        try:
+            await asyncio.to_thread(
+                self._client.request,
+                "thread/realtime/appendSpeech",
+                {"threadId": self._thread_id, "text": cleaned},
+                15,
+            )
+        except Exception as exc:
+            self._speech_gate = False
+            self._fail(f"Codex realtime speech failed: {exc}")
+            self._schedule_stop()
+            raise
+        return True
+
+    async def stop(self) -> None:
+        async with self._stop_lock:
+            was_active = self._active
+            self._active = False
+            self._speech_generation += 1
+            self._speech_gate = False
+            task = self._notification_task
+            self._notification_task = None
+            if task is not None and task is not asyncio.current_task():
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+            if was_active and self._client is not None and self._thread_id:
+                try:
+                    await asyncio.to_thread(
+                        self._client.request,
+                        "thread/realtime/stop",
+                        {"threadId": self._thread_id},
+                        10,
+                    )
+                except Exception:
+                    logger.debug("Codex realtime stop request failed", exc_info=True)
+            await self._close_resources()
+
+    async def _close_resources(self) -> None:
+        peer, self._peer = self._peer, None
+        client, self._client = self._client, None
+        self._loop = None
+        self._thread_id = None
+        self._peer_failure_reason = None
+        if peer is not None:
+            try:
+                await peer.close()
+            except Exception:
+                logger.debug("Codex realtime WebRTC close failed", exc_info=True)
+        if client is not None:
+            try:
+                await asyncio.to_thread(client.close)
+            except Exception:
+                logger.debug("Codex realtime app-server close failed", exc_info=True)

--- a/agent/transports/codex_realtime_voice.py
+++ b/agent/transports/codex_realtime_voice.py
@@ -32,6 +32,8 @@ REALTIME_CHANNELS = 1
 REALTIME_FRAME_SAMPLES = 480  # 20 ms at 24 kHz
 SPEECH_FIRST_AUDIO_TIMEOUT = 5.0
 SPEECH_AUDIO_IDLE_TIMEOUT = 0.75
+SPEECH_AUDIBLE_PEAK_MIN = 64
+SPEECH_AUDIBLE_RMS_MIN = 8.0
 
 _SPEECH_INTERFACE_PROMPT = (
     "You are a low-latency speech interface for another assistant. "
@@ -116,6 +118,21 @@ def discord_pcm_to_realtime(pcm: bytes) -> bytes:
     mono_48k = (stereo[:, 0] + stereo[:, 1]) // 2
     mono_24k = (mono_48k[0::2] + mono_48k[1::2]) // 2
     return np.clip(mono_24k, -32768, 32767).astype(np.int16).tobytes()
+
+
+def _pcm_is_audible(pcm: bytes) -> bool:
+    """Reject WebRTC silence/dither as proof that speech output started."""
+
+    usable = len(pcm) - (len(pcm) % 2)
+    if usable < 2:
+        return False
+    np = _require_numpy()
+    samples = np.frombuffer(pcm[:usable], dtype=np.int16).astype(np.int32)
+    peak = int(np.max(np.abs(samples)))
+    if peak < SPEECH_AUDIBLE_PEAK_MIN:
+        return False
+    rms = float(np.sqrt(np.mean(samples.astype(np.float64) ** 2)))
+    return rms >= SPEECH_AUDIBLE_RMS_MIN
 
 
 class _AiortcOutgoingAudioTrack:
@@ -638,12 +655,18 @@ class CodexRealtimeSession:
         if self._speech_gate:
             if not self._emit_output_pcm(pcm):
                 return
+            # The negotiated track emits zero PCM before synthesized speech.
+            # Deliver those timing frames downstream, but do not suppress
+            # classic fallback or claim output readiness until the accepted
+            # signal is actually audible.
+            if not _pcm_is_audible(pcm):
+                return
             now = time.monotonic()
             first_pcm = self._speech_last_pcm_at is None
             self._speech_last_pcm_at = now
             if first_pcm and self._speech_started_at is not None:
                 logger.info(
-                    "Codex realtime speech audio started after %.3fs",
+                    "Codex realtime audible speech started after %.3fs",
                     now - self._speech_started_at,
                 )
             self._wake_speech_start_waiter()

--- a/agent/transports/codex_realtime_voice.py
+++ b/agent/transports/codex_realtime_voice.py
@@ -35,10 +35,27 @@ SPEECH_AUDIO_IDLE_TIMEOUT = 0.75
 
 _SPEECH_INTERFACE_PROMPT = (
     "You are a low-latency speech interface for another assistant. "
-    "Transcribe the user's speech accurately. Do not answer the user, "
-    "do not call tools, and do not delegate work. Stay silent until "
-    "the client supplies text to speak."
+    "Transcribe the user's speech accurately in the language they actually "
+    "speak; preserve that language and never translate it. Do not answer "
+    "the user, do not call tools, and do not delegate work. Stay silent "
+    "until the client supplies text to speak."
 )
+
+
+def _speech_interface_prompt(spoken_language: Optional[str]) -> str:
+    """Build the speech-only prompt without claiming a native locale API."""
+
+    if not spoken_language:
+        return _SPEECH_INTERFACE_PROMPT
+    return (
+        "You are a low-latency speech interface for another assistant. "
+        f"The configured spoken language is {spoken_language}. "
+        "Transcribe the user's speech accurately in the language they actually "
+        "speak; preserve that language and never translate it. Do not answer "
+        "the user, do not call tools, and do not delegate work. Stay silent "
+        "until the client supplies text to speak, then speak that supplied text "
+        "naturally in the configured language."
+    )
 
 
 class CodexRealtimeUnavailable(RuntimeError):
@@ -322,6 +339,7 @@ class CodexRealtimeSession:
         codex_bin: str = "codex",
         codex_home: Optional[str] = None,
         protocol_version: str = DEFAULT_CODEX_REALTIME_PROTOCOL,
+        spoken_language: Optional[str] = None,
         client_factory: Callable[..., Any] = CodexAppServerClient,
         peer_factory: Callable[[], Any] = AiortcRealtimePeer,
         binary_checker: Callable[..., tuple[bool, str]] = check_codex_binary,
@@ -337,6 +355,9 @@ class CodexRealtimeSession:
             raise CodexRealtimeUnavailable(
                 "Codex realtime WebRTC protocol_version must be v1 or v3"
             )
+        self._spoken_language = (
+            " ".join(str(spoken_language).split())[:80] if spoken_language else None
+        )
         self._client_factory = client_factory
         self._peer_factory = peer_factory
         self._binary_checker = binary_checker
@@ -469,7 +490,7 @@ class CodexRealtimeSession:
             "clientManagedHandoffs": True,
             "includeStartupContext": False,
             "outputModality": "audio",
-            "prompt": _SPEECH_INTERFACE_PROMPT,
+            "prompt": _speech_interface_prompt(self._spoken_language),
             "transport": {"type": "webrtc", "sdp": offer_sdp},
             "version": self._protocol_version,
         }

--- a/agent/transports/codex_realtime_voice.py
+++ b/agent/transports/codex_realtime_voice.py
@@ -28,6 +28,8 @@ MIN_CODEX_REALTIME_VERSION = (0, 145, 0)
 REALTIME_SAMPLE_RATE = 24_000
 REALTIME_CHANNELS = 1
 REALTIME_FRAME_SAMPLES = 480  # 20 ms at 24 kHz
+SPEECH_FIRST_AUDIO_TIMEOUT = 5.0
+SPEECH_AUDIO_IDLE_TIMEOUT = 0.75
 
 _SPEECH_INTERFACE_PROMPT = (
     "You are a low-latency speech interface for another assistant. "
@@ -39,6 +41,10 @@ _SPEECH_INTERFACE_PROMPT = (
 
 class CodexRealtimeUnavailable(RuntimeError):
     """Raised when the optional Codex realtime route cannot be started."""
+
+
+class CodexRealtimeStaleSpeech(RuntimeError):
+    """Raised when a Hermes reply predates the latest user utterance."""
 
 
 def safe_realtime_error(message: Any) -> str:
@@ -316,7 +322,7 @@ class CodexRealtimeSession:
         client_factory: Callable[..., Any] = CodexAppServerClient,
         peer_factory: Callable[[], Any] = AiortcRealtimePeer,
         binary_checker: Callable[..., tuple[bool, str]] = check_codex_binary,
-        on_user_transcript: Optional[Callable[[str], Any]] = None,
+        on_user_transcript: Optional[Callable[[str, int], Any]] = None,
         on_output_pcm: Optional[Callable[[bytes], Any]] = None,
         on_error: Optional[Callable[[str], Any]] = None,
     ) -> None:
@@ -340,6 +346,9 @@ class CodexRealtimeSession:
         # second assistant that can answer independently of Hermes.
         self._speech_gate = False
         self._speech_generation = 0
+        self._speech_started_at: Optional[float] = None
+        self._speech_last_pcm_at: Optional[float] = None
+        self._speech_watchdog_task: Optional[asyncio.Task] = None
         self._peer_failure_reason: Optional[str] = None
         self._failure_notified = False
         self._stop_lock = asyncio.Lock()
@@ -526,20 +535,25 @@ class CodexRealtimeSession:
                     # can trigger independent remote-model audio.
                     self._speech_generation += 1
                     self._speech_gate = False
+                    self._cancel_speech_watchdog()
                     continue
                 if method == "thread/realtime/transcript/done":
                     role = params.get("role")
                     if role == "user":
                         self._speech_generation += 1
                         self._speech_gate = False
+                        self._cancel_speech_watchdog()
                         text = str(params.get("text") or "").strip()
                         if text:
-                            self._emit(self._on_user_transcript, text)
-                    elif role == "assistant":
-                        generation = self._speech_generation
-                        asyncio.create_task(
-                            self._close_speech_gate_after(generation, 0.3)
-                        )
+                            self._emit(
+                                self._on_user_transcript,
+                                text,
+                                self._speech_generation,
+                            )
+                    # Assistant transcript notifications carry no item or
+                    # appendSpeech generation identifier. They therefore cannot
+                    # safely close a newer speech gate; WebRTC audio inactivity
+                    # provides the response boundary instead.
                 elif method == "thread/realtime/outputAudio/delta":
                     # WebRTC audio arrives on the negotiated remote media
                     # track. Ignore defensive sideband copies so one response
@@ -571,6 +585,7 @@ class CodexRealtimeSession:
 
     def _handle_peer_pcm(self, pcm: bytes) -> None:
         if self._speech_gate:
+            self._speech_last_pcm_at = time.monotonic()
             self._emit_output_pcm(pcm)
 
     def _handle_peer_failure(self, reason: str) -> None:
@@ -580,18 +595,44 @@ class CodexRealtimeSession:
             self._fail(f"Codex realtime WebRTC failed: {safe_reason}")
             self._schedule_stop()
 
-    async def _close_speech_gate_after(self, generation: int, delay: float) -> None:
-        # Transcript completion can precede the last WebRTC audio packets.
-        await asyncio.sleep(delay)
-        if generation == self._speech_generation:
-            self._speech_gate = False
+    async def _watch_speech_gate(
+        self, generation: int, maximum_duration: float
+    ) -> None:
+        """Close one speech gate after output ends or never starts."""
+
+        try:
+            while self._speech_gate and generation == self._speech_generation:
+                await asyncio.sleep(0.05)
+                now = time.monotonic()
+                started_at = self._speech_started_at
+                last_pcm_at = self._speech_last_pcm_at
+                if started_at is None:
+                    return
+                if now - started_at >= maximum_duration:
+                    self._speech_gate = False
+                    return
+                if last_pcm_at is None:
+                    if now - started_at >= SPEECH_FIRST_AUDIO_TIMEOUT:
+                        self._speech_gate = False
+                        return
+                elif now - last_pcm_at >= SPEECH_AUDIO_IDLE_TIMEOUT:
+                    self._speech_gate = False
+                    return
+        finally:
+            if self._speech_watchdog_task is asyncio.current_task():
+                self._speech_watchdog_task = None
+
+    def _cancel_speech_watchdog(self) -> None:
+        task, self._speech_watchdog_task = self._speech_watchdog_task, None
+        if task is not None and not task.done():
+            task.cancel()
 
     @staticmethod
-    def _emit(callback: Optional[Callable[[Any], Any]], value: Any) -> None:
+    def _emit(callback: Optional[Callable[..., Any]], *values: Any) -> None:
         if callback is None:
             return
         try:
-            result = callback(value)
+            result = callback(*values)
             if asyncio.iscoroutine(result):
                 asyncio.create_task(result)
         except Exception:
@@ -604,6 +645,9 @@ class CodexRealtimeSession:
         self._active = False
         self._speech_generation += 1
         self._speech_gate = False
+        self._cancel_speech_watchdog()
+        self._speech_started_at = None
+        self._speech_last_pcm_at = None
         self._emit(self._on_error, safe_realtime_error(reason))
 
     def _schedule_stop(self) -> None:
@@ -622,7 +666,12 @@ class CodexRealtimeSession:
             self._schedule_stop()
             return False
 
-    async def append_speech(self, text: str) -> bool:
+    async def append_speech(
+        self,
+        text: str,
+        *,
+        transcript_generation: Optional[int] = None,
+    ) -> bool:
         cleaned = str(text or "").strip()
         if (
             not cleaned
@@ -631,12 +680,24 @@ class CodexRealtimeSession:
             or not self._thread_id
         ):
             return False
+        if (
+            transcript_generation is not None
+            and transcript_generation != self._speech_generation
+        ):
+            raise CodexRealtimeStaleSpeech(
+                "Hermes reply predates the latest realtime user utterance"
+            )
         self._speech_generation += 1
         generation = self._speech_generation
         self._speech_gate = True
-        # Fail closed if a backend revision never emits assistant completion.
+        self._speech_started_at = time.monotonic()
+        self._speech_last_pcm_at = None
+        # Fail closed if WebRTC output never starts or never becomes idle.
         gate_timeout = min(180.0, max(10.0, len(cleaned) / 8.0))
-        asyncio.create_task(self._close_speech_gate_after(generation, gate_timeout))
+        self._cancel_speech_watchdog()
+        self._speech_watchdog_task = asyncio.create_task(
+            self._watch_speech_gate(generation, gate_timeout)
+        )
         try:
             await asyncio.to_thread(
                 self._client.request,
@@ -657,6 +718,12 @@ class CodexRealtimeSession:
             self._active = False
             self._speech_generation += 1
             self._speech_gate = False
+            watchdog = self._speech_watchdog_task
+            self._cancel_speech_watchdog()
+            self._speech_started_at = None
+            self._speech_last_pcm_at = None
+            if watchdog is not None:
+                await asyncio.gather(watchdog, return_exceptions=True)
             task = self._notification_task
             self._notification_task = None
             if task is not None and task is not asyncio.current_task():

--- a/agent/transports/codex_realtime_voice.py
+++ b/agent/transports/codex_realtime_voice.py
@@ -25,6 +25,8 @@ from agent.transports.codex_app_server import (
 logger = logging.getLogger(__name__)
 
 MIN_CODEX_REALTIME_VERSION = (0, 145, 0)
+DEFAULT_CODEX_REALTIME_PROTOCOL = "v3"
+SUPPORTED_CODEX_REALTIME_WEBRTC_PROTOCOLS = frozenset({"v1", "v3"})
 REALTIME_SAMPLE_RATE = 24_000
 REALTIME_CHANNELS = 1
 REALTIME_FRAME_SAMPLES = 480  # 20 ms at 24 kHz
@@ -319,6 +321,7 @@ class CodexRealtimeSession:
         cwd: str | Path,
         codex_bin: str = "codex",
         codex_home: Optional[str] = None,
+        protocol_version: str = DEFAULT_CODEX_REALTIME_PROTOCOL,
         client_factory: Callable[..., Any] = CodexAppServerClient,
         peer_factory: Callable[[], Any] = AiortcRealtimePeer,
         binary_checker: Callable[..., tuple[bool, str]] = check_codex_binary,
@@ -329,6 +332,11 @@ class CodexRealtimeSession:
         self._cwd = str(cwd)
         self._codex_bin = codex_bin
         self._codex_home = codex_home
+        self._protocol_version = str(protocol_version).strip().lower()
+        if self._protocol_version not in SUPPORTED_CODEX_REALTIME_WEBRTC_PROTOCOLS:
+            raise CodexRealtimeUnavailable(
+                "Codex realtime WebRTC protocol_version must be v1 or v3"
+            )
         self._client_factory = client_factory
         self._peer_factory = peer_factory
         self._binary_checker = binary_checker
@@ -445,10 +453,14 @@ class CodexRealtimeSession:
             voices = ()
         if requested_voice and voices and requested_voice not in voices:
             raise CodexRealtimeUnavailable(
-                f"Codex realtime voice {requested_voice!r} is not supported for v1; "
+                f"Codex realtime voice {requested_voice!r} is not supported for "
+                f"{self._protocol_version}; "
                 f"choose one of: {', '.join(voices)}"
             )
-        return CodexRealtimeCapabilities(protocol_version="v1", voices=voices)
+        return CodexRealtimeCapabilities(
+            protocol_version=self._protocol_version,
+            voices=voices,
+        )
 
     def _request_start(self, offer_sdp: str, voice: Optional[str]) -> None:
         assert self._client is not None and self._thread_id is not None
@@ -459,7 +471,7 @@ class CodexRealtimeSession:
             "outputModality": "audio",
             "prompt": _SPEECH_INTERFACE_PROMPT,
             "transport": {"type": "webrtc", "sdp": offer_sdp},
-            "version": "v1",
+            "version": self._protocol_version,
         }
         if voice:
             params["voice"] = voice
@@ -483,7 +495,7 @@ class CodexRealtimeSession:
                 continue
             if method == "thread/realtime/started":
                 version = str(params.get("version") or "")
-                if version and version != "v1":
+                if version and version != self._protocol_version:
                     raise CodexRealtimeUnavailable(
                         f"Codex realtime started unsupported protocol {version!r}"
                     )

--- a/agent/transports/codex_realtime_voice.py
+++ b/agent/transports/codex_realtime_voice.py
@@ -617,12 +617,27 @@ class CodexRealtimeSession:
             self._fail(f"Codex realtime protocol error: {exc}")
             await self.stop()
 
-    def _emit_output_pcm(self, pcm: bytes) -> None:
-        if pcm:
-            self._emit(self._on_output_pcm, pcm)
+    def _emit_output_pcm(self, pcm: bytes) -> bool:
+        """Deliver PCM and report whether the downstream sink accepted it."""
+        callback = self._on_output_pcm
+        if not pcm or callback is None:
+            return False
+        try:
+            result = callback(pcm)
+            if asyncio.iscoroutine(result):
+                asyncio.create_task(result)
+                return True
+            # Existing fire-and-forget callbacks return None. Only an explicit
+            # False means the concrete output sink rejected the frame.
+            return result is not False
+        except Exception:
+            logger.exception("Codex realtime output callback failed")
+            return False
 
     def _handle_peer_pcm(self, pcm: bytes) -> None:
         if self._speech_gate:
+            if not self._emit_output_pcm(pcm):
+                return
             now = time.monotonic()
             first_pcm = self._speech_last_pcm_at is None
             self._speech_last_pcm_at = now
@@ -632,7 +647,6 @@ class CodexRealtimeSession:
                     now - self._speech_started_at,
                 )
             self._wake_speech_start_waiter()
-            self._emit_output_pcm(pcm)
 
     def _wake_speech_start_waiter(self) -> None:
         event = self._speech_first_pcm_event

--- a/gateway/codex_realtime_voice.py
+++ b/gateway/codex_realtime_voice.py
@@ -14,6 +14,7 @@ from agent.transports.codex_realtime_voice import (
     SUPPORTED_CODEX_REALTIME_WEBRTC_PROTOCOLS,
     CodexRealtimeCapabilities,
     CodexRealtimeSession,
+    CodexRealtimeUnavailable,
     safe_realtime_error,
 )
 
@@ -362,6 +363,8 @@ class CodexRealtimeVoiceManager:
         managed = self._sessions.get(self._key(adapter, guild_id))
         if managed is None:
             return False
+        if not await adapter.ensure_realtime_voice_output(guild_id):
+            raise CodexRealtimeUnavailable("Discord voice mixer is unavailable")
         return bool(
             await managed.session.append_speech(
                 text,

--- a/gateway/codex_realtime_voice.py
+++ b/gateway/codex_realtime_voice.py
@@ -47,6 +47,7 @@ class CodexRealtimeVoiceConfig:
     enabled: bool = False
     user_id: Optional[int] = None
     voice: Optional[str] = None
+    spoken_language: Optional[str] = None
     protocol_version: str = DEFAULT_CODEX_REALTIME_PROTOCOL
     fallback_to_classic: bool = True
     codex_bin: str = "codex"
@@ -61,9 +62,17 @@ class CodexRealtimeVoiceConfig:
             return cls()
         voice = raw.get("voice")
         voice = str(voice).strip() if voice is not None else None
-        protocol_version = str(
-            raw.get("protocol_version") or DEFAULT_CODEX_REALTIME_PROTOCOL
-        ).strip().lower()
+        spoken_language = raw.get("spoken_language")
+        spoken_language = (
+            " ".join(str(spoken_language).split())[:80]
+            if spoken_language is not None
+            else None
+        )
+        protocol_version = (
+            str(raw.get("protocol_version") or DEFAULT_CODEX_REALTIME_PROTOCOL)
+            .strip()
+            .lower()
+        )
         codex_bin = str(raw.get("codex_bin") or "codex").strip() or "codex"
         codex_home = raw.get("codex_home")
         codex_home = str(codex_home).strip() if codex_home else None
@@ -71,6 +80,7 @@ class CodexRealtimeVoiceConfig:
             enabled=_config_bool(raw.get("enabled"), False),
             user_id=_positive_id(raw.get("user_id")),
             voice=voice or None,
+            spoken_language=spoken_language or None,
             protocol_version=protocol_version,
             fallback_to_classic=_config_bool(raw.get("fallback_to_classic"), True),
             codex_bin=codex_bin,
@@ -145,6 +155,12 @@ class CodexRealtimeVoiceManager:
     def configured_fallback_enabled(adapter: Any) -> bool:
         """Return the durable fallback policy even after a session is removed."""
         return CodexRealtimeVoiceConfig.from_adapter(adapter).fallback_to_classic
+
+    @staticmethod
+    def configured_spoken_language(adapter: Any) -> Optional[str]:
+        """Return the prompt-level spoken-language preference for a route."""
+
+        return CodexRealtimeVoiceConfig.from_adapter(adapter).spoken_language
 
     def prepare_for_voice_channel(self, adapter: Any, guild_id: int) -> bool:
         """Reserve PCM before Discord starts its receiver during an opted-in join."""
@@ -246,6 +262,7 @@ class CodexRealtimeVoiceManager:
                     codex_bin=config.codex_bin,
                     codex_home=config.codex_home,
                     protocol_version=config.protocol_version,
+                    spoken_language=config.spoken_language,
                     on_user_transcript=_on_transcript,
                     on_output_pcm=_on_output_pcm,
                     on_error=_on_error,

--- a/gateway/codex_realtime_voice.py
+++ b/gateway/codex_realtime_voice.py
@@ -1,0 +1,381 @@
+"""Gateway ownership for the experimental Discord ↔ Codex realtime route."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from agent.transports.codex_realtime_voice import (
+    CodexRealtimeCapabilities,
+    CodexRealtimeSession,
+    safe_realtime_error,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _config_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _positive_id(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        return None
+    return result if result > 0 else None
+
+
+@dataclass(frozen=True)
+class CodexRealtimeVoiceConfig:
+    enabled: bool = False
+    user_id: Optional[int] = None
+    voice: Optional[str] = None
+    fallback_to_classic: bool = True
+    codex_bin: str = "codex"
+    codex_home: Optional[str] = None
+
+    @classmethod
+    def from_adapter(cls, adapter: Any) -> "CodexRealtimeVoiceConfig":
+        platform_config = getattr(adapter, "config", None)
+        extra = getattr(platform_config, "extra", None)
+        raw = extra.get("codex_realtime_voice") if isinstance(extra, dict) else None
+        if not isinstance(raw, dict):
+            return cls()
+        voice = raw.get("voice")
+        voice = str(voice).strip() if voice is not None else None
+        codex_bin = str(raw.get("codex_bin") or "codex").strip() or "codex"
+        codex_home = raw.get("codex_home")
+        codex_home = str(codex_home).strip() if codex_home else None
+        return cls(
+            enabled=_config_bool(raw.get("enabled"), False),
+            user_id=_positive_id(raw.get("user_id")),
+            voice=voice or None,
+            fallback_to_classic=_config_bool(raw.get("fallback_to_classic"), True),
+            codex_bin=codex_bin,
+            codex_home=codex_home,
+        )
+
+
+@dataclass(frozen=True)
+class CodexRealtimeStartResult:
+    enabled: bool
+    active: bool
+    fallback_to_classic: bool
+    reason: Optional[str] = None
+    capabilities: Optional[CodexRealtimeCapabilities] = None
+
+
+@dataclass
+class _ManagedSession:
+    session: Any
+    user_id: int
+    adapter: Any
+    fallback_to_classic: bool
+
+
+class CodexRealtimeVoiceManager:
+    """Owns one optional realtime session per Discord adapter/guild."""
+
+    def __init__(
+        self,
+        *,
+        session_factory: Callable[..., Any] = CodexRealtimeSession,
+        dependency_ensurer: Optional[Callable[[], None]] = None,
+    ) -> None:
+        self._session_factory = session_factory
+        self._dependency_ensurer = dependency_ensurer or self._ensure_dependencies
+        self._sessions: dict[tuple[int, int], _ManagedSession] = {}
+        self._starting: set[tuple[int, int]] = set()
+        self._locks: dict[tuple[int, int], asyncio.Lock] = {}
+        self._cleanup_tasks: set[asyncio.Task] = set()
+        self._closed = False
+
+    @staticmethod
+    def _ensure_dependencies() -> None:
+        from tools.lazy_deps import ensure
+
+        ensure("voice.codex_realtime", prompt=False)
+
+    @staticmethod
+    def _key(adapter: Any, guild_id: int) -> tuple[int, int]:
+        return (id(adapter), int(guild_id))
+
+    @staticmethod
+    def _end_output(adapter: Any, guild_id: int) -> None:
+        try:
+            adapter.end_realtime_voice_output(guild_id)
+        except Exception:
+            logger.debug("Codex realtime mixer cleanup failed", exc_info=True)
+
+    def session_for(self, adapter: Any, guild_id: int):
+        managed = self._sessions.get(self._key(adapter, guild_id))
+        return managed.session if managed else None
+
+    def is_active(self, adapter: Any, guild_id: int) -> bool:
+        session = self.session_for(adapter, guild_id)
+        return bool(session and getattr(session, "active", False))
+
+    def classic_fallback_enabled(self, adapter: Any, guild_id: int) -> bool:
+        managed = self._sessions.get(self._key(adapter, guild_id))
+        return True if managed is None else managed.fallback_to_classic
+
+    @staticmethod
+    def configured_fallback_enabled(adapter: Any) -> bool:
+        """Return the durable fallback policy even after a session is removed."""
+        return CodexRealtimeVoiceConfig.from_adapter(adapter).fallback_to_classic
+
+    async def start_for_voice_channel(
+        self,
+        *,
+        adapter: Any,
+        guild_id: int,
+        user_id: int,
+        on_transcript: Callable[[int, str], Any],
+        on_runtime_failure: Optional[Callable[[str, bool], Any]] = None,
+    ) -> CodexRealtimeStartResult:
+        config = CodexRealtimeVoiceConfig.from_adapter(adapter)
+        if self._closed:
+            return CodexRealtimeStartResult(
+                config.enabled,
+                False,
+                config.fallback_to_classic,
+                "realtime voice manager is shutting down",
+            )
+        if not config.enabled:
+            return CodexRealtimeStartResult(False, False, True)
+        if config.user_id is None:
+            return CodexRealtimeStartResult(
+                True,
+                False,
+                config.fallback_to_classic,
+                "codex_realtime_voice.user_id must be one positive Discord user ID",
+            )
+        bound_user_id = config.user_id
+        if int(user_id) != bound_user_id:
+            return CodexRealtimeStartResult(
+                True,
+                False,
+                config.fallback_to_classic,
+                "the joining user is not the configured realtime voice user",
+            )
+
+        key = self._key(adapter, guild_id)
+        async with self._locks.setdefault(key, asyncio.Lock()):
+            existing = self._sessions.get(key)
+            if existing and getattr(existing.session, "active", False):
+                return CodexRealtimeStartResult(True, True, config.fallback_to_classic)
+            if existing:
+                await self._stop_locked(key, adapter)
+
+            self._starting.add(key)
+            try:
+                event_loop = asyncio.get_running_loop()
+                await asyncio.to_thread(self._dependency_ensurer)
+                output_ready = await adapter.ensure_realtime_voice_output(guild_id)
+                if not output_ready:
+                    raise RuntimeError("Discord voice mixer is unavailable")
+
+                def _on_transcript(text: str) -> Any:
+                    return on_transcript(bound_user_id, text)
+
+                def _on_output_pcm(pcm: bytes) -> Any:
+                    return adapter.push_realtime_voice_pcm(guild_id, pcm)
+
+                def _on_error(reason: str) -> None:
+                    safe_reason = safe_realtime_error(reason)
+                    logger.warning(
+                        "Codex realtime voice ended: %s",
+                        safe_reason,
+                    )
+                    if not event_loop.is_closed():
+                        event_loop.call_soon_threadsafe(
+                            self._schedule_runtime_cleanup,
+                            key,
+                            adapter,
+                            session,
+                            on_runtime_failure,
+                            safe_reason,
+                            config.fallback_to_classic,
+                        )
+
+                session = self._session_factory(
+                    cwd=os.getcwd(),
+                    codex_bin=config.codex_bin,
+                    codex_home=config.codex_home,
+                    on_user_transcript=_on_transcript,
+                    on_output_pcm=_on_output_pcm,
+                    on_error=_on_error,
+                )
+                self._sessions[key] = _ManagedSession(
+                    session=session,
+                    user_id=bound_user_id,
+                    adapter=adapter,
+                    fallback_to_classic=config.fallback_to_classic,
+                )
+                capabilities = await session.start(voice=config.voice)
+                if self._closed:
+                    removed = self._sessions.pop(key, None)
+                    await session.stop()
+                    if removed is not None:
+                        self._end_output(adapter, guild_id)
+                    return CodexRealtimeStartResult(
+                        True,
+                        False,
+                        config.fallback_to_classic,
+                        "realtime voice manager is shutting down",
+                    )
+                return CodexRealtimeStartResult(
+                    True,
+                    True,
+                    config.fallback_to_classic,
+                    capabilities=capabilities,
+                )
+            except Exception as exc:
+                safe_reason = safe_realtime_error(exc)
+                logger.warning(
+                    "Codex realtime voice unavailable (%s): %s",
+                    (
+                        "classic fallback enabled"
+                        if config.fallback_to_classic
+                        else "classic fallback disabled"
+                    ),
+                    safe_reason,
+                )
+                managed = self._sessions.pop(key, None)
+                if managed is not None:
+                    try:
+                        await managed.session.stop()
+                    except Exception:
+                        logger.debug(
+                            "Partial Codex realtime cleanup failed", exc_info=True
+                        )
+                self._end_output(adapter, guild_id)
+                return CodexRealtimeStartResult(
+                    True,
+                    False,
+                    config.fallback_to_classic,
+                    safe_reason,
+                )
+            finally:
+                self._starting.discard(key)
+
+    def push_discord_pcm(
+        self,
+        adapter: Any,
+        guild_id: int,
+        user_id: int,
+        pcm: bytes,
+    ) -> bool:
+        key = self._key(adapter, guild_id)
+        # During negotiation, consume frames instead of creating a classic-STT
+        # buffer that could be emitted later alongside the new realtime route.
+        if key in self._starting:
+            return True
+        managed = self._sessions.get(key)
+        if managed is None or not getattr(managed.session, "active", False):
+            return False
+        if managed.user_id != int(user_id):
+            # An active realtime route is intentionally single-user. Consume
+            # other speakers' PCM instead of leaking it into the classic STT
+            # fallback and creating a second, ambiguous conversation path.
+            return True
+        return bool(managed.session.push_discord_pcm(pcm))
+
+    async def append_speech(
+        self,
+        adapter: Any,
+        guild_id: int,
+        text: str,
+    ) -> bool:
+        managed = self._sessions.get(self._key(adapter, guild_id))
+        if managed is None:
+            return False
+        return bool(await managed.session.append_speech(text))
+
+    async def stop_for_voice_channel(self, adapter: Any, guild_id: int) -> None:
+        key = self._key(adapter, guild_id)
+        async with self._locks.setdefault(key, asyncio.Lock()):
+            await self._stop_locked(key, adapter)
+
+    def _schedule_runtime_cleanup(
+        self,
+        key: tuple[int, int],
+        adapter: Any,
+        failed_session: Any,
+        on_runtime_failure: Optional[Callable[[str, bool], Any]],
+        reason: str,
+        fallback_to_classic: bool,
+    ) -> None:
+        task = asyncio.create_task(
+            self._cleanup_after_runtime_failure(
+                key,
+                adapter,
+                failed_session,
+                on_runtime_failure,
+                reason,
+                fallback_to_classic,
+            )
+        )
+        self._cleanup_tasks.add(task)
+        task.add_done_callback(self._cleanup_tasks.discard)
+
+    async def _cleanup_after_runtime_failure(
+        self,
+        key: tuple[int, int],
+        adapter: Any,
+        failed_session: Any,
+        on_runtime_failure: Optional[Callable[[str, bool], Any]],
+        reason: str,
+        fallback_to_classic: bool,
+    ) -> None:
+        try:
+            async with self._locks.setdefault(key, asyncio.Lock()):
+                managed = self._sessions.get(key)
+                if managed is None or managed.session is not failed_session:
+                    return
+                await self._stop_locked(key, adapter)
+        except Exception:
+            logger.debug("Codex realtime runtime cleanup failed", exc_info=True)
+        if on_runtime_failure is not None:
+            try:
+                result = on_runtime_failure(reason, fallback_to_classic)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                logger.debug("Codex realtime failure callback failed", exc_info=True)
+
+    async def _stop_locked(self, key: tuple[int, int], adapter: Any) -> None:
+        managed = self._sessions.pop(key, None)
+        if managed is not None:
+            try:
+                await managed.session.stop()
+            finally:
+                self._end_output(adapter, key[1])
+
+    async def close(self) -> None:
+        self._closed = True
+        for key, managed in list(self._sessions.items()):
+            self._sessions.pop(key, None)
+            try:
+                await managed.session.stop()
+            except Exception:
+                logger.debug("Codex realtime shutdown failed", exc_info=True)
+            finally:
+                self._end_output(managed.adapter, key[1])
+        if self._cleanup_tasks:
+            await asyncio.gather(*list(self._cleanup_tasks), return_exceptions=True)

--- a/gateway/codex_realtime_voice.py
+++ b/gateway/codex_realtime_voice.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 from agent.transports.codex_realtime_voice import (
+    DEFAULT_CODEX_REALTIME_PROTOCOL,
+    SUPPORTED_CODEX_REALTIME_WEBRTC_PROTOCOLS,
     CodexRealtimeCapabilities,
     CodexRealtimeSession,
     safe_realtime_error,
@@ -45,6 +47,7 @@ class CodexRealtimeVoiceConfig:
     enabled: bool = False
     user_id: Optional[int] = None
     voice: Optional[str] = None
+    protocol_version: str = DEFAULT_CODEX_REALTIME_PROTOCOL
     fallback_to_classic: bool = True
     codex_bin: str = "codex"
     codex_home: Optional[str] = None
@@ -58,6 +61,9 @@ class CodexRealtimeVoiceConfig:
             return cls()
         voice = raw.get("voice")
         voice = str(voice).strip() if voice is not None else None
+        protocol_version = str(
+            raw.get("protocol_version") or DEFAULT_CODEX_REALTIME_PROTOCOL
+        ).strip().lower()
         codex_bin = str(raw.get("codex_bin") or "codex").strip() or "codex"
         codex_home = raw.get("codex_home")
         codex_home = str(codex_home).strip() if codex_home else None
@@ -65,6 +71,7 @@ class CodexRealtimeVoiceConfig:
             enabled=_config_bool(raw.get("enabled"), False),
             user_id=_positive_id(raw.get("user_id")),
             voice=voice or None,
+            protocol_version=protocol_version,
             fallback_to_classic=_config_bool(raw.get("fallback_to_classic"), True),
             codex_bin=codex_bin,
             codex_home=codex_home,
@@ -172,6 +179,13 @@ class CodexRealtimeVoiceManager:
             )
         if not config.enabled:
             return CodexRealtimeStartResult(False, False, True)
+        if config.protocol_version not in SUPPORTED_CODEX_REALTIME_WEBRTC_PROTOCOLS:
+            return CodexRealtimeStartResult(
+                True,
+                False,
+                config.fallback_to_classic,
+                "codex_realtime_voice.protocol_version must be v1 or v3 for WebRTC",
+            )
         if config.user_id is None:
             return CodexRealtimeStartResult(
                 True,
@@ -231,6 +245,7 @@ class CodexRealtimeVoiceManager:
                     cwd=os.getcwd(),
                     codex_bin=config.codex_bin,
                     codex_home=config.codex_home,
+                    protocol_version=config.protocol_version,
                     on_user_transcript=_on_transcript,
                     on_output_pcm=_on_output_pcm,
                     on_error=_on_error,

--- a/gateway/codex_realtime_voice.py
+++ b/gateway/codex_realtime_voice.py
@@ -139,13 +139,27 @@ class CodexRealtimeVoiceManager:
         """Return the durable fallback policy even after a session is removed."""
         return CodexRealtimeVoiceConfig.from_adapter(adapter).fallback_to_classic
 
+    def prepare_for_voice_channel(self, adapter: Any, guild_id: int) -> bool:
+        """Reserve PCM before Discord starts its receiver during an opted-in join."""
+
+        config = CodexRealtimeVoiceConfig.from_adapter(adapter)
+        if self._closed or not config.enabled:
+            return False
+        self._starting.add(self._key(adapter, guild_id))
+        return True
+
+    def cancel_voice_channel_start(self, adapter: Any, guild_id: int) -> None:
+        """Release a pre-join PCM reservation after startup or join failure."""
+
+        self._starting.discard(self._key(adapter, guild_id))
+
     async def start_for_voice_channel(
         self,
         *,
         adapter: Any,
         guild_id: int,
         user_id: int,
-        on_transcript: Callable[[int, str], Any],
+        on_transcript: Callable[[int, str, int], Any],
         on_runtime_failure: Optional[Callable[[str, bool], Any]] = None,
     ) -> CodexRealtimeStartResult:
         config = CodexRealtimeVoiceConfig.from_adapter(adapter)
@@ -190,8 +204,8 @@ class CodexRealtimeVoiceManager:
                 if not output_ready:
                     raise RuntimeError("Discord voice mixer is unavailable")
 
-                def _on_transcript(text: str) -> Any:
-                    return on_transcript(bound_user_id, text)
+                def _on_transcript(text: str, generation: int) -> Any:
+                    return on_transcript(bound_user_id, text, generation)
 
                 def _on_output_pcm(pcm: bytes) -> Any:
                     return adapter.push_realtime_voice_pcm(guild_id, pcm)
@@ -287,25 +301,41 @@ class CodexRealtimeVoiceManager:
         if key in self._starting:
             return True
         managed = self._sessions.get(key)
-        if managed is None or not getattr(managed.session, "active", False):
-            return False
+        if managed is None:
+            config = CodexRealtimeVoiceConfig.from_adapter(adapter)
+            # With fallback explicitly disabled, PCM stays consumed for the
+            # entire failure-to-disconnect window, including after provider
+            # cleanup has removed the managed session.
+            return config.enabled and not config.fallback_to_classic
+        if not getattr(managed.session, "active", False):
+            # A no-fallback route remains fail-closed while transport cleanup
+            # runs and before Discord is disconnected.
+            return not managed.fallback_to_classic
         if managed.user_id != int(user_id):
             # An active realtime route is intentionally single-user. Consume
             # other speakers' PCM instead of leaking it into the classic STT
             # fallback and creating a second, ambiguous conversation path.
             return True
-        return bool(managed.session.push_discord_pcm(pcm))
+        consumed = bool(managed.session.push_discord_pcm(pcm))
+        return consumed or not managed.fallback_to_classic
 
     async def append_speech(
         self,
         adapter: Any,
         guild_id: int,
         text: str,
+        *,
+        transcript_generation: Optional[int] = None,
     ) -> bool:
         managed = self._sessions.get(self._key(adapter, guild_id))
         if managed is None:
             return False
-        return bool(await managed.session.append_speech(text))
+        return bool(
+            await managed.session.append_speech(
+                text,
+                transcript_generation=transcript_generation,
+            )
+        )
 
     async def stop_for_voice_channel(self, adapter: Any, guild_id: int) -> None:
         key = self._key(adapter, guild_id)
@@ -360,22 +390,25 @@ class CodexRealtimeVoiceManager:
                 logger.debug("Codex realtime failure callback failed", exc_info=True)
 
     async def _stop_locked(self, key: tuple[int, int], adapter: Any) -> None:
-        managed = self._sessions.pop(key, None)
+        managed = self._sessions.get(key)
         if managed is not None:
             try:
                 await managed.session.stop()
             finally:
+                if self._sessions.get(key) is managed:
+                    self._sessions.pop(key, None)
                 self._end_output(adapter, key[1])
 
     async def close(self) -> None:
         self._closed = True
         for key, managed in list(self._sessions.items()):
-            self._sessions.pop(key, None)
             try:
                 await managed.session.stop()
             except Exception:
                 logger.debug("Codex realtime shutdown failed", exc_info=True)
             finally:
+                if self._sessions.get(key) is managed:
+                    self._sessions.pop(key, None)
                 self._end_output(managed.adapter, key[1])
         if self._cleanup_tasks:
             await asyncio.gather(*list(self._cleanup_tasks), return_exceptions=True)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14740,6 +14740,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 response = ""
 
             # Auto voice reply: send TTS audio before the text response
+            # A realtime Discord VC turn owns one spoken-output route. If the
+            # model nevertheless called the generic text_to_speech tool, drop
+            # that tool's audio MEDIA tag before both VC synthesis and normal
+            # platform delivery. Otherwise the generic dedup path below skips
+            # the VC reply and Discord receives a clickable voice attachment
+            # in the linked text channel instead of live channel audio.
+            response = self._strip_realtime_voice_audio_media(
+                event,
+                response,
+                self._adapter_for_source(source),
+                agent_messages=agent_messages,
+            )
             _already_sent = bool(agent_result.get("already_sent"))
             if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
                 await self._send_voice_reply(event, response)
@@ -15879,8 +15891,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # adapter's classic auto-TTS path. Preserve the otherwise-lost
             # modality and language context for the normal Hermes turn.
             agent_input = (
-                "[This was spoken live in the connected Discord voice channel."
-                f"{language_context}]\n{transcript}"
+                "[This was spoken live in the connected Discord voice channel. "
+                "Reply naturally as part of that live spoken conversation. "
+                f"{language_context.strip()} "
+                "Return only your final response text. Do not call text_to_speech "
+                "or attach a voice memo for your reply; the gateway will speak "
+                "your final text directly in the connected voice channel. Media "
+                "artifacts explicitly requested by the user remain allowed.]\n"
+                f"{transcript}"
             )
         event = MessageEvent(
             source=source,
@@ -15942,7 +15960,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             for msg in agent_messages
         )
-        if has_agent_tts:
+        if has_agent_tts and not is_realtime_voice_input:
             return False
 
         # Dedup: base adapter auto-TTS already handles voice input
@@ -15954,6 +15972,207 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
 
         return True
+
+    def _strip_realtime_voice_audio_media(
+        self,
+        event: MessageEvent,
+        response: str,
+        adapter,
+        agent_messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> str:
+        """Prevent live Discord VC replies from becoming chat audio files.
+
+        The generic gateway media collector auto-appends ``MEDIA:`` tags from
+        text_to_speech tool results. That is correct for ordinary messaging,
+        but a Codex realtime VC turn has a single owner for spoken output:
+        ``_send_voice_reply``. Keep non-audio artifacts available while
+        dropping audio attachments from this specific synthetic turn.
+        """
+        if not bool(getattr(event.raw_message, "codex_realtime_voice", False)):
+            return response
+
+        from gateway.platforms.base import (
+            BasePlatformAdapter,
+            should_send_media_as_audio,
+        )
+        extract_media_candidate = getattr(adapter, "extract_media", None)
+        extract_media: Callable[[str], Any] = cast(
+            Callable[[str], Any],
+            extract_media_candidate
+            if callable(extract_media_candidate)
+            else BasePlatformAdapter.extract_media,
+        )
+        extract_local_files_candidate = getattr(adapter, "extract_local_files", None)
+        extract_local_files: Callable[[str], Any] = cast(
+            Callable[[str], Any],
+            extract_local_files_candidate
+            if callable(extract_local_files_candidate)
+            else BasePlatformAdapter.extract_local_files,
+        )
+
+        try:
+            force_document_attachments = "[[as_document]]" in response
+            media_files, cleaned = extract_media(response)
+            suppressed_audio = 0
+            preserved_media = []
+            current_turn_called_tts = self._current_turn_has_tts_tool(
+                agent_messages or []
+            )
+            for media_path, is_voice in media_files:
+                ext = Path(media_path).suffix.lower()
+                is_audio = should_send_media_as_audio(
+                    event.source.platform,
+                    ext,
+                    is_voice=is_voice,
+                )
+                # Automatic reply speech may be OGG voice media or an unmarked
+                # MP3. During a current TTS turn both are owned by the live VC;
+                # audio from unrelated artifact flows remains deliverable.
+                if is_audio and (is_voice or current_turn_called_tts):
+                    suppressed_audio += 1
+                else:
+                    preserved_media.append(media_path)
+
+            changed = bool(suppressed_audio)
+            rebuilt = cleaned.rstrip() if suppressed_audio else response
+            if suppressed_audio:
+                logger.warning(
+                    "Suppressed %d model-generated audio attachment(s) for a live Discord VC reply",
+                    suppressed_audio,
+                )
+            if (suppressed_audio or current_turn_called_tts) and not rebuilt:
+                changed = True
+                recovered = self._latest_tts_tool_text(agent_messages or [])
+                if recovered:
+                    # TTS arguments are speech content, never a second channel
+                    # through which attachment directives may re-enter delivery.
+                    _recovered_media, recovered = extract_media(recovered)
+                    # Bare paths in recovered speech are also tool payload, not
+                    # a fresh attachment request. Strip all of them here.
+                    _recovered_files, recovered = extract_local_files(recovered)
+                    rebuilt = recovered.rstrip()
+                else:
+                    rebuilt = self._realtime_voice_failure_text(adapter)
+            if suppressed_audio and preserved_media:
+                preserved = "\n".join(f"MEDIA:{path}" for path in preserved_media)
+                if force_document_attachments:
+                    preserved = f"[[as_document]]\n{preserved}"
+                rebuilt = f"{rebuilt}\n{preserved}" if rebuilt else preserved
+
+            if current_turn_called_tts:
+                local_files, local_cleaned = extract_local_files(rebuilt)
+                suppressed_local_audio = []
+                preserved_local_files = []
+                for local_path in local_files:
+                    ext = Path(local_path).suffix.lower()
+                    if should_send_media_as_audio(
+                        event.source.platform,
+                        ext,
+                        is_voice=False,
+                    ):
+                        suppressed_local_audio.append(local_path)
+                    else:
+                        preserved_local_files.append(local_path)
+                if suppressed_local_audio:
+                    changed = True
+                    rebuilt = local_cleaned.rstrip()
+                    if preserved_local_files:
+                        preserved = "\n".join(
+                            f"MEDIA:{path}" for path in preserved_local_files
+                        )
+                        if force_document_attachments:
+                            preserved = f"[[as_document]]\n{preserved}"
+                        rebuilt = f"{rebuilt}\n{preserved}" if rebuilt else preserved
+                    logger.warning(
+                        "Suppressed %d model-generated bare audio path(s) for a live Discord VC reply",
+                        len(suppressed_local_audio),
+                    )
+            if changed and not rebuilt:
+                rebuilt = self._realtime_voice_failure_text(adapter)
+            return rebuilt if changed else response
+        except Exception:
+            # Fail closed for the live-voice contract: if media parsing itself
+            # breaks, retain visible text but never leak an explicit MEDIA tag
+            # into the linked text channel as a faux voice fallback.
+            logger.warning(
+                "Failed to classify live Discord VC media; suppressing explicit media directives",
+                exc_info=True,
+            )
+            cleaned = BasePlatformAdapter.strip_media_directives_for_display(response)
+            current_turn_called_tts = self._current_turn_has_tts_tool(
+                agent_messages or []
+            )
+            if current_turn_called_tts:
+                local_files, local_cleaned = BasePlatformAdapter.extract_local_files(
+                    cleaned
+                )
+                preserved_local_files = [
+                    path
+                    for path in local_files
+                    if not should_send_media_as_audio(
+                        event.source.platform,
+                        Path(path).suffix.lower(),
+                        is_voice=False,
+                    )
+                ]
+                if len(preserved_local_files) != len(local_files):
+                    cleaned = local_cleaned.rstrip()
+                    if preserved_local_files:
+                        preserved = "\n".join(
+                            f"MEDIA:{path}" for path in preserved_local_files
+                        )
+                        cleaned = f"{cleaned}\n{preserved}" if cleaned else preserved
+            return cleaned.rstrip() or self._realtime_voice_failure_text(adapter)
+
+    @staticmethod
+    def _realtime_voice_failure_text(adapter) -> str:
+        """Return a visible/spoken failure sentence in the configured language."""
+        config = getattr(adapter, "config", None)
+        extra = getattr(config, "extra", None)
+        realtime = extra.get("codex_realtime_voice") if isinstance(extra, dict) else None
+        language = realtime.get("spoken_language", "") if isinstance(realtime, dict) else ""
+        if str(language).lower().startswith("nl"):
+            return "Sorry, ik kon het gesproken antwoord niet afmaken."
+        return "Sorry, I couldn't prepare the spoken reply."
+
+    @staticmethod
+    def _current_turn_has_tts_tool(agent_messages: List[Dict[str, Any]]) -> bool:
+        """Return whether the current turn, not history, invoked TTS."""
+        for message in reversed(agent_messages):
+            role = message.get("role")
+            if role == "user":
+                break
+            if role != "assistant":
+                continue
+            for call in message.get("tool_calls") or []:
+                if (call.get("function") or {}).get("name") == "text_to_speech":
+                    return True
+        return False
+
+    @staticmethod
+    def _latest_tts_tool_text(agent_messages: List[Dict[str, Any]]) -> str:
+        """Recover intended speech text when a TTS-only reply has no final text."""
+        for message in reversed(agent_messages):
+            role = message.get("role")
+            if role == "user":
+                break
+            if role != "assistant":
+                continue
+            for call in reversed(message.get("tool_calls") or []):
+                function = call.get("function") or {}
+                if function.get("name") != "text_to_speech":
+                    continue
+                arguments = function.get("arguments") or {}
+                if isinstance(arguments, str):
+                    try:
+                        arguments = json.loads(arguments)
+                    except (TypeError, ValueError):
+                        continue
+                if isinstance(arguments, dict):
+                    text = arguments.get("text")
+                    if isinstance(text, str) and text.strip():
+                        return text.strip()
+        return ""
 
     def _should_echo_stt_transcripts(self) -> bool:
         """Return whether inbound voice/STT transcripts should be echoed to chat."""
@@ -15975,6 +16194,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             is_realtime_voice_input = bool(
                 getattr(event.raw_message, "codex_realtime_voice", False)
             )
+            is_in_voice_channel = getattr(adapter, "is_in_voice_channel", None)
+            if is_realtime_voice_input and (
+                not guild_id
+                or not callable(is_in_voice_channel)
+                or not is_in_voice_channel(guild_id)
+            ):
+                logger.warning(
+                    "Suppressing live Discord VC speech because the voice channel is disconnected"
+                )
+                return
             linked_voice_session = (
                 guild_id
                 and adapter is not None
@@ -16079,6 +16308,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     and hasattr(adapter, "is_in_voice_channel")
                     and adapter.is_in_voice_channel(guild_id)):
                 await adapter.play_in_voice_channel(guild_id, actual_path)
+            elif (
+                event.source.platform == Platform.DISCORD
+                and bool(getattr(event.raw_message, "codex_realtime_voice", False))
+            ):
+                logger.warning(
+                    "Suppressing Discord chat voice attachment fallback for a live VC reply"
+                )
+                return
             elif adapter and hasattr(adapter, "send_voice"):
                 reply_anchor = self._reply_anchor_for_event(event)
                 thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15850,22 +15850,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return
 
-        # Show transcript in text channel (after auth, with mention sanitization)
-        try:
-            channel = adapter._client.get_channel(text_ch_id)
-            if channel:
-                safe_text = transcript[:2000].replace("@everyone", "@\u200beveryone").replace("@here", "@\u200bhere")
-                await channel.send(f"**[Voice]** <@{user_id}>: {safe_text}")
-        except Exception:
-            pass
+        # Show transcript in text channel only when raw STT echo is enabled.
+        if self._should_echo_stt_transcripts():
+            try:
+                channel = adapter._client.get_channel(text_ch_id)
+                if channel:
+                    safe_text = transcript[:2000].replace("@everyone", "@\u200beveryone").replace("@here", "@\u200bhere")
+                    await channel.send(f"**[Voice]** <@{user_id}>: {safe_text}")
+            except Exception:
+                pass
 
         # Build a synthetic MessageEvent and feed through the normal pipeline
         # Use SimpleNamespace as raw_message so _get_guild_id() can extract
         # guild_id and _send_voice_reply() plays audio in the voice channel.
         from types import SimpleNamespace
+        agent_input = transcript
+        if realtime:
+            spoken_language = self._get_codex_realtime_voice_manager().configured_spoken_language(
+                adapter
+            )
+            language_context = (
+                f" The configured spoken language is {spoken_language}; "
+                "reply naturally in that language."
+                if spoken_language
+                else " Reply naturally in the language the user spoke."
+            )
+            # Realtime audio is represented as a TEXT event to avoid the base
+            # adapter's classic auto-TTS path. Preserve the otherwise-lost
+            # modality and language context for the normal Hermes turn.
+            agent_input = (
+                "[This was spoken live in the connected Discord voice channel."
+                f"{language_context}]\n{transcript}"
+            )
         event = MessageEvent(
             source=source,
-            text=transcript,
+            text=agent_input,
             message_type=MessageType.TEXT if realtime else MessageType.VOICE,
             raw_message=SimpleNamespace(
                 guild_id=guild_id,
@@ -15938,7 +15957,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _should_echo_stt_transcripts(self) -> bool:
         """Return whether inbound voice/STT transcripts should be echoed to chat."""
-        return bool(getattr(self.config, "stt_echo_transcripts", True))
+        config = getattr(self, "config", None)
+        return bool(getattr(config, "stt_echo_transcripts", True))
 
     async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
         """Generate TTS audio and send as a voice message before the text reply."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15591,9 +15591,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._voice_key(Platform.DISCORD, str(chat_id)), "off"
             )
 
+        realtime_manager.prepare_for_voice_channel(adapter, guild_id)
         try:
             success = await adapter.join_voice_channel(voice_channel)
         except Exception as e:
+            realtime_manager.cancel_voice_channel_start(adapter, guild_id)
             logger.warning("Failed to join voice channel: %s", e)
             adapter._voice_input_callback = None
             if hasattr(adapter, "_voice_pcm_callback"):
@@ -15618,29 +15620,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 realtime_user_id = int(event.source.user_id or "0")
             except (TypeError, ValueError):
                 realtime_user_id = 0
-            realtime_result = await realtime_manager.start_for_voice_channel(
-                adapter=adapter,
-                guild_id=guild_id,
-                user_id=realtime_user_id,
-                on_transcript=lambda transcript_user_id, text: (
-                    self._handle_voice_channel_input(
-                        guild_id,
-                        transcript_user_id,
-                        text,
-                        realtime=True,
-                        adapter=adapter,
-                    )
-                ),
-                on_runtime_failure=lambda reason, fallback_to_classic: (
-                    self._handle_codex_realtime_runtime_failure(
-                        adapter,
-                        guild_id,
-                        event.source,
-                        reason,
-                        fallback_to_classic,
-                    )
-                ),
-            )
+            try:
+                realtime_result = await realtime_manager.start_for_voice_channel(
+                    adapter=adapter,
+                    guild_id=guild_id,
+                    user_id=realtime_user_id,
+                    on_transcript=lambda transcript_user_id, text, generation: (
+                        self._handle_voice_channel_input(
+                            guild_id,
+                            transcript_user_id,
+                            text,
+                            realtime=True,
+                            realtime_generation=generation,
+                            adapter=adapter,
+                        )
+                    ),
+                    on_runtime_failure=lambda reason, fallback_to_classic: (
+                        self._handle_codex_realtime_runtime_failure(
+                            adapter,
+                            guild_id,
+                            event.source,
+                            reason,
+                            fallback_to_classic,
+                        )
+                    ),
+                )
+            finally:
+                realtime_manager.cancel_voice_channel_start(adapter, guild_id)
             if realtime_result.enabled and not realtime_result.active:
                 realtime_reason = str(
                     realtime_result.reason or "Codex realtime startup failed"
@@ -15671,6 +15677,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 f"{realtime_line}"
             )
         # Join failed — clear callbacks
+        realtime_manager.cancel_voice_channel_start(adapter, guild_id)
         adapter._voice_input_callback = None
         if hasattr(adapter, "_voice_pcm_callback"):
             setattr(adapter, "_voice_pcm_callback", None)
@@ -15795,6 +15802,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         transcript: str,
         *,
         realtime: bool = False,
+        realtime_generation: Optional[int] = None,
         adapter=None,
     ):
         """Handle transcribed voice from a user in a voice channel.
@@ -15863,6 +15871,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 guild_id=guild_id,
                 guild=None,
                 codex_realtime_voice=realtime,
+                codex_realtime_generation=realtime_generation,
             ),
         )
 
@@ -15955,14 +15964,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 linked_voice_session
                 and realtime_manager.is_active(adapter, guild_id)
             ):
+                from agent.transports.codex_realtime_voice import (
+                    CodexRealtimeStaleSpeech,
+                )
+
                 fallback_to_classic = realtime_manager.classic_fallback_enabled(
                     adapter, guild_id
                 )
                 try:
+                    from tools.tts_tool import _strip_markdown_for_tts
+
+                    speech_text = _strip_markdown_for_tts(text[:4000])
+                    if not speech_text:
+                        return
                     if await realtime_manager.append_speech(
-                        adapter, guild_id, text[:4000]
+                        adapter,
+                        guild_id,
+                        speech_text,
+                        transcript_generation=getattr(
+                            event.raw_message,
+                            "codex_realtime_generation",
+                            None,
+                        ),
                     ):
                         return
+                except CodexRealtimeStaleSpeech:
+                    logger.debug(
+                        "Suppressing stale Codex realtime voice reply after barge-in"
+                    )
+                    return
                 except Exception:
                     logger.warning(
                         "Codex realtime speech failed (%s)",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15986,6 +15986,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ):
                 from agent.transports.codex_realtime_voice import (
                     CodexRealtimeStaleSpeech,
+                    safe_realtime_error,
                 )
 
                 fallback_to_classic = realtime_manager.classic_fallback_enabled(
@@ -16013,15 +16014,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "Suppressing stale Codex realtime voice reply after barge-in"
                     )
                     return
-                except Exception:
+                except Exception as exc:
                     logger.warning(
-                        "Codex realtime speech failed (%s)",
+                        "Codex realtime speech failed (%s): %s",
                         (
                             "using classic TTS fallback"
                             if fallback_to_classic
                             else "classic TTS fallback disabled"
                         ),
-                        exc_info=True,
+                        safe_realtime_error(exc),
                     )
                 if not fallback_to_classic:
                     return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3725,6 +3725,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Protects against the same utterance being emitted twice by the voice
         # capture / STT pipeline, which otherwise produces a second delayed reply.
         self._recent_voice_transcripts: Dict[tuple[int, int], List[tuple[float, str]]] = {}
+        # Experimental Codex GPT-Live route. Constructed lazily on the first
+        # Discord VC join; WebRTC dependencies remain opt-in after that.
+        self._codex_realtime_voice = None
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
@@ -9907,6 +9910,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _agent, context="shutdown idle-cache"
                     )
 
+            realtime_voice = getattr(self, "_codex_realtime_voice", None)
+            if realtime_voice is not None:
+                try:
+                    await realtime_voice.close()
+                except Exception:
+                    logger.debug("Codex realtime voice shutdown failed", exc_info=True)
+
             for platform, adapter in list(self.adapters.items()):
                 await self._bounded_adapter_teardown(adapter, platform)
 
@@ -15482,6 +15492,51 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return None
 
 
+    def _get_codex_realtime_voice_manager(self):
+        manager = getattr(self, "_codex_realtime_voice", None)
+        if manager is None:
+            from gateway.codex_realtime_voice import CodexRealtimeVoiceManager
+
+            manager = CodexRealtimeVoiceManager()
+            self._codex_realtime_voice = manager
+        return manager
+
+    async def _handle_codex_realtime_runtime_failure(
+        self,
+        adapter,
+        guild_id: int,
+        source: SessionSource,
+        reason: str,
+        fallback_to_classic: bool,
+    ) -> None:
+        if fallback_to_classic:
+            return
+        logger.warning(
+            "Codex realtime voice stopped without classic fallback: %s",
+            reason,
+        )
+        try:
+            await adapter.leave_voice_channel(guild_id)
+        except Exception:
+            logger.warning(
+                "Discord leave failed after Codex realtime failure",
+                exc_info=True,
+            )
+        finally:
+            self._voice_mode[
+                self._voice_key(source.platform, source.chat_id)
+            ] = "off"
+            self._save_voice_modes()
+            self._set_adapter_auto_tts_disabled(
+                adapter,
+                source.chat_id,
+                disabled=True,
+            )
+            if hasattr(adapter, "_voice_input_callback"):
+                setattr(adapter, "_voice_input_callback", None)
+            if hasattr(adapter, "_voice_pcm_callback"):
+                setattr(adapter, "_voice_pcm_callback", None)
+
     async def _handle_voice_channel_join(self, event: MessageEvent) -> str:
         """Join the user's current Discord voice channel."""
         adapter = self._adapter_for_source(event.source)
@@ -15501,9 +15556,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Wire callbacks BEFORE join so voice input arriving immediately
         # after connection is not lost.
         if hasattr(adapter, "_voice_input_callback"):
-            adapter._voice_input_callback = self._handle_voice_channel_input
+            adapter._voice_input_callback = (
+                lambda callback_guild_id, callback_user_id, transcript: (
+                    self._handle_voice_channel_input(
+                        callback_guild_id,
+                        callback_user_id,
+                        transcript,
+                        adapter=adapter,
+                    )
+                )
+            )
+        realtime_manager = self._get_codex_realtime_voice_manager()
+        if hasattr(adapter, "_voice_pcm_callback"):
+            setattr(
+                adapter,
+                "_voice_pcm_callback",
+                lambda callback_guild_id, callback_user_id, pcm: (
+                    realtime_manager.push_discord_pcm(
+                        adapter,
+                        callback_guild_id,
+                        callback_user_id,
+                        pcm,
+                    )
+                ),
+            )
         if hasattr(adapter, "_on_voice_disconnect"):
-            adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
+            adapter._on_voice_disconnect = lambda chat_id: self._handle_voice_timeout_cleanup(
+                chat_id, adapter=adapter
+            )
         # Let the adapter's inactivity timer see the live voice-reply mode so it
         # doesn't disconnect a deliberately text-only (/voice off) session.
         if hasattr(adapter, "_voice_mode_getter"):
@@ -15516,6 +15596,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.warning("Failed to join voice channel: %s", e)
             adapter._voice_input_callback = None
+            if hasattr(adapter, "_voice_pcm_callback"):
+                setattr(adapter, "_voice_pcm_callback", None)
             err_lower = str(e).lower()
             if "pynacl" in err_lower or "nacl" in err_lower or "davey" in err_lower:
                 return (
@@ -15531,12 +15613,67 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
             self._save_voice_modes()
             self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
+
+            try:
+                realtime_user_id = int(event.source.user_id or "0")
+            except (TypeError, ValueError):
+                realtime_user_id = 0
+            realtime_result = await realtime_manager.start_for_voice_channel(
+                adapter=adapter,
+                guild_id=guild_id,
+                user_id=realtime_user_id,
+                on_transcript=lambda transcript_user_id, text: (
+                    self._handle_voice_channel_input(
+                        guild_id,
+                        transcript_user_id,
+                        text,
+                        realtime=True,
+                        adapter=adapter,
+                    )
+                ),
+                on_runtime_failure=lambda reason, fallback_to_classic: (
+                    self._handle_codex_realtime_runtime_failure(
+                        adapter,
+                        guild_id,
+                        event.source,
+                        reason,
+                        fallback_to_classic,
+                    )
+                ),
+            )
+            if realtime_result.enabled and not realtime_result.active:
+                realtime_reason = str(
+                    realtime_result.reason or "Codex realtime startup failed"
+                )
+                if not realtime_result.fallback_to_classic:
+                    await self._handle_codex_realtime_runtime_failure(
+                        adapter,
+                        guild_id,
+                        event.source,
+                        realtime_reason,
+                        False,
+                    )
+                    return (
+                        f"Codex Live could not start ({realtime_reason}) and "
+                        "classic fallback is disabled."
+                    )
+                realtime_line = (
+                    f"\nCodex Live unavailable ({realtime_reason}); "
+                    "using classic STT/TTS voice."
+                )
+            elif realtime_result.active:
+                realtime_line = "\nCodex Live realtime voice is active (experimental)."
+            else:
+                realtime_line = ""
             return (
                 f"Joined voice channel **{voice_channel.name}**.\n"
-                f"I'll speak my replies and listen to you. Use /voice leave to disconnect."
+                "I'll speak my replies and listen to you. Use /voice leave to disconnect."
+                f"{realtime_line}"
             )
-        # Join failed — clear callback
+        # Join failed — clear callbacks
         adapter._voice_input_callback = None
+        if hasattr(adapter, "_voice_pcm_callback"):
+            setattr(adapter, "_voice_pcm_callback", None)
         return "Failed to join voice channel. Check bot permissions (Connect + Speak)."
 
     async def _handle_voice_channel_leave(self, event: MessageEvent) -> str:
@@ -15551,26 +15688,64 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return "Not in a voice channel."
 
         try:
+            await self._get_codex_realtime_voice_manager().stop_for_voice_channel(
+                adapter, guild_id
+            )
+        except Exception:
+            logger.warning(
+                "Codex realtime voice cleanup failed before Discord leave",
+                exc_info=True,
+            )
+        try:
             await adapter.leave_voice_channel(guild_id)
         except Exception as e:
             logger.warning("Error leaving voice channel: %s", e)
-        # Always clean up state even if leave raised an exception
-        self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "off"
+        # Always clean up runner state even if Discord teardown raised.
+        self._voice_mode[
+            self._voice_key(event.source.platform, event.source.chat_id)
+        ] = "off"
         self._save_voice_modes()
         self._set_adapter_auto_tts_disabled(adapter, event.source.chat_id, disabled=True)
         if hasattr(adapter, "_voice_input_callback"):
             adapter._voice_input_callback = None
+        if hasattr(adapter, "_voice_pcm_callback"):
+            setattr(adapter, "_voice_pcm_callback", None)
         return "Left voice channel."
 
-    def _handle_voice_timeout_cleanup(self, chat_id: str) -> None:
-        """Called by the adapter when a voice channel times out.
+    def _handle_voice_timeout_cleanup(self, chat_id: str, *, adapter=None) -> None:
+        """Clean runner/provider state after Discord voice inactivity timeout."""
+        if adapter is not None:
+            guild_ids = [
+                guild_id
+                for guild_id, linked_chat_id in getattr(
+                    adapter, "_voice_text_channels", {}
+                ).items()
+                if str(linked_chat_id) == str(chat_id)
+            ]
+            manager = self._get_codex_realtime_voice_manager()
 
-        Cleans up runner-side voice_mode state that the adapter cannot reach.
-        """
+            async def _stop_realtime_voice(guild_id: int) -> None:
+                try:
+                    await manager.stop_for_voice_channel(adapter, guild_id)
+                except Exception:
+                    logger.warning(
+                        "Codex realtime voice timeout cleanup failed",
+                        exc_info=True,
+                    )
+
+            for guild_id in guild_ids:
+                task = asyncio.create_task(_stop_realtime_voice(guild_id))
+                background_tasks = getattr(self, "_background_tasks", None)
+                if isinstance(background_tasks, set):
+                    background_tasks.add(task)
+                    task.add_done_callback(background_tasks.discard)
+
         self._voice_mode[self._voice_key(Platform.DISCORD, chat_id)] = "off"
         self._save_voice_modes()
-        adapter = self.adapters.get(Platform.DISCORD)
-        self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
+        resolved_adapter = adapter or self.adapters.get(Platform.DISCORD)
+        self._set_adapter_auto_tts_disabled(
+            resolved_adapter, chat_id, disabled=True
+        )
 
     def _is_duplicate_voice_transcript(self, guild_id: int, user_id: int, transcript: str) -> bool:
         """Suppress repeated STT outputs for the same recent utterance.
@@ -15614,14 +15789,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return False
 
     async def _handle_voice_channel_input(
-        self, guild_id: int, user_id: int, transcript: str
+        self,
+        guild_id: int,
+        user_id: int,
+        transcript: str,
+        *,
+        realtime: bool = False,
+        adapter=None,
     ):
         """Handle transcribed voice from a user in a voice channel.
 
         Creates a synthetic MessageEvent and processes it through the
-        adapter's full message pipeline (session, typing, agent, TTS reply).
+        adapter's full message pipeline. Realtime transcripts use a TEXT event
+        so the classic base-adapter TTS path cannot speak a duplicate reply;
+        the runner routes the final text back through Codex appendSpeech.
         """
-        adapter = self.adapters.get(Platform.DISCORD)
+        adapter = adapter or self.adapters.get(Platform.DISCORD)
         if not adapter:
             return
 
@@ -15675,8 +15858,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         event = MessageEvent(
             source=source,
             text=transcript,
-            message_type=MessageType.VOICE,
-            raw_message=SimpleNamespace(guild_id=guild_id, guild=None),
+            message_type=MessageType.TEXT if realtime else MessageType.VOICE,
+            raw_message=SimpleNamespace(
+                guild_id=guild_id,
+                guild=None,
+                codex_realtime_voice=realtime,
+            ),
         )
 
         await adapter.handle_message(event)
@@ -15704,7 +15891,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         chat_id = event.source.chat_id
         voice_mode = self._voice_mode.get(self._voice_key(event.source.platform, chat_id), "off")
-        is_voice_input = (event.message_type == MessageType.VOICE)
+        is_realtime_voice_input = bool(
+            getattr(event.raw_message, "codex_realtime_voice", False)
+        )
+        is_voice_input = (
+            event.message_type == MessageType.VOICE or is_realtime_voice_input
+        )
 
         should = (
             (voice_mode == "all")
@@ -15730,7 +15922,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # When streaming already delivered the text (already_sent=True),
         # the base adapter will receive None and can't run auto-TTS,
         # so the runner must take over.
-        if is_voice_input and not already_sent:
+        if is_voice_input and not is_realtime_voice_input and not already_sent:
             return False
 
         return True
@@ -15741,6 +15933,58 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
         """Generate TTS audio and send as a voice message before the text reply."""
+        if event.source.platform == Platform.DISCORD:
+            guild_id = self._get_guild_id(event)
+            adapter = self._adapter_for_source(event.source)
+            realtime_manager = self._get_codex_realtime_voice_manager()
+            voice_text_channels = getattr(adapter, "_voice_text_channels", {})
+            linked_chat_id = (
+                voice_text_channels.get(guild_id)
+                if isinstance(voice_text_channels, dict) and guild_id
+                else None
+            )
+            is_realtime_voice_input = bool(
+                getattr(event.raw_message, "codex_realtime_voice", False)
+            )
+            linked_voice_session = (
+                guild_id
+                and adapter is not None
+                and str(linked_chat_id) == str(event.source.chat_id)
+            )
+            if (
+                linked_voice_session
+                and realtime_manager.is_active(adapter, guild_id)
+            ):
+                fallback_to_classic = realtime_manager.classic_fallback_enabled(
+                    adapter, guild_id
+                )
+                try:
+                    if await realtime_manager.append_speech(
+                        adapter, guild_id, text[:4000]
+                    ):
+                        return
+                except Exception:
+                    logger.warning(
+                        "Codex realtime speech failed (%s)",
+                        (
+                            "using classic TTS fallback"
+                            if fallback_to_classic
+                            else "classic TTS fallback disabled"
+                        ),
+                        exc_info=True,
+                    )
+                if not fallback_to_classic:
+                    return
+            elif (
+                linked_voice_session
+                and is_realtime_voice_input
+                and not realtime_manager.configured_fallback_enabled(adapter)
+            ):
+                # A no-fallback realtime route may fail while Hermes is still
+                # processing its last transcript. Do not leak that reply into
+                # local TTS after the failed session has already been removed.
+                return
+
         import uuid as _uuid
         audio_path = None
         actual_path = None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2718,6 +2718,18 @@ DEFAULT_CONFIG = {
                 "On it.",
             ],
         },
+        # Experimental Codex GPT-Live speech interface for Discord VC audio.
+        # Disabled by default. Requires Codex CLI >=0.145 with its own login and
+        # one explicit Discord user binding; all failures fall back to classic
+        # STT → Hermes → TTS unless fallback_to_classic is set false.
+        "codex_realtime_voice": {
+            "enabled": False,
+            "user_id": "",            # one Discord user ID; quote snowflakes in YAML
+            "voice": "",              # empty = Codex v1 default; queried at runtime
+            "fallback_to_classic": True,
+            "codex_bin": "codex",
+            "codex_home": "",         # optional isolated CODEX_HOME
+        },
     },
 
     # WhatsApp platform settings (gateway mode)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2725,7 +2725,8 @@ DEFAULT_CONFIG = {
         "codex_realtime_voice": {
             "enabled": False,
             "user_id": "",            # one Discord user ID; quote snowflakes in YAML
-            "voice": "",              # empty = Codex v1 default; queried at runtime
+            "voice": "",              # empty = protocol default; queried at runtime
+            "protocol_version": "v3", # WebRTC supports v1 or v3; v3 is current
             "fallback_to_classic": True,
             "codex_bin": "codex",
             "codex_home": "",         # optional isolated CODEX_HOME

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2726,6 +2726,7 @@ DEFAULT_CONFIG = {
             "enabled": False,
             "user_id": "",            # one Discord user ID; quote snowflakes in YAML
             "voice": "",              # empty = protocol default; queried at runtime
+            "spoken_language": "",    # e.g. nl-NL; empty preserves detected language
             "protocol_version": "v3", # WebRTC supports v1 or v3; v3 is current
             "fallback_to_classic": True,
             "codex_bin": "codex",

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -448,7 +448,7 @@ class VoiceReceiver:
 
         # SSRC -> user_id mapping (populated from SPEAKING events)
         self._ssrc_to_user: Dict[int, int] = {}
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
 
         # Per-user audio buffers
         self._buffers: Dict[int, bytearray] = defaultdict(bytearray)
@@ -513,6 +513,11 @@ class VoiceReceiver:
         """Offer one decoded frame to realtime, else buffer for classic STT."""
         with self._lock:
             user_id = self._ssrc_to_user.get(ssrc, 0)
+        if not user_id:
+            # A voice reconnect may resume RTP before Discord repeats its
+            # SPEAKING event. Apply the same fail-closed sole-user inference
+            # used by classic silence handling before realtime sees the frame.
+            user_id = self._infer_user_for_ssrc(ssrc)
         if self._pcm_callback is not None:
             try:
                 # user_id may still be 0 before Discord's SPEAKING mapping
@@ -735,7 +740,7 @@ class VoiceReceiver:
             ]
             if len(candidates) == 1:
                 uid = candidates[0]
-                self._ssrc_to_user[ssrc] = uid
+                self.map_ssrc(ssrc, uid)
                 logger.info("Auto-mapped ssrc=%d -> user=%d (sole allowed member)", ssrc, uid)
                 return uid
         except Exception:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -916,6 +916,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
     # Auto-disconnect from voice channel after this many seconds of inactivity
     VOICE_TIMEOUT = 300
+    VOICE_MIXER_DRAIN_START_TIMEOUT = 1.0
+    VOICE_MIXER_DRAIN_MIN_READS = 3
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
@@ -3813,7 +3815,38 @@ class DiscordAdapter(BasePlatformAdapter):
         if vc.is_playing():
             vc.stop()
         vc.play(mixer, after=_after)
-        self._voice_mixers[guild_id] = mixer
+        # Do not call this output path ready merely because discord.py accepted
+        # ``play()``. A voice reconnect can leave AudioPlayer flags set while
+        # the sender no longer drains the mapped source. Require several real
+        # reads from the concrete player before publishing the mixer. Keep the
+        # source provisional so concurrent consumers cannot accept PCM early.
+        deadline = (
+            asyncio.get_running_loop().time()
+            + self.VOICE_MIXER_DRAIN_START_TIMEOUT
+        )
+        try:
+            while mixer.read_count < self.VOICE_MIXER_DRAIN_MIN_READS:
+                if (
+                    not vc.is_connected()
+                    or not vc.is_playing()
+                    or vc.source is not mixer
+                    or asyncio.get_running_loop().time() >= deadline
+                ):
+                    raise RuntimeError(
+                        "Discord voice mixer sender did not begin draining"
+                    )
+                await asyncio.sleep(0.01)
+            if (
+                not vc.is_connected()
+                or not vc.is_playing()
+                or vc.source is not mixer
+                or not mixer.output_is_draining()
+            ):
+                raise RuntimeError("Discord voice mixer sender stopped during startup")
+            self._voice_mixers[guild_id] = mixer
+        except BaseException:
+            self._discard_voice_mixer(guild_id, mixer, vc=vc, stop_player=True)
+            raise
         logger.info("Voice mixer installed (guild=%d, ambient=%s)", guild_id, bool(ambient))
 
     async def play_ack_in_voice(self, guild_id: int, phrase: Optional[str] = None) -> bool:
@@ -3872,6 +3905,35 @@ class DiscordAdapter(BasePlatformAdapter):
                     except OSError:
                         pass
 
+    def _discard_voice_mixer(
+        self,
+        guild_id: int,
+        mixer: Any,
+        *,
+        vc: Any = None,
+        stop_player: bool = False,
+    ) -> None:
+        """Discard one exact mixer without disturbing a replacement source."""
+
+        mixers = getattr(self, "_voice_mixers", None)
+        if isinstance(mixers, dict) and mixers.get(guild_id) is mixer:
+            mixers.pop(guild_id, None)
+        voice_client = vc
+        if voice_client is None:
+            voice_clients = getattr(self, "_voice_clients", None)
+            if isinstance(voice_clients, dict):
+                voice_client = voice_clients.get(guild_id)
+        if stop_player and voice_client is not None:
+            try:
+                if voice_client.source is mixer and voice_client.is_playing():
+                    voice_client.stop()
+            except Exception:
+                pass
+        try:
+            mixer.cleanup()
+        except Exception:
+            pass
+
     def voice_mixer_active(self, guild_id: int) -> bool:
         """True when the mapped mixer is the live Discord playback source."""
         mixers = getattr(self, "_voice_mixers", None)
@@ -3887,17 +3949,19 @@ class DiscordAdapter(BasePlatformAdapter):
                 and vc.is_playing()
                 and vc.source is mixer
             )
+            drain_check = getattr(mixer, "output_is_draining", None)
+            if active and callable(drain_check):
+                active = bool(drain_check())
         except Exception:
             active = False
         if not active:
             # A Discord AudioPlayer can terminate while the adapter still owns
-            # its old mixer object. Never accept PCM into that dead source.
-            if isinstance(mixers, dict) and mixers.get(guild_id) is mixer:
-                mixers.pop(guild_id, None)
-            try:
-                mixer.cleanup()
-            except Exception:
-                pass
+            # its old mixer object. Never accept PCM into that dead source, and
+            # stop the exact zombie player so classic fallback cannot wait on
+            # its stale ``is_playing()`` flag for PLAYBACK_TIMEOUT seconds.
+            self._discard_voice_mixer(
+                guild_id, mixer, vc=vc, stop_player=True
+            )
         return active
 
     async def ensure_realtime_voice_output(self, guild_id: int) -> bool:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -444,8 +444,6 @@ class VoiceReceiver:
         self._pcm_callback = pcm_callback
         self._running = False
 
-        # Decryption
-        self._secret_key: Optional[bytes] = None
         self._bot_ssrc: int = 0
 
         # SSRC -> user_id mapping (populated from SPEAKING events)
@@ -472,7 +470,6 @@ class VoiceReceiver:
     def start(self):
         """Start listening for voice packets."""
         conn = self._vc._connection
-        self._secret_key = bytes(conn.secret_key)
         self._bot_ssrc = conn.ssrc
 
         self._install_speaking_hook(conn)
@@ -632,7 +629,12 @@ class VoiceReceiver:
 
         try:
             import nacl.secret  # noqa: E402 — delayed import, only in voice path
-            box = nacl.secret.Aead(self._secret_key)
+            # SESSION_DESCRIPTION can replace the transport key after the
+            # receiver has started (for example during voice reconnects).
+            # Resolve the connection-owned key at packet time, just like the
+            # live DAVE session below, instead of pinning the startup value.
+            secret_key = bytes(self._vc._connection.secret_key)
+            box = nacl.secret.Aead(secret_key)
             decrypted = box.decrypt(encrypted, header, bytes(nonce))
         except Exception as e:
             if self._packet_debug_count <= 10:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -446,7 +446,6 @@ class VoiceReceiver:
 
         # Decryption
         self._secret_key: Optional[bytes] = None
-        self._dave_session = None
         self._bot_ssrc: int = 0
 
         # SSRC -> user_id mapping (populated from SPEAKING events)
@@ -474,7 +473,6 @@ class VoiceReceiver:
         """Start listening for voice packets."""
         conn = self._vc._connection
         self._secret_key = bytes(conn.secret_key)
-        self._dave_session = conn.dave_session
         self._bot_ssrc = conn.ssrc
 
         self._install_speaking_hook(conn)
@@ -671,13 +669,19 @@ class VoiceReceiver:
                 return
 
         # --- DAVE E2EE decrypt ---
-        if self._dave_session:
+        # Discord marks the voice connection ready once the transport secret is
+        # available, before the mandatory DAVE session is necessarily ready.
+        # Read the live connection state for every packet so initial negotiation
+        # and later MLS epoch transitions cannot leave the receiver pinned to a
+        # missing or stale DAVE session.
+        dave_session = getattr(self._vc._connection, "dave_session", None)
+        if dave_session is not None and getattr(dave_session, "ready", True):
             with self._lock:
                 user_id = self._ssrc_to_user.get(ssrc, 0)
             if user_id:
                 try:
                     import davey
-                    decrypted = self._dave_session.decrypt(
+                    decrypted = dave_session.decrypt(
                         user_id, davey.MediaType.audio, decrypted
                     )
                 except Exception as e:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3800,8 +3800,15 @@ class DiscordAdapter(BasePlatformAdapter):
             mixer.set_ambient(ambient)
 
         def _after(error):
+            mixers = getattr(self, "_voice_mixers", None)
+            owned = False
+            if isinstance(mixers, dict) and mixers.get(guild_id) is mixer:
+                owned = True
+                mixers.pop(guild_id, None)
             if error:
                 logger.error("Voice mixer stream error (guild=%d): %s", guild_id, error)
+            elif owned:
+                logger.warning("Voice mixer stream ended unexpectedly (guild=%d)", guild_id)
 
         if vc.is_playing():
             vc.stop()
@@ -3866,9 +3873,32 @@ class DiscordAdapter(BasePlatformAdapter):
                         pass
 
     def voice_mixer_active(self, guild_id: int) -> bool:
-        """True when a continuous mixer is installed for this guild."""
+        """True when the mapped mixer is the live Discord playback source."""
         mixers = getattr(self, "_voice_mixers", None)
-        return bool(mixers) and mixers.get(guild_id) is not None
+        mixer = mixers.get(guild_id) if isinstance(mixers, dict) else None
+        if mixer is None:
+            return False
+        voice_clients = getattr(self, "_voice_clients", None)
+        vc = voice_clients.get(guild_id) if isinstance(voice_clients, dict) else None
+        try:
+            active = bool(
+                vc is not None
+                and vc.is_connected()
+                and vc.is_playing()
+                and vc.source is mixer
+            )
+        except Exception:
+            active = False
+        if not active:
+            # A Discord AudioPlayer can terminate while the adapter still owns
+            # its old mixer object. Never accept PCM into that dead source.
+            if isinstance(mixers, dict) and mixers.get(guild_id) is mixer:
+                mixers.pop(guild_id, None)
+            try:
+                mixer.cleanup()
+            except Exception:
+                pass
+        return active
 
     async def ensure_realtime_voice_output(self, guild_id: int) -> bool:
         """Ensure Discord has one continuous mixer for realtime PCM output."""
@@ -3890,6 +3920,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def push_realtime_voice_pcm(self, guild_id: int, pcm: bytes) -> bool:
         """Append Discord-native PCM to the live WebRTC speech stream."""
+        if not self.voice_mixer_active(guild_id):
+            return False
         mixer = self._voice_mixers.get(guild_id)
         if mixer is None or not pcm:
             return False
@@ -4001,14 +4033,23 @@ class DiscordAdapter(BasePlatformAdapter):
             return False
 
         # ── Mixer path (overlap + ducking) ──────────────────────────────
-        mixer = getattr(self, "_voice_mixers", {}).get(guild_id) if getattr(self, "_voice_mixers", None) else None
+        mixer = (
+            getattr(self, "_voice_mixers", {}).get(guild_id)
+            if self.voice_mixer_active(guild_id)
+            else None
+        )
         if mixer is not None:
             try:
                 from voice_mixer import decode_to_pcm
             except ImportError:
                 from .voice_mixer import decode_to_pcm
             pcm = await asyncio.to_thread(decode_to_pcm, audio_path)
-            if pcm:
+            mixer_still_active = (
+                pcm
+                and self.voice_mixer_active(guild_id)
+                and self._voice_mixers.get(guild_id) is mixer
+            )
+            if mixer_still_active:
                 speech_gain = float(self._voice_fx_cfg.get("speech_gain", 1.0))
                 mixer.play_speech(pcm, gain=speech_gain)
                 # Block until the speech child drains so callers serialise
@@ -4023,7 +4064,15 @@ class DiscordAdapter(BasePlatformAdapter):
                     await asyncio.sleep(0.05)
                 self._reset_voice_timeout(guild_id)
                 return True
-            logger.warning("Mixer decode failed for %s; falling back to legacy playback", audio_path)
+            if pcm:
+                logger.warning(
+                    "Voice mixer became unavailable during decode; falling back to legacy playback"
+                )
+            else:
+                logger.warning(
+                    "Mixer decode failed for %s; falling back to legacy playback",
+                    audio_path,
+                )
 
         # ── Legacy one-shot path (no mixer) ─────────────────────────────
         # Pause voice receiver while playing (echo prevention)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -433,9 +433,15 @@ class VoiceReceiver:
     SAMPLE_RATE = 48000        # Discord native rate
     CHANNELS = 2               # Discord sends stereo
 
-    def __init__(self, voice_client, allowed_user_ids: set = None):
+    def __init__(
+        self,
+        voice_client,
+        allowed_user_ids: Optional[set] = None,
+        pcm_callback: Optional[Callable[[int, bytes], bool]] = None,
+    ):
         self._vc = voice_client
         self._allowed_user_ids = allowed_user_ids or set()
+        self._pcm_callback = pcm_callback
         self._running = False
 
         # Decryption
@@ -503,6 +509,23 @@ class VoiceReceiver:
     def map_ssrc(self, ssrc: int, user_id: int):
         with self._lock:
             self._ssrc_to_user[ssrc] = user_id
+
+    def handle_decoded_pcm(self, ssrc: int, pcm: bytes) -> None:
+        """Offer one decoded frame to realtime, else buffer for classic STT."""
+        with self._lock:
+            user_id = self._ssrc_to_user.get(ssrc, 0)
+        if self._pcm_callback is not None:
+            try:
+                # user_id may still be 0 before Discord's SPEAKING mapping
+                # arrives. Realtime routes can consume/drop those early frames
+                # so they never leak into a parallel classic-STT utterance.
+                if self._pcm_callback(user_id, pcm):
+                    return
+            except Exception:
+                logger.debug("Realtime PCM callback failed; using classic STT", exc_info=True)
+        with self._lock:
+            self._buffers[ssrc].extend(pcm)
+            self._last_packet_time[ssrc] = time.monotonic()
 
     def _install_speaking_hook(self, conn):
         """Wrap the voice websocket hook to capture SPEAKING events (op 5).
@@ -668,9 +691,7 @@ class VoiceReceiver:
             if ssrc not in self._decoders:
                 self._decoders[ssrc] = discord.opus.Decoder()
             pcm = self._decoders[ssrc].decode(decrypted)
-            with self._lock:
-                self._buffers[ssrc].extend(pcm)
-                self._last_packet_time[ssrc] = time.monotonic()
+            self.handle_decoded_pcm(ssrc, pcm)
         except Exception as e:
             with self._lock:
                 self._decoders.pop(ssrc, None)
@@ -903,6 +924,10 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
         self._voice_input_callback: Optional[Callable] = None  # set by run.py
+        # Sync callback from VoiceReceiver's socket thread. Returning True
+        # means realtime consumed the PCM frame and classic utterance STT must
+        # not buffer it as a duplicate input path.
+        self._voice_pcm_callback: Optional[Callable[[int, int, bytes], bool]] = None
         self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
         # linked text-channel id; set by run.py. Lets the inactivity timer leave
@@ -3729,7 +3754,13 @@ class DiscordAdapter(BasePlatformAdapter):
         self._ambient_pcm_cache = pcm
         return pcm
 
-    async def _install_voice_mixer(self, guild_id: int, vc) -> None:
+    async def _install_voice_mixer(
+        self,
+        guild_id: int,
+        vc,
+        *,
+        include_ambient: bool = True,
+    ) -> None:
         """Create a VoiceMixer, start the ambient bed, and play it on the VC.
 
         The mixer runs continuously for the life of the connection: one
@@ -3745,7 +3776,11 @@ class DiscordAdapter(BasePlatformAdapter):
             duck_gain=float(self._voice_fx_cfg.get("duck_gain", 0.06)),
             speech_gain=float(self._voice_fx_cfg.get("speech_gain", 1.0)),
         )
-        ambient = await asyncio.to_thread(self._get_ambient_pcm)
+        ambient = (
+            await asyncio.to_thread(self._get_ambient_pcm)
+            if include_ambient
+            else None
+        )
         if ambient:
             mixer.set_ambient(ambient)
 
@@ -3820,6 +3855,39 @@ class DiscordAdapter(BasePlatformAdapter):
         mixers = getattr(self, "_voice_mixers", None)
         return bool(mixers) and mixers.get(guild_id) is not None
 
+    async def ensure_realtime_voice_output(self, guild_id: int) -> bool:
+        """Ensure Discord has one continuous mixer for realtime PCM output."""
+        if self.voice_mixer_active(guild_id):
+            return True
+        vc = self._voice_clients.get(guild_id)
+        if vc is None or not vc.is_connected():
+            return False
+        try:
+            await self._install_voice_mixer(
+                guild_id,
+                vc,
+                include_ambient=bool(self._voice_fx_cfg.get("enabled")),
+            )
+        except Exception:
+            logger.warning("Realtime voice mixer failed to start", exc_info=True)
+            return False
+        return self.voice_mixer_active(guild_id)
+
+    def push_realtime_voice_pcm(self, guild_id: int, pcm: bytes) -> bool:
+        """Append Discord-native PCM to the live WebRTC speech stream."""
+        mixer = self._voice_mixers.get(guild_id)
+        if mixer is None or not pcm:
+            return False
+        if mixer.push_speech_stream("codex-realtime", pcm):
+            # Reset once per speech burst, not once per 20 ms WebRTC packet.
+            self._reset_voice_timeout(guild_id)
+        return True
+
+    def end_realtime_voice_output(self, guild_id: int) -> None:
+        mixer = self._voice_mixers.get(guild_id)
+        if mixer is not None:
+            mixer.end_speech_stream("codex-realtime")
+
     async def join_voice_channel(self, channel) -> bool:
         """Join a Discord voice channel. Returns True on success."""
         if not self._client or not DISCORD_AVAILABLE:
@@ -3843,7 +3911,17 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Start voice receiver (Phase 2: listen to users)
             try:
-                receiver = VoiceReceiver(vc, allowed_user_ids=self._allowed_user_ids)
+                pcm_callback = None
+                voice_pcm_callback = self._voice_pcm_callback
+                if voice_pcm_callback is not None:
+                    pcm_callback = lambda user_id, pcm: bool(
+                        voice_pcm_callback(guild_id, user_id, pcm)
+                    )
+                receiver = VoiceReceiver(
+                    vc,
+                    allowed_user_ids=self._allowed_user_ids,
+                    pcm_callback=pcm_callback,
+                )
                 receiver.start()
                 self._voice_receivers[guild_id] = receiver
                 self._voice_listen_tasks[guild_id] = asyncio.ensure_future(
@@ -4012,13 +4090,14 @@ class DiscordAdapter(BasePlatformAdapter):
                     return
             except Exception:
                 pass
-        await self.leave_voice_channel(guild_id)
-        # Notify the runner so it can clean up voice_mode state
+        # Notify the runner while the guild-to-text mapping still exists so it
+        # can stop any provider session before Discord teardown removes it.
         if self._on_voice_disconnect and text_ch_id:
             try:
                 self._on_voice_disconnect(str(text_ch_id))
             except Exception:
                 pass
+        await self.leave_voice_channel(guild_id)
         if text_ch_id and self._client:
             ch = self._client.get_channel(text_ch_id)
             if ch:
@@ -9472,6 +9551,9 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
         os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
     seeded_extra = {}
+    realtime_voice_cfg = discord_cfg.get("codex_realtime_voice")
+    if isinstance(realtime_voice_cfg, dict):
+        seeded_extra["codex_realtime_voice"] = dict(realtime_voice_cfg)
     backfill_cfg = discord_cfg.get("missed_message_backfill")
     if isinstance(backfill_cfg, dict):
         seeded_extra["missed_message_backfill"] = dict(backfill_cfg)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -480,7 +480,11 @@ class VoiceReceiver:
         self._install_speaking_hook(conn)
         conn.add_socket_listener(self._on_packet)
         self._running = True
-        logger.info("VoiceReceiver started (bot_ssrc=%d)", self._bot_ssrc)
+        logger.info(
+            "VoiceReceiver started (bot_ssrc=%s transport_mode=%s)",
+            self._bot_ssrc,
+            getattr(conn, "mode", "unknown"),
+        )
 
     def stop(self):
         """Stop listening and clean up."""

--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -145,6 +145,78 @@ class MixerChild:
         return samples
 
 
+class StreamingMixerChild:
+    """Incremental PCM child for low-latency WebRTC speech.
+
+    WebRTC supplies small PCM chunks over time instead of one complete clip.
+    A short underflow grace keeps the child alive across normal network jitter
+    without permanently ducking the ambient bed after a turn ends.
+    """
+
+    __slots__ = (
+        "name", "gain", "is_speech", "_buffer", "_closing",
+        "_finished", "_empty_reads", "_max_empty_reads",
+    )
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        gain: float = 1.0,
+        underflow_grace_ms: int = 200,
+    ) -> None:
+        self.name = name
+        self.gain = float(gain)
+        self.is_speech = True
+        self._buffer = bytearray()
+        self._closing = False
+        self._finished = False
+        self._empty_reads = 0
+        self._max_empty_reads = max(1, underflow_grace_ms // FRAME_LENGTH_MS)
+
+    @property
+    def finished(self) -> bool:
+        return self._finished
+
+    def push(self, pcm: bytes) -> None:
+        if not pcm or self._finished or self._closing:
+            return
+        self._buffer.extend(pcm)
+        self._empty_reads = 0
+
+    def close(self) -> None:
+        self._closing = True
+
+    def read_frame(self) -> "Optional[np.ndarray]":
+        if self._finished:
+            return None
+        if len(self._buffer) >= FRAME_SIZE:
+            chunk = bytes(self._buffer[:FRAME_SIZE])
+            del self._buffer[:FRAME_SIZE]
+            self._empty_reads = 0
+        elif self._closing:
+            if not self._buffer:
+                self._finished = True
+                return None
+            chunk = bytes(self._buffer) + b"\x00" * (FRAME_SIZE - len(self._buffer))
+            self._buffer.clear()
+        else:
+            self._empty_reads += 1
+            if self._empty_reads > self._max_empty_reads:
+                self._finished = True
+                return None
+            np = _require_numpy()
+            return np.zeros(
+                SAMPLES_PER_FRAME * CHANNELS, dtype=np.float32
+            )
+
+        np = _require_numpy()
+        samples = np.frombuffer(chunk, dtype=np.int16).astype(np.float32)
+        if self.gain != 1.0:
+            samples *= self.gain
+        return samples
+
+
 class VoiceMixer:
     """A continuous ``discord.AudioSource`` that mixes N child streams.
 
@@ -168,7 +240,7 @@ class VoiceMixer:
     ):
         self._lock = threading.Lock()
         self._ambient: Optional[MixerChild] = None
-        self._speech: List[MixerChild] = []
+        self._speech: List[MixerChild | StreamingMixerChild] = []
         self._ambient_gain = float(ambient_gain)
         self._duck_gain = float(duck_gain)
         self._speech_gain = float(speech_gain)
@@ -222,6 +294,48 @@ class VoiceMixer:
             if self._ambient is not None:
                 self._ambient.gain = self._duck_gain
 
+    def push_speech_stream(
+        self,
+        name: str,
+        pcm: bytes,
+        *,
+        gain: Optional[float] = None,
+    ) -> bool:
+        """Append PCM and return whether a new low-latency stream started."""
+        if not pcm:
+            return False
+        with self._lock:
+            child = next(
+                (
+                    item
+                    for item in self._speech
+                    if isinstance(item, StreamingMixerChild)
+                    and item.name == name
+                    and not item.finished
+                ),
+                None,
+            )
+            created = child is None
+            if child is None:
+                child = StreamingMixerChild(
+                    name,
+                    gain=self._speech_gain if gain is None else float(gain),
+                )
+                self._speech.append(child)
+            child.push(pcm)
+            self._speech_active = True
+            self._duck_release_left = 0
+            if self._ambient is not None:
+                self._ambient.gain = self._duck_gain
+            return created
+
+    def end_speech_stream(self, name: str) -> None:
+        """Close a named stream after its buffered PCM has drained."""
+        with self._lock:
+            for child in self._speech:
+                if isinstance(child, StreamingMixerChild) and child.name == name:
+                    child.close()
+
     @property
     def speech_active(self) -> bool:
         with self._lock:
@@ -257,7 +371,7 @@ class VoiceMixer:
 
             # Speech children (drop exhausted ones; release duck when last ends)
             if self._speech:
-                still_live: List[MixerChild] = []
+                still_live: List[MixerChild | StreamingMixerChild] = []
                 for child in self._speech:
                     frame = child.read_frame()
                     if frame is None:

--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -44,6 +44,7 @@ the mixer's output cannot echo back into transcription.
 
 import logging
 import threading
+import time
 from typing import TYPE_CHECKING, List, Optional
 
 import discord
@@ -74,6 +75,7 @@ FRAME_LENGTH_MS = 20
 SAMPLES_PER_FRAME = SAMPLE_RATE * FRAME_LENGTH_MS // 1000   # 960
 FRAME_SIZE = SAMPLES_PER_FRAME * CHANNELS * SAMPLE_WIDTH    # 3840 bytes
 SILENCE_FRAME = b"\x00" * FRAME_SIZE
+OUTPUT_DRAIN_STALL_SECONDS = 0.5
 
 
 class MixerChild:
@@ -251,6 +253,12 @@ class VoiceMixer(discord.AudioSource):
         self._duck_release_frames = max(1, duck_release_ms // FRAME_LENGTH_MS)
         self._duck_release_left = 0
         self._closed = False
+        # ``VoiceClient.is_playing()`` only exposes AudioPlayer flags. After a
+        # Discord voice reconnect those flags can remain true while the sender
+        # no longer polls this source. Track actual ``read()`` calls so the
+        # adapter can distinguish a live drain from a zombie player.
+        self._read_count = 0
+        self._last_read_at: Optional[float] = None
         # Tracks whether speech is currently active, for external callers that
         # want to avoid double-ducking or know when a reply is mid-flight.
         self._speech_active = False
@@ -357,6 +365,23 @@ class VoiceMixer(discord.AudioSource):
     # AudioSource interface — called from discord.py's sender thread
     # ------------------------------------------------------------------
 
+    @property
+    def read_count(self) -> int:
+        with self._lock:
+            return self._read_count
+
+    def output_is_draining(
+        self, *, max_stall_seconds: float = OUTPUT_DRAIN_STALL_SECONDS
+    ) -> bool:
+        """Whether Discord's sender has polled this source recently."""
+
+        with self._lock:
+            last_read_at = self._last_read_at
+        return bool(
+            last_read_at is not None
+            and time.monotonic() - last_read_at <= max_stall_seconds
+        )
+
     def read(self) -> bytes:
         """Return one 20 ms mixed PCM frame (always FRAME_SIZE bytes).
 
@@ -365,6 +390,8 @@ class VoiceMixer(discord.AudioSource):
         want the mixer to run continuously for the lifetime of the connection.
         """
         with self._lock:
+            self._read_count += 1
+            self._last_read_at = time.monotonic()
             if self._closed:
                 return SILENCE_FRAME
 

--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -46,6 +46,8 @@ import logging
 import threading
 from typing import TYPE_CHECKING, List, Optional
 
+import discord
+
 if TYPE_CHECKING:  # numpy is an optional ("voice" extra) dep — never import at runtime top-level
     import numpy as np
 
@@ -217,7 +219,7 @@ class StreamingMixerChild:
         return samples
 
 
-class VoiceMixer:
+class VoiceMixer(discord.AudioSource):
     """A continuous ``discord.AudioSource`` that mixes N child streams.
 
     Use :meth:`set_ambient` to install/replace the looping idle bed and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,9 @@ voice = [
   "sounddevice==0.5.5",
   "numpy==2.4.3",
 ]
+# Experimental Codex GPT-Live WebRTC speech interface. Kept separate from
+# classic voice because aiortc/PyAV are only needed when this route is enabled.
+codex-realtime-voice = ["aiortc==1.15.0", "numpy==2.4.3"]
 honcho = ["honcho-ai==2.2.0"]
 # Cloud memory providers — opt-in, lazy-installed via tools/lazy_deps.py
 # (memory.supermemory / memory.mem0) at first use. Exact pins MUST match the
@@ -281,6 +284,7 @@ all = [
   #   anthropic, exa, firecrawl, parallel-web, fal, edge-tts,
   #   modal, daytona, messaging (telegram/discord/slack),
   #   matrix, slack, honcho, voice (faster-whisper),
+  #   codex-realtime-voice (aiortc),
   #   dingtalk, feishu, bedrock, tts-premium (elevenlabs)
   #
   # Why: the matrix extra in particular pulls `mautrix[encryption]`

--- a/tests/agent/transports/test_codex_realtime_voice.py
+++ b/tests/agent/transports/test_codex_realtime_voice.py
@@ -12,6 +12,7 @@ from agent.transports.codex_realtime_voice import (
     CodexRealtimeCapabilities,
     CodexRealtimeSession,
     CodexRealtimeStaleSpeech,
+    CodexRealtimeUnavailable,
     discord_pcm_to_realtime,
     safe_realtime_error,
 )
@@ -68,6 +69,30 @@ class FakePeer:
 
     async def close(self):
         self.closed = True
+
+
+async def _append_speech_with_first_pcm(
+    session: CodexRealtimeSession,
+    peer: FakePeer,
+    text: str,
+    *,
+    pcm: bytes = b"first-pcm",
+    transcript_generation: int | None = None,
+) -> bool:
+    task = asyncio.create_task(
+        session.append_speech(
+            text,
+            transcript_generation=transcript_generation,
+        )
+    )
+    for _ in range(100):
+        if session._speech_gate:
+            break
+        await asyncio.sleep(0.001)
+    assert session._speech_gate is True
+    assert peer.on_pcm is not None
+    peer.on_pcm(pcm)
+    return await task
 
 
 @pytest.mark.asyncio
@@ -223,19 +248,28 @@ async def test_transcript_and_remote_pcm_notifications_are_forwarded(monkeypatch
     peer.on_pcm(b"\x01\x02")
     assert pcm_out == []
 
-    await session.append_speech("Hoi Maikel", transcript_generation=1)
+    await _append_speech_with_first_pcm(
+        session,
+        peer,
+        "Hoi Maikel",
+        pcm=b"\x01\x02",
+        transcript_generation=1,
+    )
     assert client.requests[-1] == (
         "thread/realtime/appendSpeech",
         {"threadId": "thread-1", "text": "Hoi Maikel"},
     )
-    peer.on_pcm(b"\x01\x02")
     assert pcm_out == [b"\x01\x02"]
     await asyncio.sleep(0.1)
     peer.on_pcm(b"\x03\x04")
     assert pcm_out == [b"\x01\x02"]
 
-    await session.append_speech("Nog een antwoord")
-    peer.on_pcm(b"\x05\x06")
+    await _append_speech_with_first_pcm(
+        session,
+        peer,
+        "Nog een antwoord",
+        pcm=b"\x05\x06",
+    )
     assert pcm_out == [b"\x01\x02", b"\x05\x06"]
     client.notifications.append({
         "method": "thread/realtime/transcript/delta",
@@ -301,7 +335,14 @@ async def test_new_user_generation_suppresses_stale_hermes_speech_and_late_compl
         for method, params in client.requests
     )
 
-    await session.append_speech("answer B", transcript_generation=generation_b)
+    await _append_speech_with_first_pcm(
+        session,
+        peer,
+        "answer B",
+        pcm=b"first-answer-b",
+        transcript_generation=generation_b,
+    )
+    pcm_out.clear()
     client.notifications.append({
         "method": "thread/realtime/transcript/done",
         "params": {
@@ -341,7 +382,8 @@ async def test_error_closes_session_and_reports_sanitized_reason():
         on_error=errors.append,
     )
     await session.start()
-    await session.append_speech("Hermes antwoord")
+    await _append_speech_with_first_pcm(session, peer, "Hermes antwoord")
+    pcm_out.clear()
     client.notifications.append({
         "method": "thread/realtime/error",
         "params": {"threadId": "thread-1", "message": "backend unavailable"},
@@ -433,12 +475,53 @@ async def test_append_speech_drops_pcm_until_request_is_acknowledged():
     peer.on_pcm(b"pre-ack")
     pcm_before_ack = list(pcm_out)
     client.release_append.set()
+    for _ in range(100):
+        if session._speech_gate:
+            break
+        await asyncio.sleep(0.001)
+    assert session._speech_gate is True
+    peer.on_pcm(b"accepted")
     assert await append_task is True
 
     assert pcm_before_ack == []
-    peer.on_pcm(b"accepted")
     assert pcm_out == [b"accepted"]
     await session.stop()
+
+
+@pytest.mark.asyncio
+async def test_append_speech_without_first_audio_fails_for_classic_fallback(
+    monkeypatch,
+):
+    import agent.transports.codex_realtime_voice as realtime_module
+
+    monkeypatch.setattr(realtime_module, "SPEECH_FIRST_AUDIO_TIMEOUT", 0.02)
+    errors: list[str] = []
+    client = FakeClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v3"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "answer"},
+        },
+    ])
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        client_factory=lambda **kwargs: client,
+        peer_factory=FakePeer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+        on_error=errors.append,
+    )
+    await session.start()
+
+    try:
+        with pytest.raises(CodexRealtimeUnavailable, match="produced no audio"):
+            await session.append_speech("Hermes antwoord")
+    finally:
+        await session.stop()
+
+    assert errors == ["Codex realtime speech produced no audio"]
 
 
 @pytest.mark.asyncio
@@ -597,7 +680,8 @@ async def test_sideband_audio_is_ignored_for_webrtc_output():
         on_error=errors.append,
     )
     await session.start()
-    await session.append_speech("Hermes antwoord")
+    await _append_speech_with_first_pcm(session, peer, "Hermes antwoord")
+    pcm_out.clear()
     client.notifications.append({
         "method": "thread/realtime/outputAudio/delta",
         "params": {

--- a/tests/agent/transports/test_codex_realtime_voice.py
+++ b/tests/agent/transports/test_codex_realtime_voice.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+
+import numpy as np
+import pytest
+
+from agent.transports.codex_realtime_voice import (
+    AiortcRealtimePeer,
+    CodexRealtimeCapabilities,
+    CodexRealtimeSession,
+    discord_pcm_to_realtime,
+    safe_realtime_error,
+)
+
+
+class FakeClient:
+    def __init__(self, notifications: list[dict] | None = None, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.notifications = deque(notifications or [])
+        self.requests: list[tuple[str, dict]] = []
+        self.initialized: dict | None = None
+        self.closed = False
+
+    def initialize(self, **kwargs):
+        self.initialized = kwargs
+        return {"userAgent": "codex-test"}
+
+    def request(self, method: str, params: dict, timeout: float = 30.0):
+        self.requests.append((method, params))
+        if method == "thread/start":
+            return {"thread": {"id": "thread-1"}}
+        if method == "thread/realtime/listVoices":
+            return {"voices": {"v1": ["cedar", "marin"], "v2": ["ash"]}}
+        return {}
+
+    def take_notification(self, timeout: float = 0.0):
+        if self.notifications:
+            return self.notifications.popleft()
+        return None
+
+    def close(self):
+        self.closed = True
+
+
+class FakePeer:
+    def __init__(self) -> None:
+        self.answer_sdp: str | None = None
+        self.input_pcm: list[bytes] = []
+        self.closed = False
+        self.on_pcm = None
+        self.on_failure = None
+
+    async def create_offer(self, on_pcm, on_failure=None):
+        self.on_pcm = on_pcm
+        self.on_failure = on_failure
+        return "v=offer\r\n"
+
+    async def accept_answer(self, sdp: str):
+        self.answer_sdp = sdp
+
+    def push_input(self, pcm: bytes):
+        self.input_pcm.append(pcm)
+        return True
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_start_uses_experimental_v1_webrtc_contract_and_lists_capabilities():
+    client = FakeClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v1"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "v=answer\r\n"},
+        },
+    ])
+    peer = FakePeer()
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        client_factory=lambda **kwargs: client,
+        peer_factory=lambda: peer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+    )
+
+    capabilities = await session.start(voice="cedar")
+
+    assert capabilities == CodexRealtimeCapabilities(
+        protocol_version="v1",
+        voices=("cedar", "marin"),
+        language_selection=False,
+        reasoning_effort=False,
+    )
+    assert client.initialized is not None
+    assert client.initialized["capabilities"] == {
+        "experimentalApi": True,
+        "optOutNotificationMethods": ["thread/realtime/outputAudio/delta"],
+    }
+    assert client.kwargs == {}
+    assert client.requests[0] == (
+        "thread/start",
+        {"cwd": "/tmp", "ephemeral": True},
+    )
+    assert client.requests[1][0] == "thread/realtime/listVoices"
+    assert client.requests[2] == (
+        "thread/realtime/start",
+        {
+            "threadId": "thread-1",
+            "clientManagedHandoffs": True,
+            "includeStartupContext": False,
+            "outputModality": "audio",
+            "prompt": (
+                "You are a low-latency speech interface for another assistant. "
+                "Transcribe the user's speech accurately. Do not answer the user, "
+                "do not call tools, and do not delegate work. Stay silent until "
+                "the client supplies text to speak."
+            ),
+            "transport": {"type": "webrtc", "sdp": "v=offer\r\n"},
+            "version": "v1",
+            "voice": "cedar",
+        },
+    )
+    assert peer.answer_sdp == "v=answer\r\n"
+    assert session.active is True
+
+    await session.stop()
+
+
+@pytest.mark.asyncio
+async def test_transcript_and_remote_pcm_notifications_are_forwarded():
+    transcripts: list[str] = []
+    pcm_out: list[bytes] = []
+    client = FakeClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v1"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "answer"},
+        },
+    ])
+    peer = FakePeer()
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        client_factory=lambda **kwargs: client,
+        peer_factory=lambda: peer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+        on_user_transcript=transcripts.append,
+        on_output_pcm=pcm_out.append,
+    )
+    await session.start()
+
+    client.notifications.extend([
+        {
+            "method": "thread/realtime/transcript/done",
+            "params": {
+                "threadId": "foreign-thread",
+                "role": "user",
+                "text": "Do not route me",
+            },
+        },
+        {
+            "method": "thread/realtime/transcript/done",
+            "params": {"threadId": "thread-1", "role": "user", "text": "Hallo Nabu"},
+        },
+    ])
+    await asyncio.sleep(0.05)
+    assert transcripts == ["Hallo Nabu"]
+
+    assert peer.on_pcm is not None
+    # Unsolicited model audio is suppressed: Hermes remains the agent.
+    peer.on_pcm(b"\x01\x02")
+    assert pcm_out == []
+
+    await session.append_speech("Hoi Maikel")
+    assert client.requests[-1] == (
+        "thread/realtime/appendSpeech",
+        {"threadId": "thread-1", "text": "Hoi Maikel"},
+    )
+    peer.on_pcm(b"\x01\x02")
+    assert pcm_out == [b"\x01\x02"]
+    client.notifications.append({
+        "method": "thread/realtime/transcript/done",
+        "params": {"threadId": "thread-1", "role": "assistant", "text": "Hoi Maikel"},
+    })
+    await asyncio.sleep(0.35)
+    peer.on_pcm(b"\x03\x04")
+    assert pcm_out == [b"\x01\x02"]
+
+    await session.append_speech("Nog een antwoord")
+    peer.on_pcm(b"\x05\x06")
+    assert pcm_out == [b"\x01\x02", b"\x05\x06"]
+    client.notifications.append({
+        "method": "thread/realtime/transcript/delta",
+        "params": {"threadId": "thread-1", "role": "user", "delta": "Stop"},
+    })
+    await asyncio.sleep(0.05)
+    peer.on_pcm(b"\x07\x08")
+    assert pcm_out == [b"\x01\x02", b"\x05\x06"]
+    await session.stop()
+
+
+@pytest.mark.asyncio
+async def test_error_closes_session_and_reports_sanitized_reason():
+    errors: list[str] = []
+    pcm_out: list[bytes] = []
+    client = FakeClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v1"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "answer"},
+        },
+    ])
+    peer = FakePeer()
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        client_factory=lambda **kwargs: client,
+        peer_factory=lambda: peer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+        on_output_pcm=pcm_out.append,
+        on_error=errors.append,
+    )
+    await session.start()
+    await session.append_speech("Hermes antwoord")
+    client.notifications.append({
+        "method": "thread/realtime/error",
+        "params": {"threadId": "thread-1", "message": "backend unavailable"},
+    })
+    await asyncio.sleep(0.05)
+
+    assert session.active is False
+    assert errors == ["backend unavailable"]
+    assert peer.on_pcm is not None
+    peer.on_pcm(b"\x01\x02")
+    assert pcm_out == []
+    await session.stop()
+    assert peer.closed is True
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_remote_close_reports_failure_and_closes_resources():
+    errors: list[str] = []
+    client = FakeClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v1"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "answer"},
+        },
+    ])
+    peer = FakePeer()
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        client_factory=lambda **kwargs: client,
+        peer_factory=lambda: peer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+        on_error=errors.append,
+    )
+    await session.start()
+    client.notifications.append({
+        "method": "thread/realtime/closed",
+        "params": {"threadId": "thread-1"},
+    })
+    await asyncio.sleep(0.05)
+
+    assert session.active is False
+    assert errors == ["Codex realtime session closed"]
+    assert peer.closed is True
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_append_speech_failure_reports_provider_failure_and_closes():
+    class BrokenSpeechClient(FakeClient):
+        def request(self, method: str, params: dict, timeout: float = 30.0):
+            if method == "thread/realtime/appendSpeech":
+                raise RuntimeError("speech backend unavailable")
+            return super().request(method, params, timeout)
+
+    errors: list[str] = []
+    client = BrokenSpeechClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v1"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "answer"},
+        },
+    ])
+    peer = FakePeer()
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        client_factory=lambda **kwargs: client,
+        peer_factory=lambda: peer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+        on_error=errors.append,
+    )
+    await session.start()
+
+    with pytest.raises(RuntimeError, match="speech backend unavailable"):
+        await session.append_speech("Hermes antwoord")
+    await asyncio.sleep(0.05)
+
+    assert session.active is False
+    assert errors == ["Codex realtime speech failed: speech backend unavailable"]
+    assert peer.closed is True
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_webrtc_runtime_failure_closes_session_and_reports_safe_reason():
+    errors: list[str] = []
+    client = FakeClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v1"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "answer"},
+        },
+    ])
+    peer = FakePeer()
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        client_factory=lambda **kwargs: client,
+        peer_factory=lambda: peer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+        on_error=errors.append,
+    )
+    await session.start()
+
+    assert peer.on_failure is not None
+    peer.on_failure("WebRTC connection failed")
+    await asyncio.sleep(0.05)
+
+    assert session.active is False
+    assert errors == ["Codex realtime WebRTC failed: WebRTC connection failed"]
+    assert peer.closed is True
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_sideband_audio_is_ignored_for_webrtc_output():
+    errors: list[str] = []
+    pcm_out: list[bytes] = []
+    client = FakeClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v1"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "answer"},
+        },
+    ])
+    peer = FakePeer()
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        client_factory=lambda **kwargs: client,
+        peer_factory=lambda: peer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+        on_output_pcm=pcm_out.append,
+        on_error=errors.append,
+    )
+    await session.start()
+    await session.append_speech("Hermes antwoord")
+    client.notifications.append({
+        "method": "thread/realtime/outputAudio/delta",
+        "params": {
+            "threadId": "thread-1",
+            "audio": {"data": "not-base64!"},
+        },
+    })
+    await asyncio.sleep(0.05)
+
+    assert session.active is True
+    assert errors == []
+    assert pcm_out == []
+    await session.stop()
+    assert peer.closed is True
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_aiortc_peer_offer_contains_audio_and_realtime_data_channel():
+    pytest.importorskip("aiortc")
+    peer = AiortcRealtimePeer()
+    offer = await peer.create_offer(lambda _pcm: None)
+    try:
+        assert "m=audio" in offer
+        assert "m=application" in offer  # SCTP data-channel media section
+        assert peer._outgoing is not None
+        first = await peer._outgoing.track.recv()
+        started = asyncio.get_running_loop().time()
+        second = await peer._outgoing.track.recv()
+        elapsed = asyncio.get_running_loop().time() - started
+        assert first.samples == 480
+        assert second.samples == 480
+        assert second.pts == first.pts + first.samples
+        assert not np.any(first.to_ndarray())
+        assert elapsed >= 0.015  # the track paces 20 ms silence between voice packets
+    finally:
+        await peer.close()
+
+
+def test_realtime_entitlement_error_is_actionable_and_drops_backend_metadata():
+    raw = (
+        "unexpected status 403 Forbidden: Voice session access denied., "
+        "url: https://chatgpt.com/backend-api/codex/realtime/calls, "
+        "cf-ray: abc-AMS, request id: deadbeef"
+    )
+    safe = safe_realtime_error(raw)
+    assert safe == "Codex account is not entitled to realtime voice"
+    assert "chatgpt.com" not in safe
+    assert "deadbeef" not in safe
+
+
+def test_discord_pcm_conversion_is_20ms_24khz_mono():
+    # 20 ms at 48 kHz: stereo interleaved with opposite channels.
+    left = np.arange(960, dtype=np.int16)
+    right = (left + 100).astype(np.int16)
+    stereo = np.column_stack((left, right)).reshape(-1).tobytes()
+
+    realtime = discord_pcm_to_realtime(stereo)
+    mono = np.frombuffer(realtime, dtype=np.int16)
+    assert mono.shape == (480,)
+    # Average L/R, then average each adjacent 48 kHz sample pair.
+    assert mono[:3].tolist() == [50, 52, 54]

--- a/tests/agent/transports/test_codex_realtime_voice.py
+++ b/tests/agent/transports/test_codex_realtime_voice.py
@@ -525,6 +525,53 @@ async def test_append_speech_without_first_audio_fails_for_classic_fallback(
 
 
 @pytest.mark.asyncio
+async def test_append_speech_rejected_by_output_sink_fails_for_classic_fallback(
+    monkeypatch,
+):
+    import agent.transports.codex_realtime_voice as realtime_module
+
+    monkeypatch.setattr(realtime_module, "SPEECH_FIRST_AUDIO_TIMEOUT", 0.02)
+    errors: list[str] = []
+    client = FakeClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v3"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "answer"},
+        },
+    ])
+    peer = FakePeer()
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        client_factory=lambda **kwargs: client,
+        peer_factory=lambda: peer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+        on_output_pcm=lambda _pcm: False,
+        on_error=errors.append,
+    )
+    await session.start()
+
+    append_task = asyncio.create_task(session.append_speech("Hermes antwoord"))
+    for _ in range(100):
+        if session._speech_gate:
+            break
+        await asyncio.sleep(0.001)
+    assert session._speech_gate is True
+    assert peer.on_pcm is not None
+    peer.on_pcm(b"provider-pcm")
+
+    try:
+        with pytest.raises(CodexRealtimeUnavailable, match="produced no audio"):
+            await append_task
+    finally:
+        await session.stop()
+
+    assert errors == ["Codex realtime speech produced no audio"]
+
+
+@pytest.mark.asyncio
 async def test_append_speech_failure_reports_provider_failure_and_closes():
     class BrokenSpeechClient(FakeClient):
         def __init__(self, notifications):

--- a/tests/agent/transports/test_codex_realtime_voice.py
+++ b/tests/agent/transports/test_codex_realtime_voice.py
@@ -525,6 +525,109 @@ async def test_append_speech_without_first_audio_fails_for_classic_fallback(
 
 
 @pytest.mark.asyncio
+async def test_append_speech_waits_for_audible_pcm_instead_of_silence(
+    monkeypatch,
+):
+    """Sink-accepted WebRTC silence must not complete first-audio readiness."""
+
+    import agent.transports.codex_realtime_voice as realtime_module
+
+    monkeypatch.setattr(realtime_module, "SPEECH_FIRST_AUDIO_TIMEOUT", 0.2)
+    pcm_out: list[bytes] = []
+    client = FakeClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v3"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "answer"},
+        },
+    ])
+    peer = FakePeer()
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        client_factory=lambda **kwargs: client,
+        peer_factory=lambda: peer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+        on_output_pcm=lambda pcm: pcm_out.append(pcm) or True,
+    )
+    await session.start()
+
+    append_task = asyncio.create_task(session.append_speech("Hermes antwoord"))
+    for _ in range(100):
+        if session._speech_gate:
+            break
+        await asyncio.sleep(0.001)
+    assert session._speech_gate is True
+    assert peer.on_pcm is not None
+
+    silence = b"\x00" * 3840
+    peer.on_pcm(silence)
+    await asyncio.sleep(0.01)
+    assert append_task.done() is False
+    assert session._speech_last_pcm_at is None
+
+    audible = np.full(1920, 2048, dtype=np.int16).tobytes()
+    peer.on_pcm(audible)
+    try:
+        assert await append_task is True
+    finally:
+        await session.stop()
+
+    assert pcm_out == [silence, audible]
+
+
+@pytest.mark.asyncio
+async def test_append_speech_with_only_silence_fails_for_classic_fallback(
+    monkeypatch,
+):
+    import agent.transports.codex_realtime_voice as realtime_module
+
+    monkeypatch.setattr(realtime_module, "SPEECH_FIRST_AUDIO_TIMEOUT", 0.02)
+    pcm_out: list[bytes] = []
+    errors: list[str] = []
+    client = FakeClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v3"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "answer"},
+        },
+    ])
+    peer = FakePeer()
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        client_factory=lambda **kwargs: client,
+        peer_factory=lambda: peer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+        on_output_pcm=lambda pcm: pcm_out.append(pcm) or True,
+        on_error=errors.append,
+    )
+    await session.start()
+
+    append_task = asyncio.create_task(session.append_speech("Hermes antwoord"))
+    for _ in range(100):
+        if session._speech_gate:
+            break
+        await asyncio.sleep(0.001)
+    assert peer.on_pcm is not None
+    silence = b"\x00" * 3840
+    peer.on_pcm(silence)
+
+    try:
+        with pytest.raises(CodexRealtimeUnavailable, match="produced no audio"):
+            await append_task
+    finally:
+        await session.stop()
+
+    assert pcm_out == [silence]
+    assert errors == ["Codex realtime speech produced no audio"]
+
+
+@pytest.mark.asyncio
 async def test_append_speech_rejected_by_output_sink_fails_for_classic_fallback(
     monkeypatch,
 ):

--- a/tests/agent/transports/test_codex_realtime_voice.py
+++ b/tests/agent/transports/test_codex_realtime_voice.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import deque
+import threading
 
 import numpy as np
 import pytest
@@ -392,14 +393,74 @@ async def test_remote_close_reports_failure_and_closes_resources():
 
 
 @pytest.mark.asyncio
-async def test_append_speech_failure_reports_provider_failure_and_closes():
-    class BrokenSpeechClient(FakeClient):
+async def test_append_speech_drops_pcm_until_request_is_acknowledged():
+    class BlockingSpeechClient(FakeClient):
+        def __init__(self, notifications):
+            super().__init__(notifications)
+            self.append_started = threading.Event()
+            self.release_append = threading.Event()
+
         def request(self, method: str, params: dict, timeout: float = 30.0):
             if method == "thread/realtime/appendSpeech":
-                raise RuntimeError("speech backend unavailable")
+                self.append_started.set()
+                self.release_append.wait(timeout=5.0)
+            return super().request(method, params, timeout)
+
+    pcm_out: list[bytes] = []
+    client = BlockingSpeechClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v3"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "answer"},
+        },
+    ])
+    peer = FakePeer()
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        client_factory=lambda **kwargs: client,
+        peer_factory=lambda: peer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+        on_output_pcm=pcm_out.append,
+    )
+    await session.start()
+
+    append_task = asyncio.create_task(session.append_speech("Hermes antwoord"))
+    assert await asyncio.to_thread(client.append_started.wait, 5.0)
+    assert peer.on_pcm is not None
+    peer.on_pcm(b"pre-ack")
+    pcm_before_ack = list(pcm_out)
+    client.release_append.set()
+    assert await append_task is True
+
+    assert pcm_before_ack == []
+    peer.on_pcm(b"accepted")
+    assert pcm_out == [b"accepted"]
+    await session.stop()
+
+
+@pytest.mark.asyncio
+async def test_append_speech_failure_reports_provider_failure_and_closes():
+    class BrokenSpeechClient(FakeClient):
+        def __init__(self, notifications):
+            super().__init__(notifications)
+            self.append_started = threading.Event()
+            self.release_append = threading.Event()
+
+        def request(self, method: str, params: dict, timeout: float = 30.0):
+            if method == "thread/realtime/appendSpeech":
+                self.append_started.set()
+                self.release_append.wait(timeout=5.0)
+                raise RuntimeError(
+                    "speech backend unavailable at "
+                    "https://user:secret@example.test/realtime, request id: deadbeef"
+                )
             return super().request(method, params, timeout)
 
     errors: list[str] = []
+    pcm_out: list[bytes] = []
     client = BrokenSpeechClient([
         {
             "method": "thread/realtime/started",
@@ -416,18 +477,67 @@ async def test_append_speech_failure_reports_provider_failure_and_closes():
         client_factory=lambda **kwargs: client,
         peer_factory=lambda: peer,
         binary_checker=lambda *_args: (True, "0.145.0"),
+        on_output_pcm=pcm_out.append,
         on_error=errors.append,
     )
     await session.start()
 
+    append_task = asyncio.create_task(session.append_speech("Hermes antwoord"))
+    assert await asyncio.to_thread(client.append_started.wait, 5.0)
+    assert peer.on_pcm is not None
+    peer.on_pcm(b"pre-failure")
+    pcm_before_failure = list(pcm_out)
+    client.release_append.set()
     with pytest.raises(RuntimeError, match="speech backend unavailable"):
-        await session.append_speech("Hermes antwoord")
+        await append_task
     await asyncio.sleep(0.05)
 
+    assert pcm_before_failure == []
+    assert pcm_out == []
     assert session.active is False
-    assert errors == ["Codex realtime speech failed: speech backend unavailable"]
+    assert len(errors) == 1
+    assert "speech backend unavailable" in errors[0]
+    assert "secret" not in errors[0]
+    assert "deadbeef" not in errors[0]
     assert peer.closed is True
     assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_stop_request_failure_logs_only_sanitized_metadata(caplog):
+    class BrokenStopClient(FakeClient):
+        def request(self, method: str, params: dict, timeout: float = 30.0):
+            if method == "thread/realtime/stop":
+                raise RuntimeError(
+                    "stop failed at https://user:secret@example.test/realtime, "
+                    "request id: deadbeef"
+                )
+            return super().request(method, params, timeout)
+
+    client = BrokenStopClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v3"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "answer"},
+        },
+    ])
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        client_factory=lambda **kwargs: client,
+        peer_factory=FakePeer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+    )
+    await session.start()
+    caplog.set_level("DEBUG", logger="agent.transports.codex_realtime_voice")
+
+    await session.stop()
+
+    assert "stop failed" in caplog.text
+    assert "secret" not in caplog.text
+    assert "deadbeef" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/agent/transports/test_codex_realtime_voice.py
+++ b/tests/agent/transports/test_codex_realtime_voice.py
@@ -117,9 +117,10 @@ async def test_start_uses_experimental_v3_webrtc_contract_and_lists_capabilities
             "outputModality": "audio",
             "prompt": (
                 "You are a low-latency speech interface for another assistant. "
-                "Transcribe the user's speech accurately. Do not answer the user, "
-                "do not call tools, and do not delegate work. Stay silent until "
-                "the client supplies text to speak."
+                "Transcribe the user's speech accurately in the language they actually "
+                "speak; preserve that language and never translate it. Do not answer "
+                "the user, do not call tools, and do not delegate work. Stay silent "
+                "until the client supplies text to speak."
             ),
             "transport": {"type": "webrtc", "sdp": "v=offer\r\n"},
             "version": "v3",
@@ -129,6 +130,42 @@ async def test_start_uses_experimental_v3_webrtc_contract_and_lists_capabilities
     assert peer.answer_sdp == "v=answer\r\n"
     assert session.active is True
 
+    await session.stop()
+
+
+@pytest.mark.asyncio
+async def test_spoken_language_guides_output_without_translating_input():
+    client = FakeClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v3"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "v=answer\r\n"},
+        },
+    ])
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        spoken_language="nl-NL",
+        client_factory=lambda **kwargs: client,
+        peer_factory=FakePeer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+    )
+
+    await session.start()
+
+    start_params = client.requests[2][1]
+    assert "nl-NL" in start_params["prompt"]
+    assert "language they actually speak" in start_params["prompt"]
+    assert "never translate it" in start_params["prompt"]
+    assert (
+        "speak that supplied text naturally in the configured language"
+        in (start_params["prompt"])
+    )
+    # Codex app-server exposes no native language field for this route; the
+    # setting is an explicit speech-interface prompt hint, not a fake protocol claim.
+    assert "language" not in start_params
     await session.stop()
 
 

--- a/tests/agent/transports/test_codex_realtime_voice.py
+++ b/tests/agent/transports/test_codex_realtime_voice.py
@@ -10,6 +10,7 @@ from agent.transports.codex_realtime_voice import (
     AiortcRealtimePeer,
     CodexRealtimeCapabilities,
     CodexRealtimeSession,
+    CodexRealtimeStaleSpeech,
     discord_pcm_to_realtime,
     safe_realtime_error,
 )
@@ -132,8 +133,11 @@ async def test_start_uses_experimental_v1_webrtc_contract_and_lists_capabilities
 
 
 @pytest.mark.asyncio
-async def test_transcript_and_remote_pcm_notifications_are_forwarded():
-    transcripts: list[str] = []
+async def test_transcript_and_remote_pcm_notifications_are_forwarded(monkeypatch):
+    import agent.transports.codex_realtime_voice as realtime_module
+
+    monkeypatch.setattr(realtime_module, "SPEECH_AUDIO_IDLE_TIMEOUT", 0.05)
+    transcripts: list[tuple[str, int]] = []
     pcm_out: list[bytes] = []
     client = FakeClient([
         {
@@ -151,7 +155,10 @@ async def test_transcript_and_remote_pcm_notifications_are_forwarded():
         client_factory=lambda **kwargs: client,
         peer_factory=lambda: peer,
         binary_checker=lambda *_args: (True, "0.145.0"),
-        on_user_transcript=transcripts.append,
+        on_user_transcript=lambda text, generation: transcripts.append((
+            text,
+            generation,
+        )),
         on_output_pcm=pcm_out.append,
     )
     await session.start()
@@ -171,25 +178,21 @@ async def test_transcript_and_remote_pcm_notifications_are_forwarded():
         },
     ])
     await asyncio.sleep(0.05)
-    assert transcripts == ["Hallo Nabu"]
+    assert transcripts == [("Hallo Nabu", 1)]
 
     assert peer.on_pcm is not None
     # Unsolicited model audio is suppressed: Hermes remains the agent.
     peer.on_pcm(b"\x01\x02")
     assert pcm_out == []
 
-    await session.append_speech("Hoi Maikel")
+    await session.append_speech("Hoi Maikel", transcript_generation=1)
     assert client.requests[-1] == (
         "thread/realtime/appendSpeech",
         {"threadId": "thread-1", "text": "Hoi Maikel"},
     )
     peer.on_pcm(b"\x01\x02")
     assert pcm_out == [b"\x01\x02"]
-    client.notifications.append({
-        "method": "thread/realtime/transcript/done",
-        "params": {"threadId": "thread-1", "role": "assistant", "text": "Hoi Maikel"},
-    })
-    await asyncio.sleep(0.35)
+    await asyncio.sleep(0.1)
     peer.on_pcm(b"\x03\x04")
     assert pcm_out == [b"\x01\x02"]
 
@@ -203,6 +206,76 @@ async def test_transcript_and_remote_pcm_notifications_are_forwarded():
     await asyncio.sleep(0.05)
     peer.on_pcm(b"\x07\x08")
     assert pcm_out == [b"\x01\x02", b"\x05\x06"]
+    await session.stop()
+
+
+@pytest.mark.asyncio
+async def test_new_user_generation_suppresses_stale_hermes_speech_and_late_completion():
+    transcripts: list[tuple[str, int]] = []
+    pcm_out: list[bytes] = []
+    client = FakeClient([
+        {
+            "method": "thread/realtime/started",
+            "params": {"threadId": "thread-1", "version": "v1"},
+        },
+        {
+            "method": "thread/realtime/sdp",
+            "params": {"threadId": "thread-1", "sdp": "answer"},
+        },
+    ])
+    peer = FakePeer()
+    session = CodexRealtimeSession(
+        cwd="/tmp",
+        client_factory=lambda **kwargs: client,
+        peer_factory=lambda: peer,
+        binary_checker=lambda *_args: (True, "0.145.0"),
+        on_user_transcript=lambda text, generation: transcripts.append((
+            text,
+            generation,
+        )),
+        on_output_pcm=pcm_out.append,
+    )
+    await session.start()
+
+    client.notifications.append({
+        "method": "thread/realtime/transcript/done",
+        "params": {"threadId": "thread-1", "role": "user", "text": "A"},
+    })
+    await asyncio.sleep(0.05)
+    generation_a = transcripts[-1][1]
+    client.notifications.extend([
+        {
+            "method": "thread/realtime/transcript/delta",
+            "params": {"threadId": "thread-1", "role": "user", "delta": "B"},
+        },
+        {
+            "method": "thread/realtime/transcript/done",
+            "params": {"threadId": "thread-1", "role": "user", "text": "B"},
+        },
+    ])
+    await asyncio.sleep(0.05)
+    generation_b = transcripts[-1][1]
+
+    with pytest.raises(CodexRealtimeStaleSpeech):
+        await session.append_speech("late answer A", transcript_generation=generation_a)
+    assert not any(
+        method == "thread/realtime/appendSpeech" and params["text"] == "late answer A"
+        for method, params in client.requests
+    )
+
+    await session.append_speech("answer B", transcript_generation=generation_b)
+    client.notifications.append({
+        "method": "thread/realtime/transcript/done",
+        "params": {
+            "threadId": "thread-1",
+            "role": "assistant",
+            "text": "late completion A",
+        },
+    })
+    await asyncio.sleep(0.35)
+    assert peer.on_pcm is not None
+    peer.on_pcm(b"\x01\x02")
+    assert pcm_out == [b"\x01\x02"]
     await session.stop()
 
 

--- a/tests/agent/transports/test_codex_realtime_voice.py
+++ b/tests/agent/transports/test_codex_realtime_voice.py
@@ -70,11 +70,11 @@ class FakePeer:
 
 
 @pytest.mark.asyncio
-async def test_start_uses_experimental_v1_webrtc_contract_and_lists_capabilities():
+async def test_start_uses_experimental_v3_webrtc_contract_and_lists_capabilities():
     client = FakeClient([
         {
             "method": "thread/realtime/started",
-            "params": {"threadId": "thread-1", "version": "v1"},
+            "params": {"threadId": "thread-1", "version": "v3"},
         },
         {
             "method": "thread/realtime/sdp",
@@ -92,7 +92,7 @@ async def test_start_uses_experimental_v1_webrtc_contract_and_lists_capabilities
     capabilities = await session.start(voice="cedar")
 
     assert capabilities == CodexRealtimeCapabilities(
-        protocol_version="v1",
+        protocol_version="v3",
         voices=("cedar", "marin"),
         language_selection=False,
         reasoning_effort=False,
@@ -122,7 +122,7 @@ async def test_start_uses_experimental_v1_webrtc_contract_and_lists_capabilities
                 "the client supplies text to speak."
             ),
             "transport": {"type": "webrtc", "sdp": "v=offer\r\n"},
-            "version": "v1",
+            "version": "v3",
             "voice": "cedar",
         },
     )
@@ -142,7 +142,7 @@ async def test_transcript_and_remote_pcm_notifications_are_forwarded(monkeypatch
     client = FakeClient([
         {
             "method": "thread/realtime/started",
-            "params": {"threadId": "thread-1", "version": "v1"},
+            "params": {"threadId": "thread-1", "version": "v3"},
         },
         {
             "method": "thread/realtime/sdp",
@@ -216,7 +216,7 @@ async def test_new_user_generation_suppresses_stale_hermes_speech_and_late_compl
     client = FakeClient([
         {
             "method": "thread/realtime/started",
-            "params": {"threadId": "thread-1", "version": "v1"},
+            "params": {"threadId": "thread-1", "version": "v3"},
         },
         {
             "method": "thread/realtime/sdp",
@@ -286,7 +286,7 @@ async def test_error_closes_session_and_reports_sanitized_reason():
     client = FakeClient([
         {
             "method": "thread/realtime/started",
-            "params": {"threadId": "thread-1", "version": "v1"},
+            "params": {"threadId": "thread-1", "version": "v3"},
         },
         {
             "method": "thread/realtime/sdp",
@@ -326,7 +326,7 @@ async def test_remote_close_reports_failure_and_closes_resources():
     client = FakeClient([
         {
             "method": "thread/realtime/started",
-            "params": {"threadId": "thread-1", "version": "v1"},
+            "params": {"threadId": "thread-1", "version": "v3"},
         },
         {
             "method": "thread/realtime/sdp",
@@ -366,7 +366,7 @@ async def test_append_speech_failure_reports_provider_failure_and_closes():
     client = BrokenSpeechClient([
         {
             "method": "thread/realtime/started",
-            "params": {"threadId": "thread-1", "version": "v1"},
+            "params": {"threadId": "thread-1", "version": "v3"},
         },
         {
             "method": "thread/realtime/sdp",
@@ -399,7 +399,7 @@ async def test_webrtc_runtime_failure_closes_session_and_reports_safe_reason():
     client = FakeClient([
         {
             "method": "thread/realtime/started",
-            "params": {"threadId": "thread-1", "version": "v1"},
+            "params": {"threadId": "thread-1", "version": "v3"},
         },
         {
             "method": "thread/realtime/sdp",
@@ -433,7 +433,7 @@ async def test_sideband_audio_is_ignored_for_webrtc_output():
     client = FakeClient([
         {
             "method": "thread/realtime/started",
-            "params": {"threadId": "thread-1", "version": "v1"},
+            "params": {"threadId": "thread-1", "version": "v3"},
         },
         {
             "method": "thread/realtime/sdp",

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -120,6 +120,7 @@ def _ensure_discord_mock() -> None:
     discord_mod.Intents.default.return_value = MagicMock()
     discord_mod.Client = MagicMock
     discord_mod.File = MagicMock
+    discord_mod.AudioSource = type("AudioSource", (), {})
     discord_mod.DMChannel = type("DMChannel", (), {})
     discord_mod.Thread = type("Thread", (), {})
     discord_mod.ForumChannel = type("ForumChannel", (), {})

--- a/tests/gateway/test_codex_realtime_voice_manager.py
+++ b/tests/gateway/test_codex_realtime_voice_manager.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.codex_realtime_voice import CodexRealtimeVoiceManager
+
+
+def test_discord_yaml_bridge_preserves_realtime_voice_config():
+    from plugins.platforms.discord.adapter import _apply_yaml_config
+
+    raw = {
+        "codex_realtime_voice": {
+            "enabled": True,
+            "user_id": "42",
+            "fallback_to_classic": True,
+        }
+    }
+    seeded = _apply_yaml_config({"discord": raw}, raw)
+
+    assert seeded is not None
+    assert seeded["codex_realtime_voice"] == raw["codex_realtime_voice"]
+
+
+class FakeSession:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.active = False
+        self.pcm: list[bytes] = []
+        self.spoken: list[str] = []
+        self.stopped = False
+
+    async def start(self, *, voice=None):
+        self.active = True
+        self.voice = voice
+        return SimpleNamespace(protocol_version="v1", voices=("cedar",))
+
+    def push_discord_pcm(self, pcm: bytes) -> bool:
+        if not self.active:
+            return False
+        self.pcm.append(pcm)
+        return True
+
+    async def append_speech(self, text: str) -> bool:
+        if not self.active:
+            return False
+        self.spoken.append(text)
+        return True
+
+    async def stop(self):
+        self.active = False
+        self.stopped = True
+
+
+class FakeAdapter:
+    def __init__(self, config: dict) -> None:
+        self.config = SimpleNamespace(extra={"codex_realtime_voice": config})
+        self.output_pcm: list[tuple[int, bytes]] = []
+        self.mixer_started: list[int] = []
+        self.stream_ended: list[int] = []
+        self._profile_name = None
+
+    async def ensure_realtime_voice_output(self, guild_id: int) -> bool:
+        self.mixer_started.append(guild_id)
+        return True
+
+    def push_realtime_voice_pcm(self, guild_id: int, pcm: bytes) -> bool:
+        self.output_pcm.append((guild_id, pcm))
+        return True
+
+    def end_realtime_voice_output(self, guild_id: int) -> None:
+        self.stream_ended.append(guild_id)
+
+
+@pytest.mark.asyncio
+async def test_disabled_config_preserves_classic_voice_without_session():
+    created: list[FakeSession] = []
+    manager = CodexRealtimeVoiceManager(
+        session_factory=lambda **kwargs: (
+            created.append(FakeSession(**kwargs)) or created[-1]
+        ),
+        dependency_ensurer=lambda: None,
+    )
+    adapter = FakeAdapter({"enabled": False})
+
+    result = await manager.start_for_voice_channel(
+        adapter=adapter,
+        guild_id=7,
+        user_id=42,
+        on_transcript=lambda *_: None,
+    )
+
+    assert result.enabled is False
+    assert result.active is False
+    assert result.fallback_to_classic is True
+    assert created == []
+
+
+@pytest.mark.asyncio
+async def test_enabled_route_requires_the_configured_single_user():
+    manager = CodexRealtimeVoiceManager(
+        session_factory=FakeSession,
+        dependency_ensurer=lambda: None,
+    )
+    adapter = FakeAdapter({"enabled": True, "user_id": "42", "voice": "cedar"})
+
+    rejected = await manager.start_for_voice_channel(
+        adapter=adapter,
+        guild_id=7,
+        user_id=99,
+        on_transcript=lambda *_: None,
+    )
+    assert rejected.enabled is True
+    assert rejected.active is False
+    assert rejected.fallback_to_classic is True
+
+    accepted = await manager.start_for_voice_channel(
+        adapter=adapter,
+        guild_id=7,
+        user_id=42,
+        on_transcript=lambda *_: None,
+    )
+    assert accepted.active is True
+    assert accepted.capabilities.protocol_version == "v1"
+    assert adapter.mixer_started == [7]
+
+    # While realtime is active, non-bound speakers are consumed/dropped rather
+    # than leaking into a second classic-STT conversation path.
+    assert manager.push_discord_pcm(adapter, 7, 99, b"no") is True
+    assert manager.push_discord_pcm(adapter, 7, 0, b"unmapped") is True
+    assert manager.push_discord_pcm(adapter, 7, 42, b"yes") is True
+    session = manager.session_for(adapter, 7)
+    assert session.pcm == [b"yes"]
+
+    assert await manager.append_speech(adapter, 7, "Hoi") is True
+    assert session.spoken == ["Hoi"]
+
+    await manager.stop_for_voice_channel(adapter, 7)
+    assert session.stopped is True
+    assert adapter.stream_ended == [7]
+
+
+@pytest.mark.asyncio
+async def test_transcript_is_stamped_with_bound_user_and_output_reaches_adapter():
+    sessions: list[FakeSession] = []
+    manager = CodexRealtimeVoiceManager(
+        session_factory=lambda **kwargs: (
+            sessions.append(FakeSession(**kwargs)) or sessions[-1]
+        ),
+        dependency_ensurer=lambda: None,
+    )
+    adapter = FakeAdapter({"enabled": True, "user_id": 42})
+    transcripts: list[tuple[int, str]] = []
+
+    result = await manager.start_for_voice_channel(
+        adapter=adapter,
+        guild_id=7,
+        user_id=42,
+        on_transcript=lambda user_id, text: transcripts.append((user_id, text)),
+    )
+    assert result.active is True
+    session = sessions[0]
+
+    session.kwargs["on_user_transcript"]("wat is de status")
+    session.kwargs["on_output_pcm"](b"pcm")
+
+    assert transcripts == [(42, "wat is de status")]
+    assert adapter.output_pcm == [(7, b"pcm")]
+
+
+@pytest.mark.asyncio
+async def test_runtime_failure_releases_session_and_realtime_mixer_stream():
+    sessions: list[FakeSession] = []
+    manager = CodexRealtimeVoiceManager(
+        session_factory=lambda **kwargs: (
+            sessions.append(FakeSession(**kwargs)) or sessions[-1]
+        ),
+        dependency_ensurer=lambda: None,
+    )
+    adapter = FakeAdapter({
+        "enabled": True,
+        "user_id": 42,
+        "fallback_to_classic": False,
+    })
+    failures: list[tuple[str, bool]] = []
+
+    result = await manager.start_for_voice_channel(
+        adapter=adapter,
+        guild_id=7,
+        user_id=42,
+        on_transcript=lambda *_: None,
+        on_runtime_failure=lambda reason, fallback: failures.append((reason, fallback)),
+    )
+    assert result.active is True
+
+    sessions[0].kwargs["on_error"]("WebRTC connection failed")
+    await asyncio.sleep(0.05)
+
+    assert sessions[0].stopped is True
+    assert manager.session_for(adapter, 7) is None
+    assert adapter.stream_ended == [7]
+    assert failures == [("WebRTC connection failed", False)]
+
+
+@pytest.mark.asyncio
+async def test_stale_runtime_failure_cannot_stop_a_replacement_session():
+    sessions: list[FakeSession] = []
+    manager = CodexRealtimeVoiceManager(
+        session_factory=lambda **kwargs: (
+            sessions.append(FakeSession(**kwargs)) or sessions[-1]
+        ),
+        dependency_ensurer=lambda: None,
+    )
+    adapter = FakeAdapter({"enabled": True, "user_id": 42})
+    failures: list[tuple[str, bool]] = []
+
+    first = await manager.start_for_voice_channel(
+        adapter=adapter,
+        guild_id=7,
+        user_id=42,
+        on_transcript=lambda *_: None,
+        on_runtime_failure=lambda reason, fallback: failures.append((reason, fallback)),
+    )
+    assert first.active is True
+    stale_error = sessions[0].kwargs["on_error"]
+
+    await manager.stop_for_voice_channel(adapter, 7)
+    second = await manager.start_for_voice_channel(
+        adapter=adapter,
+        guild_id=7,
+        user_id=42,
+        on_transcript=lambda *_: None,
+        on_runtime_failure=lambda reason, fallback: failures.append((reason, fallback)),
+    )
+    assert second.active is True
+
+    stale_error("old WebRTC connection failed")
+    await asyncio.sleep(0.05)
+
+    assert manager.session_for(adapter, 7) is sessions[1]
+    assert sessions[1].stopped is False
+    assert failures == []
+
+
+@pytest.mark.asyncio
+async def test_start_failure_falls_back_and_cleans_partial_session():
+    class BrokenSession(FakeSession):
+        async def start(self, *, voice=None):
+            raise RuntimeError(
+                "experimental API unavailable at https://secret.example/realtime, "
+                "request id: deadbeef"
+            )
+
+    manager = CodexRealtimeVoiceManager(
+        session_factory=BrokenSession,
+        dependency_ensurer=lambda: None,
+    )
+    adapter = FakeAdapter({"enabled": True, "user_id": 42, "fallback_to_classic": True})
+
+    result = await manager.start_for_voice_channel(
+        adapter=adapter,
+        guild_id=7,
+        user_id=42,
+        on_transcript=lambda *_: None,
+    )
+
+    assert result.enabled is True
+    assert result.active is False
+    assert result.fallback_to_classic is True
+    assert result.reason is not None
+    assert "secret.example" not in result.reason
+    assert "deadbeef" not in result.reason
+    assert manager.session_for(adapter, 7) is None
+
+
+@pytest.mark.asyncio
+async def test_pcm_is_consumed_during_startup_to_avoid_parallel_classic_buffer():
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    class SlowSession(FakeSession):
+        async def start(self, *, voice=None):
+            entered.set()
+            await release.wait()
+            return await super().start(voice=voice)
+
+    manager = CodexRealtimeVoiceManager(
+        session_factory=SlowSession,
+        dependency_ensurer=lambda: None,
+    )
+    adapter = FakeAdapter({"enabled": True, "user_id": 42})
+    startup = asyncio.create_task(
+        manager.start_for_voice_channel(
+            adapter=adapter,
+            guild_id=7,
+            user_id=42,
+            on_transcript=lambda *_: None,
+        )
+    )
+    await entered.wait()
+
+    assert manager.push_discord_pcm(adapter, 7, 42, b"during-start") is True
+    assert manager.push_discord_pcm(adapter, 7, 99, b"other-speaker") is True
+    session = manager.session_for(adapter, 7)
+    assert session is not None
+    assert session.pcm == []
+
+    release.set()
+    result = await startup
+    assert result.active is True
+
+
+@pytest.mark.asyncio
+async def test_close_racing_start_cannot_publish_a_late_active_session():
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    class SlowSession(FakeSession):
+        async def start(self, *, voice=None):
+            entered.set()
+            await release.wait()
+            return await super().start(voice=voice)
+
+    manager = CodexRealtimeVoiceManager(
+        session_factory=SlowSession,
+        dependency_ensurer=lambda: None,
+    )
+    adapter = FakeAdapter({"enabled": True, "user_id": 42})
+    startup = asyncio.create_task(
+        manager.start_for_voice_channel(
+            adapter=adapter,
+            guild_id=7,
+            user_id=42,
+            on_transcript=lambda *_: None,
+        )
+    )
+    await entered.wait()
+
+    await manager.close()
+    release.set()
+    result = await startup
+
+    assert result.active is False
+    assert "shutting down" in str(result.reason)
+    assert manager.session_for(adapter, 7) is None
+    assert adapter.stream_ended == [7]

--- a/tests/gateway/test_codex_realtime_voice_manager.py
+++ b/tests/gateway/test_codex_realtime_voice_manager.py
@@ -62,11 +62,12 @@ class FakeAdapter:
         self.output_pcm: list[tuple[int, bytes]] = []
         self.mixer_started: list[int] = []
         self.stream_ended: list[int] = []
+        self.output_ready = True
         self._profile_name = None
 
     async def ensure_realtime_voice_output(self, guild_id: int) -> bool:
         self.mixer_started.append(guild_id)
-        return True
+        return self.output_ready
 
     def push_realtime_voice_pcm(self, guild_id: int, pcm: bytes) -> bool:
         self.output_pcm.append((guild_id, pcm))
@@ -176,11 +177,34 @@ async def test_enabled_route_requires_the_configured_single_user():
     assert (
         await manager.append_speech(adapter, 7, "Hoi", transcript_generation=9) is True
     )
+    assert adapter.mixer_started == [7, 7]
     assert session.spoken == [("Hoi", 9)]
 
     await manager.stop_for_voice_channel(adapter, 7)
     assert session.stopped is True
     assert adapter.stream_ended == [7]
+
+
+@pytest.mark.asyncio
+async def test_append_speech_fails_fast_when_discord_output_cannot_be_restored():
+    from agent.transports.codex_realtime_voice import CodexRealtimeUnavailable
+
+    manager = CodexRealtimeVoiceManager(
+        session_factory=FakeSession,
+        dependency_ensurer=lambda: None,
+    )
+    adapter = FakeAdapter({"enabled": True, "user_id": "42"})
+    started = await manager.start_for_voice_channel(
+        adapter=adapter,
+        guild_id=7,
+        user_id=42,
+        on_transcript=lambda *_: None,
+    )
+    assert started.active is True
+    adapter.output_ready = False
+
+    with pytest.raises(CodexRealtimeUnavailable, match="mixer is unavailable"):
+        await manager.append_speech(adapter, 7, "Hoi")
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_codex_realtime_voice_manager.py
+++ b/tests/gateway/test_codex_realtime_voice_manager.py
@@ -134,7 +134,12 @@ async def test_enabled_route_requires_the_configured_single_user():
         session_factory=FakeSession,
         dependency_ensurer=lambda: None,
     )
-    adapter = FakeAdapter({"enabled": True, "user_id": "42", "voice": "cedar"})
+    adapter = FakeAdapter({
+        "enabled": True,
+        "user_id": "42",
+        "voice": "cedar",
+        "spoken_language": "nl-NL",
+    })
 
     rejected = await manager.start_for_voice_channel(
         adapter=adapter,
@@ -157,6 +162,7 @@ async def test_enabled_route_requires_the_configured_single_user():
     active_session = manager.session_for(adapter, 7)
     assert active_session is not None
     assert active_session.kwargs["protocol_version"] == "v3"
+    assert active_session.kwargs["spoken_language"] == "nl-NL"
     assert adapter.mixer_started == [7]
 
     # While realtime is active, non-bound speakers are consumed/dropped rather

--- a/tests/gateway/test_codex_realtime_voice_manager.py
+++ b/tests/gateway/test_codex_realtime_voice_manager.py
@@ -29,7 +29,7 @@ class FakeSession:
         self.kwargs = kwargs
         self.active = False
         self.pcm: list[bytes] = []
-        self.spoken: list[str] = []
+        self.spoken: list[tuple[str, int | None]] = []
         self.stopped = False
 
     async def start(self, *, voice=None):
@@ -43,10 +43,12 @@ class FakeSession:
         self.pcm.append(pcm)
         return True
 
-    async def append_speech(self, text: str) -> bool:
+    async def append_speech(
+        self, text: str, *, transcript_generation: int | None = None
+    ) -> bool:
         if not self.active:
             return False
-        self.spoken.append(text)
+        self.spoken.append((text, transcript_generation))
         return True
 
     async def stop(self):
@@ -134,8 +136,10 @@ async def test_enabled_route_requires_the_configured_single_user():
     session = manager.session_for(adapter, 7)
     assert session.pcm == [b"yes"]
 
-    assert await manager.append_speech(adapter, 7, "Hoi") is True
-    assert session.spoken == ["Hoi"]
+    assert (
+        await manager.append_speech(adapter, 7, "Hoi", transcript_generation=9) is True
+    )
+    assert session.spoken == [("Hoi", 9)]
 
     await manager.stop_for_voice_channel(adapter, 7)
     assert session.stopped is True
@@ -152,21 +156,25 @@ async def test_transcript_is_stamped_with_bound_user_and_output_reaches_adapter(
         dependency_ensurer=lambda: None,
     )
     adapter = FakeAdapter({"enabled": True, "user_id": 42})
-    transcripts: list[tuple[int, str]] = []
+    transcripts: list[tuple[int, str, int]] = []
 
     result = await manager.start_for_voice_channel(
         adapter=adapter,
         guild_id=7,
         user_id=42,
-        on_transcript=lambda user_id, text: transcripts.append((user_id, text)),
+        on_transcript=lambda user_id, text, generation: transcripts.append((
+            user_id,
+            text,
+            generation,
+        )),
     )
     assert result.active is True
     session = sessions[0]
 
-    session.kwargs["on_user_transcript"]("wat is de status")
+    session.kwargs["on_user_transcript"]("wat is de status", 12)
     session.kwargs["on_output_pcm"](b"pcm")
 
-    assert transcripts == [(42, "wat is de status")]
+    assert transcripts == [(42, "wat is de status", 12)]
     assert adapter.output_pcm == [(7, b"pcm")]
 
 
@@ -310,6 +318,64 @@ async def test_pcm_is_consumed_during_startup_to_avoid_parallel_classic_buffer()
     release.set()
     result = await startup
     assert result.active is True
+
+
+def test_pcm_is_reserved_before_discord_join_starts():
+    manager = CodexRealtimeVoiceManager(
+        session_factory=FakeSession,
+        dependency_ensurer=lambda: None,
+    )
+    adapter = FakeAdapter({"enabled": True, "user_id": 42})
+
+    assert manager.prepare_for_voice_channel(adapter, 7) is True
+    assert manager.push_discord_pcm(adapter, 7, 42, b"early") is True
+    manager.cancel_voice_channel_start(adapter, 7)
+    assert manager.push_discord_pcm(adapter, 7, 42, b"classic") is False
+
+
+@pytest.mark.asyncio
+async def test_no_fallback_failure_consumes_pcm_until_slow_cleanup_finishes():
+    stop_entered = asyncio.Event()
+    release_stop = asyncio.Event()
+
+    class SlowStopSession(FakeSession):
+        async def stop(self):
+            self.active = False
+            stop_entered.set()
+            await release_stop.wait()
+            self.stopped = True
+
+    sessions: list[SlowStopSession] = []
+    manager = CodexRealtimeVoiceManager(
+        session_factory=lambda **kwargs: (
+            sessions.append(SlowStopSession(**kwargs)) or sessions[-1]
+        ),
+        dependency_ensurer=lambda: None,
+    )
+    adapter = FakeAdapter({
+        "enabled": True,
+        "user_id": 42,
+        "fallback_to_classic": False,
+    })
+    result = await manager.start_for_voice_channel(
+        adapter=adapter,
+        guild_id=7,
+        user_id=42,
+        on_transcript=lambda *_: None,
+    )
+    assert result.active is True
+
+    sessions[0].push_discord_pcm = lambda _pcm: False
+    assert manager.push_discord_pcm(adapter, 7, 42, b"input-failure") is True
+    sessions[0].active = False
+    sessions[0].kwargs["on_error"]("WebRTC failed")
+    await stop_entered.wait()
+    assert manager.push_discord_pcm(adapter, 7, 42, b"during-cleanup") is True
+
+    release_stop.set()
+    await asyncio.sleep(0.05)
+    assert manager.session_for(adapter, 7) is None
+    assert manager.push_discord_pcm(adapter, 7, 42, b"before-disconnect") is True
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_codex_realtime_voice_manager.py
+++ b/tests/gateway/test_codex_realtime_voice_manager.py
@@ -35,7 +35,7 @@ class FakeSession:
     async def start(self, *, voice=None):
         self.active = True
         self.voice = voice
-        return SimpleNamespace(protocol_version="v1", voices=("cedar",))
+        return SimpleNamespace(protocol_version="v3", voices=("cedar",))
 
     def push_discord_pcm(self, pcm: bytes) -> bool:
         if not self.active:
@@ -101,6 +101,34 @@ async def test_disabled_config_preserves_classic_voice_without_session():
 
 
 @pytest.mark.asyncio
+async def test_webrtc_rejects_v2_protocol_without_starting_session():
+    created: list[FakeSession] = []
+    manager = CodexRealtimeVoiceManager(
+        session_factory=lambda **kwargs: (
+            created.append(FakeSession(**kwargs)) or created[-1]
+        ),
+        dependency_ensurer=lambda: None,
+    )
+    adapter = FakeAdapter({
+        "enabled": True,
+        "user_id": "42",
+        "protocol_version": "v2",
+    })
+
+    result = await manager.start_for_voice_channel(
+        adapter=adapter,
+        guild_id=7,
+        user_id=42,
+        on_transcript=lambda *_: None,
+    )
+
+    assert result.enabled is True
+    assert result.active is False
+    assert "protocol_version must be v1 or v3" in str(result.reason)
+    assert created == []
+
+
+@pytest.mark.asyncio
 async def test_enabled_route_requires_the_configured_single_user():
     manager = CodexRealtimeVoiceManager(
         session_factory=FakeSession,
@@ -125,7 +153,10 @@ async def test_enabled_route_requires_the_configured_single_user():
         on_transcript=lambda *_: None,
     )
     assert accepted.active is True
-    assert accepted.capabilities.protocol_version == "v1"
+    assert accepted.capabilities.protocol_version == "v3"
+    active_session = manager.session_for(adapter, 7)
+    assert active_session is not None
+    assert active_session.kwargs["protocol_version"] == "v3"
     assert adapter.mixer_started == [7]
 
     # While realtime is active, non-bound speakers are consumed/dropped rather

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -7,6 +7,7 @@ integration (install on join, play routing, ack) is tested with the standard
 ``object.__new__(DiscordAdapter)`` helper used elsewhere in the voice suite.
 """
 
+import asyncio
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -46,6 +47,21 @@ class TestVoiceMixerCore:
             frame = mx.read()
             assert len(frame) == vm.FRAME_SIZE
             assert frame == vm.SILENCE_FRAME
+
+    def test_read_heartbeat_proves_sender_drain(self, monkeypatch):
+        now = [100.0]
+        monkeypatch.setattr(vm.time, "monotonic", lambda: now[0])
+        mx = vm.VoiceMixer()
+        assert mx.output_is_draining() is False
+        assert mx.read_count == 0
+
+        mx.read()
+
+        assert mx.read_count == 1
+        assert mx.output_is_draining() is True
+
+        now[0] += vm.OUTPUT_DRAIN_STALL_SECONDS + 0.01
+        assert mx.output_is_draining() is False
 
     def test_is_discord_audio_source(self):
         import discord
@@ -246,6 +262,8 @@ class TestVoiceMixerActive:
         def _play(source, **_kwargs):
             vc.source = source
             vc.is_playing.return_value = True
+            for _ in range(3):
+                source.read()
 
         vc.play.side_effect = _play
         adapter._voice_clients[111] = vc
@@ -261,10 +279,9 @@ class TestVoiceMixerActive:
         adapter.end_realtime_voice_output(111)
 
     @pytest.mark.asyncio
-    async def test_realtime_output_reinstalls_stale_mixer_with_stopped_player(self):
+    async def test_realtime_output_rejects_player_that_never_drains_source(self):
         adapter = _make_adapter({"enabled": False})
-        stale = object()
-        adapter._voice_mixers[111] = stale
+        adapter.VOICE_MIXER_DRAIN_START_TIMEOUT = 0.0
         vc = MagicMock()
         vc.is_connected.return_value = True
         vc.is_playing.return_value = False
@@ -276,8 +293,183 @@ class TestVoiceMixerActive:
         vc.play.side_effect = _play
         adapter._voice_clients[111] = vc
 
+        assert await adapter.ensure_realtime_voice_output(111) is False
+        assert 111 not in adapter._voice_mixers
+        vc.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_realtime_output_is_provisional_until_sender_drains(self):
+        adapter = _make_adapter({"enabled": False})
+        installed: list[vm.VoiceMixer] = []
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = False
+
+        def _play(source, **_kwargs):
+            installed.append(source)
+            vc.source = source
+            vc.is_playing.return_value = True
+            source.read()
+
+        vc.play.side_effect = _play
+        adapter._voice_clients[111] = vc
+
+        install_task = asyncio.create_task(adapter.ensure_realtime_voice_output(111))
+        for _ in range(100):
+            if installed:
+                break
+            await asyncio.sleep(0.001)
+
+        try:
+            assert installed
+            assert 111 not in adapter._voice_mixers
+        finally:
+            installed[0].read()
+            installed[0].read()
+            await install_task
+
+        assert adapter._voice_mixers[111] is installed[0]
+
+    @pytest.mark.asyncio
+    async def test_cancelled_mixer_install_cleans_provisional_player(self):
+        adapter = _make_adapter({"enabled": False})
+        installed: list[vm.VoiceMixer] = []
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = False
+
+        def _play(source, **_kwargs):
+            installed.append(source)
+            vc.source = source
+            vc.is_playing.return_value = True
+            source.read()
+
+        vc.play.side_effect = _play
+        adapter._voice_clients[111] = vc
+
+        install_task = asyncio.create_task(adapter.ensure_realtime_voice_output(111))
+        for _ in range(100):
+            if installed:
+                break
+            await asyncio.sleep(0.001)
+        install_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await install_task
+
+        assert 111 not in adapter._voice_mixers
+        vc.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_realtime_output_reinstalls_stale_mixer_with_stopped_player(self):
+        adapter = _make_adapter({"enabled": False})
+        stale = object()
+        adapter._voice_mixers[111] = stale
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = False
+
+        def _play(source, **_kwargs):
+            vc.source = source
+            vc.is_playing.return_value = True
+            for _ in range(3):
+                source.read()
+
+        vc.play.side_effect = _play
+        adapter._voice_clients[111] = vc
+
         assert await adapter.ensure_realtime_voice_output(111) is True
         assert adapter._voice_mixers[111] is not stale
+        vc.play.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_realtime_output_reinstalls_flagged_mixer_that_is_not_draining(self):
+        adapter = _make_adapter({"enabled": False})
+        stale = vm.VoiceMixer()
+        adapter._voice_mixers[111] = stale
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = True
+        vc.source = stale
+
+        def _stop():
+            vc.is_playing.return_value = False
+            vc.source = None
+
+        vc.stop.side_effect = _stop
+
+        def _play(source, **_kwargs):
+            vc.source = source
+            vc.is_playing.return_value = True
+            for _ in range(3):
+                source.read()
+            # Simulate discord.py's AudioPlayer polling the replacement source.
+            source.read()
+
+        vc.play.side_effect = _play
+        adapter._voice_clients[111] = vc
+
+        assert await adapter.ensure_realtime_voice_output(111) is True
+        assert adapter._voice_mixers[111] is not stale
+        vc.stop.assert_called_once()
+        vc.play.assert_called_once()
+
+    def test_realtime_pcm_rejects_flagged_mixer_that_is_not_draining(self):
+        adapter = _make_adapter({"enabled": False})
+        stale = vm.VoiceMixer()
+        adapter._voice_mixers[111] = stale
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = True
+        vc.source = stale
+        adapter._voice_clients[111] = vc
+
+        assert (
+            adapter.push_realtime_voice_pcm(111, b"\x01\x00" * 1920)
+            is False
+        )
+        assert 111 not in adapter._voice_mixers
+
+    @pytest.mark.asyncio
+    async def test_stale_realtime_mixer_stops_zombie_before_classic_fallback(
+        self, monkeypatch
+    ):
+        now = [100.0]
+        monkeypatch.setattr(vm.time, "monotonic", lambda: now[0])
+        adapter = _make_adapter({"enabled": False})
+        stale = vm.VoiceMixer()
+        stale.read()
+        now[0] += vm.OUTPUT_DRAIN_STALL_SECONDS + 0.01
+        adapter._voice_mixers[111] = stale
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = True
+        vc.source = stale
+
+        def _stop():
+            vc.is_playing.return_value = False
+            vc.source = None
+
+        vc.stop.side_effect = _stop
+        adapter._voice_clients[111] = vc
+        adapter._voice_receivers[111] = MagicMock()
+        adapter._reset_voice_timeout = MagicMock()
+
+        assert adapter.push_realtime_voice_pcm(111, b"\x01\x00" * 1920) is False
+        vc.stop.assert_called_once()
+
+        async def _fast(coro, *args, **kwargs):
+            if hasattr(coro, "close"):
+                coro.close()
+            return None
+
+        with (
+            patch("plugins.platforms.discord.adapter.discord") as mock_discord,
+            patch("asyncio.wait_for", _fast),
+        ):
+            mock_discord.FFmpegPCMAudio.return_value = MagicMock()
+            mock_discord.PCMVolumeTransformer.return_value = MagicMock()
+            assert await adapter.play_in_voice_channel(111, "/tmp/fallback.mp3")
+
         vc.play.assert_called_once()
 
     @pytest.mark.asyncio
@@ -290,6 +482,8 @@ class TestVoiceMixerActive:
         def _play(source, **_kwargs):
             vc.source = source
             vc.is_playing.return_value = True
+            for _ in range(3):
+                source.read()
 
         vc.play.side_effect = _play
         adapter._voice_clients[111] = vc

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -196,8 +196,39 @@ class TestVoiceMixerActive:
 
     def test_true_when_mixer_present(self):
         adapter = _make_adapter()
-        adapter._voice_mixers[111] = object()
+        mixer = object()
+        adapter._voice_mixers[111] = mixer
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = True
+        vc.source = mixer
+        adapter._voice_clients[111] = vc
         assert adapter.voice_mixer_active(111) is True
+
+    def test_false_and_discards_stale_mixer_when_audio_player_stopped(self):
+        adapter = _make_adapter()
+        mixer = object()
+        adapter._voice_mixers[111] = mixer
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = False
+        vc.source = mixer
+        adapter._voice_clients[111] = vc
+
+        assert adapter.voice_mixer_active(111) is False
+        assert 111 not in adapter._voice_mixers
+
+    def test_false_and_discards_stale_mixer_when_player_uses_another_source(self):
+        adapter = _make_adapter()
+        adapter._voice_mixers[111] = object()
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = True
+        vc.source = object()
+        adapter._voice_clients[111] = vc
+
+        assert adapter.voice_mixer_active(111) is False
+        assert 111 not in adapter._voice_mixers
 
     @pytest.mark.asyncio
     async def test_realtime_output_installs_mixer_without_ambient_when_fx_disabled(self):
@@ -211,6 +242,12 @@ class TestVoiceMixerActive:
         vc = MagicMock()
         vc.is_connected.return_value = True
         vc.is_playing.return_value = False
+
+        def _play(source, **_kwargs):
+            vc.source = source
+            vc.is_playing.return_value = True
+
+        vc.play.side_effect = _play
         adapter._voice_clients[111] = vc
 
         assert await adapter.ensure_realtime_voice_output(111) is True
@@ -222,6 +259,47 @@ class TestVoiceMixerActive:
         assert adapter.push_realtime_voice_pcm(111, frame) is True
         assert mixer.speech_active is True
         adapter.end_realtime_voice_output(111)
+
+    @pytest.mark.asyncio
+    async def test_realtime_output_reinstalls_stale_mixer_with_stopped_player(self):
+        adapter = _make_adapter({"enabled": False})
+        stale = object()
+        adapter._voice_mixers[111] = stale
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = False
+
+        def _play(source, **_kwargs):
+            vc.source = source
+            vc.is_playing.return_value = True
+
+        vc.play.side_effect = _play
+        adapter._voice_clients[111] = vc
+
+        assert await adapter.ensure_realtime_voice_output(111) is True
+        assert adapter._voice_mixers[111] is not stale
+        vc.play.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_audio_player_completion_discards_its_mixer_mapping(self):
+        adapter = _make_adapter({"enabled": False})
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = False
+
+        def _play(source, **_kwargs):
+            vc.source = source
+            vc.is_playing.return_value = True
+
+        vc.play.side_effect = _play
+        adapter._voice_clients[111] = vc
+        assert await adapter.ensure_realtime_voice_output(111) is True
+        mixer = adapter._voice_mixers[111]
+
+        after = vc.play.call_args.kwargs["after"]
+        after(None)
+
+        assert adapter._voice_mixers.get(111) is not mixer
 
     def test_false_when_attr_missing(self):
         # Defensive getattr path (object.__new__ helper that forgot the attr).
@@ -254,6 +332,8 @@ class TestPlayInVoiceChannelMixerPath:
 
         mixer = _Mixer()
         adapter._voice_mixers[111] = mixer
+        vc.is_playing.return_value = True
+        vc.source = mixer
         adapter._reset_voice_timeout = MagicMock()
 
         fake_pcm = b"\x00" * vm.FRAME_SIZE
@@ -290,6 +370,68 @@ class TestPlayInVoiceChannelMixerPath:
                 ok = await adapter.play_in_voice_channel(111, "/tmp/x.mp3")
         # Fell through to legacy path -> vc.play called.
         assert vc.play.called
+
+    @pytest.mark.asyncio
+    async def test_stale_mixer_uses_legacy_playback_instead_of_false_success(self):
+        adapter = _make_adapter()
+        stale = MagicMock()
+        adapter._voice_mixers[111] = stale
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = False
+        vc.source = stale
+        adapter._voice_clients[111] = vc
+        adapter._reset_voice_timeout = MagicMock()
+        adapter._voice_receivers[111] = MagicMock()
+
+        async def _fast(coro, *args, **kwargs):
+            if hasattr(coro, "close"):
+                coro.close()
+            return None
+
+        with patch("plugins.platforms.discord.adapter.discord") as mock_discord, \
+                patch("asyncio.wait_for", _fast):
+            mock_discord.FFmpegPCMAudio.return_value = MagicMock()
+            mock_discord.PCMVolumeTransformer.return_value = MagicMock()
+            assert await adapter.play_in_voice_channel(111, "/tmp/fallback.mp3") is True
+
+        stale.play_speech.assert_not_called()
+        vc.play.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_mixer_lost_during_decode_uses_legacy_playback(self):
+        adapter = _make_adapter()
+        mixer = MagicMock()
+        mixer.speech_active = False
+        adapter._voice_mixers[111] = mixer
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = True
+        vc.source = mixer
+        adapter._voice_clients[111] = vc
+        adapter._reset_voice_timeout = MagicMock()
+        adapter._voice_receivers[111] = MagicMock()
+
+        def _decode(_audio_path):
+            vc.is_playing.return_value = False
+            adapter._voice_mixers.pop(111, None)
+            mixer.cleanup()
+            return b"\x00" * vm.FRAME_SIZE
+
+        async def _fast(coro, *args, **kwargs):
+            if hasattr(coro, "close"):
+                coro.close()
+            return None
+
+        with patch.object(vm, "decode_to_pcm", side_effect=_decode), \
+                patch("plugins.platforms.discord.adapter.discord") as mock_discord, \
+                patch("asyncio.wait_for", _fast):
+            mock_discord.FFmpegPCMAudio.return_value = MagicMock()
+            mock_discord.PCMVolumeTransformer.return_value = MagicMock()
+            assert await adapter.play_in_voice_channel(111, "/tmp/fallback.mp3") is True
+
+        mixer.play_speech.assert_not_called()
+        vc.play.assert_called_once()
 
 
 class TestPlayAckInVoice:

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -99,6 +99,33 @@ class TestVoiceMixerCore:
         mx.read()
         assert not mx.speech_active
 
+    def test_streamed_speech_accepts_incremental_pcm_without_restarting(self):
+        mx = vm.VoiceMixer()
+        first = (np.ones(vm.SAMPLES_PER_FRAME * 2) * 1000).astype(np.int16).tobytes()
+        second = (np.ones(vm.SAMPLES_PER_FRAME * 2) * 2000).astype(np.int16).tobytes()
+
+        assert mx.push_speech_stream("codex-live", first) is True
+        assert np.frombuffer(mx.read(), dtype=np.int16)[0] == 1000
+        assert mx.push_speech_stream("codex-live", second) is False
+        assert np.frombuffer(mx.read(), dtype=np.int16)[0] == 2000
+        assert mx.speech_active
+
+        mx.end_speech_stream("codex-live")
+        mx.read()
+        assert not mx.speech_active
+
+    def test_streamed_speech_survives_short_network_underflow(self):
+        mx = vm.VoiceMixer()
+        frame = (np.ones(vm.SAMPLES_PER_FRAME * 2) * 500).astype(np.int16).tobytes()
+        mx.push_speech_stream("codex-live", frame)
+        mx.read()
+        # A handful of empty 20 ms mixer reads must not destroy the stream;
+        # the next WebRTC packet should continue in the same child.
+        for _ in range(4):
+            assert mx.read() == vm.SILENCE_FRAME
+        mx.push_speech_stream("codex-live", frame)
+        assert np.frombuffer(mx.read(), dtype=np.int16)[0] == 500
+
     def test_set_ambient_none_clears(self):
         mx = vm.VoiceMixer()
         mx.set_ambient(vm.synth_ambient_pcm(seconds=0.5))
@@ -164,6 +191,30 @@ class TestVoiceMixerActive:
         adapter = _make_adapter()
         adapter._voice_mixers[111] = object()
         assert adapter.voice_mixer_active(111) is True
+
+    @pytest.mark.asyncio
+    async def test_realtime_output_installs_mixer_without_ambient_when_fx_disabled(self):
+        adapter = _make_adapter({
+            "enabled": False,
+            "ambient_enabled": True,
+            "ambient_gain": 0.18,
+            "duck_gain": 0.06,
+            "speech_gain": 1.0,
+        })
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = False
+        adapter._voice_clients[111] = vc
+
+        assert await adapter.ensure_realtime_voice_output(111) is True
+        assert adapter.voice_mixer_active(111) is True
+        mixer = adapter._voice_mixers[111]
+        assert mixer._ambient is None
+
+        frame = b"\x00" * vm.FRAME_SIZE
+        assert adapter.push_realtime_voice_pcm(111, frame) is True
+        assert mixer.speech_active is True
+        adapter.end_realtime_voice_output(111)
 
     def test_false_when_attr_missing(self):
         # Defensive getattr path (object.__new__ helper that forgot the attr).

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -47,6 +47,13 @@ class TestVoiceMixerCore:
             assert len(frame) == vm.FRAME_SIZE
             assert frame == vm.SILENCE_FRAME
 
+    def test_is_discord_audio_source(self):
+        import discord
+
+        # VoiceClient.play() enforces this at runtime; merely implementing
+        # read()/is_opus() is not enough.
+        assert issubclass(vm.VoiceMixer, discord.AudioSource)
+
     def test_is_opus_false(self):
         # discord.py sends raw PCM when is_opus() is False.
         assert vm.VoiceMixer().is_opus() is False

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -470,6 +470,43 @@ class TestSendVoiceReply:
         local_tts.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_realtime_no_audio_failure_uses_classic_tts_fallback(self, runner):
+        from agent.transports.codex_realtime_voice import CodexRealtimeUnavailable
+        from gateway.config import Platform
+
+        adapter = MagicMock()
+        adapter._voice_text_channels = {111: 123}
+        adapter.is_in_voice_channel.return_value = True
+        adapter.play_in_voice_channel = AsyncMock(return_value=True)
+        event = _make_event()
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(guild_id=111, guild=None)
+        runner.adapters[Platform.DISCORD] = adapter
+        manager = MagicMock()
+        manager.is_active.return_value = True
+        manager.classic_fallback_enabled.return_value = True
+        manager.append_speech = AsyncMock(
+            side_effect=CodexRealtimeUnavailable(
+                "Codex realtime speech produced no audio"
+            )
+        )
+        runner._codex_realtime_voice = manager
+
+        tts_result = '{"success": true, "file_path": "/tmp/fallback.mp3"}'
+        with patch(
+            "tools.tts_tool.text_to_speech_tool", return_value=tts_result
+        ) as local_tts, patch("os.path.isfile", return_value=True), patch("os.unlink"):
+            await runner._send_voice_reply(event, "Hoi Maikel")
+
+        manager.append_speech.assert_awaited_once_with(
+            adapter, 111, "Hoi Maikel", transcript_generation=None
+        )
+        local_tts.assert_called_once()
+        adapter.play_in_voice_channel.assert_awaited_once_with(
+            111, "/tmp/fallback.mp3"
+        )
+
+    @pytest.mark.asyncio
     async def test_realtime_reply_uses_tts_clean_text_and_drops_stale_generation(
         self, runner
     ):
@@ -777,7 +814,7 @@ class TestVoiceInHelp:
 class TestVoiceReceiver:
     """Test VoiceReceiver silence detection, SSRC mapping, and lifecycle."""
 
-    def _make_receiver(self, pcm_callback=None):
+    def _make_receiver(self, pcm_callback=None, *, allowed_user_ids=None, members=None):
         from plugins.platforms.discord.adapter import VoiceReceiver
         mock_vc = MagicMock()
         mock_vc._connection.secret_key = [0] * 32
@@ -786,7 +823,13 @@ class TestVoiceReceiver:
         mock_vc._connection.add_socket_listener = MagicMock()
         mock_vc._connection.remove_socket_listener = MagicMock()
         mock_vc._connection.hook = None
-        receiver = VoiceReceiver(mock_vc, pcm_callback=pcm_callback)
+        mock_vc.user = SimpleNamespace(id=9999)
+        mock_vc.channel = SimpleNamespace(members=members or [])
+        receiver = VoiceReceiver(
+            mock_vc,
+            pcm_callback=pcm_callback,
+            allowed_user_ids=allowed_user_ids,
+        )
         return receiver
 
     def test_initial_state(self):
@@ -845,6 +888,41 @@ class TestVoiceReceiver:
         receiver.handle_decoded_pcm(100, b"early")
 
         assert consumed == [(0, b"early")]
+        assert receiver._buffers[100] == bytearray()
+
+    def test_realtime_pcm_infers_sole_allowed_member_when_speaking_event_is_missing(self):
+        consumed = []
+        receiver = self._make_receiver(
+            pcm_callback=lambda user_id, pcm: consumed.append((user_id, pcm)) or True,
+            allowed_user_ids={"42"},
+            members=[
+                SimpleNamespace(id=9999),
+                SimpleNamespace(id=42),
+            ],
+        )
+
+        receiver.handle_decoded_pcm(100, b"pcm")
+
+        assert consumed == [(42, b"pcm")]
+        assert receiver._ssrc_to_user[100] == 42
+        assert receiver._buffers[100] == bytearray()
+
+    def test_realtime_pcm_does_not_guess_between_multiple_allowed_members(self):
+        consumed = []
+        receiver = self._make_receiver(
+            pcm_callback=lambda user_id, pcm: consumed.append((user_id, pcm)) or True,
+            allowed_user_ids={"42", "43"},
+            members=[
+                SimpleNamespace(id=9999),
+                SimpleNamespace(id=42),
+                SimpleNamespace(id=43),
+            ],
+        )
+
+        receiver.handle_decoded_pcm(100, b"pcm")
+
+        assert consumed == [(0, b"pcm")]
+        assert 100 not in receiver._ssrc_to_user
         assert receiver._buffers[100] == bytearray()
 
     def test_unconsumed_pcm_falls_back_to_classic_stt_buffer(self):

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1280,6 +1280,9 @@ class TestVoiceChannelCommands:
         bound_adapter = AsyncMock()
         bound_adapter._voice_text_channels = {111: 123}
         bound_adapter._voice_sources = {}
+        bound_adapter.config = SimpleNamespace(extra={
+            "codex_realtime_voice": {"spoken_language": "nl-NL"}
+        })
         bound_adapter._client = MagicMock()
         bound_adapter._client.get_channel = MagicMock(return_value=AsyncMock())
         bound_adapter.handle_message = AsyncMock()
@@ -1295,6 +1298,9 @@ class TestVoiceChannelCommands:
 
         event = bound_adapter.handle_message.call_args.args[0]
         assert event.message_type == MessageType.TEXT
+        assert "connected Discord voice channel" in event.text
+        assert "nl-NL" in event.text
+        assert event.text.endswith("Realtime transcript")
         assert event.raw_message.guild_id == 111
         primary_adapter.handle_message.assert_not_called()
 
@@ -1347,6 +1353,26 @@ class TestVoiceChannelCommands:
         msg = mock_channel.send.call_args[0][0]
         assert "Test transcript" in msg
         assert "42" in msg  # user_id in mention
+
+    @pytest.mark.asyncio
+    async def test_input_respects_disabled_transcript_echo(self, runner):
+        """Voice input remains actionable without posting raw STT into chat."""
+        from gateway.config import Platform
+
+        runner.config = SimpleNamespace(stt_echo_transcripts=False)
+        mock_adapter = AsyncMock()
+        mock_adapter._voice_text_channels = {111: 123}
+        mock_adapter._voice_sources = {}
+        mock_channel = AsyncMock()
+        mock_adapter._client = MagicMock()
+        mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter.handle_message = AsyncMock()
+        runner.adapters[Platform.DISCORD] = mock_adapter
+
+        await runner._handle_voice_channel_input(111, 42, "Quiet transcript")
+
+        mock_channel.send.assert_not_awaited()
+        mock_adapter.handle_message.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_input_suppresses_duplicate_transcript(self, runner):

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1,5 +1,6 @@
 """Tests for the /voice command and auto voice reply in the gateway."""
 
+import asyncio
 import importlib.util
 import json
 import os
@@ -353,6 +354,13 @@ class TestAutoVoiceReply:
         """voice_only + text input: neither fires."""
         assert self._call(runner, "voice_only", MessageType.TEXT) is False
 
+    def test_realtime_voice_marker_preserves_voice_only_semantics(self, runner):
+        runner._voice_mode["telegram:123"] = "voice_only"
+        event = _make_event(message_type=MessageType.TEXT)
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+
+        assert runner._should_send_voice_reply(event, "Hello!", []) is True
+
     # -- Mode off: nothing fires -------------------------------------------
 
     def test_off_mode_voice(self, runner):
@@ -436,6 +444,106 @@ class TestSendVoiceReply:
         assert mock_tts.call_args.kwargs["output_path"].endswith(".ogg")
         call_args = mock_adapter.send_voice.call_args
         assert call_args.kwargs.get("chat_id") == "123"
+
+    @pytest.mark.asyncio
+    async def test_discord_realtime_session_speaks_through_codex_without_local_tts(self, runner):
+        from gateway.config import Platform
+
+        adapter = MagicMock()
+        adapter._voice_text_channels = {111: 123}
+        event = _make_event()
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(guild_id=111, guild=None)
+        runner.adapters[Platform.DISCORD] = adapter
+        manager = MagicMock()
+        manager.is_active.return_value = True
+        manager.classic_fallback_enabled.return_value = True
+        manager.append_speech = AsyncMock(return_value=True)
+        runner._codex_realtime_voice = manager
+
+        with patch("tools.tts_tool.text_to_speech_tool") as local_tts:
+            await runner._send_voice_reply(event, "Hoi Maikel")
+
+        manager.append_speech.assert_awaited_once_with(adapter, 111, "Hoi Maikel")
+        local_tts.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_realtime_speech_failure_stays_silent_when_classic_fallback_is_disabled(
+        self, runner
+    ):
+        from gateway.config import Platform
+
+        adapter = MagicMock()
+        adapter._voice_text_channels = {111: 123}
+        event = _make_event()
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(guild_id=111, guild=None)
+        runner.adapters[Platform.DISCORD] = adapter
+        manager = MagicMock()
+        manager.is_active.return_value = True
+        manager.classic_fallback_enabled.return_value = False
+        manager.append_speech = AsyncMock(side_effect=RuntimeError("speech failed"))
+        runner._codex_realtime_voice = manager
+
+        with patch("tools.tts_tool.text_to_speech_tool") as local_tts:
+            await runner._send_voice_reply(event, "Hoi Maikel")
+
+        manager.append_speech.assert_awaited_once_with(adapter, 111, "Hoi Maikel")
+        local_tts.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_removed_no_fallback_realtime_session_does_not_leak_local_tts(
+        self, runner
+    ):
+        from gateway.config import Platform
+
+        adapter = MagicMock()
+        adapter._voice_text_channels = {111: 123}
+        event = _make_event()
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(
+            guild_id=111,
+            guild=None,
+            codex_realtime_voice=True,
+        )
+        runner.adapters[Platform.DISCORD] = adapter
+        manager = MagicMock()
+        manager.is_active.return_value = False
+        manager.configured_fallback_enabled.return_value = False
+        manager.append_speech = AsyncMock()
+        runner._codex_realtime_voice = manager
+
+        with patch("tools.tts_tool.text_to_speech_tool") as local_tts:
+            await runner._send_voice_reply(event, "Hoi Maikel")
+
+        manager.append_speech.assert_not_awaited()
+        local_tts.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_discord_realtime_does_not_speak_reply_from_unlinked_text_channel(self, runner):
+        from gateway.config import Platform
+
+        adapter = AsyncMock()
+        adapter._voice_text_channels = {111: 999}
+        adapter.send_voice = AsyncMock()
+        event = _make_event()
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(guild_id=111, guild=None)
+        runner.adapters[Platform.DISCORD] = adapter
+        manager = MagicMock()
+        manager.is_active.return_value = True
+        manager.append_speech = AsyncMock(return_value=True)
+        runner._codex_realtime_voice = manager
+        tts_result = json.dumps({"success": True, "file_path": "/tmp/test.mp3"})
+
+        with patch(
+            "tools.tts_tool.text_to_speech_tool",
+            return_value=tts_result,
+        ) as local_tts, patch("os.path.isfile", return_value=False):
+            await runner._send_voice_reply(event, "Niet voor de VC")
+
+        manager.append_speech.assert_not_awaited()
+        local_tts.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_non_telegram_auto_voice_reply_uses_mp3(self, runner):
@@ -624,7 +732,7 @@ class TestVoiceInHelp:
 class TestVoiceReceiver:
     """Test VoiceReceiver silence detection, SSRC mapping, and lifecycle."""
 
-    def _make_receiver(self):
+    def _make_receiver(self, pcm_callback=None):
         from plugins.platforms.discord.adapter import VoiceReceiver
         mock_vc = MagicMock()
         mock_vc._connection.secret_key = [0] * 32
@@ -633,7 +741,7 @@ class TestVoiceReceiver:
         mock_vc._connection.add_socket_listener = MagicMock()
         mock_vc._connection.remove_socket_listener = MagicMock()
         mock_vc._connection.hook = None
-        receiver = VoiceReceiver(mock_vc)
+        receiver = VoiceReceiver(mock_vc, pcm_callback=pcm_callback)
         return receiver
 
     def test_initial_state(self):
@@ -670,6 +778,38 @@ class TestVoiceReceiver:
         receiver.map_ssrc(100, 42)
         receiver.map_ssrc(100, 99)
         assert receiver._ssrc_to_user[100] == 99
+
+    def test_realtime_pcm_callback_can_consume_frame_before_classic_stt_buffer(self):
+        consumed = []
+        receiver = self._make_receiver(
+            pcm_callback=lambda user_id, pcm: consumed.append((user_id, pcm)) or True
+        )
+        receiver.map_ssrc(100, 42)
+
+        receiver.handle_decoded_pcm(100, b"pcm")
+
+        assert consumed == [(42, b"pcm")]
+        assert receiver._buffers[100] == bytearray()
+
+    def test_realtime_pcm_callback_can_consume_unmapped_early_frame(self):
+        consumed = []
+        receiver = self._make_receiver(
+            pcm_callback=lambda user_id, pcm: consumed.append((user_id, pcm)) or True
+        )
+
+        receiver.handle_decoded_pcm(100, b"early")
+
+        assert consumed == [(0, b"early")]
+        assert receiver._buffers[100] == bytearray()
+
+    def test_unconsumed_pcm_falls_back_to_classic_stt_buffer(self):
+        receiver = self._make_receiver(pcm_callback=lambda _user_id, _pcm: False)
+        receiver.map_ssrc(100, 42)
+
+        receiver.handle_decoded_pcm(100, b"pcm")
+
+        assert receiver._buffers[100] == bytearray(b"pcm")
+        assert 100 in receiver._last_packet_time
 
     def test_pause_resume(self):
         receiver = self._make_receiver()
@@ -847,6 +987,99 @@ class TestVoiceChannelCommands:
         assert mock_adapter._voice_sources[111]["chat_type"] == "group"
 
     @pytest.mark.asyncio
+    async def test_join_starts_opt_in_realtime_after_binding_and_wires_pcm_before_connect(self, runner):
+        mock_channel = MagicMock()
+        mock_channel.name = "General"
+        mock_adapter = AsyncMock()
+        mock_adapter.get_user_voice_channel = AsyncMock(return_value=mock_channel)
+        mock_adapter._voice_text_channels = {}
+        mock_adapter._voice_sources = {}
+        mock_adapter._voice_input_callback = None
+        mock_adapter._voice_pcm_callback = None
+
+        manager = MagicMock()
+        manager.push_discord_pcm.return_value = True
+        manager.start_for_voice_channel = AsyncMock(
+            return_value=SimpleNamespace(
+                enabled=True,
+                active=True,
+                fallback_to_classic=True,
+                reason=None,
+                capabilities=SimpleNamespace(protocol_version="v1"),
+            )
+        )
+        runner._codex_realtime_voice = manager
+        runner._handle_voice_channel_input = AsyncMock()
+
+        async def _join(_channel):
+            assert callable(mock_adapter._voice_pcm_callback)
+            assert mock_adapter._voice_pcm_callback(111, 42, b"pcm") is True
+            return True
+
+        mock_adapter.join_voice_channel = AsyncMock(side_effect=_join)
+        event = self._make_discord_event(user_id="42")
+        runner.adapters[event.source.platform] = mock_adapter
+
+        result = await runner._handle_voice_channel_join(event)
+
+        assert "codex live" in result.lower()
+        manager.start_for_voice_channel.assert_awaited_once()
+        kwargs = manager.start_for_voice_channel.await_args.kwargs
+        assert kwargs["adapter"] is mock_adapter
+        assert kwargs["guild_id"] == 111
+        assert kwargs["user_id"] == 42
+        assert callable(kwargs["on_transcript"])
+        assert callable(kwargs["on_runtime_failure"])
+        await kwargs["on_runtime_failure"]("temporary failure", True)
+        assert runner._voice_mode["discord:123"] == "all"
+        await mock_adapter._voice_input_callback(111, 42, "classic fallback")
+        runner._handle_voice_channel_input.assert_awaited_with(
+            111,
+            42,
+            "classic fallback",
+            adapter=mock_adapter,
+        )
+
+    @pytest.mark.asyncio
+    async def test_join_without_classic_fallback_clears_state_when_leave_fails(self, runner):
+        mock_channel = MagicMock()
+        mock_channel.name = "General"
+        mock_adapter = AsyncMock()
+        mock_adapter.get_user_voice_channel = AsyncMock(return_value=mock_channel)
+        mock_adapter.join_voice_channel = AsyncMock(return_value=True)
+        mock_adapter.leave_voice_channel = AsyncMock(
+            side_effect=RuntimeError("Discord disconnect failed")
+        )
+        mock_adapter._voice_text_channels = {}
+        mock_adapter._voice_sources = {}
+        mock_adapter._voice_input_callback = None
+        mock_adapter._voice_pcm_callback = None
+
+        manager = MagicMock()
+        manager.push_discord_pcm.return_value = False
+        manager.start_for_voice_channel = AsyncMock(
+            return_value=SimpleNamespace(
+                enabled=True,
+                active=False,
+                fallback_to_classic=False,
+                reason="not entitled",
+                capabilities=None,
+            )
+        )
+        runner._codex_realtime_voice = manager
+        event = self._make_discord_event(user_id="42")
+        runner.adapters[event.source.platform] = mock_adapter
+
+        result = await runner._handle_voice_channel_join(event)
+
+        assert "fallback is disabled" in result
+        assert "not entitled" in result
+        mock_adapter.leave_voice_channel.assert_awaited_once_with(111)
+        assert runner._voice_mode["discord:123"] == "off"
+        assert mock_adapter._voice_input_callback is None
+        assert mock_adapter._voice_pcm_callback is None
+
+    @pytest.mark.asyncio
     async def test_join_failure(self, runner):
         """Failed join returns permissions error."""
         mock_channel = MagicMock()
@@ -865,12 +1098,16 @@ class TestVoiceChannelCommands:
         mock_channel = MagicMock()
         mock_channel.name = "General"
         mock_adapter = AsyncMock()
+        mock_adapter._voice_input_callback = None
+        mock_adapter._voice_pcm_callback = None
         mock_adapter.join_voice_channel = AsyncMock(side_effect=RuntimeError("No permission"))
         mock_adapter.get_user_voice_channel = AsyncMock(return_value=mock_channel)
         event = self._make_discord_event()
         runner.adapters[event.source.platform] = mock_adapter
         result = await runner._handle_voice_channel_join(event)
         assert "failed" in result.lower()
+        assert mock_adapter._voice_input_callback is None
+        assert mock_adapter._voice_pcm_callback is None
 
     @pytest.mark.asyncio
     async def test_join_missing_voice_dependencies(self, runner):
@@ -926,6 +1163,24 @@ class TestVoiceChannelCommands:
         assert runner._voice_mode["discord:123"] == "off"
         mock_adapter.leave_voice_channel.assert_called_once_with(111)
 
+    @pytest.mark.asyncio
+    async def test_leave_still_disconnects_when_realtime_cleanup_fails(self, runner):
+        mock_adapter = AsyncMock()
+        mock_adapter.is_in_voice_channel = MagicMock(return_value=True)
+        mock_adapter.leave_voice_channel = AsyncMock()
+        manager = MagicMock()
+        manager.stop_for_voice_channel = AsyncMock(
+            side_effect=RuntimeError("provider teardown failed")
+        )
+        runner._codex_realtime_voice = manager
+        event = self._make_discord_event("/voice leave")
+        runner.adapters[event.source.platform] = mock_adapter
+
+        result = await runner._handle_voice_channel_leave(event)
+
+        assert "left" in result.lower()
+        mock_adapter.leave_voice_channel.assert_awaited_once_with(111)
+
     # -- _handle_voice_channel_input --
 
     @pytest.mark.asyncio
@@ -963,6 +1218,33 @@ class TestVoiceChannelCommands:
         assert event.message_type == MessageType.VOICE
         assert event.source.chat_id == "123"
         assert event.source.chat_type == "channel"
+
+    @pytest.mark.asyncio
+    async def test_realtime_transcript_uses_bound_adapter_text_pipeline(self, runner):
+        from gateway.config import Platform
+
+        primary_adapter = AsyncMock()
+        primary_adapter.handle_message = AsyncMock()
+        bound_adapter = AsyncMock()
+        bound_adapter._voice_text_channels = {111: 123}
+        bound_adapter._voice_sources = {}
+        bound_adapter._client = MagicMock()
+        bound_adapter._client.get_channel = MagicMock(return_value=AsyncMock())
+        bound_adapter.handle_message = AsyncMock()
+        runner.adapters[Platform.DISCORD] = primary_adapter
+
+        await runner._handle_voice_channel_input(
+            111,
+            42,
+            "Realtime transcript",
+            realtime=True,
+            adapter=bound_adapter,
+        )
+
+        event = bound_adapter.handle_message.call_args.args[0]
+        assert event.message_type == MessageType.TEXT
+        assert event.raw_message.guild_id == 111
+        primary_adapter.handle_message.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_input_reuses_bound_source_metadata(self, runner):
@@ -1351,22 +1633,35 @@ class TestVoiceReceiverThreadSafety:
             "check_silence must hold self._lock while iterating buffers"
         )
 
-    def test_on_packet_buffer_write_holds_lock(self):
-        """_on_packet must hold lock when writing to buffers."""
-        import ast, inspect, textwrap
-        from plugins.platforms.discord.adapter import VoiceReceiver
-        source = textwrap.dedent(inspect.getsource(VoiceReceiver._on_packet))
-        tree = ast.parse(source)
-        # Find 'with self._lock:' that contains buffer extend
-        found_lock_with_extend = False
-        for node in ast.walk(tree):
-            if isinstance(node, ast.With):
-                src_fragment = ast.dump(node)
-                if "lock" in src_fragment and "extend" in src_fragment:
-                    found_lock_with_extend = True
-        assert found_lock_with_extend, (
-            "_on_packet must hold self._lock when extending buffers"
-        )
+    def test_decoded_pcm_fallback_writes_buffer_under_lock(self):
+        """Decoded PCM fallback must hold the lock while extending buffers."""
+        receiver = self._make_receiver()
+
+        class RecordingLock:
+            def __init__(self):
+                self.depth = 0
+
+            def __enter__(self):
+                self.depth += 1
+                return self
+
+            def __exit__(self, *_args):
+                self.depth -= 1
+
+        lock = RecordingLock()
+
+        class GuardedBuffer(bytearray):
+            def extend(self, data):
+                assert lock.depth > 0, "buffer write happened outside receiver lock"
+                super().extend(data)
+
+        setattr(receiver, "_lock", lock)
+        receiver._ssrc_to_user[100] = 42
+        receiver._buffers[100] = GuardedBuffer()
+
+        receiver.handle_decoded_pcm(100, b"pcm")
+
+        assert receiver._buffers[100] == bytearray(b"pcm")
 
     def test_concurrent_buffer_access_safe(self):
         """Simulate concurrent buffer writes and reads under lock."""
@@ -1963,6 +2258,20 @@ class TestVoiceTimeoutCleansRunnerState:
 
         assert runner._voice_mode["discord:999"] == "off", \
             "voice_mode must persist explicit off state after timeout cleanup"
+
+    @pytest.mark.asyncio
+    async def test_runner_timeout_cleanup_stops_realtime_for_bound_guild(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        adapter = MagicMock()
+        adapter._voice_text_channels = {111: 999}
+        manager = MagicMock()
+        manager.stop_for_voice_channel = AsyncMock()
+        runner._codex_realtime_voice = manager
+
+        runner._handle_voice_timeout_cleanup("999", adapter=adapter)
+        await asyncio.sleep(0)
+
+        manager.stop_for_voice_channel.assert_awaited_once_with(adapter, 111)
 
     @pytest.mark.asyncio
     async def test_timeout_without_callback_does_not_crash(self, adapter):

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -505,7 +505,7 @@ class TestSendVoiceReply:
 
     @pytest.mark.asyncio
     async def test_realtime_speech_failure_stays_silent_when_classic_fallback_is_disabled(
-        self, runner
+        self, runner, caplog
     ):
         from gateway.config import Platform
 
@@ -518,7 +518,12 @@ class TestSendVoiceReply:
         manager = MagicMock()
         manager.is_active.return_value = True
         manager.classic_fallback_enabled.return_value = False
-        manager.append_speech = AsyncMock(side_effect=RuntimeError("speech failed"))
+        manager.append_speech = AsyncMock(
+            side_effect=RuntimeError(
+                "speech failed at https://user:secret@example.test/realtime, "
+                "request id: deadbeef"
+            )
+        )
         runner._codex_realtime_voice = manager
 
         with patch("tools.tts_tool.text_to_speech_tool") as local_tts:
@@ -528,6 +533,8 @@ class TestSendVoiceReply:
             adapter, 111, "Hoi Maikel", transcript_generation=None
         )
         local_tts.assert_not_called()
+        assert "secret" not in caplog.text
+        assert "deadbeef" not in caplog.text
 
     @pytest.mark.asyncio
     async def test_removed_no_fallback_realtime_session_does_not_leak_local_tts(

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -399,6 +399,22 @@ class TestAutoVoiceReply:
         }]
         assert self._call(runner, "all", MessageType.TEXT, agent_messages=messages) is False
 
+    def test_realtime_voice_tts_tool_cannot_suppress_vc_reply(self, runner):
+        """A model-side TTS call must not steal a live VC reply into chat media."""
+        runner._voice_mode["telegram:123"] = "voice_only"
+        event = _make_event(message_type=MessageType.TEXT)
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        messages = [{
+            "role": "assistant",
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "text_to_speech", "arguments": "{}"},
+            }],
+        }]
+
+        assert runner._should_send_voice_reply(event, "Hoi Maikel", messages) is True
+
     def test_no_dedup_for_other_tools(self, runner):
         messages = [{
             "role": "assistant",
@@ -505,6 +521,40 @@ class TestSendVoiceReply:
         adapter.play_in_voice_channel.assert_awaited_once_with(
             111, "/tmp/fallback.mp3"
         )
+
+    @pytest.mark.asyncio
+    async def test_realtime_vc_disconnect_never_falls_back_to_chat_voice_attachment(
+        self, runner
+    ):
+        from agent.transports.codex_realtime_voice import CodexRealtimeUnavailable
+        from gateway.config import Platform
+
+        adapter = MagicMock()
+        adapter._voice_text_channels = {111: 123}
+        adapter.is_in_voice_channel.return_value = False
+        adapter.send_voice = AsyncMock()
+        event = _make_event()
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(
+            guild_id=111,
+            guild=None,
+            codex_realtime_voice=True,
+        )
+        runner.adapters[Platform.DISCORD] = adapter
+        manager = MagicMock()
+        manager.is_active.return_value = True
+        manager.classic_fallback_enabled.return_value = True
+        manager.append_speech = AsyncMock(
+            side_effect=CodexRealtimeUnavailable("voice route disconnected")
+        )
+        runner._codex_realtime_voice = manager
+
+        with patch("tools.tts_tool.text_to_speech_tool") as local_tts:
+            await runner._send_voice_reply(event, "Hoi Maikel")
+
+        manager.append_speech.assert_not_awaited()
+        local_tts.assert_not_called()
+        adapter.send_voice.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_realtime_reply_uses_tts_clean_text_and_drops_stale_generation(
@@ -1385,9 +1435,527 @@ class TestVoiceChannelCommands:
         assert event.message_type == MessageType.TEXT
         assert "connected Discord voice channel" in event.text
         assert "nl-NL" in event.text
+        assert "Return only your final response text" in event.text
+        assert "Do not call text_to_speech" in event.text
         assert event.text.endswith("Realtime transcript")
         assert event.raw_message.guild_id == 111
         primary_adapter.handle_message.assert_not_called()
+
+    def test_realtime_voice_drops_audio_media_but_preserves_other_media(self, runner):
+        """Live VC turns may not become clickable audio attachments in text chat."""
+        from gateway.config import Platform
+
+        event = _make_event(message_type=MessageType.TEXT)
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        adapter = MagicMock()
+        adapter.extract_media.return_value = (
+            [
+                ("/tmp/hermes_voice/reply.ogg", True),
+                ("/tmp/generated/chart.png", False),
+            ],
+            "Hier is mijn antwoord.",
+        )
+
+        cleaned = runner._strip_realtime_voice_audio_media(
+            event,
+            "Hier is mijn antwoord.\nMEDIA:/tmp/hermes_voice/reply.ogg",
+            adapter,
+        )
+
+        assert cleaned == "Hier is mijn antwoord.\nMEDIA:/tmp/generated/chart.png"
+        assert "reply.ogg" not in cleaned
+
+    def test_non_realtime_reply_keeps_audio_media(self, runner):
+        event = _make_event(message_type=MessageType.TEXT)
+        event.raw_message = SimpleNamespace(codex_realtime_voice=False)
+        adapter = MagicMock()
+        response = "Luister hiernaar.\nMEDIA:/tmp/reply.ogg"
+
+        assert runner._strip_realtime_voice_audio_media(event, response, adapter) == response
+        adapter.extract_media.assert_not_called()
+
+    def test_realtime_voice_preserves_non_voice_audio_artifact_without_tts_call(self, runner):
+        """A requested music/audio file is not the forbidden reply voice memo."""
+        event = _make_event(message_type=MessageType.TEXT)
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        adapter = MagicMock()
+        adapter.extract_media.return_value = (
+            [("/tmp/generated/song.mp3", False)],
+            "Je audiobestand staat klaar.",
+        )
+        response = "Je audiobestand staat klaar.\nMEDIA:/tmp/generated/song.mp3"
+
+        assert (
+            runner._strip_realtime_voice_audio_media(
+                event,
+                response,
+                adapter,
+                agent_messages=[],
+            )
+            == response
+        )
+
+    def test_realtime_voice_suppresses_mp3_from_current_tts_turn(self, runner):
+        event = _make_event(message_type=MessageType.TEXT)
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        adapter = MagicMock()
+        response = "Je audiobestand staat klaar.\nMEDIA:/tmp/generated/song.mp3"
+        adapter.extract_media.return_value = (
+            [("/tmp/generated/song.mp3", False)],
+            "Je audiobestand staat klaar.",
+        )
+        adapter.extract_local_files.return_value = ([], response)
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "text_to_speech",
+                            "arguments": {"text": "Hier is je audiobestand."},
+                        },
+                    }
+                ],
+            }
+        ]
+
+        cleaned = runner._strip_realtime_voice_audio_media(
+            event,
+            response,
+            adapter,
+            agent_messages=messages,
+        )
+
+        assert cleaned == "Je audiobestand staat klaar."
+        assert "song.mp3" not in cleaned
+
+    def test_realtime_tts_without_voice_media_does_not_duplicate_other_media(
+        self, runner
+    ):
+        event = _make_event(message_type=MessageType.TEXT)
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        adapter = MagicMock()
+        response = "Hier is de grafiek.\nMEDIA:/tmp/chart.png"
+        adapter.extract_media.return_value = (
+            [("/tmp/chart.png", False)],
+            "Hier is de grafiek.",
+        )
+        adapter.extract_local_files.return_value = ([], response)
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "text_to_speech",
+                            "arguments": {"text": "Hier is de grafiek."},
+                        },
+                    }
+                ],
+            }
+        ]
+
+        cleaned = runner._strip_realtime_voice_audio_media(
+            event,
+            response,
+            adapter,
+            agent_messages=messages,
+        )
+
+        assert cleaned == response
+        assert cleaned.count("MEDIA:/tmp/chart.png") == 1
+
+    def test_realtime_media_only_reply_recovers_tts_text_for_vc(self, runner):
+        event = _make_event(message_type=MessageType.TEXT)
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        adapter = MagicMock()
+        adapter.extract_media.side_effect = [
+            ([("/tmp/hermes_voice/reply.ogg", True)], ""),
+            ([], "Ik praat rechtstreeks in de voicechannel."),
+        ]
+        adapter.extract_local_files.return_value = (
+            [],
+            "Ik praat rechtstreeks in de voicechannel.",
+        )
+        messages = [{
+            "role": "assistant",
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "text_to_speech",
+                    "arguments": '{"text":"Ik praat rechtstreeks in de voicechannel."}',
+                },
+            }],
+        }]
+
+        cleaned = runner._strip_realtime_voice_audio_media(
+            event,
+            "MEDIA:/tmp/hermes_voice/reply.ogg",
+            adapter,
+            agent_messages=messages,
+        )
+
+        assert cleaned == "Ik praat rechtstreeks in de voicechannel."
+
+    def test_realtime_empty_reply_recovers_current_turn_tts_text(self, runner):
+        event = _make_event(message_type=MessageType.TEXT)
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        adapter = MagicMock()
+        adapter.extract_media.side_effect = [
+            ([], ""),
+            ([], "Ik praat rechtstreeks in de voicechannel."),
+        ]
+        adapter.extract_local_files.return_value = (
+            [],
+            "Ik praat rechtstreeks in de voicechannel.",
+        )
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "text_to_speech",
+                            "arguments": {
+                                "text": "Ik praat rechtstreeks in de voicechannel."
+                            },
+                        },
+                    }
+                ],
+            }
+        ]
+
+        cleaned = runner._strip_realtime_voice_audio_media(
+            event,
+            "",
+            adapter,
+            agent_messages=messages,
+        )
+
+        assert cleaned == "Ik praat rechtstreeks in de voicechannel."
+
+    def test_realtime_recovered_tts_text_cannot_reintroduce_media(self, runner):
+        from gateway.config import Platform
+
+        event = _make_event(message_type=MessageType.TEXT)
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        adapter = MagicMock()
+        adapter.extract_media.side_effect = [
+            ([("/tmp/hermes_voice/reply.ogg", True)], ""),
+            ([("/tmp/hermes_voice/reply.ogg", False)], "Ik praat live."),
+        ]
+        adapter.extract_local_files.return_value = ([], "Ik praat live.")
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "text_to_speech",
+                            "arguments": json.dumps(
+                                {
+                                    "text": "Ik praat live. MEDIA:/tmp/hermes_voice/reply.ogg"
+                                }
+                            ),
+                        },
+                    }
+                ],
+            }
+        ]
+
+        cleaned = runner._strip_realtime_voice_audio_media(
+            event,
+            "MEDIA:/tmp/hermes_voice/reply.ogg",
+            adapter,
+            agent_messages=messages,
+        )
+
+        assert cleaned == "Ik praat live."
+        assert "MEDIA:" not in cleaned
+
+    def test_realtime_tts_bare_audio_path_is_not_delivered(self, runner):
+        from gateway.config import Platform
+
+        event = _make_event(message_type=MessageType.TEXT)
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        adapter = MagicMock()
+        response = "Ik praat live. /tmp/hermes_voice/reply.ogg"
+        adapter.extract_media.return_value = ([], response)
+        adapter.extract_local_files.return_value = (
+            ["/tmp/hermes_voice/reply.ogg"],
+            "Ik praat live.",
+        )
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "text_to_speech",
+                            "arguments": {"text": "Ik praat live."},
+                        },
+                    }
+                ],
+            }
+        ]
+
+        cleaned = runner._strip_realtime_voice_audio_media(
+            event,
+            response,
+            adapter,
+            agent_messages=messages,
+        )
+
+        assert cleaned == "Ik praat live."
+
+    def test_realtime_tts_bare_audio_only_returns_failure_text(self, runner):
+        from gateway.config import Platform
+
+        event = _make_event(message_type=MessageType.TEXT)
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        adapter = MagicMock()
+        response = "/tmp/hermes_voice/reply.ogg"
+        adapter.extract_media.return_value = ([], response)
+        adapter.extract_local_files.return_value = (
+            ["/tmp/hermes_voice/reply.ogg"],
+            "",
+        )
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "text_to_speech",
+                            "arguments": {},
+                        },
+                    }
+                ],
+            }
+        ]
+
+        cleaned = runner._strip_realtime_voice_audio_media(
+            event,
+            response,
+            adapter,
+            agent_messages=messages,
+        )
+
+        assert cleaned == "Sorry, I couldn't prepare the spoken reply."
+
+    def test_realtime_recovered_tts_text_cannot_attach_bare_file(self, runner):
+        event = _make_event(message_type=MessageType.TEXT)
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        adapter = MagicMock()
+        adapter.extract_media.side_effect = [
+            ([("/tmp/hermes_voice/reply.ogg", True)], ""),
+            ([], "Ik praat live. /tmp/chart.png"),
+        ]
+        adapter.extract_local_files.side_effect = [
+            (["/tmp/chart.png"], "Ik praat live."),
+            ([], "Ik praat live."),
+        ]
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "text_to_speech",
+                            "arguments": {"text": "Ik praat live. /tmp/chart.png"},
+                        },
+                    }
+                ],
+            }
+        ]
+
+        cleaned = runner._strip_realtime_voice_audio_media(
+            event,
+            "MEDIA:/tmp/hermes_voice/reply.ogg",
+            adapter,
+            agent_messages=messages,
+        )
+
+        assert cleaned == "Ik praat live."
+        assert "/tmp/chart.png" not in cleaned
+
+    def test_realtime_adapter_unavailable_still_strips_voice_media(
+        self, runner, tmp_path
+    ):
+        from gateway.config import Platform
+
+        audio = tmp_path / "reply.ogg"
+        audio.write_bytes(b"not real audio")
+        event = _make_event(message_type=MessageType.TEXT)
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        response = f"[[audio_as_voice]]\nMEDIA:{audio}"
+
+        cleaned = runner._strip_realtime_voice_audio_media(
+            event,
+            response,
+            None,
+            agent_messages=[],
+        )
+
+        assert str(audio) not in cleaned
+        assert cleaned == "Sorry, I couldn't prepare the spoken reply."
+
+    def test_realtime_sanitized_reply_has_no_audio_for_normal_or_stream_delivery(
+        self, runner, tmp_path
+    ):
+        from gateway.config import Platform
+        from gateway.platforms.base import (
+            BasePlatformAdapter,
+            should_send_media_as_audio,
+        )
+
+        audio = tmp_path / "reply.ogg"
+        image = tmp_path / "chart.png"
+        audio.write_bytes(b"not real audio")
+        image.write_bytes(b"not real image")
+        event = _make_event(message_type=MessageType.TEXT)
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        response = (
+            f"Hier is de grafiek.\n[[audio_as_voice]]\nMEDIA:{audio}\nMEDIA:{image}"
+        )
+
+        cleaned = runner._strip_realtime_voice_audio_media(
+            event,
+            response,
+            None,
+            agent_messages=[],
+        )
+
+        explicit_media, visible = BasePlatformAdapter.extract_media(cleaned)
+        bare_media, _visible = BasePlatformAdapter.extract_local_files(visible)
+        delivered_paths = [path for path, _is_voice in explicit_media] + bare_media
+        assert str(audio) not in delivered_paths
+        assert str(image) in delivered_paths
+        assert not any(
+            should_send_media_as_audio(
+                Platform.DISCORD,
+                os.path.splitext(path)[1],
+                is_voice=is_voice,
+            )
+            for path, is_voice in explicit_media
+        )
+
+    def test_realtime_parser_failure_strips_inline_media_directive(self, runner):
+        event = _make_event(message_type=MessageType.TEXT)
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        adapter = MagicMock()
+        adapter.extract_media.side_effect = RuntimeError("parser failed")
+        response = "Ik praat live. MEDIA:/tmp/hermes_voice/reply.ogg"
+
+        cleaned = runner._strip_realtime_voice_audio_media(event, response, adapter)
+
+        assert "MEDIA:" not in cleaned
+        assert "Ik praat live." in cleaned
+
+    def test_realtime_parser_failure_still_strips_bare_tts_audio(
+        self, runner, tmp_path
+    ):
+        from gateway.config import Platform
+
+        audio = tmp_path / "reply.ogg"
+        audio.write_bytes(b"not real audio")
+        event = _make_event(message_type=MessageType.TEXT)
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        adapter = MagicMock()
+        adapter.extract_media.side_effect = RuntimeError("parser failed")
+        response = f"Ik praat live. {audio}"
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "text_to_speech",
+                            "arguments": {"text": "Ik praat live."},
+                        },
+                    }
+                ],
+            }
+        ]
+
+        cleaned = runner._strip_realtime_voice_audio_media(
+            event,
+            response,
+            adapter,
+            agent_messages=messages,
+        )
+
+        assert str(audio) not in cleaned
+        assert cleaned == "Ik praat live."
+
+    def test_realtime_preserved_document_keeps_as_document_marker(self, runner):
+        event = _make_event(message_type=MessageType.TEXT)
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        adapter = MagicMock()
+        adapter.extract_media.return_value = (
+            [
+                ("/tmp/hermes_voice/reply.ogg", True),
+                ("/tmp/chart.png", False),
+            ],
+            "Hier is de grafiek.",
+        )
+        response = (
+            "Hier is de grafiek.\n[[as_document]]\n"
+            "MEDIA:/tmp/hermes_voice/reply.ogg\nMEDIA:/tmp/chart.png"
+        )
+
+        cleaned = runner._strip_realtime_voice_audio_media(event, response, adapter)
+
+        assert "[[as_document]]" in cleaned
+        assert "MEDIA:/tmp/chart.png" in cleaned
+        assert "reply.ogg" not in cleaned
+
+    def test_realtime_media_only_reply_never_reuses_stale_tts_text(self, runner):
+        event = _make_event(message_type=MessageType.TEXT)
+        event.raw_message = SimpleNamespace(codex_realtime_voice=True)
+        adapter = MagicMock()
+        adapter.extract_media.return_value = (
+            [("/tmp/hermes_voice/reply.ogg", True)],
+            "",
+        )
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [{
+                    "function": {
+                        "name": "text_to_speech",
+                        "arguments": '{"text":"Oude zin van een vorige beurt."}',
+                    },
+                }],
+            },
+            {"role": "user", "content": "Nieuwe gesproken beurt"},
+            {"role": "assistant", "content": ""},
+        ]
+
+        cleaned = runner._strip_realtime_voice_audio_media(
+            event,
+            "MEDIA:/tmp/hermes_voice/reply.ogg",
+            adapter,
+            agent_messages=messages,
+        )
+
+        assert cleaned == "Sorry, I couldn't prepare the spoken reply."
 
     @pytest.mark.asyncio
     async def test_input_reuses_bound_source_metadata(self, runner):

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -464,7 +464,43 @@ class TestSendVoiceReply:
         with patch("tools.tts_tool.text_to_speech_tool") as local_tts:
             await runner._send_voice_reply(event, "Hoi Maikel")
 
-        manager.append_speech.assert_awaited_once_with(adapter, 111, "Hoi Maikel")
+        manager.append_speech.assert_awaited_once_with(
+            adapter, 111, "Hoi Maikel", transcript_generation=None
+        )
+        local_tts.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_realtime_reply_uses_tts_clean_text_and_drops_stale_generation(
+        self, runner
+    ):
+        from agent.transports.codex_realtime_voice import CodexRealtimeStaleSpeech
+        from gateway.config import Platform
+
+        adapter = MagicMock()
+        adapter._voice_text_channels = {111: 123}
+        event = _make_event()
+        event.source.platform = Platform.DISCORD
+        event.raw_message = SimpleNamespace(
+            guild_id=111,
+            guild=None,
+            codex_realtime_voice=True,
+            codex_realtime_generation=7,
+        )
+        runner.adapters[Platform.DISCORD] = adapter
+        manager = MagicMock()
+        manager.is_active.return_value = True
+        manager.classic_fallback_enabled.return_value = True
+        manager.append_speech = AsyncMock(side_effect=CodexRealtimeStaleSpeech())
+        runner._codex_realtime_voice = manager
+
+        with patch(
+            "tools.tts_tool._strip_markdown_for_tts", return_value="Hoi Maikel"
+        ), patch("tools.tts_tool.text_to_speech_tool") as local_tts:
+            await runner._send_voice_reply(event, "**Hoi** [Maikel](https://example.com)")
+
+        manager.append_speech.assert_awaited_once_with(
+            adapter, 111, "Hoi Maikel", transcript_generation=7
+        )
         local_tts.assert_not_called()
 
     @pytest.mark.asyncio
@@ -488,7 +524,9 @@ class TestSendVoiceReply:
         with patch("tools.tts_tool.text_to_speech_tool") as local_tts:
             await runner._send_voice_reply(event, "Hoi Maikel")
 
-        manager.append_speech.assert_awaited_once_with(adapter, 111, "Hoi Maikel")
+        manager.append_speech.assert_awaited_once_with(
+            adapter, 111, "Hoi Maikel", transcript_generation=None
+        )
         local_tts.assert_not_called()
 
     @pytest.mark.asyncio
@@ -998,6 +1036,7 @@ class TestVoiceChannelCommands:
         mock_adapter._voice_pcm_callback = None
 
         manager = MagicMock()
+        manager.prepare_for_voice_channel.return_value = True
         manager.push_discord_pcm.return_value = True
         manager.start_for_voice_channel = AsyncMock(
             return_value=SimpleNamespace(
@@ -1012,6 +1051,9 @@ class TestVoiceChannelCommands:
         runner._handle_voice_channel_input = AsyncMock()
 
         async def _join(_channel):
+            manager.prepare_for_voice_channel.assert_called_once_with(
+                mock_adapter, 111
+            )
             assert callable(mock_adapter._voice_pcm_callback)
             assert mock_adapter._voice_pcm_callback(111, 42, b"pcm") is True
             return True
@@ -1024,11 +1066,21 @@ class TestVoiceChannelCommands:
 
         assert "codex live" in result.lower()
         manager.start_for_voice_channel.assert_awaited_once()
+        manager.cancel_voice_channel_start.assert_called_once_with(mock_adapter, 111)
         kwargs = manager.start_for_voice_channel.await_args.kwargs
         assert kwargs["adapter"] is mock_adapter
         assert kwargs["guild_id"] == 111
         assert kwargs["user_id"] == 42
         assert callable(kwargs["on_transcript"])
+        await kwargs["on_transcript"](42, "realtime transcript", 8)
+        runner._handle_voice_channel_input.assert_any_await(
+            111,
+            42,
+            "realtime transcript",
+            realtime=True,
+            realtime_generation=8,
+            adapter=mock_adapter,
+        )
         assert callable(kwargs["on_runtime_failure"])
         await kwargs["on_runtime_failure"]("temporary failure", True)
         assert runner._voice_mode["discord:123"] == "all"

--- a/tests/integration/test_voice_channel_flow.py
+++ b/tests/integration/test_voice_channel_flow.py
@@ -254,6 +254,54 @@ class TestRealNaClWithDAVE:
 
         assert len(receiver._buffers.get(100, b"")) == 0
 
+    def test_dave_session_initialized_after_receiver_start_is_used(self, monkeypatch):
+        """A DAVE session negotiated after voice connect decrypts later packets."""
+        monkeypatch.setattr(
+            discord.opus,
+            "Decoder",
+            lambda: SimpleNamespace(decode=lambda _payload: b"\x00" * 3840),
+        )
+        key = _make_secret_key()
+        receiver = _make_voice_receiver(key, dave_session=None)
+        receiver.map_ssrc(100, 42)
+
+        dave = MagicMock()
+        dave.ready = True
+        dave.decrypt.return_value = b"\xf8\xff\xfe"
+        receiver._vc._connection.dave_session = dave
+
+        packet = _build_encrypted_rtp_packet(key, b"\xf8\xff\xfe", ssrc=100)
+        receiver._on_packet(packet)
+
+        dave.decrypt.assert_called_once()
+        assert 100 in receiver._buffers
+        assert len(receiver._buffers[100]) > 0
+
+    def test_dave_session_transition_uses_current_connection_session(self, monkeypatch):
+        """A DAVE epoch transition must not keep using the startup session."""
+        monkeypatch.setattr(
+            discord.opus,
+            "Decoder",
+            lambda: SimpleNamespace(decode=lambda _payload: b"\x00" * 3840),
+        )
+        key = _make_secret_key()
+        old_dave = MagicMock()
+        old_dave.ready = True
+        receiver = _make_voice_receiver(key, dave_session=old_dave)
+        receiver.map_ssrc(100, 42)
+
+        new_dave = MagicMock()
+        new_dave.ready = True
+        new_dave.decrypt.return_value = b"\xf8\xff\xfe"
+        receiver._vc._connection.dave_session = new_dave
+
+        packet = _build_encrypted_rtp_packet(key, b"\xf8\xff\xfe", ssrc=100)
+        receiver._on_packet(packet)
+
+        old_dave.decrypt.assert_not_called()
+        new_dave.decrypt.assert_called_once()
+        assert len(receiver._buffers[100]) > 0
+
 
 class TestRTPPaddingStrip:
     """RFC 3550 §5.1 — strip RTP padding before DAVE/Opus decode."""

--- a/tests/integration/test_voice_channel_flow.py
+++ b/tests/integration/test_voice_channel_flow.py
@@ -154,6 +154,27 @@ class TestRealNaClDecrypt:
         assert 100 in receiver._buffers
         assert len(receiver._buffers[100]) > 0
 
+    def test_transport_key_rotation_uses_current_connection_key(self):
+        """A later Discord session description must replace the startup key."""
+        startup_key = _make_secret_key()
+        rotated_key = _make_secret_key()
+        receiver = _make_voice_receiver(startup_key)
+        receiver._vc._connection.secret_key = list(rotated_key)
+
+        packet = _build_padded_rtp_packet(
+            rotated_key,
+            b"\xf8\xff\xfe",
+            pad_len=4,
+            ext_words=1,
+            ssrc=100,
+        )
+        assert len(packet[:16]) == 16
+        assert len(packet[16:-4]) == 27
+        receiver._on_packet(packet)
+
+        assert 100 in receiver._buffers
+        assert len(receiver._buffers[100]) > 0
+
     def test_wrong_key_packet_dropped(self):
         """Packet encrypted with wrong key → NaCl fails → not buffered."""
         real_key = _make_secret_key()

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -63,6 +63,7 @@ def test_lazy_installable_extras_excluded_from_all():
         "fal",
         "edge-tts", "tts-premium",
         "voice",  # faster-whisper / sounddevice / numpy
+        "codex-realtime-voice",  # aiortc / numpy
         "modal", "daytona",
         "messaging", "slack", "matrix", "dingtalk", "feishu",
         "honcho", "hindsight",

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -136,6 +136,12 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "sounddevice==0.5.5",
         "numpy==2.4.3",
     ),
+    # OAuth-compatible Codex GPT-Live uses a local WebRTC peer. This is
+    # intentionally opt-in because aiortc/PyAV are not needed by classic STT/TTS.
+    "voice.codex_realtime": (
+        "aiortc==1.15.0",
+        "numpy==2.4.3",
+    ),
 
     # ─── Image generation backends ─────────────────────────────────────────
     "image.fal": ("fal-client==0.13.1",),

--- a/uv.lock
+++ b/uv.lock
@@ -140,6 +140,37 @@ wheels = [
 ]
 
 [[package]]
+name = "aioice"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "ifaddr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/04/df7286233f468e19e9bedff023b6b246182f0b2ccb04ceeb69b2994021c6/aioice-0.10.2.tar.gz", hash = "sha256:bf236c6829ee33c8e540535d31cd5a066b531cb56de2be94c46be76d68b1a806", size = 44307, upload-time = "2025-11-28T15:56:48.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/e3/0d23b1f930c17d371ce1ec36ee529f22fd19ebc2a07fe3418e3d1d884ce2/aioice-0.10.2-py3-none-any.whl", hash = "sha256:14911c15ab12d096dd14d372ebb4aecbb7420b52c9b76fdfcf54375dec17fcbf", size = 24875, upload-time = "2025-11-28T15:56:47.847Z" },
+]
+
+[[package]]
+name = "aiortc"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aioice" },
+    { name = "av" },
+    { name = "cryptography" },
+    { name = "google-crc32c" },
+    { name = "pyee" },
+    { name = "pylibsrtp" },
+    { name = "pyopenssl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/42/af1e5755f4cdeb5926ef4aee4bd99d2fbc04b497dfe09f036d359219993e/aiortc-1.15.0.tar.gz", hash = "sha256:ee6c0757ca070cf6d6bee441936d6ede24eef51211bbff6653409c540f72e625", size = 1182039, upload-time = "2026-07-13T19:26:43.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/5f/8435ba02c9278b6cec6f168db92e1d3280dd3af8f2225e20dc7c3be5ab22/aiortc-1.15.0-py3-none-any.whl", hash = "sha256:4e1e54bff31a9c2cb654c7b7edc068085a7df53365e5df24a5cb24168e3f95f7", size = 93678, upload-time = "2026-07-13T19:26:42.241Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1069,6 +1100,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1397,6 +1437,31 @@ wheels = [
 ]
 
 [[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872, upload-time = "2025-12-16T00:33:58.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243, upload-time = "2025-12-16T00:40:21.46Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/4820b3bd99c9653d1a5210cb32f9ba4da9681619b4d35b6a052432df4773/google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a", size = 33608, upload-time = "2025-12-16T00:40:22.204Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/acf61476a11437bf9733fb2f70599b1ced11ec7ed9ea760fdd9a77d0c619/google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2", size = 34439, upload-time = "2025-12-16T00:35:20.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.73.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1584,6 +1649,10 @@ bedrock = [
 cli = [
     { name = "simple-term-menu" },
 ]
+codex-realtime-voice = [
+    { name = "aiortc" },
+    { name = "numpy" },
+]
 computer-use = [
     { name = "mcp" },
     { name = "starlette" },
@@ -1743,6 +1812,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'sms'", specifier = "==3.14.1" },
     { name = "aiohttp", marker = "extra == 'teams'", specifier = "==3.14.1" },
     { name = "aiohttp-socks", marker = "extra == 'matrix'", specifier = "==0.11.0" },
+    { name = "aiortc", marker = "extra == 'codex-realtime-voice'", specifier = "==1.15.0" },
     { name = "aiosqlite", marker = "extra == 'matrix'", specifier = "==0.22.1" },
     { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = "==2.2.42" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = "==0.87.0" },
@@ -1808,6 +1878,7 @@ requires-dist = [
     { name = "mistralai", marker = "extra == 'mistral'", specifier = "==2.4.8" },
     { name = "modal", marker = "extra == 'modal'", specifier = "==1.3.4" },
     { name = "nemo-relay", marker = "extra == 'nemo-relay'", specifier = ">=0.5,<1.0" },
+    { name = "numpy", marker = "extra == 'codex-realtime-voice'", specifier = "==2.4.3" },
     { name = "numpy", marker = "extra == 'voice'", specifier = "==2.4.3" },
     { name = "openai", specifier = "==2.24.0" },
     { name = "packaging", specifier = "==26.0" },
@@ -1857,7 +1928,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "codex-realtime-voice", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -2037,6 +2108,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+]
+
+[[package]]
+name = "ifaddr"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/fb4c578f4a3256561548cd825646680edcadb9440f3f68add95ade1eb791/ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4", size = 10485, upload-time = "2022-06-15T21:40:27.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/1f/19ebc343cc71a7ffa78f17018535adc5cbdd87afb31d7c34874680148b32/ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748", size = 12314, upload-time = "2022-06-15T21:40:25.756Z" },
 ]
 
 [[package]]
@@ -3345,6 +3425,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3368,6 +3460,28 @@ crypto = [
 ]
 
 [[package]]
+name = "pylibsrtp"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/a6/6e532bec974aaecbf9fe4e12538489fb1c28456e65088a50f305aeab9f89/pylibsrtp-1.0.0.tar.gz", hash = "sha256:b39dff075b263a8ded5377f2490c60d2af452c9f06c4d061c7a2b640612b34d4", size = 10858, upload-time = "2025-10-13T16:12:31.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/af/89e61a62fa3567f1b7883feb4d19e19564066c2fcd41c37e08d317b51881/pylibsrtp-1.0.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:822c30ea9e759b333dc1f56ceac778707c51546e97eb874de98d7d378c000122", size = 1865017, upload-time = "2025-10-13T16:12:15.62Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0e/8d215484a9877adcf2459a8b28165fc89668b034565277fd55d666edd247/pylibsrtp-1.0.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:aaad74e5c8cbc1c32056c3767fea494c1e62b3aea2c908eda2a1051389fdad76", size = 2182739, upload-time = "2025-10-13T16:12:17.121Z" },
+    { url = "https://files.pythonhosted.org/packages/57/3f/76a841978877ae13eac0d4af412c13bbd5d83b3df2c1f5f2175f2e0f68e5/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9209b86e662ebbd17c8a9e8549ba57eca92a3e87fb5ba8c0e27b8c43cd08a767", size = 2732922, upload-time = "2025-10-13T16:12:18.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/14/cf5d2a98a66fdfe258f6b036cda570f704a644fa861d7883a34bc359501e/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:293c9f2ac21a2bd689c477603a1aa235d85cf252160e6715f0101e42a43cbedc", size = 2434534, upload-time = "2025-10-13T16:12:20.074Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/08/a3f6e86c04562f7dce6717cd2206a0f84ca85c5e38121d998e0e330194c3/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_28_i686.whl", hash = "sha256:81fb8879c2e522021a7cbd3f4bda1b37c192e1af939dfda3ff95b4723b329663", size = 2345818, upload-time = "2025-10-13T16:12:21.439Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d5/130c2b5b4b51df5631684069c6f0a6761c59d096a33d21503ac207cf0e47/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4ddb562e443cf2e557ea2dfaeef0d7e6b90e96dd38eb079b4ab2c8e34a79f50b", size = 2774490, upload-time = "2025-10-13T16:12:22.659Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e3/715a453bfee3bea92a243888ad359094a7727cc6d393f21281320fe7798c/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:f02e616c9dfab2b03b32d8cc7b748f9d91814c0211086f987629a60f05f6e2cc", size = 2372603, upload-time = "2025-10-13T16:12:24.036Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/56/52fa74294254e1f53a4ff170ee2006e57886cf4bb3db46a02b4f09e1d99f/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c134fa09e7b80a5b7fed626230c5bc257fd771bd6978e754343e7a61d96bc7e6", size = 2451269, upload-time = "2025-10-13T16:12:25.475Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/51/2e9b34f484cbdd3bac999bf1f48b696d7389433e900639089e8fc4e0da0d/pylibsrtp-1.0.0-cp310-abi3-win32.whl", hash = "sha256:bae377c3b402b17b9bbfbfe2534c2edba17aa13bea4c64ce440caacbe0858b55", size = 1247503, upload-time = "2025-10-13T16:12:27.39Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/70/43db21af194580aba2d9a6d4c7bd8c1a6e887fa52cd810b88f89096ecad2/pylibsrtp-1.0.0-cp310-abi3-win_amd64.whl", hash = "sha256:8d6527c4a78a39a8d397f8862a8b7cdad4701ee866faf9de4ab8c70be61fd34d", size = 1601659, upload-time = "2025-10-13T16:12:29.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ec/6e02b2561d056ea5b33046e3cad21238e6a9097b97d6ccc0fbe52b50c858/pylibsrtp-1.0.0-cp310-abi3-win_arm64.whl", hash = "sha256:2696bdb2180d53ac55d0eb7b58048a2aa30cd4836dd2ca683669889137a94d2a", size = 1159246, upload-time = "2025-10-13T16:12:30.285Z" },
+]
+
+[[package]]
 name = "pynacl"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3385,6 +3499,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/1a/cc308a884bd299b651f1633acb978e8596c71c33ca85e9dc9fa33a5399b9/PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff", size = 1117912, upload-time = "2022-01-07T22:05:58.665Z" },
     { url = "https://files.pythonhosted.org/packages/25/2d/b7df6ddb0c2a33afdb358f8af6ea3b8c4d1196ca45497dd37a56f0c122be/PyNaCl-1.5.0-cp36-abi3-win32.whl", hash = "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543", size = 204624, upload-time = "2022-01-07T22:06:00.085Z" },
     { url = "https://files.pythonhosted.org/packages/5e/22/d3db169895faaf3e2eda892f005f433a62db2decbcfbc2f61e6517adfa87/PyNaCl-1.5.0-cp36-abi3-win_amd64.whl", hash = "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93", size = 212141, upload-time = "2022-01-07T22:06:01.861Z" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "26.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
 ]
 
 [[package]]

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -399,6 +399,7 @@ discord:
     enabled: true
     user_id: "123456789012345678"
     voice: ""                    # empty = selected protocol's default
+    spoken_language: ""          # e.g. nl-NL; empty preserves spoken language
     protocol_version: "v3"       # WebRTC supports v1 or v3
     fallback_to_classic: true
     codex_bin: "codex"
@@ -412,10 +413,12 @@ Requirements and limits:
 - account entitlement to Codex realtime voice; availability is checked when `/voice join` starts
 - WebRTC protocol `v3` by default; `v1` remains available as an explicit compatibility option, while `v2` does not support this WebRTC route
 - supported voices are queried from Codex at runtime; V3 preserves the V1 Codex Voice family
+- `spoken_language` optionally pins Hermes' reply and synthesized speech to a language such as `nl-NL`; input transcription still preserves the language the user spoke
+- `spoken_language` is a prompt preference, because Codex app-server does not expose a native language/locale field for this route
 - each voice session uses an ephemeral Codex app-server thread rather than a persisted Codex conversation
 - decoded Discord audio and Hermes' synthesized reply text are sent to Codex/OpenAI for the duration of the session; do not enable this route in channels where that external processing is inappropriate
 - while realtime is active, PCM from other VC users is ignored rather than routed through a parallel classic-STT path
-- no realtime reasoning-effort control, language selector, or guaranteed language-auto-detection contract
+- no realtime reasoning-effort control or native provider language/locale selector; automatic language detection is not a contractual guarantee
 - no extra OpenAI API key is required for the WebRTC route when the Codex account is entitled
 
 If dependency loading, Codex capability checks, account entitlement, SDP negotiation, or the realtime transport fails, `fallback_to_classic: true` keeps the existing Whisper/STT → Hermes → TTS path active. The join response states which path is active.

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -411,6 +411,7 @@ Requirements and limits:
 - account entitlement to Codex realtime voice; availability is checked when `/voice join` starts
 - WebRTC protocol `v1`; supported voices are queried from Codex at runtime
 - each voice session uses an ephemeral Codex app-server thread rather than a persisted Codex conversation
+- decoded Discord audio and Hermes' synthesized reply text are sent to Codex/OpenAI for the duration of the session; do not enable this route in channels where that external processing is inappropriate
 - while realtime is active, PCM from other VC users is ignored rather than routed through a parallel classic-STT path
 - no realtime reasoning-effort control, language selector, or guaranteed language-auto-detection contract
 - no extra OpenAI API key is required for the WebRTC route when the Codex account is entitled

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -387,6 +387,40 @@ In a Discord text channel where the bot is present:
 - use a dedicated bot/testing channel at first
 - verify STT and TTS work in ordinary text-chat voice mode before trying VC mode
 
+### Experimental Codex GPT-Live speech interface
+
+Hermes can optionally replace the completed-utterance STT/TTS edges of a Discord VC session with a low-latency Codex realtime WebRTC connection. Hermes still owns the conversation, tools, memory, and approvals: user transcripts enter the normal Hermes pipeline, and only Hermes' final response is sent back to Codex with `thread/realtime/appendSpeech` for speech synthesis. Codex startup context is excluded and the realtime session receives a speech-interface-only prompt. Unsolicited model audio is additionally dropped as a defense-in-depth boundary.
+
+This route is disabled by default and currently supports one explicitly bound Discord user per VC session:
+
+```yaml
+discord:
+  codex_realtime_voice:
+    enabled: true
+    user_id: "123456789012345678"
+    voice: ""                    # empty = Codex v1 default
+    fallback_to_classic: true
+    codex_bin: "codex"
+    codex_home: ""               # optional isolated CODEX_HOME
+```
+
+Requirements and limits:
+
+- Codex CLI `0.145.0` or newer, authenticated in its own `CODEX_HOME`
+- the optional `codex-realtime-voice` dependencies; Hermes installs them lazily when allowed, or install `hermes-agent[codex-realtime-voice]` yourself
+- account entitlement to Codex realtime voice; availability is checked when `/voice join` starts
+- WebRTC protocol `v1`; supported voices are queried from Codex at runtime
+- each voice session uses an ephemeral Codex app-server thread rather than a persisted Codex conversation
+- while realtime is active, PCM from other VC users is ignored rather than routed through a parallel classic-STT path
+- no realtime reasoning-effort control, language selector, or guaranteed language-auto-detection contract
+- no extra OpenAI API key is required for the WebRTC route when the Codex account is entitled
+
+If dependency loading, Codex capability checks, account entitlement, SDP negotiation, or the realtime transport fails, `fallback_to_classic: true` keeps the existing Whisper/STT → Hermes → TTS path active. The join response states which path is active.
+
+:::warning Experimental availability
+Codex may return `Voice session access denied` for an otherwise valid ChatGPT/Codex login. That is an account/backend entitlement result, not a Discord configuration error. Classic voice continues when fallback is enabled.
+:::
+
 ## Voice quality recommendations
 
 ### Best quality setup

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -398,7 +398,8 @@ discord:
   codex_realtime_voice:
     enabled: true
     user_id: "123456789012345678"
-    voice: ""                    # empty = Codex v1 default
+    voice: ""                    # empty = selected protocol's default
+    protocol_version: "v3"       # WebRTC supports v1 or v3
     fallback_to_classic: true
     codex_bin: "codex"
     codex_home: ""               # optional isolated CODEX_HOME
@@ -409,7 +410,8 @@ Requirements and limits:
 - Codex CLI `0.145.0` or newer, authenticated in its own `CODEX_HOME`
 - the optional `codex-realtime-voice` dependencies; Hermes installs them lazily when allowed, or install `hermes-agent[codex-realtime-voice]` yourself
 - account entitlement to Codex realtime voice; availability is checked when `/voice join` starts
-- WebRTC protocol `v1`; supported voices are queried from Codex at runtime
+- WebRTC protocol `v3` by default; `v1` remains available as an explicit compatibility option, while `v2` does not support this WebRTC route
+- supported voices are queried from Codex at runtime; V3 preserves the V1 Codex Voice family
 - each voice session uses an ephemeral Codex app-server thread rather than a persisted Codex conversation
 - decoded Discord audio and Hermes' synthesized reply text are sent to Codex/OpenAI for the duration of the session; do not enable this route in channels where that external processing is inappropriate
 - while realtime is active, PCM from other VC users is ignored rather than routed through a parallel classic-STT path

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -388,6 +388,36 @@ Only users listed in `DISCORD_ALLOWED_USERS` can interact via voice. Other users
 DISCORD_ALLOWED_USERS=284102345871466496
 ```
 
+### Experimental Codex realtime WebRTC
+
+The opt-in `discord.codex_realtime_voice` route streams one configured user's Discord PCM over WebRTC to Codex GPT-Live. It uses Codex for transcription and speaking only; Hermes remains the assistant and retains the normal session, memory, tool, and approval pipeline. Codex startup context is excluded and the realtime session receives a speech-interface-only prompt. Remote audio is additionally blocked until Hermes explicitly submits response text with `appendSpeech`.
+
+```yaml
+discord:
+  codex_realtime_voice:
+    enabled: true
+    user_id: "284102345871466496"  # exactly one bound Discord user
+    voice: ""                      # empty uses Codex's v1 default
+    fallback_to_classic: true
+    codex_bin: "codex"
+    codex_home: ""                 # optional isolated Codex config/auth home
+```
+
+The route requires Codex CLI `0.145.0` or newer plus its own Codex login. The standard Hermes `openai-codex` provider authentication does not replace that CLI login. Install the optional dependency extra manually with `hermes-agent[codex-realtime-voice]`, or allow Hermes' normal lazy dependency installation.
+
+Capability boundaries are explicit:
+
+- WebRTC realtime protocol `v1`
+- supported voice names are discovered at startup
+- Codex app-server thread state is ephemeral for each voice session
+- while the route is active, audio from users other than the configured `user_id` is ignored
+- realtime reasoning effort is not configurable
+- language/locale selection is not exposed
+- automatic language detection is not a contractual guarantee
+- account entitlement is checked at session start and can be denied independently of a valid login
+
+With `fallback_to_classic: true`, any missing dependency, unsupported Codex version, entitlement error, SDP failure, or transport close leaves classic STT/TTS voice available. `/voice join` reports whether Codex Live or classic voice is active.
+
 ---
 
 ## Configuration Reference

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -398,6 +398,7 @@ discord:
     enabled: true
     user_id: "284102345871466496"  # exactly one bound Discord user
     voice: ""                      # empty uses the selected protocol's default
+    spoken_language: ""            # e.g. nl-NL; empty preserves spoken language
     protocol_version: "v3"         # WebRTC supports v1 or v3
     fallback_to_classic: true
     codex_bin: "codex"
@@ -411,11 +412,12 @@ Capability boundaries are explicit:
 - WebRTC realtime protocol `v3` by default; `v1` is an explicit compatibility option and `v2` is rejected for WebRTC
 - V3 preserves the V1 Codex Voice behavior and voice family
 - supported voice names are discovered at startup
+- `spoken_language` can pin Hermes' reply and synthesized speech to a language such as `nl-NL`; input transcription still preserves the language the user spoke
 - Codex app-server thread state is ephemeral for each voice session
 - decoded Discord audio and Hermes' synthesized reply text are sent to Codex/OpenAI for the session, so only enable the route where that external processing is appropriate
 - while the route is active, audio from users other than the configured `user_id` is ignored
 - realtime reasoning effort is not configurable
-- language/locale selection is not exposed
+- no native Codex language/locale protocol field is exposed; `spoken_language` is an explicit speech-interface prompt preference instead
 - automatic language detection is not a contractual guarantee
 - account entitlement is checked at session start and can be denied independently of a valid login
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -397,7 +397,8 @@ discord:
   codex_realtime_voice:
     enabled: true
     user_id: "284102345871466496"  # exactly one bound Discord user
-    voice: ""                      # empty uses Codex's v1 default
+    voice: ""                      # empty uses the selected protocol's default
+    protocol_version: "v3"         # WebRTC supports v1 or v3
     fallback_to_classic: true
     codex_bin: "codex"
     codex_home: ""                 # optional isolated Codex config/auth home
@@ -407,7 +408,8 @@ The route requires Codex CLI `0.145.0` or newer plus its own Codex login. The st
 
 Capability boundaries are explicit:
 
-- WebRTC realtime protocol `v1`
+- WebRTC realtime protocol `v3` by default; `v1` is an explicit compatibility option and `v2` is rejected for WebRTC
+- V3 preserves the V1 Codex Voice behavior and voice family
 - supported voice names are discovered at startup
 - Codex app-server thread state is ephemeral for each voice session
 - decoded Discord audio and Hermes' synthesized reply text are sent to Codex/OpenAI for the session, so only enable the route where that external processing is appropriate

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -410,6 +410,7 @@ Capability boundaries are explicit:
 - WebRTC realtime protocol `v1`
 - supported voice names are discovered at startup
 - Codex app-server thread state is ephemeral for each voice session
+- decoded Discord audio and Hermes' synthesized reply text are sent to Codex/OpenAI for the session, so only enable the route where that external processing is appropriate
 - while the route is active, audio from users other than the configured `user_id` is ignored
 - realtime reasoning effort is not configurable
 - language/locale selection is not exposed


### PR DESCRIPTION
## What does this PR do?

Adds an experimental, disabled-by-default Codex realtime speech route for Discord voice channels.

Hermes stays in charge of the conversation, memory, tools, approvals, and final response. Codex app-server is limited to the speech edges:

1. Discord PCM enters an ephemeral Codex WebRTC session for transcription.
2. The finalized transcript goes through the normal Hermes message pipeline.
3. Hermes sends its final text through `thread/realtime/appendSpeech`.
4. The negotiated WebRTC audio track streams into Discord's existing `VoiceMixer`.

Classic Discord STT/TTS remains the default fallback.

## Related work

Related to #21504 and #27650, which contain useful realtime voice and lifecycle work on older Discord paths. Those PRs connect directly to the OpenAI Realtime API and give the provider ownership of assistant turns. This PR uses Codex app-server/WebRTC on the current Discord adapter and keeps Hermes as the agent.

Discord join-on-presence remains separate in #71191. This PR uses the existing `/voice join` lifecycle.

## Type of change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes made

- Added a Codex app-server/WebRTC transport for 24 kHz mono input and 48 kHz stereo Discord output.
- Added per-adapter/guild session ownership, capability checks, fallback, and bounded teardown.
- Added decoded-PCM interception so realtime and classic STT cannot process the same utterance in parallel.
- Added incremental named streams to the existing Discord mixer.
- Added acknowledgement-gated output and transcript generations so Codex cannot play pre-acceptance, unsolicited, or stale speech.
- Requires accepted, audible PCM before realtime speech is treated as started; silent or rejected output hands control back to classic fallback.
- Verifies the concrete Discord sender is actively draining the exact mixer before speech, and repairs/rejects stale mixer ownership after reconnects.
- Keeps marked realtime replies inside the connected VC: generic `text_to_speech` reply audio is stripped before normal/post-stream media delivery, while separately requested non-audio artifacts remain available.
- Added lazy optional dependencies through `.[codex-realtime-voice]`.
- Added configurable backend voice, WebRTC protocol, isolated `CODEX_HOME`, fallback policy, and a prompt-level `spoken_language` hint.
- Made `VoiceMixer` a valid `discord.AudioSource`.
- Made inbound Discord media follow the connection's current DAVE session and current transport secret instead of startup snapshots. Discord can rotate both after the receiver starts.
- Honored `stt.echo_transcripts: false` without suppressing the actual voice turn.

### Configuration

```yaml
discord:
  codex_realtime_voice:
    enabled: false
    user_id: "123456789012345678"
    voice: ""
    spoken_language: ""     # optional hint, for example nl-NL
    protocol_version: "v3" # v1 is available as a compatibility option
    fallback_to_classic: true
    codex_bin: "codex"
    codex_home: ""
```

The route is intentionally single-user. Other speakers' PCM is consumed while it is active so a second classic-STT conversation cannot start in parallel.

`spoken_language` guides Hermes's reply and speech synthesis, but it is not presented as a native Codex locale field. The app-server protocol does not currently expose one. Input transcription still preserves the language actually spoken and tells the speech edge not to translate it.

## How to test

1. Install or lazily resolve `.[codex-realtime-voice]` and use Codex CLI 0.145.0 or newer.
2. Log Codex in, configure one Discord user, and keep `fallback_to_classic: true` for the first run.
3. Join a Discord VC with `/voice join`.
4. Verify the entitled route transcribes into the normal Hermes pipeline and speaks the final Hermes response.
5. Make realtime unavailable and verify classic STT/TTS still works.
6. Leave the VC and confirm the app-server, peer connection, callbacks, mixer stream, and voice state are gone.

Validation on exact head `5c3bc4288ec0ce5cef5d641251f62c204b3646d0` after rebasing onto current `main`:

```text
scripts/run_tests.sh <realtime transport/manager/voice/mixer/race tests> -q
292 passed, 0 failed

pytest tests/integration/test_voice_channel_flow.py -m integration -q
37 passed, 0 failed

scripts/run_tests.sh -j 4 tests/gateway -q
11,425 passed, 0 failed across 550 files

ruff check <changed Python and tests>
ty check --python <dev venv> <new production modules>
uv lock --check
git diff --check
compileall <changed production modules>
git merge-tree --write-tree origin/main HEAD
added-line sensitive-pattern scan
```

A real Linux/Discord canary exercised the refreshed route with Codex WebRTC `v3`: the bot joined the configured VC, inbound Discord RTP decryption and DAVE succeeded, the user's speech appeared as a transcript, Hermes produced the response, and the user confirmed that the normal response was audibly played in the same VC. No generated `.ogg`/MP3 voice memo was posted to the linked text channel. The canary also covered retry after an initial Discord voice handshake `4006`, mixer recovery/drain checks, subsequent turns, and continued gateway health.

Earlier canaries found concrete failures that are now regression-tested: stale DAVE state, a rotated RTP transport secret, accepted-but-silent provider output, stale/non-draining Discord mixer ownership, and generic TTS reply media escaping into text chat instead of being spoken in the VC.

## Risk and impact

- Disabled by default and scoped to Discord voice sessions.
- Requires one explicit Discord user ID.
- Uses an ephemeral Codex thread with startup context excluded.
- Codex receives voice PCM and final reply text while the route is active, but does not own Hermes tools or agent turns.
- Remote audio is dropped until app-server has accepted Hermes's exact `appendSpeech` request for the current transcript generation. Failed or superseded requests never open the gate.
- Realtime output is considered ready only after accepted non-silent PCM reaches a currently draining Discord mixer; otherwise configured classic fallback remains available.
- Marked realtime turns never fall through to linked-text-channel voice attachments when the VC sink is missing or a generic TTS tool produced reply audio.
- Realtime notifications are filtered by the active thread ID.
- Backend URLs, request metadata, entitlement details, and credential-bearing errors are sanitized before they surface in replies or logs.
- Startup, runtime failure, leave, and shutdown tear down the app-server, peer, callbacks, mixer stream, and voice state.
- `fallback_to_classic: false` stays fail-closed through teardown and does not leak PCM into classic STT or replies into local TTS.
- Discord's negotiated transport secret and DAVE session are live connection state; the receiver reads the current values for each packet.

## Scope boundaries

Included:

- Codex app-server WebRTC `v3`, with `v1` as a compatibility option
- one-user Discord speech input/output
- backend-discovered voice selection
- prompt-level spoken-language guidance
- classic fallback and lifecycle cleanup
- optional dependencies, config, tests, and docs

Not included:

- Discord auto-join-on-presence
- multi-user realtime conversations
- Codex-generated assistant turns or tools
- OpenAI API-key Realtime transport
- WebRTC protocol `v2`
- realtime reasoning/intelligence controls
- a guaranteed native language/locale control
- local deployment configuration

## Known limitation

This is realtime media transport, but it is still a serial agent turn: finalized transcript, full Hermes response, then `appendSpeech`. The production canary showed that this can leave several seconds of silence before speech starts. Fixing that properly needs a separate full-duplex conversation design; lowering audio watchdogs would not remove the agent-turn latency.

## Rollout

The default remains off. Users opt in per Discord profile. If dependencies, Codex version/login, entitlement, SDP negotiation, WebRTC, or the app-server session fail, classic voice remains available by default. Removing or disabling the config returns to the existing Discord voice path without a migration.

## Reviewer focus

- Can any output-gate or generation race play pre-acknowledgement, unsolicited, or stale Codex audio?
- Can startup, failure, leave, or shutdown leak a session, callback, peer, or mixer stream?
- Do adapter/profile/guild and configured-user boundaries remain intact?
- Can no-fallback mode accidentally invoke classic STT or local TTS?
- Are the `v1`/`v3` WebRTC and prompt-level language contracts represented honestly?
- Does the receiver always use the current Discord transport key and DAVE session?
- Can reconnect or player replacement leave a stale/non-draining mixer that falsely accepts realtime PCM?
- Can model-generated TTS media bypass the VC path and escape into ordinary or post-stream text-channel delivery?

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs
- [x] My PR contains only related changes
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Linux with Python 3.11

### Documentation & housekeeping

- [x] I've updated the relevant voice documentation
- [x] The generated config defaults include the new keys
- [x] I've considered cross-platform impact
- [x] Tool descriptions/schemas are unchanged or N/A

## Screenshots / logs

No UI change. The feature is config-driven and disabled by default.
