### PR TITLE
feat(tools): opt-in Docker runtime override + read-only rootfs for the sandbox backend

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,6 +87,18 @@ Terminal-backend isolation is the right posture when the concern is
 LLM-emitted destructive shell or unwanted file-tool writes, and the
 operator is otherwise trusted.
 
+Two additional opt-in `config.yaml` knobs are available for operators who
+already run an alternate container runtime or want a stricter rootfs, without
+adopting the whole-process wrapper below: `terminal.docker_runtime` (points
+the sandbox at an already-installed alternate Docker runtime, e.g. gVisor's
+`"runsc"` — fails loud at startup if the named runtime isn't registered with
+the daemon, rather than silently falling back to `runc`) and
+`terminal.docker_readonly` (makes the image's root filesystem immutable on
+top of the existing tmpfs mounts). These are configuration options for
+operators who already have the underlying tooling, not a recommended
+default, and they don't change the guidance below for untrusted-input
+operators — that guidance still points at NVIDIA OpenShell.
+
 #### Whole-process wrapping
 
 Whole-process wrapping runs the entire agent process tree inside a

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -268,6 +268,17 @@ terminal:
 #   # docker_extra_args:
 #   #   - "--cap-add"
 #   #   - "SETUID"
+#   # Optional: run the container under an alternate Docker runtime you've already
+#   # installed and registered with your Docker daemon (e.g. gVisor's "runsc").
+#   # Fails loud at startup if the named runtime isn't registered, rather than
+#   # silently falling back to the default runc runtime. Requires installing
+#   # gVisor separately: https://gvisor.dev/docs/user_guide/install/
+#   # docker_runtime: "runsc"
+#   # Optional: make the container's root filesystem read-only. Additive with the
+#   # existing tmpfs mounts for /tmp, /workspace, etc. — but package installs that
+#   # write outside those paths (e.g. "apt install") will fail unless you also add
+#   # an extra writable mount via docker_extra_args or docker_volumes.
+#   # docker_readonly: true
 
 # -----------------------------------------------------------------------------
 # OPTION 4: Singularity/Apptainer container

--- a/cli.py
+++ b/cli.py
@@ -684,6 +684,8 @@ def load_cli_config() -> Dict[str, Any]:
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
         "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
         "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
+        "docker_runtime": "TERMINAL_DOCKER_RUNTIME",
+        "docker_readonly": "TERMINAL_DOCKER_READONLY",
         "sandbox_dir": "TERMINAL_SANDBOX_DIR",
         # Persistent shell (non-local backends)
         "persistent_shell": "TERMINAL_PERSISTENT_SHELL",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1854,6 +1854,8 @@ if _config_path.exists():
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
                 "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
                 "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
