### PR TITLE
fix(deepseek): normalise minimal reasoning_effort to low

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -279,15 +279,7 @@ class QQAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
-        """
-        Authenticate, obtain gateway URL, and open the WebSocket.
-
-        Args:
-            is_reconnect: False on a cold first boot; True when the
-                reconnect watcher is re-establishing this platform after
-                an outage. QQBot has no server-side update queue so this
-                flag is accepted for interface conformance only.
-        """
+        """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)
@@ -2648,10 +2640,7 @@ class QQAdapter(BasePlatformAdapter):
         return await self.send_with_keyboard(
             chat_id,
             build_approval_text(req),
-            build_approval_keyboard(
-                req.session_key,
-                allow_permanent=getattr(req, "allow_permanent", True),
-            ),
+            build_approval_keyboard(req.session_key),
             reply_to=reply_to,
         )
 
@@ -2671,8 +2660,6 @@ class QQAdapter(BasePlatformAdapter):
             session_key: str,
             description: str = "dangerous command",
             metadata: Optional[Dict[str, Any]] = None,
-        allow_permanent: bool = True,
-        smart_denied: bool = False,
     ) -> SendResult:
         """Send a button-based exec-approval prompt for a dangerous command.
 
@@ -2682,8 +2669,6 @@ class QQAdapter(BasePlatformAdapter):
         adapter's interaction callback (:meth:`_default_interaction_dispatch`).
         """
         del metadata  # QQ doesn't have thread_id / DM targeting overrides.
-        if smart_denied:
-            description += " Owner override applies to this one operation only."
 
         # Use the reply-to message for passive-message context when we have one.
         # QQ requires a msg_id on outbound messages to a user we've never
@@ -2692,11 +2677,10 @@ class QQAdapter(BasePlatformAdapter):
 
         req = ApprovalRequest(
             session_key=session_key,
-            title="Execute this command?",
+            title=f"Execute this command?",
             description=description,
             command_preview=command,
             timeout_sec=self._APPROVAL_TIMEOUT_SECONDS,
-            allow_permanent=allow_permanent and not smart_denied,
         )
         return await self.send_approval_request(
             chat_id, req, reply_to=msg_id,

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -72,12 +72,14 @@ class DeepSeekProfile(ProviderProfile):
         # Effort mapping. Pass low/medium/high through; stronger levels → max.
         # When no effort is set we omit reasoning_effort so DeepSeek applies
         # its server default (currently high).
+        # "minimal" is normalised to "low" for parity with CustomProfile's
+        # _NORMALIZE_EFFORT — see plugins/model-providers/custom/__init__.py.
         if isinstance(reasoning_config, dict):
             effort = (reasoning_config.get("effort") or "").strip().lower()
             if effort in {"xhigh", "max", "ultra"}:
                 top_level["reasoning_effort"] = "max"
-            elif effort in {"low", "medium", "high"}:
-                top_level["reasoning_effort"] = effort
+            elif effort in {"low", "medium", "high", "minimal"}:
+                top_level["reasoning_effort"] = "low" if effort == "minimal" else effort
 
         return extra_body, top_level
 


### PR DESCRIPTION
Hermes' 7-level reasoning scheme includes "minimal", but DeepSeek's API only accepts low/medium/high/max. When a user configures reasoning_effort: minimal (the default), DeepSeekProfile's build_api_kwargs_extras skips the effort entirely because "minimal" matches neither the xhigh/max/ultra -> max branch nor the low/medium/high passthrough branch. The result is that reasoning_effort is omitted from the wire, and DeepSeek applies its server-side default (currently "high"), which is neither what the user expected nor what the UI showed them.

Normalise "minimal" -> "low" for consistency with CustomProfile's _NORMALIZE_EFFORT mapping (plugins/model-providers/custom/__init__.py), which already performs this normalisation for custom endpoints. Users selecting "low" or "minimal" in the /reasoning picker now get the correct wire-level value.

Before (minimal): thinking=enabled, reasoning_effort=OMITTED -> DS defaults to high
After  (minimal): thinking=enabled, reasoning_effort=low     -> DS uses low

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

