### PR TITLE
fix(tirith): reset breaker streak on verdicts

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -205,6 +205,27 @@ class TestUnknownExitCode:
         assert "exit code 99" in result["summary"]
 
 
+class TestVerdictExitBreakerAccounting:
+    @pytest.mark.parametrize("returncode", [1, 2])
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_verdict_exit_resets_crash_streak(
+        self, mock_cfg, mock_run, returncode
+    ):
+        mock_cfg.return_value = {
+            "tirith_enabled": True, "tirith_path": "tirith",
+            "tirith_timeout": 5, "tirith_fail_open": True,
+        }
+        _tirith_mod._crash_count = _tirith_mod._CRASH_LIMIT - 1
+        mock_run.return_value = _mock_run(returncode, _json_stdout())
+
+        result = check_command_security("echo hi")
+
+        assert result["action"] in {"block", "warn"}
+        assert _tirith_mod._crash_count == 0
+        assert _tirith_mod._circuit_open is False
+
+
 # ---------------------------------------------------------------------------
 # Disabled + path expansion
 # ---------------------------------------------------------------------------

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -806,10 +806,12 @@ def check_command_security(command: str) -> dict:
 
     # Map exit code to action
     exit_code = result.returncode
+    if exit_code in (0, 1, 2):
+        # All documented verdict exits mean the scanner ran successfully.
+        _crash_count = 0
+
     if exit_code == 0:
         action = "allow"
-        # Successful execution — reset circuit breaker
-        _crash_count = 0
     elif exit_code == 1:
         action = "block"
     elif exit_code == 2:


### PR DESCRIPTION
## Summary

- reset Tirith's consecutive-failure counter after every documented scanner verdict exit;
- treat exits `1` (block) and `2` (warn) as successful scanner executions, matching exit `0`;
- prevent old transient failures from accumulating across normal verdicts and opening the circuit breaker later.

Follow-up to #53797 and the secondary defect in #71350.

## Root cause

Only exit code `0` reset `_crash_count`. Tirith exit codes `1` and `2` are normal verdicts, not crashes, but they left the prior failure streak untouched. A transient spawn failure followed by valid block/warn verdicts could therefore preserve stale crash debt and open the breaker on a later unrelated failure.

This change leaves actual failure accounting unchanged: spawn errors, timeouts, and unknown exit codes still count toward the breaker.

## Regression coverage

The test seeds `_crash_count` at `_CRASH_LIMIT - 1`, returns a real verdict code (`1` or `2`), and requires the streak to reset without opening the breaker. It fails on current `main` for both cases and passes with this patch.

## Verification

- `tests/tools/test_tirith_security.py`: **97 passed**;
- Ruff: clean;
- `py_compile`: clean;
- `git diff --check`: clean.
