### PR TITLE
fix(delegate): preserve inherited fixed child credentials

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -825,6 +825,80 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
         result = _resolve_child_credential_pool("openrouter", parent)
         self.assertIs(result, mock_pool)
 
+    def test_same_provider_without_parent_pool_keeps_fixed_credential(self):
+        parent = _make_mock_parent()
+        parent.provider = "anthropic"
+        parent._credential_pool = None
+
+        with patch("agent.credential_pool.load_pool") as load_mock:
+            result = _resolve_child_credential_pool(
+                "anthropic", parent, "http://localhost:8080/anthropic"
+            )
+
+        self.assertIsNone(result)
+        load_mock.assert_not_called()
+
+    def test_fixed_proxy_child_does_not_lease_provider_default_pool(self):
+        parent = _make_mock_parent()
+        parent.provider = "anthropic"
+        parent.api_mode = "anthropic_messages"
+        parent.base_url = "https://api.anthropic.com"
+        parent.api_key = ""
+        parent._client_kwargs = {
+            "api_key": "proxy-credential",
+            "base_url": "http://localhost:8080/anthropic",
+        }
+        parent._credential_pool = None
+
+        provider_pool = MagicMock(name="provider_default_pool")
+        provider_pool.has_credentials.return_value = True
+        provider_pool.acquire_lease.return_value = "anthropic-default"
+        provider_pool.current.return_value = MagicMock(id="anthropic-default")
+
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("agent.credential_pool.load_pool", return_value=provider_pool),
+        ):
+            child = MagicMock()
+            child._credential_pool = None
+            child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+            MockAgent.return_value = child
+
+            built_child = _build_child_agent(
+                task_index=0,
+                goal="Use the parent's fixed proxy route",
+                context=None,
+                toolsets=["terminal"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+            from tools.delegate_tool import _run_single_child
+
+            result = _run_single_child(
+                task_index=0,
+                goal="Use the parent's fixed proxy route",
+                child=built_child,
+                parent_agent=parent,
+            )
+
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(
+            MockAgent.call_args.kwargs["base_url"],
+            "http://localhost:8080/anthropic",
+        )
+        self.assertEqual(MockAgent.call_args.kwargs["api_key"], "proxy-credential")
+        provider_pool.acquire_lease.assert_not_called()
+        child._swap_credential.assert_not_called()
+
     # --- Custom-endpoint identity resolution (issue #7833) ---
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3458,7 +3458,10 @@ def _resolve_child_credential_pool(
             )
         return None
 
-    if parent_pool is not None and effective_provider == parent_provider:
+    if effective_provider == parent_provider:
+        # A same-provider parent with no pool is using a fixed credential.
+        # Loading a separate provider pool here can replace the inherited
+        # endpoint and key when the child acquires its startup lease (#71424).
         return parent_pool
 
     try:


### PR DESCRIPTION
## What does this PR do?

Fixes delegated subagents replacing an inherited fixed proxy endpoint and key with a separately loaded provider-default credential pool.

When a parent uses a native provider name such as `anthropic` with a custom active `base_url` and fixed proxy credential, `_build_child_agent()` correctly inherits the live route from the parent's client. However, if the parent has no `_credential_pool`, `_resolve_child_credential_pool()` fell through to `load_pool(effective_provider)`. The child's startup lease then called `_swap_credential()` and could replace the inherited proxy route with the provider-default endpoint and credential, causing the reported 401/fallback/timeout chain.

The resolver now treats a missing same-provider parent pool as fixed-credential mode and returns `None`. Loading a separate pool remains limited to children delegated to a different provider.

## Related Issue

Fixes #71424

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor
- [ ] New skill

## Why this is the right fix

The existing resolver contract already distinguishes these cases:

- same provider: share the parent's pool so cooldown and rotation state remain synchronized;
- different provider: load the child's provider-specific pool;
- no pool: keep the child's inherited fixed credential.

The implementation only enforced the first rule when the parent pool was non-null, so a same-provider parent in fixed-credential mode incorrectly entered the different-provider fallback. Returning `parent_pool` for every same-provider case, including `None`, aligns the code with that existing contract without disabling valid pool rotation.

The custom-provider endpoint-identity branch remains unchanged and still resolves `custom:<name>` pools by endpoint.

## Changes Made

- `tools/delegate_tool.py`: stop loading a provider-default child pool when a same-provider parent has no credential pool.
- `tests/tools/test_delegate.py`: cover the resolver invariant and the complete child build/startup lease path with a fixed Anthropic proxy route.

## How to Test

1. Configure a parent with `provider: anthropic`, an active local proxy `base_url` and proxy credential, no parent credential pool, and a persisted Anthropic provider-default pool entry.
2. Before this change, child construction inherits the proxy route but startup leasing selects the provider-default pool and calls `_swap_credential()`.
3. After this change, the child keeps the inherited proxy route and no provider-default pool lease occurs.

```bash
.hermes/with-env.sh python -m pytest -o addopts='' \
  tests/tools/test_delegate.py::TestChildCredentialPoolResolution::test_same_provider_without_parent_pool_keeps_fixed_credential \
  tests/tools/test_delegate.py::TestChildCredentialPoolResolution::test_fixed_proxy_child_does_not_lease_provider_default_pool -q

.hermes/with-env.sh scripts/run_tests.sh tests/tools/test_delegate.py -q

.hermes/with-env.sh scripts/run_tests.sh \
  tests/tools/test_credential_pool_env_fallback.py \
  tests/agent/test_credential_pool_routing.py \
  tests/run_agent/test_fallback_credential_isolation.py -q

.hermes/with-env.sh python -m ruff check \
  tools/delegate_tool.py tests/tools/test_delegate.py
```

## Compatibility Notes

- Same-provider children with an existing parent pool still share that exact pool.
- Same-provider children whose parent uses fixed credentials keep the inherited endpoint and key.
- Different-provider children still load their own provider pool.
- Custom endpoint identity and unregistered custom endpoint behavior are unchanged.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows the repository's Conventional Commit style.
- [x] I searched open, closed, and merged issues/PRs for overlapping fixes.
- [x] The PR contains only changes related to this bug.
- [ ] I've run the complete `pytest tests/ -q` suite.
- [x] I've added regression tests.
- [x] Tested on macOS 26.5.2 with Python 3.12.4.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing configuration or API changed.
- [x] `cli-config.yaml.example` update: N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered; the change is provider-resolution logic with no OS-specific behavior.
- [x] Tool schema update: N/A; no model-facing tool behavior or parameters changed.

## Validation Logs

Baseline: `upstream/main@07e97d2f5dc3d2092cfe693ef07b2527a36cd2d8`

```text
Pre-fix targeted regressions: 2 failed
Post-fix targeted regressions: 2 passed
tests/tools/test_delegate.py: 161 passed
credential-pool routing/fallback files: 42 passed
Ruff: passed
git diff --check: passed
```

## Remaining Risks

The regression exercises the real delegation resolver and startup lease path with test doubles for the LLM client and credential pool; it does not make a live request to a local proxy or Anthropic. The complete repository test suite was not run.
