### PR TITLE
fix(cli): guard config set against overwriting dict sections with scalars

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4854,6 +4854,25 @@ def set_config_value(key: str, value: str, force: bool = False):
             coerced_value = float(value)
 
     value = coerced_value
+
+    # Guard: refuse to overwrite a dict-typed section with a scalar value.
+    # `hermes config set model openai-codex/gpt-5.6-sol` would replace the
+    # entire ``model:`` mapping (losing ``provider``, ``base_url``,
+    # ``context_length``, etc.) with a bare string.  Route the user to the
+    # dotted key form instead (#71047).
+    _top = key.split(".")[0]
+    if "." not in key and isinstance(user_config.get(_top), dict):
+        print(
+            color(
+                f"⚠ Refusing to overwrite '{_top}' (a mapping with "
+                f"{len(user_config[_top])} keys) with a scalar value.\n"
+                f"  Use a dotted key, e.g. `hermes config set {_top}.default {value}`",
+                Colors.YELLOW,
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4855,23 +4855,34 @@ def set_config_value(key: str, value: str, force: bool = False):
 
     value = coerced_value
 
-    # Guard: refuse to overwrite a dict-typed section with a scalar value.
-    # `hermes config set model openai-codex/gpt-5.6-sol` would replace the
-    # entire ``model:`` mapping (losing ``provider``, ``base_url``,
-    # ``context_length``, etc.) with a bare string.  Route the user to the
-    # dotted key form instead (#71047).
+    # Guard against overwriting a dict-typed section with a scalar (#71047).
+    # Bare `hermes config set model <id>` is a documented shorthand that must
+    # become `model.default` when ``model`` is already a mapping, preserving
+    # sibling keys (provider/base_url/context_length).  Other bare top-level
+    # keys that already hold mappings still refuse the destructive overwrite.
     _top = key.split(".")[0]
     if "." not in key and isinstance(user_config.get(_top), dict):
-        print(
-            color(
-                f"⚠ Refusing to overwrite '{_top}' (a mapping with "
-                f"{len(user_config[_top])} keys) with a scalar value.\n"
-                f"  Use a dotted key, e.g. `hermes config set {_top}.default {value}`",
-                Colors.YELLOW,
-            ),
-            file=sys.stderr,
-        )
-        sys.exit(1)
+        if _top == "model":
+            key = "model.default"
+            print(
+                color(
+                    f"  (note: bare 'model' is a shorthand — saving as model.default; "
+                    f"sibling keys under model: preserved)",
+                    Colors.YELLOW,
+                ),
+                file=sys.stderr,
+            )
+        else:
+            print(
+                color(
+                    f"⚠ Refusing to overwrite '{_top}' (a mapping with "
+                    f"{len(user_config[_top])} keys) with a scalar value.\n"
+                    f"  Use a dotted key, e.g. `hermes config set {_top}.<field> {value}`",
+                    Colors.YELLOW,
+                ),
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),

--- a/tests/cli/test_71047_config_set_dict_guard.py
+++ b/tests/cli/test_71047_config_set_dict_guard.py
@@ -1,13 +1,15 @@
-"""#71047: `hermes config set <top-level-key> <scalar>` must not silently
-overwrite a dict-typed section (e.g. ``model:``) with a bare string."""
+"""#71047: bare scalar sets must not silently destroy dict-typed sections.
+
+Documented exception: ``hermes config set model <id>`` is a shorthand for
+``model.default`` when ``model`` is already a mapping — siblings are kept.
+"""
 
 from __future__ import annotations
 
-import os
-import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 def _make_config_dir(tmp_path: Path) -> Path:
@@ -27,28 +29,29 @@ def _make_config_dir(tmp_path: Path) -> Path:
     return hermes_home
 
 
-def test_set_scalar_refuses_to_overwrite_dict(tmp_path, monkeypatch):
-    """`hermes config set model openai-codex/gpt-5.6-sol` must refuse and exit."""
+def _read_cfg(hermes_home: Path) -> dict:
+    with open(hermes_home / "config.yaml", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def test_bare_model_shorthand_sets_default_and_keeps_siblings(tmp_path, monkeypatch):
+    """`hermes config set model <id>` → model.default; provider/context preserved."""
     hermes_home = _make_config_dir(tmp_path)
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     from hermes_cli.config import set_config_value
 
-    with pytest.raises(SystemExit):
-        set_config_value("model", "openai-codex/gpt-5.6-sol", force=True)
+    set_config_value("model", "openai-codex/gpt-5.6-sol", force=True)
 
-    # Verify the config was NOT modified
-    import yaml
-    with open(hermes_home / "config.yaml") as f:
-        cfg = yaml.safe_load(f)
-    assert isinstance(cfg["model"], dict), "model section was overwritten!"
-    assert cfg["model"]["default"] == "gpt-4o"
+    cfg = _read_cfg(hermes_home)
+    assert isinstance(cfg["model"], dict), "model section must remain a mapping"
+    assert cfg["model"]["default"] == "openai-codex/gpt-5.6-sol"
     assert cfg["model"]["provider"] == "openai-api"
     assert cfg["model"]["context_length"] == 128000
 
 
-def test_set_dotted_key_still_works(tmp_path, monkeypatch):
-    """`hermes config set model.default openai-codex/gpt-5.6-sol` must work."""
+def test_set_dotted_model_default_still_works(tmp_path, monkeypatch):
+    """Explicit dotted form must still work and preserve siblings."""
     hermes_home = _make_config_dir(tmp_path)
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
@@ -56,13 +59,27 @@ def test_set_dotted_key_still_works(tmp_path, monkeypatch):
 
     set_config_value("model.default", "openai-codex/gpt-5.6-sol", force=True)
 
-    import yaml
-    with open(hermes_home / "config.yaml") as f:
-        cfg = yaml.safe_load(f)
+    cfg = _read_cfg(hermes_home)
     assert cfg["model"]["default"] == "openai-codex/gpt-5.6-sol"
-    # Siblings preserved
     assert cfg["model"]["provider"] == "openai-api"
     assert cfg["model"]["context_length"] == 128000
+
+
+def test_set_scalar_refuses_to_overwrite_non_model_dict(tmp_path, monkeypatch):
+    """Bare set on a non-model mapping (e.g. platforms) must refuse and exit."""
+    hermes_home = _make_config_dir(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli.config import set_config_value
+
+    with pytest.raises(SystemExit):
+        set_config_value("platforms", "broken-scalar", force=True)
+
+    cfg = _read_cfg(hermes_home)
+    assert isinstance(cfg["platforms"], dict), "platforms section was overwritten!"
+    assert cfg["platforms"]["telegram"]["streaming"] is True
+    # model untouched
+    assert cfg["model"]["default"] == "gpt-4o"
 
 
 def test_set_scalar_on_scalar_key_still_works(tmp_path, monkeypatch):
@@ -72,10 +89,22 @@ def test_set_scalar_on_scalar_key_still_works(tmp_path, monkeypatch):
 
     from hermes_cli.config import set_config_value
 
-    # timezone is a scalar — setting it should work
     set_config_value("timezone", "America/New_York", force=True)
 
-    import yaml
-    with open(hermes_home / "config.yaml") as f:
-        cfg = yaml.safe_load(f)
+    cfg = _read_cfg(hermes_home)
     assert cfg["timezone"] == "America/New_York"
+
+
+def test_bare_model_when_model_absent_still_sets_top_level(tmp_path, monkeypatch):
+    """If model key is not yet a mapping, bare set remains a simple write."""
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("timezone: UTC\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli.config import set_config_value
+
+    set_config_value("model", "gpt-4o", force=True)
+    cfg = _read_cfg(hermes_home)
+    # No pre-existing mapping → historical bare write is allowed.
+    assert cfg["model"] == "gpt-4o"

--- a/tests/cli/test_71047_config_set_dict_guard.py
+++ b/tests/cli/test_71047_config_set_dict_guard.py
@@ -1,0 +1,81 @@
+"""#71047: `hermes config set <top-level-key> <scalar>` must not silently
+overwrite a dict-typed section (e.g. ``model:``) with a bare string."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _make_config_dir(tmp_path: Path) -> Path:
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir()
+    config = hermes_home / "config.yaml"
+    config.write_text(
+        "model:\n"
+        "  default: gpt-4o\n"
+        "  provider: openai-api\n"
+        "  context_length: 128000\n"
+        "platforms:\n"
+        "  telegram:\n"
+        "    streaming: true\n",
+        encoding="utf-8",
+    )
+    return hermes_home
+
+
+def test_set_scalar_refuses_to_overwrite_dict(tmp_path, monkeypatch):
+    """`hermes config set model openai-codex/gpt-5.6-sol` must refuse and exit."""
+    hermes_home = _make_config_dir(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli.config import set_config_value
+
+    with pytest.raises(SystemExit):
+        set_config_value("model", "openai-codex/gpt-5.6-sol", force=True)
+
+    # Verify the config was NOT modified
+    import yaml
+    with open(hermes_home / "config.yaml") as f:
+        cfg = yaml.safe_load(f)
+    assert isinstance(cfg["model"], dict), "model section was overwritten!"
+    assert cfg["model"]["default"] == "gpt-4o"
+    assert cfg["model"]["provider"] == "openai-api"
+    assert cfg["model"]["context_length"] == 128000
+
+
+def test_set_dotted_key_still_works(tmp_path, monkeypatch):
+    """`hermes config set model.default openai-codex/gpt-5.6-sol` must work."""
+    hermes_home = _make_config_dir(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli.config import set_config_value
+
+    set_config_value("model.default", "openai-codex/gpt-5.6-sol", force=True)
+
+    import yaml
+    with open(hermes_home / "config.yaml") as f:
+        cfg = yaml.safe_load(f)
+    assert cfg["model"]["default"] == "openai-codex/gpt-5.6-sol"
+    # Siblings preserved
+    assert cfg["model"]["provider"] == "openai-api"
+    assert cfg["model"]["context_length"] == 128000
+
+
+def test_set_scalar_on_scalar_key_still_works(tmp_path, monkeypatch):
+    """Setting a scalar on a key that's already a scalar must work."""
+    hermes_home = _make_config_dir(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli.config import set_config_value
+
+    # timezone is a scalar — setting it should work
+    set_config_value("timezone", "America/New_York", force=True)
+
+    import yaml
+    with open(hermes_home / "config.yaml") as f:
+        cfg = yaml.safe_load(f)
+    assert cfg["timezone"] == "America/New_York"


### PR DESCRIPTION
## Issue

Fixes #71047 (Problem A).

## Problem

`hermes config set model openai-codex/gpt-5.6-sol` silently replaced the entire `model:` mapping (losing `provider`, `base_url`, `context_length`, etc.) with a bare scalar string. The runtime config reader normalizes scalar `model:` to a nested form, but `hermes doctor` does not — so the diagnostic breaks while the runtime appears fine (see also #71019).

## Fix

Guard in `set_config_value()`: when the target top-level key currently holds a dict and the user passed a bare scalar (no dots in the key), refuse with `SystemExit` and route the user to the dotted-key form:

```
⚠ Refusing to overwrite 'model' (a mapping with 3 keys) with a scalar value.
  Use a dotted key, e.g. `hermes config set model.default openai-codex/gpt-5.6-sol`
```

Dotted keys (`hermes config set model.default ...`) are unaffected. Setting a scalar on a scalar key (e.g. `hermes config set timezone America/New_York`) is also unaffected.

## Tests

3 new regression tests:
- `test_set_scalar_refuses_to_overwrite_dict` — verifies refusal + config unchanged
- `test_set_dotted_key_still_works` — verifies dotted key path still works, siblings preserved
- `test_set_scalar_on_scalar_key_still_works` — verifies scalar-on-scalar still works

Signed-off-by: Jasmine Naderi <jasmine@smfworks.com>