### PR TITLE
feat(telegram): stage static location for next message

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1412,6 +1412,20 @@ display:
 #     base_url: "https://ollama.com/v1"
 
 # =============================================================================
+# Telegram static location pins (optional)
+# =============================================================================
+# Default behavior is "conversational": a static pin is its own agent turn.
+# Opt into "stage_next" to acknowledge the pin without an agent call and attach
+# it once to the next accepted text message from the same sender/chat/topic.
+#
+# gateway:
+#   platforms:
+#     telegram:
+#       extra:
+#         location_pin_mode: stage_next
+#         location_pin_ttl_seconds: 300  # 1–3600 seconds
+
+# =============================================================================
 # Privacy
 # =============================================================================
 # privacy:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8546,8 +8546,17 @@ class TelegramAdapter(BasePlatformAdapter):
         event.text = self._clean_bot_trigger_text(event.text)
         self._attach_staged_location(event)
         await self._cache_replied_media(msg, event)
+        # Group-observation attribution deliberately replaces the sender with
+        # a shared chat/topic source. In stage-next mode, preserve the
+        # sender-scoped key while the original source is still available so
+        # adjacent messages from different users cannot share a text batch.
+        batch_key = (
+            self._text_batch_key(event)
+            if self._location_pin_staging_enabled()
+            else None
+        )
         event = self._apply_telegram_group_observe_attribution(event)
-        self._enqueue_text_event(event)
+        self._enqueue_text_event(event, batch_key=batch_key)
 
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming command messages."""
@@ -8720,7 +8729,12 @@ class TelegramAdapter(BasePlatformAdapter):
             profile=event.source.profile,
         )
 
-    def _enqueue_text_event(self, event: MessageEvent) -> None:
+    def _enqueue_text_event(
+        self,
+        event: MessageEvent,
+        *,
+        batch_key: Optional[str] = None,
+    ) -> None:
         """Buffer a text event and reset the flush timer.
 
         When Telegram splits a long user message into multiple updates,
@@ -8732,7 +8746,7 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.debug("[Telegram] Dropping text batch enqueue after disconnect started")
             return
 
-        key = self._text_batch_key(event)
+        key = batch_key if batch_key is not None else self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
         chunk_len = len(event.text or "")
         if existing is None:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -641,6 +641,7 @@ class TelegramAdapter(BasePlatformAdapter):
     _TEXT_BATCH_FAST_DELAY_S = 0.18
     _TEXT_BATCH_SHORT_LEN = 1024
     _TEXT_BATCH_SHORT_DELAY_S = 0.24