+                "docker_runtime": "TERMINAL_DOCKER_RUNTIME",
+                "docker_readonly": "TERMINAL_DOCKER_READONLY",
                 "sandbox_dir": "TERMINAL_SANDBOX_DIR",
                 "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
             }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1229,6 +1229,18 @@ DEFAULT_CONFIG = {
         # When on, SETUID/SETGID caps are omitted from the container since
         # no privilege drop is needed.
         "docker_run_as_host_user": False,
+        # Opt-in alternate Docker runtime (e.g. "runsc" for gVisor), for
+        # operators who already have it installed and registered with their
+        # Docker daemon. DockerEnvironment fails loud at construction if the
+        # named runtime isn't registered, rather than silently falling back
+        # to the default runc. Empty string = default runc runtime.
+        "docker_runtime": "",
+        # Opt-in read-only root filesystem (--read-only). Additive with the
+        # existing tmpfs/bind mounts for /tmp, /workspace, etc. — but package
+        # installs that write outside those mounted paths (e.g. `apt install`
+        # touching /usr) will fail unless you also declare an extra writable
+        # mount via docker_extra_args/docker_volumes.
+        "docker_readonly": False,
         # Persistent shell — keep a long-lived bash shell across execute() calls
         # so cwd/env vars/shell variables survive between commands.
         # Enabled by default for non-local backends (SSH); local is always opt-in
@@ -7490,6 +7502,8 @@ TERMINAL_CONFIG_ENV_MAP = {
     "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
     "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
     "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
+    "docker_runtime": "TERMINAL_DOCKER_RUNTIME",
+    "docker_readonly": "TERMINAL_DOCKER_READONLY",
     "sandbox_dir": "TERMINAL_SANDBOX_DIR",
     "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
 }

--- a/tests/tools/test_docker_gvisor_hardening.py
+++ b/tests/tools/test_docker_gvisor_hardening.py
@@ -1,0 +1,281 @@
+"""Tests for the opt-in Docker runtime override + read-only rootfs option in
+the Docker terminal backend (``terminal.docker_runtime`` /
+``terminal.docker_readonly``).
+
+Both are additive to the existing cap-drop/no-new-privileges/tmpfs hardening:
+``docker_runtime`` lets an operator who already has an alternate Docker
+runtime installed (e.g. gVisor's ``runsc``) point the sandbox at it;
+``docker_readonly`` makes the image's root filesystem immutable on top of
+the existing tmpfs mounts. Both fail loud rather than silently degrading: an
+unregistered runtime raises at ``DockerEnvironment`` construction instead of
+falling back to ``runc``, and the reuse path rejects a persisted container
+that predates either setting — the same bug class the existing
+network-mode guard already fixes for ``docker_network``.
+"""
+
+import json
+
+import pytest
+
+import tools.terminal_tool as terminal_tool
+from tools.environments import docker as docker_env
+
+
+@pytest.fixture(autouse=True)
+def _reset_docker_probe_caches():
+    """Module-level probe caches must not leak between tests in this file."""
+    docker_env._cgroup_limits_ok = None
+    docker_env._storage_opt_ok = None
+    docker_env._runtime_availability_cache = {}
+    yield
+    docker_env._cgroup_limits_ok = None
+    docker_env._storage_opt_ok = None
+    docker_env._runtime_availability_cache = {}
+
+
+def _make_fake_run(*, runtimes=None, ps_stdout="", inspect_stdout=""):
+    """Build a fake subprocess.run answering docker info/ps/inspect/run.
+
+    Returns ``(fake_run, commands)`` — commands is the list of argv lists
+    issued, for assertions.
+    """
+    commands = []
+
+    def fake_run(cmd, *args, **kwargs):
+        commands.append(cmd)
+
+        class Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        if len(cmd) > 1 and cmd[1] == "info":
+            Result.stdout = json.dumps(runtimes or {})
+        elif len(cmd) > 1 and cmd[1] == "ps":
+            Result.stdout = ps_stdout
+        elif len(cmd) > 1 and cmd[1] == "inspect":
+            Result.stdout = inspect_stdout
+        elif len(cmd) > 1 and cmd[1] == "run":
+            Result.stdout = "fake-container-id\n"
+        return Result()
+
+    return fake_run, commands
+
+
+# --- terminal_tool config bridging ------------------------------------------
+
+
+def test_terminal_env_config_reads_docker_runtime_and_readonly(monkeypatch):
+    monkeypatch.setenv("TERMINAL_DOCKER_RUNTIME", "runsc")
+    monkeypatch.setenv("TERMINAL_DOCKER_READONLY", "true")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["docker_runtime"] == "runsc"
+    assert config["docker_readonly"] is True
+
+
+def test_create_environment_passes_runtime_and_readonly(monkeypatch):
+    captured = {}
+    sentinel = object()
+
+    def _fake_docker_environment(**kwargs):
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(terminal_tool, "_DockerEnvironment", _fake_docker_environment)
+
+    env = terminal_tool._create_environment(
+        env_type="docker",
+        image="python:3.11",
+        cwd="/workspace",
+        timeout=60,
+        container_config={"docker_runtime": "runsc", "docker_readonly": True},
+    )
+
+    assert env is sentinel
+    assert captured["runtime"] == "runsc"
+    assert captured["read_only"] is True
+
+
+# --- _docker_runtime_available probe ----------------------------------------
+
+
+def test_runtime_probe_true_when_registered(monkeypatch):
+    fake_run, commands = _make_fake_run(runtimes={"runsc": {"path": "/usr/bin/runsc"}})
+    monkeypatch.setattr(docker_env.subprocess, "run", fake_run)
+
+    assert docker_env._docker_runtime_available("/usr/bin/docker", "runsc") is True
+    assert any(cmd[1] == "info" for cmd in commands)
+
+
+def test_runtime_probe_false_when_not_registered(monkeypatch):
+    fake_run, _ = _make_fake_run(runtimes={})
+    monkeypatch.setattr(docker_env.subprocess, "run", fake_run)
+
+    assert docker_env._docker_runtime_available("/usr/bin/docker", "runsc") is False
+
+
+def test_runtime_probe_result_is_cached(monkeypatch):
+    fake_run, commands = _make_fake_run(runtimes={"runsc": {}})
+    monkeypatch.setattr(docker_env.subprocess, "run", fake_run)
+
+    docker_env._docker_runtime_available("/usr/bin/docker", "runsc")
+    docker_env._docker_runtime_available("/usr/bin/docker", "runsc")
+
+    info_calls = [c for c in commands if len(c) > 1 and c[1] == "info"]
+    assert len(info_calls) == 1
+
+
+# --- DockerEnvironment construction -----------------------------------------
+
+
+def test_docker_environment_raises_when_runtime_unregistered(monkeypatch):
+    fake_run, _ = _make_fake_run(runtimes={})
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="runsc"):
+        docker_env.DockerEnvironment(
+            image="python:3.11",
+            cwd="/workspace",
+            timeout=60,
+            task_id="runtime-missing-test",
+            runtime="runsc",
+        )
+
+
+def test_docker_environment_adds_runtime_flag_when_available(monkeypatch):
+    fake_run, commands = _make_fake_run(runtimes={"runsc": {}})
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env.subprocess, "run", fake_run)
+
+    env = docker_env.DockerEnvironment(
+        image="python:3.11",
+        cwd="/workspace",
+        timeout=60,
+        task_id="runtime-ok-test",
+        runtime="runsc",
+    )
+
+    run_cmd = next(cmd for cmd in commands if len(cmd) > 2 and cmd[1:3] == ["run", "-d"])
+    assert "--runtime" in run_cmd
+    assert run_cmd[run_cmd.index("--runtime") + 1] == "runsc"
+    env.cleanup()
+
+
+def test_docker_environment_omits_runtime_flag_by_default(monkeypatch):
+    fake_run, commands = _make_fake_run()
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env.subprocess, "run", fake_run)
+
+    env = docker_env.DockerEnvironment(
+        image="python:3.11", cwd="/workspace", timeout=60,
+        task_id="runtime-default-test",
+    )
+
+    run_cmd = next(cmd for cmd in commands if len(cmd) > 2 and cmd[1:3] == ["run", "-d"])
+    assert "--runtime" not in run_cmd
+    env.cleanup()
+
+
+def test_docker_environment_adds_read_only_flag_when_enabled(monkeypatch):
+    fake_run, commands = _make_fake_run()
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env.subprocess, "run", fake_run)
+
+    env = docker_env.DockerEnvironment(
+        image="python:3.11", cwd="/workspace", timeout=60,
+        task_id="readonly-test", read_only=True,
+    )
+
+    run_cmd = next(cmd for cmd in commands if len(cmd) > 2 and cmd[1:3] == ["run", "-d"])
+    assert "--read-only" in run_cmd
+    env.cleanup()
+
+
+def test_docker_environment_omits_read_only_flag_by_default(monkeypatch):
+    fake_run, commands = _make_fake_run()
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env.subprocess, "run", fake_run)
+
+    env = docker_env.DockerEnvironment(
+        image="python:3.11", cwd="/workspace", timeout=60,
+        task_id="readonly-default-test",
+    )
+
+    run_cmd = next(cmd for cmd in commands if len(cmd) > 2 and cmd[1:3] == ["run", "-d"])
+    assert "--read-only" not in run_cmd
+    env.cleanup()
+
+
+# --- reuse guard -------------------------------------------------------------
+
+
+def _reuse_harness(monkeypatch, *, actual_runtime: str, actual_readonly: str, **kwargs):
+    fake_run, commands = _make_fake_run(
+        runtimes={"runsc": {}},
+        ps_stdout="existing-container-id\trunning\t<no value>\n",
+        inspect_stdout=f"{actual_runtime}\t{actual_readonly}\n",
+    )
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env.subprocess, "run", fake_run)
+
+    docker_env.DockerEnvironment(
+        image="python:3.11",
+        cwd="/workspace",
+        timeout=60,
+        task_id="reuse-hardening-test",
+        persist_across_processes=True,
+        **kwargs,
+    )
+    return commands
+
+
+def test_reuse_rejects_container_with_wrong_runtime(monkeypatch):
+    commands = _reuse_harness(
+        monkeypatch, actual_runtime="runc", actual_readonly="false", runtime="runsc",
+    )
+
+    assert any(cmd[1:3] == ["rm", "-f"] for cmd in commands), (
+        "container created under runc must be removed when docker_runtime=runsc "
+        "is requested"
+    )
+    run_cmd = next(cmd for cmd in commands if len(cmd) > 2 and cmd[1:3] == ["run", "-d"])
+    assert "--runtime" in run_cmd
+
+
+def test_reuse_rejects_container_not_readonly(monkeypatch):
+    commands = _reuse_harness(
+        monkeypatch, actual_runtime="runc", actual_readonly="false", read_only=True,
+    )
+
+    assert any(cmd[1:3] == ["rm", "-f"] for cmd in commands), (
+        "writable-rootfs container must be removed when docker_readonly=true "
+        "is requested"
+    )
+    run_cmd = next(cmd for cmd in commands if len(cmd) > 2 and cmd[1:3] == ["run", "-d"])
+    assert "--read-only" in run_cmd
+
+
+def test_reuse_keeps_matching_hardened_container(monkeypatch):
+    commands = _reuse_harness(
+        monkeypatch, actual_runtime="runsc", actual_readonly="true",
+        runtime="runsc", read_only=True,
+    )
+
+    assert not any(cmd[1] == "rm" for cmd in commands)
+    assert not any(cmd[1:3] == ["run", "-d"] for cmd in commands), (
+        "matching container must be reused, not recreated"
+    )
+
+
+def test_reuse_skips_inspect_when_no_hardening_requested(monkeypatch):
+    """Default config (no docker_runtime, docker_readonly=False) never churns
+    containers, even ones that happen to run under a stricter posture already
+    (e.g. created via docker_extra_args)."""
+    commands = _reuse_harness(monkeypatch, actual_runtime="runc", actual_readonly="false")
+
+    assert not any(cmd[1] == "inspect" for cmd in commands)
+    assert not any(cmd[1] == "rm" for cmd in commands)
+    assert not any(cmd[1:3] == ["run", "-d"] for cmd in commands)

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -308,6 +308,33 @@ def test_docker_volumes_is_bridged_everywhere():
     assert "TERMINAL_DOCKER_VOLUMES" in _terminal_tool_env_var_names()
 
 
