### PR TITLE
fix(desktop): give pop-out session windows their own fullscreen chrome state

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -171,7 +171,8 @@ import {
   createSessionWindowRegistry,
   instanceWindowBounds,
   SESSION_WINDOW_MIN_HEIGHT,
-  SESSION_WINDOW_MIN_WIDTH
+  SESSION_WINDOW_MIN_WIDTH,
+  wireChatWindowFullscreenState
 } from './session-windows'
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
@@ -8672,8 +8673,9 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
     }
   })
 
-  win.on('enter-full-screen', () => sendWindowStateChanged(true))
-  win.on('leave-full-screen', () => sendWindowStateChanged(false))
+  // Per-window fullscreen chrome: send this window its own titlebar inset so its
+  // traffic lights hide/show independently of the primary.
+  wireChatWindowFullscreenState(win, sendWindowStateChanged)
 
   wireCommonWindowHandlers(win, zoomWiringForWindowKind('chat'))
 
@@ -8755,8 +8757,7 @@ function createInstanceWindow() {
 
   // Per-window fullscreen chrome: send this window its own titlebar inset so its
   // traffic lights hide/show independently of the primary.
-  win.on('enter-full-screen', () => sendWindowStateChanged(true, win))
-  win.on('leave-full-screen', () => sendWindowStateChanged(false, win))
+  wireChatWindowFullscreenState(win, sendWindowStateChanged)
 
   wireCommonWindowHandlers(win, zoomWiringForWindowKind('chat'))
 

--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -241,3 +241,26 @@ test('wireChatWindowFullscreenState reports fullscreen against the window that c
   assert.equal(sent[0].target, win, 'enter-full-screen names its own window, not the primary')
   assert.equal(sent[1].target, win, 'leave-full-screen names its own window, not the primary')
 })
+
+test('wireChatWindowFullscreenState also reports the start of the transition, like mainWindow', () => {
+  // mainWindow wires all four events, so its titlebar inset updates when the
+  // fullscreen animation BEGINS. A secondary window listening only to the bare
+  // pair holds its pre-transition chrome for the whole animation and then snaps.
+  const win = makeFakeWindow()
+  const sent: { isFullscreen: boolean; target: unknown }[] = []
+
+  wireChatWindowFullscreenState(win, (isFullscreen, target) => {
+    sent.push({ isFullscreen, target })
+  })
+
+  win.emit('will-enter-full-screen')
+  win.emit('will-leave-full-screen')
+
+  assert.deepEqual(
+    sent.map(entry => entry.isFullscreen),
+    [true, false],
+    'will-enter reports fullscreen, will-leave reports windowed'
+  )
+  assert.equal(sent[0].target, win, 'will-enter-full-screen names its own window, not the primary')
+  assert.equal(sent[1].target, win, 'will-leave-full-screen names its own window, not the primary')
+})

--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -6,7 +6,8 @@ import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
   createSessionWindowRegistry,
-  instanceWindowBounds
+  instanceWindowBounds,
+  wireChatWindowFullscreenState
 } from './session-windows'
 
 // A minimal fake BrowserWindow: tracks listeners + destroyed state and lets a
