### PR TITLE
fix: offload context engine startup from gateway loop

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -55,7 +55,7 @@ import sys
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, cast
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
@@ -1244,6 +1244,10 @@ class APIServerAdapter(BasePlatformAdapter):
         # Active run agent/task references for stop support
         self._active_run_agents: Dict[str, Any] = {}
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
+        # Standalone adapters (primarily tests/embedders without a GatewayRunner)
+        # retain late cleanup tasks when executor-backed construction outlives a
+        # cancelled /v1/runs wrapper.
+        self._deferred_run_agent_cleanup_tasks: set["asyncio.Task"] = set()
         # Stop is cooperative: the executor thread may outlive the HTTP request.
         self._stopping_run_ids: set[str] = set()
         # Pollable run status for dashboards and external control-plane UIs.
@@ -1296,6 +1300,95 @@ class APIServerAdapter(BasePlatformAdapter):
             )
         except Exception:
             return 0
+
+    def _defer_run_agent_cleanup_until_construction_done(
+        self,
+        future: "asyncio.Future[Any]",
+    ) -> None:
+        """Clean up a run agent whose worker constructor outlived cancellation."""
+
+        async def _cleanup_when_constructed() -> None:
+            try:
+                agent = await asyncio.shield(future)
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                logger.debug(
+                    "Deferred API run agent construction finished with an error: %s",
+                    exc,
+                )
+                return
+
+            try:
+                agent._end_session_on_close = False
+            except Exception:
+                pass
+
+            runner = getattr(self, "gateway_runner", None)
+            cleanup_candidate = getattr(
+                runner,
+                "_cleanup_agent_resources_off_loop",
+                None,
+            )
+            if callable(cleanup_candidate) and asyncio.iscoroutinefunction(
+                cleanup_candidate
+            ):
+                cleanup = cast(Callable[..., Awaitable[None]], cleanup_candidate)
+                await cleanup(
+                    agent,
+                    context="API run construction cancellation",
+                )
+                return
+
+            def _cleanup_without_runner() -> None:
+                try:
+                    shutdown = getattr(agent, "shutdown_memory_provider", None)
+                    if callable(shutdown):
+                        shutdown()
+                except Exception:
+                    pass
+                try:
+                    close = getattr(agent, "close", None)
+                    if callable(close):
+                        close()
+                except Exception:
+                    pass
+
+            await asyncio.to_thread(_cleanup_without_runner)
+
+        task = asyncio.create_task(_cleanup_when_constructed())
+        self._deferred_run_agent_cleanup_tasks.add(task)
+        task.add_done_callback(self._deferred_run_agent_cleanup_tasks.discard)
+
+    async def _construct_run_agent_off_loop(
+        self,
+        factory: Callable[[], Any],
+    ) -> Any:
+        """Construct a /v1/runs agent off-loop and retain cleanup on cancellation."""
+        runner = getattr(self, "gateway_runner", None)
+        construct_candidate = getattr(
+            runner,
+            "_construct_temporary_agent_off_loop",
+            None,
+        )
+        if callable(construct_candidate) and asyncio.iscoroutinefunction(
+            construct_candidate
+        ):
+            construct = cast(Callable[..., Awaitable[Any]], construct_candidate)
+            return await construct(
+                factory,
+                context="API run construction cancellation",
+            )
+
+        # APIServerAdapter is also used standalone in tests and embedders. Keep
+        # that path context-preserving and cancellation-safe too; asyncio.to_thread
+        # copies the current Context and a shielded Task keeps the result reachable.
+        future = asyncio.create_task(asyncio.to_thread(factory))
+        try:
+            return await asyncio.shield(future)
+        except asyncio.CancelledError:
+            self._defer_run_agent_cleanup_until_construction_done(future)
+            raise
 
     @staticmethod
     def _gateway_is_draining() -> bool:
@@ -6234,16 +6327,18 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                     return
                 with self._profile_scope(request_profile):
