### PR TITLE
fix(cli): make chat -q delegation stateless

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16240,6 +16240,16 @@ def main(
     
     # Handle query shorthand
     query = query or q
+
+    # A single-query CLI process exits after this turn and has no later event
+    # loop that can deliver a detached delegation result. Mark it stateless
+    # before agent/tool initialization so delegate_task uses its existing
+    # inline fallback instead of dispatching work that shutdown will interrupt.
+    # Interactive CLI sessions remain delivery-capable. See #71453.
+    if query or image:
+        from gateway.session_context import declare_stateless_channel
+
+        declare_stateless_channel()
     
     # Parse toolsets - handle both string and tuple/list inputs
     # Default to hermes-cli toolset which includes cronjob management tools

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -357,8 +357,9 @@ def async_delivery_supported() -> bool:
     Returns ``False`` for finite runtimes that can end before a detached result
     is delivered: sessions explicitly bound by a stateless channel — an adapter
     that cannot route a notification back after the turn ends (the API server),
-    or a one-shot runner that exits after its final response (``hermes -z``,
-    cron — see :func:`declare_stateless_channel`) — and dispatcher-spawned
+    or a finite runner that exits after its final response (``hermes -z``,
+    ``hermes chat -q``, cron — see :func:`declare_stateless_channel`) — and
+    dispatcher-spawned
     Kanban workers (identified by ``HERMES_KANBAN_TASK``), which are one-shot
     ``chat -q`` subprocesses. The real gateway platforms, the interactive CLI,
     and any other path that never bound the contextvar return ``True``.

--- a/tests/cli/test_chat_q_stateless_delegation.py
+++ b/tests/cli/test_chat_q_stateless_delegation.py
@@ -1,0 +1,69 @@
+"""Regression for #71453: finite ``chat -q`` cannot deliver async results."""
+
+from types import SimpleNamespace
+
+import cli as cli_mod
+from gateway.session_context import async_delivery_supported, reset_session_vars
+
+
+def test_single_query_declares_stateless_channel_before_agent_turn(monkeypatch):
+    """A detached delegate must fall back inline before the finite turn starts."""
+    observed_delivery_capability: list[bool] = []
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.console = SimpleNamespace(print=lambda *_a, **_kw: None)
+            self.session_id = "chat-q-session"
+            self.agent = SimpleNamespace(
+                session_id="chat-q-session",
+                platform="cli",
+            )
+
+        def _claim_active_session(self, _surface, *, stderr=False):
+            return True
+
+        def _show_security_advisories(self):
+            return None
+
+        def chat(self, _query, images=None):
+            observed_delivery_capability.append(async_delivery_supported())
+            return "done"
+
+        def _print_exit_summary(self, clear_screen=True):
+            return None
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli_mod, "_finalize_single_query", lambda _cli: None)
+
+    reset_session_vars()
+    try:
+        assert async_delivery_supported() is True
+        cli_mod.main(query="delegate this", quiet=False, toolsets="terminal")
+    finally:
+        reset_session_vars()
+
+    assert observed_delivery_capability == [False]
+
+
+def test_interactive_cli_keeps_async_delivery_capability(monkeypatch):
+    """Long-lived CLI sessions still accept late delegation completions."""
+    observed_delivery_capability: list[bool] = []
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.agent = None
+
+        def run(self):
+            observed_delivery_capability.append(async_delivery_supported())
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_a, **_kw: None)
+
+    reset_session_vars()
+    try:
+        cli_mod.main(query=None, quiet=False, toolsets="terminal")
+    finally:
+        reset_session_vars()
+
+    assert observed_delivery_capability == [True]


### PR DESCRIPTION
## Summary

- mark finite `hermes chat -q` / image-only CLI invocations as a stateless delivery channel before agent and tool initialization;
- reuse the existing `delegate_task` synchronous fallback rather than dispatching a child whose completion cannot re-enter the exiting process;
- leave the long-lived interactive CLI delivery-capable;
- document `chat -q` alongside the other finite runtimes in the shared capability contract.

Fixes #71453.

## Root cause

`hermes -z` and cron already bind `async_delivery=False`, but the classic single-query path in `cli.main()` never did. `async_delivery_supported()` therefore defaulted to `True`, so top-level `delegate_task` dispatched asynchronously. The query returned, shutdown called `interrupt_all()`, and useful child work was marked interrupted before its result could reach the parent.

The fix declares the channel stateless immediately after resolving `query` / `q`, before `HermesCLI` constructs the agent. Existing delegate logic then runs the child inline and returns the work product within the only turn.

## Regression coverage

- single-query `cli.main(query=...)` observes `async_delivery_supported() == False` before its agent turn;
- interactive `cli.main()` remains `True` as a negative control;
- the existing shared capability test continues to prove that a stateless channel does not call the async dispatcher and returns the child result inline.

The new single-query regression was verified red on current `main` (`[True] != [False]`) before the production change.

## Verification

- full `tests/cli` plus shared async-delivery capability suite: **95 files, 1,159 passed, 0 failed**;
- Ruff: clean;
- `py_compile`: clean;
- Windows-footgun scan: **809 files, no findings**;
- `git diff --check`: clean.
