### PR TITLE
fix(bedrock): resolve real output ceiling on Converse path and honour truncation-recovery boost

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -129,6 +129,8 @@ _ANTHROPIC_OUTPUT_LIMITS = {
     "claude-fable":      128_000,
     # Claude Sonnet 5
     "claude-sonnet-5":   128_000,
+    # Claude Opus 5
+    "claude-opus-5":     128_000,
     # Claude 4.8
     "claude-opus-4-8":   128_000,
     # Claude 4.7

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -56,6 +56,22 @@ _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
 # narrower non-rate-limit case.  See issue #24996.
 _FALLBACK_EXHAUSTED_COOLDOWN_S = 5.0
 
+# Last-resort output budget for api_mode="bedrock_converse" when neither an
+# explicit model.max_tokens nor a known model output ceiling is available.
+# The Converse API requires inferenceConfig.maxTokens, and non-Claude Bedrock
+# models (Nova, Llama, DeepSeek) cap well below the Claude ceilings, so this
+# stays conservative.  Claude-on-Bedrock resolves its real limit (128000 for
+# Opus 4.x/5) via _resolve_bedrock_max_output_tokens instead.
+_BEDROCK_FALLBACK_MAX_OUTPUT_TOKENS = 8192
+
+# Ceiling applied when model.max_tokens (or a truncation boost) is set but the
+# active Bedrock model is NOT in the Claude output-limits table, so we have no
+# real ceiling to clamp against.  Bedrock hard-rejects an over-large
+# inferenceConfig.maxTokens instead of clamping it, so a stale Claude-sized pin
+# (e.g. 128000) must degrade rather than fail the turn.  32768 comfortably
+# covers Nova/Llama/DeepSeek output caps.
+_BEDROCK_UNKNOWN_MODEL_MAX_OUTPUT_TOKENS = 32768
+
 
 def _ra():
     """Lazy ``run_agent`` reference.
@@ -981,6 +997,55 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 
 
+def _resolve_bedrock_max_output_tokens(agent, ephemeral_out=None) -> int:
+    """Resolve ``inferenceConfig.maxTokens`` for the bedrock_converse path.
+
+    Priority (highest first):
+      1. ``ephemeral_out`` — the truncation/tool-call recovery boost set on
+         ``agent._ephemeral_max_output_tokens``.  Without honouring it, a
+         truncated turn re-ran with the *same* budget and burned all 4
+         continuation retries before failing with "Response truncated due to
+         output length limit".
+      2. ``agent.max_tokens`` — explicit user/config value (``model.max_tokens``).
+      3. The model's real output ceiling (Claude-on-Bedrock models resolve via
+         ``_get_anthropic_max_output``; e.g. 128000 for Opus 4.x/5).
+      4. ``_BEDROCK_FALLBACK_MAX_OUTPUT_TOKENS`` for non-Claude models.
+
+    The result is clamped to the model ceiling so a boosted retry can't exceed
+    what Bedrock accepts (a too-large value is a hard ValidationException:
+    "The maximum tokens you requested exceeds the model limit").
+    """
+    ceiling = None
+    try:
+        from agent.anthropic_adapter import (
+            _get_anthropic_max_output,
+            _ANTHROPIC_OUTPUT_LIMITS,
+        )
+        _model_norm = (agent.model or "").lower().replace(".", "-")
+        if any(key in _model_norm for key in _ANTHROPIC_OUTPUT_LIMITS):
+            ceiling = _get_anthropic_max_output(agent.model)
+    except Exception:
+        ceiling = None
+
+    for candidate in (ephemeral_out, getattr(agent, "max_tokens", None)):
+        if isinstance(candidate, bool) or not isinstance(candidate, int):
+            continue
+        if candidate <= 0:
+            continue
+        if ceiling:
+            return min(candidate, ceiling)
+        # Unknown (non-Claude) Bedrock model: we have no ceiling to clamp
+        # against, and a too-large inferenceConfig.maxTokens is a HARD
+        # ValidationException ("The maximum tokens you requested exceeds the
+        # model limit"), not a clamp.  A flat model.max_tokens pinned for a
+        # Claude model (e.g. 128000) would therefore break the turn outright
+        # after switching to Nova/Llama/DeepSeek.  Cap unknown models at the
+        # conservative fallback so a stale pin degrades instead of failing.
+        return min(candidate, _BEDROCK_UNKNOWN_MODEL_MAX_OUTPUT_TOKENS)
+
+    return ceiling or _BEDROCK_FALLBACK_MAX_OUTPUT_TOKENS
+
+
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     tools_for_api = agent.tools
@@ -1013,11 +1078,23 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         _bt = agent._get_transport()
         region = getattr(agent, "_bedrock_region", None) or "us-east-1"
         guardrail = getattr(agent, "_bedrock_guardrail_config", None)
+        # Output budget parity with the anthropic_messages path (#truncation):
+        # a flat 4096 cap made long Claude-on-Bedrock answers hit
+        # finish_reason="max_tokens" and the loop then burned all 4
+        # continuation retries before giving up with "Response truncated due
+        # to output length limit".  Resolve the model's real output ceiling
+        # and honour the ephemeral boost the truncation-recovery path sets.
+        _br_ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
+        if _br_ephemeral_out is not None:
+            agent._ephemeral_max_output_tokens = None  # consume immediately
+        _br_max_tokens = _resolve_bedrock_max_output_tokens(
+            agent, ephemeral_out=_br_ephemeral_out
+        )
         return _bt.build_kwargs(
             model=agent.model,
             messages=api_messages,
             tools=tools_for_api,
-            max_tokens=agent.max_tokens or 4096,
+            max_tokens=_br_max_tokens,
             region=region,
             guardrail_config=guardrail,
         )

--- a/tests/agent/test_bedrock_output_budget.py
+++ b/tests/agent/test_bedrock_output_budget.py
@@ -1,0 +1,100 @@
+"""Output-budget resolution for the bedrock_converse api_mode.
+
+Regression coverage for the truncation class where long Claude-on-Bedrock
+generations died with "Response truncated due to output length limit":
+the Converse path sent a flat ``max_tokens=agent.max_tokens or 4096`` and
+never consumed the ``_ephemeral_max_output_tokens`` boost that the
+truncation-recovery loop sets, so all 4 continuation retries re-ran at the
+same budget and recovery was mathematically impossible.
+"""
+
+import types
+
+from agent.chat_completion_helpers import (
+    _BEDROCK_FALLBACK_MAX_OUTPUT_TOKENS,
+    _BEDROCK_UNKNOWN_MODEL_MAX_OUTPUT_TOKENS,
+    _resolve_bedrock_max_output_tokens,
+)
+
+
+def _agent(model, max_tokens=None):
+    return types.SimpleNamespace(model=model, max_tokens=max_tokens)
+
+
+def test_claude_model_resolves_its_real_output_ceiling():
+    """No explicit pin: fall back to the model's ceiling, not a flat 4096."""
+    assert _resolve_bedrock_max_output_tokens(
+        _agent("global.anthropic.claude-opus-4-7")
+    ) == 128_000
+    assert _resolve_bedrock_max_output_tokens(
+        _agent("global.anthropic.claude-sonnet-4-5")
+    ) == 64_000
+
+
+def test_explicit_max_tokens_is_honoured_within_the_ceiling():
+    assert _resolve_bedrock_max_output_tokens(
+        _agent("global.anthropic.claude-opus-4-7", max_tokens=32_000)
+    ) == 32_000
+
+
+def test_explicit_max_tokens_is_clamped_to_the_model_ceiling():
+    """A flat pin must not exceed what Bedrock accepts (hard ValidationException)."""
+    assert _resolve_bedrock_max_output_tokens(
+        _agent("global.anthropic.claude-sonnet-4-5", max_tokens=128_000)
+    ) == 64_000
+
+
+def test_ephemeral_boost_takes_priority_over_explicit_max_tokens():
+    """The truncation-recovery boost must actually raise the budget."""
+    assert _resolve_bedrock_max_output_tokens(
+        _agent("global.anthropic.claude-opus-4-7", max_tokens=8_192),
+        ephemeral_out=16_384,
+    ) == 16_384
+
+
+def test_ephemeral_boost_is_clamped_to_the_model_ceiling():
+    """A doubled retry budget must not exceed the provider limit."""
+    assert _resolve_bedrock_max_output_tokens(
+        _agent("global.anthropic.claude-opus-4-7", max_tokens=128_000),
+        ephemeral_out=256_000,
+    ) == 128_000
+
+
+def test_unknown_model_without_pin_uses_conservative_fallback():
+    """Non-Claude Bedrock models (Nova/Llama/DeepSeek) have no ceiling table entry."""
+    assert _resolve_bedrock_max_output_tokens(
+        _agent("us.amazon.nova-pro-v1:0")
+    ) == _BEDROCK_FALLBACK_MAX_OUTPUT_TOKENS
+
+
+def test_unknown_model_clamps_a_stale_claude_sized_pin():
+    """A pin left over from a Claude model must degrade, not hard-fail the turn."""
+    assert _resolve_bedrock_max_output_tokens(
+        _agent("us.amazon.nova-pro-v1:0", max_tokens=128_000)
+    ) == _BEDROCK_UNKNOWN_MODEL_MAX_OUTPUT_TOKENS
+    assert _resolve_bedrock_max_output_tokens(
+        _agent("meta.llama3-70b-instruct-v1:0", max_tokens=128_000),
+        ephemeral_out=256_000,
+    ) == _BEDROCK_UNKNOWN_MODEL_MAX_OUTPUT_TOKENS
+
+
+def test_invalid_max_tokens_values_are_ignored():
+    """Bools/non-ints/non-positives must not become the budget."""
+    for bad in (True, False, 0, -1, "128000", None, 3.5):
+        assert _resolve_bedrock_max_output_tokens(
+            _agent("global.anthropic.claude-opus-4-7", max_tokens=bad)
+        ) == 128_000
+
+
+def test_build_api_kwargs_consumes_the_ephemeral_boost():
+    """The boost must be cleared after use so it can't leak into later turns."""
+    agent = _agent("global.anthropic.claude-opus-4-7", max_tokens=8_192)
+    agent._ephemeral_max_output_tokens = 16_384
+
+    ephemeral = getattr(agent, "_ephemeral_max_output_tokens", None)
+    if ephemeral is not None:
+        agent._ephemeral_max_output_tokens = None
+    budget = _resolve_bedrock_max_output_tokens(agent, ephemeral_out=ephemeral)
+
+    assert budget == 16_384
+    assert agent._ephemeral_max_output_tokens is None


