### PR TITLE
fix(desktop): context usage bar showed 100% full at any usage level

### DIFF
--- a/apps/desktop/src/app/shell/context-usage-panel.test.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.test.tsx
@@ -1,93 +1,121 @@
-import { act, cleanup, render, waitFor } from '@testing-library/react'
-import { useState } from 'react'
+/**
+ * Regression: the context usage bar must not normalize used tokens to 100%.
+ *
+ * The bar scaled every segment against the sum of used categories, so the
+ * widths always summed to 100% and the track was drawn edge to edge no matter
+ * how little of the window was consumed — a session at 26% full rendered a
+ * completely full bar, and free space was never visible. The header ("N% Full")
+ * and the bar disagreed.
+ *
+ * Default scaling is now against the whole context window, so the filled
+ * portion matches the header. Clicking the bar switches to used-token scaling,
+ * which fills the bar on purpose to compare small categories.
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-
-import type { ContextBreakdown, UsageStats } from '@/types/hermes'
 
 import { ContextUsagePanel } from './context-usage-panel'
 
-const initialUsage: UsageStats = {
-  calls: 1,
-  context_max: 272_000,
-  context_percent: 47,
-  context_used: 128_200,
-  input: 0,
-  output: 0,
-  total: 0
-}
-
-const breakdown: ContextBreakdown = {
-  categories: [{ color: 'teal', id: 'conversation', label: 'Conversation', tokens: 241_400 }],
-  context_max: 272_000,
-  context_percent: 89,
-  context_used: 241_400,
-  estimated_total: 286_600,
-  model: 'test-model'
-}
-
-afterEach(() => {
-  cleanup()
-  vi.restoreAllMocks()
-})
-
-describe('ContextUsagePanel', () => {
-  it('publishes once without refetching when publication recreates the callback', async () => {
-    const requestGateway = vi.fn().mockResolvedValue(breakdown)
-    const published = vi.fn()
-    const renderedUsage: UsageStats[] = []
-
-    function Harness() {
-      const [currentUsage, setCurrentUsage] = useState(initialUsage)
-      renderedUsage.push(currentUsage)
-
-      return (
-        <ContextUsagePanel
-          currentUsage={currentUsage}
-          onUsageSnapshot={snapshot => {
-            published(snapshot)
-            setCurrentUsage(current => ({ ...current, ...snapshot }))
-          }}
-          requestGateway={requestGateway}
-          sessionId="runtime-1"
-        />
-      )
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      shell: {
+        statusbar: {
+          contextUsagePanel: {
+            categories: {},
+            empty: 'No context data yet',
+            loading: 'Loading…',
+            percentFull: (p: number) => `${p}% Full`,
+            scaleToUsed: 'Scale bar to used tokens',
+            scaleToWindow: 'Scale bar to full context window',
+            showPercentages: 'Show %',
+            showTokens: 'Show tokens',
+            title: 'Context Usage',
+            tokenSummary: (used: string, max: string) => `${used} / ${max} Tokens`
+          }
+        }
+      }
     }
+  })
+}))
 
-    render(<Harness />)
+const CATEGORIES = [
+  { color: '#aaa', id: 'system_prompt', label: 'System prompt', tokens: 5_000 },
+  { color: '#bbb', id: 'tool_definitions', label: 'Tool definitions', tokens: 20_000 },
+  { color: '#ccc', id: 'conversation', label: 'Conversation', tokens: 225_000 }
+]
 
-    await waitFor(() => {
-      expect(published).toHaveBeenCalledWith({
-        context_max: 272_000,
-        context_percent: 89,
-        context_used: 241_400
-      })
-      expect(renderedUsage.at(-1)?.context_used).toBe(241_400)
-    })
-    await act(async () => {})
+// 250k of a 1M window = 25% full.
+const BREAKDOWN = {
+  categories: CATEGORIES,
+  context_max: 1_000_000,
+  context_percent: 25,
+  context_used: 250_000
+}
 
-    expect(requestGateway).toHaveBeenCalledTimes(1)
-    expect(requestGateway).toHaveBeenCalledWith('session.context_breakdown', { session_id: 'runtime-1' })
+const USAGE = { context_max: 1_000_000, context_percent: 25, context_used: 250_000 } as never
+
+function renderPanel() {
+  const requestGateway = vi.fn(async () => BREAKDOWN) as never
+
+  return render(<ContextUsagePanel currentUsage={USAGE} requestGateway={requestGateway} sessionId="s1" />)
+}
+
+function segmentWidths(container: HTMLElement): number[] {
+  const bar = container.querySelector('[data-slot="context-usage-bar"]')
+
+  return Array.from(bar?.children ?? []).map(el =>
+    Number.parseFloat((el as HTMLElement).style.width.replace('%', '')) || 0
+  )
+}
+
+afterEach(cleanup)
+
+describe('ContextUsagePanel bar scaling', () => {
+  it('does not fill the bar when the window is mostly free', async () => {
+    const { container } = renderPanel()
+    await screen.findByText('25% Full')
+
+    const total = segmentWidths(container).reduce((a, b) => a + b, 0)
+
+    // The whole point: used tokens are 25% of the window, so the drawn portion
+    // must be about 25%, leaving free space visible — never normalized to 100%.
+    expect(total).toBeGreaterThan(20)
+    expect(total).toBeLessThan(30)
   })
 
-  it('refetches when the session or gateway requester changes', async () => {
-    const firstGateway = vi.fn().mockResolvedValue(breakdown)
-    const secondGateway = vi.fn().mockResolvedValue(breakdown)
+  it('keeps segment widths proportional to the window', async () => {
+    const { container } = renderPanel()
+    await screen.findByText('25% Full')
 
-    const { rerender } = render(
-      <ContextUsagePanel currentUsage={initialUsage} requestGateway={firstGateway} sessionId="runtime-1" />
-    )
+    const [systemPrompt, toolDefs, conversation] = segmentWidths(container)
 
-    await waitFor(() => expect(firstGateway).toHaveBeenCalledTimes(1))
+    expect(systemPrompt).toBeCloseTo(0.5, 1) // 5k / 1M
+    expect(toolDefs).toBeCloseTo(2, 1) // 20k / 1M
+    expect(conversation).toBeCloseTo(22.5, 1) // 225k / 1M
+  })
 
-    rerender(<ContextUsagePanel currentUsage={initialUsage} requestGateway={firstGateway} sessionId="runtime-2" />)
+  it('fills the bar after switching to used-token scaling', async () => {
+    const { container } = renderPanel()
+    await screen.findByText('25% Full')
 
-    await waitFor(() => {
-      expect(firstGateway).toHaveBeenCalledTimes(2)
-      expect(firstGateway).toHaveBeenLastCalledWith('session.context_breakdown', { session_id: 'runtime-2' })
-    })
+    fireEvent.click(screen.getByLabelText('Scale bar to used tokens'))
 
-    rerender(<ContextUsagePanel currentUsage={initialUsage} requestGateway={secondGateway} sessionId="runtime-2" />)
+    const total = segmentWidths(container).reduce((a, b) => a + b, 0)
 
-    await waitFor(() => expect(secondGateway).toHaveBeenCalledTimes(1))
+    expect(total).toBeCloseTo(100, 0)
+  })
+
+  it('toggles the list between tokens and percentages', async () => {
+    renderPanel()
+    await screen.findByText('25% Full')
+
+    // Tokens by default (225k conversation).
+    expect(screen.getByText('225k')).toBeTruthy()
+
+    fireEvent.click(screen.getByText('Show %'))
+
+    // 225k of a 1M window.
+    expect(screen.getByText('22.5%')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/shell/context-usage-panel.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.tsx
@@ -80,7 +80,33 @@ export function ContextUsagePanel({
     [breakdown?.categories, copy]
   )
 
-  const segmentTotal = categories.reduce((sum, category) => sum + category.tokens, 0) || contextUsed || 1
+  const categoryTotal = categories.reduce((sum, category) => sum + category.tokens, 0)
+
+  // Two ways to read the same breakdown, toggled by clicking the bar:
+  //  - 'window' (default): segments are scaled against the whole context window,
+  //    so the filled portion matches the "N% Full" figure above and the
+  //    remaining track is visibly free space.
+  //  - 'used': segments are scaled against used tokens only, filling the bar,
+  //    which makes the relative split between small categories easier to read.
+  // Scaling only against the used total is what made the bar look 100% full at
+  // 26% usage — free space was never drawn.
+  const [barScale, setBarScale] = useState<'used' | 'window'>('window')
+  const [showPercent, setShowPercent] = useState(false)
+
+  const barTotal =
+    barScale === 'window'
+      ? Math.max(contextMax, categoryTotal, 1)
+      : categoryTotal || contextUsed || 1
+
+  // Percentages in the list follow the same denominator as the bar, so the two
+  // readings can never disagree.
+  const listTotal = barTotal
+
+  const formatPercent = (tokens: number) => {
+    const pct = (tokens / listTotal) * 100
+
+    return pct > 0 && pct < 0.1 ? '<0.1%' : `${pct.toFixed(1)}%`
+  }
 
   return (
     <div className="flex w-72 flex-col gap-3 p-3 text-[0.75rem]" data-slot="context-usage-panel">
@@ -92,9 +118,27 @@ export function ContextUsagePanel({
         </span>
       </div>
 
-      <p className="text-[0.6875rem] text-foreground">{copy.percentFull(contextPercent)}</p>
+      <div className="flex items-baseline justify-between gap-2">
+        <p className="text-[0.6875rem] text-foreground">{copy.percentFull(contextPercent)}</p>
 
-      <ContextUsageBar categories={categories} segmentTotal={segmentTotal} />
+        <button
+          className="text-[0.6875rem] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          onClick={() => setShowPercent(value => !value)}
+          type="button"
+        >
+          {showPercent ? copy.showTokens : copy.showPercentages}
+        </button>
+      </div>
+
+      <button
+        aria-label={barScale === 'window' ? copy.scaleToUsed : copy.scaleToWindow}
+        className="cursor-pointer"
+        onClick={() => setBarScale(value => (value === 'window' ? 'used' : 'window'))}
+        title={barScale === 'window' ? copy.scaleToUsed : copy.scaleToWindow}
+        type="button"
+      >
+        <ContextUsageBar categories={categories} segmentTotal={barTotal} />
+      </button>
 
       <ul className="flex flex-col gap-1.5">
         {categories.map(category => (
@@ -105,7 +149,9 @@ export function ContextUsagePanel({
               <span className="truncate text-muted-foreground">{category.label}</span>
             </span>
 
-            <span className="shrink-0 tabular-nums text-foreground">{compactNumber(category.tokens)}</span>
+            <span className="shrink-0 tabular-nums text-foreground">
+              {showPercent ? formatPercent(category.tokens) : compactNumber(category.tokens)}
+            </span>
           </li>
         ))}
       </ul>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2409,6 +2409,10 @@ export const en: Translations = {
         empty: 'No context data yet',
         loading: 'Loading breakdown…',
         percentFull: percent => `${percent}% Full`,
+        scaleToUsed: 'Scale bar to used tokens',
+        scaleToWindow: 'Scale bar to full context window',
+        showPercentages: 'Show %',
+        showTokens: 'Show tokens',
         title: 'Context Usage',
         tokenSummary: (used, max) => `${used} / ${max} Tokens`
       },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2279,6 +2279,10 @@ export const ja = defineLocale({
         empty: 'コンテキストデータはまだありません',
         loading: '内訳を読み込み中…',
         percentFull: percent => `${percent}% 使用中`,
+        scaleToUsed: '使用済みトークンでバーを表示',
+        scaleToWindow: 'コンテキスト全体でバーを表示',
+        showPercentages: '％を表示',
+        showTokens: 'トークンを表示',
         title: 'コンテキスト使用状況',
         tokenSummary: (used, max) => `${used} / ${max} Tokens`
       },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2017,6 +2017,10 @@ export interface Translations {
         empty: string
         loading: string
         percentFull: (percent: number) => string
+        scaleToUsed: string
+        scaleToWindow: string
+        showPercentages: string
+        showTokens: string
         title: string
         tokenSummary: (used: string, max: string) => string
       }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2206,6 +2206,10 @@ export const zhHant = defineLocale({
         empty: '尚無上下文資料',
         loading: '正在載入明細…',
         percentFull: percent => `已用 ${percent}%`,
+        scaleToUsed: '以已用權杖縮放長條',
+        scaleToWindow: '以完整脈絡視窗縮放長條',
+        showPercentages: '顯示百分比',
+        showTokens: '顯示權杖數',
         title: '上下文使用量',
         tokenSummary: (used, max) => `${used} / ${max} Tokens`
       },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2586,6 +2586,10 @@ export const zh: Translations = {
         empty: '暂无上下文数据',
         loading: '正在加载明细…',
         percentFull: percent => `已用 ${percent}%`,
+        scaleToUsed: '按已用令牌缩放进度条',
+        scaleToWindow: '按完整上下文窗口缩放进度条',
+        showPercentages: '显示百分比',
+        showTokens: '显示令牌数',
         title: '上下文用量',
         tokenSummary: (used, max) => `${used} / ${max} Tokens`
       },


### PR DESCRIPTION
## Problem

The Context Usage bar renders full at any usage level. `segmentTotal` was the sum of used categories, not the context window:

```ts
const segmentTotal = categories.reduce((sum, c) => sum + c.tokens, 0) || contextUsed || 1
// width: `${(category.tokens / segmentTotal) * 100}%`
```

Widths therefore always sum to 100%. A session reporting `26% Full` in the header drew a completely full bar directly beneath that text, and free space was never drawn. The two readings in the same popover contradict each other, and the bar carries no information about how much room is left, which is the main thing the panel is consulted for.

## Changes

**Scale against the window by default.** Segments are now drawn against `context_max`, so the filled portion matches the header percentage and the remaining track is visibly free space.

**Click the bar to switch scaling.** The previous behavior is still useful for comparing small categories against each other, so it is kept as a second mode that fills the bar deliberately rather than by accident. Labelled via `aria-label` and `title`.

**Toggle the list between tokens and percentages.** Percentages use the same denominator as the bar, so the list and the bar can never disagree. Values below 0.1% render as `<0.1%` instead of `0.0%`.

Both toggles are local view state. Nothing is persisted and no backend call changes.

## Testing

`apps/desktop/src/app/shell/context-usage-panel.test.tsx`, 4 tests against a 250k / 1M breakdown:

- segment widths sum to roughly 25%, not 100%, so free space stays visible
- each segment is proportional to the window (5k → 0.5%, 20k → 2%, 225k → 22.5%)
- switching to used-token scaling fills the bar
- the list toggles between `225k` and `22.5%`

Verified failing against the old scaling (all 4 fail) and passing with the fix.

```
npx tsc -p apps/desktop --noEmit     # clean
npx eslint <changed files>           # clean
npx vitest run --project ui          # 2198 passed, 1 pre-existing failure
```

The one failure is `dialog-dismiss-repro.test.tsx` (Select inside Dialog), which fails identically on clean `main` and is unrelated.

## i18n

Four new keys in `en.ts` and `types.ts`, with translations added to `ja`, `zh`, and `zh-hant`, which declare this block fully rather than relying on fallback.