-                    agent = self._create_agent(
-                        ephemeral_system_prompt=ephemeral_system_prompt,
-                        session_id=session_id,
-                        stream_delta_callback=_text_cb,
-                        tool_progress_callback=event_cb,
-                        gateway_session_key=gateway_session_key,
-                        requested_model=agent_overrides.get("requested_model"),
-                        requested_provider=agent_overrides.get("requested_provider"),
-                        model_options=agent_overrides.get("model_options"),
-                        route=route,
+                    agent = await self._construct_run_agent_off_loop(
+                        lambda: self._create_agent(
+                            ephemeral_system_prompt=ephemeral_system_prompt,
+                            session_id=session_id,
+                            stream_delta_callback=_text_cb,
+                            tool_progress_callback=event_cb,
+                            gateway_session_key=gateway_session_key,
+                            requested_model=agent_overrides.get("requested_model"),
+                            requested_provider=agent_overrides.get("requested_provider"),
+                            model_options=agent_overrides.get("model_options"),
+                            route=route,
+                        )
                     )
                 self._active_run_agents[run_id] = agent
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9163,6 +9163,64 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # loop is never blocked; mirrors the /new reset path's fix (#35994).
     _CLEANUP_TIMEOUT_S = 30.0
 
+    def _defer_agent_cleanup_until_construction_done(
+        self,
+        future: asyncio.Future,
+        *,
+        context: str,
+    ) -> None:
+        """Clean up an agent whose off-loop constructor outlived its caller.
+
+        Executor work cannot be cancelled once it has started. Keep the
+        shielded construction task alive, then apply the same temporary-agent
+        session and resource cleanup once the constructor really returns.
+        """
+
+        async def _cleanup_when_constructed() -> None:
+            try:
+                agent = await asyncio.shield(future)
+            except asyncio.CancelledError:
+                # Loop shutdown can cancel this waiter. The executor is already
+                # shutting down independently, so do not block teardown here.
+                return
+            except Exception as exc:
+                logger.debug(
+                    "Deferred agent construction%s finished with an error: %s",
+                    f" ({context})" if context else "",
+                    exc,
+                )
+                return
+            try:
+                agent._end_session_on_close = False
+            except Exception:
+                pass
+            await self._cleanup_agent_resources_off_loop(agent, context=context)
+
+        task = asyncio.create_task(_cleanup_when_constructed())
+        tasks = getattr(self, "_deferred_agent_cleanup_tasks", None)
+        if tasks is None:
+            tasks = set()
+            self._deferred_agent_cleanup_tasks = tasks
+        tasks.add(task)
+        task.add_done_callback(tasks.discard)
+
+    async def _construct_temporary_agent_off_loop(
+        self,
+        factory,
+        *,
+        context: str,
+    ) -> Any:
+        """Construct a temporary agent off-loop without leaking on cancellation."""
+        future = asyncio.ensure_future(self._run_in_executor_with_context(factory))
+        try:
+            return await asyncio.shield(future)
+        except asyncio.CancelledError:
+            self._defer_agent_cleanup_until_construction_done(
+                future,
+                context=context,
+            )
+            raise
+
     def _defer_agent_cleanup_until_future_done(
         self,
         future: asyncio.Future,
@@ -16106,15 +16164,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         exc_info=True,
                                     )
                                 _hyg_session_db = getattr(self._session_db, "_db", self._session_db)
-                                _hyg_agent = AIAgent(
-                                    **_hyg_runtime,
-                                    model=_hyg_model,
-                                    max_iterations=4,
-                                    quiet_mode=True,
-                                    skip_memory=True,
-                                    enabled_toolsets=["memory"],
-                                    session_id=session_entry.session_id,
-                                    session_db=_hyg_session_db,
+                                # A context engine's synchronous lifecycle hook is
+                                # plugin code and may perform provider-backed work.
+                                # Construct the helper behind the same
+                                # context-propagating executor boundary as normal
+                                # gateway agents so it can never stall platform
+                                # heartbeats on the asyncio event loop.
+                                _hyg_agent = await self._construct_temporary_agent_off_loop(
+                                    lambda: AIAgent(
+                                        **_hyg_runtime,
+                                        model=_hyg_model,
+                                        max_iterations=4,
+                                        quiet_mode=True,
+                                        skip_memory=True,
+                                        enabled_toolsets=["memory"],
+                                        session_id=session_entry.session_id,
+                                        session_db=_hyg_session_db,
+                                    ),
+                                    context="session hygiene construction cancellation",
                                 )
                                 _seed_hygiene_system_prompt(
                                     _hyg_agent,
@@ -16151,15 +16218,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     _hyg_agent._end_session_on_close = False
                                     _hyg_agent._print_fn = lambda *a, **kw: None
 
-                                    loop = asyncio.get_running_loop()
                                     _hyg_commit_fence = CompressionCommitFence()
-                                    _hyg_future = loop.run_in_executor(
-                                        None,
-                                        lambda: _hyg_agent._compress_context(
-                                            _hyg_msgs, "",
-                                            approx_tokens=_approx_tokens,
-                                            commit_fence=_hyg_commit_fence,
-                                        ),
+                                    _hyg_future = asyncio.ensure_future(
+                                        self._run_in_executor_with_context(
+                                            lambda: _hyg_agent._compress_context(
+                                                _hyg_msgs,
+                                                "",
+                                                approx_tokens=_approx_tokens,
+                                                commit_fence=_hyg_commit_fence,
+                                            )
+                                        )
                                     )
                                     try:
                                         # Progress-aware wait: the timeout is an

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3919,7 +3919,6 @@ class GatewaySlashCommandsMixin:
             if platform_key is not None:
                 runtime_kwargs["platform"] = platform_key
             runtime_kwargs["gateway_session_key"] = session_key
-
             # The manual compression helper skips memory-provider initialization,
             # but _compress_context may persist its cached system prompt. Restore
             # the exact live-session prompt so provider blocks are retained.
@@ -3938,15 +3937,21 @@ class GatewaySlashCommandsMixin:
                         exc_info=True,
                     )
 
-            tmp_agent = AIAgent(
-                **runtime_kwargs,
-                model=model,
-                max_iterations=4,
-                quiet_mode=True,
-                skip_memory=True,
-                enabled_toolsets=["memory"],
-                session_id=session_entry.session_id,
-                session_db=getattr(self._session_db, "_db", self._session_db),
+            # Construction runs the selected context engine's synchronous
+            # session-start hook. Keep plugin-controlled work off the gateway
+            # event loop just like normal turns and automatic hygiene.
+            tmp_agent = await self._construct_temporary_agent_off_loop(
+                lambda: AIAgent(
+                    **runtime_kwargs,
+                    model=model,
+                    max_iterations=4,
+                    quiet_mode=True,
+                    skip_memory=True,
+                    enabled_toolsets=["memory"],
+                    session_id=session_entry.session_id,
+                    session_db=getattr(self._session_db, "_db", self._session_db),
+                ),
+                context="manual compress construction cancellation",
             )
             _seed_hygiene_system_prompt(tmp_agent, session_row)
             # Keep the real source platform during construction so external

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -11,7 +11,7 @@ Covers:
 import asyncio
 import threading
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
@@ -144,6 +144,108 @@ class TestStartRun:
                 assert status["run_id"] == data["run_id"]
                 assert status["status"] in {"queued", "running", "completed"}
                 assert status["object"] == "hermes.run"
+
+    @pytest.mark.asyncio
+    async def test_start_blocking_agent_construction_does_not_block_event_loop(
+        self, adapter
+    ):
+        """A blocking context-engine startup hook must not stall aiohttp."""
+        app = _create_runs_app(adapter)
+        construction_started = threading.Event()
+        release_construction = threading.Event()
+        loop_serviced = threading.Event()
+        callback_ran_before_release = []
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "done"}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        def _construct_agent(**_kwargs):
+            construction_started.set()
+            assert release_construction.wait(timeout=3)
+            return mock_agent
+
+        loop = asyncio.get_running_loop()
+
+        def _release_after_loop_probe():
+            assert construction_started.wait(timeout=2)
+            loop.call_soon_threadsafe(loop_serviced.set)
+            callback_ran_before_release.append(loop_serviced.wait(timeout=1))
+            release_construction.set()
+
+        controller = threading.Thread(
+            target=_release_after_loop_probe,
+            daemon=True,
+        )
+        controller.start()
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(adapter, "_create_agent", side_effect=_construct_agent):
+                    resp = await cli.post("/v1/runs", json={"input": "hello"})
+                    assert resp.status == 202
+        finally:
+            release_construction.set()
+            await asyncio.to_thread(controller.join, 2)
+
+        assert callback_ran_before_release == [True], (
+            "the API server event loop did not service a scheduled callback "
+            "while agent construction was blocked"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancelled_run_agent_construction_cleans_eventual_agent(self, adapter):
+        """Cancellation cannot orphan an API agent still constructing off-loop."""
+        construction_started = threading.Event()
+        release_construction = threading.Event()
+        mock_agent = MagicMock()
+        mock_agent._end_session_on_close = True
+        mock_agent.shutdown_memory_provider = MagicMock()
+        mock_agent.close = MagicMock()
+
+        def _construct_agent():
+            construction_started.set()
+            assert release_construction.wait(timeout=3)
+            return mock_agent
+
+        construction_task = asyncio.create_task(
+            adapter._construct_run_agent_off_loop(_construct_agent)
+        )
+        try:
+            assert await asyncio.to_thread(construction_started.wait, 1)
+            construction_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await construction_task
+
+            deferred_tasks = list(adapter._deferred_run_agent_cleanup_tasks)
+            assert len(deferred_tasks) == 1
+            release_construction.set()
+            await asyncio.gather(*deferred_tasks)
+
+            assert mock_agent._end_session_on_close is False
+            mock_agent.shutdown_memory_provider.assert_called_once()
+            mock_agent.close.assert_called_once()
+        finally:
+            release_construction.set()
+
+    @pytest.mark.asyncio
+    async def test_run_agent_construction_reuses_gateway_boundary(self, adapter):
+        """Production adapters reuse the runner's proven construction boundary."""
+        expected_agent = MagicMock()
+        runner = MagicMock()
+        runner._construct_temporary_agent_off_loop = AsyncMock(
+            return_value=expected_agent
+        )
+        adapter.gateway_runner = runner
+        factory = MagicMock()
+
+        result = await adapter._construct_run_agent_off_loop(factory)
+
+        assert result is expected_agent
+        runner._construct_temporary_agent_off_loop.assert_awaited_once_with(
+            factory,
+            context="API run construction cancellation",
+        )
 
     @pytest.mark.asyncio
     async def test_start_binds_chat_id_for_delegation_wake_target(self, adapter):
@@ -357,8 +459,8 @@ class TestRunEvents:
                 victim_run = (await victim_resp.json())["run_id"]
                 attacker_run = (await attacker_resp.json())["run_id"]
 
-                victim_ready.wait(timeout=3.0)
-                attacker_ready.wait(timeout=3.0)
+                assert await asyncio.to_thread(victim_ready.wait, 3.0)
+                assert await asyncio.to_thread(attacker_ready.wait, 3.0)
                 assert auth_adapter._run_approval_sessions[victim_run] == victim_run
                 assert auth_adapter._run_approval_sessions[attacker_run] == attacker_run
                 assert auth_adapter._run_approval_sessions[victim_run] != auth_adapter._run_approval_sessions[attacker_run]
@@ -424,7 +526,7 @@ class TestRunLifecycleSweep:
                 start_resp = await cli.post("/v1/runs", json={"input": "hello"})
                 assert start_resp.status == 202
                 run_id = (await start_resp.json())["run_id"]
-                assert agent_ready.wait(timeout=3.0)
+                assert await asyncio.to_thread(agent_ready.wait, 3.0)
 
                 task = adapter._active_run_tasks[run_id]
                 assert isinstance(task, asyncio.Task)
@@ -503,7 +605,7 @@ class TestStopRun:
 
                 resp = await cli.post("/v1/runs", json={"input": "hello"})
                 run_id = (await resp.json())["run_id"]
-                assert started.wait(timeout=3)
+                assert await asyncio.to_thread(started.wait, 3)
 
                 stop_resp = await cli.post(f"/v1/runs/{run_id}/stop")
                 assert stop_resp.status == 200
@@ -540,7 +642,7 @@ class TestStopRun:
                 run_id = data["run_id"]
 
                 # Wait for agent to start running in the thread
-                agent_ready.wait(timeout=3.0)
+                assert await asyncio.to_thread(agent_ready.wait, 3.0)
                 await asyncio.sleep(0.1)
 
                 # Verify agent ref is stored
@@ -582,7 +684,7 @@ class TestStopRun:
                 data = await resp.json()
                 run_id = data["run_id"]
 
-                agent_ready.wait(timeout=3.0)
+                assert await asyncio.to_thread(agent_ready.wait, 3.0)
                 await asyncio.sleep(0.1)
 
                 # Subscribe to events in background

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -1,6 +1,8 @@
 """Tests for gateway /compress user-facing messaging."""
 
+import asyncio
 from datetime import datetime
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -56,6 +58,113 @@ def _make_runner(history: list[dict[str, str]]):
     runner.session_store._save = MagicMock()
     runner._session_db = None
     return runner
+
+
+@pytest.mark.asyncio
+async def test_compress_command_constructs_agent_off_event_loop():
+    """Manual compression must isolate the same context-engine start hook."""
+    history = _make_history()
+    runner = _make_runner(history)
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.session_id = "sess-1"
+    agent_instance._compress_context.return_value = (list(history), "")
+    agent_instance._compression_skipped_due_to_lock = False
+    constructor_threads = []
+
+    def _construct_agent(**_kwargs):
+        constructor_threads.append(threading.get_ident())
+        return agent_instance
+
+    loop_thread = threading.get_ident()
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", side_effect=_construct_agent),
+        patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100),
+    ):
+        await runner._handle_compress_command(_make_event())
+
+    assert constructor_threads
+    assert all(thread_id != loop_thread for thread_id in constructor_threads)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_temporary_agent_construction_cleans_eventual_agent():
+    """Cancellation cannot orphan an agent still constructing in the executor."""
+    runner = _make_runner(_make_history())
+    construction_started = threading.Event()
+    release_construction = threading.Event()
+    agent_instance = MagicMock()
+    agent_instance._end_session_on_close = True
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+
+    def _construct_agent():
+        construction_started.set()
+        assert release_construction.wait(timeout=3)
+        return agent_instance
+
+    try:
+        construction_task = asyncio.create_task(
+            runner._construct_temporary_agent_off_loop(
+                _construct_agent,
+                context="cancelled construction test",
+            )
+        )
+        assert await asyncio.to_thread(construction_started.wait, 1)
+        construction_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await construction_task
+
+        deferred_tasks = list(runner._deferred_agent_cleanup_tasks)
+        assert len(deferred_tasks) == 1
+        release_construction.set()
+        await asyncio.gather(*deferred_tasks)
+
+        assert agent_instance._end_session_on_close is False
+        agent_instance.shutdown_memory_provider.assert_called_once()
+        agent_instance.close.assert_called_once()
+    finally:
+        release_construction.set()
+        runner._shutdown_executor()
+
+
+@pytest.mark.asyncio
+async def test_compress_command_reports_noop_without_success_banner():
+    history = _make_history()
+    runner = _make_runner(history)
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.session_id = "sess-1"
+    agent_instance._compress_context.return_value = (list(history), "")
+    agent_instance._compression_skipped_due_to_lock = False
+
+    def _estimate(messages, **_kwargs):
+        assert messages == history
+        return 100
+
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance),
+        patch("agent.model_metadata.estimate_request_tokens_rough", side_effect=_estimate),
+    ):
+        result = await runner._handle_compress_command(_make_event())
+
+    assert "No changes from compression" in result
+    assert "Compressed:" not in result
+    assert "Approx request size: ~100 tokens (unchanged)" in result
+    agent_instance.shutdown_memory_provider.assert_called_once()
+    agent_instance.close.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -896,3 +896,129 @@ def _make_progress_runner(monkeypatch, tmp_path, agent_cls, cfg_text):
     return runner, adapter, event
 
 
