### PR TITLE
fix(cli): target the managed install root in the ZIP update path

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7124,6 +7124,73 @@ def _atomic_replace_dir(src: str, dst: str) -> None:
         shutil.rmtree(backup, ignore_errors=True)
 
 
+def _looks_like_hermes_checkout(path: Path) -> bool:
+    """True when ``path`` is a hermes-agent source tree we can reinstall from."""
+    try:
+        return (path / "pyproject.toml").is_file() and (
+            path / "hermes_cli" / "main.py"
+        ).is_file()
+    except OSError:
+        return False
+
+
+def _resolve_managed_install_root() -> Path:
+    """Return the hermes-agent checkout this install actually manages.
+
+    ``PROJECT_ROOT`` is derived from the *running* ``hermes_cli`` package, so it
+    is the install root only when the ``hermes`` entry point on PATH belongs to
+    the managed install. The two diverge when the entry point lives elsewhere —
+    e.g. a ``hermes`` shim in a conda env while the agent itself sits under
+    ``%LOCALAPPDATA%\\hermes\\hermes-agent`` (#59850). Updating relative to
+    ``PROJECT_ROOT`` then copies the new tree into the shim's site-packages and
+    runs ``pip install -e .`` in a directory with no ``pyproject.toml``, which
+    exits 2 on every run while the real install stays stale.
+
+    Candidates are probed in order; the first that looks like a hermes-agent
+    checkout wins. ``PROJECT_ROOT`` is probed first so nothing changes for the
+    normal case where both roots already agree, and it is also the final
+    fallback so an unrecognized layout keeps today's behavior rather than
+    updating some unrelated directory.
+    """
+    candidates: list[Path] = [PROJECT_ROOT]
+
+    # Explicit installer override (``scripts/install.sh --install-dir``).
+    env_dir = os.environ.get("HERMES_INSTALL_DIR")
+    if env_dir:
+        candidates.append(Path(env_dir).expanduser())
+
+    # The managed venv lives at ``<install root>/venv``, so when hermes runs out
+    # of that venv the parent of sys.prefix / $VIRTUAL_ENV is the install root.
+    for venv_dir in (sys.prefix, os.environ.get("VIRTUAL_ENV")):
+        if venv_dir:
+            candidates.append(Path(venv_dir).parent)
+
+    # Installer defaults: ``$HERMES_HOME/hermes-agent`` (where the Windows
+    # platform default home is ``%LOCALAPPDATA%\\hermes``), then the
+    # system-wide location used for Linux root installs.
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        candidates.append(get_default_hermes_root() / "hermes-agent")
+    except Exception as exc:
+        logger.debug("Could not derive the default Hermes root: %s", exc)
+    candidates.append(Path("/usr/local/lib/hermes-agent"))
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if _looks_like_hermes_checkout(resolved):
+            return resolved
+
+    return PROJECT_ROOT
+
+
 def _update_via_zip(args):
     """Update Hermes Agent by downloading a ZIP archive.
 
@@ -7156,6 +7223,13 @@ def _update_via_zip(args):
     zip_url = (
         f"https://github.com/NousResearch/hermes-agent/archive/refs/heads/{branch}.zip"
     )
+
+    # Everything below writes to the managed install, which is NOT always the
+    # directory the running hermes_cli was imported from (#59850).
+    install_root = _resolve_managed_install_root()
+    if install_root != PROJECT_ROOT:
+        print(f"→ Updating managed install at {install_root}")
+        print(f"  (running `hermes` is loaded from {PROJECT_ROOT})")
 
     print("→ Downloading latest version...")
     tmp_dir = tempfile.mkdtemp(prefix="hermes-update-")
@@ -7207,7 +7281,7 @@ def _update_via_zip(args):
             if item in preserve:
                 continue
             src = os.path.join(extracted, item)
-            dst = os.path.join(str(PROJECT_ROOT), item)
+            dst = os.path.join(str(install_root), item)
             if os.path.isdir(src):
                 # Atomic-ish replace: never leave dst half-deleted if the copy
                 # fails partway (the failure mode behind #49145 on Windows).
@@ -7225,7 +7299,7 @@ def _update_via_zip(args):
         shutil.rmtree(tmp_dir, ignore_errors=True)
 
     # Clear stale bytecode after ZIP extraction
-    removed = _clear_bytecode_cache(PROJECT_ROOT)
+    removed = _clear_bytecode_cache(install_root)
     if removed:
         print(
             f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
@@ -7247,11 +7321,13 @@ def _update_via_zip(args):
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        uv_env = {**os.environ, "VIRTUAL_ENV": str(install_root / "venv")}
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
-        _install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
+        _install_python_dependencies_with_optional_fallback(
+            [uv_bin, "pip"], env=uv_env, cwd=install_root
+        )
     else:
         # Use sys.executable to explicitly call the venv's pip module,
         # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
@@ -7260,20 +7336,20 @@ def _update_via_zip(args):
         try:
             subprocess.run(
                 pip_cmd + ["--version"],
-                cwd=PROJECT_ROOT,
+                cwd=install_root,
                 check=True,
                 capture_output=True,
             )
         except subprocess.CalledProcessError:
             subprocess.run(
                 [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
-                cwd=PROJECT_ROOT,
+                cwd=install_root,
                 check=True,
             )
-        _install_python_dependencies_with_optional_fallback(pip_cmd)
+        _install_python_dependencies_with_optional_fallback(pip_cmd, cwd=install_root)
 
     node_failures = _update_node_dependencies()
-    _build_web_ui(PROJECT_ROOT / "web")
+    _build_web_ui(install_root / "web")
 
     # Sync skills
     try:
@@ -7305,7 +7381,7 @@ def _update_via_zip(args):
     try:
         from hermes_cli.model_catalog import seed_cache_from_checkout
 
-        if seed_cache_from_checkout(PROJECT_ROOT):
+        if seed_cache_from_checkout(install_root):
             print("  ✓ Model catalog cache refreshed from checkout")
     except Exception as e:
         logger.debug("Model catalog seed during zip update failed: %s", e)
@@ -8347,12 +8423,17 @@ def _run_install_with_heartbeat(
     *,
     env: dict[str, str] | None = None,
     heartbeat_interval_seconds: int = 30,
+    cwd: Path | None = None,
 ) -> None:
     """Run dependency install command with periodic heartbeat output.
 
     Some resolvers/build backends (especially when compiling Rust/C extensions)
     can stay quiet for minutes. Emit a simple elapsed-time heartbeat so users
     know ``hermes update`` is still progressing even if pip/uv itself is silent.
