### PR TITLE
fix(desktop): hide terminal overlay when its pane becomes inactive

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
@@ -2,7 +2,15 @@ import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { hiddenPaneProps, PANE_HIDDEN_ATTR } from '@/components/pane-shell/pane-visibility'
+
+import { $terminalTakeover } from '../store'
+
 import { PersistentTerminal, TerminalSlot } from './persistent'
+
+vi.mock('../store', async () => ({
+  $terminalTakeover: (await import('nanostores')).atom(false)
+}))
 
 vi.mock('./terminals', () => ({
   ensureTerminal: vi.fn()
@@ -123,6 +131,17 @@ function Harness() {
   )
 }
 
+function HiddenPaneHarness({ hidden }: { hidden: boolean }) {
+  return (
+    <>
+      <div {...hiddenPaneProps(hidden)}>
+        <TerminalSlot className="slot" />
+      </div>
+      <PersistentTerminal onAddSelectionToChat={() => undefined} />
+    </>
+  )
+}
+
 describe('PersistentTerminal rect tracking', () => {
   beforeEach(() => {
     ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -162,6 +181,7 @@ describe('PersistentTerminal rect tracking', () => {
 
   afterEach(() => {
     cleanup()
+    $terminalTakeover.set(false)
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
     setVisibility(false)
@@ -242,6 +262,64 @@ describe('PersistentTerminal rect tracking', () => {
     })
 
     expect(raf.pending()).toBe(0)
+  })
+
+  it('hides the overlay but keeps its workspace mounted when the terminal tab becomes inactive', () => {
+    const raf = installRaf()
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(rect(10, 20, 200, 100))
+    $terminalTakeover.set(true)
+
+    render(<HiddenPaneHarness hidden={false} />)
+
+    const overlay = container!.lastElementChild as HTMLElement
+    const workspace = container!.querySelector('[data-testid="terminal-workspace"]')
+
+    expect(overlay.style.visibility).toBe('visible')
+    expect(overlay.style.opacity).toBe('1')
+    expect(overlay.style.pointerEvents).toBe('auto')
+    expect(workspace).not.toBeNull()
+    expect(mutationObserveCalls.some(call => call.options?.attributeFilter?.includes(PANE_HIDDEN_ATTR))).toBe(true)
+
+    // Let the initial changed-rect follow-up settle. The hidden-pane transition
+    // must wake the observer from an otherwise idle state.
+    act(() => {
+      raf.runNext()
+    })
+    expect(raf.pending()).toBe(0)
+
+    act(() => {
+      root!.render(<HiddenPaneHarness hidden />)
+      mutationObserverCallback?.([], {} as MutationObserver)
+    })
+    expect(raf.pending()).toBe(1)
+
+    act(() => {
+      raf.runNext()
+    })
+
+    expect(overlay.style.visibility).toBe('hidden')
+    expect(overlay.style.opacity).toBe('0')
+    expect(overlay.style.pointerEvents).toBe('none')
+    expect(container!.querySelector('[data-testid="terminal-workspace"]')).toBe(workspace)
+
+    act(() => {
+      raf.runNext()
+    })
+    expect(raf.pending()).toBe(0)
+
+    act(() => {
+      root!.render(<HiddenPaneHarness hidden={false} />)
+      mutationObserverCallback?.([], {} as MutationObserver)
+    })
+
+    act(() => {
+      raf.runNext()
+    })
+
+    expect(overlay.style.visibility).toBe('visible')
+    expect(overlay.style.opacity).toBe('1')
+    expect(overlay.style.pointerEvents).toBe('auto')
+    expect(container!.querySelector('[data-testid="terminal-workspace"]')).toBe(workspace)
   })
 
   it('does not schedule rect RAFs while the Electron window is paused, then resumes when visible', () => {

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { atom } from 'nanostores'
 import { type CSSProperties, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
+import { isElementInHiddenPane, PANE_HIDDEN_ATTR } from '@/components/pane-shell/pane-visibility'
 import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
 
 import { $terminalTakeover } from '../store'
@@ -47,6 +48,7 @@ interface PersistentTerminalProps {
 }
 
 interface Rect {
+  hidden: boolean
   top: number
   left: number
   width: number
@@ -54,7 +56,7 @@ interface Rect {
 }
 
 const sameRect = (a: Rect | null, b: Rect) =>
-  !!a && a.top === b.top && a.left === b.left && a.width === b.width && a.height === b.height
+  !!a && a.hidden === b.hidden && a.top === b.top && a.left === b.left && a.width === b.width && a.height === b.height
 
 export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalProps) {
   const slot = useStore($slot)
@@ -107,7 +109,16 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
       // full pixel footprint, so half-pixel rects can't leak page bg through.
       const top = Math.floor(r.top)
       const left = Math.floor(r.left)
-      const next: Rect = { top, left, width: Math.ceil(r.right) - left, height: Math.ceil(r.bottom) - top }
+
+      // Inactive keep-alive panes deliberately retain the same rect as the
+      // foreground pane, so visibility must be sampled independently.
+      const next: Rect = {
+        hidden: isElementInHiddenPane(slot),
+        top,
+        left,
+        width: Math.ceil(r.right) - left,
+        height: Math.ceil(r.bottom) - top
+      }
 
       if (!sameRect(prev, next)) {
         prev = next
@@ -171,7 +182,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
 
     for (let node: HTMLElement | null = slot; node; node = node.parentElement) {
       positionObserver?.observe(node, {
-        attributeFilter: ['class', 'style', 'hidden', 'aria-hidden', 'data-state'],
+        attributeFilter: ['class', 'style', 'hidden', 'aria-hidden', 'data-state', PANE_HIDDEN_ATTR],
         attributes: true,
         childList: true,
         subtree: true
@@ -192,7 +203,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
     }
   }, [slot])
 
-  const visible = Boolean(rect && rect.width > 0 && rect.height > 0)
+  const visible = Boolean(rect && !rect.hidden && rect.width > 0 && rect.height > 0)
 
   const style: CSSProperties = {
     position: 'fixed',
@@ -203,6 +214,10 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
     display: 'flex',
     flexDirection: 'column',
     visibility: visible ? 'visible' : 'hidden',
+    // Electron may keep xterm's WebGL canvas visually composited after an
+    // ancestor becomes visibility:hidden. Opacity clears that compositor layer
+    // while preserving the mounted DOM, terminal dimensions, and live PTY.
+    opacity: visible ? 1 : 0,
     pointerEvents: visible ? 'auto' : 'none',
     zIndex: 4,
     // Match the live skin surface so the header strip (transparent) and body

--- a/apps/desktop/src/components/pane-shell/pane-visibility.ts
+++ b/apps/desktop/src/components/pane-shell/pane-visibility.ts
@@ -42,9 +42,12 @@ export const PaneGroupContext = createContext(NO_PANE_GROUP)
 
 export const usePaneGroup = (): string => useContext(PaneGroupContext)
 
+/** Whether an element belongs to an inactive keep-alive pane. */
+export const isElementInHiddenPane = (element: Element): boolean => Boolean(element.closest(HIDDEN_PANE))
+
 /** `querySelectorAll` minus anything inside an inactive tab. */
 export const queryAllVisible = <T extends HTMLElement>(selector: string, root: ParentNode = document): T[] =>
-  [...root.querySelectorAll<T>(selector)].filter(el => !el.closest(HIDDEN_PANE))
+  [...root.querySelectorAll<T>(selector)].filter(el => !isElementInHiddenPane(el))
 
 /** `querySelector` minus anything inside an inactive tab. */
 export const queryVisible = <T extends HTMLElement>(selector: string, root: ParentNode = document): null | T =>


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop Focus layout getting trapped behind a full-window terminal overlay after the terminal pane becomes inactive.

Keep-alive panes deliberately retain their layout geometry while hidden. The persistent terminal therefore continued treating its fixed overlay as visible because its slot still had a non-zero rectangle. This change includes the pane's `data-pane-hidden` state in the overlay measurement, so an inactive terminal overlay becomes hidden and non-interactive while its xterm workspace and PTYs remain mounted.

## Related Issue

Fixes #71407

Related to #69827, which changes the same terminal geometry loop for idle scheduling. That PR does not currently observe keep-alive ancestor visibility; if it lands first, the reconciliation must preserve the hidden-pane signal added here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Export a shared `isElementInHiddenPane()` predicate from the pane visibility policy.
- Sample hidden-pane state alongside terminal slot geometry.
- Hide the fixed terminal overlay and disable pointer events when its keep-alive pane is inactive.
- Add a regression test covering visible -> hidden -> visible transitions with unchanged geometry, including the invariant that `TerminalWorkspace` remains mounted.

## How to Test

1. Open the Desktop Focus layout and activate the terminal pane.
2. Switch to chat or another session and verify the terminal no longer covers or intercepts the UI.
3. Return to the terminal and verify the existing terminal workspace is still mounted.
4. Run:

   ```bash
   cd apps/desktop
   npm exec vitest -- run --project ui src/app/right-sidebar/terminal/persistent.test.tsx src/components/pane-shell/pane-visibility.test.ts
   npm run typecheck
   npm run lint
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (Desktop TypeScript-only change; Python suite not run)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: automated UI tests run on macOS; no packaged-app manual run

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - DOM-only behavior, no platform-specific APIs added
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Pre-fix regression signal:

```text
expected 'visible' to be 'hidden'
Received: 'visible'
```

Post-fix validation:

```text
Targeted UI tests: 2 files passed, 4 tests passed
Desktop TypeScript typecheck: passed
Desktop lint: 0 errors (existing warnings only)
Desktop UI suite excluding the pre-existing Dialog/Select dismiss repro: 259 files passed, 2196 tests passed, 1 skipped
```

The full UI run's only failure was `src/components/ui/dialog-dismiss-repro.test.tsx`, which also fails in isolation and is unrelated to this change.