+@pytest.mark.asyncio
+async def test_session_hygiene_blocking_context_engine_start_does_not_block_loop(
+    monkeypatch, tmp_path
+):
+    """A synchronous context-engine startup hook must run off the gateway loop."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    init_started = threading.Event()
+    release_init = threading.Event()
+    loop_serviced = threading.Event()
+    callback_ran_before_release = []
+
+    class BlockingContextEngine:
+        def on_session_start(self):
+            init_started.set()
+            assert release_init.wait(timeout=3)
+
+    class BlockingLifecycleAgent:
+        last_instance = None
+
+        def __init__(self, **kwargs):
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self.context_compressor = SimpleNamespace(
+                bind_session_state=MagicMock(),
+                _last_compress_aborted=False,
+                _last_aux_model_failure_model=None,
+            )
+            self._last_compaction_in_place = False
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+            self.engine = BlockingContextEngine()
+            type(self).last_instance = self
+            # Mirrors AIAgent.__init__ invoking the selected context engine's
+            # synchronous lifecycle hook.
+            self.engine.on_session_start()
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            return (messages, None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = BlockingLifecycleAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: HygieneCaptureAdapter()}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:dm:12345",
+        session_id="sess-blocking-start",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(
+        6, content_size=400
+    )
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100,
+    )
+
+    loop = asyncio.get_running_loop()
+
+    def release_after_loop_probe():
+        assert init_started.wait(timeout=2)
+        loop.call_soon_threadsafe(loop_serviced.set)
+        callback_ran_before_release.append(loop_serviced.wait(timeout=1))
+        release_init.set()
+
+    controller = threading.Thread(target=release_after_loop_probe, daemon=True)
+    controller.start()
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+            user_id="12345",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+    controller.join(timeout=2)
+
+    assert result == "ok"
+    assert callback_ran_before_release == [True], (
+        "the gateway event loop did not service a scheduled callback while the "
+        "context engine's on_session_start hook was blocked"
+    )
+    assert BlockingLifecycleAgent.last_instance is not None


### PR DESCRIPTION
## What does this PR do?

Moves temporary `AIAgent` construction off gateway/aiohttp event loops for three direct async entry paths:

- automatic session-hygiene compression;
- manual `/compress`;
- API `POST /v1/runs`.

Context-engine `on_session_start()` hooks remain synchronous-compatible, but plugin-defined startup work now runs behind a context-preserving executor boundary. Cancellation-safe acquisition retains an in-flight constructor and cleans up the eventual agent instead of orphaning it.

This addresses the `/v1/runs` sibling path identified in [Teknium's review](https://github.com/NousResearch/hermes-agent/pull/71376#issuecomment-5129970625).

Companion plugin-side root-cause fix: [stephenschoettler/hermes-lcm#440](https://github.com/stephenschoettler/hermes-lcm/pull/440)

## Related Issue

No existing issue or PR matched the reproduced lifecycle-blocking path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - adds one context-preserving, cancellation-safe temporary-agent construction boundary;
  - retains shielded in-flight construction after caller cancellation;
  - performs the existing bounded agent cleanup off-loop once construction finishes;
  - uses the boundary for session-hygiene compression.
- `gateway/slash_commands.py`
  - constructs the temporary `/compress` agent through the same boundary.
- `gateway/platforms/api_server.py`
  - constructs `/v1/runs` agents off the aiohttp loop;
  - reuses the `GatewayRunner` boundary in normal gateway operation;
  - provides the same context-preserving/cancellation-safe fallback for standalone adapters used by tests and embedders.
- Regression tests prove:
  - blocked startup does not stall gateway or API event-loop callbacks;
  - `/compress` construction runs off-loop;
  - cancellation cannot orphan an agent that finishes constructing later;
  - `/v1/runs` uses the shared production boundary;
  - existing run lifecycle, stop, SSE, and approval-isolation behavior remains intact.

## How to Test

Run the affected gateway/context-engine surface:

```bash
scripts/run_tests.sh -j 4 \
  tests/gateway/test_session_hygiene.py \
  tests/gateway/test_compress_command.py \
  tests/gateway/test_api_server_runs.py \
  tests/gateway/test_api_server_active_work_drain.py \
  tests/gateway/test_agent_cache.py \
  tests/gateway/test_discord_channel_prompts.py \
  tests/gateway/test_compression_concurrent_sessions.py \
  tests/agent/test_compression_concurrent_fork.py \
  tests/run_agent/test_plugin_context_engine_init.py \
  tests/agent/test_context_engine_host_contract.py
```

Result on final base `056761349`: `105 passed, 0 failed`.

Focused API-run file:

```bash
.venv/bin/python -m pytest tests/gateway/test_api_server_runs.py -q
```

Result: `19 passed`.

Static checks:

```bash
.venv/bin/ruff check \
  gateway/run.py gateway/slash_commands.py gateway/platforms/api_server.py \
  tests/gateway/test_compress_command.py \
  tests/gateway/test_session_hygiene.py \
  tests/gateway/test_api_server_runs.py

git diff --check origin/main...HEAD
```

Result: clean.

The canonical full per-file runner reached 61% before the local 10-minute command cap. Its sole observed deterministic failure was `tests/hermes_cli/test_doctor.py::test_doctor_reports_vercel_backend_diagnostics`; that exact failure reproduces on clean base `14db1a99e` and is outside this PR's files and behavior. The final six upstream commits touched only desktop/installer files; the feature patch checksum remained byte-identical after rebasing onto `056761349`. Exact-head CI remains the full-suite authority.

A bounded independent rereview of the byte-identical pre-rebase patch at `06da10e11` returned `CLEAN` for event-loop isolation, context propagation, cancellation cleanup, run ownership, standalone fallback, and regression coverage. The final rebased head is `fe6b331d7`; patch checksum before and after rebase: `fa6b2912b5bc341627caaadde594177f6d0cbcc7f2a4f6c950beb40a8060ab18`.

## Risk / impact

- Constructor exceptions still propagate through existing caller error paths.
- `contextvars`, including profile/session scope, are copied into worker construction.
- Cancellation retains a strong construction-task reference and applies cleanup once construction finishes.
- Normal completed `/v1/runs` agents retain their existing run ownership and lifecycle.
- No timeout increase, plugin-specific branch, context-engine API change, prompt-cache change, model change, or config key is introduced.

## Scope boundaries

- This is generic host-level resilience for synchronous context-engine lifecycle implementations.
- It does not change LCM rollup scheduling; that root-cause fix is in [stephenschoettler/hermes-lcm#440](https://github.com/stephenschoettler/hermes-lcm/pull/440).
- The companion PRs are coordinated but have no intended merge-order dependency.
- The unrelated current-main doctor-test failure is not patched here.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs and issues; no matching open item was found.
- [x] My PR contains only changes related to this fix.
- [ ] I've run the repository's canonical full test runner. It was attempted but exceeded the local command window; the affected canonical surface is green and CI is the exact-head full-suite gate.
- [x] I've added behavioral regression tests for the bug.
- [x] Tested on Linux (Ubuntu).

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing behavior or configuration changed.
- [x] `cli-config.yaml.example`: N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow or public architecture contract changed.
- [x] Cross-platform impact considered: existing asyncio/executor abstractions only; no OS-specific code.
- [x] Tool descriptions/schemas: N/A; no model tool changed.

## Reviewer focus

- Direct async entry-path coverage: hygiene, `/compress`, and `/v1/runs`.
- Context-preserving construction and cancellation-safe eventual cleanup.
- `/v1/runs` normal ownership/status/stop/SSE behavior.
- Compression commit-fence, prompt-cache, and session semantics.

## Screenshots / Logs

N/A; this is gateway lifecycle/scheduling behavior covered by behavioral tests.
