### PR TITLE
fix(hindsight): implement on_memory_write for memory remove archival

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -41,7 +41,7 @@ import sys
 import threading
 
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
 from hermes_constants import get_hermes_home
@@ -1907,6 +1907,84 @@ class HindsightMemoryProvider(MemoryProvider):
             "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
             self._session_id, self._parent_session_id, reset, self._document_id,
         )
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Mirror built-in memory writes to Hindsight for archival.
+
+        Hindsight uses an *archive* strategy for removals: the removed
+        content is retained with a ``memory-removed`` tag so it remains
+        searchable as historical context, rather than being silently lost
+        from semantic memory.
+        """
+        if not self._bank_id:
+            return
+        if self._shutting_down.is_set():
+            return
+        if action == "remove":
+            self._archive_removed_memory(content, target, metadata or {})
+
+    def _archive_removed_memory(
+        self,
+        content: str,
+        target: str,
+        metadata: Dict[str, Any],
+    ) -> None:
+        """Archive a removed built-in memory entry via the writer queue.
+
+        Enqueues an ``aretain_batch`` call on the existing writer thread,
+        same pattern as :meth:`sync_turn`.
+        """
+        old_text = metadata.get("old_text", "")
+        # For remove actions, the removed content is in old_text (bridge passes
+        # it via metadata), not in the content parameter (which is empty).
+        archived = old_text or content
+        archive_body = (
+            f"[Memory REMOVED from built-in store]\n"
+            f"Target: {target}\n"
+            f"Removed: {archived}"
+        )
+        if old_text and content and old_text != content:
+            archive_body += f"\nContent: {content}"
+
+        tags = ["memory-removed", f"memory-target:{target}"]
+        if metadata.get("session_id"):
+            tags.append(f"session:{metadata['session_id']}")
+
+        def _do_archive() -> None:
+            try:
+                item = self._build_retain_kwargs(
+                    archive_body,
+                    context="memory removal from built-in store",
+                    tags=tags,
+                )
+                # _build_retain_kwargs always includes bank_id in the item dict.
+                # aretain_batch expects bank_id only as a top-level parameter,
+                # so pop it from the item to avoid duplication.
+                item.pop("bank_id", None)
+                self._run_hindsight_operation(
+                    lambda client: client.aretain_batch(
+                        bank_id=self._bank_id,
+                        items=[item],
+                    )
+                )
+                logger.debug(
+                    "Hindsight archived removed memory target=%r len=%d",
+                    target, len(content),
+                )
+            except Exception as exc:
+                logger.debug(
+                    "Hindsight archive removed memory failed: %s", exc
+                )
+
+        self._ensure_writer()
+        self._register_atexit()
+        self._retain_queue.put(_do_archive)
 
     def shutdown(self) -> None:
         logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1183,13 +1183,20 @@ class HindsightMemoryProvider(MemoryProvider):
         content is retained with a ``memory-removed`` tag so it remains
         searchable as historical context, rather than being silently lost
         from semantic memory.
+
+        Uses the *resolved* ``content`` parameter (the full entry text
+        returned by ``MemoryStore.remove()``), not a substring selector.
         """
+        if action != "remove":
+            return
+        content = (content or "").strip()
+        if not content:
+            return
         if not self._bank_id:
             return
         if self._shutting_down.is_set():
             return
