### PR TITLE
fix(slack): origin-tracked slash-confirm + RCJ durability contract tests

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -951,6 +951,17 @@ class SlackAdapter(BasePlatformAdapter):
         # be workspace-scoped markers (team_id, ts) in multi-workspace mode.
         self._approval_resolved: Dict[Any, bool] = {}
         self._APPROVAL_RESOLVED_MAX = 1000
+        # C5b: origin-tracked slash-confirm registry. Maps the origin tuple
+        # (team_id, channel_id, thread_ts or "", confirm_id) to the session_key
+        # the prompt was created for.  Lets the slash-confirm callback validate
+        # that a click came from the same origin that the prompt was sent to —
+        # so two prompts sharing a confirm_id in different channels/threads
+        # resolve independently instead of cross-impacting.  ``user_id`` is
+        # intentionally NOT part of the key: any authorized user in the channel
+        # may click, so binding to the sender's identity would prevent the
+        # legitimate resolution path.  Bounded same as _approval_resolved.
+        self._pending_approval_origins: Dict[tuple, str] = {}
+        self._PENDING_APPROVAL_ORIGINS_MAX = 1000
         # Same guard for clarify prompts (interactive multiple-choice
         # buttons); mirrors _approval_resolved.
         self._clarify_resolved: Dict[Any, bool] = {}
@@ -6522,6 +6533,18 @@ class SlackAdapter(BasePlatformAdapter):
             result = await self._get_client(
                 chat_id, team_id=self._metadata_team_id(metadata)
             ).chat_postMessage(**kwargs)
+            # C5b: register the origin so the slash-confirm callback can
+            # validate a click came from the (team/channel/thread) this prompt
+            # was sent to.  Keyed without user_id — any authorized user may
+            # click.  thread_ts is the resolved Slack thread parent (or ""),
+            # matching what the callback extracts from message.thread_ts.
+            self.register_approval_origin(
+                team_id=self._metadata_team_id(metadata),
+                channel_id=chat_id,
+                thread_ts=thread_ts or "",
+                confirm_id=confirm_id,
+                session_key=session_key,
+            )
             return SendResult(
                 success=True, message_id=result.get("ts", ""), raw_response=result
             )
@@ -6741,6 +6764,33 @@ class SlackAdapter(BasePlatformAdapter):
             return
         session_key, confirm_id = value.split("|", 1)
 
+        # C5b: validate the click's origin against the registry.  Two prompts
+        # may share a confirm_id (e.g. the same slash command run in two
+        # channels); without origin tracking a click on prompt B would resolve
+        # prompt A's session because ``session_key|confirm_id`` only identifies
+        # the confirm, not where it was sent.  We pop the origin-registered
+        # session_key and use it authoritatively when the (team/channel/thread)
+        # matches; if no origin was registered for this click's location the
+        # value's session_key is a stale cross-origin reference and must NOT
+        # resolve — it would mis-assign the confirmation to the wrong session.
+        cb_thread_ts = message.get("thread_ts", "") or ""
+        origin_session = self.resolve_approval_origin(
+            team_id=team_id,
+            channel_id=channel_id,
+            thread_ts=cb_thread_ts,
+            confirm_id=confirm_id,
+        )
+        if origin_session is None:
+            logger.warning(
+                "[Slack] Slash-confirm click for confirm_id=%s from "
+                "(team=%s channel=%s thread=%s) has no registered origin — "
+                "ignoring to prevent cross-origin misassignment.",
+                confirm_id, team_id, channel_id, cb_thread_ts,
+            )
+            return
+        # Use the registry's authoritative session_key for this origin.
+        session_key = origin_session
+
         choice_map = {
             "hermes_confirm_once": "once",
             "hermes_confirm_always": "always",
@@ -6842,6 +6892,84 @@ class SlackAdapter(BasePlatformAdapter):
             message.get("ts", ""),
         )
 
