### PR TITLE
fix(desktop): hide terminal overlay for inactive panes (#71406)

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
@@ -1,0 +1,69 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PersistentTerminal, TerminalSlot } from './persistent'
+
+vi.mock('./terminals', () => ({ ensureTerminal: vi.fn() }))
+vi.mock('./workspace', () => ({ TerminalWorkspace: () => <div /> }))
+
+describe('PersistentTerminal', () => {
+  let nextFrame: FrameRequestCallback | undefined
+
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      nextFrame = callback
+
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      bottom: 220,
+      height: 200,
+      left: 10,
+      right: 310,
+      top: 20,
+      width: 300,
+      x: 10,
+      y: 20,
+      toJSON: () => undefined
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('hides the fixed overlay when its kept-alive pane becomes inactive', () => {
+    const view = render(
+      <>
+        <div>
+          <TerminalSlot />
+        </div>
+        <PersistentTerminal onAddSelectionToChat={vi.fn()} />
+      </>
+    )
+
+    const overlay = view.container.querySelector<HTMLElement>('[aria-hidden]')
+
+    if (!overlay) {
+      throw new Error('Persistent terminal overlay was not rendered')
+    }
+
+    expect(overlay.style.visibility).toBe('visible')
+
+    view.rerender(
+      <>
+        <div data-pane-hidden>
+          <TerminalSlot />
+        </div>
+        <PersistentTerminal onAddSelectionToChat={vi.fn()} />
+      </>
+    )
+    act(() => nextFrame?.(0))
+
+    expect(overlay.style.pointerEvents).toBe('none')
+    expect(overlay.style.visibility).toBe('hidden')
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -2,6 +2,8 @@ import { useStore } from '@nanostores/react'
 import { atom } from 'nanostores'
 import { type CSSProperties, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
+import { PANE_HIDDEN_ATTR } from '@/components/pane-shell/pane-visibility'
+
 import { $terminalTakeover } from '../store'
 
 import { ensureTerminal } from './terminals'
@@ -59,6 +61,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
   const terminalTakeover = useStore($terminalTakeover)
   const [rect, setRect] = useState<Rect | null>(null)
   const [ready, setReady] = useState(false)
+  const [slotVisible, setSlotVisible] = useState(false)
 
   // VS Code parity: once the pane has ever been opened, keep the terminals
   // mounted — and their shells alive — even while hidden. Hiding the pane just
@@ -86,6 +89,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
 
     const tick = () => {
       const r = slot.getBoundingClientRect()
+      setSlotVisible(!slot.closest(`[${PANE_HIDDEN_ATTR}]`))
       // floor top/left + ceil right/bottom: overlay always covers the slot's
       // full pixel footprint, so half-pixel rects can't leak page bg through.
       const top = Math.floor(r.top)
@@ -109,7 +113,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
     return () => cancelAnimationFrame(frame)
   }, [slot])
 
-  const visible = Boolean(rect && rect.width > 0 && rect.height > 0)
+  const visible = Boolean(slotVisible && rect && rect.width > 0 && rect.height > 0)
 
   const style: CSSProperties = {
     position: 'fixed',


### PR DESCRIPTION
## What does this PR do?

Prevents the persistent terminal's fixed overlay from covering the workspace after switching away from a terminal tab in a keep-alive pane group. Inactive panes retain a non-zero layout rect, so the overlay now also checks the pane shell's `data-pane-hidden` marker while leaving the xterm instance and PTY mounted.

## Related Issue

Fixes #71406

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `apps/desktop/src/app/right-sidebar/terminal/persistent.tsx` to hide and disable pointer events on the fixed terminal overlay whenever its slot is inside an inactive keep-alive pane.
- Add `apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx` to reproduce the non-zero-rect hidden-pane case and verify the overlay becomes hidden.

## How to Test

1. In the Focus layout, open the terminal tab and then switch back to the workspace tab; confirm the terminal overlay no longer covers chat.
2. Run `cd apps/desktop && npm exec -- vitest run --project ui src/app/right-sidebar/terminal/persistent.test.tsx src/components/pane-shell/pane-visibility.test.ts`.
3. Run `cd apps/desktop && npm run typecheck`, then ESLint and Prettier checks for the two changed files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A: Desktop TypeScript-only change; targeted Vitest suites and TypeScript checks pass)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 12, Linux 6.1.0-42-amd64, Node.js 24.18.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression and pane-visibility tests: 4 passed. The terminal and pane-shell related suite passed 44 tests. TypeScript typecheck, ESLint, Prettier, and `git diff --check` pass.
