### PR TITLE
fix(cron): harden runtime maintenance failures

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -87,6 +87,41 @@ def _set_cron_session_title(session_db, session_id, base_title):
         return deduped
 
 
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_PYTHON_EXCEPTION_LINE_RE = re.compile(
+    r"^(?:[A-Za-z_][\w.]*\.)*[A-Za-z_]\w*(?:Error|Exception):\s+.+$"
+)
+
+
+def _actionable_script_failure_line(text: str) -> str | None:
+    """Extract the terminal diagnostic from a failed script's captured output."""
+    if not text.lower().startswith("script exited with code "):
+        return None
+
+    lines = [
+        _ANSI_ESCAPE_RE.sub("", line).strip()
+        for line in text.splitlines()
+    ]
+    lines = [line for line in lines if line]
+    for line in reversed(lines):
+        if _PYTHON_EXCEPTION_LINE_RE.match(line):
+            return line
+
+    ignored_prefixes = (
+        "stderr:",
+        "stdout:",
+        "traceback (most recent call last):",
+        "file ",
+        "deprecated .env settings detected:",
+        "move to config.yaml instead:",
+        "then remove the old entries from ",
+    )
+    for line in reversed(lines[1:]):
+        if not line.lower().startswith(ignored_prefixes):
+            return line
+    return None
+
+
 def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     """Return a compact one-line failure message for chat delivery.
 
@@ -97,6 +132,19 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     job_name = job.get("name") or job.get("id") or "cron job"
     text = (error or "unknown error").strip()
     lower = text.lower()
+
+    # Script stderr commonly begins with warnings before the actual exception.
+    # Prefer the final traceback diagnostic so chat truncation cannot hide the
+    # actionable cause while the complete output remains persisted.
+    script_diagnostic = _actionable_script_failure_line(text)
+    if script_diagnostic:
+        cleaned_diagnostic = re.sub(r"\s+", " ", script_diagnostic).strip()
+        if len(cleaned_diagnostic) > 180:
+            cleaned_diagnostic = cleaned_diagnostic[:177].rstrip() + "..."
+        return (
+            f"⚠️ Cron '{job_name}' failed: script {cleaned_diagnostic} "
+            "Full details saved in cron output."
+        )
 
     # Provider/API failures are the common noisy path. Keep these short.
     if "429" in text or "rate limit" in lower or "usage limit" in lower:
@@ -597,6 +645,18 @@ def _get_lock_paths() -> tuple[Path, Path]:
     hermes_home = _get_hermes_home()
     lock_dir = hermes_home / "cron"
     return lock_dir, lock_dir / ".tick.lock"
+
+
+def _cron_maintenance_active(lock_dir: Path) -> bool:
+    """Return whether an operator has paused dispatch for runtime maintenance.
+
+    Deployments can create ``cron/.maintenance`` before replacing scripts or
+    plugins and remove it after their import probes pass.  The ticker leaves
+    due jobs untouched while the marker exists, so they run normally on the
+    first post-maintenance tick instead of firing against a partially updated
+    runtime.
+    """
+    return (lock_dir / ".maintenance").is_file()
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
@@ -4072,6 +4132,13 @@ def tick(
         return 0
 
     try:
+        if _cron_maintenance_active(lock_dir):
+            logger.info(
+                "Cron dispatch paused by maintenance marker: %s",
+                lock_dir / ".maintenance",
+            )
+            return 0
+
         if can_dispatch is not None and not can_dispatch():
             logger.debug("Cron dispatch paused while gateway drains existing work")
             return 0

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5949,14 +5949,30 @@ def print_config_warnings(config: Optional[Dict[str, Any]] = None) -> None:
     sys.stderr.write("\n".join(lines) + "\n\n")
 
 
-def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> None:
+def warn_deprecated_cwd_env_vars(
+    config: Optional[Dict[str, Any]] = None,
+    env_values: Optional[Dict[str, str]] = None,
+) -> None:
     """Warn if MESSAGING_CWD or TERMINAL_CWD is set in .env instead of config.yaml.
 
     These env vars are deprecated — the canonical setting is terminal.cwd