+def test_docker_runtime_is_bridged_everywhere():
+    """Regression pin for ``terminal.docker_runtime`` (opt-in gVisor/alternate
+    Docker runtime hardening).
+
+    Same four-site bridge invariant as docker_run_as_host_user /
+    docker_network — drift between any of the four sites means
+    ``terminal.docker_runtime: "runsc"`` in config.yaml silently does nothing
+    for that entry point, leaving the operator believing they have a
+    stronger kernel boundary than they actually do.
+    """
+    assert "docker_runtime" in _cli_env_map_keys()
+    assert "docker_runtime" in _gateway_env_map_keys()
+    assert "docker_runtime" in _save_config_env_sync_keys()
+    assert "TERMINAL_DOCKER_RUNTIME" in _terminal_tool_env_var_names()
+
+
+def test_docker_readonly_is_bridged_everywhere():
+    """Regression pin for ``terminal.docker_readonly`` (opt-in read-only
+    root filesystem hardening). Same four-site bridge invariant as
+    docker_runtime above.
+    """
+    assert "docker_readonly" in _cli_env_map_keys()
+    assert "docker_readonly" in _gateway_env_map_keys()
+    assert "docker_readonly" in _save_config_env_sync_keys()
+    assert "TERMINAL_DOCKER_READONLY" in _terminal_tool_env_var_names()
+
+
 def test_docker_forward_env_is_bridged_everywhere():
     """Regression pin for ``terminal.docker_forward_env`` — the sibling gap to
     docker_volumes.

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -2,7 +2,10 @@
 
 Security hardened (cap-drop ALL, no-new-privileges, PID limits),
 configurable resource limits (CPU, memory, disk), and optional filesystem
-persistence via bind mounts.
+persistence via bind mounts. Optional further hardening on top of the
+namespace/cgroup boundary: an alternate Docker runtime (e.g. gVisor's
+``runsc``) and a read-only root filesystem — see ``DockerEnvironment``'s
+``runtime``/``read_only`` params.
 """
 
 import hashlib
