### PR TITLE
test(gateway): fail loudly when platform-plugin discovery finds nothing

### DIFF
--- a/tests/gateway/test_plugin_platform_interface.py
+++ b/tests/gateway/test_plugin_platform_interface.py
@@ -6,6 +6,7 @@ enumeration — and verifies each one implements the required contract.
 """
 
 import importlib
+import os
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -14,7 +15,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).parent.parent.resolve()
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 PLATFORMS_DIR = PROJECT_ROOT / "plugins" / "platforms"
 
 
@@ -33,6 +34,32 @@ def _discover_platform_plugins() -> list[str]:
 _PLATFORM_NAMES = _discover_platform_plugins()
 
 
+def test_platform_discovery_is_not_empty():
+    """Discovery must find the bundled platform plugins.
+
+    Every test below is parametrised over ``_PLATFORM_NAMES``. If discovery
+    returns an empty list, pytest silently reports "skipped" for each one and
+    the whole module asserts nothing — a green run that guards no regression.
+    This test makes that failure mode loud.
+
+    Empty is never legitimate when running against a source checkout:
+    ``plugins/platforms/`` is tracked in git and ships in the wheel
+    (``plugins.*`` is in ``[tool.setuptools.packages.find] include``). The
+    only honest reason to find nothing is that the tests are running somewhere
+    without the repo tree at all, which is gated below rather than blanket
+    -skipped, so a real discovery break still fails.
+    """
+    if not (PROJECT_ROOT / "pyproject.toml").is_file():
+        pytest.skip(f"not a source checkout: {PROJECT_ROOT} has no pyproject.toml")
+
+    assert PLATFORMS_DIR.is_dir(), f"platform plugin dir missing: {PLATFORMS_DIR}"
+    assert _PLATFORM_NAMES, (
+        f"no platform plugins discovered under {PLATFORMS_DIR} — the "
+        f"interface-compliance tests in this module would all silently skip. "
+        f"Directory contains: {sorted(p.name for p in PLATFORMS_DIR.iterdir())}"
+    )
+
+
 @pytest.fixture
 def clean_registry():
     """Yield with a clean platform registry, restoring state afterwards."""
@@ -48,12 +75,17 @@ def clean_registry():
 class _MockPluginContext:
     """Minimal mock of hermes_cli.plugins.PluginContext.
 
