### PR TITLE
fix(agent): skip retries when stream times out with zero data delivered

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -40,11 +40,23 @@ from agent.message_sanitization import (
     _repair_tool_call_arguments,
 )
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
+from agent.turn_retry_state import ZERO_DELIVERY_STREAM_TIMEOUT_ATTR
 from tools.terminal_tool import is_persistent_env
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
 logger = logging.getLogger(__name__)
 _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
+
+
+def _is_stream_timeout(error: BaseException) -> bool:
+    """Use one timeout classifier for stream retries and outer-loop routing."""
+    import httpx
+    from openai import APITimeoutError
+
+    return isinstance(
+        error,
+        (APITimeoutError, httpx.ReadTimeout, httpx.ConnectTimeout, httpx.PoolTimeout),
+    )
 
 # When the fallback chain is fully exhausted on a non-rate-limit failure
 # (e.g. every provider returns a non-retryable client error like HTTP 400),
@@ -3725,14 +3737,23 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             type(e).__name__,
                         )
                         return
-                    _is_timeout = isinstance(
-                        e, (_httpx.ReadTimeout, _httpx.ConnectTimeout, _httpx.PoolTimeout)
-                    )
+                    _is_timeout = _is_stream_timeout(e)
                     _is_conn_err = isinstance(
                         e, (_httpx.ConnectError, _httpx.RemoteProtocolError, ConnectionError)
                     )
                     _is_stream_parse_err = agent._is_provider_stream_parse_error(e)
                     _is_empty_stream = isinstance(e, EmptyStreamError)
+
+                    # A timeout before the first delivered delta is escalated
+                    # immediately to the outer recovery pipeline. Retrying the
+                    # identical payload in both this loop and the outer loop
+                    # multiplies long provider timeouts. The marker lets the
+                    # outer loop preserve one primary transport rebuild and
+                    # configured fallbacks without another ordinary retry cycle.
+                    if _is_timeout and not deltas_were_sent["yes"]:
+                        setattr(e, ZERO_DELIVERY_STREAM_TIMEOUT_ATTR, True)
+                        result["error"] = e
+                        return
 
                     # If the stream died AFTER some tokens were delivered:
                     # normally we don't retry (the user already saw text,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -51,11 +51,13 @@ _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
 def _is_stream_timeout(error: BaseException) -> bool:
     """Use one timeout classifier for stream retries and outer-loop routing."""
     import httpx
-    from openai import APITimeoutError
 
