### PR TITLE
fix(tirith): honor fail_open=false when circuit breaker is open

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -1325,6 +1325,134 @@ class TestSpawnWarningDedup:
 
 
 # ---------------------------------------------------------------------------
+# Circuit breaker + fail_open interaction (issue #71350)
+#
+# When the circuit breaker is open (_circuit_open=True), the short-circuit
+# return must honor tirith_fail_open: fail_open=true allows (fail-open),
+# fail_open=false blocks (fail-closed). Previously the breaker returned
+# allow unconditionally, ignoring fail_open. Additionally, _crash_count
+# must reset on documented verdict exit codes (0/1/2), not just 0, so a
+# run of legitimate block/warn verdicts can't open the breaker.
+# ---------------------------------------------------------------------------
+
+class TestCircuitBreakerFailOpenHonored:
+    """The circuit breaker short-circuit must respect fail_open (#71350)."""
+
+    @patch("tools.tirith_security._load_security_config")
+    def test_breaker_fail_open_true_allows(self, mock_cfg):
+        mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
+                                 "tirith_timeout": 5, "tirith_fail_open": True}
+        _tirith_mod._circuit_open = True
+        try:
+            result = check_command_security("echo hi")
+            assert result["action"] == "allow"
+            assert "circuit breaker" in result["summary"]
+            assert "fail-closed" not in result["summary"]
+        finally:
+            _tirith_mod._circuit_open = False
+
+    @patch("tools.tirith_security._load_security_config")
+    def test_breaker_fail_open_false_blocks(self, mock_cfg):
+        """Regression for #71350: fail_open=false must block when breaker open."""
+        mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
+                                 "tirith_timeout": 5, "tirith_fail_open": False}
+        _tirith_mod._circuit_open = True
+        try:
+            result = check_command_security("echo hi")
+            assert result["action"] == "block"
+            assert "circuit breaker" in result["summary"]
+            assert "fail-closed" in result["summary"]
+            assert result["findings"] == []
+        finally:
+            _tirith_mod._circuit_open = False
+
+
+class TestCircuitBreakerCrashCountResetOnVerdicts:
+    """_crash_count must reset on documented verdict exits (0/1/2), not just 0
+    (#71350).  Exit codes 1 (block) and 2 (warn) are documented tirith
+    verdict outcomes, not crashes — a run of them must not open the breaker."""
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    @patch("tools.tirith_security.is_platform_supported", return_value=True)
+    def test_block_verdict_resets_crash_count(self, _mock_plat, mock_cfg, mock_run):
+        mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
+                                 "tirith_timeout": 5, "tirith_fail_open": True}
+        _tirith_mod._resolved_path = "tirith"
+        _tirith_mod._crash_count = _tirith_mod._CRASH_LIMIT - 1
+        mock_run.return_value = _mock_run(1, _json_stdout(
+            [{"rule_id": "homograph_url"}], "blocked"))
+        try:
+            result = check_command_security("bad cmd")
+            assert result["action"] == "block"
+            # Exit code 1 is a verdict, not a crash — counter resets.
+            assert _tirith_mod._crash_count == 0
+            assert _tirith_mod._circuit_open is False
+        finally:
+            _tirith_mod._crash_count = 0
+            _tirith_mod._circuit_open = False
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    @patch("tools.tirith_security.is_platform_supported", return_value=True)
+    def test_warn_verdict_resets_crash_count(self, _mock_plat, mock_cfg, mock_run):
+        mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
+                                 "tirith_timeout": 5, "tirith_fail_open": True}
+        _tirith_mod._resolved_path = "tirith"
+        _tirith_mod._crash_count = _tirith_mod._CRASH_LIMIT - 1
+        mock_run.return_value = _mock_run(2, _json_stdout(
+            [{"rule_id": "shortened_url"}], "warned"))
+        try:
+            result = check_command_security("suspicious cmd")
+            assert result["action"] == "warn"
+            # Exit code 2 is a verdict, not a crash — counter resets.
+            assert _tirith_mod._crash_count == 0
+            assert _tirith_mod._circuit_open is False
+        finally:
+            _tirith_mod._crash_count = 0
+            _tirith_mod._circuit_open = False
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    @patch("tools.tirith_security.is_platform_supported", return_value=True)
+    def test_repeated_block_verdicts_do_not_open_breaker(self, _mock_plat, mock_cfg, mock_run):
+        """A run of legitimate block verdicts must never trip the breaker."""
+        mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
+                                 "tirith_timeout": 5, "tirith_fail_open": True}
+        _tirith_mod._resolved_path = "tirith"
+        mock_run.return_value = _mock_run(1, _json_stdout(
+            [{"rule_id": "homograph_url"}], "blocked"))
+        try:
+            for _ in range(_tirith_mod._CRASH_LIMIT * 3):
+                result = check_command_security("bad cmd")
+                assert result["action"] == "block"
+            # Breaker must remain closed despite many block verdicts.
+            assert _tirith_mod._circuit_open is False
+            assert _tirith_mod._crash_count == 0
+        finally:
+            _tirith_mod._crash_count = 0
+            _tirith_mod._circuit_open = False
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    @patch("tools.tirith_security.is_platform_supported", return_value=True)
+    def test_unknown_exit_code_still_increments_crash_count(self, _mock_plat, mock_cfg, mock_run):
+        """Unknown exit codes (99, signals) are real crashes and must still
+        count toward the breaker, unlike documented verdicts 0/1/2."""
+        mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
+                                 "tirith_timeout": 5, "tirith_fail_open": True}
+        _tirith_mod._resolved_path = "tirith"
+        mock_run.return_value = _mock_run(99, "")
+        try:
+            result = check_command_security("cmd")
+            assert result["action"] == "allow"
+            assert _tirith_mod._crash_count == 1
+        finally:
+            _tirith_mod._crash_count = 0
+            _tirith_mod._circuit_open = False
+
+
+# ---------------------------------------------------------------------------
 # .app TLD suppression (issue #24461)
 # ---------------------------------------------------------------------------
 

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -740,6 +740,7 @@ def check_command_security(command: str) -> dict:
     global _crash_count, _circuit_open
 
     cfg = _load_security_config()
