### PR TITLE
fix(discord): slash channel gates test the wrong key set when interaction.channel is unresolved

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4354,6 +4354,15 @@ class DiscordAdapter(BasePlatformAdapter):
                 if isinstance(chan_obj, discord.Thread)
                 else None,
             )
+            # ``interaction.channel`` is resolved from the client cache and is
+            # frequently ``None`` (or present without an id) even though the
+            # gateway payload carried ``channel_id`` — which is why
+            # ``channel_ids`` is derived from ``channel_id`` first above.
+            # Without this union ``channel_keys`` is empty in exactly that
+            # case, so the id-form membership tests below can never match:
+            # the allowlist rejects an allow-listed channel, and the
+            # ignore-list silently stops rejecting an ignored one.
+            channel_keys |= channel_ids
 
             allowed_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
             if allowed_raw:

--- a/tests/gateway/test_discord_slash_auth.py
+++ b/tests/gateway/test_discord_slash_auth.py
@@ -324,6 +324,47 @@ async def test_channel_allowlist_wildcard_passes(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_allowlisted_channel_passes_when_interaction_channel_unresolved(
+    adapter, monkeypatch,
+):
+    """``interaction.channel_id`` alone is enough to satisfy the allowlist.
+
+    Discord resolves ``interaction.channel`` from the client cache, so it can
+    arrive as ``None`` while ``interaction.channel_id`` is populated (cold
+    cache, uncached guild, restart). The channel scope must key off the id
+    that is always present, not the object that is not — otherwise every
+    slash command in an allow-listed channel is rejected, including ``/reset``
+    and ``/new``, which are the operator's way out of a stuck session.
+    """
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "1111,2222")
+    interaction = _make_interaction("100200300", channel_id=1111)
+    interaction.channel = None
+
+    assert await adapter._check_slash_authorization(interaction, "/help") is True
+
+
+@pytest.mark.asyncio
+async def test_ignored_channel_rejected_when_interaction_channel_unresolved(
+    adapter, monkeypatch, caplog,
+):
+    """The same unresolved-channel payload must not fail *open* on the ignore list.
+
+    Asserting the rejection *reason* rather than just the boolean: with the
+    user allowlist satisfied, the ignore list is the only gate left that can
+    reject, so a bare ``is False`` would pass even when the ignore list was
+    skipped entirely.
+    """
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "100200300")
+    monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "1111")
+    interaction = _make_interaction("100200300", channel_id=1111)
+    interaction.channel = None
+
+    with caplog.at_level(logging.WARNING):
+        assert await adapter._check_slash_authorization(interaction, "/help") is False
+    assert any("DISCORD_IGNORED_CHANNELS" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_channel_allowlist_matches_by_name(adapter, monkeypatch):
     """Allowlist configured by channel NAME matches slash interactions too —
     the same name-form matching on_message gained. Without it, a deployment


### PR DESCRIPTION
## Problem

`_evaluate_slash_authorization` builds two collections for the channel scope:

| collection | derived from |
|---|---|
| `channel_ids` | `interaction.channel_id`, falling back to `interaction.channel.id` |
| `channel_keys` | `_discord_channel_keys_from_channel(interaction.channel)` |

The fail-closed guard tests `channel_ids`:

```python
if not channel_ids:
    return (False, "channel id missing with DISCORD_ALLOWED_CHANNELS configured")
```

but both membership tests use `channel_keys`:

```python
if not (channel_keys & allowed):
    return (False, "channel not in DISCORD_ALLOWED_CHANNELS")
...
if "*" in ignored or (channel_keys & ignored):
    return (False, "channel in DISCORD_IGNORED_CHANNELS")
```

`interaction.channel` is resolved from the client cache, so it is routinely
`None` while `interaction.channel_id` is populated — cold cache, uncached guild,
shortly after a reconnect. When that happens `channel_keys` is **empty** and
`channel_ids` holds the real id, so neither membership test can ever match:

- **`DISCORD_ALLOWED_CHANNELS` rejects an allow-listed channel.** Every slash
  command in a correctly configured channel answers "You're not authorized to
  use this command" — including `/reset` and `/new`, which are the operator's
  way out of a stuck session. That is how this surfaced for us.
- **`DISCORD_IGNORED_CHANNELS` stops rejecting an ignored channel.** Same root
  cause, opposite direction: a quiet fail-open on a gate this module exists to
  enforce.

The rejection log makes it look impossible, because the logged channel comes
from `channel_id` (populated) while the set that failed the test came from
`channel` (empty):

```
Unauthorized slash attempt: user… channel=1511036071734153247 guild=…
cmd='/new' reason='channel not in DISCORD_ALLOWED_CHANNELS'
```

…with `1511036071734153247` present in `DISCORD_ALLOWED_CHANNELS`.

## Fix

Union `channel_ids` into `channel_keys` so the id form is always testable. Name
forms still come from the channel object when it resolved, so `name` / `#name`
matching is unchanged.

## Tests

Two tests in `tests/gateway/test_discord_slash_auth.py`, both of which fail on
`main` and pass with the fix:

- `test_allowlisted_channel_passes_when_interaction_channel_unresolved`
- `test_ignored_channel_rejected_when_interaction_channel_unresolved`

The second asserts the rejection *reason* rather than just the boolean — with
the user allowlist satisfied the ignore list is the only gate left that can
reject, so a bare `is False` would pass even if the ignore list were skipped
entirely.

`tests/gateway/test_discord_slash_auth.py` and
`tests/gateway/test_discord_slash_commands.py`: 81 passed.

The existing coverage misses this because `_make_interaction` always builds a
channel object with an `.id` when `channel_id` is set; the only `channel=None`
case in the file also sets `channel_id=None`, which is the fail-closed path.

## Note

This looks like a narrow regression from the fix for #17724, which correctly
closed the opposite hole (slash commands bypassing the channel allowlist
entirely). The gates it added are right; they just key off the field that isn't
always there.
