### PR TITLE
docs(messaging): surface /handoff on the messaging gateway page

### DIFF
--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -193,7 +193,6 @@ platform network disconnect as an event-loop failure.
 | `/approve` | Approve a pending dangerous command |
 | `/deny` | Reject a pending dangerous command |
 | `/sethome` | Set this chat as the home channel |
-| `/handoff <platform>` | Move the live session to another platform's home channel (see [Cross-Platform Handoff](/docs/user-guide/sessions#cross-platform-handoff)) |
 | `/compress` | Manually compress conversation context |
 | `/title [name]` | Set or show the session title |
 | `/resume [name]` | Resume a previously named session |
@@ -669,6 +668,9 @@ transfers the live conversation to that platform's home channel — same session
 transcript, tool calls included. The destination adapter opens a fresh thread where it can
 (Telegram forum topic, Discord thread, Slack thread anchor) and falls back to the home channel
 where it cannot.
+
+`/handoff` runs from the CLI only. It is not one of the chat commands above, so typing it in a
+messaging chat will not start a handoff.
 
 To come back, run `/resume <title>` from the CLI (or `hermes -r "<title>"`).
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -193,6 +193,7 @@ platform network disconnect as an event-loop failure.
 | `/approve` | Approve a pending dangerous command |
 | `/deny` | Reject a pending dangerous command |
 | `/sethome` | Set this chat as the home channel |
+| `/handoff <platform>` | Move the live session to another platform's home channel (see [Cross-Platform Handoff](/docs/user-guide/sessions#cross-platform-handoff)) |
 | `/compress` | Manually compress conversation context |
 | `/title [name]` | Set or show the session title |
 | `/resume [name]` | Resume a previously named session |
@@ -660,6 +661,26 @@ Scheduled auto-resume for N restart-interrupted session(s)
 ```
 
 No configuration is required. If you don't want the heads-up, set `gateway_restart_notification: false` on the platform.
+
+### Moving a session between surfaces
+
+A session is not locked to the surface it started on. From a CLI session, `/handoff <platform>`
+transfers the live conversation to that platform's home channel — same session id, full
+transcript, tool calls included. The destination adapter opens a fresh thread where it can
+(Telegram forum topic, Discord thread, Slack thread anchor) and falls back to the home channel
+where it cannot.
+
+To come back, run `/resume <title>` from the CLI (or `hermes -r "<title>"`).
+
+The destination needs a home channel configured once, with `/sethome` from that chat.
+
+See [Cross-Platform Handoff](/docs/user-guide/sessions#cross-platform-handoff) for the full
+flow, per-platform thread behaviour, and failure modes.
+
+:::note
+This is distinct from [session resume across gateway restarts](#session-resume-across-gateway-restarts),
+which recovers an interrupted session on the same surface after the gateway restarts.
+:::
 
 ### Mobile-friendly progress defaults
 


### PR DESCRIPTION
## What does this PR do?

Makes cross-surface session handoff discoverable from the Messaging Gateway page.

`/handoff <platform>` and the `/resume <title>` return leg are documented in full on the Sessions page under [Cross-Platform Handoff](https://hermes-agent.nousresearch.com/docs/user-guide/sessions#cross-platform-handoff), but the messaging page contains no reference to them: zero occurrences of "handoff", "cross-platform", or "continuity". `/handoff` is also missing from that page's Chat Commands table, which does list `/sethome` and `/resume`.

The result is that users looking for "can I move my Telegram chat to Desktop and back" land on the messaging page, see "Session resume across gateway restarts" (a different feature, crash recovery on the same surface), and conclude the capability does not exist.

## Why

This came out of a community question about messaging channels. The single most-requested missing feature in the replies was cross-surface session continuity:

> "By far and away the chat syncing between a channel (like Telegram) and the desktop app. You can't start on telegram and pick up the session seamlessly on desktop app and vice versa. Unless I'm missing something"

and the follow-up:

> "Yeah but if you want to then continue on desktop and later continue on Telegram, you can't - right?"

They were missing something, and the docs are why. #54981 is open requesting this as a feature; a meaningful part of it already shipped.

## Changes Made

- `website/docs/user-guide/messaging/index.md`
  - new "Moving a session between surfaces" subsection under "Operating a multi-platform gateway", cross-linking the canonical Sessions documentation and disambiguating it from gateway-restart resume
  - `/handoff <platform>` added to the Chat Commands table

No behaviour change, and no duplication of the Sessions page content.

## Type of Change

- [x] 📝 Documentation update
