### PR TITLE
fix(tests): register three unregistered pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,6 +333,9 @@ markers = [
     "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",
     "real_agent_prewarm: opt out of the autouse stub that disables the tui_gateway deferred agent pre-warm timer",
     "requires_wal: needs the runtime to actually enable SQLite WAL mode (skipped where Hermes falls back to journal_mode=DELETE)",
+    "no_isolate: opt out of per-file subprocess isolation (tests share mutable module-level state)",
+    "ssh: marks tests requiring a reachable SSH server (skipped in normal CI)",
+    "live_system_guard_bypass: opt out of the os.kill monkeypatch guard for tests that need real signal delivery",
 ]
 # integration tests take way too long to run in the normal CI environments
 addopts = "-m 'not integration'"


### PR DESCRIPTION
## Summary

Three custom pytest markers were used across test files but never registered in `[tool.pytest.ini_options] markers`, producing **15 `PytestUnknownMarkWarning` warnings** on every test run.

## Markers registered

| Marker | Uses | Files | Purpose |
|--------|------|-------|---------|
| `no_isolate` | 12 | 6 MCP test files | Opt out of per-file subprocess isolation |
| `ssh` | 1 | `test_file_sync_perf.py` | Skip tests requiring a reachable SSH server |
| `live_system_guard_bypass` | 1 | `test_live_system_guard_self_test.py` | Opt out of the `os.kill` monkeypatch guard |

## Verification

- Before: 15 `PytestUnknownMarkWarning` warnings
- After: 0 warnings
- All affected test files still pass in isolation

This is a pure documentation fix — no test behavior changes.