### PR TITLE
fix(cron): deliver multiplexed profile jobs via profile config

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1202,6 +1202,7 @@ def create_job(
     repeat: Optional[int] = None,
     deliver: Optional[str] = None,
     origin: Optional[Dict[str, Any]] = None,
+    profile: Optional[str] = None,
     skill: Optional[str] = None,
     skills: Optional[List[str]] = None,
     model: Optional[str] = None,
@@ -1225,6 +1226,7 @@ def create_job(
         repeat: How many times to run (None = forever, 1 = once)
         deliver: Where to deliver output ("origin", "local", "telegram", etc.)
         origin: Source info where job was created (for "origin" delivery)
+        profile: Optional Hermes profile name that authored/owns the job
         skill: Optional legacy single skill name to load before running the prompt
         skills: Optional ordered list of skills to load before running the prompt
         model: Optional per-job model override
@@ -1289,6 +1291,7 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_profile = _normalize_job_optional_text(profile)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1376,6 +1379,7 @@ def create_job(
         # Delivery configuration
         "deliver": deliver,
         "origin": origin,  # Tracks where job was created for "origin" delivery
+        "profile": normalized_profile,
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -599,6 +599,33 @@ def _get_lock_paths() -> tuple[Path, Path]:
     return lock_dir, lock_dir / ".tick.lock"
 
 
+def _resolve_job_profile_home(job: dict) -> Optional[Path]:
+    """Return the Hermes home for a stored cron job's owning profile, if any.
+
+    Multiplexed gateways may keep cron storage at the tier root while the
+    Telegram bot/config live under profiles/<name>.  A job-level profile lets
+    delivery resolve the correct profile config without moving jobs.json.
+    """
+    profile = str(job.get("profile") or "").strip()
+    if not profile or profile == "default":
+        return None
+    try:
+        from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+        from hermes_constants import get_default_hermes_root
+
+        profile = normalize_profile_name(profile)
+        validate_profile_name(profile)
+        candidate = get_default_hermes_root() / "profiles" / profile
+        if candidate.is_dir():
+            return candidate
+    except Exception as exc:
+        logger.debug(
+            "Job '%s': could not resolve profile home for profile=%r: %s",
+            job.get("id", "?"), profile, exc,
+        )
+    return None
+
+
 def _resolve_origin(job: dict) -> Optional[dict]:
     """Extract origin info from a job, preserving any extra routing metadata.
 
@@ -1501,7 +1528,20 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     wrap_response = True
     user_cfg = None
     try:
-        user_cfg = load_config()
+        profile_home = _resolve_job_profile_home(job)
+        if profile_home is not None:
+            from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+            from hermes_cli.env_loader import load_hermes_dotenv, reset_secret_source_cache
+
+            token = set_hermes_home_override(profile_home)
+            try:
+                reset_secret_source_cache()
+                load_hermes_dotenv(hermes_home=profile_home)
+                user_cfg = load_config()
+            finally:
+                reset_hermes_home_override(token)
+        else:
+            user_cfg = load_config()
         wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
     except Exception:
         pass
@@ -1538,7 +1578,20 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         mirror_text = (mirror_text or "").strip()
 
     try:
-        config = load_gateway_config()
+        profile_home = _resolve_job_profile_home(job)
+        if profile_home is not None:
+            from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+            from hermes_cli.env_loader import load_hermes_dotenv, reset_secret_source_cache
+
+            token = set_hermes_home_override(profile_home)
+            try:
+                reset_secret_source_cache()
+                load_hermes_dotenv(hermes_home=profile_home)
+                config = load_gateway_config()
+            finally:
+                reset_hermes_home_override(token)
+        else:
+            config = load_gateway_config()
     except Exception as e:
         msg = f"failed to load gateway config: {e}"
         logger.error("Job '%s': %s", job["id"], msg)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10067,6 +10067,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
             try:
                 with _profile_runtime_scope(profile_home):
+                    if hasattr(platform_config, "extra") and isinstance(platform_config.extra, dict):
+                        platform_config.extra.setdefault("profile", profile_name)
                     adapter = self._create_adapter(platform, platform_config)
             except Exception as e:
                 logger.error(
@@ -17239,12 +17241,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     metadata["user_id"] = str(data["user_id"])
                 if data.get("scope_id"):
                     metadata["scope_id"] = str(data["scope_id"])
-            result = await transport.send(
-                platform,
-                str(chat_id),
-                "♻ Gateway restarted successfully. Your session continues.",
-                metadata=_non_conversational_metadata(metadata, platform=platform),
-            )
+            restart_message = "♻ Gateway restarted successfully. Your session continues."
+            restart_metadata = _non_conversational_metadata(metadata, platform=platform)
+            result = None
+            # Telegram can be connected but keep its send path marked degraded
+            # until the first getUpdates request proves polling progress.  The
+            # restart notification runs immediately after connect, so wait/retry
+            # briefly instead of dropping the only "I'm back" signal.
+            for _attempt in range(6):
+                result = await transport.send(
+                    platform,
+                    str(chat_id),
+                    restart_message,
+                    metadata=restart_metadata,
+                )
+                if result is None or getattr(result, "success", True) is True:
+                    break
+                if getattr(result, "error", None) != "send_path_degraded":
+                    break
+                await asyncio.sleep(1.0)
             # adapter.send() catches provider errors (e.g. "Chat not found")
             # and returns SendResult(success=False) rather than raising, so
             # we must inspect the result before claiming success — otherwise

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -917,6 +917,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     user_id=normalized_user_id,
                     user_name=str(user_name).strip() if user_name else None,
                     thread_id=str(thread_id) if thread_id is not None else None,
+                    profile=str(self.config.extra.get("profile") or "").strip() or None,
                 )
                 return bool(auth_fn(source))
             except Exception:
@@ -994,6 +995,7 @@ class TelegramAdapter(BasePlatformAdapter):
             user_id=user_id,
             user_name=user_name,
             thread_id=thread_id,
+            profile=str(self.config.extra.get("profile") or "").strip() or None,
         )
 
     def _telegram_auth_env_configured(self) -> bool:

--- a/tests/cron/test_cron_profile_isolation.py
+++ b/tests/cron/test_cron_profile_isolation.py
@@ -102,6 +102,23 @@ def test_cron_execution_home_follows_active_profile(tmp_path, monkeypatch):
     assert scheduler._get_hermes_home().resolve() != root.resolve()
 
 
+def test_job_profile_resolves_profile_home_for_shared_cron_store(tmp_path, monkeypatch):
+    """A shared cron store can still deliver under the job owner's profile."""
+    root = tmp_path / "hermes_home"
+    profile_home = root / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+
+    _set_profile_env(monkeypatch, root, root)
+
+    import cron.scheduler as scheduler
+
+    resolved = scheduler._resolve_job_profile_home({"id": "job1", "profile": "coder"})
+    assert resolved is not None
+    assert resolved.resolve() == profile_home.resolve()
+
+    assert scheduler._resolve_job_profile_home({"id": "job2"}) is None
+
+
 def test_cron_storage_unaffected_when_no_profile(tmp_path, monkeypatch):
     """With no profile (HERMES_HOME == root), the store is the root's cron dir
     — unchanged behavior for single-profile installs."""

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -264,6 +264,40 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_create_from_profile_session_stamps_profile(self):
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars(
+            platform="telegram",
+            chat_id="12345",
+            chat_name="Profile Chat",
+            user_id="12345",
+            profile="coder",
+        )
+        try:
+            created = json.loads(
+                cronjob(
+                    action="create",
+                    prompt="Check server status",
+                    schedule="every 1h",
+                    name="Profile Server Check",
+                    deliver="origin",
+                )
+            )
+        finally:
+            clear_session_vars(tokens)
+
+        assert created["success"] is True
+        assert created["job"]["profile"] == "coder"
+
+        from cron.jobs import get_job
+        stored = get_job(created["job_id"])
+        assert stored["profile"] == "coder"
+        assert stored["origin"]["profile"] == "coder"
+
+        listing = json.loads(cronjob(action="list"))
+        assert listing["jobs"][0]["profile"] == "coder"
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -7,6 +7,7 @@ Compatibility wrappers remain for direct Python callers and legacy tests.
 
 import json
 import logging
+import os
 import re
 import sys
 from pathlib import Path
@@ -282,6 +283,19 @@ def _scan_cron_skill_assembled(assembled: str) -> tuple[str, str]:
     return cleaned, ""
 
 
+def _profile_from_env() -> Optional[str]:
+    """Return the active gateway/CLI profile name for cron job stamping."""
+    try:
+        from gateway.session_context import get_session_env
+
+        profile = (get_session_env("HERMES_SESSION_PROFILE") or "").strip()
+    except Exception:
+        profile = ""
+    if not profile:
+        profile = os.environ.get("HERMES_PROFILE", "").strip()
+    return profile or None
+
+
 def _origin_from_env() -> Optional[Dict[str, str]]:
     from gateway.session_context import get_session_env
     origin_platform = get_session_env("HERMES_SESSION_PLATFORM")
@@ -293,7 +307,7 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
                 "Cron origin captured thread_id=%s for %s:%s",
                 thread_id, origin_platform, origin_chat_id,
             )
-        return {
+        origin = {
             "platform": origin_platform,
             "chat_id": origin_chat_id,
             "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
@@ -305,6 +319,10 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
             # gateway.mirror.mirror_to_session. Harmless for DMs/shared sessions.
             "user_id": get_session_env("HERMES_SESSION_USER_ID") or None,
         }
+        profile = _profile_from_env()
+        if profile:
+            origin["profile"] = profile
+        return origin
     return None
 
 
@@ -581,6 +599,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "schedule": job.get("schedule_display") or "?",
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
+        "profile": job.get("profile"),
         "next_run_at": job.get("next_run_at"),
         "last_run_at": job.get("last_run_at"),
         "last_status": job.get("last_status"),
@@ -740,6 +759,7 @@ def cronjob(
                 repeat=repeat,
                 deliver=_normalize_deliver_param(deliver),
                 origin=_origin_from_env(),
+                profile=_profile_from_env(),
                 skills=canonical_skills,
                 model=_normalize_optional_job_value(model),
                 provider=_normalize_optional_job_value(provider),


### PR DESCRIPTION
## Summary
- Stamp cron jobs created from gateway/profile sessions with the active profile.
- Preserve the job owner on persisted jobs and expose it in cronjob list output.
- Resolve delivery config under `profiles/<profile>` for stored cron jobs so multiplexed gateways can deliver `origin` messages through the correct platform config/env without moving a shared cron store.
- Stamp Telegram `MessageEvent` sources with adapter profile metadata.
- Retry gateway restart notifications when Telegram's send path is briefly degraded immediately after reconnect.

## Why
In multiplexed/profile deployments, cron storage can be shared at a tier/root while Telegram credentials live under individual profiles. Without a persisted job owner, scheduled `deliver: origin` runs load the root gateway config and can fail with `platform 'telegram' not configured/enabled`, silently dropping scheduled reports.

## Test plan
- `python3 -m py_compile cron/jobs.py cron/scheduler.py tools/cronjob_tools.py gateway/run.py plugins/platforms/telegram/adapter.py`
- `/opt/hermes-runtime/hermes-agent/venv/bin/python -m pytest tests/tools/test_cronjob_tools.py tests/tools/test_cronjob_run_immediate.py tests/cron/test_cron_profile_isolation.py tests/cron/test_cronjob_schema.py -q`
- Result: `93 passed in 4.46s`
