### PR TITLE
fix(memory): stop the Hindsight import from rewriting the process environment

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -142,19 +142,33 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
         "hindsight-all": "hindsight",
     }
 
-    # Check which packages need installation.
+    # Check which packages are missing. Probing a module executes its module
+    # body — ``hindsight_api.config`` (pulled in by ``hindsight``) rewrites
+    # ``os.environ`` from a cwd-relative ``.env`` at import time — so restore
+    # the environment if a probe changed it.
+    #
+    # The restore runs in ``finally``: a probe that mutates ``os.environ`` and
+    # then raises something other than ImportError (a RuntimeError from a
+    # misconfigured module body, say) must not escape with the rewritten
+    # environment still in place.
     missing = []
-    for dep in pip_deps:
-        if force:
-            missing.append(dep)
-            continue
-        dep_name = re.match(r"^[A-Za-z0-9_][A-Za-z0-9_.\-]*", dep)
-        base = dep_name.group(0) if dep_name else dep
-        import_name = _IMPORT_NAMES.get(base, base.replace("-", "_").split("[")[0])
-        try:
-            __import__(import_name)
-        except ImportError:
-            missing.append(dep)
+    probe_snapshot = dict(os.environ)
+    try:
+        for dep in pip_deps:
+            if force:
+                missing.append(dep)
+                continue
+            dep_name = re.match(r"^[A-Za-z0-9_][A-Za-z0-9_.\-]*", dep)
+            base = dep_name.group(0) if dep_name else dep
+            import_name = _IMPORT_NAMES.get(base, base.replace("-", "_").split("[")[0])
+            try:
+                __import__(import_name)
+            except ImportError:
+                missing.append(dep)
+    finally:
+        if dict(os.environ) != probe_snapshot:
+            os.environ.clear()
+            os.environ.update(probe_snapshot)
 
     if not missing:
         return

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -108,14 +108,21 @@ def _install_dependencies(provider_name: str) -> None:
         "hindsight-all": "hindsight",
     }
 
-    # Check which packages are missing
+    # Check which packages are missing. Probing a module executes its module
+    # body — ``hindsight_api.config`` (pulled in by ``hindsight``) rewrites
+    # ``os.environ`` from a cwd-relative ``.env`` at import time — so restore
+    # the environment if a probe changed it.
     missing = []
+    probe_snapshot = dict(os.environ)
     for dep in pip_deps:
         import_name = _IMPORT_NAMES.get(dep, dep.replace("-", "_").split("[")[0])
         try:
             __import__(import_name)
         except ImportError:
             missing.append(dep)
+    if dict(os.environ) != probe_snapshot:
+        os.environ.clear()
+        os.environ.update(probe_snapshot)
 
     if not missing:
         return

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -114,15 +114,17 @@ def _install_dependencies(provider_name: str) -> None:
     # the environment if a probe changed it.
     missing = []
     probe_snapshot = dict(os.environ)
-    for dep in pip_deps:
-        import_name = _IMPORT_NAMES.get(dep, dep.replace("-", "_").split("[")[0])
-        try:
-            __import__(import_name)
-        except ImportError:
-            missing.append(dep)
-    if dict(os.environ) != probe_snapshot:
-        os.environ.clear()
-        os.environ.update(probe_snapshot)
+    try:
+        for dep in pip_deps:
+            import_name = _IMPORT_NAMES.get(dep, dep.replace("-", "_").split("[")[0])
+            try:
+                __import__(import_name)
+            except ImportError:
+                missing.append(dep)
+    finally:
+        if dict(os.environ) != probe_snapshot:
+            os.environ.clear()
+            os.environ.update(probe_snapshot)
 
     if not missing:
         return

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5784,11 +5784,22 @@ def _dependency_importable(dep: str) -> bool:
     import_name = _memory_provider_import_name(dep)
     if not import_name:
         return False
