### PR TITLE
fix(pricing): resolve dated Anthropic model ids to their base snapshot entry

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -997,6 +997,32 @@ def _normalize_anthropic_model_name(model: str) -> str:
     return name
 
 
+# A release date appended to an ALREADY-VERSIONED new-scheme Anthropic id, e.g.
+# claude-haiku-4-5-20251001 → the dated alias of claude-haiku-4-5.
+#
+# The trailing "-N-N" version segment before the date is required, and that is
+# the whole point of the pattern: it distinguishes a date APPENDED to a
+# versioned name (strippable, the base entry is the same SKU) from an
+# OLD-scheme id whose date is an inseparable part of the name
+# (claude-3-5-haiku-20241022 — stripping would land on the non-existent
+# claude-3-5-haiku).  ``_normalize_bedrock_model_name`` already performs the
+# equivalent ``-\d{8}$`` strip for Bedrock inference-profile ids; this is the
+# same normalization for the direct Anthropic route, which lacked it.
+_ANTHROPIC_DATED_SUFFIX_RE = re.compile(r"^(claude-.*-\d+-\d+)-\d{8}$")
+
+
+def _strip_anthropic_release_date(name: str) -> Optional[str]:
+    """Strip a trailing -YYYYMMDD from a versioned new-scheme Anthropic id.
+
+    ``claude-haiku-4-5-20251001`` → ``claude-haiku-4-5``.  Returns None when
+    there is no such suffix to strip, including for old-scheme ids like
+    ``claude-3-5-haiku-20241022`` which lack the ``-N-N`` version tail before
+    the date and so are left intact for their own direct entry.
+    """
+    match = _ANTHROPIC_DATED_SUFFIX_RE.match(name)
+    return match.group(1) if match else None
+
+
 def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]:
     model = route.model.lower()
     # Direct lookup first
@@ -1008,6 +1034,18 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
         normalized = _normalize_anthropic_model_name(model)
         if normalized != model:
             entry = _OFFICIAL_DOCS_PRICING.get((route.provider, normalized))
