### PR TITLE
feat(desktop): show cron runs in Sessions by default

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -143,6 +143,7 @@ import {
   SESSION_WINDOW_MIN_HEIGHT,
   SESSION_WINDOW_MIN_WIDTH
 } from './session-windows'
+import { fanOutSidebarSessions } from './sidebar-session-fanout'
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'
@@ -9307,56 +9308,7 @@ async function interceptSessionRequestForRemote(request) {
       return undefined // local fast path → batched endpoint's single DB open
     }
 
-    const recentsProfile = (searchParams.get('recents_profile') || 'all').trim() || 'all'
-
-    const sliceParams = (limitKey, defaultLimit, extra) => {
-      const sp = new URLSearchParams({
-        limit: searchParams.get(limitKey) || defaultLimit,
-        offset: '0',
-        min_messages: '1',
-        archived: 'exclude',
-        order: 'recent',
-        ...extra
-      })
-
-      return sp
-    }
-
-    const recentsSp = sliceParams('recents_limit', '20', { profile: recentsProfile })
-    const recentsExclude = searchParams.get('recents_exclude')
-
-    if (recentsExclude) {
-      recentsSp.set('exclude_sources', recentsExclude)
-    }
-
-    const cronSp = sliceParams('cron_limit', '50', { profile: 'all', source: 'cron' })
-
-    const messagingSp = sliceParams('messaging_limit', '100', { profile: 'all' })
-    const messagingExclude = searchParams.get('messaging_exclude')
-
-    if (messagingExclude) {
-      messagingSp.set('exclude_sources', messagingExclude)
-    }
-
-    const [recents, cron, messaging] = await Promise.all([
-      fetchProfilesSessionSlice(recentsSp, remoteProfiles),
-      fetchProfilesSessionSlice(cronSp, remoteProfiles),
-      fetchProfilesSessionSlice(messagingSp, remoteProfiles)
-    ])
-
-    return {
-      recents: {
-        sessions: rowsOf(recents),
-        total: Number(recents?.total) || 0,
-        profile_totals: recents?.profile_totals || {}
-      },
-      cron: { sessions: rowsOf(cron) },
-      messaging: {
-        sessions: rowsOf(messaging),
-        total: Number(messaging?.total) || rowsOf(messaging).length
-      },
-      errors: []
-    }
+    return fanOutSidebarSessions(searchParams, remoteProfiles, fetchProfilesSessionSlice)
   }
 
   // Per-session read/mutation. Owner is in ?profile= (reads) or request.profile

--- a/apps/desktop/electron/sidebar-session-fanout.test.ts
+++ b/apps/desktop/electron/sidebar-session-fanout.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { fanOutSidebarSessions } from './sidebar-session-fanout'
+
+describe('remote sidebar fan-out', () => {
+  it('honors a concrete cron selector and advertises the capability', async () => {
+    const calls: URLSearchParams[] = []
+
+    const fetchSlice = vi.fn(async (params: URLSearchParams) => {
+      calls.push(new URLSearchParams(params))
+
+      return { sessions: [{ id: params.get('source') === 'cron' ? 'cron' : 'other' }], total: 1 }
+    })
+
+    const result = await fanOutSidebarSessions(
+      new URLSearchParams({
+        recents_profile: 'work',
+        cron_profile: 'work',
+        cron_limit: '500'
+      }),
+      ['work'],
+      fetchSlice
+    )
+
+    expect(calls).toHaveLength(3)
+    expect(calls[0].get('profile')).toBe('work')
+    expect(calls[1].get('profile')).toBe('work')
+    expect(calls[1].get('source')).toBe('cron')
+    expect(calls[1].get('limit')).toBe('500')
+    expect(calls[2].get('profile')).toBe('all')
+    expect(result.capabilities).toEqual({ cron_profile: true })
+  })
+
+  it('preserves All Profiles cron acquisition', async () => {
+    const calls: URLSearchParams[] = []
+
+    await fanOutSidebarSessions(new URLSearchParams({ cron_profile: 'all' }), ['work'], async params => {
+      calls.push(new URLSearchParams(params))
+
+      return { sessions: [] }
+    })
+
+    expect(calls[1].get('profile')).toBe('all')
+  })
+})

