### PR TITLE
feat(gemini): add Google Gemini OAuth provider with device-code login

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -118,6 +118,23 @@ XAI_OAUTH_DEVICE_CODE_URL = f"{XAI_OAUTH_ISSUER}/oauth2/device/code"
 # leaving brief but noisy credential-expiry gaps. Refresh up to one hour
 # early so ordinary runtime calls keep the token warm without user reauth.
 XAI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 3600
+# --- Gemini OAuth (Google OAuth 2.0 device code flow) ---
+# Unlike xAI, Google does NOT expose an OIDC discovery endpoint — the device
+# code and token URLs are fixed/well-known. The user must supply their own
+# Google Cloud Console OAuth client credentials (Desktop app type) since
+# Google requires ``client_secret`` alongside ``client_id`` for the device
+# code grant. The client credentials are stored in auth.json alongside the
+# tokens so refresh works without re-prompting.
+DEFAULT_GEMINI_OAUTH_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+GEMINI_OAUTH_DEVICE_CODE_URL = "https://oauth2.googleapis.com/device/code"
+GEMINI_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
+GEMINI_OAUTH_SCOPE = (
+    "https://www.googleapis.com/auth/generative-language.retriever"
+    " https://www.googleapis.com/auth/cloud-platform"
+)
+GEMINI_OAUTH_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+# Google access tokens are JWTs with ~1h lifetime; refresh 5 min early.
+GEMINI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 300
 QWEN_OAUTH_CLIENT_ID = "f0304373b74a44d2b584a3fb70ca9e56"
 QWEN_OAUTH_TOKEN_URL = "https://chat.qwen.ai/api/v1/oauth2/token"
 QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
@@ -202,6 +219,12 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="xAI Grok OAuth (SuperGrok / Premium+)",
         auth_type="oauth_external",
         inference_base_url=DEFAULT_XAI_OAUTH_BASE_URL,