+    # Probing a module executes its module body. At least one memory backend
+    # (``hindsight_api.config``, pulled in by ``hindsight``) runs
+    # ``load_dotenv(find_dotenv(usecwd=True), override=True)`` at import time,
+    # rewriting this process's environment from whatever ``.env`` sits above
+    # the cwd. A capability probe must not inherit side effects like that, so
+    # restore ``os.environ`` if the import changed it.
+    snapshot = dict(os.environ)
     try:
         __import__(import_name)
         return True
     except ImportError:
         return False
+    finally:
+        if dict(os.environ) != snapshot:
+            os.environ.clear()
+            os.environ.update(snapshot)
 
 
 def _trim_setup_output(value: Optional[str], limit: int = 4000) -> str:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6531,11 +6531,22 @@ def _dependency_importable(dep: str) -> bool:
     import_name = _memory_provider_import_name(dep)
     if not import_name:
         return False
+    # Probing a module executes its module body. At least one memory backend
+    # (``hindsight_api.config``, pulled in by ``hindsight``) runs
+    # ``load_dotenv(find_dotenv(usecwd=True), override=True)`` at import time,
+    # rewriting this process's environment from whatever ``.env`` sits above
+    # the cwd. A capability probe must not inherit side effects like that, so
+    # restore ``os.environ`` if the import changed it.
+    snapshot = dict(os.environ)
     try:
         __import__(import_name)
         return True
     except ImportError:
         return False
+    finally:
+        if dict(os.environ) != snapshot:
+            os.environ.clear()
+            os.environ.update(snapshot)
 
 
 def _trim_setup_output(value: Optional[str], limit: int = 4000) -> str:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import contextlib
 import importlib
 import json
 import logging
@@ -49,6 +50,76 @@ from tools.registry import tool_error
 from hermes_cli.config import cfg_get
 
 logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def _preserved_process_env(what: str):
