### PR TITLE
fix(agent): let operators pin ANTHROPIC_TOKEN over borrowed Claude Code creds

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1240,7 +1240,16 @@ def _prefer_refreshable_claude_code_token(env_token: str, creds: Optional[Dict[s
     later refresh impossible because the static env token wins before we ever
     inspect Claude Code's refreshable credential file. If we have a refreshable
     Claude Code credential record, prefer it over the static env OAuth token.
+
+    Operators who manage ANTHROPIC_TOKEN deliberately (external rotation
+    scripts, multi-account pinning) can set
+    ``HERMES_ANTHROPIC_TOKEN_AUTHORITATIVE=1`` to disable this preference:
+    Claude Code's login may belong to a *different* account than the managed
+    token, and silently swapping it in moves Hermes onto the wrong account's
+    rate-limit pool.
     """
+    if os.getenv("HERMES_ANTHROPIC_TOKEN_AUTHORITATIVE", "").lower() in {"1", "true", "yes", "on"}:
+        return None
     if not env_token or not _is_oauth_token(env_token) or not isinstance(creds, dict):
         return None
     if not creds.get("refreshToken"):

--- a/tests/agent/test_anthropic_env_token_authoritative.py
+++ b/tests/agent/test_anthropic_env_token_authoritative.py
@@ -1,0 +1,75 @@
+"""HERMES_ANTHROPIC_TOKEN_AUTHORITATIVE pins an operator-managed ANTHROPIC_TOKEN.
+
+Without the flag, ``resolve_anthropic_token()`` deliberately prefers Claude
+Code's refreshable credential record over a static env OAuth token (so a
+stale persisted setup token cannot block refresh). That heuristic backfires
+when ANTHROPIC_TOKEN is *actively managed* by an external rotation script:
+Claude Code's login can belong to a different — possibly rate-limited —
+account, and the silent swap moves Hermes onto the wrong rate-limit pool
+with no log line above DEBUG.
+
+The opt-in flag declares "this env token is authoritative — never shadow it".
+Default behavior (flag unset) is unchanged.
+"""
+
+import pytest
+
+ENV_TOKEN = "sk-ant-oat01-managed-by-operator"
+CLAUDE_CODE_TOKEN = "sk-ant-oat01-claude-code-borrowed"
+
+
+def _claude_code_creds():
+    return {
+        "accessToken": CLAUDE_CODE_TOKEN,
+        "refreshToken": "rt-refreshable",
+        "expiresAt": 4102444800000,  # 2100-01-01 — always valid
+        "source": "file",
+    }
+
+
+@pytest.fixture
+def isolated_env(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "HERMES_ANTHROPIC_TOKEN_AUTHORITATIVE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials",
+        _claude_code_creds,
+    )
+    return monkeypatch
+
+
+def test_authoritative_env_token_is_never_shadowed(isolated_env):
+    isolated_env.setenv("ANTHROPIC_TOKEN", ENV_TOKEN)
+    isolated_env.setenv("HERMES_ANTHROPIC_TOKEN_AUTHORITATIVE", "1")
+
+    from agent.anthropic_adapter import resolve_anthropic_token
+
+    assert resolve_anthropic_token() == ENV_TOKEN
+
+
+def test_default_still_prefers_refreshable_claude_code_creds(isolated_env):
+    # Documents the existing default: without the opt-in flag, a refreshable
+    # Claude Code credential is preferred over a static env OAuth token.
+    isolated_env.setenv("ANTHROPIC_TOKEN", ENV_TOKEN)
+
+    from agent.anthropic_adapter import resolve_anthropic_token
+
+    assert resolve_anthropic_token() == CLAUDE_CODE_TOKEN
+
+
+def test_flag_without_env_token_falls_through_to_claude_code(isolated_env):
+    # The flag pins an EXPLICIT env token only; with no token set, the normal
+    # resolution chain (Claude Code creds, pool, API key) is unchanged.
+    isolated_env.setenv("HERMES_ANTHROPIC_TOKEN_AUTHORITATIVE", "1")
+
+    from agent.anthropic_adapter import resolve_anthropic_token
+
+    assert resolve_anthropic_token() == CLAUDE_CODE_TOKEN


### PR DESCRIPTION
## What

Adds an opt-in `HERMES_ANTHROPIC_TOKEN_AUTHORITATIVE` env flag that stops `_prefer_refreshable_claude_code_token()` from replacing an explicitly set `ANTHROPIC_TOKEN` with Claude Code's borrowed credential file. Default behavior (flag unset) is completely unchanged.

## Why

`resolve_anthropic_token()` deliberately prefers Claude Code's refreshable credential record over a static env OAuth token, so a stale persisted setup token can't block refresh. That heuristic is correct for its original case, but it backfires when the operator manages `ANTHROPIC_TOKEN` deliberately (external rotation script, multi-account pinning):

- Claude Code's login can belong to a **different account** than the managed token. The swap silently moves Hermes onto that account's rate-limit pool, and the only trace is a DEBUG-level log line.
- `_try_refresh_anthropic_client_credentials()` re-runs the resolver **on every request**, so the swap also overrides credential-pool selection — no pool priority, pinning, or rotation setup can win against it.

### Real incident (how we found this)

Our Hermes gateway went completely dark: every Anthropic call returned HTTP 429. The gateway was pinned to a dedicated account with a healthy weekly quota via a rotation script writing `ANTHROPIC_TOKEN`, and its credential pool held three more healthy OAuth accounts. None of that mattered: the machine's Claude Code login was a *different* account whose 7-day cap was at 100% (hard-rejected for ~36h, `retry-after: 129054`), and the resolver preferred it on every single request. The conversation loop capped `Retry-After` at 600s and retried the same shadowed credential, so from the outside the agent was just silent.

## How to test

```bash
scripts/run_tests.sh tests/agent/test_anthropic_env_token_authoritative.py -v
```

Three tests:
- `test_authoritative_env_token_is_never_shadowed` — flag set → env token wins (fails without this patch; this is the regression test)
- `test_default_still_prefers_refreshable_claude_code_creds` — flag unset → existing preference preserved
- `test_flag_without_env_token_falls_through_to_claude_code` — flag set but no env token → normal resolution chain unchanged

Adjacent suites (`tests/agent/test_anthropic_adapter.py`, `tests/agent/test_credential_pool_oat_authtype.py`) show identical results with and without this change (the pre-existing failures on my machine are keychain/environment-specific and reproduce on pristine `main`).

Manually verified on the affected deployment: with the flag set and a healthy managed token, the gateway recovered immediately (429s → successful turns).

## Platforms tested

macOS (Darwin 25.5.0, Python 3.11). The change is a pure env-var gate with no platform-specific behavior.

## Notes

- Searched open/merged PRs and issues for duplicates; nearest match is #6347 (OAuth refresh 403), which is a different problem.
- A follow-up worth discussing separately: the preference currently logs only at DEBUG. Even with this flag available, a WARNING when the resolver swaps accounts would make this failure mode diagnosable.