--- a/apps/desktop/electron/sidebar-session-fanout.ts
+++ b/apps/desktop/electron/sidebar-session-fanout.ts
@@ -1,0 +1,77 @@
+interface SidebarSliceResponse {
+  sessions?: unknown[]
+  total?: number
+  profile_totals?: Record<string, number>
+}
+
+interface SidebarSessionsResponse {
+  capabilities: { cron_profile: true }
+  recents: {
+    sessions: unknown[]
+    total: number
+    profile_totals: Record<string, number>
+  }
+  cron: { sessions: unknown[] }
+  messaging: { sessions: unknown[]; total: number }
+  errors: unknown[]
+}
+
+type FetchSlice = (searchParams: URLSearchParams, remoteProfiles: string[]) => Promise<SidebarSliceResponse>
+
+const rowsOf = (data: SidebarSliceResponse): unknown[] => (Array.isArray(data?.sessions) ? data.sessions : [])
+
+/** Reassemble the batched endpoint through the remote-aware per-slice path. */
+export async function fanOutSidebarSessions(
+  searchParams: URLSearchParams,
+  remoteProfiles: string[],
+  fetchSlice: FetchSlice
+): Promise<SidebarSessionsResponse> {
+  const recentsProfile = (searchParams.get('recents_profile') || 'all').trim() || 'all'
+  const cronProfile = (searchParams.get('cron_profile') || 'all').trim() || 'all'
+
+  const sliceParams = (limitKey: string, defaultLimit: string, extra: Record<string, string>) =>
+    new URLSearchParams({
+      limit: searchParams.get(limitKey) || defaultLimit,
+      offset: '0',
+      min_messages: '1',
+      archived: 'exclude',
+      order: 'recent',
+      ...extra
+    })
+
+  const recentsSp = sliceParams('recents_limit', '20', { profile: recentsProfile })
+  const recentsExclude = searchParams.get('recents_exclude')
+
+  if (recentsExclude) {
+    recentsSp.set('exclude_sources', recentsExclude)
+  }
+
+  const cronSp = sliceParams('cron_limit', '50', { profile: cronProfile, source: 'cron' })
+  const messagingSp = sliceParams('messaging_limit', '100', { profile: 'all' })
+  const messagingExclude = searchParams.get('messaging_exclude')
+
+  if (messagingExclude) {
+    messagingSp.set('exclude_sources', messagingExclude)
+  }
+
+  const [recents, cron, messaging] = await Promise.all([
+    fetchSlice(recentsSp, remoteProfiles),
+    fetchSlice(cronSp, remoteProfiles),
+    fetchSlice(messagingSp, remoteProfiles)
+  ])
+
+  return {
+    capabilities: { cron_profile: true },
+    recents: {
+      sessions: rowsOf(recents),
+      total: Number(recents?.total) || 0,
+      profile_totals: recents?.profile_totals || {}
+    },
+    cron: { sessions: rowsOf(cron) },
+    messaging: {
+      sessions: rowsOf(messaging),
+      total: Number(messaging?.total) || rowsOf(messaging).length
+    },
+    errors: []
+  }
+}

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $cronJobsHiddenFromSessions, setCronJobInSessions } from '@/store/cron'
+import type { CronJob } from '@/types/hermes'
+
+import { SidebarCronJobsSection } from './cron-jobs-section'
+
+const getCronJobRuns = vi.hoisted(() => vi.fn())
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getCronJobRuns
+}))
+
+const job: CronJob = {
+  enabled: true,
+  id: 'daily',
+  name: 'Daily review',
+  profile: 'work'
+}
+
+describe('Sidebar Cron Jobs Sessions action', () => {
+  beforeEach(() => {
+    $cronJobsHiddenFromSessions.set([])
+    getCronJobRuns.mockReset()
+    getCronJobRuns.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    cleanup()
+    $cronJobsHiddenFromSessions.set([])
+  })
+
+  it('labels the eye by its next action and forwards the owning profile', () => {
+    const onSetSessionsVisibility = vi.fn((jobId: string, profile: null | string | undefined, shown: boolean) =>
+      setCronJobInSessions(jobId, profile, shown)
+    )
+
+    render(
+      <SidebarCronJobsSection
+        jobs={[job]}
+        label="Cron Jobs"
+        onManageJob={vi.fn()}
+        onOpenRun={vi.fn()}
+        onSetSessionsVisibility={onSetSessionsVisibility}
+        onToggle={vi.fn()}
+        onTriggerJob={vi.fn()}
+        open
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide from Sessions' }))
+
+    expect(screen.getByRole('button', { name: 'Show in Sessions' })).toBeTruthy()
+    expect(onSetSessionsVisibility).toHaveBeenCalledWith('daily', 'work', false)
+  })
+
+  it('fetches and opens run history with the owning profile', async () => {
+    const onOpenRun = vi.fn()
+
+    getCronJobRuns.mockResolvedValue([
+      {
+        id: 'cron_daily_1',
+        last_active: 0,
+        profile: 'work',
+        source: 'cron',
+        started_at: 0
+      }
+    ])
+
+    render(
+      <SidebarCronJobsSection
+        jobs={[job]}
+        label="Cron Jobs"
+        onManageJob={vi.fn()}
+        onOpenRun={onOpenRun}
+        onSetSessionsVisibility={vi.fn()}
+        onToggle={vi.fn()}
+        onTriggerJob={vi.fn()}
+        open
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show runs' }))
+    fireEvent.click(await screen.findByRole('button', { name: '—' }))
+
+    expect(getCronJobRuns).toHaveBeenCalledWith('daily', 5, 'work')
+    expect(onOpenRun).toHaveBeenCalledWith('cron_daily_1', 'work')
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -8,8 +8,10 @@ import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
 import { Tip } from '@/components/ui/tooltip'
 import { getCronJobRuns, type SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { cronJobShownInSessions, cronJobVisibilityKey } from '@/lib/cron-session-visibility'
 import { fmtDayTime, relativeTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
+import { $cronJobsHiddenFromSessions } from '@/store/cron'
 import { $selectedStoredSessionId } from '@/store/session'
 import type { CronJob } from '@/types/hermes'
 
@@ -61,11 +63,12 @@ interface SidebarCronJobsSectionProps {
   label: string
   max?: number
   // Open a run session's chat (1 click to output).
-  onOpenRun: (sessionId: string) => void
+  onOpenRun: (sessionId: string, profile?: string) => void
   // Open the full Cron page focused on this job (manage / full history).
-  onManageJob: (jobId: string) => void
+  onManageJob: (jobId: string, profile?: null | string) => void
+  onSetSessionsVisibility: (jobId: string, profile: null | string | undefined, shown: boolean) => Promise<void> | void
   // Fire the job now.
-  onTriggerJob: (jobId: string) => void
+  onTriggerJob: (jobId: string, profile?: null | string) => void
   onToggle: () => void
   open: boolean
 }
@@ -76,13 +79,15 @@ export function SidebarCronJobsSection({
   max = 50,
   onManageJob,
   onOpenRun,
+  onSetSessionsVisibility,
   onTriggerJob,
   onToggle,
   open
 }: SidebarCronJobsSectionProps) {
   const [nowMs, setNowMs] = useState(() => Date.now())
+  const hiddenFromSessions = useStore($cronJobsHiddenFromSessions)
   // Single-open inline peek so the section stays scannable.
-  const [peekJobId, setPeekJobId] = useState<null | string>(null)
+  const [peekJobKey, setPeekJobKey] = useState<null | string>(null)
   // Rows revealed so far; starts compact, grows in steps via "load more".
   const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_JOBS)
 
@@ -147,14 +152,26 @@ export function SidebarCronJobsSection({
         <SidebarGroupContent className="flex max-h-72 flex-col gap-px overflow-x-hidden overflow-y-auto overscroll-contain pb-1.75 compact:max-h-none compact:overflow-visible">
           {shown.map(job => (
             <CronJobSidebarRow
-              expanded={peekJobId === job.id}
+              expanded={peekJobKey === cronJobVisibilityKey(job.id, job.profile)}
               job={job}
-              key={job.id}
+              key={cronJobVisibilityKey(job.id, job.profile)}
               nowMs={nowMs}
-              onManage={() => onManageJob(job.id)}
+              onManage={() => onManageJob(job.id, job.profile)}
               onOpenRun={onOpenRun}
-              onTogglePeek={() => setPeekJobId(prev => (prev === job.id ? null : job.id))}
-              onTrigger={() => onTriggerJob(job.id)}
+              onTogglePeek={() => {
+                const key = cronJobVisibilityKey(job.id, job.profile)
+
+                setPeekJobKey(previous => (previous === key ? null : key))
+              }}
+              onToggleSessions={() =>
+                void onSetSessionsVisibility(
+                  job.id,
+                  job.profile,
+                  !cronJobShownInSessions(hiddenFromSessions, job.id, job.profile)
+                )
+              }
+              onTrigger={() => onTriggerJob(job.id, job.profile)}
+              shownInSessions={cronJobShownInSessions(hiddenFromSessions, job.id, job.profile)}
             />
           ))}
           {hiddenCount > 0 && (
@@ -176,15 +193,19 @@ function CronJobSidebarRow({
   onManage,
   onOpenRun,
   onTogglePeek,
-  onTrigger
+  onToggleSessions,
+  onTrigger,
+  shownInSessions
 }: {
   expanded: boolean
   job: CronJob
   nowMs: number
   onManage: () => void
-  onOpenRun: (sessionId: string) => void
+  onOpenRun: (sessionId: string, profile?: string) => void
   onTogglePeek: () => void
+  onToggleSessions: () => void
   onTrigger: () => void
+  shownInSessions: boolean
 }) {
   const { t } = useI18n()
   const c = t.cron
@@ -237,6 +258,16 @@ function CronJobSidebarRow({
             {meta}
           </span>
           <div className="hidden items-center gap-0.5 group-hover/cron:flex">
+            <Tip label={shownInSessions ? c.hideFromSessionsList : c.showInSessionsList}>
+              <button
+                aria-label={shownInSessions ? c.hideFromSessionsList : c.showInSessionsList}
+                className="grid size-5 place-items-center rounded-sm text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground"
+                onClick={onToggleSessions}
+                type="button"
+              >
+                <Codicon name={shownInSessions ? 'eye-closed' : 'eye'} size="0.75rem" />
+              </button>
+            </Tip>
             <Tip label={c.triggerNow}>
               <button
                 aria-label={c.triggerNow}
@@ -260,12 +291,20 @@ function CronJobSidebarRow({
           </div>
         </div>
       </div>
-      {expanded && <CronJobSidebarRuns jobId={job.id} onOpenRun={onOpenRun} />}
+      {expanded && <CronJobSidebarRuns jobId={job.id} onOpenRun={onOpenRun} profile={job.profile} />}
     </div>
   )
 }
 
-function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (sessionId: string) => void }) {
+function CronJobSidebarRuns({
+  jobId,
+  onOpenRun,
+  profile
+}: {
+  jobId: string
+  onOpenRun: (sessionId: string, profile?: string) => void
+  profile?: null | string
+}) {
   const { t } = useI18n()
   const c = t.cron
   const selectedSessionId = useStore($selectedStoredSessionId)
@@ -275,7 +314,7 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
     let cancelled = false
 
     const load = () =>
-      getCronJobRuns(jobId, PEEK_RUN_LIMIT)
+      getCronJobRuns(jobId, PEEK_RUN_LIMIT, profile)
         .then(result => {
           if (!cancelled) {
             setRuns(result)
@@ -299,7 +338,7 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
       cancelled = true
       window.clearInterval(intervalId)
     }
-  }, [jobId])
+  }, [jobId, profile])
 
   return (
     <div className="mb-1 ml-[1.375rem] flex flex-col gap-px">
@@ -320,7 +359,7 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
                   : 'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-foreground'
               )}
               key={run.id}
-              onClick={() => onOpenRun(run.id)}
+              onClick={() => onOpenRun(run.id, profile ?? undefined)}
               type="button"
             >
               {formatRunTime(run.last_active || run.started_at)}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -25,6 +25,7 @@ import { Tip, TipKeybindLabel } from '@/components/ui/tooltip'
 import { useContributions } from '@/contrib/react/use-contributions'
 import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { mergeSessionsForPresentation, sessionsFeedShowsLoadMore } from '@/lib/cron-session-visibility'
 import { comboTokens } from '@/lib/keybinds/combo'
 import { profileColor } from '@/lib/profile-color'
 import { sessionMatchesSearch } from '@/lib/session-search'
@@ -84,11 +85,13 @@ import {
 import { openRouteTile } from '@/store/route-tiles'
 import {
   $cronSessions,
+  $cronSessionsTruncated,
   $currentCwd,
   $gatewayState,
   $messagingPlatformTotals,
   $messagingSessions,
   $messagingTruncated,
+  $presentedSessions,
   $sessionProfileTotals,
   $sessions,
   $sessionsLoading,
@@ -227,15 +230,20 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onLoadMoreSessions: () => Promise<void> | void
   onLoadMoreProfileSessions?: (profile: string) => Promise<void> | void
   onLoadMoreMessaging?: (platform: string) => Promise<void> | void
-  onResumeSession: (sessionId: string) => void
+  onResumeSession: (sessionId: string, profile?: string) => void
   onDeleteSession: (sessionId: string) => void
   onArchiveSession: (sessionId: string) => void
   onBranchSession: (sessionId: string) => void
   onNewSessionInWorkspace: (path: null | string) => void
   /** Create a brand-new session and open it as a tile on `dir`. */
   onNewSessionSplit: (dir: SplitDir) => void
-  onManageCronJob: (jobId: string) => void
-  onTriggerCronJob: (jobId: string) => void
+  onManageCronJob: (jobId: string, profile?: null | string) => void
+  onSetCronJobSessionsVisibility: (
+    jobId: string,
+    profile: null | string | undefined,
+    shown: boolean
+  ) => Promise<void> | void
+  onTriggerCronJob: (jobId: string, profile?: null | string) => void
 }
 
 export function ChatSidebar({
@@ -251,6 +259,7 @@ export function ChatSidebar({
   onNewSessionInWorkspace,
   onNewSessionSplit,
   onManageCronJob,
+  onSetCronJobSessionsVisibility,
   onTriggerCronJob
 }: ChatSidebarProps) {
   const { t } = useI18n()
@@ -294,6 +303,8 @@ export function ChatSidebar({
   const selectedSessionId = useStore($focusedStoredSessionId)
   const sessions = useStore($sessions)
   const cronSessions = useStore($cronSessions)
+  const cronSessionsTruncated = useStore($cronSessionsTruncated)
+  const presentedSessions = useStore($presentedSessions)
   const cronJobs = useStore($cronJobs)
   const messagingSessions = useStore($messagingSessions)
   const messagingPlatformTotals = useStore($messagingPlatformTotals)
@@ -385,12 +396,28 @@ export function ChatSidebar({
     [sessions, showAllProfiles, profileScope]
   )
 
+  const visiblePresentedSessions = useMemo(
+    () =>
+      showAllProfiles
+        ? presentedSessions
+        : presentedSessions.filter(s => normalizeProfileKey(s.profile) === profileScope),
+    [presentedSessions, profileScope, showAllProfiles]
+  )
+
+  const searchableSessions = useMemo(() => {
+    const visibleCron = showAllProfiles
+      ? cronSessions
+      : cronSessions.filter(s => normalizeProfileKey(s.profile) === profileScope)
+
+    return mergeSessionsForPresentation(visibleSessions, visibleCron)
+  }, [cronSessions, profileScope, showAllProfiles, visibleSessions])
+
   // Agent session order is pinned to creation time (started_at), NOT activity —
   // a new message must never float a session to the top. Position only changes
   // for a brand-new session or an explicit manual drag (agentOrderIds).
   const sortedSessions = useMemo(
-    () => [...visibleSessions].sort((a, b) => (b.started_at || 0) - (a.started_at || 0)),
-    [visibleSessions]
+    () => [...visiblePresentedSessions].sort((a, b) => (b.started_at || 0) - (a.started_at || 0)),
+    [visiblePresentedSessions]
   )
 
   const workingSessionIdSet = useMemo(() => new Set(workingSessionIds), [workingSessionIds])
@@ -475,7 +502,7 @@ export function ChatSidebar({
 
     const out = new Map<string, SessionInfo>()
 
-    for (const s of sortedSessions) {
+    for (const s of searchableSessions) {
       if (sessionMatchesSearch(s, trimmedQuery)) {
         out.set(s.id, s)
       }
@@ -491,7 +518,7 @@ export function ChatSidebar({
     }
 
     return [...out.values()]
-  }, [trimmedQuery, sortedSessions, serverMatches, sessionByAnyId])
+  }, [trimmedQuery, searchableSessions, serverMatches, sessionByAnyId])
 
   const unpinnedAgentSessions = useMemo(
     () => sortedSessions.filter(s => !pinnedRealIdSet.has(s.id)),
@@ -960,14 +987,19 @@ export function ChatSidebar({
   const loadedSessionCount = showAllProfiles ? sessions.length : visibleSessions.length
   const scopedProfileTotal = showAllProfiles ? undefined : sessionProfileTotals[profileScope]
 
-  const knownSessionTotal = Math.max(
+  const ordinarySessionTotal = Math.max(
     showAllProfiles ? sessionsTotal : (scopedProfileTotal ?? loadedSessionCount),
     loadedSessionCount
   )
 
-  const hasMoreSessions = knownSessionTotal > loadedSessionCount
+  const visibleCronCount = visiblePresentedSessions.filter(session => session.source === 'cron').length
+  const knownSessionTotal = ordinarySessionTotal + visibleCronCount
+  const ordinaryHasMoreSessions = ordinarySessionTotal > loadedSessionCount
 
-  const recentsMeta = countLabel(displayAgentSessions.length, knownSessionTotal)
+  const recentsMeta = cronSessionsTruncated
+    ? `${displayAgentSessions.length}+`
+    : countLabel(displayAgentSessions.length, knownSessionTotal)
+
   const displayRecentsCountRef = useRef(0)
   const loadedRecentsCountRef = useRef(0)
   displayRecentsCountRef.current = displayAgentSessions.length
@@ -1287,10 +1319,15 @@ export function ChatSidebar({
                   )
                 }
                 footer={
-                  // Hide "load more" only when workspace-grouped (those groups page
-                  // themselves). ALL-profiles now pages per-profile from each profile
-                  // header; the global footer only applies to non-ALL views.
-                  !showAllProfiles && !agentsGrouped && !showSessionSkeletons && hasMoreSessions ? (
+                  // Ordinary All-Profiles paging stays on each profile header,
+                  // but cron owns one shared bounded window.
+                  sessionsFeedShowsLoadMore({
+                    agentsGrouped,
+                    cronTruncated: cronSessionsTruncated,
+                    ordinaryHasMore: ordinaryHasMoreSessions,
+                    sessionsLoading: showSessionSkeletons,
+                    showAllProfiles
+                  }) ? (
                     <SidebarLoadMoreRow
                       loading={sessionsLoading || recentsLoadMorePending}
                       onClick={() => void onLoadMoreRecents()}
@@ -1475,6 +1512,7 @@ export function ChatSidebar({
                 label={s.cronJobs}
                 onManageJob={onManageCronJob}
                 onOpenRun={onResumeSession}
+                onSetSessionsVisibility={onSetCronJobSessionsVisibility}
                 onToggle={() => setSidebarCronOpen(!cronOpen)}
                 onTriggerJob={onTriggerCronJob}
                 open={cronOpen}

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -78,9 +78,16 @@ vi.mock('@/store/windows', () => ({
   openSessionInNewWindow: vi.fn()
 }))
 
-function renderMenu() {
+function renderMenu({ hideDestructiveActions = false } = {}) {
   return render(
-    <SessionActionsMenu sessionId="s1" title="My session" tooltip="Actions for My session">
+    <SessionActionsMenu
+      hideDestructiveActions={hideDestructiveActions}
+      onArchive={vi.fn()}
+      onDelete={vi.fn()}
+      sessionId="s1"
+      title="My session"
+      tooltip="Actions for My session"
+    >
       <button aria-label="Actions for My session" type="button">
         ⋮
       </button>
@@ -116,5 +123,18 @@ describe('SessionActionsMenu', () => {
     expect(await screen.findByRole('menu')).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /rename/i })).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /archive/i })).toBeTruthy()
+  })
+
+  it('omits destructive actions only when a cron row explicitly requests it', async () => {
+    renderMenu({ hideDestructiveActions: true })
+
+    const trigger = screen.getByRole('button', { name: 'Actions for My session' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+
+    expect(await screen.findByRole('menu')).toBeTruthy()
+    expect(screen.queryByRole('menuitem', { name: /archive/i })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: /delete/i })).toBeNull()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -113,6 +113,9 @@ interface SessionActions {
   title: string
   pinned?: boolean
   profile?: string
+  /** Cron rows are readable/resumable here, but their profile-blind legacy
+   * archive/delete actions are intentionally not exposed. */
+  hideDestructiveActions?: boolean
   onPin?: () => void
   onBranch?: () => void
   onArchive?: () => void
@@ -193,6 +196,7 @@ function useSessionActions({
   title,
   pinned = false,
   profile,
+  hideDestructiveActions = false,
   onPin,
   onBranch,
   onArchive,
@@ -348,28 +352,30 @@ function useSessionActions({
       : []
 
   // DANGER — put it away / destroy it (delete stays last, destructive-red).
-  const dangerItems: ItemSpec[] = [
-    spec({
-      disabled: !onArchive,
-      icon: 'archive',
-      label: r.archive,
-      onSelect: () => {
-        triggerHaptic('selection')
-        onArchive?.()
-      }
-    }),
-    {
-      className: 'text-destructive focus:text-destructive',
-      disabled: !onDelete,
-      icon: 'trash',
-      label: t.common.delete,
-      onSelect: () => {
-        triggerHaptic('warning')
-        onDelete?.()
-      },
-      variant: 'destructive'
-    }
-  ]
+  const dangerItems: ItemSpec[] = hideDestructiveActions
+    ? []
+    : [
+        spec({
+          disabled: !onArchive,
+          icon: 'archive',
+          label: r.archive,
+          onSelect: () => {
+            triggerHaptic('selection')
+            onArchive?.()
+          }
+        }),
+        {
+          className: 'text-destructive focus:text-destructive',
+          disabled: !onDelete,
+          icon: 'trash',
+          label: t.common.delete,
+          onSelect: () => {
+            triggerHaptic('warning')
+            onDelete?.()
+          },
+          variant: 'destructive'
+        }
+      ]
 
   const renderMenuItem = (Item: MenuItem, { className, disabled, icon, label, onSelect, variant }: ItemSpec) => (
     <Item className={className} disabled={disabled} key={label} onSelect={onSelect} variant={variant}>
@@ -410,8 +416,12 @@ function useSessionActions({
           {tabCloseItems.map(item => renderMenuItem(kit.Item, item))}
         </>
       )}
-      <kit.Separator />
-      {dangerItems.map(item => renderMenuItem(kit.Item, item))}
+      {dangerItems.length > 0 && (
+        <>
+          <kit.Separator />
+          {dangerItems.map(item => renderMenuItem(kit.Item, item))}
+        </>
+      )}
       {onHideTabBar && (
         <>
           <kit.Separator />

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -31,6 +31,7 @@ interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
   isPinned: boolean
   isSelected: boolean
   isWorking: boolean
+  hideDestructiveActions?: boolean
   onArchive: () => void
   onBranch?: () => void
   onDelete: () => void
@@ -60,6 +61,7 @@ export function SidebarSessionRow({
   isPinned,
   isSelected,
   isWorking,
+  hideDestructiveActions = false,
   onArchive,
   onBranch,
   onDelete,
@@ -90,6 +92,7 @@ export function SidebarSessionRow({
 
   return (
     <SessionContextMenu
+      hideDestructiveActions={hideDestructiveActions}
       onArchive={onArchive}
       onBranch={onBranch}
       onDelete={onDelete}
@@ -108,6 +111,7 @@ export function SidebarSessionRow({
               </span>
             )}
             <SessionActionsMenu
+              hideDestructiveActions={hideDestructiveActions}
               onArchive={onArchive}
               onBranch={onBranch}
               onDelete={onDelete}

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+
+import { SidebarSessionsSection } from './sessions-section'
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: { sidebar: { dateDivider: { lastWeek: 'Last week', older: 'Older', today: 'Today', yesterday: 'Yesterday' } } }
+  })
+}))
+
+const renderedRowProps = vi.hoisted(() => new Map<string, Record<string, unknown>>())
+
+vi.mock('./session-row', () => ({
+  SidebarSessionRow: (props: { onResume: () => void; session: SessionInfo }) => {
+    renderedRowProps.set(`${props.session.profile}-${props.session.id}`, props as unknown as Record<string, unknown>)
+
+    return (
+      <button
+        data-testid={`session-${props.session.profile}-${props.session.id}`}
+        onClick={props.onResume}
+        type="button"
+      >
+        {props.session.profile}/{props.session.id}
+      </button>
+    )
+  }
+}))
+
+const session = (profile: string, source = 'desktop'): SessionInfo =>
+  ({
+    archived: false,
+    cwd: null,
+    ended_at: null,
+    id: 'same',
+    input_tokens: 0,
+    is_active: false,
+    last_active: 100,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    profile,
+    source,
+    started_at: 100,
+    title: `${profile} same`,
+    tool_call_count: 0
+  }) as SessionInfo
+
+describe('Sessions cron rows', () => {
+  it('opens a cron row with its actual owner', () => {
+    const onResumeSession = vi.fn()
+
+    render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={null}
+        label="Sessions"
+        onArchiveSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+        onResumeSession={onResumeSession}
+        onToggle={vi.fn()}
+        onTogglePin={vi.fn()}
+        open
+        pinned={false}
+        sessions={[session('work', 'cron')]}
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('session-work-same'))
+
+    expect(onResumeSession).toHaveBeenCalledWith('same', 'work')
+  })
+
+  it('leaves ordinary row resume behavior profile-agnostic', () => {
+    const onResumeSession = vi.fn()
+
+    render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={null}
+        label="Sessions"
+        onArchiveSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+        onResumeSession={onResumeSession}
+        onToggle={vi.fn()}
+        onTogglePin={vi.fn()}
+        open
+        pinned={false}
+        sessions={[session('work')]}
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('session-work-same'))
+
+    expect(onResumeSession).toHaveBeenCalledWith('same', undefined)
+  })
+
+  it('does not provide archive or delete actions for cron rows', () => {
+    render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={null}
+        label="Sessions"
+        onArchiveSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+        onResumeSession={vi.fn()}
+        onToggle={vi.fn()}
+        onTogglePin={vi.fn()}
+        open
+        pinned={false}
+        sessions={[session('work', 'cron')]}
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    const props = renderedRowProps.get('work-same')
+
+    expect(props?.hideDestructiveActions).toBe(true)
+    expect(props?.onArchive).toBeTypeOf('function')
+    expect(props?.onDelete).toBeTypeOf('function')
+    expect(props?.onResume).toBeTypeOf('function')
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -8,6 +8,7 @@ import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
 import type { HermesGitWorktree } from '@/global'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { sessionPresentationKey } from '@/lib/cron-session-visibility'
 import { flattenSessionsWithBranches } from '@/lib/session-branch-tree'
 import { groupEntriesByRecency, type SidebarListRow, toSessionRows } from '@/lib/session-date-groups'
 import { sessionBucketLabel } from '@/lib/time'
@@ -89,7 +90,7 @@ interface SidebarSessionsSectionProps {
   sessions: SessionInfo[]
   activeSessionId: null | string
   workingSessionIdSet: Set<string>
-  onResumeSession: (sessionId: string) => void
+  onResumeSession: (sessionId: string, profile?: string) => void
   onDeleteSession: (sessionId: string) => void
   onArchiveSession: (sessionId: string) => void
   onBranchSession?: (sessionId: string, profile?: string) => void
@@ -210,6 +211,7 @@ export function SidebarSessionsSection({
   const renderRow = (session: SessionInfo, draggable: boolean, branchStem?: string) => {
     const rowProps = {
       branchStem,
+      hideDestructiveActions: session.source === 'cron',
       isPinned: pinned,
       isSelected: session.id === activeSessionId,
       isWorking: workingSessionIdSet.has(session.id),
@@ -217,16 +219,16 @@ export function SidebarSessionsSection({
       onBranch: onBranchSession ? () => onBranchSession(session.id, session.profile) : undefined,
       onDelete: () => onDeleteSession(session.id),
       onPin: () => onTogglePin(sessionPinId(session)),
-      onResume: () => onResumeSession(session.id),
+      onResume: () => onResumeSession(session.id, session.source === 'cron' ? session.profile : undefined),
       reorderable: draggable && !branchStem,
       session,
       showProfile: showProfileTags
     }
 
     return draggable && !branchStem ? (
-      <SortableSidebarSessionRow key={session.id} {...rowProps} />
+      <SortableSidebarSessionRow key={sessionPresentationKey(session)} {...rowProps} />
     ) : (
-      <SidebarSessionRow key={session.id} {...rowProps} />
+      <SidebarSessionRow key={sessionPresentationKey(session)} {...rowProps} />
     )
   }
 
@@ -397,16 +399,7 @@ export function SidebarSessionsSection({
   )
 }
 
-interface SortableSessionRowProps {
-  session: SessionInfo
-  isPinned: boolean
-  isSelected: boolean
-  isWorking: boolean
-  onArchive: () => void
-  onDelete: () => void
-  onPin: () => void
-  onResume: () => void
-}
+type SortableSessionRowProps = React.ComponentProps<typeof SidebarSessionRow>
 
 function SortableSidebarSessionRow(props: SortableSessionRowProps) {
   return <SidebarSessionRow {...props} {...useSortableBindings(props.session.id)} />

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -1,10 +1,11 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { type FC, useCallback, useRef } from 'react'
+import { type ComponentProps, type FC, useCallback, useRef } from 'react'
 
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { sessionPresentationKey } from '@/lib/cron-session-visibility'
 import { type SidebarListRow } from '@/lib/session-date-groups'
 import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
@@ -13,19 +14,7 @@ import { sessionPinId } from '@/store/session'
 import { SidebarDateDivider } from './chrome'
 import { SidebarSessionRow } from './session-row'
 
-interface SessionRowCommonProps {
-  branchStem?: string
-  isPinned: boolean
-  isSelected: boolean
-  isWorking: boolean
-  onArchive: () => void
-  onBranch?: () => void
-  onDelete: () => void
-  onPin: () => void
-  onResume: () => void
-  reorderable?: boolean
-  showProfile?: boolean
-}
+type SessionRowCommonProps = Omit<ComponentProps<typeof SidebarSessionRow>, 'session'>
 
 interface VirtualSessionListProps {
   activeSessionId: null | string
@@ -34,7 +23,7 @@ interface VirtualSessionListProps {
   onArchiveSession: (sessionId: string) => void
   onBranchSession?: (sessionId: string, profile?: string) => void
   onDeleteSession: (sessionId: string) => void
-  onResumeSession: (sessionId: string) => void
+  onResumeSession: (sessionId: string, profile?: string) => void
   onTogglePin: (sessionId: string) => void
   pinned: boolean
   showProfileTags?: boolean
@@ -69,7 +58,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     getItemKey: index => {
       const row = listRows[index]
 
-      return row ? (row.kind === 'divider' ? row.key : row.entry.session.id) : index
+      return row ? (row.kind === 'divider' ? row.key : sessionPresentationKey(row.entry.session)) : index
     },
     getScrollElement: () => scrollerRef.current,
     // jsdom-friendly default; the real rect takes over on first observe.
@@ -106,6 +95,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
 
     const commonProps: SessionRowCommonProps = {
       branchStem,
+      hideDestructiveActions: session.source === 'cron',
       isPinned: pinned,
       isSelected: session.id === activeSessionId,
       isWorking: workingSessionIdSet.has(session.id),
@@ -113,7 +103,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
       onBranch: onBranchSession ? () => onBranchSession(session.id, session.profile) : undefined,
       onDelete: () => onDeleteSession(session.id),
       onPin: () => onTogglePin(sessionPinId(session)),
-      onResume: () => onResumeSession(session.id),
+      onResume: () => onResumeSession(session.id, session.source === 'cron' ? session.profile : undefined),
       reorderable,
       showProfile: showProfileTags
     }
@@ -121,7 +111,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     return reorderable ? (
       <VirtualSortableRow
         index={virtualItem.index}
-        key={session.id}
+        key={sessionPresentationKey(session)}
         measureRef={virtualizer.measureElement}
         rowProps={commonProps}
         session={session}
@@ -130,7 +120,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
       <SidebarSessionRow
         {...commonProps}
         data-index={virtualItem.index}
-        key={session.id}
+        key={sessionPresentationKey(session)}
         ref={virtualizer.measureElement}
         session={session}
       />

--- a/apps/desktop/src/app/contrib/types.ts
+++ b/apps/desktop/src/app/contrib/types.ts
@@ -22,6 +22,7 @@ export type SidebarActions = Pick<
   | 'onNewSessionInWorkspace'
   | 'onNewSessionSplit'
   | 'onResumeSession'
+  | 'onSetCronJobSessionsVisibility'
   | 'onTriggerCronJob'
 >
 

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -29,7 +29,7 @@ import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { isMessagingSource } from '@/lib/session-source'
 import { latestSessionTodos } from '@/lib/todos'
 import { $billingSettingsRequest } from '@/store/billing-block'
-import { setCronFocusJobId } from '@/store/cron'
+import { setCronFocusJob } from '@/store/cron'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { $filePreviewTarget, $previewTarget } from '@/store/preview'
 import { $activeGatewayProfile, $freshSessionRequest, $profileScope, refreshActiveProfile } from '@/store/profile'
@@ -74,7 +74,14 @@ import { RemoteFolderPicker } from '../right-sidebar/files/remote-picker'
 import { resetProjectTreeState } from '../right-sidebar/files/use-project-tree'
 import { PersistentTerminal } from '../right-sidebar/terminal/persistent'
 import { closeAllTerminals } from '../right-sidebar/terminal/terminals'
-import { CRON_ROUTE, routeSessionId, sessionRoute, SETTINGS_ROUTE, syncWorkspaceIsPage } from '../routes'
+import {
+  CRON_ROUTE,
+  routeSessionId,
+  sessionProfileFromSearch,
+  sessionRoute,
+  SETTINGS_ROUTE,
+  syncWorkspaceIsPage
+} from '../routes'
 import { SessionPickerOverlay } from '../session-picker-overlay'
 import { SessionSwitcher } from '../session-switcher'
 import { useBackgroundQueueDrain } from '../session/hooks/use-background-queue-drain'
@@ -162,6 +169,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const profileScope = useStore($profileScope)
 
   const routedSessionId = routeSessionId(location.pathname)
+  const routedSessionProfile = sessionProfileFromSearch(location.search)
   const routedSessionIdRef = useRef(routedSessionId)
 
   routedSessionIdRef.current = routedSessionId
@@ -229,7 +237,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     loadMoreSessionsForProfile,
     refreshCronJobs,
     refreshMessagingSessions,
-    refreshSessions
+    refreshSessions,
+    setCronJobSessionsVisibility
   } = useSessionListActions({ profileScope })
 
   const updateActiveSessionRuntimeInfo = useCallback(
@@ -632,6 +641,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     freshDraftReady,
     gatewayState,
     locationPathname: location.pathname,
+    routedSessionProfile,
     resumeSession,
     resumeFailedSessionId,
     resumeExhaustedSessionId,
@@ -783,8 +793,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onLoadMoreMessaging: loadMoreMessagingForPlatform,
     onLoadMoreProfileSessions: loadMoreSessionsForProfile,
     onLoadMoreSessions: loadMoreSessions,
-    onManageCronJob: jobId => {
-      setCronFocusJobId(jobId)
+    onManageCronJob: (jobId, profile) => {
+      setCronFocusJob({ id: jobId, profile })
       navigate(CRON_ROUTE)
     },
     onNavigate: selectSidebarItem,
@@ -799,19 +809,20 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onRestoreToMessage: restoreToMessage,
     // Already on screen (open tile, or the main session)? Jump to its tab;
     // otherwise load it into main.
-    onResumeSession: sessionId => {
-      if (!focusOpenSession(sessionId)) {
-        navigate(sessionRoute(sessionId))
+    onResumeSession: (sessionId, profile) => {
+      if (profile || !focusOpenSession(sessionId)) {
+        navigate(sessionRoute(sessionId, profile))
       }
     },
+    onSetCronJobSessionsVisibility: setCronJobSessionsVisibility,
     onRetryResume: sessionId => void resumeSession(sessionId, true),
     onSteer: steerPrompt,
     onSubmit: submitText,
     onThreadMessagesChange: handleThreadMessagesChange,
     onToggleSelectedPin: toggleSelectedPin,
     onTranscribeAudio: transcribeVoiceAudio,
-    onTriggerCronJob: jobId => {
-      void triggerCronJob(jobId)
+    onTriggerCronJob: (jobId, profile) => {
+      void triggerCronJob(jobId, profile)
         .then(() => refreshCronJobs())
         .catch(() => undefined)
     },
@@ -1003,7 +1014,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         <Suspense fallback={null}>
           <CronView
             onClose={closeOverlayToPreviousRoute}
-            onOpenSession={sessionId => navigate(sessionRoute(sessionId))}
+            onOpenSession={(sessionId, profile) => navigate(sessionRoute(sessionId, profile))}
+            onSetSessionsVisibility={setCronJobSessionsVisibility}
           />
         </Suspense>
       )}

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -44,10 +44,18 @@ import {
   updateCronJob
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
+import { cronJobShownInSessions, cronJobVisibilityKey } from '@/lib/cron-session-visibility'
 import { AlertTriangle } from '@/lib/icons'
 import { requestModelOptions } from '@/lib/model-options'
 import { asText } from '@/lib/text'
-import { $cronFocusJobId, $cronJobs, setCronFocusJobId, setCronJobs, updateCronJobs } from '@/store/cron'
+import {
+  $cronFocusJob,
+  $cronJobs,
+  $cronJobsHiddenFromSessions,
+  setCronFocusJob,
+  setCronJobs,
+  updateCronJobs
+} from '@/store/cron'
 import { notify, notifyError } from '@/store/notifications'
 import { $profileScope, ALL_PROFILES } from '@/store/profile'
 
@@ -133,6 +141,14 @@ function jobModel(job: CronJob): string {
 
 function jobProvider(job: CronJob): string {
   return asText(job.provider).trim()
+}
+
+function jobKey(job: Pick<CronJob, 'id' | 'profile'>): string {
+  return cronJobVisibilityKey(job.id, job.profile)
+}
+
+function retainJobProfile(response: CronJob, owner: CronJob): CronJob {
+  return response.profile ? response : { ...response, profile: owner.profile }
 }
 
 function cronParts(expr: string): null | string[] {
@@ -278,26 +294,33 @@ function matchesQuery(job: CronJob, q: string): boolean {
 
 interface CronViewProps extends React.ComponentProps<'section'> {
   onClose: () => void
-  onOpenSession?: (sessionId: string) => void
+  onOpenSession?: (sessionId: string, profile?: string) => void
+  onSetSessionsVisibility: (jobId: string, profile: null | string | undefined, shown: boolean) => Promise<void> | void
   setStatusbarItemGroup?: SetStatusbarItemGroup
 }
 
-export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setStatusbarItemGroup }: CronViewProps) {
+export function CronView({
+  onClose,
+  onOpenSession,
+  onSetSessionsVisibility,
+  setStatusbarItemGroup: _setStatusbarItemGroup
+}: CronViewProps) {
   const { t } = useI18n()
   const c = t.cron
   // Source of truth is the shared atom (also fed by the controller poll), so the
   // sidebar and this overlay never drift — a delete here clears the sidebar row
   // immediately. `loading` only gates the first paint before the atom is filled.
   const jobs = useStore($cronJobs)
+  const hiddenFromSessions = useStore($cronJobsHiddenFromSessions)
   const [loading, setLoading] = useState(jobs.length === 0)
   const [query, setQuery] = useState('')
-  const [busyJobId, setBusyJobId] = useState<null | string>(null)
+  const [busyJobKey, setBusyJobKey] = useState<null | string>(null)
   // Master/detail: the job whose schedule + run history fill the right pane.
-  const [selectedJobId, setSelectedJobId] = useState<null | string>(null)
+  const [selectedJobKey, setSelectedJobKey] = useState<null | string>(null)
   // Set when a job is opened from the sidebar so we scroll it into view once the
   // row exists. Cleared after the scroll fires.
   const pendingScrollRef = useRef<null | string>(null)
-  const focusJobId = useStore($cronFocusJobId)
+  const focusJob = useStore($cronFocusJob)
 
   const [editor, setEditor] = useState<EditorState>({ mode: 'closed' })
   const [pendingDelete, setPendingDelete] = useState<CronJob | null>(null)
@@ -328,19 +351,23 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
   // it, queue a scroll, then clear the one-shot focus so re-opening cron
   // normally doesn't re-trigger it.
   useEffect(() => {
-    if (!focusJobId) {
+    if (!focusJob) {
       return
     }
 
-    const match = jobs.find(job => job.id === focusJobId || jobName(job) === focusJobId)
+    const match = jobs.find(
+      job =>
+        (job.id === focusJob.id || jobName(job) === focusJob.id) &&
+        (focusJob.profile == null || jobKey(job) === cronJobVisibilityKey(focusJob.id, focusJob.profile))
+    )
 
     if (match) {
-      setSelectedJobId(match.id)
-      pendingScrollRef.current = match.id
+      setSelectedJobKey(jobKey(match))
+      pendingScrollRef.current = jobKey(match)
     }
 
-    setCronFocusJobId(null)
-  }, [focusJobId, jobs])
+    setCronFocusJob(null)
+  }, [focusJob, jobs])
 
   const visibleJobs = useMemo(
     () => jobs.filter(job => matchesQuery(job, query.trim())).sort((a, b) => jobTitle(a).localeCompare(jobTitle(b))),
@@ -350,15 +377,15 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
   // Detail always reflects a concrete job: the explicitly selected one, else the
   // first visible row, so the right pane is never empty while jobs exist.
   const selectedJob = useMemo(
-    () => visibleJobs.find(job => job.id === selectedJobId) ?? visibleJobs[0] ?? null,
-    [visibleJobs, selectedJobId]
+    () => visibleJobs.find(job => jobKey(job) === selectedJobKey) ?? visibleJobs[0] ?? null,
+    [visibleJobs, selectedJobKey]
   )
 
   // Scroll a sidebar-opened job into view once its list row is mounted.
   useEffect(() => {
     const target = pendingScrollRef.current
 
-    if (!target || selectedJob?.id !== target) {
+    if (!target || !selectedJob || jobKey(selectedJob) !== target) {
       return
     }
 
@@ -371,12 +398,13 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
   const totalCount = jobs.length
 
   async function handlePauseResume(job: CronJob) {
-    setBusyJobId(job.id)
+    setBusyJobKey(jobKey(job))
 
     try {
       const isPaused = jobState(job) === 'paused'
-      const updated = isPaused ? await resumeCronJob(job.id) : await pauseCronJob(job.id)
-      updateCronJobs(rows => rows.map(row => (row.id === job.id ? updated : row)))
+      const response = isPaused ? await resumeCronJob(job.id, job.profile) : await pauseCronJob(job.id, job.profile)
+      const updated = retainJobProfile(response, job)
+      updateCronJobs(rows => rows.map(row => (jobKey(row) === jobKey(job) ? updated : row)))
       notify({
         kind: 'success',
         title: isPaused ? c.resumed : c.paused,
@@ -385,21 +413,21 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
     } catch (err) {
       notifyError(err, c.failedUpdate)
     } finally {
-      setBusyJobId(null)
+      setBusyJobKey(null)
     }
   }
 
   async function handleTrigger(job: CronJob) {
-    setBusyJobId(job.id)
+    setBusyJobKey(jobKey(job))
 
     try {
-      const updated = await triggerCronJob(job.id)
-      updateCronJobs(rows => rows.map(row => (row.id === job.id ? updated : row)))
+      const updated = retainJobProfile(await triggerCronJob(job.id, job.profile), job)
+      updateCronJobs(rows => rows.map(row => (jobKey(row) === jobKey(job) ? updated : row)))
       notify({ kind: 'success', title: c.triggered, message: truncate(jobTitle(job), 60) })
     } catch (err) {
       notifyError(err, c.failedTrigger)
     } finally {
-      setBusyJobId(null)
+      setBusyJobKey(null)
     }
   }
 
@@ -411,8 +439,8 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
     setDeleting(true)
 
     try {
-      await deleteCronJob(pendingDelete.id)
-      updateCronJobs(rows => rows.filter(row => row.id !== pendingDelete.id))
+      await deleteCronJob(pendingDelete.id, pendingDelete.profile)
+      updateCronJobs(rows => rows.filter(row => jobKey(row) !== jobKey(pendingDelete)))
       notify({ kind: 'success', title: c.deleted, message: truncate(jobTitle(pendingDelete), 60) })
       setPendingDelete(null)
     } catch (err) {
@@ -437,9 +465,12 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
     } else if (editor.mode === 'edit') {
       const scriptOnlyJob = jobIsScriptOnly(editor.job)
 
-      const updated = await updateCronJob(editor.job.id, cronEditorUpdates(values, { scriptOnlyJob }))
+      const updated = retainJobProfile(
+        await updateCronJob(editor.job.id, cronEditorUpdates(values, { scriptOnlyJob }), editor.job.profile),
+        editor.job
+      )
 
-      updateCronJobs(rows => rows.map(row => (row.id === updated.id ? updated : row)))
+      updateCronJobs(rows => rows.map(row => (jobKey(row) === jobKey(editor.job) ? updated : row)))
       notify({ kind: 'success', title: c.updated, message: truncate(jobTitle(updated), 60) })
     }
 
@@ -456,7 +487,7 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
     const job = await instantiateAutomationBlueprint({ blueprint: blueprint.key, values }, profile)
 
     updateCronJobs(rows => {
-      const rest = rows.filter(row => row.id !== job.id)
+      const rest = rows.filter(row => jobKey(row) !== jobKey(job))
 
       return [...rest, job]
     })
@@ -496,18 +527,30 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
           >
             {visibleJobs.map(job => (
               <CronJobListRow
-                active={selectedJob?.id === job.id}
+                active={selectedJob ? jobKey(selectedJob) === jobKey(job) : false}
                 job={job}
-                key={job.id}
+                key={jobKey(job)}
                 menu={
                   <PanelRowMenu
                     items={[
+                      {
+                        icon: cronJobShownInSessions(hiddenFromSessions, job.id, job.profile) ? 'eye-closed' : 'eye',
+                        label: cronJobShownInSessions(hiddenFromSessions, job.id, job.profile)
+                          ? c.hideFromSessionsList
+                          : c.showInSessionsList,
+                        onSelect: () =>
+                          void onSetSessionsVisibility(
+                            job.id,
+                            job.profile,
+                            !cronJobShownInSessions(hiddenFromSessions, job.id, job.profile)
+                          )
+                      },
                       { icon: 'edit', label: c.edit, onSelect: () => setEditor({ mode: 'edit', job }) },
                       { icon: 'trash', label: t.common.delete, onSelect: () => setPendingDelete(job), tone: 'danger' }
                     ]}
                   />
                 }
-                onSelect={() => setSelectedJobId(job.id)}
+                onSelect={() => setSelectedJobKey(jobKey(job))}
               />
             ))}
             {visibleJobs.length === 0 && (
@@ -518,12 +561,20 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
 
           {selectedJob ? (
             <CronJobDetail
-              busy={busyJobId === selectedJob.id}
+              busy={busyJobKey === jobKey(selectedJob)}
               c={c}
               job={selectedJob}
               onOpenSession={onOpenSession}
               onPauseResume={() => void handlePauseResume(selectedJob)}
+              onToggleSessions={() =>
+                void onSetSessionsVisibility(
+                  selectedJob.id,
+                  selectedJob.profile,
+                  !cronJobShownInSessions(hiddenFromSessions, selectedJob.id, selectedJob.profile)
+                )
+              }
               onTrigger={() => void handleTrigger(selectedJob)}
+              shownInSessions={cronJobShownInSessions(hiddenFromSessions, selectedJob.id, selectedJob.profile)}
             />
           ) : (
             <PanelEmpty description={c.emptyDescSearch} icon="search" />
@@ -585,7 +636,7 @@ function CronJobListRow({
       dotClassName={STATE_DOT[state] ?? 'bg-muted-foreground'}
       menu={menu}
       onSelect={onSelect}
-      rowKey={job.id}
+      rowKey={jobKey(job)}
       title={jobTitle(job)}
     />
   )
@@ -597,14 +648,18 @@ function CronJobDetail({
   job,
   onOpenSession,
   onPauseResume,
-  onTrigger
+  onToggleSessions,
+  onTrigger,
+  shownInSessions
 }: {
   busy: boolean
   c: Translations['cron']
   job: CronJob
-  onOpenSession?: (sessionId: string) => void
+  onOpenSession?: (sessionId: string, profile?: string) => void
   onPauseResume: () => void
+  onToggleSessions: () => void
   onTrigger: () => void
+  shownInSessions: boolean
 }) {
   const state = jobState(job)
   const isPaused = state === 'paused'
@@ -621,6 +676,9 @@ function CronJobDetail({
             <PanelPill tone={STATE_TONE[state] ?? 'muted'}>{c.states[state] ?? state}</PanelPill>
           </div>
           <div className="flex shrink-0 items-center gap-0.5">
+            <PanelAction icon={shownInSessions ? 'eye-closed' : 'eye'} onClick={onToggleSessions}>
+              {shownInSessions ? c.hideFromSessionsList : c.showInSessionsList}
+            </PanelAction>
             <PanelAction disabled={busy} icon={isPaused ? 'play' : 'debug-pause'} onClick={onPauseResume}>
               {isPaused ? c.resumeTitle : c.pauseTitle}
             </PanelAction>
@@ -655,7 +713,7 @@ function CronJobDetail({
         </section>
       ) : null}
 
-      <CronJobRuns c={c} jobId={job.id} onOpenSession={onOpenSession} />
+      <CronJobRuns c={c} jobId={job.id} onOpenSession={onOpenSession} profile={job.profile} />
     </PanelDetail>
   )
 }
@@ -678,11 +736,13 @@ const RUNS_POLL_INTERVAL_MS = 8000
 function CronJobRuns({
   c,
   jobId,
-  onOpenSession
+  onOpenSession,
+  profile
 }: {
   c: Translations['cron']
   jobId: string
-  onOpenSession?: (sessionId: string) => void
+  onOpenSession?: (sessionId: string, profile?: string) => void
+  profile?: null | string
 }) {
   const [runs, setRuns] = useState<null | SessionInfo[]>(null)
 
@@ -690,7 +750,7 @@ function CronJobRuns({
     let cancelled = false
 
     const load = () =>
-      getCronJobRuns(jobId)
+      getCronJobRuns(jobId, 20, profile)
         .then(result => {
           if (!cancelled) {
             setRuns(result)
@@ -723,7 +783,7 @@ function CronJobRuns({
       window.clearInterval(intervalId)
       document.removeEventListener('visibilitychange', onVisible)
     }
-  }, [jobId])
+  }, [jobId, profile])
 
   return (
     <div>
@@ -743,7 +803,7 @@ function CronJobRuns({
             <button
               className="row-hover flex items-center justify-between gap-3 rounded-md px-2 py-1 text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
               key={run.id}
-              onClick={() => onOpenSession?.(run.id)}
+              onClick={() => onOpenSession?.(run.id, profile ?? undefined)}
               type="button"
             >
               <span className="truncate text-foreground/85">{run.title?.trim() || run.preview?.trim() || run.id}</span>

--- a/apps/desktop/src/app/routes.test.ts
+++ b/apps/desktop/src/app/routes.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { NEW_CHAT_ROUTE, primaryRouteSelectedSessionId, sessionRoute, SETTINGS_ROUTE } from './routes'
+import {
+  NEW_CHAT_ROUTE,
+  primaryRouteSelectedSessionId,
+  sessionProfileFromSearch,
+  sessionRoute,
+  SETTINGS_ROUTE
+} from './routes'
 
 const SESS_A = 'sess-a'
 const SESS_B = 'sess-b'
@@ -26,5 +32,13 @@ describe('primaryRouteSelectedSessionId', () => {
 
   it('returns null on a non-chat route with no store selection', () => {
     expect(primaryRouteSelectedSessionId(SETTINGS_ROUTE, null)).toBeNull()
+  })
+})
+
+describe('profile-qualified session routes', () => {
+  it('keeps the raw id in the path and the owner in the query', () => {
+    expect(sessionRoute('same/raw', 'work profile')).toBe('/same%2Fraw?profile=work%20profile')
+    expect(sessionProfileFromSearch('?profile=work%20profile')).toBe('work profile')
+    expect(sessionProfileFromSearch('?profile=')).toBeUndefined()
   })
 })

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -164,8 +164,14 @@ export function primaryRouteSelectedSessionId(pathname: string, storeSelectedSes
   return routeSessionId(pathname) ?? storeSelectedSessionId
 }
 
-export function sessionRoute(sessionId: string): string {
-  return `${SESSION_ROUTE_PREFIX}${encodeURIComponent(sessionId)}`
+export function sessionRoute(sessionId: string, profile?: null | string): string {
+  const route = `${SESSION_ROUTE_PREFIX}${encodeURIComponent(sessionId)}`
+
+  return profile ? `${route}?profile=${encodeURIComponent(profile)}` : route
+}
+
+export function sessionProfileFromSearch(search: string): string | undefined {
+  return new URLSearchParams(search).get('profile')?.trim() || undefined
 }
 
 export function appViewForPath(pathname: string): AppView {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -14,10 +14,11 @@ interface HarnessProps {
   freshDraftReady: boolean
   gatewayState: string
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
+  resumeSession: (sessionId: string, focus: boolean, targetProfile?: string) => Promise<unknown>
   resumeFailedSessionId?: null | string
   resumeExhaustedSessionId?: null | string
   routedSessionId: null | string
+  routedSessionProfile?: string
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: null | string
   selectedStoredSessionIdRef: MutableRefObject<null | string>
@@ -258,6 +259,38 @@ describe('useRouteResume', () => {
 
     expect(resumeSession).toHaveBeenCalledTimes(1)
     expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+  })
+
+  it('resumes the new owner when only the profile query changes for the same raw id', () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: 'runtime-1' }
+    const creatingSessionRef = { current: false }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['same', 'runtime-1']]) }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'same' }
+
+    const props = {
+      activeSessionId: 'runtime-1',
+      activeSessionIdRef,
+      creatingSessionRef,
+      currentView: 'chat',
+      freshDraftReady: false,
+      gatewayState: 'open',
+      locationPathname: '/same',
+      resumeSession,
+      routedSessionId: 'same',
+      runtimeIdByStoredSessionIdRef,
+      selectedStoredSessionId: 'same',
+      selectedStoredSessionIdRef,
+      startFreshSessionDraft: vi.fn()
+    }
+
+    const { rerender } = render(<RouteResumeHarness {...props} />)
+
+    expect(resumeSession).not.toHaveBeenCalled()
+
+    rerender(<RouteResumeHarness {...props} routedSessionProfile="work" />)
+
+    expect(resumeSession).toHaveBeenCalledWith('same', true, 'work')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -11,7 +11,8 @@ interface RouteResumeOptions {
   freshDraftReady: boolean
   gatewayState: string | undefined
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
+  routedSessionProfile?: string
+  resumeSession: (sessionId: string, focus: boolean, targetProfile?: string) => Promise<unknown>
   // Stored-session id whose most recent resume failed terminally (set by
   // useSessionActions, mirrored from $resumeFailedSessionId). While this equals
   // routedSessionId the window would otherwise latch on the loader forever, so
@@ -73,6 +74,7 @@ export function useRouteResume({
   freshDraftReady,
   gatewayState,
   locationPathname,
+  routedSessionProfile,
   resumeSession,
   resumeFailedSessionId,
   resumeExhaustedSessionId,
@@ -83,6 +85,7 @@ export function useRouteResume({
   startFreshSessionDraft
 }: RouteResumeOptions) {
   const lastPathnameRef = useRef<string | null>(null)
+  const lastRoutedProfileRef = useRef<string | undefined>(undefined)
   const seenGatewayStateRef = useRef(false)
   const wasGatewayOpenRef = useRef(false)
   // Per-session retry bookkeeping for the bounded auto-retry effect below. Keyed
@@ -99,12 +102,14 @@ export function useRouteResume({
   useEffect(() => {
     const gatewayOpen = gatewayState === 'open'
     const pathnameChanged = lastPathnameRef.current !== locationPathname
+    const routedProfileChanged = lastRoutedProfileRef.current !== routedSessionProfile
     // Fire only on a genuine closed->open transition (a reconnect). seenGatewayStateRef
     // stays false until the first effect run, so a session that mounts with the gateway
     // already open is not mistaken for "became open" and does not double-resume with the
     // pathname-driven initial resume below.
     const gatewayBecameOpen = seenGatewayStateRef.current && !wasGatewayOpenRef.current && gatewayOpen
     lastPathnameRef.current = locationPathname
+    lastRoutedProfileRef.current = routedSessionProfile
     seenGatewayStateRef.current = true
     wasGatewayOpenRef.current = gatewayOpen
 
@@ -140,14 +145,20 @@ export function useRouteResume({
       // we're stranded on a routed session that never loaded. The first two
       // guard against a transient /:sid re-resume during "new chat" state clears
       // before the pathname updates from /:sid -> /.
-      const shouldResume = pathnameChanged || gatewayBecameOpen || stuckOnRoutedSession
+      const shouldResume = pathnameChanged || routedProfileChanged || gatewayBecameOpen || stuckOnRoutedSession
 
       // On a reconnect (gatewayBecameOpen) re-resume even when the route looks
       // `alreadyActive`: the cached runtime id can be stale once the gateway
       // rebinds/reaps the session on its side, and trusting it strands Desktop on
       // a dead id ("session not found"). Otherwise keep skipping when already active.
-      if ((gatewayBecameOpen || !alreadyActive) && shouldResume && !creatingSessionRef.current) {
-        void resumeSession(routedSessionId, true)
+      if (
+        (gatewayBecameOpen || routedProfileChanged || !alreadyActive) &&
+        shouldResume &&
+        !creatingSessionRef.current
+      ) {
+        void (routedSessionProfile
+          ? resumeSession(routedSessionId, true, routedSessionProfile)
+          : resumeSession(routedSessionId, true))
       }
 
       return
@@ -171,6 +182,7 @@ export function useRouteResume({
     locationPathname,
     resumeSession,
     routedSessionId,
+    routedSessionProfile,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,
     selectedStoredSessionIdRef,
@@ -267,7 +279,9 @@ export function useRouteResume({
       // having fired. A flapping backend could then hit MAX in a couple of
       // re-renders with far fewer than MAX real attempts. (Point 3)
       retryAttemptRef.current += 1
-      void resumeSession(sessionId, true)
+      void (routedSessionProfile
+        ? resumeSession(sessionId, true, routedSessionProfile)
+        : resumeSession(sessionId, true))
     }, resumeRetryDelayMs(attempt))
 
     return () => clearTimeout(timer)
@@ -280,6 +294,7 @@ export function useRouteResume({
     resumeFailedSessionId,
     resumeExhaustedSessionId,
     routedSessionId,
+    routedSessionProfile,
     selectedStoredSessionIdRef
   ])
 }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -3,7 +3,7 @@ import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import type { NavigateFunction } from 'react-router-dom'
 
 import { revealTreePane } from '@/components/pane-shell/tree/store'
-import { deleteSession, getSessionMessages, setSessionArchived } from '@/hermes'
+import { deleteSession, getSession, getSessionMessages, type SessionInfo, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
@@ -23,6 +23,7 @@ import {
 } from '@/store/projects'
 import {
   $activeSessionStoredIdRotation,
+  $cronSessions,
   $currentCwd,
   $currentFastMode,
   $currentModel,
@@ -90,6 +91,20 @@ import {
   toBranchMessages,
   upsertOptimisticSession
 } from './utils'
+
+function findCachedStoredSession(storedSessionId: string, profile?: string): SessionInfo | undefined {
+  const rows = [...$sessions.get(), ...$cronSessions.get()]
+
+  if (profile) {
+    const profileKey = normalizeProfileKey(profile)
+
+    return rows.find(
+      session => sessionMatchesStoredId(session, storedSessionId) && normalizeProfileKey(session.profile) === profileKey
+    )
+  }
+
+  return rows.find(session => sessionMatchesStoredId(session, storedSessionId))
+}
 
 interface SessionActionsOptions {
   activeSessionId: string | null
@@ -534,10 +549,14 @@ export function useSessionActions({
   }, [navigate, selectedStoredSessionId])
 
   const resumeSession = useCallback(
-    async (storedSessionId: string, replaceRoute = false) => {
+    async (storedSessionId: string, replaceRoute = false, targetProfile?: string) => {
       const requestId = resumeRequestRef.current + 1
       resumeRequestRef.current = requestId
-      const resumedSameSelectedSession = selectedStoredSessionIdRef.current === storedSessionId
+
+      const resumedSameSelectedSession =
+        selectedStoredSessionIdRef.current === storedSessionId &&
+        (!targetProfile || normalizeProfileKey(targetProfile) === normalizeProfileKey($activeGatewayProfile.get()))
+
       const resumeStartMessages = resumedSameSelectedSession ? $messages.get() : []
 
       const isCurrentResume = () =>
@@ -583,6 +602,14 @@ export function useSessionActions({
           return null
         }
 
+        if (targetProfile && normalizeProfileKey(targetProfile) !== normalizeProfileKey($activeGatewayProfile.get())) {
+          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+          sessionStateByRuntimeIdRef.current.delete(runtimeId)
+          dropSessionState(runtimeId)
+
+          return null
+        }
+
         if (state.storedSessionId !== storedSessionId) {
           runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
           sessionStateByRuntimeIdRef.current.delete(runtimeId)
@@ -607,8 +634,15 @@ export function useSessionActions({
       // gateway call (no-op when it's already on that profile / single-profile).
       // resolveStoredSession finds the row by id (cheap), so an uncached pasted
       // id loads as fast as a sidebar click instead of hanging on a list scan.
-      const storedForProfile = await resolveStoredSession(storedSessionId)
-      const sessionProfile = storedForProfile?.profile
+      let storedForProfile = findCachedStoredSession(storedSessionId, targetProfile)
+
+      if (!storedForProfile) {
+        storedForProfile = targetProfile
+          ? await getSession(storedSessionId, targetProfile).catch(() => undefined)
+          : await resolveStoredSession(storedSessionId)
+      }
+
+      const sessionProfile = targetProfile ?? storedForProfile?.profile
 
       if (resumeRequestRef.current !== requestId) {
         return
@@ -625,8 +659,7 @@ export function useSessionActions({
         const cachedRuntimeId = warmHit.runtimeId
         const cachedState = warmHit.state
 
-        const stored =
-          $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ?? storedForProfile
+        const stored = findCachedStoredSession(storedSessionId, targetProfile) ?? storedForProfile
 
         let cachedViewState =
           !cachedState.model && stored?.model != null
@@ -812,8 +845,7 @@ export function useSessionActions({
       selectedStoredSessionIdRef.current = storedSessionId
       setSessionStartedAt(Date.now())
 
-      const stored =
-        $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ?? storedForProfile
+      const stored = findCachedStoredSession(storedSessionId, targetProfile) ?? storedForProfile
 
       applyStoredSessionPreviewRuntimeInfo(stored)
 

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -2,12 +2,18 @@ import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo, SidebarSessionsResponse } from '@/hermes'
+import { cronJobVisibilityKey } from '@/lib/cron-session-visibility'
+import { $cronJobsHiddenFromSessions } from '@/store/cron'
+import { $sessionsLimit, resetSessionsLimit, SIDEBAR_SESSIONS_PAGE_SIZE } from '@/store/layout'
 import {
   $cronSessions,
+  $cronSessionsInSessionList,
+  $cronSessionsTruncated,
   $messagingSessions,
   $sessions,
   $sessionsLoading,
   setCronSessions,
+  setCronSessionsAcquisitionTruncated,
   setMessagingSessions,
   setSessions,
   setSessionsLoading
@@ -54,10 +60,12 @@ const sidebar = (
 
 const listSidebarSessions = vi.fn()
 const listAllProfileSessions = vi.fn()
+const getCronJobRuns = vi.fn()
 
 vi.mock('@/hermes', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
   getCronJobs: vi.fn(async () => []),
+  getCronJobRuns: (...args: unknown[]) => getCronJobRuns(...args),
   listAllProfileSessions: (...args: unknown[]) => listAllProfileSessions(...args),
   listSidebarSessions: (...args: unknown[]) => listSidebarSessions(...args)
 }))
@@ -73,9 +81,13 @@ vi.mock('@/store/projects', () => ({
 beforeEach(() => {
   listSidebarSessions.mockReset()
   listAllProfileSessions.mockReset()
+  getCronJobRuns.mockReset()
   removed.ids = new Set()
+  $cronJobsHiddenFromSessions.set([])
+  resetSessionsLimit()
   setSessions([])
   setCronSessions([])
+  setCronSessionsAcquisitionTruncated(false)
   setMessagingSessions([])
   setSessionsLoading(false)
 })
@@ -83,8 +95,11 @@ beforeEach(() => {
 afterEach(() => {
   setSessions([])
   setCronSessions([])
+  setCronSessionsAcquisitionTruncated(false)
   setMessagingSessions([])
   setSessionsLoading(false)
+  $cronJobsHiddenFromSessions.set([])
+  resetSessionsLimit()
 })
 
 describe('refreshSessions identity + loading hygiene', () => {
@@ -231,9 +246,79 @@ describe('refreshSessions batches slices into one request', () => {
       expect.objectContaining({
         recentsProfile: 'work',
         recentsExclude: expect.arrayContaining(['cron']),
+        cronProfile: 'work',
+        cronLimit: 50,
         messagingExclude: expect.arrayContaining(['cron'])
       })
     )
+  })
+
+  it('filters hidden jobs before the Sessions limit and asks for one bounded cron window', async () => {
+    $cronJobsHiddenFromSessions.set([cronJobVisibilityKey('noisy', 'work')])
+    $sessionsLimit.set(SIDEBAR_SESSIONS_PAGE_SIZE)
+
+    const noisy = Array.from({ length: 55 }, (_, index) =>
+      row(`cron_noisy_${index}`, { profile: 'work', source: 'cron', started_at: 1_000 - index })
+    )
+
+    const useful = row('cron_useful_1', { profile: 'work', source: 'cron', started_at: 900 })
+
+    listSidebarSessions.mockResolvedValue(
+      sidebar({ sessions: [], total: 0, profile_totals: { work: 0 } }, [...noisy, useful])
+    )
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'work' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect(listSidebarSessions).toHaveBeenCalledWith(expect.objectContaining({ cronLimit: 500, cronProfile: 'work' }))
+    expect($cronSessionsInSessionList.get().map(session => session.id)).toEqual(['cron_useful_1'])
+    expect(getCronJobRuns).not.toHaveBeenCalled()
+  })
+
+  it.each([500, 550])('caps a %i-row cron response at 500 and keeps truncation conservative', async rowCount => {
+    $cronJobsHiddenFromSessions.set([cronJobVisibilityKey('hidden')])
+
+    const cron = Array.from({ length: rowCount }, (_, index) =>
+      row(`cron_visible_${index}`, { source: 'cron', started_at: 1_000 - index })
+    )
+
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [], total: 0, profile_totals: {} }, cron))
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($cronSessions.get()).toHaveLength(500)
+    expect($cronSessionsTruncated.get()).toBe(true)
+    expect(listSidebarSessions).toHaveBeenCalledWith(expect.objectContaining({ cronLimit: 500 }))
+  })
+
+  it('recomputes from cache immediately and performs exactly one batched backfill', async () => {
+    setCronSessions([row('cron_daily_1', { source: 'cron' }), row('cron_weekly_1', { source: 'cron' })])
+    let resolveRefresh!: (value: SidebarSessionsResponse) => void
+    listSidebarSessions.mockReturnValue(
+      new Promise<SidebarSessionsResponse>(resolve => {
+        resolveRefresh = resolve
+      })
+    )
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    let pending!: Promise<void>
+    act(() => {
+      pending = result.current.setCronJobSessionsVisibility('daily', 'default', false)
+    })
+
+    expect($cronSessionsInSessionList.get().map(session => session.id)).toEqual(['cron_weekly_1'])
+    expect(listSidebarSessions).toHaveBeenCalledTimes(1)
+    expect(getCronJobRuns).not.toHaveBeenCalled()
+
+    resolveRefresh(sidebar({ sessions: [], total: 0, profile_totals: {} }, $cronSessions.get()))
+    await act(async () => pending)
   })
 
   it('scopes the cron-jobs fetch to the active profile (all → unified view)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from 'react'
 
 import { getCronJobs, listAllProfileSessions, listSidebarSessions, type SessionInfo } from '@/hermes'
+import { hasValidCronJobVisibilityKeys } from '@/lib/cron-session-visibility'
 import { sameCronSignature } from '@/lib/session-signatures'
 import {
   isMessagingSource,
@@ -8,7 +9,7 @@ import {
   MESSAGING_SESSION_SOURCE_IDS,
   normalizeSessionSource
 } from '@/lib/session-source'
-import { setCronJobs } from '@/store/cron'
+import { $cronJobsHiddenFromSessions, setCronJobInSessions, setCronJobs } from '@/store/cron'
 import { $pinnedSessionIds, $sessionsLimit, bumpSessionsLimit, SIDEBAR_SESSIONS_PAGE_SIZE } from '@/store/layout'
 import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
 import { $removedSessionIds } from '@/store/projects'
@@ -20,6 +21,7 @@ import {
   mergeSessionPage,
   MESSAGING_SECTION_LIMIT,
   setCronSessions,
+  setCronSessionsAcquisitionTruncated,
   setMessagingPlatformTotals,
   setMessagingSessions,
   setMessagingTruncated,
@@ -39,6 +41,7 @@ const SIDEBAR_EXCLUDED_SOURCES = ['cron', 'subagent', 'tool', ...MESSAGING_SESSI
 // The messaging slice is the inverse: drop cron + every local source so only
 // external-platform conversations remain, then split per platform in the UI.
 const MESSAGING_EXCLUDED_SOURCES = ['cron', ...LOCAL_SESSION_SOURCE_IDS]
+export const CRON_INBOX_ACQUISITION_LIMIT = 500
 
 // Rows a session refresh must preserve even if the aggregator omits them:
 // in-flight first turns (message_count 0), pinned rows aged off the page, the
@@ -153,6 +156,14 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
     try {
       const limit = $sessionsLimit.get()
+      const hiddenCronJobKeys = $cronJobsHiddenFromSessions.get()
+
+      const cronRequestLimit = Math.min(
+        CRON_INBOX_ACQUISITION_LIMIT,
+        hasValidCronJobVisibilityKeys(hiddenCronJobKeys)
+          ? CRON_INBOX_ACQUISITION_LIMIT
+          : Math.max(CRON_SECTION_LIMIT, limit)
+      )
 
       // Require at least one message so abandoned/empty "Untitled" drafts (one
       // was created per TUI/desktop launch before the lazy-create fix) don't
@@ -173,7 +184,8 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         recentsProfile: sessionProfile,
         recentsLimit: limit,
         recentsExclude: SIDEBAR_EXCLUDED_SOURCES,
-        cronLimit: CRON_SECTION_LIMIT,
+        cronProfile: sessionProfile,
+        cronLimit: cronRequestLimit,
         messagingLimit: MESSAGING_SECTION_LIMIT,
         messagingExclude: MESSAGING_EXCLUDED_SOURCES
       })
@@ -212,9 +224,19 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
             : next
         })
 
-        // Cron section: latest N cron sessions (kept so a pinned cron run still
-        // resolves via sessionByAnyId), signature-gated like above.
-        setCronSessions(prev => (sameCronSignature(prev, result.cron.sessions) ? prev : result.cron.sessions))
+        // Keep raw acquisition separate from the Sessions presentation model.
+        // Cap defensively even if an older/non-conforming backend over-returns.
+        const boundedCronRows = result.cron.sessions.slice(0, CRON_INBOX_ACQUISITION_LIMIT)
+
+        const cronRows = tombstones.size
+          ? boundedCronRows.filter(
+              session =>
+                !tombstones.has(session.id) && !(session._lineage_root_id && tombstones.has(session._lineage_root_id))
+            )
+          : boundedCronRows
+
+        setCronSessions(prev => (sameCronSignature(prev, cronRows) ? prev : cronRows))
+        setCronSessionsAcquisitionTruncated(result.cron.sessions.length >= cronRequestLimit)
 
         // Messaging sections: drop any non-messaging source the broad exclude
         // didn't catch (custom sources stay in local recents), then split per
@@ -239,6 +261,16 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     bumpSessionsLimit()
     await refreshSessions()
   }, [refreshSessions])
+
+  const setCronJobSessionsVisibility = useCallback(
+    async (jobId: string, profile: null | string | undefined, shown: boolean) => {
+      // Presentation recomputes synchronously from cached rows. One normal
+      // batched refresh then backfills the bounded cron window.
+      setCronJobInSessions(jobId, profile, shown)
+      await refreshSessions()
+    },
+    [refreshSessions]
+  )
 
   // ALL-profiles view pages one profile at a time: fetch that profile's next
   // page and merge it in place, leaving every other profile's rows untouched.
@@ -268,6 +300,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     loadMoreSessionsForProfile,
     refreshCronJobs,
     refreshMessagingSessions,
-    refreshSessions
+    refreshSessions,
+    setCronJobSessionsVisibility
   }
 }

--- a/apps/desktop/src/hermes-cron-scope.test.ts
+++ b/apps/desktop/src/hermes-cron-scope.test.ts
@@ -71,4 +71,22 @@ describe('cron helpers are profile-scoped', () => {
     void getCronJobs()
     expect(api.mock.calls.at(-1)?.[0].path).toBe('/api/cron/jobs')
   })
+
+  it('explicit ownership overrides the ambient profile for run reads and mutations', () => {
+    setApiRequestProfile('ambient')
+
+    void getCronJobRuns('job-1', 7, 'worker')
+    void updateCronJob('job-1', { enabled: false } as never, 'worker')
+    void pauseCronJob('job-1', 'worker')
+    void resumeCronJob('job-1', 'worker')
+    void triggerCronJob('job-1', 'worker')
+    void deleteCronJob('job-1', 'worker')
+
+    for (const call of api.mock.calls) {
+      expect(call[0].profile).toBe('worker')
+      expect(call[0].path).toContain('profile=worker')
+    }
+
+    expect(api.mock.calls[0][0].path).toBe('/api/cron/jobs/job-1/runs?limit=7&profile=worker')
+  })
 })

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -92,6 +92,54 @@ describe('Hermes REST helpers', () => {
     )
   })
 
+  it('uses concrete cron_profile only with capability proof and falls back correctly for an old backend', async () => {
+    api.mockImplementation(({ path }: { path: string }) => {
+      if (path.startsWith('/api/profiles/sessions/sidebar')) {
+        return Promise.resolve({
+          recents: { sessions: [], total: 0 },
+          cron: { sessions: [{ id: 'wrong-all-profile' }] },
+          messaging: { sessions: [] }
+        })
+      }
+
+      return Promise.resolve(emptySessionsResponse)
+    })
+
+    await listSidebarSessions({
+      recentsProfile: 'work',
+      recentsLimit: 30,
+      recentsExclude: ['cron'],
+      cronProfile: 'work',
+      cronLimit: 500,
+      messagingLimit: 100,
+      messagingExclude: ['cron']
+    })
+
+    const paths = api.mock.calls.map(call => (call[0] as { path: string }).path)
+
+    expect(paths[0]).toContain('cron_profile=work')
+    expect(paths).toHaveLength(4)
+    expect(paths.slice(1)).toContainEqual(expect.stringContaining('profile=work'))
+    expect(paths.slice(1)).toContainEqual(expect.stringContaining('source=cron'))
+  })
+
+  it('keeps All Profiles on the batched response when an old backend has no cron capability marker', async () => {
+    api.mockResolvedValue({ recents: { sessions: [] }, cron: { sessions: [] }, messaging: { sessions: [] } })
+
+    await listSidebarSessions({
+      recentsProfile: 'all',
+      recentsLimit: 20,
+      recentsExclude: [],
+      cronProfile: 'all',
+      cronLimit: 50,
+      messagingLimit: 100,
+      messagingExclude: []
+    })
+
+    expect(api).toHaveBeenCalledTimes(1)
+    expect((api.mock.calls[0][0] as { path: string }).path).toContain('cron_profile=all')
+  })
+
   it('defaults missing sidebar slices to empty session arrays', async () => {
     api.mockResolvedValue({})
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -425,6 +425,7 @@ export interface SidebarSessionSlice {
 }
 
 export interface SidebarSessionsResponse {
+  capabilities?: { cron_profile?: boolean }
   recents: SidebarSessionSlice
   cron: SidebarSessionSlice
   messaging: SidebarSessionSlice
@@ -435,6 +436,7 @@ export interface SidebarSessionsRequest {
   recentsProfile: 'all' | (string & {})
   recentsLimit: number
   recentsExclude: string[]
+  cronProfile?: 'all' | (string & {})
   cronLimit: number
   messagingLimit: number
   messagingExclude: string[]
@@ -478,14 +480,14 @@ function isEndpointMissingError(err: unknown): boolean {
 // Compatibility fallback: reassemble the three sidebar slices from the
 // per-slice endpoint, mirroring the batched route's semantics (min_messages=1,
 // archived excluded, recency order; recents scoped to the caller's profile,
-// cron + messaging cross-profile). Rides the same Electron remote-splice
+// cron caller-scoped + messaging cross-profile). Rides the same Electron remote-splice
 // interception as the pre-batching desktop, so remote profiles stay correct.
 async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<SidebarSessionsResponse> {
   const [recents, cron, messaging] = await Promise.all([
     listAllProfileSessions(req.recentsLimit, 1, 'exclude', 'recent', req.recentsProfile, {
       excludeSources: req.recentsExclude
     }),
-    listAllProfileSessions(req.cronLimit, 1, 'exclude', 'recent', 'all', { source: 'cron' }),
+    listAllProfileSessions(req.cronLimit, 1, 'exclude', 'recent', req.cronProfile ?? 'all', { source: 'cron' }),
     listAllProfileSessions(req.messagingLimit, 1, 'exclude', 'recent', 'all', {
       excludeSources: req.messagingExclude
     })
@@ -494,6 +496,7 @@ async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<S
   const errors = [...(recents.errors ?? []), ...(cron.errors ?? []), ...(messaging.errors ?? [])]
 
   return {
+    capabilities: { cron_profile: true },
     recents: { profile_totals: recents.profile_totals, sessions: recents.sessions, total: recents.total },
     cron: { sessions: cron.sessions },
     messaging: { sessions: messaging.sessions },
@@ -512,6 +515,10 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
     cron_limit: String(Math.max(1, req.cronLimit)),
     messaging_limit: String(Math.max(1, req.messagingLimit))
   })
+
+  if (req.cronProfile) {
+    params.set('cron_profile', req.cronProfile)
+  }
 
   if (req.recentsExclude.length) {
     params.set('recents_exclude', req.recentsExclude.join(','))
@@ -539,7 +546,14 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
     return listSidebarSessionsLegacy(req)
   }
 
+  // Early batched endpoints return HTTP 200 but ignore cron_profile. Concrete
+  // selectors require positive capability proof; All Profiles does not.
+  if (req.cronProfile && req.cronProfile !== 'all' && result.capabilities?.cron_profile !== true) {
+    return listSidebarSessionsLegacy(req)
+  }
+
   return {
+    capabilities: result.capabilities,
     recents: { ...result.recents, sessions: result.recents?.sessions ?? [] },
     cron: { ...result.cron, sessions: result.cron?.sessions ?? [] },
     messaging: { ...result.messaging, sessions: result.messaging?.sessions ?? [] },
@@ -1207,10 +1221,22 @@ export function getCronJob(jobId: string): Promise<CronJob> {
   })
 }
 
-export async function getCronJobRuns(jobId: string, limit = 20): Promise<SessionInfo[]> {
+function cronJobPath(jobId: string, suffix = '', profile?: null | string): string {
+  const query = new URLSearchParams()
+
+  if (profile) {
+    query.set('profile', profile)
+  }
+
+  const separator = suffix.includes('?') ? '&' : '?'
+
+  return `/api/cron/jobs/${encodeURIComponent(jobId)}${suffix}${query.size ? `${separator}${query}` : ''}`
+}
+
+export async function getCronJobRuns(jobId: string, limit = 20, profile?: null | string): Promise<SessionInfo[]> {
   const { runs } = await window.hermesDesktop.api<{ runs: SessionInfo[] }>({
-    ...profileScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/runs?limit=${limit}`
+    ...profileScoped(profile),
+    path: cronJobPath(jobId, `/runs?limit=${limit}`, profile)
   })
 
   return runs ?? []
@@ -1237,43 +1263,43 @@ export function createCronJob(body: CronJobCreatePayload): Promise<CronJob> {
   })
 }
 
-export function updateCronJob(jobId: string, updates: CronJobUpdates): Promise<CronJob> {
+export function updateCronJob(jobId: string, updates: CronJobUpdates, profile?: null | string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
-    ...profileScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}`,
+    ...profileScoped(profile),
+    path: cronJobPath(jobId, '', profile),
     method: 'PUT',
     body: { updates }
   })
 }
 
-export function pauseCronJob(jobId: string): Promise<CronJob> {
+export function pauseCronJob(jobId: string, profile?: null | string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
-    ...profileScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/pause`,
+    ...profileScoped(profile),
+    path: cronJobPath(jobId, '/pause', profile),
     method: 'POST'
   })
 }
 
-export function resumeCronJob(jobId: string): Promise<CronJob> {
+export function resumeCronJob(jobId: string, profile?: null | string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
-    ...profileScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/resume`,
+    ...profileScoped(profile),
+    path: cronJobPath(jobId, '/resume', profile),
     method: 'POST'
   })
 }
 
-export function triggerCronJob(jobId: string): Promise<CronJob> {
+export function triggerCronJob(jobId: string, profile?: null | string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
-    ...profileScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/trigger`,
+    ...profileScoped(profile),
+    path: cronJobPath(jobId, '/trigger', profile),
     method: 'POST'
   })
 }
 
-export function deleteCronJob(jobId: string): Promise<{ ok: boolean }> {
+export function deleteCronJob(jobId: string, profile?: null | string): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    ...profileScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}`,
+    ...profileScoped(profile),
+    path: cronJobPath(jobId, '', profile),
     method: 'DELETE'
   })
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1635,6 +1635,8 @@ export const en: Translations = {
     manage: 'Manage',
     showRuns: 'Show runs',
     hideRuns: 'Hide runs',
+    showInSessionsList: 'Show in Sessions',
+    hideFromSessionsList: 'Hide from Sessions',
     runHistory: 'Run history',
     actionsFor: title => `Actions for ${title}`,
     actionsTitle: 'Cron job actions',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1506,6 +1506,8 @@ export const ja = defineLocale({
     manage: '管理',
     showRuns: '実行履歴を表示',
     hideRuns: '実行履歴を隠す',
+    showInSessionsList: 'セッションに表示',
+    hideFromSessionsList: 'セッションから非表示',
     runHistory: '実行履歴',
     actionsFor: title => `${title} のアクション`,
     actionsTitle: 'Cron ジョブのアクション',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1346,6 +1346,8 @@ export interface Translations {
     manage: string
     showRuns: string
     hideRuns: string
+    showInSessionsList: string
+    hideFromSessionsList: string
     runHistory: string
     actionsFor: (title: string) => string
     actionsTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1456,6 +1456,8 @@ export const zhHant = defineLocale({
     manage: '管理',
     showRuns: '顯示執行記錄',
     hideRuns: '隱藏執行記錄',
+    showInSessionsList: '在工作階段中顯示',
+    hideFromSessionsList: '從工作階段中隱藏',
     runHistory: '執行記錄',
     actionsFor: title => `${title} 的動作`,
     actionsTitle: '排程工作動作',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1826,6 +1826,8 @@ export const zh: Translations = {
     manage: '管理',
     showRuns: '显示运行记录',
     hideRuns: '隐藏运行记录',
+    showInSessionsList: '在会话中显示',
+    hideFromSessionsList: '从会话中隐藏',
     runHistory: '运行记录',
     actionsFor: title => `${title} 的操作`,
     actionsTitle: '定时任务操作',

--- a/apps/desktop/src/lib/cron-session-visibility.test.ts
+++ b/apps/desktop/src/lib/cron-session-visibility.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import {
+  cronJobShownInSessions,
+  cronJobVisibilityKey,
+  mergeSessionsForPresentation,
+  sessionsFeedShowsLoadMore,
+  visibleCronSessions
+} from './cron-session-visibility'
+
+const row = (id: string, over: Partial<SessionInfo> = {}): SessionInfo =>
+  ({
+    archived: false,
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 0,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    profile: 'default',
+    source: 'cron',
+    started_at: 0,
+    title: id,
+    tool_call_count: 0,
+    ...over
+  }) as SessionInfo
+
+describe('cron session visibility', () => {
+  it('defaults to visible, filters archived rows, and restores a hidden job from the same cache', () => {
+    const rows = [row('cron_daily_1'), row('cron_weekly_1'), row('cron_daily_old', { archived: true })]
+    const hidden = [cronJobVisibilityKey('daily')]
+
+    expect(visibleCronSessions(rows, []).map(session => session.id)).toEqual(['cron_daily_1', 'cron_weekly_1'])
+    expect(visibleCronSessions(rows, hidden).map(session => session.id)).toEqual(['cron_weekly_1'])
+    expect(visibleCronSessions(rows, []).map(session => session.id)).toContain('cron_daily_1')
+  })
+
+  it('profile-qualifies identical job ids and normalizes a missing profile to default', () => {
+    const rows = [row('cron_daily_default', { profile: undefined }), row('cron_daily_work', { profile: 'work' })]
+    const hidden = [cronJobVisibilityKey('daily', 'work')]
+
+    expect(cronJobVisibilityKey('daily')).toBe(JSON.stringify(['default', 'daily']))
+    expect(visibleCronSessions(rows, hidden).map(session => session.id)).toEqual(['cron_daily_default'])
+    expect(cronJobShownInSessions(hidden, 'daily', 'default')).toBe(true)
+    expect(cronJobShownInSessions(hidden, 'daily', 'work')).toBe(false)
+  })
+
+  it('ignores malformed keys and observes the exact cron job prefix boundary', () => {
+    const rows = [row('cron_daily_1'), row('cron_daily'), row('prefix_cron_daily_2'), row('cron_dailylong_3')]
+    const malformed = ['not-json', JSON.stringify(['default']), JSON.stringify(['default', 7])]
+
+    expect(visibleCronSessions(rows, malformed)).toEqual(rows)
+    expect(visibleCronSessions(rows, [cronJobVisibilityKey('daily')]).map(session => session.id)).toEqual([
+      'cron_daily',
+      'prefix_cron_daily_2',
+      'cron_dailylong_3'
+    ])
+  })
+})
+
+describe('Sessions presentation merge', () => {
+  it('deduplicates by normalized profile and durable lineage, then sorts by started_at', () => {
+    const ordinary = [
+      row('ordinary', { profile: undefined, source: 'desktop', started_at: 10 }),
+      row('tip', { _lineage_root_id: 'root', profile: 'work', source: 'desktop', started_at: 20 })
+    ]
+
+    const cron = [
+      row('cron_same_lineage', { _lineage_root_id: 'root', profile: 'work', started_at: 30 }),
+      row('cron_other_profile', { _lineage_root_id: 'root', profile: 'default', started_at: 40 })
+    ]
+
+    expect(mergeSessionsForPresentation(ordinary, cron).map(session => session.id)).toEqual([
+      'cron_other_profile',
+      'tip',
+      'ordinary'
+    ])
+  })
+
+  it('preserves the shared cron Load more affordance in All Profiles when truncated', () => {
+    expect(
+      sessionsFeedShowsLoadMore({
+        agentsGrouped: false,
+        cronTruncated: true,
+        ordinaryHasMore: false,
+        sessionsLoading: false,
+        showAllProfiles: true
+      })
+    ).toBe(true)
+    expect(
+      sessionsFeedShowsLoadMore({
+        agentsGrouped: false,
+        cronTruncated: false,
+        ordinaryHasMore: true,
+        sessionsLoading: false,
+        showAllProfiles: true
+      })
+    ).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/cron-session-visibility.ts
+++ b/apps/desktop/src/lib/cron-session-visibility.ts
@@ -1,0 +1,108 @@
+import type { SessionInfo } from '@/types/hermes'
+
+export type CronJobVisibilityIdentity = [profile: string, jobId: string]
+
+function normalizeVisibilityProfile(profile?: null | string): string {
+  return profile?.trim() || 'default'
+}
+
+export function cronJobVisibilityKey(jobId: string, profile?: null | string): string {
+  return JSON.stringify([normalizeVisibilityProfile(profile), jobId])
+}
+
+export function parseCronJobVisibilityKey(key: string): CronJobVisibilityIdentity | null {
+  try {
+    const parsed: unknown = JSON.parse(key)
+
+    if (
+      Array.isArray(parsed) &&
+      parsed.length === 2 &&
+      typeof parsed[0] === 'string' &&
+      typeof parsed[1] === 'string' &&
+      parsed[1].length > 0
+    ) {
+      return [normalizeVisibilityProfile(parsed[0]), parsed[1]]
+    }
+  } catch {
+    // Presentation preferences are best-effort; corrupt entries hide nothing.
+  }
+
+  return null
+}
+
+export function hasValidCronJobVisibilityKeys(keys: readonly string[]): boolean {
+  return keys.some(key => parseCronJobVisibilityKey(key) !== null)
+}
+
+export function cronJobShownInSessions(
+  hiddenJobKeys: readonly string[],
+  jobId: string,
+  profile?: null | string
+): boolean {
+  return !hiddenJobKeys.includes(cronJobVisibilityKey(jobId, profile))
+}
+
+/** Apply per-job opt-outs to an already-acquired cron slice. */
+export function visibleCronSessions(rows: readonly SessionInfo[], hiddenJobKeys: readonly string[]): SessionInfo[] {
+  const hiddenJobs = hiddenJobKeys.flatMap(key => {
+    const parsed = parseCronJobVisibilityKey(key)
+
+    return parsed ? [parsed] : []
+  })
+
+  return rows.filter(session => {
+    if (session.archived) {
+      return false
+    }
+
+    const profile = normalizeVisibilityProfile(session.profile)
+
+    return !hiddenJobs.some(([jobProfile, jobId]) => jobProfile === profile && session.id.startsWith(`cron_${jobId}_`))
+  })
+}
+
+export function sessionPresentationKey(session: Pick<SessionInfo, 'id' | 'profile'>): string {
+  return JSON.stringify([normalizeVisibilityProfile(session.profile), session.id])
+}
+
+/** Merge only for Sessions presentation; acquisition stays independently paged. */
+export function mergeSessionsForPresentation(
+  ordinary: readonly SessionInfo[],
+  cron: readonly SessionInfo[]
+): SessionInfo[] {
+  const seen = new Set<string>()
+
+  return [...ordinary, ...cron]
+    .filter(session => {
+      const key = JSON.stringify([normalizeVisibilityProfile(session.profile), session._lineage_root_id ?? session.id])
+
+      if (seen.has(key)) {
+        return false
+      }
+
+      seen.add(key)
+
+      return true
+    })
+    .sort((a, b) => (b.started_at || 0) - (a.started_at || 0))
+}
+
+export function sessionsFeedShowsLoadMore({
+  agentsGrouped,
+  cronTruncated,
+  ordinaryHasMore,
+  sessionsLoading,
+  showAllProfiles
+}: {
+  agentsGrouped: boolean
+  cronTruncated: boolean
+  ordinaryHasMore: boolean
+  sessionsLoading: boolean
+  showAllProfiles: boolean
+}): boolean {
+  if (sessionsLoading) {
+    return false
+  }
+
+  return showAllProfiles ? cronTruncated : !agentsGrouped && (ordinaryHasMore || cronTruncated)
+}

--- a/apps/desktop/src/store/cron.ts
+++ b/apps/desktop/src/store/cron.ts
@@ -1,6 +1,10 @@
 import { atom } from 'nanostores'
 
+import { cronJobVisibilityKey } from '@/lib/cron-session-visibility'
+import { Codecs, persistentAtom } from '@/lib/persisted'
 import type { CronJob } from '@/types/hermes'
+
+const HIDDEN_CRON_JOBS_STORAGE_KEY = 'hermes.desktop.cronJobsHiddenFromSessions.v1'
 
 // Cron *jobs* (not run sessions) power the sidebar "Cron jobs" section. Listing
 // the job — schedule, state, live next-run countdown — makes the job the
@@ -12,8 +16,33 @@ export const setCronJobs = (jobs: CronJob[]) => $cronJobs.set(jobs)
 // land in the same atom the sidebar renders — no stale list until the next poll.
 export const updateCronJobs = (fn: (jobs: CronJob[]) => CronJob[]) => $cronJobs.set(fn($cronJobs.get()))
 
+// Presentation opt-outs: absence means every cron job is visible in Sessions.
+// Each key is JSON [normalizedProfile, jobId], so profiles may reuse job ids.
+export const $cronJobsHiddenFromSessions = persistentAtom<string[]>(
+  HIDDEN_CRON_JOBS_STORAGE_KEY,
+  [],
+  Codecs.stringArray
+)
+
+export function setCronJobInSessions(jobId: string, profile: null | string | undefined, shown: boolean): void {
+  const key = cronJobVisibilityKey(jobId, profile)
+  const current = $cronJobsHiddenFromSessions.get()
+  const hidden = current.includes(key)
+
+  if (shown === !hidden) {
+    return
+  }
+
+  $cronJobsHiddenFromSessions.set(shown ? current.filter(item => item !== key) : [...current, key])
+}
+
 // One-shot focus target: clicking "Manage" on a job sets this, then opens the
 // cron overlay, which reads it once to select + scroll to that job. Cleared
 // after consumption so re-opening cron normally doesn't re-focus a stale job.
-export const $cronFocusJobId = atom<null | string>(null)
-export const setCronFocusJobId = (id: null | string) => $cronFocusJobId.set(id)
+export interface CronJobIdentity {
+  id: string
+  profile?: null | string
+}
+
+export const $cronFocusJob = atom<CronJobIdentity | null>(null)
+export const setCronFocusJob = (job: CronJobIdentity | null) => $cronFocusJob.set(job)

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -3,12 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { $sessionsLimit, resetSessionsLimit, SIDEBAR_SESSIONS_PAGE_SIZE } from '@/store/layout'
 import {
   $cronSessions,
+  $cronSessionsTruncated,
   $freshDraftReady,
   $messagingSessions,
   $sessions,
   $sessionsLoading,
   $sessionsTotal,
   setCronSessions,
+  setCronSessionsAcquisitionTruncated,
   setFreshDraftReady,
   setMessagingSessions,
   setSessions,
@@ -29,6 +31,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     setSessions([{ id: 's1', title: 'old', profile: 'default' } as never])
     setSessionsTotal(1)
     setCronSessions([{ id: 'c1', title: 'cron', profile: 'default' } as never])
+    setCronSessionsAcquisitionTruncated(true)
     setMessagingSessions([{ id: 'm1', title: 'tg', profile: 'default' } as never])
     $stalledSessionIds.set(['s1'])
     setSessionsLoading(false)
@@ -40,6 +43,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     resetSessionsLimit()
     setSessions([])
     setCronSessions([])
+    setCronSessionsAcquisitionTruncated(false)
     setMessagingSessions([])
     $stalledSessionIds.set([])
     setSessionsLoading(true)
@@ -52,6 +56,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     expect($sessions.get()).toEqual([])
     expect($sessionsTotal.get()).toBe(0)
     expect($cronSessions.get()).toEqual([])
+    expect($cronSessionsTruncated.get()).toBe(false)
     expect($messagingSessions.get()).toEqual([])
     expect($stalledSessionIds.get()).toEqual([])
     expect($sessionsLoading.get()).toBe(true)

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -7,6 +7,7 @@ import {
   $unreadFinishedSessionIds,
   setActiveSessionId,
   setCronSessions,
+  setCronSessionsAcquisitionTruncated,
   setFreshDraftReady,
   setMessages,
   setMessagingPlatformTotals,
@@ -45,6 +46,7 @@ export function wipeSessionListsForGatewaySwitch(): void {
   setSessionsTotal(0)
   setSessionProfileTotals({})
   setCronSessions([])
+  setCronSessionsAcquisitionTruncated(false)
   setMessagingSessions([])
   setMessagingPlatformTotals({})
   setMessagingTruncated(false)

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -5,7 +5,10 @@ import { lastVisibleMessageIsUser } from '@/app/chat/thread-loading'
 import type { ContextSuggestion } from '@/app/types'
 import type { HermesConnection } from '@/global'
 import type { ChatMessage } from '@/lib/chat-messages'
+import { mergeSessionsForPresentation, visibleCronSessions } from '@/lib/cron-session-visibility'
 import { persistBoolean, persistString, storedBoolean, storedString } from '@/lib/storage'
+import { $cronJobsHiddenFromSessions } from '@/store/cron'
+import { $sessionsLimit } from '@/store/layout'
 import type { SessionInfo, UsageStats } from '@/types/hermes'
 
 type Updater<T> = T | ((current: T) => T)
@@ -271,15 +274,23 @@ export const $connection = atom<HermesConnection | null>(null)
 export const $gatewayState = atom<ConnectionState>('idle')
 export const $sessions = atom<SessionInfo[]>([])
 export const $sessionsTotal = atom<number>(0)
-// Cron-job sessions (source === 'cron') are fetched as their own list so the
-// scheduler's always-newest sessions never crowd recents out of the page
-// budget. Powers the collapsed "Cron jobs" sidebar section.
+// Cron-job sessions stay in their own acquired slice so scheduler bursts never
+// consume the ordinary-recents page budget.
 export const $cronSessions = atom<SessionInfo[]>([])
-// Max cron sessions fetched for the sidebar section (single bounded page). When
-// the fetch returns exactly this many rows we know more exist, so the section
-// badge renders "N+". Lives here so the controller (fetch) and sidebar (badge)
-// share one source of truth without a circular import.
 export const CRON_SECTION_LIMIT = 50
+const $cronSessionsAcquisitionTruncated = atom<boolean>(false)
+// Hide is a Sessions-feed presentation preference. Raw cron rows remain in
+// $cronSessions so Pins and full-text Search keep their existing behavior.
+export const $cronSessionsInSessionList = computed(
+  [$cronSessions, $cronJobsHiddenFromSessions, $sessionsLimit],
+  (rows, hiddenJobs, limit) => visibleCronSessions(rows, hiddenJobs).slice(0, limit)
+)
+export const $cronSessionsTruncated = computed(
+  [$cronSessions, $cronJobsHiddenFromSessions, $sessionsLimit, $cronSessionsAcquisitionTruncated],
+  (rows, hiddenJobs, limit, acquisitionTruncated) =>
+    acquisitionTruncated || visibleCronSessions(rows, hiddenJobs).length > limit
+)
+export const $presentedSessions = computed([$sessions, $cronSessionsInSessionList], mergeSessionsForPresentation)
 // Messaging-platform sessions (telegram/discord/...) are fetched as their own
 // slice — separate from local recents — so each platform renders a
 // self-managed sidebar section and never interleaves with (or buries) local
@@ -378,6 +389,8 @@ export const setGatewayState = (next: Updater<ConnectionState>) => updateAtom($g
 export const setSessions = (next: Updater<SessionInfo[]>) => updateAtom($sessions, next)
 export const setSessionsTotal = (next: Updater<number>) => updateAtom($sessionsTotal, next)
 export const setCronSessions = (next: Updater<SessionInfo[]>) => updateAtom($cronSessions, next)
+export const setCronSessionsAcquisitionTruncated = (next: Updater<boolean>) =>
+  updateAtom($cronSessionsAcquisitionTruncated, next)
 export const setMessagingSessions = (next: Updater<SessionInfo[]>) => updateAtom($messagingSessions, next)
 export const setMessagingPlatformTotals = (next: Updater<Record<string, number>>) =>
   updateAtom($messagingPlatformTotals, next)

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -5,6 +5,14 @@ import type { DesktopUpdateStatus } from '@/global'
 const storage = new Map<string, string>()
 
 vi.mock('@/lib/storage', () => ({
+  readKey: (key: string) => storage.get(key) ?? null,
+  writeKey: (key: string, value: null | string) => {
+    if (value === null) {
+      storage.delete(key)
+    } else {
+      storage.set(key, value)
+    }
+  },
   persistBoolean: (key: string, value: boolean) => {
     storage.set(key, String(value))
   },

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -713,6 +713,7 @@ export interface CronJob {
   next_run_at?: null | string
   no_agent?: boolean
   prompt?: null | string
+  profile?: null | string
   provider?: null | string
   schedule?: CronJobSchedule
   schedule_display?: null | string

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5040,6 +5040,7 @@ def get_profiles_sessions_sidebar(
     recents_profile: str = "all",
     recents_limit: int = 20,
     recents_exclude: str = None,
+    cron_profile: str = "all",
     cron_limit: int = 50,
     messaging_limit: int = 100,
     messaging_exclude: str = None,
@@ -5047,8 +5048,9 @@ def get_profiles_sessions_sidebar(
     """Batched sidebar session slices — one profile-DB open per refresh.
 
     The desktop sidebar needs three source-scoped windows per refresh: recents
-    (local chats, scoped to the active profile), cron sessions (all profiles),
-    and messaging-platform sessions (all profiles). Served as three separate
+    (local chats, scoped to the active profile), cron sessions (scoped to the
+    selected profile, or all profiles in the unified view), and
+    messaging-platform sessions (all profiles). Served as three separate
     ``/api/profiles/sessions`` calls they reopened every profile's ``state.db``
     three times and re-counted each refresh. This opens each DB once and runs
     the three filtered queries together, returning the three windows in one
@@ -5064,7 +5066,7 @@ def get_profiles_sessions_sidebar(
     from hermes_state import SessionDB
     from hermes_cli import profiles as profiles_mod
 
-    # cron + messaging are cross-profile; recents is scoped to recents_profile.
+    # messaging is cross-profile; recents and cron have independent selectors.
     # Scan every profile once regardless (each DB opened a single time).
     try:
         infos = profiles_mod.list_profiles()
@@ -5076,6 +5078,7 @@ def get_profiles_sessions_sidebar(
         targets.append(("default", profiles_mod.get_profile_dir("default")))
 
     recents_scope = (recents_profile or "all").strip() or "all"
+    cron_scope = (cron_profile or "all").strip() or "all"
     recents_exclude_list = [s for s in (recents_exclude or "").split(",") if s.strip()]
     messaging_exclude_list = [s for s in (messaging_exclude or "").split(",") if s.strip()]
 
@@ -5138,7 +5141,8 @@ def get_profiles_sessions_sidebar(
                 )
                 recents_total += rtotal
                 recents_profile_totals[name] = rtotal
-            cron_rows.extend(_tag(_slice(db, source="cron", cap=cron_cap), name))
+            if cron_scope == "all" or name == cron_scope:
+                cron_rows.extend(_tag(_slice(db, source="cron", cap=cron_cap), name))
             messaging_rows.extend(
                 _tag(_slice(db, exclude=messaging_exclude_list, cap=messaging_cap), name)
             )
@@ -5154,6 +5158,7 @@ def get_profiles_sessions_sidebar(
         return win
 
     return {
+        "capabilities": {"cron_profile": True},
         "recents": {
             "sessions": _window(recents_rows, recents_cap),
             "total": recents_total,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2038,6 +2038,7 @@ class TestWebServerEndpoints:
         pass, each source-scoped by the caller-supplied excludes, so the desktop
         stops reopening every profile DB three times per refresh."""
         from hermes_state import SessionDB
+        from hermes_cli import profiles as profiles_mod
 
         db = SessionDB()
         try:
@@ -2051,6 +2052,17 @@ class TestWebServerEndpoints:
         finally:
             db.close()
 
+        worker_home = profiles_mod.get_profile_dir("worker")
+        worker_home.mkdir(parents=True)
+        worker_db = SessionDB(db_path=worker_home / "state.db")
+        try:
+            worker_db.create_session(session_id="sb-worker-cron", source="cron")
+            worker_db.append_message(
+                session_id="sb-worker-cron", role="user", content="worker cron"
+            )
+        finally:
+            worker_db.close()
+
         resp = self.client.get(
             "/api/profiles/sessions/sidebar"
             "?recents_profile=all&recents_limit=20&recents_exclude=cron,telegram"
@@ -2059,6 +2071,7 @@ class TestWebServerEndpoints:
         )
         assert resp.status_code == 200
         data = resp.json()
+        assert data["capabilities"] == {"cron_profile": True}
 
         recents_ids = {s["id"] for s in data["recents"]["sessions"]}
         cron_ids = {s["id"] for s in data["cron"]["sessions"]}
@@ -2078,6 +2091,24 @@ class TestWebServerEndpoints:
         assert row["is_default_profile"] is True
         assert isinstance(data.get("errors"), list)
         assert data["recents"]["total"] >= 1
+
+        worker_resp = self.client.get(
+            "/api/profiles/sessions/sidebar"
+            "?recents_profile=all&cron_profile=worker&cron_limit=50"
+        )
+        assert worker_resp.status_code == 200
+        worker_cron = worker_resp.json()["cron"]["sessions"]
+        assert {row["id"] for row in worker_cron} == {"sb-worker-cron"}
+        assert {row["profile"] for row in worker_cron} == {"worker"}
+
+        all_resp = self.client.get(
+            "/api/profiles/sessions/sidebar"
+            "?recents_profile=all&cron_profile=all&cron_limit=50"
+        )
+        assert {row["id"] for row in all_resp.json()["cron"]["sessions"]} >= {
+            "sb-cron",
+            "sb-worker-cron",
+        }
 
     def test_sessions_endpoint_reads_requested_profile(self):
         """The machine dashboard's global profile switcher must retarget


### PR DESCRIPTION
## Summary

- Show cron-run sessions in the normal, time-grouped **Sessions** list by default.
- Add a per-job **Hide from Sessions** / **Show in Sessions** control in both the sidebar Cron Jobs section and Master Cron.
- Keep cron acquisition separate from ordinary recents so a cron burst cannot consume the ordinary-session fetch budget.
- Persist opt-outs by profile and job ID, then filter the cron slice before applying the Sessions presentation limit.

## Why default-visible?

Hermes currently optimizes for a valid concern: scheduled jobs can fire in bursts, and those runs should not drown out ordinary conversations. Keeping cron acquisition in its own bounded slice is the right architectural response to that concern.

Hiding every cron transcript behind the Cron Jobs submenu is not the right product default, though. In professional-service work, cron output is often closer to an employee's work queue than scheduler exhaust. A lawyer, accountant, consultant, or other human-in-the-loop operator may need to read the result, answer a question, correct course, or continue the session. For these workflows, the cron burst is not noise; it is the primary interaction surface. Reminder-style jobs make this especially clear: an agent may schedule a future re-check, and the resulting transcript is precisely what the user must notice.

When those runs are only discoverable by opening Cron Jobs and inspecting individual jobs, the user must remember that a result exists, remember or guess which job produced it, and search across what may be dozens or hundreds of jobs. There is currently no inbox-level notification that compensates for that hidden placement.

This PR treats cron output as first-class session work product while preserving control over noisy automation:

- New and existing jobs are visible in Sessions by default, so reminders and human-in-the-loop work cannot silently disappear.
- A noisy or fully autonomous job can be hidden with one eye toggle.
- The preference applies to all runs from that job and is available from both places users manage cron work.
- Acquisition remains separate, so visibility does not let cron activity starve ordinary session retrieval.

The default matters. An opt-in assumes the user knows in advance which agent-created jobs will later require interaction. An opt-out instead favors discoverability, then lets the user suppress automation that proves unhelpful in the inbox.

This builds on the time-based Sessions grouping already landed in #70822. Visible cron runs participate in the same chronology rather than creating another navigation silo.

## Implementation

- Continue fetching ordinary recents and cron runs as independent slices through the existing batched sidebar endpoint. Ordinary recents still explicitly exclude `cron`.
- Cache the raw cron slice separately, apply archived/per-job visibility filters, then apply the current Sessions limit before merging for presentation.
- Request the current Sessions limit for cron runs normally. If any job is hidden, request a bounded 500-row cron window so a prolific hidden job does not consume the visible page before filtering.
- Merge ordinary and visible cron sessions by profile-qualified lineage identity, sort by `started_at`, and feed the result into the existing date-grouping renderer from #70822.
- Persist an opt-out array under `hermes.desktop.cronJobsHiddenFromSessions.v1`. Entries are collision-safe JSON tuples of `[normalizedProfile, jobId]`; malformed entries are ignored.
- Recompute the visible list from cached rows immediately when an eye toggle changes. The toggle does not issue per-job run requests.
- Carry explicit profile ownership only where this feature needs it: Cron acquisition, job controls, and opening a selected Cron run. Cron rows remain readable and resumable but do not expose legacy archive/delete actions whose ownership model is outside this PR.
- Define **Hide from Sessions** narrowly as the ordinary time-grouped Sessions feed. Deliberately pinned runs and full-text Search keep their existing behavior.
- Preserve the current Cron Blueprint catalog and creation paths unchanged.

The 500-row hidden-job window is intentionally bounded. It avoids a per-job request fanout or a new backend filtering API in this focused PR; reaching that cap is represented conservatively as `N+` with the existing Load More affordance.

## Test plan

- [x] Focused Desktop feature suite: 71 tests passed.
- [x] Full Desktop Vitest suite: 2,944 passed, 3 skipped.
- [x] Desktop typecheck passed.
- [x] Desktop lint passed with 0 errors (23 existing warnings).
- [x] Production Desktop build passed.
- [x] Python endpoint test and syntax check passed.
- [x] `git diff --check` passed before and after the cherry-pick.

## Scope

This is a focused product PR extracted from the earlier experiment in #42294. It intentionally does not include that branch's broader profile/session identity audit or unrelated navigation changes.

Related PR #62247 keeps `no_agent` cron runs out of the sidebar while repairing their run history. This PR proposes the opposite product default for the Sessions feed, but preserves the same anti-starvation concern through a separate bounded cron slice and per-job opt-outs.
