### PR TITLE
fix: prevent import-lock deadlock in _check_gateway_running with 30+ profiles

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -34,6 +34,10 @@ from typing import List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
 
+# Pre-load gateway.status at module level to avoid import-lock deadlock
+# when list_profiles() iterates 30+ profiles via run_in_executor.
+from gateway.status import get_running_pid, get_runtime_status_running_pid, read_runtime_status
+
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
 # Directories bootstrapped inside every new profile
@@ -691,7 +695,6 @@ def _check_gateway_running(profile_dir: Path) -> bool:
     agree.  Parameterized by ``profile_dir`` so it never mutates ``HERMES_HOME``.
     """
     try:
-        from gateway.status import get_running_pid
         if (
             get_running_pid(profile_dir / "gateway.pid", cleanup_stale=False)
             is not None
@@ -700,10 +703,6 @@ def _check_gateway_running(profile_dir: Path) -> bool:
     except Exception:
         pass
     try:
-        from gateway.status import (
-            get_runtime_status_running_pid,
-            read_runtime_status,
-        )
         runtime = read_runtime_status(profile_dir / "gateway_state.json")
         return get_runtime_status_running_pid(runtime, expected_home=profile_dir) is not None
     except Exception:


### PR DESCRIPTION
## Problem

When a Hermes Dashboard serves 30+ profiles, /api/profiles hangs (never responds). Process shows high CPU, zero I/O.

## Root Cause

Two interacting issues:

1. **Design: list_profiles() scans all profiles on every call.** Each /api/profiles request rebuilds 30 ProfileInfo objects, reading config.yaml + counting skills + checking gateway status. No caching at the function level — the 30-profile scan repeats on every browser refresh.

2. **Import-lock deadlock: _check_gateway_running() hot-imports inside the scan loop.** The function contains two from gateway.status import ... blocks inside the function body. When list_profiles() iterates 30+ profiles via loop.run_in_executor(), each iteration triggers these dynamic imports. Multiple threads contend for Python's global import lock simultaneously with Dashboard startup imports — causing the deadlock.

If issue #1 were addressed (e.g., a simple TTL cache on list_profiles()), the import-lock contention window would shrink enough that issue #2 would rarely trigger. However, the import-lock bug is still a latent correctness issue regardless.

## Fix (this PR)

Move the three gateway.status symbols to a single module-level import:

- +4 lines: module-level import
- -5 lines: function-level imports removed

## Suggested Follow-up

Add a lightweight TTL cache (e.g., 30-60s) to list_profiles() itself. Profile metadata (name, model, skill count) changes rarely — rebuilding 30 ProfileInfo objects on every browser refresh is wasteful and amplifies any thread-pool contention.

## Testing

- 30 profiles: /api/profiles responds in 6s (was: infinite hang)
- 1-5 profiles: no behavioral change
- Standalone list_profiles(): no regression