### PR TITLE
fix(cli): refresh config defaults on new session

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7454,8 +7454,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.conversation_history = []
         self._pending_title = None
         self._resumed = False
+        # Config may change while the interactive process is running. Read one
+        # fresh snapshot for every setting that /new re-derives instead of using
+        # the import-time CLI_CONFIG value (#71188).
+        _fresh_cli_config = load_cli_config()
+        _fresh_agent_config = _fresh_cli_config.get("agent", {})
+        if not isinstance(_fresh_agent_config, dict):
+            _fresh_agent_config = {}
         self.reasoning_config = _parse_reasoning_config(
-            CLI_CONFIG["agent"].get("reasoning_effort", "")
+            _fresh_agent_config.get("reasoning_effort", "")
         )
         # /new is a full conversation boundary: session-scoped runtime
         # overrides (/model --session, /fast, one-turn restores) do not carry
@@ -7464,9 +7471,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # #23131).
         self._pending_one_turn_model_restore = None
         self.service_tier = _parse_service_tier_config(
-            CLI_CONFIG["agent"].get("service_tier", "")
+            _fresh_agent_config.get("service_tier", "")
         )
-        _model_config = CLI_CONFIG.get("model", {})
+        _model_config = _fresh_cli_config.get("model", {})
         _config_model = (
             (_model_config.get("default") or _model_config.get("model") or "")
             if isinstance(_model_config, dict)

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -196,7 +196,7 @@ class TestHandleReasoningCommand(unittest.TestCase):
 
     def test_new_session_clears_session_reasoning_override(self):
         """/new and /clear must not carry a session-only effort override forward."""
-        from cli import CLI_CONFIG, HermesCLI
+        from cli import HermesCLI
 
         agent = SimpleNamespace(
             reasoning_config={"enabled": True, "effort": "high"},
@@ -213,7 +213,10 @@ class TestHandleReasoningCommand(unittest.TestCase):
             _notify_session_boundary=MagicMock(),
         )
 
-        with patch.dict(CLI_CONFIG.setdefault("agent", {}), {"reasoning_effort": "medium"}):
+        with patch(
+            "cli.load_cli_config",
+            return_value={"agent": {"reasoning_effort": "medium"}, "model": {}},
+        ):
             HermesCLI.new_session(stub, silent=True)
 
         self.assertEqual(stub.reasoning_config, {"enabled": True, "effort": "medium"})
@@ -258,16 +261,23 @@ class TestHandleReasoningCommand(unittest.TestCase):
             base_url="https://openrouter.ai/api/v1",
             api_mode="chat_completions",
         )
+        fresh_config = {
+            "agent": {"reasoning_effort": "medium", "service_tier": "normal"},
+            "model": {"default": "config-default-model", "provider": "openrouter"},
+        }
         with patch.dict(
-            CLI_CONFIG.setdefault("agent", {}),
-            {"reasoning_effort": "medium", "service_tier": "normal"},
-        ), patch.dict(
             CLI_CONFIG,
-            {"model": {"default": "config-default-model", "provider": "openrouter"}},
-        ), patch(
+            {
+                "agent": {"reasoning_effort": "high", "service_tier": "priority"},
+                "model": {"default": "stale-import-time-model", "provider": "openrouter"},
+            },
+        ), patch("cli.load_cli_config", return_value=fresh_config), patch(
             "hermes_cli.model_switch.switch_model", return_value=fake_result
-        ):
+        ) as switch_model:
             HermesCLI.new_session(stub, silent=True)
+
+        switch_model.assert_called_once()
+        self.assertEqual(switch_model.call_args.kwargs["raw_input"], "config-default-model")
 
         # Fast override cleared back to config default (normal → None).
         self.assertIsNone(stub.service_tier)


### PR DESCRIPTION
## Summary

- reload `config.yaml` when `/new` starts a fresh conversation;
- derive the new session's reasoning effort, service tier, model, and provider from one current config snapshot;
- stop the import-time `CLI_CONFIG` snapshot from restoring a model the user has already changed on disk.

Fixes #71188.

## Root cause

`HermesCLI.new_session()` claimed to re-derive session defaults from `config.yaml`, but it read `CLI_CONFIG`, which is created once when `cli.py` is imported. A config edit during a long-lived interactive process was therefore ignored, and `/new` could switch back to the old model.

The session boundary now calls `load_cli_config()` once and uses that same fresh snapshot for every setting it resets. This also keeps reasoning effort and service tier consistent with the model/provider defaults at the boundary.

## Regression coverage

The regression deliberately gives `CLI_CONFIG` an old model while `load_cli_config()` returns the new on-disk model. It fails on current `main` because `/new` passes the stale model to `switch_model`; the refreshed implementation passes the new model.

## Verification

- `tests/cli/test_reasoning_command.py` + `tests/cli/test_cli_new_session.py`: all passed;
- Ruff: clean;
- `py_compile`: clean;
- `git diff --check`: clean.