+    _LOCATION_PIN_MAX_PENDING = 1024
 
     @staticmethod
     def _env_float_clamped(
@@ -742,6 +743,12 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        # One pending static pin per Telegram sender/session when the optional
+        # stage-next mode is enabled. Coordinates never cross sender, chat, or
+        # topic boundaries and are discarded on adapter shutdown.
+        self._pending_location_context: Dict[str, tuple[object, float, str]] = {}
+        self._pending_location_expiry_handles: Dict[str, asyncio.TimerHandle] = {}
+        self._pending_location_ack_intents: Dict[str, object] = {}
         self._drop_delayed_deliveries = False
         self._polling_error_task: Optional[asyncio.Task] = None
         self._polling_conflict_count: int = 0
@@ -4103,6 +4110,11 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_photo_batches.clear()
         self._pending_text_batch_tasks.clear()
         self._pending_text_batches.clear()
+        for handle in getattr(self, "_pending_location_expiry_handles", {}).values():
+            handle.cancel()
+        getattr(self, "_pending_location_expiry_handles", {}).clear()
+        getattr(self, "_pending_location_context", {}).clear()
+        getattr(self, "_pending_location_ack_intents", {}).clear()
         if getattr(self, "_polling_error_task", None) is not current_task:
             self._polling_error_task = None
         if getattr(self, "_polling_progress_verifier_task", None) is not current_task:
@@ -8251,7 +8263,13 @@ class TelegramAdapter(BasePlatformAdapter):
         user_id = getattr(from_user, "id", None)
         return bot_id is not None and user_id is not None and bot_id == user_id
 
-    def _should_process_message(self, message: Message, *, is_command: bool = False) -> bool:
+    def _should_process_message(
+        self,
+        message: Message,
+        *,
+        is_command: bool = False,
+        ignore_trigger: bool = False,
+    ) -> bool:
         """Apply Telegram group trigger rules.
 
         DMs remain unrestricted. Group/supergroup messages are accepted when:
@@ -8322,6 +8340,11 @@ class TelegramAdapter(BasePlatformAdapter):
         if allowed and chat_id_str not in allowed:
             return guest_mention
 
+        # Passive attachments may opt out of mention/reply/wake-word triggers
+        # after all authorization, chat, and topic gates above have passed.
+        if ignore_trigger:
+            return True
+
         if guest_mention:
             return True
         if chat_id_str in self._telegram_free_response_chats():
@@ -8373,6 +8396,115 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    def _location_stage_key(self, event: MessageEvent) -> str:
+        """Return a sender-scoped session key for a pending static pin."""
+        return f"{self._text_batch_key(event)}\x1f{event.source.user_id or ''}"
+
+    def _location_pin_staging_enabled(self) -> bool:
+        """Whether static location pins should attach to the next text turn."""
+        mode = str(
+            self.config.extra.get("location_pin_mode", "conversational")
+        ).strip().lower()
+        return mode == "stage_next"
+
+    def _location_pin_ttl_seconds(self) -> float:
+        """Return the bounded lifetime of an unconsumed static pin."""
+        raw = self.config.extra.get("location_pin_ttl_seconds", 300.0)
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            value = 300.0
+        return max(1.0, min(value, 3600.0))
+
+    @staticmethod
+    def _is_static_location_update(update: Update, location: Any) -> bool:
+        """Distinguish deliberate fixed pins from Telegram live telemetry."""
+        if getattr(location, "live_period", None) is not None:
+            return False
+        return not (
+            getattr(update, "edited_message", None)
+            or getattr(update, "edited_channel_post", None)
+        )
+
+    def _is_authorized_for_location_staging(self, event: MessageEvent) -> bool:
+        """Require the gateway's canonical authorization decision before staging."""
+        source = event.source
+        if not source.user_id:
+            logger.warning(
+                "[Telegram] Refusing location staging without stable sender identity"
+            )
+            return False
+        authorized = self._is_sender_authorized(
+            source.user_id,
+            source.chat_type,
+            source.chat_id,
+        )
+        if authorized is None:
+            logger.warning(
+                "[Telegram] Cannot verify canonical authorization for location staging"
+            )
+            return False
+        return authorized
+
+    def _remove_staged_location(self, key: str) -> None:
+        """Remove one staged pin and cancel its active expiry callback."""
+        self._pending_location_context.pop(key, None)
+        handle = self._pending_location_expiry_handles.pop(key, None)
+        if handle is not None:
+            handle.cancel()
+
+    def _expire_staged_location(self, key: str, token: object) -> None:
+        """Discard a pin at its deadline unless a newer pin replaced it."""
+        pending = self._pending_location_context.get(key)
+        if pending is not None and pending[0] is token:
+            self._pending_location_context.pop(key, None)
+            self._pending_location_expiry_handles.pop(key, None)
+            logger.info("[Telegram] Discarded expired staged location pin")
+
+    def _stage_location(self, key: str, location_text: str) -> None:
+        """Store a bounded, actively expiring static location attachment."""
+        if key not in self._pending_location_context and len(
+            self._pending_location_context
+        ) >= self._LOCATION_PIN_MAX_PENDING:
+            oldest_key = min(
+                self._pending_location_context,
+                key=lambda candidate: self._pending_location_context[candidate][1],
+            )
+            self._remove_staged_location(oldest_key)
+            logger.warning("[Telegram] Evicted oldest staged location pin at capacity")
+        self._remove_staged_location(key)
+        token = object()
+        staged_at = time.monotonic()
+        self._pending_location_context[key] = (token, staged_at, location_text)
+        self._pending_location_expiry_handles[key] = (
+            asyncio.get_running_loop().call_later(
+                self._location_pin_ttl_seconds(),
+                self._expire_staged_location,
+                key,
+                token,
+            )
+        )
+
+    def _attach_staged_location(self, event: MessageEvent) -> None:
+        """Consume a fresh staged pin and prepend it to this text request."""
+        if not self._location_pin_staging_enabled():
+            return
+        key = self._location_stage_key(event)
+        pending = self._pending_location_context.get(key)
+        if not pending:
+            return
+        _token, staged_at, location_text = pending
+        self._remove_staged_location(key)
+        if time.monotonic() - staged_at > self._location_pin_ttl_seconds():
+            logger.info("[Telegram] Discarded expired staged location pin")
+            return
+        request_text = event.text or ""
+        event.text = (
+            f"{location_text}\n\n"
+            "[The user's request follows.]\n"
+            f"{request_text}"
+        )
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -8402,6 +8534,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
+        self._attach_staged_location(event)
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
         self._enqueue_text_event(event)
@@ -8440,7 +8573,28 @@ class TelegramAdapter(BasePlatformAdapter):
                 getattr(getattr(msg, "chat", None), "id", None),
             )
             return
-        if not self._should_process_message(msg):
+        stage_candidate = getattr(
+            getattr(msg, "venue", None), "location", None
+        ) or getattr(msg, "location", None)
+        location_event = None
+        stage_static_pin = False
+        if (
+            self._location_pin_staging_enabled()
+            and stage_candidate is not None
+            and self._is_static_location_update(update, stage_candidate)
+        ):
+            location_event = self._build_message_event(
+                msg,
+                MessageType.LOCATION,
+                update_id=update.update_id,
+            )
+            stage_static_pin = self._is_authorized_for_location_staging(
+                location_event
+            )
+        if not self._should_process_message(
+            msg,
+            ignore_trigger=stage_static_pin,
+        ):
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.LOCATION, update_id=update.update_id)
             return
