### PR TITLE
fix(desktop): fall back from gated health probes

### DIFF
--- a/apps/desktop/electron/backend-health.test.ts
+++ b/apps/desktop/electron/backend-health.test.ts
@@ -52,6 +52,32 @@ test('falls back to /api/status only for old backends without /api/health', asyn
   ])
 })
 
+test('falls back to /api/status when auth middleware masks a missing health route as 401', async () => {
+  const calls: string[][] = []
+
+  await waitForHermesReady('http://127.0.0.1:9000', {
+    token: 'secret-token',
+    fetchPublicJson: async url => {
+      calls.push(['public', url])
+
+      throw new Error('401: {"error":"unauthenticated","reason":"no_cookie"}')
+    },
+    fetchJson: async (url, token) => {
+      calls.push(['token', url, token ?? ''])
+
+      return { version: 'old' }
+    },
+    sleep: async () => {},
+    timeoutMs: 100,
+    pollMs: 1
+  })
+
+  assert.deepEqual(calls, [
+    ['public', 'http://127.0.0.1:9000/api/health'],
+    ['token', 'http://127.0.0.1:9000/api/status', 'secret-token']
+  ])
+})
+
 test('does not fall back to heavyweight /api/status for transient health failures', async () => {
   const calls: string[][] = []
   let currentTime = 0

--- a/apps/desktop/electron/backend-health.ts
+++ b/apps/desktop/electron/backend-health.ts
@@ -28,6 +28,16 @@ export function isMissingHealthEndpointError(error: unknown): boolean {
   return /^404:/.test(message) || message.includes('endpoint is likely missing')
 }
 
+export function shouldFallbackFromHealthProbe(error: unknown): boolean {
+  if (isMissingHealthEndpointError(error)) {
+    return true
+  }
+
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  return /^401:/.test(message)
+}
+
 function supersededError() {
   const error: any = new Error('SSH bootstrap was superseded by newer connection settings.')
   error.kind = 'superseded'
@@ -80,7 +90,7 @@ export async function waitForHermesReady(baseUrl: string, options: HermesReadyOp
 
       // Only an explicitly missing route means the backend predates
       // /api/health; timeouts and server errors keep polling health.
-      if (!useStatusFallback && isMissingHealthEndpointError(error)) {
+      if (!useStatusFallback && shouldFallbackFromHealthProbe(error)) {
         useStatusFallback = true
 
         continue


### PR DESCRIPTION
## Summary

- treat a `401` from the unauthenticated `/api/health` readiness probe as a compatibility fallback signal;
- retry readiness through the existing `/api/status` path, including the configured session token when present;
- preserve health polling for timeouts and server failures;
- keep `isMissingHealthEndpointError()` scoped to actual missing-route shapes.

Fixes #71515.

## Root cause

Desktop now probes the lightweight `/api/health` route before `/api/status`. Older authenticated backends do not have that route, but their auth middleware runs before routing and returns `401` rather than `404`. The compatibility fallback therefore never activated even though `/api/status` was healthy.

The new `shouldFallbackFromHealthProbe()` helper accepts the existing missing-route cases plus HTTP 401. Readiness succeeds only if the status probe itself succeeds, so authentication is not bypassed.

## Verification

- regression was red on current `main`: the 401 probe exhausted the readiness deadline without calling status;
- focused backend-health suite: **7 passed**;
- ESLint and `git diff --check`: clean.
