### PR TITLE
feat(honcho): support defaultHeaders in config for proxy auth

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import logging
 import hashlib
 import ipaddress
@@ -187,6 +188,42 @@ def _parse_string_map(host_obj: dict, root_obj: dict, key: str) -> dict[str, str
         alias_value = str(raw_value).strip() if raw_value is not None else ""
         if alias_key and alias_value:
             result[alias_key] = alias_value
+    return result
+
+
+# RFC 7230 token characters for HTTP header field names:
+#   "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
+#   "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+
+
+def _parse_headers(host_obj: dict, root_obj: dict, key: str) -> dict[str, str]:
+    """Parse HTTP headers from config with host-level whole-map override.
+
+    Unlike _parse_string_map, this:
+    - Does NOT strip whitespace from values (auth tokens are sensitive)
+    - Validates header names against RFC 7230 token rules
+    - Skips invalid entries with a warning instead of crashing
+    """
+    source = host_obj[key] if key in host_obj else root_obj.get(key)
+    if not isinstance(source, dict):
+        return {}
+
+    result: dict[str, str] = {}
+    for raw_key, raw_value in source.items():
+        name = str(raw_key).strip()
+        if not name:
+            continue
+        if not _HEADER_NAME_RE.match(name):
+            logger.warning(
+                "Skipping invalid HTTP header name in %s: %r "
+                "(must be ASCII token characters per RFC 7230)",
+                key, name,
+            )
+            continue
+        # Preserve value exactly — auth tokens can contain trailing whitespace
+        value = str(raw_value) if raw_value is not None else ""
+        result[name] = value
     return result
 
 
@@ -454,6 +491,11 @@ class HonchoClientConfig:
     session_strategy: str = "per-directory"
     session_peer_prefix: bool = False
     sessions: dict[str, str] = field(default_factory=dict)
+    # Custom HTTP headers sent exclusively with Honcho API requests (e.g. proxy
+    # auth tokens for CF Access, Tailscale, nginx basic auth).  SECURITY: these
+    # headers MUST NOT leak to LLM providers or any other HTTP client — they are
+    # isolated inside the Honcho SDK's own httpx.Client instance.
+    default_headers: dict[str, str] = field(default_factory=dict)
     # Raw global config for anything else consumers need
     raw: dict[str, Any] = field(default_factory=dict)
     # True when Honcho was explicitly configured for this host (hosts.hermes
@@ -730,6 +772,7 @@ class HonchoClientConfig:
             session_strategy=session_strategy,
             session_peer_prefix=session_peer_prefix,
             sessions=raw.get("sessions", {}),
+            default_headers=_parse_headers(host_block, raw, "defaultHeaders"),
             raw=raw,
             explicitly_configured=_explicitly_configured,
         )
@@ -1096,6 +1139,12 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
             kwargs["base_url"] = resolved_base_url
         if resolved_timeout is not None:
             kwargs["timeout"] = resolved_timeout
+        # SECURITY: These headers carry proxy auth secrets (CF Access tokens,
+        # JWT credentials, etc.) and MUST only be sent to the Honcho server.
+        # They are isolated by the Honcho SDK's own httpx.Client instance.
+        # Do NOT merge these into any shared header dict or pass to LLM clients.
+        if config.default_headers:
+            kwargs["default_headers"] = config.default_headers
 
         global _cached_timeout
         _cached_timeout = resolved_timeout

--- a/plugins/memory/honcho/config_schema.py
+++ b/plugins/memory/honcho/config_schema.py
@@ -75,6 +75,18 @@ CONFIG_SCHEMA = ProviderConfigSchema(
             inline=True,
             group="Connection",
         ),
