### PR TITLE
feat: harden subscription credential orchestration

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4300,6 +4300,30 @@ def _try_configured_fallback_chain(
         label = f"fallback_chain[{i}]({fb_provider})"
 
         try:
+            from agent.provider_route_policy import (
+                Capability,
+                RouteRole,
+                SubscriptionRoutePolicy,
+            )
+
+            decision = SubscriptionRoutePolicy(load_config()).evaluate(
+                entry,
+                role=RouteRole.BUILDER,
+                capability=Capability.WRITE,
+            )
+            if not decision.allowed:
+                logger.info(
+                    "Auxiliary %s: skipping %s blocked by orchestrator route policy (%s)",
+                    task,
+                    label,
+                    decision.reason,
+                )
+                tried.append(f"{label} (orchestrator policy)")
+                continue
+        except Exception:
+            pass
+
+        try:
             fb_client, resolved_model = _resolve_fallback_entry(entry)
         except Exception:
             fb_client, resolved_model = None, None

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1627,6 +1627,30 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     if not fb_provider or not fb_model:
         return agent._try_activate_fallback(reason)  # skip invalid, try next
 
+    try:
+        from agent.provider_route_policy import (
+            Capability,
+            RouteRole,
+            SubscriptionRoutePolicy,
+        )
+        from hermes_cli.config import load_config_readonly
+
+        route_decision = SubscriptionRoutePolicy(load_config_readonly()).evaluate(
+            fb,
+            role=RouteRole.BUILDER,
+            capability=Capability.WRITE,
+        )
+        if not route_decision.allowed:
+            logger.warning(
+                "Fallback skip: %s/%s blocked by orchestrator route policy (%s)",
+                fb_provider,
+                fb_model,
+                route_decision.reason,
+            )
+            return agent._try_activate_fallback(reason)
+    except Exception:
+        pass
+
     local_skip_reason = _fallback_entry_unavailable_without_network(agent, fb)
     if local_skip_reason:
         unavailable.add(fb_key)
@@ -1699,6 +1723,52 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_provider)
             unavailable.add(fb_key)
             return agent._try_activate_fallback(reason)  # try next in chain
+
+        # Config fallback entries normally carry only provider+model. Verify
+        # the exact resolved pooled credential before assigning this turn so
+        # Claude subscription OAuth is allowed but Anthropic API/Console keys
+        # remain forbidden under subscription-only policy.
+        try:
+            from agent.credential_pool import load_pool
+            from agent.provider_route_policy import (
+                Capability,
+                RouteRole,
+                SubscriptionRoutePolicy,
+            )
+            from hermes_cli.config import load_config_readonly
+
+            resolved_route = dict(fb)
+            resolved_pool = load_pool(fb_provider)
+            resolved_entry = resolved_pool.current() or resolved_pool.peek()
+            if resolved_entry is not None:
+                resolved_route["auth_type"] = resolved_entry.auth_type
+                resolved_route["source"] = resolved_entry.source
+            runtime_decision = SubscriptionRoutePolicy(load_config_readonly()).evaluate(
+                resolved_route,
+                role=RouteRole.BUILDER,
+                capability=Capability.WRITE,
+            )
+            if (
+                not runtime_decision.allowed
+                or runtime_decision.reason == "runtime_subscription_check_required"
+            ):
+                unavailable.add(fb_key)
+                logger.warning(
+                    "Fallback skip: resolved %s/%s credential failed subscription policy (%s)",
+                    fb_provider,
+                    fb_model,
+                    runtime_decision.reason,
+                )
+                return agent._try_activate_fallback(reason)
+        except Exception as policy_exc:
+            logger.warning(
+                "Fallback skip: could not verify resolved credential provenance for %s/%s: %s",
+                fb_provider,
+                fb_model,
+                policy_exc,
+            )
+            unavailable.add(fb_key)
+            return agent._try_activate_fallback(reason)
         try:
             from hermes_cli.model_normalize import normalize_model_for_provider
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1738,20 +1738,28 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             from hermes_cli.config import load_config_readonly
 
             resolved_route = dict(fb)
