### PR TITLE
Add defuddle skill: web content extraction via CLI

### DIFF
--- a/skills/research/defuddle/SKILL.md
+++ b/skills/research/defuddle/SKILL.md
@@ -1,0 +1,341 @@
+---
+name: defuddle
+description: "Use when you need to extract clean article content and metadata from a web page URL or raw HTML. Defuddle removes clutter (sidebars, nav, ads, footers) and returns clean Markdown or HTML with rich metadata (title, author, published date, schema.org data). Complements walled-web-research (access) and headless-web-research (data) for the content-cleanup step."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [defuddle, content-extraction, readability, markdown, web-scraping, html-cleanup, article-parser]
+    related_skills: [walled-web-research, headless-web-research, web-content-extraction, obsidian]
+---
+
+# Defuddle — Web Content Extraction
+
+## Overview
+
+Defuddle is a CLI and library by Steph Ango (kepano) that extracts the main content from any web page and returns clean HTML or Markdown with rich metadata. It was created for the [Obsidian Web Clipper](https://github.com/obsidianmd/obsidian-clipper) and is designed as a modern replacement for Mozilla Readability with better metadata extraction, consistent footnote/math/code handling, and mobile-style-based clutter detection.
+
+In the Hermes research skill stack, Defuddle fills the **content-cleanup layer** — the step between *getting the HTML* (via curl, r.jina.ai, Wayback, browser_snapshot) and *using the content* (summarization, note-taking, research reports). It replaces fragile manual CSS-selector approaches with a purpose-built, actively maintained tool.
+
+| Property | Value |
+|----------|-------|
+| Package | `defuddle` on npm |
+| Latest | 0.19.2 (July 2026, actively maintained) |
+| License | MIT |
+| Dependency | `commander` only (1 dep, 2.6 MB unpacked) |
+| Runtime | Node.js (npx or global install) |
+| Repo | https://github.com/kepano/defuddle |
+| Homepage | https://defuddle.md |
+
+## When to Use
+
+- You have a URL and need the article content as clean Markdown for summarization, note-taking, or research.
+- You have raw HTML (from curl, r.jina.ai, Wayback, or browser_snapshot) and need to strip clutter (sidebars, nav, ads, comments, footers).
+- You need page metadata: title, author, description, published date, domain, favicon, main image, language, schema.org data.
+- You want Obsidian-compatible output with YAML frontmatter for direct note creation.
+- A page returns 403 to default User-Agent and you need content extraction with a custom UA string.
+- You need to extract a single property (e.g. just the title or author) without downloading the full article body.
+
+## Don't Use For
+
+- Client-side rendered SPAs where the HTML shell has no content (use `browser_snapshot` or `r.jina.ai` first to get rendered HTML, then pipe to Defuddle).
+- Sites behind Cloudflare challenges or login walls (use `walled-web-research` access ladder first).
+- Structured data extraction from JSON APIs (use `headless-web-research` JSON-LD patterns).
+- Bulk crawling or sitemap enumeration (Defuddle processes one page at a time).
+
+## Skill Stack Position
+
+```
+┌─────────────────────────────────────────────────────┐
+│              ACCESS LAYER (get the HTML)             │
+│  curl · r.jina.ai · Wayback · browser_snapshot       │
+│  walled-web-research · headless-web-research         │
+└──────────────────────┬──────────────────────────────┘
+                       │ raw HTML
+                       ▼
+┌─────────────────────────────────────────────────────┐
+│         CLEANUP LAYER (this skill)                   │
+│  Defuddle: strip clutter, extract content + meta     │
+│  → clean Markdown / HTML / JSON / frontmatter        │
+└──────────────────────┬──────────────────────────────┘
+                       │ clean content
+                       ▼
+┌─────────────────────────────────────────────────────┐
+│              USE LAYER (consume content)             │
+│  Summarize · save to Obsidian · research report      │
+│  obsidian · automated-briefings · arxiv              │
+└─────────────────────────────────────────────────────┘
+```
+
+## Prerequisites
+
+Node.js and npx must be available on the host:
+
+```bash
+node --version    # needs v18+
+npx --version
+```
+
+No global install required — `npx -y defuddle@latest` downloads on first use and caches. For repeated use, install globally:
+
+```bash
+npm install -g defuddle
+```
+
+## Core Commands
+
+### 1. URL directly to Markdown (simplest)
+
+```bash
+npx -y defuddle@latest parse <url> --markdown
+```
+
+### 2. Pipe HTML from curl (agent workflow — most flexible)
+
+```bash
+curl -sL <url> | npx -y defuddle@latest parse --markdown
+```
+
+This is the preferred pattern for Hermes agents because it separates fetching (where you control headers, proxies, retries) from parsing.
+
+### 3. Pipe from access tools (walled sites)
+
+```bash
+# Wayback Machine → Defuddle cleanup
+curl -sL "https://web.archive.org/web/2026/https://example.com/article" | npx -y defuddle@latest parse --markdown
+```
+
+Do NOT pipe r.jina.ai output into Defuddle — r.jina.ai returns Markdown, not HTML, and Defuddle expects HTML. When using r.jina.ai, you already have clean content.
+
+### 4. JSON output with full metadata
+
+```bash
+npx -y defuddle@latest parse <url> --json
+```
+
+Returns: `content`, `title`, `description`, `author`, `domain`, `favicon`, `image`, `language`, `published`, `site`, `wordCount`, `metaTags`, `schemaOrgData`, `parseTime`.
+
+### 5. Markdown with YAML frontmatter (Obsidian-compatible)
+
+```bash
+npx -y defuddle@latest parse <url> --markdown --frontmatter
+```
+
+Output:
+```yaml
+---
+title: "Article Title"
+author: "Author Name"
+site: "Site Name"
+published: 2025-10-20T00:00:00+00:00
+source: "https://example.com/article"
+domain: "example.com"
+language: "en"
+description: "Article description"
+word_count: 143
+---
+
+Article content in Markdown...
+```
+
+This integrates directly with the `obsidian` skill for note creation.
+
+### 6. Extract a single property
+
+```bash
+npx -y defuddle@latest parse <url> --property title
+npx -y defuddle@latest parse <url> --property author
+npx -y defuddle@latest parse <url> --property description
+npx -y defuddle@latest parse <url> --property domain
+```
+
+### 7. Save output to file
+
+```bash
+npx -y defuddle@latest parse <url> --markdown --output /tmp/article.md
+```
+
+### 8. Custom User-Agent (403/FORBIDDEN fix)
+
+```bash
+npx -y defuddle@latest parse <url> --markdown \
+  --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+```
+
+### 9. Language preference
+
+```bash
+npx -y defuddle@latest parse <url> --markdown --lang fr
+```
+
+### 10. Parse a local HTML file
+
+```bash
+npx -y defuddle@latest parse page.html --markdown
+npx -y defuddle@latest parse page.html --json
+```
+
+## CLI Reference
+
+```
+Usage: defuddle parse [options] [source]
+
+Parse HTML content from a file, URL, or stdin
+
+Arguments:
+  source                     HTML file path, URL, or "-" to read from stdin
+
+Options:
+  -o, --output <file>        Output file path (default: stdout)
+  -m, --markdown             Convert content to markdown format
+  --md                       Alias for --markdown
+  -j, --json                 Output as JSON with metadata and content
+  -f, --frontmatter          Prepend YAML frontmatter (title, author, source,
+                             etc.) to the output
+  -p, --property <name>      Extract a specific property (e.g., title,
+                             description, domain)
+  --debug                    Enable debug mode
+  -l, --lang <code>          Preferred language (BCP 47, e.g. en, fr, ja)
+  -u, --user-agent <string>  Custom User-Agent header for HTTP requests (helps
+                             with 403/FORBIDDEN responses)
+  -h, --help                 display help for command
+```
+
+## JSON Response Schema
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `author` | string | Author of the article |
+| `content` | string | Cleaned up extracted content (HTML or Markdown) |
+| `description` | string | Description or summary of the article |
+| `domain` | string | Domain name of the website |
+| `favicon` | string | URL of the website's favicon |
+| `image` | string | URL of the article's main image |
+| `language` | string | Language in BCP 47 format (e.g. `en`, `en-US`) |
+| `metaTags` | object | Meta tags |
+| `parseTime` | number | Time taken to parse in milliseconds |
+| `published` | string | Publication date of the article |
+| `site` | string | Name of the website |
+| `schemaOrgData` | object | Raw schema.org data extracted from the page |
+| `title` | string | Title of the article |
+| `wordCount` | number | Total number of words in the extracted content |
+| `debug` | object | Debug info (when `--debug` is used) |
+
+## Integration Recipes
+
+### Recipe A: URL → Obsidian note (one-liner)
+
+```bash
+npx -y defuddle@latest parse "https://example.com/article" --markdown --frontmatter > /tmp/note.md
+```
+
+Then use the `obsidian` skill to save it to the vault.
+
+### Recipe B: Walled site → clean content
+
+```bash
+# Step 1: get HTML via Wayback Machine (from walled-web-research skill)
+curl -sL "https://web.archive.org/web/2026/https://walled-site.com/article" > /tmp/raw.html
+
+# Step 2: clean with Defuddle
+npx -y defuddle@latest parse /tmp/raw.html --markdown
+```
+
+Note: do NOT pipe r.jina.ai output into Defuddle. r.jina.ai already returns clean Markdown, not HTML — Defuddle expects HTML input and will return empty on Markdown. Use Defuddle with raw HTML sources (curl, Wayback, browser snapshots). When using r.jina.ai, you already have clean content and don't need Defuddle.
+
+### Recipe C: Research workflow — fetch + extract + summarize
+
+```bash
+# Fetch and clean in one pipe
+curl -sL "https://example.com/article" | npx -y defuddle@latest parse --markdown --output /tmp/article.md
+
+# Read the cleaned content for summarization
+cat /tmp/article.md
+```
+
+### Recipe D: Bulk metadata extraction (single property)
+
+When you only need the title or author from multiple pages, extract just that property:
+
+```bash
+npx -y defuddle@latest parse "https://example.com/page1" --property title
+npx -y defuddle@latest parse "https://example.com/page2" --property title
+```
+
+### Recipe E: Browser snapshot → Defuddle (SPA content)
+
+For client-side rendered sites where curl gets only a JS shell:
+
+1. Navigate with `browser_navigate` to the target URL.
+2. Extract the rendered HTML with `browser_console`:
+   ```javascript
+   document.documentElement.outerHTML
+   ```
+3. Save to a file and pipe to Defuddle:
+   ```bash
+   npx -y defuddle@latest parse /tmp/rendered.html --markdown
+   ```
+
+## What Defuddle Standardizes
+
+### Headings
+- First H1/H2 matching the title is removed (no duplicate).
+- All H1s converted to H2s.
+- Anchor links in headings removed (plain headings).
+
+### Code blocks
+- Line numbers and syntax highlighting stripped.
+- Language preserved as `data-lang` attribute and class.
+
+### Footnotes
+- Inline references standardized to `<sup>` format.
+- Footnote sections converted to ordered lists with backref links.
+- In Markdown: `[^1]` syntax with footnote definitions.
+
+### Math
+- MathJax and KaTeX converted to standard MathML.
+- Full bundle adds LaTeX conversion via `temml` and `mathml-to-latex`.
+
+### Callouts
+- GitHub markdown alerts, Obsidian callouts, Bootstrap alerts standardized.
+- In Markdown: Obsidian-style `> [!info]` callout syntax.
+
+## Common Pitfalls
+
+1. **SPAs have no content for Defuddle to parse.** Defuddle works on static HTML. If the page is client-side rendered (React, Vue, Wix), `curl` will get a JS shell with no article text. Use `browser_snapshot` or `r.jina.ai` to get the rendered HTML first, then pipe to Defuddle. See Recipe E above.
+
+2. **403/FORBIDDEN from sites blocking default User-Agent.** Use `--user-agent "Mozilla/5.0 ..."` with a real browser UA string. Sites like Wikipedia and many news outlets block bot-like User-Agents.
+
+3. **Forgetting `-y` with npx.** Without `npx -y`, the CLI prompts for confirmation to install the package, which hangs in non-interactive terminal sessions. Always use `npx -y defuddle@latest`.
+
+4. **Using `defuddle@latest` for reproducibility.** `@latest` always gets the newest version. For reproducible results in scripts, pin a version: `npx -y defuddle@0.19.2`. The package is actively developed with 44 versions in 5 months.
+
+5. **stdin mode requires `-` or no argument.** When piping HTML via stdin, you can either pass `-` explicitly or omit the source argument entirely. Both work: `cat page.html | npx defuddle parse` and `cat page.html | npx defuddle parse -`.
+
+6. **`--frontmatter` only works with `--markdown`.** Frontmatter is a YAML block prepended to Markdown output. It has no effect with `--json` or default HTML output.
+
+7. **`--json` and `--markdown` are mutually exclusive in practice.** `--json` returns the content field as HTML. If you want JSON with Markdown content, use the library API with `separateMarkdown: true` option, not the CLI.
+
+8. **Past security advisory (fixed).** GHSA-5mq8-78gm-pjmq was an XSS via unescaped string interpolation, fixed in v0.9.0. Current versions (0.19.x) are clean. Always use v0.9.0+.
+
+9. **npm may trigger security scan warnings.** Hermes terminal security scanning flags `npx defuddle@latest` due to the historical OSV advisory. The advisory is fixed in current versions. The flag is informational, not a blocker.
+
+10. **Global install vs npx caching.** `npx -y` downloads and caches the package on first run (~3s). Subsequent runs are instant. For high-frequency use, `npm install -g defuddle` avoids the npx overhead entirely.
+
+## Verification Checklist
+
+- [ ] `node --version` returns v18+ and `npx --version` works
+- [ ] `npx -y defuddle@latest parse https://stephango.com/saw --markdown` returns clean article text
+- [ ] `npx -y defuddle@latest parse https://stephango.com/saw --json` returns JSON with `title`, `content`, `author` fields
+- [ ] `npx -y defuddle@latest parse https://stephango.com/saw --markdown --frontmatter` prepends YAML block
+- [ ] `curl -sL https://stephango.com/saw | npx -y defuddle@latest parse --markdown` produces same output as direct URL mode
+- [ ] `npx -y defuddle@latest parse https://stephango.com/saw --property title` returns only the title string
+
+## Source
+
+- Repository: https://github.com/kepano/defuddle
+- npm: https://www.npmjs.com/package/defuddle
+- Homepage: https://defuddle.md
+- Author: Steph Ango (@kepano), CEO of Obsidian
+- License: MIT

--- a/skills/research/defuddle/references/integration-patterns.md
+++ b/skills/research/defuddle/references/integration-patterns.md
@@ -1,0 +1,198 @@
+# Defuddle Integration Patterns for Hermes Agents
+
+## Comparison: Defuddle vs existing research skills
+
+| Skill | Layer | What it does | When to use |
+|-------|-------|-------------|-------------|
+| `walled-web-research` | Access | Bypasses Cloudflare, bot-walls, JS shells via Wayback, r.jina.ai, sitemaps | Page is blocked or returns JS shell to curl |
+| `headless-web-research` | Access | curl + JSON APIs for data extraction when browsers unavailable | Catalogs, benchmarks, structured data, user sentiment |
+| `web-content-extraction` | Access+Cleanup | browser_console + manual CSS selectors for SPA DOM extraction | JS-rendered SPAs where you need the rendered DOM |
+| **`defuddle`** | **Cleanup** | **Purpose-built content extraction from HTML/URL → clean Markdown + metadata** | **You have HTML (from any source) and need clean article content** |
+
+Key distinction: the first three skills solve *getting to the content*. Defuddle solves *cleaning the content once you have it*. They are complementary, not competing.
+
+## Defuddle vs Mozilla Readability
+
+Defuddle was explicitly designed as a Readability replacement:
+
+| Feature | Defuddle | Readability |
+|---------|----------|-------------|
+| Clutter removal | More forgiving, removes fewer uncertain elements | Aggressive removal |
+| Footnotes | Consistent standardized format | Inconsistent |
+| Math | MathML standardization + LaTeX conversion | No math support |
+| Code blocks | Standardized with language preserved | Basic |
+| Mobile styles | Uses mobile CSS to detect unnecessary elements | No |
+| Metadata | Rich (schema.org, meta tags, favicon, image, published) | Basic (title, byline, length) |
+| Output format | HTML, Markdown, JSON | HTML only |
+| Frontmatter | YAML frontmatter for Obsidian | No |
+| CLI | Built-in | None (library only) |
+| Callouts | GitHub/Obsidian/Bootstrap standardized | No |
+
+## Full integration workflow
+
+### Scenario 1: Simple article extraction
+
+```
+User: "Extract the content from https://example.com/article"
+
+Agent:
+1. Run: npx -y defuddle@latest parse "https://example.com/article" --markdown
+2. Receive clean Markdown
+3. Present to user or save to file
+```
+
+### Scenario 2: Walled site research
+
+```
+User: "Get the content from this Cloudflare-protected page"
+
+Agent:
+1. Load walled-web-research skill for access strategy
+2. Fetch HTML: curl -sL "https://web.archive.org/web/2026/https://walled-site.com/article" > /tmp/raw.html
+   (Use Wayback Machine — it returns full HTML. Do NOT use r.jina.ai here, it returns Markdown not HTML.)
+3. Load defuddle skill for cleanup
+4. Clean: npx -y defuddle@latest parse /tmp/raw.html --markdown
+5. Present clean content
+```
+
+### Scenario 3: Research report with multiple sources
+
+```
+User: "Research X from these 3 articles"
+
+Agent:
+1. For each URL:
+   a. curl -sL <url> | npx -y defuddle@latest parse --markdown --output /tmp/article_N.md
+   b. Also extract metadata: npx -y defuddle@latest parse <url> --json --output /tmp/meta_N.json
+2. Read all /tmp/article_N.md files
+3. Synthesize research report from clean content
+```
+
+### Scenario 4: Obsidian note creation
+
+```
+User: "Save this article to my Obsidian vault"
+
+Agent:
+1. npx -y defuddle@latest parse "https://example.com/article" --markdown --frontmatter --output /tmp/note.md
+2. Load obsidian skill
+3. Save /tmp/note.md to the vault with proper frontmatter already included
+```
+
+### Scenario 5: SPA content extraction (browser + Defuddle)
+
+```
+User: "Extract content from this React site"
+
+Agent:
+1. browser_navigate to the URL
+2. browser_console with expression: document.documentElement.outerHTML
+3. Save HTML to /tmp/rendered.html
+4. npx -y defuddle@latest parse /tmp/rendered.html --markdown
+```
+
+## Programmatic usage (Node.js library)
+
+For agents that need to integrate Defuddle into a Node.js script rather than the CLI:
+
+```javascript
+import { parseHTML } from 'linkedom';
+import { Defuddle } from 'defuddle/node';
+
+const { document } = parseHTML(html);
+const result = await Defuddle(document, 'https://example.com/article', {
+  markdown: true,
+  // Options:
+  // debug: false,
+  // url: 'https://example.com/article',
+  // markdown: true,
+  // separateMarkdown: false,
+  // removeExactSelectors: true,
+  // removePartialSelectors: true,
+  // removeHiddenElements: true,
+  // removeLowScoring: true,
+  // removeSmallImages: true,
+  // removeImages: false,
+  // standardize: true,
+  // contentSelector: 'css-selector',  // bypass auto-detection
+  // useAsync: true,   // allow third-party API fallback for SPAs
+  // language: 'en',
+  // includeReplies: 'extractors',
+});
+
+console.log(result.content);    // cleaned content
+console.log(result.title);      // article title
+console.log(result.author);     // author
+console.log(result.wordCount);  // word count
+```
+
+Requires a DOM implementation:
+```bash
+npm install linkedom   # lightweight, recommended
+# or
+npm install jsdom       # heavier, more complete
+```
+
+## Fleet deployment recommendations
+
+### Which profiles should have this skill
+
+The `research` category exists across 14 profiles. Defuddle is most valuable for:
+
+| Profile | Priority | Reason |
+|---------|----------|--------|
+| `u365-orchestrator` | **Done** (installed here) | Central coordination, research synthesis |
+| `u365-research` | High | Primary research profile |
+| `u365-intelligence` | High | Already has `terminal-web-research` skill |
+| `u365-strategy` | Medium | Strategic research needs clean content |
+| `u365-academics` | Medium | Academic content extraction |
+| `coding` | Medium | Already has `web-content-extraction` peer |
+| `u365-engagement` | Low | Occasional content needs |
+| Others | Low | Can delegate to orchestrator or research |
+
+### Deployment options
+
+**Option A: Per-profile install (current)**
+- Skill lives at `~/.hermes/profiles/<profile>/skills/research/defuddle/SKILL.md`
+- Each profile that needs it gets its own copy
+- Pro: simple, isolated
+- Con: duplication, maintenance across profiles
+
+**Option B: Workspace-external (recommended for fleet-wide)**
+- Skill lives at `/workspace/u365-skills/defuddle/SKILL.md`
+- All profiles load from `skills.external_dirs` in config.yaml
+- Pro: single source of truth, one update propagates everywhere
+- Con: requires config change on each profile
+
+**Option C: In-repo (if contributing upstream)**
+- Skill lives at `skills/research/defuddle/SKILL.md` in the hermes-agent repo
+- Ships with every clone
+- Pro: maximum distribution
+- Con: requires upstream PR and merge
+
+### Recommendation
+
+Start with Option A (current — installed in u365-orchestrator). When the skill is validated through real use, promote to Option B (workspace-external) for fleet-wide access. Option C is a future possibility if the Hermes Agent project accepts community skills.
+
+## Version history and maturity
+
+| Version | Date | Notes |
+|---------|------|-------|
+| 0.19.2 | 2026-07-22 | Latest (3 days ago) |
+| 0.19.0 | 2026-06-16 | Recent feature release |
+| 0.18.0 | 2026-04-21 | |
+| 0.17.0 | 2026-04-15 | |
+| 0.16.0 | 2026-04-09 | |
+| 0.15.0 | 2026-03-31 | |
+| 0.14.0 | 2026-03-17 | |
+| 0.9.0 | early 2025 | Fixed XSS advisory GHSA-5mq8-78gm-pjmq |
+| 0.1.0 | 2025-02-27 | Initial release |
+
+44 versions in 5 months = active development, weekly release cadence.
+
+## Security assessment
+
+- **GHSA-5mq8-78gm-pjmq**: XSS via unescaped string interpolation in `_findContentBySchemaText` image tag. Affected versions < 0.9.0. Fixed in 0.9.0. Current version (0.19.2) is not affected.
+- **Dependency surface**: Single runtime dependency (`commander`), a well-established CLI framework. No transitive dependency chain risk.
+- **No network calls beyond the target URL**: Defuddle fetches only the URL you specify (or reads from stdin/file). The `useAsync` option can make third-party API calls for SPA fallback, but this is disabled by default in the CLI.
+- **No credential handling**: Defuddle does not process or store any credentials, tokens, or secrets.

--- a/skills/research/defuddle/scripts/verify.sh
+++ b/skills/research/defuddle/scripts/verify.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Defuddle skill verification script
+# Run after installing the defuddle skill to confirm it works end-to-end.
+# Usage: bash scripts/verify.sh
+
+set -euo pipefail
+
+TEST_URL="https://stephango.com/saw"
+EXPECTED_TITLE="Use the saw, fear the saw"
+PASS=0
+FAIL=0
+
+echo "=== Defuddle Skill Verification ==="
+echo ""
+
+# Check prerequisites
+echo -n "1. Node.js available... "
+if command -v node &>/dev/null; then
+    echo "OK (v$(node --version 2>/dev/null | sed 's/v//'))"
+    PASS=$((PASS+1))
+else
+    echo "FAIL — node not found"
+    FAIL=$((FAIL+1))
+fi
+
+echo -n "2. npx available... "
+if command -v npx &>/dev/null; then
+    echo "OK"
+    PASS=$((PASS+1))
+else
+    echo "FAIL — npx not found"
+    FAIL=$((FAIL+1))
+fi
+
+# Test 1: URL → Markdown
+echo -n "3. URL → Markdown... "
+OUTPUT=$(npx -y defuddle@latest parse "$TEST_URL" --markdown 2>/dev/null)
+if echo "$OUTPUT" | grep -q "Fear the saw"; then
+    echo "OK"
+    PASS=$((PASS+1))
+else
+    echo "FAIL — expected content not found"
+    FAIL=$((FAIL+1))
+fi
+
+# Test 2: URL → JSON with metadata
+echo -n "4. URL → JSON metadata... "
+JSON_OUTPUT=$(npx -y defuddle@latest parse "$TEST_URL" --json 2>/dev/null)
+if echo "$JSON_OUTPUT" | grep -q "$EXPECTED_TITLE"; then
+    echo "OK"
+    PASS=$((PASS+1))
+else
+    echo "FAIL — title not found in JSON"
+    FAIL=$((FAIL+1))
+fi
+
+# Test 3: Frontmatter output
+echo -n "5. Markdown + frontmatter... "
+FM_OUTPUT=$(npx -y defuddle@latest parse "$TEST_URL" --markdown --frontmatter 2>/dev/null)
+if echo "$FM_OUTPUT" | head -1 | grep -q "^---"; then
+    echo "OK"
+    PASS=$((PASS+1))
+else
+    echo "FAIL — no YAML frontmatter"
+    FAIL=$((FAIL+1))
+fi
+
+# Test 4: Pipe from curl
+echo -n "6. Pipe from curl (stdin mode)... "
+PIPE_OUTPUT=$(curl -sL "$TEST_URL" | npx -y defuddle@latest parse --markdown 2>/dev/null)
+if echo "$PIPE_OUTPUT" | grep -q "Fear the saw"; then
+    echo "OK"
+    PASS=$((PASS+1))
+else
+    echo "FAIL — piped content not extracted"
+    FAIL=$((FAIL+1))
+fi
+
+# Test 5: Single property extraction
+echo -n "7. Single property (--property title)... "
+TITLE_OUTPUT=$(npx -y defuddle@latest parse "$TEST_URL" --property title 2>/dev/null | tr -d '[:space:]')
+if echo "$TITLE_OUTPUT" | grep -q "Usethesaw,fearthesaw"; then
+    echo "OK"
+    PASS=$((PASS+1))
+else
+    echo "FAIL — title property mismatch (got: $TITLE_OUTPUT)"
+    FAIL=$((FAIL+1))
+fi
+
+# Test 6: Wikipedia article (heavier content)
+echo -n "8. Wikipedia article extraction... "
+WIKI_OUTPUT=$(npx -y defuddle@latest parse "https://en.wikipedia.org/wiki/Readability" --markdown 2>/dev/null | head -5)
+if echo "$WIKI_OUTPUT" | grep -q "Readability"; then
+    echo "OK"
+    PASS=$((PASS+1))
+else
+    echo "FAIL — Wikipedia content not extracted"
+    FAIL=$((FAIL+1))
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ $FAIL -eq 0 ]; then
+    echo "ALL TESTS PASSED"
+    exit 0
+else
+    echo "SOME TESTS FAILED"
+    exit 1
+fi