+            if entry:
+                return entry
+        # Last resort: strip a trailing -YYYYMMDD release date appended to an
+        # already-versioned id and retry on the base (claude-haiku-4-5-20251001
+        # → claude-haiku-4-5).  Runs AFTER the direct and dot-normalized
+        # lookups, so an id that has its own table entry — dated or not —
+        # always wins on its own key and this never overrides a real rate.
+        # Without it, the dated aliases Anthropic publishes (and that this repo
+        # ships in hermes_cli/models.py) record cost_usd NULL for every turn.
+        base = _strip_anthropic_release_date(normalized)
+        if base and base != normalized:
+            entry = _OFFICIAL_DOCS_PRICING.get((route.provider, base))
             if entry:
                 return entry
     # Bedrock cross-region inference profiles carry a region prefix

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,3 +1,4 @@
+import re
 from types import SimpleNamespace
 
 from agent.usage_pricing import (
@@ -636,3 +637,115 @@ def test_deepseek_v4_flash_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $0.14/M + 500K output × $0.28/M = $0.14 + $0.14 = $0.28
     assert float(result.amount_usd) == 0.28
+
+
+def test_anthropic_dated_alias_resolves_to_its_base_pricing():
+    """A dated Anthropic id must price identically to its undated base.
+
+    Anthropic publishes each model under both a rolling alias
+    (``claude-haiku-4-5``) and a dated alias pinning a specific release
+    (``claude-haiku-4-5-20251001``).  They are the same SKU at the same rate,
+    but only the rolling form is a pricing-table key, so a session pinned to
+    the dated id recorded ``cost_usd`` NULL for every turn.
+
+    Asserted as a relation to the base entry rather than as literal dollar
+    figures, so the guard survives a rate update.
+    """
+    for dated, base in (
+        ("claude-haiku-4-5-20251001", "claude-haiku-4-5"),
+        ("claude-sonnet-4-5-20250929", "claude-sonnet-4-5"),
+        ("claude-opus-4-5-20251101", "claude-opus-4-5"),
+    ):
+        base_entry = get_pricing_entry(base, provider="anthropic")
+        assert base_entry is not None, base
+        dated_entry = get_pricing_entry(dated, provider="anthropic")
+        assert dated_entry is not None, dated
+        for field in (
+            "input_cost_per_million",
+            "output_cost_per_million",
+            "cache_read_cost_per_million",
+            "cache_write_cost_per_million",
+        ):
+            assert getattr(dated_entry, field) == getattr(base_entry, field), (
+                f"{dated} must price as {base} on {field}"
+            )
+
+
+def test_anthropic_old_scheme_dated_ids_keep_their_own_pricing():
+    """Old-scheme ids whose date is part of the name must NOT be rewritten.
+
+    ``claude-3-5-haiku-20241022`` is the model's actual id, not an alias of a
+    ``claude-3-5-haiku`` that does not exist.  Stripping its date would either
+    miss (best case) or, worse, collide with an unrelated family entry — so
+    these must continue to resolve on their own key at their own rate.
+    """
+    haiku_35 = get_pricing_entry("claude-3-5-haiku-20241022", provider="anthropic")
+    sonnet_35 = get_pricing_entry("claude-3-5-sonnet-20241022", provider="anthropic")
+
+    assert haiku_35 is not None
+    assert sonnet_35 is not None
+    # Distinct models must not have been collapsed onto one entry.
+    assert haiku_35.input_cost_per_million != sonnet_35.input_cost_per_million
+
+
+def test_anthropic_dated_fallback_never_overrides_an_explicit_entry():
+    """A dated id that HAS its own table key must resolve on that key.
+
+    The date-stripping fallback runs last, after the direct and dot-normalized
+    lookups, so a deliberately priced dated entry always wins over its base.
+    """
+    from agent.usage_pricing import _OFFICIAL_DOCS_PRICING
+
+    explicitly_dated = [
+        model
+        for (provider, model) in _OFFICIAL_DOCS_PRICING
+        if provider == "anthropic" and re.search(r"-\d{8}$", model)
+    ]
+    assert explicitly_dated, "expected the snapshot to carry some dated keys"
+
+    for model in explicitly_dated:
+        resolved = get_pricing_entry(model, provider="anthropic")
+        assert resolved is not None, model
+        assert resolved is _OFFICIAL_DOCS_PRICING[("anthropic", model)], model
+
+
+def test_every_shipped_dated_anthropic_id_is_priceable():
+    """Invariant: every dated Anthropic id this repo ships in its own catalog
+    resolves to pricing.
+
+    ``hermes_cli/models.py`` is what the picker offers users, so a dated id
+    listed there that the pricing table cannot resolve is a guaranteed
+    unpriced session.  Asserting the relation between the two structures
+    (rather than freezing either list) keeps this correct as models are added
+    — a newly listed dated model that nobody adds a rate for turns this red.
+
+    Scoped to dated ids on purpose: undated catalog entries include
+    subscription-bridge slugs (e.g. ``claude-code``) that are priced by a
+    different mechanism and are out of scope here.
+    """
+    from hermes_cli import models as catalog
+
+    def _walk(value):
+        if isinstance(value, str):
+            yield value
+        elif isinstance(value, dict):
+            for item in value.values():
+                yield from _walk(item)
+        elif isinstance(value, (list, tuple, set)):
+            for item in value:
+                yield from _walk(item)
+
+    shipped_dated = {
+        model
+        for value in vars(catalog).values()
+        for model in _walk(value)
+        if model.startswith("claude-") and re.search(r"-\d{8}$", model)
+    }
+    assert shipped_dated, "expected the catalog to list some dated claude-* ids"
+
+    unpriced = sorted(
+        model
+        for model in shipped_dated
+        if get_pricing_entry(model, provider="anthropic") is None
+    )
+    assert not unpriced, f"catalog models with no resolvable pricing: {unpriced}"

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -749,3 +749,41 @@ def test_every_shipped_dated_anthropic_id_is_priceable():
         if get_pricing_entry(model, provider="anthropic") is None
     )
     assert not unpriced, f"catalog models with no resolvable pricing: {unpriced}"