+
+    ``cwd`` is the directory the editable install resolves ``.`` against and
+    defaults to ``PROJECT_ROOT``; the update path passes the managed install
+    root, which is not always the same directory (#59850).
     """
     done = threading.Event()
     start = _time.time()
@@ -8372,7 +8453,7 @@ def _run_install_with_heartbeat(
     try:
         subprocess.run(
             cmd,
-            cwd=PROJECT_ROOT,
+            cwd=cwd or PROJECT_ROOT,
             check=True,
             env=env,
         )
@@ -8385,9 +8466,13 @@ def _is_windows() -> bool:
     return sys.platform == "win32"
 
 
-def _venv_scripts_dir() -> Path | None:
-    """Return the venv Scripts directory if we're running inside the project venv."""
-    venv_dir = PROJECT_ROOT / "venv"
+def _venv_scripts_dir(root: Path | None = None) -> Path | None:
+    """Return the venv Scripts directory for ``root`` (default ``PROJECT_ROOT``).
+
+    Callers that install into a specific checkout pass its root so the shims
+    they quarantine belong to the venv being written to (#59850).
+    """
+    venv_dir = (root or PROJECT_ROOT) / "venv"
     if not venv_dir.is_dir():
         return None
     scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
@@ -8707,6 +8792,7 @@ def _run_quarantined_install(
     *,
     env: dict[str, str] | None = None,
     scripts_dir: Path | None = None,
+    cwd: Path | None = None,
 ) -> None:
     """Run an editable install, quarantining the running ``hermes.exe`` first.
 
@@ -8727,7 +8813,7 @@ def _run_quarantined_install(
     if scripts_dir is not None:
         moved = _quarantine_running_hermes_exe(scripts_dir)
     try:
-        _run_install_with_heartbeat(cmd, env=env)
+        _run_install_with_heartbeat(cmd, env=env, cwd=cwd)
     except BaseException:
         # Restore shims if pip/uv didn't write replacements (e.g. install
         # failed before the entry-points step). Don't swallow the error.
@@ -9105,6 +9191,7 @@ def _install_python_dependencies_with_optional_fallback(
     *,
     env: dict[str, str] | None = None,
     group: str = "all",
+    cwd: Path | None = None,
 ) -> None:
     """Install base deps plus as many optional extras as the environment supports.
 
@@ -9115,12 +9202,15 @@ def _install_python_dependencies_with_optional_fallback(
     in the venv Scripts dir before each install attempt so uv can write fresh
     copies (Windows blocks REPLACE on a running .exe but allows RENAME). See
     ``_quarantine_running_hermes_exe`` for the rationale.
+
+    ``cwd`` selects the checkout ``.`` resolves against — and therefore the venv
+    whose shims get quarantined — defaulting to ``PROJECT_ROOT`` (#59850).
     """
-    scripts_dir = _venv_scripts_dir() if _is_windows() else None
+    scripts_dir = _venv_scripts_dir(cwd) if _is_windows() else None
 
     def _install(args: list[str]) -> None:
         _run_quarantined_install(
-            install_cmd_prefix + args, env=env, scripts_dir=scripts_dir
+            install_cmd_prefix + args, env=env, scripts_dir=scripts_dir, cwd=cwd
         )
 
     try:

--- a/tests/hermes_cli/test_update_zip_install_root.py
+++ b/tests/hermes_cli/test_update_zip_install_root.py
@@ -1,0 +1,158 @@
+"""Regression: the ZIP update path must target the managed install (#59850).
+
+``PROJECT_ROOT`` is derived from the running ``hermes_cli`` package. When the
+``hermes`` entry point on PATH belongs to a different environment than the
+managed install — a conda/miniforge shim in front of an agent installed under
+``%LOCALAPPDATA%\\hermes\\hermes-agent`` — the ZIP update copied the new tree
+into the shim's site-packages and then ran ``uv pip install -e .`` there, in a
+directory with no ``pyproject.toml``. uv exits 2 and the install is left half
+updated on every run.
+"""
+
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+from hermes_cli import main as hermes_main
+
+
+def _make_checkout(root: Path) -> Path:
+    """Create the minimal file set that marks a hermes-agent checkout."""
+    (root / "hermes_cli").mkdir(parents=True, exist_ok=True)
+    (root / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "hermes-agent"\n', encoding="utf-8"
+    )
+    return root
+
+
+def _build_update_zip(zip_path: Path) -> None:
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("hermes-agent-main/README.md", "ok\n")
+
+
+def test_looks_like_hermes_checkout_needs_both_markers(tmp_path):
+    checkout = _make_checkout(tmp_path / "install")
+    assert hermes_main._looks_like_hermes_checkout(checkout)
+
+    # A site-packages directory holding an installed hermes_cli has the package
+    # but no pyproject.toml — exactly the directory `pip install -e .` chokes on.
+    site_packages = tmp_path / "site-packages"
+    (site_packages / "hermes_cli").mkdir(parents=True)
+    (site_packages / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+    assert not hermes_main._looks_like_hermes_checkout(site_packages)
+    assert not hermes_main._looks_like_hermes_checkout(tmp_path / "missing")
+
+
+def test_resolve_install_root_prefers_the_running_checkout(tmp_path, monkeypatch):
+    """When both roots agree, resolution is a no-op — no behavior change."""
+    running = _make_checkout(tmp_path / "running")
+    managed = _make_checkout(tmp_path / "managed")
+
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", running)
+    monkeypatch.setenv("HERMES_INSTALL_DIR", str(managed))
+
+    assert hermes_main._resolve_managed_install_root() == running.resolve()
+
+
+def test_resolve_install_root_recovers_when_roots_diverge(tmp_path, monkeypatch):
+    """Module root that isn't a checkout must not be treated as the install."""
+    site_packages = tmp_path / "conda" / "Lib" / "site-packages"
+    (site_packages / "hermes_cli").mkdir(parents=True)
+    (site_packages / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+    managed = _make_checkout(tmp_path / "managed")
+
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", site_packages)
+    monkeypatch.setenv("HERMES_INSTALL_DIR", str(managed))
+
+    assert hermes_main._resolve_managed_install_root() == managed.resolve()
+
+
+def test_resolve_install_root_falls_back_to_project_root(tmp_path, monkeypatch):
+    """No candidate validates → keep today's behavior, don't guess."""
+    module_root = tmp_path / "module_root"
+    module_root.mkdir()
+
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", module_root)
+    monkeypatch.setattr(hermes_main, "_looks_like_hermes_checkout", lambda _p: False)
+
+    assert hermes_main._resolve_managed_install_root() == module_root
+
+
+def test_run_install_with_heartbeat_honors_cwd(tmp_path, monkeypatch):
+    """The install cwd is what makes ``pip install -e .`` resolve correctly."""
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path / "module_root")
+    target = tmp_path / "managed"
+
+    with patch("subprocess.run") as fake_run:
+        hermes_main._run_install_with_heartbeat(["uv", "pip", "install", "-e", "."])
+        assert fake_run.call_args.kwargs["cwd"] == tmp_path / "module_root"
+
+        hermes_main._run_install_with_heartbeat(
+            ["uv", "pip", "install", "-e", "."], cwd=target
+        )
+        assert fake_run.call_args.kwargs["cwd"] == target
+
+
+def test_update_via_zip_writes_and_installs_into_managed_root(tmp_path, monkeypatch):
+    """End to end: divergent roots must not send the update to the shim's tree.
+
+    Both halves of the update are asserted — the file replacement lands in the
+    managed checkout, and the dependency install runs with that same directory
+    as its cwd (and its venv as ``VIRTUAL_ENV``).
+    """
+    zip_path = tmp_path / "update.zip"
+    _build_update_zip(zip_path)
+
+    # Running hermes_cli lives in a site-packages dir that is NOT a checkout.
+    site_packages = tmp_path / "conda" / "Lib" / "site-packages"
+    (site_packages / "hermes_cli").mkdir(parents=True)
+    (site_packages / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+    managed = _make_checkout(tmp_path / "managed")
+
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", site_packages)
+    monkeypatch.setenv("HERMES_INSTALL_DIR", str(managed))
+    monkeypatch.setattr(hermes_main, "get_hermes_home", lambda: tmp_path / "home")
+
+    captured: dict = {}
+
+    def fake_urlretrieve(url, dest):
+        Path(dest).write_bytes(zip_path.read_bytes())
+        return dest, None
+
+    def fake_install(install_cmd_prefix, *, env=None, group="all", cwd=None):
+        captured["cwd"] = cwd
+        captured["env"] = env
+
+    monkeypatch.setattr(
+        hermes_main, "_install_python_dependencies_with_optional_fallback", fake_install
+    )
+    monkeypatch.setattr(hermes_main, "_update_node_dependencies", lambda: [])
+    monkeypatch.setattr(
+        hermes_main, "_build_web_ui", lambda web_dir, **kw: captured.setdefault(
+            "web_dir", web_dir
+        )
+    )
+    monkeypatch.setattr(
+        hermes_main, "_kill_stale_dashboard_processes", lambda **kw: None
+    )
+    # Post-install steps that would otherwise touch the real Hermes home.
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda **kw: {"copied": []})
+    monkeypatch.setattr(
+        "hermes_cli.model_catalog.seed_cache_from_checkout", lambda root: False
+    )
+    monkeypatch.setattr(hermes_main, "_print_curator_first_run_notice", lambda: None)
+    monkeypatch.setattr(hermes_main, "_print_curator_recent_run_notice", lambda: None)
+
+    args = type("Args", (), {})()
+
+    with patch("urllib.request.urlretrieve", side_effect=fake_urlretrieve), patch(
+        "hermes_cli.managed_uv.ensure_uv", return_value="/fake/bin/uv"
+    ), patch("hermes_cli.managed_uv.update_managed_uv"):
+        hermes_main._update_via_zip(args)
+
+    assert (managed / "README.md").read_text(encoding="utf-8") == "ok\n"
+    assert not (site_packages / "README.md").exists()
+    assert captured["cwd"] == managed.resolve()
+    assert captured["env"]["VIRTUAL_ENV"] == str(managed.resolve() / "venv")
+    assert captured["web_dir"] == managed.resolve() / "web"

--- a/tests/hermes_cli/test_verify_console_scripts.py
+++ b/tests/hermes_cli/test_verify_console_scripts.py
@@ -101,6 +101,7 @@ class TestVerifyConsoleScriptsInstalled:
             ["uv", "pip", "install", "-e", ".[all]"],
             env={"VIRTUAL_ENV": "x"},
             scripts_dir=None,
+            cwd=None,
         )
         mock_verify.assert_called_once_with(["uv", "pip"], env={"VIRTUAL_ENV": "x"})
 


### PR DESCRIPTION
## What does this PR do?

Makes the Windows ZIP update path write to the install it is actually managing.

`PROJECT_ROOT` is derived from the *running* `hermes_cli` package, so it equals the install root only when the `hermes` entry point on PATH belongs to the managed install. When they diverge — a `hermes` shim in a conda/miniforge env in front of an agent installed under `%LOCALAPPDATA%\hermes\hermes-agent` — `_update_via_zip` copies the freshly downloaded tree into the shim's `site-packages` and then runs `uv pip install -e .` in that same directory. There is no `pyproject.toml` there, so uv exits 2 on every run and the install is left half updated: files replaced in the wrong place, dependencies never installed.

`_resolve_managed_install_root()` probes, in order:

1. `PROJECT_ROOT` — so nothing changes when both roots already agree
2. `$HERMES_INSTALL_DIR` — the installer's own `--install-dir` override
3. the parent of `sys.prefix` / `$VIRTUAL_ENV` — the managed venv lives at `<install root>/venv`
4. `get_default_hermes_root() / "hermes-agent"` — the installer default (`%LOCALAPPDATA%\hermes\hermes-agent` on Windows, `$HERMES_HOME/hermes-agent` on POSIX)
5. `/usr/local/lib/hermes-agent` — the Linux root-install location

The first candidate that looks like a hermes-agent checkout (`pyproject.toml` + `hermes_cli/main.py`) wins, and `PROJECT_ROOT` is also the final fallback — an unrecognized layout keeps today's behavior rather than updating some unrelated directory.

## Related Issue

Fixes #59850

Builds on @liuhao1024's #59866, which correctly identified the `cwd` plumbing but kept passing `PROJECT_ROOT` at the ZIP call sites, so the failing directory selection was unchanged (per the review on that PR). This adds the distinct resolved install root that review asked for, uses it for both the replacement and the dependency install, and adds the divergent-root regression test. Happy to close this in favour of #59866 if @liuhao1024 would rather fold the diff into their branch.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`
  - new `_looks_like_hermes_checkout()` / `_resolve_managed_install_root()`
  - `_update_via_zip()` resolves the install root once and uses it for the file replacement, bytecode clear, `VIRTUAL_ENV`, dependency install, web build, and model-catalog seed; prints both paths when they diverge
  - `cwd` threaded through `_install_python_dependencies_with_optional_fallback` → `_run_quarantined_install` → `_run_install_with_heartbeat` (defaults to `PROJECT_ROOT`)
  - `_venv_scripts_dir(root=None)` so shim quarantine follows the venv being written to
- `tests/hermes_cli/test_update_zip_install_root.py` — new
- `tests/hermes_cli/test_verify_console_scripts.py` — mock assertion picks up the new `cwd` kwarg

## How to Test

Reproduce (Windows, `hermes` entry point outside the managed install):

```
hermes update
# → ⚠ Optional extras failed, reinstalling base dependencies and retrying extras individually...
# → subprocess.CalledProcessError: '...\hermes\bin\uv.exe pip install -e .' returned non-zero exit status 2
```

The same command with the cwd corrected by hand succeeds, which is what isolates it to the directory selection:

```
cd %LOCALAPPDATA%\hermes\hermes-agent
set VIRTUAL_ENV=%LOCALAPPDATA%\hermes\hermes-agent\venv
%LOCALAPPDATA%\hermes\bin\uv.exe pip install -e .
# -> Built hermes-agent, Installed 1 package
```

Automated:

```
pytest tests/hermes_cli/test_update_zip_install_root.py tests/hermes_cli/test_verify_console_scripts.py -q
```

`test_update_via_zip_writes_and_installs_into_managed_root` builds the divergent case — a `site-packages` module root that is not a checkout plus a separate managed checkout — and asserts the ZIP content lands in the managed root, *not* in the module root, and that the dependency install receives that same directory as its `cwd` with its venv as `VIRTUAL_ENV`. All six tests in the new file fail against `main` and pass with this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs — #59866 is the related one, addressed above
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11.9, uv 0.11.26

Test run: `tests/hermes_cli/` update+install files — 112 passed. Two pre-existing failures in `test_cmd_update.py` (`test_resolve_rejects_windows_npm_and_rescans_path`, `test_update_refreshes_repo_and_tui_node_dependencies`) reproduce unchanged on `main` on a native-Windows host; they simulate a WSL npm layout.

### Documentation & Housekeeping

- [x] Docs — N/A (internal update-path behavior; the divergent case now prints both paths)
- [x] `cli-config.yaml.example` — N/A (no new config keys; `HERMES_INSTALL_DIR` is the installer's existing flag)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — the resolver is ordered so POSIX and dev-checkout installs hit `PROJECT_ROOT` first and are unaffected
- [x] Tool descriptions/schemas — N/A

## Known remaining gap

`_update_node_dependencies()` is still `PROJECT_ROOT`-relative, as is the git-pull update path in `_cmd_update_impl`. Both are the same class of assumption, but threading a root through them is a wider change than this fix needs, so it is left for a follow-up — `_resolve_managed_install_root()` is written to be reusable there. On a divergent install the Node step is a no-op today (no `package.json` in the shim's directory) rather than a corruption.
