### PR TITLE
fix(desktop): bind webhooks state to backend profile

### DIFF
--- a/apps/desktop/src/app/webhooks/index.test.tsx
+++ b/apps/desktop/src/app/webhooks/index.test.tsx
@@ -1,0 +1,127 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getWebhooks: vi.fn(),
+  enableWebhooks: vi.fn(),
+  createWebhook: vi.fn(),
+  deleteWebhook: vi.fn(),
+  setWebhookEnabled: vi.fn(),
+  runGatewayRestart: vi.fn(),
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+vi.mock('@/hermes', () => ({
+  getWebhooks: (profile?: string) => mocks.getWebhooks(profile),
+  enableWebhooks: (profile?: string) => mocks.enableWebhooks(profile),
+  createWebhook: (body: unknown, profile?: string) => mocks.createWebhook(body, profile),
+  deleteWebhook: (name: string, profile?: string) => mocks.deleteWebhook(name, profile),
+  setWebhookEnabled: (name: string, enabled: boolean, profile?: string) => mocks.setWebhookEnabled(name, enabled, profile)
+}))
+
+vi.mock('@/store/profile', async () => {
+  const { atom } = await import('nanostores')
+
+  return {
+    $activeGatewayProfile: atom('alpha'),
+    $profileScope: atom('__all__'),
+    normalizeProfileKey: (value: string | null | undefined) => String(value ?? '').trim() || 'default'
+  }
+})
+
+vi.mock('@/store/system-actions', () => ({
+  runGatewayRestart: (profile?: string) => mocks.runGatewayRestart(profile)
+}))
+
+vi.mock('@/store/notifications', () => ({ notify: mocks.notify, notifyError: mocks.notifyError }))
+
+import { $activeGatewayProfile } from '@/store/profile'
+
+import { WebhooksView } from './index'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, reject, resolve }
+}
+
+function renderView() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  return render(
+    <QueryClientProvider client={client}>
+      <WebhooksView onClose={() => undefined} />
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  )
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+
+  $activeGatewayProfile.set('alpha')
+  mocks.getWebhooks.mockResolvedValue({ enabled: true, subscriptions: [] })
+  mocks.enableWebhooks.mockResolvedValue({ restart_started: true })
+  mocks.deleteWebhook.mockResolvedValue({ ok: true })
+  mocks.setWebhookEnabled.mockResolvedValue({ enabled: true, name: 'hook', ok: true })
+  mocks.runGatewayRestart.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('WebhooksView profile ownership', () => {
+  it('drops the create draft when the backend profile changes under All profiles', async () => {
+    renderView()
+
+    fireEvent.click(await screen.findByRole('button', { name: /new subscription/i }))
+    fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: 'alpha-hook' } })
+    expect(screen.getByDisplayValue('alpha-hook')).toBeTruthy()
+
+    act(() => $activeGatewayProfile.set('beta'))
+
+    await waitFor(() => expect(mocks.getWebhooks).toHaveBeenCalledWith('beta'))
+    expect(screen.queryByDisplayValue('alpha-hook')).toBeNull()
+  })
+
+  it('ignores a create completion owned by the previous profile', async () => {
+    const create = deferred<{ secret: string; url: string }>()
+    mocks.createWebhook.mockReturnValue(create.promise)
+    renderView()
+
+    fireEvent.click(await screen.findByRole('button', { name: /new subscription/i }))
+    fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: 'alpha-hook' } })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() =>
+      expect(mocks.createWebhook).toHaveBeenCalledWith(expect.objectContaining({ name: 'alpha-hook' }), 'alpha')
+    )
+
+    act(() => $activeGatewayProfile.set('beta'))
+    await act(async () => create.resolve({ secret: 'alpha-secret', url: 'https://alpha.example/hook' }))
+
+    await waitFor(() => expect(mocks.getWebhooks).toHaveBeenCalledWith('beta'))
+    expect(screen.queryByText('alpha-secret')).toBeNull()
+    expect(mocks.notify).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/webhooks/index.test.tsx
+++ b/apps/desktop/src/app/webhooks/index.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { StrictMode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -18,7 +19,8 @@ vi.mock('@/hermes', () => ({
   enableWebhooks: (profile?: string) => mocks.enableWebhooks(profile),
   createWebhook: (body: unknown, profile?: string) => mocks.createWebhook(body, profile),
   deleteWebhook: (name: string, profile?: string) => mocks.deleteWebhook(name, profile),
-  setWebhookEnabled: (name: string, enabled: boolean, profile?: string) => mocks.setWebhookEnabled(name, enabled, profile)
+  setWebhookEnabled: (name: string, enabled: boolean, profile?: string) =>
+    mocks.setWebhookEnabled(name, enabled, profile)
 }))
 
 vi.mock('@/store/profile', async () => {
@@ -53,14 +55,16 @@ function deferred<T>() {
   return { promise, reject, resolve }
 }
 
-function renderView() {
+function renderView({ strictMode = false }: { strictMode?: boolean } = {}) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
-  return render(
+  const view = (
     <QueryClientProvider client={client}>
       <WebhooksView onClose={() => undefined} />
     </QueryClientProvider>
   )
+
+  return render(strictMode ? <StrictMode>{view}</StrictMode> : view)
 }
 
 beforeEach(() => {
@@ -102,6 +106,24 @@ describe('WebhooksView profile ownership', () => {
 
     await waitFor(() => expect(mocks.getWebhooks).toHaveBeenCalledWith('beta'))
     expect(screen.queryByDisplayValue('alpha-hook')).toBeNull()
+  })
+
+  it('accepts a create completion after the StrictMode effect rehearsal', async () => {
+    const create = deferred<{ secret: string; url: string }>()
+    mocks.createWebhook.mockReturnValue(create.promise)
+    renderView({ strictMode: true })
+
+    fireEvent.click(await screen.findByRole('button', { name: /new subscription/i }))
+    fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: 'strict-hook' } })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() =>
+      expect(mocks.createWebhook).toHaveBeenCalledWith(expect.objectContaining({ name: 'strict-hook' }), 'alpha')
+    )
+    await act(async () => create.resolve({ secret: 'strict-secret', url: 'https://alpha.example/strict' }))
+
+    expect(await screen.findByText('strict-secret')).toBeTruthy()
+    expect(mocks.notify).toHaveBeenCalledWith(expect.objectContaining({ kind: 'success' }))
   })
 
   it('ignores a create completion owned by the previous profile', async () => {

--- a/apps/desktop/src/app/webhooks/index.tsx
+++ b/apps/desktop/src/app/webhooks/index.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { PageLoader } from '@/components/page-loader'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -33,7 +33,7 @@ import { useI18n } from '@/i18n'
 import { AlertTriangle, Globe, Plus, RefreshCw } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
-import { $profileScope } from '@/store/profile'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { runGatewayRestart } from '@/store/system-actions'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
@@ -77,13 +77,32 @@ interface WebhooksViewProps {
   onClose: () => void
 }
 
+interface ProfileOwnedWebhooksViewProps extends WebhooksViewProps {
+  backendProfile: string
+}
+
 export function WebhooksView({ onClose }: WebhooksViewProps) {
+  const backendProfile = normalizeProfileKey(useStore($activeGatewayProfile))
+
+  // Profile-owned draft/dialog/secret state must disappear at the same boundary
+  // as the backend owner. The key unmounts the old operation scope immediately,
+  // including while the sidebar remains in All profiles mode (#71352).
+  return <ProfileOwnedWebhooksView backendProfile={backendProfile} key={backendProfile} onClose={onClose} />
+}
+
+function ProfileOwnedWebhooksView({ backendProfile, onClose }: ProfileOwnedWebhooksViewProps) {
   const { t } = useI18n()
   const w = t.webhooks
-  // Re-load when the active profile changes so REST routes to the right backend.
-  const profileScope = useStore($profileScope)
   const queryClient = useQueryClient()
-  const queryKey = useMemo(() => ['webhooks', profileScope] as const, [profileScope])
+  const queryKey = useMemo(() => ['webhooks', backendProfile] as const, [backendProfile])
+  const ownerActive = useRef(true)
+
+  useEffect(
+    () => () => {
+      ownerActive.current = false
+    },
+    []
+  )
 
   const [query, setQuery] = useState('')
   const [enabling, setEnabling] = useState(false)
@@ -113,7 +132,7 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
     refetch
   } = useQuery({
     queryKey,
-    queryFn: getWebhooks
+    queryFn: () => getWebhooks(backendProfile)
   })
 
   // React Query v5 dropped useQuery onError; surface a load failure toast once
@@ -134,7 +153,7 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
       try {
         await queryClient.invalidateQueries({ queryKey })
       } catch (err) {
-        if (!silent) {
+        if (!silent && ownerActive.current) {
           notifyError(err, w.loadFailed)
         }
       }
@@ -148,19 +167,34 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
     setRestarting(true)
 
     try {
-      await runGatewayRestart()
+      await runGatewayRestart(backendProfile)
+
+      if (!ownerActive.current) {
+        return
+      }
+
       setRestartNeeded(false)
       setRestartError(null)
       // Give the receiver a moment to bind before re-reading state.
-      window.setTimeout(() => void reload(true), 4000)
+      window.setTimeout(() => {
+        if (ownerActive.current) {
+          void reload(true)
+        }
+      }, 4000)
     } catch (err) {
+      if (!ownerActive.current) {
+        return
+      }
+
       setRestartNeeded(true)
       setRestartError(String(err))
       notifyError(err, w.restartFailed(''))
     } finally {
-      setRestarting(false)
+      if (ownerActive.current) {
+        setRestarting(false)
+      }
     }
-  }, [reload, w])
+  }, [backendProfile, reload, w])
 
   const handleEnable = useCallback(async () => {
     setEnabling(true)
@@ -168,12 +202,25 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
     setRestartError(null)
 
     try {
-      const result = await enableWebhooks()
+      const result = await enableWebhooks(backendProfile)
+
+      if (!ownerActive.current) {
+        return
+      }
+
       await reload(true)
+
+      if (!ownerActive.current) {
+        return
+      }
 
       if (result.restart_started) {
         notify({ kind: 'success', message: w.enabledRestarting })
-        window.setTimeout(() => void reload(true), 4000)
+        window.setTimeout(() => {
+          if (ownerActive.current) {
+            void reload(true)
+          }
+        }, 4000)
       } else {
         const detail = result.restart_error ? `: ${result.restart_error}` : '.'
         setRestartNeeded(true)
@@ -181,11 +228,15 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
         notify({ kind: 'error', message: w.restartFailed(detail) })
       }
     } catch (err) {
-      notifyError(err, w.restartFailed(''))
+      if (ownerActive.current) {
+        notifyError(err, w.restartFailed(''))
+      }
     } finally {
-      setEnabling(false)
+      if (ownerActive.current) {
+        setEnabling(false)
+      }
     }
-  }, [reload, w])
+  }, [backendProfile, reload, w])
 
   const resetForm = useCallback(() => {
     setName('')
@@ -226,26 +277,37 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
         .map(s => s.trim())
         .filter(Boolean)
 
-      const res = await createWebhook({
-        deliver,
-        deliver_only: deliverOnly,
-        description: description.trim() || undefined,
-        events: eventsList.length ? eventsList : undefined,
-        name: name.trim(),
-        prompt: prompt.trim() || undefined,
-        skills: skillsList.length ? skillsList : undefined
-      })
+      const res = await createWebhook(
+        {
+          deliver,
+          deliver_only: deliverOnly,
+          description: description.trim() || undefined,
+          events: eventsList.length ? eventsList : undefined,
+          name: name.trim(),
+          prompt: prompt.trim() || undefined,
+          skills: skillsList.length ? skillsList : undefined
+        },
+        backendProfile
+      )
+
+      if (!ownerActive.current) {
+        return
+      }
 
       notify({ kind: 'success', message: w.created })
       setCreated({ secret: res.secret, url: res.url })
       resetForm()
       void reload(true)
     } catch (err) {
-      notifyError(err, w.createFailed(''))
+      if (ownerActive.current) {
+        notifyError(err, w.createFailed(''))
+      }
     } finally {
-      setCreating(false)
+      if (ownerActive.current) {
+        setCreating(false)
+      }
     }
-  }, [deliver, deliverOnly, description, events, name, prompt, reload, resetForm, skills, w])
+  }, [backendProfile, deliver, deliverOnly, description, events, name, prompt, reload, resetForm, skills, w])
 
   const handleToggle = useCallback(
     async (subName: string, nextEnabled: boolean) => {
@@ -260,15 +322,24 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
       )
 
       try {
-        await setWebhookEnabled(subName, nextEnabled)
+        await setWebhookEnabled(subName, nextEnabled, backendProfile)
+
+        if (!ownerActive.current) {
+          return
+        }
+
         notify({ kind: 'success', message: nextEnabled ? w.enabled(subName) : w.disabled(subName) })
         void reload(true)
       } catch (err) {
+        if (!ownerActive.current) {
+          return
+        }
+
         await reload(true)
         notifyError(err, w.toggleFailed(subName, nextEnabled))
       }
     },
