### PR TITLE
fix(network): default to IPv4-first DNS ordering to avoid dead-IPv6-route timeouts

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3218,10 +3218,13 @@ def run_job(
 
         # Apply IPv4 preference if configured.
         try:
-            from hermes_constants import apply_ipv4_preference
+            from hermes_constants import apply_ipv4_preference, apply_ipv6_fallback_ordering
             _net_cfg = _cfg.get("network", {})
-            if isinstance(_net_cfg, dict) and _net_cfg.get("force_ipv4"):
-                apply_ipv4_preference(force=True)
+            if isinstance(_net_cfg, dict):
+                if _net_cfg.get("ipv4_first", True):
+                    apply_ipv6_fallback_ordering(enabled=True)
+                if _net_cfg.get("force_ipv4"):
+                    apply_ipv4_preference(force=True)
         except Exception:
             pass
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2040,10 +2040,13 @@ if _config_path.exists():
 
 # Apply IPv4 preference if configured (before any HTTP clients are created).
 try:
-    from hermes_constants import apply_ipv4_preference
+    from hermes_constants import apply_ipv4_preference, apply_ipv6_fallback_ordering
     _network_cfg = (_cfg if '_cfg' in dir() else {}).get("network", {})
-    if isinstance(_network_cfg, dict) and _network_cfg.get("force_ipv4"):
-        apply_ipv4_preference(force=True)
+    if isinstance(_network_cfg, dict):
+        if _network_cfg.get("ipv4_first", True):
+            apply_ipv6_fallback_ordering(enabled=True)
+        if _network_cfg.get("force_ipv4"):
+            apply_ipv4_preference(force=True)
 except Exception as _bootstrap_exc:
     print(f"  Warning: IPv4 preference application failed: {_bootstrap_exc}", file=sys.stderr)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3041,6 +3041,11 @@ DEFAULT_CONFIG = {
         # Python tries AAAA records first and hangs for the full TCP timeout
         # before falling back to IPv4.  Set to true to skip IPv6 entirely.
         "force_ipv4": False,
+        # Try IPv4 before IPv6 in DNS resolution ordering.  Lighter-weight than
+        # force_ipv4: keeps IPv6 available but sorts A records before AAAA so
+        # that dual-stack hosts with dead IPv6 routes don't pay the TCP connect
+        # timeout on every call before falling back to IPv4.  On by default.
+        "ipv4_first": True,
     },
 
     # Gateway settings — control how messaging platforms (Telegram, Discord,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -693,6 +693,9 @@ load_hermes_dotenv(project_env=PROJECT_ROOT / ".env")
 # separate config.yaml reads (saves ~17ms on every CLI startup — the second
 # `load_config()` was doing a full deep-merge for one boolean lookup).
 _FORCE_IPV4_EARLY = False
+# network.ipv4_first defaults on even for a configless profile. Explicit
+# ``ipv4_first: false`` below disables this lighter-weight ordering.
+_IPV4_FIRST_EARLY = True
 try:
     import yaml as _yaml_early
 
@@ -719,8 +722,13 @@ try:
                 if _early_redact is not None:
                     os.environ["HERMES_REDACT_SECRETS"] = str(_early_redact).lower()
         _early_net_cfg = _early_cfg_raw.get("network", {})
-        if isinstance(_early_net_cfg, dict) and _early_net_cfg.get("force_ipv4"):
-            _FORCE_IPV4_EARLY = True
+        if isinstance(_early_net_cfg, dict):
+            if _early_net_cfg.get("force_ipv4"):
+                _FORCE_IPV4_EARLY = True
+            # ipv4_first defaults to True — apply the lighter-weight IPv4-first
+            # DNS ordering unless explicitly disabled.
+            if _early_net_cfg.get("ipv4_first") is False:
+                _IPV4_FIRST_EARLY = False
         del _early_cfg_raw
     del _cfg_path
 except Exception:
@@ -752,6 +760,17 @@ if _FORCE_IPV4_EARLY:
         from hermes_constants import apply_ipv4_preference as _apply_ipv4
 
         _apply_ipv4(force=True)
+    except Exception:
+        pass  # best-effort — don't crash if hermes_constants not importable yet
+
+# Apply the lighter-weight IPv4-first DNS ordering (issue #71215).  This sorts
+# getaddrinfo results so A records are tried before AAAA, avoiding the 10-30 s
+# IPv6 connect timeout on dual-stack hosts with dead IPv6 routes.  On by default.
+if _IPV4_FIRST_EARLY:
+    try:
+        from hermes_constants import apply_ipv6_fallback_ordering as _apply_ipv4first
+
+        _apply_ipv4first(enabled=True)
     except Exception:
         pass  # best-effort — don't crash if hermes_constants not importable yet
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1220,6 +1220,48 @@ def apply_ipv4_preference(force: bool = False) -> None:
     socket.getaddrinfo = _ipv4_getaddrinfo  # type: ignore[assignment]
 
 
+def apply_ipv6_fallback_ordering(enabled: bool = True) -> None:
+    """Monkey-patch ``socket.getaddrinfo`` to sort results IPv4-first.
+
+    Unlike :func:`apply_ipv4_preference` — which fully removes IPv6 from the
+    resolution — this keeps both IPv4 and IPv6 addresses available but reorders
+    ``getaddrinfo`` results so that A records come before AAAA records.
+
+    This is the lighter-weight fix for the "dead IPv6 route" problem (issue
+    #71215): dual-stack hosts whose providers publish AAAA records that route
+    nowhere pay a 10-30 s TCP connect timeout on every API call before falling
+    back to IPv4.  Trying IPv4 first eliminates the timeout while still allowing
+    IPv6 to be used when no A record exists.
+
+    Safe to call multiple times — only patches once.
+    Set ``network.ipv4_first: true`` in ``config.yaml`` to enable (on by default).
+    """
+    if not enabled:
+        return
+
+    import socket
+
+    # Guard against double-patching
+    if getattr(socket.getaddrinfo, "_hermes_ipv4first_patched", False):
+        return
+
+    _original_getaddrinfo = socket.getaddrinfo
+
+    def _ipv4first_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+        if family == 0:  # AF_UNSPEC — caller didn't request a specific family
+            results = _original_getaddrinfo(host, port, family, type, proto, flags)
+            # Sort IPv4 (AF_INET) before IPv6 (AF_INET6); leave other families
+            # (e.g. AF_UNIX) in their original order via a stable sort.
+            return sorted(
+                results,
+                key=lambda r: 0 if r[0] == socket.AF_INET else (1 if r[0] == socket.AF_INET6 else 2),
+            )
+        return _original_getaddrinfo(host, port, family, type, proto, flags)
+
+    _ipv4first_getaddrinfo._hermes_ipv4first_patched = True  # type: ignore[attr-defined]
+    socket.getaddrinfo = _ipv4first_getaddrinfo  # type: ignore[assignment]
+
+
 # ─── Streaming Response Constants ────────────────────────────────────────────
 
 # Response ID for partial stream stubs used during error recovery

--- a/tests/test_ipv4_first.py
+++ b/tests/test_ipv4_first.py
@@ -1,0 +1,111 @@
+"""Tests for network.ipv4_first — the IPv4-first DNS ordering monkey-patch.
+
+Mirrors the test pattern in test_ipv4_preference.py but for the lighter-weight
+apply_ipv6_fallback_ordering() introduced for issue #71215.
+"""
+
+import importlib
+import socket
+
+
+def _reload_constants():
+    """Reload hermes_constants to get a fresh apply_ipv6_fallback_ordering."""
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    return hermes_constants
+
+
+class TestApplyIPv6FallbackOrdering:
+    """Tests for apply_ipv6_fallback_ordering()."""
+
+    def setup_method(self):
+        """Save the original getaddrinfo before each test."""
+        self._original = socket.getaddrinfo
+
+    def teardown_method(self):
+        """Restore the original getaddrinfo after each test."""
+        socket.getaddrinfo = self._original
+
+    def test_noop_when_enabled_false(self):
+        """No patch when enabled=False."""
+        from hermes_constants import apply_ipv6_fallback_ordering
+        original = socket.getaddrinfo
+        apply_ipv6_fallback_ordering(enabled=False)
+        assert socket.getaddrinfo is original
+
+    def test_patches_getaddrinfo_when_enabled(self):
+        """Patches socket.getaddrinfo when enabled=True (default)."""
+        from hermes_constants import apply_ipv6_fallback_ordering
+        original = socket.getaddrinfo
+        apply_ipv6_fallback_ordering()
+        assert socket.getaddrinfo is not original
+        assert getattr(socket.getaddrinfo, "_hermes_ipv4first_patched", False) is True
+
+    def test_double_patch_is_safe(self):
+        """Calling apply twice doesn't double-wrap."""
+        from hermes_constants import apply_ipv6_fallback_ordering
+        apply_ipv6_fallback_ordering()
+        first_patch = socket.getaddrinfo
+        apply_ipv6_fallback_ordering()
+        assert socket.getaddrinfo is first_patch
+
+    def test_af_unspec_results_sorted_ipv4_first(self):
+        """AF_UNSPEC results are sorted so AF_INET comes before AF_INET6."""
+        from hermes_constants import apply_ipv6_fallback_ordering
+
+        ipv6_result = (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 80))
+        ipv4_result = (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80))
+
+        def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+            # Return IPv6 first to verify the patch reorders.
+            return [ipv6_result, ipv4_result]
+
+        socket.getaddrinfo = mock_getaddrinfo
+        apply_ipv6_fallback_ordering()
+
+        result = socket.getaddrinfo("example.com", 80)
+        assert result[0][0] == socket.AF_INET, "AF_INET should be sorted first"
+        assert result[1][0] == socket.AF_INET6, "AF_INET6 should come after AF_INET"
+
+    def test_explicit_family_preserved(self):
+        """Explicit AF_INET6 requests are not reordered (pass-through)."""
+        from hermes_constants import apply_ipv6_fallback_ordering
+
+        calls = []
+
+        ipv6_result = (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 80))
+
+        def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+            calls.append(family)
+            return [ipv6_result]
+
+        socket.getaddrinfo = mock_getaddrinfo
+        apply_ipv6_fallback_ordering()
+
+        socket.getaddrinfo("example.com", 80, family=socket.AF_INET6)
+        assert calls[-1] == socket.AF_INET6, "Explicit AF_INET6 should pass through"
+
+    def test_ipv6_only_results_preserved(self):
+        """Pure-IPv6 hosts still resolve (just in IPv6 order)."""
+        from hermes_constants import apply_ipv6_fallback_ordering
+
+        ipv6_result = (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 80))
+
+        def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+            return [ipv6_result]
+
+        socket.getaddrinfo = mock_getaddrinfo
+        apply_ipv6_fallback_ordering()
+
+        result = socket.getaddrinfo("ipv6only.example.com", 80)
+        assert len(result) == 1
+        assert result[0][0] == socket.AF_INET6
+
+
+class TestConfigDefault:
+    """Verify network.ipv4_first exists in DEFAULT_CONFIG."""
+
+    def test_ipv4_first_in_default_config(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        assert "network" in DEFAULT_CONFIG
+        assert DEFAULT_CONFIG["network"]["ipv4_first"] is True

--- a/tests/test_ipv4_first_cli_startup.py
+++ b/tests/test_ipv4_first_cli_startup.py
@@ -1,0 +1,57 @@
+"""CLI startup regression tests for the default IPv4-first DNS ordering."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _import_main_with_home(repo_root: Path, hermes_home: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["PYTHONPATH"] = str(repo_root)
+    env.pop("HERMES_REDACT_SECRETS", None)
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import socket; "
+                "import hermes_cli.main; "
+                "print(getattr(socket.getaddrinfo, '_hermes_ipv4first_patched', False))"
+            ),
+        ],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+
+def test_cli_startup_applies_ipv4_first_for_configless_profile(tmp_path):
+    """network.ipv4_first defaults on even when HERMES_HOME has no config.yaml."""
+    repo_root = Path(__file__).resolve().parents[1]
+    hermes_home = tmp_path / "configless-profile"
+    hermes_home.mkdir()
+
+    result = _import_main_with_home(repo_root, hermes_home)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith("True")
+
+
+def test_cli_startup_respects_explicit_ipv4_first_false(tmp_path):
+    """Users can opt out of the default without enabling force_ipv4."""
+    repo_root = Path(__file__).resolve().parents[1]
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("network:\n  ipv4_first: false\n", encoding="utf-8")
+
+    result = _import_main_with_home(repo_root, hermes_home)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith("False")

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2104,10 +2104,13 @@ Connectivity workarounds for outbound HTTP:
 
 ```yaml
 network:
+  ipv4_first: true    # Try IPv4 answers before IPv6 while keeping IPv6 available (default: true)
   force_ipv4: false   # Force IPv4 for outbound connections (default: false)
 ```
 
-`force_ipv4` — on servers with broken or unreachable IPv6, Python resolves AAAA records first and can hang for the full TCP timeout before falling back to IPv4. Set this to `true` to skip IPv6 entirely and connect over IPv4 directly.
+`ipv4_first` — on servers with broken or unreachable IPv6 routes, dual-stack DNS can return AAAA records first and the TCP connect can hang before falling back to IPv4. This default-on setting keeps IPv6 usable, but reorders DNS results so IPv4 (`A`) answers are tried before IPv6 (`AAAA`) answers. Set `ipv4_first: false` to preserve the platform's original DNS ordering.
+
+`force_ipv4` — a stronger workaround for hosts where IPv6 should be skipped entirely. When set to `true`, Hermes requests IPv4 addresses directly instead of merely reordering dual-stack results. Use this only if `ipv4_first` is not enough.
 
 ## Onboarding
 


### PR DESCRIPTION
Fixes #71215.

## Problem

Dual-stack hosts whose providers publish AAAA records that route nowhere pay a 10–30 s IPv6 connect timeout on **every** API call before falling back to IPv4. Python's `socket.getaddrinfo()` tries IPv6 first per the default address ordering. The existing workaround (`network.force_ipv4: true`) fully disables IPv6, which is too aggressive for hosts that genuinely need it for some destinations.

## Approach

Add a lighter-weight `network.ipv4_first` option (on by default) that monkey-patches `socket.getaddrinfo` to **sort** results IPv4-first instead of filtering IPv6 out entirely. Both A and AAAA records remain available — IPv4 is just tried first. If no A record exists (pure-IPv6 host), the original ordering is preserved, so IPv6 connectivity is retained.

This is applied alongside (and before) the existing `apply_ipv4_preference` at all three entrypoints:
- `gateway/run.py` (gateway bootstrap)
- `cron/scheduler.py` (cron scheduler init)
- `hermes_cli/main.py` (early CLI bootstrap)

### Changes
- `hermes_constants.py`: new `apply_ipv6_fallback_ordering(enabled: bool = True)` matching the style of `apply_ipv4_preference` (same guard-against-double-patch pattern, same `_hermes_*_patched` attribute convention).
- `hermes_cli/config.py`: add `"ipv4_first": True` to `DEFAULT_CONFIG["network"]` alongside `force_ipv4`.
- `gateway/run.py`, `cron/scheduler.py`, `hermes_cli/main.py`: wire `apply_ipv6_fallback_ordering` into the same blocks that call `apply_ipv4_preference`. `ipv4_first` defaults to `True`, so the fix is active out of the box.
- `tests/test_ipv4_first.py`: new test file mirroring `test_ipv4_preference.py` — covers no-op when disabled, patching, double-patch safety, IPv4-first sorting of `AF_UNSPEC` results, explicit-family pass-through, IPv6-only preservation, and config default.

## Relationship to #52538

PR #52538 (open) proposes **auto-detection** of dead IPv6 routes (probing + caching). This PR is a smaller-scope, immediately-shippable complement: it changes the default DNS ordering so IPv4 is tried first, which eliminates the timeout for the common case without the complexity of a detection/cache layer. The two approaches compose — if #52538 lands, `ipv4_first` can become a fallback for when auto-detection is inconclusive, or be demoted to opt-in.

## Testing

`pytest tests/test_ipv4_first.py tests/test_ipv4_preference.py -v` → **14 passed**.