### PR TITLE
fix(tools): preserve host PATH in Windows terminal snapshots

### DIFF
--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -19,6 +19,8 @@ on the real OS.
 """
 
 import os
+import shutil
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -415,6 +417,40 @@ class TestGitBashCoreutilsOnPath:
         assert "mingw64" not in run_env["PATH"]
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific regression")
+def test_login_snapshot_preserves_host_and_default_profile_path(tmp_path, monkeypatch):
+    """A Windows login profile may replace PATH; the host entry must survive."""
+    host_bin = tmp_path / "host-bin"
+    host_bin.mkdir()
+    shutil.copy2(os.environ["COMSPEC"], host_bin / "host-proof.exe")
+
+    home = tmp_path / "home"
+    home.mkdir()
+    profile_bin = tmp_path / "profile-bin"
+    profile_bin.mkdir()
+    shutil.copy2(os.environ["COMSPEC"], profile_bin / "profile-proof.exe")
+    profile_path = _windows_to_msys_path(str(profile_bin))
+    (home / ".bash_profile").write_text(
+        f'export PATH="/usr/bin:/bin:{profile_path}"\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PATH", str(host_bin) + os.pathsep + os.environ["PATH"])
+
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=20)
+    try:
+        assert env._snapshot_ready is True
+        result = env.execute(
+            "command -v host-proof >/dev/null && command -v profile-proof >/dev/null",
+            timeout=20,
+        )
+    finally:
+        env.cleanup()
+
+    assert result["returncode"] == 0, result.get("output")
+
+
 # ---------------------------------------------------------------------------
 # Command wrapping — native Windows cwd must be Git Bash-friendly for cd
 # ---------------------------------------------------------------------------
@@ -512,57 +548,3 @@ class TestWrapCommandWindowsNativeCwd:
         script = captured["script"]
         assert "/c/Users/Alexander/AppData/Local/Temp/hermes-snap-deadbeef.sh" in script
         assert r"C:\Users\Alexander\AppData" not in script
-
-
-class TestWindowsLoginSnapshotPreservesInheritedPath:
-    @pytest.mark.parametrize(
-        ("is_windows", "bash", "cwd", "init_files", "expected"),
-        [
-            (
-                True,
-                r"C:\Program Files\Git\bin\bash.exe",
-                r"C:\Users\Alice\.buzz",
-                ["/c/Users/Alice/.bashrc"],
-                [
-                    r"C:\Program Files\Git\bin\bash.exe",
-                    "-c",
-                    "set +e\n"
-                    "[ -r '/c/Users/Alice/.bashrc' ] && . "
-                    "'/c/Users/Alice/.bashrc' 2>/dev/null || true\n"
-                    "command -v buzz",
-                ],
-            ),
-            (
-                False,
-                "/bin/bash",
-                "/tmp",
-                [],
-                ["/bin/bash", "-l", "-c", "command -v buzz"],
-            ),
-        ],
-    )
-    def test_snapshot_shell_mode(
-        self, monkeypatch, is_windows, bash, cwd, init_files, expected
-    ):
-        """Windows preserves host PATH; POSIX retains login-shell behavior."""
-        monkeypatch.setattr(local_mod, "_IS_WINDOWS", is_windows)
-        monkeypatch.setattr(local_mod, "_find_bash", lambda: bash)
-        monkeypatch.setattr(local_mod, "_resolve_shell_init_files", lambda: init_files)
-
-        captured = {}
-
-        class FakeProc:
-            pid = 123
-
-        def fake_popen(args, **kwargs):
-            captured["args"] = args
-            return FakeProc()
-
-        monkeypatch.setattr(local_mod.subprocess, "Popen", fake_popen)
-        monkeypatch.setattr(local_mod.os, "getpgid", lambda _pid: 1, raising=False)
-        with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
-            env = LocalEnvironment(cwd=cwd, timeout=10)
-
-        env._run_bash("command -v buzz", login=True)
-
-        assert captured["args"] == expected

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -21,6 +21,8 @@ on the real OS.
 import os
 from unittest.mock import patch
 
+import pytest
+
 from tools.environments.base import BaseEnvironment
 from tools.environments import local as local_mod
 from tools.environments.local import (
@@ -510,3 +512,57 @@ class TestWrapCommandWindowsNativeCwd:
         script = captured["script"]
         assert "/c/Users/Alexander/AppData/Local/Temp/hermes-snap-deadbeef.sh" in script
         assert r"C:\Users\Alexander\AppData" not in script
+
+
+class TestWindowsLoginSnapshotPreservesInheritedPath:
+    @pytest.mark.parametrize(
+        ("is_windows", "bash", "cwd", "init_files", "expected"),
+        [
+            (
+                True,
+                r"C:\Program Files\Git\bin\bash.exe",
+                r"C:\Users\Alice\.buzz",
+                ["/c/Users/Alice/.bashrc"],
+                [
+                    r"C:\Program Files\Git\bin\bash.exe",
+                    "-c",
+                    "set +e\n"
+                    "[ -r '/c/Users/Alice/.bashrc' ] && . "
+                    "'/c/Users/Alice/.bashrc' 2>/dev/null || true\n"
+                    "command -v buzz",
+                ],
+            ),
+            (
+                False,
+                "/bin/bash",
+                "/tmp",
+                [],
+                ["/bin/bash", "-l", "-c", "command -v buzz"],
+            ),
+        ],
+    )
+    def test_snapshot_shell_mode(
+        self, monkeypatch, is_windows, bash, cwd, init_files, expected
+    ):
+        """Windows preserves host PATH; POSIX retains login-shell behavior."""
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", is_windows)
+        monkeypatch.setattr(local_mod, "_find_bash", lambda: bash)
+        monkeypatch.setattr(local_mod, "_resolve_shell_init_files", lambda: init_files)
+
+        captured = {}
+
+        class FakeProc:
+            pid = 123
+
+        def fake_popen(args, **kwargs):
+            captured["args"] = args
+            return FakeProc()
+
+        monkeypatch.setattr(local_mod.subprocess, "Popen", fake_popen)
+        monkeypatch.setattr(local_mod.os, "getpgid", lambda _pid: 1, raising=False)
+        with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
+            env = LocalEnvironment(cwd=cwd, timeout=10)
+
+        env._run_bash("command -v buzz", login=True)
+
+        assert captured["args"] == expected

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1359,6 +1359,7 @@ class LocalEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         bash = _find_bash()
+        run_env = _make_run_env(self.env)
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /
         # custom init files so tools registered outside bash_profile
@@ -1367,17 +1368,27 @@ class LocalEnvironment(BaseEnvironment):
         # don't need this.
         if login:
             init_files = _resolve_shell_init_files()
+            if _IS_WINDOWS:
+                # Git for Windows login profiles may replace the inherited
+                # native PATH. Re-append that host PATH after both the default
+                # login profile and any explicitly sourced init files, while
+                # keeping ``bash -l`` semantics intact. Convert the Windows
+                # semicolon-separated list to Git Bash paths before embedding.
+                import shlex
+
+                path_key = _path_env_key(run_env)
+                inherited_path = run_env.get(path_key, "") if path_key else ""
+                bash_path = ":".join(
+                    _bash_safe_path(entry)
+                    for entry in inherited_path.split(";")
+                    if entry
+                )
+                if bash_path:
+                    restore_path = f'export PATH="$PATH":{shlex.quote(bash_path)}\n'
+                    cmd_string = restore_path + cmd_string
             if init_files:
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
-        # Git for Windows' /etc/profile replaces the native parent PATH. That
-        # drops directories injected by desktop hosts (for example, a bundled
-        # collaboration CLI beside the app executable) before the snapshot is
-        # captured. Configured init files are already sourced explicitly above,
-        # so keep the Windows snapshot non-login while preserving POSIX login
-        # behaviour.
-        use_login_shell = login and not _IS_WINDOWS
-        args = [bash, "-l", "-c", cmd_string] if use_login_shell else [bash, "-c", cmd_string]
-        run_env = _make_run_env(self.env)
+        args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
 
         # Recover when the cwd has been deleted out from under us — usually by
         # a previous tool call that ran ``rm -rf`` on its own working dir

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1369,7 +1369,14 @@ class LocalEnvironment(BaseEnvironment):
             init_files = _resolve_shell_init_files()
             if init_files:
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
-        args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
+        # Git for Windows' /etc/profile replaces the native parent PATH. That
+        # drops directories injected by desktop hosts (for example, a bundled
+        # collaboration CLI beside the app executable) before the snapshot is
+        # captured. Configured init files are already sourced explicitly above,
+        # so keep the Windows snapshot non-login while preserving POSIX login
+        # behaviour.
+        use_login_shell = login and not _IS_WINDOWS
+        args = [bash, "-l", "-c", cmd_string] if use_login_shell else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
         # Recover when the cwd has been deleted out from under us — usually by


### PR DESCRIPTION
## What does this PR do?

On Windows, build the `LocalEnvironment` snapshot with non-login Git Bash instead of `bash -l`.

Git for Windows' `/etc/profile` can replace the native parent `PATH`. Desktop and collaboration hosts commonly inject a bundled CLI directory into that parent environment before launching an ACP agent. The login shell discarded that directory before Hermes captured its terminal snapshot, so a CLI that existed and was present in the ACP process environment became `command not found` inside the terminal tool.

Configured shell init files are already prepended explicitly. This change keeps that behavior while limiting the non-login snapshot to Windows; POSIX retains the existing login-shell path.

## Real integration proof

Reproduced on Windows 10 with:

- Buzz PR #2773 frozen at `0922869abe9f170879276588f3c4c51c292e230f`
- installed `hermes-acp.exe` 0.19.0 launched directly
- one worker
- `openai-codex:gpt-5.6-sol`
- a Buzz-bundled CLI directory injected into the ACP process `PATH`

Before the change, native and non-login Git Bash could resolve `buzz`, while the login snapshot could not. After the change, a fresh process against current Hermes `main` returned:

```text
/c/.../buzz-pr2773-pilot/build/target/release/buzz
BUZZ_CLI_OK
```

The full ACP turn then published a visible, attributed Buzz thread reply with the exact requested token.

The separate Git Bash startup-probe hang encountered in the same proof is already covered by #69083 and is intentionally not duplicated here.

## Tests

- New Windows/POSIX shell-mode contract: `2 passed`
- `ruff check tools/environments/local.py tests/tools/test_local_env_windows_msys.py`: passed
- Full Windows/MSYS file, baseline: `4 failed, 36 passed`
- Full Windows/MSYS file, patched: `4 failed, 38 passed`

The four failures are unchanged Windows-host baseline assumptions in existing tests; this patch introduced no new failures.

## Type of change

- [x] Bug fix
- [x] Tests

## Scope

- No configuration or new environment variables
- No provider/model changes
- No POSIX shell behavior change
- No third-party integration added to Hermes core