+    """Restore ``os.environ`` after importing a third-party module.
+
+    ``hindsight_api.config`` calls
+    ``load_dotenv(find_dotenv(usecwd=True), override=True)`` at module scope,
+    and ``from hindsight import HindsightEmbedded`` imports it transitively.
+    ``find_dotenv`` walks up from the process cwd, so in a Hermes gateway it
+    resolves to the *default* profile's ``~/.hermes/.env`` regardless of which
+    profile is running -- and ``override=True`` then replaces variables this
+    process already loaded from its own ``$HERMES_HOME/.env``.
+
+    The damage is not limited to Hindsight's own settings: the file is a full
+    profile env, so ``DISCORD_BOT_TOKEN``, ``DISCORD_ALLOWED_CHANNELS``,
+    ``DISCORD_FREE_RESPONSE_CHANNELS``, ``DISCORD_HOME_CHANNEL``,
+    ``MATRIX_USER_ID`` and ``MATRIX_ACCESS_TOKEN`` all flip to the default
+    profile's values. Memory initializes lazily on the first turn that uses
+    it, so the symptom is a non-default profile that answers one message and
+    then goes permanently silent mid-conversation: every later message is
+    dropped by the channel allow-list, which now belongs to another bot.
+
+    Hindsight reads what it needs while the module body runs; snapshotting and
+    restoring around the import leaves Hindsight configured and leaves Hermes'
+    env exactly as Hermes built it.
+    """
+    snapshot = dict(os.environ)
+    try:
+        yield
+    finally:
+        clobbered = sorted(
+            k for k in set(snapshot) | set(os.environ)
+            if snapshot.get(k) != os.environ.get(k)
+        )
+        if clobbered:
+            os.environ.clear()
+            os.environ.update(snapshot)
+            # INFO, not WARNING: this is expected with current Hindsight
+            # releases and fires at most once per process, but the key list
+            # is worth having in the log if a profile ever misbehaves again.
+            logger.info(
+                "Importing %s rewrote %d process env var(s) from a foreign "
+                ".env; restored Hermes' own values (%s)",
+                what, len(clobbered), ", ".join(clobbered),
+            )
+
+def _import_guarded(module_name: str):
+    """``importlib.import_module`` with the process env protected.
+
+    EVERY hindsight import in this module must go through here. The env damage
+    happens on the *first* import of ``hindsight_api.config`` anywhere in the
+    process, so guarding only the obvious call site is not enough: whichever
+    path imports it first wins, and the later guarded import sees the module
+    already in ``sys.modules`` and has nothing left to restore.
+    """
+    with _preserved_process_env(module_name):
+        return importlib.import_module(module_name)
+
+
+def _import_hindsight_embedded():
+    """Import ``HindsightEmbedded`` without inheriting its env side effects.
+
+    Kept as its own function so the isolation seam is directly testable and so
+    every future caller gets the guard by construction rather than by
+    remembering to wrap the import.
+    """
+    return _import_guarded("hindsight").HindsightEmbedded
+
+
 
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
@@ -133,8 +204,10 @@ def _check_local_runtime() -> tuple[bool, str | None]:
     a broken local memory backend.
     """
     try:
-        importlib.import_module("hindsight")
-        importlib.import_module("hindsight_embed.daemon_embed_manager")
+        # Guarded: this probe is what imports hindsight_api.config first in a
+        # live gateway, so it is where the env would otherwise be rewritten.
+        _import_guarded("hindsight")
+        _import_guarded("hindsight_embed.daemon_embed_manager")
         return True, None
     except Exception as exc:
         return False, str(exc)
@@ -1032,7 +1105,10 @@ class HindsightMemoryProvider(MemoryProvider):
                     pass
                 except Exception as _e:
                     raise ImportError(str(_e))
-                from hindsight import HindsightEmbedded
+                # Guarded: this import runs load_dotenv(override=True)
+                # against whatever .env sits above the cwd, which is the
+                # default profile's, not ours. See _preserved_process_env.
+                HindsightEmbedded = _import_hindsight_embedded()
                 HindsightEmbedded.__del__ = lambda self: None
                 llm_provider = self._config.get("llm_provider", "")
                 if llm_provider in {"openai_compatible", "openrouter"}:
@@ -1058,7 +1134,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = HindsightEmbedded(**kwargs)
             else:
                 _ensure_cloud_client_dependency()
-                from hindsight_client import Hindsight
+                Hindsight = _import_guarded("hindsight_client").Hindsight
                 timeout = self._timeout or _DEFAULT_TIMEOUT
                 kwargs = {"base_url": self._api_url, "timeout": float(timeout)}
                 if self._api_key:
@@ -1414,7 +1490,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     # Redirect the daemon manager's Rich console to our log file
                     # instead of stderr. This avoids global fd redirects that
                     # would capture output from other threads.
-                    import hindsight_embed.daemon_embed_manager as dem
+                    dem = _import_guarded("hindsight_embed.daemon_embed_manager")
                     from rich.console import Console
                     dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -134,8 +134,16 @@ def _import_hindsight_embedded():
     Kept as its own function so the isolation seam is directly testable and so
     every future caller gets the guard by construction rather than by
     remembering to wrap the import.
+
+    Uses a plain ``import`` rather than ``importlib.import_module`` so tests
+    (and any other caller) can substitute the module via ``sys.modules`` /
+    ``builtins.__import__`` interception. ``import_module`` bypasses both,
+    which silently defeats those seams.
     """
-    return _import_guarded("hindsight").HindsightEmbedded
+    with _preserved_process_env("hindsight"):
+        from hindsight import HindsightEmbedded
+
+        return HindsightEmbedded
 
 
 
@@ -1348,7 +1356,13 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = HindsightEmbedded(**kwargs)
             else:
                 _ensure_cloud_client_dependency()
-                Hindsight = _import_guarded("hindsight_client").Hindsight
+                # Plain `import` (not importlib) so the module resolution
+                # stays interceptable via builtins.__import__ — the lazy-dep
+                # ordering tests guard this seam, and importlib bypasses it.
+                # The env guard is what actually matters here and it wraps
+                # either form.
+                with _preserved_process_env("hindsight_client"):
+                    from hindsight_client import Hindsight
                 timeout = self._timeout or _DEFAULT_TIMEOUT
                 kwargs = {"base_url": self._api_url, "timeout": float(timeout)}
                 if self._api_key:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import contextlib
 import contextvars
 import importlib
 import json
