### PR TITLE
fix(failover): honour configured api_mode/transport on fallback activation

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1574,6 +1574,55 @@ def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str
 
 
 
+def configured_fallback_api_mode(fb: dict, fb_provider: str) -> str:
+    """Return the api_mode the operator declared for a fallback entry, or "".
+
+    Resolution order (first hit wins):
+
+    1. An explicit ``api_mode`` on the fallback entry itself.
+    2. The ``transport`` declared for ``fb_provider`` under config.yaml
+       ``providers:``, mapped through ``TRANSPORT_TO_API_MODE``.
+
+    Why this exists: ``try_activate_fallback`` used to derive the wire
+    protocol purely from heuristics that only recognise Anthropic by
+    hostname (``api.anthropic.com``) or a ``/anthropic`` path suffix.  An
+    Anthropic-Messages-compatible endpoint on any other host — a
+    self-hosted shim, a reverse proxy, a Cloudflare Worker — matched
+    neither, silently fell through to ``chat_completions``, and POSTed
+    ``/chat/completions`` to a server that only serves ``/v1/messages``,
+    yielding HTTP 404 on every fallback attempt.
+
+    The primary path already honours both signals via
+    ``determine_api_mode()``; only the fallback path ignored them.  Config
+    is authoritative here precisely because the heuristics cannot know
+    about an arbitrary host.
+
+    Returns "" when the operator declared nothing, leaving the existing
+    provider/base-URL/model heuristics untouched.
+    """
+    explicit = (fb.get("api_mode") or "").strip()
+    if explicit:
+        return explicit
+
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.providers import TRANSPORT_TO_API_MODE
+
+        entry = ((load_config() or {}).get("providers") or {}).get(fb_provider)
+        if isinstance(entry, dict):
+            transport = (entry.get("transport") or "").strip()
+            if transport:
+                return TRANSPORT_TO_API_MODE.get(transport, "")
+    except Exception as exc:
+        # Never let config resolution break failover — fall through to the
+        # heuristics, which is the pre-existing behaviour.
+        logger.debug(
+            "Fallback api_mode: could not resolve provider transport for %s: %s",
+            fb_provider, exc,
+        )
+    return ""
+
+
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
@@ -1713,7 +1762,15 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         fb_api_mode = "chat_completions"
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
+
+        _fb_explicit_mode = configured_fallback_api_mode(fb, fb_provider)
+        if _fb_explicit_mode:
+            fb_api_mode = _fb_explicit_mode
+            logger.info(
+                "Fallback to %s/%s: using configured api_mode=%s",
+                fb_provider, fb_model, fb_api_mode,
+            )
+        elif fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
         elif (
             fb_provider == "anthropic"

--- a/tests/agent/test_fallback_api_mode_from_config.py
+++ b/tests/agent/test_fallback_api_mode_from_config.py
@@ -1,0 +1,133 @@
+"""Fallback wire-protocol selection must honour operator config.
+
+``try_activate_fallback`` derives the api_mode (wire protocol) for the
+fallback target.  It used to do so purely from heuristics that recognise
+Anthropic only by hostname (``api.anthropic.com``) or a ``/anthropic``
+path suffix.  An Anthropic-Messages-compatible endpoint on any other host
+— a self-hosted shim, a reverse proxy, a Cloudflare Worker — matched
+neither, silently fell through to ``chat_completions``, and POSTed
+``/chat/completions`` to a server that only serves ``/v1/messages``.
+Every fallback attempt then failed with HTTP 404, so a transient empty
+response on the primary model became a hard turn failure with no
+recovery.
+
+The primary path already honours both an explicit ``api_mode`` and the
+provider's declared ``transport`` (via ``determine_api_mode()``); only
+the fallback path ignored them.  These tests pin that contract.
+"""
+
+import pytest
+
+from agent.chat_completion_helpers import configured_fallback_api_mode
+from hermes_cli.providers import TRANSPORT_TO_API_MODE
+
+
+@pytest.fixture
+def config(monkeypatch):
+    """Patch the config loader the resolver reads, returning a setter."""
+
+    def _set(cfg):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: cfg, raising=False
+        )
+
+    return _set
+
+
+class TestExplicitApiMode:
+    def test_explicit_api_mode_on_entry_wins(self, config):
+        # An operator who spells out api_mode must be obeyed even when the
+        # provider config disagrees — the entry is the more specific signal.
+        config({"providers": {"shim": {"transport": "openai_chat"}}})
+        entry = {"provider": "shim", "api_mode": "anthropic_messages"}
+        assert configured_fallback_api_mode(entry, "shim") == "anthropic_messages"
+
+    def test_whitespace_only_api_mode_is_not_a_declaration(self, config):
+        config({})
+        assert configured_fallback_api_mode({"api_mode": "   "}, "p") == ""
+
+    def test_none_api_mode_does_not_crash(self, config):
+        config({})
+        assert configured_fallback_api_mode({"api_mode": None}, "p") == ""
+
+
+class TestTransportFallback:
+    def test_anthropic_shim_on_arbitrary_host_resolves_to_messages(self, config):
+        # The regression: an Anthropic-Messages worker on a non-Anthropic
+        # hostname. Without this, api_mode fell through to chat_completions
+        # and the fallback POSTed /chat/completions -> 404.
+        config(
+            {
+                "providers": {
+                    "myworker": {
+                        "base_url": "https://worker.example.workers.dev",
+                        "transport": "anthropic_messages",
+                    }
+                }
+            }
+        )
+        entry = {"provider": "myworker", "model": "claude-opus-4.8"}
+        assert configured_fallback_api_mode(entry, "myworker") == "anthropic_messages"
+
+    def test_openai_chat_transport_maps_to_chat_completions(self, config):
+        config({"providers": {"vllm": {"transport": "openai_chat"}}})
+        assert configured_fallback_api_mode({}, "vllm") == "chat_completions"
+
+    @pytest.mark.parametrize("transport,expected", sorted(TRANSPORT_TO_API_MODE.items()))
+    def test_every_known_transport_maps(self, config, transport, expected):
+        # Guards the mapping as a contract rather than freezing a literal
+        # list: a newly supported transport is covered automatically.
+        config({"providers": {"p": {"transport": transport}}})
+        assert configured_fallback_api_mode({}, "p") == expected
+
+    def test_unknown_transport_falls_through_to_heuristics(self, config):
+        config({"providers": {"p": {"transport": "carrier-pigeon"}}})
+        assert configured_fallback_api_mode({}, "p") == ""
+
+
+class TestNoDeclarationLeavesHeuristicsIntact:
+    """Returning "" is load-bearing: the caller then runs its heuristics.
+
+    Any of these accidentally returning a mode would override the
+    provider/base-URL/model detection that existing providers rely on.
+    """
+
+    def test_provider_absent_from_config(self, config):
+        config({"providers": {"other": {"transport": "openai_chat"}}})
+        assert configured_fallback_api_mode({}, "openrouter") == ""
+
+    def test_provider_entry_without_transport(self, config):
+        config({"providers": {"p": {"base_url": "https://x.example"}}})
+        assert configured_fallback_api_mode({}, "p") == ""
+
+    def test_no_providers_section(self, config):
+        config({})
+        assert configured_fallback_api_mode({}, "p") == ""
+
+    def test_null_providers_section(self, config):
+        config({"providers": None})
+        assert configured_fallback_api_mode({}, "p") == ""
+
+    def test_config_loader_returning_none(self, config):
+        config(None)
+        assert configured_fallback_api_mode({}, "p") == ""
+
+    def test_non_dict_provider_entry_is_ignored(self, config):
+        # A malformed config (string where a mapping belongs) must not raise
+        # mid-failover — failover is the recovery path, it cannot crash.
+        config({"providers": {"p": "https://x.example"}})
+        assert configured_fallback_api_mode({}, "p") == ""
+
+
+def test_config_load_failure_does_not_break_failover(monkeypatch):
+    """A broken/unreadable config must degrade, never raise.
+
+    This runs while the agent is already failing over; an exception here
+    would turn a recoverable provider blip into a dead turn.
+    """
+
+    def boom():
+        raise OSError("config.yaml unreadable")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", boom, raising=False)
+    assert configured_fallback_api_mode({}, "p") == ""


