### PR TITLE
test(cli): restore real coverage for the bpo-9338 subparser-routing fallback

### DIFF
--- a/tests/hermes_cli/test_subparser_routing_fallback.py
+++ b/tests/hermes_cli/test_subparser_routing_fallback.py
@@ -1,65 +1,156 @@
 """Tests for the defensive subparser routing workaround (bpo-9338).
 
-The main() function in hermes_cli/main.py sets subparsers.required=True
-when argv contains a known subcommand name.  This forces deterministic
-routing on Python versions where argparse fails to match subcommand tokens
-when the parent parser has nargs='?' optional arguments (--continue).
+``hermes_cli.main.main()`` sets ``subparsers.required=True`` when argv contains
+a known subcommand name.  This forces deterministic routing on Python versions
+where argparse fails to match subcommand tokens because the parent parser has
+an ``nargs='?'`` optional argument (``--continue``).  The symptom without the
+workaround is ``unrecognized arguments: model`` for a plain ``hermes model``.
 
-If the subcommand token is consumed as a flag value (e.g. `hermes -c model`
-to resume a session named 'model'), the required=True parse raises
-SystemExit and the code falls back to the default required=False behaviour.
+If the subcommand token was actually consumed as a flag value (e.g.
+``hermes -c model`` to resume a session *named* "model"), the ``required=True``
+parse raises ``SystemExit`` and the code falls back to ``required=False``.
+
+These tests drive the **real** ``main()`` parser rather than a hand-built
+replica, so they stay honest if the production argv handling changes.  Command
+handlers are patched to capture the resolved namespace instead of executing.
 """
-import argparse
-import io
-import sys
+
+import pytest
+
+import hermes_cli.main as main_module
 
 
+@pytest.fixture
+def route(monkeypatch):
+    """Drive the real ``main()`` and return which handler got which namespace.
 
-def _build_parser():
-    """Build a minimal replica of the hermes top-level parser."""
-    parser = argparse.ArgumentParser(prog="hermes")
-    parser.add_argument("--version", "-V", action="store_true")
-    parser.add_argument("--resume", "-r", metavar="SESSION", default=None)
-    parser.add_argument(
-        "--continue", "-c",
-        dest="continue_last",
-        nargs="?",
-        const=True,
-        default=None,
-        metavar="SESSION_NAME",
-    )
-    parser.add_argument("--worktree", "-w", action="store_true", default=False)
-    parser.add_argument("--skills", "-s", action="append", default=None)
-    parser.add_argument("--yolo", action="store_true", default=False)
-    parser.add_argument("--pass-session-id", action="store_true", default=False)
+    Returns a callable taking an argv list (without the ``hermes`` prog name)
+    and returning ``(handler_name, argparse.Namespace)``.
+    """
+    captured: dict = {}
 
-    subparsers = parser.add_subparsers(dest="command", help="Command to run")
-    chat_p = subparsers.add_parser("chat")
-    chat_p.add_argument("-q", "--query", default=None)
-    subparsers.add_parser("model")
-    subparsers.add_parser("gateway")
-    subparsers.add_parser("setup")
-    return parser, subparsers
+    def _record(name):
+        def _handler(args):
+            captured["handler"] = name
+            captured["args"] = args
+
+        return _handler
+
+    # Skip plugin discovery / shell-hook registration: irrelevant to routing
+    # and expensive (plus it can prompt for hook consent).
+    monkeypatch.setattr(main_module, "_prepare_agent_startup", lambda args: None)
+    monkeypatch.setattr(main_module, "cmd_chat", _record("chat"))
+    monkeypatch.setattr(main_module, "cmd_model", _record("model"))
+
+    def _route(argv):
+        captured.clear()
+        monkeypatch.setattr("sys.argv", ["hermes"] + list(argv))
+        main_module.main()
+        assert "handler" in captured, f"no handler ran for argv={argv!r}"
+        return captured["handler"], captured["args"]
+
+    return _route
 
 
-def _safe_parse(parser, subparsers, argv):
-    """Replica of the defensive parsing logic from main()."""
-    known_cmds = set(subparsers.choices.keys()) if hasattr(subparsers, "choices") else set()
-    has_cmd_token = any(t in known_cmds for t in argv if not t.startswith("-"))
+class TestSubparserRoutingFallback:
+    """Verify the bpo-9338 defensive routing works for all key cases."""
 