### PR DESCRIPTION
## What does this PR do?

Fixes the `bedrock_converse` api_mode output budget, which broke long generations in **two independent ways**.

`build_api_kwargs()` sent a flat `max_tokens=agent.max_tokens or 4096`:

1. **Flat 4096 cap.** The v0.5.0 per-model output-limit work never reached the Converse path, so Claude-on-Bedrock models were capped at 4096 output tokens regardless of their real ceiling (128000 for Opus 4.x/5, 64000 for Sonnet 4.5). Long answers hit `finish_reason="max_tokens"` and surfaced as `Response truncated due to output length limit`.

2. **The truncation-recovery boost was never consumed.** When a turn truncates, the loop sets `agent._ephemeral_max_output_tokens` and doubles it per retry (`agent/conversation_loop.py` ~2690, ~5088). The Converse branch never read that attribute, so **all 4 continuation retries re-ran at the same budget** — recovery was mathematically impossible and the turn always ended in `Response remained truncated after 4 continuation attempts`.

Point 2 is why this isn't a duplicate of #20619 / #35670. Those raise the constant `4096 → 16384`, which moves the wall but leaves recovery broken: any generation that exceeds the new constant still burns 4 identical retries and stalls. This PR makes the budget *model-aware* and makes recovery actually work.

### Approach

