### PR TITLE
fix(tui): auto-scroll to bottom when agent starts streaming output

### DIFF
--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -424,6 +424,16 @@ export function useMainApp(gw: GatewayClient) {
     onHeightsChange: syncHeightCache
   })
 
+  // Auto-scroll to bottom when the agent starts streaming output, but only if
+  // the user is already pinned to the tail (hasn't manually scrolled up). This
+  // ensures the TUI follows along during agent output without yanking the view
+  // out from under a user who is reading earlier content.
+  useEffect(() => {
+    if (turnLiveTailActive && scrollRef.current?.isSticky()) {
+      scrollRef.current.scrollToBottom()
+    }
+  }, [turnLiveTailActive])
+
   const scrollWithSelection = useCallback(
     (delta: number) => scrollWithSelectionBy(delta, { scrollRef, selection }),
     [selection]


### PR DESCRIPTION
## Summary
When the agent begins streaming (`turnLiveTailActive` becomes true), pin the TUI scroll box to the bottom **only if** the user is already sticky at the tail. This keeps the view following live output without yanking users who scrolled up to read earlier content.

## Context
- Closes / addresses #69873
- Small, contained change in `ui-tui/src/app/useMainApp.ts` (+10 lines)

## Test plan
- [ ] Open TUI, start a long agent turn, confirm viewport follows streaming output when at bottom
- [ ] Scroll up mid-stream, confirm view stays put (no forced jump)
- [ ] Scroll back to bottom / sticky, confirm follow resumes on next stream activity
- [ ] Existing ui-tui tests still pass on CI