### PR TITLE
fix(desktop): isolate hidden pane composer metrics

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-metrics.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-metrics.test.tsx
@@ -1,0 +1,165 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { type RefObject, useRef } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { PANE_HIDDEN_ATTR } from '@/components/pane-shell/pane-visibility'
+
+import { useComposerMetrics } from './use-composer-metrics'
+
+vi.mock('@assistant-ui/react', () => ({
+  useAuiState: (selector: (state: { composer: { text: string } }) => unknown) => selector({ composer: { text: '' } })
+}))
+
+vi.mock('@/store/composer-popout', () => ({
+  $composerPoppedOut: { get: () => false }
+}))
+
+vi.mock('@/store/windows', () => ({
+  isSecondaryWindow: () => false
+}))
+
+const observers = new Set<TestResizeObserver>()
+
+class TestResizeObserver {
+  private readonly elements = new Set<Element>()
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    observers.add(this)
+  }
+
+  observe(element: Element) {
+    this.elements.add(element)
+  }
+
+  disconnect() {
+    observers.delete(this)
+    this.elements.clear()
+  }
+
+  trigger() {
+    this.callback(
+      [...this.elements].map(target => ({ target }) as ResizeObserverEntry),
+      this as unknown as ResizeObserver
+    )
+  }
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+function setRect(element: HTMLElement, width: number, height: number) {
+  element.getBoundingClientRect = () =>
+    ({
+      bottom: height,
+      height,
+      left: 0,
+      right: width,
+      top: 0,
+      width,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    }) as DOMRect
+}
+
+function triggerObservers() {
+  act(() => {
+    for (const observer of observers) {
+      observer.trigger()
+    }
+  })
+}
+
+function rootStyle(name: string) {
+  return globalThis.document.documentElement.style.getPropertyValue(name)
+}
+
+function MetricsPane({ hidden, height, surfaceHeight, width = 520 }: { hidden?: boolean; height: number; surfaceHeight: number; width?: number }) {
+  const composerRef = useRef<HTMLFormElement | null>(null)
+  const surfaceRef = useRef<HTMLDivElement | null>(null)
+  const editorRef = useRef<HTMLDivElement | null>(null)
+
+  useComposerMetrics({
+    composerRef: composerRef as RefObject<HTMLFormElement | null>,
+    composerSurfaceRef: surfaceRef as RefObject<HTMLDivElement | null>,
+    editorRef: editorRef as RefObject<HTMLDivElement | null>,
+    poppedOut: false
+  })
+
+  return (
+    <div {...(hidden ? { [PANE_HIDDEN_ATTR]: '' } : {})}>
+      <form
+        ref={node => {
+          composerRef.current = node
+
+          if (node) {
+            setRect(node, width, height)
+          }
+        }}
+      >
+        <div
+          ref={node => {
+            surfaceRef.current = node
+
+            if (node) {
+              setRect(node, width, surfaceHeight)
+            }
+          }}
+        />
+        <div ref={editorRef} />
+      </form>
+    </div>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  observers.clear()
+  globalThis.document.documentElement.style.removeProperty('--composer-measured-height')
+  globalThis.document.documentElement.style.removeProperty('--composer-surface-measured-height')
+})
+
+describe('useComposerMetrics pane visibility', () => {
+  it('publishes and updates root metrics from the visible composer', () => {
+    const { rerender } = render(<MetricsPane height={80} surfaceHeight={56} />)
+    triggerObservers()
+
+    expect(rootStyle('--composer-measured-height')).toBe('80px')
+    expect(rootStyle('--composer-surface-measured-height')).toBe('56px')
+
+    rerender(<MetricsPane height={104} surfaceHeight={72} />)
+    triggerObservers()
+
+    expect(rootStyle('--composer-measured-height')).toBe('104px')
+    expect(rootStyle('--composer-surface-measured-height')).toBe('72px')
+  })
+
+  it('keeps foreground root metrics when a hidden kept-alive pane measures later', () => {
+    render(
+      <>
+        <MetricsPane height={88} surfaceHeight={64} />
+        <MetricsPane height={32} hidden surfaceHeight={24} />
+      </>
+    )
+
+    triggerObservers()
+
+    expect(rootStyle('--composer-measured-height')).toBe('88px')
+    expect(rootStyle('--composer-surface-measured-height')).toBe('64px')
+  })
+
+  it('keeps foreground root metrics when a hidden kept-alive pane unmounts', () => {
+    const { rerender } = render(
+      <>
+        <MetricsPane height={88} surfaceHeight={64} />
+        <MetricsPane height={32} hidden surfaceHeight={24} />
+      </>
+    )
+
+    triggerObservers()
+
+    rerender(<MetricsPane height={88} surfaceHeight={64} />)
+
+    expect(rootStyle('--composer-measured-height')).toBe('88px')
+    expect(rootStyle('--composer-surface-measured-height')).toBe('64px')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-metrics.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-metrics.ts
@@ -1,6 +1,7 @@
 import { useAuiState } from '@assistant-ui/react'
-import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
+import { type RefObject, useCallback, useEffect, useId, useRef, useState } from 'react'
 
+import { PANE_HIDDEN_ATTR } from '@/components/pane-shell/pane-visibility'
 import { useMediaQuery } from '@/hooks/use-media-query'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { $composerPoppedOut } from '@/store/composer-popout'
@@ -14,6 +15,9 @@ interface UseComposerMetricsArgs {
   editorRef: RefObject<HTMLDivElement | null>
   poppedOut: boolean
 }
+
+const COMPOSER_METRICS_OWNER_ATTR = 'data-composer-metrics-owner'
+const HIDDEN_PANE_SELECTOR = `[${PANE_HIDDEN_ATTR}]`
 
 /**
  * Owns the composer's *sizing* engine: the stacked-vs-inline layout decision
@@ -31,6 +35,7 @@ export function useComposerMetrics({ composerRef, composerSurfaceRef, editorRef,
   const [tight, setTight] = useState(false)
   // Wider than `tight`: the pill goes icon-only before the row has to stack.
   const [compactPill, setCompactPill] = useState(false)
+  const metricsOwnerId = useId()
   const narrow = useMediaQuery('(max-width: 30rem)')
 
   // Edge signals, not the live text: these only re-render when emptiness / the
@@ -84,6 +89,10 @@ export function useComposerMetrics({ composerRef, composerSurfaceRef, editorRef,
       return
     }
 
+    if (composer.closest(HIDDEN_PANE_SELECTOR)) {
+      return
+    }
+
     // Floating composer is out of the thread's flow — it must not reserve any
     // bottom clearance. Zero the measured vars so the thread reclaims the space.
     // (Read globals here so the callback stays stable; mirror the popoutAllowed
@@ -92,6 +101,7 @@ export function useComposerMetrics({ composerRef, composerSurfaceRef, editorRef,
       const root = document.documentElement
       lastBucketedHeightRef.current = 0
       lastBucketedSurfaceHeightRef.current = 0
+      root.setAttribute(COMPOSER_METRICS_OWNER_ATTR, metricsOwnerId)
       root.style.setProperty('--composer-measured-height', '0px')
       root.style.setProperty('--composer-surface-measured-height', '0px')
 
@@ -101,6 +111,7 @@ export function useComposerMetrics({ composerRef, composerSurfaceRef, editorRef,
     const { height, width } = composer.getBoundingClientRect()
     const surfaceHeight = composerSurfaceRef.current?.getBoundingClientRect().height
     const root = document.documentElement
+    root.setAttribute(COMPOSER_METRICS_OWNER_ATTR, metricsOwnerId)
 
     if (width > 0) {
       const nextTight = width < COMPOSER_STACK_BREAKPOINT_PX
@@ -147,7 +158,7 @@ export function useComposerMetrics({ composerRef, composerSurfaceRef, editorRef,
         root.style.setProperty('--composer-surface-measured-height', `${bucket}px`)
       }
     }
-  }, [composerRef, composerSurfaceRef, editorRef])
+  }, [composerRef, composerSurfaceRef, editorRef, metricsOwnerId])
 
   useResizeObserver(syncComposerMetrics, composerRef, composerSurfaceRef, editorRef)
 
@@ -162,10 +173,17 @@ export function useComposerMetrics({ composerRef, composerSurfaceRef, editorRef,
   useEffect(() => {
     return () => {
       const root = document.documentElement
+
+      if (root.getAttribute(COMPOSER_METRICS_OWNER_ATTR) !== metricsOwnerId) {
+        return
+      }
+
       root.style.removeProperty('--composer-measured-height')
       root.style.removeProperty('--composer-surface-measured-height')
+
+      root.removeAttribute(COMPOSER_METRICS_OWNER_ATTR)
     }
-  }, [])
+  }, [metricsOwnerId])
 
   // Pill compacts on real width (tile/pane), OR when stacked for any reason
   // (viewport-narrow / wrapped) so the controls row never over-runs.


### PR DESCRIPTION
## Summary

- prevent kept-alive hidden Desktop chat panes from publishing shared composer height metrics
- make document-root composer metric cleanup owner-aware so a background pane cannot clear the foreground pane's values
- add focused component regressions for hidden-pane measurement and unmount behavior

Addresses #71264.

## Validation

- RED on `origin/main`: `NODE_ENV=test npm run test:ui -- src/app/chat/composer/hooks/use-composer-metrics.test.tsx` (2 expected failures: hidden measurement overwrote `88px` with `32px`; hidden unmount cleared the foreground value)
- GREEN: `NODE_ENV=test npm run test:ui -- src/app/chat/composer/hooks/use-composer-metrics.test.tsx` (3 passed)
- `NODE_ENV=test npm run test:ui -- src/components/pane-shell/pane-visibility.test.ts src/app/chat/composer/focus.test.ts src/app/chat/session-drag.test.ts src/app/chat/composer/hooks/use-composer-metrics.test.tsx` (11 passed)
- `npx eslint src/app/chat/composer/hooks/use-composer-metrics.ts src/app/chat/composer/hooks/use-composer-metrics.test.tsx`
- `npm run typecheck`
- `git diff --check`

## Duplicate Check

Checked live on 2026-07-26 against `origin/main` at `07e97d2f5dc3d2092cfe693ef07b2527a36cd2d8`. Issue #71264 remains open with no linked PR or comments. Searches by issue number, `useComposerMetrics`, `composer-measured-height`, and hidden-pane metrics found no equivalent active or merged fix. PR #39564 addresses separate scrolling/stacked-layout behavior and does not modify the shared metric hook or hidden-pane ownership.

## Browser / Playwright

Not run: this is a Desktop/Electron issue reported on Windows 11, while the validation environment is Linux. The component regression uses the production `data-pane-hidden` marker and directly exercises the document-root CSS variables that control thread bottom clearance. A Windows 11 Desktop smoke test remains useful for final pixel-level confirmation.
