### PR TITLE
docs(feishu): update feishu_comment_rules CLI path to current module location

### DIFF
--- a/plugins/platforms/feishu/feishu_comment_rules.py
+++ b/plugins/platforms/feishu/feishu_comment_rules.py
@@ -357,7 +357,7 @@ def _main() -> int:
         pass
 
     usage = (
-        "Usage: python -m gateway.platforms.feishu_comment_rules <command> [args]\n"
+        "Usage: python -m plugins.platforms.feishu.feishu_comment_rules <command> [args]\n"
         "\n"
         "Commands:\n"
         "  status                              Show rules config and pairing state\n"

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -336,15 +336,15 @@ CLI:
 
 ```bash
 # Inspect current rules and pairing state
-python -m gateway.platforms.feishu_comment_rules status
+python -m plugins.platforms.feishu.feishu_comment_rules status
 
 # Simulate an access check for a specific doc + user
-python -m gateway.platforms.feishu_comment_rules check <fileType:fileToken> <user_open_id>
+python -m plugins.platforms.feishu.feishu_comment_rules check <fileType:fileToken> <user_open_id>
 
 # Manage pairing grants at runtime
-python -m gateway.platforms.feishu_comment_rules pairing list
-python -m gateway.platforms.feishu_comment_rules pairing add <user_open_id>
-python -m gateway.platforms.feishu_comment_rules pairing remove <user_open_id>
+python -m plugins.platforms.feishu.feishu_comment_rules pairing list
+python -m plugins.platforms.feishu.feishu_comment_rules pairing add <user_open_id>
+python -m plugins.platforms.feishu.feishu_comment_rules pairing remove <user_open_id>
 ```
 
 ### Required Feishu App Configuration

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/feishu.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/feishu.md
@@ -302,15 +302,15 @@ CLI：
 
 ```bash
 # 查看当前规则和 pairing 状态
-python -m gateway.platforms.feishu_comment_rules status
+python -m plugins.platforms.feishu.feishu_comment_rules status
 
 # 模拟特定文档 + 用户的访问检查
-python -m gateway.platforms.feishu_comment_rules check <fileType:fileToken> <user_open_id>
+python -m plugins.platforms.feishu.feishu_comment_rules check <fileType:fileToken> <user_open_id>
 
 # 运行时管理 pairing 授权
-python -m gateway.platforms.feishu_comment_rules pairing list
-python -m gateway.platforms.feishu_comment_rules pairing add <user_open_id>
-python -m gateway.platforms.feishu_comment_rules pairing remove <user_open_id>
+python -m plugins.platforms.feishu.feishu_comment_rules pairing list
+python -m plugins.platforms.feishu.feishu_comment_rules pairing add <user_open_id>
+python -m plugins.platforms.feishu.feishu_comment_rules pairing remove <user_open_id>
 ```
 
 ### 飞书应用所需配置


### PR DESCRIPTION
## Problem

The `feishu_comment_rules` CLI examples in the Feishu user guide (both English and zh-Hans locale) and the module's own usage string reference the old `gateway.platforms.feishu_comment_rules` path. The module was moved to `plugins/platforms/feishu/` during the gateway-to-plugins restructuring, so these CLI invocations would fail with a `ModuleNotFoundError`.

## Root cause

Five `python -m gateway.platforms.feishu_comment_rules` examples in `website/docs/user-guide/messaging/feishu.md`, the same five in the zh-Hans locale mirror, and the module's own `Usage:` string in `plugins/platforms/feishu/feishu_comment_rules.py` (line 360) were not updated when the module was migrated from `gateway/platforms/` to `plugins/platforms/feishu/`.

## Fix

- Updated all 5 CLI examples in `website/docs/user-guide/messaging/feishu.md` to `python -m plugins.platforms.feishu.feishu_comment_rules`
- Updated the same 5 examples in the zh-Hans locale mirror
- Updated the module's own usage string to match

## Verification

- Confirmed the target module exists at `plugins/platforms/feishu/feishu_comment_rules.py` on upstream/main (07e97d2f5) with an `if __name__ == "__main__"` entry point
- Confirmed no stale `gateway.platforms.feishu_comment_rules` references remain in the codebase
- Preflight passed: no open PRs or issues addressing this path drift
