### PR TITLE
fix(tui_gateway): send gateway.ready before starting MCP discovery

### DIFF
--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -44,6 +44,83 @@ def test_ws_startup_starts_background_mcp_discovery(monkeypatch):
     assert calls == [{"logger": ws_mod._log, "thread_name": "tui-ws-mcp-discovery"}]
 
 
+def test_ws_sends_ready_frame_before_starting_mcp_discovery(monkeypatch):
+    """gateway.ready must hit the wire before MCP discovery starts.
+
+    Discovery's import/connect work holds the GIL hard enough on MCP-heavy
+    configs to starve the event loop for 10s+; when it ran before the ready
+    frame, desktop clients timed out waiting for gateway.ready and dropped the
+    socket ("ws ready frame send failed", boot-failure overlay -- #62771,
+    #71226). The agent build is unaffected by the later start: _make_agent
+    waits on the discovery thread via wait_for_mcp_discovery regardless of
+    when it was spawned (#38945).
+    """
+    events = []
+    monkeypatch.setattr(
+        mcp_startup,
+        "start_background_mcp_discovery",
+        lambda **kw: events.append("discovery_started"),
+    )
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            frame = json.loads(line)
+            events.append(frame.get("params", {}).get("type"))
+
+        async def receive_text(self):
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    server._sessions.clear()
+    try:
+        asyncio.run(ws_mod.handle_ws(FakeWS()))
+    finally:
+        server._sessions.clear()
+
+    assert "gateway.ready" in events
+    assert "discovery_started" in events
+    assert events.index("gateway.ready") < events.index("discovery_started")
+
+
+def test_ws_skips_mcp_discovery_when_ready_send_fails(monkeypatch):
+    """A client that died before gateway.ready could be delivered should not
+    spawn discovery from this connection -- handle_ws returns on the failed
+    ready send, and the next (live) connection starts discovery instead
+    (start_background_mcp_discovery is idempotent per process)."""
+    events = []
+    monkeypatch.setattr(
+        mcp_startup,
+        "start_background_mcp_discovery",
+        lambda **kw: events.append("discovery_started"),
+    )
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            raise ws_mod._WebSocketDisconnect()
+
+        async def receive_text(self):
+            raise AssertionError("receive loop must not be reached")
+
+        async def close(self):
+            pass
+
+    server._sessions.clear()
+    try:
+        asyncio.run(ws_mod.handle_ws(FakeWS()))
+    finally:
+        server._sessions.clear()
+
+    assert events == []
+
+
 def _run_disconnect(monkeypatch, seed):
     """Drive handle_ws to its disconnect `finally`, seeding sessions against the
     live WSTransport the moment it exists. Returns nothing; inspect _sessions."""

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -303,22 +303,6 @@ async def handle_ws(ws: Any) -> None:
 
         transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer)
 
