### PR TITLE
docs(tools-reference): fix stale feishu_comment.py path

### DIFF
--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -64,7 +64,7 @@ These two tools live in the `browser` toolset but only register when a Chrome De
 
 ## `feishu_doc` toolset
 
-Scoped to the Feishu document-comment intelligent-reply handler (`gateway/platforms/feishu_comment.py`). Not exposed on `hermes-cli` or the regular Feishu chat adapter.
+Scoped to the Feishu document-comment intelligent-reply handler (`plugins/platforms/feishu/feishu_comment.py`). Not exposed on `hermes-cli` or the regular Feishu chat adapter.
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|


### PR DESCRIPTION
## Problem

The [Built-in Tools Reference](https://hermesagents.com/docs/reference/tools-reference) page references `gateway/platforms/feishu_comment.py` as the location of the Feishu document-comment handler. That path is stale — the feishu adapter was migrated from `gateway/platforms/` to `plugins/platforms/feishu/` in the platform-plugin migration (#49408).

## Root cause

Line 67 of `website/docs/reference/tools-reference.md` still uses the pre-migration path.

## Fix

- Updated `gateway/platforms/feishu_comment.py` → `plugins/platforms/feishu/feishu_comment.py` to match the current codebase location.

## Verification

- Confirmed `plugins/platforms/feishu/feishu_comment.py` exists on `upstream/main` (commit `6ad632bf9`)
- Confirmed `gateway/platforms/feishu_comment.py` does **not** exist in `gateway/platforms/` (only legacy adapters remain there)
- No other `gateway/platforms/` references in the website docs are stale — all other referenced files still exist at their documented paths