### PR TITLE
fix(cli): read fresh config in /new instead of stale CLI_CONFIG snapshot

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9427,19 +9427,32 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # was for the previous session only, not for every session spawned
         # afterwards.
         self._explicit_model_override = False
-        self.reasoning_config = _parse_reasoning_config(
-            CLI_CONFIG["agent"].get("reasoning_effort", "")
-        )
         # /new is a full conversation boundary: session-scoped runtime
         # overrides (/model --session, /fast, one-turn restores) do not carry
         # forward.  Re-derive model/provider and service tier from config.yaml
         # so a session-only switch never leaks into the next session (#48055,
         # #23131).
+        #
+        # Read fresh from disk via load_cli_config() instead of the module-level
+        # CLI_CONFIG snapshot — the latter is loaded once at import time and
+        # never refreshed, so edits to config.yaml made after the CLI started
+        # (e.g. `hermes config set model.default ...`) would be invisible to
+        # /new and silently reset the model to the stale import-time value
+        # (#71188).
+        _fresh_config = load_cli_config() or {}
+        _agent_cfg = _fresh_config.get("agent")
+        if not isinstance(_agent_cfg, dict):
+            _agent_cfg = {}
+        self.reasoning_config = _parse_reasoning_config(
+            _agent_cfg.get("reasoning_effort", "")
+        )
         self._pending_one_turn_model_restore = None
         self.service_tier = _parse_service_tier_config(
-            CLI_CONFIG["agent"].get("service_tier", "")
+            _agent_cfg.get("service_tier", "")
         )
-        _model_config = CLI_CONFIG.get("model", {})
+        _model_config = _fresh_config.get("model", {})
+        if not isinstance(_model_config, dict):
+            _model_config = {}
         _raw_default2 = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
         _config_model, _ = _split_model_config_default(_raw_default2)
         if _config_model and _config_model != getattr(self, "model", None):

