### PR TITLE
fix(hindsight): report incompatible client versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -898,7 +898,7 @@ After the [litellm supply chain compromise](https://github.com/BerriAI/litellm/i
 # ✅ Correct — pre-1.0 (tight minor window)
 "asyncpg>=0.29,<0.32"
 "aiosqlite>=0.20,<0.23"
-"hindsight-client>=0.4.22,<0.5"
+"example-pre1-package>=0.4.22,<0.7"
 
 # ❌ Rejected — no upper bound
 "some-package>=1.2.3"

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -144,4 +144,4 @@ Available in `hybrid` and `tools` memory modes:
 
 ## Client Version
 
-Requires `hindsight-client >= 0.6.1`. The plugin auto-upgrades on session start if an older version is detected.
+Requires `hindsight-client == 0.6.1`. The plugin installs the pinned client on session start when an older version is detected and reports a precise conflict when a newer user-site package shadows it.

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -144,4 +144,4 @@ Available in `hybrid` and `tools` memory modes:
 
 ## Client Version
 
-Requires `hindsight-client == 0.6.1`. The plugin installs the pinned client on session start when an older version is detected and reports a precise conflict when a newer user-site package shadows it.
+Requires exactly `hindsight-client==0.6.1`. The plugin installs the pin on session start when an older version is detected. If a higher-priority installation shadows Hermes' copy, remove or uninstall the distribution at the path reported by the diagnostic before reinstalling the pin; force-reinstalling only the lower-priority environment does not change Python import precedence.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -56,7 +56,8 @@ logger = logging.getLogger(__name__)
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
 # Keep in sync with tools/lazy_deps.py ("memory.hindsight") and plugin.yaml.
-_MIN_CLIENT_VERSION = "0.6.1"
+_CLIENT_VERSION = "0.6.1"
+_CLIENT_REQUIREMENT = f"hindsight-client=={_CLIENT_VERSION}"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # Mirrors hindsight-integrations/openclaw — Hindsight 0.5.0 added
@@ -152,8 +153,48 @@ def _check_local_runtime() -> tuple[bool, str | None]:
         return False, str(exc)
 
 
+def _installed_cloud_client_version() -> str | None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        return version("hindsight-client")
+    except PackageNotFoundError:
+        return None
+    except Exception:
+        return None
+
+
+def _cloud_client_version_error(installed: str) -> str:
+    origin = ""
+    try:
+        spec = importlib.util.find_spec("hindsight_client")
+        origin = str(getattr(spec, "origin", "") or "")
+    except Exception:
+        pass
+    location = f" Loaded from {origin}." if origin else ""
+    return (
+        f"Incompatible hindsight-client {installed}; Hermes requires "
+        f"{_CLIENT_REQUIREMENT}.{location} A user-site package may be "
+        "shadowing Hermes' pinned dependency. Remove the conflicting package "
+        f"or reinstall with: {sys.executable} -m pip install --force-reinstall "
+        f"'{_CLIENT_REQUIREMENT}'"
+    )
+
+
 def _ensure_cloud_client_dependency() -> None:
-    """Install the Hindsight cloud client lazily before importing it."""
+    """Install the pinned cloud client and reject shadowing incompatible builds."""
+    installed = _installed_cloud_client_version()
+    if installed:
+        try:
+            from packaging.version import Version
+
+            if Version(installed) > Version(_CLIENT_VERSION):
+                raise ImportError(_cloud_client_version_error(installed))
+        except ImportError:
+            raise
+        except Exception:
+            raise ImportError(_cloud_client_version_error(installed))
+
     try:
         from tools.lazy_deps import ensure as _lazy_ensure
         _lazy_ensure("memory.hindsight", prompt=False)
@@ -161,6 +202,10 @@ def _ensure_cloud_client_dependency() -> None:
         pass
     except Exception as exc:
         raise ImportError(str(exc)) from exc
+
+    installed = _installed_cloud_client_version()
+    if installed and installed != _CLIENT_VERSION:
+        raise ImportError(_cloud_client_version_error(installed))
 
 
 # ---------------------------------------------------------------------------
@@ -877,7 +922,7 @@ class HindsightMemoryProvider(MemoryProvider):
         env_writes: dict = {}
 
         # Step 2: Install/upgrade deps for selected mode
-        cloud_dep = f"hindsight-client>={_MIN_CLIENT_VERSION}"
+        cloud_dep = _CLIENT_REQUIREMENT
         local_dep = "hindsight-all"
         if mode == "local_embedded":
             deps_to_install = [local_dep]
@@ -1468,21 +1513,31 @@ class HindsightMemoryProvider(MemoryProvider):
             from importlib.metadata import version as pkg_version
             from packaging.version import Version
             installed = pkg_version("hindsight-client")
-            if Version(installed) < Version(_MIN_CLIENT_VERSION):
-                logger.warning("hindsight-client %s is outdated (need >=%s), attempting upgrade...",
-                               installed, _MIN_CLIENT_VERSION)
+            if Version(installed) < Version(_CLIENT_VERSION):
+                logger.warning(
+                    "hindsight-client %s is outdated (need %s), installing pinned client...",
+                    installed,
+                    _CLIENT_VERSION,
+                )
                 # Environment-aware install: sealed hosted venvs redirect to the
                 # durable data-volume target instead of /opt/hermes (NS-605).
                 from tools.lazy_deps import install_specs
-                outcome = install_specs([f"hindsight-client>={_MIN_CLIENT_VERSION}"], timeout=120)
+
+                outcome = install_specs([_CLIENT_REQUIREMENT], timeout=120)
                 if outcome.ok:
-                    logger.info("hindsight-client upgraded to >=%s", _MIN_CLIENT_VERSION)
+                    logger.info("hindsight-client installed at %s", _CLIENT_VERSION)
                 elif outcome.blocked:
-                    logger.warning("Auto-upgrade unavailable: %s. Run: uv pip install 'hindsight-client>=%s'",
-                                   outcome.reason, _MIN_CLIENT_VERSION)
+                    logger.warning(
+                        "Auto-upgrade unavailable: %s. Run: uv pip install '%s'",
+                        outcome.reason,
+                        _CLIENT_REQUIREMENT,
+                    )
                 else:
-                    logger.warning("Auto-upgrade failed: %s. Run: uv pip install 'hindsight-client>=%s'",
-                                   (outcome.stderr or "").strip() or "install error", _MIN_CLIENT_VERSION)
+                    logger.warning(
+                        "Auto-upgrade failed: %s. Run: uv pip install '%s'",
+                        (outcome.stderr or "").strip() or "install error",
+                        _CLIENT_REQUIREMENT,
+                    )
         except Exception:
             pass  # packaging not available or other issue — proceed anyway
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -172,12 +172,21 @@ def _cloud_client_version_error(installed: str) -> str:
     except Exception:
         pass
     location = f" Loaded from {origin}." if origin else ""
+    owner = (
+        f"the Python environment that owns {origin}"
+        if origin
+        else "the higher-priority Python environment"
+    )
     return (
         f"Incompatible hindsight-client {installed}; Hermes requires "
-        f"{_CLIENT_REQUIREMENT}.{location} A user-site package may be "
-        "shadowing Hermes' pinned dependency. Remove the conflicting package "
-        f"or reinstall with: {sys.executable} -m pip install --force-reinstall "
-        f"'{_CLIENT_REQUIREMENT}'"
+        f"{_CLIENT_REQUIREMENT}.{location} A higher-priority installation may be "
+        "shadowing Hermes' pinned dependency. First uninstall hindsight-client "
+        f"from {owner} (run that environment's Python with "
+        "`-m pip uninstall hindsight-client`) or remove that distribution "
+        "directly. Then install the Hermes pin with: "
+        f"{sys.executable} -m pip install '{_CLIENT_REQUIREMENT}'. "
+        "Reinstalling only the lower-priority Hermes environment does not change "
+        "Python import precedence."
     )
 
 

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -2,7 +2,7 @@ name: hindsight
 version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
-  - "hindsight-client>=0.6.1"
+  - "hindsight-client==0.6.1"
 requires_env: []
 hooks:
   - on_session_end

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -115,6 +115,33 @@ def _provider_for_mode(tmp_path, monkeypatch, mode: str):
     return provider
 
 
+def test_newer_hindsight_client_reports_precise_version_conflict(monkeypatch):
+    import plugins.memory.hindsight as hindsight
+
+    ensure_calls = []
+    monkeypatch.setattr("importlib.metadata.version", lambda _name: "0.8.4")
+    monkeypatch.setattr(
+        "importlib.util.find_spec",
+        lambda _name: SimpleNamespace(
+            origin="/Users/example/Library/Python/3.14/site-packages/hindsight_client/__init__.py"
+        ),
+    )
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda *args, **kwargs: ensure_calls.append((args, kwargs)),
+    )
+
+    with pytest.raises(ImportError) as exc_info:
+        hindsight._ensure_cloud_client_dependency()
+
+    message = str(exc_info.value)
+    assert "0.8.4" in message
+    assert "hindsight-client==0.6.1" in message
+    assert "user-site" in message
+    assert "Library/Python/3.14/site-packages" in message
+    assert ensure_calls == []
+
+
 def _assert_cloud_client_lazy_installed_before_import(tmp_path, monkeypatch, mode: str):
     """Cloud/local-external clients must ensure lazy deps before importing."""
     import builtins