+    ),
+    "gemini-oauth": ProviderConfig(
+        id="gemini-oauth",
+        name="Google Gemini OAuth",
+        auth_type="oauth_external",
+        inference_base_url=DEFAULT_GEMINI_OAUTH_BASE_URL,
     ),
     "qwen-oauth": ProviderConfig(
         id="qwen-oauth",
@@ -1884,6 +1907,8 @@ def resolve_provider(
         "x-ai": "xai", "x.ai": "xai", "grok": "xai",
         "xai-oauth": "xai-oauth", "x-ai-oauth": "xai-oauth",
         "grok-oauth": "xai-oauth", "xai-grok-oauth": "xai-oauth",
+        "gemini-oauth": "gemini-oauth", "google-oauth": "gemini-oauth",
+        "google-gemini-oauth": "gemini-oauth",
         "kimi": "kimi-coding", "kimi-for-coding": "kimi-coding", "moonshot": "kimi-coding",
         "kimi-cn": "kimi-coding-cn", "moonshot-cn": "kimi-coding-cn",
         "step": "stepfun", "stepfun-coding-plan": "stepfun",
@@ -4908,6 +4933,414 @@ def resolve_xai_oauth_runtime_credentials(
 
 
 # =============================================================================
+# Gemini OAuth (Google OAuth 2.0 device code flow)
+# =============================================================================
+#
+# Mirrors the xai-oauth pattern above, adapted for Google's fixed OAuth 2.0
+# device code endpoints. Key differences from xAI:
+#   * Google requires ``client_secret`` alongside ``client_id`` for both the
+#     device code token poll and the refresh_token grant. The user must supply
+#     their own Google Cloud Console OAuth client credentials (Desktop app
+#     type); there is no hardcoded client_id.
+#   * Google does NOT expose an OIDC discovery endpoint — the device code and
+#     token URLs are fixed constants (``GEMINI_OAUTH_DEVICE_CODE_URL`` /
+#     ``GEMINI_OAUTH_TOKEN_URL``).
+#   * The user-supplied ``client_credentials`` (client_id + client_secret) are
+#     stored in the provider state alongside the tokens so that refresh works
+#     without re-prompting the user.
+
+
+def _gemini_oauth_state_from_store(auth_store: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Return usable Gemini OAuth state from provider state or credential pool."""
+    state = _load_provider_state(auth_store, "gemini-oauth")
+    tokens = state.get("tokens") if isinstance(state, dict) else None
+    if isinstance(tokens, dict):
+        access_token = str(tokens.get("access_token", "") or "").strip()
+        refresh_token = str(tokens.get("refresh_token", "") or "").strip()
+        if access_token and refresh_token:
+            return state
+
+    credential_pool = auth_store.get("credential_pool")
+    entries = (
+        credential_pool.get("gemini-oauth")
+        if isinstance(credential_pool, dict)
+        else None
+    )
+    if isinstance(entries, list):
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            access_token = str(entry.get("access_token", "") or "").strip()
+            refresh_token = str(entry.get("refresh_token", "") or "").strip()
+            if not access_token or not refresh_token:
+                continue
+            merged = dict(state or {})
+            merged["tokens"] = {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "token_type": str(entry.get("token_type") or "Bearer"),
+            }
+            if entry.get("last_refresh"):
+                merged["last_refresh"] = entry.get("last_refresh")
+            merged.setdefault("auth_mode", "oauth_device_code")
+            return merged
+
+    return state if isinstance(state, dict) else None
+
+
+def _gemini_oauth_state_has_usable_tokens(state: Optional[Dict[str, Any]]) -> bool:
+    tokens = state.get("tokens") if isinstance(state, dict) else None
+    return (
+        isinstance(tokens, dict)
+        and bool(str(tokens.get("access_token", "") or "").strip())
+        and bool(str(tokens.get("refresh_token", "") or "").strip())
+    )
+
+
+def _read_gemini_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
+    if _lock:
+        with _auth_store_lock():
+            auth_store = _load_auth_store()
+    else:
+        auth_store = _load_auth_store()
+    state = _gemini_oauth_state_from_store(auth_store)
+    if not _gemini_oauth_state_has_usable_tokens(state):
+        global_state = _gemini_oauth_state_from_store(_load_global_auth_store())
+        if _gemini_oauth_state_has_usable_tokens(global_state):
+            state = global_state
+    if not state:
+        raise AuthError(
+            "No Gemini OAuth credentials stored. Select Google Gemini OAuth in `hermes model`.",
+            provider="gemini-oauth",
+            code="gemini_auth_missing",
+            relogin_required=True,
+        )
+    tokens = state.get("tokens")
+    if not isinstance(tokens, dict):
+        raise AuthError(
+            "Gemini OAuth state is missing tokens. Re-authenticate with `hermes model`.",
+            provider="gemini-oauth",
+            code="gemini_auth_invalid_shape",
+            relogin_required=True,
+        )
+    access_token = str(tokens.get("access_token", "") or "").strip()
+    refresh_token = str(tokens.get("refresh_token", "") or "").strip()
+    if not access_token:
+        raise AuthError(
+            "Gemini OAuth state is missing access_token. Re-authenticate with `hermes model`.",
+            provider="gemini-oauth",
+            code="gemini_auth_missing_access_token",
+            relogin_required=True,
+        )
+    if not refresh_token:
+        raise AuthError(
+            "Gemini OAuth state is missing refresh_token. Re-authenticate with `hermes model`.",
+            provider="gemini-oauth",
+            code="gemini_auth_missing_refresh_token",
+            relogin_required=True,
+        )
+    return {
+        "tokens": tokens,
+        "last_refresh": state.get("last_refresh"),
+        "client_credentials": state.get("client_credentials") or {},
+    }
+
+
+def _profile_has_own_gemini_oauth_state(auth_store: Dict[str, Any]) -> bool:
+    """True when this store has its OWN ``providers.gemini-oauth`` block."""
+    providers = auth_store.get("providers")
+    return isinstance(providers, dict) and isinstance(providers.get("gemini-oauth"), dict)
+
+
+def _write_through_gemini_oauth_to_global_root(state: Dict[str, Any]) -> None:
+    """Persist a rotated Gemini OAuth ``state`` into the global-root auth.json.
+
+    Best-effort write-through for the multi-profile rotation hazard (mirrors
+    the xai-oauth pattern). Only updates ``providers.gemini-oauth`` in the
+    root store; never touches the profile store. Swallows all errors.
+    """
+    global_path = _global_auth_file_path()
+    if global_path is None:
+        return
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        real_home_env = os.environ.get("HOME", "")
+        if real_home_env:
+            real_root = Path(real_home_env) / ".hermes" / "auth.json"
+            try:
+                if global_path.resolve(strict=False) == real_root.resolve(strict=False):
+                    return
+            except Exception:
+                return
+    try:
+        _persist_provider_state_to_store(
+            "gemini-oauth",
+            state,
+            global_path,
+            set_active=False,
+        )
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.debug("Gemini OAuth: write-through to global root failed: %s", exc)
+
+
+def _save_gemini_oauth_tokens(
+    tokens: Dict[str, Any],
+    *,
+    client_credentials: Optional[Dict[str, Any]] = None,
+    last_refresh: Optional[str] = None,
+    auth_mode: str = "oauth_device_code",
+) -> None:
+    if last_refresh is None:
+        last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        write_through_to_root = not _profile_has_own_gemini_oauth_state(auth_store)
+        state = _load_provider_state(auth_store, "gemini-oauth") or {}
+        state["tokens"] = tokens
+        state["last_refresh"] = last_refresh
+        state["auth_mode"] = auth_mode
+        if client_credentials:
+            state["client_credentials"] = client_credentials
+        _save_provider_state(auth_store, "gemini-oauth", state)
+        _save_auth_store(auth_store)
+        if write_through_to_root:
+            _write_through_gemini_oauth_to_global_root(state)
+
+
+def _gemini_access_token_is_expiring(access_token: str, skew_seconds: int = 0) -> bool:
+    """Check whether a Google JWT access token is past its ``exp`` (minus skew).
+
+    Google access tokens are JWTs; decode the payload and read ``exp`` exactly
+    like the xAI helper.
+    """
+    if not isinstance(access_token, str) or "." not in access_token:
+        return False
+    try:
+        parts = access_token.split(".")
+        if len(parts) < 2:
+            return False
+        payload_b64 = parts[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64.encode("ascii")).decode("utf-8"))
+        exp = payload.get("exp")
+        if not isinstance(exp, (int, float)):
+            return False
+        return float(exp) <= (time.time() + max(0, int(skew_seconds)))
+    except Exception:
+        return False
+
+
+def _refresh_gemini_oauth_tokens(
+    tokens: Dict[str, Any],
+    *,
+    client_id: str,
+    client_secret: str,
+    timeout_seconds: float,
+) -> Dict[str, Any]:
+    """Refresh a Gemini OAuth access token using the refresh_token grant.
+
+    Google uses the standard ``refresh_token`` grant type with ``client_id``,
+    ``client_secret``, and ``refresh_token`` at the fixed token endpoint.
+    """
+    try:
+        state = _load_provider_state(_load_auth_store(), "gemini-oauth") or {}
+        auth_mode = str(state.get("auth_mode") or "oauth_device_code")
+    except Exception:
+        auth_mode = "oauth_device_code"
+    refresh_token = str(tokens.get("refresh_token", "") or "").strip()
+    if not refresh_token:
+        raise AuthError(
+            "Gemini OAuth is missing refresh_token. Re-authenticate with `hermes model`.",
+            provider="gemini-oauth",
+            code="gemini_auth_missing_refresh_token",
+            relogin_required=True,
+        )
+    timeout = httpx.Timeout(max(5.0, float(timeout_seconds)))
+    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}) as client:
+        response = client.post(
+            GEMINI_OAUTH_TOKEN_URL,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "grant_type": "refresh_token",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "refresh_token": refresh_token,
+            },
+        )
+    if response.status_code != 200:
+        detail = response.text.strip()
+        raise AuthError(
+            "Gemini token refresh failed."
+            + (f" Response: {detail}" if detail else ""),
+            provider="gemini-oauth",
+            code="gemini_refresh_failed",
+            relogin_required=(response.status_code in {400, 401, 403}),
+        )
+    try:
+        payload = response.json()
+    except Exception as exc:
+        raise AuthError(
+            f"Gemini token refresh returned invalid JSON: {exc}",
+            provider="gemini-oauth",
+            code="gemini_refresh_invalid_json",
+        ) from exc
+    if not isinstance(payload, dict):
+        raise AuthError(
+            "Gemini token refresh response was not a JSON object.",
+            provider="gemini-oauth",
+            code="gemini_refresh_invalid_response",
+            relogin_required=True,
+        )
+    refreshed_access = str(payload.get("access_token", "") or "").strip()
+    if not refreshed_access:
+        raise AuthError(
+            "Gemini token refresh response was missing access_token.",
+            provider="gemini-oauth",
+            code="gemini_refresh_missing_access_token",
+            relogin_required=True,
+        )
+    updated_tokens = dict(tokens)
+    updated_tokens["access_token"] = refreshed_access
+    # Google may rotate the refresh_token; keep the new one if present,
+    # otherwise preserve the existing one.
+    new_refresh = str(payload.get("refresh_token") or "").strip()
+    if new_refresh:
+        updated_tokens["refresh_token"] = new_refresh
+    if payload.get("expires_in") is not None:
+        updated_tokens["expires_in"] = payload.get("expires_in")
+    token_type = str(payload.get("token_type") or "").strip()
+    if token_type:
+        updated_tokens["token_type"] = token_type
+    last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    _save_gemini_oauth_tokens(
+        updated_tokens,
+        client_credentials={"client_id": client_id, "client_secret": client_secret},
+        last_refresh=last_refresh,
+        auth_mode=auth_mode,
+    )
+    return updated_tokens
+
+
+def _is_terminal_gemini_oauth_refresh_error(exc: Exception) -> bool:
+    """True when retrying the same Gemini OAuth refresh token cannot succeed."""
+    return (
+        isinstance(exc, AuthError)
+        and exc.provider == "gemini-oauth"
+        and exc.code in {"gemini_refresh_failed", "gemini_auth_missing_refresh_token"}
+        and bool(exc.relogin_required)
+    )
+
+
+def resolve_gemini_oauth_runtime_credentials(
+    *,
+    force_refresh: bool = False,
+    refresh_if_expiring: bool = True,
+    refresh_skew_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    data = _read_gemini_oauth_tokens()
+    tokens = dict(data["tokens"])
+    access_token = str(tokens.get("access_token", "") or "").strip()
+    refresh_timeout_seconds = env_float("HERMES_GEMINI_REFRESH_TIMEOUT_SECONDS", 20)
+    client_credentials = dict(data.get("client_credentials") or {})
+    client_id = str(client_credentials.get("client_id", "") or "").strip()
+    client_secret = str(client_credentials.get("client_secret", "") or "").strip()
+
+    effective_skew = (
+        int(refresh_skew_seconds)
+        if refresh_skew_seconds is not None
+        else GEMINI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS
+    )
+    should_refresh = bool(force_refresh)
+    if (not should_refresh) and refresh_if_expiring:
+        should_refresh = _gemini_access_token_is_expiring(access_token, effective_skew)
+    if should_refresh:
+        if not client_id or not client_secret:
+            raise AuthError(
+                "Gemini OAuth client credentials (client_id/client_secret) are "
+                "missing from auth.json. Re-authenticate with `hermes model` to "
+                "supply them.",
+                provider="gemini-oauth",
+                code="gemini_auth_missing_client_credentials",
+                relogin_required=True,
+            )
+        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
+            data = _read_gemini_oauth_tokens(_lock=False)
+            tokens = dict(data["tokens"])
+            access_token = str(tokens.get("access_token", "") or "").strip()
+            client_credentials = dict(data.get("client_credentials") or {})
+            client_id = str(client_credentials.get("client_id", "") or "").strip()
+            client_secret = str(client_credentials.get("client_secret", "") or "").strip()
+            effective_skew = (
+                int(refresh_skew_seconds)
+                if refresh_skew_seconds is not None
+                else GEMINI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS
+            )
+            should_refresh = bool(force_refresh)
+            if (not should_refresh) and refresh_if_expiring:
+                should_refresh = _gemini_access_token_is_expiring(access_token, effective_skew)
+            if should_refresh:
+                if not client_id or not client_secret:
+                    raise AuthError(
+                        "Gemini OAuth client credentials (client_id/client_secret) "
+                        "are missing from auth.json. Re-authenticate with "
+                        "`hermes model` to supply them.",
+                        provider="gemini-oauth",
+                        code="gemini_auth_missing_client_credentials",
+                        relogin_required=True,
+                    )
+                try:
+                    tokens = _refresh_gemini_oauth_tokens(
+                        tokens,
+                        client_id=client_id,
+                        client_secret=client_secret,
+                        timeout_seconds=refresh_timeout_seconds,
+                    )
+                    access_token = str(tokens.get("access_token", "") or "").strip()
+                except AuthError as exc:
+                    if _is_terminal_gemini_oauth_refresh_error(exc):
+                        # Terminal failure — quarantine dead tokens so
+                        # subsequent sessions fail fast without a retry.
+                        try:
+                            _q_store = _load_auth_store()
+                            _q_state = _load_provider_state(_q_store, "gemini-oauth") or {}
+                            _q_tokens = dict(_q_state.get("tokens") or {})
+                            _q_tokens.pop("access_token", None)
+                            _q_tokens.pop("refresh_token", None)
+                            _q_state["tokens"] = _q_tokens
+                            _q_state["last_auth_error"] = {
+                                "provider": "gemini-oauth",
+                                "code": exc.code or "gemini_refresh_failed",
+                                "message": str(exc),
+                                "reason": "runtime_refresh_failure",
+                                "relogin_required": True,
+                                "at": datetime.now(timezone.utc).isoformat(),
+                            }
+                            _store_provider_state(_q_store, "gemini-oauth", _q_state, set_active=False)
+                            _save_auth_store(_q_store)
+                        except Exception as _save_exc:
+                            logger.debug(
+                                "Gemini OAuth: failed to persist quarantined state: %s",
+                                _save_exc,
+                            )
+                    raise
+
+    base_url = DEFAULT_GEMINI_OAUTH_BASE_URL
+    env_override = (
+        os.getenv("HERMES_GEMINI_BASE_URL", "").strip().rstrip("/")
+        or os.getenv("GEMINI_BASE_URL", "").strip().rstrip("/")
+    )
+    if env_override:
+        base_url = env_override
+    return {
+        "provider": "gemini-oauth",
+        "base_url": base_url,
+        "api_key": access_token,
+        "source": "hermes-auth-store",
+        "last_refresh": data.get("last_refresh"),
+        "auth_mode": "oauth_device_code",
+    }
+
+
+# =============================================================================
 # TLS verification helper
 # =============================================================================
 
@@ -6684,6 +7117,48 @@ def get_xai_oauth_auth_status() -> Dict[str, Any]:
         }
 
 
+def get_gemini_oauth_auth_status() -> Dict[str, Any]:
+    try:
+        from agent.credential_pool import load_pool
+
+        pool = load_pool("gemini-oauth")
+        if pool and pool.has_credentials():
+            entry = pool.select()
+            if entry is not None:
+                api_key = (
+                    getattr(entry, "runtime_api_key", None)
+                    or getattr(entry, "access_token", "")
+                )
+                if api_key and not _gemini_access_token_is_expiring(api_key, 0):
+                    return {
+                        "logged_in": True,
+                        "auth_store": str(_auth_file_path()),
+                        "last_refresh": getattr(entry, "last_refresh", None),
+                        "auth_mode": "oauth_device_code",
+                        "source": f"pool:{getattr(entry, 'label', 'unknown')}",
+                        "api_key": api_key,
+                    }
+    except Exception:
+        pass
+
+    try:
+        creds = resolve_gemini_oauth_runtime_credentials()
+        return {
+            "logged_in": True,
+            "auth_store": str(_auth_file_path()),
+            "last_refresh": creds.get("last_refresh"),
+            "auth_mode": creds.get("auth_mode"),
+            "source": creds.get("source"),
+            "api_key": creds.get("api_key"),
+        }
+    except AuthError as exc:
+        return {
+            "logged_in": False,
+            "auth_store": str(_auth_file_path()),
+            "error": str(exc),
+        }
+
+
 def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for API-key providers (z.ai, Kimi, MiniMax)."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
@@ -7578,6 +8053,144 @@ def _login_xai_oauth(
     print(f"  Config updated: {config_path} (model.provider=xai-oauth)")
 
 
+def _login_gemini_oauth(
+    args,
+    pconfig: ProviderConfig,
+    *,
+    force_new_login: bool = False,
+) -> None:
+    """Interactive Gemini OAuth login flow.
+
+    Unlike xAI, Google requires the user to provide their own OAuth client
+    credentials (client_id + client_secret) from the Google Cloud Console
+    (Desktop app type). If credentials are already stored in auth.json, they
+    are reused; otherwise the user is prompted to supply them.
+    """
+    del pconfig
+
+    # --- Resolve client credentials (stored or prompted) ---
+    client_id = ""
+    client_secret = ""
+    try:
+        with _auth_store_lock():
+            auth_store = _load_auth_store()
+        state = _load_provider_state(auth_store, "gemini-oauth") or {}
+        stored_creds = state.get("client_credentials") if isinstance(state, dict) else None
+        if isinstance(stored_creds, dict):
+            client_id = str(stored_creds.get("client_id", "") or "").strip()
+            client_secret = str(stored_creds.get("client_secret", "") or "").strip()
+    except Exception:
+        pass
+
+    if not force_new_login and client_id and client_secret:
+        try:
+            existing = resolve_gemini_oauth_runtime_credentials()
+            api_key = existing.get("api_key", "")
+            if isinstance(api_key, str) and api_key and not _gemini_access_token_is_expiring(api_key, 60):
+                print("Existing Gemini OAuth credentials found in Hermes auth store.")
+                try:
+                    reuse = input("Use existing credentials? [Y/n]: ").strip().lower()
+                except (EOFError, KeyboardInterrupt):
+                    reuse = "y"
+                if reuse in {"", "y", "yes"}:
+                    config_path = _update_config_for_provider(
+                        "gemini-oauth",
+                        existing.get("base_url", DEFAULT_GEMINI_OAUTH_BASE_URL),
+                    )
+                    print()
+                    print("Login successful!")
+                    print(f"  Config updated: {config_path} (model.provider=gemini-oauth)")
+                    return
+        except AuthError:
+            pass
+
+    # Prompt for client credentials if not already stored
+    if not client_id or not client_secret:
+        print()
+        print("Google Gemini OAuth requires a Google Cloud Console OAuth client.")
+        print("Create a 'Desktop app' type OAuth client at:")
+        print("  https://console.cloud.google.com/apis/credentials")
+        print("Enable the 'Generative Language API' for your project.")
+        print()
+        print("You can provide the client_id and client_secret directly, or")
+        print("provide the path to a downloaded client_secret.json file.")
+        print()
+
+        # Try path to client_secret.json first
+        try:
+            secret_path = input("Path to client_secret.json (or press Enter to type credentials): ").strip()
+        except (EOFError, KeyboardInterrupt):
+            secret_path = ""
+
+        if secret_path:
+            try:
+                with open(secret_path, "r") as f:
+                    secret_data = json.load(f)
+                # Google client_secret.json format: {"installed": {...}} or {"web": {...}}
+                block = secret_data.get("installed") or secret_data.get("web") or {}
+                client_id = str(block.get("client_id", "") or "").strip()
+                client_secret = str(block.get("client_secret", "") or "").strip()
+            except Exception as exc:
+                raise AuthError(
+                    f"Failed to read client_secret.json: {exc}",
+                    provider="gemini-oauth",
+                    code="gemini_client_credentials_invalid",
+                ) from exc
+
+        if not client_id:
+            try:
+                client_id = input("Google OAuth client_id: ").strip()
+            except (EOFError, KeyboardInterrupt):
+                client_id = ""
+        if not client_secret:
+            try:
+                client_secret = input("Google OAuth client_secret: ").strip()
+            except (EOFError, KeyboardInterrupt):
+                client_secret = ""
+
+        if not client_id or not client_secret:
+            raise AuthError(
+                "Google OAuth client_id and client_secret are required for "
+                "Gemini OAuth. Re-run `hermes model` and provide them.",
+                provider="gemini-oauth",
+                code="gemini_client_credentials_missing",
+                relogin_required=True,
+            )
+
+    print()
+    print("Signing in to Google Gemini OAuth...")
+    print("(Using Google OAuth 2.0 device code flow)")
+    print()
+
+    timeout_seconds = float(getattr(args, "timeout", None) or 20.0)
+    open_browser = not getattr(args, "no_browser", False)
+    if _is_remote_session():
+        open_browser = False
+
+    creds = _gemini_oauth_device_code_login(
+        client_id=client_id,
+        client_secret=client_secret,
+        timeout_seconds=timeout_seconds,
+        open_browser=open_browser,
+    )
+    _save_gemini_oauth_tokens(
+        creds["tokens"],
+        client_credentials=creds.get("client_credentials"),
+        last_refresh=creds.get("last_refresh"),
+        auth_mode="oauth_device_code",
+    )
+    unsuppress_credential_source("gemini-oauth", "device_code")
+    config_path = _update_config_for_provider(
+        "gemini-oauth",
+        creds.get("base_url", DEFAULT_GEMINI_OAUTH_BASE_URL),
+    )
+    print()
+    print("Login successful!")
+    from hermes_constants import display_hermes_home as _dhh
+    print(f"  Auth state: {_dhh()}/auth.json")
+    print(f"  Config updated: {config_path} (model.provider=gemini-oauth)")
+
+
 def _xai_oauth_request_device_code(
     client: httpx.Client,
     *,
@@ -7757,6 +8370,204 @@ def _xai_oauth_device_code_login(
         },
         "discovery": discovery,
         "redirect_uri": "",
+        "base_url": base_url,
+        "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "source": "oauth-device-code",
+    }
+
+
+def _gemini_oauth_request_device_code(
+    client: httpx.Client,
+    *,
+    client_id: str,
+    scope: str = GEMINI_OAUTH_SCOPE,
+) -> Dict[str, Any]:
+    """POST to Google's device code endpoint."""
+    response = client.post(
+        GEMINI_OAUTH_DEVICE_CODE_URL,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        },
+        data={
+            "client_id": client_id,
+            "scope": scope,
+        },
+    )
+    if response.status_code != 200:
+        raise AuthError(
+            f"Gemini device-code request failed (HTTP {response.status_code})."
+            + (f" Response: {response.text.strip()}" if response.text else ""),
+            provider="gemini-oauth",
+            code="device_code_request_failed",
+        )
+    payload = response.json()
+    required = (
+        "device_code",
+        "user_code",
+        "verification_uri",
+        "expires_in",
+        "interval",
+    )
+    missing = [key for key in required if key not in payload]
+    if missing:
+        raise AuthError(
+            f"Gemini device-code response missing fields: {', '.join(missing)}",
+            provider="gemini-oauth",
+            code="device_code_invalid",
+        )
+    return payload
+
+
+def _gemini_oauth_poll_device_token(
+    client: httpx.Client,
+    *,
+    client_id: str,
+    client_secret: str,
+    device_code: str,
+    expires_in: int,
+    poll_interval: int,
+) -> Dict[str, Any]:
+    """Poll Google's token endpoint until the user approves or the code expires.
+
+    Unlike xAI, Google requires ``client_secret`` alongside ``client_id`` and
+    uses the ``urn:ietf:params:oauth:grant-type:device_code`` grant type.
+    """
+    deadline = time.monotonic() + max(1, int(expires_in))
+    current_interval = max(1, int(poll_interval))
+    while time.monotonic() < deadline:
+        response = client.post(
+            GEMINI_OAUTH_TOKEN_URL,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+            },
+            data={
+                "grant_type": GEMINI_OAUTH_GRANT_TYPE,
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "device_code": device_code,
+            },
+        )
+        if response.status_code == 200:
+            payload = response.json()
+            if not payload.get("access_token"):
+                raise AuthError(
+                    "Gemini device-code token response did not include an access_token.",
+                    provider="gemini-oauth",
+                    code="gemini_device_token_invalid",
+                )
+            if not payload.get("refresh_token"):
+                raise AuthError(
+                    "Gemini device-code token response did not include a refresh_token.",
+                    provider="gemini-oauth",
+                    code="gemini_device_token_invalid",
+                )
+            return payload
+
+        try:
+            error_payload = response.json()
+        except Exception:
+            response.raise_for_status()
+            raise AuthError(
+                "Gemini device-code token polling returned a non-JSON error response.",
+                provider="gemini-oauth",
+                code="gemini_device_token_failed",
+            )
+        error_code = str(error_payload.get("error") or "")
+        if error_code == "authorization_pending":
+            time.sleep(current_interval)
+            continue
+        if error_code == "slow_down":
+            current_interval = min(current_interval + 1, 30)
+            time.sleep(current_interval)
+            continue
+        description = (
+            error_payload.get("error_description")
+            or error_payload.get("error")
+            or response.text
+        )
+        raise AuthError(
+            f"Gemini device-code token polling failed: {description}",
+            provider="gemini-oauth",
+            code="gemini_device_token_failed",
+        )
+    raise AuthError(
+        "Timed out waiting for Gemini device authorization.",
+        provider="gemini-oauth",
+        code="device_code_timeout",
+    )
+
+
+def _gemini_oauth_device_code_login(
+    *,
+    client_id: str,
+    client_secret: str,
+    timeout_seconds: float = 20.0,
+    open_browser: bool = True,
+) -> Dict[str, Any]:
+    """Orchestrate the full Google device code login flow."""
+    timeout = httpx.Timeout(max(20.0, timeout_seconds))
+    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}) as client:
+        device_data = _gemini_oauth_request_device_code(client, client_id=client_id)
+        verification_url = str(
+            device_data.get("verification_uri_complete")
+            or device_data["verification_uri"]
+        )
+        user_code = str(device_data["user_code"])
+        expires_in = int(device_data["expires_in"])
+        interval = int(device_data["interval"])
+
+        print()
+        print("To continue:")
+        print(f"  1. Open: {verification_url}")
+        print(f"  2. If prompted, enter code: {user_code}")
+        if open_browser and not _is_remote_session() and _can_open_graphical_browser():
+            try:
+                opened = webbrowser.open(verification_url)
+            except Exception:
+                opened = False
+            if opened:
+                print("  (Opened browser for verification)")
+            else:
+                print("  Could not open browser automatically -- use the URL above.")
+        print(f"Waiting for approval (polling every {max(1, interval)}s)...")
+
+        payload = _gemini_oauth_poll_device_token(
+            client,
+            client_id=client_id,
+            client_secret=client_secret,
+            device_code=str(device_data["device_code"]),
+            expires_in=expires_in,
+            poll_interval=interval,
+        )
+
+    access_token = str(payload.get("access_token", "") or "").strip()
+    refresh_token = str(payload.get("refresh_token", "") or "").strip()
+    if not access_token or not refresh_token:
+        raise AuthError(
+            "Gemini device-code token response was missing required tokens.",
+            provider="gemini-oauth",
+            code="gemini_device_token_invalid",
+        )
+    base_url = DEFAULT_GEMINI_OAUTH_BASE_URL
+    env_override = (
+        os.getenv("HERMES_GEMINI_BASE_URL", "").strip().rstrip("/")
+        or os.getenv("GEMINI_BASE_URL", "").strip().rstrip("/")
+    )
+    if env_override:
+        base_url = env_override
+    return {
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "expires_in": payload.get("expires_in"),
+            "token_type": str(payload.get("token_type") or "Bearer").strip() or "Bearer",
+        },
+        "client_credentials": {
+            "client_id": client_id,
+            "client_secret": client_secret,
+        },
         "base_url": base_url,
         "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "source": "oauth-device-code",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -771,6 +771,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_nous,
     _model_flow_openai_codex,
     _model_flow_xai_oauth,
