### PR TITLE
fix(cron): reject repeated one-shot durations

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -661,6 +661,38 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     )
 
 
+def _validate_duration_repeat(
+    schedule: Dict[str, Any], repeat: Optional[int]
+) -> None:
+    """Reject a multi-run repeat count paired with a bare one-shot duration."""
+    if (
+        schedule.get("kind") != "once"
+        or not isinstance(repeat, int)
+        or repeat <= 1
+    ):
+        return
+
+    display = schedule.get("display")
+    match = (
+        re.fullmatch(r"once in\s+(.+)", display, flags=re.IGNORECASE)
+        if isinstance(display, str)
+        else None
+    )
+    if not match:
+        return
+
+    duration = match.group(1).strip()
+    try:
+        parse_duration(duration)
+    except ValueError:
+        return
+
+    raise ValueError(
+        f"Bare duration schedule '{duration}' is one-shot and cannot be combined "
+        f"with repeat={repeat}. Use schedule='every {duration}' for repeated runs."
+    )
+
+
 def _ensure_aware(dt: datetime) -> datetime:
     """Return a timezone-aware datetime in Hermes configured timezone.
 
@@ -1318,6 +1350,7 @@ def create_job(
     # Auto-set repeat=1 for one-shot schedules if not specified
     if parsed_schedule["kind"] == "once" and repeat is None:
         repeat = 1
+    _validate_duration_repeat(parsed_schedule, repeat)
 
     # Default delivery to origin if available, otherwise local
     if deliver is None:
@@ -1533,6 +1566,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
             schedule_changed = "schedule" in updates
+            repeat_changed = "repeat" in updates
             inference_fields_changed = bool(
                 {"provider", "model", "base_url", "no_agent"}.intersection(updates)
             ) and _normalized_inference_axes(updated) != previous_inference_axes
@@ -1542,19 +1576,27 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 updated["skills"] = normalized_skills
                 updated["skill"] = normalized_skills[0] if normalized_skills else None
 
-            if schedule_changed:
+            if schedule_changed or repeat_changed:
                 updated_schedule = updated["schedule"]
                 # The API may pass schedule as a raw string (e.g. "every 10m")
                 # instead of a pre-parsed dict.  Normalize it the same way
                 # create_job() does so downstream code can call .get() safely.
                 if isinstance(updated_schedule, str):
                     updated_schedule = parse_schedule(updated_schedule)
-                    updated["schedule"] = updated_schedule
-                updated["schedule_display"] = updates.get(
-                    "schedule_display",
-                    updated_schedule.get("display", updated.get("schedule_display")),
+                repeat_state = updated.get("repeat")
+                repeat_times = (
+                    repeat_state.get("times")
+                    if isinstance(repeat_state, dict)
+                    else repeat_state
                 )
-                if updated.get("state") != "paused":
+                _validate_duration_repeat(updated_schedule, repeat_times)
+                if schedule_changed:
+                    updated["schedule"] = updated_schedule
+                    updated["schedule_display"] = updates.get(
+                        "schedule_display",
+                        updated_schedule.get("display", updated.get("schedule_display")),
+                    )
+                if schedule_changed and updated.get("state") != "paused":
                     updated_next_run = compute_next_run(updated_schedule)
                     # Same guard as create_job: an UPDATE that sets a one-shot
                     # to a time >ONESHOT_GRACE_SECONDS in the past would store

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -216,6 +216,35 @@ class TestJobCRUD:
         job = create_job(prompt="One-shot", schedule="1h")
         assert job["repeat"]["times"] == 1
 
+    def test_duration_with_multiple_repeats_is_rejected(self, tmp_cron_dir):
+        with pytest.raises(ValueError, match="every 2m"):
+            create_job(prompt="Repeat", schedule="2m", repeat=3)
+
+        assert load_jobs() == []
+
+    def test_load_does_not_revive_completed_duration_repeat_job(self, tmp_cron_dir):
+        job = create_job(prompt="Completed", schedule="every 1m", repeat=3)
+        duration_schedule = parse_schedule("2m")
+        job.update(
+            {
+                "schedule": duration_schedule,
+                "schedule_display": duration_schedule["display"],
+                "repeat": {"times": 3, "completed": 1},
+                "enabled": False,
+                "state": "completed",
+                "next_run_at": None,
+            }
+        )
+        save_jobs([job])
+
+        loaded = load_jobs()[0]
+
+        assert loaded["schedule"] == duration_schedule
+        assert loaded["repeat"] == {"times": 3, "completed": 1}
+        assert loaded["enabled"] is False
+        assert loaded["state"] == "completed"
+        assert loaded["next_run_at"] is None
+
     def test_rejects_stale_past_one_shot_at_creation(self, tmp_cron_dir, monkeypatch):
         now = datetime(2026, 3, 18, 4, 30, 0, tzinfo=timezone.utc)
         monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
@@ -250,6 +279,39 @@ class TestUpdateJob:
         # Verify persisted to disk
         fetched = get_job(job["id"])
         assert fetched["name"] == "New Name"
+
+    def test_update_duration_schedule_with_existing_repeat_is_rejected(self, tmp_cron_dir):
+        job = create_job(prompt="Repeat", schedule="every 1m", repeat=3)
+
+        with pytest.raises(ValueError, match="every 2m"):
+            update_job(job["id"], {"schedule": "2m"})
+
+        fetched = get_job(job["id"])
+        assert fetched is not None
+        assert fetched["schedule"] == job["schedule"]
+        assert fetched["repeat"] == job["repeat"]
+
+    def test_update_repeat_on_duration_schedule_is_rejected(self, tmp_cron_dir):
+        job = create_job(prompt="One shot", schedule="2m")
+
+        with pytest.raises(ValueError, match="every 2m"):
+            update_job(job["id"], {"repeat": 3})
+
+        fetched = get_job(job["id"])
+        assert fetched is not None
+        assert fetched["schedule"] == job["schedule"]
+        assert fetched["repeat"] == job["repeat"]
+
+    def test_update_duration_and_repeat_together_is_rejected(self, tmp_cron_dir):
+        job = create_job(prompt="Recurring", schedule="every 1m")
+
+        with pytest.raises(ValueError, match="every 2m"):
+            update_job(job["id"], {"schedule": "2m", "repeat": 3})
+
+        fetched = get_job(job["id"])
+        assert fetched is not None
+        assert fetched["schedule"] == job["schedule"]
+        assert fetched["repeat"] == job["repeat"]
 
 
 class TestPauseResumeJob:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -973,7 +973,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "schedule": {
                 "type": "string",
-                "description": "REQUIRED for action=create. For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp. Examples: '30m' (every 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (one-shot). You MUST include this field when action=create."
+                "description": "REQUIRED for action=create. For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp. Examples: '30m' (once in 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (one-shot). You MUST include this field when action=create."
             },
             "name": {
                 "type": "string",


### PR DESCRIPTION
## Summary

Reject ambiguous one-shot duration schedules that also request multiple runs.

- Keep bare durations such as `2m` as one-shot delays.
- Reject `repeat > 1` when paired with a bare duration during both create and update operations, with guidance to use `every 2m` instead.
- Leave existing jobs untouched: there is no load-time migration and completed jobs are never re-enabled.
- Correct the cron tool schema example so `30m` is described as a one-shot delay.

## Behavior

- `schedule="2m"` with no repeat (or `repeat=1`) remains a one-shot.
- `schedule="2m", repeat=3` is rejected with guidance to use `schedule="every 2m"`.
- `schedule="every 2m", repeat=3` remains supported and stops after three runs.
- Historical completed jobs remain completed and disabled.

## Validation

- `python -m pytest tests/cron -q` — 378 passed
- `ruff check cron/jobs.py tools/cronjob_tools.py tests/cron/test_jobs.py`
- `python -m py_compile cron/jobs.py tools/cronjob_tools.py tests/cron/test_jobs.py`
- `git diff --check`

Addresses #29392.
