### PR TITLE
fix(skills): return POSIX-separated names from normalize_skill_lookup_name

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -632,12 +632,12 @@ def normalize_skill_lookup_name(identifier: str) -> str:
     # an arbitrary absolute path that skill_view() refuses to load.
     for root in trusted_roots:
         try:
-            return str(identifier_path.relative_to(root))
+            return identifier_path.relative_to(root).as_posix()
         except ValueError:
             continue
 
     try:
-        return str(identifier_path.resolve().relative_to(primary_root.resolve()))
+        return identifier_path.resolve().relative_to(primary_root.resolve()).as_posix()
     except Exception:
         logger.debug(
             "Skill identifier %r is an absolute path outside trusted skills "

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from agent.skill_utils import (
     extract_skill_config_vars,
     extract_skill_conditions,
@@ -192,6 +194,19 @@ class TestNormalizeSkillLookupName:
 
         # Relative identifiers early-return before any root lookup.
         assert normalize_skill_lookup_name("foo/bar") == "foo/bar"
+
+
+    def test_absolute_nested_path_uses_posix_separators(self, tmp_path, monkeypatch):
+        from agent.skill_utils import normalize_skill_lookup_name
+
+        skills_dir = tmp_path / "skills"
+        nested = skills_dir / "category" / "my-skill"
+        nested.mkdir(parents=True)
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
+        # Skill names are matched as plain strings everywhere (skills.disabled,
+        # slash commands, the cron skill_name), so a nested skill resolved from
+        # an absolute path has to come back slash-separated on every platform.
+        assert normalize_skill_lookup_name(str(nested)) == "category/my-skill"
 
 
     def test_absolute_via_symlink_uses_lexical_relative_path(self, tmp_path, monkeypatch):


### PR DESCRIPTION
`normalize_skill_lookup_name()` documents its result as a `skill_view()`-safe relative path, and its own test asserts `"category/my-skill"`. On Windows `str(Path.relative_to())` hands back `"category\my-skill"`, so a nested skill resolved from an absolute path stops matching the same skill named anywhere else: `skills.disabled` entries, slash-command names and the `skill_name` stored on cron jobs are all slash-separated.

`as_posix()` keeps the separator stable across platforms and is a no-op on POSIX.

The test module also calls `pytest.skip()` in the symlink fallback without importing `pytest`, so on any platform that cannot create symlinks that test raised `NameError` instead of skipping. Added the import.

`tests/agent/test_skill_utils.py::TestNormalizeSkillLookupName::test_absolute_nested_path_uses_posix_separators` fails before the change and passes after it. `test_absolute_via_symlink_uses_lexical_relative_path` skips on a Windows account without the symlink privilege; the added import is what makes it skip cleanly instead of raising `NameError`.

Verified on Windows 11, Python 3.13, cherry-picked onto current main:

- before: 1 failed, 13 passed, 1 skipped
- after: 14 passed, 1 skipped

Green ubuntu run for this head: https://github.com/cryptoyasenka/hermes-agent/actions/runs/31056704674

`ruff check` clean.
