### PR TITLE
fix(redact): mask secrets in Python mapping reprs

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -182,6 +182,58 @@ _JSON_FIELD_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Python ``repr`` uses single-quoted mapping fields, so opaque credentials in
+# tracebacks and pytest failure introspection bypass the double-quoted JSON rule
+# above: ``{'BRAVE_API_KEY': 'opaque-value'}``. Capture identifier-shaped keys
+# here, then apply the canonical high-confidence key policy in the callback.
+_PYTHON_REPR_SECRET_KEYS = frozenset({
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "auth_token",
+    "token",
+    "api_key",
+    "apikey",
+    "client_secret",
+    "secret",
+    "password",
+    "passwd",
+    "private_key",
+    "credential",
+    "credentials",
+    "authorization",
+    "bearer",
+    "secret_value",
+    "raw_secret",
+    "secret_input",
+    "key_material",
+})
+_PYTHON_REPR_ENV_SUFFIXES = (
+    "_API_KEY",
+    "_TOKEN",
+    "_SECRET",
+    "_PASSWORD",
+    "_PASSWD",
+    "_CREDENTIAL",
+    "_CREDENTIALS",
+)
+_PYTHON_REPR_FIELD_RE = re.compile(
+    r"'(?P<key>[A-Za-z_][A-Za-z0-9_]*)'(?P<sep>\s*:\s*)"
+    r"(?:"
+    r"(?P<single_prefix>[bB]?)'(?P<single_value>(?:\\.|[^'\\])+)'"
+    r"|(?P<double_prefix>[bB]?)\"(?P<double_value>(?:\\.|[^\"\\])+)\""
+    r")"
+)
+
+# Terminal/process output normally uses ``code_file=True`` to preserve source.
+# Add repr masking only to high-confidence diagnostic lines: pytest assertion
+# introspection (``E       ...``) and final Python exception lines.
+_PYTEST_DIAGNOSTIC_LINE_RE = re.compile(r"^(?P<prefix>[ \t]*E[ \t]{2,})(?P<body>.*)$")
+_PYTHON_EXCEPTION_LINE_RE = re.compile(
+    r"^(?P<prefix>(?:[A-Za-z_]\w*\.)*[A-Za-z_]\w*"
+    r"(?:Error|Exception|Warning):[ \t]*)(?P<body>.*)$"
+)
+
 # Authorization headers — any scheme (Bearer, Basic, Token, Digest, …) plus the
 # bare-credential form, and Proxy-Authorization. The credential token is masked
 # while the header name and scheme word are preserved for debuggability. The
@@ -378,6 +430,65 @@ def _mask_token(token: str) -> str:
     return mask_secret(token, head=6, tail=4, floor=18)
 
 
