### PR TITLE
fix(tui): preserve escaped dollars and currency ranges

### DIFF
--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -185,12 +185,17 @@ describe('inline math tokenization', () => {
     expect(dollarMatches(String.raw`three slashes: \\\$x$`)).toEqual([])
   })
 
+  it('allows escaped literal dollars next to inline math delimiters', () => {
+    expect(dollarMatches(String.raw`\$$x$`)).toEqual(['$x$'])
+    expect(dollarMatches(String.raw`$x\$$`)).toEqual([String.raw`$x\$$`])
+  })
+
   it('keeps dollar math inside inline code verbatim', () => {
     const rendered = renderPlain(
-      React.createElement(Md, { t: DEFAULT_THEME, text: 'code: `$x^2$`; math: $x^2$' })
+      React.createElement(Md, { t: DEFAULT_THEME, text: 'code: `$x^2$ and \\$x$`; math: $x^2$' })
     ).join('\n')
 
-    expect(rendered).toContain('code: $x^2$; math: x²')
+    expect(rendered).toContain(String.raw`code: $x^2$ and \$x$; math: x²`)
   })
 
   it.each(['$4$', '$2/3$', '$5x=10$', '$4xy$', '$10kg$'])('preserves numeric inline math: %s', input => {
@@ -230,8 +235,18 @@ describe('inline math tokenization', () => {
     expect(rendered).toContain('x² is valid math')
     expect(rendered).toContain('it costs $5 and $10')
     expect(rendered).toContain('$5-$10')
-    expect(rendered).toContain('literal \\$x$')
+    expect(rendered).toContain('literal $x$')
+    expect(rendered).not.toContain('literal \\$x$')
     expect(rendered).toContain('formula x + $5')
+  })
+
+  it('renders escaped literal dollars adjacent to math without leaking escapes', () => {
+    const text = [String.raw`literal then math: \$$x$`, String.raw`math then literal: $x\$$`].join('\n')
+    const rendered = renderPlain(React.createElement(Md, { t: DEFAULT_THEME, text })).join('\n')
+
+    expect(rendered).toContain('literal then math: $x')
+    expect(rendered).toContain('math then literal: x$')
+    expect(rendered).not.toContain('\\$')
   })
 })
 

--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AUDIO_DIRECTIVE_RE, INLINE_RE, Md, MEDIA_LINE_RE, stripInlineMarkup } from '../components/markdown.js'
 import { __resetLinkTitleCache, fetchLinkTitle } from '../lib/externalLink.js'
+import { inlineMathSpans } from '../lib/inlineMath.js'
 import { stripAnsi } from '../lib/text.js'
 import { DEFAULT_THEME, LIGHT_THEME } from '../theme.js'
 
@@ -32,6 +33,7 @@ const stubFetchedTitle = (url: string, title: string) => {
 }
 
 const matches = (text: string) => [...text.matchAll(INLINE_RE)].map(m => m[0])
+const dollarMatches = (text: string) => [...inlineMathSpans(text)].map(span => span.raw)
 const BEL = String.fromCharCode(7)
 const ESC = String.fromCharCode(27)
 const CSI_RE = new RegExp(`${ESC}\\[[0-?]*[ -/]*[@-~]`, 'g')
@@ -139,60 +141,97 @@ describe('stripInlineMarkup', () => {
     expect(stripInlineMarkup('$\\mathbb{Z}$ is a ring')).toBe('\\mathbb{Z} is a ring')
     expect(stripInlineMarkup('see \\(a + b\\) ok')).toBe('see a + b ok')
   })
+
+  it('preserves currency ranges and escaped dollar delimiters', () => {
+    expect(stripInlineMarkup('$5-$10')).toBe('$5-$10')
+    expect(stripInlineMarkup('literal \\$x$')).toBe('literal \\$x$')
+    expect(stripInlineMarkup('formula $x + \\$5$')).toBe('formula x + \\$5')
+  })
 })
 
