### PR TITLE
fix(errors): stop empty-content stream stubs from poisoning the transcript

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2759,6 +2759,117 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
 
 
 
+# Placeholder substituted for an empty non-final message that would otherwise
+# make the provider reject the whole request. Kept identical to the stub-
+# creation placeholder in chat_completion_helpers so a healed transcript reads
+# consistently whether the empty turn was caught at write time or send time.
+_INTERRUPTED_PLACEHOLDER = "[response interrupted]"
+
+
+def _msg_has_payload(msg: Dict[str, Any]) -> bool:
+    """True if ``msg`` carries anything the API treats as non-empty content.
+
+    Covers string content, non-empty multimodal content lists, tool_calls,
+    tool_call_id linkage (tool results), and reasoning payloads. Mirrors the
+    emptiness checks used by ``AIAgent._is_thinking_only_assistant`` but is
+    role-agnostic so it can vet user/assistant/tool turns uniformly.
+    """
+    content = msg.get("content")
+    if isinstance(content, str):
+        if content.strip():
+            return True
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict):
+                # any typed block (text/image/tool_use/document/...) counts,
+                # as long as a text block is not itself blank
+                if block.get("type") == "text":
+                    if isinstance(block.get("text"), str) and block["text"].strip():
+                        return True
+                    continue
+                return True
+            elif block:
+                return True
+    elif content not in (None, ""):
+        return True
+    # Structural payloads that make an "empty-content" message still valid.
+    if msg.get("tool_calls"):
+        return True
+    if isinstance(msg.get("reasoning_content"), str) and msg["reasoning_content"].strip():
+        return True
+    if msg.get("reasoning") or msg.get("reasoning_details"):
+        return True
+    return False
+
+
+def repair_empty_non_final_messages(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Heal empty-content non-final messages before they reach the provider.
+
+    Root-cause context: a stream that dies with 0 recovered characters (peer
+    reset, stall-kill) could persist an assistant turn with ``content=None``
+    and no tool_calls. The Anthropic message schema — and the litellm/Bedrock
+    proxies in front of it — reject ANY request whose transcript contains an
+    empty non-final message:
+
+        "all messages must have non-empty content except for the optional
+         final assistant message"  (HTTP 400 INVALID_REQUEST_BODY)
+
+    Once such a message lands mid-transcript it poisons EVERY subsequent turn
+    of that session until it scrolls out of context. The write-time guard in
+    ``chat_completion_helpers`` stops NEW stubs, but sessions already carrying
+    one (persisted before the guard, or fed in from a host history) stay stuck
+    and previously needed a manual DB edit + gateway restart to recover.
+
+    This pass is the self-healing counterpart: it runs unconditionally on the
+    per-call ``api_messages`` copy, so a poisoned transcript repairs itself
+    IN MEMORY on the very next send — no restart, no DB surgery. The final
+    message is left untouched (an empty final assistant turn is legal). The
+    stored conversation history is never mutated; only the wire copy is
+    repaired, so the UI/session trace stays faithful.
+
+    Repair strategy is substitution, not deletion: dropping a mid-transcript
+    turn can break role alternation and tool-call pairing, whereas an honest
+    minimal placeholder keeps the sequence intact and reads correctly as an
+    interrupted turn on replay.
+    """
+    if not messages or len(messages) < 2:
+        return messages
+
+    repaired: List[Dict[str, Any]] = []
+    healed = 0
+    last_idx = len(messages) - 1
+    for idx, msg in enumerate(messages):
+        if (
+            idx != last_idx
+            and isinstance(msg, dict)
+            # tool results are validated by their own orphan/pairing pass; an
+            # empty tool result is a separate (and rarer) concern.
+            and msg.get("role") in ("assistant", "user")
+            and not _msg_has_payload(msg)
+        ):
+            # Shallow-copy so stored history / prompt caching stays byte-stable.
+            fixed = dict(msg)
+            fixed["content"] = _INTERRUPTED_PLACEHOLDER
+            repaired.append(fixed)
+            healed += 1
+        else:
+            repaired.append(msg)
+
+    if healed:
+        _ra().logger.warning(
+            "Pre-call sanitizer: healed %d empty non-final message(s) by "
+            "substituting placeholder content — an empty-content turn was in "
+            "the transcript and would 400 the request ('messages must have "
+            "non-empty content' / INVALID_REQUEST_BODY). Self-recovering the "
+            "poisoned transcript in memory; no restart needed.",
+            healed,
+        )
+        return repaired
+    return messages
+
+
 def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Fix orphaned tool_call / tool_result pairs before every LLM call.
 
@@ -2778,6 +2889,15 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             continue
         filtered.append(msg)
     messages = filtered
+
+    # --- Heal empty-content non-final messages (self-recovery) ---
+    # A dead stream can leave an empty assistant stub (or an empty user turn)
+    # mid-transcript; the provider then 400s EVERY subsequent request until it
+    # scrolls out. Repair it here, on the per-call copy, so a poisoned session
+    # recovers itself in memory on the next send — no restart, no DB edit.
+    # Done first so a substituted turn participates normally in the tool-pair
+    # and dedup passes below.
+    messages = repair_empty_non_final_messages(messages)
 
     # --- Drop empty / malformed tool_calls arrays on assistant messages ---
     # An assistant message carrying ``tool_calls: []`` (an empty array) — or a

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3904,6 +3904,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # and the continuation prompt still reads as an interrupted turn.
             if not _partial_text:
                 _partial_text = "[response interrupted]"
+                logger.warning(
+                    "Empty partial-stream stub (0 chars recovered, no tool "
+                    "call) — substituting placeholder content so the assistant "
+                    "message is not persisted empty (would otherwise 400 every "
+                    "later request with 'messages must have non-empty content' "
+                    "/ INVALID_REQUEST_BODY). error=%s",
+                    result["error"],
+                )
             _stub_msg = SimpleNamespace(
                 role="assistant", content=_partial_text, tool_calls=None,
                 reasoning_content=None,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3889,6 +3889,21 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     result["error"],
                 )
                 _stub_finish_reason = FINISH_REASON_LENGTH
+            # Never persist a content-less, tool-call-less assistant stub.
+            # When a stream dies before any text arrives (and no partial tool
+            # calls were captured), _partial_text is None → the stub becomes an
+            # empty assistant message.  The Anthropic message schema (and the
+            # litellm/Bedrock proxies in front of it) reject any request whose
+            # transcript contains an empty non-final message:
+            #   "all messages must have non-empty content except for the
+            #    optional final assistant message"  (400 INVALID_REQUEST_BODY)
+            # Once such a stub lands mid-transcript, EVERY subsequent turn 400s
+            # until it scrolls out of context — and the 400 gets misread as a
+            # context-overflow "Cannot compress further" loop.  Substitute a
+            # minimal, honest placeholder so the message is always API-valid
+            # and the continuation prompt still reads as an interrupted turn.
+            if not _partial_text:
+                _partial_text = "[response interrupted]"
             _stub_msg = SimpleNamespace(
                 role="assistant", content=_partial_text, tool_calls=None,
                 reasoning_content=None,

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -321,6 +321,30 @@ _MODEL_NOT_FOUND_PATTERNS = [
     "no endpoints found that support tool use",
 ]
 
+# Malformed-message-array 400s.  Deterministic request-shape rejections that
+# describe the *transcript* being invalid, not a parameter.  The canonical
+# case: a stream dies mid-response and Hermes persists a content-less
+# assistant stub; on the next turn the Anthropic message schema (and the
+# litellm/Bedrock proxies in front of it) reject the whole request with
+#   "all messages must have non-empty content except for the optional final
+#    assistant message"  /  errorCode INVALID_REQUEST_BODY
+# These are NOT context overflow — the input may be tiny — but a large
+# session used to mis-route them into the compression loop via the generic
+# "400 + large session" heuristic below, ending in "Cannot compress further"
+# every retry (the input is unchanged, so compression cannot help).  Match
+# the message-shape signals explicitly and fail fast as a format_error so the
+# loop stops looping.  The empty-stub creation is the root cause (fixed in
+# chat_completion_helpers); this pattern stops the misclassification symptom
+# for transcripts that already contain a poisoned stub.
+_INVALID_MESSAGE_BODY_PATTERNS = [
+    "must have non-empty content",
+    "messages must have non-empty",
+    "invalid_request_body",
+    "text content blocks must be non-empty",
+    "content field is required",
+    "messages: at least one message is required",
+]
+
 # Request-validation patterns — the request is malformed and will fail
 # identically on every retry. Some OpenAI-compatible gateways (notably
 # codex.nekos.me) return these as 5xx instead of the standard 4xx, which
@@ -1271,6 +1295,25 @@ def _classify_400(
             should_fallback=True,
         )
 
+    # Malformed message array (empty-content assistant stub, etc.). Must be
+    # checked BEFORE context_overflow: the input can be tiny, so the generic
+    # "400 + large session" heuristic would otherwise mis-route it into the
+    # compression loop and thrash until "Cannot compress further" on every
+    # retry (the request is unchanged, so compression cannot fix it). This is
+    # a deterministic request-shape rejection — fail fast as a non-retryable
+    # format_error and fall back. Checked against the message text AND the
+    # structured error code, since proxies (litellm/Bedrock) surface the
+    # signal in errorCode=INVALID_REQUEST_BODY.
+    if (
+        any(p in error_msg for p in _INVALID_MESSAGE_BODY_PATTERNS)
+        or error_code_lower == "invalid_request_body"
+    ):
+        return result_fn(
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=True,
+        )
+
     # Empty-provider-response advisories must not enter compression. They
     # often mention "max_tokens" as a possible cause and used to match the
     # bare overflow pattern, then thrash compress until "Cannot compress
@@ -1331,6 +1374,18 @@ def _classify_400(
         # Responses API (and some providers) use flat body: {"message": "..."}
         if not err_body_msg:
             err_body_msg = str(body.get("message") or "").strip().lower()
+        # litellm / Bedrock proxies use a custom shape: {"errorMessage": "...",
+        # "errorCode": "...", "errorArgs": {"reason": "..."}}.  Without these
+        # keys err_body_msg stays "" and a long, descriptive rejection is
+        # wrongly treated as a "generic" (bare) error below, which — on a
+        # large session — mis-routes into the compression loop.  Recognize
+        # them so the is_generic heuristic sees the real message length.
+        if not err_body_msg:
+            err_body_msg = str(body.get("errorMessage") or "").strip().lower()
+        if not err_body_msg:
+            _args = body.get("errorArgs")
+            if isinstance(_args, dict):
+                err_body_msg = str(_args.get("reason") or "").strip().lower()
     is_generic = len(err_body_msg) < 30 or err_body_msg in {"error", ""}
     # Absolute token/message-count thresholds are only a proxy for smaller
     # context windows.  Large-context sessions can have many messages while
@@ -1629,7 +1684,7 @@ def _extract_error_code(body: dict) -> str:
                 return nested_code
 
     # Top-level code
-    code = body.get("code") or body.get("error_code") or ""
+    code = body.get("code") or body.get("error_code") or body.get("errorCode") or ""
     if isinstance(code, (str, int)):
         text = str(code).strip()
         if text and text != "400":
@@ -1649,6 +1704,16 @@ def _extract_message(error: Exception, body: dict) -> str:
         msg = body.get("message", "")
         if isinstance(msg, str) and msg.strip():
             return msg.strip()[:500]
+        # litellm / Bedrock proxy shape: {"errorMessage": "...",
+        # "errorArgs": {"reason": "..."}}.
+        msg = body.get("errorMessage", "")
+        if isinstance(msg, str) and msg.strip():
+            return msg.strip()[:500]
+        args = body.get("errorArgs")
+        if isinstance(args, dict):
+            reason = args.get("reason", "")
+            if isinstance(reason, str) and reason.strip():
+                return reason.strip()[:500]
     # Fallback to str(error)
     return str(error)[:500]
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1308,6 +1308,14 @@ def _classify_400(
         any(p in error_msg for p in _INVALID_MESSAGE_BODY_PATTERNS)
         or error_code_lower == "invalid_request_body"
     ):
+        logger.warning(
+            "Malformed message array 400 (invalid request body) classified as "
+            "format_error, NOT context overflow — failing fast + falling back "
+            "instead of entering the compression loop. This usually means an "
+            "empty-content assistant stub is in the transcript; num_messages=%s "
+            "approx_tokens=%s. error=%.200s",
+            num_messages, approx_tokens, error_msg,
+        )
         return result_fn(
             FailoverReason.format_error,
             retryable=False,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1326,7 +1326,7 @@ class TestClassifyApiError:
         assert result.retryable is False
         assert result.should_compress is not True
 
-    def test_400_litellm_invalid_request_body_shape(self):
+    def test_400_litellm_invalid_request_body_shape(self, caplog):
         """litellm/Bedrock proxy shape (errorMessage/errorCode) → format_error.
 
         The proxy in front of Anthropic surfaces the empty-content rejection
@@ -1335,8 +1335,10 @@ class TestClassifyApiError:
         are not the standard error.message / message, so err_body_msg used to
         come back empty → is_generic=True → mis-routed into compression on a
         large session.  Both the message pattern and the errorCode must be
-        recognized.
+        recognized, and a distinct warning must be logged so the condition is
+        observable in the field.
         """
+        import logging
         proxy_msg = ("The provided request body is invalid: claude "
                      "messages.208: all messages must have non-empty content "
                      "except for the optional final assistant message")
@@ -1350,12 +1352,17 @@ class TestClassifyApiError:
                 "errorArgs": {"reason": "claude messages.208: ..."},
             },
         )
-        result = classify_api_error(
-            e, approx_tokens=66000, context_length=200000, num_messages=219,
-        )
+        with caplog.at_level(logging.WARNING, logger="agent.error_classifier"):
+            result = classify_api_error(
+                e, approx_tokens=66000, context_length=200000, num_messages=219,
+            )
         assert result.reason == FailoverReason.format_error
         assert result.retryable is False
         assert result.should_compress is not True
+        assert any(
+            "Malformed message array 400" in r.getMessage()
+            for r in caplog.records
+        ), "Expected a distinct warning identifying the malformed-body 400"
 
     def test_400_real_context_overflow_still_compresses(self):
         """Guard: the new empty-content guard must NOT swallow real overflows.

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1298,6 +1298,84 @@ class TestClassifyApiError:
         result = classify_api_error(e, approx_tokens=100000, context_length=200000)
         assert result.reason == FailoverReason.context_overflow
 
+    def test_400_empty_content_message_not_context_overflow(self):
+        """Anthropic 'non-empty content' 400 → format_error, NOT compression.
+
+        Regression for the empty-assistant-stub bug: a stream dies with 0
+        recovered chars, an empty assistant message is persisted, and every
+        subsequent request 400s with 'all messages must have non-empty
+        content'.  On a large session the generic '400 + large session'
+        heuristic used to mis-route this into the compression loop, ending in
+        'Cannot compress further' on every retry (compression can't fix a
+        malformed transcript).  It must classify as a non-retryable
+        format_error so the loop stops looping.
+        """
+        msg = ("all messages must have non-empty content except for the "
+               "optional final assistant message")
+        e = MockAPIError(
+            msg,
+            status_code=400,
+            body={"error": {"message": msg, "type": "invalid_request_error"}},
+        )
+        # Large session (many messages / tokens) to prove the overflow
+        # heuristic does NOT capture it.
+        result = classify_api_error(
+            e, approx_tokens=66000, context_length=200000, num_messages=219,
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_compress is not True
+
+    def test_400_litellm_invalid_request_body_shape(self):
+        """litellm/Bedrock proxy shape (errorMessage/errorCode) → format_error.
+
+        The proxy in front of Anthropic surfaces the empty-content rejection
+        as {"errorMessage": "...non-empty content...", "errorCode":
+        "INVALID_REQUEST_BODY", "errorArgs": {"reason": "..."}}.  Those keys
+        are not the standard error.message / message, so err_body_msg used to
+        come back empty → is_generic=True → mis-routed into compression on a
+        large session.  Both the message pattern and the errorCode must be
+        recognized.
+        """
+        proxy_msg = ("The provided request body is invalid: claude "
+                     "messages.208: all messages must have non-empty content "
+                     "except for the optional final assistant message")
+        e = MockAPIError(
+            proxy_msg,
+            status_code=400,
+            body={
+                "errorMessage": proxy_msg,
+                "errorCode": "INVALID_REQUEST_BODY",
+                "statusCode": 400,
+                "errorArgs": {"reason": "claude messages.208: ..."},
+            },
+        )
+        result = classify_api_error(
+            e, approx_tokens=66000, context_length=200000, num_messages=219,
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_compress is not True
+
+    def test_400_real_context_overflow_still_compresses(self):
+        """Guard: the new empty-content guard must NOT swallow real overflows.
+
+        A genuine 'maximum context length' 400 must still route into
+        compression — the fix is surgical, not a blanket 400→format_error.
+        """
+        msg = ("This model's maximum context length is 200000 tokens. "
+               "However, your messages resulted in 250000 tokens.")
+        e = MockAPIError(
+            msg,
+            status_code=400,
+            body={"error": {"message": msg, "type": "invalid_request_error"}},
+        )
+        result = classify_api_error(
+            e, approx_tokens=250000, context_length=200000, num_messages=219,
+        )
+        assert result.reason == FailoverReason.context_overflow
+        assert result.should_compress is True
+
     # ── Peer closed + large session ──
 
     def test_peer_closed_large_session(self):

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -770,3 +770,101 @@ def test_sanitize_preserves_populated_tool_calls():
     out = sanitize_api_messages(list(messages))
     assistant = [m for m in out if m.get("role") == "assistant"][0]
     assert [tc["id"] for tc in assistant["tool_calls"]] == ["call_Z"]
+
+
+# ── Self-recovery: heal empty-content non-final messages ──────────────────
+# Repro of the production incident: a dead stream persisted an empty-content
+# assistant stub mid-transcript, and every later request 400'd with
+# "all messages must have non-empty content except for the optional final
+# assistant message" (INVALID_REQUEST_BODY). sanitize_api_messages now heals
+# such turns on the per-call copy so the session recovers itself in memory.
+
+def test_sanitize_heals_empty_assistant_stub_between_tool_and_user():
+    """The exact production shape: tool -> EMPTY assistant (finish=length) ->
+    user recovery. The empty assistant would 400 the whole request; it must be
+    substituted with non-empty placeholder content, not left empty."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "do a thing"},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "call_A", "type": "function",
+             "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_A", "content": "result"},
+        {"role": "assistant", "content": None},  # <-- poison stub (non-final)
+        {"role": "user", "content": "[System: previous response was cut off]"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    # Every non-final message now has non-empty content.
+    for m in out[:-1]:
+        c = m.get("content")
+        assert m.get("tool_calls") or (isinstance(c, str) and c.strip()) or (
+            isinstance(c, list) and c), f"empty non-final survived: {m}"
+    # The stub specifically became the placeholder.
+    stub = out[3]
+    assert stub["role"] == "assistant"
+    assert stub["content"] == "[response interrupted]"
+
+
+def test_sanitize_heals_empty_user_message():
+    """An empty user turn mid-transcript is equally invalid and is healed."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": ""},          # <-- empty user (non-final)
+        {"role": "assistant", "content": "still here"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert out[1]["content"] == "[response interrupted]"
+
+
+def test_sanitize_allows_empty_final_assistant():
+    """Negative control: an empty FINAL assistant message is legal per the API
+    ('except for the optional final assistant message') and must NOT be
+    touched."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": ""},  # final — allowed empty
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert out[-1]["content"] == ""  # untouched
+
+
+def test_sanitize_empty_heal_is_non_destructive():
+    """Healing must not mutate the caller's persisted dicts — only the per-call
+    copy is repaired, so the stored trajectory keeps the true empty turn."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    original_stub = {"role": "assistant", "content": None}
+    messages = [
+        {"role": "user", "content": "q"},
+        original_stub,
+        {"role": "user", "content": "recovery"},
+    ]
+    sanitize_api_messages(list(messages))
+    assert original_stub["content"] is None  # untouched in-place
+
+
+def test_sanitize_preserves_reasoning_only_and_toolcall_turns():
+    """Negative control: a non-final assistant turn that is 'empty content' but
+    carries reasoning OR tool_calls is valid payload and must NOT be rewritten
+    to the placeholder (that would clobber real model output)."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "call_R", "type": "function",
+             "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_R", "content": "r"},
+        {"role": "user", "content": "next"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    # tool_call assistant keeps its tool_calls, content not clobbered to text
+    tc_asst = out[1]
+    assert tc_asst.get("tool_calls") and tc_asst["tool_calls"][0]["id"] == "call_R"
+    assert tc_asst["content"] != "[response interrupted]"
+

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1583,6 +1583,84 @@ class TestPartialToolCallWarning:
             f"Unexpected warning on text-only partial stream: {content!r}"
         )
 
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_empty_partial_stream_never_yields_empty_content(
+        self, mock_close, mock_create,
+    ):
+        """Stream dies with 0 recovered chars and no tool call → stub content
+        must be a non-empty placeholder, never None/''.
+
+        Root-cause regression for the empty-assistant-stub bug: a stream
+        delivered some deltas, then died before any text landed in
+        ``_current_streamed_assistant_text`` (and no tool call was captured).
+        The stub was built with ``content=None`` → an empty assistant message
+        got persisted mid-transcript.  The Anthropic message schema (and the
+        litellm/Bedrock proxies in front of it) then reject EVERY subsequent
+        request:
+            "all messages must have non-empty content except for the optional
+             final assistant message"  (400 INVALID_REQUEST_BODY)
+        which the loop misreads as a context-overflow "Cannot compress
+        further" spiral.  The stub must carry a minimal placeholder so the
+        message is always API-valid.
+        """
+        from run_agent import AIAgent
+
+        class _StallError(RuntimeError):
+            pass
+
+        def _stalling_stream():
+            # A real content delta fires (deltas_were_sent=True → the
+            # post-delivery stub path runs), but the recovered-text
+            # accumulator is empty by the time the stub is built (cleared on
+            # reset in prod), and no tool call was captured — the exact
+            # "0 chars recovered, no tool call" production condition.
+            yield _make_stream_chunk(content="partial token")
+            raise _StallError("simulated upstream stall after a delta")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _stalling_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+        agent._fire_stream_delta = lambda text: None
+        # Empty recovered text — this is what produced the empty stub in prod
+        # even though a delta was delivered to the platform above.
+        agent._current_streamed_assistant_text = ""
+
+        import os as _os
+        _prev = _os.environ.get("HERMES_STREAM_RETRIES")
+        _os.environ["HERMES_STREAM_RETRIES"] = "0"
+        try:
+            response = agent._interruptible_streaming_api_call({})
+        finally:
+            if _prev is None:
+                _os.environ.pop("HERMES_STREAM_RETRIES", None)
+            else:
+                _os.environ["HERMES_STREAM_RETRIES"] = _prev
+
+        content = response.choices[0].message.content
+        assert content, (
+            f"Empty-partial-stream stub must NOT have empty/None content "
+            f"(it poisons the transcript and 400s every later request). "
+            f"Got content={content!r}"
+        )
+        assert content.strip() != "", (
+            f"Stub content is whitespace-only, still API-invalid: {content!r}"
+        )
+        assert response.choices[0].message.tool_calls is None
+
 
 class TestSilentRetryMidToolCall:
     """Regression: when the stream dies mid tool-call JSON after text was


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where a dead streaming connection leaves a content-less assistant message in the transcript. Every subsequent Anthropic request (direct or via litellm/Bedrock proxy) is then rejected with HTTP 400 ("all messages must have non-empty content"). Worse, that 400 was misclassified as context overflow, triggering a compression death-spiral that logged `Context length exceeded … Cannot compress further` on sessions nowhere near their context limit.

This fixes the entire class in three defensive layers: prevent (don't persist empty stubs), don't panic (classify the 400 correctly), and self-heal (repair already-poisoned transcripts on the next send).

## Related Issue

Fixes a live production incident on a long-lived Telegram session (`claude-opus` behind a litellm proxy). No prior issue tracked.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: When a stream dies with 0 recovered characters and no tool calls, persist a `"[response interrupted]"` placeholder instead of `content=None` — prevents transcript poisoning at write time
- `agent/error_classifier.py`: Add `_INVALID_MESSAGE_BODY_PATTERNS` guard checked before the context-overflow heuristic; classifies the empty-content 400 as non-retryable `format_error` (fail fast + fall back) instead of routing into compression. Broaden `_extract_message` / `_extract_error_code` to recognize litellm/Bedrock proxy error shapes (`errorMessage` / `errorCode` / `errorArgs.reason`)
- `agent/agent_runtime_helpers.py`: `sanitize_api_messages()` now repairs empty non-final assistant messages on the per-call copy so already-poisoned sessions self-heal on the very next send. Final message untouched (empty final assistant turn is legal); stored history never mutated; reasoning-only and tool_call turns preserved

## How to Test

1. Run the full changed-path test suite:
   ```bash
   pytest tests/agent/test_error_classifier.py tests/run_agent/test_message_sequence_repair.py tests/run_agent/test_streaming.py -v
   ```
2. Error classifier test: litellm-shape 400 → `format_error` (not context overflow); real context overflow still compresses
3. Streaming test: stream dies with 0 recovered chars → stub content is `"[response interrupted]"`, not empty (RED-verified — fails without the guard)
4. Message-sequence-repair test: production-shape self-heal (tool → empty assistant → user), empty-user case, non-destructive guarantee, negative controls (empty final assistant allowed; reasoning-only / tool_call turns preserved). RED-verified by disabling the wire-in

All via canonical `scripts/run_tests.sh`: **350 passed** across changed-path suites.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(errors):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (error classifier, streaming stub, message-sequence-repair — all RED-verified)
- [x] I've tested on my platform: Ubuntu 24.04 (AWS)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (internal runtime behavior, no user-facing config)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure Python string/message handling, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Field Evidence

Developed against a live production incident. The A/B is clean: the **same** poisoned transcript hit old code (misclassify → compression spiral) and then, after restarting onto patched code, hit the same condition and was handled correctly.

| | old code | patched code |
|---|---|---|
| compression-spiral errors | 6+ | **0** |

After adding layer 3 (self-heal), the same session recovered with **no manual DB edit and no restart** — `sanitize_api_messages` fired on the next send (verified live).