+def _is_python_repr_secret_key(key: str) -> bool:
+    """Return True for exact secret keys or uppercase env credential suffixes."""
+    if key.casefold() in _PYTHON_REPR_SECRET_KEYS:
+        return True
+    return key.isupper() and key.endswith(_PYTHON_REPR_ENV_SUFFIXES)
+
+
+def _redact_python_repr_fields(text: str) -> str:
+    """Fully mask credential fields in Python mapping ``repr`` output."""
+    def _sub(match: re.Match) -> str:
+        key = match.group("key")
+        if not _is_python_repr_secret_key(key):
+            return match.group(0)
+
+        single_value = match.group("single_value")
+        if single_value is not None:
+            prefix = match.group("single_prefix") or ""
+            quote = "'"
+            value = single_value
+        else:
+            prefix = match.group("double_prefix") or ""
+            quote = '"'
+            value = match.group("double_value")
+
+        # Mapping repr can contain code-shaped fixture values too. Preserve
+        # programmatic env lookups just like the ENV/JSON/YAML passes do.
+        if _ENV_LOOKUP_VALUE_RE.match(value):
+            return match.group(0)
+        # Do not retain head/tail characters here: escaped repr atoms can cross
+        # a slicing boundary and leave an unescaped quote behind. A full mask is
+        # parseable for both str and bytes values and leaks no opaque bytes.
+        return f"'{key}'{match.group('sep')}{prefix}{quote}***{quote}"
+
+    return _PYTHON_REPR_FIELD_RE.sub(_sub, text)
+
+
+def _redact_python_diagnostic_repr_fields(text: str) -> str:
+    """Mask repr fields only on pytest/error lines in source-preserving output."""
+    lines = text.splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        ending = ""
+        body_line = line
+        if line.endswith("\r\n"):
+            body_line, ending = line[:-2], "\r\n"
+        elif line.endswith("\n") or line.endswith("\r"):
+            body_line, ending = line[:-1], line[-1:]
+
+        match = _PYTEST_DIAGNOSTIC_LINE_RE.match(body_line)
+        if match is None:
+            match = _PYTHON_EXCEPTION_LINE_RE.match(body_line)
+        if match is not None:
+            lines[index] = (
+                match.group("prefix")
+                + _redact_python_repr_fields(match.group("body"))
+                + ending
+            )
+    return "".join(lines)
+
+
 def _redact_query_string(query: str) -> str:
     """Redact sensitive parameter values in a URL query string.
 
@@ -560,7 +671,7 @@ def redact_sensitive_text(
     URL userinfo. The default remains False because actionable OAuth callback,
     magic-link, and pre-signed URLs must survive ordinary tool flows unchanged.
 
-    Set code_file=True to skip the ENV-assignment and JSON-field regex
+    Set code_file=True to skip the ENV-assignment, JSON-field, and Python-repr
     patterns when the text is known to be source code (e.g. MAX_TOKENS=***
     constants, "apiKey": "test" fixtures). Prefix patterns, auth headers,
     private keys, DB connstrings, JWTs, and URL secrets are still redacted.
@@ -635,6 +746,12 @@ def redact_sensitive_text(
                     return m.group(0)
                 return f'{key}: "{_mask_token(value)}"'
             text = _JSON_FIELD_RE.sub(_redact_json, text)
+
+        # Python mapping repr fields: {'API_KEY': '***'}. This is a log /
+        # traceback shape, not ordinary source-code handling; terminal output
+        # from Python commands gets a narrowly scoped pass below.
+        if ":" in text and "'" in text:
+            text = _redact_python_repr_fields(text)
 
         # Unquoted YAML / colon config: password: ***  (after JSON so quoted
         # values are handled there; the lookahead in _YAML_ASSIGN_RE skips
@@ -792,7 +909,8 @@ def redact_terminal_output(
     - env-dump command (``env``/``printenv``/``set``/``export``/``declare``)
       → ``code_file=False`` so the ENV-assignment pass masks opaque tokens.
     - anything else (or unknown command) → ``code_file=True`` to avoid
-      false positives on source/config dumps.
+      false positives on source/config dumps. High-confidence pytest diagnostic
+      and final exception lines still receive the Python-repr credential pass.
 
     ``force=True`` bypasses the global ``security.redact_secrets`` preference
     for safety boundaries that must never emit raw credentials.
@@ -800,7 +918,15 @@ def redact_terminal_output(
     if not output:
         return output
     code_file = not is_env_dump_command(command or "")
-    return redact_sensitive_text(output, force=force, code_file=code_file)
+    redacted = redact_sensitive_text(output, force=force, code_file=code_file)
+    if (
+        code_file
+        and (force or _REDACT_ENABLED)
+        and ":" in redacted
+        and "'" in redacted
+    ):
+        redacted = _redact_python_diagnostic_repr_fields(redacted)
+    return redacted
 
 
 # Substrings used to gate ``_PREFIX_RE`` execution. If none of these appear in

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1,5 +1,6 @@
 """Tests for agent.redact -- secret masking in logs and output."""
 
+import ast
 import logging
 
 import pytest
@@ -229,6 +230,76 @@ class TestJsonFields:
         text = '{"name": "John", "model": "gpt-4"}'
         result = redact_sensitive_text(text)
         assert result == text
+
+
+class TestPythonReprFields:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "BRAVE_API_KEY",
+            "SERVICE_TOKEN",
+            "DB_PASSWORD",
+            "api_key",
+            "access_token",
+            "client_secret",
+            "id_token",
+            "private_key",
+        ],
+    )
+    def test_secret_field_in_nested_python_repr_is_redacted(self, key):
+        secret = f"opaque-{key.lower()}-value-1234567890"
+        text = f"kwargs={{'env': {{'{key}': '{secret}'}}}}"
+
+        result = redact_sensitive_text(text, force=True)
+
+        assert secret not in result
+        assert f"'{key}': '***'" in result
+
+    @pytest.mark.parametrize(
+        "key",
+        ["TOKEN_COUNT", "AUTH_METHOD", "PASSWORD_POLICY", "SECRET_NAME", "CREDENTIAL_TYPE"],
+    )
+    def test_uppercase_metadata_field_is_unchanged(self, key):
+        text = f"{{'{key}': 'public-metadata-value'}}"
+        assert redact_sensitive_text(text, force=True) == text
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "apostrophe-near-head-'1234567890",
+            "apostrophe-near-tail-1234567890'",
+            b"bytes-apostrophe-near-head-'1234567890",
+            b"bytes-apostrophe-near-tail-1234567890'",
+        ],
+    )
+    def test_escaped_repr_value_remains_parseable(self, value):
+        text = repr({"API_KEY": value})
+
+        result = redact_sensitive_text(text, force=True)
+        parsed = ast.literal_eval(result)
+
+        assert parsed["API_KEY"] == (b"***" if isinstance(value, bytes) else "***")
+
+    def test_double_quoted_repr_value_is_redacted(self):
+        secret = "opaque-double-quoted-value-1234567890"
+        text = f"payload={{'SERVICE_TOKEN': \"{secret}\"}}"
+
+        result = redact_sensitive_text(text, force=True)
+
+        assert secret not in result
+        assert "'SERVICE_TOKEN': \"***\"" in result
+
+    def test_programmatic_env_lookup_is_preserved(self):
+        text = "{'API_KEY': \"os.getenv('OPENAI_API_KEY')\"}"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_non_secret_python_repr_field_is_unchanged(self):
+        text = "{'model': 'gpt-5', 'token_count': '123'}"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def test_code_file_preserves_secret_shaped_fixture(self):
+        text = "CONFIG = {'BRAVE_API_KEY': 'fixture-value-1234567890'}"
+        assert redact_sensitive_text(text, force=True, code_file=True) == text
 
 
 class TestAuthHeaders:
@@ -958,6 +1029,66 @@ class TestTerminalOutputRedaction:
         red = redact_terminal_output(out, "cat config.py")
         assert "MAX_TOKENS=100" in red
         assert "abc123def456" not in red
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "python -m pytest",
+            "uv run pytest",
+            "poetry run pytest",
+            "coverage run -m pytest",
+            "PYTHONPATH=. pytest",
+            "/usr/bin/env pytest",
+            "bash -lc 'pytest tests/agent/test_redact.py'",
+        ],
+    )
+    def test_pytest_diagnostic_masks_python_repr_secret_field(self, command):
+        from agent.redact import redact_terminal_output
+
+        secret = "opaque-brave-value-1234567890"
+        out = f"E       kwargs={{'env': {{'BRAVE_API_KEY': '{secret}'}}}}"
+
+        red = redact_terminal_output(out, command, force=True)
+
+        assert secret not in red
+        assert "'BRAVE_API_KEY': '***'" in red
+
+    def test_exception_line_masks_python_repr_secret_field(self):
+        from agent.redact import redact_terminal_output
+
+        secret = "opaque-exception-value-1234567890"
+        out = f"RuntimeError: payload={{'API_KEY': '{secret}'}}"
+
+        red = redact_terminal_output(out, "python app.py", force=True)
+
+        assert secret not in red
+        assert "'API_KEY': '***'" in red
+
+    def test_source_dump_preserves_python_repr_fixture(self):
+        from agent.redact import redact_terminal_output
+
+        out = "CONFIG = {'BRAVE_API_KEY': 'fixture-value-1234567890'}"
+        assert redact_terminal_output(out, "cat config.py", force=True) == out
+        assert redact_terminal_output(out, "python dump_source.py", force=True) == out
+
+    def test_pytest_source_line_preserves_python_repr_fixture(self):
+        from agent.redact import redact_terminal_output
+
+        source = "    CONFIG = {'BRAVE_API_KEY': 'fixture-value-1234567890'}"
+        out = source + "\nE       assert False"
+
+        red = redact_terminal_output(out, "uv run pytest", force=True)
+
+        assert source in red
+
+    def test_disabled_pytest_diagnostic_passes_through(self, monkeypatch):
+        from agent.redact import redact_terminal_output
+
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        secret = "opaque-disabled-value-1234567890"
+        out = f"E       payload={{'API_KEY': '{secret}'}}"
+
+        assert redact_terminal_output(out, "uv run pytest") == out
 
     def test_unknown_command_uses_safe_code_file_path(self):
         from agent.redact import redact_terminal_output


### PR DESCRIPTION
## What does this PR do?

Masks opaque credential values embedded in Python mapping `repr` output, including pytest/traceback shapes such as:

```text
E       kwargs={'env': {'BRAVE_API_KEY': 'opaque-provider-value'}}
```

Hermes already redacts `KEY=value`, double-quoted JSON fields, known vendor prefixes, headers, URLs, and other credential forms. Python `repr` normally uses single-quoted mapping fields, so an opaque value with no recognized vendor prefix bypassed both `redact_sensitive_text(..., force=True)` and pytest diagnostic output.

### Before

```python
sample = "kwargs={'env': {'BRAVE_API_KEY': 'opaque-provider-value-1234567890'}}"
redact_sensitive_text(sample, force=True) == sample
```

### After

```text
kwargs={'env': {'BRAVE_API_KEY': '***'}}
```

The full value is replaced with `***` rather than a head/tail mask. This prevents an escaped quote from being split at a masking boundary and keeps real `repr()` output parseable for both `str` and `bytes` values.

## Design

- Captures identifier-shaped keys, then applies a high-confidence policy:
  - exact established credential fields (`api_key`, `access_token`, `client_secret`, `private_key`, etc.);
  - uppercase env keys ending in credential suffixes (`_API_KEY`, `_TOKEN`, `_PASSWORD`, etc.).
- Explicitly leaves metadata such as `TOKEN_COUNT`, `AUTH_METHOD`, `PASSWORD_POLICY`, `SECRET_NAME`, and `CREDENTIAL_TYPE` unchanged.
- Supports single- or double-quoted values, optional `b` prefixes, and escaped characters.
- Preserves programmatic env lookup fixtures such as `{'API_KEY': "os.getenv('OPENAI_API_KEY')"}`.
- Keeps `code_file=True` byte-preserving.
- At terminal/process boundaries, applies repr masking only to high-confidence pytest diagnostic lines (`E       ...`) and final Python `*Error` / `*Exception` / `*Warning` lines. Ordinary source emitted by `cat`, Python scripts, or pytest remains unchanged.
- Diagnostic classification is content-based rather than launcher-based, so wrapped invocations (`uv run pytest`, `poetry run pytest`, `coverage run -m pytest`, `/usr/bin/env pytest`, etc.) behave consistently.
- Uses the existing redaction preference and `force=True` behavior; no new config or tool surface.

## Related work

- #50259 documented the same single-quoted Python-dict limitation for `hermes config show`, but that report was closed as implemented through a config-specific structured path rather than the generic log/terminal redactor.
- #69196 addresses escaped quotes inside double-quoted JSON fields. This PR is complementary: it adds a separate Python-repr matcher and does not modify `_JSON_FIELD_RE`.

No exact open issue/PR for generic Python mapping repr redaction was found.

## Type of change

- [x] Bug fix
- [x] Security hardening
- [x] Tests

## Verification

```text
scripts/run_tests.sh \
  tests/agent/test_redact.py \
  tests/tools/test_terminal_output_transform_hook.py -q
→ 198 passed

uvx --from ruff==0.15.10 ruff check agent/redact.py tests/agent/test_redact.py
→ All checks passed

python3 -m py_compile agent/redact.py tests/agent/test_redact.py
git diff --check
→ passed
```

Additional synthetic verification:

- 32-case escaped `str`/`bytes` repr oracle passed with `ast.literal_eval`;
- 6 negative metadata-key controls passed;
- 7 wrapped pytest launcher diagnostics passed;
- Python/cat/pytest source-preservation controls passed;
- a 1,000,039-character escaped repr value was fully masked in ~109 ms on the test host.

All test values are synthetic; no real credentials are used.

## Checklist

- [x] Scoped to `agent/redact.py` and `tests/agent/test_redact.py`
- [x] Existing source-code false-positive protections preserved
- [x] Focused canonical test runner passed
- [x] Ruff and syntax checks passed
- [x] No config/schema/tool changes
- [x] Linux verification