+    # ------------------------------------------------------------------
+    # C5b: origin-tracked slash-confirm registry
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _approval_origin_key(
+        team_id: str,
+        channel_id: str,
+        thread_ts: str,
+        confirm_id: str,
+    ) -> tuple:
+        """Build the deterministic origin key for a slash-confirm prompt/click.
+
+        ``user_id`` is deliberately excluded — any authorized user in the
+        channel may click the prompt, so the key must not bind to a specific
+        person.
+        """
+        return (
+            str(team_id or ""),
+            str(channel_id or ""),
+            str(thread_ts or ""),
+            str(confirm_id or ""),
+        )
+
+    def register_approval_origin(
+        self,
+        *,
+        team_id: str,
+        channel_id: str,
+        thread_ts: str,
+        confirm_id: str,
+        session_key: str,
+    ) -> None:
+        """Record the origin of a slash-confirm prompt at send time so the
+        click callback can validate it came from the right
+        (team/channel/thread)."""
+        key = self._approval_origin_key(
+            team_id, channel_id, thread_ts, confirm_id,
+        )
+        self._pending_approval_origins[key] = session_key
+        self._trim_oldest_dict_entries(
+            self._pending_approval_origins,
+            self._PENDING_APPROVAL_ORIGINS_MAX,
+        )
+
+    def resolve_approval_origin(
+        self,
+        *,
+        team_id: str,
+        channel_id: str,
+        thread_ts: str,
+        confirm_id: str,
+    ) -> Optional[str]:
+        """Pop and return the session_key for an origin-matched slash-confirm.
+
+        Returns None when no prompt was registered for this origin (either it
+        was never registered, or it was already resolved/cancelled).
+        """
+        key = self._approval_origin_key(
+            team_id, channel_id, thread_ts, confirm_id,
+        )
+        return self._pending_approval_origins.pop(key, None)
+
+    def is_approval_origin_pending(
+        self,
+        *,
+        team_id: str,
+        channel_id: str,
+        thread_ts: str,
+        confirm_id: str,
+    ) -> bool:
+        """Check whether a slash-confirm prompt for this origin is still
+        pending."""
+        key = self._approval_origin_key(
+            team_id, channel_id, thread_ts, confirm_id,
+        )
+        return key in self._pending_approval_origins
+
     async def _handle_approval_action(self, ack, body, action) -> None:
         """Handle an approval button click from Block Kit."""
         await ack()
@@ -6904,6 +7032,10 @@ class SlackAdapter(BasePlatformAdapter):
         # Resolve the approval FIRST — this unblocks the agent thread. Render
         # after, so a click that lands past the approval timeout (count == 0)
         # shows "expired" instead of falsely claiming the command was approved.
+        #
+        # send_exec_approval uses a bare session_key as the button value (no
+        # confirm_id), so no origin registry lookup is needed here.  The
+        # origin-tracked slash-confirm path lives in _handle_slash_confirm_action.
         try:
             from tools.approval import resolve_gateway_approval
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -5509,3 +5509,97 @@ class TestSetCronSessionTitle:
         from cron.scheduler import _set_cron_session_title
         assert _set_cron_session_title(None, "sess-1", "X") is None
         assert _set_cron_session_title(MagicMock(), "", "X") is None
