### PR TITLE
fix(terminal): prevent session snapshot injection

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -6,7 +6,11 @@ init_session() failure handling, and the CWD marker contract.
 
 from unittest.mock import MagicMock
 
-from tools.environments.base import BaseEnvironment, _BoundedOutputCollector
+from tools.environments.base import (
+    BaseEnvironment,
+    _BoundedOutputCollector,
+    _export_dump_excluding_session_vars,
+)
 
 
 class _TestableEnv(BaseEnvironment):
@@ -67,7 +71,7 @@ class TestWrapCommand:
         assert "cd -- /tmp" in wrapped or "cd -- '/tmp'" in wrapped
         assert "eval 'echo hello'" in wrapped
         assert "__hermes_ec=$?" in wrapped
-        assert "export -p" in wrapped and "> " in wrapped
+        assert "compgen -e" in wrapped and "export -p" in wrapped and "> " in wrapped
         # cwd travels via the stdout marker only — no temp-file write.
         assert "pwd -P >" not in wrapped
         assert env._cwd_marker in wrapped
@@ -141,7 +145,7 @@ class TestAtomicSnapshotWrite:
         env._snapshot_ready = True
         wrapped = env._wrap_command("echo hi", "/tmp")
         # Env dump goes to a temp file, not directly over the live snapshot.
-        assert "export -p" in wrapped and "> " in wrapped
+        assert "compgen -e" in wrapped and "export -p" in wrapped and "> " in wrapped
         assert ".tmp." in wrapped
         # Then an atomic rename onto the real snapshot path.
         assert "mv -f " in wrapped
@@ -180,14 +184,13 @@ class TestAtomicSnapshotWrite:
         # word-split into two args and break the redirect/mv).
         assert " space/hermes-snap-x.sh.tmp.$BASHPID" not in wrapped
 
-    def test_wrap_command_mv_chained_on_export_success(self):
-        """A failed/partial ``export -p`` must NOT mv a torn temp over a good
-        snapshot.  The mv is chained with ``&&`` on the export, and the temp is
-        removed on failure."""
+    def test_wrap_command_mv_chained_on_dump_success(self):
+        """A failed/partial env dump must not replace a good snapshot."""
         env = _TestableEnv()
         env._snapshot_ready = True
         wrapped = env._wrap_command("echo hi", "/tmp")
-        assert "export -p" in wrapped and "> " in wrapped and "&& mv -f " in wrapped
+        assert "compgen -e" in wrapped and "export -p" in wrapped
+        assert "> " in wrapped and "&& mv -f " in wrapped
         assert "rm -f " in wrapped  # temp cleanup on failure
 
     def test_init_session_bootstrap_also_atomic_and_bashpid(self):
@@ -210,6 +213,7 @@ class TestAtomicSnapshotWrite:
         assert ".tmp." in boot and "mv -f " in boot, boot
         assert "$BASHPID" in boot
         assert ".tmp.$$" not in boot
+        assert "|| { rm -f " in boot and "exit 1; }" in boot
 
     def test_snapshot_writes_use_private_umask_after_user_command(self):
         env = _TestableEnv()
@@ -259,15 +263,23 @@ class TestAtomicSnapshotConcurrencyBehavioral:
         if not shutil.which("bash"):
             import pytest
             pytest.skip("bash required")
+        # macOS /bin/bash 3.2 has no BASHPID. The production strategy and this
+        # stress test require a per-background-subshell identifier; using the
+        # empty expansion would make every writer share one temp path and test
+        # a guarantee the shell cannot provide (pre-existing #38249 limitation).
+        if self._run('test -n "${BASHPID:-}"').returncode != 0:
+            import pytest
+            pytest.skip("Bash lacks BASHPID for unique concurrent temp paths")
         import shlex
         snap = str(tmp_path / "hermes-snap-x.sh")
         _q = shlex.quote
         _snap_tmp = _q(snap + ".tmp.") + "$BASHPID"
         # One writer iteration = the exact atomic sequence _wrap_command emits.
