### PR TITLE
test: set USERPROFILE alongside HOME in tilde-expansion tests

### DIFF
--- a/tests/agent/lsp/test_workspace.py
+++ b/tests/agent/lsp/test_workspace.py
@@ -70,6 +70,8 @@ def test_resolve_workspace_for_file_uses_cwd_first(tmp_path: Path, monkeypatch):
 
 
 def test_normalize_path_expands_tilde(monkeypatch):
+    # expanduser() reads USERPROFILE on Windows and ignores HOME.
     monkeypatch.setenv("HOME", "/home/user")
+    monkeypatch.setenv("USERPROFILE", "/home/user")
     p = normalize_path("~/x.py")
     assert p == os.path.abspath("/home/user/x.py")

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -47,7 +47,9 @@ class TestNormalizeWorkdir:
 
     def test_tilde_expands(self, tmp_path, monkeypatch):
         from cron.jobs import _normalize_workdir
+        # expanduser() reads USERPROFILE on Windows and ignores HOME.
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         result = _normalize_workdir("~")
         assert result == str(tmp_path.resolve())
 


### PR DESCRIPTION
Two tests set `HOME` to a temporary directory and then assert that `~` expands into it. On Windows `ntpath.expanduser()` reads `USERPROFILE` and ignores `HOME`, so `~` kept resolving to the real user profile and both failed.

Setting both variables leaves POSIX behaviour untouched and lets the tests actually exercise the expansion on Windows instead of asserting against whatever home directory the developer happens to have.

**Updated:** rebased onto current main and narrowed from four tests to the two that are still affected:

- `tests/agent/lsp/test_workspace.py::test_normalize_path_expands_tilde`
- `tests/cron/test_cron_workdir.py::TestNormalizeWorkdir::test_tilde_expands`

The two CLI tests this PR originally touched (`tests/cli/test_cli_file_drop.py`, `tests/cli/test_cli_image_command.py`) already received the same fix on main in 53f7d137e, so they are dropped here. That is also what the conflict was about, and it is now gone.

Verified on Windows 11, Python 3.13, cherry-picked onto current main:

- before: 2 failed, 16 passed
- after: 18 passed

Linux and macOS are unaffected, since `posixpath.expanduser()` prefers `HOME` either way.

Green ubuntu run for this head: https://github.com/cryptoyasenka/hermes-agent/actions/runs/31056700675

Test only, no source changes. `ruff check` clean.