@@ -217,4 +218,26 @@ test('chatWindowWebPreferences allows autoplay so wake-started voice speaks its 
   const prefs = chatWindowWebPreferences('/tmp/preload.cjs')
 
   assert.equal(prefs.autoplayPolicy, 'no-user-gesture-required')
+})
+
+test('wireChatWindowFullscreenState reports fullscreen against the window that changed', () => {
+  // Regression: the pop-out builder wired `() => sendWindowStateChanged(true)`
+  // with no target, so both events fell through to the `mainWindow` default and
+  // a fullscreen pop-out rewrote the PRIMARY window's titlebar inset.
+  const win = makeFakeWindow()
+  const sent: { isFullscreen: boolean; target: unknown }[] = []
+
+  wireChatWindowFullscreenState(win, (isFullscreen, target) => {
+    sent.push({ isFullscreen, target })
+  })
+
+  win.emit('enter-full-screen')
+  win.emit('leave-full-screen')
+
+  assert.deepEqual(
+    sent.map(entry => entry.isFullscreen),
+    [true, false]
+  )
+  assert.equal(sent[0].target, win, 'enter-full-screen names its own window, not the primary')
+  assert.equal(sent[1].target, win, 'leave-full-screen names its own window, not the primary')
 })

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -60,11 +60,20 @@ type FullscreenEventWindow = { on: (event: string, handler: () => void) => unkno
 // instance builder kept it. That is the same failure mode as the
 // chatWindowWebPreferences note above, where the copy silently lost
 // `backgroundThrottling: false`. One wiring path, so the two cannot drift again.
+//
+// All FOUR events, matching mainWindow's own wiring. Electron fires the `will-`
+// pair at the START of the fullscreen transition and the bare pair at the END,
+// so a window that only listens to the bare pair keeps its old titlebar inset
+// for the whole animation and then snaps. The primary window has always wired
+// both; wiring them here is what makes a pop-out or instance window's chrome
+// transition look the same as the primary's rather than lagging it.
 function wireChatWindowFullscreenState(
   win: FullscreenEventWindow,
   send: (isFullscreen: boolean, target: FullscreenEventWindow) => void
 ) {
+  win.on('will-enter-full-screen', () => send(true, win))
   win.on('enter-full-screen', () => send(true, win))
+  win.on('will-leave-full-screen', () => send(false, win))
   win.on('leave-full-screen', () => send(false, win))
 }
 

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -44,6 +44,30 @@ function chatWindowWebPreferences(preloadPath: string) {
   }
 }
 
+// The slice of BrowserWindow the fullscreen wiring touches, so this module
+// stays Electron-free and unit-testable.
+type FullscreenEventWindow = { on: (event: string, handler: () => void) => unknown }
+
+// Per-window fullscreen chrome. Every chat window that isn't the primary must
+// tell the state push WHICH window changed, or the push falls through to the
+// `target = mainWindow` default in main.ts's sendWindowStateChanged() and the
+// primary's renderer gets a fullscreen flag it never earned — its titlebar
+// cluster slides under the still-visible traffic lights on macOS, and its panes
+// stop reserving the native control band on Windows/WSLg.
+//
+// Both secondary-window builders in main.ts wire this pair, and they are
+// hand-copies: the pop-out builder dropped the `win` argument while the
+// instance builder kept it. That is the same failure mode as the
+// chatWindowWebPreferences note above, where the copy silently lost
+// `backgroundThrottling: false`. One wiring path, so the two cannot drift again.
+function wireChatWindowFullscreenState(
+  win: FullscreenEventWindow,
+  send: (isFullscreen: boolean, target: FullscreenEventWindow) => void
+) {
+  win.on('enter-full-screen', () => send(true, win))
+  win.on('leave-full-screen', () => send(false, win))
+}
+
 // Build the renderer URL for a secondary window. The renderer uses a
 // HashRouter, so the session route lives after the '#'. The `?win=secondary`
 // flag MUST sit in the query string BEFORE the '#': anything after the '#' is
@@ -153,5 +177,6 @@ export {
   createSessionWindowRegistry,
   instanceWindowBounds,
   SESSION_WINDOW_MIN_HEIGHT,
-  SESSION_WINDOW_MIN_WIDTH
+  SESSION_WINDOW_MIN_WIDTH,
+  wireChatWindowFullscreenState
 }


### PR DESCRIPTION
## What does this PR do?

`main.ts` documents the contract for its own state push, right above the function:

> Push titlebar/fullscreen chrome state to a window's renderer. Defaults to the primary, but any full chat window (primary or a secondary "instance" peer) passes itself so its own fullscreen toggle drives its own traffic-light inset.

```ts
function sendWindowStateChanged(nextIsFullscreen?: boolean, target = mainWindow) {
```

`spawnSecondaryWindow` — the ⌘-click chat pop-out and the subagent watch window — violates it:

```ts
win.on('enter-full-screen', () => sendWindowStateChanged(true))
win.on('leave-full-screen', () => sendWindowStateChanged(false))
```

