### PR TITLE
fix(tests): reuse main checkout venv in worktrees

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -11,7 +11,8 @@
 #   * Env vars blanked (conftest.py also does this, but this
 #     is belt-and-suspenders for anyone running pytest outside our
 #     conftest path — e.g. on a single file)
-#   * Proper venv activation (probes .venv, venv, then ~/.hermes/...)
+#   * Proper venv activation (local checkout, shared worktree checkout, then
+#     ~/.hermes/...)
 #
 # Usage:
 #   scripts/run_tests.sh                            # full suite
@@ -51,7 +52,33 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 VENV=""
 VENV_PYTHON=""
 SKIPPED_VENVS=""
-for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
+SHARED_CHECKOUT_ROOT=""
+COMMON_GIT_DIR="$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -n "$COMMON_GIT_DIR" ]; then
+  # Resolve relative output from the checkout root without relying on Git's
+  # newer --path-format option. Let `cd` also normalize Git-for-Windows drive
+  # paths into the path spelling understood by the current shell.
+  if RESOLVED_COMMON_GIT_DIR="$(
+    cd "$REPO_ROOT" &&
+    cd "$COMMON_GIT_DIR" 2>/dev/null &&
+    pwd -P
+  )"; then
+    COMMON_GIT_DIR="$RESOLVED_COMMON_GIT_DIR"
+  else
+    COMMON_GIT_DIR=""
+  fi
+fi
+if [ "${COMMON_GIT_DIR##*/}" = ".git" ]; then
+  SHARED_CHECKOUT_ROOT="${COMMON_GIT_DIR%/.git}"
+fi
+
+CANDIDATE_VENVS=("$REPO_ROOT/.venv" "$REPO_ROOT/venv")
+if [ -n "$SHARED_CHECKOUT_ROOT" ] && [ "$SHARED_CHECKOUT_ROOT" != "$REPO_ROOT" ]; then
+  CANDIDATE_VENVS+=("$SHARED_CHECKOUT_ROOT/.venv" "$SHARED_CHECKOUT_ROOT/venv")
+fi
+CANDIDATE_VENVS+=("$HOME/.hermes/hermes-agent/venv")
+
+for candidate in "${CANDIDATE_VENVS[@]}"; do
   if [ -f "$candidate/bin/activate" ]; then
     if "$candidate/bin/python" -c 'import pytest' 2>/dev/null; then
       VENV="$candidate"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -11,7 +11,8 @@
 #   * Env vars blanked (conftest.py also does this, but this
 #     is belt-and-suspenders for anyone running pytest outside our
 #     conftest path — e.g. on a single file)
-#   * Proper venv activation (probes .venv, venv, then ~/.hermes/...)
+#   * Proper venv activation (local checkout, shared worktree checkout, then
+#     ~/.hermes/...)
 #
 # Usage:
 #   scripts/run_tests.sh                            # full suite
@@ -50,7 +51,30 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # exit code is 1). Skip such a venv and keep probing instead.
 VENV=""
 SKIPPED_VENVS=""
-for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
+SHARED_CHECKOUT_ROOT=""
+COMMON_GIT_DIR="$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -n "$COMMON_GIT_DIR" ]; then
+  case "$COMMON_GIT_DIR" in
+    /*) ;;
+    *) COMMON_GIT_DIR="$REPO_ROOT/$COMMON_GIT_DIR" ;;
+  esac
+  if [ -d "$COMMON_GIT_DIR" ]; then
+    COMMON_GIT_DIR="$(cd "$COMMON_GIT_DIR" && pwd -P)"
+  else
+    COMMON_GIT_DIR=""
+  fi
+fi
+if [ "${COMMON_GIT_DIR##*/}" = ".git" ]; then
+  SHARED_CHECKOUT_ROOT="${COMMON_GIT_DIR%/.git}"
+fi
+
+CANDIDATE_VENVS=("$REPO_ROOT/.venv" "$REPO_ROOT/venv")
+if [ -n "$SHARED_CHECKOUT_ROOT" ] && [ "$SHARED_CHECKOUT_ROOT" != "$REPO_ROOT" ]; then
+  CANDIDATE_VENVS+=("$SHARED_CHECKOUT_ROOT/.venv" "$SHARED_CHECKOUT_ROOT/venv")
+fi
+CANDIDATE_VENVS+=("$HOME/.hermes/hermes-agent/venv")
+
+for candidate in "${CANDIDATE_VENVS[@]}"; do
   if [ -f "$candidate/bin/activate" ]; then
     if "$candidate/bin/python" -c 'import pytest' 2>/dev/null; then
       VENV="$candidate"

