### PR TITLE
fix(docker): label SELinux bind mounts across all sandbox mount sites

### DIFF
--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -294,6 +294,57 @@ def test_start_proxy_idempotent_when_already_running(hermes_home, monkeypatch):
 
 
 
+def test_docker_egress_args_full_path(hermes_home, monkeypatch):
+    """Wire up everything (config, CA, mappings, fake running proxy) and
+    verify the docker helper emits the right mounts and env."""
+
+    from tools.environments.docker import _egress_proxy_args_for_docker
+    from hermes_cli.config import load_config, save_config
+
+    # Materialize config, CA, mappings.
+    state = ip._proxy_state_dir()
+    ca = state / "ca.crt"
+    ca.write_text("fake-ca")
+    (state / "ca.key").write_text("fake-key")
+    mapping = _sample_mapping("OPENROUTER_API_KEY")
+    proxy_cfg = ip.build_proxy_config(
+        mappings=[mapping], ca_cert=ca, ca_key=state / "ca.key", tunnel_port=9090,
+    )
+    ip.write_proxy_config(proxy_cfg)
+    ip.write_mappings([mapping])
+
+    cfg = load_config()
+    cfg.setdefault("proxy", {})["enabled"] = True
+    cfg["proxy"]["enforce_on_docker"] = True
+    save_config(cfg)
+
+    # Fake running proxy.
+    (state / "iron-proxy.pid").write_text("99999")
+    monkeypatch.setattr(ip, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(ip, "_port_listening", lambda h, p: True)
+
+    vol, env, host = _egress_proxy_args_for_docker()
+    # CA mount present and in -v form
+    assert "-v" in vol
+    assert any("hermes-egress-ca.crt" in arg for arg in vol)
+    # Env contains both casings of HTTPS_PROXY and the CA env vars
+    assert env["HTTPS_PROXY"].endswith(":9090")
+    assert env["https_proxy"] == env["HTTPS_PROXY"]
+    assert env["REQUESTS_CA_BUNDLE"].endswith("hermes-egress-ca.crt")
+    assert env["NODE_EXTRA_CA_CERTS"] == env["REQUESTS_CA_BUNDLE"]
+    # NO_PROXY excludes loopback
+    assert "127.0.0.1" in env["NO_PROXY"]
+    # Per-mapping proxy token is surfaced under both the standard provider env
+    # name (so existing SDKs work without egress-specific code) and the
+    # introspection name.
+    assert env["OPENROUTER_API_KEY"] == mapping.proxy_token
+    assert env["HERMES_PROXY_TOKEN_OPENROUTER_API_KEY"] == mapping.proxy_token
+    # Linux host-gateway mapping
+    assert host == ["--add-host", "host.docker.internal:host-gateway"]
+    # CA cert bind mount must carry the SELinux :z label alongside :ro, or
+    # containers on SELinux-enforcing hosts (Fedora/RHEL + podman) can't
+    # read it — same root cause as the /workspace and /root mounts.
+    assert any(arg.endswith("hermes-egress-ca.crt:ro,z") for arg in vol)
 
 
 

--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -288,6 +288,57 @@ def test_start_proxy_idempotent_when_already_running(hermes_home, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def test_docker_egress_args_full_path(hermes_home, monkeypatch):
+    """Wire up everything (config, CA, mappings, fake running proxy) and
+    verify the docker helper emits the right mounts and env."""
+
+    from tools.environments.docker_egress import _egress_proxy_args_for_docker
+    from hermes_cli.config import load_config, save_config
+
+    # Materialize config, CA, mappings.
+    state = ip._proxy_state_dir()
+    ca = state / "ca.crt"
+    ca.write_text("fake-ca")
+    (state / "ca.key").write_text("fake-key")
+    mapping = _sample_mapping("OPENROUTER_API_KEY")
+    proxy_cfg = ip.build_proxy_config(
+        mappings=[mapping], ca_cert=ca, ca_key=state / "ca.key", tunnel_port=9090,
+    )
+    ip.write_proxy_config(proxy_cfg)
+    ip.write_mappings([mapping])
+
+    cfg = load_config()
+    cfg.setdefault("proxy", {})["enabled"] = True
+    cfg["proxy"]["enforce_on_docker"] = True
+    save_config(cfg)
+
+    # Fake running proxy.
+    (state / "iron-proxy.pid").write_text("99999")
+    monkeypatch.setattr(ip, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(ip, "_port_listening", lambda h, p: True)
+
+    vol, env, host = _egress_proxy_args_for_docker()
+    # CA mount present and in -v form
+    assert "-v" in vol
+    assert any("hermes-egress-ca.crt" in arg for arg in vol)
+    # Env contains both casings of HTTPS_PROXY and the CA env vars
+    assert env["HTTPS_PROXY"].endswith(":9090")
+    assert env["https_proxy"] == env["HTTPS_PROXY"]
+    assert env["REQUESTS_CA_BUNDLE"].endswith("hermes-egress-ca.crt")
+    assert env["NODE_EXTRA_CA_CERTS"] == env["REQUESTS_CA_BUNDLE"]
+    # NO_PROXY excludes loopback
+    assert "127.0.0.1" in env["NO_PROXY"]
+    # Per-mapping proxy token is surfaced under both the standard provider env
+    # name (so existing SDKs work without egress-specific code) and the
+    # introspection name.
+    assert env["OPENROUTER_API_KEY"] == mapping.proxy_token
+    assert env["HERMES_PROXY_TOKEN_OPENROUTER_API_KEY"] == mapping.proxy_token
+    # Linux host-gateway mapping
+    assert host == ["--add-host", "host.docker.internal:host-gateway"]
+    # CA cert bind mount must carry the SELinux :z label alongside :ro, or
+    # containers on SELinux-enforcing hosts (Fedora/RHEL + podman) can't
+    # read it — same root cause as the /workspace and /root mounts.
+    assert any(arg.endswith("hermes-egress-ca.crt:ro,z") for arg in vol)
 
 
 

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -101,6 +101,120 @@ def test_auto_mount_host_cwd_adds_volume(monkeypatch, tmp_path):
     assert f"{project_dir}:/workspace" in run_args_str
 
 
+def test_auto_mount_disabled_by_default(monkeypatch, tmp_path):
+    """Host cwd should not be mounted unless the caller explicitly opts in."""
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/root",
+        host_cwd=str(project_dir),
+        auto_mount_cwd=False,
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert f"{project_dir}:/workspace" not in run_args_str
+
+
+def test_auto_mount_skipped_when_workspace_already_mounted(monkeypatch, tmp_path):
+    """Explicit user volumes for /workspace should take precedence over cwd mount."""
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/workspace",
+        host_cwd=str(project_dir),
+        auto_mount_cwd=True,
+        volumes=[f"{other_dir}:/workspace"],
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert f"{other_dir}:/workspace" in run_args_str
+    assert run_args_str.count(":/workspace") == 1
+
+
+def test_auto_mount_replaces_persistent_workspace_bind(monkeypatch, tmp_path):
+    """Persistent mode should still prefer the configured host cwd at /workspace."""
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/workspace",
+        persistent_filesystem=True,
+        host_cwd=str(project_dir),
+        auto_mount_cwd=True,
+        task_id="test-persistent-auto-mount",
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert f"{project_dir}:/workspace" in run_args_str
+    assert "/sandboxes/docker/test-persistent-auto-mount/workspace:/workspace" not in run_args_str
+
+
+def test_persistent_home_and_workspace_mounts_are_selinux_labeled(monkeypatch, tmp_path):
+    """Persistent /root and /workspace bind mounts must carry the :z SELinux
+    label so containers can write to them on SELinux-enforcing hosts (e.g.
+    Fedora/RHEL + podman) — without it these mounts default to user_home_t
+    and every write fails with Permission denied despite correct Unix
+    ownership. :z is a no-op on non-SELinux hosts, so this is safe
+    everywhere.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr("tools.environments.base.get_sandbox_dir", lambda: tmp_path)
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/workspace",
+        persistent_filesystem=True,
+        task_id="test-selinux-labels",
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert ":/root:z" in run_args_str
+    assert ":/workspace:z" in run_args_str
+
+
+def test_auto_mounted_host_cwd_is_selinux_labeled(monkeypatch, tmp_path):
+    """The opt-in host-cwd-to-/workspace bind mount also needs :z, same
+    reasoning as test_persistent_home_and_workspace_mounts_are_selinux_labeled.
+    """
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/workspace",
+        host_cwd=str(project_dir),
+        auto_mount_cwd=True,
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert f"{project_dir}:/workspace:z" in run_args_str
+
+
 def test_non_persistent_cleanup_removes_container(monkeypatch):
     """When persist_across_processes=false, cleanup() must docker stop AND
     docker rm so containers don't leak across hermes processes.
@@ -1313,6 +1427,77 @@ def test_credential_mount_skipped_when_source_missing(monkeypatch, tmp_path, cap
         "source not found" in rec.getMessage()
         for rec in caplog.records
     )
+
+
+def test_credential_mount_works_when_source_is_valid_file(monkeypatch, tmp_path):
+    """Credential mount should proceed normally when source is a valid file."""
+    valid_file = tmp_path / "token.json"
+    valid_file.write_text('{"token": "REDACTED"}')
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    fake_mounts = [
+        {"host_path": str(valid_file), "container_path": "/root/.hermes/token.json"},
+    ]
+    monkeypatch.setattr(
+        "tools.credential_files.get_credential_file_mounts",
+        lambda: fake_mounts,
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_skills_directory_mount",
+        lambda: [],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_cache_directory_mounts",
+        lambda: [],
+    )
+
+    _make_dummy_env()
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert "token.json" in run_args_str
+
+
+def test_credential_skills_cache_mounts_are_selinux_labeled(monkeypatch, tmp_path):
+    """Credential file, skills directory, and cache directory mounts are all
+    read-only host bind mounts built the same way as /workspace and /root —
+    they need the same :z SELinux label or they're unreadable inside the
+    container on SELinux-enforcing hosts.
+    """
+    valid_file = tmp_path / "token.json"
+    valid_file.write_text('{"token": "REDACTED"}')
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    cache_dir = tmp_path / "cache" / "documents"
+    cache_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    monkeypatch.setattr(
+        "tools.credential_files.get_credential_file_mounts",
+        lambda: [{"host_path": str(valid_file), "container_path": "/root/.hermes/token.json"}],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_skills_directory_mount",
+        lambda: [{"host_path": str(skills_dir), "container_path": "/root/.hermes/skills"}],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_cache_directory_mounts",
+        lambda: [{"host_path": str(cache_dir), "container_path": "/root/.hermes/cache/documents"}],
+    )
+
+    _make_dummy_env()
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert f"{valid_file}:/root/.hermes/token.json:ro,z" in run_args_str
+    assert f"{skills_dir}:/root/.hermes/skills:ro,z" in run_args_str
+    assert f"{cache_dir}:/root/.hermes/cache/documents:ro,z" in run_args_str
 
 
 # ── s6-overlay /init image handling (issue #34628) ────────────────

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -215,6 +215,57 @@ def test_auto_mounted_host_cwd_is_selinux_labeled(monkeypatch, tmp_path):
     assert f"{project_dir}:/workspace:z" in run_args_str
 
 
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("/home/user/projects:/workspace/projects", "/home/user/projects:/workspace/projects:z"),
+        ("/home/user/data:/data:ro", "/home/user/data:/data:ro,z"),
+        ("~/datasets:/data", "~/datasets:/data:z"),
+        ("./relative:/data", "./relative:/data:z"),
+    ],
+)
+def test_docker_volumes_host_paths_are_selinux_labeled(monkeypatch, tmp_path, raw, expected):
+    """User-configured `terminal.docker_volumes` host-directory bind mounts
+    need the same :z label as the internal mount sites — otherwise a
+    correctly-configured docker_volumes entry still hits Permission denied
+    on SELinux-enforcing hosts. Preserves any user-provided mode (:ro).
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(volumes=[raw])
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert expected in run_args_str
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "my-named-volume:/data",
+        "my-named-volume:/data:ro",
+    ],
+)
+def test_docker_volumes_named_volumes_are_not_selinux_labeled(monkeypatch, tmp_path, raw):
+    """Named Docker/podman volumes (no leading /, ~, or .) aren't host
+    directories — SELinux relabeling doesn't apply, and appending :z would
+    silently change the volume driver's interpretation of the mount, so
+    these must pass through unmodified."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(volumes=[raw])
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert raw in run_args_str
+    assert f"{raw}:z" not in run_args_str
+    assert f"{raw},z" not in run_args_str
+
+
 def test_non_persistent_cleanup_removes_container(monkeypatch):
     """When persist_across_processes=false, cleanup() must docker stop AND
     docker rm so containers don't leak across hermes processes.

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -103,6 +103,171 @@ def test_auto_mount_host_cwd_adds_volume(monkeypatch, tmp_path):
     assert f"{project_dir}:/workspace" in run_args_str
 
 
+def test_auto_mount_disabled_by_default(monkeypatch, tmp_path):
+    """Host cwd should not be mounted unless the caller explicitly opts in."""
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/root",
+        host_cwd=str(project_dir),
+        auto_mount_cwd=False,
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert f"{project_dir}:/workspace" not in run_args_str
+
+
+def test_auto_mount_skipped_when_workspace_already_mounted(monkeypatch, tmp_path):
+    """Explicit user volumes for /workspace should take precedence over cwd mount."""
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/workspace",
+        host_cwd=str(project_dir),
+        auto_mount_cwd=True,
+        volumes=[f"{other_dir}:/workspace"],
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert f"{other_dir}:/workspace" in run_args_str
+    assert run_args_str.count(":/workspace") == 1
+
+
+def test_auto_mount_replaces_persistent_workspace_bind(monkeypatch, tmp_path):
+    """Persistent mode should still prefer the configured host cwd at /workspace."""
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/workspace",
+        persistent_filesystem=True,
+        host_cwd=str(project_dir),
+        auto_mount_cwd=True,
+        task_id="test-persistent-auto-mount",
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert f"{project_dir}:/workspace" in run_args_str
+    assert "/sandboxes/docker/test-persistent-auto-mount/workspace:/workspace" not in run_args_str
+
+
+def test_persistent_home_and_workspace_mounts_are_selinux_labeled(monkeypatch, tmp_path):
+    """Persistent /root and /workspace bind mounts must carry the :z SELinux
+    label so containers can write to them on SELinux-enforcing hosts (e.g.
+    Fedora/RHEL + podman) — without it these mounts default to user_home_t
+    and every write fails with Permission denied despite correct Unix
+    ownership. :z is a no-op on non-SELinux hosts, so this is safe
+    everywhere.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr("tools.environments.base.get_sandbox_dir", lambda: tmp_path)
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/workspace",
+        persistent_filesystem=True,
+        task_id="test-selinux-labels",
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert ":/root:z" in run_args_str
+    assert ":/workspace:z" in run_args_str
+
+
+def test_auto_mounted_host_cwd_is_selinux_labeled(monkeypatch, tmp_path):
+    """The opt-in host-cwd-to-/workspace bind mount also needs :z, same
+    reasoning as test_persistent_home_and_workspace_mounts_are_selinux_labeled.
+    """
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/workspace",
+        host_cwd=str(project_dir),
+        auto_mount_cwd=True,
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert f"{project_dir}:/workspace:z" in run_args_str
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("/home/user/projects:/workspace/projects", "/home/user/projects:/workspace/projects:z"),
+        ("/home/user/data:/data:ro", "/home/user/data:/data:ro,z"),
+        ("~/datasets:/data", "~/datasets:/data:z"),
+        ("./relative:/data", "./relative:/data:z"),
+    ],
+)
+def test_docker_volumes_host_paths_are_selinux_labeled(monkeypatch, tmp_path, raw, expected):
+    """User-configured `terminal.docker_volumes` host-directory bind mounts
+    need the same :z label as the internal mount sites — otherwise a
+    correctly-configured docker_volumes entry still hits Permission denied
+    on SELinux-enforcing hosts. Preserves any user-provided mode (:ro).
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(volumes=[raw])
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert expected in run_args_str
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "my-named-volume:/data",
+        "my-named-volume:/data:ro",
+    ],
+)
+def test_docker_volumes_named_volumes_are_not_selinux_labeled(monkeypatch, tmp_path, raw):
+    """Named Docker/podman volumes (no leading /, ~, or .) aren't host
+    directories — SELinux relabeling doesn't apply, and appending :z would
+    silently change the volume driver's interpretation of the mount, so
+    these must pass through unmodified."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(volumes=[raw])
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert raw in run_args_str
+    assert f"{raw}:z" not in run_args_str
+    assert f"{raw},z" not in run_args_str
+
+
 def test_non_persistent_cleanup_removes_container(monkeypatch):
     """When persist_across_processes=false, cleanup() must docker stop AND
     docker rm so containers don't leak across hermes processes.
@@ -658,16 +823,16 @@ def test_persistent_bind_mounts_survive_a_session_key_task_id(monkeypatch, tmp_p
     )
 
     specs = _bind_mount_specs(_run_args_from_calls(calls))
-    mounts = [s for s in specs if s.endswith((":/root", ":/workspace"))]
+    mounts = [s for s in specs if s.endswith((":/root:z", ":/workspace:z"))]
     assert len(mounts) == 2, f"expected /root and /workspace binds; got {specs}"
     for spec in mounts:
-        source, _, target = spec.rpartition(":")
+        source, target, _z = spec.split(":")
         assert ":" not in source, (
             f"bind source still contains a colon, docker run would fail with "
             f"'too many colons': {spec}"
         )
-        # Docker splits on ':' — a sane spec has exactly source:target.
-        assert spec.count(":") == 1, f"spec is not a two-field bind: {spec}"
+        # Docker splits on ':' — a sane spec has exactly source:target:z.
+        assert spec.count(":") == 2, f"spec is not a three-field bind: {spec}"
         assert target in {"/root", "/workspace"}
 
 
@@ -690,7 +855,7 @@ def test_distinct_session_keys_get_distinct_sandbox_dirs(monkeypatch, tmp_path):
         _make_dummy_env(task_id=task_id, persistent_filesystem=True)
         specs = _bind_mount_specs(_run_args_from_calls(calls))
         sources.append(
-            next(s.rpartition(":")[0] for s in specs if s.endswith(":/root"))
+            next(s.split(":")[0] for s in specs if s.endswith(":/root:z"))
         )
 
     assert len(set(sources)) == 3, f"sandbox sources collided: {sources}"
@@ -1566,6 +1731,77 @@ def test_credential_mount_skipped_when_source_missing(monkeypatch, tmp_path, cap
         "source not found" in rec.getMessage()
         for rec in caplog.records
     )
+
+
+def test_credential_mount_works_when_source_is_valid_file(monkeypatch, tmp_path):
+    """Credential mount should proceed normally when source is a valid file."""
+    valid_file = tmp_path / "token.json"
+    valid_file.write_text('{"token": "REDACTED"}')
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    fake_mounts = [
+        {"host_path": str(valid_file), "container_path": "/root/.hermes/token.json"},
+    ]
+    monkeypatch.setattr(
+        "tools.credential_files.get_credential_file_mounts",
+        lambda: fake_mounts,
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_skills_directory_mount",
+        lambda: [],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_cache_directory_mounts",
+        lambda: [],
+    )
+
+    _make_dummy_env()
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert "token.json" in run_args_str
+
+
+def test_credential_skills_cache_mounts_are_selinux_labeled(monkeypatch, tmp_path):
+    """Credential file, skills directory, and cache directory mounts are all
+    read-only host bind mounts built the same way as /workspace and /root —
+    they need the same :z SELinux label or they're unreadable inside the
+    container on SELinux-enforcing hosts.
+    """
+    valid_file = tmp_path / "token.json"
+    valid_file.write_text('{"token": "REDACTED"}')
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    cache_dir = tmp_path / "cache" / "documents"
+    cache_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    monkeypatch.setattr(
+        "tools.credential_files.get_credential_file_mounts",
+        lambda: [{"host_path": str(valid_file), "container_path": "/root/.hermes/token.json"}],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_skills_directory_mount",
+        lambda: [{"host_path": str(skills_dir), "container_path": "/root/.hermes/skills"}],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_cache_directory_mounts",
+        lambda: [{"host_path": str(cache_dir), "container_path": "/root/.hermes/cache/documents"}],
+    )
+
+    _make_dummy_env()
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert f"{valid_file}:/root/.hermes/token.json:ro,z" in run_args_str
+    assert f"{skills_dir}:/root/.hermes/skills:ro,z" in run_args_str
+    assert f"{cache_dir}:/root/.hermes/cache/documents:ro,z" in run_args_str
 
 
 # ── s6-overlay /init image handling (issue #34628) ────────────────

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -489,7 +489,7 @@ def _egress_proxy_args_for_docker() -> tuple[list[str], dict[str, str], list[str
         return ([], {}, [])
 
     container_ca = "/etc/ssl/certs/hermes-egress-ca.crt"
-    volume_args = ["-v", f"{status.ca_cert_path}:{container_ca}:ro"]
+    volume_args = ["-v", f"{status.ca_cert_path}:{container_ca}:ro,z"]
 
     # tunnel_port serves CONNECT (HTTPS); the plain-HTTP forward listener
     # is on tunnel_port + 1 (see build_proxy_config's listener-role notes).
@@ -984,13 +984,13 @@ class DockerEnvironment(BaseEnvironment):
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
             writable_args.extend([
-                "-v", f"{self._home_dir}:/root",
+                "-v", f"{self._home_dir}:/root:z",
             ])
             if not bind_host_cwd and not workspace_explicitly_mounted:
                 self._workspace_dir = str(sandbox / "workspace")
                 os.makedirs(self._workspace_dir, exist_ok=True)
                 writable_args.extend([
-                    "-v", f"{self._workspace_dir}:/workspace",
+                    "-v", f"{self._workspace_dir}:/workspace:z",
                 ])
         else:
             if not bind_host_cwd and not workspace_explicitly_mounted:
@@ -1004,7 +1004,7 @@ class DockerEnvironment(BaseEnvironment):
 
         if bind_host_cwd:
             logger.info("Mounting configured host cwd to /workspace: %s", host_cwd_abs)
-            volume_args = ["-v", f"{host_cwd_abs}:/workspace", *volume_args]
+            volume_args = ["-v", f"{host_cwd_abs}:/workspace:z", *volume_args]
         elif workspace_explicitly_mounted:
             logger.debug("Skipping docker cwd mount: /workspace already mounted by user config")
 
@@ -1036,7 +1036,7 @@ class DockerEnvironment(BaseEnvironment):
                     continue
                 volume_args.extend([
                     "-v",
-                    f"{mount_entry['host_path']}:{mount_entry['container_path']}:ro",
+                    f"{mount_entry['host_path']}:{mount_entry['container_path']}:ro,z",
                 ])
                 logger.info(
                     "Docker: mounting credential %s -> %s",
@@ -1056,7 +1056,7 @@ class DockerEnvironment(BaseEnvironment):
                     continue
                 volume_args.extend([
                     "-v",
-                    f"{skills_mount['host_path']}:{skills_mount['container_path']}:ro",
+                    f"{skills_mount['host_path']}:{skills_mount['container_path']}:ro,z",
                 ])
                 logger.info(
                     "Docker: mounting skills dir %s -> %s",
@@ -1078,7 +1078,7 @@ class DockerEnvironment(BaseEnvironment):
                     continue
                 volume_args.extend([
                     "-v",
-                    f"{cache_mount['host_path']}:{cache_mount['container_path']}:ro",
+                    f"{cache_mount['host_path']}:{cache_mount['container_path']}:ro,z",
                 ])
                 logger.info(
                     "Docker: mounting cache dir %s -> %s",

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -100,6 +100,30 @@ def _normalize_env_dict(env: dict | None) -> dict[str, str]:
     return normalized
 
 
+def _selinux_label_user_volume(vol: str) -> str:
+    """Append the SELinux ``z`` relabel option to a user-configured
+    ``docker_volumes`` entry, iff it's a host-directory bind mount.
+
+    ``-v`` entries come in two shapes: ``host_path:container_path[:opts]``
+    (a bind mount — needs the label, same as every other internal mount
+    site) and ``volume_name:container_path[:opts]`` (a named Docker/podman
+    volume, which is unaffected by the host's SELinux context and whose
+    user-provided opts — e.g. ``:ro``, ``:nocopy`` — should pass through
+    untouched). Host paths are distinguished by a leading ``/``, ``~``, or
+    ``.`` per the documented ``docker_volumes`` format; anything else is
+    treated as a named volume and left alone.
+    """
+    parts = vol.split(":")
+    if len(parts) not in (2, 3) or not parts[0].startswith(("/", "~", ".")):
+        return vol
+
+    host_path, container_path = parts[0], parts[1]
+    opts = [o for o in parts[2].split(",") if o] if len(parts) == 3 else []
+    if "z" not in opts and "Z" not in opts:
+        opts.append("z")
+    return f"{host_path}:{container_path}:{','.join(opts)}"
+
+
 def _load_hermes_env_vars() -> dict[str, str]:
     """Load ~/.hermes/.env values without failing Docker command execution."""
     try:
@@ -960,6 +984,7 @@ class DockerEnvironment(BaseEnvironment):
             if not vol:
                 continue
             if ":" in vol:
+                vol = _selinux_label_user_volume(vol)
                 volume_args.extend(["-v", vol])
                 if ":/workspace" in vol:
                     workspace_explicitly_mounted = True

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -61,6 +61,30 @@ def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
     return normalized
 
 
+def _selinux_label_user_volume(vol: str) -> str:
+    """Append the SELinux ``z`` relabel option to a user-configured
+    ``docker_volumes`` entry, iff it's a host-directory bind mount.
+
+    ``-v`` entries come in two shapes: ``host_path:container_path[:opts]``
+    (a bind mount — needs the label, same as every other internal mount
+    site) and ``volume_name:container_path[:opts]`` (a named Docker/podman
+    volume, which is unaffected by the host's SELinux context and whose
+    user-provided opts — e.g. ``:ro``, ``:nocopy`` — should pass through
+    untouched). Host paths are distinguished by a leading ``/``, ``~``, or
+    ``.`` per the documented ``docker_volumes`` format; anything else is
+    treated as a named volume and left alone.
+    """
+    parts = vol.split(":")
+    if len(parts) not in (2, 3) or not parts[0].startswith(("/", "~", ".")):
+        return vol
+
+    host_path, container_path = parts[0], parts[1]
+    opts = [o for o in parts[2].split(",") if o] if len(parts) == 3 else []
+    if "z" not in opts and "Z" not in opts:
+        opts.append("z")
+    return f"{host_path}:{container_path}:{','.join(opts)}"
+
+
 def _normalize_env_dict(env: dict | None) -> dict[str, str]:
     """Validate a docker_env dict to {str: str}; scalars are coerced, other values dropped."""
     if not env:
@@ -459,7 +483,7 @@ def _readonly_skill_mount_args() -> list[str]:
                 if problem:
                     logger.warning("Docker: skipping %s mount — %s: %s", noun.split()[0], problem, src)
                     continue
-                args.extend(["-v", f"{entry['host_path']}:{entry['container_path']}:ro"])
+                args.extend(["-v", f"{entry['host_path']}:{entry['container_path']}:ro,z"])
                 logger.info("Docker: mounting %s %s -> %s", noun, entry["host_path"], entry["container_path"])
     except Exception as e:
         logger.debug("Docker: could not load credential file mounts: %s", e)
@@ -678,7 +702,7 @@ class DockerEnvironment(BaseEnvironment):
             if ":" not in vol:
                 logger.warning("Docker volume '%s' missing colon, skipping", vol)
                 continue
-            volume_args.extend(["-v", vol])
+            volume_args.extend(["-v", _selinux_label_user_volume(vol)])
         workspace_explicitly_mounted = any(":/workspace" in v for v in volume_args)
 
         host_cwd_abs = os.path.abspath(os.path.expanduser(host_cwd)) if host_cwd else ""
@@ -697,18 +721,18 @@ class DockerEnvironment(BaseEnvironment):
             sandbox = get_sandbox_dir() / "docker" / _sandbox_dir_name(task_id)
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
-            writable_args += ["-v", f"{self._home_dir}:/root"]
+            writable_args += ["-v", f"{self._home_dir}:/root:z"]
             if mount_workspace:
                 self._workspace_dir = str(sandbox / "workspace")
                 os.makedirs(self._workspace_dir, exist_ok=True)
-                writable_args += ["-v", f"{self._workspace_dir}:/workspace"]
+                writable_args += ["-v", f"{self._workspace_dir}:/workspace:z"]
         else:
             writable_args += ["--tmpfs", "/workspace:rw,exec,size=10g"] if mount_workspace else []
             writable_args += ["--tmpfs", "/home:rw,exec,size=1g", "--tmpfs", "/root:rw,exec,size=1g"]
 
         if bind_host_cwd:
             logger.info("Mounting configured host cwd to /workspace: %s", host_cwd_abs)
-            volume_args = ["-v", f"{host_cwd_abs}:/workspace", *volume_args]
+            volume_args = ["-v", f"{host_cwd_abs}:/workspace:z", *volume_args]
         elif workspace_explicitly_mounted:
             logger.debug("Skipping docker cwd mount: /workspace already mounted by user config")
         return volume_args, writable_args

--- a/tools/environments/docker_egress.py
+++ b/tools/environments/docker_egress.py
@@ -75,7 +75,7 @@ def _egress_proxy_args_for_docker() -> tuple[list[str], dict[str, str], list[str
             "corrupt.  Re-run `hermes egress setup` to mint provider "
             "tokens before starting a sandbox.")
 
-    volume_args = ["-v", f"{status.ca_cert_path}:{_CONTAINER_CA}:ro"]
+    volume_args = ["-v", f"{status.ca_cert_path}:{_CONTAINER_CA}:ro,z"]
 
     # tunnel_port serves CONNECT (HTTPS); the plain-HTTP forward listener is on +1.
     proxy_url = f"http://host.docker.internal:{status.tunnel_port}"


### PR DESCRIPTION
## What does this PR do?

Fixes the Docker/podman terminal backend being unusable on SELinux-enforcing hosts (Fedora, RHEL, OpenSUSE). `DockerEnvironment`'s host-side bind mounts (`/workspace`, `/root` home, the auto-mounted cwd, mounted credential files, the skills directory, cache directories, and the egress-proxy CA cert) inherit the host directory's existing SELinux type — typically `user_home_t` — which container processes cannot access. Every read/write against any of these mounts fails with `Permission denied` despite completely correct Unix ownership and permissions, because the failure is SELinux type-enforcement, not a Unix permission problem.

Appends the `:z` mount-label suffix (shared relabel — several of these directories are also touched by native host processes, or read by more than one container over the sandbox's lifetime) to all 7 internal `-v host:container` bind-mount call sites. `:z` is a documented no-op on non-SELinux hosts (Docker Desktop, plain Linux without SELinux, Windows, macOS), so this is safe everywhere without needing runtime OS detection.

**Relation to prior PRs on this issue** (found these after already drafting my own fix — flagging for the reviewer rather than silently duplicating):
- Supersedes #45252, which took the same `:z`-labeling approach with broader dynamic SELinux detection and covered the same set of mount sites. It got a clean automated review ("Clean implementation, no findings") but had one blocking `ruff enforcement` CI failure that was never addressed, went stale, and was closed for inactivity — not because the approach was wrong. This PR keeps that PR's full scope (all bind-mount sites, not just `/workspace`/`/root`) but uses unconditional labeling instead of runtime detection, since `:z` is a no-op wherever it isn't needed, which keeps the diff smaller.
- Deliberately does **not** take the approach in #45111 (`--security-opt label=disable`), which disables SELinux confinement for the *entire container process*, not just the specific mounted directories. This project's own `SECURITY.md` names OS-level isolation as the only real boundary against an adversarial LLM — widening that boundary for the whole container is a materially larger security tradeoff than relabeling the handful of directories that actually need container access. Targeted `:z` labeling fixes the bug without touching the container's baseline confinement.

## Related Issue

Fixes #45106

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/docker.py`: append `:z` to all 7 host-directory bind-mount call sites — persistent `/root` home, persistent `/workspace`, auto-mounted host-cwd `/workspace`, mounted credential files, the skills directory mount, cache directory mounts, and the egress-proxy CA cert mount.
- `tests/tools/test_docker_environment.py`: two new regression tests — one for the persistent home/workspace mounts and the auto-mounted cwd mount, one for the credential/skills/cache mounts — asserting the `:z` label is present. Verified both fail without the fix and pass with it.
- `tests/test_iron_proxy.py`: extended the existing full-path egress test with an assertion that the CA cert mount carries `:ro,z`. Verified it fails without the fix and passes with it.

## How to Test

1. On a SELinux-enforcing host (Fedora, RHEL, OpenSUSE Tumbleweed) with rootless podman, set `terminal.backend: docker` in Hermes config.
2. Start a session with `container_persistent: true` (the default) and run any command that writes to `/workspace` or `~` inside the sandbox, or reads a mounted credential/skill file.
3. Without this fix: `Permission denied`, even though the host-side directory is correctly owned by the invoking user (confirmed on a live Fedora 42 + podman 5.8.4 rootless box — `ls -ldZ` showed the mount at `user_home_t`; `chcon -t container_file_t` on the same directory, no ownership change, immediately fixed it, which is what `:z` does automatically at mount time).
4. With this fix: reads/writes succeed.
5. Automated: `pytest tests/tools/test_docker_environment.py tests/test_iron_proxy.py -q` — 190 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see "Relation to prior PRs" above
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/tools/test_docker_environment.py tests/test_iron_proxy.py -q` and all tests pass (190/190)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Fedora Linux 42 (7.1.3-100.fc43.x86_64), podman 5.8.4, rootless

### Documentation & Housekeeping

- [ ] N/A — no config keys added/changed
- [ ] N/A — no architecture/workflow change requiring `CONTRIBUTING.md`/`AGENTS.md` updates
- [x] Considered cross-platform impact — `:z` is a documented no-op on Docker Desktop, non-SELinux Linux, Windows, and macOS
- [ ] N/A — no tool schema/behavior change
