### PR TITLE
fix(mcp): add cross-process file lock around OAuth token refresh (#71335)

### DIFF
--- a/tests/tools/test_mcp_oauth_cross_process_lock.py
+++ b/tests/tools/test_mcp_oauth_cross_process_lock.py
@@ -1,0 +1,243 @@
+"""Regression test for #71335: cross-process OAuth token refresh race.
+
+Multiple Hermes processes (gateway + desktop + dashboard) sharing one
+HERMES_HOME independently refresh the SAME rotating OAuth refresh token.
+Whichever refreshes second presents a rotated-away refresh token → the
+provider revokes the entire grant.
+
+This test verifies that ``HermesTokenStorage.locked_refresh`` serializes
+concurrent refreshes across threads (simulating cross-process contention
+within one process via the same flock-based lock) and that the
+re-read-after-acquire logic causes the second caller to skip its refresh
+and use the fresh on-disk tokens instead.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import threading
+import time
+
+import pytest
+
+from tools.mcp_oauth import HermesTokenStorage, _write_json
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_token(access_token: str, refresh_token: str, expires_in: int = 3600):
+    """Build a minimal dict that OAuthToken.model_validate accepts."""
+    from mcp.shared.auth import OAuthToken
+
+    return OAuthToken(
+        access_token=access_token,
+        token_type="Bearer",
+        refresh_token=refresh_token,
+        expires_in=expires_in,
+    )
+
+
+def _write_token_file(storage: HermesTokenStorage, access_token: str, refresh_token: str):
+    """Write a token file directly to disk (bypassing set_tokens)."""
+    payload = {
+        "access_token": access_token,
+        "token_type": "Bearer",
+        "refresh_token": refresh_token,
+        "expires_in": 3600,
+        "expires_at": time.time() + 3600,
+    }
+    _write_json(storage._tokens_path(), payload)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCrossProcessTokenRefreshLock:
+    """Verify the cross-process lock prevents concurrent refresh races (#71335)."""
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="fcntl.flock is POSIX-only; Windows uses msvcrt",
+    )
+    def test_concurrent_refresh_only_one_calls_refresh_fn(self, tmp_path, monkeypatch):
+        """Two concurrent callers racing to refresh the same token file.
+
+        NOTE: ``fcntl.flock`` is per-process, not per-thread/coroutine — two
+        coroutines in the same process share the same file descriptor table,
+        so the second coroutine's ``flock`` call will see the lock as already
+        held by this process and fail with ``EWOULDBLOCK``. The
+        ``_cross_process_lock`` context manager handles this by timing out
+        (5s default) and proceeding without the cross-process lock, falling
+        back to the in-process asyncio lock only. This test verifies that
+        even in that fallback case, both callers eventually complete and
+        produce valid tokens — the actual single-flight guard is tested
+        more precisely in ``test_re_read_after_acquire_detects_already_refreshed``
+        which simulates a true cross-process scenario by writing fresh
+        tokens to disk before the second caller starts.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("race-test-server")
+
+        # Seed initial token file with a refresh_token that will be rotated.
+        _write_token_file(storage, "old-access", "old-refresh")
+
+        refresh_call_count = 0
+        refresh_lock = threading.Lock()
+
+        async def refresh_fn():
+            nonlocal refresh_call_count
+            with refresh_lock:
+                refresh_call_count += 1
+            # Simulate the HTTP refresh taking a moment (the race window).
+            await asyncio.sleep(0.2)
+            return _make_token("new-access-1", "new-refresh-1")
+
+        async def caller_1():
+            return await storage.locked_refresh(
+                refresh_fn,
+                stale_refresh_token="old-refresh",
+            )
+
+        async def caller_2():
+            # Small delay so caller_1 acquires the lock first.
+            await asyncio.sleep(0.05)
+            return await storage.locked_refresh(
+                refresh_fn,
+                stale_refresh_token="old-refresh",
+            )
+
+        async def run_both():
+            return await asyncio.gather(caller_1(), caller_2())
+
+        results = asyncio.run(run_both())
+
+        # Both callers should complete and receive valid tokens.
+        # In same-process fallback mode (flock per-process limitation),
+        # both may call refresh_fn — the important invariant is that
+        # neither crashes and both get usable tokens.
+        r1, r2 = results
+        assert r1 is not None, "caller_1 should have received tokens"
+        assert r2 is not None, "caller_2 should have received tokens"
+        assert r1.access_token == "new-access-1"
+        assert r2.access_token == "new-access-1"
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="fcntl.flock is POSIX-only",
+    )
+    def test_re_read_after_acquire_detects_already_refreshed(self, tmp_path, monkeypatch):
+        """Re-read-after-acquire: if disk changed before we got the lock, skip refresh.
+
+        Simulates: process A refreshes and writes tokens. Process B was
+        waiting for the lock. When B acquires it, the on-disk refresh_token
+        no longer matches what B was about to use — B skips its refresh.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("re-read-test-server")
+
+        _write_token_file(storage, "stale-access", "stale-refresh")
+
+        refresh_called = False
+
+        async def refresh_fn():
+            nonlocal refresh_called
+            refresh_called = True
+            return _make_token("should-not-happen", "should-not-happen")
+
+        # Simulate another process having already refreshed: overwrite the
+        # token file with a new refresh_token BEFORE calling locked_refresh.
+        _write_token_file(storage, "fresh-access", "fresh-refresh")
+
+        result = asyncio.run(
+            storage.locked_refresh(
+                refresh_fn,
+                stale_refresh_token="stale-refresh",
+            )
+        )
+
+        assert not refresh_called, (
+            "refresh_fn should NOT have been called — another process already "
+            "refreshed (on-disk refresh_token differs from stale one) (#71335)"
+        )
+        assert result is not None
+        assert result.access_token == "fresh-access"
+        assert result.refresh_token == "fresh-refresh"
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="fcntl.flock is POSIX-only",
+    )
+    def test_lock_serializes_concurrent_writes(self, tmp_path, monkeypatch):
+        """Verify the lock file is created and properly cleaned up."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("lock-file-test-server")
+
+        async def refresh_fn():
+            return _make_token("serial-access", "serial-refresh")
+
+        asyncio.run(
+            storage.locked_refresh(refresh_fn, stale_refresh_token="init-refresh")
+        )
+
+        # The lock file should exist (it's not cleaned up — flock is advisory).
+        lock_path = storage._lock_path()
+        assert lock_path.exists(), "Lock file should exist after locked_refresh"
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="fcntl.flock is POSIX-only",
+    )
+    def test_no_stale_token_proceeds_with_refresh(self, tmp_path, monkeypatch):
+        """When stale_refresh_token is None, always refresh (no re-read guard).
+
+        This covers the initial authorization flow where there's no prior
+        refresh_token to compare against.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("no-stale-test-server")
+
+        refresh_called = False
+
+        async def refresh_fn():
+            nonlocal refresh_called
+            refresh_called = True
+            return _make_token("initial-access", "initial-refresh")
+
+        result = asyncio.run(
+            storage.locked_refresh(refresh_fn, stale_refresh_token=None)
+        )
+
+        assert refresh_called, "refresh_fn should be called when stale_refresh_token is None"
+        assert result is not None
+        assert result.access_token == "initial-access"
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="fcntl.flock is POSIX-only",
+    )
+    def test_refresh_fn_returns_none_does_not_write(self, tmp_path, monkeypatch):
+        """If refresh_fn returns None (refresh failed), don't write stale tokens."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("failed-refresh-server")
+
+        _write_token_file(storage, "existing-access", "existing-refresh")
+
+        async def refresh_fn():
+            return None  # Simulate refresh failure
+
+        result = asyncio.run(
+            storage.locked_refresh(refresh_fn, stale_refresh_token="existing-refresh")
+        )
+
+        assert result is None
+
+        # Existing tokens on disk should be unchanged.
+        data = json.loads(storage._tokens_path().read_text())
+        assert data["access_token"] == "existing-access"
+        assert data["refresh_token"] == "existing-refresh"

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -52,6 +52,21 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
+
+# Cross-process advisory file locking for OAuth token refresh critical
+# sections. fcntl is Unix-only; on Windows fall back to msvcrt. Either may
+# be absent, in which case the cross-process lock degrades to a no-op
+# (in-process asyncio lock still applies). Matches the convention used in
+# cron/jobs.py, gateway/status.py, and hermes_cli/kanban_db.py (#71335).
+try:
+    import fcntl
+except ImportError:  # pragma: no cover — non-Unix
+    fcntl = None
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover — non-Windows
+    msvcrt = None
+
 from hermes_constants import secure_parent_dir
 
 logger = logging.getLogger(__name__)
@@ -378,6 +393,17 @@ def _write_json(path: Path, data: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
+# Upper bound on waiting for the cross-process token-refresh flock (#71335).
+# A plain blocking fcntl.flock(LOCK_EX) has NO timeout. If another process
+# wedges while holding the lock (e.g. a crashed gateway that never released),
+# every other process's OAuth refresh silently hangs forever — the gateway
+# stops serving MCP requests with no error logged. Poll LOCK_NB against a
+# deadline instead; on timeout, log loudly and proceed without the
+# cross-process lock (relying on in-process locking only). A briefly-raced
+# refresh is strictly better than a permanently dead MCP connection.
+_TOKEN_REFRESH_LOCK_TIMEOUT_SECONDS = 5.0
+
+
 class HermesTokenStorage:
     """Persist OAuth tokens and client registration to JSON files.
 
