### PR TITLE
fix(computer_use): revive ended cua-driver sessions once

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1556,6 +1556,7 @@ class TestCuaDriverSessionReconnect:
         session._shutdown_event = None
         session._lifecycle_future = None
         session._setup_error = None
+        session._declared_session_id = None
         session._call_tool_async = lambda name, args: ("call", name, args)
         # Record what reconnect does — stop then start, in that order.
         session._reconnect_log = []
@@ -1589,6 +1590,152 @@ class TestCuaDriverSessionReconnect:
         assert session._reconnect_log == ["stop", "start"]
         assert bridge.calls[1][0] == ("call", "list_apps", {})
         assert len(bridge.calls) == 2
+
+    def test_reconnect_retry_can_revive_ended_session(self):
+        """A reconnect result may still require reviving the declared session."""
+        from anyio import ClosedResourceError
+
+        ended = {
+            "data": "session 'hermes-test' has ended; call start_session to revive it",
+            "images": [],
+            "structuredContent": None,
+            "isError": True,
+        }
+        revived = {"data": "revived", "isError": False}
+        windows = {
+            "data": "",
+            "structuredContent": {"windows": []},
+            "isError": False,
+        }
+
+        class FakeBridge:
+            def __init__(self):
+                self.calls = []
+                self.effects = [
+                    ClosedResourceError(),
+                    ended,
+                    revived,
+                    windows,
+                ]
+
+            def run(self, value, timeout=None):
+                self.calls.append((value, timeout))
+                effect = self.effects.pop(0)
+                if isinstance(effect, Exception):
+                    raise effect
+                return effect
+
+        bridge = FakeBridge()
+        session = self._make_session(bridge)
+        session._declared_session_id = "hermes-test"
+
+        result = session.call_tool(
+            "list_windows", {"session": "hermes-test"}
+        )
+
+        assert result is windows
+        assert session._reconnect_log == ["stop", "start"]
+        assert [call[0] for call in bridge.calls] == [
+            ("call", "list_windows", {"session": "hermes-test"}),
+            ("call", "list_windows", {"session": "hermes-test"}),
+            ("call", "start_session", {"session": "hermes-test"}),
+            ("call", "list_windows", {"session": "hermes-test"}),
+        ]
+
+    def test_call_tool_revives_ended_session_then_retries_once(self):
+        """Logical ended-session errors revive the same id before one replay."""
+        ended = {
+            "data": (
+                "session 'hermes-test' has ended; tool call 'list_windows' "
+                "was rejected. Call start_session with this id to revive it."
+            ),
+            "images": [],
+            "structuredContent": None,
+            "isError": True,
+        }
+        ok = {"data": "revived", "images": [], "structuredContent": None, "isError": False}
+        windows = {
+            "data": "",
+            "images": [],
+            "structuredContent": {"windows": [{"pid": 1, "window_id": 2}]},
+            "isError": False,
+        }
+
+        class FakeBridge:
+            def __init__(self):
+                self.calls = []
+                self.effects = [ended, ok, windows]
+
+            def run(self, value, timeout=None):
+                self.calls.append((value, timeout))
+                return self.effects.pop(0)
+
+        bridge = FakeBridge()
+        session = self._make_session(bridge)
+        session._declared_session_id = "hermes-test"
+
+        result = session.call_tool(
+            "list_windows", {"on_screen_only": True, "session": "hermes-test"}
+        )
+
+        assert result is windows
+        assert [call[0] for call in bridge.calls] == [
+            ("call", "list_windows", {"on_screen_only": True, "session": "hermes-test"}),
+            ("call", "start_session", {"session": "hermes-test"}),
+            ("call", "list_windows", {"on_screen_only": True, "session": "hermes-test"}),
+        ]
+
+    def test_call_tool_does_not_loop_when_retry_is_still_ended(self):
+        """A repeated ended-session result is surfaced after one revival."""
+        ended = {
+            "data": "session 'hermes-test' has ended; call start_session to revive it",
+            "images": [],
+            "structuredContent": None,
+            "isError": True,
+        }
+
+        class FakeBridge:
+            def __init__(self):
+                self.calls = []
+                self.effects = [ended, {"isError": False}, ended]
+
+            def run(self, value, timeout=None):
+                self.calls.append((value, timeout))
+                return self.effects.pop(0)
+
+        bridge = FakeBridge()
+        session = self._make_session(bridge)
+        session._declared_session_id = "hermes-test"
+
+        result = session.call_tool("list_windows", {"session": "hermes-test"})
+
+        assert result is ended
+        assert len(bridge.calls) == 3
+
+    def test_lifecycle_call_does_not_try_to_revive_itself(self):
+        """start_session failures stay single-shot and cannot recurse."""
+        ended = {
+            "data": "session 'hermes-test' has ended; call start_session to revive it",
+            "images": [],
+            "structuredContent": None,
+            "isError": True,
+        }
+
+        class FakeBridge:
+            def __init__(self):
+                self.calls = []
+
+            def run(self, value, timeout=None):
+                self.calls.append((value, timeout))
+                return ended
+
+        bridge = FakeBridge()
+        session = self._make_session(bridge)
+
+        result = session.call_tool("start_session", {"session": "hermes-test"})
+
+        assert result is ended
+        assert len(bridge.calls) == 1
 
     def test_call_tool_does_not_retry_on_unrelated_error(self):
         """Non-transport errors must propagate without a reconnect attempt."""

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -901,6 +901,10 @@ class _CuaDriverSession:
         self._shutdown_event: Optional[asyncio.Event] = None  # created on bridge loop
         self._lifecycle_future = None  # concurrent.futures.Future
         self._setup_error: Optional[BaseException] = None
