### PR TITLE
feat(billing): carry the payment-method union through to clients

### DIFF
--- a/agent/billing_view.py
+++ b/agent/billing_view.py
@@ -108,6 +108,16 @@ class CardInfo:
 
 
 @dataclass(frozen=True)
+class PaymentMethodInfo:
+    kind: str
+    brand: Optional[str] = None
+    last4: Optional[str] = None
+    wallet: Optional[str] = None
+    email: Optional[str] = None
+    resolved_via: Optional[str] = None
+
+
+@dataclass(frozen=True)
 class MonthlyCap:
     limit_usd: Optional[Decimal] = None
     spent_this_month_usd: Optional[Decimal] = None
@@ -150,6 +160,7 @@ class BillingState:
     min_usd: Optional[Decimal] = None
     max_usd: Optional[Decimal] = None
     card: Optional[CardInfo] = None
+    payment_method: Optional[PaymentMethodInfo] = None
     monthly_cap: Optional[MonthlyCap] = None
     auto_reload: Optional[AutoReload] = None
     portal_url: Optional[str] = None
@@ -199,6 +210,27 @@ def _parse_card(raw: Any) -> Optional[CardInfo]:
     if not isinstance(resolved_via, str):
         resolved_via = None
     return CardInfo(brand=brand, last4=last4, resolved_via=resolved_via)
+
+
+def _parse_payment_method(raw: Any) -> Optional[PaymentMethodInfo]:
+    if not isinstance(raw, dict):
+        return None
+    kind = raw.get("kind")
+    if not isinstance(kind, str):
+        return None
+
+    def _optional_string(key: str) -> Optional[str]:
+        value = raw.get(key)
+        return value if isinstance(value, str) else None
+
+    return PaymentMethodInfo(
+        kind=kind,
+        brand=_optional_string("brand"),
+        last4=_optional_string("last4"),
+        wallet=_optional_string("wallet"),
+        email=_optional_string("email"),
+        resolved_via=_optional_string("resolvedVia"),
+    )
 
 
 def _parse_monthly_cap(raw: Any) -> Optional[MonthlyCap]:
