### PR TITLE
fix(install): select supported Python on Termux

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -612,21 +612,34 @@ install_uv() {
 check_python() {
     if [ "$DISTRO" = "termux" ]; then
         log_info "Checking Termux Python..."
-        if command -v python >/dev/null 2>&1; then
-            PYTHON_PATH="$(command -v python)"
-            if "$PYTHON_PATH" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
-                PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
-                log_success "Python found: $PYTHON_FOUND_VERSION"
-                return 0
-            fi
-        fi
+        local install_attempted=false
+        local candidate
+        while true; do
+            # Prefer the project's pinned minor when Termux also exposes a
+            # newer default `python`. Keep this range in sync with pyproject.toml.
+            for candidate in "python${PYTHON_VERSION}" python; do
+                if ! command -v "$candidate" >/dev/null 2>&1; then
+                    continue
+                fi
+                PYTHON_PATH="$(command -v "$candidate")"
+                if "$PYTHON_PATH" -c 'import sys; raise SystemExit(0 if (3, 11) <= sys.version_info < (3, 14) else 1)' 2>/dev/null; then
+                    PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
+                    log_success "Python found: $PYTHON_FOUND_VERSION"
+                    return 0
+                fi
+            done
 
-        log_info "Installing Python via pkg..."
-        pkg install -y python >/dev/null
-        PYTHON_PATH="$(command -v python)"
-        PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
-        log_success "Python installed: $PYTHON_FOUND_VERSION"
-        return 0
+            if [ "$install_attempted" = true ]; then
+                break
+            fi
+            log_info "Installing Python via pkg..."
+            pkg install -y python >/dev/null
+            install_attempted=true
+        done
+
+        log_error "Hermes requires Python >=3.11,<3.14 on Termux"
+        log_info "Install python${PYTHON_VERSION} and re-run this script"
+        exit 1
     fi
 
     log_info "Checking Python $PYTHON_VERSION..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -615,9 +615,9 @@ check_python() {
         local install_attempted=false
         local candidate
         while true; do
-            # Prefer the project's pinned minor when Termux also exposes a
-            # newer default `python`. Keep this range in sync with pyproject.toml.
-            for candidate in "python${PYTHON_VERSION}" python; do
+            # Prefer every explicitly supported minor before Termux's default
+            # `python`, which may already be newer than Hermes supports.
+            for candidate in python3.11 python3.12 python3.13 python; do
                 if ! command -v "$candidate" >/dev/null 2>&1; then
                     continue
                 fi
@@ -638,7 +638,7 @@ check_python() {
         done
 
         log_error "Hermes requires Python >=3.11,<3.14 on Termux"
-        log_info "Install python${PYTHON_VERSION} and re-run this script"
+        log_info "Install Python 3.11, 3.12, or 3.13 and re-run this script"
         exit 1
     fi
 

--- a/tests/test_install_sh_termux_python_selection.py
+++ b/tests/test_install_sh_termux_python_selection.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+INSTALL_SH = Path(__file__).resolve().parents[1] / "scripts" / "install.sh"
+
+
+def _check_python_source() -> str:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    match = re.search(r"^check_python\(\) \{.*?^\}", text, re.MULTILINE | re.DOTALL)
+    assert match, "check_python() missing from install.sh"
+    return match.group(0)
+
+
+def _fake_python(path: Path, version: str, supported: bool) -> None:
+    path.write_text(
+        "#!/bin/sh\n"
+        "if [ \"${1:-}\" = \"-c\" ]; then exit " + ("0" if supported else "1") + "; fi\n"
+        f"if [ \"${{1:-}}\" = \"--version\" ]; then echo 'Python {version}'; exit 0; fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _run_check_python(tmp_path: Path, *, with_python311: bool) -> subprocess.CompletedProcess[str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _fake_python(bin_dir / "python", "3.14.6", supported=False)
+    if with_python311:
+        _fake_python(bin_dir / "python3.11", "3.11.15", supported=True)
+    pkg_log = tmp_path / "pkg.log"
+    pkg = bin_dir / "pkg"
+    pkg.write_text(f"#!/bin/sh\necho \"$*\" >> {pkg_log!s}\nexit 0\n", encoding="utf-8")
+    pkg.chmod(0o755)
+
+    harness = f"""
+set -u
+DISTRO=termux
+PYTHON_VERSION=3.11
+PYTHON_PATH=""
+PYTHON_FOUND_VERSION=""
+log_info() {{ :; }}
+log_success() {{ :; }}
+log_error() {{ echo "$*" >&2; }}
+{_check_python_source()}
+check_python
+echo "SELECTED=$PYTHON_PATH"
+echo "VERSION=$PYTHON_FOUND_VERSION"
+"""
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:/usr/bin:/bin"
+    return subprocess.run(
+        ["/bin/bash", "-c", harness],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_termux_prefers_supported_python311_over_default_python314(tmp_path: Path) -> None:
+    result = _run_check_python(tmp_path, with_python311=True)
+    assert result.returncode == 0, result.stderr
+    assert f"SELECTED={tmp_path / 'bin' / 'python3.11'}" in result.stdout
+    assert "VERSION=Python 3.11.15" in result.stdout
+    assert not (tmp_path / "pkg.log").exists()
+
+
+def test_termux_rejects_python314_after_package_install_attempt(tmp_path: Path) -> None:
+    result = _run_check_python(tmp_path, with_python311=False)
+    assert result.returncode != 0
+    assert "Python >=3.11,<3.14" in result.stderr
+    assert (tmp_path / "pkg.log").read_text(encoding="utf-8").strip() == "install -y python"

--- a/tests/test_install_sh_termux_python_selection.py
+++ b/tests/test_install_sh_termux_python_selection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -19,11 +20,11 @@ def _fake_python(path: Path, version: str, supported: bool, probe_log: Path) -> 
         path,
         f"""case "${{1:-}}" in
   -c)
-    echo "$(basename "$0") -c" >> {probe_log!s}
+    echo "{path.name} -c" >> {probe_log!s}
     exit {0 if supported else 1}
     ;;
   --version)
-    echo "$(basename "$0") --version" >> {probe_log!s}
+    echo "{path.name} --version" >> {probe_log!s}
     echo "Python {version}"
     exit 0
     ;;
@@ -51,6 +52,14 @@ def _run_termux_prerequisites(
         bin_dir / "pkg",
         f'echo "$*" >> {pkg_log!s}\nexit 0',
     )
+    # Keep PATH hermetic so a host-installed python3.11/3.12/3.13 cannot
+    # preempt the simulated Termux candidates. Link only non-Python utilities
+    # exercised by the public prerequisites stage.
+    for tool in ("awk", "head", "mktemp", "rm", "sed", "tr"):
+        target = shutil.which(tool)
+        assert target is not None
+        (bin_dir / tool).symlink_to(target)
+
     _write_executable(bin_dir / "uname", 'echo "Linux"')
     _write_executable(bin_dir / "git", 'echo "git version 2.50.0"')
     _write_executable(bin_dir / "node", 'echo "v22.22.0"')
@@ -67,7 +76,7 @@ def _run_termux_prerequisites(
     env.update({
         "HOME": str(home),
         "HERMES_HOME": str(home / ".hermes"),
-        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "PATH": str(bin_dir),
         "PREFIX": str(prefix),
         "TERMUX_VERSION": "0.118.2",
     })

--- a/tests/test_install_sh_termux_python_selection.py
+++ b/tests/test_install_sh_termux_python_selection.py
@@ -1,77 +1,130 @@
 from __future__ import annotations
 
 import os
-import re
 import subprocess
 from pathlib import Path
+
+import pytest
 
 INSTALL_SH = Path(__file__).resolve().parents[1] / "scripts" / "install.sh"
 
 
-def _check_python_source() -> str:
-    text = INSTALL_SH.read_text(encoding="utf-8")
-    match = re.search(r"^check_python\(\) \{.*?^\}", text, re.MULTILINE | re.DOTALL)
-    assert match, "check_python() missing from install.sh"
-    return match.group(0)
-
-
-def _fake_python(path: Path, version: str, supported: bool) -> None:
-    path.write_text(
-        "#!/bin/sh\n"
-        "if [ \"${1:-}\" = \"-c\" ]; then exit " + ("0" if supported else "1") + "; fi\n"
-        f"if [ \"${{1:-}}\" = \"--version\" ]; then echo 'Python {version}'; exit 0; fi\n"
-        "exit 0\n",
-        encoding="utf-8",
-    )
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
     path.chmod(0o755)
 
 
-def _run_check_python(tmp_path: Path, *, with_python311: bool) -> subprocess.CompletedProcess[str]:
+def _fake_python(path: Path, version: str, supported: bool, probe_log: Path) -> None:
+    _write_executable(
+        path,
+        f"""case "${{1:-}}" in
+  -c)
+    echo "$(basename "$0") -c" >> {probe_log!s}
+    exit {0 if supported else 1}
+    ;;
+  --version)
+    echo "$(basename "$0") --version" >> {probe_log!s}
+    echo "Python {version}"
+    exit 0
+    ;;
+esac
+exit 0""",
+    )
+
+
+def _run_termux_prerequisites(
+    tmp_path: Path,
+    *,
+    supported_candidate: tuple[str, str] | None,
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    _fake_python(bin_dir / "python", "3.14.6", supported=False)
-    if with_python311:
-        _fake_python(bin_dir / "python3.11", "3.11.15", supported=True)
+    probe_log = tmp_path / "python-probes.log"
     pkg_log = tmp_path / "pkg.log"
-    pkg = bin_dir / "pkg"
-    pkg.write_text(f"#!/bin/sh\necho \"$*\" >> {pkg_log!s}\nexit 0\n", encoding="utf-8")
-    pkg.chmod(0o755)
 
-    harness = f"""
-set -u
-DISTRO=termux
-PYTHON_VERSION=3.11
-PYTHON_PATH=""
-PYTHON_FOUND_VERSION=""
-log_info() {{ :; }}
-log_success() {{ :; }}
-log_error() {{ echo "$*" >&2; }}
-{_check_python_source()}
-check_python
-echo "SELECTED=$PYTHON_PATH"
-echo "VERSION=$PYTHON_FOUND_VERSION"
-"""
+    _fake_python(bin_dir / "python", "3.14.6", False, probe_log)
+    if supported_candidate is not None:
+        candidate, version = supported_candidate
+        _fake_python(bin_dir / candidate, version, True, probe_log)
+
+    _write_executable(
+        bin_dir / "pkg",
+        f'echo "$*" >> {pkg_log!s}\nexit 0',
+    )
+    _write_executable(bin_dir / "uname", 'echo "Linux"')
+    _write_executable(bin_dir / "git", 'echo "git version 2.50.0"')
+    _write_executable(bin_dir / "node", 'echo "v22.22.0"')
+    _write_executable(bin_dir / "npm", 'echo "11.9.0"')
+    _write_executable(bin_dir / "curl", "exit 0")
+    _write_executable(bin_dir / "rg", 'echo "ripgrep 14.1.0"')
+    _write_executable(bin_dir / "ffmpeg", 'echo "ffmpeg version 7.1 Copyright"')
+
+    home = tmp_path / "home"
+    prefix = tmp_path / "com.termux" / "files" / "usr"
+    home.mkdir()
+    prefix.mkdir(parents=True)
     env = os.environ.copy()
-    env["PATH"] = f"{bin_dir}:/usr/bin:/bin"
-    return subprocess.run(
-        ["/bin/bash", "-c", harness],
+    env.update({
+        "HOME": str(home),
+        "HERMES_HOME": str(home / ".hermes"),
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "PREFIX": str(prefix),
+        "TERMUX_VERSION": "0.118.2",
+    })
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            str(INSTALL_SH),
+            "--stage",
+            "prerequisites",
+            "--json",
+            "--non-interactive",
+        ],
         text=True,
         capture_output=True,
         env=env,
         check=False,
     )
+    return result, probe_log, pkg_log
 
 
-def test_termux_prefers_supported_python311_over_default_python314(tmp_path: Path) -> None:
-    result = _run_check_python(tmp_path, with_python311=True)
-    assert result.returncode == 0, result.stderr
-    assert f"SELECTED={tmp_path / 'bin' / 'python3.11'}" in result.stdout
-    assert "VERSION=Python 3.11.15" in result.stdout
-    assert not (tmp_path / "pkg.log").exists()
+@pytest.mark.parametrize(
+    ("candidate", "version"),
+    [
+        ("python3.11", "3.11.15"),
+        ("python3.12", "3.12.11"),
+        ("python3.13", "3.13.7"),
+    ],
+)
+def test_termux_prefers_each_supported_explicit_interpreter_over_python314(
+    tmp_path: Path,
+    candidate: str,
+    version: str,
+) -> None:
+    result, probe_log, pkg_log = _run_termux_prerequisites(
+        tmp_path,
+        supported_candidate=(candidate, version),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert f"Python found: Python {version}" in result.stdout
+    assert probe_log.read_text(encoding="utf-8").splitlines() == [
+        f"{candidate} -c",
+        f"{candidate} --version",
+    ]
+    assert "install -y python" not in pkg_log.read_text(encoding="utf-8").splitlines()
 
 
 def test_termux_rejects_python314_after_package_install_attempt(tmp_path: Path) -> None:
-    result = _run_check_python(tmp_path, with_python311=False)
+    result, probe_log, pkg_log = _run_termux_prerequisites(
+        tmp_path,
+        supported_candidate=None,
+    )
+
     assert result.returncode != 0
-    assert "Python >=3.11,<3.14" in result.stderr
-    assert (tmp_path / "pkg.log").read_text(encoding="utf-8").strip() == "install -y python"
+    assert "Python >=3.11,<3.14" in result.stdout + result.stderr
+    assert probe_log.read_text(encoding="utf-8").splitlines() == [
+        "python -c",
+        "python -c",
+    ]
+    assert pkg_log.read_text(encoding="utf-8").splitlines() == ["install -y python"]


### PR DESCRIPTION
## Summary

- probe every explicitly supported Termux interpreter in order: `python3.11`, `python3.12`, then `python3.13`, before falling back to default `python`;
- enforce Hermes' supported Python range (`>=3.11,<3.14`) before creating the venv;
- reject Python 3.14+ even when it is Termux's default;
- retry selection after the existing `pkg install python` step and fail with guidance covering all supported minors if Termux still exposes only an unsupported interpreter;
- replace source-reading/regex extraction tests with behavioral execution of the installer's real `--stage prerequisites` boundary;
- isolate that boundary from host-installed Python minors so Linux and macOS exercise the same simulated Termux environment.

Fixes #71331.

## Root cause

The Termux installer accepted any Python `>=3.11`, while `pyproject.toml` rejects Python 3.14 and newer. The initial fix preferred only `python3.11`; a host with default `python` 3.14 and a valid installed `python3.12` or `python3.13` still skipped the supported interpreter and entered a doomed install/failure path.

`check_python()` now probes the complete declared support set before default `python`, validates both bounds, and never reports an unsupported interpreter as successfully installed.

## Regression coverage

The regression suite launches `scripts/install.sh --stage prerequisites --json --non-interactive` with an isolated Termux environment and fake executable boundary. It does not read or extract installer source. Its PATH contains only the simulated Python candidates and explicitly linked non-Python stage utilities, preventing a runner's own `python3.11`/`python3.12`/`python3.13` from affecting outcomes.

Behavioral outcomes cover:

- default `python` 3.14 + only `python3.11` available → selects 3.11;
- default `python` 3.14 + only `python3.12` available → selects 3.12;
- default `python` 3.14 + only `python3.13` available → selects 3.13;
- only default `python` 3.14 → attempts `pkg install -y python` once, rechecks, then exits with the supported-range diagnostic.

The Python 3.12 case fails on the pre-fix branch and passes with `4d68b9ac0`. Cross-host fixture isolation is in `f5b574d96`.

## Verification

- rebased cleanly onto current `main` (`f51aa6a9`);
- real Termux prerequisites-stage behavior: **4 passed** across explicit Python 3.11/3.12/3.13 selection and unsupported-default rejection;
- `bash -n scripts/install.sh`: passed;
- focused Ruff: passed;
- `py_compile`: clean;
- `git diff --check`: clean.
- upstream `All required checks pass`: green.