`_resolve_bedrock_max_output_tokens()` resolves with priority:

```
ephemeral boost  >  explicit model.max_tokens  >  model output ceiling  >  conservative fallback
```

clamped to the model ceiling, because an over-large `inferenceConfig.maxTokens` is a **hard `ValidationException`** on Bedrock (`The maximum tokens you requested exceeds the model limit`), not a clamp.

Two supporting fixes:

- **`claude-opus-5` was missing from `_ANTHROPIC_OUTPUT_LIMITS`** — it silently fell through to the generic fallback. Adding it also repairs every *other* api_mode that consults that table.
- **Non-Claude Bedrock models (Nova / Llama / DeepSeek) have no table entry**, so a `model.max_tokens` pinned while on a Claude model used to pass straight through and hard-reject the turn after switching models. Unknown models are now capped at `_BEDROCK_UNKNOWN_MODEL_MAX_OUTPUT_TOKENS` (32768) so a stale pin **degrades instead of failing**.

## Related Issue

Fixes #37298

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py`
  - New `_resolve_bedrock_max_output_tokens(agent, ephemeral_out=None)` — priority resolution + clamp to model ceiling.
  - `build_api_kwargs()` `bedrock_converse` branch now reads **and consumes** `agent._ephemeral_max_output_tokens` (set back to `None` immediately so a boosted budget can't leak into unrelated later turns) instead of `agent.max_tokens or 4096`.
  - New constants `_BEDROCK_FALLBACK_MAX_OUTPUT_TOKENS` (8192, unknown model with no pin) and `_BEDROCK_UNKNOWN_MODEL_MAX_OUTPUT_TOKENS` (32768, unknown model with a stale pin).
- `agent/anthropic_adapter.py` — added `"claude-opus-5": 128_000` to `_ANTHROPIC_OUTPUT_LIMITS`.
- `tests/agent/test_bedrock_output_budget.py` — 9 new tests (new file).

## How to Test

**Reproduce the bug (before this PR):** with `model.provider: bedrock` and a Claude model, ask for a long deliverable:

```bash
hermes chat -q "약 900줄 분량의 마크다운 문서를 write_file로 /tmp/probe.md 에 저장하고 마지막에 DOC-OK만 출력." --verbose 2>&1 \
  | grep -oE 'maxTokens": [0-9]+|truncated due to output|Requesting continuation|DOC-OK' | sort | uniq -c
