### PR TITLE
fix(telegram): bind exec-approval taps to the session that raised them

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -884,6 +884,34 @@ class TelegramAdapter(BasePlatformAdapter):
             return {}
         return {"disable_notification": True}
 
+    @staticmethod
+    def _session_owner_id(
+        session_key: str,
+        *,
+        chat_id: Optional[str] = None,
+        thread_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """Return the user a session belongs to, or None if it is shared.
+
+        ``build_session_key`` appends the participant id last for per-user
+        sessions (``<ns>:telegram:group:<chat_id>[:<thread_id>]:<user_id>``)
+        but omits it for sessions that are shared by design — forum topics
+        with ``thread_sessions_per_user`` off, and DMs, whose trailing
+        component is the chat/thread id instead. Since the callback carries
+        the chat and thread ids, a trailing component that is neither of them
+        is the owning participant; anything else means "no single owner", and
+        the caller keeps the plain allowlist check.
+        """
+        parts = [p for p in str(session_key or "").split(":") if p]
+        if len(parts) < 4:
+            return None
+        last = parts[-1]
+        if chat_id is not None and last == str(chat_id):
+            return None
+        if thread_id is not None and last == str(thread_id):
+            return None
+        return last
+
     def _is_callback_user_authorized(
         self,
         user_id: str,
@@ -6180,6 +6208,35 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to approve commands.")
                     return
 
+                session_key = self._approval_state.get(approval_id)
+                if not session_key:
+                    await query.answer(text="This approval has already been resolved.")
+                    return
+
+                # Being allowed to talk to the bot is not the same as owning
+                # this approval. In a group the allowlist admits every member
+                # (and a chat-scoped allowlist admits them without listing any
+                # user at all), so without an owner check any bystander could
+                # tap "Allow Always" on someone else's dangerous command —
+                # running it AND writing it into the permanent allowlist. Mirrors
+                # qqbot's _is_authorized_interaction_for_session.
+                owner_id = self._session_owner_id(
+                    session_key,
+                    chat_id=query_chat_id,
+                    thread_id=query_thread_id,
+                )
+                if owner_id is not None and owner_id != caller_id:
+                    logger.warning(
+                        "[%s] Rejected approval tap from %s on session owned by %s",
+                        self.name, caller_id, owner_id,
+                    )
+                    await query.answer(
+                        text="⛔ Only the user who triggered this command can answer it."
+                    )
+                    return
+
+                # Claim the approval only once the tap is fully authorized, so a
+                # rejected tap cannot consume the prompt for its rightful owner.
                 session_key = self._approval_state.pop(approval_id, None)
                 if not session_key:
                     await query.answer(text="This approval has already been resolved.")

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -372,7 +372,7 @@ class TestTelegramApprovalCallback:
         update = MagicMock()
         update.callback_query = query
         context = MagicMock()
-        query.from_user.id = "12345"
+        query.from_user.id = "99"
 
         with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
             with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
@@ -404,7 +404,7 @@ class TestTelegramApprovalCallback:
         query.message.chat_id = 12345
         query.from_user = MagicMock()
         query.from_user.first_name = "Norbert"
-        query.from_user.id = "12345"
+        query.from_user.id = "99"
         query.answer = AsyncMock()
         query.edit_message_text = AsyncMock()
 
@@ -432,7 +432,7 @@ class TestTelegramApprovalCallback:
         query.message.chat_id = 12345
         query.from_user = MagicMock()
         query.from_user.first_name = "Norbert"
-        query.from_user.id = "12345"
+        query.from_user.id = "99"
         query.answer = AsyncMock()
         query.edit_message_text = AsyncMock()
 
@@ -461,7 +461,7 @@ class TestTelegramApprovalCallback:
         query.message.chat_id = 12345
         query.from_user = MagicMock()
         query.from_user.first_name = "Teknium"
-        query.from_user.id = "12345"
+        query.from_user.id = "99"
         query.answer = AsyncMock()
         query.edit_message_text = AsyncMock()
 
@@ -496,7 +496,7 @@ class TestTelegramApprovalCallback:
         update = MagicMock()
         update.callback_query = query
         context = MagicMock()
-        query.from_user.id = "12345"
+        query.from_user.id = "99"
 
         with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
             with patch("tools.approval.resolve_gateway_approval", return_value=1):
@@ -524,7 +524,7 @@ class TestTelegramApprovalCallback:
         update = MagicMock()
         update.callback_query = query
         context = MagicMock()
-        query.from_user.id = "12345"
+        query.from_user.id = "99"
 
         with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
             with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
@@ -585,7 +585,7 @@ class TestTelegramApprovalCallback:
         update = MagicMock()
         update.callback_query = query
         context = MagicMock()
-        query.from_user.id = "12345"
+        query.from_user.id = "99"
 
         with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
             with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
@@ -736,3 +736,97 @@ class TestTelegramApprovalCallback:
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
         assert (tmp_path / ".update_response").read_text() == "n"
+
+
+# ===========================================================================
+# Approval taps are bound to the session that raised them
+# ===========================================================================
+
+class TestApprovalTapOwnership:
+    """A group member who may talk to the bot still may not answer someone
+    else's approval prompt (mirrors qqbot's per-session interaction check)."""
+
+    def _query(self, *, caller_id, approval_id, chat_id=12345, thread_id=None):
+        query = AsyncMock()
+        query.data = f"ea:always:{approval_id}"
+        query.message = MagicMock()
+        query.message.chat_id = chat_id
+        query.message.message_thread_id = thread_id
+        query.from_user = MagicMock()
+        query.from_user.id = caller_id
+        query.from_user.first_name = "Bystander"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+        return query
+
+    @pytest.mark.asyncio
+    async def test_bystander_cannot_answer_another_users_approval(self):
+        """The whole point: an allowlisted bystander taps "Allow Always" on a
+        command they did not trigger. Before the fix this ran the command and
+        wrote it into the permanent allowlist."""
+        adapter = _make_adapter()
+        adapter._approval_state[10] = "agent:main:telegram:group:12345:99"
+
+        query = self._query(caller_id="777", approval_id=10)
+        update = MagicMock()
+        update.callback_query = query
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+                await adapter._handle_callback_query(update, MagicMock())
+
+        mock_resolve.assert_not_called()
+        assert "only the user who triggered" in query.answer.call_args[1]["text"].lower()
+        query.edit_message_text.assert_not_called()
+        # The prompt must survive for its owner rather than being consumed.
+        assert adapter._approval_state[10] == "agent:main:telegram:group:12345:99"
+
+    @pytest.mark.asyncio
+    async def test_owner_can_answer_their_own_approval(self):
+        adapter = _make_adapter()
+        adapter._approval_state[11] = "agent:main:telegram:group:12345:99"
+
+        query = self._query(caller_id="99", approval_id=11)
+        update = MagicMock()
+        update.callback_query = query
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+                await adapter._handle_callback_query(update, MagicMock())
+
+        mock_resolve.assert_called_once_with("agent:main:telegram:group:12345:99", "always")
+        assert 11 not in adapter._approval_state
+
+    @pytest.mark.asyncio
+    async def test_shared_thread_session_stays_answerable_by_any_member(self):
+        """Forum topics with thread_sessions_per_user off are shared by design:
+        the key ends in the thread id, so there is no single owner to enforce."""
+        adapter = _make_adapter()
+        adapter._approval_state[12] = "agent:main:telegram:group:12345:777"
+
+        query = self._query(caller_id="42", approval_id=12, thread_id=777)
+        update = MagicMock()
+        update.callback_query = query
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+                await adapter._handle_callback_query(update, MagicMock())
+
+        mock_resolve.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dm_session_is_not_treated_as_owned_by_a_stranger(self):
+        """A DM key ends in the chat id, which is the peer themselves — the
+        owner check must not misread it as a foreign participant id."""
+        adapter = _make_adapter()
+        adapter._approval_state[13] = "agent:main:telegram:dm:12345"
+
+        query = self._query(caller_id="12345", approval_id=13)
+        update = MagicMock()
+        update.callback_query = query
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+                await adapter._handle_callback_query(update, MagicMock())
+
+        mock_resolve.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

The Telegram `ea:` approval callback checks only whether the tapper is allowed to talk to the bot — not whether the approval is theirs:

```python
if not self._is_callback_user_authorized(caller_id, ...):
    return
session_key = self._approval_state.pop(approval_id, None)   # no owner check
count = resolve_gateway_approval(session_key, choice)
```

`_approval_state` is just `approval_id -> session_key`, with no link to who triggered the command. In a group every member passes that check — and a chat-scoped allowlist (`TELEGRAM_GROUP_ALLOWED_CHATS`) passes them **without naming a single user**, which is the documented way to authorize a whole group. So any bystander in an authorized group can answer another member's approval prompt: tapping **"✅ Always"** runs the dangerous command *and* writes it into the permanent allowlist, logged under the bystander's display name.

**qqbot already defends exactly this**, in `gateway/platforms/qqbot/adapter.py:1091` `_is_authorized_interaction_for_session`: it parses the session key and requires `operator == session_user` for group/guild interactions before calling `resolve_gateway_approval`. This PR brings Telegram in line.

## Related Issue

No open issue; found while auditing interaction-authorization paths against the qqbot implementation. Dedup: searched PRs and issues for the handler, the helper, and the behavior — the existing work in this area is qqbot-side (#39133, #64870, #63232, #67877, all about admitting *DM* taps) and Discord-side (#51730, merged), none of it Telegram.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `plugins/platforms/telegram/adapter.py`: new `_session_owner_id()` helper; the `ea:` branch rejects a tap whose owner differs from the tapper.
- The prompt is claimed from `_approval_state` **after** the ownership check, so a rejected tap can no longer consume the prompt for its rightful owner (previously `pop()` ran before any such check could).
- `tests/gateway/test_telegram_approval_buttons.py`: `TestApprovalTapOwnership` — bystander rejected (fails without the fix), owner still resolves, plus two guards that the fix does **not** narrow legitimate paths.

### How the owner is resolved, and why shared sessions stay shared

`build_session_key` appends the participant id last for per-user sessions (`<ns>:telegram:group:<chat_id>[:<thread_id>]:<user_id>`) but omits it where a session is shared by design: forum topics with `thread_sessions_per_user` off, and DMs, whose trailing component is the chat id. The callback carries both the chat id and the thread id, so a trailing component that is *neither* is the owning participant. Anything else means "no single owner" and keeps the previous allowlist-only behavior — shared forum threads and DMs remain answerable exactly as before, both covered by tests.

### Behavior change worth flagging

In a group with per-user sessions (the default), a second operator can no longer answer someone else's prompt. That is the intended semantics and matches qqbot, but it is a real change for anyone relying on "any admin can approve"; `/approve` in the owner's own session and shared-thread sessions are unaffected.

## How to Test

1. `git stash` the adapter change and run `pytest tests/gateway/test_telegram_approval_buttons.py -q -k TestApprovalTapOwnership` → `test_bystander_cannot_answer_another_users_approval` fails (the tap resolves the approval).
2. Restore and re-run → 30 passed for the file.
3. `pytest tests/gateway/ -k telegram -q -p no:randomly` → identical failure set with and without this change (9 pre-existing failures on this Windows checkout, none introduced).

### Note on three updated fixtures

`test_resolves_approval_on_click`, `test_resume_typing_after_inline_approval` and `test_approval_callback_escapes_dynamic_user_name` set `from_user.id = "12345"` (the chat id) while their session key names user `99` as the owner — incidental in a fixture, but rejected under the new check. They now tap as `99` so each keeps exercising its own subject (resolution, typing resume, name escaping) rather than the ownership rule.