@@ -8468,9 +8622,55 @@ class TelegramAdapter(BasePlatformAdapter):
         parts.append(f"latitude: {lat}")
         parts.append(f"longitude: {lon}")
         parts.append(f"Map: https://www.google.com/maps/search/?api=1&query={lat},{lon}")
-        parts.append("Ask what they'd like to find nearby (restaurants, cafes, etc.) and any preferences.")
 
-        event = self._build_message_event(msg, MessageType.LOCATION, update_id=update.update_id)
+        event = location_event or self._build_message_event(
+            msg,
+            MessageType.LOCATION,
+            update_id=update.update_id,
+        )
+        if stage_static_pin:
+            parts[0] = (
+                "[The user shared this location immediately before the current "
+                "request. Treat it as a location attachment; do not comment on "
+                "the pin itself.]"
+            )
+            location_key = self._location_stage_key(event)
+            ack_intent = object()
+            if (
+                location_key not in self._pending_location_ack_intents
+                and len(self._pending_location_ack_intents)
+                >= self._LOCATION_PIN_MAX_PENDING
+            ):
+                self._pending_location_ack_intents.pop(
+                    next(iter(self._pending_location_ack_intents)),
+                    None,
+                )
+            self._pending_location_ack_intents[location_key] = ack_intent
+            try:
+                await msg.reply_text(
+                    "Location will be attached to your next message."
+                )
+            except Exception as exc:
+                if self._pending_location_ack_intents.get(location_key) is ack_intent:
+                    self._pending_location_ack_intents.pop(location_key, None)
+                logger.warning(
+                    "[Telegram] Location pin acknowledgement failed; pin not staged: %s",
+                    _redact_telegram_error_text(exc),
+                )
+                return
+            if self._pending_location_ack_intents.get(location_key) is not ack_intent:
+                logger.info(
+                    "[Telegram] Skipped superseded static location pin after acknowledgement"
+                )
+                return
+            self._pending_location_ack_intents.pop(location_key, None)
+            self._stage_location(location_key, "\n".join(parts))
+            logger.info(
+                "[Telegram] Staged authorized static location pin for next text request"
+            )
+            return
+
+        parts.append("Ask what they'd like to find nearby (restaurants, cafes, etc.) and any preferences.")
         event.text = "\n".join(parts)
         event = self._apply_telegram_group_observe_attribution(event)
         await self.handle_message(event)
@@ -8488,10 +8688,19 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         from gateway.session import build_session_key
         self._apply_topic_recovery(event)
+        sender_scoped = self._location_pin_staging_enabled()
         return build_session_key(
             event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+            group_sessions_per_user=(
+                True
+                if sender_scoped
+                else self.config.extra.get("group_sessions_per_user", True)
+            ),
+            thread_sessions_per_user=(
+                True
+                if sender_scoped
+                else self.config.extra.get("thread_sessions_per_user", False)
+            ),
             profile=event.source.profile,
         )
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4110,11 +4110,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_photo_batches.clear()
         self._pending_text_batch_tasks.clear()
         self._pending_text_batches.clear()
-        for handle in getattr(self, "_pending_location_expiry_handles", {}).values():
-            handle.cancel()
-        getattr(self, "_pending_location_expiry_handles", {}).clear()
-        getattr(self, "_pending_location_context", {}).clear()
-        getattr(self, "_pending_location_ack_intents", {}).clear()
+        self._clear_pending_location_state()
         if getattr(self, "_polling_error_task", None) is not current_task:
             self._polling_error_task = None
         if getattr(self, "_polling_progress_verifier_task", None) is not current_task:
@@ -4220,6 +4216,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[%s] Error during Telegram disconnect: %s",
                     self.name, _redact_telegram_error_text(e),
                 )
+        # Updater shutdown can race a final location handler after the first
+        # cleanup pass. This authoritative second pass prevents precise pins,
+        # acknowledgement intents, or timer handles from surviving teardown.
+        self._clear_pending_location_state()
         self._release_platform_lock()
 
         self._app = None
@@ -8453,6 +8453,16 @@ class TelegramAdapter(BasePlatformAdapter):
         if handle is not None:
             handle.cancel()
 
+    def _clear_pending_location_state(self) -> None:
+        """Cancel and discard all staged pins and in-flight acknowledgements."""
+        for handle in getattr(
+            self, "_pending_location_expiry_handles", {}
+        ).values():
+            handle.cancel()
+        getattr(self, "_pending_location_expiry_handles", {}).clear()
+        getattr(self, "_pending_location_context", {}).clear()
+        getattr(self, "_pending_location_ack_intents", {}).clear()
+
     def _expire_staged_location(self, key: str, token: object) -> None:
         """Discard a pin at its deadline unless a newer pin replaced it."""
         pending = self._pending_location_context.get(key)
@@ -8566,6 +8576,8 @@ class TelegramAdapter(BasePlatformAdapter):
         msg = self._effective_update_message(update)
         if not msg:
             return
