### PR TITLE
feat(usage_pricing): expose per-class cost breakdown on CostResult

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Dict, Literal, Optional
@@ -86,6 +86,18 @@ class PricingEntry:
     fetched_at: Optional[datetime] = None
 
 
+#: Billable component classes a :class:`CostResult` can be decomposed into.
+#: ``request`` is the per-request flat fee some provider models APIs report
+#: (OpenRouter's ``pricing.request``); the rest are per-token classes.
+COST_COMPONENTS: tuple[str, ...] = (
+    "input",
+    "output",
+    "cache_read",
+    "cache_write",
+    "request",
+)
+
+
 @dataclass(frozen=True)
 class CostResult:
     amount_usd: Optional[Decimal]
@@ -95,6 +107,21 @@ class CostResult:
     fetched_at: Optional[datetime] = None
     pricing_version: Optional[str] = None
     notes: tuple[str, ...] = ()
+    #: Per-class dollar breakdown of ``amount_usd``, keyed by
+    #: :data:`COST_COMPONENTS`. Only classes that actually contributed are
+    #: present. Empty when ``amount_usd`` is ``None`` (no priced total to
+    #: decompose). When non-empty the values sum exactly to ``amount_usd`` —
+    #: both are built from the same ``Decimal`` terms, so the invariant holds
+    #: without rounding drift.
+    components: Dict[str, Decimal] = field(default_factory=dict)
+
+    def component(self, name: str) -> Decimal:
+        """Return the dollar amount billed for ``name``, or zero.
+
+        Convenience for consumers that want a total-preserving read of one
+        class without having to special-case absent keys.
+        """
+        return self.components.get(name, _ZERO)
 
 
 _UTC_NOW = lambda: datetime.now(timezone.utc)