+        dump = _export_dump_excluding_session_vars(_snap_tmp)
         writer = (
             "for i in $(seq 1 80); do "
             "export BIG_$i=$(head -c 600 /dev/zero | tr '\\0' x); "
-            f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_q(snap)}; }} "
+            f"{{ {dump} && mv -f {_snap_tmp} {_q(snap)}; }} "
             f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true; "
             "done"
         )
@@ -280,7 +292,7 @@ class TestAtomicSnapshotConcurrencyBehavioral:
             "case \"$PATH\" in *'declare -x'*|*'export '*) echo CORRUPT;; esac ); "
             "done"
         )
-        self._run(f"export -p > {_q(snap)}")  # seed a valid snapshot
+        self._run(_export_dump_excluding_session_vars(_q(snap)))
         # 4 concurrent writers + 4 readers, repeated.
         w = " & ".join([writer] * 4)
         r = " & ".join([reader] * 4)
@@ -290,9 +302,8 @@ class TestAtomicSnapshotConcurrencyBehavioral:
         final = self._run(f"source {_q(snap)} >/dev/null 2>&1 && echo OK || echo BROKEN")
         assert "OK" in final.stdout, f"final snapshot not sourceable: {final.stdout} {final.stderr}"
 
-    def test_failed_export_does_not_destroy_good_snapshot(self, tmp_path):
-        """If ``export -p`` fails, the ``&&``-chained mv must NOT clobber the
-        existing good snapshot."""
+    def test_failed_dump_does_not_destroy_good_snapshot(self, tmp_path):
+        """If the env dump fails, the chained move preserves the snapshot."""
         import shutil
         if not shutil.which("bash"):
             import pytest
@@ -301,11 +312,12 @@ class TestAtomicSnapshotConcurrencyBehavioral:
         snap = str(tmp_path / "snap.sh")
         _q = shlex.quote
         self._run(f"echo 'export GOOD=1' > {_q(snap)}")  # seed good snapshot
-        # Redirect export into an unwritable dir so the export side fails; mv
+        # Redirect the dump into an unwritable dir so it fails; mv
         # must then NOT run (&&) and not clobber snap.
         bad_tmp = _q("/nonexistent-dir/snap.tmp.") + "$BASHPID"
