### PR TITLE
fix(matrix): detect stale cross-signing signatures the homeserver won't replace

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1129,6 +1129,53 @@ class MatrixAdapter(BasePlatformAdapter):
             return False
         return True
 
+    async def _warn_if_cross_signing_signature_stale(self, client: Any) -> bool | None:
+        """Check the self-signing signature the server serves for our device.
+
+        Returns True if valid, False if the server has an invalid (stale)
+        signature, and None if the state could not be determined. A stale
+        signature cannot be replaced via /keys/signatures/upload — the
+        homeserver silently keeps the old one — so the only fix is a fresh
+        device (new access token), which is what the logged error says.
+        """
+        try:
+            from mautrix.crypto.signature import verify_signature_json
+
+            resp = await client.query_keys({client.mxid: [client.device_id]})
+            device_keys = resp.device_keys[client.mxid][client.device_id]
+            ssk_obj = resp.self_signing_keys[client.mxid]
+            ssk_pubkey = next(iter(ssk_obj.keys.values()))
+        except Exception as exc:
+            logger.warning(
+                "Matrix: could not check cross-signing signature state: %s", exc
+            )
+            return None
+        signed = (
+            device_keys.serialize()
+            if hasattr(device_keys, "serialize")
+            else device_keys
+        )
+        sigs = (signed.get("signatures") or {}).get(str(client.mxid)) or {}
+        if f"ed25519:{ssk_pubkey}" not in sigs:
+            logger.warning(
+                "Matrix: device %s has no cross-signing signature on the server",
+                client.device_id,
+            )
+            return False
+        if verify_signature_json(signed, client.mxid, ssk_pubkey, ssk_pubkey):
+            return True
+        logger.error(
+            "Matrix: the homeserver has a stale cross-signing signature for "
+            "device %s (left over from earlier device-key changes) and "
+            "silently refuses to replace it. Other clients will show this "
+            "bot as unverified and may withhold encryption keys. Fix: sign "
+            "the bot out of this session, create a new access token (fresh "
+            "device ID), update MATRIX_ACCESS_TOKEN, and restart — the "
+            "local crypto store resets automatically on device change.",
+            client.device_id,
+        )
+        return False
+
     async def _verify_device_keys_on_server(self, client: Any, olm: Any) -> bool:
         """Verify our device keys are on the homeserver after loading crypto state.
 
@@ -1444,6 +1491,14 @@ class MatrixAdapter(BasePlatformAdapter):
                         try:
                             await olm.verify_with_recovery_key(recovery_key)
                             logger.info("Matrix: cross-signing verified via recovery key")
+                            # verify_with_recovery_key signs this device with the
+                            # self-signing key and uploads the signature, but the
+                            # homeserver silently keeps a pre-existing (possibly
+                            # stale) signature and mautrix ignores per-key upload
+                            # failures. A stale signature makes other clients show
+                            # the bot as unverified and withhold room keys, so
+                            # check what the server actually serves.
+                            await self._warn_if_cross_signing_signature_stale(client)
                         except Exception as exc:
                             logger.warning("Matrix: recovery key verification failed: %s", exc)
                     else:

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -5342,14 +5342,25 @@ def _make_xsign_client(device_sigs, ssk_pubkey="sskpubkey"):
 
 
 class TestStaleCrossSigningSignatureWarning:
+    @staticmethod
+    def _fake_signature_module(verifies: bool):
+        """Fake mautrix.crypto.signature.
+
+        The helper imports it lazily; patching the real attribute would
+        require libolm, which is not needed to exercise this logic.
+        """
+        mod = types.ModuleType("mautrix.crypto.signature")
+        mod.verify_signature_json = lambda *a, **kw: verifies
+        return {"mautrix.crypto.signature": mod}
+
     @pytest.mark.asyncio
     async def test_invalid_signature_logs_actionable_error(self, caplog):
         import logging
         adapter = _make_adapter()
         client = _make_xsign_client({"ed25519:sskpubkey": "bogus-signature"})
 
-        with patch(
-            "mautrix.crypto.signature.verify_signature_json", return_value=False
+        with patch.dict(
+            sys.modules, self._fake_signature_module(False)
         ), caplog.at_level(logging.ERROR):
             result = await adapter._warn_if_cross_signing_signature_stale(client)
 
@@ -5363,8 +5374,8 @@ class TestStaleCrossSigningSignatureWarning:
         adapter = _make_adapter()
         client = _make_xsign_client({"ed25519:sskpubkey": "good-signature"})
 
-        with patch(
-            "mautrix.crypto.signature.verify_signature_json", return_value=True
+        with patch.dict(
+            sys.modules, self._fake_signature_module(True)
         ), caplog.at_level(logging.WARNING):
             result = await adapter._warn_if_cross_signing_signature_stale(client)
 
@@ -5377,8 +5388,8 @@ class TestStaleCrossSigningSignatureWarning:
         adapter = _make_adapter()
         client = _make_xsign_client({"ed25519:DEVICE1": "self-sig-only"})
 
-        with patch(
-            "mautrix.crypto.signature.verify_signature_json", return_value=True
+        with patch.dict(
+            sys.modules, self._fake_signature_module(True)
         ), caplog.at_level(logging.WARNING):
             result = await adapter._warn_if_cross_signing_signature_stale(client)
 
@@ -5399,3 +5410,138 @@ class TestStaleCrossSigningSignatureWarning:
 
         assert result is None
         assert "could not check cross-signing signature state" in caplog.text
+
+    def _connect_mocks(self):
+        """Client/olm mocks for a successful encrypted connect()."""
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = "DEV1"
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = MagicMock()
+        mock_client.crypto = None
+        mock_client.whoami = AsyncMock(
+            return_value=MagicMock(user_id="@bot:example.org", device_id="DEV1")
+        )
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {}}})
+        mock_client.add_event_handler = MagicMock()
+        mock_client.handle_sync = MagicMock(return_value=[])
+        mock_client.query_keys = AsyncMock(return_value={"device_keys": {}})
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+
+        mock_olm = MagicMock()
+        mock_olm.load = AsyncMock()
+        mock_olm.share_keys = AsyncMock()
+        mock_olm.share_keys_min_trust = None
+        mock_olm.send_keys_min_trust = None
+        mock_olm.account = MagicMock()
+        mock_olm.account.identity_keys = {"ed25519": "fake_ed25519_key"}
+        return mock_client, mock_olm
+
+    async def _run_connect(self, adapter, mock_client, mock_olm, stale_check):
+        fake_mautrix_mods = _make_fake_mautrix()
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(
+            return_value=mock_client
+        )
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(
+            return_value=mock_olm
+        )
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        with patch.object(
+            matrix_mod, "_check_e2ee_deps", return_value=True
+        ), patch.dict("sys.modules", fake_mautrix_mods), patch.object(
+            adapter, "_refresh_dm_cache", AsyncMock()
+        ), patch.object(
+            adapter, "_sync_loop", AsyncMock(return_value=None)
+        ), patch.object(
+            adapter, "_verify_device_keys_on_server", AsyncMock(return_value=True)
+        ), patch.object(
+            adapter, "_warn_if_cross_signing_signature_stale", stale_check
+        ):
+            return await adapter.connect()
+
+    def _encrypted_adapter(self):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        return MatrixAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="syt_test_access_token",
+                extra={
+                    "homeserver": "https://matrix.example.org",
+                    "user_id": "@bot:example.org",
+                    "encryption": True,
+                    "device_id": "DEV1",
+                },
+            )
+        )
+
+    @pytest.mark.asyncio
+    async def test_connect_checks_signature_after_recovery_key_verify(
+        self, monkeypatch
+    ):
+        """The server-side check must run at the call site, not just in tests.
+
+        A green helper proves nothing if connect() never awaits it.
+        """
+        monkeypatch.setenv("MATRIX_RECOVERY_KEY", "EsTfakerecoverykey")
+        adapter = self._encrypted_adapter()
+        mock_client, mock_olm = self._connect_mocks()
+        mock_olm.verify_with_recovery_key = AsyncMock()
+        stale_check = AsyncMock(return_value=True)
+
+        assert await self._run_connect(
+            adapter, mock_client, mock_olm, stale_check
+        ) is True
+
+        mock_olm.verify_with_recovery_key.assert_awaited_once()
+        stale_check.assert_awaited_once_with(mock_client)
+
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_skips_signature_check_when_verify_fails(
+        self, monkeypatch
+    ):
+        """If recovery-key verification itself failed there is no new
+        signature to inspect, so the check must not run."""
+        monkeypatch.setenv("MATRIX_RECOVERY_KEY", "EsTfakerecoverykey")
+        adapter = self._encrypted_adapter()
+        mock_client, mock_olm = self._connect_mocks()
+        mock_olm.verify_with_recovery_key = AsyncMock(
+            side_effect=RuntimeError("bad recovery key")
+        )
+        stale_check = AsyncMock(return_value=True)
+
+        assert await self._run_connect(
+            adapter, mock_client, mock_olm, stale_check
+        ) is True
+
+        stale_check.assert_not_awaited()
+
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_skips_signature_check_without_recovery_key(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("MATRIX_RECOVERY_KEY", raising=False)
+        adapter = self._encrypted_adapter()
+        mock_client, mock_olm = self._connect_mocks()
+        mock_olm.verify_with_recovery_key = AsyncMock()
+        mock_olm.get_own_cross_signing_public_keys = AsyncMock(
+            return_value=MagicMock()
+        )
+        stale_check = AsyncMock(return_value=True)
+
+        assert await self._run_connect(
+            adapter, mock_client, mock_olm, stale_check
+        ) is True
+
+        mock_olm.verify_with_recovery_key.assert_not_awaited()
+        stale_check.assert_not_awaited()
+
+        await adapter.disconnect()

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -5312,3 +5312,90 @@ class TestMatrixDispatchSyncIsolation:
 
         assert ran["ok"] is True  # the sibling handler still ran
         assert "event handler failed" in caplog.text  # failure surfaced, not swallowed
+
+
+# ---------------------------------------------------------------------------
+# Stale cross-signing signature detection
+# ---------------------------------------------------------------------------
+
+def _make_xsign_client(device_sigs, ssk_pubkey="sskpubkey"):
+    """Client whose query_keys returns a device signed with the given sigs."""
+    client = MagicMock()
+    client.mxid = "@bot:example.org"
+    client.device_id = "DEVICE1"
+
+    device_keys = MagicMock()
+    device_keys.serialize.return_value = {
+        "algorithms": ["m.megolm.v1.aes-sha2"],
+        "device_id": "DEVICE1",
+        "keys": {"ed25519:DEVICE1": "devpubkey"},
+        "user_id": "@bot:example.org",
+        "signatures": {"@bot:example.org": device_sigs},
+    }
+    ssk_obj = MagicMock()
+    ssk_obj.keys = {f"ed25519:{ssk_pubkey}": ssk_pubkey}
+    client.query_keys = AsyncMock(return_value=MagicMock(
+        device_keys={"@bot:example.org": {"DEVICE1": device_keys}},
+        self_signing_keys={"@bot:example.org": ssk_obj},
+    ))
+    return client
+
+
+class TestStaleCrossSigningSignatureWarning:
+    @pytest.mark.asyncio
+    async def test_invalid_signature_logs_actionable_error(self, caplog):
+        import logging
+        adapter = _make_adapter()
+        client = _make_xsign_client({"ed25519:sskpubkey": "bogus-signature"})
+
+        with patch(
+            "mautrix.crypto.signature.verify_signature_json", return_value=False
+        ), caplog.at_level(logging.ERROR):
+            result = await adapter._warn_if_cross_signing_signature_stale(client)
+
+        assert result is False
+        assert "stale cross-signing signature" in caplog.text
+        assert "new access token" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_valid_signature_is_quiet(self, caplog):
+        import logging
+        adapter = _make_adapter()
+        client = _make_xsign_client({"ed25519:sskpubkey": "good-signature"})
+
+        with patch(
+            "mautrix.crypto.signature.verify_signature_json", return_value=True
+        ), caplog.at_level(logging.WARNING):
+            result = await adapter._warn_if_cross_signing_signature_stale(client)
+
+        assert result is True
+        assert caplog.text == ""
+
+    @pytest.mark.asyncio
+    async def test_missing_signature_warns(self, caplog):
+        import logging
+        adapter = _make_adapter()
+        client = _make_xsign_client({"ed25519:DEVICE1": "self-sig-only"})
+
+        with patch(
+            "mautrix.crypto.signature.verify_signature_json", return_value=True
+        ), caplog.at_level(logging.WARNING):
+            result = await adapter._warn_if_cross_signing_signature_stale(client)
+
+        assert result is False
+        assert "no cross-signing signature" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_query_failure_returns_none(self, caplog):
+        import logging
+        adapter = _make_adapter()
+        client = MagicMock()
+        client.mxid = "@bot:example.org"
+        client.device_id = "DEVICE1"
+        client.query_keys = AsyncMock(side_effect=RuntimeError("network down"))
+
+        with caplog.at_level(logging.WARNING):
+            result = await adapter._warn_if_cross_signing_signature_stale(client)
+
+        assert result is None
+        assert "could not check cross-signing signature state" in caplog.text

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -477,6 +477,18 @@ MATRIX_RECOVERY_KEY=EsT... your recovery key here
 
 On each startup, if `MATRIX_RECOVERY_KEY` is set, Hermes imports cross-signing keys from the homeserver's secure secret storage and signs the current device. This is idempotent and safe to leave enabled permanently.
 
+:::warning[Stale cross-signing signatures]
+Signing the device on startup succeeds locally but is **not** always enough. If the homeserver already holds a cross-signing signature for this device — typically left over from an earlier device-key change — it silently keeps the old one, and `/keys/signatures/upload` reports no error. The bot then keeps starting cleanly while other clients show it as unverified and withhold room keys.
+
+Hermes now checks what the server actually serves after signing and logs an error when the served signature does not verify:
+
+```
+Matrix: the homeserver has a stale cross-signing signature for device ABCD1234 ...
+```
+
+A stale signature cannot be replaced in place. To recover, sign the bot out of that session, create a **new access token** (which yields a fresh device ID), update `MATRIX_ACCESS_TOKEN`, and restart. The local crypto store resets automatically on device change. Re-running startup signing with the same device will not clear it.
+:::
+
 If Hermes bootstraps a new Matrix recovery key, it never logs the raw key. Set
 `MATRIX_RECOVERY_KEY_OUTPUT_FILE=/secure/path/matrix-recovery-key.txt` before
 startup to write a generated key once with file mode `0600`; the file is not


### PR DESCRIPTION
## What does this PR do?

Fixes a silent E2EE trust-degradation bug. `mautrix`'s `verify_with_recovery_key()` signs the bot's current device with the self-signing key and uploads that signature via `/keys/signatures/upload` — but it silently swallows per-key upload failures, and matrix.org's homeserver silently *keeps a pre-existing signature* instead of replacing it when a new one is uploaded for the same device ID (this can happen after earlier device-key changes/re-uploads).

Net effect: the bot's own logs say "cross-signing verified via recovery key" and everything looks fine locally, while other clients (Element, etc.) actually see the device as **unverified** and withhold Megolm room keys from it — the bot silently stops being able to decrypt messages from some peers, with zero diagnostic signal anywhere.

This PR adds a check, run immediately after `verify_with_recovery_key()`, that queries what the homeserver *actually* serves for our device's cross-signing signature and validates it locally with `mautrix.crypto.signature.verify_signature_json` (the same primitive the library uses internally) — so a stale/invalid signature is caught and logged with an actionable fix, instead of silently degrading trust.

## Related Issue

No open issue found for this exact symptom. Closed PR #8272 ("restore verify_with_recovery_key after device key rotation") is related background — it's what originally restored the `verify_with_recovery_key()` call this PR hooks into — but doesn't address the stale-signature case itself.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix (encryption-trust integrity)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: add `_warn_if_cross_signing_signature_stale(client)`; call it right after `olm.verify_with_recovery_key(recovery_key)` succeeds.
- `tests/gateway/test_matrix.py`: add `TestStaleCrossSigningSignatureWarning` (4 cases: invalid/stale signature logs an actionable error, valid signature is quiet, missing signature warns, and a `query_keys` failure returns `None` without raising) plus a `_make_xsign_client` test helper.

## How to Test

Reproducing the actual stale-signature server state requires a homeserver history with a prior device-key rotation, so the included tests mock `client.query_keys` and `mautrix.crypto.signature.verify_signature_json` to exercise all four branches deterministically:

1. `test_invalid_signature_logs_actionable_error` — server returns a signature that fails verification → logs `"stale cross-signing signature"` + `"new access token"` guidance, returns `False`.
2. `test_valid_signature_is_quiet` — verification succeeds → no log output, returns `True`.
3. `test_missing_signature_warns` — no self-signing-key signature present at all → warns `"no cross-signing signature"`, returns `False`.
4. `test_query_failure_returns_none` — `query_keys` raises → warns, returns `None` (distinguishing "couldn't determine" from "confirmed stale").

Manual verification path: force a device-key rotation with `MATRIX_RECOVERY_KEY` set, then check gateway logs after reconnect — with this fix, a stale signature now surfaces as `Matrix: the homeserver has a stale cross-signing signature for device ... silently refuses to replace it...` instead of no signal at all.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(matrix): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (split out of a larger local E2EE patch into one fix per PR)
- [x] I've run `pytest tests/gateway/test_matrix.py -q` and all tests pass (255 passed, up from 251 baseline; run in a Linux container since `python-olm` has no macOS wheel)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (dev), test suite executed on Linux (Python 3.12 via Docker), matching how CI runs

### Documentation & Housekeeping

- [ ] N/A — no user-facing docs/config keys changed
- [ ] N/A — no config keys added
- [ ] N/A — no architecture/workflow change
- [x] Cross-platform impact considered — pure Python, no OS-specific APIs; `scripts/check-windows-footguns.py --diff origin/main` clean
- [ ] N/A — no tool schemas changed

## Screenshots / Logs

```
ERROR Matrix: the homeserver has a stale cross-signing signature for device DEVICE1 (left over from earlier device-key changes) and silently refuses to replace it. Other clients will show this bot as unverified and may withhold encryption keys. Fix: sign the bot out of this session, create a new access token (fresh device ID), update MATRIX_ACCESS_TOKEN, and restart — the local crypto store resets automatically on device change.
```