+
+
+def test_anthropic_dated_snapshot_ids_price_as_family_alias():
+    """Dated snapshot ids must price field-equal to their family alias.
+
+    Contributed by @Parker-Fawcett on #71441 (salvaged from closed #92749);
+    pins the table layer of the dated-suffix fallback.
+    """
+    for alias, dated in (
+        ("claude-haiku-4-5", "claude-haiku-4-5-20251001"),
+        ("claude-sonnet-4-5", "claude-sonnet-4-5-20250929"),
+    ):
+        ref = get_pricing_entry(alias, provider="anthropic")
+        assert ref is not None, alias
+        entry = get_pricing_entry(dated, provider="anthropic")
+        assert entry is not None, dated
+        assert entry.input_cost_per_million == ref.input_cost_per_million, dated
+        assert entry.output_cost_per_million == ref.output_cost_per_million, dated
+
+
+def test_anthropic_dated_snapshot_session_estimates_cost_not_unknown():
+    """Pinned snapshot ids must yield status='estimated', not unknown.
+
+    Contributed by @Parker-Fawcett on #71441; mirrors the Bedrock
+    estimate-level regression shape and pins the estimate layer that
+    empty_response_guard's cost-aware retry throttle depends on
+    (@vszgdcn8cj-ctrl's consumer report on the same PR).
+    """
+    usage = SimpleNamespace(
+        input_tokens=1000,
+        output_tokens=500,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+    )
+    for model in ("claude-haiku-4-5-20251001", "claude-sonnet-4-5-20250929"):
+        result = estimate_usage_cost(model, usage, provider="anthropic")
+        assert result.status == "estimated", model
+        assert result.amount_usd is not None, model


### PR DESCRIPTION
# fix(pricing): resolve dated Anthropic model ids to their base snapshot entry

## Symptom on current `main`

Select any dated Anthropic model from Hermes' **own** model picker and every
turn records `cost_usd` NULL. `/usage`, the cost footer and the credits tracker
all report `n/a` / `unknown` indefinitely — real spend is silently unaccounted.

Reproduced on `main` with no fixture, using the ids this repo ships:

```python
>>> from agent.usage_pricing import get_pricing_entry
>>> get_pricing_entry("claude-opus-4-5-20251101",  provider="anthropic")   # None
>>> get_pricing_entry("claude-sonnet-4-5-20250929", provider="anthropic")  # None
>>> get_pricing_entry("claude-haiku-4-5-20251001",  provider="anthropic")  # None
>>> get_pricing_entry("claude-haiku-4-5",           provider="anthropic")  # <PricingEntry ...>
```

These are not exotic strings. All three are listed in this repo's own catalog
at `hermes_cli/models.py:384-388`, and `claude-haiku-4-5-20251001` is also the
Anthropic plugin's `default_aux_model`
(`plugins/model-providers/anthropic/__init__.py:51`) — so the aux model ships
unpriced out of the box.

## Exact line where it manifests

`agent/usage_pricing.py:1000`, `_lookup_official_docs_pricing()`:

```python
def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]:
    model = route.model.lower()
    entry = _OFFICIAL_DOCS_PRICING.get((route.provider, model))     # miss
    if entry:
        return entry
    if route.provider == "anthropic":
        normalized = _normalize_anthropic_model_name(model)          # no-op: no dots
        if normalized != model:
            ...
    if route.provider == "bedrock":
        ...
    return None                                                      # ← unpriced
```

For `claude-haiku-4-5-20251001` the direct lookup misses (the table is keyed on
`claude-haiku-4-5`), `_normalize_anthropic_model_name` only rewrites dot
notation so it returns the string unchanged and the `if normalized != model`
branch never fires, and the Bedrock branch does not apply. Control reaches
`return None` and the caller records the turn as unpriced.

## Root cause

Anthropic publishes each model under two ids: a **rolling** alias
(`claude-haiku-4-5`) and a **dated** alias pinning a specific release
(`claude-haiku-4-5-20251001`). They are the same SKU at the same published
rate. `_OFFICIAL_DOCS_PRICING` is keyed on the rolling form, and nothing maps
the dated form onto it.

The project already knows this normalization is required — it just isn't
applied on this route. `_normalize_bedrock_model_name()`
(`agent/usage_pricing.py:942`) performs exactly this strip for Bedrock
inference-profile ids:

```python
name = re.sub(r":\d+$", "", name)
name = re.sub(r"-v\d+$", "", name)
name = re.sub(r"-\d{8}$", "", name)   # ← the same trailing release date
```

which is why `us.anthropic.claude-haiku-4-5-20251001-v1:0` **does** price on
`main` while the plain `claude-haiku-4-5-20251001` does not. Routing the same
model through Bedrock gets a cost; routing it directly does not.

## The fix

Add the equivalent normalization for the direct Anthropic route, as a **last
resort** after the existing lookups:

```python
_ANTHROPIC_DATED_SUFFIX_RE = re.compile(r"^(claude-.*-\d+-\d+)-\d{8}$")

def _strip_anthropic_release_date(name: str) -> Optional[str]: ...
```

Two deliberate properties:

**1. The `-N-N` version segment before the date is required.** This is what
separates a date *appended* to an already-versioned name (`claude-haiku-4-5`
`-20251001` → strippable, same SKU) from an **old-scheme** id whose date is an
inseparable part of the name (`claude-3-5-haiku-20241022` — stripping would
land on a `claude-3-5-haiku` that does not exist, and risks colliding with an
unrelated family). Old-scheme ids are left intact and keep resolving on their
own keys at their own rates.

**2. It runs last**, after the direct and dot-normalized lookups. Any id with
its own table entry — dated or not, e.g. `claude-opus-4-6-20250414` — still
resolves on that key. The fallback can only fill a gap, never override a
deliberately-set rate. Both properties are pinned by tests.

This is *"Extend, don't duplicate"*: the fix makes the two provider routes
agree on one already-established normalization rather than inventing a
mechanism. No new config key, no new env var, no new dependency, no change to
the pricing data itself.

## Test evidence

Four new tests in `tests/agent/test_usage_pricing.py`, following the
conventions of the adjacent `test_bedrock_*_resolves_to_bare_pricing` tests:

| test | asserts |
|---|---|
| `test_anthropic_dated_alias_resolves_to_its_base_pricing` | each dated id prices **identically to its base** across all four rate fields |
| `test_anthropic_old_scheme_dated_ids_keep_their_own_pricing` | `claude-3-5-haiku-20241022` / `claude-3-5-sonnet-20241022` still resolve, and were not collapsed onto one entry |
| `test_anthropic_dated_fallback_never_overrides_an_explicit_entry` | every explicitly-dated snapshot key resolves to *that exact object* (`is` identity), so the fallback can't shadow it |
| `test_every_shipped_dated_anthropic_id_is_priceable` | invariant between `hermes_cli/models.py` and the pricing table: no dated catalog id may be unpriceable |

Per *"Behavior contracts over snapshots"*, none of these freeze a dollar
figure or a model list. The first asserts a **relation to the base entry** (so
a rate update keeps it green); the last asserts a **relation between two
existing structures** — it turns red only when a newly-listed dated model has
no resolvable rate, which is precisely the bug class. They are not
change-detector tests.

```
# fix applied
$ pytest tests/agent/test_usage_pricing.py -q
36 passed in 2.10s          # 32 pre-existing + 4 new

# RED proof — fix reverted, tests kept
$ pytest tests/agent/test_usage_pricing.py -q
2 failed, 34 passed
  FAILED ...::test_anthropic_dated_alias_resolves_to_its_base_pricing
  FAILED ...::test_every_shipped_dated_anthropic_id_is_priceable
      AssertionError: catalog models with no resolvable pricing:
        ['claude-haiku-4-5-20251001', 'claude-opus-4-5-20251101', 'claude-sonnet-4-5-20250929']

# no regression across pricing / usage / cost / model-metadata
$ pytest tests/agent/ -q -k "pricing or usage or cost or model_metadata"
298 passed, 6541 deselected in 21.04s
```

The RED run names the three shipped catalog models directly — the invariant
test reports the symptom rather than just failing.

## Footprint

- `agent/usage_pricing.py`: +38 lines (one regex, one 10-line helper, one
  12-line fallback branch). No signature or public API change.
- No new core tool, no new `HERMES_*` env var, no config key, no new
  dependency, no pricing-data edits.
