### PR TITLE
fix(gateway): persist shutdown-notification dedup across process restarts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1813,6 +1813,148 @@ def _clear_planned_restart_notification() -> None:
     _planned_restart_notification_path().unlink(missing_ok=True)
 
 
+# ── #71180: persisted shutdown-notification dedup ─────────────────────────
+# WSL suspend/resume (and other host suspend/resume cycles) restart the
+# gateway process.  Each new process re-broadcasts the "gateway shutting
+# down" notification to every home channel, flooding the home channel
+# (240 messages in 10 minutes observed).  The in-memory ``notified`` set
+# in ``_notify_active_sessions_of_shutdown`` is per-process and doesn't
+# persist across restarts, so it can't prevent the flood.
+#
+# ``_shutdown_notify_sent_path()`` is a per-destination state file that
+# records the last-sent timestamp.  Before sending the home-channel
+# shutdown broadcast, ``_should_suppress_shutdown_notify`` checks whether
+# a notification was sent within a cooldown window (default 60 s).
+# Design constraints (issue #71180):
+#   * Fail open — an unreadable / corrupt state file must never silence a
+#     legitimate broadcast.
+#   * Clock skew — a future-dated timestamp from a skewed clock must not
+#     cause an infinite cooldown.
+#   * A cooldown of 0 disables dedup entirely (always-send behaviour).
+
+
+# Default cooldown window for home-channel shutdown notifications, in
+# seconds.  Override via config.yaml ``gateway.shutdown_notify_cooldown``.
+# Set to 0 to disable dedup (always send).
+DEFAULT_SHUTDOWN_NOTIFY_COOLDOWN_SECONDS: int = 60
+
+
+def _shutdown_notify_cooldown_seconds() -> int:
+    """Return the configured shutdown-notification cooldown in seconds.
+
+    Source of truth: ``gateway.shutdown_notify_cooldown`` in config.yaml
+    (default 60). A value of 0 disables dedup entirely. An internal env
+    override ``HERMES_GATEWAY_SHUTDOWN_NOTIFY_COOLDOWN`` is honoured only
+    when set (tests / emergency), matching other gateway bridges — it is
+    not a documented user-facing setting.
+    """
+    raw = os.environ.get("HERMES_GATEWAY_SHUTDOWN_NOTIFY_COOLDOWN")
+    if raw is None:
+        try:
+            from hermes_cli.config import read_user_config_raw
+
+            cfg = read_user_config_raw(_hermes_home / "config.yaml") or {}
+            gw = cfg.get("gateway") if isinstance(cfg, dict) else None
+            if isinstance(gw, dict) and "shutdown_notify_cooldown" in gw:
+                raw = gw.get("shutdown_notify_cooldown")
+        except Exception as exc:
+            logger.debug("shutdown_notify_cooldown config read failed: %s", exc)
+            raw = None
+    if raw is not None:
+        try:
+            val = int(raw)
+            if val < 0:
+                raise ValueError
+            return val
+        except (TypeError, ValueError):
+            logger.debug(
+                "Unparseable gateway.shutdown_notify_cooldown=%r, "
+                "falling back to default %ds",
+                raw, DEFAULT_SHUTDOWN_NOTIFY_COOLDOWN_SECONDS,
+            )
+    return DEFAULT_SHUTDOWN_NOTIFY_COOLDOWN_SECONDS
+
+
+def _shutdown_notify_sent_path() -> Path:
+    """Path to the persisted last-sent-timestamp state file (JSON).
+
+    Lives under HERMES_HOME so it survives process restarts.  The file is
+    a dict mapping destination keys (platform:chat_id[:thread_id]) to
+    float epoch timestamps of the last notification sent.
+    """
+    return _hermes_home / ".shutdown_notify_sent.json"
+
+
+def _shutdown_notify_dest_key(platform_value: str, chat_id: str, thread_id: str | None) -> str:
+    """Build a stable string key for a home-channel destination."""
+    if thread_id:
+        return f"{platform_value}:{chat_id}:{thread_id}"
+    return f"{platform_value}:{chat_id}"
+
+
+def _should_suppress_shutdown_notify(dest_key: str, cooldown_seconds: int) -> bool:
+    """Return True when a notification was sent within the cooldown window.
+
+    Fail-open: any error reading the state file returns False (send).  Clock
+    skew is handled by clamping a future-dated timestamp to "now" so it can
+    never cause an effectively-infinite cooldown.
+
+    A ``cooldown_seconds`` of 0 always returns False (dedup disabled).
+    """
+    if cooldown_seconds <= 0:
+        return False
+    try:
+        data = json.loads(_shutdown_notify_sent_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError) as exc:
+        # Fail open: unreadable / missing / corrupt → send.
+        logger.debug("shutdown-notify dedup state unreadable (%s); sending", exc)
+        return False
+    if not isinstance(data, dict):
+        logger.debug("shutdown-notify dedup state not a dict (%r); sending", type(data))
+        return False
+    last_sent_raw = data.get(dest_key)
+    if not last_sent_raw:
+        return False
+    try:
+        last_sent = float(last_sent_raw)
+    except (TypeError, ValueError):
+        logger.debug("shutdown-notify dedup timestamp unparseable (%r); sending", last_sent_raw)
+        return False
+    now = time.time()
+    # Clamp future-dated timestamps to "now" and rewrite the state file so a
+    # skewed clock cannot pin suppression forever (local-only clamp left the
+    # future value on disk, re-suppressing every subsequent check).
+    if last_sent > now:
+        last_sent = now
+        try:
+            data[dest_key] = now
+            atomic_json_write(_shutdown_notify_sent_path(), data)
+        except Exception as exc:
+            logger.debug("Failed to rewrite future shutdown-notify timestamp: %s", exc)
+    elapsed = now - last_sent
+    return elapsed < cooldown_seconds
+
+
+def _record_shutdown_notify_sent(dest_key: str) -> None:
+    """Persist (best-effort) the timestamp of a just-sent notification.
+
+    Failures are logged and swallowed — a write failure only means the next
+    restart *might* re-broadcast, which is the safer failure mode.
+    """
+    try:
+        path = _shutdown_notify_sent_path()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+        data[dest_key] = time.time()
+        atomic_json_write(path, data)
+    except Exception as exc:
+        logger.debug("Failed to persist shutdown-notify timestamp: %s", exc)
+
+
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
 # knows not to clobber TERMINAL_CWD if lazily imported.
 os.environ["_HERMES_GATEWAY"] = "1"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1924,6 +1924,148 @@ def _clear_planned_restart_notification() -> None:
     _planned_restart_notification_path().unlink(missing_ok=True)
 
 
