### PR TITLE
fix(desktop): honor themed user bubble borders

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
@@ -138,6 +138,10 @@ describe('click-to-edit user message', () => {
 
     const bubble = await screen.findByRole('button', { name: 'Edit message' })
 
+    // Themes provide a dedicated user-bubble border. The message component
+    // must consume it rather than flattening every theme to the generic stroke.
+    expect(bubble.className).toContain('border-(--dt-user-bubble-border)')
+
     fireEvent.click(bubble)
 
     await waitFor(() => {

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -220,7 +220,7 @@ export const UserMessage: FC<{
   const bubbleClassName = cn(
     USER_BUBBLE_BASE_CLASS,
     'cursor-pointer pr-9 text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground/95 transition-colors',
-    'border-(--ui-stroke-tertiary) hover:border-(--ui-stroke-secondary)'
+    'border-(--dt-user-bubble-border) hover:border-(--ui-stroke-secondary)'
   )
 
   const bubbleContent = hasBody && (


### PR DESCRIPTION
## What changed and why

Per the reporter's July 16 clarification, user-message bubbles now use the active theme's `--dt-user-bubble-border` token rather than the generic tertiary stroke. Theme authors already provide this semantic token; rendering it makes user prompts easier to identify while preserving the existing restrained, theme-aware layout.

A focused component test protects the contract so a future styling change cannot silently flatten all user-bubble borders back to the generic stroke.

## Addressing maintainer feedback

The maintainer referenced #49574 as the existing CSS-level chat-readability work. This follow-up stays within that restrained direction: it consumes the established user-bubble theme token and does not add avatars, role labels, left/right alignment, or a separate appearance configuration surface.

## How to test

1. Run `cd apps/desktop && npx vitest run src/components/assistant-ui/thread/user-message-edit.test.tsx`.
2. Start the Desktop app, select a theme with a custom user-bubble border, and confirm user prompts use that border while assistant messages retain their normal conversation surface.

Validation completed:

- `npx vitest run src/components/assistant-ui/thread/user-message-edit.test.tsx`
- `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`

`npm run typecheck` could not run in this worktree because the local TypeScript compiler (`tsc`) is not installed.

## What platforms tested on

- macOS: focused Vitest test and repository pytest suite
- Windows: not run
- Linux: not run

Fixes #52426

<!-- autocontrib:worker-id=issue-followup-4b31c22e kind=pr-open -->