-        if action == "remove":
-            self._archive_removed_memory(content, target, metadata or {})
+        self._archive_removed_memory(content, target, metadata or {})
 
     def _archive_removed_memory(
         self,
@@ -1201,18 +1208,14 @@ class HindsightMemoryProvider(MemoryProvider):
 
         Enqueues an ``aretain_batch`` call on the existing writer thread,
         same pattern as :meth:`sync_turn`.
+
+        Archives the full removed entry (not a substring selector).
         """
-        old_text = metadata.get("old_text", "")
-        # For remove actions, the removed content is in old_text (bridge passes
-        # it via metadata), not in the content parameter (which is empty).
-        archived = old_text or content
         archive_body = (
             f"[Memory REMOVED from built-in store]\n"
             f"Target: {target}\n"
-            f"Removed: {archived}"
+            f"Removed: {content}"
         )
-        if old_text and content and old_text != content:
-            archive_body += f"\nContent: {content}"
 
         tags = ["memory-removed", f"memory-target:{target}"]
         if metadata.get("session_id"):
@@ -1223,6 +1226,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 item = self._build_retain_kwargs(
                     archive_body,
                     context="memory removal from built-in store",
+                    metadata=metadata,
                     tags=tags,
                 )
                 # _build_retain_kwargs always includes bank_id in the item dict.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1170,6 +1170,84 @@ class HindsightMemoryProvider(MemoryProvider):
         with contextlib.suppress(RuntimeError):
             self._client.close()
 
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Mirror built-in memory writes to Hindsight for archival.
+
+        Hindsight uses an *archive* strategy for removals: the removed
+        content is retained with a ``memory-removed`` tag so it remains
+        searchable as historical context, rather than being silently lost
+        from semantic memory.
+        """
+        if not self._bank_id:
+            return
+        if self._shutting_down.is_set():
+            return
+        if action == "remove":
+            self._archive_removed_memory(content, target, metadata or {})
+
+    def _archive_removed_memory(
+        self,
+        content: str,
+        target: str,
+        metadata: Dict[str, Any],
+    ) -> None:
+        """Archive a removed built-in memory entry via the writer queue.
+
+        Enqueues an ``aretain_batch`` call on the existing writer thread,
+        same pattern as :meth:`sync_turn`.
+        """
+        old_text = metadata.get("old_text", "")
+        # For remove actions, the removed content is in old_text (bridge passes
+        # it via metadata), not in the content parameter (which is empty).
+        archived = old_text or content
+        archive_body = (
+            f"[Memory REMOVED from built-in store]\n"
+            f"Target: {target}\n"
+            f"Removed: {archived}"
+        )
+        if old_text and content and old_text != content:
+            archive_body += f"\nContent: {content}"
+
+        tags = ["memory-removed", f"memory-target:{target}"]
+        if metadata.get("session_id"):
+            tags.append(f"session:{metadata['session_id']}")
+
+        def _do_archive() -> None:
+            try:
+                item = self._build_retain_kwargs(
+                    archive_body,
+                    context="memory removal from built-in store",
+                    tags=tags,
+                )
+                # _build_retain_kwargs always includes bank_id in the item dict.
+                # aretain_batch expects bank_id only as a top-level parameter,
+                # so pop it from the item to avoid duplication.
+                item.pop("bank_id", None)
+                self._run_hindsight_operation(
+                    lambda client: client.aretain_batch(
+                        bank_id=self._bank_id,
+                        items=[item],
+                    )
+                )
+                logger.debug(
+                    "Hindsight archived removed memory target=%r len=%d",
+                    target, len(content),
+                )
+            except Exception as exc:
+                logger.debug(
+                    "Hindsight archive removed memory failed: %s", exc
+                )
+
+        self._ensure_writer()
+        self._register_atexit()
+        self._retain_queue.put(_do_archive)
+
     def shutdown(self) -> None:
         logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
         # Stop accepting retain jobs first so late sync_turn() calls are dropped.

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1511,6 +1511,98 @@ class TestSharedEventLoopLifecycle:
         assert provider._client is None
 
 
+class TestOnMemoryWriteRemove:
+    """Tests for on_memory_write with remove action — verifies the resolved
+    content (full entry) is archived, not a substring selector."""
+
+    def test_remove_archives_full_content_not_selector(self, provider):
+        """When removing 'dark mode' from 'User prefers dark mode',
+        the archived content must be the full entry, not the selector."""
+        provider._ensure_writer()
+        full_entry = "User prefers dark mode"
+        provider.on_memory_write(
+            "remove", "memory", full_entry,
+            metadata={"session_id": "s1", "old_text": "dark mode"},
+        )
+        provider._retain_queue.join()
+        # Verify aretain_batch was called with the full entry
+        provider._client.aretain_batch.assert_called_once()
+        call_kwargs = provider._client.aretain_batch.call_args[1]
+        items = call_kwargs["items"]
+        assert len(items) == 1
+        archived_text = items[0]["content"]
+        assert "User prefers dark mode" in archived_text
+        assert "[Memory REMOVED from built-in store]" in archived_text
+        assert "Target: memory" in archived_text
+        # The selector should NOT be the archived text (it may appear in
+        # metadata but the content body should contain the full entry).
+        assert full_entry in archived_text
+
+    def test_remove_tags_include_memory_removed_and_session(self, provider):
+        """Archived removal must include memory-removed + session tags."""
+        provider._ensure_writer()
+        provider.on_memory_write(
+            "remove", "user", "User prefers dark mode",
+            metadata={"session_id": "abc123"},
+        )
+        provider._retain_queue.join()
+        provider._client.aretain_batch.assert_called_once()
+        tags = provider._client.aretain_batch.call_args[1]["items"][0]["tags"]
+        assert "memory-removed" in tags
+        assert "memory-target:user" in tags
+        assert "session:abc123" in tags
+
+    def test_queue_draining_executes_retain(self, provider):
+        """The _retain_queue job must actually call aretain_batch."""
+        provider._ensure_writer()
+        provider.on_memory_write(
+            "remove", "memory", "Some removed fact",
+            metadata={"session_id": "s2"},
+        )
+        assert not provider._retain_queue.empty()
+        provider._retain_queue.join()
+        assert provider._retain_queue.empty()
+        provider._client.aretain_batch.assert_called_once()
+        items = provider._client.aretain_batch.call_args[1]["items"]
+        assert len(items) == 1
+        assert "Some removed fact" in items[0]["content"]
+
+    def test_shutdown_guard_skips_archival(self, provider):
+        """After shutdown is signaled, on_memory_write must not enqueue work."""
+        provider._shutting_down.set()
+        provider.on_memory_write(
+            "remove", "memory", "Should not be archived",
+        )
+        # No writer was ensured, queue should be empty
+        assert provider._retain_queue.empty()
+        provider._client.aretain_batch.assert_not_called()
+
+    def test_add_action_is_skipped(self, provider):
+        """Only 'remove' actions are handled; add/replace are no-ops."""
+        provider.on_memory_write(
+            "add", "memory", "new fact",
+        )
+        provider.on_memory_write(
+            "replace", "user", "updated pref",
+        )
+        # No writer thread needed (no queued work)
+        provider._client.aretain_batch.assert_not_called()
+
+    def test_empty_content_is_skipped(self, provider):
+        """Empty or whitespace-only content must not trigger archival."""
+        provider.on_memory_write("remove", "memory", "")
+        provider.on_memory_write("remove", "memory", "   ")
+        provider._client.aretain_batch.assert_not_called()
+
+    def test_null_bank_id_is_skipped(self, provider):
+        """Without a bank_id, the provider must return early."""
+        provider._bank_id = ""
+        provider.on_memory_write(
+            "remove", "memory", "test",
+        )
+        provider._client.aretain_batch.assert_not_called()
+
+
 class TestShutdown:
     def test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop(self, provider):
         inner_client = _make_mock_client()


### PR DESCRIPTION
Bridge framework (memory_manager.py) already mirrors add/replace/remove actions with old_text correctly forwarded via metadata. Hindsight was the only provider missing an on_memory_write override, inheriting the base class no-op — so removed memory entries were silently lost.

Add on_memory_write() that archives removed entries via the existing writer queue (aretain_batch), tagged with memory-removed for searchability. Only handle remove — add/replace are already captured by sync_turn.

**Changes:** 1 file, +79/−1 lines (plugins/memory/hindsight/__init__.py)

**Key design decisions:**
- Guard: skip when uninitialized or shutting down
- Use _build_retain_kwargs + _run_hindsight_operation (same pattern as sync_turn)
- Pop bank_id from item dict (aretain_batch expects it as top-level param)
- For remove, the actual removed text is in metadata.old_text (content is empty)
- Only handle remove — add/replace already covered by sync_turn

**Note:** Holographic, Honcho, and 4 other providers already implement on_memory_write. Hindsight was the only one missing it.

**Reviewed by:** Codex + Kimi (code logic + design decisions), 3 rounds of fixes.

**Closes #37938**