+# ── #71180: persisted shutdown-notification dedup ─────────────────────────
+# WSL suspend/resume (and other host suspend/resume cycles) restart the
+# gateway process.  Each new process re-broadcasts the "gateway shutting
+# down" notification to every home channel, flooding the home channel
+# (240 messages in 10 minutes observed).  The in-memory ``notified`` set
+# in ``_notify_active_sessions_of_shutdown`` is per-process and doesn't
+# persist across restarts, so it can't prevent the flood.
+#
+# ``_shutdown_notify_sent_path()`` is a per-destination state file that
+# records the last-sent timestamp.  Before sending the home-channel
+# shutdown broadcast, ``_should_suppress_shutdown_notify`` checks whether
+# a notification was sent within a cooldown window (default 60 s).
+# Design constraints (issue #71180):
+#   * Fail open — an unreadable / corrupt state file must never silence a
+#     legitimate broadcast.
+#   * Clock skew — a future-dated timestamp from a skewed clock must not
+#     cause an infinite cooldown.
+#   * A cooldown of 0 disables dedup entirely (always-send behaviour).
+
+
+# Default cooldown window for home-channel shutdown notifications, in
+# seconds.  Override via config.yaml ``gateway.shutdown_notify_cooldown``.
+# Set to 0 to disable dedup (always send).
+DEFAULT_SHUTDOWN_NOTIFY_COOLDOWN_SECONDS: int = 60
+
+
+def _shutdown_notify_cooldown_seconds() -> int:
+    """Return the configured shutdown-notification cooldown in seconds.
+
+    Source of truth: ``gateway.shutdown_notify_cooldown`` in config.yaml
+    (default 60). A value of 0 disables dedup entirely. An internal env
+    override ``HERMES_GATEWAY_SHUTDOWN_NOTIFY_COOLDOWN`` is honoured only
+    when set (tests / emergency), matching other gateway bridges — it is
+    not a documented user-facing setting.
+    """
+    raw = os.environ.get("HERMES_GATEWAY_SHUTDOWN_NOTIFY_COOLDOWN")
+    if raw is None:
+        try:
+            from hermes_cli.config import read_user_config_raw
+
+            cfg = read_user_config_raw(_hermes_home / "config.yaml") or {}
+            gw = cfg.get("gateway") if isinstance(cfg, dict) else None
+            if isinstance(gw, dict) and "shutdown_notify_cooldown" in gw:
+                raw = gw.get("shutdown_notify_cooldown")
+        except Exception as exc:
+            logger.debug("shutdown_notify_cooldown config read failed: %s", exc)
+            raw = None
+    if raw is not None:
+        try:
+            val = int(raw)
+            if val < 0:
+                raise ValueError
+            return val
+        except (TypeError, ValueError):
+            logger.debug(
+                "Unparseable gateway.shutdown_notify_cooldown=%r, "
+                "falling back to default %ds",
+                raw, DEFAULT_SHUTDOWN_NOTIFY_COOLDOWN_SECONDS,
+            )
+    return DEFAULT_SHUTDOWN_NOTIFY_COOLDOWN_SECONDS
+
+
+def _shutdown_notify_sent_path() -> Path:
+    """Path to the persisted last-sent-timestamp state file (JSON).
+
+    Lives under HERMES_HOME so it survives process restarts.  The file is
+    a dict mapping destination keys (platform:chat_id[:thread_id]) to
+    float epoch timestamps of the last notification sent.
+    """
+    return _hermes_home / ".shutdown_notify_sent.json"
+
+
+def _shutdown_notify_dest_key(platform_value: str, chat_id: str, thread_id: str | None) -> str:
+    """Build a stable string key for a home-channel destination."""
+    if thread_id:
+        return f"{platform_value}:{chat_id}:{thread_id}"
+    return f"{platform_value}:{chat_id}"
+
+
+def _should_suppress_shutdown_notify(dest_key: str, cooldown_seconds: int) -> bool:
+    """Return True when a notification was sent within the cooldown window.
+
+    Fail-open: any error reading the state file returns False (send).  Clock
+    skew is handled by clamping a future-dated timestamp to "now" so it can
+    never cause an effectively-infinite cooldown.
+
+    A ``cooldown_seconds`` of 0 always returns False (dedup disabled).
+    """
+    if cooldown_seconds <= 0:
+        return False
+    try:
+        data = json.loads(_shutdown_notify_sent_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError) as exc:
+        # Fail open: unreadable / missing / corrupt → send.
+        logger.debug("shutdown-notify dedup state unreadable (%s); sending", exc)
+        return False
+    if not isinstance(data, dict):
+        logger.debug("shutdown-notify dedup state not a dict (%r); sending", type(data))
+        return False
+    last_sent_raw = data.get(dest_key)
+    if not last_sent_raw:
+        return False
+    try:
+        last_sent = float(last_sent_raw)
+    except (TypeError, ValueError):
+        logger.debug("shutdown-notify dedup timestamp unparseable (%r); sending", last_sent_raw)
+        return False
+    now = time.time()
+    # Clamp future-dated timestamps to "now" and rewrite the state file so a
+    # skewed clock cannot pin suppression forever (local-only clamp left the
+    # future value on disk, re-suppressing every subsequent check).
+    if last_sent > now:
+        last_sent = now
+        try:
+            data[dest_key] = now
+            atomic_json_write(_shutdown_notify_sent_path(), data)
+        except Exception as exc:
+            logger.debug("Failed to rewrite future shutdown-notify timestamp: %s", exc)
+    elapsed = now - last_sent
+    return elapsed < cooldown_seconds
+
+
+def _record_shutdown_notify_sent(dest_key: str) -> None:
+    """Persist (best-effort) the timestamp of a just-sent notification.
+
+    Failures are logged and swallowed — a write failure only means the next
+    restart *might* re-broadcast, which is the safer failure mode.
+    """
+    try:
+        path = _shutdown_notify_sent_path()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+        data[dest_key] = time.time()
+        atomic_json_write(path, data)
+    except Exception as exc:
+        logger.debug("Failed to persist shutdown-notify timestamp: %s", exc)
+
+
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
 # knows not to clobber TERMINAL_CWD if lazily imported.
 os.environ["_HERMES_GATEWAY"] = "1"