-    [queryClient, queryKey, reload, w]
+    [backendProfile, queryClient, queryKey, reload, w]
   )
 
   // ConfirmDialog owns the pending→done→close beat; throw to surface its inline
@@ -280,14 +351,23 @@ export function WebhooksView({ onClose }: WebhooksViewProps) {
     }
 
     try {
-      await deleteWebhook(pendingDelete)
+      await deleteWebhook(pendingDelete, backendProfile)
+
+      if (!ownerActive.current) {
+        return
+      }
+
       notify({ kind: 'success', title: w.deleted, message: pendingDelete })
       void reload(true)
     } catch (err) {
+      if (!ownerActive.current) {
+        return
+      }
+
       notifyError(err, w.deleteFailed(pendingDelete))
       throw err
     }
-  }, [pendingDelete, reload, w])
+  }, [backendProfile, pendingDelete, reload, w])
 
   const visible = useMemo(() => {
     const q = query.trim().toLowerCase()

--- a/apps/desktop/src/app/webhooks/index.tsx
+++ b/apps/desktop/src/app/webhooks/index.tsx
@@ -97,12 +97,14 @@ function ProfileOwnedWebhooksView({ backendProfile, onClose }: ProfileOwnedWebho
   const queryKey = useMemo(() => ['webhooks', backendProfile] as const, [backendProfile])
   const ownerActive = useRef(true)
 
-  useEffect(
-    () => () => {
+  // eslint-disable-next-line no-restricted-syntax -- lifecycle ownership flag, not an atom mirror
+  useEffect(() => {
+    ownerActive.current = true
+
+    return () => {
       ownerActive.current = false
-    },
-    []
-  )
+    }
+  }, [])
 
   const [query, setQuery] = useState('')
   const [enabling, setEnabling] = useState(false)

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1329,33 +1329,33 @@ export function revokePairing(platform: string, userId: string): Promise<{ ok: b
 // shared JSON store the CLI/dashboard also drive. Enable mutates config and
 // best-effort restarts the gateway; subscription changes hot-reload.
 
-export function getWebhooks(): Promise<WebhooksResponse> {
+export function getWebhooks(profile?: null | string): Promise<WebhooksResponse> {
   return window.hermesDesktop.api<WebhooksResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/webhooks'
   })
 }
 
-export function enableWebhooks(): Promise<WebhookEnableResponse> {
+export function enableWebhooks(profile?: null | string): Promise<WebhookEnableResponse> {
   return window.hermesDesktop.api<WebhookEnableResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/webhooks/enable',
     method: 'POST'
   })
 }
 
-export function createWebhook(body: WebhookCreatePayload): Promise<WebhookCreateResponse> {
+export function createWebhook(body: WebhookCreatePayload, profile?: null | string): Promise<WebhookCreateResponse> {
   return window.hermesDesktop.api<WebhookCreateResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/webhooks',
     method: 'POST',
     body
   })
 }
 
-export function deleteWebhook(name: string): Promise<{ ok: boolean }> {
+export function deleteWebhook(name: string, profile?: null | string): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/webhooks/${encodeURIComponent(name)}`,
     method: 'DELETE'
   })
@@ -1363,10 +1363,11 @@ export function deleteWebhook(name: string): Promise<{ ok: boolean }> {
 
 export function setWebhookEnabled(
   name: string,
-  enabled: boolean
+  enabled: boolean,
+  profile?: null | string
 ): Promise<{ enabled: boolean; name: string; ok: boolean }> {
   return window.hermesDesktop.api<{ enabled: boolean; name: string; ok: boolean }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/webhooks/${encodeURIComponent(name)}/enabled`,
     method: 'PUT',
     body: { enabled }
@@ -1675,9 +1676,9 @@ export function setModelAssignment(body: ModelAssignmentRequest): Promise<ModelA
   })
 }
 
