### PR TITLE
test(cron): skip POSIX mode assertions on Windows

### DIFF
--- a/tests/cron/test_file_permissions.py
+++ b/tests/cron/test_file_permissions.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 
+@unittest.skipIf(os.name == "nt", "POSIX mode bits not enforced on Windows")
 class TestCronFilePermissions(unittest.TestCase):
     """Verify cron files get secure permissions."""
 
@@ -74,6 +75,7 @@ class TestCronFilePermissions(unittest.TestCase):
             self.assertEqual(dir_mode, 0o700)
 
 
+@unittest.skipIf(os.name == "nt", "POSIX mode bits not enforced on Windows")
 class TestConfigFilePermissions(unittest.TestCase):
     """Verify config files get secure permissions."""
 


### PR DESCRIPTION
`tests/cron/test_file_permissions.py` asserts exact POSIX modes (`0o700` / `0o600`). Windows `chmod()` only toggles the read-only bit, so `os.stat()` never reports those values and all six tests in the two permission classes fail on a Windows checkout.

Both classes assert nothing but modes, so they are gated at class level with the same idiom the suite already uses elsewhere: `os.name == "nt"` with reason `POSIX mode bits not enforced on Windows`. `TestSecureHelpers` is untouched and still runs everywhere.

Verified on Windows 11, Python 3.13, cherry-picked onto current main:

- before: 6 failed, 1 passed
- after: 1 passed, 6 skipped

Green ubuntu run for this head: https://github.com/cryptoyasenka/hermes-agent/actions/runs/31056703155

Test only, no source changes. `ruff check` clean.
