### PR TITLE
fix(homeassistant): make group management proposal-safe

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5749,6 +5749,7 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "multiplex_profiles",    # top-level form accepted alongside gateway.multiplex_profiles
     "profile_routes",        # top-level form accepted alongside gateway.profile_routes
     "platforms",             # top-level per-platform map merged by gateway/config.py
+    "homeassistant",         # action policy + native config-management settings
     "require_mention",       # top-level convenience form honored by the gateway (#3979)
     "unauthorized_dm_behavior",  # top-level form read by gateway/config.py
     "signal",            # Signal settings bridged to env vars by gateway/config.py

--- a/tests/fakes/fake_ha_server.py
+++ b/tests/fakes/fake_ha_server.py
@@ -89,6 +89,8 @@ class FakeHAServer:
         # Observability -- tests inspect these after exercising the adapter.
         self.received_service_calls: List[Dict[str, Any]] = []
         self.received_notifications: List[Dict[str, Any]] = []
+        self.automation_configs = {"morning": {"id": "morning", "alias": "Morning"}}
+        self.helpers = {"timer": {"tea": {"id": "tea", "name": "Tea", "duration": "00:05:00"}}}
 
         # Control -- tests push events, server forwards them over WS.
         self._event_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
@@ -148,6 +150,13 @@ class FakeHAServer:
         app.router.add_get("/api/websocket", self._handle_ws)
         app.router.add_get("/api/states", self._handle_get_states)
         app.router.add_get("/api/states/{entity_id}", self._handle_get_state)
