### PR TITLE
fix(desktop): restore native OAuth tokens after restart

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6239,6 +6239,10 @@ function _loadNativeTokens(baseUrl: string): NativeTokenSet | null {
     const plaintext = decryptDesktopSecret(secret)
 
     if (!plaintext) {
+      rememberLog(
+        `[native-oauth] failed to decrypt stored tokens for ${baseUrl}; keeping stored entry for retry`
+      )
+
       return null
     }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6247,8 +6247,10 @@ function _loadNativeTokens(baseUrl: string): NativeTokenSet | null {
 
     return tokens
   } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+
     rememberLog(
-      `[native-oauth] failed to load stored tokens for ${baseUrl}: ${(error as Error).message}`
+      `[native-oauth] failed to load stored tokens for ${baseUrl}: ${detail}`
     )
 
     return null

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -145,6 +145,7 @@ import {
 import {
   nativeRefreshUrl,
   type NativeTokenSet,
+  parseStoredTokenSet,
   parseTokenResponse,
   resolveLoginStrategy,
   tokenNeedsRefresh
@@ -6241,11 +6242,15 @@ function _loadNativeTokens(baseUrl: string): NativeTokenSet | null {
       return null
     }
 
-    const tokens = parseTokenResponse(JSON.parse(plaintext))
+    const tokens = parseStoredTokenSet(JSON.parse(plaintext))
     _nativeTokens.set(baseUrl, tokens)
 
     return tokens
-  } catch {
+  } catch (error) {
+    rememberLog(
+      `[native-oauth] failed to load stored tokens for ${baseUrl}: ${(error as Error).message}`
+    )
+
     return null
   }
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -145,12 +145,12 @@ import {
 import {
   nativeRefreshUrl,
   type NativeTokenSet,
-  parseStoredTokenSet,
   parseTokenResponse,
   resolveLoginStrategy,
   tokenNeedsRefresh
 } from './native-oauth'
 import { runNativeLogin } from './native-oauth-login'
+import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
@@ -6190,35 +6190,24 @@ function _nativeTokenStorePath() {
   return path.join(app.getPath('userData'), 'native-oauth-tokens.json')
 }
 
-function _readNativeTokenStore(): Record<string, any> {
-  try {
-    const raw = fs.readFileSync(_nativeTokenStorePath(), 'utf8')
-    const parsed = JSON.parse(raw)
-
-    return parsed && typeof parsed === 'object' ? parsed : {}
-  } catch {
-    return {}
+// The electron-coupled half of the token store: safeStorage encryption plus the
+// userData file. native-token-store.ts owns the serialization/parse round trip
+// so it can be tested without an Electron runtime.
+function _nativeTokenStoreIo(): NativeTokenStoreIo {
+  return {
+    encrypt: encryptDesktopSecret,
+    decrypt: decryptDesktopSecret,
+    readStoreText: () => fs.readFileSync(_nativeTokenStorePath(), 'utf8'),
+    writeStoreText: (text: string) => {
+      fs.mkdirSync(path.dirname(_nativeTokenStorePath()), { recursive: true })
+      fs.writeFileSync(_nativeTokenStorePath(), text, { mode: 0o600 })
+    },
+    rememberLog
   }
 }
 
 function _persistNativeTokens(baseUrl: string, tokens: NativeTokenSet | null) {
-  const store = _readNativeTokenStore()
-
-  if (tokens) {
-    // Encrypt the whole token set as one blob so the refresh token never
-    // lands in plaintext on disk. Reuse the hardened encrypt helper.
-    const secret = encryptDesktopSecret(JSON.stringify(tokens))
-    store[baseUrl] = secret
-  } else {
-    delete store[baseUrl]
-  }
-
-  try {
-    fs.mkdirSync(path.dirname(_nativeTokenStorePath()), { recursive: true })
-    fs.writeFileSync(_nativeTokenStorePath(), JSON.stringify(store), { mode: 0o600 })
-  } catch (error) {
-    rememberLog(`[native-oauth] failed to persist tokens: ${(error as Error).message}`)
-  }
+  persistNativeTokenSet(baseUrl, tokens, _nativeTokenStoreIo())
 }
 
 function _loadNativeTokens(baseUrl: string): NativeTokenSet | null {
@@ -6228,37 +6217,13 @@ function _loadNativeTokens(baseUrl: string): NativeTokenSet | null {
     return cached
   }
 
-  const store = _readNativeTokenStore()
-  const secret = store[baseUrl]
+  const tokens = loadNativeTokenSet(baseUrl, _nativeTokenStoreIo())
 
-  if (!secret) {
-    return null
-  }
-
-  try {
-    const plaintext = decryptDesktopSecret(secret)
-
-    if (!plaintext) {
-      rememberLog(
-        `[native-oauth] failed to decrypt stored tokens for ${baseUrl}; keeping stored entry for retry`
-      )
-
-      return null
-    }
-
-    const tokens = parseStoredTokenSet(JSON.parse(plaintext))
+  if (tokens) {
     _nativeTokens.set(baseUrl, tokens)
-
-    return tokens
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error)
-
-    rememberLog(
-      `[native-oauth] failed to load stored tokens for ${baseUrl}: ${detail}`
-    )
-
-    return null
   }
+
+  return tokens
 }
 
 function _storeNativeTokens(baseUrl: string, tokens: NativeTokenSet) {

--- a/apps/desktop/electron/native-oauth.test.ts
+++ b/apps/desktop/electron/native-oauth.test.ts
@@ -193,6 +193,19 @@ test('parseStoredTokenSet maps the encrypted on-disk camelCase shape', () => {
   assert.equal(t.userId, 'u-stored')
 })
 
+test('parseTokenResponse cannot read a persisted set (the reload bug #73271)', () => {
+  // Guards against regressing to the wrong parser on the reload path: a
+  // persisted camelCase set has no snake_case access_token, so the raw-response
+  // parser throws — which is exactly why the stored path must use
+  // parseStoredTokenSet instead.
+  const persisted = JSON.parse(
+    JSON.stringify({ accessToken: 'AT', refreshToken: 'RT', expiresAt: 1, provider: 'nous', userId: 'u' })
+  )
+
+  assert.throws(() => parseTokenResponse(persisted), /missing access_token/i)
+  assert.equal(parseStoredTokenSet(persisted).accessToken, 'AT')
+})
+
 test('parseStoredTokenSet rejects a non-normalized server response', () => {
   assert.throws(
     () => parseStoredTokenSet({ access_token: 'AT-server' }),

--- a/apps/desktop/electron/native-oauth.test.ts
+++ b/apps/desktop/electron/native-oauth.test.ts
@@ -20,6 +20,7 @@ import {
   nativeRefreshUrl,
   nativeTokenUrl,
   parseLoopbackCallback,
+  parseStoredTokenSet,
   parseTokenResponse,
   resolveLoginStrategy,
   statusSupportsNativeFlow,
@@ -174,6 +175,29 @@ test('parseTokenResponse tolerates an absent refresh token / expiry', () => {
 
   assert.equal(t.refreshToken, '')
   assert.equal(t.expiresAt, 0)
+})
+
+test('parseStoredTokenSet maps the encrypted on-disk camelCase shape', () => {
+  const t = parseStoredTokenSet({
+    accessToken: 'AT-stored',
+    refreshToken: 'RT-stored',
+    expiresAt: 1893456000,
+    provider: 'self-hosted',
+    userId: 'u-stored'
+  })
+
+  assert.equal(t.accessToken, 'AT-stored')
+  assert.equal(t.refreshToken, 'RT-stored')
+  assert.equal(t.expiresAt, 1893456000)
+  assert.equal(t.provider, 'self-hosted')
+  assert.equal(t.userId, 'u-stored')
+})
+
+test('parseStoredTokenSet rejects a non-normalized server response', () => {
+  assert.throws(
+    () => parseStoredTokenSet({ access_token: 'AT-server' }),
+    /missing accessToken/i
+  )
 })
 
 // --- refresh timing ---

--- a/apps/desktop/electron/native-oauth.ts
+++ b/apps/desktop/electron/native-oauth.ts
@@ -194,6 +194,31 @@ export function parseTokenResponse(body: any): NativeTokenSet {
 }
 
 /**
+ * Validate a token set loaded from the encrypted local store.
+ *
+ * The stored representation is already normalized as NativeTokenSet and
+ * therefore uses camelCase. Gateway token responses use snake_case and
+ * remain handled separately by parseTokenResponse().
+ */
+export function parseStoredTokenSet(body: any): NativeTokenSet {
+  const accessToken = String(body?.accessToken || '')
+
+  if (!accessToken) {
+    throw new Error('Stored token set missing accessToken')
+  }
+
+  const expiresAt = Number(body?.expiresAt)
+
+  return {
+    accessToken,
+    refreshToken: String(body?.refreshToken || ''),
+    expiresAt: Number.isFinite(expiresAt) ? expiresAt : 0,
+    provider: String(body?.provider || ''),
+    userId: String(body?.userId || '')
+  }
+}
+
+/**
  * True when a stored token set is at/near expiry and should be refreshed
  * before use. `skewSeconds` refreshes slightly early to avoid a race where
  * the token expires in flight (mirrors the server's 60s cookie floor).

--- a/apps/desktop/electron/native-token-store.test.ts
+++ b/apps/desktop/electron/native-token-store.test.ts
@@ -326,3 +326,34 @@ test('an unusable keychain fails the write loudly and writes nothing', () => {
   // ...and must not clobber the tokens already on disk.
   assert.equal(broken.fileText(), before)
 })
+
+test('an encrypt that returns null is refused rather than blanking the stored entry', () => {
+  const existing = createFakeDisk()
+
+  persistNativeTokenSet(GATEWAY, TOKENS, existing.io)
+
+  const before = existing.fileText()
+  const nulled = createFakeDisk(before, { encrypt: () => null })
+  let writes = 0
+
+  // Spy that still delegates, so a stray write would show up in BOTH the
+  // counter and the file text.
+  const io = {
+    ...nulled.io,
+    writeStoreText: (text: string) => {
+      writes += 1
+      nulled.io.writeStoreText(text)
+    }
+  }
+
+  // A quiet null is the same failure as a throw and must be just as loud.
+  assert.throws(
+    () => persistNativeTokenSet(GATEWAY, { ...TOKENS, accessToken: 'AT-new' }, io),
+    /refusing to overwrite stored native tokens/
+  )
+  assert.equal(writes, 0, 'the store file must not be written at all')
+  // Byte-for-byte unchanged...
+  assert.equal(nulled.fileText(), before)
+  // ...and the original token set still loads, refresh token intact.
+  assert.deepEqual(loadNativeTokenSet(GATEWAY, createFakeDisk(before).io), TOKENS)
+})

--- a/apps/desktop/electron/native-token-store.test.ts
+++ b/apps/desktop/electron/native-token-store.test.ts
@@ -232,6 +232,29 @@ test('a corrupt store file loads as signed out instead of throwing', () => {
   assert.deepEqual(disk.logs, [])
 })
 
+test('an array store file loads as signed out instead of throwing', () => {
+  const disk = createFakeDisk('[]')
+
+  assert.equal(loadNativeTokenSet(GATEWAY, disk.io), null)
+  assert.deepEqual(disk.logs, [])
+})
+
+test('an array store file is replaced by a real map rather than swallowing the write', () => {
+  const disk = createFakeDisk('[]')
+
+  persistNativeTokenSet(GATEWAY, TOKENS, disk.io)
+
+  const written = JSON.parse(disk.fileText()!)
+
+  // Assigning store[baseUrl] on an array sets a non-index property, which
+  // JSON.stringify drops — the write would report success and the tokens would
+  // be gone on the next launch.
+  assert.equal(Array.isArray(written), false)
+  assert.ok(written[GATEWAY], 'the gateway entry must survive serialization')
+  // And it really does come back after a restart.
+  assert.deepEqual(loadNativeTokenSet(GATEWAY, createFakeDisk(disk.fileText()).io), TOKENS)
+})
+
 test('a corrupt decrypted blob is reported and loads as signed out', () => {
   const disk = createFakeDisk(JSON.stringify({ [GATEWAY]: { encoding: 'safeStorage', value: 'bm90LWpzb24=' } }))
 
@@ -270,6 +293,19 @@ test('an unwritable store file is logged rather than thrown', () => {
 
   assert.doesNotThrow(() => persistNativeTokenSet(GATEWAY, TOKENS, disk.io))
   assert.match(disk.logs[0], /failed to persist tokens: EACCES/)
+})
+
+test('a non-Error write failure keeps its detail in the log', () => {
+  const disk = createFakeDisk(null, {
+    writeStoreText: () => {
+      throw 'disk went away'
+    }
+  })
+
+  // `(error as Error).message` on a thrown string reads as undefined and loses
+  // the only diagnostic there was.
+  assert.doesNotThrow(() => persistNativeTokenSet(GATEWAY, TOKENS, disk.io))
+  assert.equal(disk.logs[0], '[native-oauth] failed to persist tokens: disk went away')
 })
 
 test('an unusable keychain fails the write loudly and writes nothing', () => {

--- a/apps/desktop/electron/native-token-store.test.ts
+++ b/apps/desktop/electron/native-token-store.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for electron/native-token-store.ts — the encrypted-at-rest persistence
+ * seam main.ts uses for RFC 8252 native OAuth tokens.
+ *
+ * The regression this file exists for (#73271): tokens are persisted as a
+ * normalized camelCase NativeTokenSet, but the reload path fed the freshly
+ * decrypted object to parseTokenResponse(), which only understands the
+ * gateway's snake_case response. It threw on every launch, so a signed-in user
+ * came back signed out. The parser boundary now lives inside
+ * loadNativeTokenSet(), so these tests fail if it is ever crossed again.
+ *
+ * "Fresh load" here means what it means after a restart: nothing survives but
+ * the bytes of the store file, so every assertion below is served by
+ * deserializing and decrypting that text — never by an in-memory object.
+ *
+ * (Wired into the vitest `electron` project via electron/**\/*.test.ts.)
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { type NativeTokenSet, parseStoredTokenSet, parseTokenResponse } from './native-oauth'
+import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
+
+const GATEWAY = 'https://gw.example.com'
+
+const TOKENS: NativeTokenSet = {
+  accessToken: 'AT-live-abc123',
+  refreshToken: 'RT-live-xyz789',
+  expiresAt: 1_893_456_000,
+  provider: 'nous',
+  userId: 'u-42'
+}
+
+interface FakeDisk {
+  io: NativeTokenStoreIo
+  logs: string[]
+  /** The store-file text as it would sit on disk; null when the file is absent. */
+  fileText: () => string | null
+}
+
+/**
+ * A stand-in for the userData store file plus safeStorage. Encryption is
+ * base64 rather than the OS keychain — opaque-blob-in, same-plaintext-out is
+ * the only property this seam depends on, and it keeps the round trip
+ * observable. `initialText` models a process restart: the new "process" starts
+ * with nothing but the bytes the previous one wrote.
+ */
+function createFakeDisk(initialText: string | null = null, overrides: Partial<NativeTokenStoreIo> = {}): FakeDisk {
+  let text = initialText
+  const logs: string[] = []
+
+  const io: NativeTokenStoreIo = {
+    encrypt: plaintext => ({ encoding: 'safeStorage', value: Buffer.from(plaintext, 'utf8').toString('base64') }),
+    decrypt: secret =>
+      secret?.encoding === 'safeStorage' ? Buffer.from(String(secret.value), 'base64').toString('utf8') : '',
+    readStoreText: () => {
+      if (text === null) {
+        // Matches fs.readFileSync on a missing file: throws, not empty string.
+        throw Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' })
+      }
+
+      return text
+    },
+    writeStoreText: next => {
+      text = next
+    },
+    rememberLog: message => logs.push(message),
+    ...overrides
+  }
+
+  return { io, logs, fileText: () => text }
+}
+
+// --- the restart round trip ---
+
+test('a camelCase token set survives store then a fresh load', () => {
+  const first = createFakeDisk()
+
+  persistNativeTokenSet(GATEWAY, TOKENS, first.io)
+
+  const onDisk = first.fileText()
+
+  assert.ok(onDisk, 'persisting must write the store file')
+
+  // Nothing may survive the "restart" except those bytes.
+  const restarted = createFakeDisk(onDisk)
+  const loaded = loadNativeTokenSet(GATEWAY, restarted.io)
+
+  assert.ok(loaded, 'a stored token set must reload after a restart')
+  // Reconstructed from the payload, not handed back the object we stored.
+  assert.notEqual(loaded, TOKENS)
+  assert.deepEqual(loaded, TOKENS)
+  assert.deepEqual(restarted.logs, [])
+})
+
+test('a fresh load restores both tokens and preserves expiry, provider and user', () => {
+  const first = createFakeDisk()
+
+  persistNativeTokenSet(GATEWAY, TOKENS, first.io)
+
+  const loaded = loadNativeTokenSet(GATEWAY, createFakeDisk(first.fileText()).io)!
+
+  assert.equal(loaded.accessToken, 'AT-live-abc123')
+  assert.equal(loaded.refreshToken, 'RT-live-xyz789')
+  // Still a number after the JSON round trip, not "1893456000".
+  assert.equal(loaded.expiresAt, 1_893_456_000)
+  assert.equal(typeof loaded.expiresAt, 'number')
+  assert.equal(loaded.provider, 'nous')
+  assert.equal(loaded.userId, 'u-42')
+})
+
+test('the loaded set is accepted by the stored-token parsing boundary', () => {
+  const first = createFakeDisk()
+
+  persistNativeTokenSet(GATEWAY, TOKENS, first.io)
+
+  const loaded = loadNativeTokenSet(GATEWAY, createFakeDisk(first.fileText()).io)!
+
+  // What comes back out of the store is itself a valid stored set — re-parsing
+  // it is a no-op, so callers can hand it straight to the refresh path.
+  assert.deepEqual(parseStoredTokenSet(loaded), loaded)
+})
+
+test('the persisted payload is what broke the old reload path (#73271)', () => {
+  const first = createFakeDisk()
+
+  persistNativeTokenSet(GATEWAY, TOKENS, first.io)
+
+  const restarted = createFakeDisk(first.fileText())
+  const secret = JSON.parse(restarted.fileText()!)[GATEWAY]
+  const decrypted = JSON.parse(restarted.io.decrypt(secret))
+
+  // The old code passed exactly this object to parseTokenResponse(). A
+  // normalized set has no snake_case access_token, so every launch threw and
+  // the user was shown as signed out...
+  assert.throws(() => parseTokenResponse(decrypted), /missing access_token/i)
+  // ...while the real load path reads the same bytes successfully.
+  assert.deepEqual(loadNativeTokenSet(GATEWAY, restarted.io), TOKENS)
+})
+
+test('the full login-to-restart sequence keeps the two parser boundaries apart', () => {
+  // Login: the gateway answers /auth/native/token in snake_case, and only
+  // parseTokenResponse() understands that shape.
+  const fromGateway = parseTokenResponse({
+    access_token: 'AT-fresh',
+    refresh_token: 'RT-fresh',
+    expires_at: 1_893_456_789,
+    provider: 'nous',
+    user_id: 'u-77'
+  })
+
+  const first = createFakeDisk()
+
+  persistNativeTokenSet(GATEWAY, fromGateway, first.io)
+
+  // Restart: what was stored is normalized, so the store's own boundary reads
+  // it back unchanged.
+  assert.deepEqual(loadNativeTokenSet(GATEWAY, createFakeDisk(first.fileText()).io), fromGateway)
+})
+
+// --- storage hygiene ---
+
+test('tokens are encrypted at rest, never plaintext in the store file', () => {
+  const disk = createFakeDisk()
+
+  persistNativeTokenSet(GATEWAY, TOKENS, disk.io)
+
+  const onDisk = disk.fileText()!
+
+  assert.doesNotMatch(onDisk, /AT-live-abc123/)
+  assert.doesNotMatch(onDisk, /RT-live-xyz789/)
+  assert.equal(JSON.parse(onDisk)[GATEWAY].encoding, 'safeStorage')
+})
+
+test('persisting one gateway leaves other gateways intact', () => {
+  const other = 'https://other.example.com'
+  const disk = createFakeDisk()
+
+  persistNativeTokenSet(GATEWAY, TOKENS, disk.io)
+  persistNativeTokenSet(other, { ...TOKENS, accessToken: 'AT-other', userId: 'u-99' }, disk.io)
+
+  const restarted = createFakeDisk(disk.fileText())
+
+  assert.equal(loadNativeTokenSet(GATEWAY, restarted.io)!.accessToken, 'AT-live-abc123')
+  assert.equal(loadNativeTokenSet(other, restarted.io)!.accessToken, 'AT-other')
+})
+
+test('clearing removes only that gateway and reloads as signed out', () => {
+  const other = 'https://other.example.com'
+  const disk = createFakeDisk()
+
+  persistNativeTokenSet(GATEWAY, TOKENS, disk.io)
+  persistNativeTokenSet(other, TOKENS, disk.io)
+  persistNativeTokenSet(GATEWAY, null, disk.io)
+
+  const restarted = createFakeDisk(disk.fileText())
+
+  assert.equal(loadNativeTokenSet(GATEWAY, restarted.io), null)
+  assert.ok(loadNativeTokenSet(other, restarted.io))
+})
+
+test('an absent store file loads as signed out without logging a failure', () => {
+  const disk = createFakeDisk()
+
+  assert.equal(loadNativeTokenSet(GATEWAY, disk.io), null)
+  assert.deepEqual(disk.logs, [])
+})
+
+// --- failure paths (unchanged by the extraction) ---
+
+test('a locked keychain keeps the stored entry for a later retry', () => {
+  const first = createFakeDisk()
+
+  persistNativeTokenSet(GATEWAY, TOKENS, first.io)
+
+  // safeStorage unavailable at load time ⇒ decryptDesktopSecret returns ''.
+  const locked = createFakeDisk(first.fileText(), { decrypt: () => '' })
+
+  assert.equal(loadNativeTokenSet(GATEWAY, locked.io), null)
+  assert.match(locked.logs[0], /failed to decrypt stored tokens for https:\/\/gw\.example\.com/)
+  assert.match(locked.logs[0], /keeping stored entry for retry/)
+  // The refresh token must NOT be dropped just because the keychain was locked.
+  assert.deepEqual(locked.fileText(), first.fileText())
+})
+
+test('a corrupt store file loads as signed out instead of throwing', () => {
+  const disk = createFakeDisk('{not json')
+
+  assert.equal(loadNativeTokenSet(GATEWAY, disk.io), null)
+  assert.deepEqual(disk.logs, [])
+})
+
+test('a corrupt decrypted blob is reported and loads as signed out', () => {
+  const disk = createFakeDisk(JSON.stringify({ [GATEWAY]: { encoding: 'safeStorage', value: 'bm90LWpzb24=' } }))
+
+  assert.equal(loadNativeTokenSet(GATEWAY, disk.io), null)
+  assert.match(disk.logs[0], /failed to load stored tokens for https:\/\/gw\.example\.com/)
+})
+
+test('a decrypted blob missing accessToken is rejected, not half-restored', () => {
+  const plaintext = JSON.stringify({ refreshToken: 'RT-only', provider: 'nous' })
+
+  const disk = createFakeDisk(
+    JSON.stringify({ [GATEWAY]: { encoding: 'safeStorage', value: Buffer.from(plaintext).toString('base64') } })
+  )
+
+  assert.equal(loadNativeTokenSet(GATEWAY, disk.io), null)
+  assert.match(disk.logs[0], /missing accessToken/i)
+})
+
+test('a non-Error decryption failure keeps its detail in the log', () => {
+  const disk = createFakeDisk(JSON.stringify({ [GATEWAY]: { encoding: 'safeStorage', value: 'AAAA' } }), {
+    decrypt: () => {
+      throw 'keychain exploded'
+    }
+  })
+
+  assert.equal(loadNativeTokenSet(GATEWAY, disk.io), null)
+  assert.match(disk.logs[0], /keychain exploded/)
+})
+
+test('an unwritable store file is logged rather than thrown', () => {
+  const disk = createFakeDisk(null, {
+    writeStoreText: () => {
+      throw new Error('EACCES: permission denied')
+    }
+  })
+
+  assert.doesNotThrow(() => persistNativeTokenSet(GATEWAY, TOKENS, disk.io))
+  assert.match(disk.logs[0], /failed to persist tokens: EACCES/)
+})
+
+test('an unusable keychain fails the write loudly and writes nothing', () => {
+  const existing = createFakeDisk()
+
+  persistNativeTokenSet(GATEWAY, TOKENS, existing.io)
+
+  const before = existing.fileText()
+
+  const broken = createFakeDisk(before, {
+    encrypt: () => {
+      throw new Error('Secure token storage is unavailable')
+    }
+  })
+
+  // Storing must not pretend to succeed when the token cannot be encrypted...
+  assert.throws(() => persistNativeTokenSet(GATEWAY, { ...TOKENS, accessToken: 'AT-new' }, broken.io), /unavailable/)
+  // ...and must not clobber the tokens already on disk.
+  assert.equal(broken.fileText(), before)
+})

--- a/apps/desktop/electron/native-token-store.test.ts
+++ b/apps/desktop/electron/native-token-store.test.ts
@@ -357,3 +357,67 @@ test('an encrypt that returns null is refused rather than blanking the stored en
   // ...and the original token set still loads, refresh token intact.
   assert.deepEqual(loadNativeTokenSet(GATEWAY, createFakeDisk(before).io), TOKENS)
 })
+
+// --- credential redaction in logs ---
+//
+// normalizeRemoteBaseUrl() strips query/fragment/trailing slashes but not
+// userinfo, so a configured gateway URL can carry `user:password@` into this
+// store. It must stay intact as the store KEY and never reach a log line.
+
+const CRED_GATEWAY = 'https://alice:supersecret@gw.example.com/hermes'
+
+test('a decryption failure logs the gateway host and path but not its credentials', () => {
+  const first = createFakeDisk()
+
+  persistNativeTokenSet(CRED_GATEWAY, TOKENS, first.io)
+
+  const before = first.fileText()
+  const locked = createFakeDisk(before, { decrypt: () => '' })
+
+  assert.equal(loadNativeTokenSet(CRED_GATEWAY, locked.io), null)
+  // Still identifies which gateway failed...
+  assert.match(locked.logs[0], /failed to decrypt stored tokens for https:\/\/gw\.example\.com\/hermes/)
+  assert.match(locked.logs[0], /keeping stored entry for retry/)
+  // ...without the userinfo.
+  assert.doesNotMatch(locked.logs[0], /alice/)
+  assert.doesNotMatch(locked.logs[0], /supersecret/)
+  // Redaction is log-only: the entry stays under the credential-bearing key.
+  assert.ok(JSON.parse(locked.fileText()!)[CRED_GATEWAY])
+  assert.equal(locked.fileText(), before)
+})
+
+test('a parsing failure logs the gateway host and path but not its credentials', () => {
+  const disk = createFakeDisk(JSON.stringify({ [CRED_GATEWAY]: { encoding: 'safeStorage', value: 'bm90LWpzb24=' } }))
+
+  assert.equal(loadNativeTokenSet(CRED_GATEWAY, disk.io), null)
+  assert.match(disk.logs[0], /failed to load stored tokens for https:\/\/gw\.example\.com\/hermes/)
+  assert.doesNotMatch(disk.logs[0], /alice/)
+  assert.doesNotMatch(disk.logs[0], /supersecret/)
+})
+
+test('the credential-bearing base URL stays the exact store key', () => {
+  const first = createFakeDisk()
+
+  persistNativeTokenSet(CRED_GATEWAY, TOKENS, first.io)
+
+  assert.deepEqual(Object.keys(JSON.parse(first.fileText()!)), [CRED_GATEWAY])
+  // The original key still round-trips a full set after a restart.
+  assert.deepEqual(loadNativeTokenSet(CRED_GATEWAY, createFakeDisk(first.fileText()).io), TOKENS)
+  // The redacted form is a log string, never a lookup key.
+  assert.equal(loadNativeTokenSet('https://gw.example.com/hermes', createFakeDisk(first.fileText()).io), null)
+})
+
+test('an unparseable gateway URL logs a fixed placeholder rather than the raw value', () => {
+  // A space makes this unparseable by URL, so redaction cannot fall back to
+  // echoing the input — that would leak the very credentials it guards.
+  const invalid = 'ht tp://alice:supersecret@gw.example.com'
+
+  const disk = createFakeDisk(JSON.stringify({ [invalid]: { encoding: 'safeStorage', value: 'AAAA' } }), {
+    decrypt: () => ''
+  })
+
+  assert.equal(loadNativeTokenSet(invalid, disk.io), null)
+  assert.match(disk.logs[0], /<invalid gateway URL>/)
+  assert.doesNotMatch(disk.logs[0], /alice/)
+  assert.doesNotMatch(disk.logs[0], /supersecret/)
+})

--- a/apps/desktop/electron/native-token-store.ts
+++ b/apps/desktop/electron/native-token-store.ts
@@ -1,0 +1,118 @@
+/**
+ * native-token-store.ts
+ *
+ * The encrypted-at-rest persistence seam for RFC 8252 native OAuth tokens:
+ * NativeTokenSet → JSON → safeStorage blob → store file, and back again on the
+ * next launch.
+ *
+ * Kept standalone (no `import 'electron'`) so the whole restart path unit-tests
+ * with the `electron` vitest project — the same pattern as native-oauth.ts.
+ * main.ts owns the electron-coupled halves and injects them: the safeStorage
+ * encrypt/decrypt pair and the userData store-file read/write.
+ *
+ * The parser direction is the load-bearing detail. What lands on disk is the
+ * *normalized* camelCase NativeTokenSet, so the reload boundary is
+ * parseStoredTokenSet(). Gateway `/auth/native/token` responses are snake_case
+ * and stay with parseTokenResponse(); crossing the two made the decrypted set
+ * throw on every launch, which surfaced as "signed out after restart" (#73271).
+ */
+
+import { type NativeTokenSet, parseStoredTokenSet } from './native-oauth'
+
+/** One encrypted blob as written per gateway base URL. */
+export interface StoredTokenSecret {
+  encoding?: string
+  value?: string
+}
+
+/**
+ * The narrow set of side effects main.ts owns. Everything here is injected so
+ * the store/load round trip can be exercised without an Electron runtime, and
+ * so production keeps using safeStorage unchanged.
+ */
+export interface NativeTokenStoreIo {
+  /**
+   * Encrypt one plaintext blob. main.ts passes the strict safeStorage helper,
+   * which THROWS when the OS keychain is unavailable — that must stay loud.
+   */
+  encrypt: (plaintext: string) => StoredTokenSecret | null
+  /** Decrypt a stored payload; returns '' when it cannot be read. */
+  decrypt: (secret: any) => string
+  /** Raw store-file text. Throws when the file is absent — treated as empty. */
+  readStoreText: () => string
+  /** Persist the store-file text (main.ts writes mode 0600 under userData). */
+  writeStoreText: (text: string) => void
+  rememberLog?: (message: string) => void
+}
+
+/**
+ * baseUrl → encrypted payload. A missing, unreadable, or hand-mangled store
+ * reads as empty rather than throwing: a failed *read* falls to the next rung.
+ */
+function readStore(io: NativeTokenStoreIo): Record<string, any> {
+  try {
+    const parsed = JSON.parse(io.readStoreText())
+
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Write (or, with `tokens === null`, drop) one gateway's token set, merging
+ * into whatever other gateways are already stored.
+ */
+export function persistNativeTokenSet(baseUrl: string, tokens: NativeTokenSet | null, io: NativeTokenStoreIo): void {
+  const store = readStore(io)
+
+  if (tokens) {
+    // Encrypt the whole set as one blob so the refresh token never lands in
+    // plaintext on disk. Deliberately outside the try below: an unusable
+    // keychain is an authoritative write failure and must surface to the
+    // caller, not be logged away as if the tokens were saved.
+    store[baseUrl] = io.encrypt(JSON.stringify(tokens))
+  } else {
+    delete store[baseUrl]
+  }
+
+  try {
+    io.writeStoreText(JSON.stringify(store))
+  } catch (error) {
+    io.rememberLog?.(`[native-oauth] failed to persist tokens: ${(error as Error).message}`)
+  }
+}
+
+/**
+ * Reconstruct a gateway's token set from the stored encrypted payload. Returns
+ * null when nothing is stored, when the blob cannot be decrypted, or when it
+ * does not parse — never a partially-populated set.
+ */
+export function loadNativeTokenSet(baseUrl: string, io: NativeTokenStoreIo): NativeTokenSet | null {
+  const secret = readStore(io)[baseUrl]
+
+  if (!secret) {
+    return null
+  }
+
+  try {
+    const plaintext = io.decrypt(secret)
+
+    if (!plaintext) {
+      // A keychain that is merely locked/unavailable right now must not cost
+      // the user their refresh token — leave the entry for the next attempt.
+      io.rememberLog?.(`[native-oauth] failed to decrypt stored tokens for ${baseUrl}; keeping stored entry for retry`)
+
+      return null
+    }
+
+    // Stored blobs are normalized camelCase sets, never raw gateway responses.
+    return parseStoredTokenSet(JSON.parse(plaintext))
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+
+    io.rememberLog?.(`[native-oauth] failed to load stored tokens for ${baseUrl}: ${detail}`)
+
+    return null
+  }
+}

--- a/apps/desktop/electron/native-token-store.ts
+++ b/apps/desktop/electron/native-token-store.ts
@@ -67,6 +67,31 @@ function readStore(io: NativeTokenStoreIo): Record<string, any> {
 }
 
 /**
+ * A gateway URL safe to write into a log line.
+ *
+ * normalizeRemoteBaseUrl() strips query, fragment, and trailing slashes but
+ * NOT userinfo, so a configured gateway can legitimately carry
+ * `user:password@` all the way down to this store. Interpolating that into a
+ * failure log would spill the credentials into the desktop log file, so drop
+ * the userinfo and keep only what makes the line useful — scheme, host, port,
+ * path. A value URL cannot parse never falls back to the raw input: echoing it
+ * is the exact leak this guards against.
+ */
+function redactGatewayUrl(baseUrl: string): string {
+  try {
+    const parsed = new URL(baseUrl)
+
+    parsed.username = ''
+    parsed.password = ''
+
+    // `host` already carries a non-default port.
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`
+  } catch {
+    return '<invalid gateway URL>'
+  }
+}
+
+/**
  * Write (or, with `tokens === null`, drop) one gateway's token set, merging
  * into whatever other gateways are already stored.
  */
@@ -108,6 +133,7 @@ export function persistNativeTokenSet(baseUrl: string, tokens: NativeTokenSet | 
  * does not parse — never a partially-populated set.
  */
 export function loadNativeTokenSet(baseUrl: string, io: NativeTokenStoreIo): NativeTokenSet | null {
+  // The UNREDACTED url is the store key — redaction is for logs only.
   const secret = readStore(io)[baseUrl]
 
   if (!secret) {
@@ -120,7 +146,9 @@ export function loadNativeTokenSet(baseUrl: string, io: NativeTokenStoreIo): Nat
     if (!plaintext) {
       // A keychain that is merely locked/unavailable right now must not cost
       // the user their refresh token — leave the entry for the next attempt.
-      io.rememberLog?.(`[native-oauth] failed to decrypt stored tokens for ${baseUrl}; keeping stored entry for retry`)
+      io.rememberLog?.(
+        `[native-oauth] failed to decrypt stored tokens for ${redactGatewayUrl(baseUrl)}; keeping stored entry for retry`
+      )
 
       return null
     }
@@ -130,7 +158,7 @@ export function loadNativeTokenSet(baseUrl: string, io: NativeTokenStoreIo): Nat
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error)
 
-    io.rememberLog?.(`[native-oauth] failed to load stored tokens for ${baseUrl}: ${detail}`)
+    io.rememberLog?.(`[native-oauth] failed to load stored tokens for ${redactGatewayUrl(baseUrl)}: ${detail}`)
 
     return null
   }

--- a/apps/desktop/electron/native-token-store.ts
+++ b/apps/desktop/electron/native-token-store.ts
@@ -48,12 +48,17 @@ export interface NativeTokenStoreIo {
 /**
  * baseUrl → encrypted payload. A missing, unreadable, or hand-mangled store
  * reads as empty rather than throwing: a failed *read* falls to the next rung.
+ *
+ * Arrays are rejected alongside every other non-object shape: assigning
+ * store[baseUrl] on an array would set a non-index property, which
+ * JSON.stringify drops on the way back out — the write would look like it
+ * succeeded and the tokens would be gone on the next launch.
  */
 function readStore(io: NativeTokenStoreIo): Record<string, any> {
   try {
     const parsed = JSON.parse(io.readStoreText())
 
-    return parsed && typeof parsed === 'object' ? parsed : {}
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
   } catch {
     return {}
   }
@@ -79,7 +84,9 @@ export function persistNativeTokenSet(baseUrl: string, tokens: NativeTokenSet | 
   try {
     io.writeStoreText(JSON.stringify(store))
   } catch (error) {
-    io.rememberLog?.(`[native-oauth] failed to persist tokens: ${(error as Error).message}`)
+    const detail = error instanceof Error ? error.message : String(error)
+
+    io.rememberLog?.(`[native-oauth] failed to persist tokens: ${detail}`)
   }
 }
 

--- a/apps/desktop/electron/native-token-store.ts
+++ b/apps/desktop/electron/native-token-store.ts
@@ -34,6 +34,8 @@ export interface NativeTokenStoreIo {
   /**
    * Encrypt one plaintext blob. main.ts passes the strict safeStorage helper,
    * which THROWS when the OS keychain is unavailable — that must stay loud.
+   * A `null` return is treated as the same authoritative failure: the caller
+   * throws rather than persisting an empty entry over good tokens.
    */
   encrypt: (plaintext: string) => StoredTokenSecret | null
   /** Decrypt a stored payload; returns '' when it cannot be read. */
@@ -76,7 +78,17 @@ export function persistNativeTokenSet(baseUrl: string, tokens: NativeTokenSet | 
     // plaintext on disk. Deliberately outside the try below: an unusable
     // keychain is an authoritative write failure and must surface to the
     // caller, not be logged away as if the tokens were saved.
-    store[baseUrl] = io.encrypt(JSON.stringify(tokens))
+    const secret = io.encrypt(JSON.stringify(tokens))
+
+    if (!secret) {
+      // A null blob is the same failure as a throw, only quieter. Storing it
+      // would replace a good entry with nothing: the write would report
+      // success, the next launch would show signed out, and the refresh token
+      // would be unrecoverable. Fail before touching the store.
+      throw new Error('Secure token storage returned no encrypted payload; refusing to overwrite stored native tokens.')
+    }
+
+    store[baseUrl] = secret
   } else {
     delete store[baseUrl]
   }


### PR DESCRIPTION
## Summary

- Restore encrypted native OAuth tokens correctly after a desktop restart.
- Keep gateway token response parsing separate from persisted token parsing.
- Log stored-token loading failures instead of silently discarding the error.
- Add regression tests for the encrypted on-disk camelCase token shape.

## Root cause

The desktop persists an already-normalized `NativeTokenSet` using camelCase fields:

- `accessToken`
- `refreshToken`
- `expiresAt`
- `userId`

On restart, the stored object was passed to `parseTokenResponse()`, which expects the gateway response format using snake_case fields such as `access_token`.

This caused `parseTokenResponse()` to throw `Gateway token response missing access_token`. The exception was silently caught, `_loadNativeTokens()` returned `null`, and the desktop reported that the user was not signed in after every restart.

## Fix

Add a dedicated `parseStoredTokenSet()` parser for the normalized camelCase storage format while keeping `parseTokenResponse()` unchanged for gateway responses.

## Validation

- `npm --prefix apps/desktop run test:desktop:platforms -- electron/native-oauth.test.ts`
  - 18 tests passed
- `npm exec -- tsc -p tsconfig.electron.json --noEmit`
- `npm run build`
- `npm run builder -- --dir`
- Manually validated on Windows:
  1. Sign in to a remote OAuth-protected Hermes gateway.
  2. Completely close Hermes Desktop.
  3. Relaunch the application.
  4. The remote session is restored automatically without signing in again.