### PR TITLE
feat: add record_session option to cron jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1261,6 +1261,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    record_session: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1305,6 +1306,12 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        record_session: When False, skip recording this job's execution as a
+                session in state.db. The agent still runs the full LLM
+                pipeline and delivers output, but no session entry is created.
+                Useful for high-frequency monitoring or alerting jobs where
+                session history is not needed. Defaults to True (session is
+                recorded).
 
     Returns:
         The created job dict
@@ -1337,6 +1344,7 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_record_session = record_session  # None = default True
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1432,6 +1440,8 @@ def create_job(
     # global cron.mirror_delivery config, default off).
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
+    if normalized_record_session is not None:
+        job["record_session"] = normalized_record_session
 
     with _jobs_lock():
         jobs = load_jobs()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2897,59 +2897,68 @@ def run_job(
     # _running_job_ids never runs, so the job stays wedged "running" until
     # the whole gateway process is restarted, silently skipping every
     # scheduled fire in between with "already running — skipping".
+    #
+    # When ``record_session`` is False (set per-job), we skip the SessionDB
+    # entirely.  The agent's ``_persist_disabled`` flag (set below after
+    # construction) prevents lazy session creation.  This is useful for
+    # high-frequency agent jobs (e.g. every-5-minute monitoring) whose
+    # output is delivered to a chat platform and does not need to be
+    # searchable in session history.
+    _record_session = job.get("record_session", True)
     _session_db = None
-    try:
-        from hermes_state import SessionDB
+    if _record_session:
+        try:
+            from hermes_state import SessionDB
 
-        # Resolve timeout: env override → config.yaml → default 10s.
-        # Mirrors the script_timeout_seconds resolution pattern.
-        _session_db_timeout: float | None = None
-        _raw_env_timeout = os.getenv("HERMES_CRON_SESSION_DB_TIMEOUT", "").strip()
-        if _raw_env_timeout:
-            try:
-                _session_db_timeout = float(_raw_env_timeout)
-            except (ValueError, TypeError):
-                logger.warning(
-                    "Invalid HERMES_CRON_SESSION_DB_TIMEOUT=%r; using config/default",
-                    _raw_env_timeout,
-                )
-        if _session_db_timeout is None:
-            try:
-                from hermes_cli.config import load_config
-                _cfg = load_config() or {}
-                _cron_cfg = _cfg.get("cron", {}) if isinstance(_cfg, dict) else {}
-                _configured = _cron_cfg.get("session_db_timeout_seconds")
-                if _configured is not None:
-                    _session_db_timeout = float(_configured)
-            except Exception as exc:
-                logger.debug(
-                    "Failed to load cron.session_db_timeout_seconds from config: %s",
-                    exc,
-                )
-        if _session_db_timeout is None:
-            _session_db_timeout = 10.0
+            # Resolve timeout: env override → config.yaml → default 10s.
+            # Mirrors the script_timeout_seconds resolution pattern.
+            _session_db_timeout: float | None = None
+            _raw_env_timeout = os.getenv("HERMES_CRON_SESSION_DB_TIMEOUT", "").strip()
+            if _raw_env_timeout:
+                try:
+                    _session_db_timeout = float(_raw_env_timeout)
+                except (ValueError, TypeError):
+                    logger.warning(
+                        "Invalid HERMES_CRON_SESSION_DB_TIMEOUT=%r; using config/default",
+                        _raw_env_timeout,
+                    )
+            if _session_db_timeout is None:
+                try:
+                    from hermes_cli.config import load_config
+                    _cfg = load_config() or {}
+                    _cron_cfg = _cfg.get("cron", {}) if isinstance(_cfg, dict) else {}
+                    _configured = _cron_cfg.get("session_db_timeout_seconds")
+                    if _configured is not None:
+                        _session_db_timeout = float(_configured)
+                except Exception as exc:
+                    logger.debug(
+                        "Failed to load cron.session_db_timeout_seconds from config: %s",
+                        exc,
+                    )
+            if _session_db_timeout is None:
+                _session_db_timeout = 10.0
 
-        if _session_db_timeout > 0:
-            _session_db_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            try:
-                _session_db = _session_db_pool.submit(SessionDB).result(timeout=_session_db_timeout)
-            finally:
-                # Don't wait for a wedged connect() to unwind — abandon the
-                # worker thread (same pattern as the agent inactivity timeout
-                # further down) rather than blocking shutdown on it too.
-                _session_db_pool.shutdown(wait=False)
-        else:
-            # 0 = unlimited (legacy behavior, opt-in for debugging)
-            _session_db = SessionDB()
-    except concurrent.futures.TimeoutError:
-        logger.error(
-            "Job '%s': SessionDB init did not return within %.0fs — proceeding "
-            "without a session store for this run instead of blocking it "
-            "forever",
-            job.get("id", "?"), _session_db_timeout,
-        )
-    except Exception as e:
-        logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
+            if _session_db_timeout > 0:
+                _session_db_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+                try:
+                    _session_db = _session_db_pool.submit(SessionDB).result(timeout=_session_db_timeout)
+                finally:
+                    # Don't wait for a wedged connect() to unwind — abandon the
+                    # worker thread (same pattern as the agent inactivity timeout
+                    # further down) rather than blocking shutdown on it too.
+                    _session_db_pool.shutdown(wait=False)
+            else:
+                # 0 = unlimited (legacy behavior, opt-in for debugging)
+                _session_db = SessionDB()
+        except concurrent.futures.TimeoutError:
+            logger.error(
+                "Job '%s': SessionDB init did not return within %.0fs — proceeding "
+                "without a session store for this run instead of blocking it "
+                "forever",
+                job.get("id", "?"), _session_db_timeout,
+            )
+        except Exception as e:
+            logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
 
     # Wake-gate: if this job has a pre-check script, run it BEFORE building
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
@@ -3506,7 +3515,14 @@ def run_job(
             session_id=_cron_session_id,
             session_db=_session_db,
         )
-        
+
+        # When ``record_session`` is False, disable session persistence so
+        # the agent runs the full LLM pipeline but no session entry is
+        # written to state.db.  The SessionDB was already skipped above;
+        # this flag prevents the agent from creating a session lazily.
+        if not _record_session:
+            agent._persist_disabled = True
+
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,
         # but a hung API call or stuck tool with no activity for the configured

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -163,6 +163,8 @@ def cron_list(show_all: bool = False):
         workdir = job.get("workdir")
         if workdir:
             print(f"    Workdir:   {workdir}")
+        if job.get("record_session") is False:
+            print(f"    Record:    {color('no session', Colors.DIM)} (session recording disabled)")
 
         # Execution history
         last_status = job.get("last_status")
@@ -352,6 +354,7 @@ def cron_create(args):
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        record_session=getattr(args, "record_session", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -417,6 +420,7 @@ def cron_edit(args):
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
         no_agent=getattr(args, "no_agent", None),
+        record_session=getattr(args, "record_session", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -371,6 +371,8 @@ def cron_create(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if job_data.get("workdir"):
         print(f"  Workdir: {job_data['workdir']}")
+    if job_data.get("record_session") is False:
+        print("  Record:  no session (session recording disabled)")
     print(f"  Next run: {result['next_run_at']}")
     _warn_if_gateway_not_running()
     return 0
@@ -440,6 +442,8 @@ def cron_edit(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
+    if updated.get("record_session") is False:
+        print("  Record:  no session (session recording disabled)")
     return 0
 
 

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -83,6 +83,23 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         dest="model_provider",
         help="Inference provider paired with --model (e.g. 'openrouter', 'nous').",
     )
+    cron_create.add_argument(
+        "--record-session",
+        dest="record_session",
+        action="store_true",
+        default=None,
+        help=(
+            "Record this job's execution as a session in state.db. "
+            "Set --no-record-session to skip session recording for "
+            "high-frequency monitoring jobs. Defaults to True."
+        ),
+    )
+    cron_create.add_argument(
+        "--no-record-session",
+        dest="record_session",
+        action="store_false",
+        help="Skip recording this job's execution as a session in state.db.",
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -159,6 +176,19 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--provider",
         dest="model_provider",
         help="Inference provider paired with --model. Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--record-session",
+        dest="record_session",
+        action="store_true",
+        default=None,
+        help="Record this job's execution as a session in state.db.",
+    )
+    cron_edit.add_argument(
+        "--no-record-session",
+        dest="record_session",
+        action="store_false",
+        help="Skip recording this job's execution as a session in state.db.",
     )
 
     # lifecycle actions

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -562,6 +562,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if "record_session" in job:
+        result["record_session"] = job["record_session"]
     return result
 
 
@@ -641,6 +643,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    record_session: Optional[bool] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -714,6 +717,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                record_session=record_session,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -1040,6 +1044,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "record_session": {
+                "type": "boolean",
+                "description": "When False, skip recording this job's execution as a session in state.db. The agent still runs the full LLM pipeline and delivers output, but no session entry is created. Useful for high-frequency monitoring or alerting jobs where session history is not needed. Defaults to True (session is recorded)."
+            },
         },
         "required": ["action"]
     }
@@ -1097,6 +1105,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        record_session=args.get("record_session"),
         task_id=kw.get("task_id"),
     ),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
## Summary

Add a per-job ``record_session`` option that controls whether a cron job's execution creates a session entry in state.db. When set to ``False``, the agent still runs the full LLM pipeline and delivers output, but no session is persisted.

This is useful for high-frequency monitoring or alerting cron jobs (e.g. every-5-minute health checks) where session history is not needed and would otherwise contribute to state.db growth.

## Changes

### `cron/jobs.py`
- Add ``record_session`` parameter to ``create_job()`` (default ``None`` = ``True``)
- Store in job dict when explicitly set

### `cron/scheduler.py`
- When ``record_session`` is ``False``, skip SessionDB construction entirely
- Set ``agent._persist_disabled = True`` after agent creation to prevent lazy session creation
- The agent runs the full LLM pipeline but no data is written to state.db

### `tools/cronjob_tools.py`
- Expose ``record_session`` parameter in the ``cronjob`` tool
- Include in ``_format_job()`` output for visibility

## Usage

```bash
hermes cron create "*/5 * * * *" \
  --prompt "Check system health and report" \
  --record-session false
```

Or via the ``cronjob`` tool:
```
cronjob action='create' schedule='*/5 * * * *' prompt='Check health' record_session=false
```

## Testing

- ``tests/cron/test_jobs.py``: 85 passed, 1 failed (pre-existing ``croniter`` missing)
- ``tests/cron/test_cron_no_agent.py``: all passed
- ``tests/tools/test_cronjob_tools.py``: 77 passed
- ``tests/test_hermes_state.py -k archive``: 21 passed

## Related

Closes #71418