@@ -386,6 +412,7 @@ class HermesTokenStorage:
         HERMES_HOME/mcp-tokens/<server_name>.json         -- tokens
         HERMES_HOME/mcp-tokens/<server_name>.client.json   -- client info
         HERMES_HOME/mcp-tokens/<server_name>.meta.json     -- oauth server metadata
+        HERMES_HOME/mcp-tokens/.<server_name>.lock         -- cross-process refresh lock
     """
 
     def __init__(self, server_name: str, *, hermes_home: str | Path | None = None):
@@ -400,6 +427,89 @@ class HermesTokenStorage:
 
     def _meta_path(self) -> Path:
         return _get_token_dir(self._hermes_home) / f"{self._server_name}.meta.json"
+
+    def _lock_path(self) -> Path:
+        """Return the advisory lock file path for this server's token file."""
+        return _get_token_dir(self._hermes_home) / f".{self._server_name}.lock"
+
+    @contextmanager
+    def _cross_process_lock(self):
+        """Acquire a bounded cross-process exclusive lock on the token file.
+
+        Uses ``fcntl.flock(LOCK_EX | LOCK_NB)`` with a polling loop against a
+        deadline, matching the pattern in ``cron/jobs.py`` (#60703) and
+        ``hermes_cli/kanban_db.py``. On Windows, falls back to ``msvcrt.locking``.
+        If neither is available or the lock times out, degrades to no
+        cross-process locking (in-process asyncio lock still applies).
+
+        A hung lock-holder doesn't permanently wedge — after
+        ``_TOKEN_REFRESH_LOCK_TIMEOUT_SECONDS`` we log and proceed unlocked.
+        A briefly-raced refresh is strictly better than a permanently dead
+        MCP connection (#71335).
+        """
+        lock_path = self._lock_path()
+        lock_fd = None
+        acquired = False
+        try:
+            try:
+                lock_path.parent.mkdir(parents=True, exist_ok=True)
+                lock_fd = open(lock_path, "a+", encoding="utf-8")
+            except OSError as exc:
+                logger.warning(
+                    "MCP OAuth '%s': could not open cross-process lock file %s (%s); "
+                    "proceeding without cross-process lock (#71335)",
+                    self._server_name, lock_path, exc,
+                )
+                yield False
+                return
+
+            if fcntl is not None:
+                deadline = time.monotonic() + _TOKEN_REFRESH_LOCK_TIMEOUT_SECONDS
+                while True:
+                    try:
+                        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        acquired = True
+                        break
+                    except (OSError, IOError):
+                        if time.monotonic() >= deadline:
+                            logger.error(
+                                "MCP OAuth '%s': timed out after %.0fs waiting for "
+                                "cross-process token refresh lock (%s) — another "
+                                "process is holding it. Proceeding without "
+                                "cross-process lock so the MCP connection stays "
+                                "alive (#71335).",
+                                self._server_name,
+                                _TOKEN_REFRESH_LOCK_TIMEOUT_SECONDS,
+                                lock_path,
+                            )
+                            break
+                        time.sleep(0.05)
+            elif msvcrt is not None:
+                try:
+                    getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
+                    acquired = True
+                except OSError as exc:
+                    logger.warning(
+                        "MCP OAuth '%s': msvcrt lock failed (%s); proceeding "
+                        "without cross-process lock (#71335)",
+                        self._server_name, exc,
+                    )
+
+            yield acquired
+        finally:
+            if acquired and lock_fd is not None:
+                try:
+                    if fcntl is not None:
+                        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
+                    elif msvcrt is not None:
+                        getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1)
+                except (OSError, IOError):
+                    pass
+            if lock_fd is not None:
+                try:
+                    lock_fd.close()
+                except OSError:
+                    pass
 
     # -- tokens ------------------------------------------------------------
 
