### PR TITLE
fix(compression): jitter-retry compression lock on SQLite busy (#71330)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4538,6 +4538,18 @@ class SessionDB:
             )
             return False
 
+    # Compression-lock acquisition runs through ``_execute_write`` (15 jittered
+    # retries on ``database is locked``), but contention from the gateway write
+    # queue can still exhaust that budget. The cost of a spurious skip is high
+    # for auto-compress: a silent ``nothing to compress`` leaves the agent on
+    # an oversized context (#71330). We add a small outer retry loop on top of
+    # the inner one so a transient busy storm — not a genuinely held live lock
+    # — does not skip compression. Constants deliberately track the inner
+    # ``_WRITE_*`` cadence to keep backoff uniform across the write paths.
+    _COMPRESS_LOCK_MAX_ATTEMPTS = 4
+    _COMPRESS_LOCK_RETRY_MIN_S = 0.020   # 20ms — mirrors _WRITE_RETRY_MIN_S
+    _COMPRESS_LOCK_RETRY_MAX_S = 0.150   # 150ms — mirrors _WRITE_RETRY_MAX_S
+
     def try_acquire_compression_lock(
         self,
         session_id: str,
@@ -4560,6 +4572,14 @@ class SessionDB:
         Implementation: single-transaction DELETE-expired + INSERT-or-IGNORE,
         followed by a SELECT to confirm we got the row. SQLite serialises
         writes, so the whole sequence is atomic against other writers.
+
+        On transient SQLite ``database is locked`` / ``busy`` from the inner
+        ``_execute_write`` retry exhaustion (a burst of gateway writes can
+        drain its 15-attempt budget), we sleep a small jittered backoff and
+        retry up to :data:`_COMPRESS_LOCK_MAX_ATTEMPTS` times before failing
+        over to the skip path (#71330). A genuinely held live lock surfaces as
+        a clean ``False`` (the SELECT-then-INSERT sees the foreign holder) and
+        is NOT retried — only the busy/locked ``OperationalError`` class is.
         """
         if not session_id:
             return False
@@ -4617,6 +4637,32 @@ class SessionDB:
                     reclaimed_holder,
                 )
             return bool(acquired)
+        except sqlite3.OperationalError as exc:
+            # _execute_write already exhausted its 15-attempt inner retry
+            # loop, but a sustained burst of gateway/cron writes can still
+            # drain that budget and surface ``database is locked`` here.
+            # Auto-compress silently skipping on this path is the severe
+            # case in #71330: the agent stays on an oversized context and
+            # the TUI reports a misleading ``nothing to compress``. Retry a
+            # small bounded number of times with the same jittered backoff
+            # cadence the write path uses, so a transient busy storm does
+            # not skip compression.
+            #
+            # We ONLY retry the busy/locked OperationalError class — a clean
+            # ``False`` (genuine live holder seen by the SELECT) returns
+            # immediately from the inner call and never reaches here, and
+            # non-busy OperationalError (e.g. schema corruption) propagates
+            # to the generic handler below.
+            err_msg = str(exc).lower()
+            if "locked" not in err_msg and "busy" not in err_msg:
+                logger.warning(
+                    "try_acquire_compression_lock(%s) failed: %s",
+                    session_id, exc,
+                )
+                # Fail open: returning False makes the caller skip compression,
+                # which is the safe behaviour when the lock subsystem is broken.
+                return False
+            last_busy_exc = exc
         except sqlite3.Error as exc:
             logger.warning(
                 "try_acquire_compression_lock(%s) failed: %s",
@@ -4625,6 +4671,61 @@ class SessionDB:
             # Fail open: returning False makes the caller skip compression,
             # which is the safe behaviour when the lock subsystem is broken.
             return False
+
+        # Transient busy retry loop (#71330). ``now`` and ``expires_at`` are
+        # recomputed per attempt so the lease reflects the actual acquire time
+        # rather than the (possibly stale) pre-retry timestamp.
+        for attempt in range(1, self._COMPRESS_LOCK_MAX_ATTEMPTS):
+            jitter = random.uniform(
+                self._COMPRESS_LOCK_RETRY_MIN_S,
+                self._COMPRESS_LOCK_RETRY_MAX_S,
+            )
+            time.sleep(jitter)
+            now = time.time()
+            expires_at = now + ttl_seconds
+            try:
+                acquired, reclaimed_holder = self._execute_write(_do)
+                if reclaimed_holder:
+                    logger.warning(
+                        "Reclaimed stale compression lock for session=%s "
+                        "(holder=%s)",
+                        session_id,
+                        reclaimed_holder,
+                    )
+                return bool(acquired)
+            except sqlite3.OperationalError as exc:
+                err_msg = str(exc).lower()
+                if "locked" in err_msg or "busy" in err_msg:
+                    last_busy_exc = exc
+                    if attempt < self._COMPRESS_LOCK_MAX_ATTEMPTS - 1:
+                        continue
+                # Non-busy OperationalError: fall through to the generic
+                # fail-open handler below.
+                logger.warning(
+                    "try_acquire_compression_lock(%s) failed: %s",
+                    session_id, exc,
+                )
+                return False
+            except sqlite3.Error as exc:
+                logger.warning(
+                    "try_acquire_compression_lock(%s) failed: %s",
+                    session_id, exc,
+                )
+                # Fail open: returning False makes the caller skip compression,
+                # which is the safe behaviour when the lock subsystem is broken.
+                return False
+
+        # Retry budget exhausted on transient busy. Distinguish this from a
+        # genuine concurrent holder: the caller's ``_compression_skipped_due_to_lock``
+        # signal must still fire so the TUI shows "compression skipped" rather
+        # than the misleading "nothing to compress", but we log the busy-storm
+        # origin so operators can size the write contention.
+        logger.warning(
+            "try_acquire_compression_lock(%s) failed after %d busy retries: %s "
+            "— skipping compression this cycle (transient SQLite lock contention)",
+            session_id, self._COMPRESS_LOCK_MAX_ATTEMPTS, last_busy_exc,
+        )
+        return False
 
     def release_compression_lock(self, session_id: str, holder: str) -> None:
         """Release the compression lock for ``session_id`` iff we own it.

--- a/tests/test_hermes_state_compression_locks.py
+++ b/tests/test_hermes_state_compression_locks.py
@@ -13,6 +13,7 @@ diagnostic accessor) — not the wiring into compression.
 from __future__ import annotations
 
 import os
+import sqlite3
 import threading
 import time
 from pathlib import Path
@@ -312,3 +313,106 @@ def test_concurrent_acquire_only_one_winner(db: SessionDB) -> None:
     assert sum(1 for r in results if r is False) == 7
     # The single winner still owns it
     assert db.get_compression_lock_holder("contended_session") is not None
+
+
+# ----------------------------------------------------------------------
+# Transient SQLite busy retry on compression-lock acquire (#71330)
+# ----------------------------------------------------------------------
+
+
+def test_acquire_retries_on_transient_busy_then_succeeds(
+    db: SessionDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``try_acquire_compression_lock`` must retry on transient SQLite
+    ``database is locked`` rather than skipping compression outright.
+
+    Regression for #71330: a burst of gateway writes can exhaust the inner
+    ``_execute_write`` retry budget and surface ``OperationalError`` here.
+    Without the outer retry loop, auto-compress silently skipped with a
+    misleading ``nothing to compress``. We simulate two transient busy
+    failures from ``_execute_write`` then a success, and assert the lock is
+    acquired (not skipped) and that ``_execute_write`` was called three
+    times total.
+    """
+    calls: list[int] = []
+
+    real_execute_write = db._execute_write
+
+    def flaky_execute_write(fn):
+        calls.append(1)
+        if len(calls) <= 2:
+            raise sqlite3.OperationalError("database is locked")
+        return real_execute_write(fn)
+
+    monkeypatch.setattr(db, "_execute_write", flaky_execute_write)
+    # Keep the retry backoff instant so the test is fast.
+    monkeypatch.setattr(db, "_COMPRESS_LOCK_RETRY_MIN_S", 0.0)
+    monkeypatch.setattr(db, "_COMPRESS_LOCK_RETRY_MAX_S", 0.0)
+
+    got = db.try_acquire_compression_lock("sess_busy", "holder1")
+    assert got is True
+    assert len(calls) == 3
+    assert db.get_compression_lock_holder("sess_busy") == "holder1"
+
+
+def test_acquire_returns_false_after_busy_retry_exhaustion(
+    db: SessionDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When transient busy persists past the retry budget, the acquire must
+    return ``False`` (fail-open skip) so the caller's
+    ``_compression_skipped_due_to_lock`` signal still fires — NOT raise.
+    The skip path then surfaces an honest ``compression skipped`` status
+    instead of the misleading ``nothing to compress`` (#71330).
+    """
+    def always_busy(fn):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(db, "_execute_write", always_busy)
+    monkeypatch.setattr(db, "_COMPRESS_LOCK_RETRY_MIN_S", 0.0)
+    monkeypatch.setattr(db, "_COMPRESS_LOCK_RETRY_MAX_S", 0.0)
+
+    got = db.try_acquire_compression_lock("sess_busy_forever", "holder1")
+    assert got is False
+
+
+def test_acquire_does_not_retry_on_non_busy_operational_error(
+    db: SessionDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-busy ``OperationalError`` (e.g. schema corruption) must NOT be
+    retried — it should fail open immediately and not burn the retry budget.
+    """
+    calls: list[int] = []
+
+    def corrupt_schema(fn):
+        calls.append(1)
+        raise sqlite3.OperationalError("no such table: compression_locks")
+
+    monkeypatch.setattr(db, "_execute_write", corrupt_schema)
+    monkeypatch.setattr(db, "_COMPRESS_LOCK_RETRY_MIN_S", 0.0)
+    monkeypatch.setattr(db, "_COMPRESS_LOCK_RETRY_MAX_S", 0.0)
+
+    got = db.try_acquire_compression_lock("sess_corrupt", "holder1")
+    assert got is False
+    assert len(calls) == 1
+
+
+def test_acquire_does_not_retry_on_clean_false_from_live_holder(
+    db: SessionDB, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A genuine live holder returns ``False`` cleanly (the SELECT sees the
+    foreign holder) — that path must NOT enter the busy retry loop at all.
+    """
+    calls: list[int] = []
+    real_execute_write = db._execute_write
+
+    def counting_execute_write(fn):
+        calls.append(1)
+        return real_execute_write(fn)
+
+    monkeypatch.setattr(db, "_execute_write", counting_execute_write)
+
+    assert db.try_acquire_compression_lock("sess_live", "holder1") is True
+    calls.clear()
+    # Second acquire sees the live holder and returns False — no retry.
+    assert db.try_acquire_compression_lock("sess_live", "holder2") is False
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary

Manual `/compress` and **auto-compression** can fail to acquire the session compression lock when SQLite raises `database is locked` after the inner `_execute_write` retry budget (15 attempts) is drained by a burst of gateway/cron writes. The acquire then returned `False` unconditionally, skipping compression and — for auto-compress, the severe case — leaving the agent on an oversized context with a misleading `nothing to compress` TUI status (#71330).

## Fix

Add a small outer jittered retry loop in `SessionDB.try_acquire_compression_lock`:
- **4 attempts**, 20–150ms randomized backoff mirroring the existing `_WRITE_RETRY_MIN_S` / `_WRITE_RETRY_MAX_S` constants in `hermes_state.py`.
- **Only** the busy/locked `OperationalError` class is retried.
- A clean `False` (genuine live holder seen by the SELECT-then-INSERT) returns immediately and is **not** retried.
- Non-busy `OperationalError` (e.g. schema corruption) fails open at once.

On retry exhaustion the acquire still returns `False`, so the existing `_compression_skipped_due_to_lock` signal in `conversation_compression.py` propagates correctly — callers see an honest `compression skipped` status instead of `nothing to compress`. The busy-storm origin is logged so operators can size write contention.

## Why auto-compress is the severe case

Manual `/compress` can be retried by the user. Auto-compress is what keeps long sessions under budget; a single failed acquire → silent skip leaves the agent on an oversized context (cost/quality/hard limits) with weak/misleading telemetry. The jittered retry turns a transient busy storm into a brief delay rather than a lost compression cycle.

## Evidence

```
try_acquire_compression_lock(<session>) failed: database is locked
compression skipped: ... (holder=None) — returning messages unchanged
```
`holder=None` meant DB busy, not a confirmed concurrent compressor. A later manual retry succeeded.

## Regression tests

Added to `tests/test_hermes_state_compression_locks.py`:
1. `test_acquire_retries_on_transient_busy_then_succeeds` — two transient busy failures then success → lock acquired, `_execute_write` called 3×.
2. `test_acquire_returns_false_after_busy_retry_exhaustion` — persistent busy → returns `False` (fail-open skip), does not raise, so `_compression_skipped_due_to_lock` still fires.
3. `test_acquire_does_not_retry_on_non_busy_operational_error` — schema-corruption class is not retried.
4. `test_acquire_does_not_retry_on_clean_false_from_live_holder` — genuine live holder returns `False` cleanly without entering the busy retry loop.

All 23 tests in the file pass. Tests confirmed to fail without the fix (no `_COMPRESS_LOCK_RETRY_MIN_S` attribute on the old code).

Fixes #71330