--- a/tests/cli/test_71188_new_session_fresh_config.py
+++ b/tests/cli/test_71188_new_session_fresh_config.py
@@ -1,0 +1,150 @@
+"""#71188: /new must read fresh config, not the stale CLI_CONFIG snapshot."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _make_stub(*, model: str = "session-switched-model"):
+    agent = SimpleNamespace(
+        reasoning_config={"enabled": True, "effort": "high"},
+        reset_session_state=MagicMock(),
+        switch_model=MagicMock(),
+    )
+    stub = SimpleNamespace(
+        agent=agent,
+        conversation_history=[],
+        session_id="old-session",
+        _session_db=None,
+        _pending_title=None,
+        _resumed=False,
+        reasoning_config={"enabled": True, "effort": "high"},
+        _notify_session_boundary=MagicMock(),
+        service_tier="priority",
+        _pending_one_turn_model_restore={"model": "stale"},
+        model=model,
+        provider="openrouter",
+        requested_provider="openrouter",
+        api_key="k",
+        base_url="",
+        api_mode="",
+    )
+    return stub, agent
+
+
+def test_new_session_uses_fresh_load_cli_config_not_stale_CLI_CONFIG():
+    """Keep CLI_CONFIG stale; fresh load_cli_config() must drive /new defaults."""
+    from cli import CLI_CONFIG, HermesCLI
+
+    stub, agent = _make_stub(model="session-switched-model")
+
+    stale_model = {"default": "stale-import-model", "provider": "openrouter"}
+    fresh_config = {
+        "agent": {
+            "reasoning_effort": "medium",
+            "service_tier": "normal",
+        },
+        "model": {
+            "default": "fresh-config-model",
+            "provider": "openrouter",
+        },
+    }
+    fake_result = SimpleNamespace(
+        success=True,
+        new_model="fresh-config-model",
+        target_provider="openrouter",
+        api_key="k2",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="chat_completions",
+    )
+
+    with patch.dict(
+        CLI_CONFIG.setdefault("agent", {}),
+        {"reasoning_effort": "low", "service_tier": "priority"},
+    ), patch.dict(
+        CLI_CONFIG,
+        {"model": stale_model},
+    ), patch(
+        "cli.load_cli_config",
+        return_value=fresh_config,
+    ) as load_fresh, patch(
+        "hermes_cli.model_switch.switch_model",
+        return_value=fake_result,
+    ) as switch_model:
+        HermesCLI.new_session(stub, silent=True)
+
+    load_fresh.assert_called()
+    assert stub.reasoning_config == {"enabled": True, "effort": "medium"}
+    assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
+    assert stub.service_tier is None
+    assert stub._pending_one_turn_model_restore is None
+    assert stub.model == "fresh-config-model"
+    assert stub.model != "stale-import-model"
+    switch_model.assert_called_once()
+    assert switch_model.call_args.kwargs["raw_input"] == "fresh-config-model"
+    agent.switch_model.assert_called_once()
+    agent.reset_session_state.assert_called_once()
+
+
+def test_new_session_ignores_stale_CLI_CONFIG_when_fresh_differs_only_in_model():
+    from cli import CLI_CONFIG, HermesCLI
+
+    stub, agent = _make_stub(model="old-session-model")
+    fresh_config = {
+        "agent": {"reasoning_effort": "medium", "service_tier": ""},
+        "model": {"default": "only-fresh-model", "provider": "openrouter"},
+    }
+    fake_result = SimpleNamespace(
+        success=True,
+        new_model="only-fresh-model",
+        target_provider="openrouter",
+        api_key="k",
+        base_url="",
+        api_mode="chat_completions",
+    )
+
+    with patch.dict(
+        CLI_CONFIG.setdefault("agent", {}),
+        {"reasoning_effort": "medium", "service_tier": ""},
+    ), patch.dict(
+        CLI_CONFIG,
+        {"model": {"default": "stale-model", "provider": "openrouter"}},
+    ), patch(
+        "cli.load_cli_config",
+        return_value=fresh_config,
+    ), patch(
+        "hermes_cli.model_switch.switch_model",
+        return_value=fake_result,
+    ) as switch_model:
+        HermesCLI.new_session(stub, silent=True)
+
+    assert stub.model == "only-fresh-model"
+    assert switch_model.call_args.kwargs["raw_input"] == "only-fresh-model"
+    agent.reset_session_state.assert_called_once()
+
+
+def test_new_session_tolerates_thin_fresh_config_without_agent_key():
+    from cli import HermesCLI
+
+    stub, agent = _make_stub(model="keep-me")
+    with patch("cli.load_cli_config", return_value={"model": {}}), patch(
+        "hermes_cli.model_switch.switch_model"
+    ) as switch_model:
+        HermesCLI.new_session(stub, silent=True)
+
+    switch_model.assert_not_called()
+    assert stub.model == "keep-me"
+    agent.reset_session_state.assert_called_once()
+
+
+def test_new_session_tolerates_non_dict_agent_section():
+    from cli import HermesCLI
+
+    stub, agent = _make_stub(model="keep-me")
+    with patch(
+        "cli.load_cli_config",
+        return_value={"agent": "broken", "model": {}},
+    ):
+        HermesCLI.new_session(stub, silent=True)
+    agent.reset_session_state.assert_called_once()

--- a/tests/cli/test_71188_new_session_fresh_config.py
+++ b/tests/cli/test_71188_new_session_fresh_config.py
@@ -1,0 +1,162 @@
+"""#71188: /new must read fresh config, not the stale CLI_CONFIG snapshot."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _make_stub(*, model: str = "session-switched-model"):
+    agent = SimpleNamespace(
+        reasoning_config={"enabled": True, "effort": "high"},
+        reset_session_state=MagicMock(),
+        switch_model=MagicMock(),
+    )
+    stub = SimpleNamespace(
+        agent=agent,
+        conversation_history=[],
+        session_id="old-session",
+        _session_db=None,
+        _pending_title=None,
+        _resumed=False,
+        reasoning_config={"enabled": True, "effort": "high"},
+        _notify_session_boundary=MagicMock(),
+        service_tier="priority",
+        _pending_one_turn_model_restore={"model": "stale"},
+        model=model,
+        provider="openrouter",
+        requested_provider="openrouter",
+        api_key="k",
+        base_url="",
+        api_mode="",
+    )
+    return stub, agent
+
+
+def test_new_session_uses_fresh_load_cli_config_not_stale_CLI_CONFIG():
+    """Keep CLI_CONFIG stale; fresh load_cli_config() must drive /new defaults.
+
+    Behavioral contract for #71188: if config.yaml changes after import,
+    `/new` must pick up the fresh model/agent settings rather than the
+    import-time CLI_CONFIG snapshot.
+    """
+    from cli import CLI_CONFIG, HermesCLI
+
+    stub, agent = _make_stub(model="session-switched-model")
+
+    # Stale import-time snapshot — deliberately different from fresh config.
+    stale_model = {"default": "stale-import-model", "provider": "openrouter"}
+    fresh_config = {
+        "agent": {
+            "reasoning_effort": "medium",
+            "service_tier": "normal",
+        },
+        "model": {
+            "default": "fresh-config-model",
+            "provider": "openrouter",
+        },
+    }
+    fake_result = SimpleNamespace(
+        success=True,
+        new_model="fresh-config-model",
+        target_provider="openrouter",
+        api_key="k2",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="chat_completions",
+    )
+
+    with patch.dict(
+        CLI_CONFIG.setdefault("agent", {}),
+        {"reasoning_effort": "low", "service_tier": "priority"},
+    ), patch.dict(
+        CLI_CONFIG,
+        {"model": stale_model},
+    ), patch(
+        "cli.load_cli_config",
+        return_value=fresh_config,
+    ) as load_fresh, patch(
+        "hermes_cli.model_switch.switch_model",
+        return_value=fake_result,
+    ) as switch_model:
+        HermesCLI.new_session(stub, silent=True)
+
+    load_fresh.assert_called()
+    # Fresh config wins: medium effort (not stale "low").
+    assert stub.reasoning_config == {"enabled": True, "effort": "medium"}
+    assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
+    # Fresh service_tier "normal" clears to None (not stale "priority").
+    assert stub.service_tier is None
+    assert stub._pending_one_turn_model_restore is None
+    # Fresh model, not the stale import-time default.
+    assert stub.model == "fresh-config-model"
+    assert stub.model != "stale-import-model"
+    switch_model.assert_called_once()
+    assert switch_model.call_args.kwargs["raw_input"] == "fresh-config-model"
+    agent.switch_model.assert_called_once()
+    agent.reset_session_state.assert_called_once()
+
+
+def test_new_session_ignores_stale_CLI_CONFIG_when_fresh_differs_only_in_model():
+    """Even if agent settings match, a changed model.default must still apply."""
+    from cli import CLI_CONFIG, HermesCLI
+
+    stub, agent = _make_stub(model="old-session-model")
+    fresh_config = {
+        "agent": {"reasoning_effort": "medium", "service_tier": ""},
+        "model": {"default": "only-fresh-model", "provider": "openrouter"},
+    }
+    fake_result = SimpleNamespace(
+        success=True,
+        new_model="only-fresh-model",
+        target_provider="openrouter",
+        api_key="k",
+        base_url="",
+        api_mode="chat_completions",
+    )
+
+    with patch.dict(
+        CLI_CONFIG.setdefault("agent", {}),
+        {"reasoning_effort": "medium", "service_tier": ""},
+    ), patch.dict(
+        CLI_CONFIG,
+        {"model": {"default": "stale-model", "provider": "openrouter"}},
+    ), patch(
+        "cli.load_cli_config",
+        return_value=fresh_config,
+    ), patch(
+        "hermes_cli.model_switch.switch_model",
+        return_value=fake_result,
+    ) as switch_model:
+        HermesCLI.new_session(stub, silent=True)
+
+    assert stub.model == "only-fresh-model"
+    assert switch_model.call_args.kwargs["raw_input"] == "only-fresh-model"
+    agent.reset_session_state.assert_called_once()
+
+
+def test_new_session_tolerates_thin_fresh_config_without_agent_key():
+    """/new must not KeyError if load_cli_config returns a thin mapping."""
+    from cli import HermesCLI
+
+    stub, agent = _make_stub(model="keep-me")
+    # No agent key, empty model — keep current model, no crash.
+    with patch("cli.load_cli_config", return_value={"model": {}}), patch(
+        "hermes_cli.model_switch.switch_model"
+    ) as switch_model:
+        HermesCLI.new_session(stub, silent=True)
+
+    switch_model.assert_not_called()
+    assert stub.model == "keep-me"
+    agent.reset_session_state.assert_called_once()
+
+
+def test_new_session_tolerates_non_dict_agent_section():
+    from cli import HermesCLI
+
+    stub, agent = _make_stub(model="keep-me")
+    with patch(
+        "cli.load_cli_config",
+        return_value={"agent": "broken", "model": {}},
+    ):
+        HermesCLI.new_session(stub, silent=True)
+    agent.reset_session_state.assert_called_once()

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -124,7 +124,11 @@ class TestHandleReasoningCommand(unittest.TestCase):
             _notify_session_boundary=MagicMock(),
         )
 