-    if has_cmd_token:
-        subparsers.required = True
-        saved_stderr = sys.stderr
-        try:
-            sys.stderr = io.StringIO()
-            args = parser.parse_args(argv)
-            sys.stderr = saved_stderr
-            return args
-        except SystemExit:
-            sys.stderr = saved_stderr
-            subparsers.required = False
-            return parser.parse_args(argv)
-    else:
-        subparsers.required = False
-        return parser.parse_args(argv)
+    def test_direct_subcommand(self, route):
+        handler, args = route(["model"])
+        assert handler == "model"
+        assert args.command == "model"
 
+    def test_subcommand_with_flags(self, route):
+        handler, args = route(["--yolo", "model"])
+        assert handler == "model"
+        assert args.command == "model"
+        assert args.yolo is True
+
+    def test_bare_hermes_defaults_to_chat(self, route):
+        handler, args = route([])
+        assert handler == "chat"
+        assert args.command is None
+
+    def test_flags_only_defaults_to_chat(self, route):
+        handler, args = route(["--yolo"])
+        assert handler == "chat"
+        assert args.command is None
+        assert args.yolo is True
+
+    def test_continue_flag_alone(self, route):
+        handler, args = route(["-c"])
+        assert handler == "chat"
+        assert args.continue_last is True
+
+    def test_continue_with_session_name(self, route):
+        handler, args = route(["-c", "myproject"])
+        assert handler == "chat"
+        assert args.continue_last == "myproject"
+
+    def test_continue_with_subcommand_name_as_session(self, route):
+        """Session named 'model' is a session name, not a subcommand.
+
+        This is the fallback branch: the ``required=True`` parse raises
+        SystemExit because 'model' was eaten by ``-c``, so routing retries
+        with ``required=False``.
+        """
+        handler, args = route(["-c", "model"])
+        assert handler == "chat"
+        assert args.continue_last == "model"
+
+    def test_continue_with_session_then_subcommand(self, route):
+        handler, args = route(["-c", "myproject", "model"])
+        assert handler == "model"
+        assert args.command == "model"
+        assert args.continue_last == "myproject"
+
+    def test_chat_with_query(self, route):
+        handler, args = route(["chat", "-q", "hello"])
+        assert handler == "chat"
+        assert args.command == "chat"
+        assert args.query == "hello"
+
+    def test_resume_flag(self, route):
+        handler, args = route(["-r", "abc123"])
+        assert handler == "chat"
+        assert args.resume == "abc123"
+
+    def test_resume_with_subcommand(self, route):
+        handler, args = route(["-r", "abc123", "chat"])
+        assert handler == "chat"
+        assert args.command == "chat"
+        assert args.resume == "abc123"
+
+    def test_skills_flag_with_subcommand(self, route):
+        handler, args = route(["-s", "myskill", "model"])
+        assert handler == "model"
+        assert args.command == "model"
+        assert args.skills == ["myskill"]
+
+    def test_all_flags_with_subcommand(self, route):
+        handler, args = route(["--yolo", "-w", "-s", "myskill", "model"])
+        assert handler == "model"
+        assert args.command == "model"
+        assert args.yolo is True
+        assert args.worktree is True
+        assert args.skills == ["myskill"]
+
+
+class TestHelpNotDuplicated:
+    """``--help`` must print usage exactly once (#10230).
+
+    The ``required=True`` attempt can exit 0 for help/version.  Re-parsing in
+    that case would print the same help text a second time, so the fallback
+    re-raises instead of retrying.
+    """
+
+    @pytest.mark.parametrize("argv", [["--help"], ["chat", "--help"]])
+    def test_help_prints_usage_once(self, argv, monkeypatch, capsys):
+        monkeypatch.setattr(main_module, "_prepare_agent_startup", lambda args: None)
+        monkeypatch.setattr("sys.argv", ["hermes"] + argv)
+
+        with pytest.raises(SystemExit) as exc:
+            main_module.main()
+
+        assert exc.value.code == 0
+        assert capsys.readouterr().out.count("usage: ") == 1


