### PR TITLE
fix(terminal): config.yaml terminal.backend takes precedence over .env TERMINAL_ENV

### DIFF
--- a/tests/tools/test_terminal_env_config_precedence.py
+++ b/tests/tools/test_terminal_env_config_precedence.py
@@ -1,0 +1,160 @@
+"""Regression tests for issue #71137 — config.yaml terminal.backend precedence.
+
+``TERMINAL_ENV`` (written to ``.env`` by ``hermes setup``) used to silently
+override ``terminal.backend`` in config.yaml because ``_get_env_config``
+read ``os.getenv("TERMINAL_ENV", "local")`` unconditionally.  When a user
+set ``terminal.backend: local`` in config.yaml but ``.env`` still carried
+``TERMINAL_ENV=ssh``, the stale env var won and the session bricked when
+SSH was unreachable.
+
+The fix (``_resolve_terminal_backend``) makes config.yaml authoritative:
+when ``terminal.backend`` is explicitly set, it wins over ``TERMINAL_ENV``,
+and a warning is logged so the override is visible.  ``TERMINAL_ENV`` only
+applies when config.yaml doesn't pin a backend.
+"""
+
+import logging
+
+import pytest
+
+import tools.terminal_tool as terminal_tool
+from hermes_constants import get_hermes_home
+
+
+@pytest.fixture(autouse=True)
+def _reset_bridge_state(monkeypatch):
+    """Each test starts with an un-attempted bridge and no TERMINAL_ENV."""
+    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", False)
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    monkeypatch.delenv("TERMINAL_DOCKER_IMAGE", raising=False)
+    yield
+
+
+def _write_config(text: str) -> None:
+    home = get_hermes_home()
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(text)
+
+
+def test_config_backend_overrides_stale_terminal_env_ssh(monkeypatch, caplog):
+    """#71137 core: config.yaml ``terminal.backend: local`` wins over a stale
+    ``TERMINAL_ENV=ssh`` written to .env by ``hermes setup``."""
+    _write_config("terminal:\n  backend: local\n")
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+
+    with caplog.at_level(logging.WARNING, logger="tools.terminal_tool"):
+        config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "local"
+    # The override must be surfaced — silent overrides are the bug.
+    assert any(
+        "terminal.backend" in rec.getMessage() and "overrides TERMINAL_ENV" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+def test_config_backend_overrides_env_for_docker_too(monkeypatch):
+    """Config precedence holds regardless of the backend pair — docker in
+    config wins over ssh in env."""
+    _write_config("terminal:\n  backend: docker\n")
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "docker"
+
+
+def test_terminal_env_used_when_config_has_no_backend(monkeypatch):
+    """When config.yaml has no ``terminal.backend``, TERMINAL_ENV still
+    applies (fallback path unchanged)."""
+    _write_config("terminal:\n  docker_image: img:1\n")
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "ssh"
+
+
+def test_terminal_env_used_when_no_terminal_section(monkeypatch):
+    """No ``terminal`` section at all → TERMINAL_ENV / default wins."""
+    _write_config("model:\n  name: test\n")
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "docker"
+
+
+def test_default_local_when_neither_set(monkeypatch):
+    """Neither config.yaml nor TERMINAL_ENV → local (historical default)."""
+    _write_config("{}\n")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "local"
+
+
+def test_no_warning_when_config_and_env_agree(monkeypatch, caplog):
+    """When config.yaml and TERMINAL_ENV agree, no override warning is
+    logged — only disagreements are surfaced."""
+    _write_config("terminal:\n  backend: docker\n")
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    with caplog.at_level(logging.WARNING, logger="tools.terminal_tool"):
+        config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "docker"
+    assert not any(
+        "overrides TERMINAL_ENV" in rec.getMessage() for rec in caplog.records
+    )
+
+
+def test_resolve_terminal_backend_helper_directly(monkeypatch):
+    """``_resolve_terminal_backend`` returns config value when set."""
+    _write_config("terminal:\n  backend: local\n")
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+
+    assert terminal_tool._resolve_terminal_backend() == "local"
+
+
+def test_resolve_terminal_backend_falls_back_to_env(monkeypatch):
+    """``_resolve_terminal_backend`` returns TERMINAL_ENV when config has no
+    backend."""
+    _write_config("terminal:\n  docker_image: img:1\n")
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+
+    assert terminal_tool._resolve_terminal_backend() == "ssh"
+
+
+def test_resolve_terminal_backend_falls_back_to_local_default(monkeypatch):
+    """``_resolve_terminal_backend`` returns 'local' when nothing is set."""
+    _write_config("{}\n")
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    assert terminal_tool._resolve_terminal_backend() == "local"
+
+
+def test_resolve_terminal_backend_config_read_failure_falls_back(monkeypatch):
+    """A broken config layer must not take the terminal tool down — fall back
+    to TERMINAL_ENV / local."""
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("config exploded")
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(config_mod, "read_raw_config", _boom)
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+
+    # Should fall back to env, not raise.
+    assert terminal_tool._resolve_terminal_backend() == "ssh"
+
+
+def test_resolve_terminal_backend_empty_config_backend_uses_env(monkeypatch):
+    """When ``terminal.backend`` is present but empty, fall back to
+    TERMINAL_ENV rather than treating empty as authoritative."""
+    _write_config("terminal:\n  backend: ''\n")
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    assert terminal_tool._resolve_terminal_backend() == "docker"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1346,12 +1346,60 @@ def _ensure_terminal_env_bridged() -> None:
         logger.debug("terminal config → env fallback bridge failed", exc_info=True)
 
 
+def _resolve_terminal_backend() -> str:
+    """Resolve the terminal backend with correct config.yaml > .env precedence.
+
+    Issue #71137: ``hermes setup`` writes ``TERMINAL_ENV`` to ``.env``.  When
+    a user later changes ``terminal.backend`` in config.yaml but the stale
+    ``.env`` value survives, ``os.getenv("TERMINAL_ENV", "local")`` silently
+    picks up the old env var and overrides the user's explicit config choice —
+    bricking the session when the old backend (e.g. ssh) is unreachable.
+
+    Precedence (highest → lowest):
+      1. ``terminal.backend`` in config.yaml (explicit user choice, non-empty)
+      2. ``TERMINAL_ENV`` env var (from .env or a launcher bridge)
+      3. ``"local"`` (historical default)
+
+    A warning is logged when config.yaml overrides a *different* TERMINAL_ENV,
+    so the previously-silent override is surfaced.  TERMINAL_ENV is left
+    untouched in os.environ — callers that still read it directly (e.g. the
+    container-backend branches in ``_get_env_config``) are unaffected; only
+    the backend selection itself is redirected.
+
+    Any failure reading config falls back to TERMINAL_ENV / local so a broken
+    config never takes the terminal tool down.
+    """
+    env_backend = os.getenv("TERMINAL_ENV")
+    try:
+        from hermes_cli.config import read_raw_config
+
+        raw = read_raw_config() or {}
+        terminal_cfg = raw.get("terminal") or {}
+        config_backend = (terminal_cfg.get("backend") or "").strip() if isinstance(terminal_cfg, dict) else ""
+    except Exception:
+        logger.debug("terminal backend config read failed; falling back to TERMINAL_ENV", exc_info=True)
+        return env_backend or "local"
+
+    if config_backend:
+        if env_backend and env_backend != config_backend:
+            logger.warning(
+                "config.yaml terminal.backend=%r overrides TERMINAL_ENV=%r from .env; "
+                "clear TERMINAL_ENV in .env to silence this.",
+                config_backend,
+                env_backend,
+            )
+        return config_backend
+
+    # No explicit config.backend — TERMINAL_ENV / default wins (unchanged).
+    return env_backend or "local"
+
+
 def _get_env_config() -> Dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
     _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    env_type = _resolve_terminal_backend()
     
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
     container_backend = env_type in {"docker", "singularity", "modal", "daytona"}


### PR DESCRIPTION
## Summary

Fixes #71137.

`hermes setup` writes `TERMINAL_ENV` to `.env`. When a user later changes `terminal.backend` in config.yaml but the stale `.env` value survives, `os.getenv("TERMINAL_ENV", "local")` in `_get_env_config` silently picked up the old env var and overrode the user's explicit config choice — bricking the session when the old backend (e.g. `ssh`) was unreachable.

## Fix

Added `_resolve_terminal_backend()` with correct precedence (highest → lowest):

1. **`terminal.backend` in config.yaml** (explicit user choice, non-empty) — **wins**
2. **`TERMINAL_ENV` env var** (from `.env` or a launcher bridge) — fallback when config.yaml doesn't pin a backend
3. **`"local"`** (historical default) — when neither is set

A **warning is logged** when config.yaml overrides a *different* `TERMINAL_ENV`, so the previously-silent override is surfaced:

```
config.yaml terminal.backend='local' overrides TERMINAL_ENV='ssh' from .env; clear TERMINAL_ENV in .env to silence this.
```

`TERMINAL_ENV` is left untouched in `os.environ` — only the backend selection is redirected. All other env-var reads (container backend branches, docker config, etc.) are unaffected.

Config read failures fall back to `TERMINAL_ENV` / `local` so a broken config never takes the terminal tool down.

## Test plan

- [x] 11 regression tests in `tests/tools/test_terminal_env_config_precedence.py` — all pass
- [x] Existing `test_terminal_tool.py` (27 tests) — all pass
- [x] Existing `test_terminal_env_bridge.py` + `test_terminal_config_env_sync.py` (15 tests) — all pass

Covers: config overrides stale env, docker-vs-ssh, env fallback when no config backend, no terminal section, default local, no warning when agree, helper direct tests, config read failure fallback, empty config backend.

Closes #71137