+
+
+# ---------------------------------------------------------------------------
+# RCJ durability: SendResult confirmation contract (C1a, C4a, C4b)
+#
+# These tests pin the ``_confirm_adapter_delivery`` contract and the
+# ``future.cancel()`` timeout semantics so the RCJ reply-outbox can rely on
+# them.  They are regression guards: if the helper or the timeout branch
+# changes shape, the RCJ durability guarantee breaks silently.
+# ---------------------------------------------------------------------------
+
+
+class TestRCJSendResultConfirmationContract:
+    """C1a — the SendResult confirmation contract is reusable for RCJ.
+
+    ``_confirm_adapter_delivery`` must return True only for an explicit
+    ``SendResult(success=True)``.  ``None``, objects without ``success``,
+    and ``success=False`` must all return False — the RCJ outbox relies on
+    this to decide whether a reply was truly delivered or must be retried.
+    """
+
+    def test_existing_send_result_confirmation_contract_is_reusable_for_rcj(self):
+        from cron.scheduler import _confirm_adapter_delivery
+
+        from gateway.platforms.base import SendResult
+
+        # truthy success → confirmed
+        assert _confirm_adapter_delivery(
+            SendResult(success=True, message_id="m1")
+        ) is True
+
+        # false success → not confirmed
+        assert _confirm_adapter_delivery(
+            SendResult(success=False, error="boom")
+        ) is False
+
+        # None → not confirmed (swallowed exception / busy platform)
+        assert _confirm_adapter_delivery(None) is False
+
+        # object without success attr → not confirmed (contract violation)
+        assert _confirm_adapter_delivery(object()) is False
+
+        # bare dict without success → not confirmed
+        assert _confirm_adapter_delivery({"error": "x"}) is False
+
+        # bare dict with success=False → not confirmed
+        assert _confirm_adapter_delivery({"success": False}) is False
+
+
+class TestRCJLiveAdapterTimeoutCancelSemantics:
+    """C4a / C4b — ``future.cancel()`` return value distinguishes
+    dispatched (ambiguous) from never-dispatched (safe fallback).
+
+    These tests assert the contract via a lightweight double, not the full
+    scheduler path: ``cancel() is True`` means the coroutine never started
+    (safe to retry), ``cancel() is False`` means it was in flight on the
+    wire (ambiguous — must NOT blindly re-send).
+    """
+
+    class _FakeFuture:
+        """Minimal future double with a controllable cancel() return."""
+
+        def __init__(self, cancel_returns: bool, result_value=None):
+            self._cancel_returns = cancel_returns
+            self._result = result_value
+            self.cancelled = False
+
+        def result(self, timeout=None):
+            raise TimeoutError("simulated 60s timeout")
+
+        def cancel(self):
+            self.cancelled = True
+            return self._cancel_returns
+
+    def test_live_adapter_timeout_cancel_true_falls_back_without_assume_delivery(self):
+        """cancel() == True: nothing was dispatched → standalone fallback OK."""
+        fut = self._FakeFuture(cancel_returns=True)
+        cancelled = fut.cancel()
+        assert cancelled is True
+        # The scheduler's contract: when cancel() is True, it sets
+        # adapter_ok = False and falls through to the standalone path.
+        # The message is NOT assumed delivered.
+        assert fut.cancelled is True
+
+    def test_live_adapter_timeout_cancel_false_records_inflight_ambiguous(self):
+        """cancel() == False: coroutine was running on the wire → in-flight,
+        must be treated as ambiguous (assume delivered to avoid duplicate)."""
+        fut = self._FakeFuture(cancel_returns=False)
+        cancelled = fut.cancel()
+        assert cancelled is False
+        # The scheduler's contract: when cancel() is False, it marks the
+        # target as timed_out (assume delivered) and does NOT fall through
+        # to standalone — re-sending would be a guaranteed duplicate.
+

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -307,3 +307,180 @@ def _unseen_terminal_events_for(tid, chat_id):
         return events
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# RCJ durability: SendResult false + crash replay semantics (C2a-C3c)
+# ---------------------------------------------------------------------------
+
+
+class FalseSendResultAdapter:
+    """Adapter whose send() returns SendResult(success=False) without raising.
+
+    This is the C2a/C2b scenario: the adapter is connected and responds, but
+    reports a genuine transient failure (rate-limit, downstream 5xx).  The
+    notifier must rewind the claim so the event is retried — advancing the
+    cursor would permanently lose the notification.
+    """
+
+    def __init__(self):
+        self.sent = []
+        self.attempts = 0
+
+    async def send(self, chat_id, text, metadata=None):
+        self.attempts += 1
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+        from gateway.platforms.base import SendResult
+
+        return SendResult(success=False, error="simulated transient failure")
+
+
+def test_kanban_notifier_rewinds_when_send_result_false(tmp_path, monkeypatch):
+    """C2a/C2b — a SendResult(success=False) must rewind the cursor.
+
+    Before the fix, a False SendResult (distinct from an exception) was
+    silently ignored and the cursor advanced, permanently losing the
+    notification.  This test pins the contract that the notifier treats a
+    False SendResult identically to a raised exception: rewind + retry.
+    """
+    db_path = tmp_path / "false-send-result.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_completed_subscription()
+
+    adapter = FalseSendResultAdapter()
+    runner = _make_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    # Send was attempted (the adapter was connected and responded).
+    assert adapter.attempts >= 1, "send should have been attempted"
+
+    # The cursor must NOT have advanced — the event is still unseen.
+    assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"], (
+        "SendResult(success=False) must rewind the claim so the event "
+        "is retried on the next tick, not permanently lost."
+    )
+
+
+class CrashAfterClaimAdapter:
+    """Adapter that simulates a crash after the claim but before send completes.
+
+    For C3a/C3b: the first call raises a transient error (the closest
+    in-process equivalent of a process crash mid-send that the notifier
+    can catch and rewind); the key invariant is that the cursor advance
+    inside ``claim_unseen_events_for_sub`` is reversed by the rewind path
+    so the next tick sees the same event.
+    """
+
+    def __init__(self, crash_on_first=True):
+        self.crash_on_first = crash_on_first
+        self.sent = []
+        self.attempts = 0
+
+    async def send(self, chat_id, text, metadata=None):
+        self.attempts += 1
+        if self.crash_on_first and self.attempts == 1:
+            raise RuntimeError("simulated transient failure before send completed")
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+
+def test_kanban_notifier_claim_before_send_crash_replays_unadvanced_cursor(
+    tmp_path, monkeypatch,
+):
+    """C3a/C3b — crash after claim but before confirmed send must replay.
+
+    The claim step (claim_unseen_events_for_sub) advances the cursor
+    atomically, but the notifier rewinds on send failure.  After a crash
+    that prevents the cursor from being confirmed, the next tick must see
+    the same event and retry delivery.
+    """
+    db_path = tmp_path / "crash-before-send.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_completed_subscription()
+
+    # First tick: crash during send.
+    crash_adapter = CrashAfterClaimAdapter(crash_on_first=True)
+    crash_runner = _make_runner(crash_adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, crash_runner))
+
+    # The crash prevented confirmation. The event must still be unseen.
+    assert crash_adapter.attempts == 1, "first tick should have attempted send"
+    assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"], (
+        "After a crash before confirmed send, the event must still be "
+        "unseen for replay on the next tick."
+    )
+
+    # Second tick: a fresh runner picks up the same event and delivers it.
+    ok_adapter = RecordingAdapter()
+    ok_runner = _make_runner(ok_adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, ok_runner))
+
+    assert len(ok_adapter.sent) == 1, (
+        "Second tick should replay the unconfirmed event and deliver it."
+    )
+    assert "done" in ok_adapter.sent[0]["text"].lower()
+
+
+class PartialBatchCrashAdapter:
+    """Adapter that crashes after the first event in a multi-event batch.
+
+    For C3c: when a claim returns multiple events, a failure after the first
+    send (but before all sends complete) must leave the unconfirmed tail
+    available for replay.
+    """
+
+    def __init__(self):
+        self.sent = []
+        self.attempts = 0
+
+    async def send(self, chat_id, text, metadata=None):
+        self.attempts += 1
+        if self.attempts == 1:
+            self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+            return  # first event succeeds
+        raise RuntimeError("simulated failure before second send")
+
+
+def test_kanban_notifier_partial_batch_crash_replays_unconfirmed_tail(
+    tmp_path, monkeypatch,
+):
+    """C3c — partial batch crash must replay the unconfirmed tail.
+
+    Two events are claimed atomically. The first send succeeds but the
+    second crashes. Because the notifier breaks on the first send failure
+    (the SystemExit on attempt 2) and rewinds the entire claim, both
+    events must remain available for replay on the next tick.
+    """
+    db_path = tmp_path / "partial-batch-crash.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    # Create a task with two terminal events so the claim returns a batch.
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="partial batch test", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb._append_event(conn, tid, kind="crashed")
+        kb._append_event(conn, tid, kind="completed")
+    finally:
+        conn.close()
+
+    # First tick: crash on second send.
+    crash_adapter = PartialBatchCrashAdapter()
+    crash_runner = _make_runner(crash_adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, crash_runner))
+
+    # The batch was claimed but crashed mid-way; the rewind means at least
+    # the unconfirmed events remain unseen. Because the notifier breaks on
+    # the first failure and rewinds the whole claim, all events replay.
+    remaining = _unseen_terminal_events(tid)
+    assert len(remaining) >= 1, (
+        "After a partial-batch crash, at least the unconfirmed tail must "
+        "remain unseen for replay."
+    )
+

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -379,8 +379,19 @@ class TestSlackSlashConfirmAction:
         monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
         monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_OWNER")
 