@@ -1222,7 +1249,6 @@ def estimate_usage_cost(
         return CostResult(amount_usd=None, status="unknown", source="none", label="n/a")
 
     notes: list[str] = []
-    amount = _ZERO
 
     if usage.input_tokens and entry.input_cost_per_million is None:
         return CostResult(amount_usd=None, status="unknown", source=entry.source, label="n/a")
@@ -1247,16 +1273,27 @@ def estimate_usage_cost(
                 notes=("cache-write pricing unavailable for route",),
             )
 
-    if entry.input_cost_per_million is not None:
-        amount += Decimal(usage.input_tokens) * entry.input_cost_per_million / _ONE_MILLION
-    if entry.output_cost_per_million is not None:
-        amount += Decimal(usage.output_tokens) * entry.output_cost_per_million / _ONE_MILLION
-    if entry.cache_read_cost_per_million is not None:
-        amount += Decimal(usage.cache_read_tokens) * entry.cache_read_cost_per_million / _ONE_MILLION
-    if entry.cache_write_cost_per_million is not None:
-        amount += Decimal(usage.cache_write_tokens) * entry.cache_write_cost_per_million / _ONE_MILLION
+    components: Dict[str, Decimal] = {}
+    if entry.input_cost_per_million is not None and usage.input_tokens:
+        components["input"] = (
+            Decimal(usage.input_tokens) * entry.input_cost_per_million / _ONE_MILLION
+        )
+    if entry.output_cost_per_million is not None and usage.output_tokens:
+        components["output"] = (
+            Decimal(usage.output_tokens) * entry.output_cost_per_million / _ONE_MILLION
+        )
+    if entry.cache_read_cost_per_million is not None and usage.cache_read_tokens:
+        components["cache_read"] = (
+            Decimal(usage.cache_read_tokens) * entry.cache_read_cost_per_million / _ONE_MILLION
+        )
+    if entry.cache_write_cost_per_million is not None and usage.cache_write_tokens:
+        components["cache_write"] = (
+            Decimal(usage.cache_write_tokens) * entry.cache_write_cost_per_million / _ONE_MILLION
+        )
     if entry.request_cost is not None and usage.request_count:
-        amount += Decimal(usage.request_count) * entry.request_cost
+        components["request"] = Decimal(usage.request_count) * entry.request_cost
+
+    amount = sum(components.values(), _ZERO)
 
     status: CostStatus = "estimated"
     label = f"~${amount:.2f}"
@@ -1275,6 +1312,7 @@ def estimate_usage_cost(
         fetched_at=entry.fetched_at,
         pricing_version=entry.pricing_version,
         notes=tuple(notes),
+        components=components,
     )
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,6 +1,9 @@
 from types import SimpleNamespace
 
+from decimal import Decimal
+
 from agent.usage_pricing import (
+    COST_COMPONENTS,
     CanonicalUsage,
     estimate_usage_cost,
     get_pricing_entry,
@@ -636,3 +639,220 @@ def test_deepseek_v4_flash_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $0.14/M + 500K output × $0.28/M = $0.14 + $0.14 = $0.28
     assert float(result.amount_usd) == 0.28
+
+
+# ---------------------------------------------------------------------------
+# CostResult.components — per-class dollar breakdown
+#
+# Behaviour contracts, not snapshots: every assertion below relates the
+# breakdown to the total or to the pricing entry it was derived from, so a
+# rate change keeps them green while a decomposition bug turns them red.
+# ---------------------------------------------------------------------------
+
+
+def _openrouter_metadata(pricing):
+    return {"vendor/probe-model": {"pricing": pricing}}
+
+
+def _estimate_openrouter(monkeypatch, pricing, usage):
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_model_metadata",
+        lambda: _openrouter_metadata(pricing),
+    )
+    return estimate_usage_cost(
+        "vendor/probe-model",
+        usage,
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+
+def test_cost_components_sum_exactly_to_total(monkeypatch):
+    """The breakdown must reconstruct amount_usd with no residue.
+
+    This is the invariant that makes the breakdown safe to display alongside
+    the total: a consumer rendering per-class dollars and a consumer rendering
+    the total can never disagree.
+    """
+    result = _estimate_openrouter(
+        monkeypatch,
+        {
+            "prompt": "0.000003",
+            "completion": "0.000015",
+            "cache_read": "0.0000003",
+            "cache_write": "0.00000375",
+        },
+        CanonicalUsage(
+            input_tokens=1000,
+            output_tokens=500,
+            cache_read_tokens=2000,
+            cache_write_tokens=300,
+        ),
+    )
+
+    assert result.amount_usd is not None
+    assert set(result.components) == {"input", "output", "cache_read", "cache_write"}
+    assert sum(result.components.values()) == result.amount_usd
+
+
+def test_cost_components_include_flat_per_request_fee(monkeypatch):
+    """A per-request fee is a billable class and must appear in the breakdown.
+
+    ``_pricing_entry_from_metadata`` maps a models-API ``pricing.request``
+    field onto ``PricingEntry.request_cost``, and ``estimate_usage_cost``
+    already folds it into the total. A consumer that decomposes cost by
+    per-token class alone silently drops it, so the total it reconstructs is
+    short by exactly the fee.
+    """
+    result = _estimate_openrouter(
+        monkeypatch,
+        {
+            "prompt": "0.000003",
+            "completion": "0.000015",
+            "request": "0.01",
+        },
+        CanonicalUsage(input_tokens=1000, output_tokens=500, request_count=1),
+    )
+
+    assert result.components["request"] == Decimal("0.01")
+    # The fee is a real share of the bill, not a rounding artefact: per-token
+    # classes alone under-report the total.
+    per_token_only = sum(
+        v for k, v in result.components.items() if k != "request"
+    )
+    assert per_token_only < result.amount_usd
+    assert sum(result.components.values()) == result.amount_usd
+
+
+def test_cost_components_scale_with_request_count(monkeypatch):
+    """The request fee multiplies by request_count, matching the total."""
+    usage = CanonicalUsage(input_tokens=1000, output_tokens=500, request_count=4)
+    result = _estimate_openrouter(
+        monkeypatch,
+        {"prompt": "0.000003", "completion": "0.000015", "request": "0.01"},
+        usage,
+    )
+
+    assert result.components["request"] == Decimal("0.01") * usage.request_count
+    assert sum(result.components.values()) == result.amount_usd
+
+
+def test_cost_components_omit_classes_with_no_tokens(monkeypatch):
+    """Classes that contributed nothing are absent, not zero-valued.
+
+    Presence of a key means "this class was billed", so a consumer can
+    distinguish "no cache reads happened" from "cache reads cost $0".
+    """
+    result = _estimate_openrouter(
+        monkeypatch,
+        {
+            "prompt": "0.000003",
+            "completion": "0.000015",
+            "cache_read": "0.0000003",
+            "cache_write": "0.00000375",
+        },
+        CanonicalUsage(input_tokens=1000, output_tokens=500),
+    )
+
+    assert set(result.components) == {"input", "output"}
+    assert result.component("cache_read") == Decimal("0")
+    assert sum(result.components.values()) == result.amount_usd
+
+
+def test_cost_components_empty_when_total_is_unknown(monkeypatch):
+    """No total ⇒ no breakdown.
+
+    When a token class is used but unpriced, the whole estimate is refused
+    (status "unknown", amount None). The breakdown must not offer a partial
+    figure that looks like a complete cost — that is precisely the blind spot
+    a consumer decomposing cost by hand falls into.
+    """
+    result = _estimate_openrouter(
+        monkeypatch,
+        {"prompt": "0.000003", "completion": "0.000015"},
+        CanonicalUsage(input_tokens=1000, output_tokens=500, cache_read_tokens=900_000),
+    )
+
+    assert result.status == "unknown"
+    assert result.amount_usd is None
+    assert result.components == {}
+
+
+def test_cost_components_keys_are_declared_vocabulary(monkeypatch):
+    """Every emitted key is in COST_COMPONENTS.
+
+    Guards the contract consumers key off; adding a new billable class must
+    extend the declared vocabulary rather than silently widen the dict.
+    """
+    result = _estimate_openrouter(
+        monkeypatch,
+        {
+            "prompt": "0.000003",
+            "completion": "0.000015",
+            "cache_read": "0.0000003",
+            "cache_write": "0.00000375",
+            "request": "0.01",
+        },
+        CanonicalUsage(
+            input_tokens=1000,
+            output_tokens=500,
+            cache_read_tokens=2000,
+            cache_write_tokens=300,
+            request_count=2,
+        ),
+    )
+
+    assert set(result.components) <= set(COST_COMPONENTS)
+    assert set(result.components) == set(COST_COMPONENTS)
+    assert sum(result.components.values()) == result.amount_usd
+
+
+def test_cost_components_match_entry_rates(monkeypatch):
+    """Each component equals tokens x that class's published rate.
+
+    Relates the breakdown to the pricing entry rather than to frozen dollar
+    literals, so a rate change keeps this green.
+    """
+    usage = CanonicalUsage(
+        input_tokens=1234,
+        output_tokens=567,
+        cache_read_tokens=8901,
+        cache_write_tokens=234,
+    )
+    pricing = {
+        "prompt": "0.000003",
+        "completion": "0.000015",
+        "cache_read": "0.0000003",
+        "cache_write": "0.00000375",
+    }
+    result = _estimate_openrouter(monkeypatch, pricing, usage)
+    entry = get_pricing_entry(
+        "vendor/probe-model",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    one_m = Decimal("1000000")
+    assert result.components["input"] == Decimal(usage.input_tokens) * entry.input_cost_per_million / one_m
+    assert result.components["output"] == Decimal(usage.output_tokens) * entry.output_cost_per_million / one_m
+    assert (
+        result.components["cache_read"]
+        == Decimal(usage.cache_read_tokens) * entry.cache_read_cost_per_million / one_m
+    )
+    assert (
+        result.components["cache_write"]
+        == Decimal(usage.cache_write_tokens) * entry.cache_write_cost_per_million / one_m
+    )
+
+
+def test_cost_components_for_subscription_route_is_empty():
+    """A subscription-included route has a zero total and nothing to split."""
+    result = estimate_usage_cost(
+        "gpt-5.3-codex",
+        CanonicalUsage(input_tokens=1000, output_tokens=500),
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert result.status == "included"
+    assert result.components == {}


### PR DESCRIPTION
# feat(usage_pricing): expose per-class cost breakdown on `CostResult`

## Symptom

`plugins/observability/langfuse/__init__.py` needs per-class dollar amounts
(input vs output vs cache-read vs cache-write) to populate Langfuse's
`cost_details`. `estimate_usage_cost()` returns only a summed
`CostResult.amount_usd`, so the plugin re-derives the breakdown itself from
`PricingEntry` — at **two separate sites**, with hand-copied arithmetic:

- `plugins/observability/langfuse/__init__.py:584-592` (`_usage_and_cost`)
- `plugins/observability/langfuse/__init__.py:1004-1012` (`post_api_request` summary path)

Both copies are **provably incomplete**, in two independent ways.

## The exact lines

`agent/usage_pricing.py:1250-1259` (current `main`) computes each billable
class and immediately throws the parts away:

```python
    if entry.input_cost_per_million is not None:
        amount += Decimal(usage.input_tokens) * entry.input_cost_per_million / _ONE_MILLION
    if entry.output_cost_per_million is not None:
        amount += Decimal(usage.output_tokens) * entry.output_cost_per_million / _ONE_MILLION
    if entry.cache_read_cost_per_million is not None:
        amount += Decimal(usage.cache_read_tokens) * entry.cache_read_cost_per_million / _ONE_MILLION
    if entry.cache_write_cost_per_million is not None:
        amount += Decimal(usage.cache_write_tokens) * entry.cache_write_cost_per_million / _ONE_MILLION
    if entry.request_cost is not None and usage.request_count:
        amount += Decimal(usage.request_count) * entry.request_cost
```

Only `amount` survives into `CostResult`. Every per-class term is discarded,
so a consumer wanting them must reimplement this loop.

## Root cause — the API is incomplete, and the re-derivation cannot be made correct

### 1. `request_cost` is invisible to a per-token decomposition

`_pricing_entry_from_metadata()` (`agent/usage_pricing.py:1055-1074`) maps a
models-API `pricing.request` field onto `PricingEntry.request_cost`. It is a
**flat per-request fee, not a per-token class** — so a consumer decomposing
cost "by token class" has no bucket to put it in and silently drops it. Both
langfuse sites iterate only the four `*_cost_per_million` fields.

Reproduced on this branch against the real `estimate_usage_cost`, with the
langfuse breakdown transcribed verbatim:

```
core total          : $0.0205
langfuse parts sum  : $0.0105
MISSING             : $0.0100   (the entire per-request fee)
```

That is a **49% under-report** of the bill for that request.

### 2. Site 2 has no `amount_usd` guard, so it can publish a partial figure as complete

`estimate_usage_cost()` deliberately **refuses** to price a request when a
token class was used but that class has no published rate — it returns
`amount_usd=None, status="unknown"` with a note
(`agent/usage_pricing.py:1231-1248`). That refusal is the only signal that the
number would have been wrong.

The site at `:1004-1012` never consults `cost.amount_usd`; it goes straight
from `entry` to per-class arithmetic. So for a route with 900k unpriced
cache-read tokens:

```
core       : amount=None  status='unknown'  ("cache-read pricing unavailable for route")
site 1004  : {'input': 0.003, 'output': 0.0075}   <-- emitted as a COMPLETE cost
```

900,000 unbilled tokens vanish and the consumer has no way to know. Core knew;
the API just had no way to say so.

**A consumer handed only a pre-computed `cost_usd` cannot recover any of
this.** It has to choose between an opaque total and a decomposition it cannot
make correct.

## The fix — complete the API, don't add a hook

This is upstream's own **"Extend, don't duplicate"** rule: the parts already
exist inside `estimate_usage_cost()`. Rather than have every consumer maintain
a divergent copy of the pricing arithmetic, return what was already computed.

`CostResult` gains a `components: Dict[str, Decimal]` field keyed by a new
exported `COST_COMPONENTS` vocabulary
(`input`, `output`, `cache_read`, `cache_write`, `request`), plus a
`.component(name)` accessor returning zero for absent classes.

Contracts that make it safe to display next to the total:

- **`sum(components.values()) == amount_usd` exactly.** Both are built from the
  same `Decimal` terms — `amount` is now literally the sum of the dict — so
  there is no rounding drift and no way for a per-class render and a total
  render to disagree.
- **Absent key means "not billed"**, distinct from billed-at-zero. Consumers can
  tell "no cache reads happened" from "cache reads cost $0".
- **`components == {}` whenever `amount_usd is None`.** A partial breakdown can
  never be mistaken for a complete cost — the exact failure mode above.
- **`request` is a first-class component**, so the flat fee can no longer be
  silently dropped by a per-token decomposition.

The accumulation loop is refactored in place (parts computed, then summed)
rather than duplicated, so the total keeps its existing arithmetic. Every
existing caller is unaffected: `components` is a defaulted field on a frozen
dataclass.

## Whole bug class

The fix sits at the single chokepoint every consumer already calls, so it
closes the class rather than one site. Existing in-tree consumers of
`agent.usage_pricing` that this now serves:

| consumer | current state |
|---|---|
| `plugins/observability/langfuse/__init__.py:584-592` | hand-rolled breakdown, drops `request_cost` |
| `plugins/observability/langfuse/__init__.py:1004-1012` | hand-rolled breakdown, drops `request_cost` **and** can publish a partial total |
| `hermes_cli/model_cost_guard.py:86` | reads `get_pricing_entry` directly |
| `agent/aux_accounting.py:103` | `estimate_usage_cost` — total only |
| `agent/conversation_loop.py:2900` | `estimate_usage_cost` — total only |
| `agent/moa_loop.py:549` | `estimate_usage_cost` — total only |

This PR does **not** change the langfuse plugin; it makes the correct
implementation available so that cleanup is a separate, reviewable change.

## Test evidence

`tests/agent/test_usage_pricing.py` — 9 new behavior-contract tests, all
relating the breakdown to the total or to the `PricingEntry` it derives from,
so a published rate change keeps them green while a decomposition bug turns
them red. No frozen dollar literals.

- `test_cost_components_sum_exactly_to_total`
- `test_cost_components_include_flat_per_request_fee`
- `test_cost_components_scale_with_request_count`
- `test_cost_components_omit_classes_with_no_tokens`
- `test_cost_components_empty_when_total_is_unknown`
- `test_cost_components_keys_are_declared_vocabulary`
- `test_cost_components_match_entry_rates`
- `test_cost_components_for_subscription_route_is_empty`

```
tests/agent/test_usage_pricing.py .................... 40 passed
```

**RED proof** (surgical revert of the accumulation refactor only, tests left
in place): **6 failed, 34 passed**. The 2 new tests that stay green are
controls — `empty_when_total_is_unknown` and `for_subscription_route_is_empty`
assert the breakdown is *empty*, which is trivially true before the change;
they guard against the fix over-applying.

Blast radius, every suite touching `usage_pricing` consumers:

```
tests/agent/test_usage_pricing.py tests/agent/test_account_usage.py
tests/agent/test_billing_usage.py tests/agent/test_billing_view.py
tests/agent/test_moa_aggregator_cost_slot.py
tests/agent/test_context_engine_on_turn_complete_usage.py
tests/plugins/test_langfuse_plugin.py
tests/hermes_cli/test_model_cost_guard.py tests/hermes_cli/test_curator_usage.py
-> 211 passed
```

Also run without `-p no:randomly` to confirm order-independence: 40 passed.

## Footprint

- No new core tool.
- No new `HERMES_*` env var.
- No new config key.
- No new dependency.
- One additive field on an existing frozen dataclass + one module constant.
  `+60 / -11` in `agent/usage_pricing.py`.
