### PR TITLE
fix(cron): bound Codex max-iteration summaries

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2069,7 +2069,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         if agent.api_mode == "codex_responses":
             codex_kwargs = agent._build_api_kwargs(api_messages)
             codex_kwargs.pop("tools", None)
-            summary_response = agent._run_codex_stream(codex_kwargs)
+            # Keep max-iteration summaries on the same request seam as normal
+            # Codex turns. Calling _run_codex_stream directly bypasses the
+            # absolute stale timeout, interrupt handling, and request-local
+            # client cleanup, so an unattended cron summary can wedge forever
+            # instead of returning control to cron's completion/error delivery lifecycle.
+            summary_response = agent._interruptible_api_call(codex_kwargs)
             _ct_sum = agent._get_transport()
             _cnr_sum = _ct_sum.normalize_response(summary_response)
             final_response = (_cnr_sum.content or "").strip()
@@ -2162,7 +2167,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             if agent.api_mode == "codex_responses":
                 codex_kwargs = agent._build_api_kwargs(api_messages)
                 codex_kwargs.pop("tools", None)
-                retry_response = agent._run_codex_stream(codex_kwargs)
+                retry_response = agent._interruptible_api_call(codex_kwargs)
                 _ct_retry = agent._get_transport()
                 _cnr_retry = _ct_retry.normalize_response(retry_response)
                 final_response = (_cnr_retry.content or "").strip()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4067,6 +4067,86 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         assert "sort" not in kwargs.get("extra_body", {}).get("provider", {})
 
+    def test_codex_summary_uses_interruptible_request_path(self, agent):
+        """Max-iteration Codex summaries must retain request watchdogs.
+
+        A direct ``_run_codex_stream`` call bypasses the absolute stale timeout,
+        interrupt handling, and request-local client cleanup. In unattended cron
+        sessions that turns a wedged summary stream into a job that never returns
+        to cron's completion/error delivery lifecycle (#70943).
+        """
+        agent.api_mode = "codex_responses"
+        agent.provider = "xai-oauth"
+        agent.base_url = "https://api.x.ai/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent._base_url_hostname = "api.x.ai"
+        agent.model = "grok-4.5"
+        agent.platform = "cron"
+        agent._cached_system_prompt = "You are helpful."
+        response = SimpleNamespace(
+            status="completed",
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text="Summary")],
+                )
+            ],
+        )
+
+        with patch.object(
+            agent, "_interruptible_api_call", return_value=response
+        ) as guarded_call, patch.object(
+            agent,
+            "_run_codex_stream",
+            side_effect=AssertionError("summary bypassed request watchdogs"),
+        ):
+            result = agent._handle_max_iterations(
+                [{"role": "user", "content": "do stuff"}], 4
+            )
+
+        assert result == "Summary"
+        guarded_call.assert_called_once()
+
+    def test_codex_summary_retry_uses_interruptible_request_path(self, agent):
+        """The empty-summary retry must use the same bounded request seam."""
+        agent.api_mode = "codex_responses"
+        agent.provider = "xai-oauth"
+        agent.base_url = "https://api.x.ai/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent._base_url_hostname = "api.x.ai"
+        agent.model = "grok-4.5"
+        agent.platform = "cron"
+        agent._cached_system_prompt = "You are helpful."
+
+        def codex_response(text):
+            return SimpleNamespace(
+                status="completed",
+                output=[
+                    SimpleNamespace(
+                        type="message",
+                        status="completed",
+                        content=[SimpleNamespace(type="output_text", text=text)],
+                    )
+                ],
+            )
+
+        with patch.object(
+            agent,
+            "_interruptible_api_call",
+            side_effect=[codex_response(""), codex_response("Summary after retry")],
+        ) as guarded_call, patch.object(
+            agent,
+            "_run_codex_stream",
+            side_effect=AssertionError("summary retry bypassed request watchdogs"),
+        ):
+            result = agent._handle_max_iterations(
+                [{"role": "user", "content": "do stuff"}], 4
+            )
+
+        assert result == "Summary after retry"
+        assert guarded_call.call_count == 2
+
     def test_codex_summary_sanitizes_orphan_tool_results(self, agent):
         agent.api_mode = "codex_responses"
         agent.provider = "openai-codex"
@@ -4077,7 +4157,7 @@ class TestHandleMaxIterations:
         agent._cached_system_prompt = "You are helpful."
         captured = {}
 
-        def fake_run_codex_stream(kwargs):
+        def fake_run_codex_stream(kwargs, client=None, on_first_delta=None):
             captured.update(kwargs)
             return SimpleNamespace(
                 status="completed",


### PR DESCRIPTION
## Summary

- route Codex max-iteration summary requests through the normal interruptible request path;
- preserve the absolute stale timeout, TTFB/event-idle watchdogs, interrupt handling, and request-local client cleanup;
- apply the same bound to the empty-summary retry;
- cover the `xai-oauth` + `codex_responses` + cron path directly.

Refs #70943.

## Root cause

Normal Codex turns call `_interruptible_api_call()`, which owns the request-local client and polls the worker against the configured absolute stale timeout plus Codex-specific liveness watchdogs.

`handle_max_iterations()` bypassed that seam. Both its first Codex summary attempt and its empty-summary retry called `_run_codex_stream()` directly. A provider stream that remained open during forced summary generation therefore had no caller-side wall-clock bound or interrupt cleanup. In an unattended cron job, that prevents the turn from returning to cron's completion/error delivery lifecycle.

The summary path now uses `agent._interruptible_api_call(codex_kwargs)`, exactly like an ordinary Codex turn. Response normalization and summary semantics are unchanged.

## Relationship to #70943

Current `main` already bounds the normal xAI Codex turn path even when synthetic SSE keepalives continuously refresh event/activity timestamps; I verified that path independently against the real watchdog loop. This PR closes a separate direct-call escape hatch in the same unattended Codex lifecycle rather than claiming to explain every historical hang in #70943.

## Regression coverage

- the first max-iteration summary must call `_interruptible_api_call()` and may not call `_run_codex_stream()` directly;
- an empty first summary must route its retry through the same bounded seam;
- existing orphan-tool-result sanitization remains green after the request-path change.

Mutation proof: on pre-fix code, both regressions fail because `_run_codex_stream()` is invoked directly and bypasses the guarded mock.

## Verification

- complete max-iteration summary class plus cron Codex execution-path tests: **18 passed**;
- Ruff: clean;
- `py_compile`: clean;
- Windows-footgun scan: clean;
- `git diff --check`: clean.
