### PR TITLE
fix(hermes_cli): stop TTS/setup xAI OAuth from hijacking the active chat provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4452,7 +4452,15 @@ def _save_xai_oauth_tokens(
     redirect_uri: str = "",
     last_refresh: Optional[str] = None,
     auth_mode: str = "oauth_device_code",
+    set_active: bool = True,
 ) -> None:
+    """Persist xAI OAuth tokens into the auth store.
+
+    When *set_active* is True (default), also promote ``xai-oauth`` to
+    ``active_provider`` — appropriate for intentional model/auth login.
+    Pass ``set_active=False`` for side-tool credential bootstrap (TTS, STT,
+    dashboard token save, token refresh) so inference routing is unchanged.
+    """
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     with _auth_store_lock():
@@ -4470,7 +4478,9 @@ def _save_xai_oauth_tokens(
             state["discovery"] = discovery
         if redirect_uri:
             state["redirect_uri"] = redirect_uri
-        _save_provider_state(auth_store, "xai-oauth", state)
+        _store_provider_state(
+            auth_store, "xai-oauth", state, set_active=set_active
+        )
         _save_auth_store(auth_store)
         if write_through_to_root:
             _write_through_xai_oauth_to_global_root(state)
@@ -4808,6 +4818,9 @@ def _refresh_xai_oauth_tokens(
         redirect_uri=redirect_uri,
         last_refresh=refreshed["last_refresh"],
         auth_mode=auth_mode,
+        # Refresh must not flip active_provider — TTS/side tools can refresh
+        # xAI tokens while chat still routes through another provider.
+        set_active=False,
     )
     return updated_tokens
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4458,8 +4458,9 @@ def _save_xai_oauth_tokens(
 
     When *set_active* is True (default), also promote ``xai-oauth`` to
     ``active_provider`` — appropriate for intentional model/auth login.
-    Pass ``set_active=False`` for side-tool credential bootstrap (TTS, STT,
-    dashboard token save, token refresh) so inference routing is unchanged.
+    Pass ``set_active=False`` for side-tool credential bootstrap (TTS/setup,
+    tools config, dashboard token save, token refresh) so inference routing
+    is unchanged.
     """
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -908,6 +908,7 @@ def _run_xai_oauth_login_from_setup() -> bool:
             _is_remote_session,
             _save_xai_oauth_tokens,
             _xai_oauth_device_code_login,
+            unsuppress_credential_source,
         )
     except Exception as exc:
         print_warning(f"xAI Grok OAuth helpers unavailable: {exc}")
@@ -926,6 +927,9 @@ def _run_xai_oauth_login_from_setup() -> bool:
             auth_mode="oauth_device_code",
             set_active=False,
         )
+        # Mirror model/dashboard re-login: clear device_code suppression so
+        # the pool can seed from the singleton after a prior `auth remove`.
+        unsuppress_credential_source("xai-oauth", "device_code")
         return True
     except Exception as exc:
         print_warning(f"xAI Grok OAuth login failed: {exc}")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -896,15 +896,17 @@ def _xai_oauth_logged_in_for_setup() -> bool:
 def _run_xai_oauth_login_from_setup() -> bool:
     """Run the xAI Grok OAuth device-code login from inside the setup wizard.
 
+    Saves OAuth tokens only. Does **not** switch the active inference
+    provider or rewrite ``model.provider`` — callers (TTS setup, tools
+    config) only need credentials for side tools.
+
     Returns True on success, False on any failure (the caller falls back
     to whatever the user picked next, e.g. Edge TTS).
     """
     try:
         from hermes_cli.auth import (
-            DEFAULT_XAI_OAUTH_BASE_URL,
             _is_remote_session,
             _save_xai_oauth_tokens,
-            _update_config_for_provider,
             _xai_oauth_device_code_login,
         )
     except Exception as exc:
@@ -922,9 +924,7 @@ def _run_xai_oauth_login_from_setup() -> bool:
             redirect_uri=creds.get("redirect_uri", ""),
             last_refresh=creds.get("last_refresh"),
             auth_mode="oauth_device_code",
-        )
-        _update_config_for_provider(
-            "xai-oauth", creds.get("base_url", DEFAULT_XAI_OAUTH_BASE_URL)
+            set_active=False,
         )
         return True
     except Exception as exc:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10974,6 +10974,7 @@ def _xai_device_poller(session_id: str) -> None:
         _save_xai_oauth_tokens,
         _xai_oauth_discovery,
         _xai_oauth_poll_device_token,
+        mark_provider_active_if_unset,
         unsuppress_credential_source,
     )
 
@@ -11010,10 +11011,13 @@ def _xai_device_poller(session_id: str) -> None:
                 discovery=discovery,
                 last_refresh=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
                 auth_mode="oauth_device_code",
-                # Dashboard OAuth only bootstraps credentials for side tools;
-                # do not hijack the active chat inference provider.
+                # Persist credentials without hijacking an existing active
+                # chat provider.
                 set_active=False,
             )
+            # Mirror `hermes auth add xai-oauth`: first credential may become
+            # active when none is set yet; never overwrite an existing choice.
+            mark_provider_active_if_unset("xai-oauth")
             # The singleton write above is the single source of truth: the
             # credential-pool load seeds it as the canonical ``device_code``
             # entry. Do NOT also insert a parallel ``manual:dashboard_*`` pool

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11010,6 +11010,9 @@ def _xai_device_poller(session_id: str) -> None:
                 discovery=discovery,
                 last_refresh=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
                 auth_mode="oauth_device_code",
+                # Dashboard OAuth only bootstraps credentials for side tools;
+                # do not hijack the active chat inference provider.
+                set_active=False,
             )
             # The singleton write above is the single source of truth: the
             # credential-pool load seeds it as the canonical ``device_code``

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -281,6 +281,40 @@ def test_save_and_read_xai_oauth_tokens_roundtrip(tmp_path, monkeypatch):
     assert data["discovery"]["token_endpoint"] == "https://auth.x.ai/oauth2/token"
 
 
+def test_save_xai_oauth_tokens_set_active_false_preserves_active_provider(
+    tmp_path, monkeypatch
+):
+    """Side-tool credential saves must not flip auth.json active_provider."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    auth_path = hermes_home / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_provider": "openrouter",
+                "providers": {},
+            }
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _save_xai_oauth_tokens(
+        {
+            "access_token": "side-tool-at",
+            "refresh_token": "side-tool-rt",
+            "id_token": "",
+            "token_type": "Bearer",
+        },
+        discovery={"token_endpoint": "https://auth.x.ai/oauth2/token"},
+        set_active=False,
+    )
+
+    raw = json.loads(auth_path.read_text())
+    assert raw["active_provider"] == "openrouter"
+    assert raw["providers"]["xai-oauth"]["tokens"]["access_token"] == "side-tool-at"
+
+
 def test_read_xai_oauth_tokens_missing(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -14,6 +14,7 @@ from hermes_cli.auth import (
     XAI_OAUTH_CLIENT_ID,
     XAI_OAUTH_SCOPE,
     _read_xai_oauth_tokens,
+    _refresh_xai_oauth_tokens,
     _save_xai_oauth_tokens,
     _xai_access_token_is_expiring,
     _xai_oauth_poll_device_token,
@@ -313,6 +314,75 @@ def test_save_xai_oauth_tokens_set_active_false_preserves_active_provider(
     raw = json.loads(auth_path.read_text())
     assert raw["active_provider"] == "openrouter"
     assert raw["providers"]["xai-oauth"]["tokens"]["access_token"] == "side-tool-at"
+
+
+def test_save_xai_oauth_tokens_default_sets_active_provider(tmp_path, monkeypatch):
+    """Intentional login default must promote xai-oauth to active_provider."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    auth_path = hermes_home / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_provider": "openrouter",
+                "providers": {},
+            }
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _save_xai_oauth_tokens(
+        {
+            "access_token": "login-at",
+            "refresh_token": "login-rt",
+            "id_token": "",
+            "token_type": "Bearer",
+        },
+        discovery={"token_endpoint": "https://auth.x.ai/oauth2/token"},
+    )
+
+    raw = json.loads(auth_path.read_text())
+    assert raw["active_provider"] == "xai-oauth"
+    assert raw["providers"]["xai-oauth"]["tokens"]["access_token"] == "login-at"
+
+
+def test_refresh_xai_oauth_tokens_preserves_active_provider(tmp_path, monkeypatch):
+    """Token refresh must not flip active_provider away from the chat provider."""
+    hermes_home = tmp_path / "hermes"
+    near = _jwt_with_exp(int(time.time()) + 30)
+    _setup_hermes_auth(hermes_home, access_token=near, refresh_token="rt-old")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    auth_path = hermes_home / "auth.json"
+    raw = json.loads(auth_path.read_text())
+    raw["active_provider"] = "openrouter"
+    auth_path.write_text(json.dumps(raw))
+
+    new_access = _jwt_with_exp(int(time.time()) + 7200)
+
+    def _fake_pure(access_token, refresh_token, **kwargs):
+        return {
+            "access_token": new_access,
+            "refresh_token": "rt-new",
+            "id_token": "",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "last_refresh": "2026-07-25T12:00:00Z",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_xai_oauth_pure", _fake_pure)
+
+    tokens = _read_xai_oauth_tokens()["tokens"]
+    _refresh_xai_oauth_tokens(
+        tokens,
+        token_endpoint="https://auth.x.ai/oauth2/token",
+        timeout_seconds=5.0,
+    )
+
+    after = json.loads(auth_path.read_text())
+    assert after["active_provider"] == "openrouter"
+    assert after["providers"]["xai-oauth"]["tokens"]["access_token"] == new_access
 
 
 def test_read_xai_oauth_tokens_missing(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_setup_tts_xai_oauth.py
+++ b/tests/hermes_cli/test_setup_tts_xai_oauth.py
@@ -1,4 +1,4 @@
-﻿"""Regression: TTS/setup xAI OAuth must not hijack the active chat provider."""
+"""Regression: TTS/setup xAI OAuth must not hijack the active chat provider."""
 
 import json
 
@@ -62,9 +62,15 @@ def test_run_xai_oauth_login_from_setup_does_not_hijack_active_provider(
     )
     monkeypatch.setattr("hermes_cli.auth._is_remote_session", lambda: True)
 
+    from hermes_cli.auth import is_source_suppressed, suppress_credential_source
     from hermes_cli.setup import _run_xai_oauth_login_from_setup
 
+    suppress_credential_source("xai-oauth", "device_code")
+    assert is_source_suppressed("xai-oauth", "device_code") is True
+
     assert _run_xai_oauth_login_from_setup() is True
+
+    assert is_source_suppressed("xai-oauth", "device_code") is False
 
     auth = json.loads(auth_path.read_text(encoding="utf-8"))
     assert auth["active_provider"] == "openrouter"

--- a/tests/hermes_cli/test_setup_tts_xai_oauth.py
+++ b/tests/hermes_cli/test_setup_tts_xai_oauth.py
@@ -1,0 +1,78 @@
+﻿"""Regression: TTS/setup xAI OAuth must not hijack the active chat provider."""
+
+import json
+
+import yaml
+
+
+def test_run_xai_oauth_login_from_setup_does_not_hijack_active_provider(
+    tmp_path, monkeypatch
+):
+    """TTS/setup OAuth must save tokens without switching chat inference routing.
+
+    Regression: `_run_xai_oauth_login_from_setup` used to call
+    `_update_config_for_provider("xai-oauth")` (and token save flipped
+    `active_provider`), so `hermes setup tts` OAuth login hijacked the main
+    chat provider.
+    """
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    auth_path = hermes_home / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_provider": "openrouter",
+                "providers": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "provider": "openrouter",
+                    "default": "anthropic/claude-sonnet-4",
+                    "base_url": "https://openrouter.ai/api/v1",
+                },
+                "tts": {"provider": "edge"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_device_code_login",
+        lambda **kwargs: {
+            "tokens": {
+                "access_token": "tts-xai-access",
+                "refresh_token": "tts-xai-refresh",
+                "id_token": "",
+                "token_type": "Bearer",
+            },
+            "discovery": {"token_endpoint": "https://auth.x.ai/oauth2/token"},
+            "redirect_uri": "",
+            "base_url": "https://api.x.ai/v1",
+            "last_refresh": "2026-07-25T12:00:00Z",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.auth._is_remote_session", lambda: True)
+
+    from hermes_cli.setup import _run_xai_oauth_login_from_setup
+
+    assert _run_xai_oauth_login_from_setup() is True
+
+    auth = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert auth["active_provider"] == "openrouter"
+    xai_state = auth["providers"]["xai-oauth"]
+    assert xai_state["tokens"]["access_token"] == "tts-xai-access"
+    assert xai_state["tokens"]["refresh_token"] == "tts-xai-refresh"
+
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert config["model"]["provider"] == "openrouter"
+    assert config["model"]["base_url"] == "https://openrouter.ai/api/v1"
+    assert config["model"]["default"] == "anthropic/claude-sonnet-4"

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -20,6 +20,7 @@ The fix:
 These tests pin the corrected behavior.
 """
 import asyncio
+import json
 import time
 from datetime import datetime, timezone
 from unittest.mock import patch
@@ -665,6 +666,19 @@ def test_xai_dashboard_poller_seeds_single_entry_and_clears_suppression(tmp_path
     monkeypatch.delenv("HERMES_XAI_BASE_URL", raising=False)
     monkeypatch.delenv("XAI_BASE_URL", raising=False)
 
+    # Existing chat provider must not be overwritten by dashboard OAuth.
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "active_provider": "openrouter",
+                "providers": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
     # Prior `hermes auth remove xai-oauth` left the source suppressed.
     auth_mod.suppress_credential_source("xai-oauth", "device_code")
     assert auth_mod.is_source_suppressed("xai-oauth", "device_code") is True
@@ -707,6 +721,10 @@ def test_xai_dashboard_poller_seeds_single_entry_and_clears_suppression(tmp_path
     # The interactive dashboard login cleared the suppression marker.
     assert auth_mod.is_source_suppressed("xai-oauth", "device_code") is False
 
+    after = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert after["active_provider"] == "openrouter"
+    assert after["providers"]["xai-oauth"]["tokens"]["access_token"] == "xai-dashboard-access"
+
     # The credential pool has exactly one entry, seeded from the
     # singleton as ``device_code`` — no parallel ``manual:dashboard_*``
     # duplicate sharing the single-use refresh token.
@@ -717,6 +735,61 @@ def test_xai_dashboard_poller_seeds_single_entry_and_clears_suppression(tmp_path
     assert not any(
         getattr(e, "source", "").startswith("manual:dashboard") for e in entries
     )
+
+
+def test_xai_dashboard_poller_marks_active_when_unset(tmp_path, monkeypatch):
+    """First dashboard xAI login may set active_provider when none is set yet."""
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import web_server as ws
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_XAI_BASE_URL", raising=False)
+    monkeypatch.delenv("XAI_BASE_URL", raising=False)
+
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(
+        json.dumps({"version": 1, "providers": {}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        auth_mod,
+        "_xai_oauth_discovery",
+        lambda *a, **k: {"token_endpoint": "https://auth.x.ai/token"},
+    )
+    monkeypatch.setattr(
+        auth_mod,
+        "_xai_oauth_poll_device_token",
+        lambda client, **kwargs: {
+            "access_token": "xai-dashboard-first",
+            "refresh_token": "rt-first",
+            "id_token": "",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+    )
+
+    session_id = "xai-dashboard-first-active-test"
+    ws._oauth_sessions[session_id] = {
+        "session_id": session_id,
+        "provider": "xai-oauth",
+        "flow": "device_code",
+        "created_at": time.time(),
+        "status": "pending",
+        "error_message": None,
+        "device_code": "device-code",
+        "interval": 5,
+        "expires_at": time.time() + 600,
+    }
+    try:
+        ws._xai_device_poller(session_id)
+        assert ws._oauth_sessions[session_id]["status"] == "approved"
+    finally:
+        ws._oauth_sessions.pop(session_id, None)
+
+    after = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert after["active_provider"] == "xai-oauth"
+    assert after["providers"]["xai-oauth"]["tokens"]["access_token"] == "xai-dashboard-first"
 
 
 def test_unknown_pkce_provider_rejected_cleanly():


### PR DESCRIPTION
## What does this PR do?

Prevents `hermes setup tts` (and shared setup/tools OAuth helpers) from rewriting the active inference provider when the user only meant to authenticate xAI for side tools. Token save for TTS/setup, token refresh, and dashboard OAuth no longer promote `xai-oauth` over an existing chat provider; intentional model/auth login still does.

### Bug Cause

`_run_xai_oauth_login_from_setup` saved OAuth tokens then called `_update_config_for_provider("xai-oauth")`, which rewrote `auth.json` `active_provider` and `config.yaml` `model.provider`. Independently, `_save_xai_oauth_tokens` always went through `_save_provider_state`, which also forced `active_provider=xai-oauth`, so even token-only paths (TTS setup, refresh, dashboard) could hijack chat routing.

### Reproduction Steps

1. Set chat to a non-xAI provider (for example `model.provider: openrouter`).
2. Ensure xAI OAuth is logged out and `XAI_API_KEY` is unset.
3. Run `hermes setup tts`, choose xAI TTS, then Sign in with xAI Grok OAuth.
4. Inspect `auth.json` `active_provider` and `config.yaml` `model.provider`.

Expected: TTS credentials saved; chat provider unchanged.
Before fix: `active_provider` became `xai-oauth` and `model.provider` was rewritten (then possibly partially restored by wizard `save_config`, leaving auth/config desynced).

### Fix

- Add `set_active` to `_save_xai_oauth_tokens` (default `True` for intentional login).
- TTS/setup login uses `set_active=False` and no longer calls `_update_config_for_provider`.
- Token refresh uses `set_active=False`.
- Dashboard OAuth uses `set_active=False` plus `mark_provider_active_if_unset` (first credential may activate; existing choice preserved).
- Setup login clears `device_code` suppression after save.
- Regression tests cover setup hijack, save modes, refresh, and dashboard preserve/mark-if-unset.

## Related Issue

No issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Changes Made

- `hermes_cli/auth.py` - `set_active` on `_save_xai_oauth_tokens`; refresh does not flip `active_provider`
- `hermes_cli/setup.py` - TTS/setup OAuth saves tokens only; unsuppress `device_code`
- `hermes_cli/web_server.py` - dashboard OAuth preserve/mark-if-unset
- `tests/hermes_cli/test_setup_tts_xai_oauth.py` - setup hijack + unsuppress regression
- `tests/hermes_cli/test_auth_xai_oauth_provider.py` - save/refresh active_provider contracts
- `tests/hermes_cli/test_web_oauth_dispatch.py` - dashboard preserve vs mark-if-unset

## How to Test

1. Manual: follow Reproduction Steps; after login, chat provider must stay unchanged while xAI TTS credentials exist.
2. Automated (already run locally, 119 passed):

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_setup_tts_xai_oauth.py \
  tests/hermes_cli/test_auth_xai_oauth_provider.py \
  tests/hermes_cli/test_web_oauth_dispatch.py \
  tests/hermes_cli/test_setup.py \
  -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (WSL test runner)

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact - N/A (auth/config path, OS-agnostic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
