### PR TITLE
fix(desktop): authenticate the boot readiness probe and keep the reauth overlay clickable

### DIFF
--- a/apps/desktop/electron/backend-health.test.ts
+++ b/apps/desktop/electron/backend-health.test.ts
@@ -2,7 +2,15 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { DEFAULT_HEALTH_PROBE_TIMEOUT_MS, isMissingHealthEndpointError, waitForHermesReady } from './backend-health'
+import {
+  DEFAULT_HEALTH_PROBE_TIMEOUT_MS,
+  isAuthRejectionError,
+  isMissingHealthEndpointError,
+  isReauthRequiredError,
+  makeReauthRequiredError,
+  REMOTE_SESSION_EXPIRED_MESSAGE,
+  waitForHermesReady
+} from './backend-health'
 
 test('uses lightweight /api/health for current backends', async () => {
   const calls: string[][] = []
@@ -133,4 +141,140 @@ test('recognizes missing-route shapes only', () => {
   )
   assert.equal(isMissingHealthEndpointError(new Error('Timed out connecting to Hermes backend after 15000ms')), false)
   assert.equal(isMissingHealthEndpointError(new Error('500: boom')), false)
+})
+
+test('uses the credentialed probeHealth for /api/health when provided', async () => {
+  const calls: string[][] = []
+
+  await waitForHermesReady('http://gateway.example/hermes', {
+    // A credential-free fetch would 401 no_cookie on a gated gateway — the probe
+    // must go through the authed path instead.
+    fetchPublicJson: async url => {
+      calls.push(['public', url])
+      throw new Error('401: {"reason":"no_cookie"}')
+    },
+    fetchJson: async () => {
+      throw new Error('status should not be called')
+    },
+    probeHealth: async url => {
+      calls.push(['authed', url])
+
+      return { ok: true }
+    },
+    sleep: async () => {},
+    timeoutMs: 100,
+    pollMs: 1
+  })
+
+  assert.deepEqual(calls, [['authed', 'http://gateway.example/hermes/api/health']])
+})
+
+test('fails fast (no polling) when the credentialed probe reports reauth-required', async () => {
+  let probes = 0
+  let slept = 0
+
+  await assert.rejects(
+    waitForHermesReady('http://gateway.example/hermes', {
+      fetchPublicJson: async () => ({ ok: true }),
+      fetchJson: async () => {
+        throw new Error('status should not be called')
+      },
+      // Simulates the oauth probe converting a confirmed 401 into the terminal
+      // reauth error — polling can't revive an expired session.
+      probeHealth: async () => {
+        probes += 1
+        throw makeReauthRequiredError(new Error('401: {"reason":"no_cookie"}'))
+      },
+      sleep: async () => {
+        slept += 1
+      },
+      timeoutMs: 10_000,
+      pollMs: 1
+    }),
+    (error: unknown) => isReauthRequiredError(error) && error instanceof Error
+  )
+
+  // One probe, then straight out — not a 10s poll loop.
+  assert.equal(probes, 1)
+  assert.equal(slept, 0)
+})
+
+test('isAuthRejectionError matches a confirmed 401/403 status prefix only', () => {
+  assert.equal(isAuthRejectionError(new Error('401: {"reason":"no_cookie"}')), true)
+  assert.equal(isAuthRejectionError(new Error('403: {"detail":"Forbidden"}')), true)
+  assert.equal(isAuthRejectionError(new Error('404: {"detail":"Not Found"}')), false)
+  assert.equal(isAuthRejectionError(new Error('500: boom')), false)
+  assert.equal(isAuthRejectionError(new Error('Timed out connecting to Hermes backend after 5000ms')), false)
+})
+
+test('reauth-required error is tagged for both the boot latch and the renderer overlay', () => {
+  const error = makeReauthRequiredError(new Error('401: {"reason":"no_cookie"}'))
+
+  // Duck-typed needsOauthLogin so isReauthRequiredError (and @hermes/shared's
+  // isGatewayReauthRequired) recognize it without a shared import.
+  assert.equal(isReauthRequiredError(error), true)
+  // Message carries the phrase the renderer's isRemoteReauthError keys on.
+  assert.equal(error.message, REMOTE_SESSION_EXPIRED_MESSAGE)
+  assert.ok(error.message.toLowerCase().includes('remote gateway session has expired'))
+  assert.equal(isReauthRequiredError(new Error('plain error')), false)
+  assert.equal(isReauthRequiredError(null), false)
+})
+
+test('routes the /api/status fallback through the credentialed probe, not the raw token fetch', async () => {
+  const calls: string[] = []
+
+  await waitForHermesReady('http://gateway.example/hermes', {
+    fetchPublicJson: async () => {
+      throw new Error('fetchPublicJson must not be used when a credentialed probe is provided')
+    },
+    // An oauth remote's token is null and fetchJson attaches no cookie/bearer —
+    // the fallback must NOT fall back to this uncredentialed path.
+    fetchJson: async () => {
+      throw new Error('legacy uncredentialed fetchJson must not probe /api/status for a credentialed connection')
+    },
+    probeHealth: async url => {
+      calls.push(url)
+      // Old backend: no /api/health → 404 drives the fallback; /api/status then
+      // answers over the SAME credentialed probe.
+      if (url.endsWith('/api/health')) {
+        throw new Error('404: {"detail":"Not Found"}')
+      }
+
+      return { ok: true }
+    },
+    sleep: async () => {},
+    timeoutMs: 100,
+    pollMs: 1
+  })
+
+  assert.deepEqual(calls, ['http://gateway.example/hermes/api/health', 'http://gateway.example/hermes/api/status'])
+})
+
+test('fails fast when the credentialed /api/status fallback reports reauth', async () => {
+  let slept = 0
+
+  await assert.rejects(
+    waitForHermesReady('http://gateway.example/hermes', {
+      fetchPublicJson: async () => ({ ok: true }),
+      fetchJson: async () => {
+        throw new Error('legacy fetchJson must not be used')
+      },
+      probeHealth: async url => {
+        if (url.endsWith('/api/health')) {
+          throw new Error('404: {"detail":"Not Found"}')
+        }
+        // Auth-gated /api/status on an old oauth gateway → terminal reauth.
+        throw makeReauthRequiredError(new Error('401: {"reason":"no_cookie"}'))
+      },
+      sleep: async () => {
+        slept += 1
+      },
+      timeoutMs: 10_000,
+      pollMs: 1
+    }),
+    (error: unknown) => isReauthRequiredError(error)
+  )
+
+  // Straight out on the reauth from the fallback leg — not a poll-to-timeout.
+  assert.equal(slept, 0)
 })

--- a/apps/desktop/electron/backend-health.ts
+++ b/apps/desktop/electron/backend-health.ts
@@ -10,9 +10,20 @@ export const DEFAULT_HEALTH_PROBE_TIMEOUT_MS = 5_000
 type FetchPublicJson = (url: string, options?: { timeoutMs?: number }) => Promise<unknown>
 type FetchJson = (url: string, token?: string | null, options?: { timeoutMs?: number }) => Promise<unknown>
 
+// User-facing readiness-failure copy for an expired remote session. Phrased so
+// the renderer's isRemoteReauthError() classifies it (substring "remote gateway
+// session has expired") and surfaces the "Sign in" recovery instead of the
+// local Retry/Repair buttons.
+export const REMOTE_SESSION_EXPIRED_MESSAGE =
+  'Your remote gateway session has expired. Open Settings → Gateway and sign in again.'
+
 export interface HermesReadyOptions {
   fetchPublicJson: FetchPublicJson
   fetchJson: FetchJson
+  // Health-endpoint probe. Defaults to the credential-free fetchPublicJson;
+  // oauth/token remotes pass a credentialed probe so an auth-gated /api/health
+  // does not 401-loop the whole boot (see resolveReadinessProbeAuth).
+  probeHealth?: FetchPublicJson
   token?: string | null
   signal?: AbortSignal
   timeoutMs?: number
@@ -26,6 +37,38 @@ export function isMissingHealthEndpointError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error ?? '')
 
   return /^404:/.test(message) || message.includes('endpoint is likely missing')
+}
+
+// A confirmed 401/403 from the health probe — the session is rejected, not the
+// backend warming up. fetchJson/fetchJsonViaOauthSession surface HTTP errors as
+// `${status}: ${body}`, so the status leads the message.
+export function isAuthRejectionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  return /^(401|403):/.test(message)
+}
+
+// True for an error tagged "needs OAuth sign-in" (duck-typed on needsOauthLogin,
+// matching @hermes/shared's isGatewayReauthRequired without importing it into
+// the main-process bundle). Such a probe failure is terminal for boot — polling
+// cannot fix an expired session.
+export function isReauthRequiredError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as { needsOauthLogin?: unknown }).needsOauthLogin === true
+}
+
+// Build the terminal reauth error a credentialed probe throws on a confirmed
+// 401/403. Tagged so the boot latch (isReauthRequiredError) and the renderer
+// overlay (message) both recognize it as "sign in again", not a transient blip.
+export function makeReauthRequiredError(cause?: unknown): Error {
+  const error = new Error(REMOTE_SESSION_EXPIRED_MESSAGE) as Error & { needsOauthLogin: boolean; kind: string }
+  error.needsOauthLogin = true
+  error.kind = 'reauth'
+
+  if (cause !== undefined) {
+    ;(error as Error & { cause?: unknown }).cause = cause
+  }
+
+  return error
 }
 
 function supersededError() {
@@ -58,6 +101,16 @@ export async function waitForHermesReady(baseUrl: string, options: HermesReadyOp
       }))
 
   const base = baseUrl.replace(/\/+$/, '')