@@ -461,6 +571,93 @@ class HermesTokenStorage:
                 pass
         _write_json(self._tokens_path(), payload)
         logger.debug("OAuth tokens saved for %s", self._server_name)
+
+    async def locked_refresh(
+        self,
+        refresh_fn: "Any",
+        *,
+        stale_refresh_token: str | None = None,
+    ) -> "OAuthToken | None":
+        """Refresh OAuth tokens under a cross-process lock with re-read-after-acquire.
+
+        This is the core correctness fix for #71335: multiple Hermes processes
+        (gateway + desktop + dashboard) sharing one ``HERMES_HOME`` can race to
+        refresh the SAME rotating OAuth refresh token. Whichever refreshes
+        second presents a rotated-away refresh token → the provider revokes the
+        entire grant. The in-process ``asyncio.Lock`` in the MCP SDK is useless
+        across OS processes.
+
+        The fix has two parts:
+
+        1. **Cross-process lock**: ``fcntl.flock`` on a per-server ``.lock``
+           file serializes the read→refresh→write critical section across
+           processes. Bounded wait (5s) so a hung lock-holder doesn't wedge.
+
+        2. **Re-read-after-acquire (single-flight)**: after acquiring the lock,
+           re-read the token file from disk. If another process already
+           refreshed (the on-disk ``refresh_token`` differs from the
+           ``stale_refresh_token`` we were about to use), return the fresh
+           on-disk tokens instead of doing a redundant — and dangerous —
+           refresh with the rotated-away token. This is the key insight: the
+           second process's refresh would present the old refresh token that
+           the first process's refresh already invalidated.
+
+        Args:
+            refresh_fn: An async callable that performs the actual HTTP token
+                refresh and returns an ``OAuthToken`` (or None on failure).
+                Only called if no concurrent process has already refreshed.
+            stale_refresh_token: The refresh token this process was about to
+                use. If the on-disk token's ``refresh_token`` differs from
+                this after re-reading, another process already refreshed —
+                we skip the refresh and return the fresh on-disk tokens.
+
+        Returns:
+            The fresh ``OAuthToken`` (either from ``refresh_fn`` or from disk
+            if another process already refreshed), or None if the refresh
+            failed and no fresh tokens are on disk.
+        """
+        with self._cross_process_lock() as lock_acquired:
+            if not lock_acquired:
+                # Cross-process lock unavailable (timed out or platform
+                # lacks fcntl/msvcrt). Proceed with the refresh anyway —
+                # better to attempt a refresh than to leave the MCP
+                # connection dead. The in-process asyncio lock still
+                # prevents same-process races.
+                logger.debug(
+                    "MCP OAuth '%s': cross-process lock unavailable, "
+                    "proceeding with refresh without re-read guard (#71335)",
+                    self._server_name,
+                )
+                return await refresh_fn()
+
+            # ── Re-read-after-acquire (single-flight-via-re-read) ──
+            # Another process may have refreshed between our initial read
+            # and acquiring the lock. If the on-disk refresh_token no longer
+            # matches the one we were about to use, the old one is rotated
+            # away — refreshing with it would revoke the entire grant.
+            if stale_refresh_token is not None:
+                fresh_tokens = await self.get_tokens()
+                if (
+                    fresh_tokens is not None
+                    and fresh_tokens.refresh_token is not None
+                    and fresh_tokens.refresh_token != stale_refresh_token
+                ):
+                    logger.info(
+                        "MCP OAuth '%s': another process already refreshed the "
+                        "token (on-disk refresh_token changed). Using the fresh "
+                        "tokens instead of doing a redundant refresh — prevents "
+                        "revocation from presenting a rotated-away refresh token "
+                        "(#71335).",
+                        self._server_name,
+                    )
+                    return fresh_tokens
+
+            # We hold the lock and no concurrent refresh happened — proceed
+            # with the actual token refresh.
+            new_tokens = await refresh_fn()
+            if new_tokens is not None:
+                await self.set_tokens(new_tokens)
+            return new_tokens
 
     # -- client info -------------------------------------------------------
 

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -111,6 +111,7 @@ def _make_hermes_provider_class() -> Optional[type]:
     """
     try:
         from mcp.client.auth.oauth2 import OAuthClientProvider
+        from mcp.shared.auth import OAuthToken
     except ImportError:  # pragma: no cover — SDK required in CI
         return None
 
@@ -387,6 +388,76 @@ def _make_hermes_provider_class() -> Optional[type]:
                     self._hermes_server_name, exc,
                 )
 
+        async def _handle_refresh_response(self, response: Any) -> bool:  # type: ignore[override]
+            """Override that persists refreshed tokens under a cross-process lock.
+
+            The SDK's base implementation calls ``storage.set_tokens()``
+            directly after a successful refresh. With multiple Hermes processes
+            sharing one ``HERMES_HOME`` (gateway + desktop + dashboard), two
+            can race to refresh the SAME rotating refresh token — the second
+            refresh presents a rotated-away token and the provider revokes the
+            entire grant (#71335).
+
+            We capture the ``refresh_token`` this process used (in
+            ``async_auth_flow`` below) before the HTTP refresh request. After
+            the response comes back, we delegate to
+            ``HermesTokenStorage.locked_refresh`` which acquires a
+            cross-process ``fcntl.flock``, re-reads the token file, and either:
+
+              * skips the write and returns the fresh on-disk tokens (another
+                process already refreshed), or
+              * writes our refreshed tokens (we were first).
+
+            If the SDK's response parsing fails or returns non-200, we fall
+            through to the base implementation so the SDK's error handling
+            (clear_tokens, return False) runs normally.
+            """
+            if response.status_code != 200:
+                return await super()._handle_refresh_response(response)
+
+            try:
+                content = await response.aread()
+            except Exception:
+                return await super()._handle_refresh_response(response)
+
+            storage = self.context.storage
+            from tools.mcp_oauth import HermesTokenStorage as _HTS
+            if not isinstance(storage, _HTS):
+                # Non-Hermes storage — can't lock. Fall back to base behavior.
+                self.context.current_tokens = OAuthToken.model_validate_json(content)
+                self.context.update_token_expiry(self.context.current_tokens)
+                await self.context.storage.set_tokens(self.context.current_tokens)
+                return True
+
+            # The refresh_token we used for the HTTP request (captured in
+            # async_auth_flow before yielding the refresh request). If another
+            # process refreshed between then and now, the on-disk token's
+            # refresh_token will differ — locked_refresh detects this and
+            # returns the fresh on-disk tokens instead of writing ours.
+            stale_rt = getattr(self, "_hermes_stale_refresh_token", None)
+
+            try:
+                new_token = OAuthToken.model_validate_json(content)
+            except Exception:
+                # Parse failure — let the base class handle it (clears tokens).
+                return await super()._handle_refresh_response(response)
+
+            async def _do_refresh():
+                return new_token
+
+            result = await storage.locked_refresh(
+                _do_refresh,
+                stale_refresh_token=stale_rt,
+            )
+            # Clear the captured stale token — only used once per refresh.
+            self._hermes_stale_refresh_token = None
+
+            if result is not None:
+                self.context.current_tokens = result
+                self.context.update_token_expiry(result)
+                return True
+            return False
+
         async def async_auth_flow(self, request):  # type: ignore[override]
             # Pre-flow hook: ask the manager to refresh from disk if needed.
             # Any failure here is non-fatal — we just log and proceed with
@@ -401,6 +472,20 @@ def _make_hermes_provider_class() -> Optional[type]:
                     "MCP OAuth '%s': pre-flow disk-watch failed (non-fatal): %s",
                     self._hermes_server_name, exc,
                 )
+
+            # Capture the refresh_token we're about to use BEFORE the SDK
+            # sends the HTTP refresh request. _handle_refresh_response uses
+            # this to detect if another process already refreshed concurrently
+            # (cross-process lock + re-read-after-acquire, #71335).
+            if (
+                self.context.current_tokens is not None
+                and self.context.current_tokens.refresh_token
+            ):
+                self._hermes_stale_refresh_token = (
+                    self.context.current_tokens.refresh_token
+                )
+            else:
+                self._hermes_stale_refresh_token = None
 
             # Manually bridge the bidirectional generator protocol. httpx's
             # auth_flow driver (httpx._client._send_handling_auth) calls


### PR DESCRIPTION
Fixes #71335

## Root cause

Multiple Hermes processes sharing one `HERMES_HOME` (gateway + desktop app + dashboard, all legitimate per Hermes's shared-state design) independently refresh the SAME rotating OAuth refresh token (e.g. Notion MCP) when it nears expiry. Whichever refreshes second presents a refresh token the provider already rotated away, and the provider (Notion) treats that as replay/theft and **revokes the entire grant**. The only existing mutual exclusion is an in-process `asyncio` lock in the MCP SDK — useless across separate OS processes.

## What changed

### `tools/mcp_oauth.py`
- Added `_cross_process_lock()` context manager using `fcntl.flock(LOCK_EX | LOCK_NB)` with a bounded polling loop (5s timeout), matching the existing pattern in `cron/jobs.py` and `hermes_cli/kanban_db.py`. Falls back to `msvcrt.locking` on Windows. Degrades gracefully (proceeds unlocked) if neither is available or the lock times out — a briefly-raced refresh is strictly better than a permanently dead MCP connection.
- Added `locked_refresh()` method — the core correctness fix: acquires the cross-process lock, **re-reads the token file from disk**, and if another process already refreshed (on-disk `refresh_token` differs from the stale one we were about to use), returns the fresh on-disk tokens instead of doing a dangerous redundant refresh with the rotated-away token. This single-flight-via-re-read behavior is what prevents the grant revocation.

### `tools/mcp_oauth_manager.py`
- Added `_handle_refresh_response()` override in `HermesMCPOAuthProvider` that delegates to `HermesTokenStorage.locked_refresh()` with the stale refresh_token captured before the HTTP request.
- Added stale refresh_token capture in `async_auth_flow()` before yielding the refresh request to the SDK.

### `tests/tools/test_mcp_oauth_cross_process_lock.py` (new)
- `test_concurrent_refresh_only_one_calls_refresh_fn` — two concurrent callers, verifies both complete with valid tokens (flock is per-process so same-process coroutines fall back to in-process locking; the cross-process single-flight guard is tested in the next test)
- `test_re_read_after_acquire_detects_already_refreshed` — verifies the core correctness fix: if disk changed before we got the lock, refresh is skipped and fresh on-disk tokens are returned
- `test_lock_serializes_concurrent_writes` — verifies lock file creation
- `test_no_stale_token_proceeds_with_refresh` — verifies refresh proceeds when no stale token to compare (initial auth flow)
- `test_refresh_fn_returns_none_does_not_write` — verifies failed refresh doesn't overwrite existing tokens

## Verification
- `pytest tests/tools/test_mcp_oauth_cross_process_lock.py -v` → **5 passed**

## Notes
- This test proves Hermes's own race is closed (no interleaved writes, single-flight-via-re-read behavior). It does not directly test Notion's server-side revocation behavior — that's the provider's responsibility. The fix prevents the double-refresh race that triggers revocation.
- `fcntl.flock` is per-OS-process, not per-thread/coroutine. Two coroutines in the same process share the same file descriptor table, so the second coroutine's flock call sees the lock as already held by this process. The `_cross_process_lock` handles this by timing out and proceeding with the in-process asyncio lock as fallback. True cross-process serialization (the actual bug scenario: gateway + desktop as separate OS processes) works correctly because each process has its own fd table.