### PR TITLE
docs(zh-Hans): fix stale feishu_comment.py path in locale mirror

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/tools-reference.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/tools-reference.md
@@ -64,7 +64,7 @@ description: "Hermes 内置工具权威参考，按工具集分组"
 
 ## `feishu_doc` 工具集
 
-仅限飞书文档评论智能回复处理器（`gateway/platforms/feishu_comment.py`）使用。不在 `hermes-cli` 或常规飞书聊天适配器中暴露。
+仅限飞书文档评论智能回复处理器（`plugins/platforms/feishu/feishu_comment.py`）使用。不在 `hermes-cli` 或常规飞书聊天适配器中暴露。
 
 | 工具 | 描述 | 所需环境 |
 |------|------|----------|


### PR DESCRIPTION
## Problem

The Chinese (zh-Hans) locale mirror of `website/docs/reference/tools-reference.md` (line 67) still references `gateway/platforms/feishu_comment.py` — a path that no longer exists. The Feishu platform was migrated from `gateway/platforms/` to `plugins/platforms/feishu/`, so the correct module path is `plugins/platforms/feishu/feishu_comment.py`.

This is the same stale path already fixed in the English version of this doc page.

## Triage / Root cause

The zh-Hans locale mirror was not updated when the English source was fixed. Locale mirrors regularly drift from their primary-language source when path changes are only applied to one file.

## Fix

- Updated line 67 of the zh-Hans `tools-reference.md` to reference `plugins/platforms/feishu/feishu_comment.py` instead of `gateway/platforms/feishu_comment.py`.
- Single-line change — minimal and mechanical.

## Verification

- Confirmed the stale path `gateway/platforms/feishu_comment.py` does not exist anywhere in the current codebase (verified via `git ls-tree -r upstream/main`).
- Confirmed the corrected path `plugins/platforms/feishu/feishu_comment.py` exists on upstream/main.
- Self-sourced — no linked issue.

## Notes

- Previous PR #71190 (identical fix) was closed due to an incorrect assumption that the target files no longer existed after a repo restructuring. The files are intact and the stale path persists.