--- a/skills/research/defuddle/templates/quick-reference.md
+++ b/skills/research/defuddle/templates/quick-reference.md
@@ -1,0 +1,85 @@
+# Defuddle Quick-Reference Templates
+
+Copy-paste command templates for common agent workflows.
+
+## Basic extraction
+
+```bash
+# URL → Markdown
+npx -y defuddle@latest parse "URL" --markdown
+
+# URL → JSON (full metadata)
+npx -y defuddle@latest parse "URL" --json
+
+# URL → Markdown with YAML frontmatter
+npx -y defuddle@latest parse "URL" --markdown --frontmatter
+
+# URL → single property (title, author, description, domain)
+npx -y defuddle@latest parse "URL" --property title
+```
+
+## Pipe from curl (agent workflow)
+
+```bash
+# Fetch + clean in one pipe
+curl -sL "URL" | npx -y defuddle@latest parse --markdown
+
+# With custom User-Agent (for 403 sites)
+curl -sL -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15" "URL" | npx -y defuddle@latest parse --markdown
+
+# Save to file
+curl -sL "URL" | npx -y defuddle@latest parse --markdown --output /tmp/article.md
+```
+
+## Pipe from access tools
+
+```bash
+# Wayback Machine → Defuddle (returns HTML)
+curl -sL "https://web.archive.org/web/2026/URL" | npx -y defuddle@latest parse --markdown
+```
+
+Note: r.jina.ai returns Markdown, not HTML. Do not pipe r.jina.ai output into Defuddle — it will return empty. When you use r.jina.ai, you already have clean content.
+
+## Save to file
+
+```bash
+# Markdown to file
+npx -y defuddle@latest parse "URL" --markdown --output /tmp/article.md
+
+# JSON to file
+npx -y defuddle@latest parse "URL" --json --output /tmp/metadata.json
+```
+
+## Language preference
+
+```bash
+# French
+npx -y defuddle@latest parse "URL" --markdown --lang fr
+
+# Japanese
+npx -y defuddle@latest parse "URL" --markdown --lang ja
+```
+
+## Debug mode
+
+```bash
+# Show debug info (content selector, removals)
+npx -y defuddle@latest parse "URL" --markdown --debug
+```
+
+## Local HTML file
+
+```bash
+# Parse saved HTML
+npx -y defuddle@latest parse /tmp/page.html --markdown
+
+# Parse saved HTML with frontmatter
+npx -y defuddle@latest parse /tmp/page.html --markdown --frontmatter
+```
+
+## Pinned version (reproducibility)
+
+```bash
+# Pin to specific version
+npx -y defuddle@0.19.2 parse "URL" --markdown
+```