-describe('INLINE_RE inline math', () => {
+describe('inline math tokenization', () => {
   it('matches single-dollar math and beats emphasis at the same start', () => {
-    // Without math handling, `*b*` would have matched as italics and
-    // corrupted the formula. With math added to INLINE_RE, the leftmost
-    // match at column 0 (`$P=a*b*c$`) wins.
-    expect(matches('$P=a*b*c$')).toEqual(['$P=a*b*c$'])
-    expect(matches('see $\\mathbb{Z}$ here')).toEqual(['$\\mathbb{Z}$'])
+    expect(dollarMatches('$P=a*b*c$')).toEqual(['$P=a*b*c$'])
+    expect(dollarMatches('see $\\mathbb{Z}$ here')).toEqual(['$\\mathbb{Z}$'])
   })
 
   it('does not match currency-style prose', () => {
-    expect(matches('it costs $5 and $10')).toEqual([])
-    expect(matches('paid $5')).toEqual([])
+    expect(dollarMatches('it costs $5 and $10')).toEqual([])
+    expect(dollarMatches('paid $5')).toEqual([])
+    expect(dollarMatches('$5-$10')).toEqual([])
   })
 
   it('does not let inline math swallow a $$ display fence', () => {
     // `$$x$$` is a display block, not two abutting inline-math spans.
-    expect(matches('$$x$$')).toEqual([])
+    expect(dollarMatches('$$x$$')).toEqual([])
+  })
+
+  it('finds valid math after an unmatched dollar on an earlier line', () => {
+    expect(dollarMatches('price $5\nformula $x$')).toEqual(['$x$'])
   })
 
   it('matches \\(...\\) inline math', () => {
     expect(matches('foo \\(x + y\\) bar')).toEqual(['\\(x + y\\)'])
   })
 
-  it('does not corrupt subscripts/superscripts inside math', () => {
-    // `_n` and `^r` are markdown emphasis/superscript markers in prose, but
-    // inside a `$...$` span the entire formula is captured as a single
-    // inline-math token so the inner regexes never see those characters.
-    expect(matches('$P=a_n x^n + a_0$')).toEqual(['$P=a_n x^n + a_0$'])
-    expect(matches('$\\beta_1,\\dots,\\beta_r$')).toEqual(['$\\beta_1,\\dots,\\beta_r$'])
+  it('ignores escaped delimiters and skips escaped dollars inside math', () => {
+    expect(dollarMatches('literal \\$x$')).toEqual([])
+    expect(dollarMatches('formula $x + \\$5$')).toEqual(['$x + \\$5$'])
   })
 
-  it('places math content in the correct capture group (regression: m[16] is bare URL)', () => {
+  it('uses backslash parity when deciding whether a dollar is escaped', () => {
+    expect(dollarMatches(String.raw`one slash: \$x$`)).toEqual([])
+    expect(dollarMatches(String.raw`two slashes: \\$x$`)).toEqual(['$x$'])
+    expect(dollarMatches(String.raw`three slashes: \\\$x$`)).toEqual([])
+  })
+
+  it('keeps dollar math inside inline code verbatim', () => {
+    const rendered = renderPlain(
+      React.createElement(Md, { t: DEFAULT_THEME, text: 'code: `$x^2$`; math: $x^2$' })
+    ).join('\n')
+
+    expect(rendered).toContain('code: $x^2$; math: x²')
+  })
+
+  it.each(['$4$', '$2/3$', '$5x=10$', '$4xy$', '$10kg$'])('preserves numeric inline math: %s', input => {
+    expect(dollarMatches(input)).toEqual([input])
+  })
+
+  it('does not corrupt subscripts/superscripts inside math', () => {
+    expect(dollarMatches('$P=a_n x^n + a_0$')).toEqual(['$P=a_n x^n + a_0$'])
+    expect(dollarMatches('$\\beta_1,\\dots,\\beta_r$')).toEqual(['$\\beta_1,\\dots,\\beta_r$'])
+  })
+
+  it('keeps regex math content separate from the bare URL capture group', () => {
     // When `m[16]` was the bare URL group AND the inline-math `$...$`
-    // group simultaneously (because the bare URL pattern lacked its own
-    // capturing parens), MdInline rendered `$\\mathbb{R}$` as an
-    // underlined autolink instead of italic amber math. Lock down the
-    // numbering: math goes in m[17] / m[18], URLs go in m[16].
+    // group simultaneously, MdInline rendered math as an underlined autolink.
+    // Dollar math now uses the scanner; `\\(...\\)` remains in m[17].
     const url = [...'see https://example.com here'.matchAll(INLINE_RE)][0]!
-    const dollarMath = [...'$\\mathbb{R}$'.matchAll(INLINE_RE)][0]!
     const parenMath = [...'\\(\\pi\\)'.matchAll(INLINE_RE)][0]!
 
     expect(url[16]).toBe('https://example.com')
     expect(url[17]).toBeUndefined()
-    expect(url[18]).toBeUndefined()
-
-    expect(dollarMath[16]).toBeUndefined()
-    expect(dollarMath[17]).toBe('\\mathbb{R}')
-    expect(dollarMath[18]).toBeUndefined()
 
     expect(parenMath[16]).toBeUndefined()
-    expect(parenMath[17]).toBeUndefined()
-    expect(parenMath[18]).toBe('\\pi')
+    expect(parenMath[17]).toBe('\\pi')
+  })
+
+  it('renders the reported five-line reproduction without losing dollars', () => {
+    const text = [
+      '$x^2$ is valid math',
+      'it costs $5 and $10',
+      '$5-$10',
+      'literal \\$x$',
+      'formula $x + \\$5$'
+    ].join('\n')
+
+    const rendered = renderPlain(React.createElement(Md, { t: DEFAULT_THEME, text })).join('\n')
+
+    expect(rendered).toContain('x² is valid math')
+    expect(rendered).toContain('it costs $5 and $10')
+    expect(rendered).toContain('$5-$10')
+    expect(rendered).toContain('literal \\$x$')
+    expect(rendered).toContain('formula x + $5')
   })
 })
 

--- a/ui-tui/src/__tests__/mathUnicode.test.ts
+++ b/ui-tui/src/__tests__/mathUnicode.test.ts
@@ -262,6 +262,10 @@ describe('texToUnicode — labelled arrows', () => {
 })
 
 describe('texToUnicode — punctuation commands without lookahead', () => {
+  it('renders an escaped dollar as a literal dollar', () => {
+    expect(texToUnicode('x + \\$5')).toBe('x + $5')
+  })
+
   it('substitutes \\{ even when immediately followed by a letter', () => {
     // Regression: with a global `(?![A-Za-z])` lookahead, `\{p` refused
     // to substitute (because `p` is a letter) and rendered as `\{p`.

--- a/ui-tui/src/__tests__/streamingMarkdown.test.ts
+++ b/ui-tui/src/__tests__/streamingMarkdown.test.ts
@@ -149,6 +149,7 @@ const CORPUS = [
   '\nA paragraph before code.\n',
   '\n```ts\nconst a = 1\n\nconst b = 2\n// $$ not math $$\n```\n',
   '\nBetween-blocks narration.\n',
+  '\nInline $x^2$ math, a $5-$10 range, and an escaped closer $x + \\$5$.\n',
   '\n$$\nE = mc^2\n\n\\sum_i x_i\n$$\n',
   '\n- item one\n- item two\n\n1. first\n2. second\n',
   '\n| a | b |\n|---|---|\n| 1 | 2 |\n',

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -3,6 +3,7 @@ import { Fragment, memo, type ReactNode, useMemo } from 'react'
 
 import { ensureEmojiPresentation } from '../lib/emoji.js'
 import { normalizeExternalUrl, urlSlugTitleLabel, useLinkTitle } from '../lib/externalLink.js'
+import { findNextInlineMath, type InlineMathSpan, stripInlineMathDelimiters } from '../lib/inlineMath.js'
 import { BOX_CLOSE, BOX_OPEN, texToUnicode } from '../lib/mathUnicode.js'
 import { highlightLine, isHighlightable } from '../lib/syntax.js'
 import type { Theme } from '../theme.js'
@@ -99,12 +100,10 @@ export const AUDIO_DIRECTIVE_RE = /^\s*\[\[audio_as_voice\]\]\s*$/
 // doesn't pair up the first `~` with the next one on the line and swallow
 // the text between them as a dim `_`-prefixed span.
 //
-// Inline math (`$x$` and `\(x\)`) takes precedence over emphasis at the
-// same start position because regex alternation is leftmost-first; a
-// dollar-delimited span at column N wins over a `*` at column N+1, so
-// `$P=a*b*c$` renders as math instead of having `*b*` corrupted into
-// italics. Single-character minimums and "no space adjacent to delimiter"
-// rules keep currency prose like `$5 to $10` from being swallowed.
+// `\(...\)` inline math remains a regular regex token. Single-dollar math is
+// merged in separately by `inlineTokens`: escape parity and escaped dollars
+// inside a formula require a small scanner, not another lookaround-heavy
+// alternative here.
 export const INLINE_RE = new RegExp(
   [
     `!\\[(.*?)\\]\\(${MD_URL_RE}\\)`, // 1,2  image
@@ -122,11 +121,10 @@ export const INLINE_RE = new RegExp(
     `~([A-Za-z0-9]{1,8})~`, // 15   subscript
     `(https?:\\/\\/[^\\s<]+)`, // 16   bare URL — wrapped so it owns its own
     //                                capture group; without this, the math
-    //                                spans below would land in m[16] and the
+    //                                span below would land in m[16] and the
     //                                MdInline dispatcher would treat them as
     //                                bare URLs and render them as autolinks.
-    `(?<!\\$)\\$([^\\s$](?:[^$\\n]*?[^\\s$])?)\\$(?!\\$)`, // 17   inline math $...$
-    `\\\\\\(([^\\n]+?)\\\\\\)` // 18   inline math \(...\)
+    `\\\\\\(([^\\n]+?)\\\\\\)` // 17   inline math \(...\)
   ].join('|'),
   'g'
 )
@@ -191,7 +189,8 @@ const renderResolvedLink = (k: number, t: Theme, rawUrl: string, label?: string)
 }
 
 export const stripInlineMarkup = (v: string) =>
-  v
+  stripInlineMathDelimiters(
+    v
     .replace(/!\[(.*?)\]\(((?:[^\s()]|\([^\s()]*\))+?)\)/g, '[image: $1] $2')
     .replace(/\[(.+?)\]\(((?:[^\s()]|\([^\s()]*\))+?)\)/g, '$1')
     .replace(/<((?:https?:\/\/|mailto:)[^>\s]+|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>/g, '$1')
@@ -205,8 +204,8 @@ export const stripInlineMarkup = (v: string) =>
     .replace(/\[\^([^\]]+)\]/g, '[$1]')
     .replace(/\^([^^\s][^^]*?)\^/g, '^$1')
     .replace(/~([A-Za-z0-9]{1,8})~/g, '_$1')
-    .replace(/(?<!\$)\$([^\s$](?:[^$\n]*?[^\s$])?)\$(?!\$)/g, '$1')
     .replace(/\\\(([^\n]+?)\\\)/g, '$1')
+  )
 
 const SAFETY_MARGIN = 4
 const MIN_COL_WIDTH = 3
@@ -541,6 +540,52 @@ const renderTable = (k: number, rows: string[][], t: Theme, cols?: number) => {
   )
 }
 
+interface RegexInlineToken {
+  kind: 'regex'
+  match: RegExpMatchArray
+}
+
+interface MathInlineToken {
+  kind: 'math'
+  span: InlineMathSpan
+}
+
+type InlineToken = MathInlineToken | RegexInlineToken
+
+function* inlineTokens(text: string): Generator<InlineToken> {
+  const regexMatches = text.matchAll(INLINE_RE)
+  let nextRegex = regexMatches.next()
+  let nextMath = findNextInlineMath(text)
+  let cursor = 0
+
+  while (!nextRegex.done || nextMath) {
+    while (!nextRegex.done && (nextRegex.value.index ?? 0) < cursor) {
+      nextRegex = regexMatches.next()
+    }
+
+    if (nextMath && nextMath.index < cursor) {
+      nextMath = findNextInlineMath(text, cursor)
+    }
+
+    const regexIndex = nextRegex.done ? Number.POSITIVE_INFINITY : (nextRegex.value.index ?? 0)
+    const mathIndex = nextMath?.index ?? Number.POSITIVE_INFINITY
+
+    // Existing regex tokens retain priority on an exact tie. This keeps code
+    // spans verbatim and lets emphasis recurse into its body as before.
+    if (!nextRegex.done && regexIndex <= mathIndex) {
+      const match = nextRegex.value
+
+      yield { kind: 'regex', match }
+      cursor = regexIndex + match[0].length
+      nextRegex = regexMatches.next()
+    } else if (nextMath) {
+      yield { kind: 'math', span: nextMath }
+      cursor = mathIndex + nextMath.raw.length
+      nextMath = findNextInlineMath(text, cursor)
+    }
+  }
+}
+
 // `color` anchors the prose runs to a palette tone. Block callers that
 // already wrap MdInline in a colored <Text> (headings, quotes, footnotes)
 // leave it unset and inherit that parent; body-prose callers pass
@@ -553,13 +598,26 @@ function MdInline({ color, t, text }: { color?: string; t: Theme; text: string }
 
   let last = 0
 
-  for (const m of text.matchAll(INLINE_RE)) {
-    const i = m.index ?? 0
+  for (const token of inlineTokens(text)) {
+    const i = token.kind === 'math' ? token.span.index : (token.match.index ?? 0)
     const k = parts.length
 
     if (i > last) {
       parts.push(<Text key={k}>{text.slice(last, i)}</Text>)
     }
+
+    if (token.kind === 'math') {
+      parts.push(
+        <Text color={t.color.accent} italic key={parts.length}>
+          {renderMath(texToUnicode(token.span.content))}
+        </Text>
+      )
+      last = i + token.span.raw.length
+
+      continue
+    }
+
+    const m = token.match
 
     if (m[1] && m[2]) {
       parts.push(
@@ -637,7 +695,7 @@ function MdInline({ color, t, text }: { color?: string; t: Theme; text: string }
       if (url.length < m[16].length) {
         parts.push(<Text key={parts.length}>{m[16].slice(url.length)}</Text>)
       }
-    } else if (m[17] ?? m[18]) {
+    } else if (m[17]) {
       // Inline math is run through `texToUnicode` (Greek letters, ℕℤℚℝ,
       // operators, sub/superscripts, fractions) and rendered in italic
       // accent. Italic is the disambiguator — links use accent+underline,
@@ -647,7 +705,7 @@ function MdInline({ color, t, text }: { color?: string; t: Theme; text: string }
       // raw LaTeX rather than vanishing.
       parts.push(
         <Text color={t.color.accent} italic key={parts.length}>
-          {renderMath(texToUnicode(m[17] ?? m[18]!))}
+          {renderMath(texToUnicode(m[17]))}
         </Text>
       )
     }

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -3,7 +3,12 @@ import { Fragment, memo, type ReactNode, useMemo } from 'react'
 
 import { ensureEmojiPresentation } from '../lib/emoji.js'
 import { normalizeExternalUrl, urlSlugTitleLabel, useLinkTitle } from '../lib/externalLink.js'
-import { findNextInlineMath, type InlineMathSpan, stripInlineMathDelimiters } from '../lib/inlineMath.js'
+import {
+  findNextInlineMath,
+  type InlineMathSpan,
+  stripInlineMathDelimiters,
+  unescapeMarkdownDollars
+} from '../lib/inlineMath.js'
 import { BOX_CLOSE, BOX_OPEN, texToUnicode } from '../lib/mathUnicode.js'
 import { highlightLine, isHighlightable } from '../lib/syntax.js'
 import type { Theme } from '../theme.js'
@@ -603,7 +608,7 @@ function MdInline({ color, t, text }: { color?: string; t: Theme; text: string }
     const k = parts.length
 
     if (i > last) {
-      parts.push(<Text key={k}>{text.slice(last, i)}</Text>)
+      parts.push(<Text key={k}>{unescapeMarkdownDollars(text.slice(last, i))}</Text>)
     }
 
     if (token.kind === 'math') {
@@ -714,12 +719,12 @@ function MdInline({ color, t, text }: { color?: string; t: Theme; text: string }
   }
 
   if (last < text.length) {
-    parts.push(<Text key={parts.length}>{text.slice(last)}</Text>)
+    parts.push(<Text key={parts.length}>{unescapeMarkdownDollars(text.slice(last))}</Text>)
   }
 
   return (
     <Text {...(color ? { color } : {})} wrap="wrap-trim">
-      {parts.length ? parts : text}
+      {parts.length ? parts : unescapeMarkdownDollars(text)}
     </Text>
   )
 }

--- a/ui-tui/src/lib/inlineMath.ts
+++ b/ui-tui/src/lib/inlineMath.ts
@@ -14,6 +14,11 @@ const isEscapedAt = (text: string, index: number) => {
   return slashCount % 2 === 1
 }
 
+const isUnescapedDollarAt = (text: string, index: number) => text[index] === '$' && !isEscapedAt(text, index)
+
+export const unescapeMarkdownDollars = (text: string) =>
+  text.replace(/(\\+)\$/g, (_match, slashes: string) => `${'\\'.repeat(Math.floor(slashes.length / 2))}$`)
+
 const isLikelyNumericInlineMath = (body: string, followingCharacter: string) => {
   const value = body.trim()
 
@@ -66,10 +71,9 @@ const findNextUnescapedDollar = (text: string, fromIndex: number) => {
 export const findNextInlineMath = (text: string, fromIndex = 0): InlineMathSpan | null => {
   for (let openingIndex = fromIndex; openingIndex < text.length; openingIndex += 1) {
     if (
-      text[openingIndex] !== '$' ||
-      isEscapedAt(text, openingIndex) ||
-      text[openingIndex - 1] === '$' ||
-      text[openingIndex + 1] === '$'
+      !isUnescapedDollarAt(text, openingIndex) ||
+      isUnescapedDollarAt(text, openingIndex - 1) ||
+      isUnescapedDollarAt(text, openingIndex + 1)
     ) {
       continue
     }
@@ -91,8 +95,8 @@ export const findNextInlineMath = (text: string, fromIndex = 0): InlineMathSpan 
     const body = text.slice(openingIndex + 1, closingIndex)
 
     if (
-      text[closingIndex - 1] === '$' ||
-      text[closingIndex + 1] === '$' ||
+      isUnescapedDollarAt(text, closingIndex - 1) ||
+      isUnescapedDollarAt(text, closingIndex + 1) ||
       !body ||
       /^\s/u.test(body) ||
       /\s$/u.test(body) ||

--- a/ui-tui/src/lib/inlineMath.ts
+++ b/ui-tui/src/lib/inlineMath.ts
@@ -1,0 +1,140 @@
+export interface InlineMathSpan {
+  content: string
+  index: number
+  raw: string
+}
+
+const isEscapedAt = (text: string, index: number) => {
+  let slashCount = 0
+
+  for (let cursor = index - 1; cursor >= 0 && text[cursor] === '\\'; cursor -= 1) {
+    slashCount += 1
+  }
+
+  return slashCount % 2 === 1
+}
+
+const isLikelyNumericInlineMath = (body: string, followingCharacter: string) => {
+  const value = body.trim()
+
+  if (!/^\d/u.test(value)) {
+    return true
+  }
+
+  // A compact price range such as `$5-$10` presents its second price opener
+  // as the first candidate closer. A trailing operator is therefore evidence
+  // that this is currency prose, not a balanced numeric formula.
+  if (/[+\-*/=<>^_,;:(]$/u.test(value)) {
+    return false
+  }
+
+  if (/https?:\/\//iu.test(value)) {
+    return false
+  }
+
+  // `$5$10` and `$5$x$` are more likely adjacent currency/prose openers.
+  // Preserve the numeric candidate only when its body carries a math signal.
+  if (/^\p{N}/u.test(followingCharacter)) {
+    return false
+  }
+
+  if (/^[\p{L}\\]/u.test(followingCharacter)) {
+    return /\\[A-Za-z]+|[+*/=<>^_{}]/u.test(value)
+  }
+
+  return true
+}
+
+const findNextUnescapedDollar = (text: string, fromIndex: number) => {
+  for (let cursor = fromIndex; cursor < text.length && text[cursor] !== '\n'; cursor += 1) {
+    if (text[cursor] === '$' && !isEscapedAt(text, cursor)) {
+      return cursor
+    }
+  }
+
+  return -1
+}
+
+/**
+ * Find the next single-dollar inline-math span.
+ *
+ * Delimiter recognition is deliberately a scanner rather than another
+ * lookaround-heavy regex: whether `$` is escaped depends on the parity of the
+ * entire preceding backslash run, and an escaped dollar inside a formula must
+ * be skipped while looking for its real closer.
+ */
+export const findNextInlineMath = (text: string, fromIndex = 0): InlineMathSpan | null => {
+  for (let openingIndex = fromIndex; openingIndex < text.length; openingIndex += 1) {
+    if (
+      text[openingIndex] !== '$' ||
+      isEscapedAt(text, openingIndex) ||
+      text[openingIndex - 1] === '$' ||
+      text[openingIndex + 1] === '$'
+    ) {
+      continue
+    }
+
+    const closingIndex = findNextUnescapedDollar(text, openingIndex + 1)
+
+    if (closingIndex < 0) {
+      // Inline math cannot cross a newline, but an unmatched opener on one
+      // line must not hide valid math on a later line.
+      openingIndex = text.indexOf('\n', openingIndex)
+
+      if (openingIndex < 0) {
+        return null
+      }
+
+      continue
+    }
+
+    const body = text.slice(openingIndex + 1, closingIndex)
+
+    if (
+      text[closingIndex - 1] === '$' ||
+      text[closingIndex + 1] === '$' ||
+      !body ||
+      /^\s/u.test(body) ||
+      /\s$/u.test(body) ||
+      !isLikelyNumericInlineMath(body, text[closingIndex + 1] || '')
+    ) {
+      continue
+    }
+
+    return {
+      content: body,
+      index: openingIndex,
+      raw: text.slice(openingIndex, closingIndex + 1)
+    }
+  }
+
+  return null
+}
+
+export function* inlineMathSpans(text: string): Generator<InlineMathSpan> {
+  let cursor = 0
+
+  while (cursor < text.length) {
+    const span = findNextInlineMath(text, cursor)
+
+    if (!span) {
+      return
+    }
+
+    yield span
+    cursor = span.index + span.raw.length
+  }
+}
+
+export const stripInlineMathDelimiters = (text: string) => {
+  let out = ''
+  let cursor = 0
+
+  for (const span of inlineMathSpans(text)) {
+    out += text.slice(cursor, span.index)
+    out += span.content
+    cursor = span.index + span.raw.length
+  }
+
+  return out + text.slice(cursor)
+}

--- a/ui-tui/src/lib/mathUnicode.ts
+++ b/ui-tui/src/lib/mathUnicode.ts
@@ -685,6 +685,10 @@ const wrapForFrac = (expr: string) => {
 export function texToUnicode(input: string): string {
   let s = input
 
+  // In TeX math, `\$` emits a literal dollar. Resolve it before the command
+  // passes below so the escape cannot leak into terminal output.
+  s = s.replace(/\\\$/g, '$')
+
   s = s.replace(/\\mathbb\s*\{([A-Za-z])\}/g, (raw, c: string) => BB[c] ?? raw)
   s = s.replace(/\\mathcal\s*\{([A-Za-z])\}/g, (raw, c: string) => CAL[c] ?? raw)
   s = s.replace(/\\mathfrak\s*\{([A-Za-z])\}/g, (raw, c: string) => FRAK[c] ?? raw)


### PR DESCRIPTION
## What does this PR do?

Fixes the TUI's single-dollar inline-math tokenizer so escaped dollar signs and compact currency ranges are not consumed as math delimiters.

The previous regex could not express delimiter escape parity or skip an escaped dollar while looking for the real closer. For example, it rendered `$5-$10` as `5-10`, `literal \$x$` as `literal \x`, and `$x + \$5$` as `x + \5$`.

This replaces only the single-dollar regex alternative with a small escape-aware scanner. Existing regex tokenization remains in place for the rest of inline Markdown.

## Related Issue

Fixes #71380

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `ui-tui/src/lib/inlineMath.ts` to recognize unescaped single-dollar delimiters using full backslash-run parity.
- Skip escaped dollars inside formulas while searching for the real closing delimiter.
- Reuse the Desktop renderer's narrow numeric/currency policy so `$4$`, `$2/3$`, and `$5x=10$` remain math while `$5-$10` remains prose.
- Merge scanner spans with existing Markdown tokens so inline code remains verbatim and math retains precedence over emphasis inside a formula.
- Render TeX `\$` as a literal dollar inside recognized math.
- Remove Markdown escaping from literal dollars in prose while leaving inline-code contents unchanged.
- Handle escaped literal dollars immediately adjacent to inline-math delimiters using escape parity.
- Cover escaped opener/closer behavior, odd/even backslash runs, currency ranges, numeric formulas, inline code, the seven-line reproduction below, adjacent literal/math boundaries, and streaming/full-render parity.

## How to Test

1. Run `npm run check --workspace ui-tui` from the repository root.
2. Run `hermes chat --tui` and ask the model to output exactly:

   ```text
   $x^2$ is valid math
   it costs $5 and $10
   $5-$10
   literal \$x$
   formula $x + \$5$
   literal then math: \$$x^2$
   math then literal: $x^2\$$
   ```

3. Confirm that the TUI:
   - renders the first formula as `x²`;
   - preserves `$5`, `$10`, and `$5-$10` as currency/prose;
   - renders `literal \$x$` as `literal $x$`, without exposing the backslash;
   - renders the formula-with-literal-dollar line as `formula x + $5`;
   - renders the two adjacent cases as `literal then math: $x²` and `math then literal: x²$`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open and closed PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I ran the applicable TUI suite: `npm run check --workspace ui-tui` (Python `pytest` is N/A for this TypeScript-only change)
- [x] I've added behavioral tests for the bug
- [x] I've tested on macOS 26.5.2 and Linux 7.0.0 with Node 22

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing option or workflow changed
- [x] `cli-config.yaml.example` update — N/A; no config changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; the pure TypeScript scanner passed the full TUI suite on macOS and Linux
- [x] Tool descriptions/schemas update — N/A; no tool changed

## Screenshots / Logs

Before the fix, the model emitted the requested characters but the final TUI renderer corrupted three lines:

![TUI reproduction before the fix](https://raw.githubusercontent.com/CubeLander/formulas-workspace/4c0a599/evidence/hermes-tui-inline-math-repro.png)

Validation:

```text
macOS (current rebased head): focused tests — 118 passed
macOS (current rebased head): full TUI suite — 1403 passed, 1 skipped; typecheck, lint, and build passed
Linux: npm run check --workspace ui-tui — 1375 passed, 1 skipped; typecheck and lint passed
Baseline regression test on origin/main — failed with the reported 5-10 / \x / \5$ output
```

### After the fix

The expanded seven-line prompt on the patched branch preserves literal/currency dollars, removes Markdown escaping in prose, renders the escaped dollar inside math, and handles both adjacent literal/math boundaries:

![TUI reproduction after the fix](https://raw.githubusercontent.com/CubeLander/formulas-workspace/529c57632a996fddf667275da677eaf9c21418f3/evidence/hermes-tui-inline-math-after-review.png)
