### PR TITLE
fix(insights): use _safe_int() for non-numeric DB values in reconciliation

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -82,6 +82,26 @@ def _bar_chart(values: List[int], max_width: int = 20) -> List[str]:
     return ["█" * max(1, int(v / peak * max_width)) if v > 0 else "" for v in values]
 
 
+
+def _safe_int(value: Any) -> int:
+    """Coerce a DB value to int, returning 0 for unparseable values (#71026)."""
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        try:
+            return int(float(value))
+        except (ValueError, TypeError):
+            return 0
+
+
 class InsightsEngine:
     """
     Analyzes session history and produces usage insights.
@@ -600,14 +620,14 @@ class InsightsEngine:
                 "input_tokens", "output_tokens", "cache_read_tokens",
                 "cache_write_tokens", "reasoning_tokens", "api_call_count",
             ):
-                totals[key] += r[key] or 0
+                totals[key] += _safe_int(r[key])
             totals["estimated_cost_usd"] += r["estimated_cost_usd"] or 0.0
             totals["actual_cost_usd"] += r["actual_cost_usd"] or 0.0
             d = _accumulate(
                 r["model"], r["billing_provider"], r.get("billing_base_url"),
-                r["session_id"], r["input_tokens"] or 0, r["output_tokens"] or 0,
-                r["cache_read_tokens"] or 0, r["cache_write_tokens"] or 0,
-                r["reasoning_tokens"] or 0,
+                r["session_id"], _safe_int(r["input_tokens"]), _safe_int(r["output_tokens"]),
+                _safe_int(r["cache_read_tokens"]), _safe_int(r["cache_write_tokens"]),
+                _safe_int(r["reasoning_tokens"]),
                 stored_cost=(
                     r["estimated_cost_usd"]
                     if r.get("cost_status") or r.get("cost_source")
@@ -616,20 +636,20 @@ class InsightsEngine:
                 actual_cost=r["actual_cost_usd"],
                 cost_status=r.get("cost_status"),
             )
-            model_data[d]["api_calls"] += r["api_call_count"] or 0
+            model_data[d]["api_calls"] += _safe_int(r["api_call_count"])
 
         # Reconcile against the aggregate row. This covers legacy sessions,
         # interrupted migrations, and absolute cumulative updates without
         # double-counting already-attributed route deltas.
         for s in sessions:
             totals = usage_totals[s["id"]]
-            inp = max(0, (s.get("input_tokens") or 0) - totals["input_tokens"])
-            out = max(0, (s.get("output_tokens") or 0) - totals["output_tokens"])
+            inp = max(0, _safe_int(s.get("input_tokens")) - totals["input_tokens"])
+            out = max(0, _safe_int(s.get("output_tokens")) - totals["output_tokens"])
             cache_read = max(
-                0, (s.get("cache_read_tokens") or 0) - totals["cache_read_tokens"]
+                0, _safe_int(s.get("cache_read_tokens")) - totals["cache_read_tokens"]
             )
             cache_write = max(
-                0, (s.get("cache_write_tokens") or 0) - totals["cache_write_tokens"]
+                0, _safe_int(s.get("cache_write_tokens")) - totals["cache_write_tokens"]
             )
             residual_cost = max(
                 0.0, float(s.get("estimated_cost_usd") or 0.0)
@@ -640,7 +660,7 @@ class InsightsEngine:
                 - totals["actual_cost_usd"],
             )
             residual_calls = max(
-                0, (s.get("api_call_count") or 0) - totals["api_call_count"]
+                0, _safe_int(s.get("api_call_count")) - totals["api_call_count"]
             )
             if not (
                 inp or out or cache_read or cache_write or residual_cost

--- a/tests/agent/test_71026_safe_int.py
+++ b/tests/agent/test_71026_safe_int.py
@@ -1,0 +1,28 @@
+"""#71026: /insights must not crash with TypeError on non-numeric DB values."""
+import pytest
+from agent.insights import _safe_int
+
+
+class TestSafeInt:
+    def test_none(self):
+        assert _safe_int(None) == 0
+    def test_int(self):
+        assert _safe_int(42) == 42
+    def test_float(self):
+        assert _safe_int(3.7) == 3
+    def test_numeric_string(self):
+        assert _safe_int("123") == 123
+    def test_float_string(self):
+        assert _safe_int("45.6") == 45
+    def test_non_numeric_string(self):
+        assert _safe_int("corrupt") == 0
+    def test_empty_string(self):
+        assert _safe_int("") == 0
+    def test_bool(self):
+        assert _safe_int(True) == 1
+        assert _safe_int(False) == 0
+    def test_reconciliation_no_crash(self):
+        s = {"api_call_count": "corrupt", "input_tokens": "bad"}
+        totals = {"api_call_count": 5, "input_tokens": 10}
+        residual = max(0, _safe_int(s.get("api_call_count")) - totals["api_call_count"])
+        assert residual == 0