-        # The desktop app and dashboard chat reach the agent through this WS
-        # sidecar, NOT through tui_gateway.entry.main() (the stdio TUI path that
-        # spawns the background MCP discovery thread). Without starting it here,
-        # discovery never runs in this process: _make_agent only *waits* on the
-        # thread (wait_for_mcp_discovery), which no-ops when it was never
-        # created, so the agent snapshots an MCP-less tool list and the only way
-        # to surface MCP tools is a manual /reload-mcp. Start it once per
-        # process here (idempotent, config-gated) before gateway.ready so the
-        # first agent build can pick up already-spawning servers. (#38945)
-        from hermes_cli.mcp_startup import start_background_mcp_discovery
-
-        start_background_mcp_discovery(
-            logger=_log,
-            thread_name="tui-ws-mcp-discovery",
-        )
-
         ready_ok = await transport.write_async(
             {
                 "jsonrpc": "2.0",
@@ -340,6 +324,27 @@ async def handle_ws(ws: Any) -> None:
             send_failures += 1
             _log.error("ws ready frame send failed peer=%s", peer)
             return
+
+        # The desktop app and dashboard chat reach the agent through this WS
+        # sidecar, NOT through tui_gateway.entry.main() (the stdio TUI path that
+        # spawns the background MCP discovery thread). Without starting it here,
+        # discovery never runs in this process: _make_agent only *waits* on the
+        # thread (wait_for_mcp_discovery), which no-ops when it was never
+        # created, so the agent snapshots an MCP-less tool list and the only way
+        # to surface MCP tools is a manual /reload-mcp. Start it once per
+        # process here (idempotent, config-gated). (#38945)
+        # Started AFTER the gateway.ready frame is on the wire: discovery's
+        # import/connect work holds the GIL hard enough to starve this event
+        # loop for 10s+ on MCP-heavy configs, and the desktop client times out
+        # waiting for gateway.ready and drops the socket ("ws ready frame send
+        # failed" / boot-failure overlay). _make_agent still waits on the
+        # thread, so tool pickup is unaffected by the later start.
+        from hermes_cli.mcp_startup import start_background_mcp_discovery
+
+        start_background_mcp_discovery(
+            logger=_log,
+            thread_name="tui-ws-mcp-discovery",
+        )
 
         while True:
             try:


### PR DESCRIPTION
## What does this PR do?

`handle_ws` started background MCP discovery after accepting the socket but **before** sending the `gateway.ready` frame. Discovery's import/connect work (spawning stdio servers, listing tools) holds the GIL hard on MCP-heavy configs, so the ready frame sits behind a starved event loop; the desktop client times out waiting for it and drops the socket — logged as `ws ready frame send failed`, surfacing as boot-failure overlays and reconnect loops.

This PR sends `gateway.ready` first, then starts discovery.

The ordering requirement from #38945 is unaffected: the first agent build synchronizes on the discovery *thread* via `wait_for_mcp_discovery`, which does not care when the thread was spawned — only that it was. That contract is still covered by the existing `test_ws_startup_starts_background_mcp_discovery`, which passes unchanged. One deliberate behavior change: a connection whose ready send already failed no longer spawns discovery (handle_ws returns first); the next live connection starts it, and `start_background_mcp_discovery` is idempotent per process.

Observed on Windows 11 with 3 MCP servers (one bridged through WSL): before the change, every WS dial that landed inside a discovery window died before receiving `gateway.ready`; after it, the frame is delivered immediately on accept and the connection survives discovery churn.

## Related Issue

Contributing factor to #71226 (connect-then-immediate-disconnect boot loops) and the discovery-driven startup stalls described in #62771. Preserves the #38945 requirement.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/ws.py`: in `handle_ws`, move `start_background_mcp_discovery(...)` from before the `gateway.ready` send to after it (comment updated with the rationale; original #38945 rationale retained).
- `tests/test_tui_gateway_ws.py`: two regression tests — `gateway.ready` must be observed on the wire before discovery starts, and a connection whose ready send fails must not spawn discovery.

## How to Test

1. `pytest tests/test_tui_gateway_ws.py -q` (10 passed: 8 existing incl. the #38945 regression test, 2 new)
2. On an MCP-heavy config, cold-boot the desktop app: with this patch `gateway.ready` is delivered even while discovery churns; without it, `ws ready frame send failed` appears whenever discovery holds the GIL through the client's ready timeout.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the targeted suite (`test_tui_gateway_ws.py`, 10/10) on the affected production install; deferring the full suite to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro for Workstations (3 MCP servers, incl. a WSL-bridged one)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (in-code comment carries the rationale)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — ordering change only, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
WARNING tui_gateway.ws: ws send failed peer=127.0.0.1:63788 error_type=WebSocketDisconnect
ERROR   tui_gateway.ws: ws ready frame send failed peer=127.0.0.1:63788
```

(Repeats for every dial that lands inside a discovery/GIL window; the client had already given up on `gateway.ready` and torn the socket down. Companion PR fixes the other major GIL source on this path: the uncached `/api/status` topology scan.)
