### PR TITLE
fix(serve): cache /api/status profile-gateway topology scan (GIL stalls starve desktop boot)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3030,6 +3030,48 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
     return {"profiles": profile_names, "gateway_mode": mode, "gateways": gateways}
 
 
+# /api/status is polled ~1/s by the desktop app while it waits for the backend
+# (and again by the dashboard badge). Each uncached call above walks 7+ profile
+# homes (yaml.safe_load with the pure-Python loader + psutil process-table
+# probes + realpath walks) inside the default executor; concurrent polls pile
+# up and hold the GIL for 14-16s, starving the event loop — the desktop WS
+# never receives gateway.ready and boot fails ("event loop stalled ... GIL
+# pressure suspected"). Topology changes on gateway start/stop, so a short TTL
+# cache with a collapse lock keeps the scan to one per window. The cache also
+# remembers which collector produced the entry: tests monkeypatch
+# _collect_profile_gateway_topology per case, and the identity check keeps
+# them hermetic without needing a reset hook (a swapped collector is a miss).
+_TOPOLOGY_CACHE: Dict[str, Any] = {"ts": 0.0, "data": None, "fn": None}
+_TOPOLOGY_CACHE_LOCK = threading.Lock()
+_TOPOLOGY_CACHE_TTL = 10.0
+
+
+def _topology_cache_get(fn: Any) -> Optional[Dict[str, Any]]:
+    if (
+        _TOPOLOGY_CACHE["data"] is not None
+        and _TOPOLOGY_CACHE["fn"] is fn
+        and time.monotonic() - _TOPOLOGY_CACHE["ts"] < _TOPOLOGY_CACHE_TTL
+    ):
+        return _TOPOLOGY_CACHE["data"]
+    return None
+
+
+def _collect_profile_gateway_topology_cached() -> Dict[str, Any]:
+    fn = _collect_profile_gateway_topology
+    cached = _topology_cache_get(fn)
+    if cached is not None:
+        return cached
+    with _TOPOLOGY_CACHE_LOCK:
+        cached = _topology_cache_get(fn)
+        if cached is not None:
+            return cached
+        data = fn()
+        _TOPOLOGY_CACHE["data"] = data
+        _TOPOLOGY_CACHE["fn"] = fn
+        _TOPOLOGY_CACHE["ts"] = time.monotonic()
+        return data
+
+
 @app.get("/api/ssh/ownership")
 async def get_ssh_ownership(request: Request):
     _require_token(request)
@@ -3367,7 +3409,7 @@ async def get_status(profile: Optional[str] = None):
         # per-gateway ``gateways[]`` detail carries host ports (deployment
         # recon), so it stays gated with the host paths / PID below.
         topology = await asyncio.get_running_loop().run_in_executor(
-            None, _collect_profile_gateway_topology
+            None, _collect_profile_gateway_topology_cached
         )
         status["profiles"] = topology["profiles"]
         status["gateway_mode"] = topology["gateway_mode"]

