### PR TITLE
fix(model-metadata): OpenAI-compatible endpoints misdetected as LM Studio lose all metadata

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -725,6 +725,69 @@ def _localhost_to_ipv4(url: str) -> str:
     )
 
 
+def _is_lmstudio_models_payload(response: Any) -> bool:
+    """Return True only when an ``/api/v1/models`` 200 is genuinely LM Studio.
+
+    A 200 on this path is not by itself evidence of LM Studio: any
+    OpenAI-compatible local server is free to serve it, and several do (a
+    loopback proxy that exposes ``/api/v1/models`` so a harness can validate
+    model names, for one). Those return the standard OpenAI listing envelope,
+    ``{"object": "list", "data": [{"id": ..., "object": "model"}]}``.
+
+    LM Studio's native listing is structurally different: it keys entries under
+    ``models``, does not stamp ``object="list"``, and each entry carries fields
+    the OpenAI envelope never has (``loaded_instances``, ``max_context_length``,
+    ``arch``, ``publisher``, a publisher-qualified ``key``, or a ``type`` such as
+    "llm" paired with a ``state``). Discriminating on that shape — rather than on
+    a bare 200 — is what keeps a generic OpenAI server out of the LM Studio
+    branch.
+
+    Fails closed: any parse error or unrecognised shape returns False, so the
+    caller simply continues its detection waterfall and ends up on the
+    OpenAI-compatible path, which is the correct handling for such a server.
+    """
+    # Any ONE of these is decisive — the OpenAI listing envelope has none of them.
+    strong_markers = (
+        "loaded_instances",
+        "max_context_length",
+        "arch",
+        "publisher",
+        "key",  # publisher-qualified id, e.g. "qwen/qwen3-4b"
+    )
+    try:
+        data = response.json()
+    except Exception:
+        return False
+    if not isinstance(data, dict):
+        return False
+    # An explicit OpenAI list envelope is a decisive NEGATIVE signal: LM Studio's
+    # native payload does not stamp object="list". This rejects every standard
+    # OpenAI-compatible server up front, whatever its entries happen to carry.
+    if data.get("object") == "list":
+        return False
+    # LM Studio keys entries under `models`; the OpenAI envelope never does, so
+    # the key itself is a positive signal. Fall back to `data` for builds that
+    # use it.
+    lmstudio_keyed = isinstance(data.get("models"), list)
+    entries = data.get("models") if lmstudio_keyed else data.get("data")
+    if not isinstance(entries, list):
+        return False
+    if not entries:
+        # An idle LM Studio (running, no model loaded) returns an empty list.
+        # Accept that only on the LM Studio-native `models` key — an empty
+        # `{"data": []}` is indistinguishable from an idle OpenAI server once
+        # the `object: "list"` envelope is absent, so fail closed there.
+        return lmstudio_keyed
+    first = entries[0]
+    if not isinstance(first, dict):
+        return False
+    if any(marker in first for marker in strong_markers):
+        return True
+    # `type` and `state` are individually too generic to be evidence, so they
+    # only count together.
+    return "type" in first and "state" in first
+
+
 def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
     """Detect which local server is running at base_url by probing known endpoints.
 
@@ -757,10 +820,18 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
     result: Optional[str] = None
     try:
         with httpx.Client(timeout=2.0, headers=headers) as client:
-            # LM Studio exposes /api/v1/models — check first (most specific)
+            # LM Studio exposes /api/v1/models — check first (most specific).
+            #
+            # A 200 is NOT sufficient evidence: other OpenAI-compatible local
+            # servers answer this path too, and returning the standard OpenAI
+            # listing shape. Classifying those as LM Studio routes the caller
+            # into the LM Studio metadata parser, which reads payload["models"]
+            # — absent from an OpenAI listing — and yields NO metadata at all,
+            # so an advertised context window is discarded and the caller falls
+            # back to a probe-tier default. Require the native payload shape.
             try:
                 r = client.get(f"{lmstudio_url}/api/v1/models")
-                if r.status_code == 200:
+                if r.status_code == 200 and _is_lmstudio_models_payload(r):
                     result = "lm-studio"
             except Exception:
                 pass

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -474,6 +474,11 @@ class TestDetectLocalServerTypeAuth:
 
         resp = MagicMock()
         resp.status_code = 200
+        # LM Studio's native listing shape — detect_local_server_type
+        # discriminates on the payload shape, not on a bare 200.
+        resp.json.return_value = {
+            "models": [{"key": "publisher/model-a", "type": "llm", "state": "loaded"}]
+        }
 
         client_mock = MagicMock()
         client_mock.__enter__ = lambda s: client_mock
@@ -493,6 +498,11 @@ class TestDetectLocalServerTypeAuth:
 
         resp = MagicMock()
         resp.status_code = 200
+        # LM Studio's native listing shape — detect_local_server_type
+        # discriminates on the payload shape, not on a bare 200.
+        resp.json.return_value = {
+            "models": [{"key": "publisher/model-a", "type": "llm", "state": "loaded"}]
+        }
 
         client_mock = MagicMock()
         client_mock.__enter__ = lambda s: client_mock

--- a/tests/agent/test_probe_cache_followups.py
+++ b/tests/agent/test_probe_cache_followups.py
@@ -161,7 +161,20 @@ class TestDetectLocalServerTypeCache:
 
         lmstudio_resp = MagicMock()
         lmstudio_resp.status_code = 200
-        lmstudio_resp.json.return_value = {"data": []}
+        # LM Studio's native listing shape (entries keyed under "models" with
+        # LM Studio-specific fields). detect_local_server_type discriminates on
+        # this shape, not on a bare 200, so the fixture has to be a payload a
+        # real LM Studio would send.
+        lmstudio_resp.json.return_value = {
+            "models": [
+                {
+                    "key": "qwen/qwen3-4b",
+                    "type": "llm",
+                    "state": "loaded",
+                    "loaded_instances": [{"config": {"context_length": 8192}}],
+                }
+            ]
+        }
         swap_client = MagicMock()
         swap_client.__enter__ = lambda s: swap_client
         swap_client.__exit__ = MagicMock(return_value=False)
@@ -311,3 +324,157 @@ class TestContextCacheKeyNormalization:
 
         assert ("m1", "http://host/v1") not in model_metadata._LOCAL_CTX_PROBE_CACHE
         assert ("ollama_show", "m1", "http://host/v1") not in model_metadata._LOCAL_CTX_PROBE_CACHE
+
+
+class TestLMStudioDetectionRequiresNativePayload:
+    """A bare 200 on /api/v1/models is not evidence of LM Studio.
+
+    Other OpenAI-compatible local servers serve that path too (e.g. a loopback
+    proxy exposing it for model-name validation). Misdetecting one sends the
+    caller into the LM Studio metadata parser, which reads ``payload["models"]``
+    — a key the OpenAI listing envelope does not have — so ALL advertised
+    metadata is discarded and the caller falls back to a probe-tier default.
+    """
+
+    def _detect(self, payload):
+        from agent.model_metadata import detect_local_server_type
+
+        hit = MagicMock()
+        hit.status_code = 200
+        hit.json.return_value = payload
+        hit.text = ""
+        miss = MagicMock()
+        miss.status_code = 404
+        miss.text = ""
+        miss.json.return_value = {}
+
+        client = MagicMock()
+        client.__enter__ = lambda s: client
+        client.__exit__ = MagicMock(return_value=False)
+        client.get.side_effect = (
+            lambda url, *a, **k: hit if url.endswith("/api/v1/models") else miss
+        )
+        with patch("httpx.Client", return_value=client):
+            return detect_local_server_type("http://127.0.0.1:8080/v1")
+
+    def test_openai_listing_envelope_is_not_lm_studio(self):
+        """The standard OpenAI listing shape must never classify as LM Studio,
+        whatever its entries carry."""
+        assert self._detect(
+            {"object": "list", "data": [{"id": "some-model", "object": "model"}]}
+        ) != "lm-studio"
+        # Even when the entries carry rich metadata, the envelope decides.
+        assert self._detect(
+            {
+                "object": "list",
+                "data": [{"id": "m", "object": "model", "context_length": 1_000_000}],
+            }
+        ) != "lm-studio"
+
+    def test_lm_studio_native_payload_is_still_detected(self):
+        """The feature must survive the fix: LM Studio's own shapes still
+        classify, including an idle server with nothing loaded."""
+        assert self._detect(
+            {
+                "models": [
+                    {
+                        "key": "qwen/qwen3-4b",
+                        "loaded_instances": [{"config": {"context_length": 8192}}],
+                    }
+                ]
+            }
+        ) == "lm-studio"
+        # Idle LM Studio: running, no model loaded.
+        assert self._detect({"models": []}) == "lm-studio"
+        # `type` + `state` together are an acceptable weaker signal.
+        assert self._detect(
+            {"data": [{"id": "m", "type": "llm", "state": "loaded"}]}
+        ) == "lm-studio"
+
+    def test_unparseable_or_ambiguous_payloads_fail_closed(self):
+        """Fail closed, never open: an unrecognised body must not classify as
+        LM Studio, so the caller continues to the OpenAI-compatible path."""
+        assert self._detect("not-a-dict") != "lm-studio"
+        assert self._detect({}) != "lm-studio"
+        # An empty `data` list is indistinguishable from an idle OpenAI server.
+        assert self._detect({"data": []}) != "lm-studio"
+
+    def test_detection_agrees_with_what_the_lm_studio_parser_can_read(self):
+        """Contract between the detector and its consumer: this module's LM
+        Studio parsers read ``payload["models"]``. Classifying a payload as
+        LM Studio when that key is absent guarantees the parser yields nothing,
+        which is exactly the bug. So a NON-empty payload may only be called
+        LM Studio if the parser could actually extract a model id from it."""
+        from agent.model_metadata import _is_lmstudio_models_payload
+
+        def parser_can_read(payload):
+            # Mirrors fetch_endpoint_model_metadata's LM Studio branch.
+            if not isinstance(payload, dict):
+                return False
+            return any(
+                isinstance(m, dict) and (m.get("key") or m.get("id"))
+                for m in payload.get("models", []) or []
+            )
+
+        payloads = [
+            {"object": "list", "data": [{"id": "m", "object": "model"}]},
+            {"data": [{"id": "m", "object": "model", "context_length": 1_000_000}]},
+            {"models": [{"key": "qwen/qwen3-4b", "loaded_instances": []}]},
+            {"models": [{"id": "m", "max_context_length": 4096}]},
+            {"data": [{"id": "m", "type": "llm", "state": "loaded"}]},
+            {},
+            {"models": []},
+        ]
+        for payload in payloads:
+            resp = MagicMock()
+            resp.json.return_value = payload
+            classified = _is_lmstudio_models_payload(resp)
+            if classified and payload.get("models"):
+                assert parser_can_read(payload), (
+                    f"classified as LM Studio but the LM Studio parser reads "
+                    f"nothing from it: {payload}"
+                )
+
+
+class TestOpenAICompatProxyMetadataSurvivesDetection:
+    """End-to-end: an OpenAI-compatible server's advertised context window must
+    reach the caller. The LM Studio branch of fetch_endpoint_model_metadata
+    returns early, so a misdetection discards the payload outright rather than
+    falling through to the working OpenAI parser."""
+
+    def test_advertised_context_window_is_not_discarded(self):
+        from agent import model_metadata
+
+        payload = {
+            "object": "list",
+            "data": [
+                {"id": "big-ctx-model", "object": "model", "context_length": 1_000_000}
+            ],
+        }
+        model_metadata._endpoint_model_metadata_cache.clear()
+        model_metadata._endpoint_model_metadata_cache_time.clear()
+
+        probe = MagicMock()
+        probe.status_code = 200
+        probe.json.return_value = payload
+        probe.text = ""
+        client = MagicMock()
+        client.__enter__ = lambda s: client
+        client.__exit__ = MagicMock(return_value=False)
+        client.get.side_effect = lambda url, *a, **k: probe
+
+        def _requests_get(url, **kwargs):
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = payload
+            resp.raise_for_status = lambda: None
+            return resp
+
+        with patch("httpx.Client", return_value=client), patch(
+            "requests.get", side_effect=_requests_get
+        ):
+            metadata = model_metadata.fetch_endpoint_model_metadata(
+                "http://127.0.0.1:8080/v1", force_refresh=True
+            )
+
+        assert metadata.get("big-ctx-model", {}).get("context_length") == 1_000_000


### PR DESCRIPTION
# fix(model-metadata): don't classify an OpenAI-compatible server as LM Studio

## Symptom on current `main`

Point Hermes at a local OpenAI-compatible server that also answers
`/api/v1/models` and **all** of its advertised model metadata is silently
discarded. A server correctly publishing `context_length: 1000000` resolves to
no metadata at all, so the caller falls back to a probe-tier default and the
conversation auto-compacts far below the real window.

Reproduced on `main` with no fixture beyond a mocked HTTP client:

```python
>>> # a standard OpenAI-compatible server that also serves /api/v1/models
>>> payload = {"object": "list",
...            "data": [{"id": "big-ctx-model", "object": "model",
...                      "context_length": 1_000_000}]}
>>> detect_local_server_type("http://127.0.0.1:8080/v1")
'lm-studio'                                     # ← wrong
>>> fetch_endpoint_model_metadata("http://127.0.0.1:8080/v1", force_refresh=True)
{}                                              # ← the whole payload discarded
```

Forcing the correct detection on the *same* payload shows what was lost:

```python
>>> # with detect_local_server_type returning None (OpenAI-compatible path)
{'big-ctx-model': {'name': 'big-ctx-model', 'context_length': 1000000}}
```

## Exact line where it manifests

`agent/model_metadata.py:762`, in `detect_local_server_type()`:

```python
            # LM Studio exposes /api/v1/models — check first (most specific)
            try:
                r = client.get(f"{lmstudio_url}/api/v1/models")
                if r.status_code == 200:          # ← any 200 ⇒ "lm-studio"
                    result = "lm-studio"
```

A bare 200 on that path is treated as proof of LM Studio. Nothing about the
response **body** is examined, so any OpenAI-compatible server that serves the
route is misclassified.

## Why the mislabel destroys data rather than just being cosmetic

`fetch_endpoint_model_metadata()` branches on the result at
`agent/model_metadata.py:1005`:

```python
    if is_local_endpoint(normalized):
        try:
            if detect_local_server_type(normalized, api_key=api_key) == "lm-studio":
                ...
                for model in payload.get("models", []):     # ← absent from an
                    ...                                     #   OpenAI listing
                _endpoint_model_metadata_cache[normalized] = cache
                return cache                                # ← EARLY RETURN
```

The OpenAI envelope keys its entries under `data`, not `models`, so the loop
body never executes, `cache` stays `{}` — and the branch **returns**. The
perfectly good OpenAI-compatible parser 40 lines below at `:1062`
(`for model in payload.get("data", [])`, which calls `_extract_context_length`)
is never reached. One wrong label converts a fully-parseable payload into no
metadata at all.

The same misrouting hits the sibling probe at `:1780`, whose LM Studio branch
(`:1819`) also reads `data.get("models", [])`.

## The fix

Require LM Studio's native payload **shape**, not a bare 200:

```python
if r.status_code == 200 and _is_lmstudio_models_payload(r):
    result = "lm-studio"
```

The new module-private `_is_lmstudio_models_payload()`:

- **Decisive negative** — `object == "list"` (the OpenAI list envelope) is
  rejected up front, whatever the entries carry. LM Studio's native payload
  does not stamp that field.
- **Positive signals** — entries keyed under `models` (a key the OpenAI
  envelope never uses), or any one of `loaded_instances`, `max_context_length`,
  `arch`, `publisher`, `key`. `type` and `state` are individually too generic to
  count, so they only count *together*.
- **Idle LM Studio still detected** — a running server with nothing loaded
  returns an empty list; accepted on the LM Studio-native `models` key. An empty
  `{"data": []}` is indistinguishable from an idle OpenAI server, so it fails
  closed.
- **Fails closed everywhere else** — an unparseable or unrecognised body returns
  `False`, and the caller simply continues its waterfall onto the
  OpenAI-compatible path, which is the correct handling for such a server.

Nothing else changes: LM Studio's own detection, the probe TTL cache, and the
Ollama / llama.cpp / vLLM branches are untouched.

### The discriminator matches this module's own consumer contract

Both LM Studio parsers in the file — `fetch_endpoint_model_metadata()` at
`:1046` and the context probe at `:1819` — read `payload["models"]`.
Classifying a payload *without* that key as LM Studio can therefore only ever
yield nothing, which is precisely the bug. A test pins that relation directly:
for any non-empty payload the detector calls LM Studio, the LM Studio parser
must be able to extract a model id from it. That makes the detector and its
consumers provably consistent rather than merely consistent today.

## Test evidence

Five new tests in `tests/agent/test_probe_cache_followups.py`:

| test | asserts |
|---|---|
| `test_openai_listing_envelope_is_not_lm_studio` | the OpenAI shape never classifies as LM Studio, even with rich entries |
| `test_lm_studio_native_payload_is_still_detected` | the feature survives: loaded, idle, and `type`+`state` shapes all still detect |
| `test_unparseable_or_ambiguous_payloads_fail_closed` | garbage / `{}` / empty `data` never classify as LM Studio |
| `test_detection_agrees_with_what_the_lm_studio_parser_can_read` | detector↔parser contract (above) |
| `test_advertised_context_window_is_not_discarded` | **E2E**: the advertised 1M window reaches the caller through the real `fetch_endpoint_model_metadata` path |

Per *"Behavior contracts over snapshots"*, none freezes a payload snapshot. The
fourth asserts a **relation between the detector and its consumer**; the fifth
asserts the **user-visible outcome** (metadata survives), not the classification
string.

Per *"E2E validation, not just green unit mocks"*, the last test exercises the
real `fetch_endpoint_model_metadata` with real imports rather than asserting on
the detector alone — which is what makes the early-return data loss visible.

### Three existing fixtures corrected, not weakened

`test_passes_bearer_token_to_probe_requests`,
`test_native_api_base_url_is_not_doubled` and
`test_ttl_expiry_allows_server_swap_redetection` asserted LM Studio detection
from a bare 200 with **no body at all** (or `{"data": []}`) — they encoded the
bug as the contract. Their actual subjects are auth headers, URL construction
and TTL re-detection, all unrelated to payload shape, so each now carries a
realistic LM Studio payload and continues to test what it was written to test.

```
# fix applied
$ pytest tests/agent/test_probe_cache_followups.py \
         tests/agent/test_model_metadata_local_ctx.py -q
55 passed

# RED proof — shape check removed, tests kept
$ pytest ... -q
3 failed, 52 passed
  FAILED ...::test_openai_listing_envelope_is_not_lm_studio
  FAILED ...::test_unparseable_or_ambiguous_payloads_fail_closed
  FAILED ...::test_advertised_context_window_is_not_discarded
      AssertionError: assert None == 1000000
        where None = {}.get('big-ctx-model', {}).get('context_length')

# no regression across the model-metadata + probe surface
$ pytest tests/agent/test_probe_cache_followups.py \
         tests/agent/test_model_metadata_local_ctx.py \
         tests/agent/test_model_metadata.py tests/test_ollama_num_ctx.py -q
199 passed
```

## Footprint

- `agent/model_metadata.py`: +63 (one documented module-private predicate) and
  one condition extended at the single detection site. No signature or public
  API change.
- No new core tool, no new `HERMES_*` env var, no config key, no new dependency.