### PR DESCRIPTION
## Summary

`try_activate_fallback` derived the fallback target's wire protocol purely from heuristics that recognise Anthropic only by hostname (`api.anthropic.com`) or a `/anthropic` path suffix. An Anthropic-Messages-compatible endpoint on **any other host** — a self-hosted shim, a reverse proxy, a Cloudflare Worker — matched neither, silently fell through to `chat_completions`, and POSTed `/chat/completions` to a server that only serves `/v1/messages`.

Result: every fallback attempt 404s, so a transient empty response on the primary model becomes a hard turn failure with **no recovery at all**:

```
Empty response after 3 retries - attempting fallback (model=<primary>, provider=custom)
API call failed (attempt 1/3) error_type=NotFoundError
  base_url=https://<host> model=<fallback> summary=HTTP 404: Not found
API call failed (attempt 2/3) ... HTTP 404: Not found
API call failed (attempt 3/3) ... HTTP 404: Not found
API call failed after 3 retries. HTTP 404: Not found
```

Verified against the live endpoint that the 404 is purely a wrong-path problem — the model and credentials are fine:

| Request | Result |
|---|---|
| `POST /v1/messages` | 200 |
| `POST /v1/chat/completions` | 200 |
| `POST /chat/completions` | **404 — matches the log exactly** |