+        app.router.add_get("/api/config", self._handle_get_config)
+        app.router.add_get(
+            "/api/config/{resource_type}/config/{resource_id}", self._handle_get_resource
+        )
+        app.router.add_post(
+            "/api/config/{resource_type}/config/{resource_id}", self._handle_post_resource
+        )
         # Notification endpoint must be registered before the generic service
         # route so that it takes priority.
         app.router.add_post(
@@ -204,6 +213,14 @@ class FakeHAServer:
         sub_msg = json.loads(msg.data)
         sub_id = sub_msg.get("id", 1)
 
+        if sub_msg.get("type") != "subscribe_events":
+            result = self._handle_ws_command(sub_msg)
+            await ws.send_json({
+                "id": sub_id, "type": "result", "success": True, "result": result,
+            })
+            await ws.close()
+            return ws
+
         # Step 5: ACK
         await ws.send_json({
             "id": sub_id,
@@ -231,6 +248,23 @@ class FakeHAServer:
 
         return ws
 
+    def _handle_ws_command(self, msg: Dict[str, Any]) -> Any:
+        command = msg.get("type", "")
+        if command == "config/entity_registry/list":
+            return [
+                {"entity_id": "automation.morning", "platform": "automation", "unique_id": "morning"}
+            ]
+        if command.endswith("/list"):
+            domain = command.split("/", 1)[0]
+            return list(self.helpers.get(domain, {}).values())
+        if command.endswith("/update"):
+            domain = command.split("/", 1)[0]
+            item_id = msg[f"{domain}_id"]
+            updates = {key: value for key, value in msg.items() if key not in {"id", "type", f"{domain}_id"}}
+            self.helpers[domain][item_id].update(updates)
+            return self.helpers[domain][item_id]
+        return None
+
     # -- REST handlers ---------------------------------------------------------
 
     async def _handle_get_states(self, request: web.Request) -> web.Response:
@@ -238,6 +272,32 @@ class FakeHAServer:
         if err:
             return err
         return web.json_response(ENTITY_STATES)
+
+    async def _handle_get_config(self, request: web.Request) -> web.Response:
+        err = self._check_rest_auth(request)
+        if err:
+            return err
+        return web.json_response({"version": "2026.7.0", "components": ["automation", "timer"]})
+
+    async def _handle_get_resource(self, request: web.Request) -> web.Response:
+        err = self._check_rest_auth(request)
+        if err:
+            return err
+        if request.match_info["resource_type"] != "automation":
+            return web.Response(status=404)
+        item = self.automation_configs.get(request.match_info["resource_id"])
+        return web.json_response(item) if item else web.Response(status=404)
+
+    async def _handle_post_resource(self, request: web.Request) -> web.Response:
+        err = self._check_rest_auth(request)
+        if err:
+            return err
+        if request.match_info["resource_type"] != "automation":
+            return web.Response(status=404)
+        body = await request.json()
+        resource_id = request.match_info["resource_id"]
+        self.automation_configs[resource_id] = {"id": resource_id, **body}
+        return web.json_response({"result": "ok"})
 
     async def _handle_get_state(self, request: web.Request) -> web.Response:
         err = self._check_rest_auth(request)

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -242,6 +242,33 @@ class TestUnknownTopLevelKeys:
         assert _EXTRA_KNOWN_ROOT_KEYS.issubset(_KNOWN_ROOT_KEYS)
         assert _KNOWN_ROOT_KEYS == frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 
+    def test_hermes_written_roots_not_flagged_as_unknown(self):
+        """Roots Hermes itself writes/reads must not warn as unknown (#67397)."""
+        issues = validate_config_structure({
+            "model": {"provider": "openrouter"},
+            "homeassistant": {
+                "action_policy": {"mode": "safe", "trusted_entities": []},
+                "config_management": {"enabled": True},
+            },
+            "known_plugin_toolsets": {"cli": ["spotify"]},
+            "group_sessions_per_user": True,
+            "thread_sessions_per_user": False,
+            "stt_echo_transcripts": True,
+            "reset_triggers": ["/new"],
+            "always_log_local": True,
+            "filter_silence_narration": True,
+        })
+        unknown = [i for i in issues if "Unknown top-level config key" in i.message]
+        messages = " ".join(i.message for i in unknown)
+        assert "homeassistant" not in messages
+        assert "known_plugin_toolsets" not in messages
+        assert "group_sessions_per_user" not in messages
+        assert "thread_sessions_per_user" not in messages
+        assert "stt_echo_transcripts" not in messages
+        assert "reset_triggers" not in messages
+        assert "always_log_local" not in messages
+        assert "filter_silence_narration" not in messages
+
     def test_provider_like_unknown_root_keeps_misplaced_message(self):
         """Preserve existing base_url/api_key root-level guidance."""
         issues = validate_config_structure({

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -216,6 +216,16 @@ def test_get_platform_tools_homeassistant_toolset_enabled_for_cron_when_hass_tok
     assert "homeassistant" in cli_enabled
 
 
+def test_get_platform_tools_homeassistant_toolset_enabled_for_configured_telegram(monkeypatch):
+    """Configured Telegram keeps every registered HA tool when credentials exist."""
+    monkeypatch.setenv("HASS_TOKEN", "fake-test-token")
+    config = {"platform_toolsets": {"telegram": ["hermes-telegram"]}}
+
+    enabled = _get_platform_tools(config, "telegram")
+
+    assert "homeassistant" in enabled
+
+
 def test_get_platform_tools_homeassistant_toolset_off_for_cron_when_hass_token_missing(monkeypatch):
     """Without HASS_TOKEN, HA stays off by default — preserves #14798's behavior
     for users who never configured HA."""

--- a/tests/integration/test_ha_integration.py
+++ b/tests/integration/test_ha_integration.py
@@ -23,6 +23,8 @@ from tools.homeassistant_tool import (
     _async_get_state,
     _async_list_entities,
 )
+from tools.homeassistant_client import HomeAssistantClient
+from tools.homeassistant_config import HomeAssistantResources
 
 
 # ---------------------------------------------------------------------------
@@ -71,7 +73,7 @@ class TestGatewayWebSocket:
     async def test_event_received_and_forwarded(self):
         """Server pushes event -> adapter calls handle_message with correct MessageEvent."""
         async with FakeHAServer() as server:
-            adapter = _adapter_for(server)
+            adapter = _adapter_for(server, watch_all=True)
             adapter.handle_message = AsyncMock()
 
             await adapter.connect()
@@ -260,6 +262,38 @@ class TestToolRest:
             assert call["service"] == "turn_on"
             assert call["data"]["entity_id"] == "light.bedroom"
             assert call["data"]["brightness"] == 255
+
+
+class TestNativeConfigAPI:
+    @pytest.mark.asyncio
+    async def test_capabilities_and_automation_round_trip(self):
+        async with FakeHAServer() as server:
+            resources = HomeAssistantResources(HomeAssistantClient(server.url, server.token))
+
+            capabilities = await resources.capabilities()
+            before = await resources.get("automation", "morning")
+            after = await resources.apply(
+                "automation", "morning", "update", {"alias": "Early Morning"}
+            )
+            persisted = await resources.get("automation", "morning")
+
+            assert capabilities["home_assistant_version"] == "2026.7.0"
+            assert before["alias"] == "Morning"
+            assert after == {"alias": "Early Morning"}
+            assert persisted["alias"] == "Early Morning"
+
+    @pytest.mark.asyncio
+    async def test_timer_websocket_round_trip(self):
+        async with FakeHAServer() as server:
+            resources = HomeAssistantResources(HomeAssistantClient(server.url, server.token))
+
+            before = await resources.get("timer", "tea")
+            after = await resources.apply(
+                "timer", "tea", "update", {"name": "Tea timer", "duration": "00:06:00"}
+            )
+
+            assert before["duration"] == "00:05:00"
+            assert after["duration"] == "00:06:00"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_homeassistant_config.py
+++ b/tests/tools/test_homeassistant_config.py
@@ -1,0 +1,616 @@
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools.homeassistant_client import HomeAssistantClient, HomeAssistantClientError
+from tools.homeassistant_config import HomeAssistantResources
+
+
+def test_client_rejects_unsafe_or_credentialed_base_urls():
+    for url in (
+        "file:///tmp/ha",
+        "http://user:pass@ha.local:8123",
+        "http://ha.local:8123/api?token=secret",
+        "http://ha.local:8123/#fragment",
+    ):
+        with pytest.raises(ValueError):
+            HomeAssistantClient(url, "token")
+
+
+def test_client_requires_token():
+    with pytest.raises(ValueError, match="token"):
+        HomeAssistantClient("http://ha.local:8123", "")
+
+
+@pytest.mark.asyncio
+async def test_resource_capabilities_are_explicit_and_bounded():
+    client = MagicMock()
+    client.rest = AsyncMock(
+        return_value={"version": "2026.7.0", "components": ["automation", "timer"]}
+    )
+    resources = HomeAssistantResources(client)
+
+    capabilities = await resources.capabilities()
+
+    assert capabilities["home_assistant_version"] == "2026.7.0"
+    assert capabilities["mutable"]["automation"] == ["create", "update"]
+    assert capabilities["mutable"]["timer"] == ["create", "update"]
+    assert "input_boolean" in capabilities["unavailable"]
+    assert capabilities["mutable"]["entity"] == ["update"]
+    assert "dashboard" in capabilities["excluded"]
+    assert "integration" in capabilities["excluded"]
+
+
+@pytest.mark.asyncio
+async def test_rest_resource_get_and_apply_use_official_config_endpoint():
+    client = MagicMock()
+    client.rest = AsyncMock(side_effect=[{"alias": "Old"}, {"result": "ok"}])
+    resources = HomeAssistantResources(client)
+
+    current = await resources.get("automation", "morning")
+    result = await resources.apply("automation", "morning", "update", {"alias": "New"})
+
+    assert current == {"alias": "Old"}
+    assert result == {"alias": "New"}
+    assert client.rest.await_args_list[0].args == ("GET", "/api/config/automation/config/morning")
+    assert client.rest.await_args_list[1].args == (
+        "POST", "/api/config/automation/config/morning", {"alias": "New"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_helper_uses_websocket_collection_commands():
+    client = MagicMock()
+    client.websocket = AsyncMock(
+        side_effect=[
+            [{"id": "tea", "name": "Tea"}],
+            {"id": "tea", "name": "Tea timer"},
+        ]
+    )
+    resources = HomeAssistantResources(client)
+
+    assert await resources.get("timer", "tea") == {"id": "tea", "name": "Tea"}
+    result = await resources.apply("timer", "tea", "update", {"name": "Tea timer"})
+
+    assert result == {"id": "tea", "name": "Tea timer"}
+    assert client.websocket.await_args_list[0].args == ({"type": "timer/list"},)
+    assert client.websocket.await_args_list[1].args == (
+        {"type": "timer/update", "timer_id": "tea", "name": "Tea timer"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_rollback_only_deletes_a_resource_hermes_created():
+    client = MagicMock()
+    client.websocket = AsyncMock(return_value=None)
+    resources = HomeAssistantResources(client)
+
+    with pytest.raises(ValueError, match="authoritative.*ownership"):
+        await resources.rollback(
+            {"resource_type": "timer", "resource_id": "tea", "operation": "create",
+             "before": None, "created_by_hermes": False}
+        )
+
+    await resources.rollback(
+        {"resource_type": "timer", "resource_id": "tea", "operation": "create",
+         "before": None, "created_by_hermes": True, "authoritative_id": True}
+    )
+    client.websocket.assert_awaited_once_with({"type": "timer/delete", "timer_id": "tea"})
+
+
+@pytest.mark.asyncio
+async def test_created_resource_without_authoritative_id_cannot_be_deleted():
+    resources = HomeAssistantResources(MagicMock())
+    with pytest.raises(ValueError, match="authoritative.*ownership"):
+        await resources.rollback({
+            "resource_type": "area", "resource_id": "guest_room", "operation": "create",
+            "before": None, "created_by_hermes": True, "authoritative_id": False,
+        })
+
+
+@pytest.mark.asyncio
+async def test_helper_rollback_strips_response_only_fields():
+    client = MagicMock()
+    client.websocket = AsyncMock(return_value={"id": "tea", "name": "Tea"})
+    resources = HomeAssistantResources(client)
+
+    await resources.rollback({
+        "resource_type": "timer", "resource_id": "tea", "operation": "update",
+        "before": {"id": "tea", "entity_id": "timer.tea", "editable": True,
+                   "name": "Tea", "duration": "00:05:00"},
+    })
+
+    client.websocket.assert_awaited_once_with({
+        "type": "timer/update", "timer_id": "tea", "name": "Tea",
+        "duration": "00:05:00",
+    })
+
+
+@pytest.mark.asyncio
+async def test_registry_update_rejects_immutable_only_definition():
+    resources = HomeAssistantResources(MagicMock())
+    with pytest.raises(ValueError, match="no mutable fields"):
+        await resources.apply(
+            "entity", "light.kitchen", "update",
+            {"entity_id": "light.renamed", "unique_id": "immutable"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_unknown_resource_type_fails_closed():
+    resources = HomeAssistantResources(MagicMock())
+    with pytest.raises(ValueError, match="unsupported"):
+        await resources.get("dashboard", "lovelace")
+
+
+@pytest.mark.asyncio
+async def test_resource_id_cannot_escape_config_endpoint():
+    client = MagicMock()
+    resources = HomeAssistantResources(client)
+    with pytest.raises(ValueError, match="invalid.*resource_id"):
+        await resources.apply(
+            "automation", "../../services/persistent_notification/create", "update",
+            {"alias": "Nope"},
+        )
+    client.rest.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resource_id", [".", ".."])
+async def test_resource_id_rejects_dot_segments(resource_id):
+    resources = HomeAssistantResources(MagicMock())
+    with pytest.raises(ValueError, match="invalid.*resource_id"):
+        await resources.get("automation", resource_id)
+
+
+@pytest.mark.asyncio
+async def test_group_create_uses_config_entry_flow():
+    client = MagicMock()
+    client.rest = AsyncMock(side_effect=[
+        {"flow_id": "flow-1", "type": "menu"},
+        {"flow_id": "flow-1", "type": "form"},
+        {"type": "create_entry", "result": {"entry_id": "entry-1", "domain": "group"}},
+    ])
+    resources = HomeAssistantResources(client)
+
+    result = await resources.apply(
+        "group", "downstairs", "create",
+        {"group_type": "light", "name": "Downstairs", "entities": ["light.kitchen"],
+         "hide_members": False, "all": False},
+    )
+
+    assert result["entry_id"] == "entry-1"
+    assert client.rest.await_args_list[0].args == (
+        "POST", "/api/config/config_entries/flow",
+        {"handler": "group", "show_advanced_options": False},
+    )
+    assert client.rest.await_args_list[1].args[-1] == {"next_step_id": "light"}
+
+
+@pytest.mark.asyncio
+async def test_group_create_rejects_incomplete_config_flow():
+    client = MagicMock()
+    client.rest = AsyncMock(side_effect=[
+        {"flow_id": "flow-1", "type": "menu"},
+        {"flow_id": "flow-1", "type": "form"},
+        {
+            "flow_id": "flow-1",
+            "type": "form",
+            "errors": {"base": "invalid_group"},
+        },
+    ])
+    resources = HomeAssistantResources(client)
+
+    with pytest.raises(ValueError, match="did not complete"):
+        await resources.apply(
+            "group",
+            "downstairs",
+            "create",
+            {
+                "group_type": "light",
+                "name": "Downstairs",
+                "entities": ["light.kitchen"],
+                "hide_members": False,
+                "all": False,
+            },
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "definition,error",
+    [
+        (
+            {
+                "group_type": "light",
+                "name": "Downstairs",
+                "entities": ["light.kitchen"],
+                "hide_members": False,
+            },
+            "missing required",
+        ),
+        (
+            {
+                "group_type": "not_a_group_type",
+                "name": "Downstairs",
+                "entities": ["light.kitchen"],
+                "hide_members": False,
+                "all": False,
+            },
+            "unsupported group_type",
+        ),
+        (
+            {
+                "group_type": "light",
+                "name": "Downstairs",
+                "entities": [],
+                "hide_members": False,
+                "all": False,
+            },
+            "non-empty entities",
+        ),
+    ],
+)
+async def test_group_create_validates_complete_definition(definition, error):
+    client = MagicMock()
+    resources = HomeAssistantResources(client)
+
+    with pytest.raises(ValueError, match=error):
+        await resources.apply("group", "downstairs", "create", definition)
+
+    client.rest.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_group_update_rejects_incomplete_options_flow():
+    client = MagicMock()
+    client.rest = AsyncMock(side_effect=[
+        {"flow_id": "options-1", "type": "form"},
+        {
+            "flow_id": "options-1",
+            "type": "form",
+            "errors": {"base": "invalid_group"},
+        },
+    ])
+    resources = HomeAssistantResources(client)
+
+    with pytest.raises(ValueError, match="did not complete"):
+        await resources.apply(
+            "group",
+            "entry-1",
+            "update",
+            {
+                "name": "Downstairs",
+                "entities": ["light.kitchen"],
+                "hide_members": False,
+                "all": False,
+            },
+        )
+
+    client.websocket.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_group_update_rejects_unapplied_group_type_change():
+    client = MagicMock()
+    resources = HomeAssistantResources(client)
+
+    with pytest.raises(ValueError, match="cannot change group_type"):
+        await resources.apply(
+            "group",
+            "entry-1",
+            "update",
+            {
+                "group_type": "switch",
+                "name": "Downstairs",
+                "entities": ["switch.kitchen"],
+                "hide_members": False,
+                "all": False,
+            },
+        )
+
+    client.rest.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_group_get_snapshots_editable_options_and_aborts_flow():
+    client = MagicMock()
+    client.websocket = AsyncMock(return_value=[
+        {"entry_id": "entry-1", "domain": "group", "title": "Downstairs"}
+    ])
+    client.rest = AsyncMock(side_effect=[
+        {
+            "flow_id": "options-1",
+            "data_schema": [
+                {"name": "entities", "default": ["light.kitchen"]},
+                {"name": "hide_members", "default": False},
+                {"name": "all", "default": True},
+            ],
+        },
+        None,
+    ])
+    resources = HomeAssistantResources(client)
+
+    result = await resources.get("group", "entry-1")
+
+    assert result == {
+        "entry_id": "entry-1", "name": "Downstairs",
+        "entities": ["light.kitchen"], "hide_members": False, "all": True,
+    }
+    assert client.rest.await_args_list[-1].args == (
+        "DELETE", "/api/config/config_entries/options/flow/options-1"
+    )
+
+
+def test_generated_area_id_is_used_for_audit_and_rollback_target():
+    from tools.homeassistant_config_tool import _resource_id_from_result
+
+    assert _resource_id_from_result(
+        "area", {"area_id": "01JAREA"}, "requested-name"
+    ) == "01JAREA"
+
+
+def test_preview_apply_and_rollback_handlers_enforce_strict_approval(tmp_path):
+    from tools import homeassistant_config_tool as tool
+    from tools.homeassistant_store import HomeAssistantChangeStore
+
+    manager = MagicMock()
+    manager.get = AsyncMock(
+        side_effect=[
+            {"alias": "Old"}, {"alias": "Old"},
+            {"alias": "New"}, {"alias": "New"},
+        ]
+    )
+    manager.apply = AsyncMock(return_value={"alias": "New"})
+    manager.rollback = AsyncMock(return_value={"alias": "Old"})
+    store = HomeAssistantChangeStore(tmp_path / "changes.sqlite3")
+
+    with (
+        patch.object(tool, "_get_runtime", return_value=(manager, store, 900)),
+        patch.object(
+            tool, "request_tool_approval", return_value={"approved": True, "message": None}
+        ) as approval,
+    ):
+        preview = json.loads(tool._handle_manage({
+            "action": "preview", "resource_type": "automation", "resource_id": "morning",
+            "operation": "update", "definition": {"alias": "New"},
+        }))["result"]
+        applied = json.loads(tool._handle_manage({
+            "action": "apply", "proposal_id": preview["proposal_id"]
+        }))["result"]
+        rolled_back = json.loads(tool._handle_manage({
+            "action": "rollback", "change_id": applied["change_id"]
+        }))["result"]
+
+    assert applied["status"] == "applied"
+    assert rolled_back["status"] == "rolled_back"
+    assert approval.call_count == 2
+    for call in approval.call_args_list:
+        assert call.kwargs["allow_yolo"] is False
+        assert call.kwargs["allow_headless"] is False
+        assert call.kwargs["allow_permanent"] is False
+
+
+@pytest.mark.parametrize("approval_result", [
+    {"approved": False, "message": "denied"},
+    {"approved": False, "message": "approval_required", "approval_id": "pending-1"},
+])
+def test_denied_or_deferred_apply_never_mutates_home_assistant(
+    tmp_path, approval_result
+):
+    from tools import homeassistant_config_tool as tool
+    from tools.homeassistant_store import HomeAssistantChangeStore
+
+    manager = MagicMock()
+    manager.get = AsyncMock(return_value={"alias": "Old"})
+    manager.apply = AsyncMock()
+    store = HomeAssistantChangeStore(tmp_path / "changes.sqlite3")
+    proposal = store.create_proposal(
+        resource_type="automation", resource_id="morning", operation="update",
+        before={"alias": "Old"}, desired={"alias": "New"},
+    )
+
+    with (
+        patch.object(tool, "_get_runtime", return_value=(manager, store, 900)),
+        patch.object(tool, "request_tool_approval", return_value=approval_result),
+    ):
+        result = json.loads(tool._handle_manage({
+            "action": "apply", "proposal_id": proposal["id"],
+        }))
+
+    assert result["error"] == approval_result["message"]
+    manager.get.assert_not_called()
+    manager.apply.assert_not_called()
+    assert store.get_proposal(proposal["id"])["status"] == "pending"
+
+
+def test_denied_rollback_never_mutates_home_assistant(tmp_path):
+    from tools import homeassistant_config_tool as tool
+    from tools.homeassistant_store import HomeAssistantChangeStore
+
+    manager = MagicMock()
+    manager.get = AsyncMock()
+    manager.rollback = AsyncMock()
+    store = HomeAssistantChangeStore(tmp_path / "changes.sqlite3")
+    proposal = store.create_proposal(
+        resource_type="automation", resource_id="morning", operation="update",
+        before={"alias": "Old"}, desired={"alias": "New"},
+    )
+    store.claim_proposal(proposal["id"], proposal["before_fingerprint"])
+    change = store.record_applied(
+        proposal["id"], after={"alias": "New"}, created_by_hermes=False,
+    )
+
+    with (
+        patch.object(tool, "_get_runtime", return_value=(manager, store, 900)),
+        patch.object(
+            tool, "request_tool_approval",
+            return_value={"approved": False, "message": "denied"},
+        ),
+    ):
+        result = json.loads(tool._handle_manage({
+            "action": "rollback", "change_id": change["id"],
+        }))
+
+    assert result["error"] == "denied"
+    manager.get.assert_not_called()
+    manager.rollback.assert_not_called()
+    assert store.get_change(change["id"])["status"] == "applied"
+
+
+def test_interrupted_apply_is_audited_and_reconciled_from_remote_state(tmp_path):
+    from tools import homeassistant_config_tool as tool
+    from tools.homeassistant_store import HomeAssistantChangeStore
+
+    manager = MagicMock()
+    manager.get = AsyncMock(side_effect=[{"alias": "Old"}, {"alias": "New"}])
+    manager.apply = AsyncMock(side_effect=RuntimeError("response lost"))
+    store = HomeAssistantChangeStore(tmp_path / "changes.sqlite3")
+    proposal = store.create_proposal(
+        resource_type="automation", resource_id="morning", operation="update",
+        before={"alias": "Old"}, desired={"alias": "New"},
+    )
+
+    with (
+        patch.object(tool, "_get_runtime", return_value=(manager, store, 900)),
+        patch.object(
+            tool, "request_tool_approval",
+            return_value={"approved": True, "message": None},
+        ),
+    ):
+        failed = json.loads(tool._handle_manage({
+            "action": "apply", "proposal_id": proposal["id"],
+        }))
+        history = json.loads(tool._handle_inspect({"action": "history"}))["result"]
+
+    assert "response lost" in failed["error"]
+    assert history["reconciliation"][0]["status"] == "applied"
+    assert history["changes"][0]["status"] == "applied"
+    assert history["changes"][0]["before"] == {"alias": "Old"}
+    assert history["changes"][0]["after"] == {"alias": "New"}
+
+
+def test_response_lost_during_create_never_infers_deletion_ownership(tmp_path):
+    from tools import homeassistant_config_tool as tool
+    from tools.homeassistant_store import HomeAssistantChangeStore
+
+    manager = MagicMock()
+    manager.get = AsyncMock(side_effect=[None, None])
+    manager.apply = AsyncMock(side_effect=RuntimeError("response lost"))
+    store = HomeAssistantChangeStore(tmp_path / "changes.sqlite3")
+    proposal = store.create_proposal(
+        resource_type="area", resource_id="guest_room", operation="create",
+        before=None, desired={"name": "Guest room"},
+    )
+    with (
+        patch.object(tool, "_get_runtime", return_value=(manager, store, 900)),
+        patch.object(
+            tool, "request_tool_approval",
+            return_value={"approved": True, "message": None},
+        ),
+    ):
+        tool._handle_manage({"action": "apply", "proposal_id": proposal["id"]})
+        history = json.loads(tool._handle_inspect({"action": "history"}))["result"]
+
+    assert history["reconciliation"][0]["status"] == "manual_review"
+    change = history["changes"][0]
+    assert change["status"] == "apply_uncertain"
+    assert change["authoritative_id"] is False
+
+
+def test_preview_redacts_secret_values_from_tool_output(tmp_path):
+    from tools import homeassistant_config_tool as tool
+    from tools.homeassistant_store import HomeAssistantChangeStore
+
+    manager = MagicMock()
+    manager.get = AsyncMock(return_value=None)
+    store = HomeAssistantChangeStore(tmp_path / "changes.sqlite3")
+    with patch.object(tool, "_get_runtime", return_value=(manager, store, 900)):
+        result = tool._handle_manage({
+            "action": "preview", "resource_type": "script", "resource_id": "notify",
+            "operation": "create", "definition": {"api_token": "super-secret", "alias": "Notify"},
+        })
+
+    assert "super-secret" not in result
+    assert "[REDACTED]" in result
+
+
+def test_group_preview_rejects_incomplete_definition_before_remote_lookup(tmp_path):
+    from tools import homeassistant_config_tool as tool
+    from tools.homeassistant_store import HomeAssistantChangeStore
+
+    manager = MagicMock()
+    manager.get = AsyncMock()
+    store = HomeAssistantChangeStore(tmp_path / "changes.sqlite3")
+
+    with patch.object(tool, "_get_runtime", return_value=(manager, store, 900)):
+        result = json.loads(tool._handle_preview_tool({
+            "resource_type": "group",
+            "resource_id": "downstairs",
+            "operation": "create",
+            "definition": {
+                "group_type": "light",
+                "name": "Downstairs",
+                "entities": ["light.kitchen"],
+                "hide_members": False,
+            },
+        }))
+
+    assert "missing required fields" in result["error"]
+    manager.get.assert_not_called()
+
+
+def test_config_mutation_schemas_require_action_specific_arguments():
+    from tools.homeassistant_config_tool import (
+        HA_APPLY_CONFIG_SCHEMA,
+        HA_PREVIEW_CONFIG_SCHEMA,
+        HA_ROLLBACK_CONFIG_SCHEMA,
+    )
+
+    assert HA_PREVIEW_CONFIG_SCHEMA["parameters"]["required"] == [
+        "resource_type", "resource_id", "operation", "definition",
+    ]
+    assert HA_PREVIEW_CONFIG_SCHEMA["parameters"]["properties"]["operation"]["enum"] == [
+        "create", "update",
+    ]
+    group_fields = HA_PREVIEW_CONFIG_SCHEMA["parameters"]["properties"]["definition"][
+        "properties"
+    ]
+    assert group_fields["group_type"]["enum"] == [
+        "binary_sensor",
+        "button",
+        "cover",
+        "event",
+        "fan",
+        "light",
+        "lock",
+        "media_player",
+        "sensor",
+        "switch",
+    ]
+    assert group_fields["entities"]["items"] == {"type": "string"}
+    assert group_fields["hide_members"]["type"] == "boolean"
+    assert group_fields["all"]["type"] == "boolean"
+    assert HA_APPLY_CONFIG_SCHEMA["parameters"]["required"] == ["proposal_id"]
+    assert HA_ROLLBACK_CONFIG_SCHEMA["parameters"]["required"] == ["change_id"]
+
+
+def test_action_specific_config_handlers_dispatch_without_action_argument():
+    from tools import homeassistant_config_tool as tool
+
+    with patch.object(tool, "_handle_manage", return_value='{"result": "ok"}') as manage:
+        assert tool._handle_preview_tool({"resource_type": "group"}) == '{"result": "ok"}'
+        assert tool._handle_apply_tool({"proposal_id": "proposal-1"}) == '{"result": "ok"}'
+        assert tool._handle_rollback_tool({"change_id": "change-1"}) == '{"result": "ok"}'
+
+    assert manage.call_args_list[0].args[0] == {
+        "resource_type": "group", "action": "preview",
+    }
+    assert manage.call_args_list[1].args[0] == {
+        "proposal_id": "proposal-1", "action": "apply",
+    }
+    assert manage.call_args_list[2].args[0] == {
+        "change_id": "change-1", "action": "rollback",
+    }

--- a/tests/tools/test_homeassistant_group_config_schema.py
+++ b/tests/tools/test_homeassistant_group_config_schema.py
@@ -1,0 +1,22 @@
+"""Regression coverage for proposal-first Home Assistant group management."""
+
+
+def test_group_preview_requires_complete_definition_and_hides_legacy_tool():
+    from tools.homeassistant_config_tool import HA_PREVIEW_CONFIG_SCHEMA
+    from toolsets import TOOLSETS
+
+    parameters = HA_PREVIEW_CONFIG_SCHEMA["parameters"]
+
+    assert parameters["required"] == [
+        "resource_type",
+        "resource_id",
+        "operation",
+        "definition",
+    ]
+    assert parameters["properties"]["operation"]["enum"] == ["create", "update"]
+
+    homeassistant_tools = TOOLSETS["homeassistant"]["tools"]
+    assert "ha_preview_config" in homeassistant_tools
+    assert "ha_apply_config" in homeassistant_tools
+    assert "ha_rollback_config" in homeassistant_tools
+    assert "ha_manage_config" not in homeassistant_tools

--- a/tests/tools/test_homeassistant_policy.py
+++ b/tests/tools/test_homeassistant_policy.py
@@ -1,0 +1,73 @@
+import pytest
+
+from tools.homeassistant_policy import classify_service_action
+
+
+@pytest.mark.parametrize("domain", ["light", "fan", "media_player"])
+def test_safe_domain_with_exact_target_is_allowed(domain):
+    decision = classify_service_action(domain, f"{domain}.office", {}, mode="safe")
+    assert decision.action == "allow"
+
+
+@pytest.mark.parametrize("entity_id", ["switch.kettle", "scene.goodnight"])
+def test_switches_and_scenes_require_approval_until_trusted(entity_id):
+    domain = entity_id.split(".", 1)[0]
+    decision = classify_service_action(domain, entity_id, {}, mode="safe")
+    assert decision.action == "approve"
+
+    trusted = classify_service_action(
+        domain, entity_id, {}, mode="safe", trusted_entities={entity_id}
+    )
+    assert trusted.action == "allow"
+
+
+@pytest.mark.parametrize("domain", ["lock", "cover", "climate", "alarm_control_panel"])
+def test_sensitive_domains_always_require_approval(domain):
+    entity_id = f"{domain}.primary"
+    decision = classify_service_action(
+        domain, entity_id, {}, mode="safe", trusted_entities={entity_id}
+    )
+    assert decision.action == "approve"
+
+
+@pytest.mark.parametrize(
+    "entity_id,data",
+    [
+        (None, {}),
+        (None, {"entity_id": "all"}),
+        (None, {"entity_id": ["light.one", "light.two"]}),
+        (None, {"area_id": "kitchen"}),
+        (None, {"device_id": "abc"}),
+        ("light.one", {"target": {"area_id": "kitchen"}}),
+    ],
+)
+def test_broad_or_ambiguous_targets_require_approval(entity_id, data):
+    decision = classify_service_action("light", entity_id, data, mode="safe")
+    assert decision.action == "approve"
+
+
+def test_data_entity_id_is_normalized_for_safe_decision():
+    decision = classify_service_action(
+        "light", None, {"entity_id": "light.office"}, mode="safe"
+    )
+    assert decision.action == "allow"
+    assert decision.targets == ("light.office",)
+
+
+def test_legacy_mode_preserves_existing_nonblocked_behavior():
+    decision = classify_service_action("lock", "lock.front_door", {}, mode="legacy")
+    assert decision.action == "allow"
+
+
+def test_invalid_policy_mode_fails_closed():
+    decision = classify_service_action("light", "light.office", {}, mode="typo")
+    assert decision.action == "block"
+    assert "invalid" in decision.reason.lower()
+
+
+@pytest.mark.parametrize(
+    "domain", ["shell_command", "command_line", "python_script", "pyscript", "hassio", "rest_command"]
+)
+def test_command_execution_domains_are_blocked_in_every_mode(domain):
+    assert classify_service_action(domain, None, {}, mode="legacy").action == "block"
+    assert classify_service_action(domain, None, {}, mode="safe").action == "block"

--- a/tests/tools/test_homeassistant_store.py
+++ b/tests/tools/test_homeassistant_store.py
@@ -1,0 +1,299 @@
+import os
+import threading
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tools.homeassistant_store import (
+    HomeAssistantChangeStore,
+    ProposalExpired,
+    ProposalStale,
+    ProposalUnavailable,
+    canonical_fingerprint,
+    structured_diff,
+)
+
+
+NOW = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+
+
+def _store(tmp_path, *, history_limit=500):
+    return HomeAssistantChangeStore(
+        tmp_path / "state" / "homeassistant_changes.sqlite3",
+        history_limit=history_limit,
+    )
+
+
+def test_fingerprint_is_stable_across_mapping_key_order():
+    assert canonical_fingerprint({"b": 2, "a": 1}) == canonical_fingerprint(
+        {"a": 1, "b": 2}
+    )
+    assert canonical_fingerprint(None) != canonical_fingerprint({})
+
+
+def test_structured_diff_reports_nested_add_change_and_remove():
+    before = {"name": "Evening", "trigger": {"at": "18:00"}, "old": True}
+    after = {"name": "Night", "trigger": {"at": "19:00"}, "enabled": True}
+
+    assert structured_diff(before, after) == [
+        {"path": "/enabled", "before": None, "after": True, "change": "added"},
+        {"path": "/name", "before": "Evening", "after": "Night", "change": "changed"},
+        {"path": "/old", "before": True, "after": None, "change": "removed"},
+        {"path": "/trigger/at", "before": "18:00", "after": "19:00", "change": "changed"},
+    ]
+
+
+def test_create_and_get_proposal_uses_profile_local_private_database(tmp_path):
+    store = _store(tmp_path)
+    proposal = store.create_proposal(
+        resource_type="automation",
+        resource_id="evening",
+        operation="update",
+        before={"alias": "Evening"},
+        desired={"alias": "Night"},
+        ttl_seconds=900,
+        now=NOW,
+    )
+
+    loaded = store.get_proposal(proposal["id"])
+    assert loaded == proposal
+    assert loaded["status"] == "pending"
+    assert loaded["expires_at"] == NOW + timedelta(seconds=900)
+    assert store.path == tmp_path / "state" / "homeassistant_changes.sqlite3"
+    assert os.stat(store.path).st_mode & 0o777 == 0o600
+
+
+def test_claim_rejects_expired_proposal(tmp_path):
+    store = _store(tmp_path)
+    proposal = store.create_proposal(
+        resource_type="script",
+        resource_id="welcome",
+        operation="update",
+        before={"sequence": []},
+        desired={"sequence": [{"service": "light.turn_on"}]},
+        ttl_seconds=30,
+        now=NOW,
+    )
+
+    with pytest.raises(ProposalExpired):
+        store.claim_proposal(
+            proposal["id"],
+            current_fingerprint=proposal["before_fingerprint"],
+            now=NOW + timedelta(seconds=31),
+        )
+    assert store.get_proposal(proposal["id"])["status"] == "expired"
+
+
+def test_claim_rejects_stale_resource_snapshot(tmp_path):
+    store = _store(tmp_path)
+    proposal = store.create_proposal(
+        resource_type="scene",
+        resource_id="movie",
+        operation="update",
+        before={"name": "Movie"},
+        desired={"name": "Cinema"},
+        now=NOW,
+    )
+
+    with pytest.raises(ProposalStale):
+        store.claim_proposal(
+            proposal["id"],
+            current_fingerprint=canonical_fingerprint({"name": "Changed elsewhere"}),
+            now=NOW,
+        )
+    assert store.get_proposal(proposal["id"])["status"] == "stale"
+
+
+def test_proposal_can_only_be_claimed_once(tmp_path):
+    store = _store(tmp_path)
+    proposal = store.create_proposal(
+        resource_type="timer",
+        resource_id="tea",
+        operation="create",
+        before=None,
+        desired={"name": "Tea", "duration": "00:05:00"},
+        now=NOW,
+    )
+    store.claim_proposal(
+        proposal["id"], proposal["before_fingerprint"], now=NOW
+    )
+
+    with pytest.raises(ProposalUnavailable):
+        store.claim_proposal(
+            proposal["id"], proposal["before_fingerprint"], now=NOW
+        )
+
+
+def test_claim_and_apply_intent_are_atomic(tmp_path):
+    store = _store(tmp_path)
+    proposal = store.create_proposal(
+        resource_type="automation", resource_id="morning", operation="update",
+        before={"alias": "Morning"}, desired={"alias": "Early"}, now=NOW,
+    )
+
+    change = store.claim_and_begin_apply(
+        proposal["id"], proposal["before_fingerprint"],
+        created_by_hermes=False, now=NOW,
+    )
+
+    assert store.get_proposal(proposal["id"])["status"] == "applying"
+    assert change["status"] == "applying"
+    assert store.list_unfinished()[0]["id"] == change["id"]
+
+
+def test_only_latest_unapplied_proposal_remains_active(tmp_path):
+    store = _store(tmp_path)
+    first = store.create_proposal(
+        resource_type="timer", resource_id="tea", operation="update",
+        before={"name": "Tea"}, desired={"name": "Tea timer"}, now=NOW,
+    )
+    second = store.create_proposal(
+        resource_type="timer", resource_id="coffee", operation="update",
+        before={"name": "Coffee"}, desired={"name": "Coffee timer"}, now=NOW,
+    )
+
+    assert store.get_proposal(first["id"]) is None
+    assert store.get_proposal(second["id"])["status"] == "pending"
+
+
+def test_record_applied_creates_auditable_change_and_prunes_history(tmp_path):
+    store = _store(tmp_path, history_limit=2)
+    change_ids = []
+    for i in range(3):
+        before = {"value": i}
+        desired = {"value": i + 1}
+        proposal = store.create_proposal(
+            resource_type="counter",
+            resource_id=f"counter_{i}",
+            operation="update",
+            before=before,
+            desired=desired,
+            now=NOW + timedelta(seconds=i),
+        )
+        store.claim_proposal(
+            proposal["id"], proposal["before_fingerprint"], now=NOW + timedelta(seconds=i)
+        )
+        change = store.record_applied(
+            proposal["id"],
+            after=desired,
+            created_by_hermes=False,
+            now=NOW + timedelta(seconds=i),
+        )
+        change_ids.append(change["id"])
+
+    history = store.list_history()
+    assert [item["id"] for item in history] == list(reversed(change_ids[-2:]))
+    assert store.get_proposal(proposal["id"])["status"] == "applied"
+    assert history[0]["before"] == {"value": 2}
+    assert history[0]["after"] == {"value": 3}
+
+
+def test_history_pruning_never_deletes_unfinished_mutation_evidence(tmp_path):
+    store = _store(tmp_path, history_limit=1)
+    uncertain_proposal = store.create_proposal(
+        resource_type="automation", resource_id="morning", operation="update",
+        before={"alias": "Old"}, desired={"alias": "New"}, now=NOW,
+    )
+    store.claim_proposal(
+        uncertain_proposal["id"], uncertain_proposal["before_fingerprint"], now=NOW
+    )
+    uncertain = store.begin_apply(
+        uncertain_proposal["id"], created_by_hermes=False, now=NOW
+    )
+    store.mark_apply_uncertain(uncertain["id"])
+
+    completed_proposal = store.create_proposal(
+        resource_type="timer", resource_id="tea", operation="update",
+        before={"name": "Tea"}, desired={"name": "Tea timer"}, now=NOW,
+    )
+    store.claim_proposal(
+        completed_proposal["id"], completed_proposal["before_fingerprint"], now=NOW
+    )
+    store.record_applied(
+        completed_proposal["id"], after={"name": "Tea timer"},
+        created_by_hermes=False, now=NOW,
+    )
+
+    assert [item["id"] for item in store.list_unfinished()] == [uncertain["id"]]
+
+
+def test_rollback_claim_requires_current_state_to_match_applied_state(tmp_path):
+    store = _store(tmp_path)
+    proposal = store.create_proposal(
+        resource_type="input_boolean",
+        resource_id="guest_mode",
+        operation="create",
+        before=None,
+        desired={"name": "Guest mode"},
+        now=NOW,
+    )
+    store.claim_proposal(proposal["id"], proposal["before_fingerprint"], now=NOW)
+    change = store.begin_apply(
+        proposal["id"], created_by_hermes=True, now=NOW
+    )
+    store.identify_created_resource(change["id"], "guest_mode")
+    change = store.finalize_applied(
+        change["id"], after=proposal["desired"], resource_id="guest_mode", now=NOW
+    )
+
+    with pytest.raises(ProposalStale):
+        store.claim_rollback(
+            change["id"],
+            canonical_fingerprint({"name": "Edited manually"}),
+            now=NOW,
+        )
+
+    claimed = store.claim_rollback(
+        change["id"], change["after_fingerprint"], now=NOW
+    )
+    assert claimed["status"] == "rolling_back"
+    rolled_back = store.record_rolled_back(change["id"], now=NOW)
+    assert rolled_back["status"] == "rolled_back"
+
+
+def test_non_authoritative_create_cannot_be_claimed_for_rollback(tmp_path):
+    store = _store(tmp_path)
+    proposal = store.create_proposal(
+        resource_type="area", resource_id="guest_room", operation="create",
+        before=None, desired={"name": "Guest room"}, now=NOW,
+    )
+    store.claim_proposal(proposal["id"], proposal["before_fingerprint"], now=NOW)
+    change = store.record_applied(
+        proposal["id"], after={"name": "Guest room"},
+        created_by_hermes=True, now=NOW,
+    )
+
+    with pytest.raises(ProposalUnavailable, match="authoritative.*ownership"):
+        store.claim_rollback(
+            change["id"], change["after_fingerprint"], now=NOW,
+        )
+
+
+def test_concurrent_claim_has_exactly_one_winner(tmp_path):
+    store = _store(tmp_path)
+    proposal = store.create_proposal(
+        resource_type="automation",
+        resource_id="morning",
+        operation="update",
+        before={"alias": "Morning"},
+        desired={"alias": "Early morning"},
+        now=NOW,
+    )
+    outcomes = []
+
+    def claim():
+        try:
+            HomeAssistantChangeStore(store.path).claim_proposal(
+                proposal["id"], proposal["before_fingerprint"], now=NOW
+            )
+            outcomes.append("claimed")
+        except ProposalUnavailable:
+            outcomes.append("unavailable")
+
+    threads = [threading.Thread(target=claim) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert sorted(outcomes) == ["claimed", "unavailable"]

--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -252,6 +252,67 @@ class TestDomainBlocklist:
         assert "rest_command" in _BLOCKED_DOMAINS
 
 
+class TestSafeActionPolicy:
+    @patch("hermes_cli.config.load_config_readonly")
+    def test_invalid_configured_policy_mode_is_not_downgraded_to_legacy(self, load_config):
+        from tools.homeassistant_tool import _get_action_policy
+
+        load_config.return_value = {
+            "homeassistant": {
+                "action_policy": {
+                    "mode": "typo",
+                    "trusted_entities": [],
+                }
+            }
+        }
+
+        mode, trusted = _get_action_policy()
+
+        assert mode == "typo"
+        assert trusted == set()
+
+    @patch("tools.homeassistant_tool._run_async")
+    @patch("tools.homeassistant_tool._get_action_policy", return_value=("typo", set()))
+    def test_invalid_policy_mode_blocks_dispatch(self, policy, run_async):
+        result = json.loads(_handle_call_service({
+            "domain": "light",
+            "service": "turn_on",
+            "entity_id": "light.office",
+        }))
+
+        assert "invalid" in result["error"].lower()
+        run_async.assert_not_called()
+
+    @patch("tools.homeassistant_tool._run_async", return_value={"success": True})
+    @patch("tools.homeassistant_tool.request_tool_approval")
+    @patch("tools.homeassistant_tool._get_action_policy", return_value=("safe", set()))
+    def test_exact_light_action_does_not_prompt(self, policy, approval, run_async):
+        _handle_call_service({
+            "domain": "light", "service": "turn_on", "entity_id": "light.office"
+        })
+        approval.assert_not_called()
+        run_async.assert_called_once()
+
+    @patch("tools.homeassistant_tool._run_async")
+    @patch(
+        "tools.homeassistant_tool.request_tool_approval",
+        return_value={"approved": False, "message": "denied"},
+    )
+    @patch("tools.homeassistant_tool._get_action_policy", return_value=("safe", set()))
+    def test_sensitive_action_is_strictly_approved_before_dispatch(
+        self, policy, approval, run_async
+    ):
+        result = json.loads(_handle_call_service({
+            "domain": "lock", "service": "unlock", "entity_id": "lock.front_door"
+        }))
+        approval.assert_called_once()
+        assert approval.call_args.kwargs["allow_yolo"] is False
+        assert approval.call_args.kwargs["allow_headless"] is False
+        assert approval.call_args.kwargs["allow_permanent"] is False
+        run_async.assert_not_called()
+        assert result["error"] == "denied"
+
+
 # ---------------------------------------------------------------------------
 # Security: entity_id validation
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -32,6 +32,57 @@ def _isolate_approval_state(monkeypatch):
 
 
 class TestRequestToolApproval:
+    def test_strict_approval_does_not_allow_yolo_bypass(self, monkeypatch):
+        monkeypatch.setattr(approval, "is_current_session_yolo_enabled", lambda: True)
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", lambda *a, **k: "deny")
+
+        res = request_tool_approval(
+            "ha_manage_config",
+            "Apply Home Assistant proposal",
+            allow_yolo=False,
+        )
+
+        assert res["approved"] is False
+
+    def test_strict_approval_does_not_allow_cron_autoapproval(self, monkeypatch):
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(
+            approval, "env_var_enabled", lambda key: key == "HERMES_CRON_SESSION"
+        )
+        monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "approve")
+
+        res = request_tool_approval(
+            "ha_manage_config",
+            "Apply Home Assistant proposal",
+            allow_headless=False,
+        )
+
+        assert res["approved"] is False
+        assert "cron" in res["message"].lower()
+
+    def test_nonpermanent_approval_hides_always_choice(self, monkeypatch):
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        captured = {}
+
+        def prompt(*args, **kwargs):
+            captured.update(kwargs)
+            return "once"
+
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", prompt)
+
+        res = request_tool_approval(
+            "ha_manage_config",
+            "Apply Home Assistant proposal",
+            allow_permanent=False,
+        )
+
+        assert res["approved"] is True
+        assert captured["allow_permanent"] is False
+
     def test_session_cached_approval_short_circuits(self, monkeypatch):
         monkeypatch.setattr(approval, "is_approved", lambda sk, pk: True)
         # Should NOT prompt at all.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2651,6 +2651,9 @@ def _run_approval_gate(
     autoapprove_log_prefix: str,
     fail_closed_when_no_human: bool = False,
     no_human_block_message: str = "",
+    allow_yolo: bool = True,
+    allow_headless: bool = True,
+    allow_permanent: bool = True,
 ) -> dict:
     """Shared human-approval gate for a flagged action (command or tool).
 
@@ -2695,7 +2698,7 @@ def _run_approval_gate(
     # --yolo bypasses all approval prompts (session- or process-scoped).
     # Hardline blocks are handled by the caller BEFORE this gate, so yolo
     # here only skips the recoverable approval layer.
-    if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
+    if allow_yolo and (_YOLO_MODE_FROZEN or is_current_session_yolo_enabled()):
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
@@ -2715,7 +2718,7 @@ def _run_approval_gate(
     if not is_cli and not is_gateway:
         # Cron sessions: respect cron_mode config
         if env_var_enabled("HERMES_CRON_SESSION"):
-            if _get_cron_approval_mode() == "deny":
+            if not allow_headless or _get_cron_approval_mode() == "deny":
                 return {
                     "approved": False,
                     "message": cron_deny_message,
@@ -2768,7 +2771,7 @@ def _run_approval_gate(
                 "pattern_key": pattern_key,
                 "pattern_keys": [pattern_key],
                 "description": redact_sensitive_text(description),
-                "allow_permanent": True,
+                "allow_permanent": allow_permanent,
                 "allow_session": True,
             }
             decision = _await_gateway_decision(
@@ -2822,6 +2825,7 @@ def _run_approval_gate(
             "command": display_target,
             "pattern_key": pattern_key,
             "description": description,
+            "allow_permanent": allow_permanent,
         })
         return {
             "approved": False,
@@ -2835,8 +2839,12 @@ def _run_approval_gate(
             ),
         }
 
-    choice = prompt_dangerous_approval(display_target, description,
-                                       approval_callback=approval_callback)
+    choice = prompt_dangerous_approval(
+        display_target,
+        description,
+        approval_callback=approval_callback,
+        allow_permanent=allow_permanent,
+    )
 
     if choice == "deny":
         return {
@@ -2950,6 +2958,9 @@ def request_tool_approval(
     *,
     rule_key: str = "",
     approval_callback=None,
+    allow_yolo: bool = True,
+    allow_headless: bool = True,
+    allow_permanent: bool = True,
 ) -> dict:
     """Escalate an arbitrary tool call to the human-approval gate.
 
@@ -3023,6 +3034,9 @@ def request_tool_approval(
             "non-interactive non-gateway context"
         ),
         fail_closed_when_no_human=True,
+        allow_yolo=allow_yolo,
+        allow_headless=allow_headless,
+        allow_permanent=allow_permanent,
         no_human_block_message=(
             f"BLOCKED: Tool '{tool_name}' requires approval ({description}) "
             "but no interactive user or gateway is present to approve it. "

--- a/tools/homeassistant_client.py
+++ b/tools/homeassistant_client.py
@@ -1,0 +1,85 @@
+"""Small authenticated client for Home Assistant's official REST and WebSocket APIs."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlsplit
+
+
+class HomeAssistantClientError(RuntimeError):
+    """Sanitized Home Assistant API failure."""
+
+
+class HomeAssistantClient:
+    def __init__(self, base_url: str, token: str, *, timeout_seconds: int = 15):
+        parsed = urlsplit(base_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("Home Assistant URL must use http or https")
+        if parsed.username or parsed.password or parsed.query or parsed.fragment:
+            raise ValueError("Home Assistant URL cannot contain credentials, query, or fragment")
+        if not token:
+            raise ValueError("Home Assistant token is required")
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.timeout_seconds = timeout_seconds
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"}
+
+    async def rest(self, method: str, path: str, payload: Any = None) -> Any:
+        import aiohttp
+
+        timeout = aiohttp.ClientTimeout(total=self.timeout_seconds)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.request(
+                    method,
+                    f"{self.base_url}{path}",
+                    headers=self._headers,
+                    json=payload,
+                    allow_redirects=False,
+                ) as response:
+                    if response.status < 200 or response.status >= 300:
+                        raise HomeAssistantClientError(
+                            f"Home Assistant returned HTTP {response.status}"
+                        )
+                    if response.status == 204:
+                        return None
+                    return await response.json(content_type=None)
+        except HomeAssistantClientError:
+            raise
+        except Exception as exc:
+            raise HomeAssistantClientError(
+                f"Home Assistant request failed: {type(exc).__name__}"
+            ) from exc
+
+    async def websocket(self, command: dict[str, Any]) -> Any:
+        import aiohttp
+
+        ws_url = self.base_url.replace("http://", "ws://", 1).replace("https://", "wss://", 1)
+        timeout = aiohttp.ClientTimeout(total=self.timeout_seconds)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.ws_connect(f"{ws_url}/api/websocket") as socket:
+                    hello = await socket.receive_json()
+                    if hello.get("type") != "auth_required":
+                        raise HomeAssistantClientError("unexpected Home Assistant WebSocket handshake")
+                    await socket.send_json({"type": "auth", "access_token": self.token})
+                    auth = await socket.receive_json()
+                    if auth.get("type") != "auth_ok":
+                        raise HomeAssistantClientError("Home Assistant WebSocket authentication failed")
+                    request = {"id": 1, **command}
+                    await socket.send_json(request)
+                    result = await socket.receive_json()
+                    if result.get("type") != "result" or not result.get("success"):
+                        error = result.get("error", {})
+                        code = error.get("code", "unknown_error")
+                        raise HomeAssistantClientError(f"Home Assistant WebSocket error: {code}")
+                    return result.get("result")
+        except HomeAssistantClientError:
+            raise
+        except Exception as exc:
+            raise HomeAssistantClientError(
+                f"Home Assistant WebSocket request failed: {type(exc).__name__}"
+            ) from exc

--- a/tools/homeassistant_config.py
+++ b/tools/homeassistant_config.py
@@ -1,0 +1,402 @@
+"""Capability-gated Home Assistant configuration resource adapters."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+REST_RESOURCES = {"automation", "script", "scene"}
+GROUP_RESOURCE = "group"
+HELPER_RESOURCES = {
+    "input_boolean", "input_number", "input_select", "input_text",
+    "input_datetime", "counter", "timer", "schedule",
+}
+REGISTRY_RESOURCES = {
+    "entity": "config/entity_registry",
+    "device": "config/device_registry",
+    "area": "config/area_registry",
+}
+EXCLUDED_RESOURCES = [
+    "addon", "dashboard", "device_removal", "integration", "pairing",
+]
+REGISTRY_MUTABLE_FIELDS = {
+    "entity": {"name", "icon", "disabled_by", "hidden_by", "area_id", "labels", "aliases"},
+    "device": {"name_by_user", "area_id", "disabled_by", "labels"},
+    "area": {"name", "floor_id", "icon", "picture", "aliases", "labels"},
+}
+GROUP_MUTABLE_FIELDS = {
+    "name", "group_type", "entities", "hide_members", "all", "type",
+    "ignore_non_numeric",
+}
+GROUP_TYPES = frozenset(
+    {
+        "binary_sensor",
+        "button",
+        "cover",
+        "event",
+        "fan",
+        "light",
+        "lock",
+        "media_player",
+        "sensor",
+        "switch",
+    }
+)
+RESOURCE_ID_RE = re.compile(r"^[A-Za-z0-9_.-]{1,255}$")
+ENTITY_ID_RE = re.compile(r"^[a-z0-9_]+\.[a-z0-9_]+$")
+
+
+def validate_group_definition(operation: str, definition: dict[str, Any]) -> None:
+    """Fail closed unless a group mutation is complete and well formed."""
+    required = {"name", "entities", "hide_members", "all"}
+    if operation == "create":
+        required.add("group_type")
+    missing = sorted(required - definition.keys())
+    if missing:
+        raise ValueError(
+            f"group {operation} missing required fields: {', '.join(missing)}"
+        )
+
+    if operation == "update" and "group_type" in definition:
+        raise ValueError("group updates cannot change group_type")
+    group_type = definition.get("group_type")
+    if group_type is not None and group_type not in GROUP_TYPES:
+        raise ValueError(f"unsupported group_type: {group_type!r}")
+    if not isinstance(definition.get("name"), str) or not definition["name"].strip():
+        raise ValueError("group name must be a non-empty string")
+    entities = definition.get("entities")
+    if (
+        not isinstance(entities, list)
+        or not entities
+        or any(
+            not isinstance(entity_id, str)
+            or not ENTITY_ID_RE.fullmatch(entity_id)
+            for entity_id in entities
+        )
+    ):
+        raise ValueError("group requires a non-empty entities list of entity IDs")
+    for field in ("hide_members", "all"):
+        if not isinstance(definition.get(field), bool):
+            raise ValueError(f"group {field} must be a boolean")
+
+
+def _require_flow_type(response: Any, expected: str, context: str) -> dict[str, Any]:
+    if not isinstance(response, dict) or response.get("type") != expected:
+        details = response.get("errors") if isinstance(response, dict) else None
+        suffix = f": {details}" if details else ""
+        raise ValueError(
+            f"Home Assistant {context} flow did not complete as {expected}{suffix}"
+        )
+    return response
+
+
+class HomeAssistantResources:
+    def __init__(self, client):
+        self.client = client
+
+    def _ensure_supported(self, resource_type: str) -> None:
+        if resource_type not in REST_RESOURCES | HELPER_RESOURCES | set(REGISTRY_RESOURCES) | {GROUP_RESOURCE}:
+            raise ValueError(f"unsupported Home Assistant resource type: {resource_type}")
+
+    @staticmethod
+    def _ensure_resource_id(resource_id: str) -> None:
+        if (
+            not isinstance(resource_id, str)
+            or resource_id in {".", ".."}
+            or not RESOURCE_ID_RE.fullmatch(resource_id)
+        ):
+            raise ValueError("invalid Home Assistant resource_id")
+
+    @staticmethod
+    def _mutation_payload(resource_type: str, definition: dict[str, Any]) -> dict[str, Any]:
+        """Remove response-only and immutable fields before sending a mutation."""
+        if resource_type in REST_RESOURCES:
+            return {key: value for key, value in definition.items() if key != "id"}
+        if resource_type == GROUP_RESOURCE:
+            return {
+                key: value for key, value in definition.items()
+                if key in GROUP_MUTABLE_FIELDS
+            }
+        if resource_type in HELPER_RESOURCES:
+            return {
+                key: value for key, value in definition.items()
+                if key not in {"id", "entity_id", "editable"}
+            }
+        return {
+            key: value for key, value in definition.items()
+            if key in REGISTRY_MUTABLE_FIELDS[resource_type]
+        }
+
+    async def capabilities(self) -> dict[str, Any]:
+        config = await self.client.rest("GET", "/api/config")
+        components = set(config.get("components") or [])
+        available = (REST_RESOURCES | HELPER_RESOURCES | {GROUP_RESOURCE}) & components
+        mutable = {
+            resource: ["create", "update"]
+            for resource in sorted(available)
+        }
+        mutable.update({"entity": ["update"], "device": ["update"], "area": ["create", "update"]})
+        return {
+            "home_assistant_version": config.get("version"),
+            "mutable": mutable,
+            "unavailable": sorted(
+                (REST_RESOURCES | HELPER_RESOURCES | {GROUP_RESOURCE}) - available
+            ),
+            "excluded": EXCLUDED_RESOURCES,
+            "rollback": "update if unchanged; delete only exact Hermes-created resources",
+        }
+
+    async def list(self, resource_type: str) -> list[dict[str, Any]]:
+        self._ensure_supported(resource_type)
+        if resource_type in REST_RESOURCES:
+            entries = await self.client.websocket({"type": "config/entity_registry/list"})
+            platform = "homeassistant" if resource_type == "scene" else resource_type
+            ids = [
+                entry.get("unique_id")
+                for entry in entries
+                if entry.get("platform") == platform and entry.get("unique_id")
+            ]
+            result = []
+            for resource_id in ids:
+                item = await self.get(resource_type, resource_id)
+                if item is not None:
+                    result.append(item)
+        elif resource_type == GROUP_RESOURCE:
+            entries = await self.client.websocket({"type": "config_entries/get", "domain": "group"})
+            result = [entry for entry in entries if entry.get("domain") == "group"]
+        elif resource_type in HELPER_RESOURCES:
+            result = await self.client.websocket({"type": f"{resource_type}/list"})
+        else:
+            result = await self.client.websocket(
+                {"type": f"{REGISTRY_RESOURCES[resource_type]}/list"}
+            )
+        if isinstance(result, list):
+            return result
+        if isinstance(result, dict):
+            return list(result.values())
+        return []
+
+    @staticmethod
+    def _matches(resource_type: str, item: dict[str, Any], resource_id: str) -> bool:
+        candidates = (
+            item.get("id"), item.get(f"{resource_type}_id"), item.get("entity_id"),
+            item.get("device_id"), item.get("area_id"), item.get("unique_id"),
+        )
+        return resource_id in candidates
+
+    async def get(self, resource_type: str, resource_id: str) -> dict[str, Any] | None:
+        self._ensure_supported(resource_type)
+        if not resource_id:
+            raise ValueError("resource_id is required")
+        self._ensure_resource_id(resource_id)
+        if resource_type in REST_RESOURCES:
+            try:
+                return await self.client.rest(
+                    "GET", f"/api/config/{resource_type}/config/{resource_id}"
+                )
+            except Exception as exc:
+                if "HTTP 404" in str(exc):
+                    return None
+                raise
+        if resource_type == GROUP_RESOURCE:
+            entries = await self.list(resource_type)
+            entry = next(
+                (item for item in entries if item.get("entry_id") == resource_id), None
+            )
+            if entry is None:
+                return None
+            flow = await self.client.rest(
+                "POST", "/api/config/config_entries/options/flow",
+                {"handler": resource_id},
+            )
+            flow_id = flow.get("flow_id")
+            try:
+                fields = flow.get("data_schema") or []
+                editable = {
+                    field["name"]: field["default"]
+                    for field in fields
+                    if isinstance(field, dict) and "name" in field and "default" in field
+                }
+                if "entities" not in editable or "hide_members" not in editable:
+                    raise ValueError(
+                        "Home Assistant did not expose editable group options; refusing unsafe snapshot"
+                    )
+                return {
+                    "entry_id": resource_id,
+                    "name": entry.get("title", ""),
+                    **editable,
+                }
+            finally:
+                if flow_id:
+                    await self.client.rest(
+                        "DELETE", f"/api/config/config_entries/options/flow/{flow_id}"
+                    )
+        items = await self.list(resource_type)
+        return next(
+            (item for item in items if self._matches(resource_type, item, resource_id)), None
+        )
+
+    async def apply(
+        self,
+        resource_type: str,
+        resource_id: str,
+        operation: str,
+        definition: dict[str, Any],
+    ) -> dict[str, Any]:
+        self._ensure_supported(resource_type)
+        if operation not in {"create", "update"}:
+            raise ValueError("operation must be create or update")
+        self._ensure_resource_id(resource_id)
+        if operation == "create" and resource_type in {"entity", "device"}:
+            raise ValueError(f"Home Assistant does not support creating {resource_type} metadata")
+        definition = self._mutation_payload(resource_type, definition)
+        if not definition:
+            raise ValueError("definition contains no mutable fields for this resource type")
+        if resource_type == GROUP_RESOURCE:
+            validate_group_definition(operation, definition)
+        if resource_type in REST_RESOURCES:
+            await self.client.rest(
+                "POST", f"/api/config/{resource_type}/config/{resource_id}", definition
+            )
+            return definition
+        if resource_type == GROUP_RESOURCE:
+            if operation == "create":
+                group_type = definition["group_type"]
+                flow = _require_flow_type(
+                    await self.client.rest(
+                        "POST", "/api/config/config_entries/flow",
+                        {"handler": "group", "show_advanced_options": False},
+                    ),
+                    "menu",
+                    "group create start",
+                )
+                flow_id = flow.get("flow_id")
+                if not flow_id:
+                    raise ValueError("Home Assistant group create flow returned no flow_id")
+                try:
+                    _require_flow_type(
+                        await self.client.rest(
+                            "POST",
+                            f"/api/config/config_entries/flow/{flow_id}",
+                            {"next_step_id": group_type},
+                        ),
+                        "form",
+                        "group type selection",
+                    )
+                    result = _require_flow_type(
+                        await self.client.rest(
+                            "POST",
+                            f"/api/config/config_entries/flow/{flow_id}",
+                            {
+                                key: value
+                                for key, value in definition.items()
+                                if key != "group_type"
+                            },
+                        ),
+                        "create_entry",
+                        "group create",
+                    )
+                    created = result.get("result")
+                    if not isinstance(created, dict) or not created.get("entry_id"):
+                        raise ValueError(
+                            "Home Assistant group create flow returned no authoritative entry_id"
+                        )
+                    return created
+                except Exception:
+                    try:
+                        await self.client.rest(
+                            "DELETE", f"/api/config/config_entries/flow/{flow_id}"
+                        )
+                    except Exception:
+                        pass
+                    raise
+            flow = _require_flow_type(
+                await self.client.rest(
+                    "POST",
+                    "/api/config/config_entries/options/flow",
+                    {"handler": resource_id},
+                ),
+                "form",
+                "group update start",
+            )
+            flow_id = flow.get("flow_id")
+            if not flow_id:
+                raise ValueError("Home Assistant group update flow returned no flow_id")
+            options = {
+                key: value for key, value in definition.items()
+                if key not in {"name", "group_type"}
+            }
+            try:
+                result = _require_flow_type(
+                    await self.client.rest(
+                        "POST",
+                        f"/api/config/config_entries/options/flow/{flow_id}",
+                        options,
+                    ),
+                    "create_entry",
+                    "group update",
+                )
+            except Exception:
+                try:
+                    await self.client.rest(
+                        "DELETE", f"/api/config/config_entries/options/flow/{flow_id}"
+                    )
+                except Exception:
+                    pass
+                raise
+            if "name" in definition:
+                await self.client.websocket(
+                    {
+                        "type": "config_entries/update",
+                        "entry_id": resource_id,
+                        "title": definition["name"],
+                    }
+                )
+            return result.get("result", result)
+        if resource_type in HELPER_RESOURCES:
+            command = {"type": f"{resource_type}/{operation}", **definition}
+            if operation == "update":
+                command[f"{resource_type}_id"] = resource_id
+            result = await self.client.websocket(command)
+            return result if isinstance(result, dict) else definition
+        prefix = REGISTRY_RESOURCES[resource_type]
+        command = {"type": f"{prefix}/{operation}", **definition}
+        if operation == "update":
+            command[f"{resource_type}_id"] = resource_id
+        result = await self.client.websocket(command)
+        return result if isinstance(result, dict) else definition
+
+    async def rollback(self, change: dict[str, Any]) -> Any:
+        resource_type = change["resource_type"]
+        resource_id = change["resource_id"]
+        self._ensure_supported(resource_type)
+        self._ensure_resource_id(resource_id)
+        if change["operation"] == "update":
+            return await self.apply(
+                resource_type,
+                resource_id,
+                "update",
+                self._mutation_payload(resource_type, change["before"]),
+            )
+        if not change.get("created_by_hermes") or not change.get("authoritative_id"):
+            raise ValueError(
+                "created resource lacks authoritative Hermes ownership evidence"
+            )
+        if resource_type in REST_RESOURCES:
+            return await self.client.rest(
+                "DELETE", f"/api/config/{resource_type}/config/{resource_id}"
+            )
+        if resource_type == GROUP_RESOURCE:
+            return await self.client.websocket(
+                {"type": "config_entries/delete", "entry_id": resource_id}
+            )
+        if resource_type in HELPER_RESOURCES:
+            return await self.client.websocket(
+                {"type": f"{resource_type}/delete", f"{resource_type}_id": resource_id}
+            )
+        if resource_type == "area":
+            return await self.client.websocket(
+                {"type": "config/area_registry/delete", "area_id": resource_id}
+            )
+        raise ValueError(f"Home Assistant does not support deleting {resource_type} metadata")

--- a/tools/homeassistant_config_tool.py
+++ b/tools/homeassistant_config_tool.py
@@ -1,0 +1,487 @@
+"""Native Home Assistant configuration inspection and approved mutation tools."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from typing import Any
+
+from hermes_cli.config import cfg_get, load_config_readonly
+from tools.approval import request_tool_approval
+from tools.homeassistant_client import HomeAssistantClient
+from tools.homeassistant_config import (
+    GROUP_RESOURCE,
+    HomeAssistantResources,
+    validate_group_definition,
+)
+from tools.homeassistant_store import (
+    HomeAssistantChangeStore,
+    canonical_fingerprint,
+    structured_diff,
+)
+from tools.homeassistant_tool import _run_async
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+_SECRET_MARKERS = ("token", "secret", "password", "api_key", "access_key", "credential")
+
+
+def _redact(value: Any, key: str = "") -> Any:
+    if any(marker in key.lower() for marker in _SECRET_MARKERS):
+        return "[REDACTED]"
+    if isinstance(value, dict):
+        return {item_key: _redact(item, item_key) for item_key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    return value
+
+
+def _json_result(value: Any) -> str:
+    return json.dumps({"result": _redact(value)}, default=str)
+
+
+def _config_management() -> tuple[bool, int, int]:
+    config = load_config_readonly()
+    enabled = bool(
+        cfg_get(config, "homeassistant", "config_management", "enabled", default=False)
+    )
+    ttl = int(
+        cfg_get(
+            config,
+            "homeassistant",
+            "config_management",
+            "proposal_ttl_seconds",
+            default=900,
+        )
+    )
+    history_limit = int(
+        cfg_get(
+            config,
+            "homeassistant",
+            "config_management",
+            "history_limit",
+            default=500,
+        )
+    )
+    return enabled, max(1, ttl), max(1, history_limit)
+
+
+def _check_available() -> bool:
+    enabled, _, _ = _config_management()
+    return enabled and bool(os.getenv("HASS_TOKEN"))
+
+
+def _get_runtime():
+    _, ttl, history_limit = _config_management()
+    client = HomeAssistantClient(
+        os.getenv("HASS_URL", "http://homeassistant.local:8123"),
+        os.getenv("HASS_TOKEN", ""),
+    )
+    return HomeAssistantResources(client), HomeAssistantChangeStore(
+        history_limit=history_limit
+    ), ttl
+
+
+def _handle_inspect(args: dict, **kw) -> str:
+    del kw
+    try:
+        action = args.get("action")
+        manager, store, _ = _get_runtime()
+        if action == "capabilities":
+            return _json_result(_run_async(lambda: manager.capabilities()))
+        if action == "list":
+            resource_type = args.get("resource_type", "")
+            return _json_result(_run_async(lambda: manager.list(resource_type)))
+        if action == "get":
+            resource_type = args.get("resource_type", "")
+            resource_id = args.get("resource_id", "")
+            return _json_result(_run_async(lambda: manager.get(resource_type, resource_id)))
+        if action == "history":
+            reconciled = _run_async(lambda: _reconcile_unfinished(manager, store))
+            return _json_result(
+                {
+                    "changes": store.list_history(args.get("limit")),
+                    "reconciliation": reconciled,
+                }
+            )
+        return tool_error("action must be capabilities, list, get, or history")
+    except Exception as exc:
+        logger.error("ha_inspect_config error: %s", exc)
+        return tool_error(f"Home Assistant configuration inspection failed: {exc}")
+
+
+def _strict_approval(message: str, operation: str) -> dict[str, Any]:
+    return request_tool_approval(
+        "ha_manage_config",
+        message,
+        rule_key=f"homeassistant-config:{operation}:{uuid.uuid4().hex}",
+        allow_yolo=False,
+        allow_headless=False,
+        allow_permanent=False,
+    )
+
+
+def _resource_id_from_result(
+    resource_type: str, result: Any, fallback: str
+) -> str:
+    if not isinstance(result, dict):
+        return fallback
+    keys = {
+        "group": ("entry_id",),
+        "area": ("area_id", "id"),
+        "entity": ("entity_id", "id"),
+        "device": ("device_id", "id"),
+    }.get(resource_type, ("id",))
+    return next((result[key] for key in keys if result.get(key)), fallback)
+
+
+def _desired_matches_current(desired: Any, current: Any) -> bool:
+    """Check desired fields as a subset of a richer Home Assistant response."""
+    if isinstance(desired, dict) and isinstance(current, dict):
+        return all(
+            key in current and _desired_matches_current(value, current[key])
+            for key, value in desired.items()
+        )
+    return desired == current
+
+
+async def _reconcile_unfinished(manager, store) -> list[dict[str, str]]:
+    outcomes = []
+    for change in store.list_unfinished():
+        try:
+            current = await manager.get(change["resource_type"], change["resource_id"])
+        except Exception:
+            outcomes.append({"change_id": change["id"], "status": "unreachable"})
+            continue
+        if change["status"] in {"applying", "apply_uncertain"}:
+            if change["operation"] == "create" and not change["authoritative_id"]:
+                store.mark_apply_uncertain(change["id"])
+                outcomes.append({"change_id": change["id"], "status": "manual_review"})
+                continue
+            if _desired_matches_current(change["after"], current):
+                store.finalize_applied(change["id"], after=current)
+                status = "applied"
+            elif canonical_fingerprint(current) == canonical_fingerprint(change["before"]):
+                store.mark_apply_not_applied(change["id"])
+                status = "not_applied"
+            else:
+                store.mark_apply_uncertain(change["id"])
+                status = "manual_review"
+        else:
+            if canonical_fingerprint(current) == canonical_fingerprint(change["before"]):
+                store.record_rolled_back(change["id"])
+                status = "rolled_back"
+            elif canonical_fingerprint(current) == change["after_fingerprint"]:
+                store.mark_rollback_failed(change["id"])
+                status = "not_rolled_back"
+            else:
+                store.mark_rollback_uncertain(change["id"])
+                status = "manual_review"
+        outcomes.append({"change_id": change["id"], "status": status})
+    return outcomes
+
+
+def _handle_preview(args: dict, manager, store, ttl: int) -> str:
+    resource_type = args.get("resource_type", "")
+    resource_id = args.get("resource_id", "")
+    operation = args.get("operation", "")
+    definition = args.get("definition")
+    if operation not in {"create", "update"}:
+        return tool_error("operation must be create or update")
+    if not resource_type or not resource_id or not isinstance(definition, dict):
+        return tool_error("resource_type, resource_id, and object definition are required")
+    if resource_type == GROUP_RESOURCE:
+        validate_group_definition(operation, definition)
+    before = _run_async(lambda: manager.get(resource_type, resource_id))
+    if operation == "create" and before is not None:
+        return tool_error("resource already exists; preview an update instead")
+    if operation == "update" and before is None:
+        return tool_error("resource does not exist; preview a create instead")
+    proposal = store.create_proposal(
+        resource_type=resource_type,
+        resource_id=resource_id,
+        operation=operation,
+        before=before,
+        desired=definition,
+        ttl_seconds=ttl,
+    )
+    return _json_result(
+        {
+            "proposal_id": proposal["id"],
+            "status": proposal["status"],
+            "expires_at": proposal["expires_at"],
+            "resource_type": resource_type,
+            "resource_id": resource_id,
+            "operation": operation,
+            "diff": structured_diff(before, definition),
+        }
+    )
+
+
+def _handle_apply(args: dict, manager, store) -> str:
+    proposal_id = args.get("proposal_id", "")
+    proposal = store.get_proposal(proposal_id)
+    if proposal is None:
+        return tool_error("proposal not found")
+    message = (
+        f"Apply Home Assistant {proposal['operation']} for "
+        f"{proposal['resource_type']} {proposal['resource_id']}? "
+        f"Changes: {json.dumps(_redact(structured_diff(proposal['before'], proposal['desired'])))}"
+    )
+    approval = _strict_approval(message, "apply")
+    if not approval.get("approved"):
+        return tool_error(
+            str(approval.get("message") or "Home Assistant configuration change was not approved")
+        )
+    current = _run_async(
+        lambda: manager.get(proposal["resource_type"], proposal["resource_id"])
+    )
+    attempt = store.claim_and_begin_apply(
+        proposal_id,
+        canonical_fingerprint(current),
+        created_by_hermes=proposal["operation"] == "create",
+        resource_id=proposal["resource_id"],
+    )
+    try:
+        applied_result = _run_async(
+            lambda: manager.apply(
+                proposal["resource_type"],
+                proposal["resource_id"],
+                proposal["operation"],
+                proposal["desired"],
+            )
+        )
+    except Exception:
+        store.mark_apply_uncertain(attempt["id"])
+        raise
+    actual_resource_id = _resource_id_from_result(
+        proposal["resource_type"], applied_result, proposal["resource_id"]
+    )
+    if proposal["operation"] == "create":
+        store.identify_created_resource(attempt["id"], actual_resource_id)
+    after = _run_async(
+        lambda: manager.get(proposal["resource_type"], actual_resource_id)
+    )
+    if after is None:
+        after = applied_result
+    change = store.finalize_applied(
+        attempt["id"],
+        after=after,
+        resource_id=actual_resource_id,
+    )
+    return _json_result({"status": "applied", "change_id": change["id"], "after": after})
+
+
+def _handle_rollback(args: dict, manager, store) -> str:
+    change_id = args.get("change_id", "")
+    change = store.get_change(change_id)
+    if change is None:
+        return tool_error("change not found")
+    message = (
+        f"Rollback Home Assistant change {change_id} for "
+        f"{change['resource_type']} {change['resource_id']}?"
+    )
+    approval = _strict_approval(message, "rollback")
+    if not approval.get("approved"):
+        return tool_error(str(approval.get("message") or "Home Assistant rollback was not approved"))
+    current = _run_async(
+        lambda: manager.get(change["resource_type"], change["resource_id"])
+    )
+    store.claim_rollback(change_id, canonical_fingerprint(current))
+    try:
+        result = _run_async(lambda: manager.rollback(change))
+    except Exception:
+        store.mark_rollback_uncertain(change_id)
+        raise
+    rolled_back = store.record_rolled_back(change_id)
+    return _json_result(
+        {"status": rolled_back["status"], "change_id": change_id, "result": result}
+    )
+
+
+def _handle_manage(args: dict, **kw) -> str:
+    del kw
+    try:
+        manager, store, ttl = _get_runtime()
+        action = args.get("action")
+        if action == "preview":
+            return _handle_preview(args, manager, store, ttl)
+        if action == "apply":
+            return _handle_apply(args, manager, store)
+        if action == "rollback":
+            return _handle_rollback(args, manager, store)
+        return tool_error("action must be preview, apply, or rollback")
+    except Exception as exc:
+        logger.error("ha_manage_config error: %s", exc)
+        return tool_error(f"Home Assistant configuration change failed: {exc}")
+
+
+def _handle_preview_tool(args: dict, **kw) -> str:
+    return _handle_manage({**args, "action": "preview"}, **kw)
+
+
+def _handle_apply_tool(args: dict, **kw) -> str:
+    return _handle_manage({**args, "action": "apply"}, **kw)
+
+
+def _handle_rollback_tool(args: dict, **kw) -> str:
+    return _handle_manage({**args, "action": "rollback"}, **kw)
+
+
+HA_INSPECT_CONFIG_SCHEMA = {
+    "name": "ha_inspect_config",
+    "description": "Inspect supported Home Assistant configuration and Hermes change history.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["capabilities", "list", "get", "history"]},
+            "resource_type": {"type": "string"},
+            "resource_id": {"type": "string"},
+            "limit": {"type": "integer", "minimum": 1, "maximum": 500},
+        },
+        "required": ["action"],
+    },
+}
+
+HA_MANAGE_CONFIG_SCHEMA = {
+    "name": "ha_manage_config",
+    "description": (
+        "Preview, explicitly approve and apply, or rollback one Home Assistant configuration object. "
+        "Always preview before apply."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["preview", "apply", "rollback"]},
+            "resource_type": {"type": "string"},
+            "resource_id": {"type": "string"},
+            "operation": {"type": "string", "enum": ["create", "update"]},
+            "definition": {"type": "object", "additionalProperties": True},
+            "proposal_id": {"type": "string"},
+            "change_id": {"type": "string"},
+        },
+        "required": ["action"],
+    },
+}
+
+HA_PREVIEW_CONFIG_SCHEMA = {
+    "name": "ha_preview_config",
+    "description": (
+        "Preview one Home Assistant configuration create or update. "
+        "Returns a proposal_id; this does not change Home Assistant."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "resource_type": {
+                "type": "string",
+                "description": (
+                    "Configuration resource type, for example group, automation, "
+                    "script, scene, timer, area, entity, or device."
+                ),
+            },
+            "resource_id": {
+                "type": "string",
+                "description": (
+                    "Requested stable ID for a create, or the existing Home Assistant "
+                    "resource ID for an update."
+                ),
+            },
+            "operation": {"type": "string", "enum": ["create", "update"]},
+            "definition": {
+                "type": "object",
+                "description": (
+                    "Complete desired mutable configuration. Group creates require "
+                    "group_type, name, entities, hide_members, and all. Group updates "
+                    "must omit group_type because Home Assistant cannot change it."
+                ),
+                "properties": {
+                    "group_type": {
+                        "type": "string",
+                        "enum": [
+                            "binary_sensor",
+                            "button",
+                            "cover",
+                            "event",
+                            "fan",
+                            "light",
+                            "lock",
+                            "media_player",
+                            "sensor",
+                            "switch",
+                        ],
+                    },
+                    "name": {"type": "string"},
+                    "entities": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "hide_members": {"type": "boolean"},
+                    "all": {"type": "boolean"},
+                },
+                "additionalProperties": True,
+            },
+        },
+        "required": ["resource_type", "resource_id", "operation", "definition"],
+    },
+}
+
+HA_APPLY_CONFIG_SCHEMA = {
+    "name": "ha_apply_config",
+    "description": (
+        "Request explicit approval and apply a Home Assistant configuration proposal "
+        "previously returned by ha_preview_config."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "proposal_id": {
+                "type": "string",
+                "description": "Exact proposal_id returned by ha_preview_config.",
+            },
+        },
+        "required": ["proposal_id"],
+    },
+}
+
+HA_ROLLBACK_CONFIG_SCHEMA = {
+    "name": "ha_rollback_config",
+    "description": (
+        "Request explicit approval and safely roll back an applied Home Assistant "
+        "configuration change."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "change_id": {
+                "type": "string",
+                "description": "Exact change_id returned by ha_apply_config or history.",
+            },
+        },
+        "required": ["change_id"],
+    },
+}
+
+registry.register(
+    name="ha_inspect_config", toolset="homeassistant", schema=HA_INSPECT_CONFIG_SCHEMA,
+    handler=_handle_inspect, check_fn=_check_available, emoji="🏠",
+)
+registry.register(
+    name="ha_manage_config", toolset="homeassistant_legacy", schema=HA_MANAGE_CONFIG_SCHEMA,
+    handler=_handle_manage, check_fn=_check_available, emoji="🏠",
+)
+registry.register(
+    name="ha_preview_config", toolset="homeassistant", schema=HA_PREVIEW_CONFIG_SCHEMA,
+    handler=_handle_preview_tool, check_fn=_check_available, emoji="🏠",
+)
+registry.register(
+    name="ha_apply_config", toolset="homeassistant", schema=HA_APPLY_CONFIG_SCHEMA,
+    handler=_handle_apply_tool, check_fn=_check_available, emoji="🏠",
+)
+registry.register(
+    name="ha_rollback_config", toolset="homeassistant", schema=HA_ROLLBACK_CONFIG_SCHEMA,
+    handler=_handle_rollback_tool, check_fn=_check_available, emoji="🏠",
+)

--- a/tools/homeassistant_policy.py
+++ b/tools/homeassistant_policy.py
@@ -1,0 +1,53 @@
+"""Safety policy for native Home Assistant actions."""
+
+from dataclasses import dataclass
+from typing import Any, Collection, Mapping, Optional
+
+
+BLOCKED_DOMAINS = frozenset(
+    {"shell_command", "command_line", "python_script", "pyscript", "hassio", "rest_command"}
+)
+IMMEDIATE_DOMAINS = frozenset({"light", "fan", "media_player"})
+TRUSTABLE_DOMAINS = frozenset({"switch", "scene"})
+
+
+@dataclass(frozen=True)
+class ServicePolicyDecision:
+    action: str
+    reason: str
+    targets: tuple[str, ...] = ()
+
+
+def _targets(entity_id: Optional[str], data: Mapping[str, Any]) -> tuple[str, ...]:
+    target = entity_id if entity_id is not None else data.get("entity_id")
+    if not isinstance(target, str) or target == "all":
+        return ()
+    return (target,)
+
+
+def classify_service_action(
+    domain: str,
+    entity_id: Optional[str],
+    data: Optional[Mapping[str, Any]],
+    *,
+    mode: str = "legacy",
+    trusted_entities: Collection[str] = (),
+) -> ServicePolicyDecision:
+    """Classify a service call as allow, approve, or block."""
+    payload = data or {}
+    targets = _targets(entity_id, payload)
+    if domain in BLOCKED_DOMAINS:
+        return ServicePolicyDecision("block", f"Service domain '{domain}' is blocked")
+    if mode not in {"legacy", "safe"}:
+        return ServicePolicyDecision(
+            "block", f"Invalid Home Assistant action policy mode: {mode!r}", targets
+        )
+    if mode == "legacy":
+        return ServicePolicyDecision("allow", "Legacy Home Assistant policy", targets)
+    if any(key in payload for key in ("area_id", "device_id", "target")) or not targets:
+        return ServicePolicyDecision("approve", "Broad or ambiguous Home Assistant target", targets)
+    if domain in IMMEDIATE_DOMAINS:
+        return ServicePolicyDecision("allow", "Routine exact-target action", targets)
+    if domain in TRUSTABLE_DOMAINS and all(target in trusted_entities for target in targets):
+        return ServicePolicyDecision("allow", "Explicitly trusted Home Assistant entity", targets)
+    return ServicePolicyDecision("approve", "Sensitive Home Assistant action", targets)

--- a/tools/homeassistant_store.py
+++ b/tools/homeassistant_store.py
@@ -1,0 +1,578 @@
+"""Durable proposal and audit storage for Home Assistant configuration changes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+
+class ProposalError(RuntimeError):
+    """Base class for proposal lifecycle failures."""
+
+
+class ProposalExpired(ProposalError):
+    """The proposal approval window elapsed."""
+
+
+class ProposalStale(ProposalError):
+    """The Home Assistant resource changed after preview."""
+
+
+class ProposalUnavailable(ProposalError):
+    """The proposal or change is not in a claimable state."""
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def canonical_fingerprint(value: Any) -> str:
+    """Return a deterministic SHA-256 fingerprint for a JSON-compatible value."""
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def structured_diff(before: Any, after: Any, path: str = "") -> list[dict[str, Any]]:
+    """Return a deterministic, JSON-pointer-like recursive change list."""
+    if isinstance(before, dict) and isinstance(after, dict):
+        changes: list[dict[str, Any]] = []
+        for key in sorted(before.keys() | after.keys()):
+            child_path = f"{path}/{str(key).replace('~', '~0').replace('/', '~1')}"
+            if key not in before:
+                changes.append(
+                    {"path": child_path, "before": None, "after": after[key], "change": "added"}
+                )
+            elif key not in after:
+                changes.append(
+                    {"path": child_path, "before": before[key], "after": None, "change": "removed"}
+                )
+            else:
+                changes.extend(structured_diff(before[key], after[key], child_path))
+        return changes
+    if before == after:
+        return []
+    return [{"path": path or "/", "before": before, "after": after, "change": "changed"}]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _timestamp(value: datetime) -> str:
+    return _as_utc(value).isoformat()
+
+
+def _datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+class HomeAssistantChangeStore:
+    """SQLite-backed lifecycle store scoped to the active Hermes profile."""
+
+    def __init__(self, path: str | Path | None = None, *, history_limit: int = 500):
+        self.path = Path(path) if path else get_hermes_home() / "state" / "homeassistant_changes.sqlite3"
+        self.history_limit = max(1, int(history_limit))
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.path), timeout=10)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA busy_timeout = 10000")
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def _initialize(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            os.chmod(self.path.parent, 0o700)
+        except OSError:
+            pass
+        conn = self._connect()
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS proposals (
+                    id TEXT PRIMARY KEY,
+                    resource_type TEXT NOT NULL,
+                    resource_id TEXT,
+                    operation TEXT NOT NULL CHECK (operation IN ('create', 'update')),
+                    before_json TEXT NOT NULL,
+                    desired_json TEXT NOT NULL,
+                    before_fingerprint TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    status TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS changes (
+                    id TEXT PRIMARY KEY,
+                    proposal_id TEXT NOT NULL,
+                    resource_type TEXT NOT NULL,
+                    resource_id TEXT,
+                    operation TEXT NOT NULL,
+                    before_json TEXT NOT NULL,
+                    after_json TEXT NOT NULL,
+                    after_fingerprint TEXT NOT NULL,
+                    applied_at TEXT NOT NULL,
+                    created_by_hermes INTEGER NOT NULL,
+                    authoritative_id INTEGER NOT NULL DEFAULT 0,
+                    status TEXT NOT NULL,
+                    rollback_at TEXT,
+                    FOREIGN KEY (proposal_id) REFERENCES proposals(id)
+                );
+                CREATE INDEX IF NOT EXISTS changes_applied_at ON changes(applied_at DESC);
+                """
+            )
+            change_columns = {
+                row["name"] for row in conn.execute("PRAGMA table_info(changes)").fetchall()
+            }
+            if "authoritative_id" not in change_columns:
+                conn.execute(
+                    "ALTER TABLE changes ADD COLUMN authoritative_id INTEGER NOT NULL DEFAULT 0"
+                )
+            conn.commit()
+        finally:
+            conn.close()
+        os.chmod(self.path, 0o600)
+
+    @staticmethod
+    def _proposal(row: sqlite3.Row | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        return {
+            "id": row["id"],
+            "resource_type": row["resource_type"],
+            "resource_id": row["resource_id"],
+            "operation": row["operation"],
+            "before": json.loads(row["before_json"]),
+            "desired": json.loads(row["desired_json"]),
+            "before_fingerprint": row["before_fingerprint"],
+            "created_at": _datetime(row["created_at"]),
+            "expires_at": _datetime(row["expires_at"]),
+            "status": row["status"],
+        }
+
+    @staticmethod
+    def _change(row: sqlite3.Row | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        return {
+            "id": row["id"],
+            "proposal_id": row["proposal_id"],
+            "resource_type": row["resource_type"],
+            "resource_id": row["resource_id"],
+            "operation": row["operation"],
+            "before": json.loads(row["before_json"]),
+            "after": json.loads(row["after_json"]),
+            "after_fingerprint": row["after_fingerprint"],
+            "applied_at": _datetime(row["applied_at"]),
+            "created_by_hermes": bool(row["created_by_hermes"]),
+            "authoritative_id": bool(row["authoritative_id"]),
+            "status": row["status"],
+            "rollback_at": _datetime(row["rollback_at"]) if row["rollback_at"] else None,
+        }
+
+    def create_proposal(
+        self,
+        *,
+        resource_type: str,
+        resource_id: str | None,
+        operation: str,
+        before: Any,
+        desired: Any,
+        ttl_seconds: int = 900,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        if operation not in {"create", "update"}:
+            raise ValueError("operation must be create or update")
+        created = _as_utc(now or _utc_now())
+        expires = created + timedelta(seconds=max(1, int(ttl_seconds)))
+        proposal_id = uuid.uuid4().hex
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE proposals SET status = 'superseded' WHERE status = 'pending'"
+            )
+            conn.execute(
+                "INSERT INTO proposals VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending')",
+                (
+                    proposal_id,
+                    resource_type,
+                    resource_id,
+                    operation,
+                    _canonical_json(before),
+                    _canonical_json(desired),
+                    canonical_fingerprint(before),
+                    _timestamp(created),
+                    _timestamp(expires),
+                ),
+            )
+            conn.execute(
+                """DELETE FROM proposals
+                   WHERE status IN ('expired', 'stale', 'failed', 'superseded')
+                     AND id NOT IN (SELECT proposal_id FROM changes)"""
+            )
+        proposal = self.get_proposal(proposal_id)
+        assert proposal is not None
+        return proposal
+
+    def get_proposal(self, proposal_id: str) -> dict[str, Any] | None:
+        with self._connect() as conn:
+            row = conn.execute("SELECT * FROM proposals WHERE id = ?", (proposal_id,)).fetchone()
+        return self._proposal(row)
+
+    def mark_proposal_failed(self, proposal_id: str) -> None:
+        """Close an in-flight proposal after a remote mutation failure."""
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE proposals SET status = 'failed' WHERE id = ? AND status = 'applying'",
+                (proposal_id,),
+            )
+
+    def claim_proposal(
+        self,
+        proposal_id: str,
+        current_fingerprint: str,
+        *,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        claimed_at = _as_utc(now or _utc_now())
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute("SELECT * FROM proposals WHERE id = ?", (proposal_id,)).fetchone()
+            proposal = self._proposal(row)
+            if proposal is None or proposal["status"] != "pending":
+                conn.rollback()
+                raise ProposalUnavailable("proposal is not pending")
+            if claimed_at > proposal["expires_at"]:
+                conn.execute("UPDATE proposals SET status = 'expired' WHERE id = ?", (proposal_id,))
+                conn.commit()
+                raise ProposalExpired("proposal approval window expired")
+            if current_fingerprint != proposal["before_fingerprint"]:
+                conn.execute("UPDATE proposals SET status = 'stale' WHERE id = ?", (proposal_id,))
+                conn.commit()
+                raise ProposalStale("resource changed after preview")
+            conn.execute("UPDATE proposals SET status = 'applying' WHERE id = ?", (proposal_id,))
+            conn.commit()
+        finally:
+            conn.close()
+        proposal["status"] = "applying"
+        return proposal
+
+    def claim_and_begin_apply(
+        self,
+        proposal_id: str,
+        current_fingerprint: str,
+        *,
+        created_by_hermes: bool,
+        resource_id: str | None = None,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Atomically claim a proposal and persist its pre-mutation audit intent."""
+        claimed_at = _as_utc(now or _utc_now())
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute("SELECT * FROM proposals WHERE id = ?", (proposal_id,)).fetchone()
+            proposal = self._proposal(row)
+            if proposal is None or proposal["status"] != "pending":
+                conn.rollback()
+                raise ProposalUnavailable("proposal is not pending")
+            if claimed_at > proposal["expires_at"]:
+                conn.execute("UPDATE proposals SET status = 'expired' WHERE id = ?", (proposal_id,))
+                conn.commit()
+                raise ProposalExpired("proposal approval window expired")
+            if current_fingerprint != proposal["before_fingerprint"]:
+                conn.execute("UPDATE proposals SET status = 'stale' WHERE id = ?", (proposal_id,))
+                conn.commit()
+                raise ProposalStale("resource changed after preview")
+            change_id = uuid.uuid4().hex
+            conn.execute("UPDATE proposals SET status = 'applying' WHERE id = ?", (proposal_id,))
+            conn.execute(
+                """INSERT INTO changes (
+                    id, proposal_id, resource_type, resource_id, operation,
+                    before_json, after_json, after_fingerprint, applied_at,
+                    created_by_hermes, authoritative_id, status, rollback_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 'applying', NULL)""",
+                (
+                    change_id, proposal_id, proposal["resource_type"],
+                    resource_id or proposal["resource_id"], proposal["operation"],
+                    _canonical_json(proposal["before"]),
+                    _canonical_json(proposal["desired"]),
+                    canonical_fingerprint(proposal["desired"]),
+                    _timestamp(claimed_at), int(created_by_hermes),
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        change = self.get_change(change_id)
+        assert change is not None
+        return change
+
+    def record_applied(
+        self,
+        proposal_id: str,
+        *,
+        after: Any,
+        created_by_hermes: bool,
+        resource_id: str | None = None,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        change = self.begin_apply(
+            proposal_id,
+            created_by_hermes=created_by_hermes,
+            resource_id=resource_id,
+            now=now,
+        )
+        return self.finalize_applied(
+            change["id"], after=after, resource_id=resource_id, now=now
+        )
+
+    def begin_apply(
+        self,
+        proposal_id: str,
+        *,
+        created_by_hermes: bool,
+        resource_id: str | None = None,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Persist rollback evidence before making the remote mutation."""
+        applied_at = _as_utc(now or _utc_now())
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute("SELECT * FROM proposals WHERE id = ?", (proposal_id,)).fetchone()
+            proposal = self._proposal(row)
+            if proposal is None or proposal["status"] != "applying":
+                conn.rollback()
+                raise ProposalUnavailable("proposal is not being applied")
+            existing = conn.execute(
+                "SELECT * FROM changes WHERE proposal_id = ?", (proposal_id,)
+            ).fetchone()
+            if existing is not None:
+                conn.rollback()
+                raise ProposalUnavailable("proposal already has a mutation attempt")
+            change_id = uuid.uuid4().hex
+            conn.execute(
+                """INSERT INTO changes (
+                    id, proposal_id, resource_type, resource_id, operation,
+                    before_json, after_json, after_fingerprint, applied_at,
+                    created_by_hermes, authoritative_id, status, rollback_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 'applying', NULL)""",
+                (
+                    change_id,
+                    proposal_id,
+                    proposal["resource_type"],
+                    resource_id or proposal["resource_id"],
+                    proposal["operation"],
+                    _canonical_json(proposal["before"]),
+                    _canonical_json(proposal["desired"]),
+                    canonical_fingerprint(proposal["desired"]),
+                    _timestamp(applied_at),
+                    int(created_by_hermes),
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        change = self.get_change(change_id)
+        assert change is not None
+        return change
+
+    def identify_created_resource(self, change_id: str, resource_id: str) -> None:
+        """Persist the server-confirmed ID before any further remote read."""
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """UPDATE changes SET resource_id = ?, authoritative_id = 1
+                   WHERE id = ? AND operation = 'create'
+                     AND status IN ('applying', 'apply_uncertain')""",
+                (resource_id, change_id),
+            )
+            if cursor.rowcount != 1:
+                raise ProposalUnavailable("create attempt is not awaiting identification")
+
+    def finalize_applied(
+        self,
+        change_id: str,
+        *,
+        after: Any,
+        resource_id: str | None = None,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        applied_at = _as_utc(now or _utc_now())
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute("SELECT * FROM changes WHERE id = ?", (change_id,)).fetchone()
+            change = self._change(row)
+            if change is None or change["status"] not in {"applying", "apply_uncertain"}:
+                conn.rollback()
+                raise ProposalUnavailable("change is not awaiting apply completion")
+            conn.execute(
+                """UPDATE changes SET resource_id = ?, after_json = ?,
+                   after_fingerprint = ?, applied_at = ?, status = 'applied'
+                   WHERE id = ?""",
+                (
+                    resource_id or change["resource_id"],
+                    _canonical_json(after),
+                    canonical_fingerprint(after),
+                    _timestamp(applied_at),
+                    change_id,
+                ),
+            )
+            conn.execute(
+                "UPDATE proposals SET status = 'applied' WHERE id = ?",
+                (change["proposal_id"],),
+            )
+            conn.execute(
+                """DELETE FROM changes WHERE id IN (
+                    SELECT id FROM changes
+                    WHERE status IN ('applied', 'rolled_back', 'failed')
+                    ORDER BY applied_at DESC, rowid DESC LIMIT -1 OFFSET ?
+                )""",
+                (self.history_limit,),
+            )
+            conn.execute(
+                """DELETE FROM proposals
+                   WHERE status != 'pending'
+                     AND id NOT IN (SELECT proposal_id FROM changes)"""
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        change = self.get_change(change_id)
+        assert change is not None
+        return change
+
+    def mark_apply_uncertain(self, change_id: str) -> None:
+        """Retain an interrupted apply for later state-based reconciliation."""
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE changes SET status = 'apply_uncertain' WHERE id = ? AND status = 'applying'",
+                (change_id,),
+            )
+
+    def mark_apply_not_applied(self, change_id: str) -> None:
+        """Close an attempt when the remote resource still matches its before state."""
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT proposal_id FROM changes WHERE id = ?", (change_id,)
+            ).fetchone()
+            if row is None:
+                conn.rollback()
+                raise ProposalUnavailable("change not found")
+            conn.execute(
+                """UPDATE changes SET status = 'failed'
+                   WHERE id = ? AND status IN ('applying', 'apply_uncertain')""",
+                (change_id,),
+            )
+            conn.execute(
+                "UPDATE proposals SET status = 'failed' WHERE id = ? AND status = 'applying'",
+                (row["proposal_id"],),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def list_unfinished(self) -> list[dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """SELECT * FROM changes
+                   WHERE status IN ('applying', 'apply_uncertain', 'rolling_back', 'rollback_uncertain')
+                   ORDER BY applied_at, rowid"""
+            ).fetchall()
+        return [self._change(row) for row in rows]
+
+    def get_change(self, change_id: str) -> dict[str, Any] | None:
+        with self._connect() as conn:
+            row = conn.execute("SELECT * FROM changes WHERE id = ?", (change_id,)).fetchone()
+        return self._change(row)
+
+    def list_history(self, limit: int | None = None) -> list[dict[str, Any]]:
+        count = min(self.history_limit, max(1, int(limit or self.history_limit)))
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM changes ORDER BY applied_at DESC, rowid DESC LIMIT ?", (count,)
+            ).fetchall()
+        return [self._change(row) for row in rows]
+
+    def claim_rollback(
+        self,
+        change_id: str,
+        current_fingerprint: str,
+        *,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        del now  # Reserved for the eventual rollback audit event timestamp.
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute("SELECT * FROM changes WHERE id = ?", (change_id,)).fetchone()
+            change = self._change(row)
+            if change is None or change["status"] != "applied":
+                conn.rollback()
+                raise ProposalUnavailable("change is not available for rollback")
+            if (
+                change["operation"] == "create"
+                and (not change["created_by_hermes"] or not change["authoritative_id"])
+            ):
+                conn.rollback()
+                raise ProposalUnavailable(
+                    "created resource lacks authoritative Hermes ownership evidence"
+                )
+            if current_fingerprint != change["after_fingerprint"]:
+                conn.rollback()
+                raise ProposalStale("resource changed after Hermes applied it")
+            conn.execute("UPDATE changes SET status = 'rolling_back' WHERE id = ?", (change_id,))
+            conn.commit()
+        finally:
+            conn.close()
+        change["status"] = "rolling_back"
+        return change
+
+    def record_rolled_back(
+        self, change_id: str, *, now: datetime | None = None
+    ) -> dict[str, Any]:
+        rolled_back_at = _as_utc(now or _utc_now())
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """UPDATE changes SET status = 'rolled_back', rollback_at = ?
+                   WHERE id = ? AND status IN ('rolling_back', 'rollback_uncertain')""",
+                (_timestamp(rolled_back_at), change_id),
+            )
+            if cursor.rowcount != 1:
+                raise ProposalUnavailable("change is not being rolled back")
+        change = self.get_change(change_id)
+        assert change is not None
+        return change
+
+    def mark_rollback_failed(self, change_id: str) -> None:
+        """Return a failed rollback claim to its applied, retryable state."""
+        with self._connect() as conn:
+            conn.execute(
+                """UPDATE changes SET status = 'applied'
+                   WHERE id = ? AND status IN ('rolling_back', 'rollback_uncertain')""",
+                (change_id,),
+            )
+
+    def mark_rollback_uncertain(self, change_id: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE changes SET status = 'rollback_uncertain' WHERE id = ? AND status = 'rolling_back'",
+                (change_id,),
+            )

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -15,7 +15,11 @@ import json
 import logging
 import os
 import re
+import uuid
 from typing import Any, Dict, Optional
+
+from tools.approval import request_tool_approval
+from tools.homeassistant_policy import BLOCKED_DOMAINS, classify_service_action
 
 logger = logging.getLogger(__name__)
 
@@ -50,14 +54,26 @@ _SERVICE_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 # Service domains blocked for security -- these allow arbitrary code/command
 # execution on the HA host or enable SSRF attacks on the local network.
 # HA provides zero service-level access control; all safety must be in our layer.
-_BLOCKED_DOMAINS = frozenset({
-    "shell_command",    # arbitrary shell commands as root in HA container
-    "command_line",     # sensors/switches that execute shell commands
-    "python_script",    # sandboxed but can escalate via hass.services.call()
-    "pyscript",         # scripting integration with broader access
-    "hassio",           # addon control, host shutdown/reboot, stdin to containers
-    "rest_command",     # HTTP requests from HA server (SSRF vector)
-})
+_BLOCKED_DOMAINS = BLOCKED_DOMAINS
+
+
+def _get_action_policy() -> tuple[str, set[str]]:
+    """Return the configured action-policy mode and exact trusted entities."""
+    from hermes_cli.config import cfg_get, load_config_readonly
+
+    config = load_config_readonly()
+    mode = cfg_get(config, "homeassistant", "action_policy", "mode", default="legacy")
+    trusted = cfg_get(
+        config, "homeassistant", "action_policy", "trusted_entities", default=[]
+    )
+    configured_mode = mode if isinstance(mode, str) else "__invalid__"
+    configured_trusted = (
+        set(trusted)
+        if isinstance(trusted, (list, tuple, set))
+        and all(isinstance(entity_id, str) for entity_id in trusted)
+        else set()
+    )
+    return configured_mode, configured_trusted
 
 
 def _get_headers(token: str = "") -> Dict[str, str]:
@@ -204,8 +220,9 @@ async def _async_call_service(
 # Sync wrappers (handler signature: (args, **kw) -> str)
 # ---------------------------------------------------------------------------
 
-def _run_async(coro):
-    """Run an async coroutine from a sync handler."""
+def _run_async(coro_factory):
+    """Create and run an async coroutine from a sync handler."""
+    coro = coro_factory()
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
@@ -226,7 +243,7 @@ def _handle_list_entities(args: dict, **kw) -> str:
     domain = args.get("domain")
     area = args.get("area")
     try:
-        result = _run_async(_async_list_entities(domain=domain, area=area))
+        result = _run_async(lambda: _async_list_entities(domain=domain, area=area))
         return json.dumps({"result": result})
     except Exception as e:
         logger.error("ha_list_entities error: %s", e)
@@ -241,7 +258,7 @@ def _handle_get_state(args: dict, **kw) -> str:
     if not _ENTITY_ID_RE.match(entity_id):
         return tool_error(f"Invalid entity_id format: {entity_id}")
     try:
-        result = _run_async(_async_get_state(entity_id))
+        result = _run_async(lambda: _async_get_state(entity_id))
         return json.dumps({"result": result})
     except Exception as e:
         logger.error("ha_get_state error: %s", e)
@@ -279,9 +296,30 @@ def _handle_call_service(args: dict, **kw) -> str:
             data = json.loads(data) if data.strip() else None
         except json.JSONDecodeError as e:
             return tool_error(f"Invalid JSON string in 'data' parameter: {e}")
+    if data is not None and not isinstance(data, dict):
+        return tool_error("Invalid 'data' parameter: expected an object or JSON object string")
+
+    mode, trusted_entities = _get_action_policy()
+    decision = classify_service_action(
+        domain, entity_id, data, mode=mode, trusted_entities=trusted_entities
+    )
+    if decision.action == "block":
+        return tool_error(decision.reason)
+    if decision.action == "approve":
+        target = ", ".join(decision.targets) if decision.targets else "broad/unspecified target"
+        approval = request_tool_approval(
+            "ha_call_service",
+            f"Home Assistant {domain}.{service} on {target}: {decision.reason}",
+            rule_key=f"homeassistant-service:{uuid.uuid4().hex}",
+            allow_yolo=False,
+            allow_headless=False,
+            allow_permanent=False,
+        )
+        if not approval.get("approved"):
+            return tool_error(str(approval.get("message") or "Home Assistant action denied"))
 
     try:
-        result = _run_async(_async_call_service(domain, service, entity_id, data))
+        result = _run_async(lambda: _async_call_service(domain, service, entity_id, data))
         return json.dumps({"result": result})
     except Exception as e:
         logger.error("ha_call_service error: %s", e)
@@ -330,7 +368,7 @@ def _handle_list_services(args: dict, **kw) -> str:
     """Handler for ha_list_services tool."""
     domain = args.get("domain")
     try:
-        result = _run_async(_async_list_services(domain=domain))
+        result = _run_async(lambda: _async_list_services(domain=domain))
         return json.dumps({"result": result})
     except Exception as e:
         logger.error("ha_list_services error: %s", e)

--- a/toolsets.py
+++ b/toolsets.py
@@ -67,6 +67,7 @@ _HERMES_CORE_TOOLS = [
     "cronjob",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
+    "ha_inspect_config", "ha_preview_config", "ha_apply_config", "ha_rollback_config",
     # Kanban multi-agent coordination — only in schema when the agent is
     # spawned as a kanban worker (HERMES_KANBAN_TASK env set) or the current
     # profile explicitly enables the kanban toolset. Gated via check_fn in
@@ -256,7 +257,11 @@ TOOLSETS = {
 
     "homeassistant": {
         "description": "Home Assistant smart home control and monitoring",
-        "tools": ["ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service"],
+        "tools": [
+            "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
+            "ha_inspect_config", "ha_preview_config", "ha_apply_config",
+            "ha_rollback_config",
+        ],
         "includes": []
     },
 

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -97,7 +97,7 @@ See the [Messaging Gateway overview](/user-guide/messaging) for the platform com
 
 ## Home Automation
 
-- **[Home Assistant](/user-guide/messaging/homeassistant)** — Control smart home devices via four dedicated tools (`ha_list_entities`, `ha_get_state`, `ha_list_services`, `ha_call_service`). The Home Assistant toolset activates automatically when `HASS_TOKEN` is configured.
+- **[Home Assistant](/user-guide/messaging/homeassistant)** — Query and control smart home devices with four default tools; two additional opt-in tools inspect and safely manage selected configuration. The Home Assistant toolset activates automatically when `HASS_TOKEN` is configured.
 
 ## Plugins
 

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -95,9 +95,13 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
 | `ha_call_service` | Call a Home Assistant service to control a device. Use ha_list_services to discover available services and their parameters for each domain. | — |
+| `ha_apply_config` | Request explicit approval and apply a proposal returned by `ha_preview_config`. | `HASS_TOKEN` and `homeassistant.config_management.enabled` |
 | `ha_get_state` | Get the detailed state of a single Home Assistant entity, including all attributes (brightness, color, temperature setpoint, sensor readings, etc.). | — |
+| `ha_inspect_config` | Inspect supported configuration capabilities, list or fetch one resource, and review the local Hermes change history. | `HASS_TOKEN` and `homeassistant.config_management.enabled` |
 | `ha_list_entities` | List Home Assistant entities. Optionally filter by domain (light, switch, climate, sensor, binary_sensor, cover, fan, etc.) or by area name (living room, kitchen, bedroom, etc.). | — |
 | `ha_list_services` | List available Home Assistant services (actions) for device control. Shows what actions can be performed on each device type and what parameters they accept. Use this to discover how to control devices found via ha_list_entities. | — |
+| `ha_preview_config` | Preview one supported configuration create or update and return a proposal ID without changing Home Assistant. | `HASS_TOKEN` and `homeassistant.config_management.enabled` |
+| `ha_rollback_config` | Request explicit approval and safely roll back an applied configuration change. | `HASS_TOKEN` and `homeassistant.config_management.enabled` |
 
 ## `computer_use` toolset
 
@@ -265,5 +269,3 @@ Registered only on the `hermes-yuanbao` platform toolset. Yuanbao is Tencent's c
 | `yb_send_dm` | Send a private/direct message to a user in a group, with optional media files. | Yuanbao credentials |
 | `yb_search_sticker` | Search the built-in Yuanbao sticker (TIM face) catalogue by keyword. | Yuanbao credentials |
 | `yb_send_sticker` | Send a built-in sticker to the current Yuanbao chat. | Yuanbao credentials |
-
-

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -64,7 +64,7 @@ Or in-session:
 | `feishu_doc` | `feishu_doc_read` | Read Feishu/Lark document content. Used by the Feishu document-comment intelligent-reply handler. |
 | `feishu_drive` | `feishu_drive_add_comment`, `feishu_drive_list_comments`, `feishu_drive_list_comment_replies`, `feishu_drive_reply_comment` | Feishu/Lark drive comment operations. Scoped to the comment agent; not exposed on `hermes-cli` or other messaging toolsets. |
 | `file` | `patch`, `read_file`, `search_files`, `write_file` | File reading, writing, searching, and editing. |
-| `homeassistant` | `ha_call_service`, `ha_get_state`, `ha_list_entities`, `ha_list_services` | Smart home control via Home Assistant. Only available when `HASS_TOKEN` is set. |
+| `homeassistant` | `ha_apply_config`, `ha_call_service`, `ha_get_state`, `ha_inspect_config`, `ha_list_entities`, `ha_list_services`, `ha_preview_config`, `ha_rollback_config` | Smart home control via Home Assistant. Configuration management is separately opt-in. Only available when `HASS_TOKEN` is set. |
 | `computer_use` | `computer_use` | Background desktop control via cua-driver — does not steal cursor/focus. Works with any tool-capable model. macOS, Windows, and Linux; requires `cua-driver` on `$PATH`. |
 | `context_engine` | (varies) | Runtime tools exposed by the active context-engine plugin (empty until a plugin populates it). |
 | `image_gen` | `image_generate` | Text-to-image generation via FAL.ai (with opt-in OpenAI / xAI backends). |
@@ -93,7 +93,7 @@ Platform toolsets define the complete tool configuration for a deployment target
 | Toolset | Differences from `hermes-cli` |
 |---------|-------------------------------|
 | `hermes-cli` | Full toolset — the default for interactive CLI sessions. Includes file, terminal, web, browser, memory, skills, vision, image_gen, todo, tts, delegation, code_execution, cronjob, session_search, and clarify, plus the `safe` (read-only) bundle. |
-| `hermes-acp` | Drops `clarify`, `cronjob`, `image_generate`, `text_to_speech`, and all four Home Assistant tools. Focused on coding tasks in IDE context. |
+| `hermes-acp` | Drops `clarify`, `cronjob`, `image_generate`, `text_to_speech`, and all Home Assistant tools. Focused on coding tasks in IDE context. |
 | `hermes-api-server` | Drops `clarify` and `text_to_speech`. Keeps everything else — suitable for programmatic access where user interaction isn't possible. |
 | `hermes-cron` | Same as `hermes-cli`. |
 | `hermes-telegram` | Same as `hermes-cli`. |

--- a/website/docs/user-guide/messaging/homeassistant.md
+++ b/website/docs/user-guide/messaging/homeassistant.md
@@ -10,7 +10,7 @@ sidebar_position: 5
 Hermes Agent integrates with [Home Assistant](https://www.home-assistant.io/) in two ways:
 
 1. **Gateway platform** — subscribes to real-time state changes via WebSocket and responds to events
-2. **Smart home tools** — four LLM-callable tools for querying and controlling devices via the REST API
+2. **Smart home tools** — six LLM-callable tools for querying devices, controlling them, and optionally managing selected configuration
 
 ## Setup
 
@@ -48,7 +48,7 @@ Home Assistant will appear as a connected platform alongside any other messaging
 
 ## Available Tools
 
-Hermes Agent registers four tools for smart home control:
+Hermes Agent registers four device tools by default. Two additional configuration tools are available when configuration management is explicitly enabled.
 
 ### `ha_list_entities`
 
@@ -119,6 +119,29 @@ Set living room lights to blue at 50% brightness
 → ha_call_service(domain="light", service="turn_on",
     entity_id="light.living_room", data={"brightness": 128, "color_name": "blue"})
 ```
+
+## Safe Actions and Configuration Feedback
+
+Home Assistant configuration management is off by default. Enable it and the safe action policy in `~/.hermes/config.yaml`:
+
+```yaml
+homeassistant:
+  action_policy:
+    mode: safe
+    trusted_entities: []
+  config_management:
+    enabled: true
+    proposal_ttl_seconds: 900
+    history_limit: 500
+```
+
+In safe mode, exact light, fan, and media-player targets can run immediately. Broad targets and sensitive domains require a one-time interactive approval. Exact switch and scene targets can run immediately only when their entity IDs are listed under `trusted_entities`. Command-capable domains remain blocked.
+
+`ha_inspect_config` reports supported capabilities, lists or fetches configuration, and shows the local change history. Configuration changes use a mandatory `ha_preview_config` → `ha_apply_config` flow with action-specific required arguments. Each preview covers one object, expires after the configured TTL, and is rejected if Home Assistant changed in the meantime. `ha_rollback_config` safely reverses an eligible applied change. Apply and rollback approvals cannot be permanently remembered, bypassed by YOLO mode, or granted by a headless cron session.
+
+Supported configuration resources, when loaded by the connected Home Assistant instance, are automations, scripts, scenes, groups, standard helpers (`input_boolean`, `input_number`, `input_select`, `input_text`, `input_datetime`, `counter`, `timer`, and `schedule`), and entity/device/area metadata. `ha_inspect_config(action="capabilities")` reports what is actually available. Dashboards, integrations, add-ons, pairing, and device removal are outside this interface.
+
+Hermes stores proposal and audit records in the active profile under `state/homeassistant_changes.sqlite3` with owner-only permissions. Rollback is allowed only while the applied state is unchanged. Deleting a created object during rollback is allowed only when the audit record proves Hermes created that exact object.
 
 ## Gateway Platform: Real-Time Events
 


### PR DESCRIPTION
## What changed

- add proposal-first Home Assistant configuration management with durable audit and rollback state
- support safe Home Assistant group create and update flows
- replace the ambiguous multi-action mutation tool with strict `ha_preview_config`, `ha_apply_config`, and `ha_rollback_config` schemas
- fail closed when a group config/options flow does not reach a completed `create_entry`
- validate complete group definitions and supported group types before preview or apply
- block Home Assistant dispatch when an explicitly configured action-policy mode is invalid
- expose the strict configuration tools to Telegram and document their use

## Root cause

Telegram was given a single `ha_manage_config` schema that required only an `action`. The model could therefore emit syntactically valid preview calls containing a `change_id` while omitting `resource_type`, `resource_id`, `operation`, and `definition`. Group creation then failed repeatedly before reaching Home Assistant.

## Impact

Telegram can now construct a complete, non-mutating group preview, receive a proposal ID, and apply it only through the explicit approval path. The legacy ambiguous tool is no longer included in the Home Assistant toolset.

## Validation

- regression test observed failing on upstream before implementation
- Home Assistant/configuration suite: 158 passed, 16 deselected
- broader focused suite: 305 passed; one unrelated computer-use environment failure
- Ruff checks passed
- repository-wide local collection is incomplete because the installed runtime lacks the optional `acp` dependency; GitHub CI is the full merge gate