@@ -69,6 +70,74 @@ class _RecallResult:
 
     text: str
     count: int
+@contextlib.contextmanager
+def _preserved_process_env(what: str):
+    """Restore ``os.environ`` after importing a third-party module.
+
+    ``hindsight_api.config`` calls
+    ``load_dotenv(find_dotenv(usecwd=True), override=True)`` at module scope,
+    and ``from hindsight import HindsightEmbedded`` imports it transitively.
+    ``find_dotenv`` walks up from the process cwd, so in a Hermes gateway it
+    resolves to the *default* profile's ``~/.hermes/.env`` regardless of which
+    profile is running -- and ``override=True`` then replaces variables this
+    process already loaded from its own ``$HERMES_HOME/.env``.
+
+    The damage is not limited to Hindsight's own settings: the file is a full
+    profile env, so ``DISCORD_BOT_TOKEN``, ``DISCORD_ALLOWED_CHANNELS``,
+    ``DISCORD_FREE_RESPONSE_CHANNELS``, ``DISCORD_HOME_CHANNEL``,
+    ``MATRIX_USER_ID`` and ``MATRIX_ACCESS_TOKEN`` all flip to the default
+    profile's values. Memory initializes lazily on the first turn that uses
+    it, so the symptom is a non-default profile that answers one message and
+    then goes permanently silent mid-conversation: every later message is
+    dropped by the channel allow-list, which now belongs to another bot.
+
+    Hindsight reads what it needs while the module body runs; snapshotting and
+    restoring around the import leaves Hindsight configured and leaves Hermes'
+    env exactly as Hermes built it.
+    """
+    snapshot = dict(os.environ)
+    try:
+        yield
+    finally:
+        clobbered = sorted(
+            k for k in set(snapshot) | set(os.environ)
+            if snapshot.get(k) != os.environ.get(k)
+        )
+        if clobbered:
+            os.environ.clear()
+            os.environ.update(snapshot)
+            # INFO, not WARNING: this is expected with current Hindsight
+            # releases and fires at most once per process, but the key list
+            # is worth having in the log if a profile ever misbehaves again.
+            logger.info(
+                "Importing %s rewrote %d process env var(s) from a foreign "
+                ".env; restored Hermes' own values (%s)",
+                what, len(clobbered), ", ".join(clobbered),
+            )
+
+def _import_guarded(module_name: str):
+    """``importlib.import_module`` with the process env protected.
+
+    EVERY hindsight import in this module must go through here. The env damage
+    happens on the *first* import of ``hindsight_api.config`` anywhere in the
+    process, so guarding only the obvious call site is not enough: whichever
+    path imports it first wins, and the later guarded import sees the module
+    already in ``sys.modules`` and has nothing left to restore.
+    """
+    with _preserved_process_env(module_name):
+        return importlib.import_module(module_name)
+
+
+def _import_hindsight_embedded():
+    """Import ``HindsightEmbedded`` without inheriting its env side effects.
+
+    Kept as its own function so the isolation seam is directly testable and so
+    every future caller gets the guard by construction rather than by
+    remembering to wrap the import.
+    """
+    return _import_guarded("hindsight").HindsightEmbedded
+
+
 
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
@@ -169,9 +238,11 @@ def _check_local_runtime() -> tuple[bool, str | None]:
     status) reports the real ImportError.
     """
     try:
-        importlib.import_module("hindsight")
-        importlib.import_module("hindsight_embed.daemon_embed_manager")
-        importlib.import_module("sentence_transformers")
+        # Guarded: this probe is what imports hindsight_api.config first in a
+        # live gateway, so it is where the env would otherwise be rewritten.
+        _import_guarded("hindsight")
+        _import_guarded("hindsight_embed.daemon_embed_manager")
+        _import_guarded("sentence_transformers")
         return True, None
     except Exception as exc:
         return False, str(exc)
@@ -1248,7 +1319,10 @@ class HindsightMemoryProvider(MemoryProvider):
                     pass
                 except Exception as _e:
                     raise ImportError(str(_e))
-                from hindsight import HindsightEmbedded
+                # Guarded: this import runs load_dotenv(override=True)
+                # against whatever .env sits above the cwd, which is the
+                # default profile's, not ours. See _preserved_process_env.
+                HindsightEmbedded = _import_hindsight_embedded()
                 HindsightEmbedded.__del__ = lambda self: None
                 llm_provider = self._config.get("llm_provider", "")
                 if llm_provider in {"openai_compatible", "openrouter"}:
@@ -1274,7 +1348,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = HindsightEmbedded(**kwargs)
             else:
                 _ensure_cloud_client_dependency()
-                from hindsight_client import Hindsight
+                Hindsight = _import_guarded("hindsight_client").Hindsight
                 timeout = self._timeout or _DEFAULT_TIMEOUT
                 kwargs = {"base_url": self._api_url, "timeout": float(timeout)}
                 if self._api_key:
@@ -1815,7 +1889,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     # Redirect the daemon manager's Rich console to our log file
                     # instead of stderr. This avoids global fd redirects that
                     # would capture output from other threads.
-                    import hindsight_embed.daemon_embed_manager as dem
+                    dem = _import_guarded("hindsight_embed.daemon_embed_manager")
                     from rich.console import Console
                     dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
 

--- a/tests/plugins/test_hindsight_env_isolation.py
+++ b/tests/plugins/test_hindsight_env_isolation.py
@@ -38,14 +38,22 @@ hindsight = importlib.import_module("plugins.memory.hindsight")
 
 @pytest.fixture
 def clobbering_import(monkeypatch):
-    """Replace importlib.import_module with one that rewrites the env.
+    """Simulate a hindsight package that rewrites the env at import time.
 
-    Stands in for the real packages: the env damage happens while the module
-    body executes, i.e. inside ``import_module`` itself.
+    The env damage happens while the module body executes, so both import
+    mechanisms this module uses have to be covered:
+
+    * ``importlib.import_module`` — the availability probes.
+    * plain ``import`` (``builtins.__import__``) — the two client-construction
+      sites, which must stay interceptable so ``sys.modules`` / ``__import__``
+      substitution in other tests keeps working.
+
+    Faking only the first would let a plain-``import`` site silently escape
+    the guard while this suite still passed.
     """
     calls = []
 