+  const probeHealth = options.probeHealth ?? options.fetchPublicJson
+  // The legacy /api/status fallback (for backends predating /api/health) must
+  // carry the SAME credentials as the health probe. An oauth remote has a null
+  // token and fetchJson attaches no cookie/bearer, so a raw fetchJson here would
+  // 401-loop an auth-gated /api/status on a gateway old enough to expose neither
+  // /api/health nor a public /api/status — re-opening this very bug via the
+  // legacy leg. Route it through the credentialed probe when one was provided.
+  const probeStatus = options.probeHealth
+    ? (url: string) => options.probeHealth!(url)
+    : (url: string) => options.fetchJson(url, options.token)
   const deadline = now() + timeoutMs
   let lastError: unknown = null
   let useStatusFallback = false
@@ -69,14 +122,21 @@ export async function waitForHermesReady(baseUrl: string, options: HermesReadyOp
 
     try {
       if (useStatusFallback) {
-        await options.fetchJson(`${base}/api/status`, options.token)
+        await probeStatus(`${base}/api/status`)
       } else {
-        await options.fetchPublicJson(`${base}/api/health`, { timeoutMs: healthProbeTimeoutMs })
+        await probeHealth(`${base}/api/health`, { timeoutMs: healthProbeTimeoutMs })
       }
 
       return
     } catch (error) {
       lastError = error
+
+      // A credentialed probe that came back "needs sign-in" is terminal —
+      // polling can't revive an expired session, so surface it immediately (from
+      // either leg) for the reauth recovery path instead of burning the timeout.
+      if (isReauthRequiredError(error)) {
+        throw error
+      }
 
       // Only an explicitly missing route means the backend predates
       // /api/health; timeouts and server errors keep polling health.

--- a/apps/desktop/electron/backend-start-failure.test.ts
+++ b/apps/desktop/electron/backend-start-failure.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { shouldLatchBackendStartFailure } from './backend-start-failure'
+import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
 
 test('latches a LOCAL backend failure so the install-retry loop is broken', () => {
   assert.equal(shouldLatchBackendStartFailure({ attemptedRemote: false }), true)
@@ -20,4 +20,20 @@ test('the two branches are mutually exclusive (a failure either latches or stays
     const latched = shouldLatchBackendStartFailure({ attemptedRemote })
     assert.equal(latched, !attemptedRemote)
   }
+})
+
+test('latches a confirmed remote reauth failure so the Sign in overlay stops flickering', () => {
+  // An expired session can only be fixed by the user signing in — retrying just
+  // re-emits running:true and hides the recovery overlay.
+  assert.equal(shouldLatchRemoteReauthFailure({ attemptedRemote: true, isReauth: true }), true)
+})
+
+test('never latches a transient remote failure as reauth (it must still self-heal)', () => {
+  // Timeout / network / 5xx are NOT reauth — the next connect must retry.
+  assert.equal(shouldLatchRemoteReauthFailure({ attemptedRemote: true, isReauth: false }), false)
+})
+
+test('a local failure is never a remote reauth latch (backendStartFailure owns local)', () => {
+  assert.equal(shouldLatchRemoteReauthFailure({ attemptedRemote: false, isReauth: true }), false)
+  assert.equal(shouldLatchRemoteReauthFailure({ attemptedRemote: false, isReauth: false }), false)
 })

--- a/apps/desktop/electron/backend-start-failure.ts
+++ b/apps/desktop/electron/backend-start-failure.ts
@@ -39,3 +39,24 @@ export interface BackendStartFailureContext {
 export function shouldLatchBackendStartFailure(context: BackendStartFailureContext): boolean {
   return !context.attemptedRemote
 }
+
+export interface RemoteReauthFailureContext {
+  /** True when the failed boot was resolving/dialing a remote (or cloud) backend. */
+  attemptedRemote: boolean
+  /** True when the failure is a confirmed reauth-shaped rejection (401/403). */
+  isReauth: boolean
+}
+
+/**
+ * Whether a remote boot failure should latch into a SEPARATE `remoteReauthFailure`
+ * latch. Distinct from `shouldLatchBackendStartFailure`: a transient remote
+ * failure must still self-heal (never latch), but a confirmed reauth rejection
+ * cannot be fixed by retrying — only by the user signing in. Latching it stops
+ * startHermes() from re-driving the boot UI on every subsequent getConnection/
+ * api call, which otherwise re-emits running:true and flickers the "Sign in"
+ * recovery overlay out from under the user. Recovery paths (sign-in, reset,
+ * apply-config) clear the latch so the next boot re-probes the fresh session.
+ */
+export function shouldLatchRemoteReauthFailure(context: RemoteReauthFailureContext): boolean {
+  return context.attemptedRemote && context.isReauth
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -34,10 +34,15 @@ import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
-import { waitForHermesReady } from './backend-health'
+import {
+  isAuthRejectionError,
+  isReauthRequiredError,
+  makeReauthRequiredError,
+  waitForHermesReady
+} from './backend-health'
 import { canImportHermesCli, shouldTrustHermesOverride, verifyHermesCli } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
-import { shouldLatchBackendStartFailure } from './backend-start-failure'
+import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
 import { runBootstrap } from './bootstrap-runner'
 import { applyConnectionChange, resolveTerminalConnection } from './connection-apply'
@@ -119,7 +124,12 @@ import {
 } from './hardening'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
-import { oauthSessionIsLive, resolveJsonBody, resolveOauthRestAuth } from './native-auth-decisions'
+import {
+  oauthSessionIsLive,
+  resolveJsonBody,
+  resolveOauthRestAuth,
+  resolveReadinessProbeAuth
+} from './native-auth-decisions'
 import {
   nativeRefreshUrl,
   type NativeTokenSet,
@@ -1016,6 +1026,13 @@ let bootstrapFailure = null
 // Latched non-bootstrap backend spawn failure — stops getConnection() from
 // respawning hermes serve backend children in a tight loop while boot is broken.
 let backendStartFailure = null
+// Latched remote reauth failure: a confirmed 401/403 from a remote/oauth boot
+// means the session is expired and only a user sign-in can fix it. Retrying just
+// re-emits running:true on every getConnection/api call, flickering the "Sign
+// in" overlay out from under the user. Latch it (separately from the transient-
+// safe backendStartFailure) so subsequent startHermes() calls re-throw without
+// re-driving the boot UI. Cleared by the sign-in / reset / apply-config paths.
+let remoteReauthFailure = null
 // Active first-launch install, so the renderer's Cancel button (and app quit)
 // can abort the in-flight install.sh/ps1 instead of leaving it running.
 let bootstrapAbortController = null
@@ -4815,12 +4832,51 @@ function closePreviewWatchers() {
   }
 }
 
-async function waitForHermes(baseUrl, token, signal?) {
+// Build the /api/health readiness probe for a connection's authMode. Local and
+// unknown modes stay credential-free; oauth/token remotes probe WITH the same
+// credentials the real REST calls use, so an auth-gated /api/health can't 401-
+// loop the boot. A confirmed 401/403 becomes the terminal reauth error (only
+// for oauth, whose recovery is a sign-in; a bad static token surfaces as a plain
+// connectivity failure). Mirrors mintGatewayWsTicket's bearer-or-cookie choice.
+function buildReadinessHealthProbe(baseUrl, token, authMode) {
+  if (authMode !== 'oauth' && authMode !== 'token') {
+    return fetchPublicJson
+  }
+
+  return async (url, options: any = {}) => {
+    const nativeAt = authMode === 'oauth' ? await ensureNativeAccessToken(baseUrl).catch(() => null) : null
+    const auth = resolveReadinessProbeAuth(authMode, nativeAt)
+
+    try {
+      switch (auth.kind) {
+        case 'bearer':
+          return await fetchJson(url, null, { ...options, bearer: auth.token })
+        case 'cookie':
+          return await fetchJsonViaOauthSession(url, options)
+        case 'token':
+          return await fetchJson(url, token, options)
+        default:
+          return await fetchPublicJson(url, options)
+      }
+    } catch (error) {
+      // Only an oauth session lapse maps to "sign in again"; a rejected static
+      // token is a connectivity/config error, so leave it to the poll/timeout.
+      if (authMode === 'oauth' && isAuthRejectionError(error)) {
+        throw makeReauthRequiredError(error)
+      }
+
+      throw error
+    }
+  }
+}
+
+async function waitForHermes(baseUrl, token, signal?, authMode?) {
   return waitForHermesReady(baseUrl, {
     token,
     signal,
     fetchPublicJson,
-    fetchJson
+    fetchJson,
+    probeHealth: buildReadinessHealthProbe(baseUrl, token, authMode)
   })
 }
 
@@ -7536,6 +7592,7 @@ function stopBackendChild(child) {
 // switch / crash recovery), which still resets boot progress + reloads.
 function resetHermesConnection({ soft = false } = {}) {
   backendStartFailure = null
+  remoteReauthFailure = null
   remoteLiveness.clear()
   const hermesProcess = backendConnectionState.invalidate()
   stopBackendChild(hermesProcess)
@@ -7736,7 +7793,7 @@ async function spawnPoolBackend(profile, entry) {
   const remote = await resolveRemoteBackend(profile)
 
   if (remote) {
-    await waitForHermes(remote.baseUrl, remote.token)
+    await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode)
 
     return {
       ...remote,
@@ -7928,6 +7985,13 @@ async function startHermes() {
     throw backendStartFailure
   }
 
+  // A latched remote reauth failure re-throws before any advanceBootProgress,
+  // so a repeated getConnection/api call can't re-emit running:true and flicker
+  // the "Sign in" overlay. Cleared by the sign-in / reset / apply-config paths.
+  if (remoteReauthFailure) {
+    throw remoteReauthFailure
+  }
+
   // E2E: simulate a boot failure without breaking the real backend. The boot
   // progresses a few steps, then fails with the given error message.
   if (BOOT_FAKE_ERROR) {
@@ -7954,7 +8018,7 @@ async function startHermes() {
   const connectionPromise = (async () => {
     const connectRemote = async remote => {
       await advanceBootProgress('backend.remote', `Connecting to remote Hermes backend at ${remote.baseUrl}`, 24)
-      await waitForHermes(remote.baseUrl, remote.token)
+      await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode)
       updateBootProgress({
         phase: 'backend.ready',
         message: 'Remote Hermes backend is ready',
@@ -8189,6 +8253,13 @@ async function startHermes() {
     // "Sign out & sign in" reload, and the wake-recovery revalidate path.
     if (shouldLatchBackendStartFailure({ attemptedRemote })) {
       backendStartFailure = error instanceof Error ? error : new Error(message)
+    }
+
+    // A confirmed remote reauth rejection latches separately: it stays retryable
+    // for transient remote failures (above), but an expired session must stop
+    // re-driving the boot UI until the user signs in.
+    if (shouldLatchRemoteReauthFailure({ attemptedRemote, isReauth: isReauthRequiredError(error) })) {
+      remoteReauthFailure = error instanceof Error ? error : new Error(message)
     }
 
     updateBootProgress(
@@ -8994,6 +9065,7 @@ ipcMain.handle('hermes:bootstrap:reset', async () => {
   await teardownPrimaryBackendAndWait()
   bootstrapFailure = null
   backendStartFailure = null
+  remoteReauthFailure = null
   getFirstRunSetupGate().resetForRetry()
   resetBootstrapSnapshot()
 
@@ -9016,6 +9088,7 @@ ipcMain.handle('hermes:bootstrap:repair', async () => {
 
   bootstrapFailure = null
   backendStartFailure = null
+  remoteReauthFailure = null
   getFirstRunSetupGate().resetForRepair()
   resetHermesConnection()
 
@@ -9126,6 +9199,12 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
 
       _storeNativeTokens(baseUrl, tokens)
 
+      // A confirmed sign-in is a real recovery — drop the reauth latch (it lives
+      // in the main process and survives the "Sign in" overlay's renderer-only
+      // reload) so the post-login boot re-probes the fresh session. Cleared only
+      // on success, so a cancelled/failed login leaves the overlay actionable.
+      remoteReauthFailure = null
+
       return { ok: true, baseUrl, connected: true }
     } catch (error) {
       rememberLog(
@@ -9141,7 +9220,14 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
   // Legacy embedded-webview cookie flow.
   await openOauthLoginWindow(baseUrl)
 
-  return { ok: true, baseUrl, connected: await hasOauthSessionCookie(baseUrl) }
+  const connected = await hasOauthSessionCookie(baseUrl)
+
+  // Same as the native path: clear the latch only once a session is confirmed.
+  if (connected) {
+    remoteReauthFailure = null
+  }
+
+  return { ok: true, baseUrl, connected }
 })
 ipcMain.handle('hermes:connection-config:oauth-logout', async (_event, rawUrl) => {
   const baseUrl = rawUrl ? normalizeRemoteBaseUrl(rawUrl) : ''
@@ -9211,6 +9297,9 @@ ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
           // A remote connection bypasses local runtime/bootstrap failures. Clear
           // the local-install latch so unsupported/failure escape paths can re-home.
           bootstrapFailure = null
+          // Applying a new/edited gateway is a deliberate recovery — drop any
+          // reauth latch so the freshly-configured session boots.
+          remoteReauthFailure = null
         },
         mode: config.mode,
         notifyConnectionApplied: sendConnectionApplied,

--- a/apps/desktop/electron/native-auth-decisions.test.ts
+++ b/apps/desktop/electron/native-auth-decisions.test.ts
@@ -10,7 +10,12 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { oauthSessionIsLive, resolveJsonBody, resolveOauthRestAuth } from './native-auth-decisions'
+import {
+  oauthSessionIsLive,
+  resolveJsonBody,
+  resolveOauthRestAuth,
+  resolveReadinessProbeAuth
+} from './native-auth-decisions'
 
 // --- 1. body encoding (guards the double-JSON.stringify 422) ---
 
@@ -65,4 +70,25 @@ test('resolveOauthRestAuth falls back to cookie when there is no native token', 
   assert.deepEqual(resolveOauthRestAuth(undefined), { kind: 'cookie' })
   // Empty string is not a usable bearer — must fall back, not send "Bearer ".
   assert.deepEqual(resolveOauthRestAuth(''), { kind: 'cookie' })
+})
+
+// --- 4. readiness-probe auth selection (guards the boot 401 no_cookie loop) ---
+
+test('resolveReadinessProbeAuth uses the oauth bearer-or-cookie choice for oauth remotes', () => {
+  // The exact bug: a credential-free /api/health probe 401s ("no_cookie") on a
+  // gated gateway and loops boot forever. An oauth remote must probe WITH creds.
+  assert.deepEqual(resolveReadinessProbeAuth('oauth', 'bearer-abc'), { kind: 'bearer', token: 'bearer-abc' })
+  assert.deepEqual(resolveReadinessProbeAuth('oauth', null), { kind: 'cookie' })
+})
+
+test('resolveReadinessProbeAuth sends the static session token for token remotes', () => {
+  assert.deepEqual(resolveReadinessProbeAuth('token', null), { kind: 'token' })
+  // Token mode never consults the native bearer.
+  assert.deepEqual(resolveReadinessProbeAuth('token', 'ignored'), { kind: 'token' })
+})
+
+test('resolveReadinessProbeAuth stays credential-free for local/unknown modes', () => {
+  assert.deepEqual(resolveReadinessProbeAuth('local', null), { kind: 'public' })
+  assert.deepEqual(resolveReadinessProbeAuth(undefined, null), { kind: 'public' })
+  assert.deepEqual(resolveReadinessProbeAuth(null, 'has-token'), { kind: 'public' })
 })

--- a/apps/desktop/electron/native-auth-decisions.ts
+++ b/apps/desktop/electron/native-auth-decisions.ts
@@ -60,3 +60,29 @@ export function resolveOauthRestAuth(nativeAccessToken: string | null | undefine
 
   return { kind: 'cookie' }
 }
+
+export type ReadinessProbeAuth = OauthRestAuth | { kind: 'public' } | { kind: 'token' }
+
+/**
+ * Decide how the boot readiness probe (`GET /api/health`) authenticates for a
+ * connection's authMode. A credential-free probe 401s ("no_cookie") on any
+ * gateway that also gates /api/health, looping boot forever even seconds after
+ * a successful sign-in — so oauth/token remotes must probe WITH credentials:
+ * oauth reuses the bearer-or-cookie choice (resolveOauthRestAuth), token sends
+ * its static session token, and local/unknown stays public. `nativeAccessToken`
+ * is ensureNativeAccessToken's result (only consulted for oauth).
+ */
+export function resolveReadinessProbeAuth(
+  authMode: string | null | undefined,
+  nativeAccessToken: string | null | undefined
+): ReadinessProbeAuth {
+  if (authMode === 'oauth') {
+    return resolveOauthRestAuth(nativeAccessToken)
+  }
+
+  if (authMode === 'token') {
+    return { kind: 'token' }
+  }
+
+  return { kind: 'public' }
+}

--- a/apps/desktop/src/components/boot-failure-reauth.test.ts
+++ b/apps/desktop/src/components/boot-failure-reauth.test.ts
@@ -105,6 +105,16 @@ describe('isRemoteReauthError', () => {
     expect(isRemoteReauthError('OAuth: please sign in')).toBe(true)
   })
 
+  it('recognizes the exact readiness-probe reauth message the backend emits', () => {
+    // Cross-module contract: this literal MUST stay in sync with
+    // REMOTE_SESSION_EXPIRED_MESSAGE in electron/backend-health.ts. When the
+    // authed /api/health probe hits a confirmed 401, that message becomes
+    // boot.error, and the overlay's Sign In branch depends on it classifying here.
+    expect(isRemoteReauthError('Your remote gateway session has expired. Open Settings → Gateway and sign in again.')).toBe(
+      true
+    )
+  })
+
   it('ignores non-auth boot errors and nullish', () => {
     expect(isRemoteReauthError('Hermes background process exited during startup.')).toBe(false)
     expect(isRemoteReauthError(null)).toBe(false)

--- a/contributors/emails/diegomarino@users.noreply.github.com
+++ b/contributors/emails/diegomarino@users.noreply.github.com
@@ -1,0 +1,2 @@
+diegomarino
+# PR #71449


### PR DESCRIPTION
## Summary

An OAuth/token-gated remote gateway loops forever on boot with `401 no_cookie`, even seconds after a successful sign-in — and the recovery overlay's "Sign in" button flickers so it can't be clicked. Two independent, compounding defects:

1. **Credential-free readiness probe.** `waitForHermesReady` only ever calls the credential-free `fetchPublicJson('/api/health')`; its token path is reachable only via a **404** (`isMissingHealthEndpointError`), never a **401**, and `waitForHermes` wires the credential-free fetch regardless of `authMode`. A gateway that also gates `/api/health` (not all expose it as truly public) therefore 401s every probe until the 45s deadline. The legacy `/api/status` fallback had the same hole (uncredentialed `fetchJson` with a `null` oauth token).

2. **Flickering recovery overlay.** A remote boot failure is intentionally non-latching (transient remote failures must self-heal), so every subsequent `getConnection`/`api` call re-runs `startHermes`, re-emits `running: true`, and hides the boot-failure overlay (`visible = Boolean(boot.error) && !boot.running`) before the user can click "Sign in".

**Fix:** thread the connection's `authMode` into `waitForHermes` and probe **with credentials** for `oauth`/`token` remotes — oauth reuses the bearer-or-cookie choice (`resolveReadinessProbeAuth` over the existing `resolveOauthRestAuth`, mirroring `mintGatewayWsTicket`), token sends its session token, local stays public. A confirmed **401/403** fails fast as a terminal, reauth-tagged error — from the `/api/health` probe **and** the `/api/status` fallback (which is now routed through the same credentialed probe). That confirmed reauth failure is latched separately (`shouldLatchRemoteReauthFailure`) so `startHermes` short-circuits without re-driving the boot UI — the same shape the post-sleep reconnect path already uses via `isGatewayReauthRequired`. The latch is cleared on every recovery path (reset, repair, apply-config, and a **confirmed** sign-in only), so a fresh session boots while a cancelled sign-in leaves the overlay actionable. Transient remote failures still self-heal untouched.

The reauth error is duck-typed on `needsOauthLogin` (recognized by the main-process latch without importing `@hermes/shared` into that bundle) and carries the "remote gateway session has expired" copy the renderer overlay's `isRemoteReauthError` keys on, so the short-circuit and the "Sign in" affordance fire from one signal.

## Changes

- `apps/desktop/electron/native-auth-decisions.ts`: add `resolveReadinessProbeAuth(authMode, nativeAccessToken)` — thin reuse of `resolveOauthRestAuth`; picks bearer/cookie (oauth), token, or public.
- `apps/desktop/electron/backend-health.ts`: add an optional credentialed `probeHealth` to `HermesReadyOptions` (defaults to `fetchPublicJson`); route the `/api/status` fallback through the same credentialed probe; add `isAuthRejectionError` / `isReauthRequiredError` / `makeReauthRequiredError` + `REMOTE_SESSION_EXPIRED_MESSAGE`; fail fast on a tagged reauth error from either leg.
- `apps/desktop/electron/backend-start-failure.ts`: add `shouldLatchRemoteReauthFailure({ attemptedRemote, isReauth })` — latch a confirmed remote reauth failure separately from the transient-safe `backendStartFailure`.
- `apps/desktop/electron/main.ts`: `buildReadinessHealthProbe` + thread `authMode` into `waitForHermes` (both remote call sites); add the `remoteReauthFailure` latch — short-circuit in `startHermes`, set on a confirmed reauth failure, cleared in `resetHermesConnection` / bootstrap reset / repair / apply-config and on a confirmed `oauth-login`.
- Tests: `native-auth-decisions.test.ts`, `backend-health.test.ts`, `backend-start-failure.test.ts`, `boot-failure-reauth.test.ts`.

## Validation

Run inside `apps/desktop`:

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm run test:desktop:platforms` (vitest `electron`) — 737 passed, 2 skipped
- `npm run test:ui` (vitest `ui`) — 2198 passed, 1 skipped
- **Manual repro (real remote cloud OAuth gateway):** on `main`, boot loops on `401 no_cookie` and times out ("Hermes backend did not become ready"); with this change the boot reaches **"Remote Hermes backend is ready"** — the authed `/api/health` probe returns `200` and boot completes.

## Related issues / PRs

Fixes #71514 — the credential-free readiness-probe root cause: the health probe 401-loops a gated `/api/health`, and the `/api/status` fallback only triggers on **404**, never **401**. That is exactly the leg this PR credentials and, on a confirmed 401/403, latches for reauth.

Same-root-cause reports this also addresses (all the "stuck connecting / `401 no_cookie`" family):

- #71305 — self-hosted remote gateway boot loop that never calls `/login`.
- #71491 — Windows; bisected good `2c1a38a` / bad `07e97d2`; never launches sign-in despite `login_url` in the payload.
- #71369 — basic-auth variant of the same "stored cookie not used on the readiness probe" path.
- #61457 — earlier variant of the same session-cookie-never-used loop.

**Refs #71515** — the narrower "auth middleware masks a missing `/api/health` as 401" case. #71535 handles that by treating any 401 as a fallback-to-`/api/status` signal, but keeps the probe credential-free and does not distinguish a *missing route* from a *rejected session* — so on a hosted backend where `/api/status` is public, an expired OAuth session still reports "ready" and defers the `no_cookie` to the first real API call. This PR credentials the probe and fails fast to the reauth overlay instead.

**Refs #71167** — the multi-bug umbrella, auto-closed by #71171. That PR fixed only the `spawn-helper`/`app.asar` `chmod` half; the OAuth `no_cookie` readiness half (this PR) was closed along with it and remains unshipped.

Complements, does **not** duplicate: #67769 (merged — cold-start cookie-jar read race) and #61486 (open — cookies not flushed to disk before the login window closes). Neither touches the credential-free readiness-probe path.
