### PR TITLE
fix(fallback): resolve named provider metadata

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2034,6 +2034,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
         fb_base_url_hint = (fb.get("base_url") or "").strip() or None
         fb_api_key_hint = resolve_entry_api_key(fb)
+        from hermes_cli.runtime_provider import _parse_api_mode
+
+        fb_configured_api_mode = _parse_api_mode(fb.get("api_mode"))
         # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
         # when no explicit key is in the fallback config. Host match
         # (not substring) — see GHSA-76xc-57q6-vm5m.
@@ -2044,7 +2047,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         fb_client, _resolved_fb_model = resolve_provider_client(
             fb_provider, model=fb_model, raw_codex=True,
             explicit_base_url=fb_base_url_hint,
-            explicit_api_key=fb_api_key_hint)
+            explicit_api_key=fb_api_key_hint,
+            api_mode=fb_configured_api_mode)
         if fb_client is None:
             logger.warning(
                 "Fallback to %s failed: provider not configured",
@@ -2061,11 +2065,14 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_model, fb_provider, _norm_err,
             )
 
-        # Determine api_mode from provider / base URL / model
+        # Persisted, validated provider metadata is authoritative. Legacy
+        # entries without api_mode retain the existing transport inference.
         fb_api_mode = "chat_completions"
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
+        if fb_configured_api_mode:
+            fb_api_mode = fb_configured_api_mode
+        elif fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
         elif fb_provider in {"nous", "nous-portal", "nousresearch"}:
             # Portal is dual-wire: anthropic/* must land on /v1/messages.

--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -75,6 +75,27 @@ def _extract_fallback_from_model_cfg(model_cfg: Any) -> Optional[Dict[str, Any]]
     return entry
 
 