+        # Stable driver-side identity declared through start_session.
+        # Used to revive a logical ended-session rejection without
+        # recursive call_tool re-entry or backend-owned state (#71166).
+        self._declared_session_id: Optional[str] = None
 
     def _require_started(self) -> None:
         if not self._started:
@@ -1162,6 +1166,67 @@ class _CuaDriverSession:
         return self._capability_version
 
     @staticmethod
+    def _logical_error_text(result: Dict[str, Any]) -> str:
+        """Flatten a logical MCP error into text for narrow classification."""
+        chunks: List[str] = []
+        for value in (result.get("data"), result.get("structuredContent")):
+            if isinstance(value, str):
+                chunks.append(value)
+            elif value is not None:
+                try:
+                    chunks.append(json.dumps(value, sort_keys=True))
+                except (TypeError, ValueError):
+                    chunks.append(str(value))
+        return "\n".join(chunks)
+
+    @classmethod
+    def _is_ended_session_result(cls, result: Any) -> bool:
+        """Recognise cua-driver's explicit recoverable ended-session result."""
+        if not isinstance(result, dict) or result.get("isError") is not True:
+            return False
+        message = cls._logical_error_text(result).lower()
+        return (
+            "session" in message
+            and ("has ended" in message or "session ended" in message)
+            and "start_session" in message
+        )
+
+    def _revive_declared_session_once(
+        self,
+        name: str,
+        args: Dict[str, Any],
+        first_result: Dict[str, Any],
+        timeout: float,
+    ) -> Dict[str, Any]:
+        """Revive the stable session and replay one rejected tool call once."""
+        session_id = self._declared_session_id
+        if not session_id or name in self._LIFECYCLE_CALLS:
+            return first_result
+
+        logger.warning(
+            "cua-driver session %s ended during %s; reviving and retrying once",
+            session_id,
+            name,
+        )
+        revive_result = self._bridge.run(
+            self._call_tool_async("start_session", {"session": session_id}),
+            timeout=timeout,
+        )
+        if revive_result.get("isError") is True:
+            logger.warning(
+                "cua-driver session %s could not be revived: %s",
+                session_id,
+                self._logical_error_text(revive_result),
+            )
+            return first_result
+
+        # Return the second result as-is. A second rejection is surfaced; no loop.
+        return self._bridge.run(
+            self._call_tool_async(name, args),
+            timeout=timeout,
+        )
+
+    @staticmethod
     def _is_closed_session_error(exc: Exception) -> bool:
         """Return True for MCP/stdio failures that are recoverable by reconnecting."""
         name = exc.__class__.__name__
@@ -1339,28 +1404,19 @@ class _CuaDriverSession:
 
     def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0) -> Dict[str, Any]:
         # A prior session may have died (MCP drop / driver crash): its
