### PR TITLE
fix(model-metadata): local ctx probe must not read max_tokens as the context window

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -843,6 +843,25 @@ def _extract_first_int(payload: Dict[str, Any], keys: tuple[str, ...]) -> Option
     return None
 
 
+def _extract_flat_context_length(payload: Dict[str, Any]) -> Optional[int]:
+    """Read a context WINDOW from the top level of a model-describe payload.
+
+    Same key vocabulary as :func:`_extract_context_length` (the module's single
+    source of truth for what counts as a context window), but WITHOUT the
+    nested-dict walk — for callers that hold a specific model object and must
+    not pick up a same-named key from an unrelated nested section.
+
+    Critically, ``max_tokens`` is NOT in ``_CONTEXT_LENGTH_KEYS``: it lives in
+    ``_MAX_COMPLETION_KEYS`` because on an OpenAI-compatible ``/v1/models``
+    passthrough it is the max *output* tokens, not the context window.
+    """
+    for key in _CONTEXT_LENGTH_KEYS:
+        coerced = _coerce_reasonable_int(payload.get(key))
+        if coerced is not None:
+            return coerced
+    return None
+
+
 def _extract_context_length(payload: Dict[str, Any]) -> Optional[int]:
     return _extract_first_int(payload, _CONTEXT_LENGTH_KEYS)
 
@@ -1833,10 +1852,17 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
             resp = client.get(f"{server_url}/v1/models/{model}")
             if resp.status_code == 200:
                 data = resp.json()
-                # vLLM returns max_model_len
-                ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")
-                if ctx and isinstance(ctx, (int, float)):
-                    return int(ctx)
+                # Context-WINDOW keys only. `max_tokens` is deliberately NOT
+                # consulted: on an OpenAI-compatible /v1/models/{id} passthrough
+                # (LiteLLM, an Anthropic-compat shim, a cloud proxy) it is the
+                # max *output* tokens — e.g. 128000 for a 1M-context model — so
+                # reading it here collapses the window to the output cap and
+                # triggers premature auto-compaction. `_CONTEXT_LENGTH_KEYS` is
+                # the module's single source of truth for this distinction and
+                # already places `max_tokens` in `_MAX_COMPLETION_KEYS` instead.
+                ctx = _extract_flat_context_length(data)
+                if ctx is not None:
+                    return ctx
 
             # Try /v1/models and find the model in the list.
             # Use _model_id_matches to handle "publisher/slug" vs bare "slug".
@@ -1846,9 +1872,12 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                 models_list = data.get("data", [])
                 for m in models_list:
                     if _model_id_matches(m.get("id", ""), model):
-                        ctx = m.get("max_model_len") or m.get("context_length") or m.get("max_tokens")
-                        if ctx and isinstance(ctx, (int, float)):
-                            return int(ctx)
+                        # Context-WINDOW keys only — sibling of the
+                        # /v1/models/{id} path above; see that comment for why
+                        # `max_tokens` must not be read as a context window.
+                        ctx = _extract_flat_context_length(m)
+                        if ctx is not None:
+                            return ctx
     except Exception:
         pass
 

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -190,6 +190,94 @@ class TestQueryLocalContextLengthVllm:
 
         assert result == 32768
 