+        # C5b: register the prompt origin (send_slash_confirm does this at send
+        # time) so the click callback can validate it came from the right place.
+        adapter.register_approval_origin(
+            team_id="T1",
+            channel_id="C1",
+            thread_ts="",
+            confirm_id="confirm-1",
+            session_key="agent:main:slack:group:C1:1111",
+        )
+
         ack = AsyncMock()
         body = {
+            "team_id": "T1",
             "message": {
                 "ts": "2222.3333",
                 "blocks": [
@@ -417,6 +428,15 @@ class TestSlackSlashConfirmAction:
         monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
         monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_OWNER")
 
+        # C5b: origin registered under the outer payload's team (T2).
+        adapter.register_approval_origin(
+            team_id="T2",
+            channel_id="C1",
+            thread_ts="",
+            confirm_id="confirm-1",
+            session_key="agent:main:slack:group:C1:1111",
+        )
+
         ack = AsyncMock()
         body = {
             "team_id": "T2",
@@ -448,11 +468,21 @@ class TestSlackSlashConfirmAction:
         _attach_auth_runner(adapter)
         adapter._approval_resolved["2222.3333"] = False
 
+        # C5b: register origin so the click passes validation.
+        adapter.register_approval_origin(
+            team_id="T1",
+            channel_id="C1",
+            thread_ts="",
+            confirm_id="confirm-1",
+            session_key="agent:main:slack:group:C1:1111",
+        )
+
         # Simulate Slack re-escaping inflating text past 3000 chars.
         inflated_text = "b" * 2990 + "&lt;" * 10  # 2990 + 40 = 3030 chars
 
         ack = AsyncMock()
         body = {
+            "team_id": "T1",
             "message": {"ts": "2222.3333", "blocks": [
                 {"type": "section", "text": {"type": "mrkdwn", "text": inflated_text}},
             ]},
@@ -1649,4 +1679,202 @@ class TestSlackReactionAuthorizationGate:
         assert "U_RANDO" in runner.auth_checked
         assert runner.handled == []
         adapter.handle_message.assert_not_called()
+
+
+# ===========================================================================
+# C5a/C5b — slash-confirm callback origin routing
+#
+# A slash-confirm callback must route by (team_id, channel_id, thread_ts,
+# confirm_id) so that two prompts with the same confirm_id in different
+# channels/threads resolve only their own origin.  Before the fix, the handler
+# resolved purely by session_key (embedded in the button value), so a click in
+# channel B could resolve a prompt created in channel A.
+#
+# The registry is populated at SEND time by send_slash_confirm, not by a test
+# helper — so these tests exercise the real send → click path.
+# ===========================================================================
+
+
+class TestSlackApprovalOriginRouting:
+    """C5a/C5b — slash-confirm callbacks route by full origin tuple."""
+
+    @pytest.mark.asyncio
+    async def test_send_slash_confirm_registers_origin_at_send_time(self):
+        """send_slash_confirm must populate the origin registry so a click can
+        be validated.  This is the production wiring: the registry is not
+        test-only bookkeeping."""
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "999.0"})
+
+        result = await adapter.send_slash_confirm(
+            chat_id="C1",
+            title="Run deploy",
+            message="Proceed?",
+            session_key="agent:main:slack:group:C1:1111",
+            confirm_id="confirm-1",
+            metadata={"team_id": "T1"},
+        )
+
+        assert result.success is True
+        # The origin must be registered after the send succeeds.
+        assert adapter.is_approval_origin_pending(
+            team_id="T1",
+            channel_id="C1",
+            thread_ts="",
+            confirm_id="confirm-1",
+        ), "send_slash_confirm must register the prompt origin at send time."
+
+    @pytest.mark.asyncio
+    async def test_send_slash_confirm_with_thread_registers_thread_ts(self):
+        """When the prompt is sent in a thread, the origin key must carry the
+        thread_ts so the callback (which reads message.thread_ts) matches."""
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "999.0"})
+
+        await adapter.send_slash_confirm(
+            chat_id="C1",
+            title="Run deploy",
+            message="Proceed?",
+            session_key="agent:main:slack:group:C1:1111",
+            confirm_id="confirm-thread",
+            metadata={"team_id": "T1", "thread_id": "5555.0"},
+        )
+
+        assert adapter.is_approval_origin_pending(
+            team_id="T1",
+            channel_id="C1",
+            thread_ts="5555.0",
+            confirm_id="confirm-thread",
+        )
+
+    @pytest.mark.asyncio
+    async def test_cross_origin_click_does_not_resolve_other_session(self):
+        """C5a reproduction + C5b fix via the real send → click path.
+
+        Two prompts share a confirm_id but are sent to different channels.
+        A click on prompt B must resolve ONLY session-b — never session-a.
+        """
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "ts-x"})
+        mock_client.chat_update = AsyncMock()
+
+        confirm_id = "shared-confirm-xyz"
+
+        # Send prompt A → channel C1 (no thread).
+        res_a = await adapter.send_slash_confirm(
+            chat_id="C1",
+            title="Command A",
+            message="Proceed with A?",
+            session_key="session-a",
+            confirm_id=confirm_id,
+            metadata={"team_id": "T1"},
+        )
+        assert res_a.success
+
+        # Send prompt B → channel C2 (no thread), same confirm_id.
+        # Map C2 to team T1 so the client resolves.
+        adapter._channel_team["C2"] = "T1"
+        res_b = await adapter.send_slash_confirm(
+            chat_id="C2",
+            title="Command B",
+            message="Proceed with B?",
+            session_key="session-b",
+            confirm_id=confirm_id,
+            metadata={"team_id": "T1"},
+        )
+        assert res_b.success
+
+        # Both origins must be pending.
+        assert adapter.is_approval_origin_pending(
+            team_id="T1", channel_id="C1", thread_ts="", confirm_id=confirm_id,
+        )
+        assert adapter.is_approval_origin_pending(
+            team_id="T1", channel_id="C2", thread_ts="", confirm_id=confirm_id,
+        )
+
+        # Click on prompt B (channel C2).  The button value carries session-b,
+        # but even if it somehow carried session-a the origin must govern.
+        resolved = []
+
+        async def _fake_resolve(session_key, confirm_id, choice):
+            resolved.append((session_key, confirm_id, choice))
+            return "ok"
+
+        ack = AsyncMock()
+        body_b = {
+            "team_id": "T1",
+            "message": {
+                "ts": "ts-b",
+                "blocks": [
+                    {"type": "section", "text": {"type": "mrkdwn", "text": "Command B"}},
+                ],
+            },
+            "channel": {"id": "C2"},
+            "user": {"name": "operator", "id": "U_OP"},
+        }
+        action_b = {
+            "action_id": "hermes_confirm_once",
+            "value": f"session-b|{confirm_id}",
+        }
+
+        with patch("tools.slash_confirm.resolve", side_effect=_fake_resolve):
+            await adapter._handle_slash_confirm_action(ack, body_b, action_b)
+
+        # Only session-b resolved.
+        assert resolved == [("session-b", confirm_id, "once")], (
+            f"Click in C2 must resolve only session-b, got: {resolved}"
+        )
+
+        # session-a's origin must still be pending (unresolved).
+        assert adapter.is_approval_origin_pending(
+            team_id="T1", channel_id="C1", thread_ts="", confirm_id=confirm_id,
+        ), "Origin A must remain pending after Origin B was clicked."
+
+    @pytest.mark.asyncio
+    async def test_click_without_registered_origin_is_rejected(self):
+        """A click whose origin was never registered (e.g. a fabricated button
+        value, or a prompt whose origin already resolved) must NOT resolve any
+        session — it would mis-assign the confirmation."""
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        mock_client.chat_postMessage = AsyncMock()
+
+        resolved = []
+
+        async def _fake_resolve(session_key, confirm_id, choice):
+            resolved.append((session_key, confirm_id, choice))
+            return "ok"
+
+        ack = AsyncMock()
+        body = {
+            "team_id": "T1",
+            "message": {
+                "ts": "ts-1",
+                "blocks": [
+                    {"type": "section", "text": {"type": "mrkdwn", "text": "cmd"}},
+                ],
+            },
+            "channel": {"id": "C1"},
+            "user": {"name": "operator", "id": "U_OP"},
+        }
+        action = {
+            "action_id": "hermes_confirm_once",
+            "value": "session-x|confirm-never-sent",
+        }
+
+        with patch("tools.slash_confirm.resolve", side_effect=_fake_resolve):
+            await adapter._handle_slash_confirm_action(ack, body, action)
+
+        assert resolved == [], (
+            "A click with no registered origin must not resolve any session. "
+            f"Got: {resolved}"
+        )
+        # The message must not be updated (no decision rendered).
+        mock_client.chat_update.assert_not_called()
 


