### PR TITLE
fix(desktop): keep a turn that starts while resume is in flight (#70449)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -36,6 +36,7 @@ import {
   setSessions
 } from '@/store/session'
 import { $sessionTiles } from '@/store/session-states'
+import type { SessionResumeResponse } from '@/types/hermes'
 
 import { sessionRoute } from '../../routes'
 import type { ClientSessionState } from '../../types'
@@ -1085,6 +1086,74 @@ describe('resumeSession busy ordering guard', () => {
     // dropped the session out of $workingSessionIds mid-turn.
     expect(committed.busy).toBe(true)
     expect(committed.awaitingResponse).toBe(true)
+  })
+
+  it('keeps a prompt that starts while the persisted transcript is awaited', async () => {
+    const refs = warmCache({ busy: false, busyRevision: 3 })
+    const activation = deferred<SessionResumeResponse>()
+    const persisted = deferred<Awaited<ReturnType<typeof getSessionMessages>>>()
+
+    setSessions([storedSession({ message_count: 2 })])
+    vi.mocked(getSessionMessages).mockReturnValue(persisted.promise)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return activation.promise as never
+      }
+
+      return {} as never
+    })
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        requestGateway={requestGateway}
+        {...refs}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    const resumePromise = resume!('stored-1', true)
+
+    await act(async () => {
+      activation.resolve({
+        info: {},
+        message_count: 0,
+        messages: [],
+        resumed: 'stored-1',
+        running: false,
+        session_id: 'runtime-live'
+      })
+      await Promise.resolve()
+    })
+
+    const live = refs.sessionStateByRuntimeIdRef.current.get('runtime-live')!
+    refs.sessionStateByRuntimeIdRef.current.set('runtime-live', {
+      ...live,
+      awaitingResponse: true,
+      busy: true,
+      busyRevision: live.busyRevision + 1,
+      messages: [
+        ...live.messages,
+        {
+          id: 'user-live-prompt',
+          parts: [{ text: 'new prompt during persisted read', type: 'text' }],
+          pending: true,
+          role: 'user'
+        }
+      ]
+    })
+
+    persisted.resolve({
+      messages: [{ content: 'earlier turn', role: 'user', timestamp: 1 }],
+      session_id: 'stored-1'
+    } as never)
+    await resumePromise
+
+    const committed = refs.sessionStateByRuntimeIdRef.current.get('runtime-live')!
+    expect(committed.busy).toBe(true)
+    expect(committed.awaitingResponse).toBe(true)
+    expect(committed.messages.some(message => message.id === 'user-live-prompt')).toBe(true)
   })
 
   it('still clears busy when no live event overtook the snapshot', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
 import { getSession, getSessionMessages, type SessionInfo } from '@/hermes'
+import type { ChatMessage } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile } from '@/store/profile'
@@ -587,6 +588,8 @@ function ResumeHarness({
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
 
+  const stateRef = sessionStateByRuntimeIdRef ?? ref(new Map<string, ClientSessionState>())
+
   const actions = useSessionActions({
     activeSessionId: null,
     activeSessionIdRef: ref<string | null>(null),
@@ -601,10 +604,15 @@ function ResumeHarness({
     runtimeIdByStoredSessionIdRef: runtimeIdByStoredSessionIdRef ?? ref(new Map<string, string>()),
     selectedStoredSessionId,
     selectedStoredSessionIdRef: ref<string | null>(selectedStoredSessionId),
-    sessionStateByRuntimeIdRef: sessionStateByRuntimeIdRef ?? ref(new Map<string, ClientSessionState>()),
+    sessionStateByRuntimeIdRef: stateRef,
     syncSessionStateToView: vi.fn(),
     updateSessionState: (sessionId, updater) => {
-      const next = updater({} as ClientSessionState)
+      // Mirror use-session-state-cache: the updater sees the runtime's CURRENT
+      // state (resume's staleness guard reads `busyRevision` off it) and the
+      // result is committed back, so a later read observes what was written.
+      const next = updater(stateRef.current.get(sessionId) ?? ({} as ClientSessionState))
+
+      stateRef.current.set(sessionId, next)
       onStateUpdate?.(sessionId, next)
 
       return next
@@ -930,6 +938,7 @@ describe('resumeSession failure recovery', () => {
           'runtime-stale',
           {
             awaitingResponse: false,
+            busyRevision: 0,
             branch: '',
             busy: false,
             cwd: '',
@@ -980,6 +989,147 @@ describe('resumeSession failure recovery', () => {
     expect(sessionStateByRuntimeIdRef.current.has('runtime-stale')).toBe(false)
     expect($activeSessionId.get()).toBe('runtime-1')
     expect($messages.get().length).toBe(1)
+  })
+})
+
+// ── Resume must not rewind a turn that started while it was in flight ────────
+// #70449: viewing a session cleared its "working" indicator. `busy` is written
+// from a resume snapshot, and the snapshot is as old as the RPC round trip, so
+// a turn that starts during that window is described as idle by a response
+// that was already stale on arrival. `busyRevision` (bumped by the state cache
+// on every committed `busy` change) lets resume tell the two apart.
+//
+// The pair matters: the first test proves a live turn survives, the SECOND
+// proves the guard still lets a genuinely-finished session go idle. A fix that
+// simply refused to ever clear `busy` would pass the first and fail the second.
+describe('resumeSession busy ordering guard', () => {
+  afterEach(() => {
+    cleanup()
+    setActiveSessionId(null)
+    setResumeFailedSessionId(null)
+    setMessages([])
+    setSessions([])
+    vi.restoreAllMocks()
+  })
+
+  function warmCache(state: Partial<ClientSessionState>) {
+    const runtimeIdByStoredSessionIdRef = {
+      current: new Map([['stored-1', 'runtime-live']])
+    } satisfies MutableRefObject<Map<string, string>>
+
+    const sessionStateByRuntimeIdRef = {
+      current: new Map([
+        [
+          'runtime-live',
+          {
+            ...clientState('stored-1'),
+            messages: [{ id: 'm1', parts: [{ text: 'earlier turn', type: 'text' }], role: 'user' }] as ChatMessage[],
+            ...state
+          }
+        ]
+      ])
+    } satisfies MutableRefObject<Map<string, ClientSessionState>>
+
+    return { runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef }
+  }
+
+  async function runResume(
+    requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>,
+    options: {
+      runtimeIdByStoredSessionIdRef?: MutableRefObject<Map<string, string>>
+      sessionStateByRuntimeIdRef?: MutableRefObject<Map<string, ClientSessionState>>
+    }
+  ): Promise<void> {
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(<ResumeHarness onReady={r => (resume = r)} requestGateway={requestGateway} {...options} />)
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-1', true)
+  }
+
+  it('keeps a turn that started while session.activate was in flight', async () => {
+    const refs = warmCache({ busy: false, busyRevision: 3 })
+
+    setSessions([storedSession({ message_count: 2 })])
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [{ content: 'earlier turn', role: 'user', timestamp: 1 }],
+      session_id: 'stored-1'
+    } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        // The user sent a prompt (or a stream event arrived) between this RPC
+        // going out and its reply landing — exactly the window the bug lives in.
+        const live = refs.sessionStateByRuntimeIdRef.current.get('runtime-live')!
+
+        // What a real prompt submit / stream event writes: the flags plus the
+        // counter bump the state cache applies on any committed `busy` change.
+        refs.sessionStateByRuntimeIdRef.current.set('runtime-live', {
+          ...live,
+          awaitingResponse: true,
+          busy: true,
+          busyRevision: live.busyRevision + 1
+        })
+
+        // The backend answered before that turn existed, so it reports idle.
+        return { info: {}, messages: [], running: false, session_id: 'runtime-live' } as never
+      }
+
+      return {} as never
+    })
+
+    await runResume(requestGateway, refs)
+
+    const committed = refs.sessionStateByRuntimeIdRef.current.get('runtime-live')!
+
+    // Before the guard this was false: the stale snapshot won and the sidebar
+    // dropped the session out of $workingSessionIds mid-turn.
+    expect(committed.busy).toBe(true)
+    expect(committed.awaitingResponse).toBe(true)
+  })
+
+  it('still clears busy when no live event overtook the snapshot', async () => {
+    // Cache says busy from a turn that has since finished; nothing moves the
+    // counter during the RPC, so the snapshot is the freshest thing we have.
+    const refs = warmCache({ awaitingResponse: true, busy: true, busyRevision: 3 })
+
+    setSessions([storedSession({ message_count: 2 })])
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [{ content: 'earlier turn', role: 'user', timestamp: 1 }],
+      session_id: 'stored-1'
+    } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return { info: {}, messages: [], running: false, session_id: 'runtime-live' } as never
+      }
+
+      return {} as never
+    })
+
+    await runResume(requestGateway, refs)
+
+    const committed = refs.sessionStateByRuntimeIdRef.current.get('runtime-live')!
+
+    expect(committed.busy).toBe(false)
+    expect(committed.awaitingResponse).toBe(false)
+  })
+
+  it('applies a running snapshot when the counter is untouched', async () => {
+    const refs = warmCache({ busy: false, busyRevision: 3 })
+
+    setSessions([storedSession({ message_count: 2 })])
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return { info: {}, messages: [], running: true, session_id: 'runtime-live' } as never
+      }
+
+      return {} as never
+    })
+
+    await runResume(requestGateway, refs)
+
+    expect(refs.sessionStateByRuntimeIdRef.current.get('runtime-live')!.busy).toBe(true)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -794,10 +794,17 @@ export function useSessionActions({
                   // persisted transcript opens a second window for a live event.
                   const overtaken = state.busyRevision !== busyRevisionAtActivate
 
+                  const messages = overtaken
+                    ? preserveLocalPendingTurnMessages(
+                        reconcileResumeMessages(activatedMessages, state.messages),
+                        state.messages
+                      )
+                    : activatedMessages
+
                   return {
                     ...state,
                     ...(runtimeInfo ?? {}),
-                    messages: activatedMessages,
+                    messages,
                     busy: overtaken ? state.busy : effectiveRunning,
                     awaitingResponse: overtaken ? state.awaitingResponse : effectiveRunning
                   }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -692,6 +692,11 @@ export function useSessionActions({
           setCurrentBranch(cachedViewState.branch)
           setSessionStartedAt(Date.now())
 
+          // Read before the RPC goes out: anything that changes `busy` while we
+          // await moves this counter, which is how the handler below knows its
+          // snapshot has been overtaken by a live event (#70449).
+          const busyRevisionAtActivate = cachedViewState.busyRevision
+
           try {
             let activated: SessionResumeResponse | null = null
 
@@ -739,12 +744,26 @@ export function useSessionActions({
 
               const running = Boolean(activated.running ?? cachedViewState.busy)
 
+              // `activated.running` describes the session as it was when the
+              // backend built the response. If a live event moved `busy` while
+              // that was in flight, the live flag is newer — trust it instead
+              // (#70449). This decides the transcript merge below as well as
+              // the state write: treating a live turn as idle would let the
+              // persisted transcript overwrite a prompt that has not been
+              // persisted yet.
+              const liveDuringActivate = sessionStateByRuntimeIdRef.current.get(cachedRuntimeId)
+
+              const effectiveRunning =
+                liveDuringActivate && liveDuringActivate.busyRevision !== busyRevisionAtActivate
+                  ? liveDuringActivate.busy
+                  : running
+
               // While idle, the persisted REST transcript is the display
               // authority: session.activate returns the runtime's compressed
               // context projection, not necessarily the complete conversation.
               // During a live turn, keep the runtime/cache projection so an
               // accepted but not-yet-persisted prompt or stream is never lost.
-              if (!running && persistedTranscriptPromise) {
+              if (!effectiveRunning && persistedTranscriptPromise) {
                 const persisted = await persistedTranscriptPromise
 
                 if (!isCurrentResume()) {
@@ -765,19 +784,30 @@ export function useSessionActions({
 
               const activatedState = updateSessionState(
                 cachedRuntimeId,
-                state => ({
-                  ...state,
-                  ...(runtimeInfo ?? {}),
-                  messages: activatedMessages,
-                  busy: running,
-                  awaitingResponse: running
-                }),
+                state => {
+                  // A live event moved `busy` while session.activate was in
+                  // flight, so `running` describes the session as it was BEFORE
+                  // that event. Keep what the UI already knows rather than
+                  // rewinding it — the common case is a turn that started
+                  // during the round trip and would otherwise look idle.
+                  // Re-checked here rather than reused from above: awaiting the
+                  // persisted transcript opens a second window for a live event.
+                  const overtaken = state.busyRevision !== busyRevisionAtActivate
+
+                  return {
+                    ...state,
+                    ...(runtimeInfo ?? {}),
+                    messages: activatedMessages,
+                    busy: overtaken ? state.busy : effectiveRunning,
+                    awaitingResponse: overtaken ? state.awaitingResponse : effectiveRunning
+                  }
+                },
                 storedSessionId
               )
 
-              busyRef.current = running
-              setBusy(running)
-              setAwaitingResponse(running)
+              busyRef.current = activatedState.busy
+              setBusy(activatedState.busy)
+              setAwaitingResponse(activatedState.awaitingResponse)
               syncSessionStateToView(cachedRuntimeId, activatedState)
 
               return
@@ -860,6 +890,18 @@ export function useSessionActions({
         // Watch windows skip the prefetch — lazy resume attaches the live mirror.
         const prefetchPromise = watchWindow ? null : getSessionMessages(storedSessionId, sessionProfile)
 
+        // A cold resume does not know its runtime id until the response lands,
+        // so capture which runtime (if any) currently backs this stored session
+        // along with its busy counter. The guard below only applies when the
+        // backend hands back that SAME runtime — a genuinely fresh runtime id
+        // has no live state to protect (#70449).
+        const mappedRuntimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId) ?? null
+        const priorState = mappedRuntimeId ? sessionStateByRuntimeIdRef.current.get(mappedRuntimeId) : undefined
+        // Only trust the mapping when the runtime still claims this stored id —
+        // the same staleness check getRuntimeIdForStoredSession makes.
+        const priorRuntimeId = priorState?.storedSessionId === storedSessionId ? mappedRuntimeId : null
+        const busyRevisionAtResume = priorRuntimeId ? (priorState?.busyRevision ?? null) : null
+
         const resumePromise = requestGateway<SessionResumeResponse>('session.resume', {
           session_id: storedSessionId,
           cols: 96,
@@ -934,6 +976,19 @@ export function useSessionActions({
               })()
 
         resumedRunning = Boolean((resumed as { running?: boolean }).running)
+
+        // Same runtime came back, but its busy counter moved while we awaited:
+        // a stream event or prompt submit landed after this snapshot was taken,
+        // so the snapshot's `running` is stale. Defer to the live flag — every
+        // downstream use below (journal recovery, state write, busy setters)
+        // reads `resumedRunning`, so correcting it here corrects all of them.
+        if (priorRuntimeId && priorRuntimeId === resumed.session_id && busyRevisionAtResume !== null) {
+          const live = sessionStateByRuntimeIdRef.current.get(resumed.session_id)
+
+          if (live && live.busyRevision !== busyRevisionAtResume) {
+            resumedRunning = live.busy
+          }
+        }
 
         // Crash-survivable turn progress: fold a journaled in-flight tail
         // (persisted by use-session-state-cache while the turn streamed;

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -493,3 +493,64 @@ describe('useSessionStateCache — cross-thread error isolation', () => {
     expect(cache.getRuntimeIdForStoredSession('stored-A')).toBeNull()
   })
 })
+
+describe('useSessionStateCache — busy revision counter (#70449)', () => {
+  // Session resume reads `busy` from an RPC snapshot and applies it after the
+  // round trip. This counter is how resume distinguishes "nothing happened
+  // while I waited" from "a turn started while I waited" — so the cache must
+  // move it on every committed busy change, no matter which writer caused it,
+  // and must NOT move it for unrelated writes (or every resume would look
+  // overtaken and could never clear a finished turn).
+  it('bumps only when busy actually changes', () => {
+    let cache!: Cache
+    render(<Harness activeSessionId={null} onReady={value => (cache = value)} selectedStoredSessionId={null} />)
+
+    act(() => {
+      cache.ensureSessionState('runtime-A', 'stored-A')
+    })
+
+    const initial = cache.sessionStateByRuntimeIdRef.current.get('runtime-A')!.busyRevision
+
+    act(() => {
+      cache.updateSessionState('runtime-A', state => ({ ...state, busy: true }))
+    })
+
+    expect(cache.sessionStateByRuntimeIdRef.current.get('runtime-A')!.busyRevision).toBe(initial + 1)
+
+    // Unrelated write: same busy value, counter must hold still.
+    act(() => {
+      cache.updateSessionState('runtime-A', state => ({ ...state, cwd: '/tmp' }))
+    })
+
+    expect(cache.sessionStateByRuntimeIdRef.current.get('runtime-A')!.busyRevision).toBe(initial + 1)
+
+    // Turn ends: busy goes the other way, which counts too.
+    act(() => {
+      cache.updateSessionState('runtime-A', state => ({ ...state, busy: false }))
+    })
+
+    expect(cache.sessionStateByRuntimeIdRef.current.get('runtime-A')!.busyRevision).toBe(initial + 2)
+  })
+
+  it('ignores a busyRevision an updater tries to set itself', () => {
+    // The counter is the cache's to own: a caller writing it (by spreading a
+    // stale snapshot back in, say) would defeat the staleness check.
+    let cache!: Cache
+    render(<Harness activeSessionId={null} onReady={value => (cache = value)} selectedStoredSessionId={null} />)
+
+    act(() => {
+      cache.ensureSessionState('runtime-A', 'stored-A')
+      cache.updateSessionState('runtime-A', state => ({ ...state, busy: true, busyRevision: 99 }))
+    })
+
+    expect(cache.sessionStateByRuntimeIdRef.current.get('runtime-A')!.busyRevision).toBe(1)
+
+    // Also overruled when `busy` holds steady — the counter must not drift on
+    // a write that says nothing about whether a turn is running.
+    act(() => {
+      cache.updateSessionState('runtime-A', state => ({ ...state, busyRevision: 0 }))
+    })
+
+    expect(cache.sessionStateByRuntimeIdRef.current.get('runtime-A')!.busyRevision).toBe(1)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -288,16 +288,31 @@ export function useSessionStateCache({
       // the param was always a fresh spread, so every call looked like a
       // change — including periodic ~1/s session.info heartbeats that churn
       // $sessionStates and its computed atoms on every tick.
-      const next = updater(previous)
+      const updated = updater(previous)
 
       // If the updater returned the same reference, nothing changed for this
       // session — skip the store write, publishSessionState, and view sync.
       // The cache entry was already updated by ensureSessionState (if
       // storedSessionId rotated); the caller gets its return value from the
-      // cache, so stale reads don't regress.
-      if (next === previous) {
+      // cache, so stale reads don't regress. `busy` cannot have changed on a
+      // same-reference return, so the revision below is correct to skip too.
+      if (updated === previous) {
         return previous
       }
+
+      // `busyRevision` is owned here, not by callers: every committed change to
+      // `busy` bumps it, whatever wrote it (stream event, prompt submit, resume
+      // snapshot). That gives an in-flight resume a way to detect that a live
+      // event landed while its snapshot RPC was in the air, so it can decline to
+      // apply a `running` flag that is already out of date (#70449). An updater
+      // that writes the field itself is overruled — a caller spreading a stale
+      // snapshot back in would otherwise rewind the counter and defeat the
+      // check. Only clones when the value needs correcting, so the hot streaming
+      // path (which just spreads the previous state) allocates nothing extra.
+      const expectedRevision = updated.busy === previous.busy ? previous.busyRevision : previous.busyRevision + 1
+
+      const next =
+        updated.busyRevision === expectedRevision ? updated : { ...updated, busyRevision: expectedRevision }
 
       sessionStateByRuntimeIdRef.current.set(sessionId, next)
       // Crash-survivable turn progress: journal the running turn's visible

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -184,6 +184,15 @@ export interface ClientSessionState {
   yolo: boolean
   personality: string
   busy: boolean
+  /** Bumped by the state cache on every committed change to `busy`. Owned by
+   *  `updateSessionState` — updaters must never set it themselves.
+   *
+   *  Session resume reads `busy` from a snapshot RPC, so the value it applies
+   *  is as old as the round trip. A turn that starts while that RPC is in the
+   *  air would be clobbered by the older snapshot on arrival (#70449). Resume
+   *  captures this counter before issuing, and on landing only trusts its own
+   *  snapshot if the counter is unchanged — i.e. no live event got there first. */
+  busyRevision: number
   awaitingResponse: boolean
   streamId: string | null
   sawAssistantPayload: boolean

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -49,6 +49,7 @@ export function createClientSessionState(
     yolo: false,
     personality: '',
     busy: false,
+    busyRevision: 0,
     awaitingResponse: false,
     streamId: null,
     sawAssistantPayload: false,


### PR DESCRIPTION
Fixes #70449.

## The race

`busy` is written from a resume snapshot, and that snapshot is as old as
the RPC round trip. Both write sites take it verbatim:

- warm path, `use-session-actions/index.ts` — `const running = Boolean(activated.running ?? cachedViewState.busy)`
- cold path — `resumedRunning = Boolean((resumed as { running?: boolean }).running)`

A turn that starts while the RPC is in the air is therefore described as
idle by a response that was already stale when it landed. The later write
wins, `busy` goes false, and the session drops out of `$workingSessionIds`
mid-turn — which is exactly the reported symptom: focusing a session marks
it done while it is still working.

The warm path's `?? cachedViewState.busy` looks like it covers this, but it
only fires when the snapshot omits `running` entirely. A snapshot that
positively reports `running: false` sails straight through.

## The fix

`ClientSessionState` gains `busyRevision`, bumped by the state cache on
every committed change to `busy` — whatever wrote it (stream event, prompt
submit, resume snapshot). Doing it in `updateSessionState` rather than at
each call site means no writer can forget to.

Resume captures the counter before issuing its RPC and applies the
snapshot's `busy`/`awaitingResponse` only if the counter has not moved. If
it has, a live event got there first and the live flags stand.

Two details worth calling out:

- The counter is the cache's to own. An updater that writes the field is
  overruled, so a caller spreading a stale snapshot back in cannot rewind
  it and defeat the check. It only clones when the value needs correcting,
  so the hot streaming path allocates nothing extra.
- The same staleness check now gates the persisted-transcript merge as
  well. Treating a live turn as idle there let the persisted transcript
  overwrite a prompt that had not been persisted yet — same root cause,
  different symptom.

The cold path resolves the stored session to its current runtime id before
issuing, and only applies the guard when the backend hands back that same
runtime. A genuinely fresh runtime id has no live state to protect.

## Why it does not just pin busy on forever

The cheap version of this fix — never let a resume downgrade `busy` — would
fix the report and introduce a worse bug: a session that finished while you
were away would spin forever. There is a backstop (`SESSION_WATCHDOG_TIMEOUT_MS`,
8 minutes) but it marks the session **stalled**, it does not clear it, so
the failure would be visible rather than silent.

So the tests are a pair, and the second one is the point:

- `keeps a turn that started while session.activate was in flight` — the race
- `still clears busy when no live event overtook the snapshot` — a genuinely
  finished session still goes idle
- `applies a running snapshot when the counter is untouched` — no regression
  to the normal path

A never-downgrade fix passes the first and fails the second.

Plus cache-level coverage that the counter bumps on a real busy change,
holds still for unrelated writes, and overrules an updater that sets it.

## Verification

- Race test confirmed to **fail** with the guard disabled and **pass** with it
  (the trap I was avoiding: a test that passes either way proves nothing).
- `tsc --noEmit` clean.
- Full desktop suite: 2927 passed, 3 skipped, 0 failures.
- `eslint` clean on all changed files.
