### PR TITLE
fix: reconcile session state after desktop reconnect

### DIFF
--- a/apps/desktop/electron/backend-health.test.ts
+++ b/apps/desktop/electron/backend-health.test.ts
@@ -52,6 +52,38 @@ test('falls back to /api/status only for old backends without /api/health', asyn
   ])
 })
 
+test('uses the authenticated session for OAuth-gated health and legacy status probes', async () => {
+  const calls: string[][] = []
+
+  await waitForHermesReady('https://gateway.example.com', {
+    fetchPublicJson: async url => {
+      calls.push(['public', url])
+      throw new Error('public probe should not be called')
+    },
+    fetchJson: async url => {
+      calls.push(['token', url])
+      throw new Error('token probe should not be called')
+    },
+    fetchAuthenticatedJson: async url => {
+      calls.push(['authenticated', url])
+
+      if (url.endsWith('/api/health')) {
+        throw new Error('404: {"detail":"Not Found"}')
+      }
+
+      return { version: 'old-oauth-gated' }
+    },
+    sleep: async () => {},
+    timeoutMs: 100,
+    pollMs: 1
+  })
+
+  assert.deepEqual(calls, [
+    ['authenticated', 'https://gateway.example.com/api/health'],
+    ['authenticated', 'https://gateway.example.com/api/status']
+  ])
+})
+
 test('does not fall back to heavyweight /api/status for transient health failures', async () => {
   const calls: string[][] = []
   let currentTime = 0

--- a/apps/desktop/electron/backend-health.ts
+++ b/apps/desktop/electron/backend-health.ts
@@ -13,6 +13,7 @@ type FetchJson = (url: string, token?: string | null, options?: { timeoutMs?: nu
 export interface HermesReadyOptions {
   fetchPublicJson: FetchPublicJson
   fetchJson: FetchJson
+  fetchAuthenticatedJson?: FetchPublicJson
   token?: string | null
   signal?: AbortSignal
   timeoutMs?: number
@@ -59,6 +60,7 @@ export async function waitForHermesReady(baseUrl: string, options: HermesReadyOp
 
   const base = baseUrl.replace(/\/+$/, '')
   const deadline = now() + timeoutMs
+  const fetchHealthJson = options.fetchAuthenticatedJson ?? options.fetchPublicJson
   let lastError: unknown = null
   let useStatusFallback = false
 
@@ -69,9 +71,13 @@ export async function waitForHermesReady(baseUrl: string, options: HermesReadyOp
 
     try {
       if (useStatusFallback) {
-        await options.fetchJson(`${base}/api/status`, options.token)
+        if (options.fetchAuthenticatedJson) {
+          await options.fetchAuthenticatedJson(`${base}/api/status`)
+        } else {
+          await options.fetchJson(`${base}/api/status`, options.token)
+        }
       } else {
-        await options.fetchPublicJson(`${base}/api/health`, { timeoutMs: healthProbeTimeoutMs })
+        await fetchHealthJson(`${base}/api/health`, { timeoutMs: healthProbeTimeoutMs })
       }
 
       return

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4815,12 +4815,21 @@ function closePreviewWatchers() {
   }
 }
 
-async function waitForHermes(baseUrl, token, signal?) {
+async function waitForHermes(baseUrl, token, signal?, authMode = 'token') {
+  const fetchAuthenticatedJson =
+    authMode === 'oauth'
+      ? (url, options) =>
+          fetchJsonViaOauthSession(url, {
+            timeoutMs: options?.timeoutMs
+          })
+      : undefined
+
   return waitForHermesReady(baseUrl, {
     token,
     signal,
     fetchPublicJson,
-    fetchJson
+    fetchJson,
+    fetchAuthenticatedJson
   })
 }
 
@@ -7736,7 +7745,7 @@ async function spawnPoolBackend(profile, entry) {
   const remote = await resolveRemoteBackend(profile)
 
   if (remote) {
-    await waitForHermes(remote.baseUrl, remote.token)
+    await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode)
 
     return {
       ...remote,
@@ -7954,7 +7963,7 @@ async function startHermes() {
   const connectionPromise = (async () => {
     const connectRemote = async remote => {
       await advanceBootProgress('backend.remote', `Connecting to remote Hermes backend at ${remote.baseUrl}`, 24)
-      await waitForHermes(remote.baseUrl, remote.token)
+      await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode)
       updateBootProgress({
         phase: 'backend.ready',
         message: 'Remote Hermes backend is ready',

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -30,9 +30,16 @@ import { isMessagingSource } from '@/lib/session-source'
 import { latestSessionTodos } from '@/lib/todos'
 import { $billingSettingsRequest } from '@/store/billing-block'
 import { setCronFocusJobId } from '@/store/cron'
+import { $gatewayConnectionEpochs } from '@/store/gateway'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { $filePreviewTarget, $previewTarget } from '@/store/preview'
-import { $activeGatewayProfile, $freshSessionRequest, $profileScope, refreshActiveProfile } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  $freshSessionRequest,
+  $profileScope,
+  normalizeProfileKey,
+  refreshActiveProfile
+} from '@/store/profile'
 import { $startWorkSessionRequest, followActiveSessionCwd } from '@/store/projects'
 import {
   $activeSessionId,
@@ -138,6 +145,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const actionsRef = useRef<WiringActions | null>(null)
 
   const gatewayState = useStore($gatewayState)
+  const gatewayConnectionEpochs = useStore($gatewayConnectionEpochs)
   const activeSessionId = useStore($activeSessionId)
   const billingSettingsRequest = useStore($billingSettingsRequest)
   const currentCwd = useStore($currentCwd)
@@ -159,6 +167,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const messagingSessions = useStore($messagingSessions)
   const activeGatewayProfile = useStore($activeGatewayProfile)
+  const gatewayConnectionEpoch = gatewayConnectionEpochs[normalizeProfileKey(activeGatewayProfile)] ?? 0
   const profileScope = useStore($profileScope)
 
   const routedSessionId = routeSessionId(location.pathname)
@@ -630,6 +639,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     creatingSessionRef,
     currentView,
     freshDraftReady,
+    gatewayConnectionEpoch,
     gatewayState,
     locationPathname: location.pathname,
     resumeSession,

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -12,6 +12,7 @@ interface HarnessProps {
   creatingSessionRef: MutableRefObject<boolean>
   currentView: string
   freshDraftReady: boolean
+  gatewayConnectionEpoch?: number
   gatewayState: string
   locationPathname: string
   resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
@@ -24,8 +25,13 @@ interface HarnessProps {
   startFreshSessionDraft: (focus: boolean) => unknown
 }
 
-function RouteResumeHarness({ resumeFailedSessionId = null, resumeExhaustedSessionId = null, ...props }: HarnessProps) {
-  useRouteResume({ ...props, resumeExhaustedSessionId, resumeFailedSessionId })
+function RouteResumeHarness({
+  gatewayConnectionEpoch = 0,
+  resumeFailedSessionId = null,
+  resumeExhaustedSessionId = null,
+  ...props
+}: HarnessProps) {
+  useRouteResume({ ...props, gatewayConnectionEpoch, resumeExhaustedSessionId, resumeFailedSessionId })
 
   return null
 }
@@ -258,6 +264,45 @@ describe('useRouteResume', () => {
 
     expect(resumeSession).toHaveBeenCalledTimes(1)
     expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+  })
+
+  it('reconciles when a reconnect epoch advances even if React only renders open', () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: 'runtime-1' }
+    const creatingSessionRef = { current: false }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['session-1', 'runtime-1']]) }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'session-1' }
+    const common = {
+      activeSessionId: 'runtime-1',
+      activeSessionIdRef,
+      creatingSessionRef,
+      currentView: 'chat',
+      freshDraftReady: false,
+      gatewayState: 'open',
+      locationPathname: '/session-1',
+      resumeSession,
+      routedSessionId: 'session-1',
+      runtimeIdByStoredSessionIdRef,
+      selectedStoredSessionId: 'session-1',
+      selectedStoredSessionIdRef,
+      startFreshSessionDraft
+    } as const
+
+    const { rerender } = render(<RouteResumeHarness {...common} gatewayConnectionEpoch={1} />)
+
+    expect(resumeSession).not.toHaveBeenCalled()
+
+    // The renderer never observed closed/connecting, but the socket listener
+    // published a new generation when the replacement connection opened.
+    rerender(<RouteResumeHarness {...common} gatewayConnectionEpoch={2} />)
+
+    expect(resumeSession).toHaveBeenCalledTimes(1)
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+
+    // Ordinary renders within the same connection generation are idempotent.
+    rerender(<RouteResumeHarness {...common} gatewayConnectionEpoch={2} />)
+    expect(resumeSession).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -9,6 +9,7 @@ interface RouteResumeOptions {
   creatingSessionRef: MutableRefObject<boolean>
   currentView: string
   freshDraftReady: boolean
+  gatewayConnectionEpoch: number
   gatewayState: string | undefined
   locationPathname: string
   resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
@@ -71,6 +72,7 @@ export function useRouteResume({
   creatingSessionRef,
   currentView,
   freshDraftReady,
+  gatewayConnectionEpoch,
   gatewayState,
   locationPathname,
   resumeSession,
@@ -83,6 +85,7 @@ export function useRouteResume({
   startFreshSessionDraft
 }: RouteResumeOptions) {
   const lastPathnameRef = useRef<string | null>(null)
+  const lastGatewayConnectionEpochRef = useRef<number | null>(null)
   const seenGatewayStateRef = useRef(false)
   const wasGatewayOpenRef = useRef(false)
   // Per-session retry bookkeeping for the bounded auto-retry effect below. Keyed
@@ -104,7 +107,14 @@ export function useRouteResume({
     // already open is not mistaken for "became open" and does not double-resume with the
     // pathname-driven initial resume below.
     const gatewayBecameOpen = seenGatewayStateRef.current && !wasGatewayOpenRef.current && gatewayOpen
+    // React can batch a fast closed -> connecting -> open cycle and render only
+    // the final "open" state. The socket listener's monotonic epoch still
+    // exposes that real reconnect.
+    const gatewayConnectionAdvanced =
+      lastGatewayConnectionEpochRef.current !== null && gatewayConnectionEpoch > lastGatewayConnectionEpochRef.current
+    const gatewayReopened = gatewayBecameOpen || gatewayConnectionAdvanced
     lastPathnameRef.current = locationPathname
+    lastGatewayConnectionEpochRef.current = gatewayConnectionEpoch
     seenGatewayStateRef.current = true
     wasGatewayOpenRef.current = gatewayOpen
 
@@ -140,13 +150,13 @@ export function useRouteResume({
       // we're stranded on a routed session that never loaded. The first two
       // guard against a transient /:sid re-resume during "new chat" state clears
       // before the pathname updates from /:sid -> /.
-      const shouldResume = pathnameChanged || gatewayBecameOpen || stuckOnRoutedSession
+      const shouldResume = pathnameChanged || gatewayReopened || stuckOnRoutedSession
 
-      // On a reconnect (gatewayBecameOpen) re-resume even when the route looks
+      // On a reconnect re-resume even when the route looks
       // `alreadyActive`: the cached runtime id can be stale once the gateway
       // rebinds/reaps the session on its side, and trusting it strands Desktop on
       // a dead id ("session not found"). Otherwise keep skipping when already active.
-      if ((gatewayBecameOpen || !alreadyActive) && shouldResume && !creatingSessionRef.current) {
+      if ((gatewayReopened || !alreadyActive) && shouldResume && !creatingSessionRef.current) {
         void resumeSession(routedSessionId, true)
       }
 
@@ -167,6 +177,7 @@ export function useRouteResume({
     creatingSessionRef,
     currentView,
     freshDraftReady,
+    gatewayConnectionEpoch,
     gatewayState,
     locationPathname,
     resumeSession,

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -56,6 +56,7 @@ interface GatewayRegistryState {
   activeKey: string
   secondaries: Map<string, Secondary>
   $gateway: ReturnType<typeof atom<HermesGateway | null>>
+  $gatewayConnectionEpochs: ReturnType<typeof atom<Record<string, number>>>
 }
 
 const STATE_KEY = Symbol.for('hermes.desktop.gatewayRegistryState')
@@ -70,7 +71,11 @@ function createRegistryState(): GatewayRegistryState {
     // The active gateway instance, exposed for inline message-stream
     // components (inline ClarifyTool, model overlays) that call gateway
     // methods without the instance threaded down through props.
-    $gateway: atom<HermesGateway | null>(null)
+    $gateway: atom<HermesGateway | null>(null),
+    // Monotonic connection generation per profile. Unlike $gatewayState, this
+    // cannot collapse a real closed -> connecting -> open cycle into the same
+    // final "open" value before React renders.
+    $gatewayConnectionEpochs: atom<Record<string, number>>({})
   }
 }
 
@@ -85,6 +90,8 @@ function gatewayState(): GatewayRegistryState {
   if (import.meta.hot) {
     const store = globalThis as unknown as { [STATE_KEY]?: GatewayRegistryState }
     store[STATE_KEY] ??= createRegistryState()
+    // Shape migration for a live dev realm created before this field existed.
+    store[STATE_KEY].$gatewayConnectionEpochs ??= atom<Record<string, number>>({})
 
     return store[STATE_KEY]
   }
@@ -98,6 +105,7 @@ const g = gatewayState()
 // reload of this module hands back the SAME atom subscribers are already wired
 // to. (A fresh `atom()` per reload would orphan existing subscriptions.)
 export const $gateway = g.$gateway
+export const $gatewayConnectionEpochs = g.$gatewayConnectionEpochs
 
 export function configureGatewayRegistry(cfg: RegistryConfig): void {
   g.config = cfg
@@ -136,7 +144,17 @@ export function activeGateway(): HermesGateway | null {
 // composer reflect the active profile's socket without a background reconnect
 // flipping the foreground enabled/disabled state.
 function reportGatewayState(profile: string, state: ConnectionState): void {
-  if (normKey(profile) === g.activeKey) {
+  const key = normKey(profile)
+
+  if (state === 'open') {
+    const epochs = g.$gatewayConnectionEpochs.get()
+    g.$gatewayConnectionEpochs.set({
+      ...epochs,
+      [key]: (epochs[key] ?? 0) + 1
+    })
+  }
+
+  if (key === g.activeKey) {
     setGatewayState(state)
   }
 }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10528,6 +10528,45 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
         server._sessions.pop("sid-live", None)
 
 
+def test_session_activate_clears_stale_busy_state_after_prompt_worker_exits(monkeypatch):
+    class _DeadThread:
+        @staticmethod
+        def is_alive():
+            return False
+
+    agent = types.SimpleNamespace(model="model-stale")
+    session = _session(
+        agent=agent,
+        running=True,
+        inflight_turn={
+            "assistant": "stale partial",
+            "status": "streaming",
+            "user": "already completed",
+        },
+    )
+    session["_run_thread"] = _DeadThread()
+    server._sessions["sid-stale"] = session
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_session_info", lambda _agent: {"model": "model-stale"})
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "activate",
+                "method": "session.activate",
+                "params": {"session_id": "sid-stale"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid-stale", None)
+
+    assert resp["result"]["running"] is False
+    assert resp["result"]["status"] == "idle"
+    assert "inflight" not in resp["result"]
+    assert session["running"] is False
+    assert session.get("inflight_turn") is None
+
+
 def test_session_activate_returns_prompt_queued_during_busy_turn(monkeypatch):
     """A full client restart must recover an accepted next-turn prompt.
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7674,6 +7674,35 @@ def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> 
     return in_memory_fallback
 
 
+def _reconcile_finished_run_thread(session: dict) -> bool:
+    """Clear a stale busy projection after its prompt worker has exited.
+
+    A dropped transport must not leave ``running`` and ``inflight_turn`` pinned
+    forever after the worker is already dead.  Reconnect callers use the live
+    payload as their authority, so reconcile that impossible state before
+    returning it.  A missing thread is left untouched because other session
+    paths can briefly set ``running`` before their worker is registered.
+    """
+    if not session.get("running"):
+        return False
+
+    run_thread = session.get("_run_thread")
+    if run_thread is None:
+        return False
+
+    try:
+        alive = run_thread.is_alive()
+    except Exception:
+        return False
+
+    if alive:
+        return False
+
+    session["running"] = False
+    _clear_inflight_turn(session)
+    return True
+
+
 def _live_session_payload(
     sid: str,
     session: dict,
@@ -7683,6 +7712,7 @@ def _live_session_payload(
     transport: Transport | None = None,
 ) -> dict:
     with session["history_lock"]:
+        _reconcile_finished_run_thread(session)
         if cols is not None:
             session["cols"] = cols
         if transport is not None:


### PR DESCRIPTION
## Summary

- publish a monotonic per-profile connection epoch on every real WebSocket open
- reconcile the routed session when that epoch advances even if React batches the state transition
- reuse the current warm-session `session.activate` path to rebind the replacement transport and refresh authoritative messages/running state
- clear an impossible backend `running`/`inflight_turn` projection when its prompt worker has already exited
- authenticate remote readiness probes so OAuth/password-gated legacy backends can reconnect after a desktop restart

## Root cause

If the WebSocket disconnected during a turn, the backend could finish and persist the assistant final while its transport was detached. A fast `closed -> connecting -> open` cycle could be batched so the route hook rendered only the final `open` value and never ran selected-session reconciliation. Desktop could therefore keep showing `Thinking` until the user sent another message.

The affected live session also exposed a dead prompt worker with `running=true`, so an authoritative activation still reproduced the stale busy projection. The gateway now reconciles that impossible state before returning a live payload, while leaving live workers and the brief pre-registration window untouched.

During live installation, current Desktop `main` also found the deployed 0.18.2 remote through `Test remote` but failed bootstrap with `401 no_cookie`: readiness probing used the public/token fetch path instead of the authenticated Electron session. OAuth-gated readiness now uses that session for both `/api/health` and the legacy `/api/status` fallback.

## Tests

- `npm run test:ui -- src/app/session/hooks/use-route-resume.test.tsx src/app/session/hooks/use-session-actions.test.tsx` (49 passed)
- `npm run test:desktop:platforms -- electron/backend-health.test.ts` (7 passed)
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -q -k session_activate` (4 passed)
- `ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run build`

## Live proof

Installed a clean local macOS build from `19656e12c5f4`, started a harmless 10-second response, quit Desktop while it was running, waited for the detached backend to finish, and relaunched. Desktop displayed `HERMES_RECONNECT_RECOVERY_OK` and returned to an idle composer without a rescue message or stale Stop control.