-export function restartGateway(): Promise<ActionResponse> {
+export function restartGateway(profile?: null | string): Promise<ActionResponse> {
   return window.hermesDesktop.api<ActionResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/gateway/restart',
     method: 'POST'
   })
@@ -1701,9 +1702,9 @@ export function checkHermesUpdate(force = false): Promise<BackendUpdateCheckResp
   })
 }
 
-export function getActionStatus(name: string, lines = 200): Promise<ActionStatusResponse> {
+export function getActionStatus(name: string, lines = 200, profile?: null | string): Promise<ActionStatusResponse> {
   return window.hermesDesktop.api<ActionStatusResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/actions/${encodeURIComponent(name)}/status?lines=${Math.max(1, lines)}`
   })
 }

--- a/apps/desktop/src/store/system-actions.ts
+++ b/apps/desktop/src/store/system-actions.ts
@@ -16,10 +16,10 @@ export const $gatewayRestarting = atom(false)
 
 // Poll a backend action to completion (or a bounded window), throwing on a
 // non-zero exit so the caller can surface the failure.
-async function awaitAction(started: ActionResponse): Promise<void> {
+async function awaitAction(started: ActionResponse, profile?: string): Promise<void> {
   for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt += 1) {
     await new Promise(resolve => window.setTimeout(resolve, POLL_INTERVAL_MS))
-    const status = await getActionStatus(started.name, POLL_TIMEOUT_S)
+    const status = await getActionStatus(started.name, POLL_TIMEOUT_S, profile)
 
     if (!status.running) {
       if (status.exit_code != null && status.exit_code !== 0) {
@@ -35,11 +35,11 @@ async function awaitAction(started: ActionResponse): Promise<void> {
 // indicator. Self-contained and never rejects, so every trigger — Cmd+K, the
 // messaging save/toggle toasts — gets identical feedback from a plain
 // `void runGatewayRestart()`, and a failure is the only thing that toasts.
-export async function runGatewayRestart(): Promise<void> {
+export async function runGatewayRestart(profile?: string): Promise<void> {
   $gatewayRestarting.set(true)
 
   try {
-    await awaitAction(await restartGateway())
+    await awaitAction(await restartGateway(profile), profile)
   } catch (err) {
     notifyError(err, translateNow('commandCenter.gatewayRestartFailed'))
   } finally {

--- a/apps/desktop/src/webhooks-rest.test.ts
+++ b/apps/desktop/src/webhooks-rest.test.ts
@@ -19,15 +19,15 @@ describe('Webhook REST parity helpers', () => {
   })
 
   it('lists webhooks from the admin endpoint', async () => {
-    await getWebhooks()
+    await getWebhooks('coder')
 
-    expect(api).toHaveBeenCalledWith(expect.objectContaining({ path: '/api/webhooks' }))
+    expect(api).toHaveBeenCalledWith(expect.objectContaining({ path: '/api/webhooks', profile: 'coder' }))
   })
 
   it('enables the webhook platform with POST', async () => {
-    await enableWebhooks()
+    await enableWebhooks('coder')
 
-    expect(api).toHaveBeenCalledWith(expect.objectContaining({ method: 'POST', path: '/api/webhooks/enable' }))
+    expect(api).toHaveBeenCalledWith(expect.objectContaining({ method: 'POST', path: '/api/webhooks/enable', profile: 'coder' }))
   })
 
   it('creates a subscription with the full payload', async () => {
@@ -40,24 +40,25 @@ describe('Webhook REST parity helpers', () => {
       prompt: 'summarize the push'
     }
 
-    await createWebhook(body)
+    await createWebhook(body, 'coder')
 
-    expect(api).toHaveBeenCalledWith(expect.objectContaining({ body, method: 'POST', path: '/api/webhooks' }))
+    expect(api).toHaveBeenCalledWith(expect.objectContaining({ body, method: 'POST', path: '/api/webhooks', profile: 'coder' }))
   })
 
   it('encodes the name when deleting a subscription', async () => {
-    await deleteWebhook('my hook')
+    await deleteWebhook('my hook', 'coder')
 
-    expect(api).toHaveBeenCalledWith(expect.objectContaining({ method: 'DELETE', path: '/api/webhooks/my%20hook' }))
+    expect(api).toHaveBeenCalledWith(expect.objectContaining({ method: 'DELETE', path: '/api/webhooks/my%20hook', profile: 'coder' }))
   })
 
   it('toggles a subscription enabled state via PUT', async () => {
-    await setWebhookEnabled('github-push', false)
+    await setWebhookEnabled('github-push', false, 'coder')
 
     expect(api).toHaveBeenCalledWith(
       expect.objectContaining({
         body: { enabled: false },
         method: 'PUT',
+        profile: 'coder',
         path: '/api/webhooks/github-push/enabled'
       })
     )

--- a/apps/desktop/src/webhooks-rest.test.ts
+++ b/apps/desktop/src/webhooks-rest.test.ts
@@ -27,7 +27,9 @@ describe('Webhook REST parity helpers', () => {
   it('enables the webhook platform with POST', async () => {
     await enableWebhooks('coder')
 
-    expect(api).toHaveBeenCalledWith(expect.objectContaining({ method: 'POST', path: '/api/webhooks/enable', profile: 'coder' }))
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'POST', path: '/api/webhooks/enable', profile: 'coder' })
+    )
   })
 
   it('creates a subscription with the full payload', async () => {
@@ -42,13 +44,17 @@ describe('Webhook REST parity helpers', () => {
 
     await createWebhook(body, 'coder')
 
-    expect(api).toHaveBeenCalledWith(expect.objectContaining({ body, method: 'POST', path: '/api/webhooks', profile: 'coder' }))
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({ body, method: 'POST', path: '/api/webhooks', profile: 'coder' })
+    )
   })
 
   it('encodes the name when deleting a subscription', async () => {
     await deleteWebhook('my hook', 'coder')
 
-    expect(api).toHaveBeenCalledWith(expect.objectContaining({ method: 'DELETE', path: '/api/webhooks/my%20hook', profile: 'coder' }))
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'DELETE', path: '/api/webhooks/my%20hook', profile: 'coder' })
+    )
   })
 
   it('toggles a subscription enabled state via PUT', async () => {


### PR DESCRIPTION
## Summary

- bind Webhooks queries, mutations, and manual gateway restarts to the active backend profile captured by the view;
- key the profile-owned inner view by backend profile so drafts, dialogs, pending deletes, restart state, and one-time secrets are discarded immediately on profile switch;
- ignore asynchronous completions from an unmounted previous-profile operation scope;
- make that lifecycle guard StrictMode-safe by restoring `ownerActive.current = true` on every effect setup before installing the existing cleanup;
- extend the REST helpers to accept an explicit profile instead of resolving mutable global profile state at completion time.

Fixes #71352.

## Root cause

The Webhooks view used `$profileScope` as its React Query key. In **All profiles** mode that value remains `__all__` while `$activeGatewayProfile` changes, so the component did not reset or refetch at the backend-owner boundary. Meanwhile the REST helpers resolved the active profile globally when each call executed. A draft or in-flight create started under profile A could therefore complete after switching to profile B and surface profile A's one-time secret in profile B's view.

The view now captures the normalized active backend profile, mounts a keyed profile-owned operation scope, and passes that profile explicitly through every relevant REST and restart call.

The initial operation-scope cleanup also left `ownerActive` false after React StrictMode's development setup → cleanup → setup rehearsal. The setup now explicitly reactivates the current owner while unmount/profile-switch cleanup still deactivates the superseded owner.

## Regression coverage

- switching the active backend profile while the sidebar remains in All profiles drops the previous draft and fetches the new profile;
- a create operation started under profile A is sent explicitly to A, and its completion after switching to B cannot render A's secret or toast success;
- a normal create inside a `<StrictMode>` wrapper accepts its deferred completion when no profile switch occurs, renders the one-time secret, and emits the success notification;
- Webhook REST contract tests pin explicit profile forwarding for list, enable, create, delete, and toggle operations.

The StrictMode regression fails before `17a72d230` because the rehearsal cleanup permanently deactivates the owner, and passes with the fix.

## Verification

- rebased cleanly onto current `main` (`f51aa6a9`);
- focused Webhooks component and REST tests: **8 passed across 2 files**;
- full Desktop renderer, Electron, and E2E typecheck: passed;
- focused ESLint: passed;
- Prettier: passed;
- production renderer/Electron build and native-dependency staging: passed;
- `git diff --check`: clean.
- upstream `All required checks pass`: green, including the full Desktop UI suite.