## Root cause

The primary path already honours both an explicit `api_mode` and the provider's declared `transport` via `determine_api_mode()`. Only the fallback path ignored them — `fb.get("api_mode")` appeared **nowhere** in the tree, so a documented, already-supported config key was silently dropped on this one code path.

`agent/chat_completion_helpers.py` (before):

```python
fb_api_mode = "chat_completions"          # default
...
elif (fb_provider == "anthropic"
      or fb_base_url.rstrip("/").lower().endswith("/anthropic")
      or base_url_hostname(fb_base_url) == "api.anthropic.com"):
    fb_api_mode = "anthropic_messages"
```

A config like this was therefore ignored on failover, and the fallback spoke the wrong protocol:

```yaml
providers:
  myworker:
    base_url: https://worker.example.workers.dev
    transport: anthropic_messages
fallback_model:
  api_mode: anthropic_messages
  provider: myworker
  model: claude-opus-4.8
```

## The fix

Extract `configured_fallback_api_mode(fb, fb_provider)`, consulting in order:

1. an explicit `api_mode` on the fallback entry;
2. the `transport` declared for the provider under `providers:`, mapped through the existing `TRANSPORT_TO_API_MODE`.

It returns `""` when the operator declared nothing, so **the existing provider/base-URL/model heuristics are left completely untouched** for every provider that relies on them. Config is authoritative here precisely because the heuristics cannot know about an arbitrary host.

Deliberate choices, per `AGENTS.md`:

- **No new config surface.** Both keys already exist and are already honoured on the primary path — this makes the fallback path consistent with it rather than inventing anything. No new `HERMES_*` env var.
- **Cannot break failover.** Config resolution is wrapped so a broken/unreadable config degrades to the old heuristics instead of raising. This code runs *during* failover, where an exception would turn a recoverable provider blip into a dead turn.
- **Whole bug class, not one site.** Any Anthropic-Messages endpoint on a non-Anthropic host is covered, not just the one I hit.
- **Extracted to a module-level helper** rather than left inline in a ~2400-line function, so the behaviour is unit-testable without constructing a live agent.

## Test plan

Adds `tests/agent/test_fallback_api_mode_from_config.py` — 17 cases:

- entry-level `api_mode` takes precedence over a conflicting provider `transport`;
- the regression itself: `anthropic_messages` transport on an arbitrary host resolves to `anthropic_messages`;
- **every** known transport, parametrised over `TRANSPORT_TO_API_MODE` so a newly supported transport is covered automatically instead of freezing a literal list (behaviour contract, not a change-detector);
- the "return empty so heuristics still run" contract for absent provider / no `transport` / no `providers:` section / `providers: null` / loader returning `None` / non-dict entry;
- a config loader that raises must degrade, not propagate.

**Mutation-checked:** with the helper's explicit-`api_mode` branch removed, 7 of the 17 fail — they pin the fix rather than passing vacuously.

```
tests/agent/test_fallback_api_mode_from_config.py .................  17 passed
```

No regressions in the existing failover + config suites:

```
test_failover_identity, test_credential_pool_routing,
test_auxiliary_named_custom_providers,
test_24996_fallback_exhaustion_cooldown, test_auth_provider_failover
  -> 73 passed

tests/hermes_cli/test_config.py, test_custom_provider_model_switch.py
  -> 205 passed
```

Full `tests/agent/` was run before **and** after against a pristine worktree of the base commit, since this tree has pre-existing failures that make a raw count meaningless:

| | failed | passed | skipped |
|---|---|---|---|
| base commit (pristine worktree) | 215 | 6578 | 39 |
| this branch | 216 | 6577 | 39 |

The single delta is `test_skill_utils.py::test_skill_config_raw_cache_invalidates_on_config_edit`, an mtime-cache-invalidation test that passes 3/3 standalone on **both** trees and is timing-sensitive under parallel load; it does not touch this code path. The ~215 shared failures are pre-existing cross-test pollution on the base commit — e.g. `test_redact.py` reports 67 failures in a full run but passes 156/156 standalone — and are unrelated to this change.