-            resolved_pool = load_pool(fb_provider)
-            resolved_entry = (
-                resolved_pool.current()
-                or resolved_pool.peek()
-                or resolved_pool.select()
-            )
-            if resolved_entry is not None:
-                resolved_route["auth_type"] = resolved_entry.auth_type
-                resolved_route["source"] = resolved_entry.source
-            runtime_decision = SubscriptionRoutePolicy(load_config_readonly()).evaluate(
-                resolved_route,
-                role=RouteRole.BUILDER,
-                capability=Capability.WRITE,
-            )
+            runtime_policy = SubscriptionRoutePolicy(load_config_readonly())
+            if not runtime_policy.enabled:
+                runtime_decision = runtime_policy.evaluate(
+                    resolved_route,
+                    role=RouteRole.BUILDER,
+                    capability=Capability.WRITE,
+                )
+            else:
+                resolved_pool = load_pool(fb_provider)
+                resolved_entry = (
+                    resolved_pool.current()
+                    or resolved_pool.peek()
+                    or resolved_pool.select()
+                )
+                if resolved_entry is not None:
+                    resolved_route["auth_type"] = resolved_entry.auth_type
+                    resolved_route["source"] = resolved_entry.source
+                runtime_decision = runtime_policy.evaluate(
+                    resolved_route,
+                    role=RouteRole.BUILDER,
+                    capability=Capability.WRITE,
+                )
             if (
                 not runtime_decision.allowed
                 or runtime_decision.reason == "runtime_subscription_check_required"

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1739,7 +1739,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
             resolved_route = dict(fb)
             resolved_pool = load_pool(fb_provider)
-            resolved_entry = resolved_pool.current() or resolved_pool.peek()
+            resolved_entry = (
+                resolved_pool.current()
+                or resolved_pool.peek()
+                or resolved_pool.select()
+            )
             if resolved_entry is not None:
                 resolved_route["auth_type"] = resolved_entry.auth_type
                 resolved_route["source"] = resolved_entry.source

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2119,6 +2119,11 @@ def compress_context(
                         migrate_goal_to_session(old_session_id, agent.session_id, reason="compression")
                     except Exception as _goal_err:
                         logger.debug("Could not migrate goal on compression: %s", _goal_err)
+                    try:
+                        from hermes_cli.orchestrator_state import migrate_orchestrator_state_to_session
+                        migrate_orchestrator_state_to_session(old_session_id, agent.session_id, reason="compression")
+                    except Exception as _orch_err:
+                        logger.debug("Could not migrate orchestrator state on compression: %s", _orch_err)
                     # Auto-number the title for the continuation session
                     if old_title:
                         try:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1612,95 +1612,112 @@ class CredentialPool:
     def select_health_checked(self, probe=None) -> Optional[PooledCredential]:
         """Health-check every available credential, then select one healthy row.
 
-        This is the assignment-time gate for autonomous workers. The probe may
+        Network probes deliberately run outside ``self._lock`` so one slow
+        account cannot stall unrelated pool readers or selectors. The probe may
         return ``True``/200, ``False``/429, an HTTP status integer, or a dict
         containing ``status_code`` plus optional ``reason``/``message``/
-        ``reset_at``. A 401 always reloads persisted/source state and is pinged
-        exactly once more before it is parked; a 429 is parked until its reset.
-        Indeterminate transport failures are skipped for this assignment but
-        are not persisted as credential failures.
+        ``reset_at``. A 401 reloads persisted/source state and is pinged exactly
+        once more before it is parked; a 429 is parked until its reset.
         """
         with self._lock:
-            candidates = self._available_entries(clear_expired=True, refresh=True)
-            healthy: List[PooledCredential] = []
+            # Do not force-refresh under the lock: assignment probes classify
+            # stale auth explicitly and drive the bounded disk/source reload.
+            candidates = list(self._available_entries(clear_expired=True, refresh=False))
 
-            def _run_ping(candidate: PooledCredential):
-                if probe is not None:
-                    return probe(candidate)
-                if self.provider == "openai-codex":
-                    return auth_mod.probe_codex_credential_health(
-                        candidate.access_token,
-                        base_url=candidate.base_url,
-                    )
-                # Non-Codex providers do not yet expose a safe no-inference
-                # health endpoint here. Their proactive expiry/refresh checks
-                # above are the authoritative local preflight.
-                return True
+        def _run_ping(candidate: PooledCredential):
+            if probe is not None:
+                return probe(candidate)
+            if self.provider == "openai-codex":
+                return auth_mod.probe_codex_credential_health(
+                    candidate.access_token,
+                    base_url=candidate.base_url,
+                )
+            # Non-Codex providers do not yet expose a safe no-inference health
+            # endpoint here. Their local expiry/source sync remains authoritative.
+            return True
 
-            def _decode(result: Any) -> tuple[Optional[int], Dict[str, Any]]:
-                if result is True:
-                    return 200, {}
-                if result is False:
-                    return 429, {"reason": "usage_limit_reached"}
-                if isinstance(result, int):
-                    return result, {}
-                if isinstance(result, dict):
-                    raw_status = result.get("status_code", result.get("status"))
-                    try:
-                        status = int(raw_status) if raw_status is not None else None
-                    except (TypeError, ValueError):
-                        status = None
-                    return status, result
-                return None, {}
+        def _decode(result: Any) -> tuple[Optional[int], Dict[str, Any]]:
+            if result is True:
+                return 200, {}
+            if result is False:
+                return 429, {"reason": "usage_limit_reached"}
+            if isinstance(result, int):
+                return result, {}
+            if isinstance(result, dict):
+                raw_status = result.get("status_code", result.get("status"))
+                try:
+                    status = int(raw_status) if raw_status is not None else None
+                except (TypeError, ValueError):
+                    status = None
+                return status, result
+            return None, {}
 
-            for original in candidates:
-                entry = original
-                status, context = _decode(_run_ping(entry))
-                if status == 401:
-                    # Flush the in-memory view and reload both persisted pool
-                    # state and the singleton/source token before one retry.
-                    persisted = next(
-                        (
-                            payload
-                            for payload in read_credential_pool(self.provider)
-                            if isinstance(payload, dict) and payload.get("id") == entry.id
-                        ),
-                        None,
+        healthy_ids: set[str] = set()
+        for original in candidates:
+            entry = original
+            status, context = _decode(_run_ping(entry))
+            if status == 401:
+                # Flush the in-memory view and reload both persisted pool state
+                # and the singleton/source token before one retry. Disk I/O and
+                # the retrying network ping are not performed under the pool lock.
+                persisted = next(
+                    (
+                        payload
+                        for payload in read_credential_pool(self.provider)
+                        if isinstance(payload, dict) and payload.get("id") == entry.id
+                    ),
+                    None,
+                )
+                with self._lock:
+                    live_entry = next(
+                        (candidate for candidate in self._entries if candidate.id == entry.id),
+                        entry,
                     )
                     if isinstance(persisted, dict):
                         disk_entry = PooledCredential.from_dict(self.provider, persisted)
                         if (
-                            disk_entry.access_token != entry.access_token
-                            or disk_entry.refresh_token != entry.refresh_token
+                            disk_entry.access_token != live_entry.access_token
+                            or disk_entry.refresh_token != live_entry.refresh_token
                         ):
-                            self._replace_entry(entry, disk_entry)
-                            entry = disk_entry
+                            self._replace_entry(live_entry, disk_entry)
+                            live_entry = disk_entry
                     if self.provider == "openai-codex":
-                        entry = self._sync_codex_entry_from_auth_store(entry)
+                        live_entry = self._sync_codex_entry_from_auth_store(live_entry)
                     elif self.provider == "anthropic":
-                        entry = self._sync_anthropic_entry_from_credentials_file(entry)
-                    status, context = _decode(_run_ping(entry))
+                        live_entry = self._sync_anthropic_entry_from_credentials_file(live_entry)
+                    entry = live_entry
+                status, context = _decode(_run_ping(entry))
 
-                if status is not None and 200 <= status < 300:
-                    healthy.append(entry)
-                    continue
-                if status in {401, 429}:
-                    self._mark_exhausted(entry, status, context)
-                    continue
-                logger.info(
-                    "credential pool: preflight for %s/%s was indeterminate; skipping this assignment",
-                    self.provider,
-                    entry.id,
-                )
+            if status is not None and 200 <= status < 300:
+                healthy_ids.add(entry.id)
+                continue
+            if status in {401, 429}:
+                with self._lock:
+                    live_entry = next(
+                        (candidate for candidate in self._entries if candidate.id == entry.id),
+                        None,
+                    )
+                    if live_entry is not None:
+                        self._mark_exhausted(live_entry, status, context)
+                continue
+            logger.info(
+                "credential pool: preflight for %s/%s was indeterminate; skipping this assignment",
+                self.provider,
+                entry.id,
+            )
 
-            if not healthy:
+        with self._lock:
+            available = [
+                entry
+                for entry in self._available_entries(clear_expired=True, refresh=False)
+                if entry.id in healthy_ids
+            ]
+            if not available:
                 self._current_id = None
                 return None
-            # Selection is intentionally deterministic after the all-entry
-            # health sweep. Existing priority order still governs fill-first;
-            # failed rows have already been removed from this assignment.
-            chosen = min(healthy, key=lambda item: item.priority)
+            chosen = min(available, key=lambda item: item.priority)
             self._current_id = chosen.id
+            self._unmatched_rotation_streak = 0
             return chosen
 
     def _available_entries(self, *, clear_expired: bool = False, refresh: bool = False) -> List[PooledCredential]:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -161,7 +161,7 @@ def _normalize_pool_auth_type(provider: str, token: Any, auth_type: Any) -> str:
     return str(auth_type or AUTH_TYPE_API_KEY)
 
 
-@dataclass
+@dataclass(repr=False)
 class PooledCredential:
     provider: str
     id: str
@@ -194,6 +194,15 @@ class PooledCredential:
             self.provider,
             self.access_token,
             self.auth_type,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            "PooledCredential("
+            f"provider={self.provider!r}, id={self.id!r}, label={self.label!r}, "
+            f"auth_type={self.auth_type!r}, priority={self.priority!r}, "
+            f"source={self.source!r}, last_status={self.last_status!r}, "
+            f"base_url={self.base_url!r})"
         )
 
     def __getattr__(self, name: str):
@@ -1599,6 +1608,100 @@ class CredentialPool:
                 # failure trip the #70401 bound early next time.
                 self._unmatched_rotation_streak = 0
             return entry
+
+    def select_health_checked(self, probe=None) -> Optional[PooledCredential]:
+        """Health-check every available credential, then select one healthy row.
+
+        This is the assignment-time gate for autonomous workers. The probe may
+        return ``True``/200, ``False``/429, an HTTP status integer, or a dict
+        containing ``status_code`` plus optional ``reason``/``message``/
+        ``reset_at``. A 401 always reloads persisted/source state and is pinged
+        exactly once more before it is parked; a 429 is parked until its reset.
+        Indeterminate transport failures are skipped for this assignment but
+        are not persisted as credential failures.
+        """
+        with self._lock:
+            candidates = self._available_entries(clear_expired=True, refresh=True)
+            healthy: List[PooledCredential] = []
+
+            def _run_ping(candidate: PooledCredential):
+                if probe is not None:
+                    return probe(candidate)
+                if self.provider == "openai-codex":
+                    return auth_mod.probe_codex_credential_health(
+                        candidate.access_token,
+                        base_url=candidate.base_url,
+                    )
+                # Non-Codex providers do not yet expose a safe no-inference
+                # health endpoint here. Their proactive expiry/refresh checks
+                # above are the authoritative local preflight.
+                return True
+
+            def _decode(result: Any) -> tuple[Optional[int], Dict[str, Any]]:
+                if result is True:
+                    return 200, {}
+                if result is False:
+                    return 429, {"reason": "usage_limit_reached"}
+                if isinstance(result, int):
+                    return result, {}
+                if isinstance(result, dict):
+                    raw_status = result.get("status_code", result.get("status"))
+                    try:
+                        status = int(raw_status) if raw_status is not None else None
+                    except (TypeError, ValueError):
+                        status = None
+                    return status, result
+                return None, {}
+
+            for original in candidates:
+                entry = original
+                status, context = _decode(_run_ping(entry))
+                if status == 401:
+                    # Flush the in-memory view and reload both persisted pool
+                    # state and the singleton/source token before one retry.
+                    persisted = next(
+                        (
+                            payload
+                            for payload in read_credential_pool(self.provider)
+                            if isinstance(payload, dict) and payload.get("id") == entry.id
+                        ),
+                        None,
+                    )
+                    if isinstance(persisted, dict):
+                        disk_entry = PooledCredential.from_dict(self.provider, persisted)
+                        if (
+                            disk_entry.access_token != entry.access_token
+                            or disk_entry.refresh_token != entry.refresh_token
+                        ):
+                            self._replace_entry(entry, disk_entry)
+                            entry = disk_entry
+                    if self.provider == "openai-codex":
+                        entry = self._sync_codex_entry_from_auth_store(entry)
+                    elif self.provider == "anthropic":
+                        entry = self._sync_anthropic_entry_from_credentials_file(entry)
+                    status, context = _decode(_run_ping(entry))
+
+                if status is not None and 200 <= status < 300:
+                    healthy.append(entry)
+                    continue
+                if status in {401, 429}:
+                    self._mark_exhausted(entry, status, context)
+                    continue
+                logger.info(
+                    "credential pool: preflight for %s/%s was indeterminate; skipping this assignment",
+                    self.provider,
+                    entry.id,
+                )
+
+            if not healthy:
+                self._current_id = None
+                return None
+            # Selection is intentionally deterministic after the all-entry
+            # health sweep. Existing priority order still governs fill-first;
+            # failed rows have already been removed from this assignment.
+            chosen = min(healthy, key=lambda item: item.priority)
+            self._current_id = chosen.id
+            return chosen
 
     def _available_entries(self, *, clear_expired: bool = False, refresh: bool = False) -> List[PooledCredential]:
         """Return entries not currently in exhaustion cooldown.

--- a/agent/orchestrator_recovery.py
+++ b/agent/orchestrator_recovery.py
@@ -1,0 +1,127 @@
+"""Deterministic recovery decisions for autonomous orchestration."""
+
+from __future__ import annotations
+
+import enum
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from agent.provider_route_policy import Capability, RouteRole, SubscriptionRoutePolicy
+
+
+class FailureClass(enum.Enum):
+    SAFETY_REFUSAL = "safety_refusal"
+    TEMPORARY_RATE_LIMIT = "temporary_rate_limit"
+    BROWSER_OAUTH_TIMEOUT = "browser_oauth_timeout"
+    EXPIRED_CREDENTIAL = "expired_credential"
+    REVOKED_CREDENTIAL = "revoked_credential"
+    NO_REFRESH_CREDENTIAL = "no_refresh_credential"
+    UNAVAILABLE_MODEL = "unavailable_model"
+    PROVIDER_OUTAGE = "provider_outage"
+    WORKER_CRASH = "worker_crash"
+    LOST_WORKER_SESSION = "lost_worker_session"
+    CONTEXT_EXHAUSTION = "context_exhaustion"
+    FAILED_VERIFICATION = "failed_verification"
+    PARTIAL_CHANGES = "partial_changes"
+    DIRTY_WORKTREE = "dirty_worktree"
+    INTERRUPTED_REPORT = "interrupted_report"
+    ACTIVE_JOB_QUEUE = "active_job_queue"
+
+
+@dataclass(frozen=True)
+class RecoveryContext:
+    failure: FailureClass
+    current_route: dict[str, Any] | None = None
+    alternatives: list[dict[str, Any]] = field(default_factory=list)
+    role: RouteRole = RouteRole.BUILDER
+    capability: Capability = Capability.WRITE
+    total_attempts: int = 0
+    route_attempts: dict[str, int] = field(default_factory=dict)
+    cooldown_until: float | None = None
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RecoveryDecision:
+    failure: str
+    action: str
+    next_route: dict[str, Any] | None = None
+    wait_until: float | None = None
+    checkpoint_required: bool = False
+    escalation: str | None = None
+    blocked_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "failure": self.failure,
+            "action": self.action,
+            "next_route": self.next_route,
+            "wait_until": self.wait_until,
+            "checkpoint_required": self.checkpoint_required,
+            "escalation": self.escalation,
+            "blocked_reason": self.blocked_reason,
+        }
+
+
+def _route_key(route: dict[str, Any] | None) -> str:
+    if not route:
+        return ""
+    return f"{str(route.get('provider') or '').strip().lower()}:{str(route.get('model') or '').strip().lower()}"
+
+
+def _limits(config: dict[str, Any]) -> tuple[int, int]:
+    orch = config.get("orchestrator") if isinstance(config, dict) else {}
+    if not isinstance(orch, dict):
+        orch = {}
+    return int(orch.get("max_total_attempts") or 8), int(orch.get("max_route_attempts") or 2)
+
+
+def _approved_alternative(ctx: RecoveryContext) -> dict[str, Any] | None:
+    policy = SubscriptionRoutePolicy(ctx.config)
+    _, max_route = _limits(ctx.config)
+    current_key = _route_key(ctx.current_route)
+    for route in ctx.alternatives:
+        key = _route_key(route)
+        if key == current_key and ctx.route_attempts.get(key, 0) >= max_route:
+            continue
+        if policy.evaluate(route, role=ctx.role, capability=ctx.capability).allowed:
+            return dict(route)
+    return None
+
+
+def decide_recovery(ctx: RecoveryContext) -> RecoveryDecision:
+    max_total, _ = _limits(ctx.config)
+    failure = ctx.failure.value
+
+    if ctx.total_attempts >= max_total:
+        return RecoveryDecision(failure, "escalate", escalation="no_approved_route", blocked_reason="attempt_limit_exceeded")
+
+    if ctx.failure == FailureClass.SAFETY_REFUSAL:
+        return RecoveryDecision(failure, "escalate", escalation="strategic_business_info", blocked_reason="safety_refusal")
+    if ctx.failure in {FailureClass.BROWSER_OAUTH_TIMEOUT, FailureClass.REVOKED_CREDENTIAL, FailureClass.NO_REFRESH_CREDENTIAL}:
+        return RecoveryDecision(failure, "escalate", escalation="fresh_interactive_auth", blocked_reason=failure)
+    if ctx.failure == FailureClass.ACTIVE_JOB_QUEUE:
+        return RecoveryDecision(failure, "queue", blocked_reason="active_job_in_progress")
+    if ctx.failure == FailureClass.DIRTY_WORKTREE:
+        return RecoveryDecision(failure, "checkpoint_then_escalate", checkpoint_required=True, escalation="destructive_rollback", blocked_reason="dirty_worktree")
+    if ctx.failure == FailureClass.CONTEXT_EXHAUSTION:
+        return RecoveryDecision(failure, "checkpoint_then_rotate_context", checkpoint_required=True)
+    if ctx.failure in {FailureClass.WORKER_CRASH, FailureClass.LOST_WORKER_SESSION, FailureClass.INTERRUPTED_REPORT, FailureClass.PARTIAL_CHANGES}:
+        return RecoveryDecision(failure, "resume_from_checkpoint", checkpoint_required=True)
+    if ctx.failure == FailureClass.EXPIRED_CREDENTIAL:
+        return RecoveryDecision(failure, "refresh_saved_credential")
+    if ctx.failure == FailureClass.TEMPORARY_RATE_LIMIT:
+        if ctx.cooldown_until and ctx.cooldown_until > time.time():
+            return RecoveryDecision(failure, "wait", wait_until=ctx.cooldown_until)
+
+    route = _approved_alternative(ctx)
+    if route is not None:
+        return RecoveryDecision(failure, "switch_route", next_route=route)
+
+    if ctx.failure == FailureClass.FAILED_VERIFICATION:
+        return RecoveryDecision(failure, "retry_changed_strategy", checkpoint_required=True)
+    if ctx.failure in {FailureClass.UNAVAILABLE_MODEL, FailureClass.PROVIDER_OUTAGE, FailureClass.TEMPORARY_RATE_LIMIT}:
+        return RecoveryDecision(failure, "escalate", escalation="no_approved_route", blocked_reason=failure)
+
+    return RecoveryDecision(failure, "escalate", escalation="no_approved_route", blocked_reason=failure)

--- a/agent/provider_route_policy.py
+++ b/agent/provider_route_policy.py
@@ -1,0 +1,293 @@
+"""Subscription-only route policy for autonomous orchestration.
+
+This module is deliberately small and local-only. It classifies configured
+routes by credential provenance and metadata; it never performs inference or
+vendor protocol probes.
+"""
+
+from __future__ import annotations
+
+import enum
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+
+class RouteRole(enum.Enum):
+    BUILDER = "builder"
+    ATTACKER = "attacker"
+    DIAGNOSTICIAN = "diagnostician"
+
+
+class Capability(enum.Enum):
+    READ = "read"
+    TEST = "test"
+    WRITE = "write"
+    REPAIR = "repair"
+
+
+class RouteAvailability(enum.Enum):
+    HEALTHY_REUSABLE = "healthy_reusable"
+    TEMPORARY_RATE_LIMIT = "temporary_rate_limit"
+    EXPIRED_ACCESS_REFRESH_AVAILABLE = "expired_access_refresh_available"
+    EXPIRED_ACCESS_MISSING_REFRESH = "expired_access_missing_refresh"
+    REVOKED_DEAD = "revoked_dead"
+    BROWSER_OAUTH_TIMEOUT = "browser_oauth_timeout"
+    UNAVAILABLE_CLI_MODEL = "unavailable_cli_model"
+    PROVIDER_OUTAGE_UNKNOWN_TRANSPORT = "provider_outage_unknown_transport"
+
+
+_WRITE_CAPABILITIES = {Capability.WRITE, Capability.REPAIR}
+_FORBIDDEN_PROVIDERS = {
+    "openai",
+    "openrouter",
+    "vertex",
+    "google-vertex",
+    "anthropic-api",
+    "fable",
+}
+_CODEX_BUILDER_SOURCES = {"manual:device_code", "device_code", "chatgpt_oauth", "chatgpt", "codex_oauth", "oauth"}
+_CLAUDE_SUBSCRIPTION_SOURCES = {
+    "claude_code",
+    "hermes_pkce",
+    "anthropic_oauth",
+    "oauth",
+    "env:anthropic_token",
+    "env:claude_code_oauth_token",
+}
+_ATTACKER_SOURCES = {"claude_code", "hermes_pkce", "anthropic_oauth", "oauth", "env:anthropic_token", "env:claude_code_oauth_token"}
+_DIAGNOSTICIAN_PROVIDERS = {"gemini-code-assist", "google-code-assist", "gemini-cli"}
+_DIAGNOSTICIAN_SOURCES = {"google_code_assist", "gemini_cli", "oauth"}
+
+
+def orchestrator_subscription_only(config: dict[str, Any] | None) -> bool:
+    orch = (config or {}).get("orchestrator")
+    return (
+        isinstance(orch, dict)
+        and bool(orch.get("enabled"))
+        and str(orch.get("billing_policy") or "").strip().lower() == "subscription_only"
+    )
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _has_refresh(entry: dict[str, Any]) -> bool:
+    return bool(str(entry.get("refresh_token") or "").strip()) or bool(entry.get("has_refresh_token"))
+
+
+def _parse_expiry(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)):
+        raw = float(value)
+        return raw / 1000.0 if raw > 10_000_000_000 else raw
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return float(text)
+        except ValueError:
+            pass
+        try:
+            return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    allowed: bool
+    role: str
+    capability: str
+    provider: str
+    model: str
+    reason: str
+
+
+@dataclass(frozen=True, repr=False)
+class RouteHealth:
+    availability: RouteAvailability
+    provider: str = ""
+    model: str = ""
+    safe_reason: str = ""
+    reset_at: float | None = None
+    fresh_login_required: bool = False
+    reusable_saved_credential: bool = False
+
+    def __repr__(self) -> str:
+        return (
+            "RouteHealth("
+            f"availability={self.availability.value!r}, provider={self.provider!r}, "
+            f"model={self.model!r}, safe_reason={self.safe_reason!r}, reset_at={self.reset_at!r}, "
+            f"fresh_login_required={self.fresh_login_required!r}, "
+            f"reusable_saved_credential={self.reusable_saved_credential!r})"
+        )
+
+    def to_summary(self) -> dict[str, Any]:
+        return {
+            "availability": self.availability.value,
+            "provider": self.provider,
+            "model": self.model,
+            "safe_reason": self.safe_reason,
+            "reset_at": self.reset_at,
+            "fresh_login_required": self.fresh_login_required,
+            "reusable_saved_credential": self.reusable_saved_credential,
+        }
+
+
+def classify_route_health(entry: dict[str, Any], *, now: float | None = None) -> RouteHealth:
+    now = time.time() if now is None else float(now)
+    status = _normalize(entry.get("status") or entry.get("last_status"))
+    provider = str(entry.get("provider") or "").strip()
+    model = str(entry.get("model") or "").strip()
+    reset_at = _parse_expiry(entry.get("last_error_reset_at") or entry.get("reset_at"))
+
+    if status in {"dead", "revoked", "token_revoked", "token_invalidated"}:
+        return RouteHealth(RouteAvailability.REVOKED_DEAD, provider, model, "credential revoked or dead", fresh_login_required=True)
+    if status in {"browser_timeout", "browser_oauth_timeout"}:
+        return RouteHealth(RouteAvailability.BROWSER_OAUTH_TIMEOUT, provider, model, "browser OAuth timed out", fresh_login_required=True)
+    if status in {"unavailable_cli", "unavailable_model", "missing_cli", "missing_model"}:
+        return RouteHealth(RouteAvailability.UNAVAILABLE_CLI_MODEL, provider, model, "local CLI or model unavailable")
+    if status in {"unknown_transport", "provider_outage", "transport_unknown"}:
+        return RouteHealth(RouteAvailability.PROVIDER_OUTAGE_UNKNOWN_TRANSPORT, provider, model, "provider outage or unknown transport")
+    if status == "exhausted" and int(entry.get("last_error_code") or 0) == 429:
+        return RouteHealth(RouteAvailability.TEMPORARY_RATE_LIMIT, provider, model, "temporary rate limit", reset_at=reset_at)
+
+    expiry = _parse_expiry(entry.get("expires_at") or entry.get("expires_at_ms"))
+    if expiry is not None and expiry <= now:
+        if _has_refresh(entry):
+            return RouteHealth(
+                RouteAvailability.EXPIRED_ACCESS_REFRESH_AVAILABLE,
+                provider,
+                model,
+                "access token expired; refresh token present",
+                reusable_saved_credential=True,
+            )
+        return RouteHealth(
+            RouteAvailability.EXPIRED_ACCESS_MISSING_REFRESH,
+            provider,
+            model,
+            "access token expired without refresh token",
+            fresh_login_required=True,
+        )
+
+    return RouteHealth(
+        RouteAvailability.HEALTHY_REUSABLE,
+        provider,
+        model,
+        "saved credential reusable",
+        reusable_saved_credential=True,
+    )
+
+
+class SubscriptionRoutePolicy:
+    def __init__(self, config: dict[str, Any] | None = None):
+        self.config = config or {}
+        self.enabled = orchestrator_subscription_only(self.config)
+
+    def evaluate(
+        self,
+        route: dict[str, Any],
+        *,
+        role: RouteRole | str = RouteRole.BUILDER,
+        capability: Capability | str = Capability.WRITE,
+        builder_provider: str | None = None,
+    ) -> RouteDecision:
+        role = role if isinstance(role, RouteRole) else RouteRole(str(role))
+        capability = capability if isinstance(capability, Capability) else Capability(str(capability))
+        provider = _normalize(route.get("provider"))
+        model = str(route.get("model") or "").strip()
+        auth_type = _normalize(route.get("auth_type") or route.get("credential_type"))
+        source = _normalize(route.get("source") or route.get("credential_source") or route.get("provenance"))
+
+        if not self.enabled:
+            return RouteDecision(True, role.value, capability.value, provider, model, "orchestrator_disabled")
+
+        if provider in _FORBIDDEN_PROVIDERS or provider.startswith("vertex"):
+            return RouteDecision(False, role.value, capability.value, provider, model, "forbidden_paid_provider")
+        if (
+            auth_type == "api_key"
+            or route.get("api_key")
+            or route.get("key_env")
+            or route.get("api_key_env")
+        ):
+            return RouteDecision(False, role.value, capability.value, provider, model, "api_key_forbidden")
+
+        if role == RouteRole.BUILDER:
+            # Config-only fallback entries generally have no credential
+            # provenance. Keep approved provider names in the chain, then
+            # require the runtime caller to re-evaluate the selected pooled
+            # credential before assigning the turn.
+            if provider == "openai-codex":
+                allowed = not source or source in _CODEX_BUILDER_SOURCES
+                reason = (
+                    "approved_builder_subscription"
+                    if source
+                    else "runtime_subscription_check_required"
+                )
+                return RouteDecision(
+                    allowed,
+                    role.value,
+                    capability.value,
+                    provider,
+                    model,
+                    reason if allowed else "builder_requires_chatgpt_codex_oauth",
+                )
+            if provider == "anthropic":
+                allowed = (not source and not auth_type) or (
+                    auth_type == "oauth" and source in _CLAUDE_SUBSCRIPTION_SOURCES
+                )
+                reason = (
+                    "approved_claude_fallback_builder"
+                    if source
+                    else "runtime_subscription_check_required"
+                )
+                return RouteDecision(
+                    allowed,
+                    role.value,
+                    capability.value,
+                    provider,
+                    model,
+                    reason if allowed else "builder_requires_claude_subscription_oauth",
+                )
+            return RouteDecision(False, role.value, capability.value, provider, model, "builder_requires_approved_subscription_oauth")
+
+        if role == RouteRole.ATTACKER:
+            if capability in _WRITE_CAPABILITIES:
+                return RouteDecision(False, role.value, capability.value, provider, model, "attacker_read_only")
+            if builder_provider and provider == _normalize(builder_provider):
+                return RouteDecision(False, role.value, capability.value, provider, model, "self_attack_forbidden")
+            allowed = provider == "anthropic" and source in _ATTACKER_SOURCES
+            return RouteDecision(allowed, role.value, capability.value, provider, model, "approved_anthropic_subscription" if allowed else "attacker_requires_claude_subscription_oauth")
+
+        if role == RouteRole.DIAGNOSTICIAN:
+            if capability in _WRITE_CAPABILITIES:
+                return RouteDecision(False, role.value, capability.value, provider, model, "diagnostician_read_only")
+            allowed = provider in _DIAGNOSTICIAN_PROVIDERS and source in _DIAGNOSTICIAN_SOURCES
+            return RouteDecision(allowed, role.value, capability.value, provider, model, "approved_google_code_assist_oauth" if allowed else "diagnostician_requires_code_assist_oauth")
+
+        return RouteDecision(False, role.value, capability.value, provider, model, "unknown_role")
+
+    def filter_routes(
+        self,
+        routes: Iterable[dict[str, Any]],
+        *,
+        role: RouteRole | str = RouteRole.BUILDER,
+        capability: Capability | str = Capability.WRITE,
+    ) -> list[dict[str, Any]]:
+        if not self.enabled:
+            return [dict(r) for r in routes]
+        filtered: list[dict[str, Any]] = []
+        for route in routes:
+            if self.evaluate(route, role=role, capability=capability).allowed:
+                filtered.append(dict(route))
+        return filtered
+
+
+def sanitized_startup_summary(routes: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [classify_route_health(route).to_summary() for route in routes]

--- a/docs/autonomous-orchestrator.md
+++ b/docs/autonomous-orchestrator.md
@@ -1,0 +1,81 @@
+# Autonomous Subscription Orchestrator
+
+Hermes can enable an autonomous orchestration foundation with:
+
+```yaml
+orchestrator:
+  enabled: true
+  billing_policy: subscription_only
+  max_total_attempts: 8
+  max_route_attempts: 2
+```
+
+When disabled, provider fallback behavior is unchanged. When enabled with
+`subscription_only`, Hermes filters fallback routes by credential provenance,
+not provider name alone.
+
+## Approved Routes
+
+- Builder: `openai-codex` with saved ChatGPT/device-code OAuth provenance.
+- Fallback builder: `anthropic` only with verified Claude subscription OAuth
+  provenance. If Claude builds, its output remains `UNATTACKED — DO NOT MERGE`
+  until an independent Codex reviewer is available.
+- Attacker: `anthropic` with Claude Code or Hermes PKCE subscription OAuth
+  provenance. This role is read/test/report only.
+- Diagnostician: Google Code Assist/Gemini CLI saved OAuth provenance. This
+  role is read-only and may be represented as an external saved-subscription
+  route when no native provider exists.
+
+OpenAI API keys, Anthropic API/Console keys, Vertex, OpenRouter, Fable, Gemini
+API key/AI Studio routes, and unknown paid fallbacks are refused in
+subscription-only mode.
+
+## Health Meanings
+
+Startup health is local and no-spend. It reads only saved status metadata,
+expiry timestamps, refresh-token presence flags, and local availability hints.
+It does not make inference calls.
+
+- `healthy_reusable`: saved credential metadata is reusable.
+- `temporary_rate_limit`: route is parked until reset/cooldown.
+- `expired_access_refresh_available`: refresh can be attempted without browser login.
+- `expired_access_missing_refresh`: fresh interactive auth is required.
+- `revoked_dead`: credential is dead/revoked and requires fresh auth.
+- `browser_oauth_timeout`: prior browser login timed out and requires user action.
+- `unavailable_cli_model`: required local CLI/model is not available.
+- `provider_outage_unknown_transport`: transport/provider state is unknown.
+
+Reusable saved credentials suppress browser-login requests. Fresh interactive
+login is escalated only for missing, revoked, no-refresh, or browser-timeout
+states. State, reprs, logs, and summaries must never contain access or refresh
+token values.
+
+## Goal Queue And Recovery
+
+The standing `/goal` state now has a durable FIFO goal queue. If a goal is
+active, waiting, or paused, setting another goal appends it instead of replacing
+the current one. Exactly one queued goal is promoted after the current goal
+reaches a terminal authorized state such as done or cleared. This queue is
+separate from `/queue`, which remains a prompt queue.
+
+Recovery decisions are deterministic data: switch route, wait, refresh saved
+credential, checkpoint and rotate context, resume from checkpoint, queue, or
+escalate. Retry loops are bounded by total and per-route attempt limits.
+Escalations are limited to strategic/business information, new spending, fresh
+interactive auth, no approved route, or destructive rollback approval.
+
+## Checkpoints
+
+The orchestrator checkpoint stores sanitized handoff data in `state_meta`:
+goal text, plan/evidence paths, git dirty path/status summary, genuine
+process/session/worker IDs when known, next action, and verification status or
+digest. It does not store file contents or command output. Compression session
+rotation migrates the active goal, queued goals, and orchestrator checkpoint to
+the continuation session.
+
+## Limitations
+
+Gemini Code Assist health is represented as local saved-route metadata only.
+Hermes does not guess unsupported Google protocols or call private vendor APIs.
+Credentials are not permanent; refresh or re-auth may still be required when
+providers expire, revoke, or change subscription access.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4124,6 +4124,87 @@ def _probe_codex_quota_restored(
     return result
 
 
+_codex_credential_health_cache: Dict[str, Tuple[float, Optional[Dict[str, Any]]]] = {}
+
+
+def probe_codex_credential_health(
+    access_token: Any,
+    *,
+    base_url: Optional[str] = None,
+    min_interval_seconds: float = CODEX_QUOTA_PROBE_MIN_INTERVAL_SECONDS,
+) -> Optional[Dict[str, Any]]:
+    """Assignment-time Codex auth/quota ping with explicit 401/429 classes.
+
+    Unlike ``_probe_codex_quota_restored`` this preserves the HTTP status so
+    the credential pool can reload disk/source state on 401 and park quota on
+    429 without mislabelling either as missing credentials. Results are cached
+    per access token to avoid turning frequent worker assignment into proactive
+    usage monitoring.
+    """
+    token = str(access_token or "").strip()
+    if not token or not _decode_jwt_claims(token):
+        return None
+    cache_key = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+    now = time.monotonic()
+    with _codex_quota_probe_lock:
+        cached = _codex_credential_health_cache.get(cache_key)
+        if cached is not None and (now - cached[0]) < min_interval_seconds:
+            return dict(cached[1]) if isinstance(cached[1], dict) else None
+        _codex_credential_health_cache[cache_key] = (now, None)
+
+    result: Optional[Dict[str, Any]] = None
+    try:
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "User-Agent": "codex-cli",
+        }
+        claims = _decode_jwt_claims(token)
+        auth_claim = claims.get("https://api.openai.com/auth")
+        account_id = (
+            auth_claim.get("chatgpt_account_id")
+            if isinstance(auth_claim, dict)
+            else None
+        )
+        if isinstance(account_id, str) and account_id.strip():
+            headers["ChatGPT-Account-Id"] = account_id.strip()
+        with httpx.Client(timeout=10.0) as client:
+            response = client.get(_codex_usage_probe_url(base_url), headers=headers)
+        if response.status_code == 200:
+            payload = response.json() or {}
+            rate_limit = payload.get("rate_limit") or {}
+            windows = [rate_limit.get(key) or {} for key in ("primary_window", "secondary_window")]
+            used_values = [
+                float(window["used_percent"])
+                for window in windows
+                if isinstance(window.get("used_percent"), (int, float))
+            ]
+            if used_values and max(used_values) >= 100.0:
+                reset_candidates = [
+                    window.get("reset_at") or window.get("resets_at")
+                    for window in windows
+                    if window.get("reset_at") or window.get("resets_at")
+                ]
+                result = {
+                    "status_code": 429,
+                    "reason": "usage_limit_reached",
+                    "reset_at": reset_candidates[0] if reset_candidates else None,
+                }
+            elif used_values:
+                result = {"status_code": 200}
+        elif response.status_code == 401:
+            result = {"status_code": 401, "reason": "invalid_token"}
+        elif response.status_code == 429:
+            result = {"status_code": 429, "reason": "usage_limit_reached"}
+    except Exception:
+        logger.debug("Codex credential health probe failed", exc_info=True)
+        result = None
+
+    with _codex_quota_probe_lock:
+        _codex_credential_health_cache[cache_key] = (now, result)
+    return dict(result) if isinstance(result, dict) else None
+
+
 def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
     """Clear rate-limit cooldowns on persisted openai-codex pool entries.
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4143,14 +4143,13 @@ def probe_codex_credential_health(
     """
     token = str(access_token or "").strip()
     if not token or not _decode_jwt_claims(token):
-        return None
+        return {"status_code": 401, "reason": "invalid_token"}
     cache_key = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
     now = time.monotonic()
     with _codex_quota_probe_lock:
         cached = _codex_credential_health_cache.get(cache_key)
         if cached is not None and (now - cached[0]) < min_interval_seconds:
             return dict(cached[1]) if isinstance(cached[1], dict) else None
-        _codex_credential_health_cache[cache_key] = (now, None)
 
     result: Optional[Dict[str, Any]] = None
     try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -934,6 +934,12 @@ DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
     "fallback_providers": [],
+    "orchestrator": {
+        "enabled": False,
+        "billing_policy": "default",
+        "max_total_attempts": 8,
+        "max_route_attempts": 2,
+    },
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -89,4 +89,17 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
             seen.add(identity)
             chain.append(entry)
 
-    return chain
+    try:
+        from agent.provider_route_policy import (
+            Capability,
+            RouteRole,
+            SubscriptionRoutePolicy,
+        )
+
+        return SubscriptionRoutePolicy(config).filter_routes(
+            chain,
+            role=RouteRole.BUILDER,
+            capability=Capability.WRITE,
+        )
+    except Exception:
+        return chain

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -491,6 +491,31 @@ class GoalState:
         return "\n".join(f"- {i}. {text}" for i, text in enumerate(self.subgoals, start=1))
 
 
+@dataclass
+class QueuedGoal:
+    goal: str
+    max_turns: int = DEFAULT_MAX_TURNS
+    created_at: float = 0.0
+    contract: GoalContract = field(default_factory=GoalContract)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "goal": self.goal,
+            "max_turns": self.max_turns,
+            "created_at": self.created_at,
+            "contract": asdict(self.contract),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "QueuedGoal":
+        return cls(
+            goal=str(data.get("goal") or ""),
+            max_turns=int(data.get("max_turns", DEFAULT_MAX_TURNS) or DEFAULT_MAX_TURNS),
+            created_at=float(data.get("created_at", 0.0) or 0.0),
+            contract=GoalContract.from_dict(data.get("contract")),
+        )
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Persistence (SessionDB state_meta)
 # ──────────────────────────────────────────────────────────────────────
@@ -498,6 +523,10 @@ class GoalState:
 
 def _meta_key(session_id: str) -> str:
     return f"goal:{session_id}"
+
+
+def _queue_meta_key(session_id: str) -> str:
+    return f"goal_queue:{session_id}"
 
 
 _DB_CACHE: Dict[str, Any] = {}
@@ -576,6 +605,66 @@ def clear_goal(session_id: str) -> None:
     save_goal(session_id, state)
 
 
+def load_goal_queue(session_id: str) -> List[QueuedGoal]:
+    if not session_id:
+        return []
+    db = _get_session_db()
+    if db is None:
+        return []
+    try:
+        raw = db.get_meta(_queue_meta_key(session_id))
+    except Exception as exc:
+        logger.debug("GoalManager: get queue meta failed: %s", exc)
+        return []
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+    except Exception as exc:
+        logger.warning("GoalManager: could not parse stored goal queue for %s: %s", session_id, exc)
+        return []
+    if not isinstance(data, list):
+        return []
+    queue = [QueuedGoal.from_dict(item) for item in data if isinstance(item, dict)]
+    return [item for item in queue if item.goal.strip()]
+
+
+def save_goal_queue(session_id: str, queue: List[QueuedGoal]) -> None:
+    if not session_id:
+        return
+    db = _get_session_db()
+    if db is None:
+        return
+    raw = json.dumps([item.to_dict() for item in queue], ensure_ascii=False)
+    try:
+        db.set_meta(_queue_meta_key(session_id), raw)
+    except Exception as exc:
+        logger.debug("GoalManager: set queue meta failed: %s", exc)
+
+
+def enqueue_goal(session_id: str, goal: str, *, max_turns: Optional[int] = None, contract: Optional[GoalContract] = None) -> int:
+    queue = load_goal_queue(session_id)
+    queue.append(
+        QueuedGoal(
+            goal=(goal or "").strip(),
+            max_turns=int(max_turns) if max_turns else DEFAULT_MAX_TURNS,
+            created_at=time.time(),
+            contract=contract if contract is not None else GoalContract(),
+        )
+    )
+    save_goal_queue(session_id, queue)
+    return len(queue)
+
+
+def pop_next_goal(session_id: str) -> Optional[QueuedGoal]:
+    queue = load_goal_queue(session_id)
+    if not queue:
+        return None
+    item = queue.pop(0)
+    save_goal_queue(session_id, queue)
+    return item
+
+
 def migrate_goal_to_session(old_session_id: str, new_session_id: str, *, reason: str = "") -> bool:
     """Carry a persistent /goal from a parent session to its continuation.
 
@@ -602,6 +691,8 @@ def migrate_goal_to_session(old_session_id: str, new_session_id: str, *, reason:
         if load_goal(new_session_id) is not None:
             return False
         save_goal(new_session_id, state)
+        save_goal_queue(new_session_id, load_goal_queue(old_session_id))
+        save_goal_queue(old_session_id, [])
         # Archive the parent's row so it isn't double-counted as active.
         clear_goal(old_session_id)
         logger.debug(
@@ -1115,8 +1206,9 @@ class GoalManager:
 
     def status_line(self) -> str:
         s = self._state
+        queue_suffix = f" (queue: {self.queue_depth()})" if self.queue_depth() else ""
         if s is None or s.status in {"cleared",}:
-            return "No active goal. Set one with /goal <text>."
+            return f"No active goal. Set one with /goal <text>.{queue_suffix}"
         turns = f"{s.turns_used}/{s.max_turns} turns"
         sub = f", {len(s.subgoals)} subgoal{'s' if len(s.subgoals) != 1 else ''}" if s.subgoals else ""
         con = ", contract" if self.has_contract() else ""
@@ -1124,21 +1216,21 @@ class GoalManager:
         if s.status == "active":
             if s.waiting_on_session and _session_waiting(s.waiting_on_session):
                 wr = s.waiting_reason or f"session {s.waiting_on_session}"
-                return f"⏳ Goal (parked on {wr}, {meta}): {s.goal}"
+                return f"⏳ Goal (parked on {wr}, {meta}): {s.goal}{queue_suffix}"
             if s.waiting_on_pid and _pid_alive(s.waiting_on_pid):
                 wr = s.waiting_reason or f"pid {s.waiting_on_pid}"
-                return f"⏳ Goal (parked on {wr}, {meta}): {s.goal}"
+                return f"⏳ Goal (parked on {wr}, {meta}): {s.goal}{queue_suffix}"
             if s.waiting_until and time.time() < s.waiting_until:
                 remaining = int(s.waiting_until - time.time())
                 wr = s.waiting_reason or f"{remaining}s"
-                return f"⏳ Goal (parked {remaining}s — {wr}, {meta}): {s.goal}"
-            return f"⊙ Goal (active, {meta}): {s.goal}"
+                return f"⏳ Goal (parked {remaining}s — {wr}, {meta}): {s.goal}{queue_suffix}"
+            return f"⊙ Goal (active, {meta}): {s.goal}{queue_suffix}"
         if s.status == "paused":
             extra = f" — {s.paused_reason}" if s.paused_reason else ""
-            return f"⏸ Goal (paused, {meta}{extra}): {s.goal}"
+            return f"⏸ Goal (paused, {meta}{extra}): {s.goal}{queue_suffix}"
         if s.status == "done":
-            return f"✓ Goal done ({meta}): {s.goal}"
-        return f"Goal ({s.status}, {meta}): {s.goal}"
+            return f"✓ Goal done ({meta}): {s.goal}{queue_suffix}"
+        return f"Goal ({s.status}, {meta}): {s.goal}{queue_suffix}"
 
     # --- mutation -----------------------------------------------------
 
@@ -1146,6 +1238,14 @@ class GoalManager:
         goal = (goal or "").strip()
         if not goal:
             raise ValueError("goal text is empty")
+        if self._state is not None and self._state.status in {"active", "paused"}:
+            enqueue_goal(
+                self.session_id,
+                goal,
+                max_turns=int(max_turns) if max_turns else self.default_max_turns,
+                contract=contract,
+            )
+            return self._state
         state = GoalState(
             goal=goal,
             status="active",
@@ -1158,6 +1258,26 @@ class GoalManager:
         self._state = state
         save_goal(self.session_id, state)
         return state
+
+    def queue_depth(self) -> int:
+        return len(load_goal_queue(self.session_id))
+
+    def _promote_next_queued_goal(self) -> bool:
+        item = pop_next_goal(self.session_id)
+        if item is None:
+            return False
+        state = GoalState(
+            goal=item.goal,
+            status="active",
+            turns_used=0,
+            max_turns=item.max_turns,
+            created_at=time.time(),
+            last_turn_at=0.0,
+            contract=item.contract,
+        )
+        self._state = state
+        save_goal(self.session_id, state)
+        return True
 
     def set_contract(self, contract: GoalContract) -> Optional[GoalState]:
         """Attach or replace the completion contract on the active goal.
@@ -1206,6 +1326,7 @@ class GoalManager:
         self._state.status = "cleared"
         save_goal(self.session_id, self._state)
         self._state = None
+        self._promote_next_queued_goal()
 
     def mark_done(self, reason: str) -> None:
         if not self._state:
@@ -1214,6 +1335,7 @@ class GoalManager:
         self._state.last_verdict = "done"
         self._state.last_reason = reason
         save_goal(self.session_id, self._state)
+        self._promote_next_queued_goal()
 
     # --- /subgoal user controls ---------------------------------------
 

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -256,11 +256,37 @@ def build_models_payload(
     if capabilities:
         _apply_capabilities(rows)
 
-    return {
+    payload = {
         "providers": rows,
         "model": ctx.current_model,
         "provider": ctx.current_provider,
     }
+    try:
+        from agent.provider_route_policy import (
+            orchestrator_subscription_only,
+            sanitized_startup_summary,
+        )
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly()
+        if orchestrator_subscription_only(cfg):
+            payload["orchestrator"] = {
+                "billing_policy": "subscription_only",
+                "route_health": sanitized_startup_summary(
+                    {
+                        "provider": row.get("slug") or row.get("provider") or "",
+                        "model": (row.get("model") or row.get("current_model") or ""),
+                        "status": row.get("last_status") or row.get("status") or ("ok" if row.get("authenticated") else "unavailable_cli"),
+                        "auth_type": row.get("auth_type"),
+                        "source": row.get("source") or row.get("credential_source"),
+                        "has_refresh_token": bool(row.get("has_refresh_token")),
+                    }
+                    for row in rows
+                ),
+            }
+    except Exception:
+        pass
+    return payload
 
 
 def build_model_options_payload(

--- a/hermes_cli/orchestrator_state.py
+++ b/hermes_cli/orchestrator_state.py
@@ -1,0 +1,221 @@
+"""Durable autonomous orchestration state over SessionDB.state_meta."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _meta_key(session_id: str) -> str:
+    return f"orchestrator:{session_id}"
+
+
+def _get_session_db():
+    from hermes_cli.goals import _get_session_db
+
+    return _get_session_db()
+
+
+def _clean_path_status(item: Any) -> dict[str, str] | None:
+    if isinstance(item, str):
+        text = item.strip()
+        if not text:
+            return None
+        parts = text.split(maxsplit=1)
+        if len(parts) == 2:
+            return {"status": parts[0], "path": parts[1]}
+        return {"status": "?", "path": text}
+    if isinstance(item, dict):
+        path = str(item.get("path") or "").strip()
+        status = str(item.get("status") or item.get("xy") or "?").strip()[:8]
+        if not path:
+            return None
+        return {"path": path, "status": status}
+    return None
+
+
+def _sanitize_verification(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    result: dict[str, Any] = {}
+    for key in ("status", "command", "exit_code", "started_at", "ended_at"):
+        if key in value:
+            result[key] = value[key]
+    digest = value.get("digest") or value.get("output_digest")
+    if digest:
+        result["output_digest"] = str(digest)
+    return result
+
+
+@dataclass
+class Checkpoint:
+    goal: str = ""
+    plan_paths: list[str] = field(default_factory=list)
+    evidence_paths: list[str] = field(default_factory=list)
+    dirty_summary: list[dict[str, str]] = field(default_factory=list)
+    process_ids: list[int] = field(default_factory=list)
+    session_ids: list[str] = field(default_factory=list)
+    next_action: str = ""
+    verification: dict[str, Any] = field(default_factory=dict)
+    created_at: float = 0.0
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> "Checkpoint | None":
+        if not isinstance(data, dict):
+            return None
+        return cls(
+            goal=str(data.get("goal") or ""),
+            plan_paths=[str(p) for p in data.get("plan_paths") or []],
+            evidence_paths=[str(p) for p in data.get("evidence_paths") or []],
+            dirty_summary=[d for d in data.get("dirty_summary") or [] if isinstance(d, dict)],
+            process_ids=[int(p) for p in data.get("process_ids") or [] if isinstance(p, int) or str(p).isdigit()],
+            session_ids=[str(s) for s in data.get("session_ids") or [] if str(s).strip()],
+            next_action=str(data.get("next_action") or ""),
+            verification=dict(data.get("verification") or {}),
+            created_at=float(data.get("created_at", 0.0) or 0.0),
+        )
+
+
+@dataclass
+class OrchestratorState:
+    status: str = "idle"
+    active_job_id: str | None = None
+    attempt_id: str | None = None
+    session_id: str | None = None
+    worker_id: str | None = None
+    provider_session_id: str | None = None
+    route_decision: dict[str, Any] | None = None
+    failure_class: str | None = None
+    total_attempts: int = 0
+    route_attempts: dict[str, int] = field(default_factory=dict)
+    checkpoint: Checkpoint | None = None
+    last_verification: dict[str, Any] = field(default_factory=dict)
+    blocked_reason: str | None = None
+    updated_at: float = 0.0
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), ensure_ascii=False, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, raw: str | None) -> "OrchestratorState":
+        if not raw:
+            return cls()
+        try:
+            data = json.loads(raw)
+        except Exception:
+            return cls()
+        if not isinstance(data, dict):
+            return cls()
+        return cls(
+            status=str(data.get("status") or "idle"),
+            active_job_id=data.get("active_job_id"),
+            attempt_id=data.get("attempt_id"),
+            session_id=data.get("session_id"),
+            worker_id=data.get("worker_id"),
+            provider_session_id=data.get("provider_session_id"),
+            route_decision=data.get("route_decision") if isinstance(data.get("route_decision"), dict) else None,
+            failure_class=data.get("failure_class"),
+            total_attempts=int(data.get("total_attempts", 0) or 0),
+            route_attempts=dict(data.get("route_attempts") or {}),
+            checkpoint=Checkpoint.from_dict(data.get("checkpoint")),
+            last_verification=dict(data.get("last_verification") or {}),
+            blocked_reason=data.get("blocked_reason"),
+            updated_at=float(data.get("updated_at", 0.0) or 0.0),
+        )
+
+
+class OrchestratorStateStore:
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        self._db = _get_session_db()
+
+    def load(self) -> OrchestratorState:
+        if self._db is None:
+            return OrchestratorState(session_id=self.session_id)
+        try:
+            state = OrchestratorState.from_json(self._db.get_meta(_meta_key(self.session_id)))
+        except Exception as exc:
+            logger.debug("Orchestrator state load failed: %s", exc)
+            state = OrchestratorState()
+        if state.session_id is None:
+            state.session_id = self.session_id
+        return state
+
+    def save(self, state: OrchestratorState) -> OrchestratorState:
+        state.session_id = state.session_id or self.session_id
+        state.updated_at = time.time()
+        if self._db is not None:
+            self._db.set_meta(_meta_key(self.session_id), state.to_json())
+        return state
+
+    def update(self, **kwargs: Any) -> OrchestratorState:
+        state = self.load()
+        for key, value in kwargs.items():
+            if hasattr(state, key):
+                setattr(state, key, value)
+        if state.active_job_id:
+            state.status = "active"
+        return self.save(state)
+
+    def record_checkpoint(
+        self,
+        *,
+        goal: str,
+        plan_paths: list[str] | None = None,
+        evidence_paths: list[str] | None = None,
+        dirty_summary: list[Any] | None = None,
+        process_ids: list[int] | None = None,
+        session_ids: list[str] | None = None,
+        next_action: str = "",
+        verification: dict[str, Any] | None = None,
+    ) -> Checkpoint:
+        clean_dirty = []
+        for item in dirty_summary or []:
+            clean = _clean_path_status(item)
+            if clean is not None:
+                clean_dirty.append(clean)
+        checkpoint = Checkpoint(
+            goal=str(goal or ""),
+            plan_paths=[str(p) for p in plan_paths or []],
+            evidence_paths=[str(p) for p in evidence_paths or []],
+            dirty_summary=clean_dirty,
+            process_ids=[int(pid) for pid in process_ids or []],
+            session_ids=[str(sid) for sid in session_ids or [] if str(sid).strip()],
+            next_action=str(next_action or ""),
+            verification=_sanitize_verification(verification),
+            created_at=time.time(),
+        )
+        state = self.load()
+        state.checkpoint = checkpoint
+        state.last_verification = checkpoint.verification
+        self.save(state)
+        return checkpoint
+
+    def clear_state(self) -> OrchestratorState:
+        state = OrchestratorState(session_id=self.session_id, status="cleared")
+        return self.save(state)
+
+
+def migrate_orchestrator_state_to_session(old_session_id: str, new_session_id: str, *, reason: str = "") -> bool:
+    if not old_session_id or not new_session_id or old_session_id == new_session_id:
+        return False
+    old_store = OrchestratorStateStore(old_session_id)
+    state = old_store.load()
+    if not state.active_job_id and state.checkpoint is None:
+        return False
+    new_store = OrchestratorStateStore(new_session_id)
+    existing = new_store.load()
+    if existing.active_job_id or existing.checkpoint is not None:
+        return False
+    state.session_id = new_session_id
+    new_store.save(state)
+    old = old_store.load()
+    old.status = "migrated"
+    old.blocked_reason = reason or "session_migration"
+    old_store.save(old)
+    return True

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1826,7 +1826,21 @@ def resolve_runtime_provider(
     except Exception:
         pool = None
     if pool and pool.has_credentials():
-        entry = pool.select()
+        if provider == "openai-codex":
+            try:
+                from agent.provider_route_policy import orchestrator_subscription_only
+                from hermes_cli.config import load_config_readonly
+
+                health_gate_enabled = orchestrator_subscription_only(load_config_readonly())
+            except Exception:
+                health_gate_enabled = False
+            entry = (
+                pool.select_health_checked()
+                if health_gate_enabled
+                else pool.select()
+            )
+        else:
+            entry = pool.select()
         pool_api_key = ""
         if entry is not None:
             pool_api_key = (

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -3696,5 +3696,106 @@ class TestCredentialPoolQueryLocking:
             )
         finally:
             inner.release()
-
         assert done.wait(timeout=2.0), f"{method}() did not complete after lock release"
+
+
+def _write_codex_preflight_pool(tmp_path, entries):
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {"openai-codex": entries},
+        },
+    )
+
+
+def _codex_preflight_entry(entry_id, token, priority):
+    return {
+        "id": entry_id,
+        "label": entry_id,
+        "auth_type": "oauth",
+        "priority": priority,
+        "source": "manual:device_code",
+        "access_token": token,
+        "refresh_token": f"refresh-{entry_id}",
+    }
+
+
+def test_assignment_preflight_health_checks_every_codex_credential(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_codex_preflight_pool(
+        tmp_path,
+        [
+            _codex_preflight_entry("capped", "token-capped", 0),
+            _codex_preflight_entry("healthy", "token-healthy", 1),
+        ],
+    )
+    from agent.credential_pool import load_pool
+
+    seen = []
+
+    def probe(entry):
+        seen.append(entry.id)
+        if entry.id == "capped":
+            return {"status_code": 429, "reason": "usage_limit_reached", "reset_at": time.time() + 60}
+        return 200
+
+    pool = load_pool("openai-codex")
+    selected = pool.select_health_checked(probe)
+
+    assert seen == ["capped", "healthy"]
+    assert selected is not None and selected.id == "healthy"
+    capped = next(item for item in pool.entries() if item.id == "capped")
+    assert capped.last_status == "exhausted"
+    assert capped.last_error_code == 429
+
+
+def test_assignment_preflight_401_reloads_disk_then_retries_once(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_codex_preflight_pool(
+        tmp_path,
+        [_codex_preflight_entry("codex", "stale-token", 0)],
+    )
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    # Simulate another client rotating the token after this pool instance was
+    # loaded but before its assignment preflight.
+    _write_codex_preflight_pool(
+        tmp_path,
+        [_codex_preflight_entry("codex", "fresh-token", 0)],
+    )
+    calls = []
+
+    def probe(entry):
+        calls.append(entry.access_token)
+        return 401 if entry.access_token == "stale-token" else 200
+
+    selected = pool.select_health_checked(probe)
+
+    assert calls == ["stale-token", "fresh-token"]
+    assert selected is not None and selected.access_token == "fresh-token"
+    assert selected.last_status in {None, "ok"}
+
+
+def test_assignment_preflight_never_retries_known_broken_credential_twice(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_codex_preflight_pool(
+        tmp_path,
+        [
+            _codex_preflight_entry("broken", "broken-token", 0),
+            _codex_preflight_entry("healthy", "healthy-token", 1),
+        ],
+    )
+    from agent.credential_pool import load_pool
+
+    calls = []
+
+    def probe(entry):
+        calls.append(entry.id)
+        return {"status_code": 401, "reason": "invalid_token"} if entry.id == "broken" else 200
+
+    selected = load_pool("openai-codex").select_health_checked(probe)
+
+    assert calls.count("broken") == 2  # initial ping + exactly one post-reload retry
+    assert selected is not None and selected.id == "healthy"

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -3799,3 +3799,42 @@ def test_assignment_preflight_never_retries_known_broken_credential_twice(tmp_pa
 
     assert calls.count("broken") == 2  # initial ping + exactly one post-reload retry
     assert selected is not None and selected.id == "healthy"
+
+
+def test_assignment_preflight_does_not_hold_pool_lock_during_network_ping(tmp_path, monkeypatch):
+    import threading
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_codex_preflight_pool(
+        tmp_path,
+        [_codex_preflight_entry("healthy", "healthy-token", 0)],
+    )
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    ping_started = threading.Event()
+    release_ping = threading.Event()
+    selection_done = threading.Event()
+
+    def probe(_entry):
+        ping_started.set()
+        assert release_ping.wait(timeout=2.0)
+        return 200
+
+    def select_worker():
+        pool.select_health_checked(probe)
+        selection_done.set()
+
+    worker = threading.Thread(target=select_worker, daemon=True)
+    worker.start()
+    assert ping_started.wait(timeout=2.0)
+
+    # A reader must remain responsive while the assignment health endpoint is
+    # blocked; otherwise N slow pings serialize every pool consumer for N×10s.
+    read_done = threading.Event()
+    reader = threading.Thread(target=lambda: (pool.entries(), read_done.set()), daemon=True)
+    reader.start()
+    assert read_done.wait(timeout=0.5)
+
+    release_ping.set()
+    assert selection_done.wait(timeout=2.0)

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -384,6 +384,18 @@ class TestFailureAttribution:
 
     def _make_pool(self, tmp_path, monkeypatch, entries):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # The canonical runner intentionally uses the installed Hermes venv,
+        # whose shell may already have loaded real user OAuth credentials.
+        # This fixture exercises only its explicit temp-store rows; allowing a
+        # live Anthropic token to auto-seed here makes a nominal one-entry pool
+        # rotate into the user's account and invalidates the recovery contract.
+        for name in (
+            "ANTHROPIC_TOKEN",
+            "ANTHROPIC_API_KEY",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+        ):
+            monkeypatch.delenv(name, raising=False)
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir(parents=True, exist_ok=True)
         (hermes_home / "auth.json").write_text(

--- a/tests/agent/test_orchestrator_policy_recovery.py
+++ b/tests/agent/test_orchestrator_policy_recovery.py
@@ -1,0 +1,180 @@
+import json
+
+import pytest
+
+from agent.error_classifier import FailoverReason
+
+
+def test_subscription_policy_filters_by_provenance_and_capability():
+    from agent.provider_route_policy import (
+        Capability,
+        RouteRole,
+        SubscriptionRoutePolicy,
+    )
+
+    policy = SubscriptionRoutePolicy({"orchestrator": {"enabled": True, "billing_policy": "subscription_only"}})
+
+    builder = {"provider": "openai-codex", "model": "gpt-5-codex", "auth_type": "oauth", "source": "manual:device_code"}
+    assert policy.evaluate(builder, role=RouteRole.BUILDER, capability=Capability.WRITE).allowed is True
+
+    forbidden_openai = {"provider": "openai", "model": "gpt-5", "auth_type": "api_key", "source": "env"}
+    assert policy.evaluate(forbidden_openai, role=RouteRole.BUILDER, capability=Capability.WRITE).allowed is False
+
+    attacker = {"provider": "anthropic", "model": "claude-sonnet-4-5", "auth_type": "oauth", "source": "claude_code"}
+    assert policy.evaluate(attacker, role=RouteRole.ATTACKER, capability=Capability.READ).allowed is True
+    blocked_write = policy.evaluate(attacker, role=RouteRole.ATTACKER, capability=Capability.WRITE)
+    assert blocked_write.allowed is False
+    assert "read_only" in blocked_write.reason
+
+    anthropic_api_key = {"provider": "anthropic", "model": "claude-sonnet-4-5", "auth_type": "api_key", "source": "env"}
+    assert policy.evaluate(anthropic_api_key, role=RouteRole.ATTACKER, capability=Capability.READ).allowed is False
+
+    claude_fallback_builder = {
+        "provider": "anthropic",
+        "model": "claude-opus-4-8",
+        "auth_type": "oauth",
+        "source": "env:ANTHROPIC_TOKEN",
+    }
+    assert policy.evaluate(
+        claude_fallback_builder,
+        role=RouteRole.BUILDER,
+        capability=Capability.WRITE,
+    ).allowed is True
+    self_attack = policy.evaluate(
+        attacker,
+        role=RouteRole.ATTACKER,
+        capability=Capability.READ,
+        builder_provider="anthropic",
+    )
+    assert self_attack.allowed is False
+    assert self_attack.reason == "self_attack_forbidden"
+
+    diagnostician = {"provider": "gemini-code-assist", "model": "gemini", "auth_type": "oauth", "source": "google_code_assist"}
+    assert policy.evaluate(diagnostician, role=RouteRole.DIAGNOSTICIAN, capability=Capability.READ).allowed is True
+    vertex = {"provider": "vertex", "model": "gemini", "auth_type": "oauth", "source": "gcloud"}
+    assert policy.evaluate(vertex, role=RouteRole.DIAGNOSTICIAN, capability=Capability.READ).allowed is False
+
+
+@pytest.mark.parametrize(
+    "entry,expected",
+    [
+        ({"status": "ok", "expires_at": "2999-01-01T00:00:00Z", "refresh_token": "sentinel-refresh"}, "healthy_reusable"),
+        ({"status": "exhausted", "last_error_code": 429, "last_error_reset_at": 1999999999}, "temporary_rate_limit"),
+        ({"status": "ok", "expires_at": "2000-01-01T00:00:00Z", "refresh_token": "sentinel-refresh"}, "expired_access_refresh_available"),
+        ({"status": "ok", "expires_at": "2000-01-01T00:00:00Z"}, "expired_access_missing_refresh"),
+        ({"status": "dead", "last_error_reason": "token_revoked"}, "revoked_dead"),
+        ({"status": "browser_timeout"}, "browser_oauth_timeout"),
+        ({"status": "unavailable_cli"}, "unavailable_cli_model"),
+        ({"status": "unknown_transport"}, "provider_outage_unknown_transport"),
+    ],
+)
+def test_no_spend_health_inventory_classifies_local_metadata(entry, expected):
+    from agent.provider_route_policy import classify_route_health
+
+    health = classify_route_health(entry, now=1700000000.0)
+    assert health.availability.value == expected
+    assert "sentinel-refresh" not in repr(health)
+    assert "sentinel-refresh" not in json.dumps(health.to_summary(), sort_keys=True)
+
+
+def test_recovery_decision_table_is_bounded_and_deterministic():
+    from agent.orchestrator_recovery import FailureClass, RecoveryContext, decide_recovery
+    from agent.provider_route_policy import Capability, RouteRole
+
+    alternatives = [
+        {"provider": "openai", "model": "gpt-5", "auth_type": "api_key", "source": "env"},
+        {"provider": "openai-codex", "model": "gpt-5-codex-high", "auth_type": "oauth", "source": "manual:device_code"},
+    ]
+    cfg = {"orchestrator": {"enabled": True, "billing_policy": "subscription_only", "max_total_attempts": 3, "max_route_attempts": 1}}
+
+    decision = decide_recovery(
+        RecoveryContext(
+            failure=FailureClass.TEMPORARY_RATE_LIMIT,
+            current_route={"provider": "openai-codex", "model": "gpt-5-codex", "auth_type": "oauth", "source": "manual:device_code"},
+            alternatives=alternatives,
+            role=RouteRole.BUILDER,
+            capability=Capability.WRITE,
+            total_attempts=1,
+            route_attempts={"openai-codex:gpt-5-codex": 1},
+            config=cfg,
+        )
+    )
+    assert decision.action == "switch_route"
+    assert decision.next_route["provider"] == "openai-codex"
+    assert decision.next_route["model"] == "gpt-5-codex-high"
+    assert decision.escalation is None
+
+    exhausted = decide_recovery(
+        RecoveryContext(
+            failure=FailureClass.FAILED_VERIFICATION,
+            current_route={"provider": "openai-codex", "model": "gpt-5-codex", "auth_type": "oauth", "source": "manual:device_code"},
+            alternatives=[],
+            role=RouteRole.BUILDER,
+            capability=Capability.WRITE,
+            total_attempts=3,
+            route_attempts={},
+            config=cfg,
+        )
+    )
+    assert exhausted.action == "escalate"
+    assert exhausted.escalation == "no_approved_route"
+
+
+def test_all_required_failure_classes_have_deterministic_actions():
+    from agent.orchestrator_recovery import FailureClass, RecoveryContext, decide_recovery
+
+    cfg = {"orchestrator": {"enabled": True, "billing_policy": "subscription_only"}}
+    for failure in FailureClass:
+        decision = decide_recovery(RecoveryContext(failure=failure, config=cfg))
+        assert decision.action
+        assert decision.failure == failure.value
+        assert "prompt" not in decision.to_dict()
+
+
+def test_fallback_chain_filters_paid_routes_only_when_orchestrator_enabled():
+    from hermes_cli.fallback_config import get_fallback_chain
+
+    config = {
+        "fallback_providers": [
+            {"provider": "openai", "model": "gpt-5", "auth_type": "api_key", "source": "env"},
+            {"provider": "openai-codex", "model": "gpt-5-codex", "auth_type": "oauth", "source": "manual:device_code"},
+            {"provider": "openrouter", "model": "anthropic/claude", "auth_type": "api_key", "source": "env"},
+        ]
+    }
+    assert [e["provider"] for e in get_fallback_chain(config)] == ["openai", "openai-codex", "openrouter"]
+
+    config["orchestrator"] = {"enabled": True, "billing_policy": "subscription_only"}
+    assert [e["provider"] for e in get_fallback_chain(config)] == ["openai-codex"]
+
+
+def test_subscription_policy_keeps_unresolved_claude_fallback_for_runtime_auth_check():
+    from hermes_cli.fallback_config import get_fallback_chain
+
+    config = {
+        "orchestrator": {"enabled": True, "billing_policy": "subscription_only"},
+        "fallback_providers": [
+            {"provider": "anthropic", "model": "claude-opus-4-8"},
+        ],
+    }
+    assert get_fallback_chain(config) == [
+        {"provider": "anthropic", "model": "claude-opus-4-8"},
+    ]
+
+
+def test_pooled_credential_repr_never_serializes_token_values():
+    from agent.credential_pool import PooledCredential
+
+    cred = PooledCredential(
+        provider="openai-codex",
+        id="codex-1",
+        label="Codex",
+        auth_type="oauth",
+        priority=0,
+        source="manual:device_code",
+        access_token="sentinel-access-token",
+        refresh_token="sentinel-refresh-token",
+    )
+    text = repr(cred)
+    assert "sentinel-access-token" not in text
+    assert "sentinel-refresh-token" not in text
+    assert "openai-codex" in text

--- a/tests/hermes_cli/test_auth_codex_quota_probe.py
+++ b/tests/hermes_cli/test_auth_codex_quota_probe.py
@@ -203,6 +203,15 @@ def test_assignment_health_probe_is_cached_per_token(monkeypatch):
     assert len(calls) == 1
 
 
+def test_assignment_health_probe_classifies_corrupt_token_as_401(monkeypatch):
+    calls = _patch_httpx(monkeypatch, _StubResponse(200, _usage_payload(1.0, 2.0)))
+
+    result = probe_codex_credential_health("not-a-jwt")
+
+    assert result == {"status_code": 401, "reason": "invalid_token"}
+    assert calls == []
+
+
 def test_probe_sends_chatgpt_account_id_from_jwt(monkeypatch):
     calls = _patch_httpx(monkeypatch, _StubResponse(200, _usage_payload(0.0, 0.0)))
     token = _jwt(

--- a/tests/hermes_cli/test_auth_codex_quota_probe.py
+++ b/tests/hermes_cli/test_auth_codex_quota_probe.py
@@ -21,6 +21,7 @@ from hermes_cli.auth import (
     _is_codex_rate_limit_shaped,
     _probe_codex_quota_restored,
     clear_codex_pool_quota_cooldowns,
+    probe_codex_credential_health,
     resolve_codex_runtime_credentials,
 )
 
@@ -28,8 +29,10 @@ from hermes_cli.auth import (
 @pytest.fixture(autouse=True)
 def _clear_probe_cache():
     auth_mod._codex_quota_probe_cache.clear()
+    auth_mod._codex_credential_health_cache.clear()
     yield
     auth_mod._codex_quota_probe_cache.clear()
+    auth_mod._codex_credential_health_cache.clear()
 
 
 def _jwt(claims: dict) -> str:
@@ -165,6 +168,38 @@ def test_probe_throttles_repeat_calls(monkeypatch):
     token = _jwt({"exp": time.time() + 3600})
     assert _probe_codex_quota_restored(token) is True
     assert _probe_codex_quota_restored(token) is True  # cached
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "status,payload,expected",
+    [
+        (200, _usage_payload(12.0, 34.0), 200),
+        (200, _usage_payload(100.0, 34.0), 429),
+        (401, {}, 401),
+        (429, {}, 429),
+    ],
+)
+def test_assignment_health_probe_preserves_auth_vs_quota_class(
+    monkeypatch, status, payload, expected
+):
+    _patch_httpx(monkeypatch, _StubResponse(status, payload))
+    token = _jwt({"exp": time.time() + 3600})
+
+    result = probe_codex_credential_health(token)
+
+    assert result is not None
+    assert result["status_code"] == expected
+
+
+def test_assignment_health_probe_is_cached_per_token(monkeypatch):
+    calls = _patch_httpx(monkeypatch, _StubResponse(200, _usage_payload(1.0, 2.0)))
+    token = _jwt({"exp": time.time() + 3600})
+
+    first = probe_codex_credential_health(token)
+    second = probe_codex_credential_health(token)
+    assert first is not None and first["status_code"] == 200
+    assert second is not None and second["status_code"] == 200
     assert len(calls) == 1
 
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -86,6 +86,49 @@ def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):
     assert resolved["source"] == "manual"
 
 
+def test_subscription_orchestrator_health_checks_pool_before_codex_assignment(monkeypatch):
+    entry = SimpleNamespace(
+        access_token="healthy-pool-token",
+        source="manual:device_code",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    class _Pool:
+        def __init__(self):
+            self.health_checked = 0
+            self.plain_selected = 0
+
+        def has_credentials(self):
+            return True
+
+        def select_health_checked(self):
+            self.health_checked += 1
+            return entry
+
+        def select(self):
+            self.plain_selected += 1
+            return entry
+
+    pool = _Pool()
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: pool)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "orchestrator": {
+                "enabled": True,
+                "billing_policy": "subscription_only",
+            }
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="openai-codex")
+
+    assert resolved["api_key"] == "healthy-pool-token"
+    assert pool.health_checked == 1
+    assert pool.plain_selected == 0
+
+
 def test_resolve_runtime_provider_nous_pool_uses_env_base_url_override(monkeypatch):
     entry = SimpleNamespace(
         provider="nous",

--- a/tests/run_agent/test_auth_provider_failover.py
+++ b/tests/run_agent/test_auth_provider_failover.py
@@ -15,6 +15,7 @@ fell through to "switch providers manually" advice and never called
   3. The one-shot guard flag exists on TurnRetryState.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from run_agent import AIAgent
@@ -100,6 +101,44 @@ class TestAuthFailoverActivation:
             advanced = agent._try_activate_fallback(reason=classified.reason)
         assert advanced is True
         assert agent._fallback_index == 1
+
+    def test_codex_failure_actually_switches_to_claude_subscription(self):
+        agent = _make_agent(
+            fallback_model=[
+                {"provider": "anthropic", "model": "claude-opus-4-8"},
+            ]
+        )
+        config = {
+            "orchestrator": {
+                "enabled": True,
+                "billing_policy": "subscription_only",
+            }
+        }
+        oauth_entry = SimpleNamespace(
+            auth_type="oauth",
+            source="env:ANTHROPIC_TOKEN",
+        )
+        oauth_pool = MagicMock()
+        oauth_pool.current.return_value = oauth_entry
+        oauth_pool.entries.return_value = [oauth_entry]
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client("https://api.anthropic.com", "subscription-oauth"),
+                    "claude-opus-4-8",
+                ),
+            ),
+            patch("agent.credential_pool.load_pool", return_value=oauth_pool),
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
+        ):
+            advanced = agent._try_activate_fallback(reason=FailoverReason.rate_limit)
+
+        assert advanced is True
+        assert agent.provider == "anthropic"
+        assert agent.model == "claude-opus-4-8"
+        assert agent.api_mode == "anthropic_messages"
 
     def test_no_failover_without_chain(self):
         """A user with no fallback configured (the common case for the

--- a/tests/run_agent/test_auth_provider_failover.py
+++ b/tests/run_agent/test_auth_provider_failover.py
@@ -140,6 +140,44 @@ class TestAuthFailoverActivation:
         assert agent.model == "claude-opus-4-8"
         assert agent.api_mode == "anthropic_messages"
 
+    def test_cold_claude_pool_is_selected_then_verified_before_fallback(self):
+        agent = _make_agent(
+            fallback_model=[
+                {"provider": "anthropic", "model": "claude-opus-4-8"},
+            ]
+        )
+        config = {
+            "orchestrator": {
+                "enabled": True,
+                "billing_policy": "subscription_only",
+            }
+        }
+        oauth_entry = SimpleNamespace(
+            auth_type="oauth",
+            source="env:ANTHROPIC_TOKEN",
+        )
+        cold_pool = MagicMock()
+        cold_pool.current.return_value = None
+        cold_pool.peek.return_value = None
+        cold_pool.select.return_value = oauth_entry
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client("https://api.anthropic.com", "subscription-oauth"),
+                    "claude-opus-4-8",
+                ),
+            ),
+            patch("agent.credential_pool.load_pool", return_value=cold_pool),
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
+        ):
+            advanced = agent._try_activate_fallback(reason=FailoverReason.auth)
+
+        assert advanced is True
+        assert agent.provider == "anthropic"
+        cold_pool.select.assert_called_once_with()
+
     def test_no_failover_without_chain(self):
         """A user with no fallback configured (the common case for the
         original incident) does NOT failover — falls through to the

--- a/tests/test_orchestrator_goal_state.py
+++ b/tests/test_orchestrator_goal_state.py
@@ -1,0 +1,102 @@
+import json
+
+
+def _fresh_goal_home(monkeypatch, tmp_path):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import hermes_cli.goals as goals
+
+    goals._DB_CACHE.clear()
+    return home
+
+
+def test_goal_queue_fifo_survives_restart_and_promotes_only_on_terminal(monkeypatch, tmp_path):
+    _fresh_goal_home(monkeypatch, tmp_path)
+    from hermes_cli.goals import GoalManager
+
+    manager = GoalManager("session-a")
+    manager.set("active goal")
+    queued_state = manager.set("queued one")
+    assert queued_state.goal == "active goal"
+    assert manager.queue_depth() == 1
+    assert "queue: 1" in manager.status_line()
+
+    restarted = GoalManager("session-a")
+    assert restarted.state.goal == "active goal"
+    assert restarted.queue_depth() == 1
+
+    restarted.pause("waiting")
+    assert GoalManager("session-a").state.goal == "active goal"
+    assert GoalManager("session-a").queue_depth() == 1
+
+    restarted.resume()
+    restarted.mark_done("complete")
+    promoted = GoalManager("session-a")
+    assert promoted.state.goal == "queued one"
+    assert promoted.state.status == "active"
+    assert promoted.queue_depth() == 0
+
+
+def test_goal_queue_migrates_with_compression_session(monkeypatch, tmp_path):
+    _fresh_goal_home(monkeypatch, tmp_path)
+    from hermes_cli.goals import GoalManager, migrate_goal_to_session
+
+    parent = GoalManager("parent-session")
+    parent.set("parent goal")
+    parent.set("queued next")
+
+    assert migrate_goal_to_session("parent-session", "child-session", reason="compression") is True
+
+    child = GoalManager("child-session")
+    assert child.state.goal == "parent goal"
+    assert child.queue_depth() == 1
+    child.mark_done("done")
+    assert GoalManager("child-session").state.goal == "queued next"
+
+
+def test_orchestrator_checkpoint_persists_genuine_ids_and_sanitized_dirty_summary(monkeypatch, tmp_path):
+    _fresh_goal_home(monkeypatch, tmp_path)
+    from hermes_cli.orchestrator_state import OrchestratorStateStore
+
+    store = OrchestratorStateStore("session-a")
+    state = store.update(
+        active_job_id="job-1",
+        attempt_id="attempt-1",
+        worker_id="worker-1",
+        provider_session_id=None,
+    )
+    assert state.provider_session_id is None
+
+    checkpoint = store.record_checkpoint(
+        goal="ship the fix",
+        plan_paths=["docs/plan.md"],
+        evidence_paths=["reports/evidence.md"],
+        dirty_summary=[{"path": "agent/provider_route_policy.py", "status": "M", "contents": "sentinel-access-token"}],
+        process_ids=[123],
+        session_ids=["worker-session"],
+        next_action="run tests",
+        verification={"status": "failed", "command": "pytest", "output": "sentinel-refresh-token"},
+    )
+    raw = store._db.get_meta("orchestrator:session-a")
+    assert "sentinel-access-token" not in raw
+    assert "sentinel-refresh-token" not in raw
+    assert checkpoint.dirty_summary == [{"path": "agent/provider_route_policy.py", "status": "M"}]
+
+    restarted = OrchestratorStateStore("session-a")
+    assert restarted.load().checkpoint.next_action == "run tests"
+    assert restarted.load().checkpoint.process_ids == [123]
+
+    reverted = restarted.clear_state()
+    assert reverted.active_job_id is None
+    assert restarted.load().checkpoint is None
+
+
+def test_orchestrator_state_migrates_on_compression(monkeypatch, tmp_path):
+    _fresh_goal_home(monkeypatch, tmp_path)
+    from hermes_cli.orchestrator_state import OrchestratorStateStore, migrate_orchestrator_state_to_session
+
+    OrchestratorStateStore("old").update(active_job_id="job-1", attempt_id="attempt-1")
+    assert migrate_orchestrator_state_to_session("old", "new", reason="compression") is True
+    assert OrchestratorStateStore("new").load().active_job_id == "job-1"
+    assert OrchestratorStateStore("old").load().status == "migrated"


### PR DESCRIPTION
## Summary

Hardens Hermes subscription-only credential orchestration before autonomous worker assignment.

- health-checks every available Codex credential before assignment
- distinguishes 401 auth invalidation from 429 usage exhaustion
- reloads disk/source credentials on 401 and retries exactly once
- synchronizes external token rotations into the in-memory pool
- returns cooled-down accounts to rotation
- makes Codex -> Claude OAuth fallback actually take the turn
- forbids API-key/OpenRouter/Fable paid routes in subscription-only mode
- enforces read-only independent attacker roles and prevents self-attack
- adds resumable orchestrator goal/inventory state and compression safeguards

## Tests

Focused reliability gate: **332 passed, 0 failed**.

Post-full-suite fallback isolation gate: **316 passed, 0 failed**.

Ruff + `git diff --check`: passed.

Full visible suite: **47,513 passed, 26 failed**. One candidate-specific failure was fixed and now passes. Every remaining failure was reproduced on untouched `origin/main` under the same isolated macOS environment (platform/path/systemd/keychain assumptions unrelated to this diff).

## Independent attack

Fresh Sonnet attack initially found a pool-lock concurrency issue and cold-pool fallback coverage gap. Both were fixed with regression tests. Two subsequent fresh Sonnet reviews returned **PASS**, including the final reviewed HEAD.

## Billing / safety

- subscription OAuth only
- no OpenAI API billing
- no OpenRouter or Fable
- no merge performed by this brief