No target, so both events fall through to the `mainWindow` default and push `hermes:window-state-changed` at the **primary** window's renderer. Fullscreening a pop-out therefore tells the primary — which is not fullscreen — that it is:

- **macOS:** `app/shell/titlebar.ts` takes its `isFullscreen` early return and collapses the control cluster to `TITLEBAR_EDGE_INSET` (14px), underneath the still-visible traffic lights, so the sidebar toggle sits on top of the red close button.
- **Windows / WSLg:** `components/pane-shell/geometry.ts` returns a null `windowControlsRect` on `connection?.isFullscreen` *before* it reaches the `nativeOverlayWidth` branch, so the panes stop reserving the native control band and app chrome renders under the min/max/close overlay.
- **Inverse:** primary genuinely fullscreen, then leave-fullscreen on the pop-out → the primary reserves a phantom native-control band it no longer needs.

`createInstanceWindow`, 80 lines below, wires the identical listener pair *correctly* (`sendWindowStateChanged(true, win)`), with a comment explaining why. The two builders are hand-copies and one lost the argument.

This is the **second** time this exact pair has diverged. `session-windows.ts` already carries a comment about the first: the copy that silently dropped `backgroundThrottling: false` from secondary windows, so a streamed answer stalled until the window regained focus. Per `apps/desktop/AGENTS.md` — *"One resolver owns each policy so every caller gets the same answer. Scatter is how two call sites drift apart."* — this PR does not paste the missing argument back in twice. It adds one `wireChatWindowFullscreenState(win, send)` helper to `session-windows.ts` (the Electron-free module that exists to hold exactly this kind of shared wiring) and routes **both** builders through it, so there is a single wiring path and the two cannot drift again.

`createInstanceWindow`'s observable behaviour is unchanged — it already passed `win`; its conversion is a pure refactor. The net behaviour change is the two missing arguments on the pop-out path.

### Sibling-site sweep

`git grep -n "sendWindowStateChanged" -- apps/desktop/electron/` returns 10 sites. Every site of this concern — a per-window fullscreen event handler that must name its own window — is covered:

| Site | Verdict |
|---|---|
| `main.ts` `function sendWindowStateChanged(…, target = mainWindow)` | The definition. Its default is correct and load-bearing for the primary's call sites. |
| `spawnSecondaryWindow` `enter-full-screen` / `leave-full-screen` | **Fixed** — routed through the helper, now names `win`. |
| `createInstanceWindow` `enter-full-screen` / `leave-full-screen` | Already correct; **routed through the same helper** so the divergence cannot return. |
| `mainWindow.on('will-enter-/enter-/will-leave-/leave-full-screen')` ×4 | Correct as-is — the default target *is* the window that changed. Now also the **parity reference** for the follow-up below. |
| `mainWindow.webContents.once('did-finish-load')` | Correct as-is — same reason. |

Deliberately **excluded**, with reason:

- The four bare `getWindowState()` calls in the backend-connection resolvers (`ensureBackend` / `startHermes`). They seed the shared, promise-cached connection descriptor that every window's `getConnection()` joins — there is no single requesting window to name. Different concern, different symptom, much larger change.

## Follow-up commit: the `will-` pair, now included

An earlier revision of this PR excluded `will-enter-full-screen` / `will-leave-full-screen` on the grounds that *"only the primary listens to them"* and that `createInstanceWindow` lacks them too. **I've reversed that call and wired them in the helper.** The reasoning I had was backwards: "the already-correct sibling lacks them too" is a description of the gap, not a justification for it, and `mainWindow` — the reference implementation this whole PR is trying to match — has always wired all four.

Concretely: Electron fires the `will-` pair at the **start** of the fullscreen transition and the bare pair at the **end**. So the primary window updates its titlebar inset before the animation runs, while a pop-out or instance window kept its pre-transition chrome for the entire animation and then snapped into place at the end.

Two honest caveats:

- **This is transition-timing parity, not a correctness or data-loss fix.** The end state was already right after the main change above; this is about what the user sees *during* the ~0.5s macOS fullscreen animation. I'm not claiming severity for it.
- It goes in this PR rather than a separate one because it is the same defect class (secondary windows not inheriting the primary's fullscreen chrome behaviour), the same file, and the same helper this PR introduces — adding it here means both builders inherit it from one edit, which is the entire reason the helper exists.

## Related Issue

No filed issue. The change restores the contract written directly above `sendWindowStateChanged` in `main.ts`, which `spawnSecondaryWindow` violates.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/session-windows.ts` — add `wireChatWindowFullscreenState(win, send)`: registers all four fullscreen events (`will-enter-full-screen`, `enter-full-screen`, `will-leave-full-screen`, `leave-full-screen`) and passes the owning window to `send`. Kept Electron-free (the window is injected and typed structurally as the `on()` slice it actually touches) so it stays unit-testable, matching how `createSessionWindowRegistry` handles `win.on('closed')`. Exported.
- `apps/desktop/electron/main.ts` — import the helper; replace the inline listener pair in **both** `spawnSecondaryWindow` (the bug) and `createInstanceWindow` (already correct, now sharing the one path). No wiring is duplicated at the call sites — the helper is the single point, so the `will-` pair reaches both builders from one edit.
- `apps/desktop/electron/session-windows.test.ts` — two regression tests using the existing `makeFakeWindow()` harness that records and fires listeners: one asserting the bare pair reports against the window that changed, one asserting the same for the `will-` pair.

## How to Test

Automated:

```
cd apps/desktop
npx vitest run --project electron electron/session-windows.test.ts
```

Fails before the production change, passes after. Reverting only the helper body to the pre-fix form (`send(true)` / `send(false)`, no target — exactly what `spawnSecondaryWindow` did) gives:

```
FAIL  |electron| electron/session-windows.test.ts > wireChatWindowFullscreenState reports fullscreen against the window that changed
AssertionError: enter-full-screen names its own window, not the primary
+ actual - expected

+ undefined
- { … the window object … }

 Test Files  1 failed (1)
      Tests  1 failed | 15 passed (16)
```

Removing only the `will-` pair from the helper (the state before the follow-up commit) reds exactly the second test and leaves the first green:

```
× wireChatWindowFullscreenState also reports the start of the transition, like mainWindow
    AssertionError: will-enter reports fullscreen, will-leave reports windowed
      Tests  1 failed | 17 passed (18)
```

With everything in place: `Test Files 1 passed (1) / Tests 18 passed (18)`, and the whole electron project is `74 files / 869 passed | 2 skipped`.

Manually (macOS, reproduced):

1. Open Hermes and ⌘-click a chat in the sidebar to pop it out into its own window (a running subagent's watch window works too).
2. Leave the main window windowed. Fullscreen the pop-out.
3. **Before:** the main window's titlebar control cluster jumps to `left: 14px`, under its own still-visible traffic lights — the sidebar toggle overlaps the red close button. **After:** the main window's chrome does not move; only the pop-out's own inset changes.
4. Inverse: fullscreen the main window, then fullscreen and un-fullscreen the pop-out. **Before:** the main window reserves a phantom native-control band. **After:** unchanged.
5. For the `will-` pair, watch the pop-out's *own* titlebar during the fullscreen animation, next to the main window doing the same thing. **Before:** the pop-out holds its windowed inset for the whole animation and snaps at the end, while the primary adjusts as the animation starts. **After:** both transition identically.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is a desktop TypeScript-only change. Ran the desktop gates instead: `npx eslint electron/session-windows.ts electron/session-windows.test.ts` (clean) and `npx vitest run --project electron` → **869 passed, 2 skipped, 0 failed** across 75 files. (Unrelated to this PR: `Python tests / Run tests slice 8/8` and the aggregate `All required checks pass` gate are currently red on clean `origin/main` itself.)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helper carries the comment explaining the invariant and the prior divergence; no external docs describe this wiring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the bug is *not* macOS-only: `geometry.ts` returns early on `isFullscreen` before the `nativeOverlayWidth` branch, so Windows/WSLg loses its native-control reservation. The fix is platform-agnostic and the unit test runs everywhere. Only the macOS symptom was reproduced by hand.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