-        # lifecycle coro reset _started to False in its finally (#55048
-        # Bug 1). Re-enter start() so we rebuild the session instead of
-        # calling _require_started() straight into a "not started" raise or
-        # a None session. start() is idempotent when already started. Skip
-        # this for the start_session/end_session handshake, which start()/
-        # stop() drive directly while _started is still in flux.
+        # lifecycle coro reset _started to False in its finally (#55048).
         if not self._started and name not in self._LIFECYCLE_CALLS:
             logger.warning(
                 "cua-driver session not active on %s; (re)starting before call", name
             )
             self.start()
         self._require_started()
-        # The cua-driver daemon proxy returns POSIX EAGAIN ("Resource
-        # temporarily unavailable") for heavier calls like get_window_state when
-        # its non-blocking socket buffer is full. On some machines/builds this
-        # is persistent for get_window_state over the MCP stdio bridge, while
-        # the direct CLI transport keeps working. So: try the MCP path ONCE,
-        # and on the transient/transport error fall straight through to the CLI
-        # transport (which has its own retry + screenshot-to-file mitigation)
-        # rather than burning a long backoff chain on a path that won't recover.
+
         try:
-            return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
+            result = self._bridge.run(
+                self._call_tool_async(name, args),
+                timeout=timeout,
+            )
         except Exception as e:
             if self._is_transient_daemon_error(e):
                 logger.warning(
@@ -1370,13 +1426,31 @@ class _CuaDriverSession:
                 return self._call_tool_via_cli(name, args, timeout)
             if not self._is_closed_session_error(e):
                 raise
-            # Daemon restart closes the cached stdio channel. Reconnect once and
-            # retry exactly one more time — never loop, to avoid hammering a
-            # genuinely dead daemon.
             logger.warning("cua-driver MCP session closed during %s; reconnecting once", name)
             with self._lock:
                 self._restart_session_locked()
-            return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
+            result = self._bridge.run(
+                self._call_tool_async(name, args),
+                timeout=timeout,
+            )
+
+        # Remember only a successfully declared stable identity. Failed
+        # start_session calls must not leave stale recovery state behind.
+        if name == "start_session" and result.get("isError") is not True:
+            declared_id = args.get("session")
+            if isinstance(declared_id, str) and declared_id:
+                self._declared_session_id = declared_id
+
+        if self._is_ended_session_result(result):
+            result = self._revive_declared_session_once(name, args, result, timeout)
+
+        if (
+            name == "end_session"
+            and result.get("isError") is not True
+            and args.get("session") == self._declared_session_id
+        ):
+            self._declared_session_id = None
+        return result
 
 
 def _extract_tool_result(mcp_result: Any) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

Fixes #71166.

- detect cua-driver's in-band `session has ended` rejection
- revive the same declared session with `start_session`
- retry the rejected tool call exactly once
- preserve recovery after an MCP transport reconnect
- keep lifecycle calls non-recursive and avoid retry loops

## Root cause

Hermes recovered only when the MCP transport raised a closed-resource exception. On Windows 11 with cua-driver 0.12.x, the transport can remain alive while the driver returns a normal MCP result with `isError=true`, stating that the session has ended and must be revived. That logical result bypassed the reconnect path and was surfaced immediately by capture/list-windows calls.

## Fix

`_CuaDriverSession` now remembers the stable session ID only after a successful `start_session`. When a non-lifecycle tool returns the narrow ended-session error shape, it directly calls `start_session` with the same ID and replays the rejected call once. A second rejection is returned as-is, preventing loops. Successful `end_session` clears the remembered ID.

The same logical recovery is also applied when the first call raised a closed-resource error and the post-reconnect retry returns an ended-session result.

## Testing

- `python -m pytest tests/tools/test_computer_use.py::TestCuaDriverSessionReconnect -q -k "not test_cli_fallback_reads_screenshot_from_file"` — 10 passed, 1 deselected
- `python -m py_compile tools/computer_use/cua_backend.py tests/tools/test_computer_use.py`
- `git diff --check`

The deselected test is an existing Windows-only JSON fixture issue: it inserts an unescaped `C:\...` path into fake JSON and is unrelated to this change.