### PR TITLE
fix(delegate): preserve parent fixed proxy credential

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1874,6 +1874,67 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
         result = _resolve_child_credential_pool(None, parent)
         self.assertIs(result, mock_pool)
 
+    def test_same_provider_fixed_proxy_does_not_load_default_pool(self):
+        parent = _make_mock_parent()
+        parent.provider = "anthropic"
+        parent.base_url = "http://127.0.0.1:8080/v1"
+        parent.api_key = "proxy-key"
+        parent._client_kwargs = {
+            "base_url": parent.base_url,
+            "api_key": parent.api_key,
+        }
+        parent._credential_pool = None
+
+        provider_pool = MagicMock()
+        provider_pool.has_credentials.return_value = True
+        with patch(
+            "agent.credential_pool.load_pool", return_value=provider_pool
+        ) as load_pool:
+            result = _resolve_child_credential_pool(
+                "anthropic", parent, parent.base_url
+            )
+
+        self.assertIsNone(result)
+        load_pool.assert_not_called()
+
+    def test_build_child_agent_keeps_same_provider_fixed_proxy_bundle(self):
+        parent = _make_mock_parent()
+        parent.provider = "anthropic"
+        parent.base_url = "https://api.anthropic.com"
+        parent.api_key = None
+        parent._client_kwargs = {
+            "base_url": "http://127.0.0.1:8080/v1",
+            "api_key": "proxy-key",
+        }
+        parent._credential_pool = None
+
+        provider_pool = MagicMock(name="default_anthropic_pool")
+        provider_pool.has_credentials.return_value = True
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "agent.credential_pool.load_pool", return_value=provider_pool
+        ) as load_pool:
+            child = MagicMock()
+            child._credential_pool = None
+            MockAgent.return_value = child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Use the parent's active Anthropic proxy",
+                context=None,
+                toolsets=["terminal"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["provider"], "anthropic")
+        self.assertEqual(kwargs["base_url"], "http://127.0.0.1:8080/v1")
+        self.assertEqual(kwargs["api_key"], "proxy-key")
+        self.assertIsNone(child._credential_pool)
+        load_pool.assert_not_called()
+
     def test_different_provider_loads_own_pool(self):
         parent = _make_mock_parent()
         parent._credential_pool = MagicMock()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3181,7 +3181,11 @@ def _resolve_child_credential_pool(
             )
         return None
 
-    if parent_pool is not None and effective_provider == parent_provider:
+    if effective_provider == parent_provider:
+        # A same-provider parent with no pool is using a fixed credential
+        # bundle (for example a local proxy base URL + proxy key). Loading the
+        # provider's default pool here would overwrite that inherited endpoint
+        # and key on the child. Keep the fixed credential by returning None.
         return parent_pool
 
     try:


### PR DESCRIPTION
## Summary

- preserve a same-provider parent's fixed credential bundle when it has no credential pool;
- stop `delegate_task` from loading the provider-default pool and replacing an inherited proxy endpoint/key before the child's first request;
- keep existing shared-pool behavior for same-provider parents that do have a pool;
- keep different-provider and custom-endpoint pool resolution unchanged.

Fixes #71424.

## Root cause

`_build_child_agent()` correctly inherits the parent's live endpoint and key. However, `_resolve_child_credential_pool()` only reused the parent's pool when that pool was non-null. For a parent authenticated with fixed credentials, `parent._credential_pool` is `None`, so the function fell through to `load_pool(effective_provider)`.

`_run_single_child()` then acquired a lease from that newly loaded default pool and called `_swap_credential()` before the first LLM request. A child that had been constructed for a local Anthropic-compatible proxy was therefore rebound to the default Anthropic endpoint/key, producing the reported 401 and eventual 600-second timeout.

The same-provider rule now returns the parent's pool directly, including `None`. `None` is meaningful here: it tells the child to keep the fixed endpoint/key it was already constructed with. Only a genuinely different provider loads its own pool.

## Regression coverage

- same-provider fixed proxy does not call `load_pool()`;
- `_build_child_agent()` receives the parent's active proxy URL and key from `_client_kwargs`;
- the child remains pool-free, so `_run_single_child()` cannot lease/swap to the provider-default credential;
- same-provider shared-pool, different-provider pool, and custom-endpoint identity tests remain green.

Mutation proof: restoring the old `parent_pool is not None` guard makes both new regressions fail because the default Anthropic pool is loaded and assigned to the child.

## Verification

- delegation + async-delegation + credential-pool boundary/routing suites: **230 passed, 0 failed**;
- Ruff: clean;
- `py_compile`: clean;
- Windows-footgun scan: **809 files, no findings**;
- `git diff --check`: clean.