--- a/tests/test_run_tests_wrapper.py
+++ b/tests/test_run_tests_wrapper.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def _run(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _wrapper_checkouts(tmp_path: Path) -> tuple[Path, Path, Path]:
+    project_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "main checkout with spaces"
+    worktree = tmp_path / "linked worktree with spaces"
+    home = tmp_path / "home with spaces"
+    repo.mkdir()
+    home.mkdir()
+
+    _run("git", "init", "-b", "main", cwd=repo)
+    _run("git", "config", "user.name", "Hermes Tests", cwd=repo)
+    _run("git", "config", "user.email", "tests@example.invalid", cwd=repo)
+
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    shutil.copy2(project_root / "scripts" / "run_tests.sh", scripts / "run_tests.sh")
+    (scripts / "run_tests_parallel.py").write_text("# test stub\n", encoding="utf-8")
+    (repo / "tests").mkdir()
+    (repo / "tests" / "example.py").write_text("# test stub\n", encoding="utf-8")
+    _run("git", "add", ".", cwd=repo)
+    _run("git", "commit", "-m", "test fixture", cwd=repo)
+    _run("git", "worktree", "add", "-b", "test-worktree", str(worktree), cwd=repo)
+
+    return repo, worktree, home
+
+
+def _fake_venv_python(
+    venv: Path,
+    *,
+    windows_layout: bool = False,
+    has_pytest: bool = True,
+) -> Path:
+    scripts_dir = venv / ("Scripts" if windows_layout else "bin")
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "activate").write_text("# test stub\n", encoding="utf-8")
+    fake_python = scripts_dir / ("python.exe" if windows_layout else "python")
+    pytest_probe_status = 0 if has_pytest else 1
+    fake_python.write_text(
+        "#!/bin/sh\n"
+        f'if [ "${{1:-}}" = "-c" ]; then exit {pytest_probe_status}; fi\n'
+        'if [ "${1:-}" = "-m" ]; then exit 0; fi\n'
+        "printf 'WRAPPER_PYTHON_SELECTED:%s\\n' \"$0\"\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    return fake_python
+
+
+def _run_wrapper(
+    checkout: Path,
+    home: Path,
+    *,
+    path: str | None = None,
+    hermes_python: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env.pop("HERMES_PYTHON", None)
+    if path is not None:
+        env["PATH"] = path
+    if hermes_python is not None:
+        env["HERMES_PYTHON"] = str(hermes_python)
+    return subprocess.run(
+        ["bash", "scripts/run_tests.sh", "tests/example.py", "-q"],
+        cwd=checkout,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _assert_selected(
+    result: subprocess.CompletedProcess[str], fake_python: Path
+) -> None:
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert f"WRAPPER_PYTHON_SELECTED:{fake_python}" in result.stdout
+
+
+def test_run_tests_uses_posix_venv_from_main_checkout_in_worktree(
+    tmp_path: Path,
+) -> None:
+    repo, worktree, home = _wrapper_checkouts(tmp_path)
+    fake_python = _fake_venv_python(repo / "venv")
+
+    result = _run_wrapper(worktree, home)
+
+    _assert_selected(result, fake_python)
+
+
+def test_run_tests_uses_windows_venv_from_main_checkout_in_worktree(
+    tmp_path: Path,
+) -> None:
+    repo, worktree, home = _wrapper_checkouts(tmp_path)
+    fake_python = _fake_venv_python(repo / "venv", windows_layout=True)
+
+    result = _run_wrapper(worktree, home)
+
+    _assert_selected(result, fake_python)
+
+
+def test_run_tests_shared_venv_does_not_require_git_path_format(
+    tmp_path: Path,
+) -> None:
+    repo, worktree, home = _wrapper_checkouts(tmp_path)
+    fake_python = _fake_venv_python(repo / "venv")
+    real_git = shutil.which("git")
+    assert real_git is not None
+    shim_dir = tmp_path / "old git shim"
+    shim_dir.mkdir()
+    git_shim = shim_dir / "git"
+    git_shim.write_text(
+        "#!/bin/sh\n"
+        'for arg in "$@"; do\n'
+        '  if [ "$arg" = "--path-format=absolute" ]; then\n'
+        "    printf 'error: unknown option %s\\n' \"$arg\" >&2\n"
+        "    exit 129\n"
+        "  fi\n"
+        "done\n"
+        f'exec {shlex.quote(real_git)} "$@"\n',
+        encoding="utf-8",
+    )
+    git_shim.chmod(0o755)
+
+    result = _run_wrapper(
+        worktree,
+        home,
+        path=f"{shim_dir}{os.pathsep}{os.environ['PATH']}",
+    )
+
+    _assert_selected(result, fake_python)
+
+
+def test_run_tests_skips_venv_without_pytest_before_shared_venv(
+    tmp_path: Path,
+) -> None:
+    repo, worktree, home = _wrapper_checkouts(tmp_path)
+    _fake_venv_python(worktree / ".venv", has_pytest=False)
+    fake_python = _fake_venv_python(repo / "venv")
+
+    result = _run_wrapper(worktree, home)
+
+    _assert_selected(result, fake_python)
+    assert "skipping venv without pytest" in result.stderr
+
+
+def test_run_tests_falls_back_to_hermes_python(tmp_path: Path) -> None:
+    _repo, worktree, home = _wrapper_checkouts(tmp_path)
+    fake_python = _fake_venv_python(tmp_path / "nix dev venv with spaces")
+
+    result = _run_wrapper(worktree, home, hermes_python=fake_python)
+
+    _assert_selected(result, fake_python)
+    assert "using Nix dev venv via HERMES_PYTHON" in result.stdout
+
+
+def test_run_tests_uses_local_venv_in_non_worktree_checkout(tmp_path: Path) -> None:
+    repo, _worktree, home = _wrapper_checkouts(tmp_path)
+    fake_python = _fake_venv_python(repo / ".venv")
+
+    result = _run_wrapper(repo, home)
+
+    _assert_selected(result, fake_python)

--- a/tests/test_run_tests_wrapper.py
+++ b/tests/test_run_tests_wrapper.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def _run(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _linked_worktree_with_shared_venv(
+    tmp_path: Path,
+) -> tuple[Path, Path, Path]:
+    project_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "main checkout with spaces"
+    worktree = tmp_path / "linked worktree with spaces"
+    home = tmp_path / "home"
+    repo.mkdir()
+    home.mkdir()
+
+    _run("git", "init", "-b", "main", cwd=repo)
+    _run("git", "config", "user.name", "Hermes Tests", cwd=repo)
+    _run("git", "config", "user.email", "tests@example.invalid", cwd=repo)
+
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    shutil.copy2(project_root / "scripts" / "run_tests.sh", scripts / "run_tests.sh")
+    (scripts / "run_tests_parallel.py").write_text("# test stub\n", encoding="utf-8")
+    (repo / "tests").mkdir()
+    (repo / "tests" / "example.py").write_text("# test stub\n", encoding="utf-8")
+    _run("git", "add", ".", cwd=repo)
+    _run("git", "commit", "-m", "test fixture", cwd=repo)
+    _run("git", "worktree", "add", "-b", "test-worktree", str(worktree), cwd=repo)
+
+    shared_venv = repo / "venv" / "bin"
+    shared_venv.mkdir(parents=True)
+    (shared_venv / "activate").write_text("# test stub\n", encoding="utf-8")
+    fake_python = shared_venv / "python"
+    fake_python.write_text(
+        "#!/bin/sh\n"
+        "if [ \"${1:-}\" = \"-c\" ]; then exit 0; fi\n"
+        "if [ \"${1:-}\" = \"-m\" ]; then exit 0; fi\n"
+        "printf 'SHARED_VENV_SELECTED:%s\\n' \"$0\"\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    return worktree, home, fake_python
+
+
+def _run_worktree_wrapper(
+    worktree: Path,
+    home: Path,
+    *,
+    path: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env.pop("HERMES_PYTHON", None)
+    if path is not None:
+        env["PATH"] = path
+    return subprocess.run(
+        ["bash", "scripts/run_tests.sh", "tests/example.py", "-q"],
+        cwd=worktree,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_run_tests_uses_main_checkout_venv_from_git_worktree(tmp_path: Path) -> None:
+    worktree, home, fake_python = _linked_worktree_with_shared_venv(tmp_path)
+
+    result = _run_worktree_wrapper(worktree, home)
+
+    assert result.returncode == 0, result.stderr
+    assert f"SHARED_VENV_SELECTED:{fake_python}" in result.stdout
+
+
+def test_run_tests_shared_venv_does_not_require_git_path_format(
+    tmp_path: Path,
+) -> None:
+    worktree, home, fake_python = _linked_worktree_with_shared_venv(tmp_path)
+    real_git = shutil.which("git")
+    assert real_git is not None
+    shim_dir = tmp_path / "old git shim"
+    shim_dir.mkdir()
+    git_shim = shim_dir / "git"
+    git_shim.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -e\n"
+        "unknown=\"\"\n"
+        "args=()\n"
+        "for arg in \"$@\"; do\n"
+        "  if [ \"$arg\" = \"--path-format=absolute\" ]; then\n"
+        "    unknown=\"$arg\"\n"
+        "  else\n"
+        "    args+=(\"$arg\")\n"
+        "  fi\n"
+        "done\n"
+        "if [ -n \"$unknown\" ]; then\n"
+        "  printf '%s\\n' \"$unknown\"\n"
+        f"  {shlex.quote(real_git)} \"${{args[@]}}\"\n"
+        "  exit 0\n"
+        "fi\n"
+        f"exec {shlex.quote(real_git)} \"$@\"\n",
+        encoding="utf-8",
+    )
+    git_shim.chmod(0o755)
+
+    result = _run_worktree_wrapper(
+        worktree,
+        home,
+        path=f"{shim_dir}{os.pathsep}{os.environ['PATH']}",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"SHARED_VENV_SELECTED:{fake_python}" in result.stdout


### PR DESCRIPTION
## Summary

- detect the main checkout behind a linked Git worktree through `git-common-dir`
- reuse the main checkout's `.venv` or `venv` before falling back to the user install path
- keep the existing `pytest` import guard for every candidate
- add an end-to-end regression using a temporary repository and linked worktree

## Root cause

`scripts/run_tests.sh` only probed virtualenvs inside the current worktree and `~/.hermes/hermes-agent/venv`. Git worktrees do not copy untracked virtualenv directories, and system installs can keep the development environment in the main checkout (for example, `<main-checkout>/venv`).

The canonical wrapper therefore failed with `no virtualenv with pytest found` even though the repository's shared checkout already had a valid test environment. Every worktree required a manual `HERMES_PYTHON` override.

The wrapper now resolves the Git common directory with the worktree-era `--git-common-dir` option, absolutizes and canonicalizes the result itself, derives the main checkout only when that directory is a normal `.git` directory, and probes its virtualenvs with fully quoted paths. It does not require the newer `--path-format` option.

## Verification

```bash
bash -n scripts/run_tests.sh
scripts/run_tests.sh tests/test_run_tests_wrapper.py -q
```

Result: **2 passed, 0 failed**. The matrix covers paths containing spaces and a shim that reproduces pre-2.31 Git option handling. The same wrapper then launched the integrated targeted matrix without a `HERMES_PYTHON` override.

The regression removes `HERMES_PYTHON`, creates a real linked worktree, places a test Python only in the main checkout's `venv`, and proves that the worktree wrapper selects it.
