### PR TITLE
fix(delegate): preserve parent fixed proxy credential

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1874,6 +1874,29 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
         result = _resolve_child_credential_pool(None, parent)
         self.assertIs(result, mock_pool)
 
+    def test_same_provider_fixed_proxy_does_not_load_default_pool(self):
+        parent = _make_mock_parent()
+        parent.provider = "anthropic"
+        parent.base_url = "http://127.0.0.1:8080/v1"
+        parent.api_key = "proxy-key"
+        parent._client_kwargs = {
+            "base_url": parent.base_url,
+            "api_key": parent.api_key,
+        }
+        parent._credential_pool = None
+
+        provider_pool = MagicMock()
+        provider_pool.has_credentials.return_value = True
+        with patch(
+            "agent.credential_pool.load_pool", return_value=provider_pool
+        ) as load_pool:
+            result = _resolve_child_credential_pool(
+                "anthropic", parent, parent.base_url
+            )
+
+        self.assertIsNone(result)
+        load_pool.assert_not_called()
+
     def test_different_provider_loads_own_pool(self):
         parent = _make_mock_parent()
         parent._credential_pool = MagicMock()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3181,7 +3181,11 @@ def _resolve_child_credential_pool(
             )
         return None
 
-    if parent_pool is not None and effective_provider == parent_provider:
+    if effective_provider == parent_provider:
+        # A same-provider parent with no pool is using a fixed credential
+        # bundle (for example a local proxy base URL + proxy key). Loading the
+        # provider's default pool here would overwrite that inherited endpoint
+        # and key on the child. Keep the fixed credential by returning None.
         return parent_pool
 
     try:


### PR DESCRIPTION
## Summary

- keep a same-provider subagent on the parent agent's fixed credential bundle when the parent has no credential pool;
- prevent child construction from loading the provider-default pool and replacing an inherited local proxy endpoint/key;
- preserve existing behavior for shared parent pools, different-provider pools, and custom-endpoint identity handling.

Fixes #71424.

## Root cause

`_build_child_agent()` correctly inherited the parent's live proxy `base_url` and fixed API key. Immediately afterward, `_resolve_child_credential_pool()` saw that the parent had no pool and called `load_pool(effective_provider)`. For a same-provider Anthropic child, that loaded the default Anthropic pool and later replaced the inherited proxy credential with the public endpoint credential.

A parent with the same provider and `_credential_pool is None` is already expressing the fixed-credential path. The resolver now returns `None` for that case so the child keeps the credentials passed to `AIAgent`.

## Verification

- regression was red on current `main`: the provider-default pool was returned;
- complete `TestChildCredentialPoolResolution` class: **12 passed**;
- Ruff, `py_compile`, and `git diff --check`: clean.