-    Only implements register_platform so we can exercise the plugin's
-    register() entrypoint without importing the real plugin system.
+    Implements the registration surface a platform plugin's ``register()``
+    entrypoint may touch, so we can exercise it without importing the real
+    plugin system. Platform plugins legitimately register hooks and CLI
+    subcommands alongside their platform (e.g. photon, raft), so those are
+    recorded as no-ops rather than raising AttributeError.
     """
 
     def __init__(self):
         self.registered_names: list[str] = []
+        self.registered_hooks: list[str] = []
+        self.registered_cli_commands: list[str] = []
 
     def register_platform(
         self,
@@ -75,6 +107,19 @@ class _MockPluginContext:
         )
         platform_registry.register(entry)
         self.registered_names.append(name)
+
+    def register_hook(self, hook_name: str, callback: Any) -> None:
+        self.registered_hooks.append(hook_name)
+
+    def register_cli_command(
+        self,
+        name: str,
+        help: str = "",
+        setup_fn: Any = None,
+        handler_fn: Any = None,
+        description: str = "",
+    ) -> None:
+        self.registered_cli_commands.append(name)
 
 
 def _import_platform_module(name: str) -> ModuleType:
@@ -139,7 +184,9 @@ def test_platform_entry_has_required_fields(platform_name: str, clean_registry):
 
 
 @pytest.mark.parametrize("platform_name", _PLATFORM_NAMES)
-def test_adapter_factory_produces_valid_adapter(platform_name: str, clean_registry):
+def test_adapter_factory_produces_valid_adapter(
+    platform_name: str, clean_registry, monkeypatch
+):
     """The adapter factory must return an object with the base interface."""
     module = _import_platform_module(platform_name)
     ctx = _MockPluginContext()
@@ -148,6 +195,14 @@ def test_adapter_factory_produces_valid_adapter(platform_name: str, clean_regist
     from gateway.platform_registry import platform_registry
     entry = platform_registry.get(platform_name)
     assert entry is not None
+
+    # Some adapters read their declared credentials at construction time (the
+    # sms adapter indexes os.environ[...] directly). Satisfy the plugin's own
+    # ``required_env`` contract with dummy values so construction is testable
+    # without real credentials — rather than skipping, which would silently
+    # drop this check for every credentialed platform.
+    for key in getattr(entry, "required_env", None) or []:
+        monkeypatch.setenv(key, os.environ.get(key) or f"test-{key.lower()}")
 
     # Build a minimal synthetic config that shouldn't crash __init__
     mock_config = MagicMock()


### PR DESCRIPTION
# test(gateway): fix platform discovery so interface tests actually run

## Problem

`tests/gateway/test_plugin_platform_interface.py` reports **7 skipped, 0 run**:

```
$ python -m pytest tests/gateway/test_plugin_platform_interface.py -o 'addopts=' -q
sssssss                                                            [100%]
7 skipped in 0.11s
```

Every test in the module is parametrised over the platforms found by
`_discover_platform_plugins()`. When that returns an empty list, pytest emits an
empty parametrisation and reports "skipped" for each test. The module is green
and asserts nothing — the plugin platform interface contract has been unguarded.

## Root cause

A plain off-by-one in the repo-root calculation:

```python
PROJECT_ROOT = Path(__file__).parent.parent.resolve()
```

For `tests/gateway/test_plugin_platform_interface.py` that resolves to
`<repo>/tests`, **not** `<repo>`. So discovery looks in
`tests/plugins/platforms/` instead of `plugins/platforms/`.

That path *does* exist — it holds the photon test mirror — which is why the
failure was silent rather than a missing-directory error. It contains no package
directories, so discovery returns `[]`.

Every other repo-root reference under `tests/gateway/` already uses
`parents[2]` — 24 files, including the sibling `_plugin_adapter_loader.py`
which computes the very same `plugins/platforms` path correctly. This file was
the lone outlier.

## Changes

1. **`PROJECT_ROOT` → `Path(__file__).resolve().parents[2]`**, matching the
   convention used everywhere else in this directory.

2. **New `test_platform_discovery_is_not_empty`** so this failure mode can never
   be silent again.

   Is empty discovery ever legitimate? Not in a source checkout:
   `plugins/platforms/` is tracked in git (20 platform packages) and ships in the
   wheel — `plugins.*` is in `[tool.setuptools.packages.find] include`. So rather
   than a blanket skip, the gate is **precise**: it skips only when
   `pyproject.toml` is absent from the computed root (i.e. not a source tree at
   all). A genuine discovery break still fails loudly.

3. **`_MockPluginContext` gained `register_hook` / `register_cli_command`.**
   Real `PluginContext` has both, and platform plugins legitimately call them
   from `register()` (photon, raft). The incomplete mock raised `AttributeError`
   as soon as those plugins were actually reached.

4. **`test_adapter_factory_produces_valid_adapter` seeds declared
   `required_env`** with dummy values via `monkeypatch`. The sms adapter reads
   `os.environ["TWILIO_ACCOUNT_SID"]` directly in `__init__`, so it cannot be
   constructed without them. Seeding — rather than skipping — keeps all 20
   platforms covered instead of dropping the check for every credentialed one.

Items 3 and 4 are pre-existing latent bugs in this file that were masked by the
broken discovery; they only surface once the tests actually run.

## Result

| | before | after |
|---|---|---|
| platforms discovered | 0 | 20 |
| tests run | **0** | **133 passed** |
| skipped | 7 (silent, whole module) | 8 (legitimate "no validate_config provided" optional-field skips) |

## Verification

**The assertion fires when discovery is empty** — repointing `PLATFORMS_DIR` at
an empty directory reproduces the original condition:

```
E  AssertionError: no platform plugins discovered under .../tests/_empty_platforms_probe
   — the interface-compliance tests in this module would all silently skip.
   Directory contains: []
FAILED tests/gateway/test_plugin_platform_interface.py::test_platform_discovery_is_not_empty
1 failed, 7 skipped
```

Previously that exact state was a silent `7 skipped` pass.

**The non-checkout gate is narrow** — removing the `pyproject.toml` marker:

```
SKIPPED [1] not a source checkout: /... has no pyproject.toml
```

## Scope

Test-only change. No production code touched.

Note: the sms adapter's use of bare `os.environ[...]` for declared credentials
(vs. `os.getenv` everywhere else) is a genuine construction-time crash risk, but
fixing production behaviour is out of scope for this test-hygiene change and is
left for a separate PR.
