### PR TITLE
fix(agent): suppress verifier footer for missing patch args

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3153,9 +3153,14 @@ class AIAgent:
             )
             for path in targets:
                 # Keep the FIRST error we saw for a given path unless we
-                # later see success.  A repeated failure with a different
-                # message shouldn't silently overwrite the original.
-                if path not in state:
+                # later see success. A real apply failure supersedes a prior
+                # pre-I/O argument error for the same path, because hiding it
+                # would suppress the verifier footer for an actual failed edit.
+                existing = state.get(path)
+                if existing is None or (
+                    existing.get("kind") == "args_missing"
+                    and kind == "apply_failed"
+                ):
                     state[path] = {
                         "tool": tool_name,
                         "error_preview": preview,

--- a/run_agent.py
+++ b/run_agent.py
@@ -3116,7 +3116,7 @@ class AIAgent:
     ) -> None:
         """Record a ``write_file`` / ``patch`` outcome for the turn-end verifier.
 
-        On failure, store ``{path: {error_preview, tool}}`` entries.  On
+        On failure, store ``{path: {error_preview, tool, kind}}`` entries.  On
         success, remove any prior failure entries for the same paths (the
         model recovered within the turn).  Silently no-ops if the per-turn
         state dict hasn't been initialised yet (e.g. a tool dispatched
@@ -3137,6 +3137,20 @@ class AIAgent:
                 changed.update(_extract_landed_file_mutation_paths(tool_name, args, result))
         if is_error and not landed:
             preview = _extract_error_preview(result)
+            # A rejected call with missing conditional arguments never reached
+            # the filesystem. Keep it in per-turn state so a later successful
+            # call can supersede it, but don't present it as an attempted edit
+            # that the model may have falsely claimed succeeded (#70719).
+            kind = (
+                "args_missing"
+                if preview.strip().lower()
+                in {
+                    "path required",
+                    "old_string and new_string required",
+                    "patch content required",
+                }
+                else "apply_failed"
+            )
             for path in targets:
                 # Keep the FIRST error we saw for a given path unless we
                 # later see success.  A repeated failure with a different
@@ -3145,6 +3159,7 @@ class AIAgent:
                     state[path] = {
                         "tool": tool_name,
                         "error_preview": preview,
+                        "kind": kind,
                     }
         else:
             for path in targets:
@@ -3220,6 +3235,17 @@ class AIAgent:
         bare-path media extractor can never auto-attach a protected file
         (e.g. ``~/.hermes/config.yaml``) to a messaging channel (#35584).
         """
+        # Tool-call formation errors (for example a replace patch missing
+        # ``old_string``) never attempted a write. Their tool result remains
+        # available to the agent, but the overclaim footer is reserved for
+        # failures that actually attempted a mutation (#70719).  Missing
+        # ``kind`` preserves the pre-classification behavior for callers that
+        # construct this data directly.
+        failed = {
+            path: info
+            for path, info in failed.items()
+            if info.get("kind", "apply_failed") != "args_missing"
+        }
         if not failed:
             return ""
         lines = [

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -166,6 +166,26 @@ class TestRecordFileMutationResult:
         assert state["/tmp/a.md"]["kind"] == "args_missing"
         assert AIAgent._format_file_mutation_failure_footer(state) == ""
 
+    def test_real_patch_failure_supersedes_missing_args(self):
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch", {"mode": "replace", "path": "/tmp/a.md"},
+            json.dumps({"success": False, "error": "old_string and new_string required"}),
+            is_error=True,
+        )
+        assert agent._turn_failed_file_mutations["/tmp/a.md"]["kind"] == "args_missing"
+
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": "/tmp/a.md", "old_string": "x", "new_string": "y"},
+            json.dumps({"success": False, "error": "Could not find old_string"}),
+            is_error=True,
+        )
+
+        state = agent._turn_failed_file_mutations
+        assert state["/tmp/a.md"]["kind"] == "apply_failed"
+        assert "/tmp/a.md" in AIAgent._format_file_mutation_failure_footer(state)
+
     def test_success_removes_prior_failure(self):
         agent = _bare_agent()
         # First attempt fails

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -152,6 +152,19 @@ class TestRecordFileMutationResult:
         assert "/tmp/a.md" in state
         assert state["/tmp/a.md"]["tool"] == "patch"
         assert "Could not find old_string" in state["/tmp/a.md"]["error_preview"]
+        assert state["/tmp/a.md"]["kind"] == "apply_failed"
+
+    def test_missing_patch_arguments_do_not_render_overclaim_footer(self):
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch", {"mode": "replace", "path": "/tmp/a.md"},
+            json.dumps({"success": False, "error": "old_string and new_string required"}),
+            is_error=True,
+        )
+
+        state = agent._turn_failed_file_mutations
+        assert state["/tmp/a.md"]["kind"] == "args_missing"
+        assert AIAgent._format_file_mutation_failure_footer(state) == ""
 
     def test_success_removes_prior_failure(self):
         agent = _bare_agent()


### PR DESCRIPTION
## Summary
- classify missing `patch` arguments as pre-I/O failures
- keep the file-mutation overclaim footer for real failed edit attempts
- add a regression test for the missing-argument path

Fixes #70719

## Tests
- `scripts/run_tests.sh tests/run_agent/test_file_mutation_verifier.py`