-    return isinstance(
-        error,
-        (APITimeoutError, httpx.ReadTimeout, httpx.ConnectTimeout, httpx.PoolTimeout),
+    return (
+        any(cls.__name__ == "APITimeoutError" for cls in type(error).__mro__)
+        or isinstance(
+            error,
+            (httpx.ReadTimeout, httpx.ConnectTimeout, httpx.PoolTimeout),
+        )
     )
 
 # When the fallback chain is fully exhausted on a non-rate-limit failure
@@ -3224,6 +3226,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 reasoning_parts.append(reasoning_text)
                 _fire_first_delta()
                 agent._fire_reasoning_delta(reasoning_text)
+                deltas_were_sent["yes"] = True
 
             # Accumulate text content — fire callback only when no tool calls
             if delta and delta.content:
@@ -3644,6 +3647,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             if thinking_text:
                                 _fire_first_delta()
                                 agent._fire_reasoning_delta(thinking_text)
+                                deltas_were_sent["yes"] = True
             if not agent._interrupt_requested:
                 raw_stream = _stream_context["stream"]
                 if raw_stream is not None:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2875,6 +2875,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     first_delta_fired = {"done": False}
     deltas_were_sent = {"yes": False}  # Track if any deltas were fired (for fallback)
     provider_tool_in_flight = {"yes": False}
+    response_progress_seen = {"yes": False}
     # Wall-clock timestamp of the last real streaming chunk.  The outer
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
@@ -2916,6 +2917,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             stream_attempt_state["current"] += 1
             attempt_id = int(stream_attempt_state["current"])
         provider_tool_in_flight["yes"] = False
+        response_progress_seen["yes"] = False
         return attempt_id
 
     def _cancel_current_stream_attempt(reason: str) -> None:
@@ -3207,6 +3209,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             if not _stream_attempt_is_active(stream_attempt_id):
                 _discard_stale_stream_chunk(stream_attempt_id, chunk)
                 continue
+
+            response_progress_seen["yes"] = True
 
             if not chunk.choices:
                 if hasattr(chunk, "model") and chunk.model:
@@ -3611,6 +3615,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         try:
             for event in stream:
                 saw_stream_event = True
+                response_progress_seen["yes"] = True
                 last_chunk_time["t"] = time.time()
                 agent._touch_activity("receiving stream response")
                 try:
@@ -3748,13 +3753,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     _is_stream_parse_err = agent._is_provider_stream_parse_error(e)
                     _is_empty_stream = isinstance(e, EmptyStreamError)
 
-                    # A timeout before the first delivered delta is escalated
+                    # A timeout before the first response event is escalated
                     # immediately to the outer recovery pipeline. Retrying the
                     # identical payload in both this loop and the outer loop
                     # multiplies long provider timeouts. The marker lets the
                     # outer loop preserve one primary transport rebuild and
                     # configured fallbacks without another ordinary retry cycle.
-                    if _is_timeout and not deltas_were_sent["yes"]:
+                    # Any event — including a tool-call or metadata event — means
+                    # the provider made progress, so existing mid-stream retry
+                    # behavior must remain in control.
+                    if _is_timeout and not response_progress_seen["yes"]:
                         setattr(e, ZERO_DELIVERY_STREAM_TIMEOUT_ATTR, True)
                         result["error"] = e
                         return

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -44,7 +44,7 @@ from agent.turn_context import (
     compose_user_api_content,
     reanchor_current_turn_user_idx,
 )
-from agent.turn_retry_state import TurnRetryState
+from agent.turn_retry_state import ZERO_DELIVERY_STREAM_TIMEOUT_ATTR, TurnRetryState
 from agent.runtime_cwd import resolve_agent_cwd
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
@@ -5080,6 +5080,16 @@ def run_conversation(
                         "error": _nonretryable_summary,
                     }
 
+                # The streaming layer identified a timeout before any response
+                # data arrived. Skip the duplicate outer backoff cycle, but
+                # keep the normal primary-transport rebuild and configured
+                # fallback pipeline.
+                _zero_delivery_stream_timeout = bool(
+                    getattr(api_error, ZERO_DELIVERY_STREAM_TIMEOUT_ATTR, False)
+                )
+                if _zero_delivery_stream_timeout:
+                    retry_count = max_retries
+
                 if retry_count >= max_retries:
                     # Before falling back, try rebuilding the primary
                     # client once for transient transport errors (stale
@@ -5129,9 +5139,24 @@ def run_conversation(
                         )
                     elif is_rate_limited:
                         agent._emit_status(f"❌ Rate limited after {max_retries} retries — {_final_summary}")
+                    elif _zero_delivery_stream_timeout:
+                        agent._emit_status(
+                            "❌ Provider timed out before delivering any response "
+                            "after stream recovery was exhausted."
+                        )
                     else:
                         agent._emit_status(f"❌ API failed after {max_retries} retries — {_final_summary}")
                     agent._vprint(f"{agent.log_prefix}   💀 Final error: {_final_summary}", force=True)
+
+                    if _zero_delivery_stream_timeout:
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 The request payload may be too large "
+                            f"for this provider. Try setting "
+                            f"`providers.{_provider}.request_timeout_seconds` in "
+                            f"~/.hermes/config.yaml, reducing the enabled toolset, or "
+                            f"configuring a different fallback provider.",
+                            force=True,
+                        )
 
                     # Detect SSE stream-drop pattern (e.g. "Network
                     # connection lost") and surface actionable guidance.
