### PR TITLE
fix(pricing): price cache-write tokens when the input rate is known

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -85,6 +85,31 @@ class PricingEntry:
     pricing_version: Optional[str] = None
     fetched_at: Optional[datetime] = None
 
+    @property
+    def effective_cache_write_cost_per_million(self) -> Optional[Decimal]:
+        """The rate cache-write tokens are actually billed at.
+
+        Cache-write tokens are *prompt* tokens (see ``CanonicalUsage.prompt_tokens``,
+        which sums input + cache-read + cache-write) that the provider also wrote
+        into its prompt cache. Only some providers charge a premium for that write:
+        Anthropic bills it at 1.25x input, and every Anthropic entry in the pricing
+        snapshot sets ``cache_write_cost_per_million`` explicitly. Providers that do
+        *not* charge a write premium — OpenAI, DeepSeek, Google, and every
+        OpenAI-compatible models API that omits a cache-write field — publish no
+        such rate because the tokens are simply billed as ordinary input.
+
+        So a missing ``cache_write_cost_per_million`` means "no premium", not
+        "unpriceable": fall back to the input rate. Returns ``None`` only when the
+        input rate is unknown too, i.e. when the route is genuinely unpriceable.
+
+        Deliberately asymmetric with cache-*read*, which must never fall back to
+        the input rate — a cache read is discounted (often 10x), so substituting
+        the input rate would over-bill rather than fill a gap.
+        """
+        if self.cache_write_cost_per_million is not None:
+            return self.cache_write_cost_per_million
+        return self.input_cost_per_million
+
 
 @dataclass(frozen=True)
 class CostResult:
@@ -1238,13 +1263,21 @@ def estimate_usage_cost(
                 notes=("cache-read pricing unavailable for route",),
             )
     if usage.cache_write_tokens:
-        if entry.cache_write_cost_per_million is None:
+        # Route through the shared ``effective_`` rate so a missing cache-write
+        # premium is filled from the input rate. Only bail when that too is
+        # unknown, i.e. when the route is genuinely unpriceable.
+        if entry.effective_cache_write_cost_per_million is None:
             return CostResult(
                 amount_usd=None,
                 status="unknown",
                 source=entry.source,
                 label="n/a",
                 notes=("cache-write pricing unavailable for route",),
+            )
+        if entry.cache_write_cost_per_million is None:
+            notes.append(
+                "cache-write billed at the input rate "
+                "(provider publishes no separate cache-write rate)"
             )
 
     if entry.input_cost_per_million is not None:
@@ -1253,8 +1286,12 @@ def estimate_usage_cost(
         amount += Decimal(usage.output_tokens) * entry.output_cost_per_million / _ONE_MILLION
     if entry.cache_read_cost_per_million is not None:
         amount += Decimal(usage.cache_read_tokens) * entry.cache_read_cost_per_million / _ONE_MILLION
-    if entry.cache_write_cost_per_million is not None:
-        amount += Decimal(usage.cache_write_tokens) * entry.cache_write_cost_per_million / _ONE_MILLION
+    if entry.effective_cache_write_cost_per_million is not None:
+        amount += (
+            Decimal(usage.cache_write_tokens)
+            * entry.effective_cache_write_cost_per_million
+            / _ONE_MILLION
+        )
     if entry.request_cost is not None and usage.request_count:
         amount += Decimal(usage.request_count) * entry.request_cost
 

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -588,8 +588,11 @@ def _usage_and_cost(response: Any, *, provider: str, api_mode: str, model: str, 
                         cost_details["output"] = float(Decimal(canonical.output_tokens) * entry.output_cost_per_million / _ONE_M)
                     if entry.cache_read_cost_per_million is not None and canonical.cache_read_tokens:
                         cost_details["cache_read_input_tokens"] = float(Decimal(canonical.cache_read_tokens) * entry.cache_read_cost_per_million / _ONE_M)
-                    if entry.cache_write_cost_per_million is not None and canonical.cache_write_tokens:
-                        cost_details["cache_creation_input_tokens"] = float(Decimal(canonical.cache_write_tokens) * entry.cache_write_cost_per_million / _ONE_M)
+                    # ``effective_`` so a provider with no separate cache-write
+                    # premium still gets a cache-write line (billed at input rate)
+                    # instead of silently vanishing from the breakdown.
+                    if entry.effective_cache_write_cost_per_million is not None and canonical.cache_write_tokens:
+                        cost_details["cache_creation_input_tokens"] = float(Decimal(canonical.cache_write_tokens) * entry.effective_cache_write_cost_per_million / _ONE_M)
                 else:
                     cost_details["total"] = float(cost.amount_usd)
             except Exception:
@@ -1008,8 +1011,9 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
                     cost_details["output"] = float(Decimal(_output) * entry.output_cost_per_million / _ONE_M)
                 if entry.cache_read_cost_per_million is not None and _cache_read:
                     cost_details["cache_read_input_tokens"] = float(Decimal(_cache_read) * entry.cache_read_cost_per_million / _ONE_M)
-                if entry.cache_write_cost_per_million is not None and _cache_write:
-                    cost_details["cache_creation_input_tokens"] = float(Decimal(_cache_write) * entry.cache_write_cost_per_million / _ONE_M)
+                # ``effective_`` — see the sibling breakdown above.
+                if entry.effective_cache_write_cost_per_million is not None and _cache_write:
+                    cost_details["cache_creation_input_tokens"] = float(Decimal(_cache_write) * entry.effective_cache_write_cost_per_million / _ONE_M)
             else:
                 _cost = estimate_usage_cost(model, _cu, provider=provider, base_url=base_url, api_key="")
                 if _cost.amount_usd is not None:

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -636,3 +636,173 @@ def test_deepseek_v4_flash_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $0.14/M + 500K output × $0.28/M = $0.14 + $0.14 = $0.28
     assert float(result.amount_usd) == 0.28
+
+
+def test_cache_write_falls_back_to_input_rate_when_no_premium_published(monkeypatch):
+    """A provider that publishes no separate cache-write rate must still price
+    the turn. Cache-write tokens are prompt tokens billed as ordinary input
+    when there is no write premium, so a missing rate means "no premium", not
+    "unpriceable". Contract: the turn costs exactly the same as one where those
+    tokens had arrived as plain input tokens."""
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_model_metadata",
+        lambda: {
+            "no-write-premium-model": {
+                "pricing": {
+                    "prompt": "0.000005",
+                    "completion": "0.00003",
+                    "input_cache_read": "0.0000005",
+                    # no cache_write / input_cache_write key — the real-world gap
+                }
+            }
+        },
+    )
+    kwargs = dict(provider="openrouter", base_url="https://openrouter.ai/api/v1")
+
+    with_cache_write = estimate_usage_cost(
+        "no-write-premium-model",
+        CanonicalUsage(
+            input_tokens=6,
+            output_tokens=3104,
+            cache_read_tokens=206366,
+            cache_write_tokens=114435,
+        ),
+        **kwargs,
+    )
+    # Same prompt-token budget, but the cache-write tokens arrive as plain input.
+    as_plain_input = estimate_usage_cost(
+        "no-write-premium-model",
+        CanonicalUsage(
+            input_tokens=6 + 114435,
+            output_tokens=3104,
+            cache_read_tokens=206366,
+            cache_write_tokens=0,
+        ),
+        **kwargs,
+    )
+
+    assert as_plain_input.status == "estimated"  # control: this always worked
+    assert with_cache_write.status == "estimated"
+    assert with_cache_write.amount_usd == as_plain_input.amount_usd
+    assert any("input rate" in note for note in with_cache_write.notes)
+
+
+def test_published_cache_write_premium_is_never_replaced_by_the_input_rate(monkeypatch):
+    """The fallback may only fill a gap. When a cache-write rate IS published
+    it must be used verbatim — including a $0 rate, which is a real published
+    value and must not be mistaken for "missing" and inflated to input."""
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_model_metadata",
+        lambda: {
+            "premium-model": {
+                "pricing": {
+                    "prompt": "0.000005",
+                    "completion": "0.00003",
+                    "input_cache_write": "0.00000625",  # 1.25x input, Anthropic-style
+                }
+            },
+            "free-write-model": {
+                "pricing": {
+                    "prompt": "0.000005",
+                    "completion": "0.00003",
+                    "input_cache_write": "0",  # published as free
+                }
+            },
+        },
+    )
+    kwargs = dict(provider="openrouter", base_url="https://openrouter.ai/api/v1")
+    usage = CanonicalUsage(input_tokens=0, output_tokens=0, cache_write_tokens=1_000_000)
+
+    premium = estimate_usage_cost("premium-model", usage, **kwargs)
+    free = estimate_usage_cost("free-write-model", usage, **kwargs)
+    premium_entry = get_pricing_entry("premium-model", **kwargs)
+    input_rate = premium_entry.input_cost_per_million
+
+    # Published premium honoured, and it is strictly above the input rate —
+    # so it demonstrably was not overwritten by the fallback.
+    assert premium.amount_usd == premium_entry.cache_write_cost_per_million
+    assert premium.amount_usd > input_rate
+    # A published zero stays zero rather than being read as "missing".
+    assert free.amount_usd == 0
+    # Neither annotates the fallback.
+    assert not any("input rate" in n for n in premium.notes)
+    assert not any("input rate" in n for n in free.notes)
+
+
+def test_cache_write_still_unknown_when_input_rate_is_also_missing(monkeypatch):
+    """Guard on the bail-out: with neither a cache-write nor an input rate the
+    route is genuinely unpriceable and must stay unknown. The fallback must not
+    paper over a truly absent price."""
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_model_metadata",
+        lambda: {"output-only-model": {"pricing": {"completion": "0.00001"}}},
+    )
+
+    result = estimate_usage_cost(
+        "output-only-model",
+        CanonicalUsage(input_tokens=0, output_tokens=10, cache_write_tokens=5000),
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert result.status == "unknown"
+    assert result.amount_usd is None
+
+
+def test_cache_read_does_not_fall_back_to_the_input_rate(monkeypatch):
+    """The cache-read/cache-write asymmetry is deliberate and must hold: a
+    cache READ is discounted, so substituting the input rate would over-bill
+    rather than fill a gap. A missing cache-read rate stays unknown even
+    though the input rate is known."""
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_model_metadata",
+        lambda: {
+            "no-read-rate-model": {
+                "pricing": {"prompt": "0.000005", "completion": "0.00003"}
+            }
+        },
+    )
+
+    result = estimate_usage_cost(
+        "no-read-rate-model",
+        CanonicalUsage(input_tokens=10, output_tokens=10, cache_read_tokens=5000),
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert result.status == "unknown"
+
+
+def test_no_shipped_route_is_unpriceable_solely_because_of_cache_write():
+    """Invariant over the shipped pricing snapshot: for every entry that can
+    price a plain input+output turn, adding cache-write tokens must not turn
+    the turn unpriceable. This is the bug class — on the pre-fix code every
+    snapshot entry lacking a cache-write premium (OpenAI, DeepSeek, Google,
+    Bedrock Nova, ...) dropped the whole turn to status=unknown."""
+    from agent.usage_pricing import _OFFICIAL_DOCS_PRICING
+
+    regressed = []
+    for (provider, model), entry in _OFFICIAL_DOCS_PRICING.items():
+        if entry.input_cost_per_million is None or entry.output_cost_per_million is None:
+            continue
+        baseline = estimate_usage_cost(
+            model,
+            CanonicalUsage(input_tokens=1000, output_tokens=500),
+            provider=provider,
+        )
+        if baseline.status != "estimated":
+            continue  # not priceable for unrelated reasons; not our contract
+        with_write = estimate_usage_cost(
+            model,
+            CanonicalUsage(input_tokens=1000, output_tokens=500, cache_write_tokens=50_000),
+            provider=provider,
+        )
+        if with_write.status != "estimated" or with_write.amount_usd is None:
+            regressed.append(f"{provider}/{model}")
+        elif with_write.amount_usd <= baseline.amount_usd:
+            regressed.append(f"{provider}/{model} (cache-write billed as free)")
+
+    assert not regressed, (
+        "shipped routes made unpriceable by cache-write tokens alone: "
+        f"{sorted(regressed)}"
+    )


### PR DESCRIPTION
# fix(pricing): bill cache-write at the input rate when no write premium is published

## Symptom on current `main`

Any turn that carries **cache-write tokens** on a provider that publishes no
separate cache-write rate is dropped **entirely** as unpriced. `cost_usd`
records NULL, `/usage` and the cost footer show `n/a` — and the input, output
and cache-read components, whose rates were known all along, are discarded with
it. Real spend is silently unaccounted.

Reproduced on `main` with no fixture, using this repo's own shipped snapshot:

```python
>>> from agent.usage_pricing import estimate_usage_cost, CanonicalUsage
>>> u = CanonicalUsage(input_tokens=1000, output_tokens=500,
...                    cache_read_tokens=2000, cache_write_tokens=50_000)
>>> estimate_usage_cost("gpt-4o", u, provider="openai").status
'unknown'
>>> # identical turn, cache-write tokens removed:
>>> u2 = CanonicalUsage(input_tokens=1000, output_tokens=500, cache_read_tokens=2000)
>>> estimate_usage_cost("gpt-4o", u2, provider="openai").status
'estimated'
```

This is not one exotic model. **35 of the 66 entries** in
`_OFFICIAL_DOCS_PRICING` have a known input rate and no cache-write rate — every
OpenAI, DeepSeek, Google, Fireworks, MiniMax and Bedrock-Nova entry the repo
ships. The regression test enumerates them; the RED run below names all 35.

## Exact line where it manifests

`agent/usage_pricing.py:1241`, in `estimate_usage_cost()`:

```python
    if usage.cache_write_tokens:
        if entry.cache_write_cost_per_million is None:
            return CostResult(                       # ← whole turn discarded
                amount_usd=None,
                status="unknown",
                source=entry.source,
                label="n/a",
                notes=("cache-write pricing unavailable for route",),
            )
```

A missing rate short-circuits the entire function before the accumulation block
at `:1250-1257` ever runs, so the known input/output/cache-read money is thrown
away along with the unknown cache-write money.

## Root cause

**Cache-write tokens are prompt tokens.** This module already says so —
`CanonicalUsage.prompt_tokens` (`agent/usage_pricing.py:42`) is defined as
`input_tokens + cache_read_tokens + cache_write_tokens`, and every branch of
`normalize_usage()` derives `input_tokens` by *subtracting* the cache buckets
out of the provider's prompt total.

Only some providers charge a **premium** for the write. Anthropic bills it at
1.25x input — and accordingly every Anthropic entry in `_OFFICIAL_DOCS_PRICING`
sets `cache_write_cost_per_million` explicitly. Providers that charge **no**
premium publish no such field, because those tokens are simply billed as
ordinary input.

So the field being absent means *"no premium"*, not *"unpriceable"*. `main`
reads the second meaning, and pays for it by dropping the turn.

## The fix

One shared property on `PricingEntry`, and both consumers routed through it:

```python
@property
def effective_cache_write_cost_per_million(self) -> Optional[Decimal]:
    if self.cache_write_cost_per_million is not None:
        return self.cache_write_cost_per_million
    return self.input_cost_per_million
```

Three deliberate properties:

**1. It only fills a gap, never overrides.** A published rate — including a
published `0` — is returned verbatim. Pinned by a test that checks the premium
is used *and* is strictly above the input rate, so it demonstrably wasn't
overwritten.

**2. It still bails when the route is genuinely unpriceable.** With no
cache-write rate *and* no input rate the property returns `None` and the
estimator keeps returning `status="unknown"`. That guard is unchanged; only its
condition moved behind the property.

**3. Cache-*read* is deliberately left alone.** A cache read is *discounted*
(often 10x), so falling back to the input rate there would **over-bill** rather
than fill a gap. The asymmetry is intentional, documented on the property, and
pinned by its own test.

Turns priced via the fallback carry an explicit note
(`"cache-write billed at the input rate (provider publishes no separate
cache-write rate)"`), so the estimate is legible rather than silent.

### Sibling call paths

Per *"fixes the whole bug class — sibling call paths included"*, the two
`cache_write_cost_per_million` consumers in the langfuse cost-breakdown
(`plugins/observability/langfuse/__init__.py:591` and `:1011`) are routed
through the same property. Both previously emitted a `cost_details` breakdown
with the `cache_creation_input_tokens` line **silently missing** on exactly
these providers, so the per-type split didn't add up to the total. Using the
shared property fixes both without duplicating the policy.

## Test evidence

Five new tests in `tests/agent/test_usage_pricing.py`:

| test | asserts |
|---|---|
| `test_cache_write_falls_back_to_input_rate_when_no_premium_published` | a turn with cache-write costs **exactly what the same prompt-token budget costs as plain input** |
| `test_published_cache_write_premium_is_never_replaced_by_the_input_rate` | a published premium is used verbatim and is `> input_rate`; a published `0` stays `0` |
| `test_cache_write_still_unknown_when_input_rate_is_also_missing` | genuinely unpriceable routes stay `unknown` |
| `test_cache_read_does_not_fall_back_to_the_input_rate` | the read/write asymmetry holds |
| `test_no_shipped_route_is_unpriceable_solely_because_of_cache_write` | invariant over the shipped snapshot: adding cache-write tokens may never make a priceable route unpriceable |

Per *"Behavior contracts over snapshots"*, none freezes a dollar figure or a
model list. The first asserts an **equality between two ways of accounting for
the same tokens**; the last asserts a **property of every shipped entry**, so a
rate edit or a new model keeps it green and only the bug class turns it red.

```
# fix applied
$ pytest tests/agent/test_usage_pricing.py -q
37 passed              # 32 pre-existing + 5 new

# RED proof — fallback removed from the property, tests kept
$ pytest tests/agent/test_usage_pricing.py -q
2 failed, 35 passed
  FAILED ...::test_cache_write_falls_back_to_input_rate_when_no_premium_published
  FAILED ...::test_no_shipped_route_is_unpriceable_solely_because_of_cache_write
      AssertionError: shipped routes made unpriceable by cache-write tokens alone:
        ['bedrock/amazon.nova-lite', ..., 'openai/gpt-4o', 'openai/o3', ...]   (35 routes)

# no regression
$ pytest tests/agent/test_usage_pricing.py tests/plugins/test_langfuse_plugin.py -q
85 passed
$ pytest tests/agent/ -q -k "pricing or usage or cost or credits"
311 passed, 6526 deselected
```

## Footprint

- `agent/usage_pricing.py`: +25 (one documented property) / ~10 changed at the
  two use sites. No signature or public API change.
- `plugins/observability/langfuse/__init__.py`: 2 sibling sites routed through
  the same property.
- No new core tool, no new `HERMES_*` env var, no config key, no new
  dependency, and **no edits to the pricing data itself**.
