### PR TITLE
fix(compression): ignore model-switch display drift

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1228,6 +1228,27 @@ def finalize_context_engine_compression_notification(
     return bool(pending())
 
 
+def _rotation_drift_message_count(messages: list) -> int:
+    """Count rows that participate in the rotation stale-snapshot guard.
+
+    Desktop persists a typed ``model_switch`` timeline row even when that row
+    is absent from the compressor's live history projection. Treating the raw
+    durable row count as conversational growth wedges every later rotation.
+    Exclude only model-switch rows without ``api_content`` from BOTH sides of
+    the comparison; any row carrying model-facing sidecar content, and every
+    real user/assistant append, remains protected by the guard.
+    """
+    return sum(
+        1
+        for message in messages
+        if not (
+            isinstance(message, dict)
+            and message.get("display_kind") == "model_switch"
+            and not message.get("api_content")
+        )
+    )
+
+
 def compress_context(
     agent: Any,
     messages: list,
@@ -1689,7 +1710,11 @@ def compress_context(
             )
             if callable(durable_loader):
                 durable_parent = durable_loader(_lock_db, _lock_sid)
-                if isinstance(durable_parent, list) and len(durable_parent) > len(messages):
+                if (
+                    isinstance(durable_parent, list)
+                    and _rotation_drift_message_count(durable_parent)
+                    > _rotation_drift_message_count(messages)
+                ):
                     logger.warning(
                         "compression aborted: session=%s changed before lease "
                         "acquisition; preserving newer durable messages",

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -316,6 +316,64 @@ def test_concurrent_compression_does_not_fork_session(tmp_path: Path) -> None:
     )
 
 
+def test_preexisting_model_switch_row_does_not_abort_rotation(
+    tmp_path: Path,
+) -> None:
+    """Display-only model metadata must not look like a concurrent turn."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "MODEL_SWITCH_DISPLAY_DRIFT"
+    db.create_session(parent_sid, source="desktop")
+    db.append_message(parent_sid, "user", "old durable")
+    db.append_message(
+        parent_sid,
+        "user",
+        "[System: The active model for this chat has changed to new/model.]",
+        display_kind="model_switch",
+    )
+
+    runtime_snapshot = [{"role": "user", "content": "old durable"}]
+    agent = _build_agent_with_db(db, parent_sid)
+
+    compressed, _system_prompt = agent._compress_context(
+        runtime_snapshot, "sys", approx_tokens=120_000
+    )
+
+    agent.context_compressor.compress.assert_called_once()
+    assert compressed is not runtime_snapshot
+    assert agent.session_id != parent_sid
+    child = db.find_live_compression_child(parent_sid)
+    assert child is not None
+    assert child["id"] == agent.session_id
+
+
+def test_model_switch_row_does_not_mask_real_concurrent_append(
+    tmp_path: Path,
+) -> None:
+    """The projection exception must preserve the genuine append safety gate."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "MODEL_SWITCH_PLUS_REAL_APPEND"
+    db.create_session(parent_sid, source="desktop")
+    db.append_message(parent_sid, "user", "old durable")
+    db.append_message(
+        parent_sid,
+        "user",
+        "[System: The active model for this chat has changed to new/model.]",
+        display_kind="model_switch",
+    )
+    runtime_snapshot = [{"role": "user", "content": "old durable"}]
+    db.append_message(parent_sid, "assistant", "late committed before lease")
+    agent = _build_agent_with_db(db, parent_sid)
+
+    returned, _system_prompt = agent._compress_context(
+        runtime_snapshot, "sys", approx_tokens=120_000
+    )
+
+    assert returned is runtime_snapshot
+    assert agent.session_id == parent_sid
+    assert db.find_live_compression_child(parent_sid) is None
+    agent.context_compressor.compress.assert_not_called()
+
+
 def test_durable_message_committed_before_lease_aborts_stale_snapshot(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- compare the rotation stale-snapshot guard using the same model-facing projection on both sides;
- exclude only typed `model_switch` rows that have no `api_content` sidecar;
- preserve the existing abort for genuine user/assistant rows committed after the caller snapshot;
- leave model-switch timeline persistence, display rendering, and searchability unchanged.

Fixes #71397.

## Root cause

Rotation compression reloads durable history after acquiring its lease and aborts when the durable row count exceeds the caller's in-memory message count. Desktop can persist a `display_kind=model_switch` row that is absent from the compressor's live projection, creating a stable `durable = runtime + 1` difference. The raw length guard then mistakes that old display row for a concurrent conversational append on every attempt.

The guard still uses a length comparison, preserving its tolerance for legal in-memory content mutation. It now counts the same projection on both sides. A model-switch row carrying `api_content` remains protected because it is model-facing.

## Regression coverage

- a pre-existing model-switch display row no longer blocks rotation, and compression publishes a continuation child;
- the same display row plus a genuinely late assistant append still aborts before the compressor runs;
- the original late-durable-message regression remains green.

The first regression fails on current `main` because the compressor is never called and passes with this change.

## Verification

- complete compression concurrency/rotation suite: **48 passed**;
- Ruff: clean;
- `py_compile`: clean;
- `git diff --check`: clean.