### PR DESCRIPTION
## What this adds

A new `defuddle` skill in `skills/research/defuddle/` — web content extraction via the [Defuddle](https://github.com/kepano/defuddle) CLI by Steph Ango (@kepano, CEO of Obsidian).

**Defuddle** extracts the main content from any web page and returns clean Markdown or HTML with rich metadata (title, author, published date, schema.org data, word count). Created for the Obsidian Web Clipper, designed as a modern replacement for Mozilla Readability.

## Why it fits the research skill stack

The research category has skills for *getting to the HTML* (`walled-web-research`, `headless-web-research`) and *using content* (`obsidian`, `automated-briefings`), but nothing for the **cleanup step** between them. Defuddle fills that gap:

```
ACCESS (get HTML) → CLEANUP (defuddle) → USE (summarize, save)
```

## What's included

| File | Purpose |
|------|---------|
| `SKILL.md` | 10 CLI command patterns, CLI reference, JSON schema, 5 integration recipes, 10 pitfalls, verification checklist |
| `references/integration-patterns.md` | Comparison with existing skills, Defuddle vs Readability, fleet deployment, Node.js library usage |
| `templates/quick-reference.md` | Copy-paste command templates |
| `scripts/verify.sh` | 8-test verification script (all passing) |

## Defuddle overview

- **npm**: `defuddle` v0.19.2, MIT license
- **Dependencies**: 1 (`commander`), 2.6 MB unpacked
- **Runtime**: Node.js v18+ (npx or global install)
- **Stars**: 8.5k, actively maintained (44 releases in 5 months)
- **Security**: One past XSS advisory (GHSA-5mq8-78gm-pjmq), fixed in v0.9.0. Current versions clean.

## Verification

```bash
bash skills/research/defuddle/scripts/verify.sh
# → 8/8 tests passed (Node 22, npx, URL→MD, URL→JSON, frontmatter, pipe, property, Wikipedia)
```

## Skill frontmatter

```yaml
name: defuddle
description: "Use when you need to extract clean article content and metadata from a web page URL or raw HTML..."
metadata:
  hermes:
    tags: [defuddle, content-extraction, readability, markdown, web-scraping, html-cleanup, article-parser]
    related_skills: [walled-web-research, headless-web-research, web-content-extraction, obsidian]
```

Note: `walled-web-research` and `headless-web-research` are user-local skills in our fleet. If merged upstream, the `related_skills` may need adjustment to reference only in-repo skills.