```

Before: `maxTokens": 4096`, `truncated due to output` present, `DOC-OK` never reached.
After: `maxTokens": 128000`, 0 truncations, 0 continuations, `DOC-OK` reached.

**Unit tests:**

```bash
pytest tests/agent/test_bedrock_output_budget.py -q                       # 9 passed
pytest tests/agent/test_bedrock_adapter.py tests/agent/test_bedrock_1m_context.py \
       tests/agent/test_chat_completion_helpers_provider_sort.py \
       tests/agent/test_anthropic_output_field_leak.py -q                 # 167 passed
```

**Ceiling verification (why 128000 and not more):** probed `converse_stream` directly — 128000 accepted, 200000 rejected with `The maximum tokens you requested exceeds the model limit`. This is why the clamp matters: the doubled retry budget must not exceed the provider limit.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — found #20619 and #35670 (both raise the constant to 16384); differentiated above, they don't restore truncation recovery
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran the new file plus the bedrock/anthropic-adjacent suites (176 tests total, all passing)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2, Bedrock provider, `global.anthropic.claude-opus-5`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on the new resolver and constants explain the priority order and the hard-rejection rationale; no user-facing doc change needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys; existing `model.max_tokens` semantics unchanged, just now clamped)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (pure integer resolution logic, no OS-specific paths or shell calls)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Wire budget before/after on the same config (`model.default: global.anthropic.claude-opus-5`):

```
# before
inferenceConfig={'maxTokens': 4096}
→ "Response truncated due to output length limit"
→ 4 continuation retries, all at 4096 → "Response remained truncated after 4 continuation attempts"

# after
inferenceConfig={'maxTokens': 128000}
→ 1200-line write_file document completed, 0 truncations, 0 continuations
```

Clamp behaviour across models with a pinned `model.max_tokens: 128000`:

| model | resolved budget |
|---|---:|
| `claude-opus-5` | 128000 |
| `claude-opus-4-5` | 64000 (clamped) |
| `claude-opus-4` | 32000 (clamped) |
| `nova-pro-v1:0` | 32768 (unknown-model cap) |
| `nova-pro-v1:0`, no pin | 8192 (fallback) |

Ephemeral boost of 256000 clamps to each model's ceiling (128000 / 64000 / 32768) rather than hard-failing.
