### PR TITLE
fix(codex-runtime): honor CODEX_HOME during migration

### DIFF
--- a/hermes_cli/codex_runtime_switch.py
+++ b/hermes_cli/codex_runtime_switch.py
@@ -14,7 +14,9 @@ config value. This module just persists the value and reports the change.
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -147,7 +149,7 @@ def apply(
     # No-config-change paths. For `auto` we return immediately — disabling
     # doesn't touch ~/.codex/. For `codex_app_server`, we fall through to
     # the migration block below: the config value is already correct, but
-    # the world state (managed block in ~/.codex/config.toml, hermes-tools
+    # the world state (managed block in the active Codex config, hermes-tools
     # MCP callback, plugin discovery) may be stale or missing — common
     # footgun when users pre-set `openai_runtime: codex_app_server` in
     # config.yaml without ever running the slash command. The migration is
@@ -206,13 +208,18 @@ def apply(
         if ok:
             msg_lines.append(f"codex CLI: {ver}")
         # Auto-migrate Hermes' MCP servers + Codex's installed curated
-        # plugins into ~/.codex/config.toml so the spawned codex subprocess
+        # plugins into CODEX_HOME/config.toml (default ~/.codex/config.toml)
+        # so the spawned codex subprocess
         # sees the same tool surface AND can call back into Hermes for
         # browser/web/delegate_task/vision/memory tools (#7 fix).
         # Failures are non-fatal — the runtime change still proceeds.
         try:
             from hermes_cli.codex_runtime_plugin_migration import migrate
-            mig_report = migrate(config)
+            codex_home_raw = os.getenv("CODEX_HOME", "").strip()
+            codex_home = (
+                Path(codex_home_raw).expanduser() if codex_home_raw else None
+            )
+            mig_report = migrate(config, codex_home=codex_home)
             # Tools/MCP servers (excluding the hermes-tools callback,
             # which is internal plumbing — surface separately).
             user_servers = [

--- a/tests/hermes_cli/test_codex_runtime_switch.py
+++ b/tests/hermes_cli/test_codex_runtime_switch.py
@@ -102,7 +102,7 @@ class TestApply:
         `openai_runtime: codex_app_server` in config.yaml, then runs
         /codex-runtime codex_app_server expecting the migration. Without
         this, the slash command short-circuits with "already set" and
-        ~/.codex/config.toml never gets the hermes-tools MCP callback
+        the active Codex config never gets the hermes-tools MCP callback
         or plugin migration — silent partial setup.
         """
         cfg = {
@@ -145,6 +145,28 @@ class TestApply:
         # Caller still needs a fresh session for the cached agent to pick
         # up any migration-driven changes.
         assert r.requires_new_session is True
+
+    def test_reapply_uses_codex_home_from_environment(
+        self, tmp_path, monkeypatch
+    ):
+        codex_home = tmp_path / "profile-codex-home"
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        cfg = {"model": {"openai_runtime": "codex_app_server"}}
+
+        with patch.object(
+            crs, "check_codex_binary_ok", return_value=(True, "0.130.0")
+        ), patch("hermes_cli.codex_runtime_plugin_migration.migrate") as mig:
+            mig.return_value.migrated = ["hermes-tools"]
+            mig.return_value.migrated_plugins = []
+            mig.return_value.plugin_query_error = None
+            mig.return_value.wrote_permissions_default = ":workspace"
+            mig.return_value.errors = []
+            mig.return_value.target_path = codex_home / "config.toml"
+
+            result = crs.apply(cfg, "codex_app_server")
+
+        assert result.success
+        mig.assert_called_once_with(cfg, codex_home=codex_home)
 
     def test_enable_blocked_when_codex_missing(self):
         cfg = {}
@@ -207,7 +229,7 @@ class TestApply:
 
     def test_enable_triggers_mcp_migration(self):
         """Enabling codex_app_server should auto-migrate Hermes mcp_servers
-        to ~/.codex/config.toml so the spawned subprocess sees them."""
+        to the active Codex config so the spawned subprocess sees them."""
         cfg = {
             "mcp_servers": {
                 "filesystem": {"command": "npx", "args": ["-y", "fs-server"]},


### PR DESCRIPTION
## Summary
- honor the active `CODEX_HOME` when `/codex-runtime` migrates Codex plugins, permissions, and the Hermes callback
- preserve the existing `~/.codex` fallback when `CODEX_HOME` is unset
- add a regression test for profile-local migration

## Failure mode
`codex_runtime_switch.apply()` called `migrate(config)` without a `codex_home`, so migration always fell back to `Path.home() / ".codex"` even when Hermes had loaded a profile-local `CODEX_HOME`. The actual Codex runtime and auth paths already honor `CODEX_HOME`; the slash-command migration did not.

## Test plan
- [x] New test observed failing before production change
- [x] `32 passed` in `tests/hermes_cli/test_codex_runtime_switch.py`
- [x] Ruff passes on both changed files
- [x] Python compilation passes