+    def test_detail_branch_reads_context_window_not_output_cap(self):
+        """A payload carrying BOTH a context window and an output cap must
+        resolve to the context window.
+
+        An OpenAI-compatible ``/v1/models/{id}`` passthrough (LiteLLM, an
+        Anthropic-compat shim, a cloud proxy) returns ``max_input_tokens`` —
+        the context window — alongside ``max_tokens``, the max *output*
+        tokens.  Reading ``max_tokens`` collapses a 1M-context model to its
+        128K output cap and drives premature auto-compaction.
+
+        Contract asserted: when a describe payload contains both classes of
+        key, the resolver returns the ``_CONTEXT_LENGTH_KEYS`` value, never
+        the ``_MAX_COMPLETION_KEYS`` one.
+        """
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(200, {
+            "type": "model",
+            "id": "some-model",
+            "max_input_tokens": 1000000,   # context window
+            "max_tokens": 128000,          # max OUTPUT tokens — not a window
+        })
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.return_value = detail_resp
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="vllm"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("some-model", "http://localhost:8000/v1")
+
+        assert result == 1000000, (
+            f"must resolve the context window, not the output cap; got {result}"
+        )
+
+    def test_list_branch_reads_context_window_not_output_cap(self):
+        """Same contract on the sibling ``/v1/models`` LIST branch.
+
+        Both probe branches must share one definition of "context window";
+        fixing only the detail branch would leave the identical bug reachable
+        whenever the per-model describe endpoint 404s.
+        """
+        from agent.model_metadata import _query_local_context_length
+
+        detail_miss = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {"data": [
+            {"id": "some-model", "max_input_tokens": 1000000, "max_tokens": 128000},
+        ]})
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        # first GET is /v1/models/{model} (miss), second is /v1/models (list)
+        client_mock.get.side_effect = [detail_miss, list_resp]
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="vllm"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("some-model", "http://localhost:8000/v1")
+
+        assert result == 1000000, (
+            f"list branch must resolve the context window, not the output cap; got {result}"
+        )
+
+    def test_probe_agrees_with_the_module_key_vocabulary(self):
+        """Invariant: the probe's notion of a context window is the module's.
+
+        ``_CONTEXT_LENGTH_KEYS`` / ``_MAX_COMPLETION_KEYS`` are the single
+        source of truth for this distinction.  Asserting the relation (rather
+        than a frozen key list) keeps the guard correct as the vocabulary
+        grows, and fails if a probe branch ever re-hardcodes its own keys.
+        """
+        from agent import model_metadata as mm
+
+        assert "max_tokens" in mm._MAX_COMPLETION_KEYS
+        assert "max_tokens" not in mm._CONTEXT_LENGTH_KEYS
+        # No key may be classified as both a window and an output cap.
+        assert not (set(mm._CONTEXT_LENGTH_KEYS) & set(mm._MAX_COMPLETION_KEYS))
+
+        # Every context key the module recognises is honoured by the flat
+        # reader the probe branches use, and no completion key ever is.
+        for key in mm._CONTEXT_LENGTH_KEYS:
+            assert mm._extract_flat_context_length({key: 123456}) == 123456, key
+        for key in mm._MAX_COMPLETION_KEYS:
+            assert mm._extract_flat_context_length({key: 123456}) is None, key
+
 
 class TestQueryLocalContextLengthModelsList:
     """_query_local_context_length: falls back to /v1/models list."""


### PR DESCRIPTION
# fix(model-metadata): local ctx probe must not read `max_tokens` as the context window

## Symptom on current `main`

Point Hermes at any OpenAI-compatible endpoint that describes a model with
**both** a context window and an output cap — a LiteLLM gateway, an
Anthropic-compat shim, a self-hosted proxy — and the resolved context window
collapses to the model's **max output tokens**.

Concretely, a `/v1/models/{id}` describe payload of the common shape:

```json
{ "type": "model", "id": "<model>", "max_input_tokens": 1000000, "max_tokens": 128000 }
```

resolves to `128000`. The user sees auto-compaction fire at roughly 7× too
early on a 1M-context model, and `hermes models` reports the wrong window.

## Exact line where it manifests

`agent/model_metadata.py`, inside `_query_local_context_length_uncached()` —
**two** sibling branches:

```python
# agent/model_metadata.py:1837  (the /v1/models/{model} detail branch)
ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")

# agent/model_metadata.py:1849  (the /v1/models LIST fallback branch)
ctx = m.get("max_model_len") or m.get("context_length") or m.get("max_tokens")
```

`max_tokens` is the last alternative in each `or` chain, so it wins whenever
the server does not publish `max_model_len`/`context_length` — which is exactly
what an OpenAI-compatible passthrough does. It publishes `max_input_tokens`
(the window) and `max_tokens` (the output cap), and the chain consults neither
correctly: it skips the real window and takes the output cap.

## Root cause

These two lines hand-roll their own idea of "what key means context window",
and that idea **contradicts the module's own vocabulary declared 1,400 lines
above them**:

```python
# agent/model_metadata.py:414
_CONTEXT_LENGTH_KEYS = (
    "context_length", "context_window", "context_size", "max_context_length",
    "max_position_embeddings", "max_model_len", "max_input_tokens",
    "max_sequence_length", "max_seq_len", "n_ctx_train", "n_ctx", "ctx_size",
)

# agent/model_metadata.py:429
_MAX_COMPLETION_KEYS = ("max_completion_tokens", "max_output_tokens", "max_tokens")
```

The module already knows `max_tokens` is an output cap and already knows
`max_input_tokens` is a window. `_extract_context_length()` (line 846) honours
that split correctly. The local probe simply never used it — it duplicated the
lookup with a three-key ad-hoc chain that got the classification backwards.

## The fix

Add one small helper next to the existing extractors and route **both** probe
branches through it:

```python
def _extract_flat_context_length(payload: Dict[str, Any]) -> Optional[int]:
    """Read a context WINDOW from the top level of a model-describe payload."""
    for key in _CONTEXT_LENGTH_KEYS:
        coerced = _coerce_reasonable_int(payload.get(key))
        if coerced is not None:
            return coerced
    return None
```

Why a *flat* reader rather than reusing `_extract_context_length()` directly:
that function walks nested dicts, which is right for a whole-server payload but
wrong here — these two call sites already hold **one specific model object**,
and a nested walk could pick up a same-named key from an unrelated sibling
section. The flat reader keeps the existing call-site semantics byte-for-byte
while inheriting the correct key classification.

This is the rubric's *"Extend, don't duplicate"* — the infrastructure that
answers this question already existed; the bug was that the probe didn't use
it.

### Whole bug class, sibling call paths included

Per the rubric's *"fixes the whole bug class — sibling call paths included —
not just the one site the reporter hit"*: the symptom is reachable through
either probe branch (the LIST branch is what runs whenever the per-model
describe endpoint 404s, which is the norm on several proxies). **Both** are
fixed in this PR, and a third test pins the invariant so a future branch can't
re-hardcode its own key chain and reintroduce the bug.

The fix also *widens* correct behaviour as a side effect: both branches now
recognise every window key the module knows (`context_window`,
`max_position_embeddings`, `n_ctx`, …), not just the two they had hardcoded.

## Test evidence

`tests/agent/test_model_metadata_local_ctx.py`, three new tests in
`TestQueryLocalContextLengthVllm`:

| test | asserts |
|---|---|
| `test_detail_branch_reads_context_window_not_output_cap` | detail branch given both keys → returns the window (1,000,000), not the cap (128,000) |
| `test_list_branch_reads_context_window_not_output_cap` | LIST branch, same contract (the sibling path) |
| `test_probe_agrees_with_the_module_key_vocabulary` | invariant: the two key sets are disjoint, `max_tokens` is a completion key, every `_CONTEXT_LENGTH_KEYS` entry is honoured by the probe reader and no `_MAX_COMPLETION_KEYS` entry ever is |

Per *"Behavior contracts over snapshots"*, the third test asserts a **relation
between the two key tuples and the probe's behaviour** rather than freezing a
key list — adding a new context key to `_CONTEXT_LENGTH_KEYS` keeps it green;
misclassifying one turns it red. It is not a change-detector.

```
# fix applied
$ pytest tests/agent/test_model_metadata_local_ctx.py -q
37 passed in 1.09s

# RED proof — fix reverted, tests kept
$ pytest tests/agent/test_model_metadata_local_ctx.py -q
2 failed, 35 passed
  FAILED ...::test_detail_branch_reads_context_window_not_output_cap
      AssertionError: must resolve the context window, not the output cap; got 128000
  FAILED ...::test_list_branch_reads_context_window_not_output_cap
      AssertionError: list branch must resolve the context window, not the output cap; got 128000

# no regression across the model-metadata + probe-cache suites
$ pytest tests/agent/test_model_metadata_local_ctx.py \
         tests/agent/test_model_metadata.py \
         tests/agent/test_probe_cache_followups.py -q
185 passed in 5.24s
```

(The invariant test passes in both directions by design — it guards the
vocabulary, not the branch wiring; the two branch tests carry the RED proof.)

## Footprint

- 1 source file, +30/−7 net in `agent/model_metadata.py` (one new 17-line
  helper, two call sites simplified).
- No new core tool, no new `HERMES_*` env var, no config key, no new dependency.
- No public API change; the helper is module-private.