+        if self._should_drop_delayed_delivery():
+            return
         if not self._is_user_authorized_from_message(msg):
             logger.warning(
                 "[Telegram] Blocked unauthorized user %s in chat %s",
@@ -8657,6 +8669,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[Telegram] Location pin acknowledgement failed; pin not staged: %s",
                     _redact_telegram_error_text(exc),
                 )
+                return
+            if self._should_drop_delayed_delivery():
+                if self._pending_location_ack_intents.get(location_key) is ack_intent:
+                    self._pending_location_ack_intents.pop(location_key, None)
                 return
             if self._pending_location_ack_intents.get(location_key) is not ack_intent:
                 logger.info(

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -8,6 +8,44 @@ from gateway.platforms.base import MessageType
 from gateway.session import SessionSource
 
 
+def test_ignore_trigger_bypasses_only_group_trigger_rules():
+    adapter = _make_adapter(
+        require_mention=True,
+        allowed_chats=["-100"],
+    )
+    message = _group_message(chat_id=-100)
+
+    assert adapter._should_process_message(message) is False
+    assert adapter._should_process_message(message, ignore_trigger=True) is True
+
+
+def test_ignore_trigger_preserves_chat_and_topic_access_gates():
+    wrong_chat = _make_adapter(
+        require_mention=True,
+        allowed_chats=["-200"],
+    )
+    ignored_topic = _make_adapter(
+        require_mention=True,
+        allowed_chats=["-100"],
+        ignored_threads=[7],
+    )
+
+    assert (
+        wrong_chat._should_process_message(
+            _group_message(chat_id=-100),
+            ignore_trigger=True,
+        )
+        is False
+    )
+    assert (
+        ignored_topic._should_process_message(
+            _group_message(chat_id=-100, thread_id=7),
+            ignore_trigger=True,
+        )
+        is False
+    )
+
+
 def _make_adapter(
     require_mention=None,
     free_response_chats=None,

--- a/tests/gateway/test_telegram_location_staging.py
+++ b/tests/gateway/test_telegram_location_staging.py
@@ -72,6 +72,7 @@ def _adapter(*, mode: str = "stage_next", ttl: float = 300.0):
                     else None
                 ),
             ),
+            raw_message=msg,
         )
     )
     return adapter
@@ -86,6 +87,7 @@ def _message(
     thread_id=None,
     latitude=12.3456,
     longitude=65.4321,
+    text="message",
 ):
     return SimpleNamespace(
         chat=SimpleNamespace(id=chat_id, type=chat_type),
@@ -97,6 +99,7 @@ def _message(
             longitude=longitude,
             live_period=live_period,
         ),
+        text=text,
         reply_text=AsyncMock(),
     )
 
@@ -476,3 +479,74 @@ def test_stage_mode_text_batches_are_always_sender_scoped():
     )
 
     assert adapter._text_batch_key(alice) != adapter._text_batch_key(bob)
+
+
+@pytest.mark.asyncio
+async def test_stage_mode_observed_group_text_batches_preserve_sender_scope(monkeypatch):
+    adapter = _adapter()
+    adapter._text_batch_key = adapter.__class__._text_batch_key.__get__(adapter)
+    adapter._apply_telegram_group_observe_attribution = (
+        adapter.__class__._apply_telegram_group_observe_attribution.__get__(adapter)
+    )
+    adapter._apply_topic_recovery = lambda event: None
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = 60.0
+    adapter._text_batch_split_delay_seconds = 60.0
+    adapter._clean_bot_trigger_text = lambda text: text
+    adapter._cache_replied_media = AsyncMock()
+    adapter._ensure_forum_commands = AsyncMock()
+    adapter._bot = SimpleNamespace(username="hermes_bot", id=999)
+    adapter.config.extra.update(
+        observe_unmentioned_group_messages=True,
+        group_allowed_chats=["-1001"],
+        group_sessions_per_user=False,
+        thread_sessions_per_user=False,
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.time.monotonic", lambda: 100.0
+    )
+
+    staged_for_alice = _event(
+        "",
+        chat_id="-1001",
+        user_id="2002",
+        chat_type="group",
+    )
+    stage_key = adapter._location_stage_key(staged_for_alice)
+    adapter._pending_location_context[stage_key] = (
+        object(),
+        100.0,
+        "[Alice's staged location]",
+    )
+
+    alice = _message(
+        chat_id=-1001,
+        user_id=2002,
+        chat_type="group",
+        text="Find a cafe nearby",
+    )
+    bob = _message(
+        chat_id=-1001,
+        user_id=3003,
+        chat_type="group",
+        text="What is the weather?",
+    )
+
+    await adapter._handle_text_message(_update(alice), None)
+    await adapter._handle_text_message(_update(bob), None)
+
+    assert len(adapter._pending_text_batches) == 2
+    pending = list(adapter._pending_text_batches.values())
+    assert all(event.source.user_id is None for event in pending)
+    assert sum("Alice's staged location" in (event.text or "") for event in pending) == 1
+    assert not any(
+        "Find a cafe nearby" in (event.text or "")
+        and "What is the weather?" in (event.text or "")
+        for event in pending
+    )
+
+    tasks = list(adapter._pending_text_batch_tasks.values())
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)

