### PR TITLE
fix(desktop): late-bind memoized surface callbacks without making optional handlers always-present

### DIFF
--- a/apps/desktop/src/app/contrib/latest-actions.test.ts
+++ b/apps/desktop/src/app/contrib/latest-actions.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { latestChatActions } from './latest-actions'
+import type { ChatActions } from './types'
+
+function makeActions(onSubmit: ChatActions['onSubmit']): ChatActions {
+  return {
+    onAddContextRef: vi.fn(),
+    onAddUrl: vi.fn(),
+    onAttachDroppedItems: vi.fn(),
+    onAttachImageBlob: vi.fn(),
+    onBranchInNewChat: vi.fn(),
+    onCancel: vi.fn(),
+    onDeleteSelectedSession: vi.fn(),
+    onDismissError: vi.fn(),
+    onEdit: vi.fn(),
+    onPasteClipboardImage: vi.fn(),
+    onPickFiles: vi.fn(),
+    onPickFolders: vi.fn(),
+    onPickImages: vi.fn(),
+    onReload: vi.fn(),
+    onRemoveAttachment: vi.fn(),
+    onRestoreToMessage: vi.fn(),
+    onRetryResume: vi.fn(),
+    onSteer: vi.fn(),
+    onSubmit,
+    onThreadMessagesChange: vi.fn(),
+    onToggleSelectedPin: vi.fn(),
+    onTranscribeAudio: vi.fn()
+  }
+}
+
+describe('latestActions adapters', () => {
+  it('dereferences the latest chat handler from a stable actions object', async () => {
+    const staleSubmit = vi.fn(async () => false)
+    const latestSubmit = vi.fn(async () => true)
+    const actions = makeActions(staleSubmit)
+    const adapted = latestChatActions(actions)
+
+    actions.onSubmit = latestSubmit
+
+    await expect(adapted.onSubmit('continue in selected session')).resolves.toBe(true)
+    expect(staleSubmit).not.toHaveBeenCalled()
+    expect(latestSubmit).toHaveBeenCalledWith('continue in selected session')
+  })
+})

--- a/apps/desktop/src/app/contrib/latest-actions.test.ts
+++ b/apps/desktop/src/app/contrib/latest-actions.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { latestChatActions } from './latest-actions'
-import type { ChatActions } from './types'
+import type { SidebarNavItem } from '../types'
 
