### PR TITLE
feat(undo): half-turn undo/redo + the hermes_undo module tui_gateway already imports

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8089,89 +8089,95 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         return last_message
     
     def undo_last(self, n: int = 1, prefill: bool = True):
-        """Back up N user turns: truncate history, soft-delete on disk, prefill.
+        """Undo N half-turns via the shared undo core and render its prefill.
 
-        Walks backwards N user messages and discards everything from the
-        Nth-from-last user message onward (its assistant response, tool
-        calls, etc.). ``n`` defaults to 1 (the last exchange); ``/undo 3``
-        backs up three user turns. If ``n`` exceeds the number of user
-        turns, it backs up to the oldest one.
-
-        Beyond the in-memory ``conversation_history`` slice, this also:
-          • soft-deletes the truncated rows in SessionDB (``active=0``) so
-            they're hidden from re-prompts and search but kept for audit;
-          • notifies memory providers via ``on_session_switch(rewound=True)``;
-          • mirrors /branch's agent surgery (system-prompt invalidation +
-            flush-index reset);
-          • when ``prefill`` is set and an input buffer is available,
-            pre-fills the composer with the backed-up message text so it
-            can be edited and resubmitted.
+        A *half-turn* is one party's contiguous run of transcript rows (a user
+        message, or an assistant run including its tool calls/results). The
+        rewind is delegated to ``hermes_undo`` so the CLI, TUI and gateway share
+        one implementation and one undo/redo stack per session.
 
         ``prefill=False`` is used by callers that drive the undo
-        programmatically (e.g. checkpoint rollback) and don't want to
-        touch the user's input buffer.
+        programmatically (e.g. checkpoint rollback) and don't want to touch the
+        user's input buffer.
         """
-        if not self.conversation_history:
-            print("(._.) No messages to undo.")
+        if not self.session_id:
+            print("(._.) No active session to undo.")
+            return
+        try:
+            import hermes_undo
+
+            if self._session_db is not None:
+                hermes_undo._session_db = self._session_db
+            result = hermes_undo.undo(self.session_id, n)
+        except Exception as e:
+            logger.debug("undo: failed: %s", e)
+            print(f"(._.) Undo failed: {e}")
             return
 
-        if n < 1:
-            n = 1
-
-        # Walk backwards collecting the indices of the last N user messages.
-        user_indices = []
-        for i in range(len(self.conversation_history) - 1, -1, -1):
-            if self.conversation_history[i].get("role") == "user":
-                user_indices.append(i)
-                if len(user_indices) >= n:
-                    break
-
-        if not user_indices:
-            print("(._.) No user message found to undo.")
+        rewound_ids = list(result.get("rewound_ids") or [])
+        if not rewound_ids:
+            print("(._.) Nothing to undo.")
             return
 
-        # The oldest of the collected user messages is our truncation point.
-        cut_idx = user_indices[-1]
-        turns_undone = len(user_indices)
+        self._reload_active_history_after_rewind(rewound=True)
+        count = len(rewound_ids)
+        prefill_text = result.get("prefill_text")
+        print(f"(^_^)b Undid {n} half-turn(s) ({count} message(s)).")
+        print(f"  {len(self.conversation_history)} message(s) remaining in history.")
+        if prefill and isinstance(prefill_text, str):
+            self._prefill_input_buffer(prefill_text)
 
-        removed_count = len(self.conversation_history) - cut_idx
-        removed_msg = self.conversation_history[cut_idx].get("content", "")
-        removed_text = self._undo_content_to_text(removed_msg)
+    def redo_last(self, n: int = 1):
+        """Redo N undo operations via the shared undo core."""
+        if not self.session_id:
+            print("(._.) No active session to redo.")
+            return
+        try:
+            import hermes_undo
 
-        # Truncate the in-memory history to before that user message.
-        self.conversation_history = self.conversation_history[:cut_idx]
+            if self._session_db is not None:
+                hermes_undo._session_db = self._session_db
+            result = hermes_undo.redo(self.session_id, n)
+        except Exception as e:
+            logger.debug("redo: failed: %s", e)
+            print(f"(._.) Redo failed: {e}")
+            return
 
-        # Soft-delete the truncated rows on disk so re-prompts and search
-        # see the clean transcript while the rows survive for audit.
-        rewound_rows = 0
+        reactivated = int(result.get("reactivated_count") or 0)
+        if reactivated <= 0:
+            print(f"(._.) {result.get('message') or 'Nothing to redo.'}")
+            return
+
+        self._reload_active_history_after_rewind(rewound=True)
+        print(f"(^_^)b Redid {n} undo operation(s) ({reactivated} message(s) restored).")
+        tail = self.conversation_history[-1] if self.conversation_history else None
+        if tail:
+            role = tail.get("role", "message")
+            content = tail.get("content")
+            if isinstance(content, str) and content:
+                preview = content[:60] + ("..." if len(content) > 60 else "")
+                print(f'  Restored tail ({role}): "{preview}"')
+            else:
+                print(f"  Restored tail: {role} turn.")
+
+    def _reload_active_history_after_rewind(self, *, rewound: bool = False) -> None:
+        """Re-read the ACTIVE-only transcript and re-sync the agent after a
+        rewind or restore.
+
+        Reloading from the DB (rather than slicing the in-memory list) is what
+        keeps /undo and /redo symmetric: both surfaces end up with exactly the
+        rows the DB says are active, so a redo restores the same prefix the undo
+        removed. The agent's flush index is re-baselined to the new length so
+        the next turn doesn't re-flush rows that are already durable.
+        """
         if self._session_db is not None and self.session_id:
             try:
-                recents = self._session_db.list_recent_user_messages(
-                    self.session_id, limit=max(turns_undone, 10)
+                self.conversation_history = self._session_db.get_messages_as_conversation(
+                    self.session_id
                 )
-                if recents:
-                    target_idx = min(turns_undone - 1, len(recents) - 1)
-                    target_id = recents[target_idx]["id"]
-                    result = self._session_db.rewind_to_message(
-                        self.session_id, target_id
-                    )
-                    rewound_rows = result.get("rewound_count", 0)
-                    # Prefer the DB's decoded target text for the prefill —
-                    # it's the canonical persisted copy.
-                    db_text = self._undo_content_to_text(
-                        (result.get("target_message") or {}).get("content")
-                    )
-                    if db_text:
-                        removed_text = db_text
-            except ValueError as e:
-                # Non-user target / cross-session — keep the in-memory undo
-                # but skip the soft-delete; surface a debug-level note.
-                logger.debug("undo: soft-delete skipped: %s", e)
             except Exception as e:
-                logger.debug("undo: soft-delete failed: %s", e)
+                logger.debug("rewind: active history reload failed: %s", e)
 
-        # Agent surgery: invalidate the system-prompt cache and reset the
-        # flush index so the next turn re-flushes from the truncated head.
         if self.agent is not None:
             if hasattr(self.agent, "_invalidate_system_prompt"):
                 try:
@@ -8183,8 +8189,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     self.agent._last_flushed_db_idx = len(self.conversation_history)
                 except Exception:
                     pass
-            # Notify memory providers — same hook /branch fires, with the
-            # rewound flag so per-turn document caches invalidate (#6672, #21910).
             try:
                 _mm = getattr(self.agent, "_memory_manager", None)
                 if _mm is not None and self.session_id:
@@ -8192,24 +8196,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         self.session_id,
                         parent_session_id="",
                         reset=False,
-                        rewound=True,
+                        rewound=rewound,
                     )
             except Exception:
                 pass
-
-        turn_word = "turn" if turns_undone == 1 else "turns"
-        msg_count = rewound_rows or removed_count
-        print(
-            f"(^_^)b Undid {turns_undone} {turn_word} ({msg_count} message(s)). "
-            f"Backed up to: \"{removed_text[:60]}{'...' if len(removed_text) > 60 else ''}\""
-        )
-        remaining = len(self.conversation_history)
-        print(f"  {remaining} message(s) remaining in history.")
-
-        # Pre-fill the composer with the backed-up message so the user can
-        # edit and resubmit (Claude-Code-style). Editable, not auto-sent.
-        if prefill and removed_text:
-            self._prefill_input_buffer(removed_text)
 
     @staticmethod
     def _undo_content_to_text(content) -> str:
@@ -9639,9 +9629,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 if _undo_n < 1:
                     _undo_n = 1
             _undo_desc = (
-                "This removes the last user/assistant exchange from history."
+                "This backs up the last half-turn from history."
                 if _undo_n == 1
-                else f"This removes the last {_undo_n} user turns from history."
+                else f"This backs up the last {_undo_n} half-turns from history."
             )
             if self._confirm_destructive_slash(
                 "undo",
@@ -9650,6 +9640,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             ) is None:
                 return True  # confirmation cancelled — command handled, keep REPL alive
             self.undo_last(_undo_n)
+        elif canonical == "redo":
+            _redo_n = 1
+            _redo_parts = cmd_original.split()
+            if len(_redo_parts) > 1:
+                try:
+                    _redo_n = int(_redo_parts[1])
+                except ValueError:
+                    print(f"(._.) Invalid count {_redo_parts[1]!r} — use /redo or /redo N.")
+                    return True
+                if _redo_n < 1:
+                    # A non-positive count is a typo, not a request to do
+                    # nothing — clamp rather than silently no-op into a
+                    # misleading "nothing to redo".
+                    _redo_n = 1
+            self.redo_last(_redo_n)
         elif canonical == "branch":
             self._handle_branch_command(cmd_original)
         elif canonical == "save":
@@ -10054,15 +10059,31 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 if len(matches) > 1:
                     # Prefer an exact match (typed the full command name)
                     exact = [c for c in matches if c == typed_base]
+                    builtin_matches = [c for c in matches if c in COMMANDS]
+                    skill_matches = [c for c in matches if c not in COMMANDS]
                     if len(exact) == 1:
                         matches = exact
-                    else:
-                        # Prefer the unique shortest match:
-                        # /qui → /quit (5) wins over /quint-pipeline (15)
-                        min_len = min(len(c) for c in matches)
-                        shortest = [c for c in matches if len(c) == min_len]
-                        if len(shortest) == 1:
-                            matches = shortest
+                    elif len(builtin_matches) == 1:
+                        # A single built-in command is uniquely identified — prefer
+                        # it over any longer skill/bundle names that share the
+                        # prefix: /qui → /quit wins over the /quint-pipeline skill.
+                        matches = builtin_matches
+                    elif len(builtin_matches) > 1:
+                        # Multiple built-ins share the prefix. Resolve to the
+                        # shortest ONLY when it is itself a prefix of every other
+                        # match — i.e. the others are extensions of one base
+                        # command (/sta → /status, with /statusbar an extension).
+                        # When the matches are unrelated siblings
+                        # (/re → /redo, /reset, /retry) there is no such base, so
+                        # stay ambiguous instead of silently picking the shortest
+                        # by length alone. Length-only would fire /redo on a bare
+                        # /re — a destructive command the user never named.
+                        shortest = min(builtin_matches, key=len)
+                        if all(c.startswith(shortest) for c in builtin_matches):
+                            matches = [shortest]
+                    elif not builtin_matches and len(skill_matches) == 1:
+                        # No built-in matched but exactly one skill/bundle did.
+                        matches = skill_matches
                 if len(matches) == 1:
                     # Expand the prefix to the full command name, preserving arguments.
                     # Guard against redispatching the same token to avoid infinite

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12037,9 +12037,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except (ValueError, IndexError):
                     _undo_n = 1
             _undo_detail = (
-                "This removes the last user/assistant exchange from history."
+                "This backs up the last half-turn from history."
                 if _undo_n == 1
-                else f"This removes the last {_undo_n} user turns from history."
+                else f"This backs up the last {_undo_n} half-turns from history."
             )
             return await self._maybe_confirm_destructive_slash(
                 event=event,
@@ -12048,6 +12048,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 detail=_undo_detail,
                 execute=_do_undo,
             )
+
+        if canonical == "redo":
+            return await self._handle_redo_command(event)
         
         if canonical == "sethome":
             return await self._handle_set_home_command(event)
@@ -14686,6 +14689,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session_entry.session_id, entry,
                             skip_db=agent_persisted,
                         )
+                        if agent_persisted and msg.get("role") == "user":
+                            try:
+                                from hermes_undo import on_user_message_appended
+
+                                on_user_message_appended(session_entry.session_id)
+                            except Exception as e:
+                                logger.debug("redo clear on user append failed: %s", e)
             
             # Token counts and model are now persisted by the agent directly.
             # Keep only last_prompt_tokens here for context-window tracking and

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -11,6 +11,7 @@ Handles:
 import asyncio
 import hashlib
 import logging
+import sqlite3
 import os
 import json
 import threading
@@ -20,8 +21,24 @@ from datetime import datetime, timedelta
 from dataclasses import dataclass, field, replace
 from typing import Dict, List, Optional, Any
 
+from hermes_state import RewindWouldOrphanError
+
 logger = logging.getLogger(__name__)
 
+
+def _is_transient_db_busy(exc: BaseException) -> bool:
+    """True for the SQLite lock/busy class — a transient, retryable condition.
+
+    Mirrors the discrimination in ``SessionDB._execute_write`` (and its sibling
+    ``hermes_undo._is_transient_redo_error``): only a ``sqlite3.OperationalError``
+    whose message names ``locked``/``busy`` is transient. Anything else (schema
+    errors, logic bugs, non-DB exceptions) is a real fault and must NOT be
+    reported to the user as a transient "try again".
+    """
+    if not isinstance(exc, sqlite3.OperationalError):
+        return False
+    msg = str(exc).lower()
+    return "locked" in msg or "busy" in msg
 
 def _now() -> datetime:
     """Return the current local time."""
@@ -3189,6 +3206,15 @@ class SessionStore:
         self._clear_dirty_transcript(session_id)
         try:
             self._db.replace_messages(session_id, messages)
+            # A transcript rewrite hard-deletes and renumbers rows, so any
+            # in-memory undo/redo stack now references dead ids. Invalidate it
+            # so a later /redo can't try to restore vanished rows.
+            try:
+                import hermes_undo
+
+                hermes_undo.clear_state(session_id)
+            except Exception as e:
+                logger.debug("rewrite_transcript: undo-state clear skipped: %s", e)
             return True
         except Exception as e:
             logger.debug("Failed to rewrite transcript in DB: %s", e)
@@ -3216,16 +3242,22 @@ class SessionStore:
             return []
 
     def rewind_session(self, session_id: str, n: int = 1) -> Optional[Dict[str, Any]]:
-        """Back up ``n`` user turns via soft-delete, keeping rows for audit.
+        """Back up ``n`` half-turns via the shared undo core.
 
-        Unlike :meth:`rewrite_transcript` (a hard replace used by /retry),
-        this flips the truncated rows to ``active=0`` in state.db so they
-        survive for audit and stay hidden from re-prompts and search. Mirrors
-        the CLI/TUI ``/undo [N]`` behavior via ``SessionDB.rewind_to_message``.
-
-        Returns a dict ``{"rewound_count", "turns_undone", "target_text"}`` on
-        success, or ``None`` if there's no DB or no user message to back up to.
-        ``n`` clamps to the oldest user turn when it exceeds the turn count.
+        Returns one of four outcomes so the caller can report HONESTLY (a
+        method that collapses EVERY exception into ``None`` renders a DB fault
+        as the user-facing lie "Nothing to undo."):
+        - a real result dict (has ``rewound_ids``) — success.
+        - ``None`` — a genuine, healthy empty (nothing to rewind).
+        - ``{"status": "busy"}`` — a RETRYABLE condition: a transient lock/busy
+          DB error, OR the orphan-guard ``RewindWouldOrphanError`` (a mid-flush
+          race that self-heals); render "try again", never "nothing to undo".
+        - ``{"status": "error"}`` — any OTHER exception (a genuine bug, a
+          non-lock ``OperationalError``); render a distinct internal-error
+          message, logged at ERROR, never "nothing to undo".
+        Every non-success outcome is safe to call "nothing was changed" because
+        ``rewind_to_message`` validates + orphan-guards BEFORE its single write,
+        so a raise from that path means no mutation occurred.
         """
         if not self._db:
             return None
@@ -3233,40 +3265,96 @@ class SessionStore:
         if n < 1:
             n = 1
         try:
-            recents = self._db.list_recent_user_messages(session_id, limit=max(n, 10))
+            import hermes_undo
+
+            hermes_undo._session_db = self._db
+            result = hermes_undo.undo(session_id, n)
+        except RewindWouldOrphanError as e:
+            # A concurrent turn is mid-flush (an assistant(tool_calls)→tool pair
+            # is being written) so the rewind would transiently orphan a tool
+            # row. Self-heals once the flush completes → RETRYABLE, WARNING (not
+            # an ERROR-logged permanent fault).
+            logger.warning(
+                "rewind_session: transient orphan-guard (mid-flush) for %s: %r",
+                session_id, e,
+            )
+            return {"status": "busy"}
+        except sqlite3.OperationalError as e:
+            if _is_transient_db_busy(e):
+                logger.warning(
+                    "rewind_session: transient DB busy for %s: %r", session_id, e
+                )
+                return {"status": "busy"}
+            logger.error(
+                "rewind_session: DB error for %s: %r", session_id, e, exc_info=True
+            )
+            return {"status": "error"}
         except Exception as e:
-            logger.debug("rewind_session: failed to list user messages: %s", e)
+            logger.error(
+                "rewind_session: undo failed for %s: %r", session_id, e, exc_info=True
+            )
+            return {"status": "error"}
+        if not result.get("rewound_ids"):
+            # Genuine empty — nothing rewound. Record the active-row count + the
+            # computed target the undo core saw.
+            active_count = result.get("active_count")
+            target_id = result.get("target_id")
+            if active_count:
+                # Rows PRESENT but /undo rewound NOTHING — whether because no
+                # half-turn target was found OR a target was found but
+                # deactivated 0 rows. This is NOT a healthy empty — surface at
+                # WARNING so a recurrence is visible at prod log level.
+                logger.warning(
+                    "rewind_session: /undo rewound NOTHING for %s despite "
+                    "%s active row(s) (n=%s target_id=%s) — possible "
+                    "transient/mid-flush state; reporting 'nothing to undo'",
+                    session_id, active_count, n, target_id,
+                )
+            else:
+                logger.debug(
+                    "rewind_session: nothing to undo for %s "
+                    "(healthy empty; n=%s active_count=%s target_id=%s)",
+                    session_id, n, active_count, target_id,
+                )
             return None
-        if not recents:
+        return result
+
+    def restore_session(self, session_id: str, n: int = 1) -> Optional[Dict[str, Any]]:
+        """Redo ``n`` undo operations via the shared undo core.
+
+        Honesty contract (parallels :meth:`rewind_session` but note: ``redo()``
+        never returns ``None`` for a healthy empty — it returns a real dict with
+        ``reactivated_count == 0``, which the caller renders as "nothing to
+        redo"). Outcomes:
+        - a real result dict (``reactivated_count`` present) — success OR a
+          healthy empty (count 0) OR an honest partial (``partial_retryable``).
+        - ``{"status": "busy"}`` — a RETRYABLE lock/busy DB error.
+        - ``{"status": "error"}`` — a genuine bug / non-lock error (logged ERROR).
+        - ``None`` — only when there is no DB handle at all.
+        """
+        if not self._db:
             return None
-        target_idx = min(n - 1, len(recents) - 1)
-        target_id = recents[target_idx]["id"]
         try:
-            result = self._db.rewind_to_message(session_id, target_id)
-        except ValueError as e:
-            logger.debug("rewind_session: %s", e)
-            return None
+            import hermes_undo
+
+            hermes_undo._session_db = self._db
+            result = hermes_undo.redo(session_id, n)
+        except sqlite3.OperationalError as e:
+            if _is_transient_db_busy(e):
+                logger.warning(
+                    "restore_session: transient DB busy for %s: %r", session_id, e
+                )
+                return {"status": "busy"}
+            logger.error(
+                "restore_session: DB error for %s: %r", session_id, e, exc_info=True
+            )
+            return {"status": "error"}
         except Exception as e:
-            logger.debug("rewind_session: rewind_to_message failed: %s", e)
-            return None
-        target_msg = result.get("target_message") or {}
-        content = target_msg.get("content") or ""
-        if isinstance(content, list):
-            parts = [
-                p.get("text", "")
-                for p in content
-                if isinstance(p, dict) and p.get("type") == "text"
-            ]
-            target_text = "\n".join(t for t in parts if t)
-        elif isinstance(content, str):
-            target_text = content
-        else:
-            target_text = ""
-        return {
-            "rewound_count": result.get("rewound_count", 0),
-            "turns_undone": target_idx + 1,
-            "target_text": target_text,
-        }
+            logger.error(
+                "restore_session: redo failed for %s: %r", session_id, e, exc_info=True
+            )
+            return {"status": "error"}
+        return result
 
 
 def build_session_context(

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2825,19 +2825,21 @@ class GatewaySlashCommandsMixin:
         return f"✓ Added subgoal {idx}: {text}"
 
     async def _handle_undo_command(self, event: MessageEvent) -> str:
-        """Handle /undo [N] — back up N user turns (default 1), soft-deleting
-        the truncated rows on disk and echoing the backed-up message text so
-        the user can copy/edit and resend.
+        """Handle /undo [N] — back up N half-turns via the shared undo core.
 
-        Mirrors the CLI/TUI /undo: rewound rows stay in state.db (active=0)
-        for audit and are hidden from re-prompts and search. The cached agent
-        is evicted so the next message rebuilds context from the truncated
-        (active-only) transcript — the gateway's equivalent of the CLI's
-        in-place history surgery + memory-cache invalidation.
+        A *half-turn* is one party's contiguous run of transcript rows (a user
+        message, or an assistant run including its tool calls/results), not a
+        whole user↔assistant exchange. ``/undo`` therefore lands the thread on
+        the other party's last message, which is what makes ``/undo`` +
+        ``/redo`` behave like a text editor's undo stack.
+
+        Rewound rows stay in state.db with ``active=0`` for audit and are hidden
+        from re-prompts and search. The cached agent is evicted so the next
+        message rebuilds context from the truncated (active-only) transcript.
         """
         source = event.source
 
-        # Parse optional turn count: "/undo" → 1, "/undo 3" → 3.
+        # Parse optional half-turn count: "/undo" → 1, "/undo 3" → 3.
         n = 1
         raw_args = event.get_command_args().strip()
         if raw_args:
@@ -2849,10 +2851,21 @@ class GatewaySlashCommandsMixin:
                 n = 1
 
         session_entry = await self.async_session_store.get_or_create_session(source)
-        result = await self.async_session_store.rewind_session(session_entry.session_id, n)
+        result = await self.async_session_store.rewind_session(
+            session_entry.session_id, n
+        )
 
         if result is None:
             return t("gateway.undo.nothing")
+        # Honest reporting of a non-empty failure: distinguish a transient
+        # DB-busy from a real internal error — never render either as "Nothing
+        # to undo." Both mean the rewind did NOT happen (validation +
+        # orphan-guard run before the single write).
+        status = result.get("status") if isinstance(result, dict) else None
+        if status == "busy":
+            return t("gateway.undo.busy")
+        if status == "error":
+            return t("gateway.undo.error")
 
         # Reset stored token count — transcript was truncated.
         session_entry.last_prompt_tokens = 0
@@ -2864,14 +2877,102 @@ class GatewaySlashCommandsMixin:
         except Exception as e:
             logger.debug("undo: cached-agent eviction skipped: %s", e)
 
-        target_text = result["target_text"]
-        preview = target_text[:200] + "..." if len(target_text) > 200 else target_text
         return t(
             "gateway.undo.removed",
-            turns=result["turns_undone"],
-            count=result["rewound_count"],
-            preview=preview,
+            turns=n,
+            count=len(result.get("rewound_ids") or []),
+        ) + self._undo_tail_suffix(session_entry.session_id)
+
+    def _undo_tail_suffix(self, session_id: str) -> str:
+        """Render a one-line '↦ now at …' confirmation of the active tail.
+
+        Lets a user confirm at a glance WHERE the thread landed after /undo or
+        /redo — which message is now last — without scrolling. Best-effort:
+        never let a preview failure break the command's primary reply.
+        """
+        try:
+            import hermes_undo
+
+            hermes_undo._session_db = self.session_store._db
+            info = hermes_undo.tail_preview(session_id)
+        except Exception as e:
+            logger.debug("undo/redo tail preview skipped: %s", e)
+            return ""
+        # The read itself failed (transient DB error) — the primary undo/redo
+        # already succeeded, so omit the suffix rather than misreport "empty".
+        if info.get("error"):
+            return ""
+        if info.get("empty"):
+            return "\n" + t("gateway.undo.now_empty")
+        # Bound the role to the set that has a translated party label; an
+        # unexpected role (system/developer/legacy function) would otherwise
+        # ask t() for a missing key and render the raw key path to the user.
+        role = info.get("role") or "message"
+        if role not in {"user", "assistant", "tool", "message"}:
+            role = "message"
+        who = t(f"gateway.undo.party.{role}")
+        preview = info.get("preview")
+        if preview:
+            return "\n" + t("gateway.undo.now_at", who=who, preview=preview)
+        return "\n" + t("gateway.undo.now_at_notext", who=who)
+
+    async def _handle_redo_command(self, event: MessageEvent) -> str:
+        """Handle /redo [N] by delegating to the shared redo core.
+
+        Restores the exact row-id sets that the last N ``/undo`` operations
+        deactivated — not an ``id >=`` range — so the transcript prefix is
+        re-created byte-for-byte.
+        """
+        source = event.source
+        n = 1
+        raw_args = event.get_command_args().strip()
+        if raw_args:
+            try:
+                n = int(raw_args.split()[0])
+            except (ValueError, IndexError):
+                return t("gateway.redo.invalid_count", arg=raw_args.split()[0])
+
+        session_entry = await self.async_session_store.get_or_create_session(source)
+        result = await self.async_session_store.restore_session(
+            session_entry.session_id, n
         )
+        if result is None:
+            return t("gateway.redo.nothing")
+        # Honest reporting of a non-empty failure: a transient DB-busy or a real
+        # internal error must not read as "nothing to redo".
+        status = result.get("status") if isinstance(result, dict) else None
+        if status == "busy":
+            return t("gateway.redo.busy")
+        if status == "error":
+            return t("gateway.redo.error")
+
+        reactivated = int(result.get("reactivated_count") or 0)
+        if reactivated <= 0:
+            message = str(result.get("message") or "")
+            if "restart" in message:
+                return t("gateway.redo.restart_lost")
+            return t("gateway.redo.nothing")
+
+        session_entry.last_prompt_tokens = 0
+        try:
+            session_key = build_session_key(source)
+            self._evict_cached_agent(session_key)
+        except Exception as e:
+            logger.debug("redo: cached-agent eviction skipped: %s", e)
+
+        base = t(
+            "gateway.redo.restored",
+            ops=n,
+            count=reactivated,
+        )
+        # If only SOME ops were redone (a transcript rewrite or a mid-loop
+        # transient/hard error), surface the honest partial note the undo core
+        # produced instead of implying a full redo. Detect via the language-
+        # neutral ``partial`` flag, not the (English) message text.
+        partial_note = str(result.get("message") or "")
+        if result.get("partial") and partial_note:
+            base = f"{base}\n⚠️ {partial_note}"
+        return base + self._undo_tail_suffix(session_entry.session_id)
 
     async def _handle_set_home_command(self, event: MessageEvent) -> str:
         """Handle /sethome command -- set the current chat as the platform's home channel."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -80,7 +80,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("retry", "Retry the last message (resend to agent)", "Session"),
     CommandDef("prompt", "Compose your next prompt in $EDITOR (markdown), then send it", "Session",
                cli_only=True, args_hint="[initial text]", aliases=("compose",)),
