### PR TITLE
fix(installer): bypass uv entrypoint realpath dependency on macOS (#71320)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1654,12 +1654,26 @@ setup_path() {
     # the rm, `cat >` follows the symlink and overwrites the venv pip entry
     # point with this shim — making `exec "$HERMES_BIN"` self-recurse. (#21454)
     rm -f "$command_link_dir/hermes"
-    cat > "$command_link_dir/hermes" <<EOF
+    # For venv installs, bypass the uv-generated console script entrypoint
+    # and launch through the venv interpreter directly. The uv-generated
+    # entrypoint uses `realpath` which is not available on stock macOS
+    # (requires Homebrew coreutils). Launching via the venv python preserves
+    # venv dependencies and works on all platforms. (#71320)
+    if [ "$USE_VENV" = true ]; then
+        cat > "$command_link_dir/hermes" <<EOF
+#!/usr/bin/env bash
+unset PYTHONPATH
+unset PYTHONHOME
+exec "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/hermes" "\$@"
+EOF
+    else
+        cat > "$command_link_dir/hermes" <<EOF
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
 exec "$HERMES_BIN" "\$@"
 EOF
+    fi
     chmod +x "$command_link_dir/hermes"
     log_success "Installed hermes launcher → $command_link_display_dir/hermes"
 

--- a/tests/test_install_sh_pythonpath_sanitization.py
+++ b/tests/test_install_sh_pythonpath_sanitization.py
@@ -27,4 +27,9 @@ def test_hermes_launcher_wrapper_clears_python_env_before_exec() -> None:
     assert 'cat > "$command_link_dir/hermes" <<EOF' in text
     assert 'unset PYTHONPATH' in text
     assert 'unset PYTHONHOME' in text
-    assert 'exec "$HERMES_BIN" "\\$@"' in text
+    # For venv installs, the shim bypasses the uv-generated entrypoint (which
+    # depends on realpath, absent on stock macOS) and launches through the
+    # venv interpreter directly. (#71320)
+    assert 'exec "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/hermes"' in text
+    # Non-venv installs still exec the hermes binary directly.
+    assert 'exec "$HERMES_BIN"' in text


### PR DESCRIPTION
## Summary

Fixes #71320 (P1).

On stock macOS (no Homebrew/coreutils), `hermes update` generates a venv entrypoint that invokes `realpath` — a command macOS does not ship. This leaves the `hermes` command unusable.

## Root Cause

The `setup_path()` shim in `install.sh` does `exec "$HERMES_BIN"` which points to the uv-generated `venv/bin/hermes`. That entrypoint contains:
```sh
"$(dirname -- "$(realpath -- "$0")")"/python3
```
On macOS without coreutils, `realpath: command not found`.

## Fix

For venv installs, bypass the uv-generated entrypoint and launch through the venv interpreter directly:
```sh
exec "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/hermes" "$@"
```
This preserves venv dependencies and works on all platforms without requiring `realpath`.

Non-venv installs continue to exec `$HERMES_BIN` directly (unchanged).

## Changes

- `scripts/install.sh`: Split shim generation into venv/non-venv branches
- `tests/test_install_sh_pythonpath_sanitization.py`: Updated assertion for new venv shim path

## Testing

```
9 passed in 0.40s
```