+    _model_flow_gemini_oauth,
     _model_flow_qwen_oauth,
     _model_flow_minimax_oauth,
     _model_flow_custom,
@@ -3326,6 +3327,8 @@ def select_provider_and_model(args=None):
         _model_flow_openai_codex(config, current_model)
     elif selected_provider == "xai-oauth":
         _model_flow_xai_oauth(config, current_model, args=args)
+    elif selected_provider == "gemini-oauth":
+        _model_flow_gemini_oauth(config, current_model, args=args)
     elif selected_provider == "qwen-oauth":
         _model_flow_qwen_oauth(config, current_model)
     elif selected_provider == "minimax-oauth":
@@ -14369,7 +14372,7 @@ def _build_provider_choices() -> list[str]:
     except Exception:
         # Fallback: static list guarantees the CLI always works
         return [
-            "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "copilot-acp", "copilot",
+            "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "gemini-oauth", "copilot-acp", "copilot",
             "anthropic", "gemini", "vertex", "xai", "bedrock", "azure-foundry",
             "ollama-cloud", "huggingface", "zai", "kimi-coding", "kimi-coding-cn",
             "stepfun", "minimax", "minimax-cn", "kilocode", "novita", "xiaomi", "arcee",

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -724,6 +724,81 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
     else:
         print("No change.")
 
+def _model_flow_gemini_oauth(_config, current_model="", *, args=None):
+    """Google Gemini OAuth provider: ensure logged in, then pick model."""
+    from hermes_cli.auth import (
+        get_gemini_oauth_auth_status,
+        _prompt_model_selection,
+        _save_model_choice,
+        _update_config_for_provider,
+        resolve_gemini_oauth_runtime_credentials,
+        _login_gemini_oauth,
+        DEFAULT_GEMINI_OAUTH_BASE_URL,
+        PROVIDER_REGISTRY,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS
+
+    status = get_gemini_oauth_auth_status()
+    if status.get("logged_in"):
+        print("  Google Gemini OAuth credentials: ✓")
+        print()
+        choice = _prompt_auth_credentials_choice(
+            "Google Gemini OAuth credentials:"
+        )
+
+        if choice == "reauth":
+            print("Starting a fresh Google Gemini OAuth login...")
+            print()
+            try:
+                mock_args = argparse.Namespace(
+                    no_browser=bool(getattr(args, "no_browser", False)),
+                    timeout=getattr(args, "timeout", None),
+                )
+                _login_gemini_oauth(
+                    mock_args,
+                    PROVIDER_REGISTRY["gemini-oauth"],
+                    force_new_login=True,
+                )
+            except SystemExit:
+                print("Login cancelled or failed.")
+                return
+            except Exception as exc:
+                print(f"Login failed: {exc}")
+                return
+        elif choice == "cancel":
+            return
+    else:
+        print("Not logged into Google Gemini OAuth. Starting login...")
+        print()
+        try:
+            mock_args = argparse.Namespace(
+                no_browser=bool(getattr(args, "no_browser", False)),
+                timeout=getattr(args, "timeout", None),
+            )
+            _login_gemini_oauth(mock_args, PROVIDER_REGISTRY["gemini-oauth"])
+        except SystemExit:
+            print("Login cancelled or failed.")
+            return
+        except Exception as exc:
+            print(f"Login failed: {exc}")
+            return
+
+    base_url = DEFAULT_GEMINI_OAUTH_BASE_URL
+    try:
+        creds = resolve_gemini_oauth_runtime_credentials()
+        base_url = (creds.get("base_url") or "").strip().rstrip("/") or base_url
+    except Exception:
+        pass
+
+    models = list(_PROVIDER_MODELS.get("gemini-oauth") or _PROVIDER_MODELS.get("gemini") or [])
+    selected = _prompt_model_selection(models, current_model=current_model or (models[0] if models else "gemini-3.1-pro-preview"))
+    if selected:
+        _save_model_choice(selected)
+        _update_config_for_provider("gemini-oauth", base_url)
+        print(f"Default model set to: {selected} (via Google Gemini OAuth)")
+    else:
+        print("No change.")
+
 def _model_flow_qwen_oauth(_config, current_model=""):
     """Qwen OAuth provider: reuse local Qwen CLI login, then pick model."""
     from hermes_cli.main import _DEFAULT_QWEN_PORTAL_MODELS

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -299,6 +299,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3.5-flash",
         "gemini-3.1-flash-lite-preview",
     ],
+    "gemini-oauth": [
+        "gemini-3.1-pro-preview",
+        "gemini-3-pro-preview",
+        "gemini-3.5-flash",
+        "gemini-3.1-flash-lite-preview",
+    ],
     "zai": [
         "glm-5.2",
         "glm-5.1",
@@ -1115,6 +1121,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("bedrock",        "AWS Bedrock",              "AWS Bedrock (Claude, Nova, Llama, DeepSeek; IAM or API key)"),
     ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint, your Azure AI deployment)"),
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (Reuses local Qwen CLI login)"),
+    ProviderEntry("gemini-oauth",   "Google Gemini OAuth",      "Google Gemini OAuth (Google account, device-code login)"),
 ]
 
 # Auto-extend CANONICAL_PROVIDERS with any provider registered in providers/