--- a/tests/agent/test_auxiliary_client_anthropic_cache_tokens_71242.py
+++ b/tests/agent/test_auxiliary_client_anthropic_cache_tokens_71242.py
@@ -1,0 +1,128 @@
+"""Regression test for issue #71242.
+
+``_AnthropicCompletionsAdapter.create`` rebuilds the native Anthropic
+usage object into an OpenAI-shaped ``SimpleNamespace``.  Before this fix
+the cache accounting fields (``cache_read_input_tokens`` /
+``cache_creation_input_tokens``) were dropped, so downstream billing /
+usage accounting could not see prompt-cache reads or creations.
+
+This test exercises the usage-mapping path directly by mocking
+``create_anthropic_message`` (so no SDK is required) and the transport's
+``normalize_response`` (which only needs to return a duck-typed object
+with the attributes the adapter reads: ``content``, ``tool_calls``,
+``reasoning``, ``finish_reason``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in (
+        "OPENAI_API_KEY", "OPENAI_BASE_URL",
+        "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _make_native_response(*, input_tokens=10, output_tokens=20,
+                           cache_read=0, cache_creation=0):
+    """Build a duck-typed Anthropic response with a native usage block."""
+    usage = SimpleNamespace(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        # Anthropic does NOT set total_tokens; the adapter computes it.
+        cache_read_input_tokens=cache_read,
+        cache_creation_input_tokens=cache_creation,
+    )
+    return SimpleNamespace(
+        content=[MagicMock()],
+        usage=usage,
+        stop_reason="end_turn",
+        model="claude-test",
+    )
+
+
+def _patch_transport():
+    """Patch the anthropic_messages transport so no SDK import is needed."""
+    fake_nr = SimpleNamespace(
+        content="hello",
+        tool_calls=None,
+        reasoning=None,
+        finish_reason="stop",
+    )
+    fake_transport = MagicMock(name="anthropic_transport")
+    fake_transport.normalize_response.return_value = fake_nr
+    return patch(
+        "agent.transports.get_transport",
+        return_value=fake_transport,
+    ), fake_nr
+
+
+def _patch_create_anthropic_message(response):
+    return patch(
+        "agent.anthropic_adapter.create_anthropic_message",
+        return_value=response,
+    )
+
+
+def test_anthropic_adapter_preserves_cache_tokens_in_usage():
+    """Issue #71242: cache_read/cache_creation tokens must survive the shim."""
+    from agent.auxiliary_client import _AnthropicCompletionsAdapter
+
+    native = _make_native_response(
+        input_tokens=100, output_tokens=50,
+        cache_read=2048, cache_creation=512,
+    )
+
+    adapter = _AnthropicCompletionsAdapter(
+        real_client=MagicMock(), model="claude-test", is_oauth=False,
+    )
+
+    with _patch_create_anthropic_message(native), _patch_transport()[0]:
+        result = adapter.create(messages=[{"role": "user", "content": "hi"}])
+
+    assert result.usage is not None, "usage must be populated"
+    # Core OpenAI-shape fields preserved.
+    assert result.usage.prompt_tokens == 100
+    assert result.usage.completion_tokens == 50
+    assert result.usage.total_tokens == 150
+    # The regression: cache fields must NOT be dropped.
+    assert result.usage.cache_read_input_tokens == 2048, (
+        "cache_read_input_tokens was dropped by the usage shim (issue #71242)"
+    )
+    assert result.usage.cache_creation_input_tokens == 512, (
+        "cache_creation_input_tokens was dropped by the usage shim (issue #71242)"
+    )
+
+
+def test_anthropic_adapter_usage_cache_fields_default_to_zero_when_absent():
+    """When the provider omits cache fields, the shim must default to 0."""
+    from agent.auxiliary_client import _AnthropicCompletionsAdapter
+
+    # Native usage WITHOUT the cache fields (some providers don't report them).
+    native = SimpleNamespace(
+        content=[MagicMock()],
+        usage=SimpleNamespace(input_tokens=5, output_tokens=7),
+        stop_reason="end_turn",
+        model="claude-test",
+    )
+
+    adapter = _AnthropicCompletionsAdapter(
+        real_client=MagicMock(), model="claude-test", is_oauth=False,
+    )
+
+    with _patch_create_anthropic_message(native), _patch_transport()[0]:
+        result = adapter.create(messages=[{"role": "user", "content": "hi"}])
+
+    assert result.usage is not None
+    assert result.usage.prompt_tokens == 5
+    assert result.usage.completion_tokens == 7
+    # getattr(..., 0) fallback must yield 0, not raise AttributeError.
+    assert result.usage.cache_read_input_tokens == 0
+    assert result.usage.cache_creation_input_tokens == 0


### PR DESCRIPTION
## Issue

Fixes #71026.

## Problem

`/insights` crashed with `TypeError: unsupported operand type(s) for -: 'str' and 'int'` when the session DB contained a non-numeric string in `api_call_count` (or any numeric column). A non-numeric string is truthy, so `value or 0` keeps the string, and the subsequent subtraction fails.

## Fix

Add a `_safe_int()` helper that catches `ValueError`/`TypeError` and returns 0 for unparseable values. Applied to all five numeric fields in the reconciliation loop (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `api_call_count`) and the accumulation loop.

## Tests

9 regression tests covering: None, int, float, numeric string, float string, non-numeric string, empty string, bool, and the original crash scenario.

Signed-off-by: Jasmine Naderi <jasmine@smfworks.com>