+    fail_open = cfg["tirith_fail_open"]
 
     if not cfg["tirith_enabled"]:
         return {"action": "allow", "findings": [], "summary": ""}
@@ -748,9 +749,13 @@ def check_command_security(command: str) -> dict:
     # stop trying for the rest of the process.  Without this, a corrupted
     # or missing binary causes every tool call to hit the same spawn failure
     # → fail-open → agent retry loop, hanging the user for 20+ minutes
-    # (issue #41400).
+    # (issue #41400).  Honor fail_open here: when fail-closed, block instead
+    # of silently allowing, so a broken tirith can't bypass security
+    # (issue #71350).
     if _circuit_open:
-        return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        if fail_open:
+            return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        return {"action": "block", "findings": [], "summary": "tirith disabled (circuit breaker; fail-closed)"}
 
     # Unsupported platform (Windows etc.) — tirith has no binary here and
     # never will. Skip the resolver entirely so we don't even try to spawn.
@@ -760,7 +765,6 @@ def check_command_security(command: str) -> dict:
 
     tirith_path = _resolve_tirith_path(cfg["tirith_path"])
     timeout = cfg["tirith_timeout"]
-    fail_open = cfg["tirith_fail_open"]
 
     if tirith_path is None:
         _warn_once(
@@ -812,8 +816,14 @@ def check_command_security(command: str) -> dict:
         _crash_count = 0
     elif exit_code == 1:
         action = "block"
+        # Documented verdict (block), not a crash — reset breaker so a run
+        # of legitimate block verdicts can't open it (issue #71350).
+        _crash_count = 0
     elif exit_code == 2:
         action = "warn"
+        # Documented verdict (warn), not a crash — reset breaker for the
+        # same reason as exit code 1 (issue #71350).
+        _crash_count = 0
     else:
         # Unknown exit code (includes signal-killed processes like -11/SIGSEGV)
         # — respect fail_open


### PR DESCRIPTION
## Issue

Fixes #71350.

## Problem

When the tirith circuit breaker opens, `check_command_security` returned `{"action": "allow"}` unconditionally — before reading `fail_open`. So an operator who set `tirith_fail_open: false` still got fail-open behavior once the breaker tripped.

Additionally, `_crash_count` incremented on exit codes 1 and 2, which are documented tirith verdicts (block/warn), not crashes. Three legitimate block verdicts in a row would open the breaker.

## Fix

1. Move `fail_open = cfg["tirith_fail_open"]` above the `_circuit_open` short-circuit. When breaker is open and `fail_open=False`, return `block` instead of `allow`.
2. Reset `_crash_count = 0` on exit codes 1 and 2 (documented verdicts), matching the existing reset on exit code 0.

## Tests

6 regression tests in 2 test classes:
- `TestCircuitBreakerFailOpenHonored`: breaker allows when fail_open=True, blocks when fail_open=False
- `TestCircuitBreakerCrashCountResetOnVerdicts`: crash_count resets on exit 1/2, repeated verdicts never open breaker, unknown exit 99 still increments

Signed-off-by: Jasmine Naderi <jasmine@smfworks.com>