### PR DESCRIPTION
# test(cli): restore real coverage for bpo-9338 subparser routing fallback

## Problem

`tests/hermes_cli/test_subparser_routing_fallback.py` currently collects **zero
tests**. It is a silent tombstone: pytest reports "no tests ran" rather than
failing, so the argv-routing logic the file was written to protect has been
completely unguarded.

```
$ python -m pytest tests/hermes_cli/test_subparser_routing_fallback.py -o 'addopts=' -q
no tests ran in 0.01s
```

The file still contains a module docstring and two helper functions, so it
looks like coverage in a directory listing — but it has no `def test` and no
`class Test` anywhere in it.

## How it got that way

| commit | effect |
|---|---|
| `029938fbe` | added the file with a `TestSubparserRoutingFallback` class covering 13 argv shapes |
| `2367c6ffd` | "remove 169 change-detector tests" — deleted the test class, left the docstring and the `_build_parser()` / `_safe_parse()` helpers behind |
| `66827f894` | ruff F401 autofix pruned the now-unused `import argparse` |

The `2367c6ffd` removal was **directionally right**. The original tests built a
hand-written *replica* of the top-level parser inside the test file and asserted
against the replica. That is a textbook change-detector: it passes even if the
routing block in `hermes_cli/main.py` is deleted outright, because the replica is
what is under test. What was missing was the follow-up — the file was left as a
zero-coverage shell rather than either fixed or removed.

The fallback it guards is still very much live in `hermes_cli/main.py`
(the "Defensive subparser routing (bpo-9338 workaround)" block), so deleting the
file would leave a real code path untested.

## Fix

Restore the coverage against the **real** parser instead of a replica. The tests
drive `hermes_cli.main.main()` with a patched `sys.argv` and capture which
command handler receives which namespace, exercising the production argv path
end-to-end:

`_coalesce_session_name_args` → the `required=True` attempt → the `SystemExit`
fallback → the `--resume` / `--continue` shortcut → handler dispatch.

No replica. Delete the routing block and the tests go red.

## Coverage restored — 0 → 15 tests

**13 argv shapes carried over from the original:** direct subcommand, subcommand
with flags, bare invocation, flags-only, `-c` alone, `-c <session>`, `-c model`
(the fallback case — a session *named* like a subcommand),
`-c <session> <subcommand>`, `chat -q`, `-r`, `-r <id> chat`,
`-s <skill> <subcommand>`, and all-flags-plus-subcommand.

**2 new:** `--help` and `chat --help` each print `usage: ` exactly once,
guarding the #10230 fix where the exit-code-0 re-raise prevents the fallback
parse from printing help a second time.

## Verification (mutation testing against current `main`)

| mutation | result |
|---|---|
| remove the `SystemExit` fallback branch | `test_continue_with_subcommand_name_as_session` **FAILS** ✅ |
| remove the `if exc.code == 0: raise` guard | `test_help_prints_usage_once[chat --help]` **FAILS** ✅ |

Honest caveat: forcing `subparsers.required = False` unconditionally does *not*
fail the suite on Python 3.11, because bpo-9338 only manifests on older
interpreters — the workaround is a deliberate no-op on 3.11+. The two branches
above are the ones a 3.11 CI run can actually guard, and they now are.

```
$ python -m pytest tests/hermes_cli/test_subparser_routing_fallback.py -o 'addopts=' -q
15 passed in 1.73s
```

## Scope

Test-only change. No production code touched.
