### PR TITLE
fix(delegate): propagate session ContextVars across the subagent executor boundary

### DIFF
--- a/tests/tools/test_delegate_session_context_propagation.py
+++ b/tests/tools/test_delegate_session_context_propagation.py
@@ -1,0 +1,342 @@
+"""Session identity must survive the subagent executor boundary.
+
+``contextvars`` are per-thread: a ``ThreadPoolExecutor`` worker starts with an
+empty ``Context``. ``tools/delegate_tool.py`` runs every child agent on such a
+worker, so without an explicit snapshot the child executes with **no** gateway
+session identity — and several core, non-telemetry consumers read that identity
+to make routing and security decisions.
+
+These are behavior contracts on the propagation itself (parent value must
+survive into the worker, callbacks must NOT), not snapshots of any particular
+session shape.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from gateway.session_context import (
+    get_session_env,
+    reset_session_vars,
+    set_session_vars,
+)
+from tools.thread_context import copy_context_to_thread, propagate_context_to_thread  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def _clean_session_context():
+    reset_session_vars()
+    yield
+    reset_session_vars()
+
+
+def _bind_parent_session():
+    """Bind a gateway-style session on the calling (parent) thread."""
+    set_session_vars(
+        platform="discord",
+        source="discord",
+        chat_id="C123",
+        chat_name="ops",
+        thread_id="T9",
+        user_id="U1",
+        user_name="ace",
+        session_key="sess-discord-C123",
+        session_id="s-1",
+        ui_session_id="",
+        message_id="m-1",
+        profile="default",
+        cwd="",
+        async_delivery=True,
+    )
+
+
+def _in_worker(fn):
+    """Run *fn* on a worker thread the way delegate_tool submits a child.
+
+    Mirrors the real submit site: the wrapper delegate_tool applies is looked
+    up through the module under test, so removing the wrap at the call site is
+    what these tests detect -- not the helper existing in isolation.
+    """
+    wrap = _delegate_submit_wrapper()
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        return ex.submit(wrap(fn)).result()
+
+
+def _delegate_submit_wrapper():
+    """The context wrapper tools/delegate_tool.py applies before submit().
+
+    Read out of delegate_tool's own module namespace so this test binds to the
+    call site's actual behaviour. If the delegate submit sites stop wrapping,
+    the import below disappears with them and the tests fall back to a bare
+    submit -- which is exactly the regression under test.
+    """
+    import tools.delegate_tool as delegate_tool
+
+    wrap = getattr(delegate_tool, "copy_context_to_thread", None)
+    if wrap is None:
+        return lambda fn: fn
+    return wrap
+
+
+def _in_bare_worker(fn):
+    """Run *fn* on an unwrapped worker — the pre-fix behaviour, for contrast."""
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        return ex.submit(fn).result()
+
+
+# ---------------------------------------------------------------------------
+# The propagation contract
+# ---------------------------------------------------------------------------
+
+
+def test_session_identity_is_lost_on_a_bare_worker():
+    """Documents the limitation the fix exists to close.
+
+    Not a change-detector: it pins the *reason* the snapshot is required. If
+    ContextVars ever started crossing the boundary on their own, this test
+    would turn red and the wrapper could be removed.
+    """
+    _bind_parent_session()
+    assert get_session_env("HERMES_SESSION_PLATFORM") == "discord"
+
+    seen = _in_bare_worker(lambda: get_session_env("HERMES_SESSION_PLATFORM"))
+
+    assert seen == ""
+
+
+def test_session_identity_survives_a_wrapped_worker():
+    _bind_parent_session()
+
+    seen = _in_worker(lambda: get_session_env("HERMES_SESSION_PLATFORM"))
+
+    assert seen == get_session_env("HERMES_SESSION_PLATFORM") == "discord"
+
+
+@pytest.mark.parametrize(
+    "var",
+    [
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_CHAT_ID",
+        "HERMES_SESSION_THREAD_ID",
+        "HERMES_SESSION_USER_ID",
+        "HERMES_SESSION_KEY",
+    ],
+)
+def test_every_session_var_matches_the_parent_in_the_worker(var):
+    """Whole-identity propagation, not just the one var a caller noticed."""
+    _bind_parent_session()
+    parent_value = get_session_env(var)
+    assert parent_value  # guard: the fixture really bound this var
+
+    assert _in_worker(lambda: get_session_env(var)) == parent_value
+
+
+def test_snapshot_is_taken_at_wrap_time_not_at_run_time():
+    """The Context is captured on the parent thread, before submit().
+
+    This is why the wrap must happen at the call site rather than inside the
+    worker: by the time the worker runs, the parent's binding may already have
+    been reset for the next turn.
+    """
+    _bind_parent_session()
+    wrapped = copy_context_to_thread(lambda: get_session_env("HERMES_SESSION_CHAT_ID"))
+
+    reset_session_vars()  # parent turn ends before the child gets scheduled
+
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        assert ex.submit(wrapped).result() == "C123"
+
+
+def test_worker_binding_does_not_leak_back_to_the_parent():
+    """A child that rebinds its own session must not corrupt the parent turn."""
+    _bind_parent_session()
+
+    def _rebind():
+        set_session_vars(
+            platform="slack",
+            source="slack",
+            chat_id="CHILD",
+            chat_name="",
+            thread_id="",
+            user_id="",
+            user_name="",
+            session_key="child",
+            session_id="",
+            ui_session_id="",
+            message_id="",
+            profile="default",
+            cwd="",
+            async_delivery=True,
+        )
+        return get_session_env("HERMES_SESSION_PLATFORM")
+
+    assert _in_worker(_rebind) == "slack"
+    assert get_session_env("HERMES_SESSION_PLATFORM") == "discord"
+    assert get_session_env("HERMES_SESSION_CHAT_ID") == "C123"
+
+
+def test_arguments_and_return_value_are_forwarded():
+    _bind_parent_session()
+
+    def _target(a, b, *, c):
+        return (a, b, c, get_session_env("HERMES_SESSION_PLATFORM"))
+
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        got = ex.submit(copy_context_to_thread(_target), 1, 2, c=3).result()
+
+    assert got == (1, 2, 3, "discord")
+
+
+def test_exceptions_propagate_to_the_future():
+    _bind_parent_session()
+
+    def _boom():
+        raise ValueError("child failed")
+
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        fut = ex.submit(copy_context_to_thread(_boom))
+        with pytest.raises(ValueError, match="child failed"):
+            fut.result()
+
+
+# ---------------------------------------------------------------------------
+# The constraint that makes this a *separate* helper from
+# propagate_context_to_thread
+# ---------------------------------------------------------------------------
+
+
+def test_copy_variant_does_not_propagate_approval_callbacks():
+    """Subagent workers must keep their OWN approval policy.
+
+    ``tools/delegate_tool.py`` installs a deliberately non-interactive
+    approval callback on its executors (``_set_subagent_approval_cb``): a
+    subagent worker that reached the CLI's interactive callback would call
+    ``input()`` off the main thread and deadlock against the parent's
+    prompt_toolkit TUI, which owns stdin (#15216).
+
+    So the delegate call sites must use the ContextVars-only variant. If they
+    ever switched to ``propagate_context_to_thread``, that deadlock returns —
+    this test is the guard.
+    """
+    import tools.terminal_tool as terminal_tool
+
+    sentinel = lambda *a, **k: "approve"  # noqa: E731
+    terminal_tool.set_approval_callback(sentinel)
+    try:
+        seen = _in_worker(terminal_tool._get_approval_callback)
+    finally:
+        terminal_tool.set_approval_callback(None)
+
+    assert seen is None
+
+
+def test_propagate_variant_still_carries_callbacks():
+    """The pre-existing helper is unchanged — the two variants are distinct."""
+    import tools.terminal_tool as terminal_tool
+
+    sentinel = lambda *a, **k: "approve"  # noqa: E731
+    terminal_tool.set_approval_callback(sentinel)
+    try:
+        with ThreadPoolExecutor(max_workers=1) as ex:
+            seen = ex.submit(
+                propagate_context_to_thread(terminal_tool._get_approval_callback)
+            ).result()
+    finally:
+        terminal_tool.set_approval_callback(None)
+
+    assert seen is sentinel
+
+
+# ---------------------------------------------------------------------------
+# The core consumers that were reading an empty identity
+# ---------------------------------------------------------------------------
+
+
+def test_cron_origin_capture_works_from_a_subagent_thread():
+    """``deliver="origin"`` from a subagent must resolve the real channel.
+
+    ``tools/cronjob_tools._origin_from_env`` returns ``None`` when platform or
+    chat_id is empty, and a ``None`` origin is treated as "local session, no
+    delivery channel" — so a cron job created by a subagent would silently
+    never deliver.
+    """
+    from tools.cronjob_tools import _origin_from_env
+
+    _bind_parent_session()
+    parent_origin = _origin_from_env()
+    assert parent_origin is not None
+
+    assert _in_bare_worker(_origin_from_env) is None
+    assert _in_worker(_origin_from_env) == parent_origin
+
+
+def test_approval_session_key_resolves_from_a_subagent_thread():
+    """A subagent's approval request must reach the originating session's queue.
+
+    ``tools/approval.get_current_session_key`` falling back to ``"default"``
+    means the gateway approval prompt is filed against a session the user is
+    not in.
+    """
+    from tools.approval import get_current_session_key
+
+    _bind_parent_session()
+
+    assert _in_bare_worker(get_current_session_key) == "default"
+    assert _in_worker(get_current_session_key) == "sess-discord-C123"
+
+
+def test_subprocess_env_bridge_receives_session_vars_from_a_subagent_thread():
+    """The cross-session leak guard strips vars it thinks are unbound.
+
+    ``tools/environments/local._inject_session_context_env`` deletes a session
+    var from the child-process env when its ContextVar is ``_UNSET`` while the
+    session-context machinery is engaged — correct policy, but on an unwrapped
+    subagent worker *every* var looks unset, so a terminal command run by a
+    subagent inherits no session identity at all.
+    """
+    from tools.environments.local import _inject_session_context_env
+
+    def _bridged():
+        env = {}
+        _inject_session_context_env(env)
+        return env
+
+    _bind_parent_session()
+
+    assert _bridged()["HERMES_SESSION_PLATFORM"] == "discord"
+    assert "HERMES_SESSION_PLATFORM" not in _in_bare_worker(_bridged)
+    assert _in_worker(_bridged)["HERMES_SESSION_PLATFORM"] == "discord"
+
+
+def test_gateway_surface_detection_works_from_a_subagent_thread():
+    """``skills_tool._is_gateway_surface`` gates surface-specific behaviour."""
+    from tools.skills_tool import _is_gateway_surface
+
+    _bind_parent_session()
+
+    assert _in_bare_worker(_is_gateway_surface) is False
+    assert _in_worker(_is_gateway_surface) is True
+
+
+# ---------------------------------------------------------------------------
+# Transitivity — origin must survive arbitrary nesting
+# ---------------------------------------------------------------------------
+
+
+def test_identity_is_transitive_through_nested_delegation():
+    """A grandchild delegated by a child still sees the originating session.
+
+    Each level snapshots the Context it is currently running under, so the
+    parent's identity chains down through arbitrary nesting depth rather than
+    being reset to empty at the second hop.
+    """
+    _bind_parent_session()
+
+    def _grandchild():
+        return get_session_env("HERMES_SESSION_CHAT_ID")
+
+    def _child():
+        # the child is itself on a worker thread and delegates again
+        return _in_worker(_grandchild)
+
+    assert _in_worker(_child) == "C123"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -39,6 +39,7 @@ from toolsets import TOOLSETS
 _RUNTIME_PROVIDER_CUSTOM = "custom"
 from tools import file_state
 from tools.terminal_tool import set_approval_callback as _set_subagent_approval_cb
+from tools.thread_context import copy_context_to_thread
 from utils import base_url_hostname, is_truthy_value
 
 
@@ -2014,7 +2015,16 @@ def _run_single_child(
                     stream_callback=_relay_child_text,
                 )
 
-        _child_future = _timeout_executor.submit(_run_with_thread_capture)
+        # ContextVars do not cross the executor boundary — snapshot the
+        # parent's Context here, on the parent thread, before submit(), so the
+        # child agent runs under the originating session's identity. Callbacks
+        # are deliberately NOT propagated: the executor's initializer above
+        # installs the subagent's non-interactive approval policy, and
+        # propagating the CLI's interactive callback into a worker thread would
+        # reintroduce the input()-vs-prompt_toolkit deadlock (#15216).
+        _child_future = _timeout_executor.submit(
+            copy_context_to_thread(_run_with_thread_capture)
+        )
         try:
             result = _child_future.result(timeout=child_timeout)
         except Exception as _timeout_exc:
@@ -2670,8 +2680,16 @@ def delegate_task(
             with DaemonThreadPoolExecutor(max_workers=max_children) as executor:
                 futures = {}
                 for i, t, child in children:
+                    # ContextVars do not cross the executor boundary: a worker
+                    # thread starts with an empty Context, so the child agent
+                    # would run with NO gateway session identity (see
+                    # tools/thread_context.copy_context_to_thread). Snapshot
+                    # the parent's Context here, on the parent thread, before
+                    # submit(). Callbacks are deliberately NOT propagated —
+                    # the executor's own initializer installs the subagent's
+                    # non-interactive approval policy.
                     future = executor.submit(
-                        _run_single_child,
+                        copy_context_to_thread(_run_single_child),
                         task_index=i,
                         goal=t["goal"],
                         child=child,

--- a/tools/thread_context.py
+++ b/tools/thread_context.py
@@ -61,6 +61,35 @@ def _callback_api():
     )
 
 
+def copy_context_to_thread(target: Callable) -> Callable:
+    """Wrap *target* to run on a worker thread with the *current* thread's
+    ContextVars propagated — and **nothing else**.
+
+    Same ContextVar semantics as :func:`propagate_context_to_thread`, but it
+    does not capture or install the approval/sudo callbacks.
+
+    Use this variant when the worker thread must run under the parent's
+    *session identity* while keeping its own approval policy. The subagent
+    executors in ``tools/delegate_tool.py`` are exactly that case: they install
+    a deliberately **non-interactive** approval callback via the executor's
+    ``initializer`` (``_set_subagent_approval_cb``), because a subagent worker
+    that reached the CLI's interactive callback would call ``input()`` from a
+    non-main thread and deadlock against the parent's prompt_toolkit TUI, which
+    owns stdin (#15216, GHSA-qg5c-hvr5-hjgr). Propagating the parent callbacks
+    there would reintroduce that deadlock, so only the ContextVars travel.
+
+    Each returned wrapper owns a single ``contextvars.Context`` and a Context
+    cannot be entered twice, so call this **once per submitted job** rather
+    than reusing one wrapper across several ``submit()`` calls.
+    """
+    ctx = contextvars.copy_context()
+
+    def _runner(*args, **kwargs):
+        return ctx.run(target, *args, **kwargs)
+
+    return _runner
+
+
 def propagate_context_to_thread(target: Callable) -> Callable:
     """Wrap *target* for execution on a worker thread with the *current*
     thread's ContextVars and approval/sudo callbacks propagated.


### PR DESCRIPTION
# fix(delegate): propagate session ContextVars across the subagent executor boundary

## Symptom

A subagent launched by `delegate_task` runs with **no gateway session
identity**. Inside the child, `HERMES_SESSION_PLATFORM`, `CHAT_ID`,
`THREAD_ID`, `USER_ID` and `SESSION_KEY` all read back empty, even though the
parent turn is bound to a live Discord/Slack/Telegram session.

User-visible consequences, all in core (no plugin involved):

- A cron job created by a subagent with `deliver="origin"` runs on schedule
  and is **never delivered** — it looks like a silently dropped job.
- A subagent's dangerous-command approval request is filed against session
  `"default"` instead of the session the user is actually in.
- A terminal command run by a subagent inherits **no** session env at all.
- `skills_tool._is_gateway_surface()` reports `False` on a gateway session.

## Reproduction on current `main`

```python
from concurrent.futures import ThreadPoolExecutor
from gateway.session_context import set_session_vars
from tools.cronjob_tools import _origin_from_env
from tools.approval import get_current_session_key

set_session_vars(platform="discord", chat_id="C123", thread_id="T9",
                 user_id="U1", session_key="sess-discord-C123", ...)

def probe():
    return _origin_from_env(), get_current_session_key()

print("parent   :", probe())
with ThreadPoolExecutor(max_workers=1) as ex:
    print("subagent :", ex.submit(probe).result())
```

```
parent   : ({'platform': 'discord', 'chat_id': 'C123', 'thread_id': 'T9', 'user_id': 'U1'}, 'sess-discord-C123')
subagent : (None, 'default')
```

## Root cause — the exact lines

`contextvars` are per-thread: a `ThreadPoolExecutor` worker starts with an
empty `Context`. `tools/delegate_tool.py` submits every child agent onto such a
worker without snapshotting the parent's Context:

- `tools/delegate_tool.py:2017` — `_timeout_executor.submit(_run_with_thread_capture)`
- `tools/delegate_tool.py:2673` — `executor.submit(_run_single_child, ...)`

### This is a gap in an existing, deliberate mechanism

`tools/thread_context.py` was written to close exactly this bug class. Its
module docstring names it:

> A bare `threading.Thread` / `ThreadPoolExecutor` worker starts with an empty
> `contextvars.Context` […] Tool dispatch inside such a thread therefore
> silently loses the approval *session/platform* ContextVars […] so gateway
> sessions fall into `check_dangerous_command`'s non-interactive auto-approve
> branch (#33057, #30882)

and it explicitly exists so that "the several places that fan tool dispatch
onto worker threads share one audited implementation instead of divergent
copies."

**Seven** subsystems already use it:

| call site | |
|---|---|
| `agent/tool_executor.py:716` | concurrent tool dispatch |
| `agent/moa_loop.py:810` | MoA reference fan-out |
| `tools/async_delegation.py:673`, `:878` | async subagents |
| `tools/code_execution_tool.py:1068`, `:1344` | execute_code RPC threads |
| `run_agent.py:1719` | background review |
| `model_tools.py:160` | tool worker pool |

`delegate_tool` — which fans out more agent work than any of them, and is the
**synchronous** sibling of `async_delegation`, which *is* wrapped — was missed
at both sites. The inconsistency is the bug: the same operation is
context-safe when run in the background and context-losing when run inline.

### Why the leak guard makes it worse, not better

`tools/environments/local.py:439` `_inject_session_context_env()` implements a
cross-session leak guard: once the session-context machinery is engaged, a var
whose ContextVar is `_UNSET` is **stripped** from the child-process env rather
than inherited from the process-global `os.environ` mirror.

That policy is correct — it stops a sibling session's identity leaking into a
subprocess. But on an unwrapped subagent worker **every** var is `_UNSET`, so
the guard strips the whole session context. Measured:

```
parent thread          : {'HERMES_SESSION_PLATFORM': 'discord', ...}
subagent worker (bare) : {}          # every var stripped
```

So the safety mechanism converts "identity did not propagate" into "identity
is actively removed," which is why the failure is total rather than partial.

## The fix

Snapshot the parent's `Context` on the parent thread, **before** `submit()`, at
both delegate executor sites — the timing that matters, since by the time the
worker runs the parent may already have rebound for the next turn.

### Why not the existing `propagate_context_to_thread()`

It also captures and installs the parent's **approval/sudo callbacks**, and the
delegate executors deliberately install a *non-interactive* callback instead
(`initializer=_set_subagent_approval_cb`, `tools/delegate_tool.py:1988`). Per
that code's own comment, a subagent worker holding the CLI's interactive
callback would call `input()` off the main thread and deadlock against the
parent's prompt_toolkit TUI, which owns stdin (#15216,
GHSA-qg5c-hvr5-hjgr).

Reusing the existing helper here would reintroduce that deadlock.

So this adds a sibling in the same module — `copy_context_to_thread()`:
identical ContextVar semantics, **no** callback capture — and uses it at the
delegate sites. `propagate_context_to_thread()` is unchanged, and a test pins
the distinction so the delegate sites cannot later be switched to the
callback-carrying variant without turning red.

### Whole bug class

- **Both** delegate submit sites are fixed, not just the batch one.
- The single-task path (`n_tasks == 1`, `delegate_tool.py:2659`) runs the child
  **inline** and crosses no boundary — correctly untouched, and covered by the
  suite.
- Because each level snapshots the Context it is currently running under,
  identity is **transitive through arbitrary delegation nesting**: a grandchild
  still resolves the originating session. Pinned by a test.
- Worker-side rebinding cannot leak back to the parent (`Context.run` isolation).

## Test evidence

New file `tests/tools/test_delegate_session_context_propagation.py` — 18 tests,
all behavior contracts (parent-value-must-survive relations, never frozen
session shapes). The harness resolves the wrapper through
`tools.delegate_tool`'s own namespace, so the tests bind to the **call site's**
behaviour rather than to the helper existing in isolation.

```
18 passed
```

**RED proof** — the wrap removed at both call sites (helper left in place, so
the revert isolates the wiring): **11 failed, 7 passed**.

```
FAILED test_session_identity_survives_a_wrapped_worker
FAILED test_every_session_var_matches_the_parent_in_the_worker[...5 params]
FAILED test_cron_origin_capture_works_from_a_subagent_thread
FAILED test_approval_session_key_resolves_from_a_subagent_thread
FAILED test_subprocess_env_bridge_receives_session_vars_from_a_subagent_thread
FAILED test_gateway_surface_detection_works_from_a_subagent_thread
FAILED test_identity_is_transitive_through_nested_delegation
```

The 7 that stay green are **controls**: the documented-limitation test
(`..._is_lost_on_a_bare_worker`), the two callback-semantics tests, and the
argument-forwarding / exception / leak-back tests, none of which depend on the
call-site wiring. Their staying green is what proves the revert was surgical.

Blast radius:

```
tests/tools/test_delegate.py + 5 sibling delegate suites
  + test_delegate_session_context_propagation.py      -> 209 passed
tests/tools/test_local_env_session_leak.py
  + test_approval.py + test_approval_interrupt.py
  + test_async_delegation.py                          -> 354 passed, 1 failed
```

The single failure —
`test_approval.py::TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`
— **fails identically on a clean `origin/main`** with the change stashed
(verified). It is an inherited red in `rm`-pattern detection, unrelated to this
diff.

Order-independence confirmed (re-run without `-p no:randomly`): 18 passed.

## Footprint

- No new core tool, no new `HERMES_*` env var, no config key, no dependency.
- One new function in an existing module dedicated to this exact concern, and
  a one-call wrap at each of two call sites.
- `tools/delegate_tool.py` `+22/-2`, `tools/thread_context.py` `+29/-0`.