@@ -274,6 +306,7 @@ def billing_state_from_payload(
         min_usd=parse_money(bounds.get("minUsd")),
         max_usd=parse_money(bounds.get("maxUsd")),
         card=_parse_card(payload.get("card")),
+        payment_method=_parse_payment_method(payload.get("paymentMethod")),
         monthly_cap=_parse_monthly_cap(payload.get("monthlyCap")),
         auto_reload=_parse_auto_reload(payload.get("autoReload")),
         portal_url=portal_url,

--- a/agent/billing_view.py
+++ b/agent/billing_view.py
@@ -109,12 +109,18 @@ class CardInfo:
 
 @dataclass(frozen=True)
 class PaymentMethodInfo:
+    """The payment method on file. `kind` is "card", "link", or "unknown"
+    — anything else is normalised to "unknown" at parse time, so consumers
+    only ever see fields that belong to the kind they are looking at."""
+
     kind: str
     brand: Optional[str] = None
     last4: Optional[str] = None
     wallet: Optional[str] = None
     email: Optional[str] = None
     resolved_via: Optional[str] = None
+    #: What the server called it, when we did not recognise the kind.
+    raw_kind: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -223,13 +229,27 @@ def _parse_payment_method(raw: Any) -> Optional[PaymentMethodInfo]:
         value = raw.get(key)
         return value if isinstance(value, str) else None
 
+    resolved_via = _optional_string("resolvedVia")
+    brand = _optional_string("brand")
+    last4 = _optional_string("last4")
+    # Settle the kind here, the way _parse_card settles a card, so nothing
+    # downstream has to re-check which fields this kind is allowed to have.
+    if kind == "card" and brand and last4:
+        return PaymentMethodInfo(
+            kind="card",
+            brand=brand,
+            last4=last4,
+            wallet=_optional_string("wallet"),
+            resolved_via=resolved_via,
+        )
+    if kind == "link":
+        return PaymentMethodInfo(
+            kind="link",
+            email=_optional_string("email"),
+            resolved_via=resolved_via,
+        )
     return PaymentMethodInfo(
-        kind=kind,
-        brand=_optional_string("brand"),
-        last4=_optional_string("last4"),
-        wallet=_optional_string("wallet"),
-        email=_optional_string("email"),
-        resolved_via=_optional_string("resolvedVia"),
+        kind="unknown", raw_kind=kind, resolved_via=resolved_via
     )
 
 

--- a/apps/shared/src/billing-payment-method.test-d.ts
+++ b/apps/shared/src/billing-payment-method.test-d.ts
@@ -1,0 +1,24 @@
+/**
+ * Compile-time guard for BillingPaymentMethod.
+ *
+ * There is nothing to run here — the point is that `tsc` accepts this file.
+ * An earlier revision typed the fallback arm's `kind` as `string & {}`, which
+ * makes the discriminant non-literal and silently defeats narrowing for every
+ * arm: the `pm.brand` read below stops compiling. Keeping this file honest
+ * keeps `kind` narrowable.
+ */
+
+import type { BillingPaymentMethod } from './billing-types'
+
+export function describePaymentMethod(pm: BillingPaymentMethod): string {
+  switch (pm.kind) {
+    case 'card':
+      return pm.wallet ? `${pm.wallet} ${pm.brand} ${pm.last4}` : `${pm.brand} ${pm.last4}`
+
+    case 'link':
+      return pm.email ?? 'Link'
+
+    case 'unknown':
+      return pm.raw_kind
+  }
+}

--- a/apps/shared/src/billing-types.ts
+++ b/apps/shared/src/billing-types.ts
@@ -122,6 +122,31 @@ export interface BillingCardInfo {
   resolved_via?: null | string
 }
 
+/**
+ * The org's payment method on file as a typed union — additive companion to
+ * `card` (which stays populated when the method is a card, so existing
+ * consumers keep working). Sent by newer gateways only; older gateways omit
+ * the field entirely, so consumers must treat absence as "not provided",
+ * not "no payment method". A future kind (an unknown string) must degrade
+ * safely — keep a fallback branch, same convention as BillingRefusalCode.
+ */
+export type BillingPaymentMethod =
+  | {
+      kind: 'card'
+      brand: string
+      last4: string
+      /** Wallet that wrapped the card (e.g. "apple_pay", "google_pay"), if any. */
+      wallet: string | null
+      /** Card-resolution rung ("subPin" | "customerDefault" | "autoRefill") or null. */
+      resolved_via: null | string
+    }
+  | {
+      kind: 'link'
+      /** Link displays as the account email; can be absent on the Stripe side. */
+      email: null | string
+      resolved_via: null | string
+    }
+
 export interface BillingMonthlyCap {
   is_default_ceiling: boolean
   limit_display: string
@@ -159,6 +184,9 @@ export interface BillingStateResponse {
   can_change_plan?: boolean
   can_charge: boolean
   card: BillingCardInfo | null
+  // Typed payment-method union (newer gateways only); `card` remains the
+  // compatibility field and stays populated for kind "card".
+  payment_method?: BillingPaymentMethod | null
   charge_presets: string[]
   charge_presets_display: string[]
   cli_billing_enabled: boolean

--- a/apps/shared/src/billing-types.ts
+++ b/apps/shared/src/billing-types.ts
@@ -123,12 +123,22 @@ export interface BillingCardInfo {
 }
 
 /**
- * The org's payment method on file as a typed union — additive companion to
- * `card` (which stays populated when the method is a card, so existing
- * consumers keep working). Sent by newer gateways only; older gateways omit
- * the field entirely, so consumers must treat absence as "not provided",
- * not "no payment method". A future kind (an unknown string) must degrade
- * safely — keep a fallback branch, same convention as BillingRefusalCode.
+ * The org's payment method on file.
+ *
+ * This is the authoritative field. `card` is a lossy older view of the same
+ * thing: it is populated only when the method is a card, and is null for
+ * every other kind — so `!card` does NOT mean "no payment method on file".
+ * A surface that gates on `card` alone will tell a Link customer they have
+ * nothing on file.
+ *
+ * Older gateways omit this field entirely, so absence means "this gateway
+ * didn't say", not "nothing on file".
+ *
+ * A kind this client predates arrives as `unknown` rather than as its real
+ * name, which keeps `kind` narrowable — every arm is a literal, so
+ * `if (pm.kind === 'card')` gives you the card fields. (The `string & {}`
+ * trick used by BillingRefusalCode does not work here: on an object union it
+ * makes the discriminant non-literal and defeats narrowing for every arm.)
  */
 export type BillingPaymentMethod =
   | {
@@ -147,11 +157,9 @@ export type BillingPaymentMethod =
       resolved_via: null | string
     }
   | {
-      /**
-       * A kind this client predates. The gateway sends the name and nothing
-       * else, so render something neutral rather than assuming a shape.
-       */
-      kind: string & {}
+      kind: 'unknown'
+      /** What the server actually called it, for logs and neutral copy. */
+      raw_kind: string
       resolved_via: null | string
     }
 

--- a/apps/shared/src/billing-types.ts
+++ b/apps/shared/src/billing-types.ts
@@ -146,6 +146,14 @@ export type BillingPaymentMethod =
       email: null | string
       resolved_via: null | string
     }
+  | {
+      /**
+       * A kind this client predates. The gateway sends the name and nothing
+       * else, so render something neutral rather than assuming a shape.
+       */
+      kind: string & {}
+      resolved_via: null | string
+    }
 
 export interface BillingMonthlyCap {
   is_default_ceiling: boolean

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -13,6 +13,7 @@ export type {
   BillingErrorPayload,
   BillingMonthlyCap,
   BillingMutationResponse,
+  BillingPaymentMethod,
   BillingRefusalCode,
   BillingStateResponse,
   ChargeFailureReason,

--- a/tests/agent/test_billing_view.py
+++ b/tests/agent/test_billing_view.py
@@ -25,6 +25,7 @@ from agent.billing_view import (
     BillingState,
     CardInfo,
     MonthlyCap,
+    PaymentMethodInfo,
     billing_state_from_payload,
     build_billing_state,
     format_money,
@@ -213,6 +214,41 @@ def test_state_owner_tier_parse():
     assert s.auto_reload == AutoReload(
         enabled=True, threshold_usd=Decimal("20"), reload_to_usd=Decimal("100")
     )
+
+
+def test_state_parses_link_payment_method():
+    payload = _owner_payload()
+    payload["paymentMethod"] = {
+        "kind": "link",
+        "email": "billing@example.com",
+        "paymentMethodId": "pm_secret",
+        "purpose": "top-up",
+        "resolvedVia": "customerDefault",
+    }
+
+    state = billing_state_from_payload(payload)
+
+    assert state.payment_method == PaymentMethodInfo(
+        kind="link",
+        email="billing@example.com",
+        resolved_via="customerDefault",
+    )
+
+
+def test_state_without_payment_method_keeps_it_absent():
+    state = billing_state_from_payload(_owner_payload())
+
+    assert state.payment_method is None
+
+
+@pytest.mark.parametrize("raw_payment_method", ["link", {"email": "billing@example.com"}])
+def test_state_ignores_malformed_payment_method(raw_payment_method):
+    payload = _owner_payload()
+    payload["paymentMethod"] = raw_payment_method
+
+    state = billing_state_from_payload(payload)
+
+    assert state.payment_method is None
 
 
 @pytest.mark.parametrize(

--- a/tests/tui_gateway/test_billing_rpc.py
+++ b/tests/tui_gateway/test_billing_rpc.py
@@ -115,10 +115,11 @@ def test_billing_state_fail_open(monkeypatch):
                 "resolved_via": "customerDefault",
             },
         ),
-        # A kind added after this gateway shipped: forwarded by name only.
+        # A kind added after this gateway shipped: normalised to "unknown",
+        # keeping the real name for logs and neutral copy.
         (
             {"kind": "future_method", "resolvedVia": "subPin"},
-            {"kind": "future_method", "resolved_via": "subPin"},
+            {"kind": "unknown", "raw_kind": "future_method", "resolved_via": "subPin"},
         ),
     ],
 )

--- a/tests/tui_gateway/test_billing_rpc.py
+++ b/tests/tui_gateway/test_billing_rpc.py
@@ -16,7 +16,7 @@ import pytest
 import tui_gateway.server as srv
 import hermes_cli.nous_billing as nb
 import agent.billing_view as bv
-from agent.billing_view import BillingState, CardInfo, MonthlyCap
+from agent.billing_view import BillingState, CardInfo, MonthlyCap, PaymentMethodInfo
 
 
 def _call(method: str, params: dict) -> dict:
@@ -41,6 +41,11 @@ def test_billing_state_serializes_decimals_as_strings(monkeypatch):
         min_usd=Decimal("10"),
         max_usd=Decimal("10000"),
         card=CardInfo(brand="visa", last4="4242"),
+        payment_method=PaymentMethodInfo(
+            kind="link",
+            email="billing@example.com",
+            resolved_via="customerDefault",
+        ),
         monthly_cap=MonthlyCap(
             limit_usd=Decimal("1000"), spent_this_month_usd=Decimal("180"), is_default_ceiling=True
         ),
@@ -53,7 +58,21 @@ def test_billing_state_serializes_decimals_as_strings(monkeypatch):
     assert res["balance_usd"] == "142.5"
     assert res["balance_display"] == "$142.50"
     assert res["charge_presets"] == ["100", "250"]
-    assert res["card"]["masked"] == "visa ····4242"
+    assert res["card"] == {
+        "brand": "visa",
+        "last4": "4242",
+        "masked": "visa ····4242",
+        "display": "visa ····4242",
+        "resolved_via": None,
+    }
+    assert res["payment_method"] == {
+        "kind": "link",
+        "brand": None,
+        "last4": None,
+        "wallet": None,
+        "email": "billing@example.com",
+        "resolved_via": "customerDefault",
+    }
     assert res["monthly_cap"]["is_default_ceiling"] is True
     assert res["is_admin"] is True and res["can_charge"] is True
 
@@ -65,6 +84,18 @@ def test_billing_state_fail_open(monkeypatch):
     monkeypatch.setattr(bv, "build_billing_state", _boom)
     res = _call("billing.state", {})
     assert res["ok"] is True and res["logged_in"] is False
+
+
+def test_billing_state_serializes_absent_payment_method(monkeypatch):
+    monkeypatch.setattr(
+        bv,
+        "build_billing_state",
+        lambda *a, **kw: BillingState(logged_in=False),
+    )
+
+    res = _call("billing.state", {})
+
+    assert res["payment_method"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tui_gateway/test_billing_rpc.py
+++ b/tests/tui_gateway/test_billing_rpc.py
@@ -67,9 +67,6 @@ def test_billing_state_serializes_decimals_as_strings(monkeypatch):
     }
     assert res["payment_method"] == {
         "kind": "link",
-        "brand": None,
-        "last4": None,
-        "wallet": None,
         "email": "billing@example.com",
         "resolved_via": "customerDefault",
     }
@@ -84,6 +81,64 @@ def test_billing_state_fail_open(monkeypatch):
     monkeypatch.setattr(bv, "build_billing_state", _boom)
     res = _call("billing.state", {})
     assert res["ok"] is True and res["logged_in"] is False
+
+
+@pytest.mark.parametrize(
+    "raw_payment_method,expected",
+    [
+        (
+            {
+                "kind": "card",
+                "brand": "visa",
+                "last4": "4242",
+                "wallet": "apple_pay",
+                "paymentMethodId": "pm_card",
+                "resolvedVia": "subPin",
+            },
+            {
+                "kind": "card",
+                "brand": "visa",
+                "last4": "4242",
+                "wallet": "apple_pay",
+                "resolved_via": "subPin",
+            },
+        ),
+        (
+            {
+                "kind": "link",
+                "email": "billing@example.com",
+                "resolvedVia": "customerDefault",
+            },
+            {
+                "kind": "link",
+                "email": "billing@example.com",
+                "resolved_via": "customerDefault",
+            },
+        ),
+        # A kind added after this gateway shipped: forwarded by name only.
+        (
+            {"kind": "future_method", "resolvedVia": "subPin"},
+            {"kind": "future_method", "resolved_via": "subPin"},
+        ),
+    ],
+)
+def test_billing_state_carries_payment_method_from_server_to_client(
+    monkeypatch, raw_payment_method, expected
+):
+    payload = {
+        "org": {"id": "org_1", "name": "Acme", "role": "OWNER"},
+        "balanceUsd": "10",
+        "paymentMethod": raw_payment_method,
+    }
+    monkeypatch.setattr(
+        bv,
+        "build_billing_state",
+        lambda *a, **kw: bv.billing_state_from_payload(payload),
+    )
+
+    res = _call("billing.state", {})
+
+    assert res["payment_method"] == expected
 
 
 def test_billing_state_serializes_absent_payment_method(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8684,6 +8684,17 @@ def _serialize_billing_state(state) -> dict:
             "display": state.card.display,
             "resolved_via": state.card.resolved_via,
         }
+    payment_method = None
+    if state.payment_method is not None:
+        pm = state.payment_method
+        payment_method = {
+            "kind": pm.kind,
+            "brand": pm.brand,
+            "last4": pm.last4,
+            "wallet": pm.wallet,
+            "email": pm.email,
+            "resolved_via": pm.resolved_via,
+        }
     monthly_cap = None
     if state.monthly_cap is not None:
         mc = state.monthly_cap
@@ -8733,6 +8744,7 @@ def _serialize_billing_state(state) -> dict:
         "min_usd": _s(state.min_usd),
         "max_usd": _s(state.max_usd),
         "card": card,
+        "payment_method": payment_method,
         "monthly_cap": monthly_cap,
         "auto_reload": auto_reload,
         "portal_url": state.portal_url,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8687,11 +8687,10 @@ def _serialize_billing_state(state) -> dict:
     payment_method = None
     if state.payment_method is not None:
         pm = state.payment_method
-        # Send only the keys that belong to this kind. Emitting every key with
-        # nulls would contradict the shared type, where each kind declares its
-        # own fields — a client checking `'brand' in pm` would read every Link
-        # method as a card.
-        if pm.kind == "card" and pm.brand and pm.last4:
+        # Each kind sends only its own fields. Emitting every key with nulls
+        # would contradict the shared type — a client checking `'brand' in pm`
+        # would read every Link method as a card.
+        if pm.kind == "card":
             payment_method = {
                 "kind": "card",
                 "brand": pm.brand,
@@ -8706,11 +8705,9 @@ def _serialize_billing_state(state) -> dict:
                 "resolved_via": pm.resolved_via,
             }
         else:
-            # A kind this gateway predates, or a card missing the fields that
-            # make it renderable. Pass the kind through so clients can say
-            # something honest, and let them fall back on everything else.
             payment_method = {
-                "kind": pm.kind,
+                "kind": "unknown",
+                "raw_kind": pm.raw_kind,
                 "resolved_via": pm.resolved_via,
             }
     monthly_cap = None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8687,14 +8687,32 @@ def _serialize_billing_state(state) -> dict:
     payment_method = None
     if state.payment_method is not None:
         pm = state.payment_method
-        payment_method = {
-            "kind": pm.kind,
-            "brand": pm.brand,
-            "last4": pm.last4,
-            "wallet": pm.wallet,
-            "email": pm.email,
-            "resolved_via": pm.resolved_via,
-        }
+        # Send only the keys that belong to this kind. Emitting every key with
+        # nulls would contradict the shared type, where each kind declares its
+        # own fields — a client checking `'brand' in pm` would read every Link
+        # method as a card.
+        if pm.kind == "card" and pm.brand and pm.last4:
+            payment_method = {
+                "kind": "card",
+                "brand": pm.brand,
+                "last4": pm.last4,
+                "wallet": pm.wallet,
+                "resolved_via": pm.resolved_via,
+            }
+        elif pm.kind == "link":
+            payment_method = {
+                "kind": "link",
+                "email": pm.email,
+                "resolved_via": pm.resolved_via,
+            }
+        else:
+            # A kind this gateway predates, or a card missing the fields that
+            # make it renderable. Pass the kind through so clients can say
+            # something honest, and let them fall back on everything else.
+            payment_method = {
+                "kind": pm.kind,
+                "resolved_via": pm.resolved_via,
+            }
     monthly_cap = None
     if state.monthly_cap is not None:
         mc = state.monthly_cap


### PR DESCRIPTION
## What this does

The billing API can describe a payment method that is not a card — chiefly **Stripe Link**, a one-click wallet where the customer is identified by their email address rather than by card digits. It sends this as a `paymentMethod` field alongside the older `card` field.

This service never forwarded that field, so the terminal and desktop apps could not see it. This PR forwards it.

It does **not** change what those apps display. That is a separate follow-up.

## Why any code was needed

This service sits between the billing API and the apps, and it copies the billing response across one named field at a time rather than passing the whole thing through. That is deliberate — it keeps values the apps have no use for, such as internal identifiers, from travelling further than they need to. The cost is that a new field stays invisible until someone adds it here.

```mermaid
flowchart TB
  A[Billing API sends paymentMethod] --> B{This service}
  B -->|Before| C[Not in the copy list, dropped]
  B -->|After this PR| D[Parsed and forwarded]
  C --> E[Apps never see it]
  D --> F[Apps receive payment_method]
  F --> G[Screens ignore it, for now]
```

## What the apps now receive

A `payment_method` value that always says what kind it is, so an app can tell them apart safely:

| It says | It carries | Meaning |
|---|---|---|
| `card` | brand, last 4, wallet if any | A saved card, possibly used through Apple Pay |
| `link` | the account email (may be empty) | A saved Stripe Link account |
| `unknown` | the original type name | A payment type this app version predates |
| *(field absent)* | — | An older version of this service; it said nothing |

Two rules worth calling out, both of which caused real bugs caught during review:

- **Each kind carries only its own information.** A Link account does not arrive with blank card fields attached. An app checking "does this have a brand?" would otherwise treat every Link account as a card.
- **An unrecognized type arrives as `unknown`, keeping its real name.** An older app can then say something neutral instead of guessing at a shape it has never seen. A compile-time test fails if that guarantee is ever broken.

The payment method's identifier, and a fixed internal marker, are deliberately not forwarded. The apps get only what they need in order to display something.

## What still shows the old message

Nothing on screen changes. The `card` field stays filled in for cards, so every existing screen behaves exactly as it does today.

For a Link account that field is empty, and the terminal, desktop and command-line apps all read "no card" as "no payment method on file" — it gates the top-up flow, the buy-credits control and the payment-method row. So a customer paying this way keeps seeing the wrong message until a follow-up teaches those screens to accept either a card or a Link account.

This is not a guess: running the real terminal app against this branch, the payment method arrives correctly and the screen still reads *"No saved card on file"*.

## How to test

```
scripts/run_tests.sh tests/agent/test_billing_view.py tests/tui_gateway/test_billing_rpc.py
cd apps/shared && npm run check
```

101 tests pass. They follow a billing response all the way to what an app receives, for a card, for a Link account, and for a type this service does not recognize, plus a missing field and a malformed one.

## Where the changes are

- `agent/billing_view.py` — reads the new field and settles which kind it is.
- `tui_gateway/server.py` — sends it on to the apps, converting the name style the rest of this response already uses.
- `apps/shared/src/billing-types.ts` — the shared definition of the three kinds, plus the compile-time test that guards it.