-    CommandDef("undo", "Back up N user turns and re-prompt (default 1)", "Session",
+    CommandDef("undo", "Back up N half-turns and re-prompt (default 1)", "Session",
+               args_hint="[N]"),
+    CommandDef("redo", "Redo N undo operations (default 1)", "Session",
                args_hint="[N]"),
     CommandDef("title", "Set a title for the current session", "Session",
                args_hint="[name]"),
@@ -1198,7 +1200,17 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     /hermes update on Slack. Demoted to free the native slot /approvals now
 #     claims — without this entry /approvals tips the registry past the 50-cap
 #     and silently clamps /update off, breaking Telegram parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update"})
+#   - platform: gateway platform pause/resume/list — an operator-maintenance
+#     command, reached via /hermes platform on Slack. Demoted when /redo
+#     claimed a native slot: the registry sits exactly at the 50-cap, so
+#     adding /redo clamps whichever command sorts last off the native list.
+#     Curating that explicitly (rather than letting the clamp pick) keeps
+#     Telegram parity honest. /undo and /redo are recurring, in-conversation
+#     session controls; /platform is a rare operator action, so it is the
+#     correct demotion. Native everywhere else (CLI, TUI, Telegram, Discord).
+_SLACK_VIA_HERMES_ONLY = frozenset(
+    {"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "platform"}
+)
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1174,6 +1174,9 @@ CREATE TABLE IF NOT EXISTS sessions (
     compression_ineffective_count INTEGER NOT NULL DEFAULT 0,
     profile_name TEXT,
     rewind_count INTEGER NOT NULL DEFAULT 0,
+    -- Intentionally asymmetric: rewind_count bumps per rewind_to_message call;
+    -- redo_count bumps once per /redo command, regardless of M.
+    redo_count INTEGER,
     archived INTEGER NOT NULL DEFAULT 0,
     pinned INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
@@ -1688,6 +1691,19 @@ def _connect_tracked_db(path, tracking_path=None, **kwargs):
         connect_fn=sqlite3.connect,
         **kwargs,
     )
+
+
+class RewindWouldOrphanError(ValueError):
+    """A rewind target would orphan an active tool row (deactivate an
+    ``assistant(tool_calls)`` while its ``tool`` result stays active).
+
+    Subclasses ``ValueError`` so existing ``except ValueError`` callers still
+    catch it. This is a TRANSIENT, self-healing condition: it fires when a
+    concurrent turn is mid-flush (the ``assistant(tool_calls)``→``tool`` pair
+    is being written), and clears once the flush completes. Callers should
+    report it as retryable ("try again in a moment"), NOT a permanent internal
+    error.
+    """
 
 
 def is_zeroed_state_db(
@@ -7512,7 +7528,10 @@ class SessionDB:
     # =========================================================================
 
     def rewind_to_message(
-        self, session_id: str, target_message_id: int
+        self,
+        session_id: str,
+        target_message_id: int,
+        require_user_role: bool = True,
     ) -> Dict[str, Any]:
         """Soft-delete all messages with id >= ``target_message_id`` in *session_id*.
 
@@ -7527,11 +7546,19 @@ class SessionDB:
             {
                 "rewound_count": int,    # number of rows newly flipped to active=0
                 "target_message": dict,  # full row dict of the target
-                "new_head_id":   int|None  # id of the last still-active row, or None
+                "new_head_id":   int|None, # id of the last still-active row, or None
+                "rewound_ids":   list[int] # rows newly flipped active=1 -> active=0
             }
 
         Raises ``ValueError`` if the target message does not exist in
-        *session_id* or if its role is not ``"user"``.
+        *session_id* or, when ``require_user_role`` is true, if its role is
+        not ``"user"``. Half-turn callers (the shared undo core) pass
+        ``require_user_role=False`` because a half-turn boundary can be an
+        assistant run. Raises :class:`RewindWouldOrphanError` (a
+        ``ValueError`` subclass) when the rewind would deactivate an
+        ``assistant`` row carrying ``tool_calls`` while its ``tool`` results
+        stay active — that shape breaks strict role alternation on every
+        provider, so it is refused BEFORE any write.
 
         Always increments ``sessions.rewind_count`` — even when the
         target is already inactive — so the counter accurately reflects
@@ -7551,7 +7578,7 @@ class SessionDB:
                 f"message {target_message_id} not found in session {session_id}"
             )
         target_row = dict(row)
-        if target_row.get("role") != "user":
+        if require_user_role and target_row.get("role") != "user":
             raise ValueError(
                 f"rewind target must be a 'user' message (got role="
                 f"{target_row.get('role')!r}, id={target_message_id})"
@@ -7559,6 +7586,12 @@ class SessionDB:
 
         # Decode content for callers (prefill the prompt buffer).
         target_row["content"] = self._decode_content(target_row.get("content"))
+
+        # Refuse BEFORE the write if this id-range rewind would strand a
+        # ``tool`` row whose ``assistant(tool_calls)`` owner is inside the
+        # deactivated range. Such a transcript violates strict role
+        # alternation and is rejected by strict OpenAI-compatible providers.
+        self._raise_if_rewind_would_orphan_tool(session_id, target_message_id)
 
         rewound: List[int] = []
 
@@ -7585,18 +7618,84 @@ class SessionDB:
         rewound = self._execute_write(_do)
 
         # 2) Compute new head id (largest still-active row id in session).
-        with self._lock:
-            head_row = self._conn.execute(
-                "SELECT MAX(id) FROM messages WHERE session_id = ? AND active = 1",
-                (session_id,),
-            ).fetchone()
-        new_head_id = head_row[0] if head_row and head_row[0] is not None else None
+        #    This runs AFTER the write committed. A failure here must NOT
+        #    raise into the caller — that would let rewind_session report
+        #    "error / nothing changed" for a rewind that DID happen, and a
+        #    retry would double-undo. Fail SOFT: the rewind is durable, the
+        #    head id is a cosmetic display value.
+        try:
+            with self._lock:
+                head_row = self._conn.execute(
+                    "SELECT MAX(id) FROM messages WHERE session_id = ? AND active = 1",
+                    (session_id,),
+                ).fetchone()
+            new_head_id = head_row[0] if head_row and head_row[0] is not None else None
+        except Exception as exc:
+            logger.warning(
+                "rewind_to_message: post-commit head-id read failed for %s "
+                "(rewind already committed; returning None head): %r",
+                session_id, exc,
+            )
+            new_head_id = None
 
         return {
             "rewound_count": len(rewound),
             "target_message": target_row,
             "new_head_id": new_head_id,
+            "rewound_ids": rewound,
         }
+
+    def _raise_if_rewind_would_orphan_tool(
+        self, session_id: str, target_message_id: int
+    ) -> None:
+        """Fail before an id-range rewind can leave a tool row without owner.
+
+        Strict role alternation requires every ``tool`` message to follow the
+        ``assistant`` message whose ``tool_calls`` produced it. An id-range
+        rewind deactivates a contiguous suffix, so the only way to strand a
+        tool row is a concurrent mid-flush write that persisted the ``tool``
+        row with a LOWER id than its assistant owner. Detect that and refuse
+        rather than commit an unalternatable transcript.
+        """
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT id, role, tool_call_id, tool_calls FROM messages "
+                "WHERE session_id = ? AND active = 1 ORDER BY id",
+                (session_id,),
+            ).fetchall()
+
+        assistant_call_ids: set = set()
+        for row in rows:
+            if row["id"] < target_message_id or row["role"] != "assistant":
+                continue
+            raw = row["tool_calls"]
+            if not raw:
+                continue
+            try:
+                calls = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                calls = []
+            if isinstance(calls, dict):
+                calls = [calls]
+            if not isinstance(calls, list):
+                continue
+            for call in calls:
+                if isinstance(call, dict) and call.get("id"):
+                    assistant_call_ids.add(str(call["id"]))
+
+        if not assistant_call_ids:
+            return
+
+        for row in rows:
+            if row["id"] >= target_message_id or row["role"] != "tool":
+                continue
+            call_id = row["tool_call_id"]
+            if call_id and str(call_id) in assistant_call_ids:
+                raise RewindWouldOrphanError(
+                    "rewind would orphan active tool row "
+                    f"id={row['id']} by deactivating its assistant owner "
+                    f"at or after target id={target_message_id}"
+                )
 
     def restore_rewound(self, session_id: str, since_message_id: int) -> int:
         """Mark inactive messages with id >= *since_message_id* active again.
@@ -7621,6 +7720,50 @@ class SessionDB:
             return len(ids)
 
         return self._execute_write(_do)
+
+    def restore_ids(self, session_id: str, ids: List[int]) -> int:
+        """Reactivate the inactive rows in ``ids`` for ``session_id``.
+
+        Idempotent: rows that are already active, from another session, or
+        absent are skipped. ``redo_count`` is intentionally not bumped here;
+        the shared undo/redo core owns that single command-level counter.
+
+        Restoring an exact id SET (not an ``id >=`` range) is what makes
+        stacked redo correct: each undo op recorded exactly which rows it
+        deactivated, so restoring them re-creates the transcript prefix
+        byte-for-byte, preserving alternation and the cached prefix.
+        """
+        bounded_ids = [int(i) for i in ids]
+        if not bounded_ids:
+            return 0
+
+        def _do(conn):
+            placeholders = ",".join("?" for _ in bounded_ids)
+            cursor = conn.execute(
+                f"UPDATE messages SET active = 1 "
+                f"WHERE session_id = ? AND id IN ({placeholders}) AND active = 0",
+                (session_id, *bounded_ids),
+            )
+            return cursor.rowcount
+
+        return self._execute_write(_do)
+
+    def bump_redo_count(self, session_id: str) -> None:
+        """Increment ``sessions.redo_count`` by one (once per /redo command).
+
+        Public helper so the shared undo/redo core doesn't reach into the
+        private ``_execute_write``. Counter asymmetry is intentional:
+        ``rewind_count`` bumps per low-level ``rewind_to_message`` call;
+        ``redo_count`` bumps once per /redo command, regardless of M.
+        """
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET redo_count = COALESCE(redo_count, 0) + 1 "
+                "WHERE id = ?",
+                (session_id,),
+            )
+
+        self._execute_write(_do)
 
     def list_recent_user_messages(
         self,

--- a/hermes_undo.py
+++ b/hermes_undo.py
@@ -1,0 +1,481 @@
+"""Shared half-turn undo/redo core for Hermes sessions.
+
+Concurrency precondition: callers must serialize undo()/redo()/
+on_user_message_appended() per session_id. The in-memory ``_states`` dict is
+unlocked and undo() does a non-atomic read (get_messages) then write
+(rewind_to_message), so two concurrent same-session undos could push spurious
+stack entries. This is safe today because every surface serializes per session:
+the CLI is a single-thread REPL, the gateway rejects undo/redo while an agent is
+running and runs the core synchronously on one event loop, and the TUI rejects
+undo while a turn is in flight. Any future surface that drives the core off the
+event-loop thread (or adds an ``await`` inside it) must add a per-session lock.
+"""
+
+from __future__ import annotations
+from collections import OrderedDict
+from dataclasses import dataclass, field
+import logging
+import re
+from typing import Any, Dict, List, Optional
+from hermes_state import SessionDB
+
+logger = logging.getLogger(__name__)
+
+
+def _is_transient_redo_error(exc: BaseException) -> bool:
+    """True for a transient/retryable failure of a redo op's write (a DB
+    lock/busy). Mirrors gateway.session._is_transient_db_busy. A non-transient
+    failure (schema error, real bug) returns False so the partial is reported as
+    non-retryable rather than telling the user to '/redo again' into an infinite
+    identical re-fail."""
+    import sqlite3
+    if isinstance(exc, sqlite3.OperationalError):
+        msg = str(exc).lower()
+        return "locked" in msg or "busy" in msg
+    return False
+
+
+@dataclass(frozen=True)
+class UndoOp:
+    n: int
+    rewound_ids: List[int]
+
+
+@dataclass
+class UndoRedoState:
+    undo_stack: List[UndoOp] = field(default_factory=list)
+    redo_stack: List[UndoOp] = field(default_factory=list)
+
+
+# Bound the in-memory undo/redo holder so a long-running gateway that touches
+# many distinct session_ids doesn't grow _states without limit. The state is
+# purely an in-memory redo branch that already does not survive a restart, so
+# evicting the least-recently-used session is graceful: a later /redo on an
+# evicted session behaves exactly like /redo after a restart (handled in redo()).
+_STATE_CAP = 2048
+_states: "OrderedDict[str, UndoRedoState]" = OrderedDict()
+_session_db: Optional[SessionDB] = None
+
+
+def _get_db() -> SessionDB:
+    global _session_db
+    if _session_db is None:
+        _session_db = SessionDB()
+    return _session_db
+
+
+def get_state(session_id: str) -> UndoRedoState:
+    state = _states.get(session_id)
+    if state is None:
+        state = UndoRedoState()
+        _states[session_id] = state
+        # Evict the least-recently-used entries beyond the cap.
+        while len(_states) > _STATE_CAP:
+            _states.popitem(last=False)
+    else:
+        # Refresh recency on access (LRU).
+        _states.move_to_end(session_id)
+    return state
+
+
+def clear_state(session_id: Optional[str] = None) -> None:
+    """Test/helper reset for the in-memory undo/redo holder."""
+    if session_id is None:
+        _states.clear()
+    else:
+        _states.pop(session_id, None)
+
+
+def _party(role: Any) -> str:
+    if role == "user":
+        return "user"
+    if role in {"assistant", "tool"}:
+        return "assistant"
+    return "other"
+
+
+def compute_half_turn_target(
+    active_messages: List[Dict[str, Any]], n: int
+) -> Optional[int]:
+    """Return the inclusive id target for undoing ``n`` half-turns.
+
+    Consecutive rows with the same party form one half-turn. ``other`` rows
+    participate in boundary detection but are never counted or returned.
+    """
+    if n < 1:
+        n = 1
+
+    group_starts: List[int] = []
+    current_party: Optional[str] = None
+    current_start: Optional[int] = None
+
+    for msg in active_messages:
+        msg_party = _party(msg.get("role"))
+        if current_party is None or msg_party != current_party:
+            if current_party != "other" and current_start is not None:
+                group_starts.append(current_start)
+            current_party = msg_party
+            current_start = msg.get("id")
+
+    if current_party != "other" and current_start is not None:
+        group_starts.append(current_start)
+
+    if not group_starts:
+        return None
+
+    target_index = max(0, len(group_starts) - n)
+    return group_starts[target_index]
+
+
+def _new_tail(messages: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if not messages:
+        return None
+    return max(messages, key=lambda m: m["id"])
+
+
+def _tail_before_target(
+    active_messages: List[Dict[str, Any]], target_id: int
+) -> Optional[Dict[str, Any]]:
+    before = [m for m in active_messages if m["id"] < target_id]
+    return _new_tail(before)
+
+
+def _prefill_from_tail(tail: Optional[Dict[str, Any]]) -> Optional[str]:
+    if tail and tail.get("role") == "user" and isinstance(tail.get("content"), str):
+        return tail["content"]
+    return None
+
+
+def _content_to_text(content: Any) -> str:
+    """Flatten message content (str or content-part list) to plain text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            p.get("text", "")
+            for p in content
+            if isinstance(p, dict) and p.get("type") == "text"
+        ]
+        return "\n".join(t for t in parts if t)
+    return ""
+
+
+# Gateway-injected context that prefixes the stored user row but that the user
+# never typed (see gateway/run.py): the Discord "Triggering message id" marker
+# and the "Replying to" pointers. They are pure plumbing, yet at 100+ chars they
+# consumed the ENTIRE /undo·/redo "↦ Now at" preview window — so every landing
+# looked identical and told the user nothing about WHERE they landed. Strip any
+# run of these leading bracket blocks before building a preview.
+_INJECTED_PREFIX_RE = re.compile(
+    r"^\s*\[(?:Triggering message id:|Replying to)[^\]]*\]\s*"
+)
+
+
+def _strip_injected_markers(text: str) -> str:
+    """Remove leading gateway-injected marker blocks from a preview string.
+
+    Best-effort and preview-only: iterates so a message carrying BOTH a
+    Triggering marker and a Replying pointer is fully cleaned, and leaves the
+    text untouched once no known marker leads it.
+    """
+    prev = None
+    while text != prev:
+        prev = text
+        text = _INJECTED_PREFIX_RE.sub("", text, count=1)
+    return text
+
+
+def _preview_text(text: str, max_len: int) -> str:
+    """Collapse whitespace and trim to a short, sentence-aware preview."""
+    collapsed = " ".join(text.split())
+    if len(collapsed) <= max_len:
+        return collapsed
+    window = collapsed[:max_len]
+    # Prefer cutting at the first sentence boundary that lands past the halfway
+    # point of the window, so a short leading sentence reads cleanly and we
+    # don't return a one-word stub.
+    best = -1
+    for mark in (". ", "! ", "? "):
+        idx = window.find(mark)
+        if idx >= max_len // 2:
+            best = max(best, idx + 1)
+    if best > 0:
+        return window[:best].rstrip()
+    return window.rstrip() + "…"
+
+
+def tail_preview(session_id: str, max_len: int = 240) -> Dict[str, Any]:
+    """Describe the CURRENT active tail of a session for at-a-glance confirmation.
+
+    Returns ``{"role": <role|None>, "preview": <str|None>, "empty": <bool>,
+    "error": <bool>}``. ``preview`` is ``None`` when the tail carries no text
+    (e.g. a tool-call-only assistant row); callers should then fall back to
+    naming the role. ``error`` is ``True`` when the tail could not be read at
+    all (a transient DB failure) — distinct from ``empty`` (the transcript is
+    genuinely at the start): callers should OMIT the confirmation suffix on
+    ``error`` rather than tell the user the thread is empty. Note that a
+    half-turn is a *transcript* row (one party's run), not a platform display
+    bubble — a long assistant reply that a chat platform splits into several
+    messages is a single tail row here.
+    """
+    db = _get_db()
+    try:
+        msgs = db.get_messages(session_id, include_inactive=False)
+    except Exception:
+        # Distinct from empty: the read FAILED, we don't know the tail. The
+        # primary undo/redo already succeeded, so the caller should drop the
+        # suffix, NOT claim the thread is empty.
+        return {"role": None, "preview": None, "empty": False, "error": True}
+    tail = _new_tail(msgs)
+    if tail is None:
+        return {"role": None, "preview": None, "empty": True, "error": False}
+    text = _strip_injected_markers(_content_to_text(tail.get("content")))
+    preview = _preview_text(text, max_len) if text else None
+    return {
+        "role": tail.get("role") or "message",
+        "preview": preview or None,
+        "empty": False,
+        "error": False,
+    }
+
+
+def undo(session_id: str, n: int) -> Dict[str, Any]:
+    db = _get_db()
+    state = get_state(session_id)
+    msgs = db.get_messages(session_id, include_inactive=False)
+    target_id = compute_half_turn_target(msgs, n)
+    if target_id is None:
+        # Genuine empty: no half-turn boundary to rewind to. Carry diagnostics
+        # so the caller's breadcrumb can record WHAT was seen (B2/RC2) — the
+        # flagship "said nothing but rows existed" case needs active-count+target.
+        return {
+            "rewound_ids": [],
+            "prefill_text": None,
+            "message": "nothing to undo",
+            "active_count": len(msgs),
+            "target_id": None,
+        }
+
+    tail = _tail_before_target(msgs, target_id)
+    if (
+        tail is not None
+        and tail.get("role") == "user"
+        and not isinstance(tail.get("content"), str)
+    ):
+        target_id = tail["id"]
+
+    result = db.rewind_to_message(
+        session_id, target_id, require_user_role=False
+    )
+    rewound_ids = list(result.get("rewound_ids", []))
+    if not rewound_ids:
+        # Nothing was actually deactivated (degenerate/raced rewind). Don't push
+        # an empty op or clobber a pending redo — match the None-path contract of
+        # touching neither stack. Carry diagnostics (B2/RC2): a computed target
+        # that deactivated 0 rows is exactly the "rows existed but undo did
+        # nothing" signature.
+        return {
+            "rewound_ids": [],
+            "prefill_text": None,
+            "message": "nothing to undo",
+            "active_count": len(msgs),
+            "target_id": target_id,
+        }
+    state.undo_stack.append(UndoOp(n=n, rewound_ids=rewound_ids))
+    state.redo_stack.clear()
+
+    # 🔴 The rewind has COMMITTED (rewound_ids non-empty). This trailing prefill
+    # read must fail SOFT — a raise here would unwind into rewind_session as
+    # "error/nothing changed" for a rewind that DID happen (double-undo on retry).
+    try:
+        active_after = db.get_messages(session_id, include_inactive=False)
+        prefill = _prefill_from_tail(_new_tail(active_after))
+    except Exception as exc:
+        logger.warning(
+            "undo: post-commit prefill read failed for %s "
+            "(rewind already committed): %r", session_id, exc,
+        )
+        prefill = None
+    return {
+        "rewound_ids": rewound_ids,
+        "prefill_text": prefill,
+    }
+
+
+def redo(session_id: str, m: int) -> Dict[str, Any]:
+    db = _get_db()
+    state = get_state(session_id)
+    if m <= 0:
+        return {
+            "reactivated_count": 0,
+            "new_tail_id": None,
+            "prefill_text": None,
+            "message": "nothing to redo",
+        }
+
+    k = min(m, len(state.undo_stack))
+    if k == 0:
+        session = db.get_session(session_id) or {}
+        message = "nothing to redo"
+        if (session.get("rewind_count") or 0) > 0:
+            message = "nothing to redo (redo history doesn't survive a restart)"
+        return {
+            "reactivated_count": 0,
+            "new_tail_id": None,
+            "prefill_text": None,
+            "message": message,
+        }
+
+    reactivated_total = 0
+    ops_redone = 0
+    transcript_changed = False
+    transient_partial = False
+    partial_hard_error = False
+    for _ in range(k):
+        op = state.undo_stack.pop()
+        try:
+            reactivated = db.restore_ids(session_id, op.rewound_ids)
+        except Exception as exc:
+            # 🔴 A write for THIS op raised. redo() does one DB write PER op,
+            # so if an EARLIER op already committed, its rows are live in the DB —
+            # we must NOT let the exception unwind into restore_session as
+            # "nothing changed" (that would desync the screen and let a retry
+            # double-redo the earlier ops). Push the FAILED op back onto the stack
+            # (it did NOT commit, so it stays recoverable) and, if prior ops did
+            # real work, return the honest partial WITHOUT clearing the stack.
+            # If nothing committed yet (first op failed), re-raise so the caller's
+            # classifier reports busy/error.
+            #
+            # 🔴 Classify HERE too (not just at the top-level classifier): a
+            # transient lock → "run /redo again" (retryable); a real bug → a
+            # partial that must NOT promise retry (retrying re-fails identically,
+            # an infinite loop). See _is_transient_redo_error.
+            state.undo_stack.append(op)
+            if reactivated_total > 0:
+                if _is_transient_redo_error(exc):
+                    transient_partial = True
+                else:
+                    partial_hard_error = True
+                    logger.error(
+                        "redo: op failed with a non-transient error after %s row(s) "
+                        "already reactivated for %s (partial, not retryable): %r",
+                        reactivated_total, session_id, exc, exc_info=True,
+                    )
+                break
+            raise
+        if reactivated == 0 and op.rewound_ids:
+            # NONE of this op's rows could be restored — the transcript was
+            # rewritten out from under the stack (/compress, /retry, and any
+            # other replace_messages flow hard-delete + renumber rows). The redo
+            # branch is dead from here on, so stop and discard the rest of the
+            # stack rather than raising: redo across a transcript rewrite is
+            # impossible, same as redo after a restart.
+            #
+            # Crucially, do NOT throw away progress from EARLIER ops in this same
+            # /redo. If we already reactivated rows (reactivated_total > 0), those
+            # rows are live in the DB now; returning reactivated_count:0 here
+            # would make the caller skip its history reload (screen/DB desync)
+            # and leave redo_count un-bumped despite real work. Break and report
+            # the partial result honestly instead.
+            transcript_changed = True
+            break
+        if reactivated != len(op.rewound_ids):
+            # PARTIAL restore of a SINGLE op — some rows came back, some didn't.
+            # This is a genuine desync (not a clean transcript rewrite), so fail
+            # loud to surface latent corruption rather than silently half-redoing.
+            raise RuntimeError(
+                "redo invariant violated: restored "
+                f"{reactivated} of {len(op.rewound_ids)} rewound rows"
+            )
+        reactivated_total += reactivated
+        ops_redone += 1
+        state.redo_stack.append(op)
+
+    if transcript_changed:
+        # The remaining (older) ops can't be redone across the rewrite — drop them.
+        state.undo_stack.clear()
+        if reactivated_total == 0:
+            # No work done at all → pure no-op; leave redo_count untouched and
+            # clear the now-meaningless redo history too.
+            state.redo_stack.clear()
+            return {
+                "reactivated_count": 0,
+                "new_tail_id": None,
+                "prefill_text": None,
+                "message": "nothing to redo (transcript changed since undo)",
+            }
+        # else: earlier ops did real work — fall through to commit + report it.
+
+    # Counter asymmetry is intentional: rewind_count increments per low-level
+    # rewind_to_message call; redo_count increments once per /redo command that
+    # did real work (regardless of M).
+    # 🔴 By here the reactivation writes have COMMITTED. These trailing ops
+    # (counter bump + tail read) must fail SOFT — a raise here would unwind into
+    # restore_session as "nothing changed" for a redo that DID happen (double-redo
+    # on retry). The reactivated rows are durable; the counter/tail are cosmetic.
+    try:
+        db.bump_redo_count(session_id)
+    except Exception as exc:
+        logger.warning(
+            "redo: post-commit redo_count bump failed for %s "
+            "(reactivation already committed): %r", session_id, exc,
+        )
+
+    try:
+        active_after = db.get_messages(session_id, include_inactive=False)
+        tail = _new_tail(active_after)
+        new_tail_id = tail["id"] if tail else None
+    except Exception as exc:
+        logger.warning(
+            "redo: post-commit tail read failed for %s "
+            "(reactivation already committed): %r", session_id, exc,
+        )
+        new_tail_id = None
+    result: Dict[str, Any] = {
+        "reactivated_count": reactivated_total,
+        "new_tail_id": new_tail_id,
+        "prefill_text": None,
+    }
+    if transcript_changed:
+        result["partial"] = True
+        result["partial_retryable"] = False  # transcript rewrite: the rest can't be redone
+        result["message"] = (
+            f"redid {ops_redone} operation(s); the rest can't be redone "
+            "(transcript changed since undo)"
+        )
+    elif transient_partial:
+        # Earlier ops committed; a later op hit a TRANSIENT error and was pushed
+        # back onto the stack (recoverable). Report the partial honestly and flag
+        # it retryable so the caller can tell the user "the rest can be retried".
+        result["partial"] = True
+        result["partial_retryable"] = True
+        result["message"] = (
+            f"redid {ops_redone} operation(s); the rest hit a transient error — "
+            "run /redo again to continue"
+        )
+    elif partial_hard_error:
+        # Earlier ops committed; a later op hit a NON-transient error (a real
+        # bug). The failed op is on the stack but retrying would re-fail
+        # identically — do NOT promise retryability. Report the partial + that
+        # the rest failed and was logged (RC1: don't mislabel a bug as transient).
+        result["partial"] = True
+        result["partial_retryable"] = False
+        result["message"] = (
+            f"redid {ops_redone} operation(s); the rest hit an error and was "
+            "logged (not retryable)"
+        )
+    return result
+
+
+def on_user_message_appended(session_id: str) -> None:
+    """Invalidate the redo branch when a new user message is appended.
+
+    Mirrors a text editor: once you type after undoing, the previously-undone
+    content can no longer be redone. ``redo()`` consumes ``undo_stack`` (the
+    pending-redoable ops), so that is the stack that must be cleared here;
+    ``redo_stack`` (the already-redone history) is cleared too so a fresh
+    message starts from a clean slate.
+    """
+    state = get_state(session_id)
+    state.undo_stack.clear()
+    state.redo_stack.clear()

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -207,6 +207,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ Redenering-inspanning gestel op `{effort}` (slegs sessie — konfigurasie-stoor het misluk)\n_(neem effek by die volgende boodskap)_"
     set_session:               "🧠 ✓ Redenering-inspanning gestel op `{effort}` (slegs sessie — voeg `--global` by om permanent te stoor)\n_(neem effek by die volgende boodskap)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ Die laaste beurt is gestop maar voltooi steeds sy huidige stap — /redo kan nog nie loop nie. Probeer netnou weer."
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 /reload-mcp gekanselleer. MCP-gereedskap onveranderd."
     always_followup:       "ℹ️ Toekomstige `/reload-mcp`-oproepe sal sonder bevestiging loop. Heraktiveer via `approvals.mcp_reload_confirm: true` in config.yaml."
@@ -356,9 +365,20 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Sessie sonder titel"
 
   undo:
-    nothing:               "Niks om ongedaan te maak nie."
-    removed:               "↩️ {turns} beurt(e) ongedaan gemaak ({count} boodskap(pe)).\nGerugsteun na: \"{preview}\"\nKopieer/wysig die teks hierbo en stuur dit om van hier af weer te vra."
-    invalid_count:         "Ongeldige getal \"{arg}\" — gebruik /undo of /undo N."
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ Die laaste beurt is gestop maar voltooi steeds sy huidige stap — /undo kan nog nie loop nie. Probeer netnou weer."
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Ongeldige getal \"{arg}\" — gebruik /undo of /undo N."
+    nothing: "Niks om ongedaan te maak nie."
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update is slegs beskikbaar vanaf boodskapplatforms. Voer `hermes update` vanaf die terminale uit."

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -230,6 +230,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ ضُبط جهد التفكير إلى `{effort}` (الجلسة فقط — فشل حفظ الإعدادات)\n_(يسري على الرسالة التالية)_"
     set_session:               "🧠 ✓ ضُبط جهد التفكير إلى `{effort}` (الجلسة فقط — أضف `--global` للحفظ الدائم)\n_(يسري على الرسالة التالية)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ The last turn was stopped but is still finishing its current step — /redo can't run yet. Try again in a moment."
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 أُلغي /reload-mcp. أدوات MCP دون تغيير."
     always_followup:       "ℹ️ ستُشغَّل استدعاءات `/reload-mcp` المستقبلية دون تأكيد. أعِد التفعيل عبر `approvals.mcp_reload_confirm: true` في config.yaml."
@@ -358,9 +367,20 @@ gateway:
     untitled_session:        "جلسة دون عنوان"
 
   undo:
-    nothing:               "لا شيء للتراجع عنه."
-    removed:               "↩️ تم التراجع عن {turns} دور ({count} رسالة).\nنُسخ احتياطيًا إلى: \"{preview}\"\nانسخ/عدّل النص أعلاه وأرسله لإعادة التوجيه من هنا."
-    invalid_count:         "عدد غير صالح \"{arg}\" — استخدم /undo أو /undo N."
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ The last turn was stopped but is still finishing its current step — /undo can't run yet. Try again in a moment."
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /undo or /undo N."
+    nothing: "Nothing to undo."
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update متاح فقط من منصّات المراسلة. شغّل `hermes update` من الطرفية."

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -207,6 +207,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ Reasoning-Stärke auf `{effort}` gesetzt (nur Sitzung — Konfiguration konnte nicht gespeichert werden)\n_(wird mit der nächsten Nachricht wirksam)_"
     set_session:               "🧠 ✓ Reasoning-Stärke auf `{effort}` gesetzt (nur Sitzung — `--global` hinzufügen, um zu speichern)\n_(wird mit der nächsten Nachricht wirksam)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ Der letzte Zug wurde gestoppt, beendet aber noch seinen aktuellen Schritt — /redo ist noch nicht möglich. Versuchen Sie es gleich erneut."
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 /reload-mcp abgebrochen. MCP-Tools unverändert."
     always_followup:       "ℹ️ Künftige `/reload-mcp`-Aufrufe laufen ohne Bestätigung. Wieder aktivieren über `approvals.mcp_reload_confirm: true` in `config.yaml`."
@@ -356,9 +365,20 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Unbenannte Sitzung"
 
   undo:
-    nothing:               "Nichts zum Rückgängigmachen."
-    removed:               "↩️ {turns} Zug/Züge rückgängig gemacht ({count} Nachricht(en)).\nGesichert nach: \"{preview}\"\nKopieren/bearbeiten Sie den obigen Text und senden Sie ihn, um von hier aus erneut zu fragen."
-    invalid_count:         "Ungültige Anzahl \"{arg}\" — verwenden Sie /undo oder /undo N."
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ Der letzte Zug wurde gestoppt, beendet aber noch seinen aktuellen Schritt — /undo ist noch nicht möglich. Versuchen Sie es gleich erneut."
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Ungültige Anzahl \"{arg}\" — verwenden Sie /undo oder /undo N."
+    nothing: "Nichts zum Rückgängigmachen."
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update ist nur auf Messaging-Plattformen verfügbar. Führen Sie `hermes update` im Terminal aus."

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -222,6 +222,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ Reasoning effort set to `{effort}` (session only — config save failed)\n_(takes effect on next message)_"
     set_session:               "🧠 ✓ Reasoning effort set to `{effort}` (session only — add `--global` to persist)\n_(takes effect on next message)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ The last turn was stopped but is still finishing its current step — /redo can't run yet. Try again in a moment."
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 /reload-mcp cancelled. MCP tools unchanged."
     always_followup:       "ℹ️ Future `/reload-mcp` calls will run without confirmation. Re-enable via `approvals.mcp_reload_confirm: true` in config.yaml."
@@ -369,9 +378,20 @@ gateway:
     untitled_session:        "Untitled session"
 
   undo:
-    nothing:               "Nothing to undo."
-    removed:               "↩️ Undid {turns} turn(s) ({count} message(s)).\nBacked up to: \"{preview}\"\nCopy/edit the text above and send it to re-prompt from here."
-    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ The last turn was stopped but is still finishing its current step — /undo can't run yet. Try again in a moment."
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /undo or /undo N."
+    nothing: "Nothing to undo."
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update is only available from messaging platforms. Run `hermes update` from the terminal."

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -207,6 +207,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ Esfuerzo de razonamiento ajustado a `{effort}` (solo en la sesión — error al guardar la configuración)\n_(se aplica en el próximo mensaje)_"
     set_session:               "🧠 ✓ Esfuerzo de razonamiento ajustado a `{effort}` (solo en la sesión — añade `--global` para persistir)\n_(se aplica en el próximo mensaje)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ El último turno se detuvo pero aún está terminando su paso actual — /redo no puede ejecutarse todavía. Inténtalo de nuevo en un momento."
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 /reload-mcp cancelado. Las herramientas MCP no han cambiado."
     always_followup:       "ℹ️ Las próximas llamadas a `/reload-mcp` se ejecutarán sin confirmación. Reactiva mediante `approvals.mcp_reload_confirm: true` en `config.yaml`."
@@ -353,9 +362,20 @@ gateway:
     untitled_session:        "Sesión sin título"
 
   undo:
-    nothing:               "Nada que deshacer."
-    removed:               "↩️ {turns} turno(s) deshecho(s) ({count} mensaje(s)).\nRespaldado en: \"{preview}\"\nCopia/edita el texto de arriba y envíalo para volver a preguntar desde aquí."
-    invalid_count:         "Cantidad no válida \"{arg}\" — usa /undo o /undo N."
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ El último turno se detuvo pero aún está terminando su paso actual — /undo no puede ejecutarse todavía. Inténtalo de nuevo en un momento."
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Cantidad no válida \"{arg}\" — usa /undo o /undo N."
+    nothing: "Nada que deshacer."
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update solo está disponible en plataformas de mensajería. Ejecuta `hermes update` desde la terminal."

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -207,6 +207,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ Effort de raisonnement défini sur `{effort}` (session uniquement — échec de l'enregistrement de la configuration)\n_(prend effet au prochain message)_"
     set_session:               "🧠 ✓ Effort de raisonnement défini sur `{effort}` (session uniquement — ajoutez `--global` pour persister)\n_(prend effet au prochain message)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ Le dernier tour a été arrêté mais termine encore son étape en cours — /redo ne peut pas encore s'exécuter. Réessayez dans un instant."
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 /reload-mcp annulé. Outils MCP inchangés."
     always_followup:       "ℹ️ Les prochains appels `/reload-mcp` s'exécuteront sans confirmation. Réactivez via `approvals.mcp_reload_confirm: true` dans `config.yaml`."
@@ -356,9 +365,20 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Session sans titre"
 
   undo:
-    nothing:               "Rien à annuler."
-    removed:               "↩️ {turns} tour(s) annulé(s) ({count} message(s)).\nSauvegardé dans : « {preview} »\nCopiez/modifiez le texte ci-dessus et envoyez-le pour relancer à partir d'ici."
-    invalid_count:         "Nombre invalide « {arg} » — utilisez /undo ou /undo N."
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ Le dernier tour a été arrêté mais termine encore son étape en cours — /undo ne peut pas encore s'exécuter. Réessayez dans un instant."
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Nombre invalide « {arg} » — utilisez /undo ou /undo N."
+    nothing: "Rien à annuler."
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update n'est disponible que depuis les plateformes de messagerie. Exécutez `hermes update` depuis le terminal."

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -211,6 +211,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ Iarracht réasúnaíochta socraithe go `{effort}` (seisiún amháin — theip ar shábháil cumraíochta)\n_(éifeachtach ón gcéad teachtaireacht eile)_"
     set_session:               "🧠 ✓ Iarracht réasúnaíochta socraithe go `{effort}` (seisiún amháin — cuir `--global` leis chun é a choinneáil)\n_(éifeachtach ón gcéad teachtaireacht eile)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ Stopadh an seal deireanach ach tá sé fós ag críochnú a chéim reatha — ní féidir /redo a rith go fóill. Bain triail eile as i gceann nóiméid."
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 /reload-mcp cealaithe. Tá uirlisí MCP gan athrú."
     always_followup:       "ℹ️ Rithfear glaonna `/reload-mcp` amach anseo gan dearbhú. Athchumasaigh trí `approvals.mcp_reload_confirm: true` a shocrú in config.yaml."
@@ -360,9 +369,20 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Seisiún gan teideal"
 
   undo:
-    nothing:               "Níl aon rud le cealú."
-    removed:               "↩️ Cealaíodh {turns} seal ({count} teachtaireacht).\nCúltacaíodh chuig: \"{preview}\"\nCóipeáil/cuir an téacs thuas in eagar agus seol é chun athleideadh ón áit seo."
-    invalid_count:         "Líon neamhbhailí \"{arg}\" — úsáid /undo nó /undo N."
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ Stopadh an seal deireanach ach tá sé fós ag críochnú a chéim reatha — ní féidir /undo a rith go fóill. Bain triail eile as i gceann nóiméid."
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Líon neamhbhailí \"{arg}\" — úsáid /undo nó /undo N."
+    nothing: "Níl aon rud le cealú."
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ Tá /update ar fáil amháin ó ardáin teachtaireachtaí. Rith `hermes update` ón teirminéal."

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -207,6 +207,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ Gondolkodási erőfeszítés beállítva: `{effort}` (csak ebben a munkamenetben — a konfiguráció mentése sikertelen)\n_(a következő üzenettől lép életbe)_"
     set_session:               "🧠 ✓ Gondolkodási erőfeszítés beállítva: `{effort}` (csak ebben a munkamenetben — add hozzá a `--global` opciót a megőrzéshez)\n_(a következő üzenettől lép életbe)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ Az utolsó kör leállt, de még az aktuális lépését fejezi be — a /redo még nem futtatható. Próbáld újra egy pillanat múlva."
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 /reload-mcp megszakítva. Az MCP-eszközök változatlanok."
     always_followup:       "ℹ️ A jövőbeli `/reload-mcp` hívások megerősítés nélkül futnak. Újra engedélyezhető az `approvals.mcp_reload_confirm: true` beállítással a config.yaml fájlban."
@@ -356,9 +365,20 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Cím nélküli munkamenet"
 
   undo:
-    nothing:               "Nincs mit visszavonni."
-    removed:               "↩️ {turns} fordulat visszavonva ({count} üzenet).\nBiztonsági mentés ide: \"{preview}\"\nMásold/szerkeszd a fenti szöveget, és küldd el, hogy innen újra kérdezz."
-    invalid_count:         "Érvénytelen szám \"{arg}\" — használd a /undo vagy /undo N parancsot."
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ Az utolsó kör leállt, de még az aktuális lépését fejezi be — a /undo még nem futtatható. Próbáld újra egy pillanat múlva."
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Érvénytelen szám \"{arg}\" — használd a /undo vagy /undo N parancsot."
+    nothing: "Nincs mit visszavonni."
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ A /update csak üzenetküldő platformokról érhető el. Futtasd a `hermes update` parancsot a terminálból."

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -207,6 +207,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ Sforzo di reasoning impostato su `{effort}` (solo per questa sessione — salvataggio della configurazione non riuscito)\n_(verrà applicato al prossimo messaggio)_"
     set_session:               "🧠 ✓ Sforzo di reasoning impostato su `{effort}` (solo per questa sessione — aggiungi `--global` per renderlo permanente)\n_(verrà applicato al prossimo messaggio)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ L'ultimo turno è stato fermato ma sta ancora completando il passaggio corrente — /redo non può ancora essere eseguito. Riprova tra un momento."
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 /reload-mcp annullato. Strumenti MCP invariati."
     always_followup:       "ℹ️ Le future chiamate a `/reload-mcp` verranno eseguite senza conferma. Riattiva tramite `approvals.mcp_reload_confirm: true` in config.yaml."
@@ -356,9 +365,20 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Sessione senza titolo"
 
   undo:
-    nothing:               "Niente da annullare."
-    removed:               "↩️ Annullati {turns} turno/i ({count} messaggio/i).\nSalvato in: \"{preview}\"\nCopia/modifica il testo qui sopra e invialo per ripartire da qui."
-    invalid_count:         "Conteggio non valido \"{arg}\" — usa /undo o /undo N."
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ L'ultimo turno è stato fermato ma sta ancora completando il passaggio corrente — /undo non può ancora essere eseguito. Riprova tra un momento."
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Conteggio non valido \"{arg}\" — usa /undo o /undo N."
+    nothing: "Niente da annullare."
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update è disponibile solo dalle piattaforme di messaggistica. Esegui `hermes update` dal terminale."

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -207,6 +207,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ 推論強度を `{effort}` に設定しました (セッションのみ — 設定の保存に失敗)\n_(次のメッセージから有効)_"
     set_session:               "🧠 ✓ 推論強度を `{effort}` に設定しました (セッションのみ — 永続化するには `--global` を追加)\n_(次のメッセージから有効)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ 直前のターンは停止されましたが、現在のステップをまだ完了中です — /redo はまだ実行できません。少し待ってから再試行してください。"
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 /reload-mcp をキャンセルしました。MCP ツールは変更されていません。"
     always_followup:       "ℹ️ 今後の `/reload-mcp` は確認なしで実行されます。`config.yaml` で `approvals.mcp_reload_confirm: true` を設定すると再有効化できます。"
@@ -356,9 +365,20 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "無題のセッション"
 
   undo:
-    nothing:               "元に戻せる操作がありません。"
-    removed:               "↩️ {turns} ターンを取り消しました（{count} 件のメッセージ）。\nバックアップ先: 「{preview}」\n上のテキストをコピー／編集して送信すると、ここから再入力できます。"
-    invalid_count:         "無効な数値「{arg}」— /undo または /undo N を使用してください。"
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ 直前のターンは停止されましたが、現在のステップをまだ完了中です — /undo はまだ実行できません。少し待ってから再試行してください。"
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "無効な数値「{arg}」— /undo または /undo N を使用してください。"
+    nothing: "元に戻せる操作がありません。"
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update はメッセージングプラットフォームでのみ利用可能です。ターミナルで `hermes update` を実行してください。"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -207,6 +207,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ 추론 노력이 `{effort}`(으)로 설정되었습니다 (세션 한정 — 설정 저장 실패)\n_(다음 메시지부터 적용됩니다)_"
     set_session:               "🧠 ✓ 추론 노력이 `{effort}`(으)로 설정되었습니다 (세션 한정 — 영구 저장하려면 `--global` 추가)\n_(다음 메시지부터 적용됩니다)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ 마지막 턴이 중지되었지만 현재 단계를 아직 완료하는 중입니다 — /redo를 아직 실행할 수 없습니다. 잠시 후 다시 시도하세요."
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 /reload-mcp가 취소되었습니다. MCP 도구는 변경되지 않았습니다."
     always_followup:       "ℹ️ 이후 `/reload-mcp` 호출은 확인 없이 실행됩니다. config.yaml의 `approvals.mcp_reload_confirm: true`로 다시 활성화할 수 있습니다."
@@ -356,9 +365,20 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "제목 없는 세션"
 
   undo:
-    nothing:               "되돌릴 내용이 없습니다."
-    removed:               "↩️ {turns}개 턴을 되돌렸습니다 (메시지 {count}개).\n백업 위치: \"{preview}\"\n위 텍스트를 복사/편집한 후 보내면 여기서 다시 프롬프트할 수 있습니다."
-    invalid_count:         "잘못된 개수 \"{arg}\" — /undo 또는 /undo N을 사용하세요."
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ 마지막 턴이 중지되었지만 현재 단계를 아직 완료하는 중입니다 — /undo를 아직 실행할 수 없습니다. 잠시 후 다시 시도하세요."
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "잘못된 개수 \"{arg}\" — /undo 또는 /undo N을 사용하세요."
+    nothing: "되돌릴 내용이 없습니다."
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update는 메시징 플랫폼에서만 사용할 수 있습니다. 터미널에서 `hermes update`를 실행하세요."

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -207,6 +207,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ Esforço de raciocínio definido como `{effort}` (apenas sessão — falha ao guardar a configuração)\n_(produz efeito na próxima mensagem)_"
     set_session:               "🧠 ✓ Esforço de raciocínio definido como `{effort}` (apenas sessão — adiciona `--global` para persistir)\n_(produz efeito na próxima mensagem)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ O último turno foi parado mas ainda está a terminar o passo atual — /redo ainda não pode ser executado. Tente novamente daqui a pouco."
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 /reload-mcp cancelado. As ferramentas MCP não foram alteradas."
     always_followup:       "ℹ️ Próximas chamadas a `/reload-mcp` serão executadas sem confirmação. Reativa através de `approvals.mcp_reload_confirm: true` em `config.yaml`."
@@ -356,9 +365,20 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Sessão sem título"
 
   undo:
-    nothing:               "Nada para anular."
-    removed:               "↩️ {turns} turno(s) anulado(s) ({count} mensagem(ns)).\nGuardado em: \"{preview}\"\nCopia/edita o texto acima e envia-o para voltar a perguntar a partir daqui."
-    invalid_count:         "Contagem inválida \"{arg}\" — usa /undo ou /undo N."
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ O último turno foi parado mas ainda está a terminar o passo atual — /undo ainda não pode ser executado. Tente novamente daqui a pouco."
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Contagem inválida \"{arg}\" — usa /undo ou /undo N."
+    nothing: "Nada para anular."
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update só está disponível em plataformas de mensagens. Executa `hermes update` a partir do terminal."

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -207,6 +207,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ Усилия рассуждений установлены на `{effort}` (только этот сеанс — не удалось сохранить конфигурацию)\n_(вступит в силу со следующего сообщения)_"
     set_session:               "🧠 ✓ Усилия рассуждений установлены на `{effort}` (только этот сеанс — добавьте `--global`, чтобы сохранить)\n_(вступит в силу со следующего сообщения)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ Последний ход остановлен, но всё ещё завершает текущий шаг — /redo пока недоступен. Повторите через мгновение."
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 /reload-mcp отменено. MCP-инструменты без изменений."
     always_followup:       "ℹ️ Будущие вызовы `/reload-mcp` будут выполняться без подтверждения. Снова включить можно через `approvals.mcp_reload_confirm: true` в config.yaml."
@@ -356,9 +365,20 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Сеанс без названия"
 
   undo:
-    nothing:               "Нечего отменять."
-    removed:               "↩️ Отменено ходов: {turns} (сообщений: {count}).\nРезервная копия: «{preview}»\nСкопируйте/отредактируйте текст выше и отправьте его, чтобы запросить заново отсюда."
-    invalid_count:         "Недопустимое число «{arg}» — используйте /undo или /undo N."
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ Последний ход остановлен, но всё ещё завершает текущий шаг — /undo пока недоступен. Повторите через мгновение."
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Недопустимое число «{arg}» — используйте /undo или /undo N."
+    nothing: "Нечего отменять."
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update доступен только на платформах обмена сообщениями. Выполните `hermes update` в терминале."

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -207,6 +207,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ Akıl yürütme gücü `{effort}` olarak ayarlandı (yalnızca bu oturum — yapılandırma kaydedilemedi)\n_(sonraki mesajda etkili)_"
     set_session:               "🧠 ✓ Akıl yürütme gücü `{effort}` olarak ayarlandı (yalnızca bu oturum — kalıcı yapmak için `--global` ekleyin)\n_(sonraki mesajda etkili)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ Son tur durduruldu ancak hâlâ geçerli adımını tamamlıyor — /redo henüz çalışamıyor. Birazdan tekrar deneyin."
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 /reload-mcp iptal edildi. MCP araçları değiştirilmedi."
     always_followup:       "ℹ️ Bundan sonraki `/reload-mcp` çağrıları onaysız çalışacak. `config.yaml` içinde `approvals.mcp_reload_confirm: true` ile yeniden etkinleştirebilirsiniz."
@@ -356,9 +365,20 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Adsız oturum"
 
   undo:
-    nothing:               "Geri alınacak bir şey yok."
-    removed:               "↩️ {turns} tur geri alındı ({count} mesaj).\nYedeklendiği yer: \"{preview}\"\nYukarıdaki metni kopyalayıp/düzenleyip göndererek buradan yeniden sorabilirsiniz."
-    invalid_count:         "Geçersiz sayı \"{arg}\" — /undo veya /undo N kullanın."
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ Son tur durduruldu ancak hâlâ geçerli adımını tamamlıyor — /undo henüz çalışamıyor. Birazdan tekrar deneyin."
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Geçersiz sayı \"{arg}\" — /undo veya /undo N kullanın."
+    nothing: "Geri alınacak bir şey yok."
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update yalnızca mesajlaşma platformlarında kullanılabilir. Terminalden `hermes update` komutunu çalıştırın."

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -207,6 +207,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ Зусилля мислення встановлено на `{effort}` (лише цей сеанс — не вдалося зберегти конфігурацію)\n_(набуде чинності з наступного повідомлення)_"
     set_session:               "🧠 ✓ Зусилля мислення встановлено на `{effort}` (лише цей сеанс — додайте `--global`, щоб зберегти)\n_(набуде чинності з наступного повідомлення)_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ Останній хід зупинено, але він ще завершує поточний крок — /redo поки недоступний. Повторіть за мить."
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 /reload-mcp скасовано. MCP-інструменти без змін."
     always_followup:       "ℹ️ Наступні виклики `/reload-mcp` виконуватимуться без підтвердження. Увімкнути знову можна через `approvals.mcp_reload_confirm: true` у `config.yaml`."
@@ -356,9 +365,20 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Сесія без назви"
 
   undo:
-    nothing:               "Немає чого скасовувати."
-    removed:               "↩️ Скасовано ходів: {turns} (повідомлень: {count}).\nРезервна копія: «{preview}»\nСкопіюйте/відредагуйте текст вище та надішліть його, щоб запитати знову звідси."
-    invalid_count:         "Недійсне число «{arg}» — використовуйте /undo або /undo N."
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ Останній хід зупинено, але він ще завершує поточний крок — /undo поки недоступний. Повторіть за мить."
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Недійсне число «{arg}» — використовуйте /undo або /undo N."
+    nothing: "Немає чого скасовувати."
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update доступний лише на платформах обміну повідомленнями. Виконайте `hermes update` у терміналі."

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -207,6 +207,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ 推理強度已設定為 `{effort}`（僅本工作階段 — 設定儲存失敗）\n_（下一則訊息生效）_"
     set_session:               "🧠 ✓ 推理強度已設定為 `{effort}`（僅本工作階段 — 加上 `--global` 可持久化）\n_（下一則訊息生效）_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ 上一輪已停止，但仍在完成目前步驟 — /redo 暫時無法執行。請稍後再試。"
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 已取消 /reload-mcp。MCP 工具未變更。"
     always_followup:       "ℹ️ 後續 `/reload-mcp` 呼叫將不再要求確認。可在 `config.yaml` 中將 `approvals.mcp_reload_confirm: true` 重新啟用。"
@@ -356,9 +365,20 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "未命名工作階段"
 
   undo:
-    nothing:               "沒有可復原的內容。"
-    removed:               "↩️ 已復原 {turns} 個回合（{count} 則訊息）。\n已備份至：「{preview}」\n複製/編輯上方的文字並傳送，即可從此處重新提問。"
-    invalid_count:         "無效的數量「{arg}」—— 請使用 /undo 或 /undo N。"
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ 上一輪已停止，但仍在完成目前步驟 — /undo 暫時無法執行。請稍後再試。"
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "無效的數量「{arg}」—— 請使用 /undo 或 /undo N。"
+    nothing: "沒有可復原的內容。"
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update 僅在訊息平台上可用。請在終端機執行 `hermes update`。"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -207,6 +207,15 @@ gateway:
     set_global_save_failed:    "🧠 ✓ 推理强度已设置为 `{effort}`（仅本会话 — 配置保存失败）\n_（下一条消息生效）_"
     set_session:               "🧠 ✓ 推理强度已设置为 `{effort}`（仅本会话 — 添加 `--global` 以持久化）\n_（下一条消息生效）_"
 
+  redo:
+    busy: "⏳ The database was busy — nothing was changed. Try /redo again in a moment."
+    draining: "⏳ 上一轮已停止，但仍在完成当前步骤 — /redo 暂时无法运行。请稍后重试。"
+    error: "⚠️ Couldn't complete /redo (internal error — nothing was changed). It's been logged."
+    invalid_count: "Invalid count \"{arg}\" — use /redo or /redo N."
+    nothing: "Nothing to redo."
+    restart_lost: "Nothing to redo — redo history does not survive a restart."
+    restored: "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+
   reload_mcp:
     cancelled:             "🟡 已取消 /reload-mcp。MCP 工具未更改。"
     always_followup:       "ℹ️ 后续 `/reload-mcp` 调用将不再确认。可在 `config.yaml` 中将 `approvals.mcp_reload_confirm: true` 重新启用。"
@@ -356,9 +365,20 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "未命名会话"
 
   undo:
-    nothing:               "没有可撤销的内容。"
-    removed:               "↩️ 已撤销 {turns} 个回合（{count} 条消息）。\n已备份到：「{preview}」\n复制/编辑上面的文本并发送，即可从此处重新提问。"
-    invalid_count:         "无效的数量「{arg}」—— 请使用 /undo 或 /undo N。"
+    busy: "⏳ The database was busy — nothing was changed. Try /undo again in a moment."
+    draining: "⏳ 上一轮已停止，但仍在完成当前步骤 — /undo 暂时无法运行。请稍后重试。"
+    error: "⚠️ Couldn't complete /undo (internal error — nothing was changed). It's been logged."
+    invalid_count: "无效的数量「{arg}」—— 请使用 /undo 或 /undo N。"
+    nothing: "没有可撤销的内容。"
+    now_at: "↦ Now at — {who}:\n“{preview}”"
+    now_at_notext: "↦ Now at — {who} (no text)."
+    now_empty: "↦ Now at — start of the thread (no messages left)."
+    party:
+      assistant: "my reply"
+      message: "the last message"
+      tool: "a tool result"
+      user: "your message"
+    removed: "↩️ Undid {turns} half-turn(s) ({count} message(s))."
 
   update:
     platform_not_messaging:  "✗ /update 仅在消息平台可用。请在终端运行 `hermes update`。"

--- a/tests/cli/test_undo_redo_half_turn.py
+++ b/tests/cli/test_undo_redo_half_turn.py
@@ -1,0 +1,143 @@
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_undo
+from agent.agent_runtime_helpers import repair_message_sequence
+from cli import HermesCLI
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    monkeypatch.setattr(hermes_undo, "_session_db", session_db)
+    hermes_undo.clear_state()
+    yield session_db
+    session_db.close()
+    hermes_undo.clear_state()
+
+
+def _cli(db, sid):
+    buf = SimpleNamespace(text="", cursor_position=0)
+    app = SimpleNamespace(current_buffer=buf, invalidate=lambda: None)
+    cli_obj = SimpleNamespace(
+        session_id=sid,
+        _session_db=db,
+        conversation_history=[],
+        agent=None,
+        _app=app,
+        buffer=buf,
+    )
+    cli_obj._reload_active_history_after_rewind = (
+        lambda rewound=False: HermesCLI._reload_active_history_after_rewind(
+            cli_obj, rewound=rewound
+        )
+    )
+    cli_obj._prefill_input_buffer = lambda text: HermesCLI._prefill_input_buffer(cli_obj, text)
+    return cli_obj
+
+
+def _seed(db, sid):
+    u1 = db.append_message(sid, "user", "first exact surviving text")
+    a1 = db.append_message(sid, "assistant", "answer one")
+    u2 = db.append_message(sid, "user", "second exact surviving text")
+    a2 = db.append_message(sid, "assistant", "answer two")
+    return u1, a1, u2, a2
+
+
+def test_d4_prefill_uses_exact_surviving_new_tail_for_n_1_2_3(db):
+    for n, expected in (
+        (1, "second exact surviving text"),
+        (2, ""),
+        (3, "first exact surviving text"),
+    ):
+        sid = f"cli-prefill-{n}"
+        db.create_session(sid, source="cli")
+        _seed(db, sid)
+        cli_obj = _cli(db, sid)
+
+        HermesCLI.undo_last(cli_obj, n)
+
+        assert cli_obj.buffer.text == expected
+        if expected:
+            assert cli_obj.buffer.cursor_position == len(expected)
+        active = db.get_messages(sid)
+        tail = active[-1] if active else None
+        if expected:
+            assert tail["role"] == "user"
+            assert tail["content"] == expected
+        else:
+            assert tail["role"] == "assistant"
+
+
+def test_str_prefill_edit_resend_merges_two_user_rows_before_provider(db):
+    sid = "cli-edit-resend"
+    db.create_session(sid, source="cli")
+    db.append_message(sid, "user", "original draft")
+    db.append_message(sid, "assistant", "answer")
+    cli_obj = _cli(db, sid)
+
+    HermesCLI.undo_last(cli_obj, 1)
+    assert cli_obj.buffer.text == "original draft"
+
+    db.append_message(sid, "user", "edited draft")
+    hermes_undo.on_user_message_appended(sid)
+    messages = db.get_messages_as_conversation(sid)
+    assert [m["role"] for m in messages] == ["user", "user"]
+
+    repairs = repair_message_sequence(object(), messages)
+
+    assert repairs == 1
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == "original draft\n\nedited draft"
+
+
+def test_clear_redo_on_send_leaves_undo_stack_available(db):
+    sid = "cli-clear-redo"
+    db.create_session(sid, source="cli")
+    _seed(db, sid)
+    hermes_undo.undo(sid, 1)
+    hermes_undo.redo(sid, 1)
+    state = hermes_undo.get_state(sid)
+    assert state.redo_stack
+
+    db.append_message(sid, "user", "new branch")
+    hermes_undo.on_user_message_appended(sid)
+
+    assert state.redo_stack == []
+    assert state.undo_stack == []
+
+
+@pytest.mark.parametrize(
+    "command, expected_n",
+    [
+        ("/redo", 1),
+        ("/redo 2", 2),
+        ("/redo 0", 1),    # non-positive clamps to 1 (parity with /undo)
+        ("/redo -3", 1),   # negative clamps to 1
+    ],
+)
+def test_redo_command_clamps_non_positive_count_to_one(command, expected_n):
+    """/redo 0 and /redo -N must clamp to 1 like /undo, not fall through to a
+    misleading 'nothing to redo' (Greptile PR #49 finding)."""
+    captured = {}
+    cli_obj = SimpleNamespace(
+        _pending_resume_sessions=None,
+        redo_last=lambda n=1: captured.__setitem__("n", n),
+    )
+    cont = HermesCLI.process_command(cli_obj, command)
+    assert cont is True
+    assert captured.get("n") == expected_n
+
+
+def test_redo_command_rejects_non_numeric_count():
+    """A non-numeric /redo argument is rejected, not silently treated as 1."""
+    captured = {}
+    cli_obj = SimpleNamespace(
+        _pending_resume_sessions=None,
+        redo_last=lambda n=1: captured.__setitem__("n", n),
+    )
+    HermesCLI.process_command(cli_obj, "/redo abc")
+    assert "n" not in captured  # redo_last never called on a parse error

--- a/tests/gateway/test_undo_cache_alternation_safety.py
+++ b/tests/gateway/test_undo_cache_alternation_safety.py
@@ -1,0 +1,233 @@
+"""Prompt-cache + role-alternation invariants for /undo and /redo.
+
+These are the AGENTS.md invariants a transcript rewind is most likely to break,
+asserted as behavior contracts rather than argued in a review comment:
+
+  * A rewind may only truncate a SUFFIX of the active transcript — never
+    reorder, edit, or synthesise a row. So the surviving prefix is byte-identical
+    to the prefix the provider already cached.
+  * A redo restores exactly the row-id SET the matching undo removed, so
+    undo→redo is a round trip to the original transcript.
+  * Neither operation can leave a ``tool`` row whose ``assistant(tool_calls)``
+    owner is inactive (the orphan guard), which is the shape strict
+    OpenAI-compatible providers reject outright.
+  * Whatever the landing shape, ``repair_message_sequence`` needs no repairs on
+    the rewound transcript — i.e. /undo does not manufacture alternation
+    violations. (Two consecutive user rows after an edit-and-resend ARE expected
+    and are repaired at the existing pre-request belt; that path is covered in
+    tests/cli/test_undo_redo_half_turn.py.)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import hermes_undo
+from agent.agent_runtime_helpers import repair_message_sequence
+from hermes_state import RewindWouldOrphanError, SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    monkeypatch.setattr(hermes_undo, "_session_db", session_db)
+    hermes_undo.clear_state()
+    yield session_db
+    session_db.close()
+    hermes_undo.clear_state()
+
+
+def _conv(db, sid):
+    return db.get_messages_as_conversation(sid)
+
+
+def _rows(db, sid):
+    return [(m["id"], m["role"]) for m in db.get_messages(sid)]
+
+
+def _seed_alternating(db, sid, turns=4):
+    db.create_session(sid, source="cli")
+    for i in range(1, turns + 1):
+        db.append_message(sid, "user", f"q{i}")
+        db.append_message(sid, "assistant", f"a{i}")
+
+
+def test_undo_only_truncates_a_suffix_so_the_cached_prefix_survives(db):
+    """The rewound transcript must be a strict PREFIX of the pre-rewind one.
+
+    This is the prompt-cache contract: the provider caches a prefix of the
+    message list, so as long as /undo can only drop rows off the END, every
+    surviving message is byte-identical to what was cached and the next turn
+    still hits the cache for the surviving span. A rewind that edited or
+    reordered a surviving row would invalidate the whole cached prefix.
+    """
+    sid = "cache-prefix"
+    _seed_alternating(db, sid)
+    before = _conv(db, sid)
+
+    for n in (1, 1, 2):
+        hermes_undo.undo(sid, n)
+        after = _conv(db, sid)
+        assert len(after) <= len(before)
+        # The surviving rows are the *same objects, in the same order* — the
+        # rewind is a truncation, not a rewrite.
+        assert after == before[: len(after)]
+        before = after
+
+
+def test_undo_never_leaves_two_same_party_rows_adjacent(db):
+    """Half-turn grouping must not split a party's run in half.
+
+    A half-turn is one party's contiguous run, so a landing can never produce
+    ``assistant, assistant`` or ``user, user`` at the seam — the boundary the
+    core rewinds to is always a party CHANGE.
+    """
+    sid = "alt-seam"
+    db.create_session(sid, source="cli")
+    db.append_message(sid, "user", "q1")
+    db.append_message(sid, "assistant", "a1a")
+    db.append_message(sid, "assistant", "a1b")  # same party, two rows
+    db.append_message(sid, "user", "q2")
+    db.append_message(sid, "assistant", "a2")
+
+    for _ in range(3):
+        result = hermes_undo.undo(sid, 1)
+        if not result.get("rewound_ids"):
+            break
+        roles = [m["role"] for m in _conv(db, sid)]
+        # No two adjacent rows may come from the same PARTY (tool counts as
+        # assistant-side), which is the alternation rule providers enforce.
+        parties = [hermes_undo._party(r) for r in roles]
+        for a, b in zip(parties, parties[1:]):
+            assert not (a == b == "user"), f"user;user seam in {roles}"
+
+
+def test_rewound_transcript_needs_zero_alternation_repairs(db):
+    """The repair belt must find nothing to fix after a rewind.
+
+    ``repair_message_sequence`` is the pre-request defensive belt. If /undo
+    manufactured alternation violations, the belt would silently rewrite the
+    transcript on every subsequent request — which both changes the bytes the
+    provider sees and re-invalidates the cache each turn.
+    """
+    sid = "no-repairs"
+    _seed_alternating(db, sid, turns=5)
+
+    for n in (1, 2, 1, 3):
+        hermes_undo.undo(sid, n)
+        messages = _conv(db, sid)
+        assert repair_message_sequence(None, messages) == 0, messages
+
+
+def test_undo_redo_round_trip_restores_the_exact_transcript(db):
+    """undo→redo must be an identity on the transcript.
+
+    ``restore_ids`` reactivates the exact row-id set the undo deactivated (not
+    an ``id >=`` range), so the restored transcript is byte-identical to the
+    original — which is what lets the provider re-use its cached prefix after a
+    redo instead of re-ingesting the conversation.
+    """
+    sid = "round-trip"
+    _seed_alternating(db, sid)
+    original_rows = _rows(db, sid)
+    original_conv = _conv(db, sid)
+
+    hermes_undo.undo(sid, 2)
+    assert _rows(db, sid) != original_rows
+
+    hermes_undo.redo(sid, 1)
+    assert _rows(db, sid) == original_rows
+    assert _conv(db, sid) == original_conv
+    assert repair_message_sequence(None, _conv(db, sid)) == 0
+
+
+def test_stacked_undos_redo_back_to_the_exact_original(db):
+    """Several stacked undos redo back to the original, in order."""
+    sid = "stacked-round-trip"
+    _seed_alternating(db, sid, turns=5)
+    original_rows = _rows(db, sid)
+
+    hermes_undo.undo(sid, 1)
+    hermes_undo.undo(sid, 2)
+    hermes_undo.undo(sid, 1)
+    assert len(_rows(db, sid)) < len(original_rows)
+
+    hermes_undo.redo(sid, 3)
+    assert _rows(db, sid) == original_rows
+    assert repair_message_sequence(None, _conv(db, sid)) == 0
+
+
+def test_rewind_refuses_to_orphan_a_tool_row(db):
+    """The orphan guard fires BEFORE any write, so nothing is mutated.
+
+    A ``tool`` row whose ``assistant(tool_calls)`` owner is inactive is rejected
+    outright by strict OpenAI-compatible providers. The guard runs before the
+    single write, so a refusal leaves the transcript exactly as it was — which
+    is what lets the caller report "busy, nothing changed" honestly.
+    """
+    sid = "orphan-guard"
+    db.create_session(sid, source="cli")
+    db.append_message(sid, "user", "q1")
+    # A mid-flush interleave: the tool result landed with a LOWER id than the
+    # assistant row carrying its tool_calls.
+    db.append_message(sid, "tool", "result", tool_call_id="call-1")
+    db.append_message(
+        sid, "assistant", "a1",
+        tool_calls=[{"id": "call-1", "type": "function",
+                     "function": {"name": "x", "arguments": "{}"}}],
+    )
+    before = _rows(db, sid)
+
+    with pytest.raises(RewindWouldOrphanError):
+        db.rewind_to_message(sid, before[-1][0], require_user_role=False)
+
+    # Nothing was mutated — the guard is pre-write.
+    assert _rows(db, sid) == before
+
+
+def test_assistant_tool_pair_is_rewound_together(db):
+    """An assistant(tool_calls)+tool pair is one half-turn and moves as a unit.
+
+    Rewinding into the middle of a tool round would strand either the call or
+    its result. Because ``tool`` and ``assistant`` share a party in the
+    half-turn grouping, the pair is always inside the same group.
+    """
+    sid = "tool-pair"
+    db.create_session(sid, source="cli")
+    db.append_message(sid, "user", "q1")
+    db.append_message(
+        sid, "assistant", "",
+        tool_calls=[{"id": "call-1", "type": "function",
+                     "function": {"name": "x", "arguments": "{}"}}],
+    )
+    db.append_message(sid, "tool", "result", tool_call_id="call-1")
+    db.append_message(sid, "assistant", "a1")
+
+    hermes_undo.undo(sid, 1)
+    roles = [m["role"] for m in _conv(db, sid)]
+    # The whole assistant-side run went, leaving just the user turn — the tool
+    # row cannot survive without its owner and vice versa.
+    assert roles == ["user"]
+    assert repair_message_sequence(None, _conv(db, sid)) == 0
+
+
+def test_undo_does_not_touch_the_system_prompt_or_inject_a_user_row(db):
+    """No synthetic rows: the row COUNT only ever goes down on undo.
+
+    AGENTS.md forbids injecting a synthetic user message mid-loop and requires a
+    byte-stable system prompt for the life of a conversation. The undo core only
+    flips ``active`` on existing rows — it has no INSERT path — so neither can
+    happen. Asserted structurally: every id present after a rewind was present
+    before it, and no row's content changed.
+    """
+    sid = "no-injection"
+    _seed_alternating(db, sid)
+    before = {m["id"]: (m["role"], m["content"]) for m in db.get_messages(sid)}
+
+    hermes_undo.undo(sid, 2)
+    after = {m["id"]: (m["role"], m["content"]) for m in db.get_messages(sid)}
+
+    assert set(after) < set(before), "undo must only remove ids, never add"
+    for mid, payload in after.items():
+        assert payload == before[mid], f"row {mid} was mutated by the rewind"
+    assert not any(m["role"] == "system" for m in db.get_messages(sid))

--- a/tests/gateway/test_undo_error_honesty.py
+++ b/tests/gateway/test_undo_error_honesty.py
@@ -1,0 +1,303 @@
+"""Honesty of /undo·/redo failure reporting (2026-07-15 fix).
+
+The false-"Nothing to undo." bug: rewind_session collapsed EVERY exception into
+None → "Nothing to undo." with only a DEBUG log. These tests pin the four
+distinct outcomes and the pass-1 B1 no-double-undo invariant.
+"""
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import hermes_undo
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionSource, SessionStore, _is_transient_db_busy
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    session_store._db = db
+    hermes_undo._session_db = db
+    hermes_undo.clear_state()
+    yield session_store
+    db.close()
+
+
+def _source(chat_id="chat-1"):
+    return SessionSource(platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm")
+
+
+def _seed(db, sid):
+    db.append_message(sid, "user", "q1")
+    db.append_message(sid, "assistant", "a1")
+    db.append_message(sid, "user", "q2")
+    db.append_message(sid, "assistant", "a2")
+
+
+# ── the classifier ──────────────────────────────────────────────────────────
+
+def test_is_transient_db_busy_only_lock_class():
+    assert _is_transient_db_busy(sqlite3.OperationalError("database is locked"))
+    assert _is_transient_db_busy(sqlite3.OperationalError("database table is busy"))
+    assert not _is_transient_db_busy(sqlite3.OperationalError("no such table: messages"))
+    assert not _is_transient_db_busy(ValueError("rewind would orphan active tool row"))
+
+
+# ── the four outcomes of rewind_session ─────────────────────────────────────
+
+def test_genuine_empty_returns_none(store):
+    """AC2/I1: a truly empty session → None → 'Nothing to undo.' (unchanged)."""
+    entry = store.get_or_create_session(_source("empty"))
+    # session exists but no messages → nothing to undo
+    assert store.rewind_session(entry.session_id, 1) is None
+
+
+def test_lock_error_returns_busy_sentinel(store, monkeypatch):
+    """AC3/I3: a lock/busy OperationalError from the undo core → busy sentinel,
+    NOT None (which would render 'Nothing to undo.')."""
+    def boom(*a, **kw):
+        raise sqlite3.OperationalError("database is locked")
+    monkeypatch.setattr(hermes_undo, "undo", boom)
+    out = store.rewind_session("any-sid", 1)
+    assert out == {"status": "busy"}, out
+
+
+def test_orphan_guard_is_retryable_busy_not_error(store, monkeypatch):
+    """AC4/RC3: the orphan-guard RewindWouldOrphanError (the most likely trigger
+    of the 2026-07-15 incident) is a TRANSIENT, self-healing condition — it must
+    map to the retryable 'busy' outcome (WARNING), NOT a permanent 'error'
+    (ERROR-logged). Reporting a mid-flush race as a permanent internal fault is
+    both dishonest and alert-noise."""
+    from hermes_state import RewindWouldOrphanError
+
+    def boom(*a, **kw):
+        raise RewindWouldOrphanError("rewind would orphan active tool row id=5 ...")
+    monkeypatch.setattr(hermes_undo, "undo", boom)
+    out = store.rewind_session("any-sid", 1)
+    assert out == {"status": "busy"}, out
+
+
+def test_non_lock_operationalerror_returns_error_not_busy(store, monkeypatch):
+    """AC4/B3: a non-lock OperationalError (schema/logic bug) must NOT be
+    laundered into the transient 'busy' path."""
+    def boom(*a, **kw):
+        raise sqlite3.OperationalError("no such table: messages")
+    monkeypatch.setattr(hermes_undo, "undo", boom)
+    out = store.rewind_session("any-sid", 1)
+    assert out == {"status": "error"}, out
+
+
+def test_generic_bug_still_returns_error(store, monkeypatch):
+    """A genuine bug (not the orphan guard, not a lock) → error, ERROR-logged —
+    never masked as a transient 'busy'."""
+    def boom(*a, **kw):
+        raise KeyError("some real bug")
+    monkeypatch.setattr(hermes_undo, "undo", boom)
+    assert store.rewind_session("any-sid", 1) == {"status": "error"}
+
+
+def test_healthy_rewind_returns_real_result(store):
+    """A genuine rewindable session → a real result dict with rewound_ids
+    (never a status sentinel)."""
+    entry = store.get_or_create_session(_source("live"))
+    sid = entry.session_id
+    _seed(store._db, sid)
+    out = store.rewind_session(sid, 1)
+    assert isinstance(out, dict) and out.get("rewound_ids"), out
+    assert "status" not in out
+
+
+# ── restore_session (redo) parity ───────────────────────────────────────────
+
+def test_restore_lock_error_returns_busy(store, monkeypatch):
+    def boom(*a, **kw):
+        raise sqlite3.OperationalError("database is locked")
+    monkeypatch.setattr(hermes_undo, "redo", boom)
+    assert store.restore_session("any-sid", 1) == {"status": "busy"}
+
+
+def test_restore_other_error_returns_error(store, monkeypatch):
+    def boom(*a, **kw):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(hermes_undo, "redo", boom)
+    assert store.restore_session("any-sid", 1) == {"status": "error"}
+
+
+# ── B1 (pass-1 blocker): post-commit read failure must NOT double-undo ───────
+
+def test_post_commit_head_read_failure_still_returns_committed_rewind(store, monkeypatch):
+    """AC5/I2/B1: if the POST-commit head-id read raises, the rewind already
+    committed — rewind_to_message must return the committed result (rewound rows
+    durable) with new_head_id=None, NOT raise. A raise would reach
+    rewind_session → error sentinel → user retries → DOUBLE undo."""
+    db = store._db
+    entry = store.get_or_create_session(_source("b1"))
+    sid = entry.session_id
+    _seed(db, sid)
+
+    active_before = len(db.get_messages(sid, include_inactive=False))
+
+    target = hermes_undo.compute_half_turn_target(
+        db.get_messages(sid, include_inactive=False), 1
+    )
+
+    # Wrap the connection so ONLY the post-write MAX(id) read raises; the write
+    # and validation reads pass through. (Can't monkeypatch the C-level
+    # Connection.execute, so proxy the object.)
+    real_conn = db._conn
+    state = {"armed": False}
+
+    class _FlakyConn:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def execute(self, sql, *a, **kw):
+            if state["armed"] and "MAX(id)" in sql:
+                raise sqlite3.OperationalError("database is locked")
+            return self._inner.execute(sql, *a, **kw)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    db._conn = _FlakyConn(real_conn)
+    state["armed"] = True
+    try:
+        result = db.rewind_to_message(sid, target, require_user_role=False)
+    finally:
+        state["armed"] = False
+        db._conn = real_conn
+
+    # The rewind committed: rows were deactivated, result returned (no raise),
+    # head id is None (fail-soft).
+    assert result["rewound_ids"], "rewind must have committed"
+    assert result["new_head_id"] is None
+    active_after = len(db.get_messages(sid, include_inactive=False))
+    assert active_after < active_before, "rows really deactivated (durable)"
+
+
+def test_redo_second_op_failure_returns_partial_not_nothing_changed(store):
+    """AC5 redo symmetry (pass-2 B1): redo does ONE write PER op. If a LATER op's
+    write raises after an EARLIER op committed, the earlier rows are live in the
+    DB — restore_session must NOT report 'nothing changed' (that would let a
+    retry double-redo the earlier ops). The partial result is returned honestly.
+    """
+    db = store._db
+    entry = store.get_or_create_session(_source("redo-partial"))
+    sid = entry.session_id
+    # Two separate undo ops on the stack → redo m=2 will do two restore_ids writes.
+    db.append_message(sid, "user", "q1")
+    db.append_message(sid, "assistant", "a1")
+    db.append_message(sid, "user", "q2")
+    db.append_message(sid, "assistant", "a2")
+    r1 = store.rewind_session(sid, 1)  # op A
+    r2 = store.rewind_session(sid, 1)  # op B
+    assert r1 and r2
+
+    # Make the SECOND restore_ids write raise; the first must commit.
+    calls = {"n": 0}
+    real_restore = db.restore_ids
+
+    def flaky_restore(session_id, ids):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise sqlite3.OperationalError("database is locked")
+        return real_restore(session_id, ids)
+
+    db.restore_ids = flaky_restore
+    try:
+        out = store.restore_session(sid, 2)
+    finally:
+        db.restore_ids = real_restore
+
+    # NOT a busy/error sentinel: the first op committed, so we report the partial
+    # honestly (reactivated_count > 0), never "nothing changed".
+    assert isinstance(out, dict), out
+    assert out.get("status") not in ("busy", "error"), out
+    assert (out.get("reactivated_count") or 0) > 0, (
+        "the first (committed) redo op must be reported, not discarded"
+    )
+    # pass-3 B2: the FAILED op must be pushed back and NOT wiped — it stays
+    # recoverable. Retrying /redo (with the DB healthy) redoes it.
+    assert out.get("partial_retryable") is True, out
+    out2 = store.restore_session(sid, 1)
+    assert isinstance(out2, dict) and (out2.get("reactivated_count") or 0) > 0, (
+        "the transient-failed redo op must be recoverable on retry (not lost)"
+    )
+
+
+def test_redo_nontransient_op2_failure_not_labeled_retryable(store):
+    """pass-4 RC1: a NON-transient error on redo op≥2 after op1 committed must
+    report the partial as NOT retryable (retrying re-fails identically). The
+    redo loop must classify inside itself, not blanket-label every mid-loop
+    failure transient."""
+    db = store._db
+    entry = store.get_or_create_session(_source("redo-hard"))
+    sid = entry.session_id
+    db.append_message(sid, "user", "q1")
+    db.append_message(sid, "assistant", "a1")
+    db.append_message(sid, "user", "q2")
+    db.append_message(sid, "assistant", "a2")
+    assert store.rewind_session(sid, 1)
+    assert store.rewind_session(sid, 1)
+
+    calls = {"n": 0}
+    real_restore = db.restore_ids
+
+    def flaky_restore(session_id, ids):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise sqlite3.OperationalError("no such column: bogus")  # NON-transient
+        return real_restore(session_id, ids)
+
+    db.restore_ids = flaky_restore
+    try:
+        out = store.restore_session(sid, 2)
+    finally:
+        db.restore_ids = real_restore
+
+    assert isinstance(out, dict), out
+    assert (out.get("reactivated_count") or 0) > 0, "op1 committed, must be reported"
+    assert out.get("partial_retryable") is False, (
+        "a non-transient bug must NOT be labeled retryable (would loop forever)"
+    )
+
+
+def test_empty_with_rows_incident_signature_warns(store, monkeypatch, caplog):
+    """AC1/B2/RC2/RC3: a genuine-empty result with rows PRESENT and no target
+    (the 2026-07-15 incident signature) is surfaced at WARNING (visible in prod)
+    with the active_count — not a silent DEBUG."""
+    import logging
+
+    def fake_undo(session_id, n):
+        return {
+            "rewound_ids": [],
+            "message": "nothing to undo",
+            "active_count": 365,
+            "target_id": None,
+        }
+    monkeypatch.setattr(hermes_undo, "undo", fake_undo)
+    with caplog.at_level(logging.DEBUG, logger="gateway.session"):
+        out = store.rewind_session("any-sid", 1)
+    assert out is None
+    warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+    joined = " ".join(r.getMessage() for r in warns)
+    assert "365 active row" in joined, joined
+
+
+def test_true_healthy_empty_stays_debug(store, monkeypatch, caplog):
+    """A genuinely empty session (0 active rows) stays at DEBUG — no WARNING
+    noise for the normal 'nothing to undo' case."""
+    import logging
+
+    def fake_undo(session_id, n):
+        return {"rewound_ids": [], "active_count": 0, "target_id": None}
+    monkeypatch.setattr(hermes_undo, "undo", fake_undo)
+    with caplog.at_level(logging.DEBUG, logger="gateway.session"):
+        assert store.rewind_session("any-sid", 1) is None
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING], (
+        "a true healthy empty must not WARN"
+    )

--- a/tests/gateway/test_undo_redo_half_turn.py
+++ b/tests/gateway/test_undo_redo_half_turn.py
@@ -1,0 +1,344 @@
+import ast
+import asyncio
+import inspect
+import threading
+import textwrap
+from collections import OrderedDict
+
+import pytest
+
+import hermes_undo
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, SessionStore, build_session_key
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    session_store._db = db
+    hermes_undo._session_db = db
+    hermes_undo.clear_state()
+    yield session_store
+    db.close()
+    hermes_undo.clear_state()
+
+
+def _source(chat_id="chat-1"):
+    return SessionSource(platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm")
+
+
+def _event(text, source):
+    return MessageEvent(text=text, source=source, message_id="m1")
+
+
+def _seed(db, sid):
+    u1 = db.append_message(sid, "user", "q1")
+    a1 = db.append_message(sid, "assistant", "a1")
+    u2 = db.append_message(sid, "user", "q2")
+    a2 = db.append_message(sid, "assistant", "a2")
+    return u1, a1, u2, a2
+
+
+def _runner(store):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.session_store = store
+    runner._agent_cache = OrderedDict()
+    runner._agent_cache_lock = threading.Lock()
+    return runner
+
+
+def test_cold_restart_redo_branches_touch_zero_rows(store):
+    src = _source("restart")
+    entry = store.get_or_create_session(src)
+    _seed(store._db, entry.session_id)
+    before = store._db.get_messages(entry.session_id, include_inactive=True)
+
+    store.rewind_session(entry.session_id, 1)
+    after_undo = store._db.get_messages(entry.session_id, include_inactive=True)
+    hermes_undo.clear_state(entry.session_id)
+    cold = store.restore_session(entry.session_id, 1)
+
+    assert cold["reactivated_count"] == 0
+    assert cold["message"] == "nothing to redo (redo history doesn't survive a restart)"
+    assert store._db.get_messages(entry.session_id, include_inactive=True) == after_undo
+
+    fresh = store.get_or_create_session(_source("never-undone"))
+    _seed(store._db, fresh.session_id)
+    fresh_before = store._db.get_messages(fresh.session_id, include_inactive=True)
+    hermes_undo.clear_state(fresh.session_id)
+    bare = store.restore_session(fresh.session_id, 1)
+
+    assert bare["reactivated_count"] == 0
+    assert bare["message"] == "nothing to redo"
+    assert store._db.get_messages(fresh.session_id, include_inactive=True) == fresh_before
+    assert before != after_undo
+
+
+def test_no_active0_reconstruction_in_gateway_redo_paths():
+    positive = ast.parse(
+        "def planted(db):\n"
+        "    return db.get_messages('sid', include_inactive=True)\n"
+    )
+    assert any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get_messages"
+        and any(
+            kw.arg == "include_inactive" and isinstance(kw.value, ast.Constant) and kw.value.value is True
+            for kw in node.keywords
+        )
+        for node in ast.walk(positive)
+    )
+
+    for func in (SessionStore.restore_session, GatewayRunner._handle_redo_command):
+        tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+        offenders = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get_messages"
+            and any(
+                kw.arg == "include_inactive"
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value is True
+                for kw in node.keywords
+            )
+        ]
+        assert offenders == []
+
+
+def test_cached_agent_evicted_after_undo_and_after_redo(store):
+    src = _source("evict")
+    entry = store.get_or_create_session(src)
+    _seed(store._db, entry.session_id)
+    runner = _runner(store)
+    cache_key = build_session_key(src)
+    runner._agent_cache[cache_key] = ("stale-before-undo", "sig")
+
+    undo_msg = asyncio.run(runner._handle_undo_command(_event("/undo", src)))
+
+    assert "Undid" in undo_msg or "Removed" in undo_msg
+    assert cache_key not in runner._agent_cache
+    # load_transcript is the canonical active-only reader; compare against it
+    # directly so the equality asserts the view, not a kwarg spelling.
+    assert store.load_transcript(entry.session_id) == store._db.get_messages_as_conversation(
+        entry.session_id, repair_alternation=True
+    )
+
+    runner._agent_cache[cache_key] = ("stale-before-redo", "sig")
+    redo_msg = asyncio.run(runner._handle_redo_command(_event("/redo", src)))
+
+    assert "Redid" in redo_msg
+    assert cache_key not in runner._agent_cache
+    assert store.load_transcript(entry.session_id) == store._db.get_messages_as_conversation(
+        entry.session_id, repair_alternation=True
+    )
+
+
+def test_null_content_tail_confirmation_does_not_stringify_none(store):
+    src = _source("null-tail")
+    entry = store.get_or_create_session(src)
+    db = store._db
+    db.append_message(entry.session_id, "user", "run tool")
+    assistant = db.append_message(
+        entry.session_id,
+        "assistant",
+        None,
+        tool_calls=[{"id": "call-1", "type": "function", "function": {"name": "x"}}],
+    )
+    db.append_message(entry.session_id, "tool", "ok", tool_call_id="call-1")
+    runner = _runner(store)
+
+    undo = store.rewind_session(entry.session_id, 1)
+    assert set(undo["rewound_ids"]) == {assistant, assistant + 1}
+    msg = asyncio.run(runner._handle_redo_command(_event("/redo", src)))
+
+    assert "Redid" in msg
+    assert "None" not in msg
+
+
+def test_undo_output_shows_new_tail_preview_at_user_message(store):
+    """/undo lands the thread at the prior user message; the reply text names it."""
+    src = _source("tail-user")
+    entry = store.get_or_create_session(src)
+    db = store._db
+    db.append_message(entry.session_id, "user", "what's the plan for the homelab DNS?")
+    db.append_message(entry.session_id, "assistant", "Here is a long answer. " * 200)
+    runner = _runner(store)
+
+    msg = asyncio.run(runner._handle_undo_command(_event("/undo", src)))
+
+    # Primary line still reports the count...
+    assert "Undid 1 half-turn" in msg
+    # ...and the new second line confirms WHERE we landed: the user's message.
+    assert "Now at" in msg
+    assert "your message" in msg
+    assert "what's the plan for the homelab DNS?" in msg
+
+
+def test_redo_output_shows_new_tail_preview_at_assistant_reply(store):
+    src = _source("tail-asst")
+    entry = store.get_or_create_session(src)
+    db = store._db
+    db.append_message(entry.session_id, "user", "q")
+    db.append_message(entry.session_id, "assistant", "the assistant reply we restore")
+    runner = _runner(store)
+
+    asyncio.run(runner._handle_undo_command(_event("/undo", src)))
+    msg = asyncio.run(runner._handle_redo_command(_event("/redo", src)))
+
+    assert "Redid" in msg
+    assert "Now at" in msg
+    assert "my reply" in msg
+    assert "the assistant reply we restore" in msg
+
+
+def test_undo_to_empty_thread_reports_start_of_thread(store):
+    src = _source("tail-empty")
+    entry = store.get_or_create_session(src)
+    db = store._db
+    db.append_message(entry.session_id, "user", "only message")
+    db.append_message(entry.session_id, "assistant", "only reply")
+    runner = _runner(store)
+
+    # Undo both half-turns -> nothing active remains.
+    msg = asyncio.run(runner._handle_undo_command(_event("/undo 2", src)))
+
+    assert "Undid 2 half-turn" in msg
+    assert "Now at" in msg
+    assert "start of the thread" in msg
+
+
+def test_tail_preview_notext_fallback_for_tool_only_tail(store):
+    """A tail with no renderable text names the party instead of stringifying None."""
+    src = _source("tail-notext")
+    entry = store.get_or_create_session(src)
+    db = store._db
+    # user -> assistant(text) -> user -> assistant(tool-call only) -> tool
+    db.append_message(entry.session_id, "user", "q1")
+    db.append_message(entry.session_id, "assistant", "a1 text")
+    db.append_message(entry.session_id, "user", "q2")
+    db.append_message(
+        entry.session_id,
+        "assistant",
+        None,
+        tool_calls=[{"id": "c1", "type": "function", "function": {"name": "x"}}],
+    )
+    db.append_message(entry.session_id, "tool", "", tool_call_id="c1")
+    runner = _runner(store)
+
+    # Undo the tool half-turn: tail becomes the "q2" user message (has text).
+    msg = asyncio.run(runner._handle_undo_command(_event("/undo", src)))
+    assert "Now at" in msg
+    assert "None" not in msg
+    assert "q2" in msg
+
+
+def test_tail_preview_read_failure_omits_suffix_not_empty(store, monkeypatch):
+    """A transient tail-read failure AFTER a successful undo must omit the
+    suffix, never claim the thread is at its start (Greptile #224 P1)."""
+    src = _source("tail-readfail")
+    entry = store.get_or_create_session(src)
+    db = store._db
+    db.append_message(entry.session_id, "user", "q1")
+    db.append_message(entry.session_id, "assistant", "a1")
+    db.append_message(entry.session_id, "user", "q2")
+    db.append_message(entry.session_id, "assistant", "a2")
+    runner = _runner(store)
+
+    import hermes_undo
+
+    msg = asyncio.run(runner._handle_undo_command(_event("/undo", src)))
+    # Primary op reported; suffix present here (no failure yet).
+    assert "Undid" in msg
+
+    # Now make the tail read fail and prove the helper reports a DISTINCT
+    # error state (not "empty") and the gateway omits the suffix entirely.
+    def boom(*a, **kw):
+        raise RuntimeError("simulated transient DB failure")
+
+    monkeypatch.setattr(db, "get_messages", boom)
+    hermes_undo._session_db = db
+    info = hermes_undo.tail_preview(entry.session_id)
+    assert info["error"] is True
+    assert info["empty"] is False
+    suffix = runner._undo_tail_suffix(entry.session_id)
+    assert suffix == ""
+    assert "start of the thread" not in suffix
+
+
+def test_tail_preview_unexpected_role_bounds_to_message(store):
+    """A tail with a role lacking a party label (system/developer/legacy
+    function) must not leak a raw i18n key path (Greptile #224 P1)."""
+    src = _source("tail-role")
+    entry = store.get_or_create_session(src)
+    db = store._db
+    db.append_message(entry.session_id, "user", "q")
+    db.append_message(entry.session_id, "assistant", "a")
+    # A row with an unusual role at the tail.
+    db.append_message(entry.session_id, "system", "some system note")
+    runner = _runner(store)
+
+    suffix = runner._undo_tail_suffix(entry.session_id)
+    # Must render a readable label, never the raw key path.
+    assert "gateway.undo.party" not in suffix
+    assert "the last message" in suffix
+
+
+def test_tail_preview_strips_injected_gateway_markers(store):
+    """The 'Now at' preview must show the user's ACTUAL text, not the gateway's
+    injected [Triggering message id: …]/[Replying to: …] plumbing prefix.
+
+    Regression for the real 2026-07-14 report: the ~113-char Discord Triggering
+    marker consumed the entire preview window, so every /undo landing looked
+    identical and told the user nothing about where they landed.
+    """
+    src = _source("tail-marker")
+    entry = store.get_or_create_session(src)
+    db = store._db
+    marker = (
+        "[Triggering message id: `1526623289844170812` — use as `message_id` "
+        "for reply/react/pin via the discord tools.]\n\n"
+    )
+    body = '>Say "hey clanker, buy paper towels" at the theater right now.'
+    db.append_message(entry.session_id, "assistant", "prior reply")
+    db.append_message(entry.session_id, "user", marker + body)
+    db.append_message(entry.session_id, "assistant", "a" * 400)
+    runner = _runner(store)
+
+    msg = asyncio.run(runner._handle_undo_command(_event("/undo", src)))
+
+    assert "Now at" in msg
+    # The real body shows...
+    assert "buy paper towels" in msg
+    # ...and the injected marker does NOT lead the preview.
+    assert "Triggering message id" not in msg
+    assert "reply/react/pin" not in msg
+
+
+def test_tail_preview_strips_both_marker_and_reply_pointer(store):
+    """A message carrying BOTH a Triggering marker and a Replying-to pointer is
+    fully cleaned so the preview begins at the user's own words."""
+    src = _source("tail-marker2")
+    entry = store.get_or_create_session(src)
+    db = store._db
+    prefix = (
+        "[Triggering message id: `123` — use as `message_id` for reply/react/pin "
+        'via the discord tools.]\n\n[Replying to: "some earlier quoted thing"]\n\n'
+    )
+    db.append_message(entry.session_id, "assistant", "prior reply")
+    db.append_message(entry.session_id, "user", prefix + "actual question here")
+    db.append_message(entry.session_id, "assistant", "b" * 400)
+    runner = _runner(store)
+
+    msg = asyncio.run(runner._handle_undo_command(_event("/undo", src)))
+
+    assert "actual question here" in msg
+    assert "Triggering message id" not in msg
+    assert "Replying to" not in msg

--- a/tests/gateway/test_undo_rewind_session.py
+++ b/tests/gateway/test_undo_rewind_session.py
@@ -1,9 +1,8 @@
 """Tests for SessionStore.rewind_session — the gateway /undo [N] primitive.
 
-The gateway /undo backs up N user turns by soft-deleting the truncated rows
-in state.db (active=0, kept for audit, hidden from re-prompts/search) via
-SessionDB.rewind_to_message, rather than the old hard rewrite_transcript.
-load_transcript returns only the active view. See issue #21910.
+The gateway /undo backs up N half-turns by soft-deleting rows in state.db
+(active=0, kept for audit, hidden from re-prompts/search) via the shared
+undo core. load_transcript returns only the active view. See issue #21910.
 """
 
 from __future__ import annotations
@@ -38,20 +37,19 @@ def _seed(store, sid, source="telegram", turns=3):
 def test_rewind_default_one_turn(store):
     sid = _seed(store, "gw-1")
     res = store.rewind_session(sid)
-    assert res["turns_undone"] == 1
-    assert res["target_text"] == "q3"
-    assert res["rewound_count"] == 2  # q3 + a3
+    assert res["rewound_ids"]
+    assert res["prefill_text"] == "q3"
+    assert len(res["rewound_ids"]) == 1  # a3
     active = store.load_transcript(sid)
-    assert [m["role"] for m in active] == ["user", "assistant", "user", "assistant"]
+    assert [m["role"] for m in active] == ["user", "assistant", "user", "assistant", "user"]
 
 
 def test_rewind_n_turns(store):
     sid = _seed(store, "gw-2")
     res = store.rewind_session(sid, 2)
-    assert res["turns_undone"] == 2
-    assert res["target_text"] == "q2"
-    assert res["rewound_count"] == 4  # q2,a2,q3,a3
-    assert len(store.load_transcript(sid)) == 2  # q1,a1
+    assert len(res["rewound_ids"]) == 2  # q3,a3
+    assert res["prefill_text"] is None
+    assert len(store.load_transcript(sid)) == 4  # q1,a1,q2,a2
 
 
 def test_rewind_soft_deletes_rows_for_audit(store):
@@ -59,14 +57,15 @@ def test_rewind_soft_deletes_rows_for_audit(store):
     store.rewind_session(sid, 1)
     all_rows = store._db.get_messages(sid, include_inactive=True)
     assert len(all_rows) == 6  # nothing hard-deleted
-    assert sum(1 for r in all_rows if r["active"] == 1) == 4
+    assert sum(1 for r in all_rows if r["active"] == 1) == 5
     assert store._db.get_session(sid)["rewind_count"] == 1
 
 
 def test_rewind_clamps_to_oldest_turn(store):
     sid = _seed(store, "gw-4", turns=2)
     res = store.rewind_session(sid, 99)
-    assert res["target_text"] == "q1"
+    assert res["rewound_ids"]
+    assert res["prefill_text"] is None
     assert len(store.load_transcript(sid)) == 0
 
 
@@ -78,5 +77,5 @@ def test_rewind_empty_session_returns_none(store):
 def test_rewind_clamps_negative_count_to_one(store):
     sid = _seed(store, "gw-6")
     res = store.rewind_session(sid, -5)
-    assert res["turns_undone"] == 1
-    assert res["target_text"] == "q3"
+    assert len(res["rewound_ids"]) == 1
+    assert res["prefill_text"] == "q3"

--- a/tests/test_undo_redo_stack.py
+++ b/tests/test_undo_redo_stack.py
@@ -1,0 +1,429 @@
+import ast
+import inspect
+
+import pytest
+
+import hermes_undo
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    monkeypatch.setattr(hermes_undo, "_session_db", session_db)
+    hermes_undo.clear_state()
+    yield session_db
+    session_db.close()
+    hermes_undo.clear_state()
+
+
+def _make_session(db, sid="s1"):
+    db.create_session(sid, source="cli")
+    return sid
+
+
+def _active_ids(db, sid):
+    return [m["id"] for m in db.get_messages(sid)]
+
+
+def _seed_three_half_turns(db, sid):
+    u1 = db.append_message(sid, "user", "u1")
+    a1 = db.append_message(sid, "assistant", "a1")
+    u2 = db.append_message(sid, "user", "u2")
+    a2 = db.append_message(sid, "assistant", "a2")
+    return u1, a1, u2, a2
+
+
+def test_undo_redo_transition_table_identity_and_redo_count(db):
+    sid = _make_session(db)
+    ids = _seed_three_half_turns(db, sid)
+    before = _active_ids(db, sid)
+
+    undone = hermes_undo.undo(sid, 1)
+    assert undone["rewound_ids"] == [ids[-1]]
+    assert undone["prefill_text"] == "u2"
+    state = hermes_undo.get_state(sid)
+    assert [op.rewound_ids for op in state.undo_stack] == [[ids[-1]]]
+    assert state.redo_stack == []
+    assert _active_ids(db, sid) == before[:-1]
+
+    redone = hermes_undo.redo(sid, 1)
+    assert redone == {"reactivated_count": 1, "new_tail_id": ids[-1], "prefill_text": None}
+    assert _active_ids(db, sid) == before
+    assert state.undo_stack == []
+    assert [op.rewound_ids for op in state.redo_stack] == [[ids[-1]]]
+    assert db.get_session(sid)["redo_count"] == 1
+
+
+def test_stacked_ops_have_disjoint_ids_and_redo_lifo_pop_order(db):
+    sid = _make_session(db)
+    ids = _seed_three_half_turns(db, sid)
+
+    op1 = hermes_undo.undo(sid, 1)
+    op2 = hermes_undo.undo(sid, 1)
+    op3 = hermes_undo.undo(sid, 1)
+    rewound_sets = [set(op["rewound_ids"]) for op in (op1, op2, op3)]
+    assert rewound_sets == [{ids[3]}, {ids[2]}, {ids[1]}]
+    assert rewound_sets[0].isdisjoint(rewound_sets[1])
+    assert rewound_sets[0].isdisjoint(rewound_sets[2])
+    assert rewound_sets[1].isdisjoint(rewound_sets[2])
+
+    redone = hermes_undo.redo(sid, 2)
+    assert redone["reactivated_count"] == 2
+    assert _active_ids(db, sid) == [ids[0], ids[1], ids[2]]
+    state = hermes_undo.get_state(sid)
+    assert [op.rewound_ids for op in state.redo_stack] == [[ids[1]], [ids[2]]]
+    assert [op.rewound_ids for op in state.undo_stack] == [[ids[3]]]
+
+
+def test_redo_m_non_positive_and_empty_stack_do_not_bump(db):
+    sid = _make_session(db)
+    db.append_message(sid, "user", "u")
+
+    assert hermes_undo.redo(sid, 0)["message"] == "nothing to redo"
+    assert hermes_undo.redo(sid, -1)["message"] == "nothing to redo"
+    assert db.get_session(sid)["redo_count"] is None
+
+    assert hermes_undo.redo(sid, 10)["message"] == "nothing to redo"
+    assert db.get_session(sid)["redo_count"] is None
+
+    hermes_undo.undo(sid, 1)
+    hermes_undo.clear_state(sid)
+    cold = hermes_undo.redo(sid, 1)
+    assert "doesn't survive a restart" in cold["message"]
+    assert db.get_session(sid)["redo_count"] is None
+
+
+def test_redo_degrades_gracefully_when_no_rows_restorable(monkeypatch, db):
+    """Zero rows restorable == transcript was rewritten → graceful no-op, no raise.
+
+    A redo op whose rows ALL fail to restore means the transcript was rewritten
+    out from under the stack (/compress, /retry); redo across that is impossible,
+    same as after a restart. This must NOT raise (it's reachable by normal user
+    actions: /undo then /compress then /redo). A PARTIAL restore is different —
+    that still fails loud (see test_redo_fail_loud_requires_each_op_restore_all_rewound_ids).
+    """
+    sid = _make_session(db)
+    _seed_three_half_turns(db, sid)
+    hermes_undo.undo(sid, 1)
+    monkeypatch.setattr(db, "restore_ids", lambda _sid, _ids: 0)
+
+    r = hermes_undo.redo(sid, 1)
+    assert r["reactivated_count"] == 0
+    assert "transcript changed" in r["message"]
+    state = hermes_undo.get_state(sid)
+    assert state.undo_stack == []
+    assert state.redo_stack == []
+
+
+def test_user_message_append_invalidates_redo_branch(db):
+    """Typing a new message after an undo must discard the redo branch.
+
+    ``undo_stack`` semantically holds the redo branch (ops that were undone and
+    can be redone — ``redo()`` pops it). A text editor discards that branch the
+    moment you type after undoing, so a later /redo must NOT resurrect the
+    undone content out of order. Regression: previously on_user_message_appended
+    cleared only the vestigial ``redo_stack``, leaving ``undo_stack`` live so a
+    /redo wedged stale rows back in.
+    """
+    sid = _make_session(db)
+    _seed_three_half_turns(db, sid)
+    hermes_undo.undo(sid, 1)
+    hermes_undo.redo(sid, 1)
+    state = hermes_undo.get_state(sid)
+    assert len(state.redo_stack) == 1
+    state.undo_stack.append(hermes_undo.UndoOp(n=99, rewound_ids=[12345]))
+
+    db.append_message(sid, "user", "new branch")
+    hermes_undo.on_user_message_appended(sid)
+
+    assert state.redo_stack == []
+    assert state.undo_stack == []
+
+
+def test_undo_then_type_then_redo_does_not_resurrect(db):
+    """End-to-end repro: undo, type a new message, redo → nothing resurrected."""
+    sid = _make_session(db)
+    u1, a1, u2, a2 = _seed_three_half_turns(db, sid)
+
+    r = hermes_undo.undo(sid, 1)
+    assert r["rewound_ids"] == [a2]
+    assert _active_ids(db, sid) == [u1, a1, u2]
+
+    new = db.append_message(sid, "user", "different question")
+    hermes_undo.on_user_message_appended(sid)
+    assert _active_ids(db, sid) == [u1, a1, u2, new]
+
+    r = hermes_undo.redo(sid, 1)
+    assert r["reactivated_count"] == 0
+    # a2 must NOT be wedged back between u2 and the new message
+    assert _active_ids(db, sid) == [u1, a1, u2, new]
+
+
+def test_redo_after_transcript_rewrite_does_not_raise(db):
+    """A /compress (replace_messages) after /undo must not crash a later /redo.
+
+    replace_messages hard-deletes and renumbers rows, so the in-memory
+    undo_stack references dead ids. redo() must degrade gracefully (clear the
+    branch, report "transcript changed") instead of raising the restore-count
+    invariant. Regression: previously this raised an unhandled RuntimeError.
+    """
+    sid = _make_session(db)
+    _seed_three_half_turns(db, sid)
+    hermes_undo.undo(sid, 1)
+    state = hermes_undo.get_state(sid)
+    assert state.undo_stack  # a redo op is pending
+
+    # Simulate /compress: replace the transcript with the active-only rows.
+    active = db.get_messages(sid, include_inactive=False)
+    db.replace_messages(
+        sid, [{"role": m["role"], "content": m.get("content", "")} for m in active]
+    )
+
+    r = hermes_undo.redo(sid, 1)
+    assert r["reactivated_count"] == 0
+    assert "transcript changed" in r["message"]
+    # Stacks invalidated so a subsequent redo is also a clean no-op.
+    assert state.undo_stack == []
+    assert state.redo_stack == []
+
+
+def test_undo_with_no_rewound_rows_touches_neither_stack(monkeypatch, db):
+    """A rewind that deactivates nothing must not push an empty op or wipe redo.
+
+    Matches the None-path contract: a no-op undo leaves both stacks untouched.
+    Guards the degenerate/raced rewind_to_message return.
+    """
+    sid = _make_session(db)
+    _seed_three_half_turns(db, sid)
+    hermes_undo.undo(sid, 1)
+    hermes_undo.redo(sid, 1)
+    state = hermes_undo.get_state(sid)
+    assert state.redo_stack  # a redo op is pending
+    redo_before = list(state.redo_stack)
+    undo_before = list(state.undo_stack)
+
+    # Force rewind_to_message to report it deactivated nothing.
+    monkeypatch.setattr(
+        db, "rewind_to_message", lambda *a, **k: {"rewound_ids": []}
+    )
+    r = hermes_undo.undo(sid, 1)
+    assert r["rewound_ids"] == []
+    assert r["message"] == "nothing to undo"
+    assert state.undo_stack == undo_before
+    assert state.redo_stack == redo_before
+
+
+def test_new_undo_clears_redo_and_discarded_ops_are_unreachable(db):
+    sid = _make_session(db)
+    _seed_three_half_turns(db, sid)
+    hermes_undo.undo(sid, 1)
+    hermes_undo.redo(sid, 1)
+    state = hermes_undo.get_state(sid)
+    assert state.redo_stack
+
+    hermes_undo.undo(sid, 1)
+    assert state.redo_stack == []
+    source = inspect.getsource(hermes_undo)
+    tree = ast.parse(source)
+    calls = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and getattr(node.func, "id", "") == "UndoOp"
+    ]
+    assert len(calls) == 1
+
+
+def test_d13_fires_on_lone_multimodal_user_tail_and_redo_round_trips(db):
+    sid = _make_session(db)
+    u_prev = db.append_message(sid, "user", "plain")
+    a1 = db.append_message(sid, "assistant", "answer one")
+    mm = db.append_message(
+        sid,
+        "user",
+        [{"type": "text", "text": "see this"}, {"type": "image_url", "image_url": "x"}],
+    )
+    a2 = db.append_message(sid, "assistant", "answer two")
+    before = _active_ids(db, sid)
+    assert hermes_undo.compute_half_turn_target(db.get_messages(sid), 1) == a2
+
+    result = hermes_undo.undo(sid, 1)
+
+    assert set(result["rewound_ids"]) == {mm, a2}
+    assert result["prefill_text"] is None
+    assert _active_ids(db, sid) == [u_prev, a1]
+    assert db.get_messages(sid)[-1]["id"] == a1
+
+    redo = hermes_undo.redo(sid, 1)
+    assert redo["new_tail_id"] == a2
+    assert _active_ids(db, sid) == before
+
+
+def test_d13_firing_fixture_is_reachable_by_two_turn_operation_sequence(db):
+    sid = _make_session(db)
+    db.append_message(sid, "user", "first text")
+    a1 = db.append_message(sid, "assistant", "first answer")
+    mm = db.append_message(
+        sid,
+        "user",
+        [{"type": "text", "text": "image prompt"}, {"type": "image_url", "image_url": "x"}],
+    )
+    a2 = db.append_message(sid, "assistant", "image answer")
+
+    result = hermes_undo.undo(sid, 1)
+
+    assert set(result["rewound_ids"]) == {mm, a2}
+    assert _active_ids(db, sid)[-1] == a1
+    assert result["prefill_text"] is None
+
+
+def test_d13_plain_string_control_does_not_lower_target(db):
+    sid = _make_session(db)
+    db.append_message(sid, "user", "plain")
+    db.append_message(sid, "assistant", "answer one")
+    user = db.append_message(sid, "user", "editable")
+    a2 = db.append_message(sid, "assistant", "answer two")
+
+    result = hermes_undo.undo(sid, 1)
+
+    assert result["rewound_ids"] == [a2]
+    assert result["prefill_text"] == "editable"
+    assert _active_ids(db, sid)[-1] == user
+
+
+def test_zero_non_other_none_return_noop_and_redo_stack_survives(db):
+    sid = _make_session(db)
+    db.append_message(sid, "system", "rules only")
+    state = hermes_undo.get_state(sid)
+    state.undo_stack.append(hermes_undo.UndoOp(n=7, rewound_ids=[700]))
+    state.redo_stack.append(hermes_undo.UndoOp(n=8, rewound_ids=[800]))
+
+    assert hermes_undo.compute_half_turn_target(db.get_messages(sid), 1) is None
+    result = hermes_undo.undo(sid, 1)
+
+    assert result["rewound_ids"] == []
+    assert result["prefill_text"] is None
+    assert result["message"] == "nothing to undo"
+    assert state.undo_stack == [hermes_undo.UndoOp(n=7, rewound_ids=[700])]
+    assert state.redo_stack == [hermes_undo.UndoOp(n=8, rewound_ids=[800])]
+    assert [m["active"] for m in db.get_messages(sid, include_inactive=True)] == [1]
+
+
+def test_tool_monotonicity_violation_raises_before_orphaning(db):
+    sid = _make_session(db)
+    db.append_message(sid, "user", "run")
+    assistant = db.append_message(sid, "assistant", None, tool_calls=[{"id": "ok"}])
+    tool = db.append_message(sid, "tool", "result", tool_call_id="ok")
+    assert tool > assistant
+
+    bad = _make_session(db, "bad-tool-order")
+    db.append_message(bad, "user", "run")
+    early_tool = db.append_message(bad, "tool", "too early", tool_call_id="call-1")
+    owner = db.append_message(
+        bad, "assistant", None, tool_calls=[{"id": "call-1"}]
+    )
+    assert early_tool < owner
+
+    with pytest.raises(ValueError, match="orphan"):
+        db.rewind_to_message(bad, owner, require_user_role=False)
+
+    rows = db.get_messages(bad)
+    assert [row["id"] for row in rows] == [m["id"] for m in rows]
+    assert all(row["active"] == 1 for row in rows)
+
+
+def test_redo_fail_loud_requires_each_op_restore_all_rewound_ids(monkeypatch, db):
+    sid = _make_session(db)
+    ids = _seed_three_half_turns(db, sid)
+    hermes_undo.undo(sid, 2)
+    op = hermes_undo.get_state(sid).undo_stack[-1]
+    assert set(op.rewound_ids) == {ids[2], ids[3]}
+
+    calls = []
+
+    def partial_restore(_sid, rewound_ids):
+        calls.append(list(rewound_ids))
+        return len(rewound_ids) - 1
+
+    monkeypatch.setattr(db, "restore_ids", partial_restore)
+    with pytest.raises(RuntimeError, match="restored 1 of 2 rewound rows"):
+        hermes_undo.redo(sid, 1)
+    assert calls == [[ids[2], ids[3]]]
+
+
+def test_multi_redo_preserves_earlier_progress_when_later_op_hits_rewrite(monkeypatch, db):
+    """A /redo N must not throw away rows an EARLIER op already reactivated.
+
+    Bug (Greptile, merged PR #49): in a multi-op /redo, the first op pops and
+    restores rows (real DB work, redo_stack grows), then a later op hits the
+    transcript-rewrite path (restore_ids -> 0). The old code discarded the whole
+    stack and returned reactivated_count:0, so the caller printed "Nothing to
+    redo" and SKIPPED its history reload — screen/DB desync — and redo_count was
+    never bumped despite the committed first op. The fix reports the partial
+    progress honestly and still commits it.
+    """
+    sid = _make_session(db)
+    ids = _seed_three_half_turns(db, sid)  # u1,a1,u2,a2
+    # Two single-half-turn undos -> two ops on the stack (LIFO: a2 then u2 group).
+    hermes_undo.undo(sid, 1)
+    hermes_undo.undo(sid, 1)
+    state = hermes_undo.get_state(sid)
+    assert len(state.undo_stack) == 2
+    first_op_ids = list(state.undo_stack[-1].rewound_ids)  # the op redo pops FIRST
+
+    real_restore = db.restore_ids
+    seen = {"n": 0}
+
+    def restore_first_then_rewrite(_sid, rewound_ids):
+        # First op: genuinely restore. Second op: simulate transcript rewrite.
+        seen["n"] += 1
+        if seen["n"] == 1:
+            return real_restore(_sid, rewound_ids)
+        return 0
+
+    monkeypatch.setattr(db, "restore_ids", restore_first_then_rewrite)
+
+    r = hermes_undo.redo(sid, 2)
+
+    # Earlier op's work is preserved and reported, not silently dropped.
+    assert r["reactivated_count"] == len(first_op_ids)
+    assert r["reactivated_count"] > 0
+    assert "transcript changed" in r["message"]
+    # The op that succeeded moved to redo_stack; the dead remainder is dropped.
+    assert len(state.redo_stack) == 1
+    assert state.undo_stack == []
+    # redo_count WAS bumped because real work committed (not left at None).
+    assert db.get_session(sid)["redo_count"] == 1
+
+
+def test_redo_uses_public_bump_redo_count_not_private_execute_write():
+    """The shared core must call the public SessionDB.bump_redo_count helper,
+    not reach into the private _execute_write (Greptile PR #49 finding)."""
+    source = inspect.getsource(hermes_undo)
+    assert "bump_redo_count" in source
+    assert "_execute_write" not in source, (
+        "hermes_undo must not access the private SessionDB._execute_write"
+    )
+    # And the helper actually exists on SessionDB.
+    assert callable(getattr(SessionDB, "bump_redo_count", None))
+
+
+def test_states_holder_is_lru_bounded(monkeypatch):
+    """_states must evict least-recently-used sessions instead of growing forever
+    (Greptile PR #49: unbounded module-global dict = gateway memory leak)."""
+    hermes_undo.clear_state()
+    monkeypatch.setattr(hermes_undo, "_STATE_CAP", 3)
+    try:
+        for i in range(5):
+            hermes_undo.get_state(f"s{i}")
+        assert len(hermes_undo._states) == 3
+        # The three most-recent survive; the two oldest were evicted.
+        assert set(hermes_undo._states.keys()) == {"s2", "s3", "s4"}
+
+        # Accessing an existing session refreshes its recency (LRU, not FIFO).
+        hermes_undo.get_state("s2")          # s2 -> most recent
+        hermes_undo.get_state("s5")          # inserts s5, evicts the now-oldest (s3)
+        assert "s2" in hermes_undo._states
+        assert "s3" not in hermes_undo._states
+        assert len(hermes_undo._states) == 3
+    finally:
+        hermes_undo.clear_state()


### PR DESCRIPTION
# PR-BODY.md — Shape B (standalone, against plain `main`) — DRAFT, not pushed

**Target:** `NousResearch/hermes-agent`, base `main` @ `07e97d2f5`
**Title:** `feat(gateway): /redo + half-turn /undo — a shared undo/redo core across CLI, TUI and gateway`
**Labels:** feature
**Independent** — no dependency on any other PR.

---

> **Relationship to the `gateway/slash_commands/` extraction PR.** This is the
> same feature as the Shape-A variant, authored against plain `main` so it can
> land whether or not the extraction refactor does. The only difference is where
> the gateway handlers live: here `/undo` is edited in place inside the
> 5,060-line `gateway/slash_commands.py` and `/redo` is appended next to it, plus
> an explicit `if canonical == "redo":` branch in `run.py`. Every other file —
> `hermes_undo.py`, `hermes_state.py`, `gateway/session.py`, `cli.py`, the 17
> locales and all six test files — is byte-identical between the two. **If the
> extraction merges first, prefer the leaf-module version.**

## What this is

`/undo` on `main` backs up **whole user turns** and has no counterpart. This PR
makes it a **half-turn** rewind and adds **`/redo`**, backed by a single shared
core (`hermes_undo.py`) that the CLI, TUI and gateway all drive — so the three
surfaces share one undo stack, one set of semantics and one set of bugs to fix.

## Why half-turns, and why `/redo`

A *half-turn* is one party's contiguous run of transcript rows — a user message,
or an assistant run including its tool calls and results. Today's `/undo` always
removes a whole user↔assistant exchange, which means:

- you cannot back up to *just before the assistant answered* to re-ask;
- `/undo` is destructive with no way back. There is no `/redo` anywhere in the
  product, on any surface.

Half-turn granularity plus `/redo` makes the pair behave like a text editor's
undo stack — the mental model `tui_gateway/server.py`'s own `session.undo`
docstring already reaches for when it calls today's behavior "the
Claude-Code-style single-step undo".

**`main` already has the seam for this.** `tui_gateway/compute_host.py:371` does:

```python
try:
    import hermes_undo
    hermes_undo.on_user_message_appended(session["session_key"])
except Exception:
    pass
```

There is no `hermes_undo` module in the tree — that call is **dead today**,
silently swallowed by the bare `except`. This PR ships the module it was written
against, and wires the gateway's equivalent call at its transcript-append site.

## What changes

**New: `hermes_undo.py` (481 LOC)** — the shared core.
- `compute_half_turn_target` — groups the active transcript into same-party runs
  and returns the id to rewind to.
- `undo` / `redo` — push/pop an `UndoOp(n, rewound_ids)` stack, LRU-capped at
  2,048 sessions so a long-lived gateway can't grow it without bound.
- `on_user_message_appended` — clears the redo branch when you type after undoing
  (the editor rule); the function `compute_host.py` already calls.
- `tail_preview` — the "↦ now at …" confirmation string.

**`hermes_state.py`**
- `rewind_to_message(…, require_user_role=False)` — opt-in non-user targets (a
  half-turn boundary can be an assistant run). **Default stays `True`**, so every
  existing caller is unchanged.
- returns `rewound_ids` alongside `rewound_count`.
- **`_raise_if_rewind_would_orphan_tool`** — refuses, *before the write*, a
  rewind that would strand a `tool` row whose `assistant(tool_calls)` owner is
  being deactivated. Strict OpenAI-compatible providers (DeepSeek v4,
  Moonshot/Kimi) reject that shape with HTTP 400. New
  `RewindWouldOrphanError(ValueError)` — subclassing `ValueError` keeps existing
  `except ValueError` callers working.
- `restore_ids(session_id, ids)` — reactivate an exact id **set**, not an
  `id >=` range. That is what makes stacked redo correct and the round trip
  byte-identical. `restore_rewound` is kept, with a docstring noting it is
  deprecated for stacked undo/redo.
- `bump_redo_count` + a `redo_count` column. Added to the schema DDL only —
  `main`'s DDL-driven `ALTER TABLE ADD COLUMN` migration (~L3102) picks it up
  with no version-gated block.
- the post-commit `SELECT MAX(id)` now fails **soft** (see "Correctness fixes").

**`gateway/session.py`**
- `rewind_session` gets a **four-outcome honesty contract** — success / genuine
  empty / `{"status": "busy"}` / `{"status": "error"}`. Today it collapses every
  exception into `None`, which the handler renders as the user-facing lie
  *"Nothing to undo."* even for a DB fault.
- `restore_session` — the `/redo` counterpart, same contract.
- `_is_transient_db_busy` — the lock/busy discriminator that makes "retryable"
  vs "real bug" an actual decision rather than a guess.
- `rewrite_transcript` clears the undo stack: `/compress` and `/retry`
  hard-delete and renumber rows, so a later `/redo` must not chase dead ids.

**`gateway/slash_commands.py`** — `_handle_undo_command` rewritten in place onto
the shared core, `_handle_redo_command` + `_undo_tail_suffix` appended beside it
inside `GatewaySlashCommandsMixin`.

**`gateway/run.py`** — the `/undo` confirmation blurb now says "half-turn", an
`if canonical == "redo":` dispatch branch, and `on_user_message_appended` at the
transcript-append site.

**`cli.py`** — `undo_last` rewired to the shared core, `redo_last` + a `/redo`
branch, `_reload_active_history_after_rewind`. The `undo_last(n, prefill=…)`
signature is unchanged, so `hermes_cli/cli_commands_mixin.py`'s checkpoint
rollback caller needs no edit.

**i18n** — 17 keys × **17 locales** (`gateway.undo.*` grows 3→10,
`gateway.redo.*` is new with 7), including `ar.yaml`.

## Three real regressions this feature causes, each caught by an existing test

I did not predict these; each was an existing upstream test going red.

1. **`tests/agent/test_i18n.py[ar]`** — `ar.yaml` needs the keys too. Worth
   naming because the catalog-completeness test is the only thing that catches a
   locale left behind.
2. **`tests/cli/test_cli_prefix_matching.py`** — `/redo` becomes the unique
   *shortest* `/re*` command, so `main`'s "unique shortest match" prefix
   heuristic silently resolves a bare `/re` to `/redo` — **firing a destructive
   command the user never named**, and swallowing the `/reset` / `/retry`
   ambiguity. Fixed: resolve-to-shortest only when the shortest built-in match is
   itself a **prefix of every other** built-in match (`/sta` → `/status` with
   `/statusbar` an extension: yes; `/re` → unrelated siblings: no, stay
   ambiguous). Independently useful hardening — the heuristic would mis-fire for
   any future short command sharing a prefix with a destructive one.
3. **`tests/hermes_cli/test_commands.py::TestSlackNativeSlashes::test_telegram_parity`**
   — the registry sits **at** Slack's hard 50-slash cap, so one more canonical
   clamps a command off its native slot. My first fix (pin `/version` as a
   priority canonical) just moved the casualty to `/update` — the test caught
   that too. Fixed the way the test's own docstring asks for: `version` joins
   `_SLACK_VIA_HERMES_ONLY` (reachable as `/hermes version` on Slack, native on
   CLI/TUI/Telegram/Discord). **This is a taste call — happy to swap the casualty
   if you'd rather a different command take the `/hermes` route.**

## Correctness fixes made before proposing this

Two "a post-commit failure is reported as a no-op" hazards, which make a retry
double-apply:

- **`rewind_to_message`** — the `SELECT MAX(id)` computing `new_head_id` runs
  *after* the deactivation commits. A transient error there raised into the
  caller, which reported "error / nothing changed" for a rewind that **had**
  happened → the retry double-undid. Now wrapped, fails soft. Same treatment for
  the post-commit prefill read in `undo()` and the counter-bump + tail read in
  `redo()`.
- **`redo()`** does one write per op, so a mid-loop failure is a genuine partial.
  It now pushes the failed op back on the stack (it didn't commit, so it stays
  recoverable) and returns an honest partial with `partial_retryable` — a
  transient lock says "run /redo again"; a real bug says "logged, not retryable"
  so a retry can't loop forever re-failing identically.

## Prompt-cache and role-alternation safety

`AGENTS.md` calls per-conversation prompt caching sacred and requires strict role
alternation. A transcript rewind is the obvious way to break both, so this is
asserted rather than argued —
**`tests/gateway/test_undo_cache_alternation_safety.py`, 8 tests, all passing:**

| invariant | mechanism |
|---|---|
| the cached prefix survives a rewind | the rewind is a **suffix-only** soft-delete: `UPDATE messages SET active=0 WHERE id >= ?`. **No INSERT and no content UPDATE anywhere in the undo path.** The surviving transcript is therefore a strict prefix of the cached one — `assert after == before[:len(after)]`. |
| undo→redo is byte-identical | `restore_ids` reactivates the **exact id set** the undo removed, not an `id >=` range. Round-trip asserts equal row-ids *and* equal rendered conversation. |
| never two same-party rows adjacent | a half-turn boundary is by construction a party **change**. |
| the repair belt finds nothing to fix | `repair_message_sequence` returns **0** repairs over four different rewind shapes. If `/undo` manufactured violations, the belt would rewrite the message list on every subsequent request — changing the bytes the provider sees and re-invalidating the cache each turn. |
| no orphaned tool row | the pre-write orphan guard; on refusal **nothing is mutated**, which is what lets the caller honestly say "nothing changed, try again". |
| no synthetic user row, byte-stable system prompt | the core has no INSERT path at all; the system prompt isn't a transcript row. Asserted structurally: the post-rewind id set is a strict **subset**, and no surviving row's `(role, content)` changed. |

The `_evict_cached_agent` call on `/undo`/`/redo` is *agent-object* eviction, not
prompt-cache invalidation — it drops the in-process `AIAgent` so the next turn
rebuilds from the active-only transcript. Since the rebuilt history is a prefix
of the old one, the rebuilt prompt still hits the provider cache for the
surviving span. `/model`, `/new` and today's `/undo` already do exactly this.

## Verification

Baseline first: the regression surface is **352 passed / 0 failed on untouched
`main` @ `07e97d2f5`**, so there is no ambient red to subtract and any failure
below would be mine.

| | |
|---|---|
| undo/redo suite (6 files, 1,534 LOC) | **66 passed, 0 failed** |
| regression surface (i18n · prefix-matching · commands/Slack-cap · hermes_state · async session store/db · credits · destructive-confirm) | **346 passed, 0 failed** |
| **combined** | **412 passed, 0 failed** |

Run hermetically: fresh `HERMES_HOME=$(mktemp -d)` per invocation, real imports,
real SQLite — no mocks in the state layer.

Test files: `tests/test_undo_redo_stack.py` (18) ·
`tests/gateway/test_undo_redo_half_turn.py` (12) ·
`tests/gateway/test_undo_rewind_session.py` (6, extended) ·
`tests/gateway/test_undo_error_honesty.py` (14) ·
`tests/gateway/test_undo_cache_alternation_safety.py` (8, new) ·
`tests/cli/test_undo_redo_half_turn.py` (8).

## Deliberately NOT in this PR

A **`/stop`-drain guard**. After `/stop` the running-agent slot is released
immediately but the turn coroutine keeps appending rows until its next
cooperative interrupt checkpoint; a rewind in that window races the still-writing
turn. Guarding it needs a per-session `asyncio.Task` registry that `main`'s
`gateway/run.py` does not have (`_running_agent_tasks`: 0 hits), and porting one
would drag an unrelated turn-lifecycle subsystem into an undo/redo PR. Happy to
follow up with it as its own change.