--- a/tests/gateway/test_telegram_location_staging.py
+++ b/tests/gateway/test_telegram_location_staging.py
@@ -1,0 +1,438 @@
+"""Tests for opt-in staging of static Telegram location pins."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+
+
+def _event(
+    text: str,
+    *,
+    chat_id: str = "1001",
+    user_id: str = "2002",
+    chat_type: str = "dm",
+    thread_id: str | None = None,
+) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=chat_id,
+            chat_type=chat_type,
+            user_id=user_id,
+            thread_id=thread_id,
+        ),
+    )
+
+
+def _adapter(*, mode: str = "stage_next", ttl: float = 300.0):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.config = PlatformConfig(
+        enabled=True,
+        token="test-token",
+        extra={
+            "location_pin_mode": mode,
+            "location_pin_ttl_seconds": ttl,
+        },
+    )
+    adapter._pending_location_context = {}
+    adapter._pending_location_expiry_handles = {}
+    adapter._pending_location_ack_intents = {}
+    adapter.set_authorization_check(lambda user_id, chat_type, chat_id: True)
+    adapter.handle_message = AsyncMock()
+    adapter._text_batch_key = lambda event: "\x1f".join((
+        str(event.source.chat_id or ""),
+        str(event.source.thread_id or ""),
+    ))
+    adapter._is_user_authorized_from_message = lambda msg: True
+    adapter._should_process_message = lambda msg, **kwargs: True
+    adapter._effective_update_message = lambda update: update.effective_message
+    adapter._apply_telegram_group_observe_attribution = lambda event: event
+    adapter._build_message_event = lambda msg, message_type, update_id=None: (
+        MessageEvent(
+            text="",
+            message_type=message_type,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id=str(msg.chat.id),
+                chat_type=getattr(msg.chat, "type", "dm"),
+                user_id=(str(msg.from_user.id) if msg.from_user is not None else None),
+                thread_id=(
+                    str(msg.message_thread_id)
+                    if getattr(msg, "message_thread_id", None) is not None
+                    else None
+                ),
+            ),
+        )
+    )
+    return adapter
+
+
+def _message(
+    *,
+    live_period=None,
+    chat_id=1001,
+    user_id=2002,
+    chat_type="dm",
+    thread_id=None,
+    latitude=12.3456,
+    longitude=65.4321,
+):
+    return SimpleNamespace(
+        chat=SimpleNamespace(id=chat_id, type=chat_type),
+        from_user=SimpleNamespace(id=user_id),
+        message_thread_id=thread_id,
+        venue=None,
+        location=SimpleNamespace(
+            latitude=latitude,
+            longitude=longitude,
+            live_period=live_period,
+        ),
+        reply_text=AsyncMock(),
+    )
+
+
+def _update(msg, *, edited=False):
+    return SimpleNamespace(
+        effective_message=msg,
+        message=None if edited else msg,
+        edited_message=msg if edited else None,
+        edited_channel_post=None,
+        update_id=77,
+    )
+
+
+@pytest.mark.asyncio
+async def test_static_pin_is_staged_and_acknowledged_without_agent_call(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.time.monotonic", lambda: 100.0
+    )
+    msg = _message()
+
+    await adapter._handle_location_message(_update(msg), None)
+
+    adapter.handle_message.assert_not_called()
+    msg.reply_text.assert_awaited_once_with(
+        "Location will be attached to your next message."
+    )
+    assert len(adapter._pending_location_context) == 1
+
+
+@pytest.mark.asyncio
+async def test_next_text_consumes_staged_pin(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.time.monotonic", lambda: 100.0
+    )
+    await adapter._handle_location_message(_update(_message()), None)
+
+    request = _event("Find a cafe nearby")
+    adapter._attach_staged_location(request)
+
+    assert "Find a cafe nearby" in request.text
+    assert "latitude: 12.3456" in request.text
+    assert "longitude: 65.4321" in request.text
+    assert adapter._pending_location_context == {}
+
+
+@pytest.mark.asyncio
+async def test_staged_pin_expires(monkeypatch):
+    adapter = _adapter(ttl=60.0)
+    clock = {"now": 100.0}
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.time.monotonic",
+        lambda: clock["now"],
+    )
+    await adapter._handle_location_message(_update(_message()), None)
+
+    clock["now"] = 161.0
+    request = _event("What is nearby?")
+    adapter._attach_staged_location(request)
+
+    assert request.text == "What is nearby?"
+    assert adapter._pending_location_context == {}
+
+
+@pytest.mark.asyncio
+async def test_expiry_callback_removes_pin_without_another_message(monkeypatch):
+    adapter = _adapter(ttl=60.0)
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.time.monotonic", lambda: 100.0
+    )
+    await adapter._handle_location_message(_update(_message()), None)
+    key = next(iter(adapter._pending_location_context))
+    token = adapter._pending_location_context[key][0]
+
+    adapter._expire_staged_location(key, token)
+
+    assert adapter._pending_location_context == {}
+    assert adapter._pending_location_expiry_handles == {}
+
+
+def test_stale_expiry_callback_does_not_remove_newer_pin():
+    adapter = _adapter()
+    key = "scope"
+    stale_token = object()
+    newer_token = object()
+    newer_handle = SimpleNamespace(cancel=lambda: None)
+    adapter._pending_location_context[key] = (newer_token, 200.0, "new location")
+    adapter._pending_location_expiry_handles[key] = newer_handle
+
+    adapter._expire_staged_location(key, stale_token)
+
+    assert adapter._pending_location_context[key] == (
+        newer_token,
+        200.0,
+        "new location",
+    )
+    assert adapter._pending_location_expiry_handles[key] is newer_handle
+
+
+@pytest.mark.asyncio
+async def test_staged_pin_is_scoped_by_sender_chat_and_topic(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.time.monotonic", lambda: 100.0
+    )
+    await adapter._handle_location_message(
+        _update(_message(chat_id=-1001, user_id=2002, chat_type="group", thread_id=7)),
+        None,
+    )
+
+    for request in (
+        _event(
+            "Nearby?", chat_id="-1001", user_id="9999", chat_type="group", thread_id="7"
+        ),
+        _event(
+            "Nearby?", chat_id="-2002", user_id="2002", chat_type="group", thread_id="7"
+        ),
+        _event(
+            "Nearby?", chat_id="-1001", user_id="2002", chat_type="group", thread_id="8"
+        ),
+    ):
+        adapter._attach_staged_location(request)
+        assert request.text == "Nearby?"
+
+    matching = _event(
+        "Nearby?",
+        chat_id="-1001",
+        user_id="2002",
+        chat_type="group",
+        thread_id="7",
+    )
+    adapter._attach_staged_location(matching)
+    assert "latitude: 12.3456" in matching.text
+    assert adapter._pending_location_context == {}
+
+
+@pytest.mark.asyncio
+async def test_stage_mode_accepts_authorized_group_pin_without_mention(monkeypatch):
+    adapter = _adapter()
+    adapter._should_process_message = lambda msg, **kwargs: bool(
+        kwargs.get("ignore_trigger")
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.time.monotonic", lambda: 100.0
+    )
+    msg = _message(chat_id=-1001, chat_type="group")
+
+    await adapter._handle_location_message(_update(msg), None)
+
+    adapter.handle_message.assert_not_called()
+    msg.reply_text.assert_awaited_once()
+    assert len(adapter._pending_location_context) == 1
+
+
+@pytest.mark.asyncio
+async def test_default_mode_preserves_conversational_pin_behavior():
+    adapter = _adapter(mode="conversational")
+    msg = _message()
+
+    await adapter._handle_location_message(_update(msg), None)
+
+    msg.reply_text.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert "latitude: 12.3456" in event.text
+    assert "Ask what they'd like to find nearby" in event.text
+    assert adapter._pending_location_context == {}
+
+
+@pytest.mark.asyncio
+async def test_unpaired_sender_is_not_staged_or_acknowledged():
+    adapter = _adapter()
+    adapter.set_authorization_check(lambda user_id, chat_type, chat_id: False)
+    msg = _message()
+
+    await adapter._handle_location_message(_update(msg), None)
+
+    msg.reply_text.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    assert adapter._pending_location_context == {}
+
+
+@pytest.mark.asyncio
+async def test_identityless_group_sender_is_not_staged_or_acknowledged():
+    adapter = _adapter()
+    msg = _message(chat_id=-1001, chat_type="group")
+    msg.from_user = None
+    msg.sender_chat = SimpleNamespace(id=-2002)
+
+    await adapter._handle_location_message(_update(msg), None)
+
+    msg.reply_text.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    assert adapter._pending_location_context == {}
+
+
+def test_multiplex_profile_authorization_callback_is_supported():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._is_user_authorized = lambda source: source.profile == "secondary"
+    callback = runner._make_adapter_auth_check(
+        Platform.TELEGRAM,
+        profile_name="secondary",
+    )
+    adapter = _adapter()
+    adapter.set_authorization_check(callback)
+
+    assert adapter._is_authorized_for_location_staging(_event("")) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("edited", [False, True])
+async def test_live_location_updates_remain_conversational_in_stage_mode(edited):
+    adapter = _adapter()
+    msg = _message(live_period=900)
+
+    await adapter._handle_location_message(_update(msg, edited=edited), None)
+
+    msg.reply_text.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    assert adapter._pending_location_context == {}
+
+
+@pytest.mark.asyncio
+async def test_acknowledgement_failure_rolls_back_staged_pin(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.time.monotonic", lambda: 100.0
+    )
+    msg = _message()
+    msg.reply_text.side_effect = RuntimeError("transport unavailable")
+
+    await adapter._handle_location_message(_update(msg), None)
+
+    assert adapter._pending_location_context == {}
+    assert adapter._pending_location_expiry_handles == {}
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pin_is_not_staged_until_acknowledgement_succeeds():
+    adapter = _adapter()
+    ack_started = asyncio.Event()
+    release_ack = asyncio.Event()
+    msg = _message()
+
+    async def delayed_ack(*args, **kwargs):
+        ack_started.set()
+        await release_ack.wait()
+
+    msg.reply_text.side_effect = delayed_ack
+    task = asyncio.create_task(adapter._handle_location_message(_update(msg), None))
+    await ack_started.wait()
+    assert adapter._pending_location_context == {}
+
+    release_ack.set()
+    await task
+    assert len(adapter._pending_location_context) == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_delayed_ack_does_not_remove_newer_pin():
+    adapter = _adapter()
+    ack_started = asyncio.Event()
+    release_ack = asyncio.Event()
+    older = _message()
+    newer = _message()
+
+    async def delayed_failure(*args, **kwargs):
+        ack_started.set()
+        await release_ack.wait()
+        raise RuntimeError("transport unavailable")
+
+    older.reply_text.side_effect = delayed_failure
+    older_task = asyncio.create_task(
+        adapter._handle_location_message(_update(older), None)
+    )
+    await ack_started.wait()
+    await adapter._handle_location_message(_update(newer), None)
+    newer_pending = dict(adapter._pending_location_context)
+
+    release_ack.set()
+    await older_task
+    assert adapter._pending_location_context == newer_pending
+
+
+@pytest.mark.asyncio
+async def test_delayed_older_ack_cannot_replace_newer_pin():
+    adapter = _adapter()
+    ack_started = asyncio.Event()
+    release_ack = asyncio.Event()
+    older = _message(latitude=11.1111, longitude=22.2222)
+    newer = _message(latitude=88.8888, longitude=99.9999)
+
+    async def delayed_success(*args, **kwargs):
+        ack_started.set()
+        await release_ack.wait()
+
+    older.reply_text.side_effect = delayed_success
+    older_task = asyncio.create_task(
+        adapter._handle_location_message(_update(older), None)
+    )
+    await ack_started.wait()
+    await adapter._handle_location_message(_update(newer), None)
+
+    release_ack.set()
+    await older_task
+    pending_text = next(iter(adapter._pending_location_context.values()))[2]
+    assert "latitude: 88.8888" in pending_text
+    assert "latitude: 11.1111" not in pending_text
+
+
+def test_stage_mode_text_batches_are_always_sender_scoped():
+    adapter = _adapter()
+    adapter._text_batch_key = adapter.__class__._text_batch_key.__get__(adapter)
+    adapter._apply_topic_recovery = lambda event: None
+    adapter.config.extra.update(
+        group_sessions_per_user=False,
+        thread_sessions_per_user=False,
+    )
+
+    alice = _event(
+        "first",
+        chat_id="-1001",
+        user_id="2002",
+        chat_type="forum",
+        thread_id="7",
+    )
+    bob = _event(
+        "second",
+        chat_id="-1001",
+        user_id="3003",
+        chat_type="forum",
+        thread_id="7",
+    )
+
+    assert adapter._text_batch_key(alice) != adapter._text_batch_key(bob)

--- a/tests/gateway/test_telegram_location_staging.py
+++ b/tests/gateway/test_telegram_location_staging.py
@@ -53,6 +53,7 @@ def _adapter(*, mode: str = "stage_next", ttl: float = 300.0):
         str(event.source.thread_id or ""),
     ))
     adapter._is_user_authorized_from_message = lambda msg: True
+    adapter._should_drop_delayed_delivery = lambda: False
     adapter._should_process_message = lambda msg, **kwargs: True
     adapter._effective_update_message = lambda update: update.effective_message
     adapter._apply_telegram_group_observe_attribution = lambda event: event
@@ -409,6 +410,45 @@ async def test_delayed_older_ack_cannot_replace_newer_pin():
     pending_text = next(iter(adapter._pending_location_context.values()))[2]
     assert "latitude: 88.8888" in pending_text
     assert "latitude: 11.1111" not in pending_text
+
+
+@pytest.mark.asyncio
+async def test_location_pin_is_dropped_after_disconnect_fence():
+    adapter = _adapter()
+    adapter._should_drop_delayed_delivery = lambda: True
+    msg = _message()
+
+    await adapter._handle_location_message(_update(msg), None)
+
+    msg.reply_text.assert_not_awaited()
+    assert adapter._pending_location_context == {}
+    assert adapter._pending_location_ack_intents == {}
+    assert adapter._pending_location_expiry_handles == {}
+
+
+@pytest.mark.asyncio
+async def test_disconnect_during_ack_does_not_stage_location():
+    adapter = _adapter()
+    disconnecting = False
+    adapter._should_drop_delayed_delivery = lambda: disconnecting
+    ack_started = asyncio.Event()
+    release_ack = asyncio.Event()
+    msg = _message()
+
+    async def delayed_ack(*args, **kwargs):
+        ack_started.set()
+        await release_ack.wait()
+
+    msg.reply_text.side_effect = delayed_ack
+    task = asyncio.create_task(adapter._handle_location_message(_update(msg), None))
+    await ack_started.wait()
+    disconnecting = True
+    release_ack.set()
+    await task
+
+    assert adapter._pending_location_context == {}
+    assert adapter._pending_location_ack_intents == {}
+    assert adapter._pending_location_expiry_handles == {}
 
 
 def test_stage_mode_text_batches_are_always_sender_scoped():

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -194,6 +194,40 @@ hermes gateway
 
 The bot should come online within seconds. Send it a message on Telegram to verify.
 
+### Attach a static location pin to the next message (Optional)
+
+By default, a Telegram location pin is handled as its own conversational
+message. To treat a deliberate, one-time pin as context for the text message
+you are about to send, enable `stage_next`:
+
+```yaml
+gateway:
+  platforms:
+    telegram:
+      extra:
+        location_pin_mode: stage_next
+        location_pin_ttl_seconds: 300
+```
+
+With this opt-in mode:
+
+1. Hermes validates the static pin and sender with the gateway's normal
+   authorization rules.
+2. Hermes replies `Location will be attached to your next message.` without
+   invoking the agent for the pin itself. The pin is held in memory only after
+   that acknowledgement succeeds.
+3. The next normally accepted text message from the same sender, chat, and
+   forum topic receives the location context.
+4. The pin is consumed once, or discarded after the configured lifetime.
+
+The lifetime defaults to 300 seconds and is clamped to 1–3600 seconds. Static
+pins can be staged in DMs and authorized groups without an `@mention`, but the
+following text request must still pass the group's normal trigger rules. Pins
+without a stable Telegram sender identity (for example, anonymous sender-chat
+posts) are not staged and continue through normal message gating. Live
+location updates and edited location messages keep their existing behavior;
+this option only changes deliberate one-time pins and venues.
+
 ## Sending Generated Files from Docker-backed Terminals
 
 If your terminal backend is `docker`, keep in mind that Telegram attachments are


### PR DESCRIPTION
## What does this PR do?

Adds an entirely opt-in Telegram interaction for attaching a deliberate static location pin or venue to the user's next text message.

When `location_pin_mode: stage_next` is enabled, Hermes validates the sender with the gateway's canonical authorization path, sends a deterministic acknowledgement without invoking the agent, and keeps the pin in bounded in-memory state only after that acknowledgement succeeds. The next accepted text from the same sender/chat/topic consumes the location once; otherwise active cleanup removes it after the configured TTL.

The default remains `conversational`, so existing installations do not change behavior.

This is intentionally separate from live/background-location work such as #66280: this PR handles deliberate one-time static pins and venues only. Live-location and edited-location updates retain their existing conversational behavior.

## Related Issue

Related: #49806 (live-location handling, distinct scope)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added opt-in `location_pin_mode: stage_next` and bounded `location_pin_ttl_seconds` handling in `plugins/platforms/telegram/adapter.py`.
- Reused the gateway-installed canonical authorization callback, including pairing and multiplex-profile scoping, before retaining coordinates.
- Isolated pending pins and text batches by sender, chat, and topic; identity-less sender-chat posts are never staged.
- Added deterministic adapter acknowledgement, one-use consumption, active TTL deletion, bounded pending state, replacement/concurrency tokens, and shutdown cleanup.
- Kept static pins distinct from edited/live-location updates and preserved the default conversational path.
- Added focused staging, authorization, batching, expiry, acknowledgement-failure, concurrency, and hard-gate coverage.
- Documented the opt-in configuration in the Telegram guide and `cli-config.yaml.example`.

## How to Test

1. Configure Telegram with:
   ```yaml
   gateway:
     platforms:
       telegram:
         extra:
           location_pin_mode: stage_next
           location_pin_ttl_seconds: 300
   ```
2. Send an authorized static Telegram location pin, verify the deterministic acknowledgement, then send a text request and verify the location is attached once.
3. Run:
   ```bash
   scripts/run_tests.sh tests/gateway/test_telegram_*.py -q
   ```
   Result locally: **1,547 passed, 0 failed** across all 51 Telegram test files.
4. Run Ruff checks, Python bytecode compilation, and `git diff --check` on the changed Python files.

A full repository comparison was run with the CI-parity wrapper on both the PR
head and a separate clean worktree at the PR's upstream base:

```text
PR head ff26d60e6:       scripts/run_tests.sh -q → 23 failures in 12 files
clean main 07e97d2f5:    scripts/run_tests.sh -q → all of those same 23 tests also failed
```

There were **no PR-only full-suite failures**. The clean `main` run had additional
baseline-only failures (its runner summary reported 24 failures in 13 files), and
both runs also reported the same `tests/agent/test_context_compressor.py`
collection/import problem. The shared failures are baseline environment,
live-system, platform-specific, or CUA-related; all 1,547 Telegram tests are
green on the PR branch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (full suite attempted; baseline environment failures noted above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A)

## Screenshots / Logs

Not applicable; behavior is covered by deterministic adapter tests and the Telegram regression suite.