-        with patch.dict(CLI_CONFIG.setdefault("agent", {}), {"reasoning_effort": "medium"}):
+        fresh = {
+            "agent": {"reasoning_effort": "medium", "service_tier": ""},
+            "model": dict(CLI_CONFIG.get("model") or {}),
+        }
+        with patch("cli.load_cli_config", return_value=fresh):
             HermesCLI.new_session(stub, silent=True)
 
         self.assertEqual(stub.reasoning_config, {"enabled": True, "effort": "medium"})
@@ -169,12 +173,12 @@ class TestHandleReasoningCommand(unittest.TestCase):
             base_url="https://openrouter.ai/api/v1",
             api_mode="chat_completions",
         )
-        with patch.dict(
-            CLI_CONFIG.setdefault("agent", {}),
-            {"reasoning_effort": "medium", "service_tier": "normal"},
-        ), patch.dict(
-            CLI_CONFIG,
-            {"model": {"default": "config-default-model", "provider": "openrouter"}},
+        fresh = {
+            "agent": {"reasoning_effort": "medium", "service_tier": "normal"},
+            "model": {"default": "config-default-model", "provider": "openrouter"},
+        }
+        with patch(
+            "cli.load_cli_config", return_value=fresh
         ), patch(
             "hermes_cli.model_switch.switch_model", return_value=fake_result
         ):


### PR DESCRIPTION
## Issue

Fixes #71188.

## Problem

`/new` read `model.default`, `reasoning_effort`, and `service_tier` from the module-level `CLI_CONFIG` (loaded once at import time, line 788). When a user edited `config.yaml` mid-process (e.g. `hermes config set model.default ...`) and ran `/new`, the model silently reset to the stale import-time value.

## Fix

Replace the three `CLI_CONFIG` reads in `new_session()` with a single `_fresh_config = load_cli_config()` call, which always reads from disk.

## Test

Source-level regression test verifying `new_session()` calls `load_cli_config()` and does not read from `CLI_CONFIG` for model/agent config.

Signed-off-by: Jasmine Naderi <jasmine@smfworks.com>