@@ -5239,6 +5264,12 @@ def run_conversation(
                         # Structured recovery descriptor so every surface renders
                         # the same link + label from one signal (see helper).
                         _billing_block = _billing_block_dict(_provider, _base, _model, _billing_guidance)
+                    elif _zero_delivery_stream_timeout:
+                        _final_response = (
+                            "Provider timed out before delivering any response after "
+                            "the available recovery options were exhausted. "
+                            "The request payload may be too large for this provider."
+                        )
                     else:
                         _final_response = f"API call failed after {max_retries} retries: {_final_summary}"
                     if _is_thinking_timeout:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5110,7 +5110,15 @@ def run_conversation(
                         continue
                     # Try fallback before giving up entirely
                     if agent._has_pending_fallback():
-                        agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
+                        if _zero_delivery_stream_timeout:
+                            agent._buffer_status(
+                                "⚠️ Provider timed out before delivering any response "
+                                "— trying fallback..."
+                            )
+                        else:
+                            agent._buffer_status(
+                                f"⚠️ Max retries ({max_retries}) exhausted — trying fallback..."
+                            )
                     if agent._try_activate_fallback():
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
@@ -5141,8 +5149,8 @@ def run_conversation(
                         agent._emit_status(f"❌ Rate limited after {max_retries} retries — {_final_summary}")
                     elif _zero_delivery_stream_timeout:
                         agent._emit_status(
-                            "❌ Provider timed out before delivering any response "
-                            "after stream recovery was exhausted."
+                            "❌ Provider timed out before delivering any response after the "
+                            "available recovery options were exhausted."
                         )
                     else:
                         agent._emit_status(f"❌ API failed after {max_retries} retries — {_final_summary}")
@@ -5246,14 +5254,28 @@ def run_conversation(
                             force=True,
                         )
 
-                    logger.error(
-                        "%sAPI call failed after %s retries. %s | provider=%s model=%s msgs=%s tokens=~%s",
-                        agent.log_prefix, max_retries, _final_summary,
-                        _provider, _model, len(api_messages), f"{approx_tokens:,}",
-                    )
+                    if _zero_delivery_stream_timeout:
+                        logger.error(
+                            "%sAPI call failed: zero-delivery stream timeout recovery exhausted. "
+                            "%s | provider=%s model=%s msgs=%s tokens=~%s",
+                            agent.log_prefix, _final_summary,
+                            _provider, _model, len(api_messages), f"{approx_tokens:,}",
+                        )
+                    else:
+                        logger.error(
+                            "%sAPI call failed after %s retries. %s | provider=%s model=%s msgs=%s tokens=~%s",
+                            agent.log_prefix, max_retries, _final_summary,
+                            _provider, _model, len(api_messages), f"{approx_tokens:,}",
+                        )
                     if api_kwargs is not None:
                         agent._dump_api_request_debug(
-                            api_kwargs, reason="max_retries_exhausted", error=api_error,
+                            api_kwargs,
+                            reason=(
+                                "zero_delivery_stream_timeout"
+                                if _zero_delivery_stream_timeout
+                                else "max_retries_exhausted"
+                            ),
+                            error=api_error,
                         )
                     agent._persist_session(messages, conversation_history)
                     _billing_block = None

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -29,6 +29,9 @@ from __future__ import annotations
 from dataclasses import dataclass, fields
 
 
+ZERO_DELIVERY_STREAM_TIMEOUT_ATTR = "hermes_zero_delivery_stream_timeout"
+
+
 @dataclass
 class TurnRetryState:
     """One-shot recovery guards + restart signals for a single API-call attempt.

--- a/tests/agent/test_stream_timeout_zero_delivery.py
+++ b/tests/agent/test_stream_timeout_zero_delivery.py
@@ -1,0 +1,203 @@
+"""Regression tests for zero-delivery stream timeout retry amplification."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+import openai
+import pytest
+
+from run_agent import AIAgent
+
+
+_TIMEOUT_MARKER = "hermes_zero_delivery_stream_timeout"
+
+
+def _make_agent() -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://example.com/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    return agent
+
+
+def _timeout_cases() -> list[BaseException]:
+    request = httpx.Request("POST", "https://example.com/v1/chat/completions")
+    return [
+        openai.APITimeoutError(request=request),
+        httpx.ReadTimeout("read timeout", request=request),
+        httpx.ConnectTimeout("connect timeout", request=request),
+        httpx.PoolTimeout("pool timeout", request=request),
+    ]
+
+
+@pytest.mark.parametrize("timeout", _timeout_cases(), ids=lambda exc: type(exc).__name__)
+def test_zero_delivery_timeout_is_marked_at_stream_retry_boundary(
+    timeout: BaseException,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+    agent = _make_agent()
+    request_client = MagicMock()
+    request_client.chat.completions.create.side_effect = timeout
+    agent._create_request_openai_client = MagicMock(return_value=request_client)
+
+    with pytest.raises(type(timeout)) as caught:
+        agent._interruptible_streaming_api_call({"model": "test/model", "messages": []})
+
+    assert getattr(caught.value, _TIMEOUT_MARKER, False) is True
+    assert request_client.chat.completions.create.call_count == 1
+
+
+def test_post_delta_timeout_is_not_marked(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+    agent = _make_agent()
+    timeout = httpx.ReadTimeout(
+        "read timeout",
+        request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+    )
+
+    def stream():
+        yield SimpleNamespace(
+            choices=[SimpleNamespace(
+                index=0,
+                delta=SimpleNamespace(
+                    content="partial",
+                    tool_calls=None,
+                    reasoning_content=None,
+                    reasoning=None,
+                ),
+                finish_reason=None,
+            )],
+            model="test/model",
+            usage=None,
+        )
+        raise timeout
+
+    request_client = MagicMock()
+    request_client.chat.completions.create.return_value = stream()
+    agent._create_request_openai_client = MagicMock(return_value=request_client)
+
+    response = agent._interruptible_streaming_api_call(
+        {"model": "test/model", "messages": []}
+    )
+
+    assert response.choices[0].finish_reason == "length"
+    assert getattr(timeout, _TIMEOUT_MARKER, False) is False
+
+
+def _marked_read_timeout() -> httpx.ReadTimeout:
+    timeout = httpx.ReadTimeout(
+        "read timeout",
+        request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+    )
+    setattr(timeout, _TIMEOUT_MARKER, True)
+    return timeout
+
+
+def _run_non_streaming_turn(agent: AIAgent) -> dict:
+    agent._disable_streaming = True
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch("agent.conversation_loop.jittered_backoff", return_value=0),
+        patch("agent.conversation_loop.time.sleep"),
+    ):
+        return agent.run_conversation("hello")
+
+
+def test_zero_delivery_timeout_uses_one_primary_recovery_then_fallback():
+    agent = _make_agent()
+    agent._api_max_retries = 3
+    agent.client = MagicMock()
+    agent.client.chat.completions.create.side_effect = (
+        lambda **_kwargs: (_ for _ in ()).throw(_marked_read_timeout())
+    )
+    agent._try_recover_primary_transport = MagicMock(return_value=True)
+    agent._has_pending_fallback = MagicMock(return_value=False)
+    agent._try_activate_fallback = MagicMock(return_value=False)
+
+    result = _run_non_streaming_turn(agent)
+
+    assert result["failed"] is True
+    assert agent.client.chat.completions.create.call_count == 2
+    agent._try_recover_primary_transport.assert_called_once()
+    agent._try_activate_fallback.assert_called_once()
+
+
+def test_zero_delivery_timeout_attempts_configured_fallback_without_outer_retries():
+    agent = _make_agent()
+    agent._api_max_retries = 3
+    agent.client = MagicMock()
+    agent.client.chat.completions.create.side_effect = (
+        lambda **_kwargs: (_ for _ in ()).throw(_marked_read_timeout())
+    )
+    agent._try_recover_primary_transport = MagicMock(return_value=False)
+    agent._has_pending_fallback = MagicMock(return_value=True)
+    agent._try_activate_fallback = MagicMock(return_value=False)
+
+    result = _run_non_streaming_turn(agent)
+
+    assert agent.client.chat.completions.create.call_count == 1
+    agent._try_activate_fallback.assert_called_once()
+    assert "timed out before delivering any response" in result["final_response"]
+    assert "payload may be too large" in result["final_response"]
+
+
+def test_successful_fallback_completes_without_timeout_diagnostic():
+    agent = _make_agent()
+    agent._api_max_retries = 3
+    agent.client = MagicMock()
+    fallback_response = SimpleNamespace(
+        choices=[SimpleNamespace(
+            index=0,
+            message=SimpleNamespace(
+                role="assistant",
+                content="fallback worked",
+                tool_calls=None,
+                reasoning_content=None,
+            ),
+            finish_reason="stop",
+        )],
+        model="fallback/model",
+        usage=None,
+    )
+    agent.client.chat.completions.create.side_effect = [
+        _marked_read_timeout(),
+        fallback_response,
+    ]
+    agent._try_recover_primary_transport = MagicMock(return_value=False)
+    agent._has_pending_fallback = MagicMock(return_value=True)
+
+    def activate_fallback() -> bool:
+        agent._fallback_activated = True
+        agent.provider = "fallback-provider"
+        agent.model = "fallback/model"
+        return True
+
+    agent._try_activate_fallback = MagicMock(side_effect=activate_fallback)
+
+    result = _run_non_streaming_turn(agent)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "fallback worked"
+    assert agent.client.chat.completions.create.call_count == 2
+    agent._try_activate_fallback.assert_called_once()

--- a/tests/agent/test_stream_timeout_zero_delivery.py
+++ b/tests/agent/test_stream_timeout_zero_delivery.py
@@ -60,6 +60,25 @@ def test_zero_delivery_timeout_is_marked_at_stream_retry_boundary(
     assert request_client.chat.completions.create.call_count == 1
 
 
+def test_native_anthropic_zero_delivery_timeout_is_marked(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+    agent = _make_agent()
+    agent.api_mode = "anthropic_messages"
+    sdk_timeout_type = type("APITimeoutError", (Exception,), {})
+    timeout = sdk_timeout_type("request timed out")
+    request_client = MagicMock()
+    request_client.messages.stream.side_effect = timeout
+    agent._create_request_anthropic_client = MagicMock(return_value=request_client)
+
+    with pytest.raises(sdk_timeout_type) as caught:
+        agent._interruptible_streaming_api_call({"model": "test/model", "messages": []})
+
+    assert getattr(caught.value, _TIMEOUT_MARKER, False) is True
+    assert request_client.messages.stream.call_count == 1
+
+
 def test_post_delta_timeout_is_not_marked(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -95,6 +114,84 @@ def test_post_delta_timeout_is_not_marked(
         {"model": "test/model", "messages": []}
     )
 
+    assert response.choices[0].finish_reason == "length"
+    assert getattr(timeout, _TIMEOUT_MARKER, False) is False
+
+
+def test_openai_reasoning_delta_counts_as_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+    agent = _make_agent()
+    agent._fire_reasoning_delta = MagicMock()
+    timeout = httpx.ReadTimeout(
+        "read timeout",
+        request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+    )
+
+    def stream():
+        yield SimpleNamespace(
+            choices=[SimpleNamespace(
+                index=0,
+                delta=SimpleNamespace(
+                    content=None,
+                    tool_calls=None,
+                    reasoning_content="partial reasoning",
+                    reasoning=None,
+                ),
+                finish_reason=None,
+            )],
+            model="test/model",
+            usage=None,
+        )
+        raise timeout
+
+    request_client = MagicMock()
+    request_client.chat.completions.create.return_value = stream()
+    agent._create_request_openai_client = MagicMock(return_value=request_client)
+
+    response = agent._interruptible_streaming_api_call(
+        {"model": "test/model", "messages": []}
+    )
+
+    agent._fire_reasoning_delta.assert_called_once_with("partial reasoning")
+    assert response.choices[0].finish_reason == "length"
+    assert getattr(timeout, _TIMEOUT_MARKER, False) is False
+
+
+def test_anthropic_reasoning_delta_counts_as_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+    agent = _make_agent()
+    agent.api_mode = "anthropic_messages"
+    agent._fire_reasoning_delta = MagicMock()
+    timeout = httpx.ReadTimeout(
+        "read timeout",
+        request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+    )
+
+    def stream():
+        yield SimpleNamespace(
+            type="content_block_delta",
+            delta=SimpleNamespace(
+                type="thinking_delta",
+                thinking="partial reasoning",
+            ),
+        )
+        raise timeout
+
+    stream_manager = MagicMock()
+    stream_manager.__enter__.return_value = stream()
+    request_client = MagicMock()
+    request_client.messages.stream.return_value = stream_manager
+    agent._create_request_anthropic_client = MagicMock(return_value=request_client)
+
+    response = agent._interruptible_streaming_api_call(
+        {"model": "test/model", "messages": []}
+    )
+
+    agent._fire_reasoning_delta.assert_called_once_with("partial reasoning")
     assert response.choices[0].finish_reason == "length"
     assert getattr(timeout, _TIMEOUT_MARKER, False) is False
 

--- a/tests/agent/test_stream_timeout_zero_delivery.py
+++ b/tests/agent/test_stream_timeout_zero_delivery.py
@@ -1,5 +1,6 @@
 """Regression tests for zero-delivery stream timeout retry amplification."""
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -22,6 +23,7 @@ def _make_agent() -> AIAgent:
         agent = AIAgent(
             api_key="test-key",
             base_url="https://example.com/v1",
+            provider="test-provider",
             model="test/model",
             quiet_mode=True,
             skip_context_files=True,
@@ -196,6 +198,57 @@ def test_anthropic_reasoning_delta_counts_as_delivery(
     assert getattr(timeout, _TIMEOUT_MARKER, False) is False
 
 
+def test_timeout_after_tool_delta_uses_stream_retry(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A tool-call chunk is response progress, even without visible text."""
+    from tests.run_agent.test_streaming import (
+        _make_stream_chunk,
+        _make_tool_call_delta,
+    )
+
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "1")
+    agent = _make_agent()
+    timeout = httpx.ReadTimeout(
+        "read timeout",
+        request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+    )
+    attempts = 0
+
+    def first_stream():
+        yield _make_stream_chunk(tool_calls=[
+            _make_tool_call_delta(index=0, tc_id="call_1", name="terminal"),
+        ])
+        raise timeout
+
+    def second_stream():
+        yield _make_stream_chunk(tool_calls=[
+            _make_tool_call_delta(index=0, tc_id="call_1", name="terminal"),
+        ])
+        yield _make_stream_chunk(tool_calls=[
+            _make_tool_call_delta(index=0, arguments='{"command": "pwd"}'),
+        ])
+        yield _make_stream_chunk(finish_reason="tool_calls")
+
+    def pick_stream(**_kwargs):
+        nonlocal attempts
+        attempts += 1
+        return first_stream() if attempts == 1 else second_stream()
+
+    request_client = MagicMock()
+    request_client.chat.completions.create.side_effect = pick_stream
+    agent._create_request_openai_client = MagicMock(return_value=request_client)
+
+    response = agent._interruptible_streaming_api_call(
+        {"model": "test/model", "messages": []}
+    )
+
+    assert attempts == 2
+    assert response is not None
+    assert response.choices[0].message.tool_calls
+    assert getattr(timeout, _TIMEOUT_MARKER, False) is False
+
+
 def _marked_read_timeout() -> httpx.ReadTimeout:
     timeout = httpx.ReadTimeout(
         "read timeout",
@@ -240,7 +293,10 @@ def test_zero_delivery_timeout_uses_one_primary_recovery_then_fallback():
     agent._try_activate_fallback.assert_called_once()
 
 
-def test_zero_delivery_timeout_attempts_configured_fallback_without_outer_retries():
+def test_zero_delivery_timeout_attempts_configured_fallback_without_outer_retries(
+    caplog: pytest.LogCaptureFixture,
+):
+    caplog.set_level(logging.ERROR, logger="agent.conversation_loop")
     agent = _make_agent()
     agent._api_max_retries = 3
     agent.client = MagicMock()
@@ -250,11 +306,26 @@ def test_zero_delivery_timeout_attempts_configured_fallback_without_outer_retrie
     agent._try_recover_primary_transport = MagicMock(return_value=False)
     agent._has_pending_fallback = MagicMock(return_value=True)
     agent._try_activate_fallback = MagicMock(return_value=False)
+    agent._buffer_status = MagicMock()
+    agent._emit_status = MagicMock()
+    agent._dump_api_request_debug = MagicMock()
 
     result = _run_non_streaming_turn(agent)
 
     assert agent.client.chat.completions.create.call_count == 1
     agent._try_activate_fallback.assert_called_once()
+    agent._buffer_status.assert_called_once_with(
+        "⚠️ Provider timed out before delivering any response — trying fallback..."
+    )
+    agent._emit_status.assert_any_call(
+        "❌ Provider timed out before delivering any response after the "
+        "available recovery options were exhausted."
+    )
+    assert agent._dump_api_request_debug.call_args.kwargs["reason"] == (
+        "zero_delivery_stream_timeout"
+    )
+    assert "zero-delivery stream timeout recovery exhausted" in caplog.text
+    assert "after 3 retries" not in caplog.text
     assert "timed out before delivering any response" in result["final_response"]
     assert "payload may be too large" in result["final_response"]
 


### PR DESCRIPTION
## Summary

When a streaming API call times out before any response event arrives, Hermes can retry the same request in both the stream layer and the outer conversation loop. With the default limits, one provider timeout can expand into up to nine identical attempts (3 stream attempts × 3 outer attempts), producing minutes of silent dead air.

This change detects zero-delivery stream timeouts and routes them directly through Hermes's existing recovery chain instead of amplifying identical retries.

## Reproduction

1. Use a provider that times out while processing a large request/tool schema (for example, Xiaomi MiMo with 50+ tools).
2. Run `hermes chat -q "hello"`.
3. Before this fix, Hermes can repeat the same zero-delivery timeout across both retry layers before surfacing the failure.

## Root Cause

Three behaviors interact:

1. The stream layer retries transient failures internally.
2. The outer conversation loop also retries API failures.
3. A timeout before the first response event was not distinguished from an interrupted stream that had already made progress.

As a result, a provider-side processing timeout with no delivered data could be retried at both layers with the same payload.

## Fix

- Classify OpenAI/Anthropic SDK `APITimeoutError` exceptions and `httpx` read/connect/pool timeouts consistently in the stream layer.
- Track response progress per stream attempt, including metadata, reasoning, text, and tool-call events.
- Mark only timeout exceptions from attempts that delivered no response event; the marker is exception-scoped, so it cannot leak into later turns.
- Skip duplicate stream retries and outer backoff for marked zero-delivery timeouts.
- Preserve one primary transport recovery attempt and the configured fallback-provider chain before failing.
- Keep normal stream-retry behavior after any response progress, including tool-call-only streams with no visible text.
- Emit accurate fallback, terminal status, log, and debug-dump diagnostics instead of claiming that retries ran when they were intentionally skipped.

## Testing

- 102 targeted streaming/timeout tests pass across 7 files.
- Added regression coverage for:
  - OpenAI SDK and `httpx` timeout variants
  - native Anthropic timeout handling
  - text and reasoning progress
  - tool-call-only progress
  - primary transport recovery and fallback routing
  - truthful status/log/debug diagnostics
- `ruff check` passes for all changed files.
- Independent review found no correctness blockers.

## Related

- Mitigates the timeout-amplification symptom described in #71213; the separate v0.19.0 streaming regression remains out of scope.
- Related to #69424 (retry loop behavior for slow backends).
