### PR TITLE
fix(desktop): fall back to /api/status when /api/health requires auth

### DIFF
--- a/apps/desktop/electron/backend-health.test.ts
+++ b/apps/desktop/electron/backend-health.test.ts
@@ -2,7 +2,12 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { DEFAULT_HEALTH_PROBE_TIMEOUT_MS, isMissingHealthEndpointError, waitForHermesReady } from './backend-health'
+import {
+  DEFAULT_HEALTH_PROBE_TIMEOUT_MS,
+  isMissingHealthEndpointError,
+  isUnauthenticatedHealthError,
+  waitForHermesReady
+} from './backend-health'
 
 test('uses lightweight /api/health for current backends', async () => {
   const calls: string[][] = []
@@ -133,4 +138,42 @@ test('recognizes missing-route shapes only', () => {
   )
   assert.equal(isMissingHealthEndpointError(new Error('Timed out connecting to Hermes backend after 15000ms')), false)
   assert.equal(isMissingHealthEndpointError(new Error('500: boom')), false)
+})
+
+test('recognizes an unauthenticated /api/health response', () => {
+  assert.equal(
+    isUnauthenticatedHealthError(
+      new Error('401: {"error":"unauthenticated","detail":"Unauthorized","reason":"no_cookie","login_url":"/login"}')
+    ),
+    true
+  )
+  assert.equal(isUnauthenticatedHealthError(new Error('404: {"detail":"Not Found"}')), false)
+  assert.equal(isUnauthenticatedHealthError(new Error('500: boom')), false)
+  assert.equal(isUnauthenticatedHealthError(new Error('Timed out connecting to Hermes backend after 15000ms')), false)
+})
+
+test('falls back to /api/status when the public health probe requires auth', async () => {
+  const calls: string[][] = []
+
+  await waitForHermesReady('http://127.0.0.1:9000', {
+    token: 'secret-token',
+    fetchPublicJson: async url => {
+      calls.push(['public', url])
+
+      throw new Error('401: {"error":"unauthenticated","detail":"Unauthorized","reason":"no_cookie","login_url":"/login"}')
+    },
+    fetchJson: async (url, token) => {
+      calls.push(['token', url, token ?? ''])
+
+      return { ok: true }
+    },
+    sleep: async () => {},
+    timeoutMs: 100,
+    pollMs: 1
+  })
+
+  assert.deepEqual(calls, [
+    ['public', 'http://127.0.0.1:9000/api/health'],
+    ['token', 'http://127.0.0.1:9000/api/status', 'secret-token']
+  ])
 })

--- a/apps/desktop/electron/backend-health.ts
+++ b/apps/desktop/electron/backend-health.ts
@@ -28,6 +28,16 @@ export function isMissingHealthEndpointError(error: unknown): boolean {
   return /^404:/.test(message) || message.includes('endpoint is likely missing')
 }
 
+// Some hardened self-hosted gateways require auth on every route, including
+// the otherwise-public /api/health probe. The remedy is the same as a
+// missing route: stop probing unauthenticated and fall back to the
+// already-authenticated /api/status check.
+export function isUnauthenticatedHealthError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  return /^401:/.test(message)
+}
+
 function supersededError() {
   const error: any = new Error('SSH bootstrap was superseded by newer connection settings.')
   error.kind = 'superseded'
@@ -78,9 +88,10 @@ export async function waitForHermesReady(baseUrl: string, options: HermesReadyOp
     } catch (error) {
       lastError = error
 
-      // Only an explicitly missing route means the backend predates
-      // /api/health; timeouts and server errors keep polling health.
-      if (!useStatusFallback && isMissingHealthEndpointError(error)) {
+      // Only an explicitly missing route (or a route that demands auth we
+      // deliberately don't send here) means the public health probe can't
+      // work on this backend; timeouts and server errors keep polling health.
+      if (!useStatusFallback && (isMissingHealthEndpointError(error) || isUnauthenticatedHealthError(error))) {
         useStatusFallback = true
 
         continue


### PR DESCRIPTION
## Summary
- `waitForHermesReady` probes `/api/health` deliberately without credentials, assuming that endpoint is always public.
- Self-hosted gateways that require auth on every route (including `/api/health`) return `401`, which isn't recognized by `isMissingHealthEndpointError` (only `404` is), so the client polls the same doomed unauthenticated call forever instead of falling back to the already-authenticated `/api/status` check the way it already does for a missing route.
- This shows up as the desktop app getting stuck on a permanent "CONNECTING" screen against any remote gateway that enforces auth on `/api/health` — sign-in succeeds, but the health probe loops on 401 indefinitely.
- Fix: treat a `401` from `/api/health` the same as a `404` — fall back to `/api/status`. Added `isUnauthenticatedHealthError` alongside the existing `isMissingHealthEndpointError`.

## Test plan
- [x] Added unit tests covering the new `isUnauthenticatedHealthError` matcher and the fallback behavior in `waitForHermesReady`
- [x] `npx vitest run electron/backend-health.test.ts` — all 8 tests pass