### PR TITLE
fix(auxiliary): wire minimax-oauth into resolve_provider_client so xai-oauth → M3 fallback works

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2697,6 +2697,61 @@ def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str
     return CodexAuxiliaryClient(real_client, model), model
 
 
+def _build_minimax_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
+    """Build an AnthropicAuxiliaryClient for a MiniMax OAuth-authenticated session.
+
+    MiniMax's inference endpoint at https://api.minimax.io/anthropic speaks
+    the Anthropic Messages API. We resolve the bearer token via the
+    MiniMax-specific credential resolver (``resolve_minimax_oauth_runtime_credentials``)
+    and wrap the underlying Anthropic client so ``chat.completions.create()``
+    calls are translated into ``messages.stream()`` calls — matching the
+    AnthropicAuxiliaryClient pattern used for ``anthropic``/``minimax``/``minimax-cn``.
+
+    Added so the fallback chain can route xai-oauth → minimax-oauth when the
+    primary provider runs out of credits; without this branch the chain
+    aborts with "provider not configured". See patch context: the upstream
+    ``resolve_provider_client`` only special-cases ``nous`` / ``openai-codex`` /
+    ``xai-oauth`` under ``oauth_device_code``/``oauth_external`` and silently
+    rejects the newer ``oauth_minimax`` auth type — this builder closes the
+    gap until upstream is updated.
+
+    Returns ``(None, None)`` when no MiniMax OAuth token is available.
+    """
+    if not model:
+        logger.warning(
+            "Auxiliary client: minimax-oauth requested without a model; "
+            "pass model explicitly (auxiliary.<task>.model in config.yaml)."
+        )
+        return None, None
+    try:
+        from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
+        rt = resolve_minimax_oauth_runtime_credentials()
+    except Exception as exc:  # noqa: BLE001 — surfaced as (None, None) so fallback can advance
+        logger.warning(
+            "Auxiliary client: minimax-oauth credential resolution failed (%s)", exc,
+        )
+        return None, None
+    api_key = (rt.get("api_key") or "").strip() if isinstance(rt, dict) else ""
+    base_url = (rt.get("base_url") or "").strip() if isinstance(rt, dict) else ""
+    if not api_key or not base_url:
+        logger.warning(
+            "Auxiliary client: minimax-oauth missing api_key or base_url in resolved runtime"
+        )
+        return None, None
+    try:
+        from agent.anthropic_adapter import build_anthropic_client
+        real_client = build_anthropic_client(api_key, base_url)
+    except Exception as exc:  # noqa: BLE001 — surfaced as (None, None) so fallback can advance
+        logger.warning(
+            "Auxiliary client: minimax-oauth Anthropic client build failed (%s)", exc,
+        )
+        return None, None
+    if real_client is None:
+        return None, None
+    logger.debug("Auxiliary client: MiniMax OAuth (%s via Anthropic Messages API)", model)
+    return AnthropicAuxiliaryClient(real_client, model, api_key, base_url, is_oauth=True), model
+
+
 def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
     """Build a CodexAuxiliaryClient for an explicitly-requested model.
 
@@ -5012,6 +5067,26 @@ def resolve_provider_client(
             logger.warning(
                 "resolve_provider_client: xai-oauth requested but no xAI "
                 "OAuth token found (run: hermes model -> xAI Grok OAuth — SuperGrok / Premium+)"
+            )
+            return None, None
+        final_model = _normalize_resolved_model(model or default, provider)
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
+
+    # MiniMax OAuth (Coding Plan, minimax.io). Uses the Anthropic Messages
+    # protocol; the agent_init.py primary path already builds a dedicated
+    # Anthropic client for it, but the auxiliary fallback chain (used when
+    # the primary provider fails mid-session) routes through here. Without
+    # this branch the fallback aborts with "Fallback to minimax-oauth
+    # failed: provider not configured" because the upstream oauth switch
+    # below only special-cases nous/openai-codex/xai-oauth under the older
+    # oauth_device_code / oauth_external types.
+    if provider == "minimax-oauth":
+        client, default = _build_minimax_oauth_aux_client(model)
+        if client is None:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requested but no "
+                "MiniMax OAuth token found (run: hermes model -> MiniMax (OAuth))."
             )
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)


### PR DESCRIPTION
## What & why

`fallback_providers` chain entries that point at `minimax-oauth` abort silently with `Fallback to minimax-oauth failed: provider not configured`. Reproduction: configure a Grok-primary + MiniMax-M3-fallback setup, run the primary out of credits, observe the chain stop dead instead of swapping backends.

The auxiliary resolver `agent.auxiliary_client.py:resolve_provider_client` has dedicated branches for `nous` / `openai-codex` / `xai-oauth` (each builds a specialized OAuth client) under the `oauth_device_code` / `oauth_external` switch. The newer `minimax-oauth` provider has `auth_type=oauth_minimax`, which is not in that set, so it falls through to the unhandled branch and returns `(None, None)`.

The primary chat path in `agent/agent_init.py` is unaffected — it builds a dedicated Anthropic client for `minimax-oauth` directly. Only the auxiliary fallback path (the one triggered when the primary provider fails mid-session) hits this hole. The other `AnthropicAuxiliaryClient`-using providers (`anthropic`, `minimax`, `minimax-cn`) all work because they have proper upstream branches.

## Fix

Two new hunks in `agent/auxiliary_client.py`, mirroring the existing `xai-oauth` structure:

1. **`_build_minimax_oauth_aux_client`** — uses `hermes_cli.auth.resolve_minimax_oauth_runtime_credentials` for credential resolution and `agent.anthropic_adapter.build_anthropic_client` to construct the underlying Anthropic client, then wraps it in `AnthropicAuxiliaryClient` with `is_oauth=True`.
2. **A new provider branch** in `resolve_provider_client` after the existing `xai-oauth` branch that routes to the new builder.

## Test plan

- [x] Verified locally: `hermes chat -q "Reply OK"` on an exhausted Grok primary produces `🔄 Switched to fallback model: grok-4.5 via xai-oauth → MiniMax-M3 via minimax-oauth` and the assistant responds
- [x] `python3 -c "import ast; ast.parse(open('agent/auxiliary_client.py').read())"` — parses cleanly
- [x] `Fallback to minimax-oauth failed: provider not configured` no longer appears in `~/.hermes/logs/agent.log`
- [ ] Repro by another contributor: configure xai-oauth primary, force billing exhaustion (deplete credits), confirm chain activates M3
- [ ] No existing tests broken (no test was specifically tied to the broken branch)

## Risk

Low. The new code paths only execute when `provider == "minimax-oauth"` is requested via the auxiliary resolver — a path that currently returns `(None, None)` for that provider. No call site that worked before can stop working. If `resolve_minimax_oauth_runtime_credentials` raises or returns empty credentials, the new builder surfaces `(None, None)` matching the existing `xai-oauth` pattern.

## Labels

`type/bug`, `provider/minimax`