@@ -607,19 +610,31 @@ def _extra_args_egress_collisions(
     return sorted(set(collisions))
 
 
-def _build_security_args(run_as_host_user: bool, run_exec: bool = False) -> list[str]:
+def _build_security_args(
+    run_as_host_user: bool, run_exec: bool = False, read_only: bool = False,
+) -> list[str]:
     """Return the security/cap/tmpfs args tailored to the privilege mode.
 
     ``run_exec`` mounts ``/run`` with ``exec`` instead of the hardened
     ``noexec`` default. This is required for s6-overlay images whose ``/init``
     entrypoint execs ``/run/s6/basedir/bin/init`` during startup; see
     ``_image_uses_init_entrypoint``.
+
+    ``read_only`` adds ``--read-only``, making the image's own root layer
+    immutable. This is additive with the existing tmpfs/bind mounts (they are
+    separate mounts, not part of the root layer, so ``/tmp``, ``/workspace``,
+    etc. stay writable) — but package installs that write outside those
+    mounted paths (e.g. ``apt install`` touching ``/usr``) will fail with
+    "Read-only file system" unless the operator also declares an extra tmpfs
+    or volume for that path via ``docker_extra_args``/``docker_volumes``.
     """
     run_tmpfs = list(_RUN_TMPFS_EXEC if run_exec else _RUN_TMPFS_NOEXEC)
     args = list(_BASE_SECURITY_ARGS) + run_tmpfs
-    if run_as_host_user:
-        return args
-    return args + list(_PRIVDROP_CAP_ARGS)
+    if not run_as_host_user:
+        args = args + list(_PRIVDROP_CAP_ARGS)
+    if read_only:
+        args = args + ["--read-only"]
+    return args
 
 
 def _image_uses_init_entrypoint(docker_exe: str, image: str) -> bool:
@@ -741,6 +756,39 @@ def _cgroup_limits_available(image: str) -> bool:
     return _cgroup_limits_ok
 
 
+_runtime_availability_cache: dict[str, bool] = {}
+
+
+def _docker_runtime_available(docker_exe: str, runtime: str) -> bool:
+    """Return True if *runtime* (e.g. ``"runsc"`` for gVisor) is registered
+    with the Docker daemon.
+
+    Probes ``docker info`` once per runtime name per process and caches the
+    result — the daemon's registered runtimes don't change without a daemon
+    restart/reconfigure, which a running Hermes process wouldn't see anyway.
+    """
+    if runtime in _runtime_availability_cache:
+        return _runtime_availability_cache[runtime]
+
+    available = False
+    try:
+        result = subprocess.run(
+            [docker_exe, "info", "--format", "{{json .Runtimes}}"],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=15,
+            stdin=subprocess.DEVNULL,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            runtimes = json.loads(result.stdout.strip())
+            available = isinstance(runtimes, dict) and runtime in runtimes
+    except (subprocess.SubprocessError, OSError, ValueError) as e:
+        logger.debug("Docker: could not probe registered runtimes: %s", e)
+
+    _runtime_availability_cache[runtime] = available
+    return available
+
+
 def _ensure_docker_available() -> None:
     """Best-effort check that the docker CLI is available before use.
 
@@ -816,6 +864,19 @@ class DockerEnvironment(BaseEnvironment):
     boundary — the filesystem inside is writable so agents can install packages
     (pip, npm, apt) as needed. Writable workspace via tmpfs or bind mounts.
 
+    Two opt-in knobs are available for operators who already have the
+    underlying tooling in place (see SECURITY.md):
+
+    - ``runtime`` — a Docker runtime name (e.g. ``"runsc"`` for gVisor)
+      already registered with the operator's Docker daemon. Fails loud at
+      construction time if the requested runtime isn't registered, rather
+      than silently running under the default ``runc``.
+    - ``read_only`` — makes the image's root filesystem immutable
+      (``--read-only``), on top of the existing tmpfs/bind mounts for
+      ``/tmp``, ``/workspace``, etc. Package installs that write outside
+      those mounted paths will fail unless the operator declares an extra
+      writable mount.
+
     Persistence: when enabled, bind mounts preserve /workspace and /root
     across container restarts.
     """
@@ -839,6 +900,8 @@ class DockerEnvironment(BaseEnvironment):
         run_as_host_user: bool = False,
         extra_args: list = None,
         persist_across_processes: bool = True,
+        runtime: str = "",
+        read_only: bool = False,
     ):
         if cwd == "~":
             cwd = "/root"
@@ -848,6 +911,8 @@ class DockerEnvironment(BaseEnvironment):
         self._task_id = task_id
         self._forward_env = _normalize_forward_env_names(forward_env)
         self._env = _normalize_env_dict(env)
+        self._runtime = (runtime or "").strip()
+        self._read_only = bool(read_only)
         self._container_id: Optional[str] = None
         self._labels: dict[str, str] = {}
         self._image: str = ""
@@ -1258,7 +1323,27 @@ class DockerEnvironment(BaseEnvironment):
         security_args = _build_security_args(
             run_as_host_user and bool(user_args),
             run_exec=image_uses_s6_init,
+            read_only=self._read_only,
         )
+
+        # gVisor (or another alternate Docker runtime): fail loud rather than
+        # silently falling back to the default runc if the requested runtime
+        # isn't registered with the daemon — this is a deliberate security
+        # choice by the operator, and silently downgrading it would leave
+        # them believing they have a stronger boundary than they actually do.
+        runtime_args: list[str] = []
+        if self._runtime:
+            if not _docker_runtime_available(self._docker_exe, self._runtime):
+                raise RuntimeError(
+                    f"terminal.docker_runtime={self._runtime!r} is set but the "
+                    f"Docker daemon does not have a '{self._runtime}' runtime "
+                    "registered. Install it (e.g. gVisor's runsc: "
+                    "https://gvisor.dev/docs/user_guide/install/), register it "
+                    "in the daemon's /etc/docker/daemon.json runtimes config, "
+                    "and restart the daemon — or unset docker_runtime to use "
+                    "the default runc runtime."
+                )
+            runtime_args = ["--runtime", self._runtime]
 
         logger.info(f"Docker volume_args: {volume_args}")
         # User-supplied extra docker run flags (docker_extra_args in config.yaml).
@@ -1290,6 +1375,7 @@ class DockerEnvironment(BaseEnvironment):
 
         all_run_args = (
             security_args
+            + runtime_args
             + user_args
             + writable_args
             + resource_args
@@ -1371,6 +1457,44 @@ class DockerEnvironment(BaseEnvironment):
                         "container — removing it and starting fresh "
                         "(task=%s, profile=%s).",
                         container_id[:12], actual_mode or "unknown",
+                        task_label, profile_name,
+                    )
+                    try:
+                        subprocess.run(
+                            [self._docker_exe, "rm", "-f", container_id],
+                            capture_output=True,
+                            text=True, encoding="utf-8", errors="replace",
+                            timeout=30,
+                            check=False,
+                            stdin=subprocess.DEVNULL,
+                        )
+                    except (subprocess.TimeoutExpired, OSError) as e:
+                        logger.warning("Failed to remove mismatched container %s: %s", container_id[:12], e)
+                    existing = None
+            if existing is not None:
+                container_id, state = existing
+                # Hardening guard: same class of bug as the network-mode
+                # guard above.  A container created before the operator set
+                # ``docker_runtime``/``docker_readonly`` keeps its original
+                # runtime/rootfs mode forever — label-only reuse would hand
+                # the agent a container that looks hardened in config but
+                # isn't. Only the stronger-than-existing direction is
+                # guarded (same asymmetry as network): a container that's
+                # already stricter than requested is left alone.
+                runtime_mismatch = False
+                readonly_mismatch = False
+                if self._runtime or self._read_only:
+                    actual_runtime, actual_readonly = self._container_runtime_and_readonly(container_id)
+                    if self._runtime:
+                        runtime_mismatch = actual_runtime != self._runtime
+                    if self._read_only:
+                        readonly_mismatch = actual_readonly is not True
+                if runtime_mismatch or readonly_mismatch:
+                    logger.warning(
+                        "Existing container %s does not match the requested "
+                        "hardening (runtime=%r read_only=%r) — removing it "
+                        "and starting fresh (task=%s, profile=%s).",
+                        container_id[:12], self._runtime, self._read_only,
                         task_label, profile_name,
                     )
                     try:
@@ -1717,6 +1841,47 @@ class DockerEnvironment(BaseEnvironment):
             return None
         mode = result.stdout.strip()
         return mode or None
+
+    def _container_runtime_and_readonly(
+        self, container_id: str,
+    ) -> tuple[Optional[str], Optional[bool]]:
+        """Return ``(HostConfig.Runtime, HostConfig.ReadonlyRootfs)`` for
+        *container_id*, or ``(None, None)`` when inspection fails.
+
+        Used by the reuse path so a persisted container's actual runtime and
+        rootfs mode still matches the operator's ``docker_runtime`` /
+        ``docker_readonly`` settings. ``None`` is treated as a mismatch by
+        the caller when hardening was requested, so a failed inspect fails
+        closed rather than open — same posture as ``_container_network_mode``.
+        """
+        try:
+            result = subprocess.run(
+                [
+                    self._docker_exe, "inspect",
+                    "--format", "{{.HostConfig.Runtime}}\t{{.HostConfig.ReadonlyRootfs}}",
+                    container_id,
+                ],
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=10,
+                check=False,
+                stdin=subprocess.DEVNULL,
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            logger.debug("docker inspect Runtime/ReadonlyRootfs failed: %s", e)
+            return (None, None)
+        if result.returncode != 0:
+            logger.debug(
+                "docker inspect Runtime/ReadonlyRootfs returned %d: %s",
+                result.returncode, result.stderr.strip(),
+            )
+            return (None, None)
+        parts = result.stdout.strip().split("\t", 1)
+        if len(parts) != 2:
+            return (None, None)
+        runtime = parts[0].strip() or None
+        readonly = parts[1].strip().lower() == "true"
+        return (runtime, readonly)
 
     def _find_reusable_container(
         self,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1453,6 +1453,12 @@ def _get_env_config() -> Dict[str, Any]:
         "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
         "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
+        # Opt-in alternate Docker runtime (e.g. "runsc" for gVisor, if already
+        # installed and registered) and read-only root filesystem. Empty/false
+        # by default; DockerEnvironment fails loud at construction if a
+        # requested runtime isn't registered with the daemon.
+        "docker_runtime": os.getenv("TERMINAL_DOCKER_RUNTIME", ""),
+        "docker_readonly": os.getenv("TERMINAL_DOCKER_READONLY", "false").lower() in {"true", "1", "yes"},
         # Cross-process container reuse (issue #20561).  The docs claim
         # "ONE long-lived container shared across sessions" — this toggle
         # makes that real by probing for a labeled container at startup and
@@ -1513,6 +1519,8 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     docker_env = cc.get("docker_env", {})
     docker_extra_args = cc.get("docker_extra_args", [])
     docker_network = cc.get("docker_network", True)
+    docker_runtime = cc.get("docker_runtime", "")
+    docker_readonly = cc.get("docker_readonly", False)
 
     if env_type == "local":
         return _LocalEnvironment(cwd=cwd, timeout=timeout)
@@ -1538,6 +1546,8 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             network=docker_network,
             extra_args=docker_extra_args,
             persist_across_processes=cc.get("docker_persist_across_processes", True),
+            runtime=docker_runtime,
+            read_only=docker_readonly,
         )
     
     elif env_type == "singularity":


### PR DESCRIPTION
## Summary

- Adds `terminal.docker_runtime` — point the Docker terminal backend at an
  alternate Docker runtime you've already installed and registered with your
  daemon (e.g. gVisor's `runsc`). Fails loud at `DockerEnvironment`
  construction if the named runtime isn't registered, rather than silently
  falling back to `runc`.
- Adds `terminal.docker_readonly` — makes the image's root filesystem
  immutable (`--read-only`), additive with the existing tmpfs mounts for
  `/tmp`, `/workspace`, etc.
- Both are opt-in, off by default, and additive to the existing hardening
  already in `DockerEnvironment` (cap-drop, no-new-privileges, size-limited
  tmpfs, gated resource limits, egress proxy). This is a configuration option
  for operators who already have the underlying tooling — not a new
  recommended default, and it doesn't change `SECURITY.md`'s guidance for
  untrusted-input operators (still NVIDIA OpenShell).
- Container-reuse path now also rejects a persisted container that predates
  either setting (same bug class the existing network-mode guard already
  fixes for `docker_network`), so flipping on hardening for an existing
  `task_id` doesn't silently hand back an unhardened container.
- Wired through all four config-bridging sites (`cli.py`, `gateway/run.py`,
  `hermes_cli/config.py`, `terminal_tool.py`) per the project's own
  regression-pin pattern in `tests/tools/test_terminal_config_env_sync.py`.

Addresses #71301 — verified no duplicate/existing coverage before opening
that issue (searched `gvisor`/`seccomp`/`runsc` across issues/PRs and grepped
`docker.py`, both came back empty).

## Test plan

- [x] New unit tests in `tests/tools/test_docker_gvisor_hardening.py`
      (config bridging, runtime-availability probe + caching, flag
      construction, reuse-guard mismatch/match cases) — all mocked, no real
      Docker required.
- [x] Two new regression-pin tests in `test_terminal_config_env_sync.py`
      guarding all four bridging sites for both new keys.
- [x] `scripts/run_tests.sh tests/tools/test_docker_gvisor_hardening.py
      tests/tools/test_docker_network_config.py
      tests/tools/test_docker_cgroup_limits.py
      tests/tools/test_terminal_config_env_sync.py
      tests/tools/test_docker_environment.py` — 116/116 passed.
- [x] `ruff check` clean on all changed files.
- Tested on macOS (Darwin); no platform-specific code paths touched beyond
  the existing Docker backend's own cross-platform handling.