+def _resolve_named_provider_metadata(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Overlay endpoint metadata from the selected named provider, when any."""
+    try:
+        from hermes_cli.runtime_provider import _get_named_custom_provider
+
+        resolved = _get_named_custom_provider(str(entry.get("provider") or ""))
+    except Exception:
+        resolved = None
+    if not isinstance(resolved, dict):
+        return entry
+
+    result = dict(entry)
+    for key in ("base_url", "api_mode"):
+        value = str(resolved.get(key) or "").strip()
+        if value:
+            result[key] = value
+        else:
+            result.pop(key, None)
+    return result
+
+
 def _snapshot_auth_active_provider() -> Any:
     """Return the current ``active_provider`` in auth.json, or a sentinel if unavailable."""
     try:
@@ -175,6 +196,8 @@ def cmd_fallback_add(args) -> None:
     model_after = after_cfg.get("model")
 
     new_entry = _extract_fallback_from_model_cfg(model_after)
+    if new_entry:
+        new_entry = _resolve_named_provider_metadata(new_entry)
     if not new_entry:
         # Picker didn't complete (user cancelled or flow bailed).  Nothing to do.
         _restore_model_cfg(model_before)

--- a/tests/hermes_cli/test_fallback_cmd.py
+++ b/tests/hermes_cli/test_fallback_cmd.py
@@ -156,6 +156,48 @@ class TestAddCommand:
         out = capsys.readouterr().out
         assert "Added fallback" in out
 
+    def test_add_resolves_named_provider_endpoint_metadata(self, isolated_home):
+        _write_config(isolated_home, {
+            "model": {"provider": "anthropic", "default": "claude-sonnet-4-6"},
+            "providers": {
+                "local-backup": {
+                    "base_url": "http://127.0.0.1:8765/v1",
+                    "transport": "codex_responses",
+                    "default_model": "backup-default",
+                }
+            },
+        })
+
+        def fake_picker(args=None):
+            from hermes_cli.config import load_config, save_config
+            cfg = load_config()
+            cfg["model"] = {
+                "provider": "local-backup",
+                "default": "backup-selected",
+                # Simulate stale temporary model metadata. The selected named
+                # provider entry must be authoritative for its own endpoint.
+                "base_url": "https://stale-primary.example/v1",
+                "api_mode": "anthropic_messages",
+            }
+            save_config(cfg)
+
+        with patch("hermes_cli.main.select_provider_and_model", side_effect=fake_picker), \
+                patch("hermes_cli.main._require_tty"):
+            from hermes_cli.fallback_cmd import cmd_fallback_add
+            cmd_fallback_add(types.SimpleNamespace())
+
+        cfg = _read_config(isolated_home)
+        assert cfg["model"] == {
+            "provider": "anthropic",
+            "default": "claude-sonnet-4-6",
+        }
+        assert cfg["fallback_providers"] == [{
+            "provider": "local-backup",
+            "model": "backup-selected",
+            "base_url": "http://127.0.0.1:8765/v1",
+            "api_mode": "codex_responses",
+        }]
+
 
     def test_add_rejects_same_as_primary(self, isolated_home, capsys):
         _write_config(isolated_home, {

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -146,6 +146,41 @@ class TestFallbackChainAdvancement:
             assert mock_rpc.call_args.kwargs["explicit_api_key"] == "env-secret"
 
 
+    def test_named_provider_persisted_api_mode_controls_activation(self):
+        endpoint = "https://opaque-gateway.example/custom/v1"
+        selected_model = "provider-native-model"
+        agent = _make_agent(fallback_model=[{
+            "provider": "local-backup",
+            "model": selected_model,
+            "base_url": endpoint,
+            "api_mode": "codex_responses",
+        }])
+        fallback_client = _mock_client(base_url=endpoint, api_key="provider-key")
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fallback_client, "resolver-default-must-not-win"),
+            ) as mock_resolve,
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda model, _provider: model,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        mock_resolve.assert_called_once_with(
+            "local-backup", model=selected_model, raw_codex=True,
+            explicit_base_url=endpoint,
+            explicit_api_key=None,
+            api_mode="codex_responses")
+        assert agent.client is fallback_client
+        assert agent.provider == "local-backup"
+        assert agent.model == selected_model
+        assert agent.base_url == endpoint
+        assert agent.api_mode == "codex_responses"
+
+
     def test_nous_anthropic_fallback_uses_the_messages_wire(self):
         """Portal Claude fallbacks must not stay on chat_completions.
 


### PR DESCRIPTION
## Summary

- resolve a selected named fallback provider through the full post-picker `providers` / compatible custom-provider configuration;
- keep the exact model selected in the picker while taking `base_url` and validated `api_mode` from that provider's authoritative definition;
- carry the persisted `api_mode` into main-agent fallback client resolution and activation;
- give persisted validated transport metadata precedence over URL/model heuristics while preserving heuristic inference for legacy fallback entries;
- discard stale temporary endpoint metadata left in `config.model` by the picker and restore the primary model exactly as before.

Fixes #71519.

## Root cause

`cmd_fallback_add()` previously constructed the new entry exclusively from the temporary `config["model"]` snapshot. That snapshot knows the selected alias and model, but it is not authoritative for `providers.<alias>.base_url` or `transport` / `api_mode`.

After creation was corrected, main-agent fallback activation still ignored the persisted `api_mode`: it rebuilt transport exclusively from provider, URL, and model heuristics. Named providers whose transport cannot be inferred therefore activated the wrong client path.

The command now overlays authoritative named-provider endpoint metadata, and activation validates and forwards the persisted mode into `resolve_provider_client()` before assigning it to the active agent. Exact selected model and provider endpoint remain unchanged.

## Regression coverage

- command-level coverage proves stale temporary model endpoint/mode cannot override the selected named provider's configuration;
- activation-level coverage uses an opaque endpoint and transport-neutral model, then proves:
  - `codex_responses` reaches client construction;
  - the resolved fallback client is activated;
  - the exact selected model is preserved rather than replaced by a resolver default;
  - the exact provider `base_url` is preserved;
  - `agent.api_mode` becomes the persisted `codex_responses` mode.

The activation regression failed before `cda334774` because `api_mode` was omitted from runtime resolution and activation.

## Verification

- rebased cleanly onto current `main` (`f51aa6a9`);
- focused fallback command and activation suites: **30 passed**;
- focused Ruff checks: passed;
- `py_compile`: clean;
- `git diff --check`: clean.
- upstream `All required checks pass`: green.