@@ -10513,6 +10655,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if dedup_key in notified:
                 continue
 
+            # Persisted cross-process dedup (#71180): a prior gateway process
+            # that already broadcast to this home channel within the cooldown
+            # window suppresses this one. Fail-open — any state read error
+            # returns False and the send proceeds.
+            dest_key = _shutdown_notify_dest_key(
+                platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None
+            )
+            if _should_suppress_shutdown_notify(dest_key, _shutdown_notify_cooldown_seconds()):
+                logger.info(
+                    "Shutdown notification suppressed for home channel %s:%s (within cooldown)",
+                    platform.value,
+                    home.chat_id,
+                )
+                continue
+
             try:
                 metadata = self._thread_metadata_for_target(
                     platform,
@@ -10534,6 +10691,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     continue
 
                 notified.add(dedup_key)
+                _record_shutdown_notify_sent(dest_key)
                 logger.info(
                     "Sent shutdown notification to home channel %s:%s",
                     platform.value,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2536,6 +2536,13 @@ DEFAULT_CONFIG = {
         # works as a manual override and wins if set explicitly.
         "platform_connect_timeout": 30,
 
+        # Seconds to suppress re-broadcast of the home-channel "gateway
+        # shutting down" notification across process restarts (#71180).
+        # WSL suspend/resume and similar host cycles restart the gateway and
+        # would otherwise flood the home channel. 0 disables dedup (always
+        # send). Config.yaml is the user-facing source of truth.
+        "shutdown_notify_cooldown": 60,
+
         # In-process event-loop liveness watchdog (#69089). A daemon OS thread
         # probes the gateway asyncio loop; after consecutive missed probes it
         # dumps all-thread stacks and hard-exits with the service-restart exit

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2804,6 +2804,13 @@ DEFAULT_CONFIG = {
         # works as a manual override and wins if set explicitly.
         "platform_connect_timeout": 30,
 
+        # Seconds to suppress re-broadcast of the home-channel "gateway
+        # shutting down" notification across process restarts (#71180).
+        # WSL suspend/resume and similar host cycles restart the gateway and
+        # would otherwise flood the home channel. 0 disables dedup (always
+        # send). Config.yaml is the user-facing source of truth.
+        "shutdown_notify_cooldown": 60,
+
         # In-process event-loop liveness watchdog (#69089). A daemon OS thread
         # probes the gateway asyncio loop; after consecutive missed probes it
         # dumps all-thread stacks and hard-exits with the service-restart exit

--- a/tests/gateway/test_71180_shutdown_notify_dedup.py
+++ b/tests/gateway/test_71180_shutdown_notify_dedup.py
@@ -1,0 +1,187 @@
+"""#71180: persisted shutdown-notification dedup across process restarts."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # Refresh module path binding after HERMES_HOME change.
+    import gateway.run as gr
+    monkeypatch.setattr(gr, "_hermes_home", home)
+    return home
+
+
+def _write_config(home: Path, cooldown):
+    (home / "config.yaml").write_text(
+        f"gateway:\n  shutdown_notify_cooldown: {cooldown}\n",
+        encoding="utf-8",
+    )
+
+
+def test_cooldown_reads_config_yaml(hermes_home, monkeypatch):
+    import gateway.run as gr
+
+    monkeypatch.delenv("HERMES_GATEWAY_SHUTDOWN_NOTIFY_COOLDOWN", raising=False)
+    _write_config(hermes_home, 120)
+    assert gr._shutdown_notify_cooldown_seconds() == 120
+
+
+def test_zero_cooldown_disables_dedup(hermes_home, monkeypatch):
+    import gateway.run as gr
+
+    monkeypatch.delenv("HERMES_GATEWAY_SHUTDOWN_NOTIFY_COOLDOWN", raising=False)
+    _write_config(hermes_home, 0)
+    key = gr._shutdown_notify_dest_key("telegram", "1", None)
+    gr._record_shutdown_notify_sent(key)
+    assert gr._should_suppress_shutdown_notify(key, 0) is False
+
+
+def test_cross_process_suppression_within_cooldown(hermes_home, monkeypatch):
+    """A second process (fresh imports, same HERMES_HOME) must suppress."""
+    import gateway.run as gr
+
+    monkeypatch.delenv("HERMES_GATEWAY_SHUTDOWN_NOTIFY_COOLDOWN", raising=False)
+    _write_config(hermes_home, 60)
+    key = gr._shutdown_notify_dest_key("telegram", "home", None)
+    gr._record_shutdown_notify_sent(key)
+    assert gr._should_suppress_shutdown_notify(key, 60) is True
+
+    # Simulate second process: re-bind path, do not call record again.
+    path = hermes_home / ".shutdown_notify_sent.json"
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert key in data
+    assert gr._should_suppress_shutdown_notify(key, 60) is True
+
+
+def test_expiry_allows_resend(hermes_home, monkeypatch):
+    import gateway.run as gr
+
+    key = gr._shutdown_notify_dest_key("discord", "chan", None)
+    path = hermes_home / ".shutdown_notify_sent.json"
+    path.write_text(json.dumps({key: time.time() - 120}), encoding="utf-8")
+    assert gr._should_suppress_shutdown_notify(key, 60) is False
+
+
+def test_corrupt_state_fail_open(hermes_home, monkeypatch):
+    import gateway.run as gr
+
+    path = hermes_home / ".shutdown_notify_sent.json"
+    path.write_text("{not-json", encoding="utf-8")
+    key = gr._shutdown_notify_dest_key("telegram", "1", None)
+    assert gr._should_suppress_shutdown_notify(key, 60) is False
+
+
+def test_future_timestamp_rewritten_not_infinite(hermes_home, monkeypatch):
+    import gateway.run as gr
+
+    key = gr._shutdown_notify_dest_key("telegram", "1", None)
+    path = hermes_home / ".shutdown_notify_sent.json"
+    future = time.time() + 10_000
+    path.write_text(json.dumps({key: future}), encoding="utf-8")
+
+    # First check clamps + rewrites. Immediate second check still suppresses
+    # (cooldown from clamp time), but disk value is no longer far-future.
+    assert gr._should_suppress_shutdown_notify(key, 60) is True
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert float(data[key]) <= time.time() + 1
+
+    # After cooldown elapses from rewritten stamp, send is allowed.
+    path.write_text(json.dumps({key: time.time() - 61}), encoding="utf-8")
+    assert gr._should_suppress_shutdown_notify(key, 60) is False
+
+
+def test_missing_state_file_fail_open(hermes_home):
+    import gateway.run as gr
+
+    key = gr._shutdown_notify_dest_key("telegram", "1", None)
+    assert gr._should_suppress_shutdown_notify(key, 60) is False
+
+
+# ── Behavioral: the actual home-channel send path ──────────────────────────
+# teknium1's review asked for a test that drives _notify_active_sessions_of_shutdown
+# through a real runner (not just the dedup helpers), performs a successful
+# home-channel send, then constructs a second runner/process-equivalent and
+# verifies the persisted state suppresses the duplicate.
+
+
+@pytest.mark.asyncio
+async def test_home_channel_send_persists_and_suppresses_second_process(tmp_path, monkeypatch):
+    """A second gateway process must not re-broadcast the home-channel shutdown.
+
+    First runner sends to the home channel and persists the timestamp. A second
+    runner (fresh object, same HERMES_HOME) must see the persisted state and
+    skip the duplicate broadcast.
+    """
+    from unittest.mock import AsyncMock
+
+    import gateway.run as gateway_run
+    from gateway.config import HomeChannel, Platform
+    from gateway.platforms.base import SendResult
+    from tests.gateway.restart_test_helpers import make_restart_runner
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("HERMES_GATEWAY_SHUTDOWN_NOTIFY_COOLDOWN", raising=False)
+    _write_config(tmp_path, 60)
+
+    def _configure(runner, adapter):
+        runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+            platform=Platform.TELEGRAM,
+            chat_id="home-42",
+            name="Ops Home",
+        )
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    # First process: sends and persists.
+    runner1, adapter1 = make_restart_runner()
+    _configure(runner1, adapter1)
+    await runner1._notify_active_sessions_of_shutdown()
+    assert adapter1.send.await_count == 1
+
+    # Second process-equivalent: fresh runner, same HERMES_HOME. Must suppress.
+    runner2, adapter2 = make_restart_runner()
+    _configure(runner2, adapter2)
+    await runner2._notify_active_sessions_of_shutdown()
+    assert adapter2.send.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_home_channel_send_resends_after_cooldown_expiry(tmp_path, monkeypatch):
+    """After the cooldown window elapses, a fresh process sends again."""
+    from unittest.mock import AsyncMock
+
+    import gateway.run as gateway_run
+    from gateway.config import HomeChannel, Platform
+    from gateway.platforms.base import SendResult
+    from tests.gateway.restart_test_helpers import make_restart_runner
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("HERMES_GATEWAY_SHUTDOWN_NOTIFY_COOLDOWN", raising=False)
+    _write_config(tmp_path, 60)
+
+    # Pre-seed an expired timestamp for the home channel.
+    key = gateway_run._shutdown_notify_dest_key("telegram", "home-42", None)
+    (tmp_path / ".shutdown_notify_sent.json").write_text(
+        json.dumps({key: time.time() - 120}), encoding="utf-8"
+    )
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert adapter.send.await_count == 1

--- a/tests/gateway/test_71180_shutdown_notify_dedup.py
+++ b/tests/gateway/test_71180_shutdown_notify_dedup.py
@@ -1,0 +1,107 @@
+"""#71180: persisted shutdown-notification dedup across process restarts."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # Refresh module path binding after HERMES_HOME change.
+    import gateway.run as gr
+    monkeypatch.setattr(gr, "_hermes_home", home)
+    return home
+
+
+def _write_config(home: Path, cooldown):
+    (home / "config.yaml").write_text(
+        f"gateway:\n  shutdown_notify_cooldown: {cooldown}\n",
+        encoding="utf-8",
+    )
+
+
+def test_cooldown_reads_config_yaml(hermes_home, monkeypatch):
+    import gateway.run as gr
+
+    monkeypatch.delenv("HERMES_GATEWAY_SHUTDOWN_NOTIFY_COOLDOWN", raising=False)
+    _write_config(hermes_home, 120)
+    assert gr._shutdown_notify_cooldown_seconds() == 120
+
+
+def test_zero_cooldown_disables_dedup(hermes_home, monkeypatch):
+    import gateway.run as gr
+
+    monkeypatch.delenv("HERMES_GATEWAY_SHUTDOWN_NOTIFY_COOLDOWN", raising=False)
+    _write_config(hermes_home, 0)
+    key = gr._shutdown_notify_dest_key("telegram", "1", None)
+    gr._record_shutdown_notify_sent(key)
+    assert gr._should_suppress_shutdown_notify(key, 0) is False
+
+
+def test_cross_process_suppression_within_cooldown(hermes_home, monkeypatch):
+    """A second process (fresh imports, same HERMES_HOME) must suppress."""
+    import gateway.run as gr
+
+    monkeypatch.delenv("HERMES_GATEWAY_SHUTDOWN_NOTIFY_COOLDOWN", raising=False)
+    _write_config(hermes_home, 60)
+    key = gr._shutdown_notify_dest_key("telegram", "home", None)
+    gr._record_shutdown_notify_sent(key)
+    assert gr._should_suppress_shutdown_notify(key, 60) is True
+
+    # Simulate second process: re-bind path, do not call record again.
+    path = hermes_home / ".shutdown_notify_sent.json"
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert key in data
+    assert gr._should_suppress_shutdown_notify(key, 60) is True
+
+
+def test_expiry_allows_resend(hermes_home, monkeypatch):
+    import gateway.run as gr
+
+    key = gr._shutdown_notify_dest_key("discord", "chan", None)
+    path = hermes_home / ".shutdown_notify_sent.json"
+    path.write_text(json.dumps({key: time.time() - 120}), encoding="utf-8")
+    assert gr._should_suppress_shutdown_notify(key, 60) is False
+
+
+def test_corrupt_state_fail_open(hermes_home, monkeypatch):
+    import gateway.run as gr
+
+    path = hermes_home / ".shutdown_notify_sent.json"
+    path.write_text("{not-json", encoding="utf-8")
+    key = gr._shutdown_notify_dest_key("telegram", "1", None)
+    assert gr._should_suppress_shutdown_notify(key, 60) is False
+
+
+def test_future_timestamp_rewritten_not_infinite(hermes_home, monkeypatch):
+    import gateway.run as gr
+
+    key = gr._shutdown_notify_dest_key("telegram", "1", None)
+    path = hermes_home / ".shutdown_notify_sent.json"
+    future = time.time() + 10_000
+    path.write_text(json.dumps({key: future}), encoding="utf-8")
+
+    # First check clamps + rewrites. Immediate second check still suppresses
+    # (cooldown from clamp time), but disk value is no longer far-future.
+    assert gr._should_suppress_shutdown_notify(key, 60) is True
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert float(data[key]) <= time.time() + 1
+
+    # After cooldown elapses from rewritten stamp, send is allowed.
+    path.write_text(json.dumps({key: time.time() - 61}), encoding="utf-8")
+    assert gr._should_suppress_shutdown_notify(key, 60) is False
+
+
+def test_missing_state_file_fail_open(hermes_home):
+    import gateway.run as gr
+
+    key = gr._shutdown_notify_dest_key("telegram", "1", None)
+    assert gr._should_suppress_shutdown_notify(key, 60) is False


### PR DESCRIPTION
## Issue

Fixes #71180.

## Problem

The per-process dedup set in `_notify_active_sessions_of_shutdown` doesn't persist across restarts. When WSL suspend/resume (or any host suspend/resume cycle) restarts the gateway, each new process re-broadcasts the shutdown notification to the home channel — 240 messages in 10 minutes observed.

## Fix

Add a persisted last-sent timestamp file under `HERMES_HOME` (`.shutdown_notify_sent.json`). Before the home-channel shutdown broadcast, check if a notification was sent within a cooldown window:

- **Default cooldown:** 60 seconds
- **Configurable:** `HERMES_GATEWAY_SHUTDOWN_NOTIFY_COOLDOWN` env var (0 disables dedup entirely)
- **Fail open:** unreadable/corrupt state file always sends, never silences
- **Clock skew:** future-dated timestamps are clamped to `now` so they can't cause infinite cooldown
- **Scope:** only applies to home-channel broadcast, not per-session pings

## Tests

2 source-level regression tests verifying the helpers exist and fail-open design is documented.

Signed-off-by: Jasmine Naderi <jasmine@smfworks.com>