### PR TITLE
fix(matrix): refuse to clobber cross-signed device keys owned by another client

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1191,9 +1191,12 @@ class MatrixAdapter(BasePlatformAdapter):
                     "like Element. Replacing the keys would permanently "
                     "invalidate the cross-signing signature (the homeserver "
                     "never deletes the old one), so refusing. Use a session "
-                    "that has never been used by an encrypted client: set "
-                    "MATRIX_PASSWORD (and unset MATRIX_ACCESS_TOKEN) so the "
-                    "bot logs in itself.",
+                    "that has never been used by an encrypted client: either "
+                    "generate a fresh MATRIX_ACCESS_TOKEN, or set "
+                    "MATRIX_PASSWORD and unset MATRIX_ACCESS_TOKEN so the bot "
+                    "logs in itself. Either way MATRIX_DEVICE_ID must be unset "
+                    "— it is passed straight through to login and would reuse "
+                    "this same conflicting device.",
                     client.device_id,
                     ", ".join(foreign_sigs),
                 )

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1178,6 +1178,27 @@ class MatrixAdapter(BasePlatformAdapter):
                 )
                 return False
 
+            signed = (
+                our_keys.serialize() if hasattr(our_keys, "serialize") else our_keys
+            )
+            sigs = (signed.get("signatures") or {}).get(str(client.mxid)) or {}
+            foreign_sigs = [k for k in sigs if k != f"ed25519:{client.device_id}"]
+            if foreign_sigs:
+                logger.error(
+                    "Matrix: device %s already has cross-signed encryption keys "
+                    "on the server (signed by %s) that this bot does not own — "
+                    "the session was probably created with a full Matrix client "
+                    "like Element. Replacing the keys would permanently "
+                    "invalidate the cross-signing signature (the homeserver "
+                    "never deletes the old one), so refusing. Use a session "
+                    "that has never been used by an encrypted client: set "
+                    "MATRIX_PASSWORD (and unset MATRIX_ACCESS_TOKEN) so the "
+                    "bot logs in itself.",
+                    client.device_id,
+                    ", ".join(foreign_sigs),
+                )
+                return False
+
             logger.warning(
                 "Matrix: server has stale keys for device %s — attempting re-upload",
                 client.device_id,

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -5349,15 +5349,25 @@ class TestRefuseClobberingForeignDeviceKeys:
         client, olm = self._make_client_and_olm(
             {"ed25519:DEVICE1": "selfsig", "ed25519:sskpubkey": "crosssig"}
         )
+        # The unsafe path DELETEs the device before it ever reaches
+        # share_keys(), so asserting on share_keys() alone would still pass
+        # against a build that destroys the device. Assert on the request
+        # itself.
+        client.api = MagicMock()
+        client.api.request = AsyncMock()
         with patch.object(
             adapter, "_extract_server_ed25519", return_value="element-key"
         ), caplog.at_level(logging.ERROR):
             result = await adapter._verify_device_keys_on_server(client, olm)
 
         assert result is False
+        client.api.request.assert_not_awaited()
         olm.share_keys.assert_not_awaited()
         assert "cross-signed encryption keys" in caplog.text
-        assert "MATRIX_PASSWORD" in caplog.text
+        # Recovery guidance must not stop at MATRIX_PASSWORD: password login
+        # passes MATRIX_DEVICE_ID straight through and would reuse the same
+        # conflicting device.
+        assert "MATRIX_DEVICE_ID must be unset" in caplog.text
 
     @pytest.mark.asyncio
     async def test_reupload_proceeds_without_cross_signature(self):

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -5312,3 +5312,66 @@ class TestMatrixDispatchSyncIsolation:
 
         assert ran["ok"] is True  # the sibling handler still ran
         assert "event handler failed" in caplog.text  # failure surfaced, not swallowed
+
+
+# ---------------------------------------------------------------------------
+# Refuse to clobber cross-signed device keys owned by another client
+# ---------------------------------------------------------------------------
+
+class TestRefuseClobberingForeignDeviceKeys:
+    def _make_client_and_olm(self, server_sigs):
+        client = MagicMock()
+        client.mxid = "@bot:example.org"
+        client.device_id = "DEVICE1"
+
+        device_keys = MagicMock()
+        device_keys.serialize.return_value = {
+            "device_id": "DEVICE1",
+            "user_id": "@bot:example.org",
+            "keys": {"ed25519:DEVICE1": "element-key"},
+            "signatures": {"@bot:example.org": server_sigs},
+        }
+        client.query_keys = AsyncMock(return_value=MagicMock(
+            device_keys={"@bot:example.org": {"DEVICE1": device_keys}},
+        ))
+
+        olm = MagicMock()
+        olm.account.identity_keys = {"ed25519": "local-different-key"}
+        olm.account.shared = False
+        olm.share_keys = AsyncMock()
+        return client, olm
+
+    @pytest.mark.asyncio
+    async def test_refuses_when_device_is_cross_signed(self, caplog):
+        import logging
+        adapter = _make_adapter()
+        adapter._device_id_unverified = False
+        client, olm = self._make_client_and_olm(
+            {"ed25519:DEVICE1": "selfsig", "ed25519:sskpubkey": "crosssig"}
+        )
+        with patch.object(
+            adapter, "_extract_server_ed25519", return_value="element-key"
+        ), caplog.at_level(logging.ERROR):
+            result = await adapter._verify_device_keys_on_server(client, olm)
+
+        assert result is False
+        olm.share_keys.assert_not_awaited()
+        assert "cross-signed encryption keys" in caplog.text
+        assert "MATRIX_PASSWORD" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_reupload_proceeds_without_cross_signature(self):
+        adapter = _make_adapter()
+        adapter._device_id_unverified = False
+        client, olm = self._make_client_and_olm({"ed25519:DEVICE1": "selfsig"})
+        client.api = MagicMock()
+        client.api.request = AsyncMock()
+        with patch.object(
+            adapter, "_extract_server_ed25519", return_value="element-key"
+        ), patch.object(
+            adapter, "_reverify_keys_after_upload", AsyncMock(return_value=True)
+        ):
+            result = await adapter._verify_device_keys_on_server(client, olm)
+
+        assert result is True
+        olm.share_keys.assert_awaited_once()


### PR DESCRIPTION
## What does this PR do?

Fixes a destructive-write bug in the E2EE key-verification path. `_verify_device_keys_on_server` re-uploads this device's keys whenever the server's reported identity key doesn't match the local Olm account (the "stale keys, attempting re-upload" branch). But if the server-side key for our device ID is already **cross-signed by another client's session** — e.g. the same device ID/access token was previously used interactively with a full Matrix client like Element and went through its own verification flow — re-uploading permanently destroys that cross-signing signature. Matrix homeservers never delete or replace a device's cross-signing signature once issued for a given device ID (the same server behavior PR #71544 in this batch documents), so this isn't a transient error — it's a one-way trust downgrade for whoever verified that device.

This adds a check before the re-upload: if the server's signatures for our device key include one from a key other than our own device's self-signature, refuse and log an actionable error, rather than silently clobbering someone else's cross-signing identity.

## Related Issue

No existing issue found (searched for "matrix cross-signing", "matrix device key" — see PR #71544 in this same batch for the one tangentially-related closed PR, #8272, which is unrelated to this specific clobbering scenario).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix (prevents silently destroying another client's cross-signing trust)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: in `_verify_device_keys_on_server`, before the stale-key re-upload path, inspect `our_keys`' `signatures` for entries under a key other than our own device's `ed25519:<device_id>` self-signature. If any exist, log an error (naming the foreign signing keys and pointing at using `MATRIX_PASSWORD` with a fresh device instead) and return `False` without calling `olm.share_keys()`.
- `tests/gateway/test_matrix.py`: add `TestRefuseClobberingForeignDeviceKeys` (2 cases: refuses and logs when a foreign cross-signing signature is present; still proceeds with re-upload when the only signature present is our own self-signature, i.e. the legitimate stale-key case is unaffected).

## How to Test

Reproducing this against a live homeserver requires deliberately cross-signing a device with Element first, so the tests mock `client.query_keys` / the server response directly:

1. `test_refuses_when_device_is_cross_signed` — server reports our device key signed by both its own self-signature AND a foreign signing key → refuses, logs `"cross-signed encryption keys"` + `"MATRIX_PASSWORD"`, `olm.share_keys()` is never called.
2. `test_reupload_proceeds_without_cross_signature` — server reports only our own self-signature (the ordinary stale-key case introduced by a legitimate key rotation) → re-upload proceeds as before, `olm.share_keys()` is called once.

Manual verification: pair a device ID with Element (interactive verification), then point Hermes at that same access token/device ID with encryption enabled — before this fix, the adapter silently re-uploads and invalidates Element's trust in the device; after, it refuses with a log entry naming the conflict.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(matrix): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (split out of a larger local E2EE patch into one fix per PR)
- [x] I've run `pytest tests/gateway/test_matrix.py -q` and all tests pass (253 passed, up from 251 baseline; run in a Linux container since `python-olm` has no macOS wheel)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (dev), test suite executed on Linux (Python 3.12 via Docker), matching how CI runs

### Documentation & Housekeeping

- [ ] N/A — no user-facing docs/config keys changed
- [ ] N/A — no config keys added
- [ ] N/A — no architecture/workflow change
- [x] Cross-platform impact considered — pure Python, no OS-specific APIs; `scripts/check-windows-footguns.py --diff origin/main` clean
- [ ] N/A — no tool schemas changed

## Screenshots / Logs

```
ERROR Matrix: device DEVICE1 already has cross-signed encryption keys on the server (signed by ed25519:sskpubkey) that this bot does not own — the session was probably created with a full Matrix client like Element. Replacing the keys would permanently invalidate the cross-signing signature (the homeserver never deletes the old one), so refusing. Use a session that has never been used by an encrypted client: set MATRIX_PASSWORD (and unset MATRIX_ACCESS_TOKEN) so the bot logs in itself.
```