+        dump = _export_dump_excluding_session_vars(bad_tmp)
         script = (
-            f"{{ export -p > {bad_tmp} && mv -f {bad_tmp} {_q(snap)}; }} "
+            f"{{ {dump} && mv -f {bad_tmp} {_q(snap)}; }} "
             f"2>/dev/null || rm -f {bad_tmp} 2>/dev/null || true"
         )
         self._run(script)

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -16,56 +16,101 @@ CRON_AUTO_DELIVER_) from the snapshot at both dump sites in
 """
 
 import os
-import re
+from fnmatch import fnmatchcase
+import shlex
+import subprocess
 import sys
 
 import pytest
 
 from tools.environments.base import (
-    _SNAPSHOT_EXCLUDED_ENV_REGEX,
+    _SNAPSHOT_EXCLUDED_ENV_PATTERNS,
     _export_dump_excluding_session_vars,
 )
 
 
 # ---------------------------------------------------------------------------
-# Unit: the exclusion regex matches exactly the bridged vars, nothing else.
+# Unit: exclusion is decided from the variable name, never serialized values.
 # ---------------------------------------------------------------------------
 
-def test_regex_matches_bridged_session_vars():
-    rx = re.compile(_SNAPSHOT_EXCLUDED_ENV_REGEX)
-    # Every var the gateway bridges must be excluded.
+def test_name_filter_matches_bridged_session_vars():
     from gateway.session_context import _VAR_MAP
 
     for name in _VAR_MAP:
-        line = f'declare -x {name}="whatever"'
-        assert rx.search(line), f"{name} should be excluded from the snapshot"
+        assert any(
+            fnmatchcase(name, pattern)
+            for pattern in _SNAPSHOT_EXCLUDED_ENV_PATTERNS
+        ), f"{name} should be excluded from the snapshot"
 
 
-def test_regex_preserves_user_env():
-    rx = re.compile(_SNAPSHOT_EXCLUDED_ENV_REGEX)
-    for line in (
-        'declare -x PATH="/usr/bin:/bin"',
-        'declare -x HOME="/home/user"',
-        'declare -x HERMES_HOME="/home/user/.hermes"',  # NOT a session var
-        'declare -x HERMESX="x"',
-        'declare -x MY_HERMES_SESSION_ID="x"',  # prefix must anchor after "declare -x "
+def test_name_filter_preserves_user_env():
+    for name in (
+        "PATH",
+        "HOME",
+        "HERMES_HOME",
+        "HERMESX",
+        "MY_HERMES_SESSION_ID",
     ):
-        assert not rx.search(line), f"{line!r} must be preserved in the snapshot"
+        assert not any(
+            fnmatchcase(name, pattern)
+            for pattern in _SNAPSHOT_EXCLUDED_ENV_PATTERNS
+        ), f"{name!r} must be preserved in the snapshot"
 
 
-def test_export_snippet_shape():
+def test_export_snippet_filters_names_before_export_serialization():
     snippet = _export_dump_excluding_session_vars("/tmp/snap.tmp.$BASHPID")
+    assert "compgen -e" in snippet
+    assert "export -n" in snippet
     assert "export -p" in snippet
-    assert "grep -vE" in snippet
+    assert 'case "${HERMES_SESSION___SNAPSHOT_VAR}"' in snippet
+    assert "grep" not in snippet
     assert "/tmp/snap.tmp.$BASHPID" in snippet
-    # The redirection must be attached to a brace group wrapping the pipeline,
-    # NOT to the grep segment: a redirect on grep expands $BASHPID inside
-    # grep's pipeline subshell (a different PID than the parent shell that
-    # expands the follow-up ``mv`` operand), silently orphaning the dump and
-    # breaking snapshot env persistence entirely.
-    assert snippet.lstrip().startswith("{ ")
-    assert "|| true; }" in snippet
+    assert snippet.lstrip().startswith("{ ( while ")
     assert snippet.rstrip().endswith("> /tmp/snap.tmp.$BASHPID")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="requires POSIX bash")
+def test_multiline_session_metadata_cannot_escape_snapshot_filter(tmp_path):
+    """A bridged value's continuation lines must never enter the snapshot."""
+    snapshot = tmp_path / "snapshot.sh"
+    marker = tmp_path / "injected-command-ran"
+    preserved_marker = tmp_path / "preserved-value-command-ran"
+    env = os.environ.copy()
+    env["HERMES_SESSION_CHAT_NAME"] = (
+        f"matrix room\ntouch {shlex.quote(str(marker))} #"
+    )
+    env["HERMES_SESSION_USER_NAME"] = "alice\nprintf ignored"
+    safe_value = (
+        f"first\n$(touch {shlex.quote(str(preserved_marker))})\nsecond"
+    )
+    env["HERMES_SAFE_MULTILINE"] = safe_value
+    oldpwd_value = str(tmp_path / "previous-directory")
+
+    dump = _export_dump_excluding_session_vars(shlex.quote(str(snapshot)))
+    script = (
+        f"export OLDPWD={shlex.quote(oldpwd_value)}\n"
+        f"{dump}\n"
+        "unset HERMES_SESSION_CHAT_NAME HERMES_SESSION_USER_NAME\n"
+        f"source {shlex.quote(str(snapshot))} >/dev/null 2>&1 || true\n"
+        "printf '%s' \"$HERMES_SAFE_MULTILINE\"\n"
+    )
+    completed = subprocess.run(
+        ["bash", "-c", script],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == safe_value
+    assert not marker.exists(), "snapshot continuation executed as shell code"
+    assert not preserved_marker.exists(), "serialized value ran command substitution"
+    persisted = snapshot.read_text(encoding="utf-8")
+    assert "HERMES_SESSION_CHAT_NAME" not in persisted
+    assert "HERMES_SESSION_USER_NAME" not in persisted
+    assert "HERMES_SAFE_MULTILINE" in persisted
+    assert f'declare -x OLDPWD="{oldpwd_value}"' in persisted
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -396,36 +396,44 @@ def _cwd_marker(session_id: str) -> str:
 # should only carry the user's own shell state (PATH, functions, exports they
 # set), not Hermes' per-turn session identity.
 #
-# Kept in sync with gateway.session_context._VAR_MAP: every bridged name starts
-# with one of these prefixes.
-_SNAPSHOT_EXCLUDED_ENV_REGEX = (
-    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_)"
+# Kept in sync with gateway.session_context._VAR_MAP. Shell ``case`` globs
+# let us decide from the variable NAME before serializing its value. That is a
+# security boundary: ``export -p`` renders embedded newlines as continuation
+# lines, so filtering its text line-by-line can remove the declaration header
+# while leaving attacker-controlled continuation lines executable (#71296).
+_SNAPSHOT_EXCLUDED_ENV_PATTERNS = (
+    "HERMES_SESSION_*",
+    "HERMES_UI_SESSION_ID",
+    "HERMES_CRON_AUTO_DELIVER_*",
 )
 
 
 def _export_dump_excluding_session_vars(tmp_path: str) -> str:
-    """Return a shell snippet that dumps ``export -p`` to *tmp_path* minus the
-    per-session bridged vars (see ``_SNAPSHOT_EXCLUDED_ENV_REGEX``).
+    """Return a shell snippet that dumps exports without session metadata.
 
-    ``export -p`` emits one ``declare -x NAME="value"`` line per exported var.
-    We drop the HERMES_SESSION_* / UI / CRON_AUTO_DELIVER lines so they never
-    persist across sessions in the shared snapshot. ``grep -vE`` returns exit 1
-    when it filters everything, so ``|| true`` keeps the pipeline's success
-    contract intact for the callers that chain on it.
+    Work in a subshell, enumerate exported variable NAMES with ``compgen -e``,
+    and remove the export attribute from bridged session variables before
+    invoking Bash's own ``export -p`` serializer.  The values of excluded
+    variables are therefore never rendered at all, so an embedded newline in a
+    Matrix room/member name cannot leave executable continuation lines in the
+    shared snapshot (#71296).
 
-    The pipeline MUST be wrapped in a brace group with the redirection applied
-    to the group, not to the last pipeline segment. *tmp_path* typically embeds
-    ``$BASHPID`` for concurrency-safe temp names; a redirection attached
-    directly to ``grep`` is expanded inside grep's own pipeline subshell, where
-    ``$BASHPID`` resolves to the grep subshell's PID — while the caller's
-    follow-up ``mv $tmp`` expands in the parent shell to a DIFFERENT PID. The
-    dump then lands in an orphaned temp file and the snapshot silently never
-    updates (all exported-env persistence breaks). The brace-group redirect is
-    expanded in the current shell, keeping both expansions consistent.
+    Using ``export -n`` rather than rebuilding declarations one name at a time
+    preserves Bash's exact snapshot semantics for special exported variables
+    such as ``OLDPWD``.  It also works for readonly variables because only the
+    export attribute changes.  The mutation is confined to the subshell.
+
+    The redirection remains attached to the outer brace group. *tmp_path*
+    usually embeds ``$BASHPID``; expanding that path in the current shell keeps
+    it identical to the caller's subsequent ``mv`` operand.
     """
+    patterns = "|".join(_SNAPSHOT_EXCLUDED_ENV_PATTERNS)
+    loop_var = "HERMES_SESSION___SNAPSHOT_VAR"
     return (
-        f"{{ export -p | grep -vE '{_SNAPSHOT_EXCLUDED_ENV_REGEX}' || true; }} "
-        f"> {tmp_path}"
+        f"{{ ( while IFS= read -r {loop_var}; do "
+        f'case "${{{loop_var}}}" in {patterns}) '
+        f'export -n "${{{loop_var}}}" || exit 1 ;; esac; '
+        f"done < <(compgen -e); export -p ); }} > {tmp_path}"
     )
 
 
@@ -545,7 +553,8 @@ class BaseEnvironment(ABC):
         _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
         bootstrap = (
             f"umask 077\n"
-            f"{_export_dump_excluding_session_vars(_snap_tmp)}\n"
+            f"{_export_dump_excluding_session_vars(_snap_tmp)} "
+            f"|| {{ rm -f {_snap_tmp}; exit 1; }}\n"
             # Dump function definitions, filtering out private (``_``-prefixed)
             # helpers — mainly bash-completion internals (``_git``, ``_make``…)
             # — by NAME, not by line.  A naive ``declare -f | grep -vE '^_[^_]'``
@@ -686,14 +695,11 @@ class BaseEnvironment(ABC):
         parts.append("umask 077")
 
         # Re-dump env vars to snapshot (atomic replacement to avoid races).
-        # Chain mv on the export succeeding so a failed/partial dump never
-        # replaces a good snapshot; drop the temp on failure so it isn't
+        # Chain mv on a successful name-filtered dump so a failed/partial write
+        # never replaces a good snapshot; drop the temp on failure so it isn't
         # orphaned (cleaned up wholesale in LocalEnvironment.cleanup too).
-        # NOTE: the redirection must be attached to a brace group, not to the
-        # grep pipeline segment — ``_snap_tmp`` embeds ``$BASHPID``, and a
-        # redirect on grep is expanded inside grep's pipeline subshell (a
-        # different PID than the parent shell that expands the ``mv`` operand),
-        # silently orphaning the dump. See _export_dump_excluding_session_vars.
+        # The helper owns the outer redirection so ``$BASHPID`` is expanded in
+        # the same shell as the following ``mv`` operand.
         if self._snapshot_ready:
             parts.append(
                 f"{{ {_export_dump_excluding_session_vars(_snap_tmp)} "


### PR DESCRIPTION
## Summary

- Filter Hermes per-session environment variables by **variable name before value serialization**.
- Preserve Bash's existing `export -p` snapshot format by removing only the export attribute inside an isolated subshell, then serializing the remaining environment normally.
- Fail the initial snapshot bootstrap closed if the filtered dump cannot be produced.
- Add a real-shell regression proving a multiline Matrix room/member name cannot escape into sourced shell code.

Fixes #71296.

## Root cause

The shared terminal snapshot previously used a line filter:

```bash
export -p | grep -vE '^declare -x (HERMES_SESSION_|...)'
```

Bash renders an exported value containing a newline across multiple physical lines. The filter removed the `declare -x HERMES_SESSION_CHAT_NAME="...` header but left attacker-controlled continuation lines in the snapshot. Every later terminal command sources that snapshot, so the continuation became shell code.

## Fix

The dump now:

1. Enumerates exported variable names with `compgen -e`.
2. Matches Hermes session metadata using shell `case` patterns.
3. Removes the export attribute with `export -n` inside a subshell.
4. Calls Bash's own `export -p` serializer only after excluded values are unreachable.

`export -n` preserves values and mutates only the isolated subshell. Retaining `export -p` also preserves special Bash export behavior such as `OLDPWD`, unlike rebuilding declarations one variable at a time.

The outer redirection and existing temp-file/atomic-move scheme remain intact, so the dump path still expands in the same shell as the following `mv`.

## Regression coverage

The exploit regression supplies:

- a multiline `HERMES_SESSION_CHAT_NAME` containing `touch <marker>`;
- a multiline `HERMES_SESSION_USER_NAME`;
- an ordinary multiline user export containing literal `$(touch <second-marker>)`.

It verifies that neither marker is created, session metadata is absent from the snapshot, the ordinary multiline value round-trips exactly, and Bash special exports remain present. The test was red against the pre-fix implementation because the first marker was created.

## Verification

- Canonical per-file runner over 23 environment, backend, snapshot, and terminal suites: **374 passed, 0 failed**.
- Full repository Ruff enforcement: passed.
- `py_compile`: passed.
- `git diff --check`: passed.
- Windows-footgun scan: **809 files, no findings**.
- Ty diff: no new real diagnostics; the only apparent delta is the same pre-existing checker panic with worktree-specific absolute paths.