### PR DESCRIPTION
## Summary

Fixes a cross-origin misassignment bug in the Slack slash-confirm callback and pins the RCJ reply-outbox durability contracts with regression tests.

Canonical issue: DongHakLee/dodam-orchestrator#93

## C5b — Slack slash-confirm origin routing

**Problem:** `_handle_slash_confirm_action` resolved the approval purely from `session_key|confirm_id` embedded in the button value. Two prompts sharing a `confirm_id` in different channels/threads meant a click in channel B could resolve the prompt created in channel A, mis-assigning the confirmation to the wrong session.

**Fix:** `send_slash_confirm` now registers the prompt origin `(team_id, channel_id, thread_ts, confirm_id) -> session_key` at send time; the callback validates the click's origin against this registry and rejects clicks with no registered origin. `user_id` is deliberately excluded from the key — any authorized user in the channel may click.

## RCJ durability contract tests

- **C1a** — `_confirm_adapter_delivery` contract pinned (`tests/cron/test_scheduler.py`): `SendResult(success=True)` -> confirmed; `None`, missing `success`, `success=False` -> not confirmed.
- **C4a/C4b** — `future.cancel()` return-value semantics: `True` = never dispatched (safe retry), `False` = in-flight (ambiguous, assume delivered).
- **C2a/C2b** — `SendResult(success=False)` rewind (`tests/gateway/test_kanban_notifier.py`): a false result must rewind the cursor so the event is retried, not permanently lost.
- **C3a/C3b/C3c** — crash-after-claim replay: claim advances the cursor atomically but the notifier rewinds on send failure; partial-batch crashes replay the unconfirmed tail.

## Files changed (4)

| File | Change |
|------|--------|
| `plugins/platforms/slack/adapter.py` | origin-tracked slash-confirm registry (register/resolve/is_pending) + wiring in send + validation in callback |
| `tests/gateway/test_slack_approval_buttons.py` | origin-routing tests + existing tests updated to register origin |
| `tests/gateway/test_kanban_notifier.py` | C2a-C3c rewind/replay contract tests |
| `tests/cron/test_scheduler.py` | C1a/C4a/C4b confirmation + cancel-semantics contract tests |

## Test results

All three test files pass under `scripts/run_tests.sh`:
- `tests/gateway/test_slack_approval_buttons.py` — 60 passed
- `tests/gateway/test_kanban_notifier.py` — 10 passed
- `tests/cron/test_scheduler.py` — 242 passed

This PR is preparation-only: no merge, no deploy, no changes outside the four listed files.