-    def fake_import_module(name):
+    def _clobber(name):
         calls.append(name)
         os.environ["DISCORD_BOT_TOKEN"] = "default-profile-token"
         os.environ["DISCORD_ALLOWED_CHANNELS"] = "111,222"
@@ -55,7 +63,18 @@ def clobbering_import(monkeypatch):
         module.Hindsight = type("Hindsight", (), {})
         return module
 
+    def fake_import_module(name, package=None):
+        return _clobber(name)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "hindsight" or name.startswith("hindsight_") or name == "sentence_transformers":
+            return _clobber(name)
+        return real_import(name, globals, locals, fromlist, level)
+
     monkeypatch.setattr(hindsight.importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
     return calls
 
 

--- a/tests/plugins/test_hindsight_env_isolation.py
+++ b/tests/plugins/test_hindsight_env_isolation.py
@@ -138,6 +138,7 @@ class TestEveryImportSiteIsGuarded:
         assert clobbering_import == [
             "hindsight",
             "hindsight_embed.daemon_embed_manager",
+            "sentence_transformers",
         ]
         _assert_profile_env_intact()
 

--- a/tests/plugins/test_hindsight_env_isolation.py
+++ b/tests/plugins/test_hindsight_env_isolation.py
@@ -27,6 +27,7 @@ before ``initialize()`` reaches its import.
 
 import importlib
 import os
+import sys
 import types
 
 import pytest
@@ -152,3 +153,46 @@ class TestEveryImportSiteIsGuarded:
     def test_import_hindsight_embedded(self, clobbering_import, profile_env):
         assert hindsight._import_hindsight_embedded().__name__ == "HindsightEmbedded"
         _assert_profile_env_intact()
+
+
+class TestDependencyProbesAreGuarded:
+    """The installed-dependency probes import candidate modules for real, so
+    they hit the same import-time ``load_dotenv(override=True)`` hazard as the
+    plugin's own imports. Each probe must leave ``os.environ`` as it found it."""
+
+    @pytest.fixture()
+    def _mutating_dep(self, tmp_path, monkeypatch):
+        mod = tmp_path / "fake_env_mutating_dep.py"
+        mod.write_text(
+            "import os\nos.environ['HERMES_PROBE_CANARY'] = 'clobbered'\n",
+            encoding="utf-8",
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setenv("HERMES_PROBE_CANARY", "original")
+        yield
+        sys.modules.pop("fake_env_mutating_dep", None)
+
+    def test_web_server_dependency_probe_restores_env(self, _mutating_dep):
+        from hermes_cli import web_server
+
+        assert web_server._dependency_importable("fake-env-mutating-dep") is True
+        assert os.environ["HERMES_PROBE_CANARY"] == "original"
+
+    def test_memory_setup_missing_dep_probe_restores_env(
+        self, _mutating_dep, tmp_path, monkeypatch
+    ):
+        plugin_dir = tmp_path / "provider"
+        plugin_dir.mkdir()
+        (plugin_dir / "plugin.yaml").write_text(
+            "pip_dependencies:\n  - fake-env-mutating-dep\n", encoding="utf-8"
+        )
+        import plugins.memory
+
+        monkeypatch.setattr(
+            plugins.memory, "find_provider_dir", lambda name: plugin_dir
+        )
+        from hermes_cli import memory_setup
+
+        memory_setup._install_dependencies("provider")
+
+        assert os.environ["HERMES_PROBE_CANARY"] == "original"

--- a/tests/plugins/test_hindsight_env_isolation.py
+++ b/tests/plugins/test_hindsight_env_isolation.py
@@ -25,6 +25,7 @@ first attempt at this fix failed in production: ``_check_local_runtime()`` runs
 before ``initialize()`` reaches its import.
 """
 
+import builtins
 import importlib
 import os
 import sys
@@ -194,5 +195,36 @@ class TestDependencyProbesAreGuarded:
         from hermes_cli import memory_setup
 
         memory_setup._install_dependencies("provider")
+
+        assert os.environ["HERMES_PROBE_CANARY"] == "original"
+
+    def test_memory_setup_probe_restores_env_when_import_raises(
+        self, tmp_path, monkeypatch
+    ):
+        plugin_dir = tmp_path / "provider"
+        plugin_dir.mkdir()
+        (plugin_dir / "plugin.yaml").write_text(
+            "pip_dependencies:\n  - fake-env-mutating-dep\n", encoding="utf-8"
+        )
+        import plugins.memory
+
+        monkeypatch.setattr(
+            plugins.memory, "find_provider_dir", lambda name: plugin_dir
+        )
+        from hermes_cli import memory_setup
+
+        monkeypatch.setenv("HERMES_PROBE_CANARY", "original")
+        real_import = builtins.__import__
+
+        def mutating_failing_import(name, *args, **kwargs):
+            if name == "fake_env_mutating_dep":
+                os.environ["HERMES_PROBE_CANARY"] = "clobbered"
+                raise RuntimeError("dependency import failed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mutating_failing_import)
+
+        with pytest.raises(RuntimeError, match="dependency import failed"):
+            memory_setup._install_dependencies("provider")
 
         assert os.environ["HERMES_PROBE_CANARY"] == "original"

--- a/tests/plugins/test_hindsight_env_isolation.py
+++ b/tests/plugins/test_hindsight_env_isolation.py
@@ -1,0 +1,154 @@
+"""Third-party memory imports must not rewrite the Hermes process environment.
+
+``hindsight_api.config`` executes, at module import time::
+
+    load_dotenv(find_dotenv(usecwd=True), override=True)
+
+and every ``hindsight`` package pulls it in transitively. ``find_dotenv`` walks
+up from the *process cwd*, which for a Hermes gateway is the hermes-agent
+checkout — so it resolves to the default profile's ``~/.hermes/.env`` no matter
+which profile is running, and ``override=True`` then replaces variables the
+process already loaded from its own ``$HERMES_HOME/.env``.
+
+That is not confined to Hindsight's own settings: a profile ``.env`` also holds
+``DISCORD_BOT_TOKEN``, ``DISCORD_ALLOWED_CHANNELS``,
+``DISCORD_FREE_RESPONSE_CHANNELS`` and ``MATRIX_ACCESS_TOKEN``. Memory
+initializes lazily, on the first turn that uses it, so a non-default profile
+answers exactly one message and then goes permanently silent: every later
+message is dropped by a channel allow-list that now belongs to another bot.
+
+The damage lands on the *first* import anywhere in the process, so every import
+site has to be guarded — guarding only the obvious one leaves whichever path
+runs first free to do the damage, and the guarded call then finds the module
+already in ``sys.modules`` and nothing left to restore. That is exactly how the
+first attempt at this fix failed in production: ``_check_local_runtime()`` runs
+before ``initialize()`` reaches its import.
+"""
+
+import importlib
+import os
+import types
+
+import pytest
+
+hindsight = importlib.import_module("plugins.memory.hindsight")
+
+
+@pytest.fixture
+def clobbering_import(monkeypatch):
+    """Replace importlib.import_module with one that rewrites the env.
+
+    Stands in for the real packages: the env damage happens while the module
+    body executes, i.e. inside ``import_module`` itself.
+    """
+    calls = []
+
+    def fake_import_module(name):
+        calls.append(name)
+        os.environ["DISCORD_BOT_TOKEN"] = "default-profile-token"
+        os.environ["DISCORD_ALLOWED_CHANNELS"] = "111,222"
+        os.environ["HINDSIGHT_LEAKED_KEY"] = "from-foreign-dotenv"
+        module = types.ModuleType(name)
+        module.HindsightEmbedded = type("HindsightEmbedded", (), {})
+        module.Hindsight = type("Hindsight", (), {})
+        return module
+
+    monkeypatch.setattr(hindsight.importlib, "import_module", fake_import_module)
+    return calls
+
+
+@pytest.fixture
+def profile_env(monkeypatch):
+    """A non-default profile's own environment."""
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "oracle-token")
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "999")
+    monkeypatch.delenv("HINDSIGHT_LEAKED_KEY", raising=False)
+
+
+def _assert_profile_env_intact():
+    assert os.environ["DISCORD_BOT_TOKEN"] == "oracle-token"
+    assert os.environ["DISCORD_ALLOWED_CHANNELS"] == "999"
+    assert "HINDSIGHT_LEAKED_KEY" not in os.environ
+
+
+class TestPreservedProcessEnv:
+    def test_restores_an_overwritten_value(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "mine")
+        with hindsight._preserved_process_env("fake"):
+            os.environ["DISCORD_ALLOWED_CHANNELS"] = "someone-elses"
+        assert os.environ["DISCORD_ALLOWED_CHANNELS"] == "mine"
+
+    def test_removes_a_key_the_body_added(self, monkeypatch):
+        monkeypatch.delenv("HERMES_TEST_ONLY_KEY", raising=False)
+        with hindsight._preserved_process_env("fake"):
+            os.environ["HERMES_TEST_ONLY_KEY"] = "leaked"
+        assert "HERMES_TEST_ONLY_KEY" not in os.environ
+
+    def test_restores_a_key_the_body_deleted(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "oracle-token")
+        with hindsight._preserved_process_env("fake"):
+            del os.environ["DISCORD_BOT_TOKEN"]
+        assert os.environ["DISCORD_BOT_TOKEN"] == "oracle-token"
+
+    def test_restores_even_when_the_body_raises(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "mine")
+        with pytest.raises(RuntimeError):
+            with hindsight._preserved_process_env("fake"):
+                os.environ["DISCORD_ALLOWED_CHANNELS"] = "someone-elses"
+                raise RuntimeError("import blew up")
+        assert os.environ["DISCORD_ALLOWED_CHANNELS"] == "mine"
+
+    def test_quiet_when_nothing_changed(self, monkeypatch, caplog):
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "mine")
+        with caplog.at_level("INFO", logger=hindsight.logger.name):
+            with hindsight._preserved_process_env("fake"):
+                pass
+        assert not caplog.records
+
+    def test_logs_what_it_restored(self, monkeypatch, caplog):
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "mine")
+        with caplog.at_level("INFO", logger=hindsight.logger.name):
+            with hindsight._preserved_process_env("fake-runtime"):
+                os.environ["DISCORD_ALLOWED_CHANNELS"] = "someone-elses"
+        assert any(
+            "fake-runtime" in r.getMessage() and "DISCORD_ALLOWED_CHANNELS" in r.getMessage()
+            for r in caplog.records
+        )
+
+
+class TestImportGuarded:
+    def test_returns_the_module(self, clobbering_import, profile_env):
+        module = hindsight._import_guarded("hindsight")
+        assert module.__name__ == "hindsight"
+
+    def test_does_not_leak_the_foreign_env(self, clobbering_import, profile_env):
+        hindsight._import_guarded("hindsight")
+        _assert_profile_env_intact()
+
+
+class TestEveryImportSiteIsGuarded:
+    """Each production entry point that pulls in a hindsight package."""
+
+    def test_check_local_runtime(self, clobbering_import, profile_env):
+        # This is the one that regressed: it runs *before* initialize() reaches
+        # its own import, so leaving it unguarded made every later guard a no-op.
+        assert hindsight._check_local_runtime() == (True, None)
+        assert clobbering_import == [
+            "hindsight",
+            "hindsight_embed.daemon_embed_manager",
+        ]
+        _assert_profile_env_intact()
+
+    def test_check_local_runtime_still_reports_failure(self, monkeypatch, profile_env):
+        def boom(name):
+            raise RuntimeError("numpy exploded")
+
+        monkeypatch.setattr(hindsight.importlib, "import_module", boom)
+        available, reason = hindsight._check_local_runtime()
+        assert available is False
+        assert "numpy exploded" in reason
+        _assert_profile_env_intact()
+
+    def test_import_hindsight_embedded(self, clobbering_import, profile_env):
+        assert hindsight._import_hindsight_embedded().__name__ == "HindsightEmbedded"
+        _assert_profile_env_intact()


### PR DESCRIPTION
## Problem

Hindsight currently imports configuration that can execute `load_dotenv(find_dotenv(usecwd=True), override=True)` at module-import time. In a multi-profile gateway, that can replace the running profile's environment with values found relative to the process working directory.

Because memory initializes lazily, the mutation can happen mid-conversation and affect unrelated platform credentials and channel allowlists.

## Fix

Snapshot and restore `os.environ` around every third-party Hindsight import path. The dependency probes in `hermes_cli/web_server.py` and `hermes_cli/memory_setup.py` are guarded too because probing imports executes module bodies.

The latest follow-up puts the memory dependency loop inside `try/finally`, so the exact environment snapshot is restored even when a dependency raises a non-`ImportError` exception. Previously, restoration only ran after normal loop completion.

## Tests

Coverage verifies overwritten, added, and deleted keys; exceptions; every production Hindsight import path; web-server dependency probing; memory dependency probing; and restoration when a dependency mutates the environment and raises.

```text
pytest -q tests/plugins/test_hindsight_env_isolation.py
14 passed
```

The guard intentionally preserves the dependency exception after restoring the process environment.