### PR TITLE
fix(desktop): use unpacked icon path in packaged app

### DIFF
--- a/apps/desktop/electron/app-icon.test.ts
+++ b/apps/desktop/electron/app-icon.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { resolveAppIconPath } from './app-icon'
+
+test('packaged desktop prefers the physical unpacked icon over virtual ASAR entries', () => {
+  const appRoot = '/Applications/Hermes.app/Contents/Resources/app.asar'
+  const unpackedAppRoot = '/Applications/Hermes.app/Contents/Resources/app.asar.unpacked'
+  const unpackedIcon = path.join(unpackedAppRoot, 'dist', 'apple-touch-icon.png')
+
+  const existing = new Set([
+    path.join(appRoot, 'public', 'apple-touch-icon.png'),
+    path.join(appRoot, 'dist', 'apple-touch-icon.png'),
+    unpackedIcon
+  ])
+
+  assert.equal(
+    resolveAppIconPath({
+      appRoot,
+      unpackedAppRoot,
+      isPackaged: true,
+      fileExists: filePath => existing.has(filePath)
+    }),
+    unpackedIcon
+  )
+})
+
+test('packaged desktop does not pass a virtual ASAR icon to native APIs', () => {
+  const appRoot = '/Applications/Hermes.app/Contents/Resources/app.asar'
+  const virtualIcon = path.join(appRoot, 'public', 'apple-touch-icon.png')
+
+  assert.equal(
+    resolveAppIconPath({
+      appRoot,
+      unpackedAppRoot: '/Applications/Hermes.app/Contents/Resources/app.asar.unpacked',
+      isPackaged: true,
+      fileExists: filePath => filePath === virtualIcon
+    }),
+    undefined
+  )
+})
+
+test('development desktop falls back from public to dist when needed', () => {
+  const appRoot = '/repo/apps/desktop'
+  const distIcon = path.join(appRoot, 'dist', 'apple-touch-icon.png')
+
+  assert.equal(
+    resolveAppIconPath({
+      appRoot,
+      unpackedAppRoot: appRoot,
+      isPackaged: false,
+      fileExists: filePath => filePath === distIcon
+    }),
+    distIcon
+  )
+})

--- a/apps/desktop/electron/app-icon.ts
+++ b/apps/desktop/electron/app-icon.ts
@@ -1,0 +1,26 @@
+import path from 'node:path'
+
+interface ResolveAppIconPathOptions {
+  appRoot: string
+  fileExists: (filePath: string) => boolean
+  isPackaged: boolean
+  pathModule?: typeof path
+  unpackedAppRoot: string
+}
+
+export function resolveAppIconPath({
+  appRoot,
+  fileExists,
+  isPackaged,
+  pathModule = path,
+  unpackedAppRoot
+}: ResolveAppIconPathOptions): string | undefined {
+  const candidates = isPackaged
+    ? [pathModule.join(unpackedAppRoot, 'dist', 'apple-touch-icon.png')]
+    : [
+        pathModule.join(appRoot, 'public', 'apple-touch-icon.png'),
+        pathModule.join(appRoot, 'dist', 'apple-touch-icon.png')
+      ]
+
+  return candidates.find(fileExists)
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -30,6 +30,7 @@ import {
 } from 'electron'
 import nodePty from 'node-pty'
 
+import { resolveAppIconPath } from './app-icon'
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
@@ -613,12 +614,6 @@ const WINDOW_BUTTON_POSITION = {
 // (pure + unit-testable); computeNativeOverlayWidth() applies it per platform.
 // It's only the pre-layout fallback — the renderer measures the exact overlay
 // width live via the Window Controls Overlay API.
-const APP_ICON_PATHS = [
-  path.join(APP_ROOT, 'public', 'apple-touch-icon.png'),
-  path.join(APP_ROOT, 'dist', 'apple-touch-icon.png'),
-  path.join(unpackedPathFor(APP_ROOT), 'dist', 'apple-touch-icon.png')
-]
-
 let rendererTitleBarTheme = null
 const terminalSessions = new Map()
 
@@ -4916,7 +4911,12 @@ function registerPowerResumeListeners() {
 }
 
 function getAppIconPath() {
-  return APP_ICON_PATHS.find(fileExists)
+  return resolveAppIconPath({
+    appRoot: APP_ROOT,
+    unpackedAppRoot: unpackedPathFor(APP_ROOT),
+    isPackaged: IS_PACKAGED,
+    fileExists
+  })
 }
 
 function sendOpenUpdatesRequested() {


### PR DESCRIPTION
## What does this PR do?

Fixes a packaged Desktop startup failure where getAppIconPath selected a virtual path inside app.asar. Electron file checks can see that entry, but the native macOS dock API cannot load it; app.dock.setIcon then aborts window setup before the renderer URL loads, leaving a blank window.

Packaged builds now resolve only the physical app.asar.unpacked/dist icon. Development builds retain the public-to-dist fallback. The precedence is isolated in a pure helper with regression coverage.

## Related Issue

N/A - reproduced locally on current main; searches found no matching open or closed issue/PR.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Add a pure packaged/development icon resolver.
- Prevent virtual ASAR paths from reaching native window and dock APIs.
- Cover packaged precedence, missing physical icon behavior, and development fallback.

## How to Test

1. Run npm run test:desktop:platforms from apps/desktop.
2. Run npm run typecheck and ESLint for the touched Electron files.
3. Run npm run pack, then launch the packaged app with an isolated user data and HERMES_HOME directory.

## Checklist

### Code

- [x] I read the Contributing Guide.
- [x] The commit follows Conventional Commits.
- [x] I searched open and closed issues/PRs for duplicates.
- [x] The PR contains only this focused fix.
- [x] I added regression tests.
- [x] Tested on macOS 26.5, Apple Silicon.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing behavior or config changes.
- [x] cli-config.yaml.example: N/A.
- [x] CONTRIBUTING.md / AGENTS.md: N/A; no architecture/workflow change.
- [x] Cross-platform impact considered: packaged native APIs receive a physical file on all platforms; development fallback is unchanged.
- [x] Tool descriptions/schemas: N/A.

## Verification

- Electron Vitest project: 728 passed, 2 skipped.
- TypeScript typecheck: passed.
- ESLint on touched files: passed.
- Packaged bundle build and validation: passed.
- Isolated packaged launch: renderer and first-run setup UI displayed instead of a blank window.