### PR TITLE
feat(gateway): add post-auth message hooks

### DIFF
--- a/gateway/message_hooks.py
+++ b/gateway/message_hooks.py
@@ -128,7 +128,7 @@ class GatewayDelivery:
             if inspect.isawaitable(native_result):
                 native_result = await native_result
         except Exception:
-            return GatewayDeliveryReceipt(status="failed")
+            return GatewayDeliveryReceipt(status="unknown")
 
         if not isinstance(native_result, SendResult):
             return GatewayDeliveryReceipt(status="unknown")

--- a/gateway/message_hooks.py
+++ b/gateway/message_hooks.py
@@ -1,0 +1,142 @@
+"""Narrow immutable contracts for plugin handling of ordinary gateway messages."""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Literal, Optional
+
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.session import SessionSource
+
+
+DeliveryStatus = Literal["sent", "failed", "unknown"]
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayDeliveryReceipt:
+    """Truthful platform-neutral result of a route-bound host send."""
+
+    status: DeliveryStatus
+    message_id: Optional[str] = None
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayMessageEvent:
+    """Immutable normalized snapshot of an inbound user message."""
+
+    text: str
+    message_id: Optional[str]
+    message_type: str
+    timestamp: str
+    media_urls: tuple[str, ...]
+    media_types: tuple[str, ...]
+    reply_to_message_id: Optional[str]
+    reply_to_text: Optional[str]
+    reply_to_author_id: Optional[str]
+    reply_to_author_name: Optional[str]
+    reply_to_is_own_message: bool
+
+    @classmethod
+    def from_event(cls, event: MessageEvent) -> "GatewayMessageEvent":
+        timestamp = getattr(event, "timestamp", None)
+        timestamp_text = timestamp.isoformat() if hasattr(timestamp, "isoformat") else ""
+        message_type = getattr(getattr(event, "message_type", None), "value", None)
+        return cls(
+            text=str(getattr(event, "text", "") or ""),
+            message_id=_optional_text(getattr(event, "message_id", None)),
+            message_type=str(message_type or ""),
+            timestamp=timestamp_text,
+            media_urls=tuple(str(item) for item in (getattr(event, "media_urls", None) or ())),
+            media_types=tuple(str(item) for item in (getattr(event, "media_types", None) or ())),
+            reply_to_message_id=_optional_text(
+                getattr(event, "reply_to_message_id", None)
+            ),
+            reply_to_text=_optional_text(getattr(event, "reply_to_text", None)),
+            reply_to_author_id=_optional_text(
+                getattr(event, "reply_to_author_id", None)
+            ),
+            reply_to_author_name=_optional_text(
+                getattr(event, "reply_to_author_name", None)
+            ),
+            reply_to_is_own_message=bool(
+                getattr(event, "reply_to_is_own_message", False)
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayMessageRoute:
+    """Immutable normalized route for the current inbound source."""
+
+    session_key: str
+    platform: str
+    profile: Optional[str]
+    scope_id: Optional[str]
+    chat_id: str
+    chat_name: Optional[str]
+    chat_type: str
+    thread_id: Optional[str]
+    user_id: Optional[str]
+    user_name: Optional[str]
+
+    @classmethod
+    def from_source(
+        cls,
+        source: SessionSource,
+        *,
+        session_key: str,
+    ) -> "GatewayMessageRoute":
+        platform = getattr(getattr(source, "platform", None), "value", None)
+        profile = _optional_text(getattr(source, "profile", None))
+        if profile is None:
+            from hermes_cli.profiles import get_active_profile_name
+
+            profile = _optional_text(get_active_profile_name())
+        return cls(
+            session_key=str(session_key or ""),
+            platform=str(platform or ""),
+            profile=profile,
+            scope_id=_optional_text(getattr(source, "scope_id", None)),
+            chat_id=str(getattr(source, "chat_id", "") or ""),
+            chat_name=_optional_text(getattr(source, "chat_name", None)),
+            chat_type=str(getattr(source, "chat_type", "") or ""),
+            thread_id=_optional_text(getattr(source, "thread_id", None)),
+            user_id=_optional_text(getattr(source, "user_id", None)),
+            user_name=_optional_text(getattr(source, "user_name", None)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayDelivery:
+    """Capability that can send only to the route captured by its host callback."""
+
+    _send_callback: Callable[[str], Awaitable[Any] | Any] = field(
+        repr=False,
+        compare=False,
+    )
+
+    async def send(self, content: str) -> GatewayDeliveryReceipt:
+        """Send text to the bound source and normalize the native acknowledgement."""
+        try:
+            native_result = self._send_callback(str(content))
+            if inspect.isawaitable(native_result):
+                native_result = await native_result
+        except Exception:
+            return GatewayDeliveryReceipt(status="failed")
+
+        if not isinstance(native_result, SendResult):
+            return GatewayDeliveryReceipt(status="unknown")
+        if native_result.success is False:
+            return GatewayDeliveryReceipt(status="failed")
+        message_id = _optional_text(native_result.message_id)
+        if native_result.success is True and message_id:
+            return GatewayDeliveryReceipt(status="sent", message_id=message_id)
+        return GatewayDeliveryReceipt(status="unknown")
+
+
+def _optional_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None

--- a/gateway/message_hooks.py
+++ b/gateway/message_hooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import weakref
 from dataclasses import dataclass
@@ -40,9 +41,11 @@ class GatewayMessageEvent:
     reply_to_author_id: Optional[str]
     reply_to_author_name: Optional[str]
     reply_to_is_own_message: bool
+    coverage_gaps: tuple[str, ...] = ()
 
     @classmethod
     def from_event(cls, event: MessageEvent) -> "GatewayMessageEvent":
+        gaps: set[str] = set()
         timestamp = getattr(event, "timestamp", None)
         timestamp_text = timestamp.isoformat() if hasattr(timestamp, "isoformat") else ""
         message_type = getattr(getattr(event, "message_type", None), "value", None)
@@ -51,34 +54,95 @@ class GatewayMessageEvent:
             metadata.get("mentioned_user_ids") if isinstance(metadata, dict) else None
         )
         mentioned_user_ids = None
-        if isinstance(raw_mentioned_user_ids, (list, tuple)) and all(
-            isinstance(item, str) and item for item in raw_mentioned_user_ids
-        ):
-            mentioned_user_ids = tuple(raw_mentioned_user_ids)
+        if isinstance(raw_mentioned_user_ids, (list, tuple)):
+            mention_values = raw_mentioned_user_ids[:129]
+            if len(raw_mentioned_user_ids) > 128:
+                gaps.add("mention-count-overflow")
+            if all(isinstance(item, str) and item for item in mention_values[:128]):
+                mentioned_user_ids = tuple(
+                    _bounded_text(
+                        item,
+                        512,
+                        "mention-id-overflow",
+                        gaps,
+                    )
+                    for item in mention_values[:128]
+                )
         raw_mentions_room = metadata.get("mentions_room") if isinstance(metadata, dict) else None
         mentions_room = raw_mentions_room if isinstance(raw_mentions_room, bool) else None
+        media_urls = _bounded_items(
+            getattr(event, "media_urls", None),
+            count_limit=16,
+            item_limit=4_096,
+            count_gap="media-count-overflow",
+            item_gap="media-url-overflow",
+            gaps=gaps,
+        )
+        media_types = _bounded_items(
+            getattr(event, "media_types", None),
+            count_limit=16,
+            item_limit=256,
+            count_gap="media-count-overflow",
+            item_gap="media-type-overflow",
+            gaps=gaps,
+        )
         return cls(
-            text=str(getattr(event, "text", "") or ""),
-            message_id=_optional_text(getattr(event, "message_id", None)),
-            message_type=str(message_type or ""),
-            timestamp=timestamp_text,
-            media_urls=tuple(str(item) for item in (getattr(event, "media_urls", None) or ())),
-            media_types=tuple(str(item) for item in (getattr(event, "media_types", None) or ())),
+            text=_bounded_text(
+                getattr(event, "text", "") or "",
+                65_536,
+                "text-overflow",
+                gaps,
+            ),
+            message_id=_bounded_optional_text(
+                getattr(event, "message_id", None),
+                512,
+                "message-id-overflow",
+                gaps,
+            ),
+            message_type=_bounded_text(
+                message_type or "",
+                64,
+                "message-type-overflow",
+                gaps,
+            ),
+            timestamp=_bounded_text(
+                timestamp_text,
+                128,
+                "timestamp-overflow",
+                gaps,
+            ),
+            media_urls=media_urls,
+            media_types=media_types,
             mentioned_user_ids=mentioned_user_ids,
             mentions_room=mentions_room,
-            reply_to_message_id=_optional_text(
-                getattr(event, "reply_to_message_id", None)
+            reply_to_message_id=_bounded_optional_text(
+                getattr(event, "reply_to_message_id", None),
+                512,
+                "reply-message-id-overflow",
+                gaps,
             ),
-            reply_to_text=_optional_text(getattr(event, "reply_to_text", None)),
-            reply_to_author_id=_optional_text(
-                getattr(event, "reply_to_author_id", None)
+            reply_to_text=_bounded_optional_text(
+                getattr(event, "reply_to_text", None),
+                16_384,
+                "reply-text-overflow",
+                gaps,
             ),
-            reply_to_author_name=_optional_text(
-                getattr(event, "reply_to_author_name", None)
+            reply_to_author_id=_bounded_optional_text(
+                getattr(event, "reply_to_author_id", None),
+                512,
+                "reply-author-id-overflow",
+                gaps,
+            ),
+            reply_to_author_name=_bounded_optional_text(
+                getattr(event, "reply_to_author_name", None),
+                4_096,
+                "reply-author-name-overflow",
+                gaps,
             ),
             reply_to_is_own_message=bool(
                 getattr(event, "reply_to_is_own_message", False)
             ),
+            coverage_gaps=tuple(sorted(gaps)),
         )
 
 
@@ -96,6 +160,7 @@ class GatewayMessageRoute:
     thread_id: Optional[str]
     user_id: Optional[str]
     user_name: Optional[str]
+    coverage_gaps: tuple[str, ...] = ()
 
     @classmethod
     def from_source(
@@ -104,62 +169,243 @@ class GatewayMessageRoute:
         *,
         session_key: str,
     ) -> "GatewayMessageRoute":
+        gaps: set[str] = set()
         platform = getattr(getattr(source, "platform", None), "value", None)
-        profile = _optional_text(getattr(source, "profile", None))
+        profile_value = getattr(source, "profile", None)
+        profile = _optional_text(profile_value)
         if profile is None:
             from hermes_cli.profiles import get_active_profile_name
 
             profile = _optional_text(get_active_profile_name())
         return cls(
-            session_key=str(session_key or ""),
-            platform=str(platform or ""),
-            profile=profile,
-            scope_id=_optional_text(getattr(source, "scope_id", None)),
-            chat_id=str(getattr(source, "chat_id", "") or ""),
-            chat_name=_optional_text(getattr(source, "chat_name", None)),
-            chat_type=str(getattr(source, "chat_type", "") or ""),
-            thread_id=_optional_text(getattr(source, "thread_id", None)),
-            user_id=_optional_text(getattr(source, "user_id", None)),
-            user_name=_optional_text(getattr(source, "user_name", None)),
+            session_key=_bounded_text(
+                session_key or "", 2_048, "session-key-overflow", gaps
+            ),
+            platform=_bounded_text(
+                platform or "", 64, "platform-overflow", gaps
+            ),
+            profile=_bounded_optional_text(
+                profile, 256, "profile-overflow", gaps
+            ),
+            scope_id=_bounded_optional_text(
+                getattr(source, "scope_id", None), 512, "scope-id-overflow", gaps
+            ),
+            chat_id=_bounded_text(
+                getattr(source, "chat_id", "") or "",
+                512,
+                "chat-id-overflow",
+                gaps,
+            ),
+            chat_name=_bounded_optional_text(
+                getattr(source, "chat_name", None),
+                4_096,
+                "chat-name-overflow",
+                gaps,
+            ),
+            chat_type=_bounded_text(
+                getattr(source, "chat_type", "") or "",
+                64,
+                "chat-type-overflow",
+                gaps,
+            ),
+            thread_id=_bounded_optional_text(
+                getattr(source, "thread_id", None),
+                512,
+                "thread-id-overflow",
+                gaps,
+            ),
+            user_id=_bounded_optional_text(
+                getattr(source, "user_id", None), 512, "user-id-overflow", gaps
+            ),
+            user_name=_bounded_optional_text(
+                getattr(source, "user_name", None),
+                4_096,
+                "user-name-overflow",
+                gaps,
+            ),
+            coverage_gaps=tuple(sorted(gaps)),
         )
 
 
+@dataclass(slots=True)
+class _DeliveryRequest:
+    kind: Literal["send", "reply", "react"]
+    content: str
+    operation: str
+    future: asyncio.Future[GatewayDeliveryReceipt]
+
+
+@dataclass(slots=True)
+class _DeliveryChannel:
+    queue: asyncio.Queue[_DeliveryRequest]
+    revoked: bool = False
+    consumed: bool = False
+
+
 class GatewayDelivery:
-    """Capability that can send only to the route captured by its host callback."""
+    """Opaque, one-shot capability bound to a host-owned delivery worker."""
 
     __slots__ = ("__weakref__",)
 
-    def __init__(self, send_callback: Callable[[str], Awaitable[Any] | Any]) -> None:
+    def __init__(
+        self,
+        send_callback: Callable[[str], Awaitable[Any] | Any],
+        *,
+        reply_callback: Callable[[str], Awaitable[Any] | Any] | None = None,
+        react_callback: Callable[[str, str], Awaitable[Any] | Any] | None = None,
+    ) -> None:
         if not callable(send_callback):
             raise TypeError("send_callback must be callable")
-        _DELIVERY_SEND_CALLBACKS[self] = send_callback
+        channel = _DeliveryChannel(queue=asyncio.Queue(maxsize=1))
+        _DELIVERY_CHANNELS[self] = channel
+        worker = asyncio.create_task(
+            _delivery_worker(
+                channel,
+                send_callback,
+                reply_callback=reply_callback,
+                react_callback=react_callback,
+            )
+        )
+        worker.add_done_callback(_consume_delivery_worker_result)
 
     async def send(self, content: str) -> GatewayDeliveryReceipt:
         """Send text to the bound source and normalize the native acknowledgement."""
-        try:
-            send_callback = _DELIVERY_SEND_CALLBACKS.get(self)
-            if send_callback is None:
-                return GatewayDeliveryReceipt(status="failed")
-            native_result = send_callback(str(content))
-            if inspect.isawaitable(native_result):
-                native_result = await native_result
-        except Exception:
-            return GatewayDeliveryReceipt(status="unknown")
+        return await self._submit("send", str(content), "")
 
-        if not isinstance(native_result, SendResult):
-            return GatewayDeliveryReceipt(status="unknown")
-        if native_result.success is False:
+    async def reply(self, content: str) -> GatewayDeliveryReceipt:
+        """Reply only to the native message captured by this capability."""
+        return await self._submit("reply", str(content), "")
+
+    async def react(
+        self,
+        reaction: str,
+        *,
+        operation: str = "add",
+    ) -> GatewayDeliveryReceipt:
+        """Add/remove one reaction on the captured native message."""
+        if operation not in {"add", "remove"}:
             return GatewayDeliveryReceipt(status="failed")
-        message_id = _optional_text(native_result.message_id)
-        if native_result.success is True and message_id:
-            return GatewayDeliveryReceipt(status="sent", message_id=message_id)
-        return GatewayDeliveryReceipt(status="unknown")
+        return await self._submit("react", str(reaction), operation)
+
+    async def _submit(
+        self,
+        kind: Literal["send", "reply", "react"],
+        content: str,
+        operation: str,
+    ) -> GatewayDeliveryReceipt:
+        channel = _DELIVERY_CHANNELS.get(self)
+        if channel is None or channel.revoked or channel.consumed:
+            return GatewayDeliveryReceipt(status="failed")
+        channel.consumed = True
+        future = asyncio.get_running_loop().create_future()
+        try:
+            channel.queue.put_nowait(
+                _DeliveryRequest(
+                    kind=kind,
+                    content=content,
+                    operation=operation,
+                    future=future,
+                )
+            )
+        except asyncio.QueueFull:
+            return GatewayDeliveryReceipt(status="failed")
+        return await future
+
+    def _revoke(self) -> None:
+        """Invalidate this capability synchronously at a host lifecycle boundary."""
+        channel = _DELIVERY_CHANNELS.get(self)
+        if channel is not None:
+            channel.revoked = True
+            if not channel.consumed:
+                channel.consumed = True
+                try:
+                    future = asyncio.get_running_loop().create_future()
+                    channel.queue.put_nowait(
+                        _DeliveryRequest(
+                            kind="send",
+                            content="",
+                            operation="",
+                            future=future,
+                        )
+                    )
+                except (RuntimeError, asyncio.QueueFull):
+                    pass
 
 
-_DELIVERY_SEND_CALLBACKS: weakref.WeakKeyDictionary[
+_DELIVERY_CHANNELS: weakref.WeakKeyDictionary[
     GatewayDelivery,
-    Callable[[str], Awaitable[Any] | Any],
+    _DeliveryChannel,
 ] = weakref.WeakKeyDictionary()
+
+
+async def _delivery_worker(
+    channel: _DeliveryChannel,
+    send_callback: Callable[[str], Awaitable[Any] | Any],
+    *,
+    reply_callback: Callable[[str], Awaitable[Any] | Any] | None,
+    react_callback: Callable[[str, str], Awaitable[Any] | Any] | None,
+) -> None:
+    request: _DeliveryRequest | None = None
+    while request is None:
+        try:
+            request = channel.queue.get_nowait()
+        except asyncio.QueueEmpty:
+            if channel.revoked:
+                return
+            # Polling deliberately leaves no queue waiter that can be traversed
+            # from the public capability into this host task's callback frame.
+            await asyncio.sleep(0.01)
+    if channel.revoked:
+        if not request.future.done():
+            request.future.set_result(GatewayDeliveryReceipt(status="failed"))
+        return
+    try:
+        # No suspension occurs between the authoritative revocation check and
+        # native invocation. A boundary that wins first therefore prevents the
+        # adapter call; a boundary after invocation can only make its outcome
+        # ambiguous, never fabricate success.
+        if request.kind == "reply":
+            if not callable(reply_callback):
+                native_result = SendResult(success=False)
+            else:
+                native_result = reply_callback(request.content)
+        elif request.kind == "react":
+            if not callable(react_callback):
+                native_result = SendResult(success=False)
+            else:
+                native_result = react_callback(request.content, request.operation)
+        else:
+            native_result = send_callback(request.content)
+        if inspect.isawaitable(native_result):
+            native_result = await native_result
+    except Exception:
+        receipt = GatewayDeliveryReceipt(status="unknown")
+    else:
+        receipt = _normalize_delivery_receipt(native_result)
+        if channel.revoked and receipt.status == "sent":
+            receipt = GatewayDeliveryReceipt(status="unknown")
+    if not request.future.done():
+        request.future.set_result(receipt)
+
+
+def _normalize_delivery_receipt(native_result: Any) -> GatewayDeliveryReceipt:
+    if not isinstance(native_result, SendResult):
+        return GatewayDeliveryReceipt(status="unknown")
+    if native_result.success is False:
+        return GatewayDeliveryReceipt(status="failed")
+    message_id = _optional_text(native_result.message_id)
+    if native_result.success is True and message_id:
+        return GatewayDeliveryReceipt(status="sent", message_id=message_id)
+    return GatewayDeliveryReceipt(status="unknown")
+
+
+def _consume_delivery_worker_result(task: asyncio.Task[None]) -> None:
+    if task.cancelled():
+        return
+    try:
+        task.exception()
+    except Exception:
+        pass
 
 
 def _optional_text(value: Any) -> Optional[str]:
@@ -167,3 +413,52 @@ def _optional_text(value: Any) -> Optional[str]:
         return None
     text = str(value)
     return text if text else None
+
+
+def _bounded_text(
+    value: Any,
+    byte_limit: int,
+    gap: str,
+    gaps: set[str],
+) -> str:
+    text = str(value)
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) <= byte_limit:
+        return text
+    gaps.add(gap)
+    return encoded[:byte_limit].decode("utf-8", errors="ignore")
+
+
+def _bounded_optional_text(
+    value: Any,
+    byte_limit: int,
+    gap: str,
+    gaps: set[str],
+) -> Optional[str]:
+    if value is None:
+        return None
+    text = _bounded_text(value, byte_limit, gap, gaps)
+    return text if text else None
+
+
+def _bounded_items(
+    values: Any,
+    *,
+    count_limit: int,
+    item_limit: int,
+    count_gap: str,
+    item_gap: str,
+    gaps: set[str],
+) -> tuple[str, ...]:
+    if not values:
+        return ()
+    items = list(values[: count_limit + 1]) if isinstance(values, (list, tuple)) else []
+    if not isinstance(values, (list, tuple)):
+        gaps.add(count_gap)
+        return ()
+    if len(values) > count_limit:
+        gaps.add(count_gap)
+    return tuple(
+        _bounded_text(item, item_limit, item_gap, gaps)
+        for item in items[:count_limit]
+    )

--- a/gateway/message_hooks.py
+++ b/gateway/message_hooks.py
@@ -9,6 +9,7 @@ from typing import Any, Awaitable, Callable, Literal, Optional
 
 from gateway.platforms.base import MessageEvent, SendResult
 from gateway.session import SessionSource
+from hermes_constants import GATEWAY_MESSAGE_HOOK_API_VERSION
 
 
 DeliveryStatus = Literal["sent", "failed", "unknown"]
@@ -32,6 +33,8 @@ class GatewayMessageEvent:
     timestamp: str
     media_urls: tuple[str, ...]
     media_types: tuple[str, ...]
+    mentioned_user_ids: tuple[str, ...] | None
+    mentions_room: bool | None
     reply_to_message_id: Optional[str]
     reply_to_text: Optional[str]
     reply_to_author_id: Optional[str]
@@ -43,6 +46,17 @@ class GatewayMessageEvent:
         timestamp = getattr(event, "timestamp", None)
         timestamp_text = timestamp.isoformat() if hasattr(timestamp, "isoformat") else ""
         message_type = getattr(getattr(event, "message_type", None), "value", None)
+        metadata = getattr(event, "metadata", None)
+        raw_mentioned_user_ids = (
+            metadata.get("mentioned_user_ids") if isinstance(metadata, dict) else None
+        )
+        mentioned_user_ids = None
+        if isinstance(raw_mentioned_user_ids, (list, tuple)) and all(
+            isinstance(item, str) and item for item in raw_mentioned_user_ids
+        ):
+            mentioned_user_ids = tuple(raw_mentioned_user_ids)
+        raw_mentions_room = metadata.get("mentions_room") if isinstance(metadata, dict) else None
+        mentions_room = raw_mentions_room if isinstance(raw_mentions_room, bool) else None
         return cls(
             text=str(getattr(event, "text", "") or ""),
             message_id=_optional_text(getattr(event, "message_id", None)),
@@ -50,6 +64,8 @@ class GatewayMessageEvent:
             timestamp=timestamp_text,
             media_urls=tuple(str(item) for item in (getattr(event, "media_urls", None) or ())),
             media_types=tuple(str(item) for item in (getattr(event, "media_types", None) or ())),
+            mentioned_user_ids=mentioned_user_ids,
+            mentions_room=mentions_room,
             reply_to_message_id=_optional_text(
                 getattr(event, "reply_to_message_id", None)
             ),

--- a/gateway/message_hooks.py
+++ b/gateway/message_hooks.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import inspect
-from dataclasses import dataclass, field
+import weakref
+from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Literal, Optional
 
 from gateway.platforms.base import MessageEvent, SendResult
@@ -107,19 +108,23 @@ class GatewayMessageRoute:
         )
 
 
-@dataclass(frozen=True, slots=True)
 class GatewayDelivery:
     """Capability that can send only to the route captured by its host callback."""
 
-    _send_callback: Callable[[str], Awaitable[Any] | Any] = field(
-        repr=False,
-        compare=False,
-    )
+    __slots__ = ("__weakref__",)
+
+    def __init__(self, send_callback: Callable[[str], Awaitable[Any] | Any]) -> None:
+        if not callable(send_callback):
+            raise TypeError("send_callback must be callable")
+        _DELIVERY_SEND_CALLBACKS[self] = send_callback
 
     async def send(self, content: str) -> GatewayDeliveryReceipt:
         """Send text to the bound source and normalize the native acknowledgement."""
         try:
-            native_result = self._send_callback(str(content))
+            send_callback = _DELIVERY_SEND_CALLBACKS.get(self)
+            if send_callback is None:
+                return GatewayDeliveryReceipt(status="failed")
+            native_result = send_callback(str(content))
             if inspect.isawaitable(native_result):
                 native_result = await native_result
         except Exception:
@@ -133,6 +138,12 @@ class GatewayDelivery:
         if native_result.success is True and message_id:
             return GatewayDeliveryReceipt(status="sent", message_id=message_id)
         return GatewayDeliveryReceipt(status="unknown")
+
+
+_DELIVERY_SEND_CALLBACKS: weakref.WeakKeyDictionary[
+    GatewayDelivery,
+    Callable[[str], Awaitable[Any] | Any],
+] = weakref.WeakKeyDictionary()
 
 
 def _optional_text(value: Any) -> Optional[str]:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3119,6 +3119,17 @@ class BasePlatformAdapter(ABC):
         """
         pass
 
+    async def react(
+        self,
+        chat_id: str,
+        message_id: str,
+        reaction: str,
+        *,
+        operation: str = "add",
+    ) -> SendResult:
+        """Apply one route-bound reaction when the adapter supports it."""
+        return SendResult(success=False, error="Reactions are unavailable")
+
     # Default: the adapter treats ``finalize=True`` on edit_message as a
     # no-op and is happy to have the stream consumer skip redundant final
     # edits.  Subclasses that *require* an explicit finalize call to close

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4870,11 +4870,19 @@ class BasePlatformAdapter(ABC):
         # Offloaded: the sync hook must not block the loop.
         await asyncio.to_thread(self._apply_topic_recovery, event)
 
-        session_key = build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+        runner_session_key = getattr(
+            getattr(self, "gateway_runner", None),
+            "_session_key_for_source",
+            None,
         )
+        if callable(runner_session_key):
+            session_key = runner_session_key(event.source)
+        else:
+            session_key = build_session_key(
+                event.source,
+                group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+                thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+            )
 
         # On-entry self-heal: if the adapter still has an _active_sessions
         # entry for this key but the owner task has already exited (done or

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6246,6 +6246,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return True
 
+        # Busy ingress bypasses the cold _handle_message entry. Apply the
+        # existing pre-dispatch policy here first and mark it one-shot so a
+        # later queue fallback cannot invoke it twice.
+        if self._run_pre_gateway_dispatch(event):
+            return True
+
         # Real busy-session ingress returns from BasePlatformAdapter after this
         # handler. Invoke the post-authorization participant seam before any
         # host queue, steer, redirect, or interrupt effect so ordinary live
@@ -9617,7 +9623,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Shutdown acceptance closes before any observer or adapter await.
             # Every retained participant delivery is invalid at this point,
             # including sessions with no currently running host agent.
-            self._revoke_all_gateway_deliveries()
+            _revoke_deliveries = getattr(
+                self,
+                "_revoke_all_gateway_deliveries",
+                None,
+            )
+            if callable(_revoke_deliveries):
+                _revoke_deliveries()
 
             stop_watchdog = getattr(self, "_stop_systemd_watchdog", None)
             if callable(stop_watchdog):
@@ -10778,6 +10790,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         return switched
 
+    def _run_pre_gateway_dispatch(self, event: MessageEvent) -> bool:
+        """Apply the legacy pre-dispatch policy once; return True when skipped."""
+        marker = "_hermes_pre_gateway_dispatch_done"
+        if getattr(event, marker, False):
+            return False
+        setattr(event, marker, True)
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+            hook_results = _invoke_hook(
+                "pre_gateway_dispatch",
+                event=event,
+                gateway=self,
+                session_store=self.session_store,
+            )
+        except Exception as hook_exc:
+            logger.warning("pre_gateway_dispatch invocation failed: %s", hook_exc)
+            hook_results = []
+
+        for result in hook_results:
+            if not isinstance(result, dict):
+                continue
+            action = result.get("action")
+            if action == "skip":
+                source = event.source
+                logger.info(
+                    "pre_gateway_dispatch skip: reason=%s platform=%s chat=%s",
+                    result.get("reason"),
+                    source.platform.value if source.platform else "unknown",
+                    source.chat_id or "unknown",
+                )
+                return True
+            if action == "rewrite":
+                new_text = result.get("text")
+                if isinstance(new_text, str):
+                    event.text = new_text
+                break
+            if action == "allow":
+                break
+        return False
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
         Handle an incoming message from any platform.
@@ -10849,46 +10902,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not is_internal:
             self._scale_to_zero_note_real_inbound()
 
-        # Fire pre_gateway_dispatch plugin hook for user-originated messages.
-        # Plugins receive the MessageEvent and may return a dict influencing flow:
-        #   {"action": "skip",    "reason": ...}    -> drop (no reply, plugin handled)
-        #   {"action": "rewrite", "text":  ...}     -> replace event.text, continue
-        #   {"action": "allow"}   /   None          -> normal dispatch
-        # Hook runs BEFORE auth so plugins can handle unauthorized senders
-        # (e.g. customer handover ingest) without triggering the pairing flow.
-        if not is_internal:
-            try:
-                from hermes_cli.plugins import invoke_hook as _invoke_hook
-                _hook_results = _invoke_hook(
-                    "pre_gateway_dispatch",
-                    event=event,
-                    gateway=self,
-                    session_store=self.session_store,
-                )
-            except Exception as _hook_exc:
-                logger.warning("pre_gateway_dispatch invocation failed: %s", _hook_exc)
-                _hook_results = []
-
-            for _result in _hook_results:
-                if not isinstance(_result, dict):
-                    continue
-                _action = _result.get("action")
-                if _action == "skip":
-                    logger.info(
-                        "pre_gateway_dispatch skip: reason=%s platform=%s chat=%s",
-                        _result.get("reason"),
-                        source.platform.value if source.platform else "unknown",
-                        source.chat_id or "unknown",
-                    )
-                    return None
-                if _action == "rewrite":
-                    _new_text = _result.get("text")
-                    if isinstance(_new_text, str):
-                        event = dataclasses.replace(event, text=_new_text)
-                        source = event.source
-                    break
-                if _action == "allow":
-                    break
+        # Apply the legacy user-ingress policy exactly once. Busy ingress may
+        # already have passed through this seam in BasePlatformAdapter.
+        if not is_internal and self._run_pre_gateway_dispatch(event):
+            return None
 
         if is_internal:
             pass
@@ -12949,7 +12966,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         source: SessionSource,
         session_key: str,
     ) -> bool:
-        """Run ordinary-message hooks in the already-resolved profile scope."""
+        """Run ordinary-message hooks in the route's profile scope.
+
+        Platform adapters may batch adjacent native messages for the host agent.
+        The participant seam expands retained native snapshots so event IDs,
+        route actors, and mention facts remain attributable to each native event.
+        """
+        if getattr(event, "_hermes_startup_restore_replay", False) or getattr(
+            event,
+            "_hermes_historical_replay",
+            False,
+        ):
+            return False
 
         async def _run_scoped() -> bool:
             native_events = event.metadata.get("_gateway_native_events", ())
@@ -12963,13 +12991,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return True
                 suppressed = False
                 for native_event in native_events:
-                    # Every authorized native Discord ingress crosses the hook
-                    # independently. Continue through the batch even after one
-                    # terminal result so no constituent identity disappears.
+                    # Continue through the entire batch even after one terminal
+                    # result so no authorized native identity disappears.
                     suppressed = (
                         await self._run_gateway_message_hook_scoped(
                             native_event,
-                            source,
+                            native_event.source,
                             session_key,
                         )
                         or suppressed

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12223,15 +12223,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # No bare text matching — "yes" in normal conversation must not trigger
         # execution of a dangerous command.
 
-        # This is the cold-session counterpart to the active-session seam. All
-        # gateway controls and slash capabilities have already had first refusal.
-        if (
-            not is_internal
-            and not event.is_command()
-            and await self._run_gateway_message_hook(event, source, _quick_key)
-        ):
-            return None
-
         if await asyncio.to_thread(self._is_telegram_topic_root_lobby, source):
             # Debounce the lobby reminder so a user who forgets about
             # topic mode and fires ten prompts doesn't get ten copies.
@@ -12287,6 +12278,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _run_generation = self._begin_session_run_generation(_quick_key)
 
         try:
+            # This is the cold-session counterpart to the active-session seam.
+            # Claim before awaiting a plugin so a pass-through hook cannot
+            # reopen the duplicate-agent race protected by the sentinel.
+            if (
+                not is_internal
+                and not event.is_command()
+                and await self._run_gateway_message_hook(event, source, _quick_key)
+            ):
+                return None
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
@@ -12874,13 +12874,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         from hermes_cli.plugins import invoke_hook_async
 
         adapter = self._adapter_for_source(source)
-        metadata = self._thread_metadata_for_source(source, event.message_id)
+        delivery_platform = source.platform
+        delivery_chat_id = str(source.chat_id)
+        delivery_metadata = self._thread_metadata_for_source(source, event.message_id)
+        delivery_via_relay = (
+            getattr(source, "delivered_via_upstream_relay", False) is True
+        )
 
         async def _send_to_source(content: str):
             if adapter is None:
-                return SendResult(success=False, error="No adapter for current route")
+                return SendResult(success=False)
+            metadata = dict(delivery_metadata) if delivery_metadata else None
+            if delivery_via_relay:
+                send_for_platform: Any = getattr(adapter, "send_for_platform", None)
+                if not callable(send_for_platform):
+                    return SendResult(success=False)
+                return await send_for_platform(
+                    delivery_platform,
+                    delivery_chat_id,
+                    content,
+                    metadata=metadata,
+                )
             return await adapter.send(
-                str(source.chat_id),
+                delivery_chat_id,
                 content,
                 metadata=metadata,
             )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11186,6 +11186,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # _interrupt_requested.  Force-clean _running_agents so the session
             # is unlocked and subsequent messages are processed normally.
             if _cmd_def_inner and _cmd_def_inner.name == "stop":
+                await self._notify_gateway_session_cancel(
+                    _quick_key,
+                    source,
+                    reason="stop",
+                )
                 await self._interrupt_and_clear_session(
                     _quick_key,
                     source,
@@ -11412,6 +11417,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"⏳ Agent is running — `/{_cmd_def_inner.name}` can't run "
                     f"mid-turn. Wait for the current response or `/stop` first."
                 )
+
+            # Ordinary user messages reach the plugin seam only after access
+            # checks and every active-session control intercept above.
+            if (
+                not is_internal
+                and not event.is_command()
+                and await self._run_gateway_message_hook(event, source, _quick_key)
+            ):
+                return None
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
@@ -12209,6 +12223,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # No bare text matching — "yes" in normal conversation must not trigger
         # execution of a dangerous command.
 
+        # This is the cold-session counterpart to the active-session seam. All
+        # gateway controls and slash capabilities have already had first refusal.
+        if (
+            not is_internal
+            and not event.is_command()
+            and await self._run_gateway_message_hook(event, source, _quick_key)
+        ):
+            return None
+
         if await asyncio.to_thread(self._is_telegram_topic_root_lobby, source):
             # Debounce the lobby reminder so a user who forgets about
             # topic mode and fires ten prompts doesn't get ten copies.
@@ -12834,6 +12857,102 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
         return source
+
+    async def _run_gateway_message_hook(
+        self,
+        event: MessageEvent,
+        source: SessionSource,
+        session_key: str,
+    ) -> bool:
+        """Return True when an ordinary user-message hook suppresses dispatch."""
+        from gateway.message_hooks import (
+            GatewayDelivery,
+            GatewayMessageEvent,
+            GatewayMessageRoute,
+        )
+        from gateway.platforms.base import SendResult
+        from hermes_cli.plugins import invoke_hook_async
+
+        adapter = self._adapter_for_source(source)
+        metadata = self._thread_metadata_for_source(source, event.message_id)
+
+        async def _send_to_source(content: str):
+            if adapter is None:
+                return SendResult(success=False, error="No adapter for current route")
+            return await adapter.send(
+                str(source.chat_id),
+                content,
+                metadata=metadata,
+            )
+
+        try:
+            results = await invoke_hook_async(
+                "gateway_message",
+                event=GatewayMessageEvent.from_event(event),
+                route=GatewayMessageRoute.from_source(
+                    source,
+                    session_key=session_key,
+                ),
+                delivery=GatewayDelivery(_send_to_source),
+                raise_exceptions=True,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "gateway_message hook failed; suppressing normal dispatch (%s)",
+                type(exc).__name__,
+            )
+            return True
+
+        for result in results:
+            if not isinstance(result, dict):
+                logger.warning(
+                    "gateway_message hook returned invalid terminal result type %s; "
+                    "suppressing normal dispatch",
+                    type(result).__name__,
+                )
+                return True
+            decision = str(result.get("decision", "")).strip().lower()
+            if decision in {"handled", "suppress"}:
+                return True
+            if decision in {"continue", "pass"}:
+                continue
+            logger.warning(
+                "gateway_message hook returned an invalid decision; "
+                "suppressing normal dispatch"
+            )
+            return True
+        return False
+
+    async def _notify_gateway_session_cancel(
+        self,
+        session_key: str,
+        source: SessionSource,
+        *,
+        reason: str,
+    ) -> None:
+        """Best-effort async notification for an explicit session boundary."""
+        from gateway.message_hooks import GatewayMessageRoute
+        from hermes_cli.plugins import invoke_hook_async
+
+        try:
+            await invoke_hook_async(
+                "gateway_session_cancel",
+                route=GatewayMessageRoute.from_source(
+                    source,
+                    session_key=session_key,
+                ),
+                reason=str(reason),
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "gateway_session_cancel hook failed for %s (%s)",
+                session_key,
+                type(exc).__name__,
+            )
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6222,6 +6222,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if getattr(event, "internal", False):
             return False
 
+        # Slash commands that are not in the adapter's immediate bypass set
+        # remain queued for canonical runner command interception. They are
+        # never ordinary participant-visible conversation ingress.
+        if event.is_command():
+            return False
+
         if self._external_drain_active:
             logger.info(
                 "Refusing busy-session follow-up for %s — external drain active.",
@@ -13067,7 +13073,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         session_key=session_key,
                     ),
                     reason=str(reason),
-                    offload_sync=True,
+                    offload_callbacks=True,
                 ),
                 timeout=GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS,
             )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2572,6 +2572,7 @@ _INTERRUPT_REASON_STOP = "Stop requested"
 _INTERRUPT_REASON_RESET = "Session reset requested"
 _INTERRUPT_REASON_TIMEOUT = "Execution timed out (inactivity)"
 _INTERRUPT_REASON_SSE_DISCONNECT = "SSE client disconnected"
+GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS = 2.0
 _INTERRUPT_REASON_GATEWAY_SHUTDOWN = "Gateway shutting down"
 _INTERRUPT_REASON_GATEWAY_RESTART = "Gateway restarting"
 
@@ -10907,6 +10908,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Record rate limit so subsequent messages are silently ignored
                     self.pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
+
+        # Resolve Telegram topic-mode routing before deriving the session key or
+        # exposing the immutable post-authorization plugin route. A stale or
+        # foreign thread ID must not escape through a route-bound capability.
+        recovered = None
+        if not event.is_command():
+            recovered = await asyncio.to_thread(
+                self._recover_telegram_topic_thread_id,
+                source,
+            )
+        if recovered is not None:
+            logger.info(
+                "telegram topic recovery: chat=%s user=%s %r -> %s",
+                source.chat_id,
+                source.user_id,
+                source.thread_id,
+                recovered,
+            )
+            source = dataclasses.replace(source, thread_id=recovered)
+            event = dataclasses.replace(event, source=source)
         
         # Intercept messages that are responses to a pending /update prompt.
         # The update process (detached) wrote .update_prompt.json; the watcher
@@ -11208,6 +11229,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # doesn't get re-processed as a user message after the
             # interrupt completes.
             if _cmd_def_inner and _cmd_def_inner.name == "new":
+                # Notify plugin-owned work before the hard host interruption.
+                # The reset handler is told not to emit the same boundary twice.
+                await self._notify_gateway_session_cancel(
+                    _quick_key,
+                    source,
+                    reason="reset",
+                )
                 # Clear any pending messages so the old text doesn't replay
                 await self._interrupt_and_clear_session(
                     _quick_key,
@@ -11217,7 +11245,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 # Clean up the running agent entry so the reset handler
                 # doesn't think an agent is still active.
-                return await self._handle_reset_command(event)
+                return await self._handle_reset_command(event, cancel_notified=True)
 
             # /queue <prompt> — queue without interrupting.
             # Semantics: each /queue invocation produces its own full agent
@@ -12960,16 +12988,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         from hermes_cli.plugins import invoke_hook_async
 
         try:
-            await invoke_hook_async(
-                "gateway_session_cancel",
-                route=GatewayMessageRoute.from_source(
-                    source,
-                    session_key=session_key,
+            await asyncio.wait_for(
+                invoke_hook_async(
+                    "gateway_session_cancel",
+                    route=GatewayMessageRoute.from_source(
+                        source,
+                        session_key=session_key,
+                    ),
+                    reason=str(reason),
                 ),
-                reason=str(reason),
+                timeout=GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS,
             )
         except asyncio.CancelledError:
             raise
+        except TimeoutError:
+            logger.warning(
+                "gateway_session_cancel hook exceeded %.1fs for %s; "
+                "continuing the host session boundary",
+                GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS,
+                session_key,
+            )
         except Exception as exc:
             logger.warning(
                 "gateway_session_cancel hook failed for %s (%s)",
@@ -12990,22 +13028,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             source.chat_id or "unknown", _msg_preview, _reply_id, _reply_txt,
         )
 
-        # Get or create session
-        # Topic-mode DMs: rewrite a stale/foreign thread_id to the user's
-        # last-active topic so a cross-topic Reply or stripped plain reply
-        # doesn't fragment the conversation across sessions.
-        recovered = await asyncio.to_thread(self._recover_telegram_topic_thread_id, source)
-        if recovered is not None:
-            logger.info(
-                "telegram topic recovery: chat=%s user=%s %r -> %s",
-                source.chat_id, source.user_id, source.thread_id, recovered,
-            )
-            source = dataclasses.replace(source, thread_id=recovered)
-            try:
-                event.source = source
-            except Exception:
-                pass
-
+        # Get or create session. Telegram topic-mode recovery has already run
+        # before the post-authorization hook and session-key derivation.
         session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
         pinned_session_id = str(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6222,6 +6222,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if getattr(event, "internal", False):
             return False
 
+        if self._external_drain_active:
+            logger.info(
+                "Refusing busy-session follow-up for %s — external drain active.",
+                session_key,
+            )
+            reply_anchor = self._reply_anchor_for_event(event)
+            await adapter._send_with_retry(
+                chat_id=event.source.chat_id,
+                content=(
+                    "⏳ This agent is draining for a maintenance action and isn't "
+                    "accepting new turns right now. It'll be back in a moment — "
+                    "please resend shortly."
+                ),
+                reply_to=reply_anchor,
+                metadata=self._thread_metadata_for_source(event.source, reply_anchor),
+            )
+            return True
+
         # Real busy-session ingress returns from BasePlatformAdapter after this
         # handler. Invoke the post-authorization participant seam before any
         # host queue, steer, redirect, or interrupt effect so ordinary live
@@ -12922,6 +12940,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key: str,
     ) -> bool:
         """Return True when an ordinary user-message hook suppresses dispatch."""
+        result_marker = "_hermes_gateway_message_hook_result"
+        prior_result = getattr(event, result_marker, None)
+        if prior_result == "suppress":
+            return True
+        if prior_result == "continue":
+            return False
+        if prior_result == "pending":
+            # The same mutable host event must never enter participant hooks
+            # concurrently. Fail closed until its first invocation resolves.
+            return True
+
+        def _finish(suppress: bool) -> bool:
+            setattr(event, result_marker, "suppress" if suppress else "continue")
+            return suppress
+
         from gateway.message_hooks import (
             GatewayDelivery,
             GatewayMessageEvent,
@@ -12970,6 +13003,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             decision = str(result.get("decision", "")).strip().lower()
             return decision not in {"continue", "pass"}
 
+        setattr(event, result_marker, "pending")
         try:
             results = await invoke_hook_async(
                 "gateway_message",
@@ -12983,13 +13017,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 stop_when=_stop_after_terminal_result,
             )
         except asyncio.CancelledError:
+            if getattr(event, result_marker, None) == "pending":
+                delattr(event, result_marker)
             raise
         except Exception as exc:
             logger.warning(
                 "gateway_message hook failed; suppressing normal dispatch (%s)",
                 type(exc).__name__,
             )
-            return True
+            return _finish(True)
 
         for result in results:
             if not isinstance(result, dict):
@@ -12998,18 +13034,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "suppressing normal dispatch",
                     type(result).__name__,
                 )
-                return True
+                return _finish(True)
             decision = str(result.get("decision", "")).strip().lower()
             if decision in {"handled", "suppress"}:
-                return True
+                return _finish(True)
             if decision in {"continue", "pass"}:
                 continue
             logger.warning(
                 "gateway_message hook returned an invalid decision; "
                 "suppressing normal dispatch"
             )
-            return True
-        return False
+            return _finish(True)
+        return _finish(False)
 
     async def _notify_gateway_session_cancel(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6222,6 +6222,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if getattr(event, "internal", False):
             return False
 
+        # Real busy-session ingress returns from BasePlatformAdapter after this
+        # handler. Invoke the post-authorization participant seam before any
+        # host queue, steer, redirect, or interrupt effect so ordinary live
+        # follow-ups are neither invisible nor duplicated.
+        if await self._run_gateway_message_hook(event, event.source, session_key):
+            return True
+
         running_agent = self._running_agents.get(session_key)
 
         effective_mode = self._busy_input_mode
@@ -13024,6 +13031,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         session_key=session_key,
                     ),
                     reason=str(reason),
+                    offload_sync=True,
                 ),
                 timeout=GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS,
             )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9614,6 +9614,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             self._running = False
             self._draining = True
+            # Shutdown acceptance closes before any observer or adapter await.
+            # Every retained participant delivery is invalid at this point,
+            # including sessions with no currently running host agent.
+            self._revoke_all_gateway_deliveries()
 
             stop_watchdog = getattr(self, "_stop_systemd_watchdog", None)
             if callable(stop_watchdog):
@@ -12945,6 +12949,50 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         source: SessionSource,
         session_key: str,
     ) -> bool:
+        """Run ordinary-message hooks in the already-resolved profile scope."""
+
+        async def _run_scoped() -> bool:
+            native_events = event.metadata.get("_gateway_native_events", ())
+            if native_events:
+                if not isinstance(native_events, tuple) or not all(
+                    isinstance(item, MessageEvent) for item in native_events
+                ):
+                    logger.warning(
+                        "invalid native-event batch metadata; suppressing normal dispatch"
+                    )
+                    return True
+                suppressed = False
+                for native_event in native_events:
+                    # Every authorized native Discord ingress crosses the hook
+                    # independently. Continue through the batch even after one
+                    # terminal result so no constituent identity disappears.
+                    suppressed = (
+                        await self._run_gateway_message_hook_scoped(
+                            native_event,
+                            source,
+                            session_key,
+                        )
+                        or suppressed
+                    )
+                return suppressed
+            return await self._run_gateway_message_hook_scoped(
+                event,
+                source,
+                session_key,
+            )
+
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            profile_home = self._resolve_profile_home_for_source(source)
+            with _profile_runtime_scope(profile_home):
+                return await _run_scoped()
+        return await _run_scoped()
+
+    async def _run_gateway_message_hook_scoped(
+        self,
+        event: MessageEvent,
+        source: SessionSource,
+        session_key: str,
+    ) -> bool:
         """Return True when an ordinary user-message hook suppresses dispatch."""
         result_marker = "_hermes_gateway_message_hook_result"
         prior_result = getattr(event, result_marker, None)
@@ -12972,6 +13020,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter = self._adapter_for_source(source)
         delivery_platform = source.platform
         delivery_chat_id = str(source.chat_id)
+        delivery_message_id = str(event.message_id or "")
         delivery_metadata = self._thread_metadata_for_source(source, event.message_id)
         delivery_via_relay = (
             getattr(source, "delivered_via_upstream_relay", False) is True
@@ -13003,12 +13052,56 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 metadata=metadata,
             )
 
+        async def _reply_to_source(content: str):
+            if adapter is None or not delivery_message_id:
+                return SendResult(success=False)
+            metadata = dict(delivery_metadata) if delivery_metadata else None
+            if delivery_via_relay:
+                send_for_platform: Any = getattr(adapter, "send_for_platform", None)
+                if not callable(send_for_platform):
+                    return SendResult(success=False)
+                return await send_for_platform(
+                    delivery_platform,
+                    delivery_chat_id,
+                    content,
+                    reply_to=delivery_message_id,
+                    metadata=metadata,
+                )
+            return await adapter.send(
+                delivery_chat_id,
+                content,
+                reply_to=delivery_message_id,
+                metadata=metadata,
+            )
+
+        async def _react_to_source(reaction: str, operation: str):
+            if adapter is None or delivery_via_relay or not delivery_message_id:
+                return SendResult(success=False)
+            react: Any = getattr(adapter, "react", None)
+            if not callable(react):
+                return SendResult(success=False)
+            return await react(
+                delivery_chat_id,
+                delivery_message_id,
+                reaction,
+                operation=operation,
+            )
+
         def _stop_after_terminal_result(result: Any) -> bool:
             if not isinstance(result, dict):
                 return True
             decision = str(result.get("decision", "")).strip().lower()
             return decision not in {"continue", "pass"}
 
+        # A newly accepted ordinary ingress supersedes every previously issued
+        # capability for this session before the new one becomes visible.
+        self._revoke_gateway_deliveries(session_key)
+        delivery = GatewayDelivery(
+            _send_to_source,
+            reply_callback=_reply_to_source,
+            react_callback=_react_to_source,
+        )
+        self._register_gateway_delivery(session_key, delivery)
         setattr(event, result_marker, "pending")
         try:
             results = await invoke_hook_async(
@@ -13018,15 +13111,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     source,
                     session_key=session_key,
                 ),
-                delivery=GatewayDelivery(_send_to_source),
+                delivery=delivery,
                 raise_exceptions=True,
                 stop_when=_stop_after_terminal_result,
             )
         except asyncio.CancelledError:
+            delivery._revoke()
             if getattr(event, result_marker, None) == "pending":
                 delattr(event, result_marker)
             raise
         except Exception as exc:
+            delivery._revoke()
             logger.warning(
                 "gateway_message hook failed; suppressing normal dispatch (%s)",
                 type(exc).__name__,
@@ -13035,6 +13130,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         for result in results:
             if not isinstance(result, dict):
+                delivery._revoke()
                 logger.warning(
                     "gateway_message hook returned invalid terminal result type %s; "
                     "suppressing normal dispatch",
@@ -13046,12 +13142,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return _finish(True)
             if decision in {"continue", "pass"}:
                 continue
+            delivery._revoke()
             logger.warning(
                 "gateway_message hook returned an invalid decision; "
                 "suppressing normal dispatch"
             )
             return _finish(True)
+        delivery._revoke()
         return _finish(False)
+
+    def _register_gateway_delivery(self, session_key: str, delivery: Any) -> None:
+        deliveries = getattr(self, "_gateway_deliveries_by_session", None)
+        if deliveries is None:
+            deliveries = {}
+            self._gateway_deliveries_by_session = deliveries
+        deliveries.setdefault(str(session_key), set()).add(delivery)
+
+    def _revoke_gateway_deliveries(self, session_key: str) -> None:
+        deliveries = getattr(self, "_gateway_deliveries_by_session", None)
+        if not deliveries:
+            return
+        for delivery in deliveries.pop(str(session_key), ()):
+            try:
+                delivery._revoke()
+            except Exception:
+                logger.debug("gateway delivery revocation failed", exc_info=True)
+
+    def _revoke_all_gateway_deliveries(self) -> None:
+        deliveries = getattr(self, "_gateway_deliveries_by_session", None)
+        if not deliveries:
+            return
+        for session_key in tuple(deliveries):
+            self._revoke_gateway_deliveries(session_key)
 
     async def _notify_gateway_session_cancel(
         self,
@@ -13060,11 +13182,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         *,
         reason: str,
     ) -> None:
-        """Best-effort async notification for an explicit session boundary."""
+        """Invalidate effects, then best-effort notify an explicit boundary."""
         from gateway.message_hooks import GatewayMessageRoute
         from hermes_cli.plugins import invoke_hook_async
 
-        try:
+        # Invalidation is authoritative and synchronous. The bounded plugin
+        # observer below cannot delay it or keep a stale route capability live.
+        self._revoke_gateway_deliveries(session_key)
+        async def _invoke_cancel_observer() -> None:
             await asyncio.wait_for(
                 invoke_hook_async(
                     "gateway_session_cancel",
@@ -13077,6 +13202,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ),
                 timeout=GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS,
             )
+
+        try:
+            if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+                profile_home = self._resolve_profile_home_for_source(source)
+                with _profile_runtime_scope(profile_home):
+                    await _invoke_cancel_observer()
+            else:
+                await _invoke_cancel_observer()
         except asyncio.CancelledError:
             raise
         except TimeoutError:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12901,6 +12901,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 metadata=metadata,
             )
 
+        def _stop_after_terminal_result(result: Any) -> bool:
+            if not isinstance(result, dict):
+                return True
+            decision = str(result.get("decision", "")).strip().lower()
+            return decision not in {"continue", "pass"}
+
         try:
             results = await invoke_hook_async(
                 "gateway_message",
@@ -12911,6 +12917,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ),
                 delivery=GatewayDelivery(_send_to_source),
                 raise_exceptions=True,
+                stop_when=_stop_after_terminal_result,
             )
         except asyncio.CancelledError:
             raise

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11447,7 +11447,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
             # Ordinary user messages reach the plugin seam only after access
-            # checks and every active-session control intercept above.
+            # checks and every active-session control intercept above. During
+            # shutdown draining, no participant hook may create side effects.
+            if self._draining:
+                if self._queue_during_drain_enabled():
+                    self._queue_or_replace_pending_event(_quick_key, event)
+                return (
+                    f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+                    if self._queue_during_drain_enabled()
+                    else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
+                )
             if (
                 not is_internal
                 and not event.is_command()
@@ -11510,14 +11519,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         merge_text=True,
                     )
                 return None
-            if self._draining:
-                if self._queue_during_drain_enabled():
-                    self._queue_or_replace_pending_event(_quick_key, event)
-                return (
-                    f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
-                    if self._queue_during_drain_enabled()
-                    else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
-                )
             if self._busy_input_mode == "queue":
                 logger.debug("PRIORITY queue follow-up for session %s", _quick_key)
                 self._queue_or_replace_pending_event(_quick_key, event)
@@ -12886,6 +12887,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
+    def _source_for_session_cancel(
+        self,
+        session_key: str,
+        fallback: SessionSource,
+    ) -> SessionSource:
+        """Recover the target route identity for a session cancellation."""
+        cached = self._get_cached_session_source(session_key)
+        if cached is not None:
+            return cached
+        thread_id = str(fallback.thread_id or "")
+        marker = f":{thread_id}:" if thread_id else ""
+        if marker and marker in session_key:
+            target_user = session_key.rsplit(marker, 1)[-1]
+            if target_user and ":" not in target_user:
+                return dataclasses.replace(
+                    fallback,
+                    user_id=target_user,
+                    user_id_alt=None,
+                )
+        return fallback
+
     async def _run_gateway_message_hook(
         self,
         event: MessageEvent,
@@ -12908,6 +12930,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         delivery_via_relay = (
             getattr(source, "delivered_via_upstream_relay", False) is True
         )
+        if delivery_via_relay:
+            delivery_metadata = dict(delivery_metadata or {})
+            if source.scope_id:
+                delivery_metadata["scope_id"] = str(source.scope_id)
+            if source.user_id:
+                delivery_metadata["user_id"] = str(source.user_id)
 
         async def _send_to_source(content: str):
             if adapter is None:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -103,17 +103,23 @@ class GatewaySlashCommandsMixin:
         adapter = self.adapters.get(platform) if getattr(self, "adapters", None) else None
         return getattr(adapter, "typed_command_prefix", "/") if adapter is not None else "/"
 
-    async def _handle_reset_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
+    async def _handle_reset_command(
+        self,
+        event: MessageEvent,
+        *,
+        cancel_notified: bool = False,
+    ) -> Union[str, EphemeralReply]:
         """Handle /new or /reset command."""
         source = event.source
         
         # Get existing session key
         session_key = self._session_key_for_source(source)
-        await self._notify_gateway_session_cancel(
-            session_key,
-            source,
-            reason="reset",
-        )
+        if not cancel_notified:
+            await self._notify_gateway_session_cancel(
+                session_key,
+                source,
+                reason="reset",
+            )
         self._invalidate_session_run_generation(session_key, reason="session_reset")
         # Evict the running-agent slot now that the generation is bumped. The
         # in-flight run's own guarded release (run_generation=old) will return

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1124,6 +1124,11 @@ class GatewaySlashCommandsMixin:
         sibling_keys = self._sibling_thread_run_keys(source, session_key)
         if sibling_keys and self._is_user_authorized(source):
             for sibling_key in sibling_keys:
+                await self._notify_gateway_session_cancel(
+                    sibling_key,
+                    source,
+                    reason="stop",
+                )
                 await self._interrupt_and_clear_session(
                     sibling_key,
                     source,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -109,6 +109,11 @@ class GatewaySlashCommandsMixin:
         
         # Get existing session key
         session_key = self._session_key_for_source(source)
+        await self._notify_gateway_session_cancel(
+            session_key,
+            source,
+            reason="reset",
+        )
         self._invalidate_session_run_generation(session_key, reason="session_reset")
         # Evict the running-agent slot now that the generation is bumped. The
         # in-flight run's own guarded release (run_generation=old) will return
@@ -1082,6 +1087,11 @@ class GatewaySlashCommandsMixin:
         source = event.source
         session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        await self._notify_gateway_session_cancel(
+            session_key,
+            source,
+            reason="stop",
+        )
 
         agent = self._running_agents.get(session_key)
         if agent is _AGENT_PENDING_SENTINEL:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1093,14 +1093,14 @@ class GatewaySlashCommandsMixin:
         source = event.source
         session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
-        await self._notify_gateway_session_cancel(
-            session_key,
-            source,
-            reason="stop",
-        )
 
         agent = self._running_agents.get(session_key)
         if agent is _AGENT_PENDING_SENTINEL:
+            await self._notify_gateway_session_cancel(
+                session_key,
+                source,
+                reason="stop",
+            )
             # Force-clean the sentinel so the session is unlocked.
             await self._interrupt_and_clear_session(
                 session_key,
@@ -1111,6 +1111,11 @@ class GatewaySlashCommandsMixin:
             logger.info("STOP (pending) for session %s — sentinel cleared", session_key)
             return EphemeralReply(t("gateway.stop.stopped_pending"))
         if agent:
+            await self._notify_gateway_session_cancel(
+                session_key,
+                source,
+                reason="stop",
+            )
             # Force-clean the session lock so a truly hung agent doesn't
             # keep it locked forever.
             await self._interrupt_and_clear_session(
@@ -1129,12 +1134,24 @@ class GatewaySlashCommandsMixin:
         # agent(s) that share this thread, gated on authorization.
         sibling_keys = self._sibling_thread_run_keys(source, session_key)
         if sibling_keys and self._is_user_authorized(source):
-            for sibling_key in sibling_keys:
-                await self._notify_gateway_session_cancel(
+            cancel_routes = [(session_key, source)] + [
+                (
                     sibling_key,
-                    source,
-                    reason="stop",
+                    self._source_for_session_cancel(sibling_key, source),
                 )
+                for sibling_key in sibling_keys
+            ]
+            await asyncio.gather(
+                *(
+                    self._notify_gateway_session_cancel(
+                        key,
+                        route_source,
+                        reason="stop",
+                    )
+                    for key, route_source in cancel_routes
+                )
+            )
+            for sibling_key in sibling_keys:
                 await self._interrupt_and_clear_session(
                     sibling_key,
                     source,
@@ -1148,6 +1165,12 @@ class GatewaySlashCommandsMixin:
                 ", ".join(sibling_keys),
             )
             return EphemeralReply(t("gateway.stop.stopped"))
+
+        await self._notify_gateway_session_cancel(
+            session_key,
+            source,
+            reason="stop",
+        )
 
         # No running agent anywhere for this scope. A platform status
         # indicator can still be stuck — e.g. Slack's persistent

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -42,6 +42,7 @@ import os
 import sys
 import threading
 import types
+from contextvars import copy_context
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Union
@@ -1249,10 +1250,10 @@ class PluginContext:
         )
 
 
-async def _invoke_sync_hook_off_thread(
+async def _invoke_hook_off_thread(
     callback: Callable[..., Any], kwargs: Dict[str, Any]
 ) -> Any:
-    """Run a synchronous hook in a disposable daemon thread.
+    """Run a sync or async hook in a disposable daemon thread.
 
     Cancellation observers are advisory and may be third-party code. A daemon
     thread keeps a stuck callback from blocking the event loop, consuming the
@@ -1275,6 +1276,11 @@ async def _invoke_sync_hook_off_thread(
     def run() -> None:
         try:
             result = callback(**kwargs)
+            if inspect.isawaitable(result):
+                async def _await_result(awaitable: Any) -> Any:
+                    return await awaitable
+
+                result = asyncio.run(_await_result(result))
         except BaseException as exc:
             try:
                 loop.call_soon_threadsafe(publish_result, None, exc)
@@ -1286,8 +1292,10 @@ async def _invoke_sync_hook_off_thread(
             except RuntimeError:
                 return
 
+    callback_context = copy_context()
     threading.Thread(
-        target=run,
+        target=callback_context.run,
+        args=(run,),
         name="hermes-plugin-hook",
         daemon=True,
     ).start()
@@ -1986,6 +1994,7 @@ class PluginManager:
         raise_exceptions: bool = False,
         stop_when: Optional[Callable[[Any], bool]] = None,
         offload_sync: bool = False,
+        offload_callbacks: bool = False,
         **kwargs: Any,
     ) -> List[Any]:
         """Await sync or async callbacks registered for *hook_name*.
@@ -1993,14 +2002,18 @@ class PluginManager:
         Callback failures are isolated by default, matching :meth:`invoke_hook`.
         Decision-style callers may request fail-fast behavior with
         ``raise_exceptions=True``. Task cancellation always propagates.
+        ``offload_callbacks=True`` moves every callback, including async ones,
+        to a context-preserving disposable daemon thread so advisory hooks can
+        be abandoned by a hard host timeout.
         """
         callbacks = self._hooks.get(hook_name, [])
         results: List[Any] = []
         for cb in callbacks:
             try:
                 ret = (
-                    await _invoke_sync_hook_off_thread(cb, kwargs)
-                    if offload_sync and not inspect.iscoroutinefunction(cb)
+                    await _invoke_hook_off_thread(cb, kwargs)
+                    if offload_callbacks
+                    or (offload_sync and not inspect.iscoroutinefunction(cb))
                     else cb(**kwargs)
                 )
                 if inspect.isawaitable(ret):
@@ -2156,6 +2169,7 @@ async def invoke_hook_async(
     raise_exceptions: bool = False,
     stop_when: Optional[Callable[[Any], bool]] = None,
     offload_sync: bool = False,
+    offload_callbacks: bool = False,
     **kwargs: Any,
 ) -> List[Any]:
     """Invoke sync or async lifecycle-hook callbacks and await completion."""
@@ -2164,6 +2178,7 @@ async def invoke_hook_async(
         raise_exceptions=raise_exceptions,
         stop_when=stop_when,
         offload_sync=offload_sync,
+        offload_callbacks=offload_callbacks,
         **kwargs,
     )
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -171,6 +171,14 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Ordinary user-message interception after user access and gateway control
+    # handling, before either cold or busy-session agent behavior. Callbacks
+    # receive only immutable normalized event/route snapshots plus a route-bound
+    # delivery capability. Decisions: handled/suppress or continue/pass.
+    "gateway_message",
+    # Best-effort notification when a user explicitly cancels or resets a
+    # gateway session. Async plugin-owned work can stop at the same boundary.
+    "gateway_session_cancel",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.
@@ -1926,6 +1934,41 @@ class PluginManager:
                 )
         return results
 
+    async def invoke_hook_async(
+        self,
+        hook_name: str,
+        *,
+        raise_exceptions: bool = False,
+        **kwargs: Any,
+    ) -> List[Any]:
+        """Await sync or async callbacks registered for *hook_name*.
+
+        Callback failures are isolated by default, matching :meth:`invoke_hook`.
+        Decision-style callers may request fail-fast behavior with
+        ``raise_exceptions=True``. Task cancellation always propagates.
+        """
+        callbacks = self._hooks.get(hook_name, [])
+        results: List[Any] = []
+        for cb in callbacks:
+            try:
+                ret = cb(**kwargs)
+                if inspect.isawaitable(ret):
+                    ret = await ret
+                if ret is not None:
+                    results.append(ret)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "Async hook '%s' callback %s raised: %s",
+                    hook_name,
+                    getattr(cb, "__name__", repr(cb)),
+                    exc,
+                )
+                if raise_exceptions:
+                    raise
+        return results
+
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""
         return bool(self._hooks.get(hook_name))
@@ -2052,6 +2095,20 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     Returns a list of non-``None`` return values from plugin callbacks.
     """
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+
+
+async def invoke_hook_async(
+    hook_name: str,
+    *,
+    raise_exceptions: bool = False,
+    **kwargs: Any,
+) -> List[Any]:
+    """Invoke sync or async lifecycle-hook callbacks and await completion."""
+    return await get_plugin_manager().invoke_hook_async(
+        hook_name,
+        raise_exceptions=raise_exceptions,
+        **kwargs,
+    )
 
 
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -47,7 +47,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
-from hermes_constants import get_hermes_home
+from hermes_constants import GATEWAY_MESSAGE_HOOK_API_VERSION, get_hermes_home
 from utils import env_var_enabled, fast_safe_load
 from hermes_cli.config import cfg_get
 from hermes_cli.middleware import OBSERVER_SCHEMA_VERSION, VALID_MIDDLEWARE
@@ -394,6 +394,11 @@ class PluginContext:
             return get_active_profile_name()
         except Exception:
             return "default"
+
+    @property
+    def gateway_message_hook_api_version(self) -> int:
+        """Return the semantic version of the immutable gateway-message hook API."""
+        return GATEWAY_MESSAGE_HOOK_API_VERSION
 
     # -- tool registration --------------------------------------------------
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1249,6 +1249,51 @@ class PluginContext:
         )
 
 
+async def _invoke_sync_hook_off_thread(
+    callback: Callable[..., Any], kwargs: Dict[str, Any]
+) -> Any:
+    """Run a synchronous hook in a disposable daemon thread.
+
+    Cancellation observers are advisory and may be third-party code. A daemon
+    thread keeps a stuck callback from blocking the event loop, consuming the
+    shared asyncio executor indefinitely, or preventing process shutdown. The
+    callback cannot be forcibly stopped; caller cancellation merely abandons
+    its result after the host boundary has proceeded.
+    """
+
+    loop = asyncio.get_running_loop()
+    result_future = loop.create_future()
+
+    def publish_result(result: Any = None, error: BaseException | None = None) -> None:
+        if result_future.done():
+            return
+        if error is not None:
+            result_future.set_exception(error)
+        else:
+            result_future.set_result(result)
+
+    def run() -> None:
+        try:
+            result = callback(**kwargs)
+        except BaseException as exc:
+            try:
+                loop.call_soon_threadsafe(publish_result, None, exc)
+            except RuntimeError:
+                return
+        else:
+            try:
+                loop.call_soon_threadsafe(publish_result, result, None)
+            except RuntimeError:
+                return
+
+    threading.Thread(
+        target=run,
+        name="hermes-plugin-hook",
+        daemon=True,
+    ).start()
+    return await result_future
+
+
 # ---------------------------------------------------------------------------
 # PluginManager
 # ---------------------------------------------------------------------------
@@ -1940,6 +1985,7 @@ class PluginManager:
         *,
         raise_exceptions: bool = False,
         stop_when: Optional[Callable[[Any], bool]] = None,
+        offload_sync: bool = False,
         **kwargs: Any,
     ) -> List[Any]:
         """Await sync or async callbacks registered for *hook_name*.
@@ -1952,7 +1998,11 @@ class PluginManager:
         results: List[Any] = []
         for cb in callbacks:
             try:
-                ret = cb(**kwargs)
+                ret = (
+                    await _invoke_sync_hook_off_thread(cb, kwargs)
+                    if offload_sync and not inspect.iscoroutinefunction(cb)
+                    else cb(**kwargs)
+                )
                 if inspect.isawaitable(ret):
                     ret = await ret
                 if ret is not None:
@@ -2105,6 +2155,7 @@ async def invoke_hook_async(
     *,
     raise_exceptions: bool = False,
     stop_when: Optional[Callable[[Any], bool]] = None,
+    offload_sync: bool = False,
     **kwargs: Any,
 ) -> List[Any]:
     """Invoke sync or async lifecycle-hook callbacks and await completion."""
@@ -2112,6 +2163,7 @@ async def invoke_hook_async(
         hook_name,
         raise_exceptions=raise_exceptions,
         stop_when=stop_when,
+        offload_sync=offload_sync,
         **kwargs,
     )
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1939,6 +1939,7 @@ class PluginManager:
         hook_name: str,
         *,
         raise_exceptions: bool = False,
+        stop_when: Optional[Callable[[Any], bool]] = None,
         **kwargs: Any,
     ) -> List[Any]:
         """Await sync or async callbacks registered for *hook_name*.
@@ -1956,6 +1957,8 @@ class PluginManager:
                     ret = await ret
                 if ret is not None:
                     results.append(ret)
+                    if stop_when is not None and stop_when(ret):
+                        break
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
@@ -2101,12 +2104,14 @@ async def invoke_hook_async(
     hook_name: str,
     *,
     raise_exceptions: bool = False,
+    stop_when: Optional[Callable[[Any], bool]] = None,
     **kwargs: Any,
 ) -> List[Any]:
     """Invoke sync or async lifecycle-hook callbacks and await completion."""
     return await get_plugin_manager().invoke_hook_async(
         hook_name,
         raise_exceptions=raise_exceptions,
+        stop_when=stop_when,
         **kwargs,
     )
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -12,6 +12,9 @@ from contextvars import ContextVar, Token
 from pathlib import Path
 
 
+GATEWAY_MESSAGE_HOOK_API_VERSION = 2
+
+
 _profile_fallback_warned: bool = False
 _UNSET = object()
 _HERMES_HOME_OVERRIDE: ContextVar[str | object] = ContextVar(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7629,6 +7629,9 @@ class DiscordAdapter(BasePlatformAdapter):
         if thread_id:
             self._threads.mark(thread_id)
 
+        if recovered:
+            setattr(event, "_hermes_historical_replay", True)
+
         # Only live plain text messages use split-message batching. Recovery
         # candidates are already complete historical messages; coalescing them
         # would lose constituent IDs and make later restarts replay them.
@@ -7665,6 +7668,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _native_gateway_event_snapshot(self, event: MessageEvent) -> MessageEvent:
         """Retain one bounded-to-hook native identity before agent-text batching."""
+        mentioned_user_ids = event.metadata.get("mentioned_user_ids")
         return MessageEvent(
             text=str(event.text or ""),
             message_type=event.message_type,
@@ -7679,8 +7683,10 @@ class DiscordAdapter(BasePlatformAdapter):
             reply_to_author_name=event.reply_to_author_name,
             reply_to_is_own_message=event.reply_to_is_own_message,
             metadata={
-                "mentioned_user_ids": tuple(
-                    event.metadata.get("mentioned_user_ids", ())
+                "mentioned_user_ids": (
+                    None
+                    if mentioned_user_ids is None
+                    else tuple(mentioned_user_ids)
                 ),
                 "mentions_room": event.metadata.get("mentions_room"),
             },

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -858,6 +858,14 @@ def _read_discord_prompt_timeout() -> int:
     return seconds
 
 
+def _attested_discord_mentions(message) -> tuple[tuple[str, ...], bool]:
+    """Extract immutable Discord user and room mention facts from native ingress."""
+    mentioned_user_ids = tuple(
+        sorted({str(user.id) for user in (getattr(message, "mentions", None) or ())})
+    )
+    return mentioned_user_ids, bool(getattr(message, "mention_everyone", False))
+
+
 class DiscordAdapter(BasePlatformAdapter):
     """
     Discord bot adapter.
@@ -7567,6 +7575,7 @@ class DiscordAdapter(BasePlatformAdapter):
             if message.reference.resolved:
                 reply_to_text = getattr(message.reference.resolved, "content", None) or None
 
+        mentioned_user_ids, mentions_room = _attested_discord_mentions(message)
         event = MessageEvent(
             text=event_text,
             message_type=msg_type,
@@ -7581,6 +7590,10 @@ class DiscordAdapter(BasePlatformAdapter):
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
             channel_context=_channel_context,
+            metadata={
+                "mentioned_user_ids": mentioned_user_ids,
+                "mentions_room": mentions_room,
+            },
         )
 
         # Track thread participation so the bot won't require @mention for
@@ -7642,6 +7655,13 @@ class DiscordAdapter(BasePlatformAdapter):
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
+            existing_mentions = set(existing.metadata.get("mentioned_user_ids", ()))
+            existing_mentions.update(event.metadata.get("mentioned_user_ids", ()))
+            existing.metadata["mentioned_user_ids"] = sorted(existing_mentions)
+            existing.metadata["mentions_room"] = bool(
+                existing.metadata.get("mentions_room")
+                or event.metadata.get("mentions_room")
+            )
 
         prior_task = self._pending_text_batch_tasks.get(key)
         if prior_task and not prior_task.done():

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2830,6 +2830,34 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.debug("[%s] remove_reaction failed (%s): %s", self.name, emoji, e)
             return False
 
+    async def react(
+        self,
+        chat_id: str,
+        message_id: str,
+        reaction: str,
+        *,
+        operation: str = "add",
+    ) -> SendResult:
+        """Apply one reaction to an exact Discord message."""
+        if not self._client or operation not in {"add", "remove"}:
+            return SendResult(success=False, error="Reaction is unavailable")
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if channel is None:
+                channel = await self._client.fetch_channel(int(chat_id))
+            message = await channel.fetch_message(int(message_id))
+            succeeded = (
+                await self._add_reaction(message, reaction)
+                if operation == "add"
+                else await self._remove_reaction(message, reaction)
+            )
+            return SendResult(
+                success=succeeded,
+                message_id=str(message_id) if succeeded else None,
+            )
+        except Exception:
+            return SendResult(success=False, error="Reaction failed")
+
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
         return os.getenv("DISCORD_REACTIONS", "true").lower() not in {"false", "0", "no"}
@@ -7635,6 +7663,30 @@ class DiscordAdapter(BasePlatformAdapter):
             profile=event.source.profile,
         )
 
+    def _native_gateway_event_snapshot(self, event: MessageEvent) -> MessageEvent:
+        """Retain one bounded-to-hook native identity before agent-text batching."""
+        return MessageEvent(
+            text=str(event.text or ""),
+            message_type=event.message_type,
+            source=event.source,
+            raw_message=None,
+            message_id=event.message_id,
+            media_urls=list(event.media_urls),
+            media_types=list(event.media_types),
+            reply_to_message_id=event.reply_to_message_id,
+            reply_to_text=event.reply_to_text,
+            reply_to_author_id=event.reply_to_author_id,
+            reply_to_author_name=event.reply_to_author_name,
+            reply_to_is_own_message=event.reply_to_is_own_message,
+            metadata={
+                "mentioned_user_ids": tuple(
+                    event.metadata.get("mentioned_user_ids", ())
+                ),
+                "mentions_room": event.metadata.get("mentions_room"),
+            },
+            timestamp=event.timestamp,
+        )
+
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.
 
@@ -7645,10 +7697,16 @@ class DiscordAdapter(BasePlatformAdapter):
         key = self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
         chunk_len = len(event.text or "")
+        native_snapshot = self._native_gateway_event_snapshot(event)
         if existing is None:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            event.metadata["_gateway_native_events"] = (native_snapshot,)
             self._pending_text_batches[key] = event
         else:
+            existing.metadata["_gateway_native_events"] = (
+                *existing.metadata.get("_gateway_native_events", ()),
+                native_snapshot,
+            )
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
             existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8513,6 +8513,34 @@ class TelegramAdapter(BasePlatformAdapter):
             profile=event.source.profile,
         )
 
+    def _native_gateway_event_snapshot(self, event: MessageEvent) -> MessageEvent:
+        """Retain one native identity before host-agent batching mutates it."""
+        mentioned_user_ids = event.metadata.get("mentioned_user_ids")
+        return MessageEvent(
+            text=str(event.text or ""),
+            message_type=event.message_type,
+            source=event.source,
+            raw_message=None,
+            message_id=event.message_id,
+            platform_update_id=event.platform_update_id,
+            media_urls=list(event.media_urls),
+            media_types=list(event.media_types),
+            reply_to_message_id=event.reply_to_message_id,
+            reply_to_text=event.reply_to_text,
+            reply_to_author_id=event.reply_to_author_id,
+            reply_to_author_name=event.reply_to_author_name,
+            reply_to_is_own_message=event.reply_to_is_own_message,
+            metadata={
+                "mentioned_user_ids": (
+                    None
+                    if mentioned_user_ids is None
+                    else tuple(mentioned_user_ids)
+                ),
+                "mentions_room": event.metadata.get("mentions_room"),
+            },
+            timestamp=event.timestamp,
+        )
+
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.
 
@@ -8528,10 +8556,16 @@ class TelegramAdapter(BasePlatformAdapter):
         key = self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
         chunk_len = len(event.text or "")
+        native_snapshot = self._native_gateway_event_snapshot(event)
         if existing is None:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            event.metadata["_gateway_native_events"] = (native_snapshot,)
             self._pending_text_batches[key] = event
         else:
+            existing.metadata["_gateway_native_events"] = (
+                *existing.metadata.get("_gateway_native_events", ()),
+                native_snapshot,
+            )
             # Append text from the follow-up chunk
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
@@ -8637,9 +8671,15 @@ class TelegramAdapter(BasePlatformAdapter):
             return
 
         existing = self._pending_photo_batches.get(batch_key)
+        native_snapshot = self._native_gateway_event_snapshot(event)
         if existing is None:
+            event.metadata["_gateway_native_events"] = (native_snapshot,)
             self._pending_photo_batches[batch_key] = event
         else:
+            existing.metadata["_gateway_native_events"] = (
+                *existing.metadata.get("_gateway_native_events", ()),
+                native_snapshot,
+            )
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
             if event.text:
@@ -8945,9 +8985,15 @@ class TelegramAdapter(BasePlatformAdapter):
             return
 
         existing = self._media_group_events.get(media_group_id)
+        native_snapshot = self._native_gateway_event_snapshot(event)
         if existing is None:
+            event.metadata["_gateway_native_events"] = (native_snapshot,)
             self._media_group_events[media_group_id] = event
         else:
+            existing.metadata["_gateway_native_events"] = (
+                *existing.metadata.get("_gateway_native_events", ()),
+                native_snapshot,
+            )
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
             if event.text:
@@ -9368,12 +9414,14 @@ class TelegramAdapter(BasePlatformAdapter):
             _chat_id_str if thread_id_str else None,
         )
 
-        mentioned_user_ids = _attested_mention_user_ids(
-            getattr(message, "entities", None) or ()
+        mention_entities = (
+            *(getattr(message, "entities", None) or ()),
+            *(getattr(message, "caption_entities", None) or ()),
         )
+        mentioned_user_ids = _attested_mention_user_ids(mention_entities)
 
         return MessageEvent(
-            text=message.text or "",
+            text=message.text or getattr(message, "caption", None) or "",
             message_type=msg_type,
             source=source,
             raw_message=message,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9432,6 +9432,27 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.debug("[%s] clear reactions failed: %s", self.name, _redact_telegram_error_text(e))
             return False
 
+    async def react(
+        self,
+        chat_id: str,
+        message_id: str,
+        reaction: str,
+        *,
+        operation: str = "add",
+    ) -> SendResult:
+        """Apply one reaction to an exact Telegram message."""
+        if operation not in {"add", "remove"}:
+            return SendResult(success=False, error="Reaction is unavailable")
+        succeeded = (
+            await self._set_reaction(chat_id, message_id, reaction)
+            if operation == "add"
+            else await self._clear_reactions(chat_id, message_id)
+        )
+        return SendResult(
+            success=succeeded,
+            message_id=str(message_id) if succeeded else None,
+        )
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction when message processing begins."""
         if not self._reactions_enabled():

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -589,6 +589,24 @@ class _PollingLifecycleAbort(RuntimeError):
     """Internal control flow for polling startup fenced by teardown."""
 
 
+def _attested_mention_user_ids(entities) -> tuple[str, ...] | None:
+    """Return transport-bound mention IDs, or None when Telegram cannot attest them."""
+    mentioned_user_ids: set[str] = set()
+    for entity in entities or ():
+        entity_type = str(getattr(entity, "type", "")).split(".")[-1].lower()
+        if entity_type == "mention":
+            # Username mentions carry text offsets but no immutable Telegram user ID.
+            return None
+        if entity_type != "text_mention":
+            continue
+        mentioned_user = getattr(entity, "user", None)
+        mentioned_user_id = getattr(mentioned_user, "id", None)
+        if mentioned_user_id is None:
+            return None
+        mentioned_user_ids.add(str(mentioned_user_id))
+    return tuple(sorted(mentioned_user_ids))
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """
     Telegram bot adapter.
@@ -9350,6 +9368,10 @@ class TelegramAdapter(BasePlatformAdapter):
             _chat_id_str if thread_id_str else None,
         )
 
+        mentioned_user_ids = _attested_mention_user_ids(
+            getattr(message, "entities", None) or ()
+        )
+
         return MessageEvent(
             text=message.text or "",
             message_type=msg_type,
@@ -9362,6 +9384,10 @@ class TelegramAdapter(BasePlatformAdapter):
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
             timestamp=message.date,
+            metadata={
+                "mentioned_user_ids": mentioned_user_ids,
+                "mentions_room": False,
+            },
         )
 
     # ── Message reactions (processing lifecycle) ──────────────────────────

--- a/tests/gateway/test_discord_approval_mentions.py
+++ b/tests/gateway/test_discord_approval_mentions.py
@@ -8,6 +8,7 @@ import pytest
 from plugins.platforms.discord.adapter import (
     DiscordAdapter,
     _apply_yaml_config,
+    _attested_discord_mentions,
 )
 
 
@@ -26,6 +27,19 @@ class _FakeClient:
 
     def get_channel(self, channel_id):
         return self.channel
+
+
+def test_attested_discord_mentions_are_exact_and_deduplicated():
+    message = SimpleNamespace(
+        mentions=[SimpleNamespace(id=9), SimpleNamespace(id=7), SimpleNamespace(id=9)],
+        mention_everyone=True,
+    )
+
+    assert _attested_discord_mentions(message) == (("7", "9"), True)
+
+
+def test_attested_discord_mentions_default_to_transport_attested_empty():
+    assert _attested_discord_mentions(SimpleNamespace()) == ((), False)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_pending_text_batch_shutdown.py
+++ b/tests/gateway/test_discord_pending_text_batch_shutdown.py
@@ -51,6 +51,48 @@ from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
 
 
 @pytest.mark.asyncio
+async def test_text_batch_retains_each_native_event_identity_and_mentions():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    adapter._text_batch_delay_seconds = 99
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chat",
+        chat_type="group",
+        user_id="7",
+    )
+    first = MessageEvent(
+        text="ordinary",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+        metadata={"mentioned_user_ids": (), "mentions_room": False},
+    )
+    second = MessageEvent(
+        text="@bot",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m2",
+        metadata={"mentioned_user_ids": ("9",), "mentions_room": False},
+    )
+
+    adapter._enqueue_text_event(first)
+    adapter._enqueue_text_event(second)
+    merged = next(iter(adapter._pending_text_batches.values()))
+    native_events = merged.metadata["_gateway_native_events"]
+
+    assert [(item.message_id, item.text) for item in native_events] == [
+        ("m1", "ordinary"),
+        ("m2", "@bot"),
+    ]
+    assert native_events[0].metadata["mentioned_user_ids"] == ()
+    assert native_events[1].metadata["mentioned_user_ids"] == ("9",)
+
+    for task in adapter._pending_text_batch_tasks.values():
+        task.cancel()
+    await asyncio.gather(*adapter._pending_text_batch_tasks.values(), return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_cancel_background_tasks_awaits_pending_text_batch_before_clearing():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="fake-token"))
     flushed = asyncio.Event()

--- a/tests/gateway/test_gateway_message_hooks.py
+++ b/tests/gateway/test_gateway_message_hooks.py
@@ -547,6 +547,8 @@ async def test_discord_text_batch_invokes_hook_once_per_native_event(monkeypatch
     second = _event()
     second.message_id = "m2"
     second.text = "@bot"
+    second.source.user_id = "8"
+    second.source.user_name = "second-user"
     second.metadata["mentioned_user_ids"] = ("9",)
     merged = _event()
     merged.message_id = "m1"
@@ -565,6 +567,7 @@ async def test_discord_text_batch_invokes_hook_once_per_native_event(monkeypatch
                 kwargs["event"].message_id,
                 kwargs["event"].text,
                 kwargs["event"].mentioned_user_ids,
+                kwargs["route"].user_id,
             )
         )
         return [{"decision": "handled"}]
@@ -575,10 +578,53 @@ async def test_discord_text_batch_invokes_hook_once_per_native_event(monkeypatch
     await runner._handle_message(merged)
 
     assert observed == [
-        ("m1", "ordinary", ()),
-        ("m2", "@bot", ("9",)),
+        ("m1", "ordinary", (), "user-1"),
+        ("m2", "@bot", ("9",), "8"),
     ]
     runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_busy_pre_dispatch_skip_runs_before_gateway_message(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    event = _event()
+    session_key = build_session_key(event.source)
+    participant_hook = AsyncMock()
+
+    def pre_hook(name, **_kwargs):
+        if name == "pre_gateway_dispatch":
+            return [{"action": "skip", "reason": "fixture"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", pre_hook)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", participant_hook)
+
+    handled = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert handled is True
+    participant_hook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "marker",
+    ["_hermes_startup_restore_replay", "_hermes_historical_replay"],
+)
+async def test_replayed_ingress_never_reaches_gateway_message(monkeypatch, marker):
+    runner, _adapter = _runner_for_dispatch()
+    event = _event()
+    setattr(event, marker, True)
+    participant_hook = AsyncMock()
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", participant_hook)
+
+    suppressed = await runner._run_gateway_message_hook(
+        event,
+        event.source,
+        build_session_key(event.source),
+    )
+
+    assert suppressed is False
+    participant_hook.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_gateway_message_hooks.py
+++ b/tests/gateway/test_gateway_message_hooks.py
@@ -94,6 +94,52 @@ def test_message_snapshot_marks_unattested_mentions_unknown():
     assert normalized_event.mentions_room is None
 
 
+def test_message_hook_snapshot_bounds_oversized_fields_and_declares_gaps():
+    event = _event()
+    event.text = "x" * 2_000_000
+    event.reply_to_text = "r" * 100_000
+    event.message_id = "m" * 5_000
+    event.media_urls = [f"https://example.invalid/{index}/" + "u" * 5_000 for index in range(50)]
+    event.media_types = ["t" * 500 for _ in range(50)]
+    event.metadata["mentioned_user_ids"] = [f"user-{index}" for index in range(500)]
+
+    snapshot = GatewayMessageEvent.from_event(event)
+
+    assert len(snapshot.text.encode("utf-8")) <= 65_536
+    assert len((snapshot.reply_to_text or "").encode("utf-8")) <= 16_384
+    assert len((snapshot.message_id or "").encode("utf-8")) <= 512
+    assert len(snapshot.media_urls) <= 16
+    assert all(len(item.encode("utf-8")) <= 4_096 for item in snapshot.media_urls)
+    assert len(snapshot.media_types) <= 16
+    assert len(snapshot.mentioned_user_ids or ()) <= 128
+    assert {
+        "text-overflow",
+        "reply-text-overflow",
+        "message-id-overflow",
+        "media-count-overflow",
+        "media-url-overflow",
+        "media-type-overflow",
+        "mention-count-overflow",
+    }.issubset(set(snapshot.coverage_gaps))
+
+
+def test_route_snapshot_bounds_oversized_fields_and_declares_gaps():
+    source = _source()
+    source.chat_id = "c" * 5_000
+    source.user_name = "u" * 10_000
+
+    route = GatewayMessageRoute.from_source(source, session_key="s" * 10_000)
+
+    assert len(route.session_key.encode("utf-8")) <= 2_048
+    assert len(route.chat_id.encode("utf-8")) <= 512
+    assert len((route.user_name or "").encode("utf-8")) <= 4_096
+    assert {
+        "session-key-overflow",
+        "chat-id-overflow",
+        "user-name-overflow",
+    }.issubset(set(route.coverage_gaps))
+
+
 def test_route_snapshot_fills_resolved_active_profile_when_source_is_unset(monkeypatch):
     source = _source()
     source.profile = None
@@ -159,7 +205,10 @@ async def test_route_delivery_reports_raised_send_as_unknown_without_native_deta
     assert not hasattr(receipt, "error")
 
 
-def test_route_delivery_does_not_expose_native_send_callback():
+@pytest.mark.asyncio
+async def test_route_delivery_does_not_expose_native_send_callback():
+    import gateway.message_hooks as message_hooks
+
     async def send_native(_content: str):
         return SendResult(success=True, message_id="out-1")
 
@@ -167,6 +216,18 @@ def test_route_delivery_does_not_expose_native_send_callback():
 
     assert not hasattr(delivery, "_send_callback")
     assert not hasattr(delivery, "__dict__")
+    assert not hasattr(message_hooks, "_DELIVERY_SEND_CALLBACKS")
+    assert send_native not in vars(message_hooks).values()
+    channels = list(message_hooks._DELIVERY_CHANNELS.values())
+    assert channels
+    await asyncio.sleep(0)
+    assert all(not channel.queue._getters for channel in channels)
+    assert all(
+        not any(callable(value) for value in (channel.queue, channel.revoked, channel.consumed))
+        for channel in channels
+    )
+    assert delivery.send.__func__.__closure__ is None
+    delivery._revoke()
 
 
 def _runner_for_dispatch():
@@ -263,6 +324,261 @@ async def test_continue_hook_decisions_reach_cold_agent_dispatch(monkeypatch, de
     await runner._handle_message(_event())
 
     runner._handle_message_with_agent.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_route_multiplexed_hook_runs_inside_resolved_profile_scope(
+    monkeypatch, tmp_path
+):
+    from hermes_cli.config import get_hermes_home
+
+    runner, _adapter = _runner_for_dispatch()
+    runner.config.multiplex_profiles = True
+    default_home = tmp_path / "default"
+    work_home = tmp_path / "profiles" / "work"
+    default_home.mkdir(parents=True)
+    work_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setattr(
+        runner,
+        "_resolve_profile_home_for_source",
+        lambda _source: work_home,
+    )
+    observed = {}
+
+    async def hook(_name, **kwargs):
+        observed["home"] = get_hermes_home()
+        observed["profile"] = kwargs["route"].profile
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    await runner._handle_message(_event())
+
+    assert observed == {"home": work_home, "profile": "work"}
+
+
+@pytest.mark.asyncio
+async def test_route_multiplexed_cancel_hook_runs_inside_resolved_profile_scope(
+    monkeypatch,
+    tmp_path,
+):
+    from hermes_cli.config import get_hermes_home
+
+    runner, _adapter = _runner_for_dispatch()
+    runner.config.multiplex_profiles = True
+    profile_home = tmp_path / "profiles" / "work"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(
+        runner,
+        "_resolve_profile_home_for_source",
+        lambda _source: profile_home,
+    )
+    observed_homes = []
+
+    async def hook(name, **_kwargs):
+        if name == "gateway_session_cancel":
+            observed_homes.append(get_hermes_home())
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+    source = _source()
+    source.profile = "work"
+
+    await runner._notify_gateway_session_cancel(
+        build_session_key(source, profile="work"),
+        source,
+        reason="stop",
+    )
+
+    assert observed_homes == [profile_home.resolve()]
+
+
+@pytest.mark.asyncio
+async def test_route_delivery_reply_is_bound_to_ingress_message(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    receipts = []
+
+    async def hook(name, **kwargs):
+        if name == "gateway_message":
+            receipts.append(await kwargs["delivery"].reply("threaded"))
+            return [{"decision": "handled"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+    event = _event()
+    event.message_id = "in-1"
+
+    await runner._handle_message(event)
+
+    assert receipts == [GatewayDeliveryReceipt(status="sent", message_id="out-1")]
+    adapter.send.assert_awaited_once_with(
+        "channel-1",
+        "threaded",
+        reply_to="in-1",
+        metadata={"thread_id": "thread-1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_route_delivery_reaction_is_bound_to_ingress_message(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    adapter.react = AsyncMock(
+        return_value=SendResult(success=True, message_id="in-1")
+    )
+    receipts = []
+
+    async def hook(name, **kwargs):
+        if name == "gateway_message":
+            receipts.append(
+                await kwargs["delivery"].react("👍", operation="add")
+            )
+            return [{"decision": "handled"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+    event = _event()
+    event.message_id = "in-1"
+
+    await runner._handle_message(event)
+
+    assert receipts == [GatewayDeliveryReceipt(status="sent", message_id="in-1")]
+    adapter.react.assert_awaited_once_with(
+        "channel-1",
+        "in-1",
+        "👍",
+        operation="add",
+    )
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_session_cancel_revokes_retained_delivery_before_observer(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    retained = []
+    cancel_observed_revoked = []
+
+    async def hook(name, **kwargs):
+        if name == "gateway_message":
+            retained.append(kwargs["delivery"])
+            return [{"decision": "handled"}]
+        if name == "gateway_session_cancel":
+            cancel_observed_revoked.append(
+                (await retained[0].send("too late")).status
+            )
+            return []
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    event = _event()
+    await runner._handle_message(event)
+    session_key = build_session_key(event.source)
+    await runner._notify_gateway_session_cancel(
+        session_key,
+        event.source,
+        reason="stop",
+    )
+
+    assert cancel_observed_revoked == ["failed"]
+    assert (await retained[0].send("still too late")).status == "failed"
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_revokes_retained_delivery_without_active_agent(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    retained = []
+
+    async def hook(name, **kwargs):
+        if name == "gateway_message":
+            retained.append(kwargs["delivery"])
+            return [{"decision": "handled"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+    await runner._handle_message(_event())
+
+    runner._revoke_all_gateway_deliveries()
+
+    assert (await retained[0].send("after drain")).status == "failed"
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_new_ingress_revokes_prior_retained_delivery(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    retained = []
+
+    async def hook(name, **kwargs):
+        if name == "gateway_message":
+            retained.append(kwargs["delivery"])
+            return [{"decision": "handled"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    first = _event()
+    first.message_id = "m1"
+    second = _event()
+    second.message_id = "m2"
+    await runner._handle_message(first)
+    await runner._handle_message(second)
+
+    assert len(retained) == 2
+    assert (await retained[0].send("superseded")).status == "failed"
+    assert (await retained[1].send("current")).status == "sent"
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_discord_text_batch_invokes_hook_once_per_native_event(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    first = _event()
+    first.message_id = "m1"
+    first.text = "ordinary"
+    first.metadata["mentioned_user_ids"] = ()
+    second = _event()
+    second.message_id = "m2"
+    second.text = "@bot"
+    second.metadata["mentioned_user_ids"] = ("9",)
+    merged = _event()
+    merged.message_id = "m1"
+    merged.text = "ordinary\n@bot"
+    merged.metadata.update(
+        {
+            "mentioned_user_ids": ("9",),
+            "_gateway_native_events": (first, second),
+        }
+    )
+    observed = []
+
+    async def hook(_name, **kwargs):
+        observed.append(
+            (
+                kwargs["event"].message_id,
+                kwargs["event"].text,
+                kwargs["event"].mentioned_user_ids,
+            )
+        )
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    await runner._handle_message(merged)
+
+    assert observed == [
+        ("m1", "ordinary", ()),
+        ("m2", "@bot", ("9",)),
+    ]
+    runner._handle_message_with_agent.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_gateway_message_hooks.py
+++ b/tests/gateway/test_gateway_message_hooks.py
@@ -301,6 +301,91 @@ async def test_real_base_adapter_busy_ingress_reaches_gateway_message_hook_once(
 
 
 @pytest.mark.asyncio
+async def test_busy_pass_event_crosses_gateway_message_hook_only_once_after_replay(monkeypatch):
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, _chat_id, _content, **_kwargs):
+        return SendResult(success=True, message_id="busy-pass-out")
+
+    Adapter = type(
+        "BusyPassAdapter",
+        (BasePlatformAdapter,),
+        {"connect": connect, "disconnect": disconnect, "send": send},
+    )
+    Adapter.__abstractmethods__ = frozenset()
+
+    runner, _old_adapter = _runner_for_dispatch()
+    runner._busy_text_mode = "queue"
+    adapter = Adapter(PlatformConfig(enabled=True), Platform.DISCORD)
+    adapter._message_handler = runner._handle_message
+    adapter._busy_session_handler = runner._handle_active_session_busy_message
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {"work": {Platform.DISCORD: adapter}}
+    runner._busy_ack_ts = {}
+
+    event = MessageEvent(
+        text="busy passing follow-up",
+        message_type=MessageType.TEXT,
+        source=_source(),
+        message_id="busy-pass-in",
+    )
+    session_key = build_session_key(event.source)
+    running_agent = MagicMock()
+    running_agent.get_activity_summary.return_value = {}
+    runner._running_agents[session_key] = running_agent
+    adapter._active_sessions[session_key] = asyncio.Event()
+    calls = []
+
+    async def hook(name, **kwargs):
+        calls.append((name, kwargs["event"].message_id))
+        return [{"decision": "pass"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+
+    await adapter.handle_message(event)
+    assert calls == [("gateway_message", "busy-pass-in")]
+    queued = adapter._pending_messages.pop(session_key)
+
+    adapter._active_sessions.pop(session_key, None)
+    runner._running_agents.pop(session_key, None)
+    await adapter.handle_message(queued)
+    await adapter._session_tasks[session_key]
+
+    assert calls == [("gateway_message", "busy-pass-in")]
+
+
+@pytest.mark.asyncio
+async def test_busy_external_drain_rejects_before_gateway_message_hook(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    runner._external_drain_active = True
+    adapter._send_with_retry = AsyncMock(
+        return_value=SendResult(success=True, message_id="drain-refusal")
+    )
+    event = _event()
+    event.message_id = "busy-drain-in"
+    session_key = build_session_key(event.source)
+    calls = []
+
+    async def hook(name, **_kwargs):
+        calls.append(name)
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook)
+
+    handled = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert handled is True
+    assert calls == []
+    adapter._send_with_retry.assert_awaited_once()
+    assert "draining for a maintenance action" in adapter._send_with_retry.await_args.kwargs["content"]
+
+
+@pytest.mark.asyncio
 async def test_awaited_cold_hook_cannot_start_duplicate_agents(monkeypatch):
     runner, adapter = _runner_for_dispatch()
     first_hook_entered = asyncio.Event()

--- a/tests/gateway/test_gateway_message_hooks.py
+++ b/tests/gateway/test_gateway_message_hooks.py
@@ -386,6 +386,100 @@ async def test_busy_external_drain_rejects_before_gateway_message_hook(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_busy_multiplexed_route_uses_profile_scoped_session_key(monkeypatch):
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, _chat_id, _content, **_kwargs):
+        return SendResult(success=True, message_id="profile-out")
+
+    Adapter = type(
+        "BusyProfileAdapter",
+        (BasePlatformAdapter,),
+        {"connect": connect, "disconnect": disconnect, "send": send},
+    )
+    Adapter.__abstractmethods__ = frozenset()
+
+    runner, _old_adapter = _runner_for_dispatch()
+    runner.config.multiplex_profiles = True
+    adapter = Adapter(PlatformConfig(enabled=True), Platform.DISCORD)
+    adapter.gateway_runner = runner
+    adapter._message_handler = runner._handle_message
+    adapter._busy_session_handler = runner._handle_active_session_busy_message
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {"work": {Platform.DISCORD: adapter}}
+
+    event = _event()
+    event.source.profile = "work"
+    event.message_id = "busy-profile-in"
+    profile_key = runner._session_key_for_source(event.source)
+    legacy_key = build_session_key(event.source)
+    assert profile_key != legacy_key
+    adapter._active_sessions[profile_key] = asyncio.Event()
+    adapter._active_sessions[legacy_key] = asyncio.Event()
+    runner._running_agents[profile_key] = MagicMock()
+    runner._running_agents[legacy_key] = MagicMock()
+    seen = []
+
+    async def hook(_name, **kwargs):
+        seen.append(kwargs["route"].session_key)
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook)
+
+    await adapter.handle_message(event)
+
+    assert seen == [profile_key]
+
+
+@pytest.mark.asyncio
+async def test_busy_slash_command_queues_without_gateway_message_hook(monkeypatch):
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, _chat_id, _content, **_kwargs):
+        return SendResult(success=True, message_id="command-out")
+
+    Adapter = type(
+        "BusyCommandAdapter",
+        (BasePlatformAdapter,),
+        {"connect": connect, "disconnect": disconnect, "send": send},
+    )
+    Adapter.__abstractmethods__ = frozenset()
+
+    runner, _old_adapter = _runner_for_dispatch()
+    adapter = Adapter(PlatformConfig(enabled=True), Platform.DISCORD)
+    adapter._message_handler = AsyncMock(return_value="unknown command")
+    adapter._busy_session_handler = runner._handle_active_session_busy_message
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {"work": {Platform.DISCORD: adapter}}
+    event = _event()
+    event.text = "/plugin-command"
+    event.message_id = "busy-command-in"
+    session_key = build_session_key(event.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    seen = []
+
+    async def hook(name, **_kwargs):
+        seen.append(name)
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook)
+
+    await adapter.handle_message(event)
+
+    assert seen == []
+    adapter._message_handler.assert_not_awaited()
+    assert adapter._pending_messages[session_key] is event
+
+
+@pytest.mark.asyncio
 async def test_awaited_cold_hook_cannot_start_duplicate_agents(monkeypatch):
     runner, adapter = _runner_for_dispatch()
     first_hook_entered = asyncio.Event()
@@ -706,8 +800,8 @@ async def test_gateway_session_cancel_hook_receives_only_route_and_reason(monkey
     await runner._notify_gateway_session_cancel(session_key, source, reason="stop")
 
     assert captured["name"] == "gateway_session_cancel"
-    assert set(captured["kwargs"]) == {"route", "reason", "offload_sync"}
-    assert captured["kwargs"]["offload_sync"] is True
+    assert set(captured["kwargs"]) == {"route", "reason", "offload_callbacks"}
+    assert captured["kwargs"]["offload_callbacks"] is True
     assert captured["kwargs"]["reason"] == "stop"
     assert captured["kwargs"]["route"] == GatewayMessageRoute.from_source(
         source, session_key=session_key
@@ -734,6 +828,49 @@ async def test_gateway_session_cancel_hook_timeout_does_not_block_stop(monkeypat
     )
 
     assert entered.is_set()
+
+
+@pytest.mark.asyncio
+async def test_gateway_session_cancel_timeout_survives_cancel_suppressing_async_observer(
+    monkeypatch,
+):
+    from gateway import run as run_module
+    from hermes_cli.plugins import get_plugin_manager
+
+    runner, _adapter = _runner_for_dispatch()
+    manager = get_plugin_manager()
+    original = list(manager._hooks.get("gateway_session_cancel", []))
+    entered = threading.Event()
+    release = threading.Event()
+
+    async def cancellation_suppressing_observer(**_kwargs):
+        entered.set()
+        try:
+            while not release.is_set():
+                await asyncio.sleep(0.01)
+        except asyncio.CancelledError:
+            while not release.is_set():
+                await asyncio.sleep(0.01)
+
+    manager._hooks["gateway_session_cancel"] = [cancellation_suppressing_observer]
+    monkeypatch.setattr(run_module, "GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS", 0.01)
+    source = _source()
+    started = asyncio.get_running_loop().time()
+    try:
+        await asyncio.wait_for(
+            runner._notify_gateway_session_cancel(
+                build_session_key(source),
+                source,
+                reason="stop",
+            ),
+            timeout=0.1,
+        )
+        elapsed = asyncio.get_running_loop().time() - started
+        assert entered.is_set()
+        assert elapsed < 0.1
+    finally:
+        release.set()
+        manager._hooks["gateway_session_cancel"] = original
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_gateway_message_hooks.py
+++ b/tests/gateway/test_gateway_message_hooks.py
@@ -1,5 +1,6 @@
 """Public contract tests for the generic gateway user-message hook."""
 
+import asyncio
 from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -124,6 +125,8 @@ async def test_route_delivery_returns_truthful_normalized_receipts(native_result
     assert not hasattr(delivery, "gateway")
     assert not hasattr(delivery, "credentials")
     assert not hasattr(delivery, "event")
+    assert not hasattr(delivery, "_send_callback")
+
 
 @pytest.mark.asyncio
 async def test_route_delivery_reports_raised_send_as_failed_without_native_details():
@@ -135,6 +138,16 @@ async def test_route_delivery_reports_raised_send_as_failed_without_native_detai
     assert receipt.status == "failed"
     assert receipt.message_id is None
     assert not hasattr(receipt, "error")
+
+
+def test_route_delivery_does_not_expose_native_send_callback():
+    async def send_native(_content: str):
+        return SendResult(success=True, message_id="out-1")
+
+    delivery = GatewayDelivery(send_native)
+
+    assert not hasattr(delivery, "_send_callback")
+    assert not hasattr(delivery, "__dict__")
 
 
 def _runner_for_dispatch():
@@ -223,6 +236,86 @@ async def test_continue_hook_decisions_reach_cold_agent_dispatch(monkeypatch, de
     await runner._handle_message(_event())
 
     runner._handle_message_with_agent.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_awaited_cold_hook_cannot_start_duplicate_agents(monkeypatch):
+    runner, adapter = _runner_for_dispatch()
+    first_hook_entered = asyncio.Event()
+    release_first_hook = asyncio.Event()
+    hook_calls = 0
+    active_agent_calls = 0
+    max_concurrent_agent_calls = 0
+
+    async def hook(_name, **_kwargs):
+        nonlocal hook_calls
+        hook_calls += 1
+        if hook_calls == 1:
+            first_hook_entered.set()
+            await release_first_hook.wait()
+        return [{"decision": "pass"}]
+
+    async def run_agent(*_args, **_kwargs):
+        nonlocal active_agent_calls, max_concurrent_agent_calls
+        active_agent_calls += 1
+        max_concurrent_agent_calls = max(
+            max_concurrent_agent_calls,
+            active_agent_calls,
+        )
+        await asyncio.sleep(0)
+        active_agent_calls -= 1
+        return ""
+
+    runner._handle_message_with_agent = run_agent
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    first = asyncio.create_task(runner._handle_message(_event()))
+    await first_hook_entered.wait()
+    second = asyncio.create_task(runner._handle_message(_event()))
+    for _ in range(100):
+        if hook_calls == 2:
+            break
+        await asyncio.sleep(0)
+    release_first_hook.set()
+    await asyncio.gather(first, second)
+
+    assert hook_calls == 2
+    assert max_concurrent_agent_calls == 1
+    assert build_session_key(_source()) in adapter._pending_messages
+
+
+@pytest.mark.asyncio
+async def test_route_delivery_binds_relay_to_ingress_logical_platform(monkeypatch):
+    runner, _native_adapter = _runner_for_dispatch()
+    relay = SimpleNamespace(
+        send=AsyncMock(return_value=SendResult(success=True, message_id="wrong-route")),
+        send_for_platform=AsyncMock(
+            return_value=SendResult(success=True, message_id="relay-out")
+        ),
+        _pending_messages={},
+    )
+    runner.adapters = {Platform.RELAY: relay}
+    event = _event()
+    event.source.delivered_via_upstream_relay = True
+
+    async def hook(_name, **kwargs):
+        receipt = await kwargs["delivery"].send("relay reply")
+        assert receipt == GatewayDeliveryReceipt(status="sent", message_id="relay-out")
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    await runner._handle_message(event)
+
+    relay.send_for_platform.assert_awaited_once_with(
+        Platform.DISCORD,
+        "channel-1",
+        "relay reply",
+        metadata={"thread_id": "thread-1"},
+    )
+    relay.send.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_gateway_message_hooks.py
+++ b/tests/gateway/test_gateway_message_hooks.py
@@ -1,6 +1,8 @@
 """Public contract tests for the generic gateway user-message hook."""
 
 import asyncio
+import dataclasses
+import threading
 from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -457,6 +459,81 @@ async def test_active_session_stop_notifies_cancel_hook_before_interrupt(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_active_session_new_notifies_cancel_hook_before_interrupt(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    source = _source()
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = MagicMock()
+    order = []
+
+    async def notify(*_args, **_kwargs):
+        order.append("notify")
+
+    async def interrupt(*_args, **_kwargs):
+        order.append("interrupt")
+
+    async def reset(*_args, **kwargs):
+        order.append(("reset", kwargs))
+        return "reset"
+
+    runner._notify_gateway_session_cancel = notify
+    runner._interrupt_and_clear_session = interrupt
+    runner._handle_reset_command = reset
+    event = _event()
+    event.text = "/new"
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+
+    assert await runner._handle_message(event) == "reset"
+
+    assert order == ["notify", "interrupt", ("reset", {"cancel_notified": True})]
+
+
+@pytest.mark.asyncio
+async def test_cold_hook_sees_recovered_telegram_route(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        profile="default",
+        scope_id="scope-1",
+        chat_id="chat-1",
+        chat_name="Room",
+        chat_type="dm",
+        thread_id="stale-thread",
+        user_id="user-1",
+        user_name="User",
+    )
+    adapter = SimpleNamespace(
+        send=AsyncMock(return_value=SendResult(success=True, message_id="native-1")),
+        _pending_messages={},
+        _active_sessions={},
+        _session_locks={},
+        _stop_typing=AsyncMock(),
+        _pending_lock=threading.Lock(),
+        cancel_pending_drain=lambda _key: None,
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.config.platforms[Platform.TELEGRAM] = PlatformConfig(enabled=True, token="***")
+    runner._recover_telegram_topic_thread_id = lambda _source: "canonical-thread"
+    runner._is_telegram_topic_root_lobby = lambda _source: False
+    captured = {}
+
+    async def hook(_name, **kwargs):
+        captured.update(kwargs)
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook)
+    event = MessageEvent(text="hello", source=source, message_id="in-1")
+
+    await runner._handle_message(event)
+
+    assert captured["route"].thread_id == "canonical-thread"
+    assert captured["route"].session_key == build_session_key(
+        dataclasses.replace(source, thread_id="canonical-thread")
+    )
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_gateway_session_cancel_hook_receives_only_route_and_reason(monkeypatch):
     runner, _adapter = _runner_for_dispatch()
     captured = {}
@@ -478,3 +555,25 @@ async def test_gateway_session_cancel_hook_receives_only_route_and_reason(monkey
     assert captured["kwargs"]["route"] == GatewayMessageRoute.from_source(
         source, session_key=session_key
     )
+
+
+@pytest.mark.asyncio
+async def test_gateway_session_cancel_hook_timeout_does_not_block_stop(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    entered = asyncio.Event()
+
+    async def stuck_hook(_name, **_kwargs):
+        entered.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", stuck_hook)
+    monkeypatch.setattr("gateway.run.GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS", 0.01)
+    source = _source()
+
+    await runner._notify_gateway_session_cancel(
+        build_session_key(source),
+        source,
+        reason="stop",
+    )
+
+    assert entered.is_set()

--- a/tests/gateway/test_gateway_message_hooks.py
+++ b/tests/gateway/test_gateway_message_hooks.py
@@ -213,8 +213,16 @@ async def test_terminal_hook_handling_suppresses_cold_agent_dispatch(
     assert result is None
     runner._handle_message_with_agent.assert_not_awaited()
     assert captured["name"] == "gateway_message"
-    assert set(captured["kwargs"]) == {"event", "route", "delivery", "raise_exceptions"}
+    assert set(captured["kwargs"]) == {
+        "event",
+        "route",
+        "delivery",
+        "raise_exceptions",
+        "stop_when",
+    }
     assert captured["kwargs"]["raise_exceptions"] is True
+    assert captured["kwargs"]["stop_when"]({"decision": "handled"}) is True
+    assert captured["kwargs"]["stop_when"]({"decision": "pass"}) is False
     assert not isinstance(captured["kwargs"]["event"], MessageEvent)
     assert captured["kwargs"]["route"].session_key == build_session_key(_source())
     adapter.send.assert_awaited_once_with(

--- a/tests/gateway/test_gateway_message_hooks.py
+++ b/tests/gateway/test_gateway_message_hooks.py
@@ -44,7 +44,11 @@ def _event() -> MessageEvent:
         media_types=["image/png"],
         reply_to_message_id="prior-1",
         reply_to_text="prior text",
-        metadata={"secret": "must-not-leak"},
+        metadata={
+            "secret": "must-not-leak",
+            "mentioned_user_ids": ["user-2", "user-3"],
+            "mentions_room": True,
+        },
         raw_message={"token": "must-not-leak"},
     )
 
@@ -59,6 +63,8 @@ def test_message_and_route_contexts_are_immutable_normalized_snapshots():
     assert normalized_event.message_type == "photo"
     assert normalized_event.media_urls == ("/tmp/a.png",)
     assert normalized_event.media_types == ("image/png",)
+    assert normalized_event.mentioned_user_ids == ("user-2", "user-3")
+    assert normalized_event.mentions_room is True
     assert normalized_event.reply_to_message_id == "prior-1"
     assert route.platform == "discord"
     assert route.profile == "work"
@@ -75,6 +81,17 @@ def test_message_and_route_contexts_are_immutable_normalized_snapshots():
     assert not hasattr(normalized_event, "source")
     assert not hasattr(route, "role_authorized")
     assert not hasattr(route, "delivered_via_upstream_relay")
+
+
+def test_message_snapshot_marks_unattested_mentions_unknown():
+    event = _event()
+    event.metadata["mentioned_user_ids"] = None
+    event.metadata["mentions_room"] = "unknown"
+
+    normalized_event = GatewayMessageEvent.from_event(event)
+
+    assert normalized_event.mentioned_user_ids is None
+    assert normalized_event.mentions_room is None
 
 
 def test_route_snapshot_fills_resolved_active_profile_when_source_is_unset(monkeypatch):

--- a/tests/gateway/test_gateway_message_hooks.py
+++ b/tests/gateway/test_gateway_message_hooks.py
@@ -323,7 +323,11 @@ async def test_route_delivery_binds_relay_to_ingress_logical_platform(monkeypatc
         Platform.DISCORD,
         "channel-1",
         "relay reply",
-        metadata={"thread_id": "thread-1"},
+        metadata={
+            "thread_id": "thread-1",
+            "scope_id": "guild-1",
+            "user_id": "user-1",
+        },
     )
     relay.send.assert_not_awaited()
 
@@ -388,6 +392,21 @@ async def test_terminal_hook_runs_on_active_session_before_busy_queue(monkeypatc
     assert await runner._handle_message(_event()) is None
     runner._queue_or_replace_pending_event.assert_not_called()
     running_agent.interrupt.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_active_session_drain_gate_prevents_hook_side_effects(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    session_key = build_session_key(_source())
+    runner._running_agents[session_key] = MagicMock()
+    runner._draining = True
+    hook = AsyncMock(return_value=[])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    result = await runner._handle_message(_event())
+
+    hook.assert_not_awaited()
+    assert "not accepting" in str(result).lower()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_gateway_message_hooks.py
+++ b/tests/gateway/test_gateway_message_hooks.py
@@ -1,0 +1,379 @@
+"""Public contract tests for the generic gateway user-message hook."""
+
+from dataclasses import FrozenInstanceError
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.message_hooks import (
+    GatewayDelivery,
+    GatewayDeliveryReceipt,
+    GatewayMessageEvent,
+    GatewayMessageRoute,
+)
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource, build_session_key
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        profile="work",
+        scope_id="guild-1",
+        chat_id="channel-1",
+        chat_name="general",
+        chat_type="thread",
+        thread_id="thread-1",
+        user_id="user-1",
+        user_name="Tester",
+    )
+
+
+def _event() -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        message_type=MessageType.PHOTO,
+        source=_source(),
+        message_id="incoming-1",
+        media_urls=["/tmp/a.png"],
+        media_types=["image/png"],
+        reply_to_message_id="prior-1",
+        reply_to_text="prior text",
+        metadata={"secret": "must-not-leak"},
+        raw_message={"token": "must-not-leak"},
+    )
+
+
+def test_message_and_route_contexts_are_immutable_normalized_snapshots():
+    event = _event()
+
+    normalized_event = GatewayMessageEvent.from_event(event)
+    route = GatewayMessageRoute.from_source(event.source, session_key="route-key")
+
+    assert normalized_event.text == "hello"
+    assert normalized_event.message_type == "photo"
+    assert normalized_event.media_urls == ("/tmp/a.png",)
+    assert normalized_event.media_types == ("image/png",)
+    assert normalized_event.reply_to_message_id == "prior-1"
+    assert route.platform == "discord"
+    assert route.profile == "work"
+    assert route.scope_id == "guild-1"
+    assert route.session_key == "route-key"
+
+    with pytest.raises(FrozenInstanceError):
+        normalized_event.text = "changed"
+    with pytest.raises(FrozenInstanceError):
+        route.chat_id = "elsewhere"
+
+    assert not hasattr(normalized_event, "raw_message")
+    assert not hasattr(normalized_event, "metadata")
+    assert not hasattr(normalized_event, "source")
+    assert not hasattr(route, "role_authorized")
+    assert not hasattr(route, "delivered_via_upstream_relay")
+
+
+def test_route_snapshot_fills_resolved_active_profile_when_source_is_unset(monkeypatch):
+    source = _source()
+    source.profile = None
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name",
+        lambda: "default",
+    )
+
+    route = GatewayMessageRoute.from_source(source, session_key="route-key")
+
+    assert route.profile == "default"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("native_result", "expected"),
+    [
+        (
+            SendResult(success=True, message_id="out-1"),
+            GatewayDeliveryReceipt(status="sent", message_id="out-1"),
+        ),
+        (
+            SendResult(success=False, error="rejected with credential-shaped detail"),
+            GatewayDeliveryReceipt(status="failed"),
+        ),
+        (
+            SendResult(success=True, message_id=None),
+            GatewayDeliveryReceipt(status="unknown"),
+        ),
+        (None, GatewayDeliveryReceipt(status="unknown")),
+        (True, GatewayDeliveryReceipt(status="unknown")),
+    ],
+)
+async def test_route_delivery_returns_truthful_normalized_receipts(native_result, expected):
+    sent_content = []
+
+    async def send_native(content: str):
+        sent_content.append(content)
+        return native_result
+
+    delivery = GatewayDelivery(send_native)
+
+    assert await delivery.send("host delivery") == expected
+    assert sent_content == ["host delivery"]
+    assert not hasattr(delivery, "adapter")
+    assert not hasattr(delivery, "_adapter")
+    assert not hasattr(delivery, "runner")
+    assert not hasattr(delivery, "gateway")
+    assert not hasattr(delivery, "credentials")
+    assert not hasattr(delivery, "event")
+
+@pytest.mark.asyncio
+async def test_route_delivery_reports_raised_send_as_failed_without_native_details():
+    async def send_native(_content: str):
+        raise RuntimeError("transport down")
+
+    receipt = await GatewayDelivery(send_native).send("hello")
+
+    assert receipt.status == "failed"
+    assert receipt.message_id is None
+    assert not hasattr(receipt, "error")
+
+
+def _runner_for_dispatch():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True)}
+    )
+    adapter = SimpleNamespace(
+        send=AsyncMock(return_value=SendResult(success=True, message_id="out-1")),
+        _pending_messages={},
+    )
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {"work": {Platform.DISCORD: adapter}}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store._is_rate_limited.return_value = False
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._update_prompt_pending = {}
+    runner._startup_restore_in_progress = False
+    runner._external_drain_active = False
+    runner._draining = False
+    runner._busy_input_mode = "queue"
+    runner._scale_to_zero_note_real_inbound = lambda: None
+    runner._is_user_authorized = lambda _source: True
+    runner._is_telegram_topic_root_lobby = lambda _source: False
+    runner._claim_active_session_slot = lambda *_args, **_kwargs: (None, None)
+    runner._persist_active_agents = lambda: None
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._release_running_agent_state = MagicMock()
+    runner._release_turn_lease = MagicMock()
+    runner._restore_moa_one_shot = MagicMock()
+    runner._restore_pending_one_turn_model_override = MagicMock()
+    runner._handle_message_with_agent = AsyncMock(return_value="")
+    runner._queue_or_replace_pending_event = MagicMock()
+    runner.session_store = MagicMock()
+    runner.hooks = SimpleNamespace(emit_collect=AsyncMock(return_value=[]))
+    return runner, adapter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", ["handled", "suppress"])
+async def test_terminal_hook_handling_suppresses_cold_agent_dispatch(
+    monkeypatch, decision
+):
+    runner, adapter = _runner_for_dispatch()
+    captured = {}
+
+    async def hook(name, **kwargs):
+        captured["name"] = name
+        captured["kwargs"] = kwargs
+        receipt = await kwargs["delivery"].send("plugin reply")
+        assert receipt == GatewayDeliveryReceipt(status="sent", message_id="out-1")
+        return [{"decision": decision}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    raw_event = _event()
+    result = await runner._handle_message(raw_event)
+
+    assert result is None
+    runner._handle_message_with_agent.assert_not_awaited()
+    assert captured["name"] == "gateway_message"
+    assert set(captured["kwargs"]) == {"event", "route", "delivery", "raise_exceptions"}
+    assert captured["kwargs"]["raise_exceptions"] is True
+    assert not isinstance(captured["kwargs"]["event"], MessageEvent)
+    assert captured["kwargs"]["route"].session_key == build_session_key(_source())
+    adapter.send.assert_awaited_once_with(
+        "channel-1", "plugin reply", metadata={"thread_id": "thread-1"}
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", ["continue", "pass"])
+async def test_continue_hook_decisions_reach_cold_agent_dispatch(monkeypatch, decision):
+    runner, _adapter = _runner_for_dispatch()
+
+    async def hook(_name, **_kwargs):
+        return [{"decision": decision}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    await runner._handle_message(_event())
+
+    runner._handle_message_with_agent.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unmatched_none_hook_reaches_cold_agent_dispatch(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+
+    async def hook(_name, **_kwargs):
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    await runner._handle_message(_event())
+
+    runner._handle_message_with_agent.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_result", ["handled", {}, {"decision": "other"}])
+async def test_invalid_terminal_hook_results_fail_closed(monkeypatch, invalid_result):
+    runner, _adapter = _runner_for_dispatch()
+
+    async def hook(_name, **_kwargs):
+        return [invalid_result]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    assert await runner._handle_message(_event()) is None
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_terminal_hook_exception_fails_closed(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+
+    async def hook(_name, **_kwargs):
+        raise RuntimeError("hook failed")
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    assert await runner._handle_message(_event()) is None
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_terminal_hook_runs_on_active_session_before_busy_queue(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    session_key = build_session_key(_source())
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+
+    async def hook(_name, **_kwargs):
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    assert await runner._handle_message(_event()) is None
+    runner._queue_or_replace_pending_event.assert_not_called()
+    running_agent.interrupt.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_mutation", "authorized"),
+    [
+        (lambda event: setattr(event, "internal", True), True),
+        (lambda _event: None, False),
+        (lambda event: setattr(event, "text", "/help"), True),
+    ],
+)
+async def test_hook_never_runs_for_internal_unauthorized_or_slash_events(
+    monkeypatch, event_mutation, authorized
+):
+    runner, _adapter = _runner_for_dispatch()
+    runner._is_user_authorized = lambda _source: authorized
+    runner._handle_help_command = AsyncMock(return_value="help")
+    hook = AsyncMock(return_value=[{"decision": "handled"}])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+    event = _event()
+    if not authorized:
+        event.source.chat_type = "group"
+    event_mutation(event)
+
+    await runner._handle_message(event)
+
+    hook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_hook_runs_after_pending_update_response_intercept(monkeypatch, tmp_path):
+    runner, _adapter = _runner_for_dispatch()
+    event = _event()
+    event.text = "yes"
+    session_key = build_session_key(event.source)
+    runner._update_prompt_pending[session_key] = True
+    hook = AsyncMock(return_value=[{"decision": "handled"}])
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+
+    result = await runner._handle_message(event)
+
+    assert "Sent" in result
+    hook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_active_session_stop_notifies_cancel_hook_before_interrupt(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    source = _source()
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = MagicMock()
+    runner._notify_gateway_session_cancel = AsyncMock()
+    runner._interrupt_and_clear_session = AsyncMock()
+    event = _event()
+    event.text = "/stop"
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+
+    await runner._handle_message(event)
+
+    runner._notify_gateway_session_cancel.assert_awaited_once_with(
+        session_key,
+        source,
+        reason="stop",
+    )
+    runner._interrupt_and_clear_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_gateway_session_cancel_hook_receives_only_route_and_reason(monkeypatch):
+    runner, _adapter = _runner_for_dispatch()
+    captured = {}
+
+    async def hook(name, **kwargs):
+        captured["name"] = name
+        captured["kwargs"] = kwargs
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook, raising=False)
+    source = _source()
+    session_key = build_session_key(source)
+
+    await runner._notify_gateway_session_cancel(session_key, source, reason="stop")
+
+    assert captured["name"] == "gateway_session_cancel"
+    assert set(captured["kwargs"]) == {"route", "reason"}
+    assert captured["kwargs"]["reason"] == "stop"
+    assert captured["kwargs"]["route"] == GatewayMessageRoute.from_source(
+        source, session_key=session_key
+    )

--- a/tests/gateway/test_gateway_message_hooks.py
+++ b/tests/gateway/test_gateway_message_hooks.py
@@ -15,7 +15,7 @@ from gateway.message_hooks import (
     GatewayMessageEvent,
     GatewayMessageRoute,
 )
-from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
 from gateway.session import SessionSource, build_session_key
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 
@@ -131,13 +131,13 @@ async def test_route_delivery_returns_truthful_normalized_receipts(native_result
 
 
 @pytest.mark.asyncio
-async def test_route_delivery_reports_raised_send_as_failed_without_native_details():
+async def test_route_delivery_reports_raised_send_as_unknown_without_native_details():
     async def send_native(_content: str):
         raise RuntimeError("transport down")
 
     receipt = await GatewayDelivery(send_native).send("hello")
 
-    assert receipt.status == "failed"
+    assert receipt.status == "unknown"
     assert receipt.message_id is None
     assert not hasattr(receipt, "error")
 
@@ -246,6 +246,58 @@ async def test_continue_hook_decisions_reach_cold_agent_dispatch(monkeypatch, de
     await runner._handle_message(_event())
 
     runner._handle_message_with_agent.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_real_base_adapter_busy_ingress_reaches_gateway_message_hook_once(monkeypatch):
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, _chat_id, _content, **_kwargs):
+        return SendResult(success=True, message_id="busy-out")
+
+    Adapter = type(
+        "BusyHookAdapter",
+        (BasePlatformAdapter,),
+        {"connect": connect, "disconnect": disconnect, "send": send},
+    )
+    Adapter.__abstractmethods__ = frozenset()
+
+    runner, _old_adapter = _runner_for_dispatch()
+    adapter = Adapter(PlatformConfig(enabled=True), Platform.DISCORD)
+    adapter._message_handler = AsyncMock()
+    adapter._busy_session_handler = runner._handle_active_session_busy_message
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {"work": {Platform.DISCORD: adapter}}
+    runner._busy_ack_ts = {}
+
+    event = MessageEvent(
+        text="busy follow-up",
+        message_type=MessageType.TEXT,
+        source=_source(),
+        message_id="busy-in",
+    )
+    session_key = build_session_key(event.source)
+    running_agent = MagicMock()
+    running_agent.get_activity_summary.return_value = {}
+    runner._running_agents[session_key] = running_agent
+    adapter._active_sessions[session_key] = asyncio.Event()
+    calls = []
+
+    async def hook(name, **kwargs):
+        calls.append((name, kwargs["route"].session_key))
+        return [{"decision": "handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", hook)
+
+    await adapter.handle_message(event)
+
+    assert calls == [("gateway_message", session_key)]
+    running_agent.interrupt.assert_not_called()
+    assert session_key not in adapter._pending_messages
 
 
 @pytest.mark.asyncio
@@ -569,7 +621,8 @@ async def test_gateway_session_cancel_hook_receives_only_route_and_reason(monkey
     await runner._notify_gateway_session_cancel(session_key, source, reason="stop")
 
     assert captured["name"] == "gateway_session_cancel"
-    assert set(captured["kwargs"]) == {"route", "reason"}
+    assert set(captured["kwargs"]) == {"route", "reason", "offload_sync"}
+    assert captured["kwargs"]["offload_sync"] is True
     assert captured["kwargs"]["reason"] == "stop"
     assert captured["kwargs"]["route"] == GatewayMessageRoute.from_source(
         source, session_key=session_key
@@ -596,3 +649,33 @@ async def test_gateway_session_cancel_hook_timeout_does_not_block_stop(monkeypat
     )
 
     assert entered.is_set()
+
+
+@pytest.mark.asyncio
+async def test_gateway_session_cancel_timeout_bounds_blocking_sync_observer(monkeypatch):
+    from gateway import run as run_module
+    from hermes_cli.plugins import get_plugin_manager
+
+    runner, _adapter = _runner_for_dispatch()
+    manager = get_plugin_manager()
+    original = list(manager._hooks.get("gateway_session_cancel", []))
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocking_observer(**_kwargs):
+        entered.set()
+        release.wait(1)
+
+    manager._hooks["gateway_session_cancel"] = [blocking_observer]
+    monkeypatch.setattr(run_module, "GATEWAY_SESSION_CANCEL_TIMEOUT_SECONDS", 0.01)
+    source = _source()
+    session_key = build_session_key(source)
+    started = asyncio.get_running_loop().time()
+    try:
+        await runner._notify_gateway_session_cancel(session_key, source, reason="stop")
+        elapsed = asyncio.get_running_loop().time() - started
+        assert entered.is_set()
+        assert elapsed < 0.1
+    finally:
+        release.set()
+        manager._hooks["gateway_session_cancel"] = original

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -179,6 +179,23 @@ async def test_hook_error_does_not_break_reset(mock_invoke_hook):
 
 
 @pytest.mark.asyncio
+async def test_reset_notifies_gateway_session_cancel_hook():
+    """The confirmed reset path must notify async plugin-owned work."""
+    runner = _make_runner()
+    runner._notify_gateway_session_cancel = AsyncMock()
+    event = _make_event("/new")
+    session_key = build_session_key(event.source)
+
+    await runner._handle_reset_command(event)
+
+    runner._notify_gateway_session_cancel.assert_awaited_once_with(
+        session_key,
+        event.source,
+        reason="reset",
+    )
+
+
+@pytest.mark.asyncio
 @patch("hermes_cli.plugins.invoke_hook")
 async def test_idle_expiry_fires_finalize_hook(mock_invoke_hook):
     """Regression test for #14981.

--- a/tests/gateway/test_stop_thread_sibling.py
+++ b/tests/gateway/test_stop_thread_sibling.py
@@ -9,6 +9,7 @@ stop any run in the same thread.
 """
 
 import pytest
+from unittest.mock import AsyncMock
 
 from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL, _INTERRUPT_REASON_STOP
 from gateway.session import SessionSource, build_session_key
@@ -161,6 +162,28 @@ async def test_stop_does_not_interrupt_sibling_when_unauthorized(monkeypatch):
 # ---------------------------------------------------------------------------
 # /stop with no active agent still clears a stuck platform status (#32295)
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_notifies_gateway_session_cancel_hook():
+    runner = object.__new__(GatewayRunner)
+    key = _per_user_key("userA")
+    runner._running_agents = {}
+    runner.session_store = _FakeStore(key)
+    runner._is_user_authorized = lambda source: True
+    runner.adapters = {}
+    runner._notify_gateway_session_cancel = AsyncMock()
+    event = MessageEvent(
+        text="/stop", message_type=MessageType.TEXT, source=_thread_source("userA")
+    )
+
+    await runner._handle_stop_command(event)
+
+    runner._notify_gateway_session_cancel.assert_awaited_once_with(
+        key,
+        event.source,
+        reason="stop",
+    )
 
 
 class _FakeStatusAdapter:

--- a/tests/gateway/test_stop_thread_sibling.py
+++ b/tests/gateway/test_stop_thread_sibling.py
@@ -9,7 +9,7 @@ stop any run in the same thread.
 """
 
 import pytest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 
 from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL, _INTERRUPT_REASON_STOP
 from gateway.session import SessionSource, build_session_key
@@ -123,6 +123,7 @@ async def test_stop_interrupts_sibling_thread_run_when_authorized(monkeypatch):
 
     runner._interrupt_and_clear_session = _fake_interrupt
     runner._is_user_authorized = lambda source: True
+    runner._notify_gateway_session_cancel = AsyncMock()
 
     event = MessageEvent(
         text="/stop", message_type=MessageType.TEXT, source=_thread_source("userA")
@@ -130,6 +131,10 @@ async def test_stop_interrupts_sibling_thread_run_when_authorized(monkeypatch):
     result = await runner._handle_stop_command(event)
 
     assert interrupted == [(key_b, _INTERRUPT_REASON_STOP, "stop_command_thread_sibling")]
+    assert runner._notify_gateway_session_cancel.await_args_list == [
+        call(key_a, event.source, reason="stop"),
+        call(key_b, event.source, reason="stop"),
+    ]
     # EphemeralReply or str — both carry the "stopped" message, not "no_active".
     assert "no active" not in str(getattr(result, "text", result)).lower()
 

--- a/tests/gateway/test_stop_thread_sibling.py
+++ b/tests/gateway/test_stop_thread_sibling.py
@@ -8,8 +8,10 @@ nothing and reply "no active task to stop".  Authorized users should be able to
 stop any run in the same thread.
 """
 
+import asyncio
+
 import pytest
-from unittest.mock import AsyncMock, call
+from unittest.mock import AsyncMock
 
 from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL, _INTERRUPT_REASON_STOP
 from gateway.session import SessionSource, build_session_key
@@ -131,12 +133,42 @@ async def test_stop_interrupts_sibling_thread_run_when_authorized(monkeypatch):
     result = await runner._handle_stop_command(event)
 
     assert interrupted == [(key_b, _INTERRUPT_REASON_STOP, "stop_command_thread_sibling")]
-    assert runner._notify_gateway_session_cancel.await_args_list == [
-        call(key_a, event.source, reason="stop"),
-        call(key_b, event.source, reason="stop"),
-    ]
+    cancel_calls = runner._notify_gateway_session_cancel.await_args_list
+    assert [item.args[0] for item in cancel_calls] == [key_a, key_b]
+    assert cancel_calls[0].args[1].user_id == "userA"
+    assert cancel_calls[1].args[1].user_id == "userB"
     # EphemeralReply or str — both carry the "stopped" message, not "no_active".
     assert "no active" not in str(getattr(result, "text", result)).lower()
+
+
+@pytest.mark.asyncio
+async def test_sibling_stop_notifies_all_routes_concurrently(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    key_a = _per_user_key("userA")
+    key_b = _per_user_key("userB")
+    key_c = _per_user_key("userC")
+    runner._running_agents = {key_b: _FakeAgent(), key_c: _FakeAgent()}
+    runner.session_store = _FakeStore(key_a)
+    runner._is_user_authorized = lambda source: True
+    runner._interrupt_and_clear_session = AsyncMock()
+
+    entered = []
+    all_entered = asyncio.Event()
+
+    async def notify(session_key, _source, *, reason):
+        entered.append(session_key)
+        if len(entered) == 3:
+            all_entered.set()
+        await all_entered.wait()
+
+    runner._notify_gateway_session_cancel = notify
+    event = MessageEvent(
+        text="/stop", message_type=MessageType.TEXT, source=_thread_source("userA")
+    )
+
+    await asyncio.wait_for(runner._handle_stop_command(event), timeout=0.2)
+
+    assert set(entered) == {key_a, key_b, key_c}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -228,6 +228,27 @@ def test_observed_group_context_uses_shared_source_and_prompt_for_later_mentions
     asyncio.run(_run())
 
 
+def test_caption_mentions_are_transport_attested_in_gateway_metadata():
+    adapter = _make_adapter(require_mention=True)
+    caption = "photo for Bob"
+    entity = SimpleNamespace(
+        type="text_mention",
+        offset=10,
+        length=3,
+        user=SimpleNamespace(id=222),
+    )
+    message = _group_message(
+        text=None,
+        caption=caption,
+        caption_entities=[entity],
+    )
+
+    event = adapter._build_message_event(message, MessageType.PHOTO, update_id=1004)
+
+    assert event.text == caption
+    assert event.metadata["mentioned_user_ids"] == ("222",)
+
+
 def test_observed_group_context_replays_as_current_message_context_not_user_turns():
     from gateway.run import (
         _build_gateway_agent_history,

--- a/tests/gateway/test_telegram_mention_boundaries.py
+++ b/tests/gateway/test_telegram_mention_boundaries.py
@@ -14,7 +14,7 @@ those contexts.
 from types import SimpleNamespace
 
 from gateway.config import Platform, PlatformConfig
-from plugins.platforms.telegram.adapter import TelegramAdapter
+from plugins.platforms.telegram.adapter import TelegramAdapter, _attested_mention_user_ids
 
 
 def _make_adapter():
@@ -183,3 +183,17 @@ class TestCaseInsensitivity:
         text = "hi @Hermes_Bot"
         msg = _message(text=text, entities=[_mention_entity(text, mention="@Hermes_Bot")])
         assert adapter._message_mentions_bot(msg) is True
+
+
+class TestAttestedMentionIdentityExtraction:
+    def test_text_mentions_return_exact_transport_user_ids(self):
+        entities = [
+            _text_mention_entity(0, 3, user_id=123),
+            _text_mention_entity(4, 3, user_id=456),
+        ]
+        assert _attested_mention_user_ids(entities) == ("123", "456")
+
+    def test_username_mention_without_transport_user_id_is_unattested(self):
+        text = "@someone hello"
+        entities = [_mention_entity(text, mention="@someone")]
+        assert _attested_mention_user_ids(entities) is None

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -97,6 +97,84 @@ class TestTextBatching:
         assert "split by Telegram" in dispatched.text
 
     @pytest.mark.asyncio
+    async def test_split_batch_retains_each_native_identity_and_mentions(self):
+        adapter = _make_adapter()
+        first = _make_event("ordinary")
+        first.message_id = "m1"
+        first.metadata["mentioned_user_ids"] = ()
+        second = _make_event("@bot")
+        second.message_id = "m2"
+        second.source.user_id = "user-2"
+        second.metadata["mentioned_user_ids"] = ("9",)
+
+        adapter._enqueue_text_event(first)
+        adapter._enqueue_text_event(second)
+        pending = next(iter(adapter._pending_text_batches.values()))
+        native = pending.metadata["_gateway_native_events"]
+
+        assert [(item.message_id, item.text) for item in native] == [
+            ("m1", "ordinary"),
+            ("m2", "@bot"),
+        ]
+        assert native[0].metadata["mentioned_user_ids"] == ()
+        assert native[1].metadata["mentioned_user_ids"] == ("9",)
+        assert native[1].source.user_id == "user-2"
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_unattested_username_mention_remains_unknown_in_snapshot(self):
+        adapter = _make_adapter()
+        event = _make_event("@someone")
+        event.message_id = "m-unknown"
+        event.metadata["mentioned_user_ids"] = None
+
+        adapter._enqueue_text_event(event)
+        pending = next(iter(adapter._pending_text_batches.values()))
+        native = pending.metadata["_gateway_native_events"]
+
+        assert native[0].metadata["mentioned_user_ids"] is None
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_photo_and_media_group_batches_retain_native_ids(self):
+        adapter = _make_adapter()
+
+        first_photo = _make_event("caption one")
+        first_photo.message_type = MessageType.PHOTO
+        first_photo.message_id = "p1"
+        first_photo.media_urls = ["file:///p1.jpg"]
+        first_photo.media_types = ["image/jpeg"]
+        second_photo = _make_event("caption two")
+        second_photo.message_type = MessageType.PHOTO
+        second_photo.message_id = "p2"
+        second_photo.media_urls = ["file:///p2.jpg"]
+        second_photo.media_types = ["image/jpeg"]
+        adapter._enqueue_photo_event("photos", first_photo)
+        adapter._enqueue_photo_event("photos", second_photo)
+        photo_native = adapter._pending_photo_batches["photos"].metadata[
+            "_gateway_native_events"
+        ]
+        assert [item.message_id for item in photo_native] == ["p1", "p2"]
+
+        first_album = _make_event("")
+        first_album.message_type = MessageType.PHOTO
+        first_album.message_id = "a1"
+        first_album.media_urls = ["file:///a1.jpg"]
+        first_album.media_types = ["image/jpeg"]
+        second_album = _make_event("")
+        second_album.message_type = MessageType.PHOTO
+        second_album.message_id = "a2"
+        second_album.media_urls = ["file:///a2.jpg"]
+        second_album.media_types = ["image/jpeg"]
+        await adapter._queue_media_group_event("album", first_album)
+        await adapter._queue_media_group_event("album", second_album)
+        album_native = adapter._media_group_events["album"].metadata[
+            "_gateway_native_events"
+        ]
+        assert [item.message_id for item in album_native] == ["a1", "a2"]
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
     async def test_three_way_split_aggregated(self):
         """Three rapid messages should all merge."""
         adapter = _make_adapter()

--- a/tests/hermes_cli/test_async_plugin_hooks.py
+++ b/tests/hermes_cli/test_async_plugin_hooks.py
@@ -30,6 +30,30 @@ async def test_async_hook_invocation_supports_sync_and_async_callbacks():
 
 
 @pytest.mark.asyncio
+async def test_async_hook_invocation_can_stop_before_later_callbacks():
+    manager = PluginManager()
+    calls = []
+
+    def handled(**_kwargs):
+        calls.append("handled")
+        return {"decision": "handled"}
+
+    def must_not_run(**_kwargs):
+        calls.append("later")
+        return {"decision": "pass"}
+
+    manager._hooks["gateway_message"] = [handled, must_not_run]
+
+    results = await manager.invoke_hook_async(
+        "gateway_message",
+        stop_when=lambda result: result == {"decision": "handled"},
+    )
+
+    assert results == [{"decision": "handled"}]
+    assert calls == ["handled"]
+
+
+@pytest.mark.asyncio
 async def test_async_hook_invocation_excludes_unmatched_none_results():
     manager = PluginManager()
     manager._hooks["gateway_message"] = [lambda **_kwargs: None]

--- a/tests/hermes_cli/test_async_plugin_hooks.py
+++ b/tests/hermes_cli/test_async_plugin_hooks.py
@@ -1,6 +1,8 @@
 """Behavior tests for asynchronous plugin hook invocation."""
 
 import asyncio
+import threading
+import time
 
 import pytest
 
@@ -27,6 +29,33 @@ async def test_async_hook_invocation_supports_sync_and_async_callbacks():
 
     assert calls == [("sync", "hello"), ("async", "hello")]
     assert results == [{"decision": "pass"}, {"decision": "handled"}]
+
+
+@pytest.mark.asyncio
+async def test_async_hook_can_offload_blocking_sync_callback_for_host_timeout():
+    manager = PluginManager()
+    finished = False
+    daemon = None
+
+    def blocking_callback(**_kwargs):
+        nonlocal daemon, finished
+        daemon = threading.current_thread().daemon
+        time.sleep(0.2)
+        finished = True
+
+    manager._hooks["gateway_session_cancel"] = [blocking_callback]
+
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(
+            manager.invoke_hook_async(
+                "gateway_session_cancel",
+                offload_sync=True,
+            ),
+            timeout=0.01,
+        )
+
+    assert daemon is True
+    assert finished is False
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_async_plugin_hooks.py
+++ b/tests/hermes_cli/test_async_plugin_hooks.py
@@ -1,0 +1,63 @@
+"""Behavior tests for asynchronous plugin hook invocation."""
+
+import asyncio
+
+import pytest
+
+from hermes_cli.plugins import PluginManager
+
+
+@pytest.mark.asyncio
+async def test_async_hook_invocation_supports_sync_and_async_callbacks():
+    manager = PluginManager()
+    calls = []
+
+    def sync_callback(**kwargs):
+        calls.append(("sync", kwargs["value"]))
+        return {"decision": "pass"}
+
+    async def async_callback(**kwargs):
+        await asyncio.sleep(0)
+        calls.append(("async", kwargs["value"]))
+        return {"decision": "handled"}
+
+    manager._hooks["gateway_message"] = [sync_callback, async_callback]
+
+    results = await manager.invoke_hook_async("gateway_message", value="hello")
+
+    assert calls == [("sync", "hello"), ("async", "hello")]
+    assert results == [{"decision": "pass"}, {"decision": "handled"}]
+
+
+@pytest.mark.asyncio
+async def test_async_hook_invocation_excludes_unmatched_none_results():
+    manager = PluginManager()
+    manager._hooks["gateway_message"] = [lambda **_kwargs: None]
+
+    assert await manager.invoke_hook_async("gateway_message") == []
+
+
+@pytest.mark.asyncio
+async def test_async_hook_invocation_can_fail_fast_for_terminal_hooks():
+    manager = PluginManager()
+
+    def broken(**_kwargs):
+        raise RuntimeError("broken hook")
+
+    manager._hooks["gateway_message"] = [broken]
+
+    with pytest.raises(RuntimeError, match="broken hook"):
+        await manager.invoke_hook_async("gateway_message", raise_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_async_hook_invocation_reraises_cancelled_error():
+    manager = PluginManager()
+
+    async def cancelled(**_kwargs):
+        raise asyncio.CancelledError
+
+    manager._hooks["gateway_message"] = [cancelled]
+
+    with pytest.raises(asyncio.CancelledError):
+        await manager.invoke_hook_async("gateway_message")

--- a/tests/hermes_cli/test_async_plugin_hooks.py
+++ b/tests/hermes_cli/test_async_plugin_hooks.py
@@ -3,6 +3,7 @@
 import asyncio
 import threading
 import time
+from contextvars import ContextVar
 
 import pytest
 
@@ -56,6 +57,30 @@ async def test_async_hook_can_offload_blocking_sync_callback_for_host_timeout():
 
     assert daemon is True
     assert finished is False
+
+
+@pytest.mark.asyncio
+async def test_async_hook_can_offload_all_callbacks_with_context_to_daemon_thread():
+    manager = PluginManager()
+    profile = ContextVar("profile", default="default")
+    seen = []
+
+    async def async_callback(**_kwargs):
+        seen.append((profile.get(), threading.current_thread().daemon))
+        return "done"
+
+    manager._hooks["gateway_session_cancel"] = [async_callback]
+    token = profile.set("work")
+    try:
+        results = await manager.invoke_hook_async(
+            "gateway_session_cancel",
+            offload_callbacks=True,
+        )
+    finally:
+        profile.reset(token)
+
+    assert results == ["done"]
+    assert seen == [("work", True)]
 
 
 @pytest.mark.asyncio

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -607,13 +607,15 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | [`on_session_end`](/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit | `session_id: str, completed: bool, interrupted: bool, model: str, platform: str` | ignored |
 | [`on_session_finalize`](/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session | `session_id: str \| None, platform: str` | ignored |
 | [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`) | `session_id: str, platform: str` | ignored |
+| [`gateway_message`](/user-guide/features/hooks#gateway_message) | Authorized, routed ordinary gateway message after control interception and before normal agent dispatch | `event: GatewayMessageEvent, route: GatewayMessageRoute, delivery: GatewayDelivery` | `{"decision": "handled" \| "suppress" \| "continue" \| "pass"}` or `None` when unmatched |
+| [`gateway_session_cancel`](/user-guide/features/hooks#gateway_session_cancel) | Confirmed gateway `/stop` or `/new`/reset boundary | `route: GatewayMessageRoute, reason: str` | ignored |
 | `kanban_task_claimed` | A kanban task is claimed (dispatcher process, before the worker spawns) | `task_id: str, board: str \| None, assignee: str \| None, run_id: int \| None, profile_name: str` | ignored |
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |
 
-Most hooks are fire-and-forget observers — their return values are ignored. The exception is `pre_llm_call`, which can inject context into the conversation.
+Most hooks are fire-and-forget observers — their return values are ignored. `pre_llm_call` can inject context into the conversation, and `gateway_message` makes a terminal handled/continue decision before normal gateway dispatch.
 
-All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
+All callbacks should accept `**kwargs` for forward compatibility. Observer-hook failures are logged and skipped. A matched `gateway_message` failure or invalid terminal result fails closed and suppresses normal-agent dispatch; task cancellation still propagates.
 
 The kanban lifecycle hooks fire **after** the board DB change commits, so a callback always sees durable state and can never hold the SQLite write lock. Because kanban workers run as separate `hermes -p <profile> chat -q` subprocesses, `kanban_task_claimed` fires in the **dispatcher** process while `kanban_task_completed` / `kanban_task_blocked` fire in the **worker** process — hook in the dispatcher to observe every transition centrally, or in the worker for per-task in-session context.
 

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -621,7 +621,7 @@ The kanban lifecycle hooks fire **after** the board DB change commits, so a call
 
 ### `pre_llm_call` context injection
 
-This is the only hook whose return value matters. When a `pre_llm_call` callback returns a dict with a `"context"` key (or a plain string), Hermes injects that text into the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context.
+For `pre_llm_call`, a callback return value can inject context into the current turn. When it returns a dict with a `"context"` key (or a plain string), Hermes prepends that text to the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context. (`gateway_message` has its separate terminal-decision contract above.)
 
 #### Return format
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -392,6 +392,8 @@ def register(ctx):
 | [`subagent_start`](#subagent_start) | A `delegate_task` child has been constructed and is about to run | ignored |
 | [`subagent_stop`](#subagent_stop) | A `delegate_task` child has exited | ignored |
 | [`pre_gateway_dispatch`](#pre_gateway_dispatch) | Gateway received a user message, before auth + dispatch | `{"action": "skip" \| "rewrite" \| "allow", ...}` to influence flow |
+| [`gateway_message`](#gateway_message) | Authorized, routed ordinary user message after control interception, before normal agent dispatch | terminal handled/continue decision |
+| [`gateway_session_cancel`](#gateway_session_cancel) | Confirmed `/stop` or `/new`/reset gateway boundary | ignored |
 | [`pre_approval_request`](#pre_approval_request) | An approval decision is requested, including smart-mode auto decisions | ignored |
 | [`post_approval_response`](#post_approval_response) | An approval decision is made (or a prompt times out) | ignored |
 | [`transform_tool_result`](#transform_tool_result) | After any tool returns, before the result is handed back to the model | `str` to replace the result, `None` to leave unchanged |
@@ -995,6 +997,46 @@ def register(ctx):
 :::info
 With heavy delegation (e.g. orchestrator roles × 5 leaves × nested depth), `subagent_stop` fires many times per turn. Keep your callback fast; push expensive work to a background queue.
 :::
+
+---
+
+### `gateway_message`
+
+Fires for an ordinary user message only after Hermes has admitted and authorized the native source, resolved its profile/session route, and intercepted slash commands and other gateway controls. It runs on both cold and active/busy session paths before normal agent dispatch.
+
+The callback receives only public immutable snapshots and a route-bound capability:
+
+```python
+async def on_gateway_message(event, route, delivery, **kwargs):
+    if route.platform != "discord":
+        return None  # this handler did not match
+
+    receipt = await delivery.send("Handled by the plugin")
+    return {"decision": "handled"}
+
+def register(ctx):
+    ctx.register_hook("gateway_message", on_gateway_message)
+```
+
+- `event` is a frozen `GatewayMessageEvent`; it contains normalized message/reply/media facts but no raw native message, metadata, credentials, adapter, or mutable `MessageEvent`.
+- `route` is a frozen `GatewayMessageRoute` containing the resolved profile/session and current platform/chat/thread/user identity.
+- `delivery.send(text)` can send only to that captured native route. It returns `sent` only when the adapter positively acknowledges a non-empty native message ID, `failed` for an explicit native failure, and `unknown` for missing, malformed, or unattributable acknowledgement. Native error text is not exposed.
+
+Matched handlers return `{"decision": "handled"}` or `{"decision": "suppress"}` to stop normal dispatch, or `{"decision": "continue"}` / `{"decision": "pass"}` to allow it. `None` means the callback did not match. Callbacks may be synchronous or asynchronous. An exception or invalid non-`None` terminal result fails closed and suppresses normal dispatch; `asyncio.CancelledError` propagates.
+
+This hook is not invoked for unauthorized, internal, slash-command, or already-intercepted control events. Use it for extensions that need an authorized post-routing participant turn. Use `pre_gateway_dispatch` only for policies that intentionally operate before authorization.
+
+### `gateway_session_cancel`
+
+Fires after Hermes confirms an explicit `/stop` or `/new`/reset boundary. The callback receives the immutable `route` and a `reason` (`"stop"` or `"reset"`) so plugin-owned schedulers can invalidate active and pending work. It is an observer notification: returns are ignored, callback failures are logged, and task cancellation propagates.
+
+```python
+async def cancel_plugin_work(route, reason, **kwargs):
+    await scheduler.cancel(route.session_key, reason=reason)
+
+def register(ctx):
+    ctx.register_hook("gateway_session_cancel", cancel_plugin_work)
+```
 
 ---
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -372,9 +372,9 @@ def register(ctx):
 **General rules for all hooks:**
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
-- If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
-- Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
+- Callback failures are normally logged and skipped. `gateway_message` is deliberately stricter: once a callback matches, an exception or invalid terminal result suppresses normal dispatch. Task cancellation always propagates.
+- Three hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call, and [`gateway_message`](#gateway_message) can terminate or continue gateway dispatch. Other hooks are observers.
+- Observer callbacks invoked through the synchronous observer path receive `telemetry_schema_version` automatically. Async gateway hooks receive only the arguments documented for their specific contracts. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 
 ### Quick reference
 
@@ -1028,7 +1028,7 @@ This hook is not invoked for unauthorized, internal, slash-command, or already-i
 
 ### `gateway_session_cancel`
 
-Fires after Hermes confirms an explicit `/stop` or `/new`/reset boundary. The callback receives the immutable `route` and a `reason` (`"stop"` or `"reset"`) so plugin-owned schedulers can invalidate active and pending work. It is an observer notification: returns are ignored, callback failures are logged, and task cancellation propagates.
+Fires after Hermes confirms an explicit `/stop` or `/new`/reset boundary. The callback receives the immutable `route` and a `reason` (`"stop"` or `"reset"`) so plugin-owned schedulers can invalidate active and pending work. It is a bounded best-effort observer notification: returns are ignored, callback failures are logged, and Hermes proceeds with the host interruption/reset if callbacks do not finish within two seconds. Caller task cancellation still propagates.
 
 ```python
 async def cancel_plugin_work(route, reason, **kwargs):


### PR DESCRIPTION
## Summary

- add a generic post-authorization `gateway_message` plugin hook for authorized ordinary Discord and Telegram ingress, including cold and already-busy sessions exactly once
- expose immutable bounded message/route snapshots and opaque route-bound delivery with truthful `sent` / `failed` / `unknown` receipts
- keep host command/control, authorization, shutdown drain, session lifecycle, profile routing, cancellation, native delivery, and success attribution host-owned
- add bounded `gateway_session_cancel` notifications for `/stop`, `/new`/reset, sibling boundaries, shutdown, and restart
- publish gateway-message hook API v2 with transport-attested user/room mention facts; unresolved Telegram username mentions remain explicitly unattested

The extension is intentionally participant-neutral. Hermes contains no Nunchi attention policy, social judgment, participant scheduling, authorization policy, approval journal, or privileged-effect semantics.

## Security boundary

- hooks run only after host authorization, command interception, and drain acceptance
- unauthorized, internal, command/control, and drain-rejected ingress never reaches `gateway_message`
- authorized cold and busy ordinary ingress reaches the hook once; queued busy replay reuses the first hook result
- message and route context is immutable and excludes raw native messages, mutable events, adapters, clients, credentials, session stores, and extractable send callbacks
- delivery stays bound to the captured platform/profile/tenant/actor/room/thread route
- `sent` requires explicit native success plus an attributable message ID; exceptions and ambiguity become `unknown`
- synchronous cancellation observers run in bounded disposable daemon threads with routed `contextvars`
- profile-scoped session keys prevent multiplexed busy-session collision

## Exact candidate

- Hermes commit: `41dc47c400ec302e81a706a10c7dbd64fc315f2e`
- Hermes tree: `f9ccaba8263d659f90550adb66839cb04e0a93bf`
- paired Nunchi candidate: `9df74955d65d9d698c3bd6a5ec00ff1ee0948fb8`

## Verification

- expanded gateway/plugin/Discord/Telegram suite: **242 passed**, with one
  `shutdown_forensics` subprocess-spawn failure reproduced unchanged on exact
  base `32fd9d65…`
- Ruff passed on every changed Python file
- `git diff --check` passed
- exact Hermes archive plus exact installed Nunchi wheel passed real `PluginManager` discovery, API-v2 registration, operational config, fail-closed invalid digest and mismatched host-source evidence, public-probe redaction, two-profile multiplexing, bounded-gap rejection, route-bound reply/reaction, capability revocation, and cancellation-fence smokes
- the canonical full wrapper for superseded `7b2f442…` found 42 failures; exact base comparison isolated one real candidate regression in bare-runner shutdown revocation and it is fixed in this successor. The canonical wrapper for exact `41dc47c…` is running.

This successor closes the prior exact-review findings in native-batch actor
identity, Telegram per-native text/photo/album preservation, busy pre-dispatch
ordering, startup/history replay exclusion, caption mention attestation, and
bare-runner shutdown compatibility. Fresh named read-only exact-tree reviews
of both paired successors are in progress. The PR remains draft pending
blocker-free review, exact full-suite classification, live commissioning, and
merge approval.
