### PR TITLE
fix(matrix): migrate crypto store when the Olm pickle key changes

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1163,10 +1163,24 @@ class MatrixAdapter(BasePlatformAdapter):
                 continue
             if account is None:
                 continue
+            # Sessions first, account last. The account is the migration's
+            # commit marker: once it reads under the current key, the fast
+            # path above short-circuits every later startup. Writing it
+            # before the sweep means an interrupted sweep is never retried
+            # and the remaining legacy-key sessions are stranded for good.
+            try:
+                await self._repickle_crypto_sessions(
+                    crypto_db, acct_id, legacy_key, pickle_key
+                )
+            except Exception as exc:
+                logger.error(
+                    "Matrix: pickle key migration failed while re-pickling "
+                    "sessions (%s) — leaving the account under the legacy "
+                    "key so the migration is retried on the next start.",
+                    exc,
+                )
+                return False
             await crypto_store.put_account(account)
-            await self._repickle_crypto_sessions(
-                crypto_db, acct_id, legacy_key, pickle_key
-            )
             logger.info(
                 "Matrix: re-pickled crypto store account and sessions under "
                 "the current pickle key (device ID was configured after the "
@@ -1215,9 +1229,14 @@ class MatrixAdapter(BasePlatformAdapter):
                 try:
                     session = session_cls.from_pickle(pickled, legacy_key)
                 except Exception as exc:
+                    # Readable under neither key. The row is left untouched
+                    # rather than deleted — it is already unusable, and
+                    # removing crypto material is not worth doing on a
+                    # guess. It stays inert.
                     logger.warning(
-                        "Matrix: dropping unreadable %s row %s during pickle "
-                        "key migration: %s",
+                        "Matrix: %s row %s cannot be unpickled with the "
+                        "current or legacy key; leaving it in place, its "
+                        "sessions are unrecoverable: %s",
                         table,
                         row["session_id"],
                         exc,

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1129,6 +1129,108 @@ class MatrixAdapter(BasePlatformAdapter):
             return False
         return True
 
+    async def _migrate_legacy_crypto_pickle(
+        self, crypto_store: Any, crypto_db: Any, acct_id: str, pickle_key: str
+    ) -> bool:
+        """Re-pickle the Olm account when the pickle key changed.
+
+        The pickle key embeds the *configured* device ID. If the account was
+        created before MATRIX_DEVICE_ID was set (e.g. first password login,
+        where the device ID is only known after connecting), the store was
+        pickled under ``<acct>:default``; setting MATRIX_DEVICE_ID afterwards
+        changes the key and unpickling fails with BAD_ACCOUNT_KEY — which in
+        optional-E2EE mode silently disables encryption. Try known legacy
+        keys and re-pickle under the current one. Returns False only when an
+        account exists but no key can unpickle it.
+        """
+        try:
+            await crypto_store.get_account()
+            return True
+        except Exception:
+            pass
+
+        from mautrix.crypto.store.asyncpg import PgCryptoStore
+
+        for legacy_key in (f"{acct_id}:default", acct_id):
+            if legacy_key == pickle_key:
+                continue
+            legacy_store = PgCryptoStore(
+                account_id=acct_id, pickle_key=legacy_key, db=crypto_db
+            )
+            try:
+                account = await legacy_store.get_account()
+            except Exception:
+                continue
+            if account is None:
+                continue
+            await crypto_store.put_account(account)
+            await self._repickle_crypto_sessions(
+                crypto_db, acct_id, legacy_key, pickle_key
+            )
+            logger.info(
+                "Matrix: re-pickled crypto store account and sessions under "
+                "the current pickle key (device ID was configured after the "
+                "account was created)"
+            )
+            return True
+
+        logger.error(
+            "Matrix: crypto store account exists but cannot be unpickled "
+            "with the current or any legacy pickle key. If MATRIX_DEVICE_ID "
+            "was changed manually, restore its previous value."
+        )
+        return False
+
+    async def _repickle_crypto_sessions(
+        self, crypto_db: Any, acct_id: str, legacy_key: str, pickle_key: str
+    ) -> None:
+        """Re-pickle olm/megolm session blobs alongside the account.
+
+        The account and every stored session share the pickle key; migrating
+        only the account leaves sessions unreadable (BAD_ACCOUNT_KEY on the
+        next olm decrypt), which breaks key sharing with peers.
+        """
+        import olm as olm_lib
+
+        tables = {
+            "crypto_olm_session": olm_lib.Session,
+            "crypto_megolm_inbound_session": olm_lib.InboundGroupSession,
+            "crypto_megolm_outbound_session": olm_lib.OutboundGroupSession,
+        }
+        for table, session_cls in tables.items():
+            rows = await crypto_db.fetch(
+                f"SELECT session_id, session FROM {table} WHERE account_id=$1",
+                acct_id,
+            )
+            for row in rows:
+                blob = row["session"]
+                if blob is None:
+                    continue
+                pickled = bytes(blob)
+                try:
+                    session_cls.from_pickle(pickled, pickle_key)
+                    continue  # already readable with the current key
+                except Exception:
+                    pass
+                try:
+                    session = session_cls.from_pickle(pickled, legacy_key)
+                except Exception as exc:
+                    logger.warning(
+                        "Matrix: dropping unreadable %s row %s during pickle "
+                        "key migration: %s",
+                        table,
+                        row["session_id"],
+                        exc,
+                    )
+                    continue
+                await crypto_db.execute(
+                    f"UPDATE {table} SET session=$1 "
+                    "WHERE account_id=$2 AND session_id=$3",
+                    session.pickle(pickle_key),
+                    acct_id,
+                    row["session_id"],
+                )
+
     async def _verify_device_keys_on_server(self, client: Any, olm: Any) -> bool:
         """Verify our device keys are on the homeserver after loading crypto state.
 
@@ -1409,6 +1511,10 @@ class MatrixAdapter(BasePlatformAdapter):
 
                     if client.device_id:
                         await crypto_store.put_device_id(client.device_id)
+
+                    await self._migrate_legacy_crypto_pickle(
+                        crypto_store, crypto_db, _acct_id, _pickle_key
+                    )
 
                     crypto_state = _CryptoStateStore(state_store, self._joined_rooms)
                     olm = OlmMachine(client, crypto_store, crypto_state)

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -5356,8 +5356,15 @@ class TestCryptoPickleKeyMigration:
 
         fake_mod = types.ModuleType("mautrix.crypto.store.asyncpg")
         fake_mod.PgCryptoStore = FakePgCryptoStore
-        with patch.dict(sys.modules, {"mautrix.crypto.store.asyncpg": fake_mod}), \
-                caplog.at_level(logging.INFO):
+        with patch.dict(
+            sys.modules,
+            {
+                "mautrix.crypto.store.asyncpg": fake_mod,
+                # _repickle_crypto_sessions imports the olm C-extension;
+                # fake it so this test does not require libolm.
+                "olm": self._fake_olm_module(),
+            },
+        ), caplog.at_level(logging.INFO):
             result = await adapter._migrate_legacy_crypto_pickle(
                 store, crypto_db, "@bot:example.org", "@bot:example.org:NEWDEV"
             )
@@ -5401,3 +5408,150 @@ class TestCryptoPickleKeyMigration:
         assert result is False
         store.put_account.assert_not_awaited()
         assert "cannot be unpickled" in caplog.text
+
+    def _fake_olm_module(self):
+        """Fake the `olm` C-extension module.
+
+        _repickle_crypto_sessions does `import olm`, which needs libolm.
+        Sessions unpickle only with the key they were pickled under.
+        """
+        olm_mod = types.ModuleType("olm")
+
+        class _Session:
+            def __init__(self, key):
+                self._key = key
+
+            @classmethod
+            def from_pickle(cls, blob, key):
+                pickled_under = blob.decode().split("|")[1]
+                if pickled_under != key:
+                    raise RuntimeError("BAD_ACCOUNT_KEY")
+                return cls(key)
+
+            def pickle(self, key):
+                return f"sess|{key}".encode()
+
+        for name in ("Session", "InboundGroupSession", "OutboundGroupSession"):
+            setattr(olm_mod, name, type(name, (_Session,), {}))
+        return olm_mod
+
+    @pytest.mark.asyncio
+    async def test_session_rows_are_repickled_under_current_key(self):
+        """The session sweep must actually rewrite legacy-key rows."""
+        adapter = _make_adapter()
+        legacy = "@bot:example.org:default"
+        current = "@bot:example.org:NEWDEV"
+
+        crypto_db = MagicMock()
+        crypto_db.fetch = AsyncMock(
+            return_value=[{"session_id": "s1", "session": f"sess|{legacy}".encode()}]
+        )
+        crypto_db.execute = AsyncMock()
+
+        with patch.dict(sys.modules, {"olm": self._fake_olm_module()}):
+            await adapter._repickle_crypto_sessions(
+                crypto_db, "@bot:example.org", legacy, current
+            )
+
+        # One UPDATE per session table, each writing the current-key blob.
+        assert crypto_db.execute.await_count == 3
+        for call in crypto_db.execute.await_args_list:
+            assert call.args[1] == f"sess|{current}".encode()
+            assert call.args[3] == "s1"
+
+    @pytest.mark.asyncio
+    async def test_rows_already_on_current_key_are_left_alone(self):
+        adapter = _make_adapter()
+        current = "@bot:example.org:NEWDEV"
+
+        crypto_db = MagicMock()
+        crypto_db.fetch = AsyncMock(
+            return_value=[{"session_id": "s1", "session": f"sess|{current}".encode()}]
+        )
+        crypto_db.execute = AsyncMock()
+
+        with patch.dict(sys.modules, {"olm": self._fake_olm_module()}):
+            await adapter._repickle_crypto_sessions(
+                crypto_db, "@bot:example.org", "@bot:example.org:default", current
+            )
+
+        crypto_db.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unreadable_rows_are_left_in_place_not_dropped(self, caplog):
+        """A row readable under neither key is skipped and left untouched.
+
+        The log must not claim the row was dropped when no DELETE is issued.
+        """
+        import logging
+        adapter = _make_adapter()
+
+        crypto_db = MagicMock()
+        crypto_db.fetch = AsyncMock(
+            return_value=[{"session_id": "s1", "session": b"sess|@bot:other:KEY"}]
+        )
+        crypto_db.execute = AsyncMock()
+
+        with patch.dict(sys.modules, {"olm": self._fake_olm_module()}), \
+                caplog.at_level(logging.WARNING):
+            await adapter._repickle_crypto_sessions(
+                crypto_db,
+                "@bot:example.org",
+                "@bot:example.org:default",
+                "@bot:example.org:NEWDEV",
+            )
+
+        crypto_db.execute.assert_not_awaited()
+        assert "leaving it in place" in caplog.text
+        assert "dropping" not in caplog.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_failed_sweep_leaves_account_on_legacy_key_and_retries(
+        self, caplog
+    ):
+        """A sweep failure must not commit the account.
+
+        The account is the migration's commit marker: if it is written first
+        and the sweep then fails, the next startup takes the current-key fast
+        path and the remaining legacy-key sessions are stranded permanently.
+        """
+        import logging
+        adapter = _make_adapter()
+        legacy_account = MagicMock()
+
+        store = MagicMock()
+        store.get_account = AsyncMock(side_effect=RuntimeError("BAD_ACCOUNT_KEY"))
+        store.put_account = AsyncMock()
+
+        class FakePgCryptoStore:
+            def __init__(self, account_id, pickle_key, db):
+                self.pickle_key = pickle_key
+
+            async def get_account(self):
+                if self.pickle_key == "@bot:example.org:default":
+                    return legacy_account
+                raise RuntimeError("BAD_ACCOUNT_KEY")
+
+        crypto_db = MagicMock()
+        crypto_db.fetch = AsyncMock(side_effect=RuntimeError("db went away"))
+        crypto_db.execute = AsyncMock()
+
+        fake_mod = types.ModuleType("mautrix.crypto.store.asyncpg")
+        fake_mod.PgCryptoStore = FakePgCryptoStore
+
+        with patch.dict(
+            sys.modules,
+            {
+                "mautrix.crypto.store.asyncpg": fake_mod,
+                "olm": self._fake_olm_module(),
+            },
+        ), caplog.at_level(logging.ERROR):
+            result = await adapter._migrate_legacy_crypto_pickle(
+                store, crypto_db, "@bot:example.org", "@bot:example.org:NEWDEV"
+            )
+
+        assert result is False
+        # The critical assertion: the account was NOT committed, so the next
+        # start still sees a legacy-key account and retries the migration.
+        store.put_account.assert_not_awaited()
+        assert "retried on the next start" in caplog.text

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -5312,3 +5312,92 @@ class TestMatrixDispatchSyncIsolation:
 
         assert ran["ok"] is True  # the sibling handler still ran
         assert "event handler failed" in caplog.text  # failure surfaced, not swallowed
+
+
+# ---------------------------------------------------------------------------
+# Crypto store pickle-key migration
+# ---------------------------------------------------------------------------
+
+class TestCryptoPickleKeyMigration:
+    @pytest.mark.asyncio
+    async def test_account_loads_fine_no_migration(self):
+        adapter = _make_adapter()
+        store = MagicMock()
+        store.get_account = AsyncMock(return_value=MagicMock())
+        assert await adapter._migrate_legacy_crypto_pickle(
+            store, MagicMock(), "@bot:example.org", "@bot:example.org:DEV"
+        ) is True
+        store.put_account.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_migrates_from_default_pickle_key(self, caplog):
+        import logging
+        adapter = _make_adapter()
+        store = MagicMock()
+        store.get_account = AsyncMock(side_effect=RuntimeError("BAD_ACCOUNT_KEY"))
+        store.put_account = AsyncMock()
+
+        legacy_account = MagicMock()
+        created = []
+
+        class FakePgCryptoStore:
+            def __init__(self, account_id, pickle_key, db):
+                self.pickle_key = pickle_key
+                created.append(pickle_key)
+
+            async def get_account(self):
+                if self.pickle_key == "@bot:example.org:default":
+                    return legacy_account
+                raise RuntimeError("BAD_ACCOUNT_KEY")
+
+        crypto_db = MagicMock()
+        crypto_db.fetch = AsyncMock(return_value=[])
+        crypto_db.execute = AsyncMock()
+
+        fake_mod = types.ModuleType("mautrix.crypto.store.asyncpg")
+        fake_mod.PgCryptoStore = FakePgCryptoStore
+        with patch.dict(sys.modules, {"mautrix.crypto.store.asyncpg": fake_mod}), \
+                caplog.at_level(logging.INFO):
+            result = await adapter._migrate_legacy_crypto_pickle(
+                store, crypto_db, "@bot:example.org", "@bot:example.org:NEWDEV"
+            )
+
+        assert result is True
+        store.put_account.assert_awaited_once_with(legacy_account)
+        assert "re-pickled crypto store account" in caplog.text
+        assert "@bot:example.org:default" in created
+        # session re-pickle pass must sweep all three session tables
+        queried = " ".join(str(c.args[0]) for c in crypto_db.fetch.await_args_list)
+        for table in (
+            "crypto_olm_session",
+            "crypto_megolm_inbound_session",
+            "crypto_megolm_outbound_session",
+        ):
+            assert table in queried
+
+    @pytest.mark.asyncio
+    async def test_unrecoverable_pickle_logs_error(self, caplog):
+        import logging
+        adapter = _make_adapter()
+        store = MagicMock()
+        store.get_account = AsyncMock(side_effect=RuntimeError("BAD_ACCOUNT_KEY"))
+        store.put_account = AsyncMock()
+
+        class FakePgCryptoStore:
+            def __init__(self, account_id, pickle_key, db):
+                pass
+
+            async def get_account(self):
+                raise RuntimeError("BAD_ACCOUNT_KEY")
+
+        fake_mod = types.ModuleType("mautrix.crypto.store.asyncpg")
+        fake_mod.PgCryptoStore = FakePgCryptoStore
+        with patch.dict(sys.modules, {"mautrix.crypto.store.asyncpg": fake_mod}), \
+                caplog.at_level(logging.ERROR):
+            result = await adapter._migrate_legacy_crypto_pickle(
+                store, MagicMock(), "@bot:example.org", "@bot:example.org:NEWDEV"
+            )
+
+        assert result is False
+        store.put_account.assert_not_awaited()
+        assert "cannot be unpickled" in caplog.text


### PR DESCRIPTION
## What does this PR do?

Fixes a silent-encryption-disable bug. The Olm account's pickle key is derived as `<account_id>:<device_id_or_default>`. If the crypto store account was first created before `MATRIX_DEVICE_ID` was configured (e.g. the very first password login — the device ID is only known *after* connecting), the account gets pickled under `<acct>:default`. Setting `MATRIX_DEVICE_ID` afterwards — a reasonable thing to do once you know which device ID you want to pin the bot to — changes the derived pickle key, and every subsequent `crypto_store.get_account()` call fails with `BAD_ACCOUNT_KEY`.

In optional-E2EE mode (the default — encryption degrades gracefully if crypto setup fails) that failure is caught and encryption silently stays disabled, with no clear indication that the cause was a pickle-key mismatch rather than, say, a corrupt store.

`_migrate_legacy_crypto_pickle()` detects the `BAD_ACCOUNT_KEY` failure at connect time, tries known legacy pickle keys (`<acct>:default`, bare `<acct>`), and if one unpickles successfully, re-pickles the account **and every stored Olm/Megolm session** under the current key — sessions share the pickle key with the account, so migrating only the account would leave every session unreadable on the next decrypt (silently breaking key sharing with peers who already have sessions established). It only reports failure when no known key can unpickle the account at all.

## Related Issue

No existing issue found (searched "matrix pickle key", "matrix crypto store" — no hits).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: add `_migrate_legacy_crypto_pickle()` and `_repickle_crypto_sessions()`; call the former in `connect()` right after `crypto_store.put_device_id()`, before constructing the `OlmMachine`.
- `tests/gateway/test_matrix.py`: add `TestCryptoPickleKeyMigration` (3 cases: account loads fine → no-op, migrates cleanly from the legacy `<acct>:default` key and sweeps all three session tables, and the unrecoverable case where no known key can unpickle the account logs an actionable error).

## How to Test

The migration path requires an existing crypto store pickled under a stale key, so the tests fake `mautrix.crypto.store.asyncpg.PgCryptoStore` to simulate a store that only unpickles under the legacy key:

1. `test_account_loads_fine_no_migration` — `get_account()` succeeds normally → returns `True` immediately, no migration attempted.
2. `test_migrates_from_default_pickle_key` — current key fails with `BAD_ACCOUNT_KEY`, legacy `<acct>:default` key succeeds → account is re-pickled under the current key, and the session sweep queries all three tables (`crypto_olm_session`, `crypto_megolm_inbound_session`, `crypto_megolm_outbound_session`).
3. `test_unrecoverable_pickle_logs_error` — no key (current or legacy) can unpickle the account → returns `False`, logs `"cannot be unpickled"`.

Manual repro: start the bot without `MATRIX_DEVICE_ID` set (password login), let it create a crypto store, stop it, set `MATRIX_DEVICE_ID` to the device ID it logged, restart — before this fix, encryption silently stops working; after, the logs show `Matrix: re-pickled crypto store account and sessions under the current pickle key...` and encryption keeps working.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(matrix): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (split out of a larger local E2EE patch into one fix per PR)
- [x] I've run `pytest tests/gateway/test_matrix.py -q` and all tests pass (254 passed, up from 251 baseline; run in a Linux container since `python-olm` has no macOS wheel)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (dev), test suite executed on Linux (Python 3.12 via Docker), matching how CI runs

### Documentation & Housekeeping

- [ ] N/A — no user-facing docs/config keys changed
- [ ] N/A — no config keys added
- [ ] N/A — no architecture/workflow change
- [x] Cross-platform impact considered — pure Python, no OS-specific APIs; `scripts/check-windows-footguns.py --diff origin/main` clean
- [ ] N/A — no tool schemas changed

## Screenshots / Logs

```
INFO Matrix: re-pickled crypto store account and sessions under the current pickle key (device ID was configured after the account was created)
```