-function makeActions(onSubmit: ChatActions['onSubmit']): ChatActions {
+import { latestChatActions, latestSidebarActions } from './latest-actions'
+import type { ChatActions, SidebarActions } from './types'
+
+function makeChatActions(): ChatActions {
   return {
     onAddContextRef: vi.fn(),
     onAddUrl: vi.fn(),
@@ -23,24 +25,57 @@ function makeActions(onSubmit: ChatActions['onSubmit']): ChatActions {
     onRestoreToMessage: vi.fn(),
     onRetryResume: vi.fn(),
     onSteer: vi.fn(),
-    onSubmit,
+    onSubmit: vi.fn(),
     onThreadMessagesChange: vi.fn(),
     onToggleSelectedPin: vi.fn(),
     onTranscribeAudio: vi.fn()
   }
 }
 
+function makeSidebarActions(): SidebarActions {
+  return {
+    onArchiveSession: vi.fn(),
+    onBranchSession: vi.fn(),
+    onDeleteSession: vi.fn(),
+    onLoadMoreMessaging: vi.fn(),
+    onLoadMoreProfileSessions: vi.fn(),
+    onLoadMoreSessions: vi.fn(),
+    onManageCronJob: vi.fn(),
+    onNavigate: vi.fn(),
+    onNewSessionInWorkspace: vi.fn(),
+    onNewSessionSplit: vi.fn(),
+    onResumeSession: vi.fn(),
+    onTriggerCronJob: vi.fn()
+  }
+}
+
 describe('latestActions adapters', () => {
-  it('dereferences the latest chat handler from a stable actions object', async () => {
-    const staleSubmit = vi.fn(async () => false)
-    const latestSubmit = vi.fn(async () => true)
-    const actions = makeActions(staleSubmit)
+  it('dereferences the latest steer handler from a stable actions object', async () => {
+    const staleSteer = vi.fn(async () => false)
+    const latestSteer = vi.fn(async () => true)
+    const actions = makeChatActions()
+    actions.onSteer = staleSteer
     const adapted = latestChatActions(actions)
 
-    actions.onSubmit = latestSubmit
+    actions.onSteer = latestSteer
 
-    await expect(adapted.onSubmit('continue in selected session')).resolves.toBe(true)
-    expect(staleSubmit).not.toHaveBeenCalled()
-    expect(latestSubmit).toHaveBeenCalledWith('continue in selected session')
+    await expect(adapted.onSteer('continue in selected session')).resolves.toBe(true)
+    expect(staleSteer).not.toHaveBeenCalled()
+    expect(latestSteer).toHaveBeenCalledWith('continue in selected session')
+  })
+
+  it('dereferences the latest sidebar handler from a stable actions object', () => {
+    const staleNavigate = vi.fn()
+    const latestNavigate = vi.fn()
+    const item = { id: 'settings', icon: vi.fn(), label: 'Settings', route: '/settings' } satisfies SidebarNavItem
+    const actions = makeSidebarActions()
+    actions.onNavigate = staleNavigate
+    const adapted = latestSidebarActions(actions)
+
+    actions.onNavigate = latestNavigate
+    adapted.onNavigate(item)
+
+    expect(staleNavigate).not.toHaveBeenCalled()
+    expect(latestNavigate).toHaveBeenCalledWith(item)
   })
 })

--- a/apps/desktop/src/app/contrib/latest-actions.test.ts
+++ b/apps/desktop/src/app/contrib/latest-actions.test.ts
@@ -78,4 +78,48 @@ describe('latestActions adapters', () => {
     expect(staleNavigate).not.toHaveBeenCalled()
     expect(latestNavigate).toHaveBeenCalledWith(item)
   })
+
+  // An absent optional handler must stay absent through the adapter. Children
+  // gate on PRESENCE, not just invocation: onDismissError renders the dismiss
+  // button only when defined, onRestoreToMessage gates the restore-confirm
+  // flow, and onTranscribeAudio gates voice recording. Wrapping an undefined
+  // field in an arrow function makes it unconditionally truthy, which would
+  // paint a dead dismiss button and let voice recording run with no
+  // transcription backend.
+  it('leaves absent optional handlers undefined instead of always-truthy wrappers', () => {
+    const chat = makeChatActions()
+    chat.onDismissError = undefined
+    chat.onRestoreToMessage = undefined
+    chat.onTranscribeAudio = undefined
+
+    const adaptedChat = latestChatActions(chat)
+
+    expect(adaptedChat.onDismissError).toBeUndefined()
+    expect(adaptedChat.onRestoreToMessage).toBeUndefined()
+    expect(adaptedChat.onTranscribeAudio).toBeUndefined()
+
+    const sidebar = makeSidebarActions()
+    sidebar.onLoadMoreMessaging = undefined
+    sidebar.onLoadMoreProfileSessions = undefined
+
+    const adaptedSidebar = latestSidebarActions(sidebar)
+
+    expect(adaptedSidebar.onLoadMoreMessaging).toBeUndefined()
+    expect(adaptedSidebar.onLoadMoreProfileSessions).toBeUndefined()
+  })
+
+  it('still late-binds a PRESENT optional handler to the latest closure', async () => {
+    const staleTranscribe = vi.fn(async () => 'stale')
+    const latestTranscribe = vi.fn(async () => 'latest')
+    const actions = makeChatActions()
+    actions.onTranscribeAudio = staleTranscribe
+
+    const adapted = latestChatActions(actions)
+
+    actions.onTranscribeAudio = latestTranscribe
+
+    expect(adapted.onTranscribeAudio).toBeTypeOf('function')
+    await expect(adapted.onTranscribeAudio!(new Blob())).resolves.toBe('latest')
+    expect(staleTranscribe).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/app/contrib/latest-actions.ts
+++ b/apps/desktop/src/app/contrib/latest-actions.ts
@@ -1,0 +1,52 @@
+import type { ChatActions, SidebarActions } from './types'
+
+/**
+ * Surfaces receive one stable `actions` object whose fields are mutated by the
+ * wiring controller each render. If a memoized surface passes `actions.foo`
+ * directly, the child keeps the function from the surface's last render and can
+ * submit/click against a stale session closure. These adapters keep a stable
+ * wrapper but dereference the latest field at call time.
+ */
+export function latestChatActions(actions: ChatActions): ChatActions {
+  return {
+    onAddContextRef: (...args) => actions.onAddContextRef(...args),
+    onAddUrl: (...args) => actions.onAddUrl(...args),
+    onAttachDroppedItems: (...args) => actions.onAttachDroppedItems(...args),
+    onAttachImageBlob: (...args) => actions.onAttachImageBlob(...args),
+    onBranchInNewChat: (...args) => actions.onBranchInNewChat(...args),
+    onCancel: (...args) => actions.onCancel(...args),
+    onDeleteSelectedSession: (...args) => actions.onDeleteSelectedSession(...args),
+    onDismissError: (...args) => actions.onDismissError?.(...args),
+    onEdit: (...args) => actions.onEdit(...args),
+    onPasteClipboardImage: (...args) => actions.onPasteClipboardImage(...args),
+    onPickFiles: (...args) => actions.onPickFiles(...args),
+    onPickFolders: (...args) => actions.onPickFolders(...args),
+    onPickImages: (...args) => actions.onPickImages(...args),
+    onReload: (...args) => actions.onReload(...args),
+    onRemoveAttachment: (...args) => actions.onRemoveAttachment(...args),
+    onRestoreToMessage: (...args) => actions.onRestoreToMessage?.(...args) ?? Promise.resolve(),
+    onRetryResume: (...args) => actions.onRetryResume(...args),
+    onSteer: (...args) => actions.onSteer(...args),
+    onSubmit: (...args) => actions.onSubmit(...args),
+    onThreadMessagesChange: (...args) => actions.onThreadMessagesChange(...args),
+    onToggleSelectedPin: (...args) => actions.onToggleSelectedPin(...args),
+    onTranscribeAudio: (...args) => actions.onTranscribeAudio?.(...args) ?? Promise.resolve('')
+  }
+}
+
+export function latestSidebarActions(actions: SidebarActions): SidebarActions {
+  return {
+    onArchiveSession: (...args) => actions.onArchiveSession(...args),
+    onBranchSession: (...args) => actions.onBranchSession(...args),
+    onDeleteSession: (...args) => actions.onDeleteSession(...args),
+    onLoadMoreMessaging: (...args) => actions.onLoadMoreMessaging?.(...args),
+    onLoadMoreProfileSessions: (...args) => actions.onLoadMoreProfileSessions?.(...args),
+    onLoadMoreSessions: (...args) => actions.onLoadMoreSessions(...args),
+    onManageCronJob: (...args) => actions.onManageCronJob(...args),
+    onNavigate: (...args) => actions.onNavigate(...args),
+    onNewSessionInWorkspace: (...args) => actions.onNewSessionInWorkspace(...args),
+    onNewSessionSplit: (...args) => actions.onNewSessionSplit(...args),
+    onResumeSession: (...args) => actions.onResumeSession(...args),
+    onTriggerCronJob: (...args) => actions.onTriggerCronJob(...args)
+  }
+}

--- a/apps/desktop/src/app/contrib/latest-actions.ts
+++ b/apps/desktop/src/app/contrib/latest-actions.ts
@@ -6,7 +6,28 @@ import type { ChatActions, SidebarActions } from './types'
  * directly, the child keeps the function from the surface's last render and can
  * submit/click against a stale session closure. These adapters keep a stable
  * wrapper but dereference the latest field at call time.
+ *
+ * OPTIONAL handlers must stay optional. Several children gate on a handler's
+ * *presence*, not just call it — `onDismissError` renders the dismiss button
+ * only when it exists (assistant-message.tsx), `onRestoreToMessage` gates the
+ * restore-confirm flow (thread/index.tsx), and `onTranscribeAudio` gates voice
+ * recording/conversation (use-voice-recorder, use-voice-conversation). An
+ * unconditional arrow wrapper is always truthy, which would render a dead
+ * dismiss button and let voice recording proceed with no transcription backend.
+ * So wrap an optional field only when it is currently present, and re-read the
+ * latest value inside the wrapper for the stale-closure fix.
  */
+function latestOptional<A extends unknown[], R>(
+  read: () => ((...args: A) => R) | undefined
+): ((...args: A) => R) | undefined {
+  // Presence is sampled from the object identity the surface currently holds.
+  // The controller mutates fields in place rather than swapping a handler
+  // between defined and undefined, so presence is stable for a given actions
+  // object while the *closure* is what churns — which is exactly what the
+  // indirection below re-reads.
+  return read() ? (...args: A) => read()!(...args) : undefined
+}
+
 export function latestChatActions(actions: ChatActions): ChatActions {
   return {
     onAddContextRef: (...args) => actions.onAddContextRef(...args),
@@ -16,7 +37,7 @@ export function latestChatActions(actions: ChatActions): ChatActions {
     onBranchInNewChat: (...args) => actions.onBranchInNewChat(...args),
     onCancel: (...args) => actions.onCancel(...args),
     onDeleteSelectedSession: (...args) => actions.onDeleteSelectedSession(...args),
-    onDismissError: (...args) => actions.onDismissError?.(...args),
+    onDismissError: latestOptional(() => actions.onDismissError),
     onEdit: (...args) => actions.onEdit(...args),
     onPasteClipboardImage: (...args) => actions.onPasteClipboardImage(...args),
     onPickFiles: (...args) => actions.onPickFiles(...args),
@@ -24,13 +45,13 @@ export function latestChatActions(actions: ChatActions): ChatActions {
     onPickImages: (...args) => actions.onPickImages(...args),
     onReload: (...args) => actions.onReload(...args),
     onRemoveAttachment: (...args) => actions.onRemoveAttachment(...args),
-    onRestoreToMessage: (...args) => actions.onRestoreToMessage?.(...args) ?? Promise.resolve(),
+    onRestoreToMessage: latestOptional(() => actions.onRestoreToMessage),
     onRetryResume: (...args) => actions.onRetryResume(...args),
     onSteer: (...args) => actions.onSteer(...args),
     onSubmit: (...args) => actions.onSubmit(...args),
     onThreadMessagesChange: (...args) => actions.onThreadMessagesChange(...args),
     onToggleSelectedPin: (...args) => actions.onToggleSelectedPin(...args),
-    onTranscribeAudio: (...args) => actions.onTranscribeAudio?.(...args) ?? Promise.resolve('')
+    onTranscribeAudio: latestOptional(() => actions.onTranscribeAudio)
   }
 }
 
@@ -39,8 +60,8 @@ export function latestSidebarActions(actions: SidebarActions): SidebarActions {
     onArchiveSession: (...args) => actions.onArchiveSession(...args),
     onBranchSession: (...args) => actions.onBranchSession(...args),
     onDeleteSession: (...args) => actions.onDeleteSession(...args),
-    onLoadMoreMessaging: (...args) => actions.onLoadMoreMessaging?.(...args),
-    onLoadMoreProfileSessions: (...args) => actions.onLoadMoreProfileSessions?.(...args),
+    onLoadMoreMessaging: latestOptional(() => actions.onLoadMoreMessaging),
+    onLoadMoreProfileSessions: latestOptional(() => actions.onLoadMoreProfileSessions),
     onLoadMoreSessions: (...args) => actions.onLoadMoreSessions(...args),
     onManageCronJob: (...args) => actions.onManageCronJob(...args),
     onNavigate: (...args) => actions.onNavigate(...args),

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -25,6 +25,7 @@ import { useStatusbarItems } from '../shell/hooks/use-statusbar-items'
 import { ModelMenuPanel } from '../shell/model-menu-panel'
 import { StatusbarControls } from '../shell/statusbar-controls'
 
+import { latestChatActions, latestSidebarActions } from './latest-actions'
 import { setStatusbarItemGroup, useStatusbarContributions } from './panes'
 import type { SidebarActions, WiringActions } from './types'
 
@@ -48,7 +49,9 @@ export const SidebarSurface = memo(function SidebarSurface({
   actions: SidebarActions
   currentView: ComponentProps<typeof ChatSidebar>['currentView']
 }) {
-  return <ChatSidebar currentView={currentView} {...actions} />
+  const latestActions = useMemo(() => latestSidebarActions(actions), [actions])
+
+  return <ChatSidebar currentView={currentView} {...latestActions} />
 })
 
 export const TerminalSurface = memo(function TerminalSurface() {
@@ -137,33 +140,13 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
     [actions, activeGatewayProfile, gateway, gatewayState]
   )
 
+  const chatActions = useMemo(() => latestChatActions(actions), [actions])
   const chatView = (
     <ChatView
       gateway={gateway}
       maxVoiceRecordingSeconds={maxVoiceRecordingSeconds}
       modelMenuContent={modelMenuContent}
-      onAddContextRef={actions.onAddContextRef}
-      onAddUrl={actions.onAddUrl}
-      onAttachDroppedItems={actions.onAttachDroppedItems}
-      onAttachImageBlob={actions.onAttachImageBlob}
-      onBranchInNewChat={actions.onBranchInNewChat}
-      onCancel={actions.onCancel}
-      onDeleteSelectedSession={actions.onDeleteSelectedSession}
-      onDismissError={actions.onDismissError}
-      onEdit={actions.onEdit}
-      onPasteClipboardImage={actions.onPasteClipboardImage}
-      onPickFiles={actions.onPickFiles}
-      onPickFolders={actions.onPickFolders}
-      onPickImages={actions.onPickImages}
-      onReload={actions.onReload}
-      onRemoveAttachment={actions.onRemoveAttachment}
-      onRestoreToMessage={actions.onRestoreToMessage}
-      onRetryResume={actions.onRetryResume}
-      onSteer={actions.onSteer}
-      onSubmit={actions.onSubmit}
-      onThreadMessagesChange={actions.onThreadMessagesChange}
-      onToggleSelectedPin={actions.onToggleSelectedPin}
-      onTranscribeAudio={actions.onTranscribeAudio}
+      {...chatActions}
     />
   )
 

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -141,6 +141,7 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
   )
 
   const chatActions = useMemo(() => latestChatActions(actions), [actions])
+
   const chatView = (
     <ChatView
       gateway={gateway}

--- a/contributors/emails/eagleyouxiang@gmail.com
+++ b/contributors/emails/eagleyouxiang@gmail.com
@@ -1,0 +1,1 @@
+eagle-nyp

--- a/contributors/emails/nypyouxiang@163.com
+++ b/contributors/emails/nypyouxiang@163.com
@@ -1,0 +1,1 @@
+eagle-nyp


### PR DESCRIPTION
## Summary

Salvage of #67348 (@eagle-nyp), which fixes the other end of the stale-session bug class that #71462 just closed. #71462 fixed *which session id* the actions read; this fixes *which callback* a memoized surface holds.

`ContribWiring` keeps one stable `actions` object and mutates its fields each render so memoized pane surfaces don't re-render on session churn. But `ChatRoutesSurface` and `SidebarSurface` passed fields like `actions.onSubmit` straight into children — so a surface that didn't re-render after a session switch handed its child a stale submit/navigate closure, routing input to the previously selected session. The contributor's adapters keep a stable wrapper per field and dereference the latest one at call time, preserving the stable-actions performance contract.

## Salvage note

The contributor's two commits are cherry-picked as-is (authorship preserved). One follow-up commit fixes a real defect in the original: the adapters wrapped **every** field in an arrow function, including the optional ones — which makes an absent handler unconditionally truthy. Several children gate on a handler's **presence**, not just call it:

| Handler | Presence gate |
|---|---|
| `onDismissError` | `assistant-message.tsx` renders the dismiss button only when defined |
| `onRestoreToMessage` | `thread/index.tsx` gates the restore-confirm flow |
| `onTranscribeAudio` | `use-voice-recorder` / `use-voice-conversation` gate recording |
| `onLoadMoreMessaging`, `onLoadMoreProfileSessions` | sidebar paging |

As submitted, the adapter would paint a dead dismiss button and let voice recording proceed into a no-op transcription path even where the controller deliberately left those handlers off. Fixed by wrapping an optional field only when it is currently present, and re-reading the latest value inside the wrapper so the stale-closure fix still applies. Presence is stable for a given actions object (fields are mutated in place, never toggled between defined and undefined); the closure is what churns, and that's what the indirection re-reads.

## Changes

- `contrib/latest-actions.ts` (new, contributor): `latestChatActions` / `latestSidebarActions` late-binding adapters.
- `contrib/surfaces.tsx` (contributor): `ChatRoutesSurface` + `SidebarSurface` route callbacks through the adapters.
- `contrib/latest-actions.ts` (follow-up): `latestOptional` helper — optional fields stay optional.
- `contrib/latest-actions.test.ts`: contributor's stale-binding coverage + 2 cases for optionality.
- `contributors/emails/`: both contributor emails registered.

## Validation

| | Result |
|---|---|
| Optionality test vs unconditional-wrapper form (sabotage) | 1 fail — test provably catches the defect |
| `src/app/contrib` + `src/app/session` | 331 / 331 pass |
| `tsc --noEmit` on touched files | clean |
| `eslint` on touched files | 0 errors, 0 warnings |

## Credit

Design and implementation are @eagle-nyp's in #67348 — both commits carried with original authorship. The optionality fix and its regression coverage are added on top.

## Infographic

![late-bind-but-stay-optional](https://v3b.fal.media/files/b/0aa3b527/lUaluYym37BwclCXr0N7w_4Rsu8HmM.png)