--- a/tests/test_web_server_status_topology_cache.py
+++ b/tests/test_web_server_status_topology_cache.py
@@ -1,0 +1,117 @@
+"""Regression tests for the /api/status profile-topology cache.
+
+The desktop app polls /api/status ~1/s while waiting for the backend to become
+ready. Before the cache, every poll ran a full _collect_profile_gateway_topology
+scan (per-profile yaml.safe_load with the pure-Python loader + psutil
+process-table probes + realpath walks) in the default executor; on multi-profile
+installs the concurrent scans held the GIL for 14-16s and starved the event
+loop, so the desktop WS never received gateway.ready and boot escalated to the
+"Hermes couldn't start" overlay (#60800).
+"""
+
+import threading
+import time
+
+from hermes_cli import web_server
+
+
+def _reset_cache():
+    web_server._TOPOLOGY_CACHE["ts"] = 0.0
+    web_server._TOPOLOGY_CACHE["data"] = None
+    web_server._TOPOLOGY_CACHE["fn"] = None
+
+
+def _fake_topology(calls, delay=0.0):
+    def _collect():
+        if delay:
+            time.sleep(delay)
+        calls.append(1)
+        return {"profiles": ["default"], "gateway_mode": "single", "gateways": []}
+
+    return _collect
+
+
+def test_topology_cache_returns_cached_result_within_ttl(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        web_server, "_collect_profile_gateway_topology", _fake_topology(calls)
+    )
+    _reset_cache()
+    try:
+        first = web_server._collect_profile_gateway_topology_cached()
+        second = web_server._collect_profile_gateway_topology_cached()
+    finally:
+        _reset_cache()
+
+    assert len(calls) == 1
+    assert first is second
+
+
+def test_topology_cache_rescans_after_ttl(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        web_server, "_collect_profile_gateway_topology", _fake_topology(calls)
+    )
+    _reset_cache()
+    try:
+        web_server._collect_profile_gateway_topology_cached()
+        # Age the cache entry past the TTL instead of sleeping through it.
+        web_server._TOPOLOGY_CACHE["ts"] -= web_server._TOPOLOGY_CACHE_TTL + 1.0
+        web_server._collect_profile_gateway_topology_cached()
+    finally:
+        _reset_cache()
+
+    assert len(calls) == 2
+
+
+def test_topology_cache_collapses_concurrent_scans(monkeypatch):
+    """Concurrent status polls must not each run their own scan — that pile-up
+    is exactly the GIL storm the cache exists to prevent."""
+    calls = []
+    monkeypatch.setattr(
+        web_server,
+        "_collect_profile_gateway_topology",
+        _fake_topology(calls, delay=0.05),
+    )
+    _reset_cache()
+    results = []
+    try:
+        threads = [
+            threading.Thread(
+                target=lambda: results.append(
+                    web_server._collect_profile_gateway_topology_cached()
+                )
+            )
+            for _ in range(8)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        _reset_cache()
+
+    assert len(calls) == 1
+    assert len(results) == 8
+    assert all(r == results[0] for r in results)
+def test_topology_cache_misses_when_collector_is_swapped(monkeypatch):
+    """Tests (and hot-reload scenarios) monkeypatch the collector; a swapped
+    function identity must be a cache miss so stale data from the previous
+    collector never leaks across the swap."""
+    calls_a, calls_b = [], []
+    monkeypatch.setattr(
+        web_server, "_collect_profile_gateway_topology", _fake_topology(calls_a)
+    )
+    _reset_cache()
+    try:
+        first = web_server._collect_profile_gateway_topology_cached()
+        monkeypatch.setattr(
+            web_server, "_collect_profile_gateway_topology", _fake_topology(calls_b)
+        )
+        second = web_server._collect_profile_gateway_topology_cached()
+    finally:
+        _reset_cache()
+
+    assert len(calls_a) == 1
+    assert len(calls_b) == 1
+    assert first is not second


### PR DESCRIPTION
## What does this PR do?

`/api/status` is the liveness probe the desktop app polls (~1/s) while waiting for the backend to become ready (the dashboard badge polls it too). Since #60537, every call runs a full profile-gateway topology scan — for each profile home: `yaml.safe_load` of `config.yaml` (pure-Python loader), psutil process-table probes, and realpath walks — inside the default executor.

On multi-profile installs those scans pile up under the poll rate and hold the GIL for 14–16 s at a stretch, starving the event loop. The WS sidecar then cannot flush `gateway.ready` (`ws ready frame send failed`), the desktop client times out and re-dials into the next stall, and after enough attempts boot escalates to the **"Hermes couldn't start"** overlay.

This PR memoizes the scan behind a **10 s TTL cache with a collapse lock**, so concurrent polls share one scan. Topology only changes when gateways start/stop, so a ≤10 s stale badge is an acceptable trade for not starving the loop.

Measured on the affected machine (Windows 11, 7 profiles, 3 MCP servers):

| | before | after |
|---|---|---|
| `event loop stalled … (GIL pressure suspected)` | every 25–30 s, 14–16 s each, while desktop polls | exactly one on cold start (first scan) |
| desktop boot | fails with overlay (all WS dials land inside stalls) | boots; WS stable over 90 s observation |

py-spy stack captures during a real failing boot land squarely in the scan on executor threads:

```
construct_document / compose_mapping_node / ...
load (yaml\__init__.py:81)
safe_load (yaml\__init__.py:125)
_profile_platform_ports (hermes_cli\web_server.py:2947)
_collect_profile_gateway_topology (hermes_cli\web_server.py:3015)
run (concurrent\futures\thread.py:58)
```

## Related Issue

Fixes the dominant, measured stall source in #60800 on multi-profile installs (that issue's own hypothesis section had not located this path). Perf regression introduced by #60537.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: add `_collect_profile_gateway_topology_cached()` (10 s TTL, `threading.Lock` collapse so concurrent executor calls share one scan); the `/api/status` handler now calls the cached wrapper. Scan logic itself unchanged.
- `tests/test_web_server_status_topology_cache.py` (new): cache hit within TTL, rescan after TTL expiry, and 8-thread concurrent-poll collapse to a single scan.

## How to Test

1. `pytest tests/test_web_server_status_topology_cache.py tests/test_web_server.py -q`
2. Repro (without the patch): on a multi-profile install, launch the desktop app and watch `logs/errors.log` — repeating pairs of `event loop stalled … GIL pressure suspected` + `ws ready frame send failed` appear while the boot overlay shows.
3. With the patch: at most one cold-start stall; the desktop reaches the UI and the WS stays connected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#61742 and #68185 touch status-poll cost but not this scan)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the targeted suites (`test_web_server_status_topology_cache.py`, `test_web_server.py`) on the affected production install; deferring the full suite to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro for Workstations (7-profile install where the bug reproduces deterministically)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal perf fix, behavior documented in code comment)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure stdlib (`threading`/`time`), no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Failing boot (before), `logs/errors.log`:

```
19:01:39,757 WARNING hermes_cli.web_server: event loop stalled 15.8s (GIL pressure suspected)
19:01:39,873 ERROR   tui_gateway.ws: ws ready frame send failed peer=127.0.0.1:52792
19:02:03,055 WARNING hermes_cli.web_server: event loop stalled 14.5s (GIL pressure suspected)
19:02:03,181 ERROR   tui_gateway.ws: ws ready frame send failed peer=127.0.0.1:57212
19:02:36,324 WARNING hermes_cli.web_server: event loop stalled 14.4s (GIL pressure suspected)
19:02:36,434 ERROR   tui_gateway.ws: ws ready frame send failed peer=127.0.0.1:57933
```

After the patch (same machine, 110 s observation): a single cold-start stall, zero recurrence, desktop boots to a working UI.