@@ -338,6 +365,7 @@ class TestConfig:
 
         monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
         monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+        monkeypatch.setattr("tools.lazy_deps.ensure", lambda *args, **kwargs: None)
 
         p = HindsightMemoryProvider()
         p._mode = "local_embedded"
@@ -1350,13 +1378,13 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
         return calls
 
     def test_upgrade_uses_install_specs_not_subprocess(self, tmp_path, monkeypatch):
-        from plugins.memory.hindsight import _MIN_CLIENT_VERSION
+        from plugins.memory.hindsight import _CLIENT_REQUIREMENT
         from tools.lazy_deps import InstallSpecsResult
 
         calls = self._init_with_outdated_client(
             tmp_path, monkeypatch, InstallSpecsResult(ok=True)
         )
-        assert calls == [(f"hindsight-client>={_MIN_CLIENT_VERSION}",)]
+        assert calls == [(_CLIENT_REQUIREMENT,)]
 
     def test_blocked_upgrade_is_nonfatal_and_surfaces_reason(
         self, tmp_path, monkeypatch, caplog

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -137,8 +137,12 @@ def test_newer_hindsight_client_reports_precise_version_conflict(monkeypatch):
     message = str(exc_info.value)
     assert "0.8.4" in message
     assert "hindsight-client==0.6.1" in message
-    assert "user-site" in message
+    assert "higher-priority" in message
     assert "Library/Python/3.14/site-packages" in message
+    assert "-m pip uninstall hindsight-client" in message
+    assert "remove that distribution directly" in message
+    assert "does not change Python import precedence" in message
+    assert "--force-reinstall" not in message
     assert ensure_calls == []
 
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -432,7 +432,7 @@ hermes config set memory.provider hindsight
 echo "HINDSIGHT_API_KEY=your-key" >> ~/.hermes/.env
 ```
 
-The setup wizard installs dependencies automatically and only installs what's needed for the selected mode (`hindsight-client` for cloud, `hindsight-all` for local). Requires `hindsight-client >= 0.4.22` (auto-upgraded on session start if outdated).
+The setup wizard installs dependencies automatically and only installs what's needed for the selected mode (`hindsight-client` for cloud, `hindsight-all` for local). Cloud mode requires exactly `hindsight-client==0.6.1`; an older client is replaced with that pin on session start. If startup reports a higher-priority installation, uninstall it from the Python environment that owns the reported `site-packages` path (or remove that distribution directly) before reinstalling the pin. Force-reinstalling only Hermes' lower-priority environment does not change Python import precedence.
 
 **Local mode UI:** `hindsight-embed -p hermes ui start`
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
@@ -344,7 +344,7 @@ hermes config set memory.provider hindsight
 echo "HINDSIGHT_API_KEY=your-key" >> ~/.hermes/.env
 ```
 
-安装向导会自动安装依赖，并仅安装所选模式所需的内容（云端用 `hindsight-client`，本地用 `hindsight-all`）。需要 `hindsight-client >= 0.4.22`（会话启动时若版本过旧则自动升级）。
+安装向导会自动安装依赖，并仅安装所选模式所需的内容（云端用 `hindsight-client`，本地用 `hindsight-all`）。云端模式必须使用精确版本 `hindsight-client==0.6.1`；会话启动时，旧版本会被替换为该固定版本。如果启动时报告有更高优先级的安装，请先在拥有所报告 `site-packages` 路径的 Python 环境中卸载它（或直接删除该发行版），再重新安装固定版本。仅在优先级较低的 Hermes 环境中强制重装不会改变 Python 的导入优先级。
 
 **本地模式 UI：** `hindsight-embed -p hermes ui start`
 


### PR DESCRIPTION
## Summary

- detect a newer incompatible `hindsight-client` before lazy installation produces a misleading import error;
- report the installed version, resolved module path, and exact Hermes pin;
- make higher-priority import-shadowing recovery actionable: uninstall from the Python environment that owns the reported path or remove that distribution directly, then install the exact Hermes pin;
- explicitly explain that force-reinstalling only a lower-priority environment does not change Python import precedence;
- keep the exact `hindsight-client==0.6.1` requirement consistent across the plugin manifest, setup/runtime path, plugin README, canonical English guide, and zh-Hans guide;
- install the exact pinned client when an older version is found rather than allowing pip to choose an incompatible newer release.

Fixes #71422.

## Root cause

Hermes pins `hindsight-client==0.6.1`, but the plugin manifest and session-start upgrade path used a lower-bound requirement. When a higher-priority user-site `0.8.x` distribution shadowed the pinned environment, lazy dependency resolution tried to repair the lower-priority install and ultimately reported that the package was not importable, even though the real problem was an incompatible API version plus Python import precedence.

The cloud-client chokepoint now rejects a newer distribution before that repair attempt and reports the distribution path. Recovery targets the installation that actually wins import resolution: use that environment's Python to uninstall `hindsight-client`, or remove that distribution directly, before installing `hindsight-client==0.6.1` into Hermes.

## Regression coverage

A regression simulates `hindsight-client 0.8.4` loading from macOS user site-packages. It requires the diagnostic to include:

- the installed version;
- `hindsight-client==0.6.1`;
- the shadowing module path;
- explicit higher-priority-installation guidance;
- `-m pip uninstall hindsight-client` targeting the owning Python environment or direct distribution removal;
- the import-precedence explanation;
- no `--force-reinstall` recommendation;
- proof that the generic lazy installer was not called first.

The corrected assertions fail against the prior diagnostic and pass with `38f4f1dbe`.

## Documentation

- canonical English Hindsight user guide: exact pin and corrected shadowing recovery;
- zh-Hans translation: matching exact pin and recovery semantics;
- plugin README: matching exact pin and import-precedence guidance;
- stale Hindsight version examples removed so all documented requirements agree with `hindsight-client==0.6.1`.

## Verification

- rebased onto current `main` (`a31be4803`);
- Hindsight provider/config/environment/health/root-guard plus memory-setup suites: **140 passed across 6 files**;
- focused diagnostic red-before / green-after check: passed;
- full multilingual Docusaurus production build, including English and zh-Hans: passed;
- plugin manifest assertion for `hindsight-client==0.6.1`: passed;
- focused Ruff: passed;
- `py_compile`: passed;
- `git diff --check`: passed.