@@ -1167,7 +1174,7 @@ PROVIDER_GROUPS: dict[str, tuple[str, str, list[str]]] = {
     "kimi":     ("Kimi / Moonshot", "Coding Plan, Moonshot global & China endpoints", ["kimi-coding", "kimi-coding-cn"]),
     "minimax":  ("MiniMax",         "Global, OAuth Coding Plan & China endpoints",     ["minimax", "minimax-oauth", "minimax-cn"]),
     "xai":      ("xAI Grok",        "Direct API or SuperGrok / Premium+ OAuth",        ["xai", "xai-oauth"]),
-    "google":   ("Google Gemini",   "Google AI Studio (API key)",                     ["gemini"]),
+    "google":   ("Google Gemini",   "Google AI Studio (API key) or Google Gemini OAuth",  ["gemini", "gemini-oauth"]),
     "openai":   ("OpenAI",          "Codex CLI or direct OpenAI API",                  ["openai-codex", "openai-api"]),
     "qwen":     ("Qwen",            "Qwen Cloud / DashScope, Coding Plan & Qwen CLI OAuth", ["alibaba", "alibaba-coding-plan", "qwen-oauth"]),
     "opencode": ("OpenCode",        "Zen pay-as-you-go or Go subscription",            ["opencode-zen", "opencode-go"]),
@@ -1259,6 +1266,9 @@ _PROVIDER_ALIASES = {
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
+    "gemini-oauth": "gemini-oauth",
+    "google-oauth": "gemini-oauth",
+    "google-gemini-oauth": "gemini-oauth",
     "google-vertex": "vertex",
     "vertex-ai": "vertex",
     "gcp-vertex": "vertex",
@@ -2592,6 +2602,8 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         return get_codex_model_ids(access_token=access_token)
     if normalized == "xai-oauth":
         return list(_PROVIDER_MODELS.get("xai-oauth", _PROVIDER_MODELS.get("xai", [])))
+    if normalized == "gemini-oauth":
+        return list(_PROVIDER_MODELS.get("gemini-oauth", _PROVIDER_MODELS.get("gemini", [])))
     if normalized in {"copilot", "copilot-acp"}:
         try:
             live = _fetch_github_models(_resolve_copilot_catalog_api_key())
@@ -4496,7 +4508,7 @@ def validate_requested_model(
         }
 
     # Providers with non-standard catalog validation — /v1/models probing is not the right path.
-    if normalized in {"openai-codex", "xai-oauth"}:
+    if normalized in {"openai-codex", "xai-oauth", "gemini-oauth"}:
         try:
             catalog_models = provider_model_ids(normalized)
         except Exception:
@@ -4523,7 +4535,11 @@ def validate_requested_model(
             suggestion_text = ""
             if suggestions:
                 suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
-            provider_label = "OpenAI Codex" if normalized == "openai-codex" else "xAI Grok OAuth (SuperGrok / Premium+)"
+            provider_label = {
+                "openai-codex": "OpenAI Codex",
+                "xai-oauth": "xAI Grok OAuth (SuperGrok / Premium+)",
+                "gemini-oauth": "Google Gemini OAuth",
+            }.get(normalized, normalized)
             # Plausibility gate (#45006): the soft-accept (#16172 / #19729) exists
             # for entitlement-gated *hidden* slugs the curated listing hasn't
             # caught up with — but those are always the provider's own family
@@ -4536,6 +4552,7 @@ def validate_requested_model(
             _family_prefixes = {
                 "openai-codex": ("gpt-", "codex-", "o1", "o3", "o4"),
                 "xai-oauth": ("grok-",),
+                "gemini-oauth": ("gemini-",),
             }.get(normalized, ())
             _lower = requested_for_lookup.strip().lower()
             _plausible = (not _family_prefixes) or any(

--- a/tests/hermes_cli/test_gemini_oauth.py
+++ b/tests/hermes_cli/test_gemini_oauth.py
@@ -1,0 +1,197 @@
+"""Regression tests for Google Gemini OAuth auth resolution and model listing.
+
+Mirrors the xai-oauth test pattern (test_xai_oauth_profile_auth.py) but
+adapted for gemini-oauth's user-provided client credentials and Google's
+fixed OAuth endpoints (no OIDC discovery).
+"""
+
+import pytest
+
+from hermes_cli import auth
+from hermes_cli.auth import AuthError
+from hermes_cli import models
+
+
+# ---------------------------------------------------------------------------
+# Auth state resolution
+# ---------------------------------------------------------------------------
+
+def test_read_gemini_oauth_tokens_uses_provider_state(monkeypatch):
+    """Provider state tokens should be returned when present."""
+    store = {
+        "providers": {
+            "gemini-oauth": {
+                "tokens": {
+                    "access_token": "test-access",
+                    "refresh_token": "test-refresh",
+                    "token_type": "Bearer",
+                },
+                "client_credentials": {
+                    "client_id": "test-client-id",
+                    "client_secret": "test-client-secret",
+                },
+                "last_refresh": "2026-07-25T12:00:00Z",
+            }
+        },
+    }
+    monkeypatch.setattr(auth, "_load_auth_store", lambda: store)
+    monkeypatch.setattr(auth, "_load_global_auth_store", lambda: {})
+
+    resolved = auth._read_gemini_oauth_tokens(_lock=False)
+
+    assert resolved["tokens"]["access_token"] == "test-access"
+    assert resolved["tokens"]["refresh_token"] == "test-refresh"
+    assert resolved["tokens"]["token_type"] == "Bearer"
+
+
+def test_read_gemini_oauth_tokens_uses_credential_pool_when_provider_empty(monkeypatch):
+    """Pool tokens should be used when provider state tokens are empty.
+
+    Mirrors the xai-oauth profile/cron fallback: a profile may have fresh
+    pool tokens while the singleton provider state is empty.
+    """
+    store = {
+        "providers": {"gemini-oauth": {"tokens": {}, "last_auth_error": {}}},
+        "credential_pool": {
+            "gemini-oauth": [
+                {
+                    "access_token": "pool-access",
+                    "refresh_token": "pool-refresh",
+                    "token_type": "Bearer",
+                    "last_refresh": "2026-07-25T19:00:00Z",
+                }
+            ]
+        },
+    }
+    monkeypatch.setattr(auth, "_load_auth_store", lambda: store)
+    monkeypatch.setattr(auth, "_load_global_auth_store", lambda: {})
+
+    resolved = auth._read_gemini_oauth_tokens(_lock=False)
+
+    assert resolved["tokens"]["access_token"] == "pool-access"
+    assert resolved["tokens"]["refresh_token"] == "pool-refresh"
+    assert resolved["tokens"]["token_type"] == "Bearer"
+
+
+def test_read_gemini_oauth_tokens_uses_global_store_when_profile_empty(monkeypatch):
+    """A profile/cron process should see root gemini-oauth auth."""
+    profile_store = {"providers": {"gemini-oauth": {"tokens": {}}}}
+    global_store = {
+        "providers": {
+            "gemini-oauth": {
+                "tokens": {
+                    "access_token": "global-access",
+                    "refresh_token": "global-refresh",
+                    "token_type": "Bearer",
+                },
+                "last_refresh": "2026-07-25T19:05:00Z",
+            }
+        }
+    }
+    monkeypatch.setattr(auth, "_load_auth_store", lambda: profile_store)
+    monkeypatch.setattr(auth, "_load_global_auth_store", lambda: global_store)
+
+    resolved = auth._read_gemini_oauth_tokens(_lock=False)
+
+    assert resolved["tokens"]["access_token"] == "global-access"
+    assert resolved["tokens"]["refresh_token"] == "global-refresh"
+
+
+def test_read_gemini_oauth_tokens_raises_when_no_credentials(monkeypatch):
+    """Should raise AuthError when no usable credentials exist anywhere."""
+    monkeypatch.setattr(auth, "_load_auth_store", lambda: {"providers": {}})
+    monkeypatch.setattr(auth, "_load_global_auth_store", lambda: {})
+
+    with pytest.raises(AuthError) as exc_info:
+        auth._read_gemini_oauth_tokens(_lock=False)
+    assert exc_info.value.provider == "gemini-oauth"
+
+
+def test_get_gemini_oauth_auth_status_not_logged_in(monkeypatch):
+    """Status should report not logged in when no credentials exist."""
+    monkeypatch.setattr(auth, "_load_auth_store", lambda: {"providers": {}})
+    monkeypatch.setattr(auth, "_load_global_auth_store", lambda: {})
+
+    status = auth.get_gemini_oauth_auth_status()
+    assert status.get("logged_in") is False
+
+
+def test_get_gemini_oauth_auth_status_logged_in(monkeypatch):
+    """Status should report logged in when valid tokens exist."""
+    store = {
+        "providers": {
+            "gemini-oauth": {
+                "tokens": {
+                    "access_token": "valid-access",
+                    "refresh_token": "valid-refresh",
+                    "token_type": "Bearer",
+                }
+            }
+        }
+    }
+    monkeypatch.setattr(auth, "_load_auth_store", lambda: store)
+    monkeypatch.setattr(auth, "_load_global_auth_store", lambda: {})
+
+    status = auth.get_gemini_oauth_auth_status()
+    assert status.get("logged_in") is True
+
+
+# ---------------------------------------------------------------------------
+# Constants and provider registry
+# ---------------------------------------------------------------------------
+
+def test_gemini_oauth_constants():
+    """OAuth endpoints should be Google's well-known URLs."""
+    assert auth.DEFAULT_GEMINI_OAUTH_BASE_URL == "https://generativelanguage.googleapis.com/v1beta"
+    assert auth.GEMINI_OAUTH_DEVICE_CODE_URL == "https://oauth2.googleapis.com/device/code"
+    assert auth.GEMINI_OAUTH_TOKEN_URL == "https://oauth2.googleapis.com/token"
+
+
+def test_gemini_oauth_provider_config():
+    """ProviderConfig should be registered with oauth_external auth type."""
+    assert "gemini-oauth" in auth.PROVIDER_REGISTRY
+    pc = auth.PROVIDER_REGISTRY["gemini-oauth"]
+    assert pc.auth_type == "oauth_external"
+    assert pc.inference_base_url == auth.DEFAULT_GEMINI_OAUTH_BASE_URL
+
+
+# ---------------------------------------------------------------------------
+# Model listing and provider aliases
+# ---------------------------------------------------------------------------
+
+def test_gemini_oauth_model_list():
+    """gemini-oauth should have its own model list mirroring gemini."""
+    oauth_models = models._PROVIDER_MODELS.get("gemini-oauth", [])
+    gemini_models = models._PROVIDER_MODELS.get("gemini", [])
+    assert len(oauth_models) > 0
+    # The OAuth provider should offer the same Gemini models as the API-key provider
+    assert set(oauth_models) == set(gemini_models)
+
+
+def test_gemini_oauth_fetch_models():
+    """provider_model_ids should return gemini-oauth models."""
+    result = models.provider_model_ids("gemini-oauth")
+    assert len(result) > 0
+    assert "gemini-3.1-pro-preview" in result
+
+
+def test_gemini_oauth_provider_aliases():
+    """Provider aliases should resolve to gemini-oauth."""
+    from hermes_cli.models import _PROVIDER_ALIASES
+    assert _PROVIDER_ALIASES.get("gemini-oauth") == "gemini-oauth"
+    assert _PROVIDER_ALIASES.get("google-oauth") == "gemini-oauth"
+    assert _PROVIDER_ALIASES.get("google-gemini-oauth") == "gemini-oauth"
+
+
+def test_gemini_oauth_in_canonical_providers():
+    """gemini-oauth should be in CANONICAL_PROVIDERS."""
+    slugs = [p.slug for p in models.CANONICAL_PROVIDERS]
+    assert "gemini-oauth" in slugs
+
+
+def test_gemini_oauth_in_provider_groups():
+    """gemini-oauth should be in the google provider group alongside gemini."""
+    google_group = models.PROVIDER_GROUPS.get("google")
+    assert google_group is not None
+    assert "gemini-oauth" in google_group[2]
+    assert "gemini" in google_group[2]


### PR DESCRIPTION
## Summary

Add `gemini-oauth` as a new provider that authenticates via Google's OAuth 2.0 device code flow, enabling Gemini API access with a Google account instead of an API key.

This mirrors the existing `xai-oauth` provider pattern, adapted for Google's OAuth 2.0 device code endpoint (`https://oauth2.googleapis.com/device/code`).

## How it works

1. User selects `gemini-oauth` in `hermes model` or `hermes setup`
2. If not logged in, user provides their Google Cloud Console OAuth client credentials (client_id + client_secret for a Desktop app type) — either by pasting them or providing a path to a `client_secret.json` file
3. Hermes runs the device code flow: shows the verification URL + user code, polls for approval
4. Tokens (access_token + refresh_token) and client credentials are stored in `auth.json` under `providers.gemini-oauth`
5. At runtime, `resolve_gemini_oauth_runtime_credentials()` auto-refreshes expiring access tokens using the stored refresh_token + client credentials

## Files changed

- **`hermes_cli/auth.py`**: Constants (`DEFAULT_GEMINI_OAUTH_BASE_URL`, `GEMINI_OAUTH_DEVICE_CODE_URL`, `GEMINI_OAUTH_TOKEN_URL`, `GEMINI_OAUTH_SCOPE`), `ProviderConfig` entry, provider aliases, 12 functions mirroring xai-oauth: `get_gemini_oauth_auth_status`, `_read_gemini_oauth_tokens`, `_save_gemini_oauth_tokens`, `_login_gemini_oauth`, `_gemini_oauth_request_device_code`, `_gemini_oauth_poll_device_token`, `_gemini_oauth_device_code_login`, `_refresh_gemini_oauth_tokens`, `resolve_gemini_oauth_runtime_credentials`, `_gemini_access_token_is_expiring`, plus state helpers. User-provided client credentials stored in `client_credentials` block for future refresh.
- **`hermes_cli/models.py`**: `ProviderEntry` for `gemini-oauth`, model list (mirrors `gemini`), provider aliases (`gemini-oauth`, `google-oauth`, `google-gemini-oauth`), runtime model resolution, family-prefix validation (`gemini-`), provider group membership (`google` group alongside `gemini`).
- **`hermes_cli/model_setup_flows.py`**: `_model_flow_gemini_oauth` setup wizard flow (check login → reauth/refresh → model picker).
- **`hermes_cli/main.py`**: Wire `gemini-oauth` into provider picker dispatch and static provider list fallback.
- **`tests/hermes_cli/test_gemini_oauth.py`**: 13 tests covering auth state resolution (provider state, credential pool fallback, global store fallback, missing credentials), login status, constants, provider config, model listing, provider aliases, canonical providers, and provider groups.

## Test results

```
13 passed in 0.92s
```

## Design notes

- **User-provided client credentials**: Unlike `xai-oauth` which uses a hardcoded client ID, Google's device code flow requires a `client_secret` alongside `client_id`. The user provides their own Google Cloud Console OAuth client (Desktop app type). This follows the same pattern as the existing `google-workspace` skill.
- **No OIDC discovery**: Google's OAuth endpoints are fixed/well-known (unlike xAI which uses OIDC discovery), so no discovery function is needed.
- **Same scopes as Gemini API docs**: `generativelanguage.retriever` + `cloud-platform` per [Google's OAuth quickstart](https://ai.google.dev/gemini-api/docs/oauth).
- **Profile/cron safe**: Token resolution follows the same global-store fallback pattern as xai-oauth, so profile/cron processes can use root-level auth.