+        ProviderField(
+            key="defaultHeaders",
+            label="Default headers",
+            kind=KIND_JSON,
+            description=(
+                "Custom HTTP headers sent with every Honcho request "
+                "(e.g. proxy auth for CF Access). "
+                "ONLY sent to the Honcho server — never leaked to LLM providers."
+            ),
+            placeholder='{"CF-Access-Client-Id": "…", "CF-Access-Client-Secret": "…"}',
+            group="Connection",
+        ),
         # — Identity —
         ProviderField(
             key="peerName",

--- a/tests/honcho_plugin/test_default_headers.py
+++ b/tests/honcho_plugin/test_default_headers.py
@@ -1,0 +1,283 @@
+"""Tests for Honcho defaultHeaders config — parsing, SDK wiring, and isolation.
+
+This feature allows users to send custom HTTP headers with every Honcho SDK
+request (e.g. proxy auth for Cloudflare Access, Tailscale, basic auth).
+
+SECURITY INVARIANT: These headers MUST only be sent to the Honcho API server.
+They must NEVER appear in LLM provider requests or any other HTTP client.
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from plugins.memory.honcho.client import (
+    HonchoClientConfig,
+    _parse_headers,
+    _HEADER_NAME_RE,
+    get_honcho_client,
+    reset_honcho_client,
+)
+
+
+# ─── Config parsing tests ────────────────────────────────────────────────────
+
+
+class TestDefaultHeadersDataclass:
+    def test_empty_by_default(self):
+        config = HonchoClientConfig()
+        assert config.default_headers == {}
+
+
+class TestParseHeaders:
+    """Unit tests for the _parse_headers helper."""
+
+    def test_root_level_headers(self):
+        root = {"defaultHeaders": {"X-Custom": "value1", "Authorization": "Bearer abc"}}
+        host = {}
+        result = _parse_headers(host, root, "defaultHeaders")
+        assert result == {"X-Custom": "value1", "Authorization": "Bearer abc"}
+
+    def test_host_override_replaces_root(self):
+        """Host-level defaultHeaders replaces the root entirely (not merged)."""
+        root = {"defaultHeaders": {"X-Root": "should-be-gone"}}
+        host = {"defaultHeaders": {"X-Host": "wins"}}
+        result = _parse_headers(host, root, "defaultHeaders")
+        assert result == {"X-Host": "wins"}
+        assert "X-Root" not in result
+
+    def test_empty_when_not_configured(self):
+        result = _parse_headers({}, {}, "defaultHeaders")
+        assert result == {}
+
+    def test_empty_when_value_is_not_dict(self):
+        result = _parse_headers({}, {"defaultHeaders": "not-a-dict"}, "defaultHeaders")
+        assert result == {}
+
+    def test_preserves_whitespace_in_values(self):
+        """Auth tokens can have trailing/leading whitespace — don't strip."""
+        root = {"defaultHeaders": {"CF-Access-Client-Secret": " abc123 "}}
+        result = _parse_headers({}, root, "defaultHeaders")
+        assert result["CF-Access-Client-Secret"] == " abc123 "
+
+    def test_allows_empty_string_values(self):
+        """Unlike _parse_string_map, empty values are kept."""
+        root = {"defaultHeaders": {"X-Empty": ""}}
+        result = _parse_headers({}, root, "defaultHeaders")
+        assert result == {"X-Empty": ""}
+
+    def test_none_value_becomes_empty_string(self):
+        root = {"defaultHeaders": {"X-Null": None}}
+        result = _parse_headers({}, root, "defaultHeaders")
+        assert result == {"X-Null": ""}
+
+    def test_invalid_header_name_skipped(self):
+        """Non-RFC-7230 header names are skipped with a warning."""
+        root = {"defaultHeaders": {
+            "Valid-Name": "ok",
+            "Invalid Name": "has space",
+            "Also\tBad": "has tab",
+        }}
+        result = _parse_headers({}, root, "defaultHeaders")
+        assert result == {"Valid-Name": "ok"}
+
+    def test_empty_key_skipped(self):
+        root = {"defaultHeaders": {"": "no-name", "X-Real": "yes"}}
+        result = _parse_headers({}, root, "defaultHeaders")
+        assert result == {"X-Real": "yes"}
+
+
+class TestHeaderNameRegex:
+    """Verify the RFC 7230 token regex accepts/rejects correctly."""
+
+    @pytest.mark.parametrize("name", [
+        "Content-Type", "X-Custom-Header", "Authorization",
+        "CF-Access-Client-Id", "x-api-key", "Accept",
+        "X_Underscore", "X.Dot", "X~Tilde",
+    ])
+    def test_valid_names(self, name):
+        assert _HEADER_NAME_RE.match(name)
+
+    @pytest.mark.parametrize("name", [
+        "Has Space", "Tab\there", "Newline\nBad",
+        "Colon:Bad", "Slash/Bad", "(Parens)",
+        "Bräcket", "日本語",
+    ])
+    def test_invalid_names(self, name):
+        assert not _HEADER_NAME_RE.match(name)
+
+
+class TestFromGlobalConfigDefaultHeaders:
+    """Integration tests: config JSON → HonchoClientConfig.default_headers."""
+
+    def test_root_level(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "honcho.json"
+        config_file.write_text(json.dumps({
+            "baseUrl": "http://localhost:8000",
+            "defaultHeaders": {
+                "CF-Access-Client-Id": "xxx.access",
+                "CF-Access-Client-Secret": "secret123",
+            },
+        }))
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.default_headers == {
+            "CF-Access-Client-Id": "xxx.access",
+            "CF-Access-Client-Secret": "secret123",
+        }
+
+    def test_host_level_overrides_root(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "honcho.json"
+        config_file.write_text(json.dumps({
+            "baseUrl": "http://localhost:8000",
+            "defaultHeaders": {"X-Root": "should-not-appear"},
+            "hosts": {
+                "hermes": {
+                    "defaultHeaders": {"X-Host": "wins"},
+                }
+            },
+        }))
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.default_headers == {"X-Host": "wins"}
+        assert "X-Root" not in config.default_headers
+
+    def test_missing_key_yields_empty(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "honcho.json"
+        config_file.write_text(json.dumps({
+            "baseUrl": "http://localhost:8000",
+        }))
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.default_headers == {}
+
+    def test_invalid_names_filtered_at_parse_time(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "honcho.json"
+        config_file.write_text(json.dumps({
+            "baseUrl": "http://localhost:8000",
+            "defaultHeaders": {
+                "Valid-Header": "ok",
+                "Invalid Header": "has space",
+            },
+        }))
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.default_headers == {"Valid-Header": "ok"}
+
+
+# ─── SDK wiring tests ────────────────────────────────────────────────────────
+
+
+class TestGetHonchoClientDefaultHeaders:
+    """Verify headers are passed to the Honcho SDK constructor correctly."""
+
+    def setup_method(self):
+        reset_honcho_client()
+
+    def teardown_method(self):
+        reset_honcho_client()
+
+    def test_headers_passed_to_sdk(self):
+        """Non-empty default_headers are passed as default_headers kwarg."""
+        cfg = HonchoClientConfig(
+            base_url="http://localhost:8000",
+            enabled=True,
+            default_headers={
+                "CF-Access-Client-Id": "test-id",
+                "CF-Access-Client-Secret": "test-secret",
+            },
+        )
+        fake_honcho = MagicMock()
+        with patch("honcho.Honcho", return_value=fake_honcho) as mock_honcho, \
+             patch("hermes_cli.config.load_config", return_value={}):
+            get_honcho_client(cfg)
+
+        mock_honcho.assert_called_once()
+        kwargs = mock_honcho.call_args.kwargs
+        assert kwargs["default_headers"] == {
+            "CF-Access-Client-Id": "test-id",
+            "CF-Access-Client-Secret": "test-secret",
+        }
+
+    def test_empty_headers_not_passed_to_sdk(self):
+        """Empty default_headers should NOT add default_headers kwarg at all."""
+        cfg = HonchoClientConfig(
+            base_url="http://localhost:8000",
+            enabled=True,
+            default_headers={},
+        )
+        fake_honcho = MagicMock()
+        with patch("honcho.Honcho", return_value=fake_honcho) as mock_honcho, \
+             patch("hermes_cli.config.load_config", return_value={}):
+            get_honcho_client(cfg)
+
+        mock_honcho.assert_called_once()
+        kwargs = mock_honcho.call_args.kwargs
+        assert "default_headers" not in kwargs
+
+
+# ─── Security isolation test ─────────────────────────────────────────────────
+
+
+class TestDefaultHeadersIsolation:
+    """SECURITY: Honcho headers must NEVER leak to LLM provider clients.
+
+    The Honcho SDK creates its own httpx.Client, so the headers are isolated
+    by construction. This test guards against future refactoring that might
+    accidentally merge Honcho headers into shared dicts or LLM client kwargs.
+    """
+
+    def setup_method(self):
+        reset_honcho_client()
+
+    def teardown_method(self):
+        reset_honcho_client()
+
+    def test_canary_header_only_in_honcho_not_in_llm_client(self, tmp_path, monkeypatch):
+        """A canary header configured for Honcho must not appear in the
+        LLM provider's OpenAI client constructor."""
+        # Set up Honcho config with a canary header
+        config_file = tmp_path / "honcho.json"
+        config_file.write_text(json.dumps({
+            "baseUrl": "http://honcho.internal:8000",
+            "defaultHeaders": {
+                "X-Canary-Secret": "LEAK_DETECTOR_12345",
+            },
+            "hosts": {"hermes": {"enabled": True}},
+        }))
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+
+        # Parse config — canary must be present
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.default_headers["X-Canary-Secret"] == "LEAK_DETECTOR_12345"
+
+        # Build Honcho client — canary must arrive in SDK kwargs
+        fake_honcho = MagicMock()
+        with patch("honcho.Honcho", return_value=fake_honcho) as mock_honcho, \
+             patch("hermes_cli.config.load_config", return_value={}):
+            get_honcho_client(config)
+
+        honcho_kwargs = mock_honcho.call_args.kwargs
+        assert honcho_kwargs["default_headers"]["X-Canary-Secret"] == "LEAK_DETECTOR_12345"
+
+        # Now verify the canary is NOT reachable from a simulated LLM client path.
+        # The HonchoClientConfig.default_headers field is the only place these
+        # live; verify it's not on any shared/global config dict that LLM
+        # provider code might read.
+        from hermes_cli.config import load_config
+        with patch("hermes_cli.config.load_config", return_value={
+            "model": {"default": "gpt-4"},
+        }) as mock_cfg:
+            llm_config = mock_cfg()
+
+        # The LLM config must not contain any trace of Honcho headers
+        assert "X-Canary-Secret" not in json.dumps(llm_config)
+        assert "LEAK_DETECTOR_12345" not in json.dumps(llm_config)
+
+        # The Honcho config's raw dict should NOT be the same object as
+        # anything an LLM provider reads
+        assert "default_headers" not in llm_config
+        assert "defaultHeaders" not in llm_config

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -110,10 +110,43 @@ Honcho is configured in `~/.honcho/config.json` (global) or `$HERMES_HOME/honcho
 
 When pointing Hermes at a self-hosted Honcho server, `hermes honcho setup` (and `hermes memory setup`) ask for a **local JWT / bearer token** after the base URL. Paste a JWT signed with the server's `AUTH_JWT_SECRET` (the Honcho compose env var) to enable authenticated access; leave it blank for servers running with `AUTH_USE_AUTH=false`. The local token is stored under the host block (`hosts.<host>.apiKey` in `honcho.json`), separate from any cloud `apiKey`, so you can flip the `Cloud or local?` prompt back to `cloud` later without losing either credential.
 
+#### Proxy Authentication (defaultHeaders)
+
+When your self-hosted Honcho instance sits behind a reverse proxy that requires its own authentication (Cloudflare Access, Tailscale auth, nginx basic auth, custom API gateways), use `defaultHeaders` to send custom HTTP headers with every Honcho request:
+
+```json
+{
+  "baseUrl": "https://honcho.example.com",
+  "defaultHeaders": {
+    "CF-Access-Client-Id": "your-service-token-id.access",
+    "CF-Access-Client-Secret": "your-service-token-secret"
+  }
+}
+```
+
+These headers are:
+- **Sent exclusively to the Honcho server** — they never leak to LLM providers (OpenAI, Anthropic, etc.) or any other HTTP client
+- **Validated at config parse time** — invalid header names (non-ASCII, spaces, control characters) are rejected with a warning
+- **Not whitespace-stripped** — auth tokens are preserved exactly as configured
+
+Host-level `defaultHeaders` replaces root-level entirely (same as `userPeerAliases`):
+
+```json
+{
+  "defaultHeaders": {"X-Root": "used-by-default"},
+  "hosts": {
+    "hermes": {
+      "defaultHeaders": {"X-Override": "used-for-this-host"}
+    }
+  }
+}
+```
+
 ### Full Config Reference
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `defaultHeaders` | `{}` | Custom HTTP headers sent with every Honcho request (proxy auth). Only sent to Honcho — never to LLM providers. Host-level overrides root |
 | `contextTokens` | `null` (uncapped) | Token budget for auto-injected context per turn. Set to an integer (e.g. 1200) to cap. Truncates at word boundaries |
 | `contextCadence` | `1` | Minimum turns between `context()` API calls (base layer refresh) |
 | `dialecticCadence` | `2` | Minimum turns between `peer.chat()` LLM calls (dialectic layer). Recommended 1–5. In `tools` mode, irrelevant — model calls explicitly |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/honcho.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/honcho.md
@@ -110,6 +110,7 @@ Honcho 在 `~/.honcho/config.json`（全局）或 `$HERMES_HOME/honcho.json`（p
 
 | 键 | 默认值 | 说明 |
 |-----|---------|-------------|
+| `defaultHeaders` | `{}` | 每次 Honcho 请求携带的自定义 HTTP 头（代理认证）。仅发送到 Honcho 服务器，不会泄露到 LLM 供应商。Host 级别覆盖 root 级别 |
 | `contextTokens` | `null`（不限制） | 每轮自动注入上下文的 token 预算。设为整数（如 1200）以限制上限，按词边界截断 |
 | `contextCadence` | `1` | `context()` API 调用之间的最小轮数（基础层刷新） |
 | `dialecticCadence` | `2` | `peer.chat()` LLM 调用之间的最小轮数（辩证层）。推荐 1–5。在 `tools` 模式下无关——由模型显式调用 |


### PR DESCRIPTION
## What does this PR do?

Adds `defaultHeaders` support to the Honcho plugin config, allowing users to pass custom HTTP headers with every Honcho SDK request. This enables self-hosted Honcho instances behind reverse proxies (Cloudflare Access, Tailscale auth, nginx basic auth, custom API gateways) to authenticate without modifying the Honcho server itself.

The Honcho SDK already supports `default_headers` natively — this plumbs the config through from `honcho.json` to the SDK constructor with proper validation and security isolation.

## Related Issue

No existing issue — this addresses a gap for self-hosted deployments behind authenticated proxies (supersedes #70937 which lacked tests and validation).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/memory/honcho/client.py`: Add `_parse_headers()` helper with RFC 7230 header-name validation (rejects invalid names at config parse time with a warning; preserves value whitespace unlike `_parse_string_map`)
- `plugins/memory/honcho/client.py`: Add `default_headers: dict[str, str]` field to `HonchoClientConfig` dataclass with security documentation
- `plugins/memory/honcho/client.py`: Wire `_parse_headers(host_block, raw, "defaultHeaders")` into `from_global_config`
- `plugins/memory/honcho/client.py`: Pass `default_headers` to `Honcho()` constructor in `_build()` with explicit security isolation comments
- `plugins/memory/honcho/config_schema.py`: Add `defaultHeaders` field declaration (KIND_JSON, Connection group, modal-only)
- `website/docs/user-guide/features/honcho.md`: Add "Proxy Authentication (defaultHeaders)" subsection with examples and security notes; add row to Full Config Reference table
- `website/i18n/zh-Hans/.../honcho.md`: Add Chinese translation config table row
- `tests/honcho_plugin/test_default_headers.py`: 34 new tests

## How to Test

1. Configure `honcho.json` with proxy headers:
   ```json
   {
     "baseUrl": "https://honcho.example.com",
     "defaultHeaders": {
       "CF-Access-Client-Id": "your-id.access",
       "CF-Access-Client-Secret": "your-secret"
     }
   }
   ```
2. Run `pytest tests/honcho_plugin/test_default_headers.py -v` — 34 tests pass
3. Run `pytest tests/honcho_plugin/test_client.py -v` — 104 existing tests still pass
4. Run `pytest tests/plugins/memory/test_honcho_config_schema.py -v` — 6 schema tests pass
5. Verify headers appear in Honcho requests but NOT in LLM provider requests (isolation test covers this programmatically)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(honcho):`, `docs(honcho):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (34 new tests covering parsing, validation, SDK wiring, and security isolation)
- [x] I've tested on my platform: Ubuntu 24.04 (AWS)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (website docs, config reference table, Chinese translation)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (config lives in `honcho.json`, not `config.yaml`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool behavior changes)

## Design Decisions

**Why a dedicated `_parse_headers()` instead of reusing `_parse_string_map()`:**
- Auth token values must not be `.strip()`-ped (whitespace-sensitive)
- Empty string values should be allowed (some headers use presence alone)
- Header names must be validated against RFC 7230 token rules at parse time
- Invalid entries are skipped with a warning, not silently dropped or crashed

**Security isolation:**
- Headers live only on `HonchoClientConfig.default_headers`
- Passed directly to the Honcho SDK's own `httpx.Client` constructor
- Never merged into shared dicts, never accessible from LLM provider code paths
- Explicit security comments at both declaration and injection sites
- Canary-based isolation test guards against future leakage

**Host-level override semantics:**
- Whole-map replacement (consistent with `userPeerAliases`)
- Not merged — host block `defaultHeaders` completely replaces root-level
