### PR TITLE
fix(security): honor Tirith fail-closed breaker policy

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -205,6 +205,42 @@ class TestUnknownExitCode:
         assert "exit code 99" in result["summary"]
 
 
+class TestCircuitBreakerPolicy:
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_open_breaker_honors_fail_closed(self, mock_cfg, mock_run):
+        mock_cfg.return_value = {
+            "tirith_enabled": True, "tirith_path": "tirith",
+            "tirith_timeout": 5, "tirith_fail_open": False,
+        }
+        _tirith_mod._circuit_open = True
+
+        result = check_command_security("echo hi")
+
+        assert result["action"] == "block"
+        assert "fail-closed" in result["summary"]
+        mock_run.assert_not_called()
+
+    @pytest.mark.parametrize("returncode", [1, 2])
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_verdict_exit_resets_crash_streak(
+        self, mock_cfg, mock_run, returncode
+    ):
+        mock_cfg.return_value = {
+            "tirith_enabled": True, "tirith_path": "tirith",
+            "tirith_timeout": 5, "tirith_fail_open": True,
+        }
+        _tirith_mod._crash_count = _tirith_mod._CRASH_LIMIT - 1
+        mock_run.return_value = _mock_run(returncode, _json_stdout())
+
+        result = check_command_security("echo hi")
+
+        assert result["action"] in {"block", "warn"}
+        assert _tirith_mod._crash_count == 0
+        assert _tirith_mod._circuit_open is False
+
+
 # ---------------------------------------------------------------------------
 # Disabled + path expansion
 # ---------------------------------------------------------------------------

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -744,13 +744,21 @@ def check_command_security(command: str) -> dict:
     if not cfg["tirith_enabled"]:
         return {"action": "allow", "findings": [], "summary": ""}
 
+    fail_open = cfg["tirith_fail_open"]
+
     # Circuit breaker: if tirith has crashed _CRASH_LIMIT times in a row,
     # stop trying for the rest of the process.  Without this, a corrupted
     # or missing binary causes every tool call to hit the same spawn failure
     # → fail-open → agent retry loop, hanging the user for 20+ minutes
     # (issue #41400).
     if _circuit_open:
-        return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        if fail_open:
+            return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        return {
+            "action": "block",
+            "findings": [],
+            "summary": "tirith disabled (circuit breaker; fail-closed)",
+        }
 
     # Unsupported platform (Windows etc.) — tirith has no binary here and
     # never will. Skip the resolver entirely so we don't even try to spawn.
@@ -760,7 +768,6 @@ def check_command_security(command: str) -> dict:
 
     tirith_path = _resolve_tirith_path(cfg["tirith_path"])
     timeout = cfg["tirith_timeout"]
-    fail_open = cfg["tirith_fail_open"]
 
     if tirith_path is None:
         _warn_once(
@@ -806,10 +813,12 @@ def check_command_security(command: str) -> dict:
 
     # Map exit code to action
     exit_code = result.returncode
+    if exit_code in (0, 1, 2):
+        # All documented verdict exits mean the scanner ran successfully.
+        _crash_count = 0
+
     if exit_code == 0:
         action = "allow"
-        # Successful execution — reset circuit breaker
-        _crash_count = 0
     elif exit_code == 1:
         action = "block"
     elif exit_code == 2:


### PR DESCRIPTION
## Summary

- honor `security.tirith_fail_open: false` after the Tirith circuit breaker opens;
- keep the breaker from spawning a known-broken scanner while returning the configured fail-closed verdict;
- reset the consecutive-failure streak for every documented Tirith verdict exit (`0`, `1`, or `2`), not only `0`.

Fixes #71350.

## Root cause

The breaker returned `allow` before reading `tirith_fail_open`, so the operator's explicit fail-closed policy was bypassed once the scanner had failed three times.

Separately, exit codes `1` (block) and `2` (warn) are successful scanner verdicts, but they left `_crash_count` unchanged. A prior transient failure followed by normal block/warn verdicts could therefore keep an old crash streak alive and open the breaker on the next unrelated failure.

## Behavior

- breaker open + fail-open → `allow` as before;
- breaker open + fail-closed → `block` without spawning Tirith;
- exit `0`, `1`, or `2` → reset the crash streak;
- spawn errors, timeouts, and unknown exit codes retain the existing breaker accounting.

## Verification

- `tests/tools/test_tirith_security.py`: **98 passed**;
- new regressions were red on current `main` before the fix;
- Ruff, `py_compile`, and `git diff --check`: clean.