-    in config.yaml.  Prints a migration hint to stderr.
+    in config.yaml.  Inspect the actual ``.env`` contents rather than
+    ``os.environ``: gateway and cron subprocesses legitimately inherit the
+    internal ``TERMINAL_CWD`` runtime bridge, which does not mean the user
+    configured that value in ``.env``.  Prints a migration hint to stderr.
+
+    ``env_values`` is an injection seam for callers that already parsed the
+    file and for deterministic tests.  When omitted, the canonical Hermes
+    ``.env`` file is loaded directly.
     """
-    messaging_cwd = os.environ.get("MESSAGING_CWD")
-    terminal_cwd_env = os.environ.get("TERMINAL_CWD")
+    if env_values is None:
+        try:
+            env_values = load_env()
+        except Exception:
+            return
+
+    messaging_cwd = env_values.get("MESSAGING_CWD")
+    terminal_cwd_env = env_values.get("TERMINAL_CWD")
 
     if config is None:
         try:
@@ -5982,14 +5998,14 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
             f"this is deprecated."
         )
     if lines:
-        hint_path = os.environ.get("HERMES_HOME", "~/.hermes")
+        hint_path = get_env_path()
         lines.insert(0, "\033[33m⚠ Deprecated .env settings detected:\033[0m")
         lines.append(
             "  \033[2mMove to config.yaml instead:  "
             "terminal:\\n    cwd: /your/project/path\033[0m"
         )
         lines.append(
-            f"  \033[2mThen remove the old entries from {hint_path}/.env\033[0m"
+            f"  \033[2mThen remove the old entries from {hint_path}\033[0m"
         )
         sys.stderr.write("\n".join(lines) + "\n\n")
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -9,9 +9,44 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
+from cron.scheduler import (
+    SILENT_MARKER,
+    _build_job_prompt,
+    _deliver_result,
+    _merge_mcp_into_per_job_toolsets,
+    _resolve_cron_enabled_toolsets,
+    _resolve_delivery_target,
+    _resolve_origin,
+    _send_media_via_adapter,
+    _summarize_cron_failure_for_delivery,
+    run_job,
+)
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
+
+
+class TestCronFailureSummary:
+    def test_script_failure_surfaces_terminal_traceback_diagnostic(self):
+        error = (
+            "Script exited with code 1\n"
+            "stderr:\n"
+            "\x1b[33m⚠ Deprecated .env settings detected:\x1b[0m\n"
+            "  ⚠ TERMINAL_CWD=/opt/data found in .env — this is deprecated.\n\n"
+            "Traceback (most recent call last):\n"
+            '  File "/opt/data/scripts/relationships-urgent.py", line 4, in <module>\n'
+            "    from cyber_relationships.automation_runner import main\n"
+            "ModuleNotFoundError: No module named 'cyber_relationships'"
+        )
+
+        summary = _summarize_cron_failure_for_delivery(
+            {"name": "relationship-urgent-monitor"},
+            error,
+        )
+
+        assert "ModuleNotFoundError" in summary
+        assert "cyber_relationships" in summary
+        assert "TERMINAL_CWD" not in summary
+        assert "Full details saved" in summary
 
 
 class TestPerJobToolsetMcpMerge:
@@ -1884,6 +1919,38 @@ class TestRunJobSessionPersistence:
         ) as advance, patch("cron.scheduler.run_one_job") as run_one:
             assert tick(verbose=False, sync=True, can_dispatch=lambda: False) == 0
 
+        advance.assert_not_called()
+        run_one.assert_not_called()
+
+    def test_tick_leaves_due_jobs_untouched_during_runtime_maintenance(
+        self, tmp_path
+    ):
+        """Deploy markers pause dispatch until scripts and plugins are coherent."""
+        from cron.scheduler import tick
+
+        cron_dir = tmp_path / "cron"
+        cron_dir.mkdir()
+        (cron_dir / ".maintenance").write_text(
+            "deploying runtime plugins\n",
+            encoding="utf-8",
+        )
+        job = {
+            "id": "maintenance-due-job",
+            "name": "maintenance due job",
+            "schedule": {"kind": "interval", "seconds": 60},
+            "next_run_at": "2020-01-01T00:00:00+00:00",
+            "enabled": True,
+        }
+        with patch("cron.scheduler._hermes_home", tmp_path), patch(
+            "cron.scheduler.get_due_jobs", return_value=[job]
+        ) as get_due, patch(
+            "cron.scheduler.advance_next_run"
+        ) as advance, patch(
+            "cron.scheduler.run_one_job"
+        ) as run_one:
+            assert tick(verbose=False, sync=True) == 0
+
+        get_due.assert_not_called()
         advance.assert_not_called()
         run_one.assert_not_called()
 

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -1,7 +1,6 @@
 """Tests for warn_deprecated_cwd_env_vars() migration warning."""
 
 
-
 class TestDeprecatedCwdWarning:
     """Warn when MESSAGING_CWD or TERMINAL_CWD is set in .env."""
 
@@ -10,7 +9,10 @@ class TestDeprecatedCwdWarning:
         monkeypatch.delenv("TERMINAL_CWD", raising=False)
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
-        warn_deprecated_cwd_env_vars(config={})
+        warn_deprecated_cwd_env_vars(
+            config={},
+            env_values={"MESSAGING_CWD": "/some/path"},
+        )
 
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
@@ -23,7 +25,10 @@ class TestDeprecatedCwdWarning:
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
         # config has placeholder cwd → TERMINAL_CWD likely from .env
-        warn_deprecated_cwd_env_vars(config={"terminal": {"cwd": "."}})
+        warn_deprecated_cwd_env_vars(
+            config={"terminal": {"cwd": "."}},
+            env_values={"TERMINAL_CWD": "/project"},
+        )
 
         captured = capsys.readouterr()
         assert "TERMINAL_CWD" in captured.err
@@ -35,7 +40,10 @@ class TestDeprecatedCwdWarning:
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
         # config has explicit cwd → TERMINAL_CWD could be from config bridge
-        warn_deprecated_cwd_env_vars(config={"terminal": {"cwd": "/project"}})
+        warn_deprecated_cwd_env_vars(
+            config={"terminal": {"cwd": "/project"}},
+            env_values={"TERMINAL_CWD": "/project"},
+        )
 
         captured = capsys.readouterr()
         assert "TERMINAL_CWD" not in captured.err
@@ -45,7 +53,7 @@ class TestDeprecatedCwdWarning:
         monkeypatch.delenv("TERMINAL_CWD", raising=False)
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
-        warn_deprecated_cwd_env_vars(config={})
+        warn_deprecated_cwd_env_vars(config={}, env_values={})
 
         captured = capsys.readouterr()
         assert captured.err == ""
@@ -55,8 +63,46 @@ class TestDeprecatedCwdWarning:
         monkeypatch.setenv("TERMINAL_CWD", "/term/path")
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
-        warn_deprecated_cwd_env_vars(config={})
+        warn_deprecated_cwd_env_vars(
+            config={},
+            env_values={
+                "MESSAGING_CWD": "/msg/path",
+                "TERMINAL_CWD": "/term/path",
+            },
+        )
 
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
         assert "TERMINAL_CWD" in captured.err
+
+    def test_inherited_terminal_cwd_does_not_trigger_warning(
+        self, monkeypatch, capsys
+    ):
+        """The gateway's runtime bridge is not evidence of a deprecated file entry."""
+        monkeypatch.setenv("TERMINAL_CWD", "/opt/data")
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+
+        warn_deprecated_cwd_env_vars(config={}, env_values={})
+
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_default_path_reads_actual_env_file(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        env_path = tmp_path / ".env"
+        env_path.write_text("TERMINAL_CWD=/legacy/project\n", encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.get_env_path", lambda: env_path)
+
+        from hermes_cli import config as config_module
+
+        config_module.invalidate_env_cache()
+        config_module.warn_deprecated_cwd_env_vars(
+            config={"terminal": {"cwd": "."}},
+        )
+
+        captured = capsys.readouterr()
+        assert "TERMINAL_CWD=/legacy/project" in captured.err
+        assert str(env_path) in captured.err


### PR DESCRIPTION
## What changed
- pause built-in cron dispatch while a profile-local maintenance marker exists, without advancing due schedules
- inspect actual `.env` contents before warning about deprecated CWD settings
- surface the terminal script exception in chat failure summaries while retaining full output
- add regression coverage

## Why
Relationship cron jobs fired while their plugin was temporarily absent during deployment. The first visible stderr line was a false `TERMINAL_CWD` warning, which hid the actionable `ModuleNotFoundError`.

## Impact
Deployments can coordinate runtime replacement without jobs firing against a partial plugin set, and future script failures expose the useful exception in chat.

## Validation
- 225 focused cron/config tests passed on the original branch base
- targeted maintenance-marker, `.env` provenance, and traceback-summary regressions pass after rebasing onto current upstream `main`
- `git diff --check`