### PR TITLE
feat(desktop): add option to disable F12 DevTools shortcut

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -227,6 +227,10 @@ const IS_WSL = isWslEnvironment()
 const DARWIN_MAJOR = IS_MAC ? Number.parseInt(os.release(), 10) || 0 : 0
 const APP_ROOT = app.getAppPath()
 
+// Device-local preference: block F12 from opening DevTools.
+// Set dynamically via IPC from the renderer Settings → Advanced.
+let f12Blocked = false
+
 // Preload must be plain JS — Electron's sandbox can't run .ts, and tsx's
 // ESM loader is broken on Electron 40's Node (ERR_INVALID_RETURN_PROPERTY_VALUE).
 // Dev (`npm run dev`) and prod both load the esbuild output from dist/.
@@ -5028,7 +5032,11 @@ function buildApplicationMenu() {
     submenu: [
       { role: 'reload' },
       { role: 'forceReload' },
-      { role: 'toggleDevTools' },
+      {
+        label: 'Toggle Developer Tools',
+        accelerator: process.platform === 'darwin' ? 'Alt+Cmd+I' : 'Ctrl+Shift+I',
+        click: () => toggleDevTools(mainWindow)
+      },
       { type: 'separator' },
       {
         label: 'Actual Size',
@@ -5089,9 +5097,19 @@ function toggleDevTools(window) {
 }
 
 function installDevToolsShortcut(window) {
-  // F12 / Cmd+Opt+I works in both dev and packaged builds.
+  // Only Ctrl+Shift+I (or Cmd+Opt+I on Mac) opens DevTools.
+  // F12 is explicitly blocked so Chromium's built-in handler doesn't open it.
   window.webContents.on('before-input-event', (event, input) => {
     const key = input.key.toLowerCase()
+
+    // F12 opens DevTools by default; block only when the user disabled it.
+    if (input.key === 'F12') {
+      if (f12Blocked) {
+        event.preventDefault()
+        return
+      }
+      // Not blocked — fall through to open DevTools.
+    }
 
     const isInspectShortcut =
       input.key === 'F12' ||
@@ -8869,6 +8887,8 @@ ipcMain.on('hermes:zoom:set-percent', (event, percent) => {
 // content origin so the pet lands where it sat in-window. A remembered/dragged
 // spot passes screen-space bounds (screen=true) and is used as-is. We return the
 // resolved screen bounds so the renderer can persist exactly where it opened.
+ipcMain.on('hermes:devtools:disable-f12', (_event, blocked) => { f12Blocked = blocked })
+
 ipcMain.handle('hermes:pet-overlay:open', async (_event, request) => {
   const bounds = request && request.bounds ? request.bounds : request
   const isScreen = Boolean(request && request.screen)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5035,7 +5035,7 @@ function buildApplicationMenu() {
       {
         label: 'Toggle Developer Tools',
         accelerator: process.platform === 'darwin' ? 'Alt+Cmd+I' : 'Ctrl+Shift+I',
-        click: () => toggleDevTools(mainWindow)
+        click: (_menuItem, browserWindow) => toggleDevTools(browserWindow || mainWindow)
       },
       { type: 'separator' },
       {
@@ -8887,8 +8887,6 @@ ipcMain.on('hermes:zoom:set-percent', (event, percent) => {
 // content origin so the pet lands where it sat in-window. A remembered/dragged
 // spot passes screen-space bounds (screen=true) and is used as-is. We return the
 // resolved screen bounds so the renderer can persist exactly where it opened.
-ipcMain.on('hermes:devtools:disable-f12', (_event, blocked) => { f12Blocked = blocked })
-
 ipcMain.handle('hermes:pet-overlay:open', async (_event, request) => {
   const bounds = request && request.bounds ? request.bounds : request
   const isScreen = Boolean(request && request.screen)
@@ -9845,6 +9843,30 @@ ipcMain.on('hermes:keep-awake', (_event, on) => {
     fs.writeFileSync(KEEP_AWAKE_CONFIG_PATH, JSON.stringify({ on: enabled }, null, 2), 'utf8')
   } catch (error) {
     rememberLog(`[keep-awake] write failed: ${error.message}`)
+  }
+})
+
+// Disable F12 DevTools: maintained in the main process so a cold launch
+// restores it before any window is shown (applied on ready). The renderer
+// toggles it from Settings → Advanced over IPC. See store/disable-f12.
+const DISABLE_F12_CONFIG_PATH = path.join(app.getPath('userData'), 'disable-f12.json')
+
+function readPersistedDisableF12() {
+  try {
+    return JSON.parse(fs.readFileSync(DISABLE_F12_CONFIG_PATH, 'utf8')).on === true
+  } catch {
+    return false
+  }
+}
+
+ipcMain.on('hermes:devtools:disable-f12', (_event, on) => {
+  f12Blocked = Boolean(on)
+
+  try {
+    fs.mkdirSync(path.dirname(DISABLE_F12_CONFIG_PATH), { recursive: true })
+    fs.writeFileSync(DISABLE_F12_CONFIG_PATH, JSON.stringify({ on: f12Blocked }, null, 2), 'utf8')
+  } catch (error) {
+    rememberLog(`[disable-f12] write failed: ${error.message}`)
   }
 })
 
@@ -10864,6 +10886,7 @@ app.whenReady().then(() => {
   configureSpellChecker()
   registerPowerResumeListeners()
   keepAwake.set(readPersistedKeepAwake())
+  f12Blocked = readPersistedDisableF12()
   createWindow()
 
   // Win/Linux cold start: the launching hermes:// URL is in our own argv.

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -83,6 +83,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setNativeTheme: mode => ipcRenderer.send('hermes:native-theme', mode),
   setTranslucency: payload => ipcRenderer.send('hermes:translucency', payload),
   setKeepAwake: on => ipcRenderer.send('hermes:keep-awake', on),
+  setDisableF12: blocked => ipcRenderer.send('hermes:devtools:disable-f12', blocked),
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),
   openPreviewInBrowser: url => ipcRenderer.invoke('hermes:openPreviewInBrowser', url),

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { getElevenLabsVoices, getHermesConfigSchema, saveHermesConfig } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { $keepAwake, setKeepAwake } from '@/store/keep-awake'
+import { $disableF12, setDisableF12 } from '@/store/disable-f12'
 import { notify, notifyError } from '@/store/notifications'
 import { repoDiscoveryPolicyFromConfig, repoDiscoveryPolicySignature, scanAndRecordRepos } from '@/store/projects'
 import type { ConfigFieldSchema, HermesConfigRecord } from '@/types/hermes'
@@ -57,6 +58,7 @@ export function ConfigSettings({
   const { t } = useI18n()
   const c = t.settings.config
   const keepAwake = useStore($keepAwake)
+  const disableF12 = useStore($disableF12)
   // The editable draft is local (debounced autosave watches it), but it's seeded
   // from — and saved back through — the shared config cache, so edits are visible
   // in the MCP/model surfaces and reopening the page doesn't reload-flash.
@@ -291,7 +293,10 @@ export function ConfigSettings({
       {/* Device-local desktop pref (not config.yaml) — lives here since keeping
           the machine awake is a power-user knob. */}
       {activeSectionId === 'advanced' && (
-        <ToggleRow checked={keepAwake} description={c.keepAwakeDesc} label={c.keepAwakeTitle} onChange={setKeepAwake} />
+        <>
+          <ToggleRow checked={keepAwake} description={c.keepAwakeDesc} label={c.keepAwakeTitle} onChange={setKeepAwake} />
+          <ToggleRow checked={disableF12} description={c.disableF12Desc} label={c.disableF12Title} onChange={setDisableF12} />
+        </>
       )}
       {visibleFields.length === 0 ? (
         <EmptyState description={c.emptyDesc} title={c.emptyTitle} />

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -99,6 +99,7 @@ declare global {
       setNativeTheme?: (mode: 'dark' | 'light' | 'system') => void
       setTranslucency?: (payload: { intensity: number }) => void
       setKeepAwake?: (on: boolean) => void
+      setDisableF12?: (blocked: boolean) => void
       setPreviewShortcutActive?: (active: boolean) => void
       openExternal: (url: string) => Promise<void>
       openPreviewInBrowser?: (url: string) => Promise<void>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -541,7 +541,9 @@ export const en: Translations = {
       imported: 'Config imported',
       invalidJson: 'Invalid config JSON',
       keepAwakeTitle: 'Keep computer awake',
-      keepAwakeDesc: 'Stop this machine from sleeping so long or overnight runs keep going. The display can still dim.'
+      keepAwakeDesc: 'Stop this machine from sleeping so long or overnight runs keep going. The display can still dim.',
+      disableF12Title: 'Disable F12 DevTools',
+      disableF12Desc: 'Block F12 from opening Developer Tools. Ctrl+Shift+I (or Cmd+Opt+I on Mac) still works.'
     },
     credentials: {
       pasteKey: 'Paste key',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -448,6 +448,8 @@ export interface Translations {
       invalidJson: string
       keepAwakeTitle: string
       keepAwakeDesc: string
+      disableF12Title: string
+      disableF12Desc: string
     }
     credentials: {
       pasteKey: string

--- a/apps/desktop/src/store/disable-f12.ts
+++ b/apps/desktop/src/store/disable-f12.ts
@@ -1,0 +1,26 @@
+/**
+ * Disable F12 DevTools shortcut — a device-local preference.
+ *
+ * When enabled, F12 is blocked in the main process (before-input-event).
+ * Ctrl+Shift+I (or Cmd+Opt+I on Mac) still works regardless.
+ * Mirrors the toggle to the main process via IPC.
+ */
+
+import { atom } from 'nanostores'
+
+import { persistBoolean, storedBoolean } from '@/lib/storage'
+
+const KEY = 'hermes.desktop.disableF12.v1'
+
+export const $disableF12 = atom<boolean>(typeof window === 'undefined' ? false : storedBoolean(KEY, false))
+
+export function setDisableF12(on: boolean): void {
+  $disableF12.set(on)
+}
+
+if (typeof window !== 'undefined') {
+  $disableF12.subscribe(on => {
+    persistBoolean(KEY, on)
+    window.hermesDesktop?.setDisableF12?.(on)
+  })
+}


### PR DESCRIPTION
## Summary

Adds a toggle in **Settings → Advanced** to disable F12 from opening Developer Tools. `Ctrl+Shift+I` (or `Cmd+Opt+I` on Mac) always works regardless of the toggle state.

## Changes

### `apps/desktop/electron/main.ts`
- Replace built-in menu `{ role: 'toggleDevTools' }` (which had an implicit F12 accelerator) with an explicit menu item using `Ctrl+Shift+I` / `Alt+Cmd+I`
- Add `f12Blocked` flag, controllable via `hermes:devtools:disable-f12` IPC
- F12 opens DevTools by default; when `f12Blocked` is true, `preventDefault()` blocks it

### `apps/desktop/electron/preload.ts`
- Expose `setDisableF12` through `window.hermesDesktop`

### `apps/desktop/src/store/disable-f12.ts` (new)
- Nanostore atom + localStorage persistence + IPC sync (same pattern as `keep-awake`)

### `apps/desktop/src/app/settings/config-settings.tsx`
- Add `ToggleRow` for "Disable F12 DevTools" after "Keep computer awake" in Advanced section

### `apps/desktop/src/global.d.ts`
- Add `setDisableF12` type declaration

### `apps/desktop/src/i18n/en.ts`
- Add i18n labels for the new toggle

## Testing
1. Open Settings → Advanced
2. Toggle "Disable F12 DevTools" on → F12 no longer opens DevTools
3. Toggle off → F12 opens DevTools again
4. `Ctrl+Shift+I` (or `Cmd+Opt+I` on Mac) always works regardless of the toggle