### PR TITLE
fix(cli): centralize matching provider: and provider/ prefix stripping

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -616,6 +616,18 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
     #     bare id that matches exactly one curated entry.  Unknown names (a
     #     local NIM container, a proxied model) pass through untouched. ---
     if provider in _CATALOGUE_PREFIX_REPAIR_PROVIDERS:
+        # ``_repair_prefix_from_catalogue`` returns early on any ``/``, which
+        # is what keeps a genuine ``nvidia/nemotron-…`` slug -- and a
+        # self-hosted ``nvidia/my-local-nim`` -- untouched.  A ``nvidia:``
+        # colon prefix carries no slash, so it skips that guard and is then
+        # compared *whole* against the catalogue's post-slash suffixes,
+        # matches nothing, and reaches the API with the prefix still
+        # attached.  Strip the matching prefix first, exactly as the four
+        # branches above do; the separator check is what preserves the
+        # slash form's pass-through.
+        _, separator, _ = _split_provider_prefix(name)
+        if separator == ":":
+            name = _strip_matching_provider_prefix(name, provider)
         return _repair_prefix_from_catalogue(name, provider)
 
     # --- Authoritative native providers: preserve user-facing slugs as-is ---

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -253,12 +253,48 @@ def _normalize_provider_alias(provider_name: str) -> str:
         return raw
 
 
+# Separators that can introduce a provider prefix on a model identifier: the
+# aggregator-style ``provider/model`` slug and the ``provider:model``
+# shorthand users type at the CLI (``hermes chat -m openai-codex:gpt-5.6-sol``)
+# or store in ``model.default``.
+_PROVIDER_PREFIX_SEPARATORS: tuple[str, ...] = ("/", ":")
+
+
+def _split_provider_prefix(model_name: str) -> tuple[str, str, str]:
+    """Split off a provider prefix on whichever separator appears FIRST.
+
+    Returns ``(prefix, separator, remainder)``.  ``separator`` is ``""`` when
+    the name carries no provider prefix at all, in which case ``prefix`` is the
+    whole name and ``remainder`` is empty.
+
+    Taking the first separator is what keeps a variant suffix attached to the
+    model rather than being mistaken for a prefix boundary::
+
+        anthropic/claude-3.5-sonnet:beta -> ("anthropic", "/", "claude-3.5-sonnet:beta")
+        openai-codex:gpt-5.6-sol         -> ("openai-codex", ":", "gpt-5.6-sol")
+    """
+    index = -1
+    separator = ""
+    for candidate in _PROVIDER_PREFIX_SEPARATORS:
+        found = model_name.find(candidate)
+        if found != -1 and (index == -1 or found < index):
+            index = found
+            separator = candidate
+
+    if index == -1:
+        return model_name, "", ""
+    return model_name[:index], separator, model_name[index + 1:]
+
+
 def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> str:
-    """Strip ``provider/`` only when the prefix matches the target provider.
+    """Strip ``provider/`` or ``provider:`` when the prefix matches the target.
 
     This prevents arbitrary slash-bearing model IDs from being mangled on
     native providers while still repairing manual config values like
-    ``zai/glm-5.1`` for the ``zai`` provider.
+    ``zai/glm-5.1`` -- and the equivalent ``zai:glm-5.1`` colon shorthand --
+    for the ``zai`` provider.  Both separators go through the same
+    alias-aware match guard, so a prefix is only removed when it resolves to
+    the very provider that is about to receive the API call.
 
     ``custom`` is a generic bucket for arbitrary user-defined endpoints, not
     a vendor identity like ``zai``/``gemini``/``xai``. An alias that merely
@@ -266,18 +302,21 @@ def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> st
     does not mean a ``ollama/`` prefix is redundant -- it may be the actual
     routing prefix a proxy in front of the custom endpoint (e.g. LiteLLM)
     requires, as in ``ollama/glm-5.2``. Only a literal ``custom/`` prefix --
-    the bucket's own name -- is treated as redundant here.
+    the bucket's own name -- is treated as redundant here.  The colon form is
+    never stripped for ``custom`` at all: ``custom:<name>`` is a durable
+    custom-provider identity slug (see ``custom_provider_slug`` in
+    ``hermes_cli.providers``), not a redundant vendor prefix, so removing it
+    would erase which endpoint the user configured.
     """
-    if "/" not in model_name:
+    prefix, separator, remainder = _split_provider_prefix(model_name)
+    if not separator:
         return model_name
-
-    prefix, remainder = model_name.split("/", 1)
     if not prefix.strip() or not remainder.strip():
         return model_name
 
     normalized_target = _normalize_provider_alias(target_provider)
     if normalized_target == "custom":
-        if prefix.strip().lower() == "custom":
+        if separator == "/" and prefix.strip().lower() == "custom":
             return remainder.strip()
         return model_name
 
@@ -505,9 +544,13 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
     #     resolve to bare ``minimax-m2.7`` / ``deepseek-v4-flash`` the API
     #     actually serves.  See PR reviewing opencode-go fallback 401s. ---
     if provider in {"opencode-zen", "opencode-go"}:
-        if "/" in name:
-            _, bare_after_slash = name.split("/", 1)
-            name = bare_after_slash.strip() or name
+        _, separator, bare_after_prefix = _split_provider_prefix(name)
+        if separator == "/":
+            name = bare_after_prefix.strip() or name
+        elif separator == ":":
+            # Colon prefixes stay matching-only: a bare ``kimi-k2.5:free``
+            # style variant tag is part of the model id, not a prefix.
+            name = _strip_matching_provider_prefix(name, provider)
         if provider == "opencode-zen" and name.lower().startswith("claude-"):
             return _dots_to_hyphens(name)
         return name
@@ -526,6 +569,13 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
     #     dash-notation Claude IDs survive to the Copilot API and hit
     #     HTTP 400 "model_not_supported".  See issue #6879.
     if provider in {"copilot", "copilot-acp"}:
+        # ``normalize_copilot_model_id`` already resolves ``copilot/gpt-5.4``
+        # but not the ``copilot:gpt-5.4`` shorthand, and it returns the input
+        # unchanged rather than falsy -- so without stripping here first the
+        # colon form returns early and never reaches the generic fallback
+        # below.  Reuse the shared helper instead of re-parsing the prefix.
+        name = _strip_matching_provider_prefix(name, provider)
+
         try:
             from hermes_cli.models import normalize_copilot_model_id
 

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -179,3 +179,53 @@ class TestNormalizeModelForProvider:
         # Uses first from available list
         assert cli.model == "gpt-5.3-codex"
 
+
+
+# ── CLI-route regression: issue #64787 (``-m provider:model``) ─────────
+
+
+class TestColonProviderPrefixOnCLIRoute:
+    """End-to-end cover for ``hermes chat -m <provider>:<model>``.
+
+    ``parse_model_input()`` (which does split on the first colon) is NOT on
+    this path -- its only non-test caller is ``acp_adapter/server.py``.  The
+    CLI stores ``--model`` verbatim (only a ``moa:`` prefix is special-cased)
+    and hands it to ``_normalize_model_for_provider`` at agent startup, so the
+    redundant prefix reached the provider API until the shared normalizer
+    learned to split on ``:`` as well as ``/``.
+    """
+
+    def test_cli_stores_colon_model_verbatim(self):
+        """Guards the premise: nothing splits the colon before normalization."""
+        cli = _make_cli(model="openai-codex:gpt-5.6-sol")
+        assert cli.model == "openai-codex:gpt-5.6-sol"
+
+    def test_codex_colon_prefix_stripped_before_agent_startup(self):
+        cli = _make_cli(model="openai-codex:gpt-5.6-sol")
+        changed = cli._normalize_model_for_provider("openai-codex")
+        assert changed is True
+        assert cli.model == "gpt-5.6-sol"
+
+    def test_native_provider_colon_prefix_stripped_before_agent_startup(self):
+        cli = _make_cli(model="zai:glm-5.1")
+        changed = cli._normalize_model_for_provider("zai")
+        assert changed is True
+        assert cli.model == "glm-5.1"
+
+    def test_non_matching_colon_tag_is_left_alone(self):
+        """``llama3:8b`` is an Ollama tag, not a ``provider:model`` pair."""
+        cli = _make_cli(model="llama3:8b")
+        changed = cli._normalize_model_for_provider("ollama-cloud")
+        assert changed is False
+        assert cli.model == "llama3:8b"
+
+    def test_colon_prefix_does_not_select_the_provider(self):
+        """Scope decision: this normalizes the model string only.
+
+        Unlike ``moa:<preset>``, a ``<provider>:<model>`` string does not
+        switch the resolved provider -- that would be a routing change beyond
+        issue #64787 and is deliberately left for a separate PR.
+        """
+        cli = _make_cli(model="openai-codex:gpt-5.6-sol")
+        assert cli.provider == "auto"
+        assert cli.requested_provider == "auto"

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -187,3 +187,112 @@ class TestIssue78796NvidiaPrefixRepair:
             == "anthropic/claude-sonnet-4.6"
         )
 
+
+# ── Regression: issue #64787 — ``provider:model`` colon prefixes ───────
+
+# (provider, bare model, expected normalized result).  One row per provider
+# branch that repairs a redundant ``provider/`` prefix, so the colon form is
+# pinned everywhere the slash form already worked.
+_COLON_PREFIX_CASES = [
+    # _MATCHING_PREFIX_STRIP_PROVIDERS
+    ("xai", "grok-5", "grok-5"),
+    ("gemini", "gemini-3-pro", "gemini-3-pro"),
+    ("zai", "glm-5.1", "glm-5.1"),
+    ("minimax", "minimax-m2.7", "minimax-m2.7"),
+    ("minimax-oauth", "minimax-m2.7", "minimax-m2.7"),
+    ("minimax-cn", "minimax-m2.7", "minimax-m2.7"),
+    ("kimi-coding", "kimi-k2.5", "kimi-k2.5"),
+    ("kimi-coding-cn", "kimi-k2.5", "kimi-k2.5"),
+    ("alibaba", "qwen3-max", "qwen3-max"),
+    ("qwen-oauth", "qwen3-max", "qwen3-max"),
+    ("arcee", "trinity-2", "trinity-2"),
+    ("ollama-cloud", "qwen3", "qwen3"),
+    ("xiaomi", "mimo-v2.5-pro", "mimo-v2.5-pro"),
+    # _DOT_TO_HYPHEN_PROVIDERS
+    ("anthropic", "claude-opus-5", "claude-opus-5"),
+    # _STRIP_VENDOR_ONLY_PROVIDERS (+ the Copilot delegation ahead of it)
+    ("openai-codex", "gpt-5.6-sol", "gpt-5.6-sol"),
+    ("copilot", "gpt-5.4", "gpt-5.4"),
+    ("copilot-acp", "gpt-5.4", "gpt-5.4"),
+    # flat-namespace resellers
+    ("opencode-zen", "glm-5.1", "glm-5.1"),
+    ("opencode-go", "minimax-m2.7", "minimax-m2.7"),
+    # DeepSeek canonicalisation
+    ("deepseek", "deepseek-v4-pro", "deepseek-v4-pro"),
+]
+
+
+class TestIssue64787ColonProviderPrefix:
+    """``provider:model`` must normalize exactly like ``provider/model``.
+
+    ``hermes chat -m openai-codex:gpt-5.6-sol`` stores the flag verbatim
+    (``cli.py`` -- only a ``moa:`` prefix is special-cased) and hands it
+    straight to ``normalize_model_for_provider``.  Because
+    ``_strip_matching_provider_prefix`` split on ``/`` only, the colon form
+    survived normalization and the provider API received the redundant
+    prefix.  Same reachable inputs: the Desktop model switch
+    (``hermes_cli/web_server.py``), ``/model`` (``hermes_cli/model_switch.py``)
+    and ``model.default`` in ``config.yaml``.
+    """
+
+    @pytest.mark.parametrize("provider,model,expected", _COLON_PREFIX_CASES)
+    def test_colon_prefix_is_stripped(self, provider, model, expected):
+        assert normalize_model_for_provider(f"{provider}:{model}", provider) == expected
+
+    @pytest.mark.parametrize("provider,model,expected", _COLON_PREFIX_CASES)
+    def test_slash_prefix_still_stripped(self, provider, model, expected):
+        """Invariant control: the pre-existing slash behaviour is unchanged."""
+        assert normalize_model_for_provider(f"{provider}/{model}", provider) == expected
+
+    def test_deepseek_colon_prefix_no_longer_downgrades_v_series(self):
+        """``deepseek:deepseek-v4-pro`` used to silently resolve to Flash.
+
+        ``_DEEPSEEK_V_SERIES_RE`` is anchored at ``^deepseek-v<digit>``, so a
+        surviving ``deepseek:`` prefix defeated the match and the unrecognised
+        remainder fell through to ``_normalize_for_deepseek``'s catch-all --
+        routing a user who explicitly picked V4 Pro to the cheaper V4 Flash
+        with no error.  (Before the 2026-07-24 alias retirement the same path
+        landed on ``deepseek-chat``/V3; the catch-all moved, the downgrade did
+        not.)
+        """
+        assert normalize_model_for_provider("deepseek:deepseek-v4-pro", "deepseek") == "deepseek-v4-pro"
+        # Control: the reasoner-keyword path is unaffected by prefix stripping.
+        assert normalize_model_for_provider("deepseek:deepseek-r1", "deepseek") == "deepseek-v4-flash"
+
+    def test_non_matching_colon_prefix_is_preserved(self):
+        """A colon that is not a matching provider prefix must survive.
+
+        ``llama3:8b`` is an Ollama tag, not a ``provider:model`` pair, so the
+        alias match guard must leave it alone.
+        """
+        assert normalize_model_for_provider("llama3:8b", "ollama-cloud") == "llama3:8b"
+        assert normalize_model_for_provider("kimi-k2.5:free", "opencode-zen") == "kimi-k2.5:free"
+        assert normalize_model_for_provider("openai:gpt-5.4", "xai") == "openai:gpt-5.4"
+
+    def test_custom_provider_colon_slug_is_preserved(self):
+        """``custom:<name>`` is a durable provider identity, not a prefix."""
+        assert normalize_model_for_provider("custom:my-model", "custom") == "custom:my-model"
+        # The slash form keeps its pre-existing meaning.
+        assert normalize_model_for_provider("custom/my-model", "custom") == "my-model"
+
+    def test_variant_suffix_after_slash_prefix_is_untouched(self):
+        """First-separator split: ``/`` wins when it comes before ``:``."""
+        assert (
+            normalize_model_for_provider("anthropic/claude-3.5-sonnet:beta", "openai-codex")
+            == "anthropic/claude-3.5-sonnet:beta"
+        )
+
+    def test_openai_vendor_prefix_on_codex_still_stripped(self):
+        """Regression guard for the existing openai-codex vendor carve-out."""
+        assert normalize_model_for_provider("openai/gpt-5.4", "openai-codex") == "gpt-5.4"
+
+    @pytest.mark.parametrize("model,expected", [
+        ("openai-codex:gpt-5.6-sol", ("openai-codex", ":", "gpt-5.6-sol")),
+        ("anthropic/claude-3.5-sonnet:beta", ("anthropic", "/", "claude-3.5-sonnet:beta")),
+        ("openai-codex:anthropic/claude-opus-5", ("openai-codex", ":", "anthropic/claude-opus-5")),
+        ("gpt-5.4", ("gpt-5.4", "", "")),
+    ])
+    def test_split_provider_prefix_takes_first_separator(self, model, expected):
+        from hermes_cli.model_normalize import _split_provider_prefix
+
+        assert _split_provider_prefix(model) == expected

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -219,6 +219,14 @@ _COLON_PREFIX_CASES = [
     ("opencode-go", "minimax-m2.7", "minimax-m2.7"),
     # DeepSeek canonicalisation
     ("deepseek", "deepseek-v4-pro", "deepseek-v4-pro"),
+    # _CATALOGUE_PREFIX_REPAIR_PROVIDERS.  The odd one out: here ``nvidia/``
+    # is the *canonical* prefix the API serves, not a redundant one, so both
+    # spellings settle on the catalogue entry rather than on a bare id.
+    (
+        "nvidia",
+        "nemotron-3-ultra-550b-a55b",
+        "nvidia/nemotron-3-ultra-550b-a55b",
+    ),
 ]
 
 
@@ -258,6 +266,57 @@ class TestIssue64787ColonProviderPrefix:
         assert normalize_model_for_provider("deepseek:deepseek-v4-pro", "deepseek") == "deepseek-v4-pro"
         # Control: the reasoner-keyword path is unaffected by prefix stripping.
         assert normalize_model_for_provider("deepseek:deepseek-r1", "deepseek") == "deepseek-v4-flash"
+
+    def test_nvidia_colon_prefix_reaches_the_catalogue_repair(self):
+        """``nvidia:<bare>`` used to reach the API with the prefix attached.
+
+        ``_repair_prefix_from_catalogue`` short-circuits on ``/`` and then
+        compares the *whole* name against each catalogue entry's post-slash
+        suffix.  A colon-prefixed id has no slash, so it cleared the
+        short-circuit and then matched nothing — the one dispatch branch that
+        never stripped a matching prefix first, so ``nvidia:nemotron-…``
+        reached build.nvidia.com verbatim and drew the same content-free
+        ``404 page not found`` that #78796 set out to eliminate.
+        """
+        assert (
+            normalize_model_for_provider("nvidia:nemotron-3-super-120b-a12b", "nvidia")
+            == "nvidia/nemotron-3-super-120b-a12b"
+        )
+        # Alias-aware, like every other branch: ``nim`` resolves to ``nvidia``.
+        assert (
+            normalize_model_for_provider("nim:nemotron-3-super-120b-a12b", "nvidia")
+            == "nvidia/nemotron-3-super-120b-a12b"
+        )
+        # The repaired prefix is the catalogue's, not a hardcoded ``nvidia/``.
+        assert normalize_model_for_provider("nvidia:glm-5.2", "nvidia") == "z-ai/glm-5.2"
+
+    @pytest.mark.parametrize("model", [
+        # Slash form: the catalogue short-circuit is the only thing keeping a
+        # self-hosted id addressable, so stripping must NOT reach it.
+        "nvidia/my-local-nim-container",
+        "nvidia/nemotron-3-ultra-550b-a55b",
+        "z-ai/glm-5.2",
+        # Bare unknown name: a lookup miss stays a miss.
+        "my-local-nim-container",
+        # A colon that is not a provider prefix is left for the catalogue to
+        # match verbatim, exactly as before.
+        "nemotron-3-ultra-550b-a55b:beta",
+    ])
+    def test_nvidia_non_colon_prefixed_forms_are_untouched(self, model):
+        """The #78796 pass-through guarantees survive the colon strip."""
+        assert normalize_model_for_provider(model, "nvidia") == model
+
+    def test_nvidia_colon_prefixed_unknown_name_stays_unrepaired(self):
+        """Strip the redundant prefix, but never invent a catalogue entry.
+
+        ``nvidia:my-local-nim`` names a self-hosted container behind the NVIDIA
+        provider id; the prefix is redundant, the model is not in the
+        catalogue, so the result is the bare id the local NIM actually serves.
+        """
+        assert (
+            normalize_model_for_provider("nvidia:my-local-nim", "nvidia")
+            == "my-local-nim"
+        )
 
     def test_non_matching_colon_prefix_is_preserved(self):
         """A colon that is not a matching provider prefix must survive.


### PR DESCRIPTION
## What does this PR do?

`hermes chat -m openai-codex:gpt-5.6-sol` sends the redundant prefix straight to the provider API. `_strip_matching_provider_prefix()` — the alias-aware helper every native-provider branch shares — split on `/` only, so the equivalent `provider:model` shorthand was invisible to it.

This centralizes both separators in that one helper, keeping its match guard, and picks up every provider branch that routes through it — **including the one branch that did not route through it at all**, the catalogue-backed NVIDIA repair (see "The fifth branch" below).

The reachable chain on current `main` — note `parse_model_input()` is **not** on it (its only non-test caller is `acp_adapter/server.py:831`):

- `cli.py:4039` stores `--model` verbatim; only a `moa:` prefix is special-cased, on the next line.
- `hermes_cli/cli_agent_setup_mixin.py:172` → `cli.py:5625` hands that un-split string to `normalize_model_for_provider()`.
- The colon prefix survives normalization and reaches the API.

The same input hits the same bug from the Desktop/dashboard model switch (`hermes_cli/web_server.py:1532`), the `/model` command (`hermes_cli/model_switch.py:1485`), and `model.default` in `config.yaml`.

> Rebased onto current `main` (`70c6cf8e7ef`). All numbers below are re-measured against that base.

## The fifth branch — catalogue-backed NVIDIA repair

`normalize_model_for_provider()` dispatches to **six** provider branches that repair a redundant provider prefix. Five of them now call `_strip_matching_provider_prefix()` first. The sixth — `_CATALOGUE_PREFIX_REPAIR_PROVIDERS` (currently `nvidia`), added by #78856 — never stripped a prefix at all:

```python
if provider in _CATALOGUE_PREFIX_REPAIR_PROVIDERS:
    return _repair_prefix_from_catalogue(name, provider)   # no strip, ever
```

`_repair_prefix_from_catalogue()` returns early whenever the id contains a `/` — the guard that keeps a genuine `nvidia/nemotron-…` slug **and** a self-hosted `nvidia/my-local-nim` addressable — and otherwise compares the *whole* id against each catalogue entry's post-slash suffix. A colon-prefixed id carries no slash, so it cleared the short-circuit, then matched no suffix, and passed through untouched:

```python
>>> normalize_model_for_provider("nvidia:nemotron-3-ultra-550b-a55b", "nvidia")
'nvidia:nemotron-3-ultra-550b-a55b'      # on main — reaches build.nvidia.com verbatim
```

That is the exact failure #78856 set out to eliminate: build.nvidia.com answers an unknown id with a content-free `404 page not found` that never names the model, so it reads like an outage. Every sibling branch would have stripped `nvidia:` first and let the catalogue repair it to `nvidia/nemotron-3-ultra-550b-a55b`.

The fix routes this branch through the same shared helper, **guarded on the separator** so the slash form keeps its pass-through:

```python
_, separator, _ = _split_provider_prefix(name)
if separator == ":":
    name = _strip_matching_provider_prefix(name, provider)
return _repair_prefix_from_catalogue(name, provider)
```

Stripping unconditionally would have been wrong: `nvidia/my-local-nim` would lose the prefix and then fail the catalogue lookup, silently rewriting a self-hosted id. The separator guard is what preserves #78796's pass-through guarantees, and they are pinned by tests in both directions.

## Supersedes #64788

Credit to @maksir's #64788 for isolating this bug and writing the first repro — that diagnosis is correct, and its regression case (`anthropic/claude-3.5-sonnet:beta` on `openai-codex`) is kept green here. This PR implements the centralization the review on that PR asked for, and extends it to the providers that share the root cause:

- **Centralized rather than duplicated.** #64788 added colon parsing to the `_STRIP_VENDOR_ONLY_PROVIDERS` fallback; the inline review asked to extend `_strip_matching_provider_prefix()` instead, since that fallback is shared with the Copilot paths. Here the split lives in the helper and preserves the `_normalize_provider_alias()` match guard, so a prefix is removed only when it resolves to the provider about to receive the call. The fallback is untouched.
- **Superset scope.** #64788 scopes to `_STRIP_VENDOR_ONLY_PROVIDERS` (3 providers). The same colon blindness affected **21 providers across 6 branches**.
- **End-to-end CLI-route regression added** — the coverage gap the review named.

## Related Issue

Fixes #64787

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/model_normalize.py`
  - New `_split_provider_prefix()` helper: splits a model id on whichever of `/` or `:` comes **first**. First-separator order is what keeps a variant suffix attached to the model — `anthropic/claude-3.5-sonnet:beta` still splits on the slash, so `:beta` is never mistaken for a prefix boundary.
  - `_strip_matching_provider_prefix()` now uses it for both separators, behind the same alias-aware match guard.
  - The `opencode-zen`/`opencode-go` branch reuses the shared splitter instead of its own inline `split("/", 1)`. Slash behavior there is unchanged (any vendor prefix is stripped); the colon form is matching-only, so an unprefixed variant tag like `kimi-k2.5:free` is left alone.
  - The Copilot branch strips a matching prefix *before* delegating to `normalize_copilot_model_id()`. That function resolves `copilot/gpt-5.4` but not `copilot:gpt-5.4`, and it returns the input unchanged rather than falsy — so without this the colon form returned early and never reached the generic fallback.
  - The `_CATALOGUE_PREFIX_REPAIR_PROVIDERS` branch strips a matching **colon** prefix before the catalogue lookup, leaving the slash form to the lookup's own short-circuit. No parallel parsing mechanism; `_repair_prefix_from_catalogue()` itself is untouched.

- `tests/hermes_cli/test_model_normalize.py` — new `TestIssue64787ColonProviderPrefix` (added as a new class; no existing tests reordered).
- `tests/hermes_cli/test_codex_models.py` — new `TestColonProviderPrefixOnCLIRoute`, the end-to-end CLI-route regression.

### Coverage — the 21 providers now repaired

| Branch | Providers |
|---|---|
| `_MATCHING_PREFIX_STRIP_PROVIDERS` | `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-oauth`, `minimax-cn`, `alibaba`, `qwen-oauth`, `xiaomi`, `arcee`, `ollama-cloud`, `gemini`, `xai` |
| `_DOT_TO_HYPHEN_PROVIDERS` | `anthropic` |
| `_STRIP_VENDOR_ONLY_PROVIDERS` | `openai-codex`, `copilot`, `copilot-acp` |
| flat-namespace resellers | `opencode-zen`, `opencode-go` |
| DeepSeek canonicalization | `deepseek` |
| `_CATALOGUE_PREFIX_REPAIR_PROVIDERS` | `nvidia` |

Each is pinned by a parametrized case asserting the colon form normalizes to the model id the API serves, with the slash form asserted alongside as an unchanged-behavior control.

**`deepseek` was a silent data bug, not just a cosmetic prefix.** On `main`, `deepseek:deepseek-v4-pro` → `deepseek-v4-flash`: the colon prefix defeated the `_DEEPSEEK_V_SERIES_RE` match inside `_normalize_for_deepseek()`, so the unmatched remainder fell through to the catch-all and a user who picked V4 Pro was routed to the cheaper Flash with no error. The slash form was already correct. Covered by a dedicated test.

**`nvidia` is the one row where the prefix is canonical rather than redundant** — the API serves `nvidia/nemotron-…`, so both spellings settle on the catalogue entry instead of on a bare id. Its dedicated tests also pin the alias path (`nim:` → `nvidia`), the catalogue's third-party prefixes (`nvidia:glm-5.2` → `z-ai/glm-5.2`), and the #78796 pass-throughs that must survive the strip.

### Deliberately excluded

- **`custom`** — `custom:<name>` is a durable custom-provider identity slug, not a redundant prefix, so colon-stripping would erase which endpoint the user configured. The helper exempts it explicitly and a test pins both forms (`custom:my-model` preserved, `custom/my-model` still stripped as before). This is also why the change does not collide with #56671, which refines the *slash* semantics for the same bucket.
- **Aggregators** (`openrouter`, `nous`, `kilocode`) — they want `vendor/model`, and `cli.py:5624` skips normalization for them entirely.
- **`huggingface`** — authoritative native naming, passes through by design.
- **`openai:gpt-5.4` on `openai-codex`** — the existing `openai/` carve-out in the `_STRIP_VENDOR_ONLY_PROVIDERS` fallback is a *cross-vendor* alias (`openai` ≠ `openai-codex`), not a matching-provider prefix. Covering the colon form there means putting prefix parsing back into the shared fallback, which is exactly what the review asked to avoid. Left for a follow-up that can address the carve-out properly.
- **`suggest_prefixed_model_id()`** — the diagnostic counterpart to the catalogue repair. It returns `None` for a colon-prefixed id, but it only ever *explains* a 404 that this PR now prevents on the normalization path, so widening it is cosmetic and belongs with the carve-out follow-up.
- **`cli.py:5684`** — the codex-only "strip any `/` prefix" branch is a different mechanism (unconditional and non-matching, not the shared helper). Untouched here.

### On "decide whether `--model provider:model` must also select the provider"

**No** — this PR normalizes the model string only. Unlike `moa:<preset>`, a `provider:model` string does not switch the resolved provider; `cli.provider` stays `auto`. Making the prefix drive routing is a behavior change beyond #64787 and belongs in its own PR. The current behavior is pinned by `test_colon_prefix_does_not_select_the_provider` so a future change to it is a deliberate one.

## How to Test

1. Reproduce on `main` — the prefix survives:
   ```python
   from hermes_cli.model_normalize import normalize_model_for_provider as N
   N("openai-codex:gpt-5.6-sol", "openai-codex")        # 'openai-codex:gpt-5.6-sol'  (slash form -> 'gpt-5.6-sol')
   N("deepseek:deepseek-v4-pro", "deepseek")            # 'deepseek-v4-flash'         (silent V4 Pro -> Flash)
   N("nvidia:nemotron-3-ultra-550b-a55b", "nvidia")     # unchanged -> content-free 404 at build.nvidia.com
   ```
2. Apply this PR and re-run — the first two return the bare model (`gpt-5.6-sol`, `deepseek-v4-pro`), and the third returns `nvidia/nemotron-3-ultra-550b-a55b`.
3. Focused suites:
   ```
   pytest tests/hermes_cli/test_model_normalize.py tests/hermes_cli/test_codex_models.py -q
   ```
   **92 passed.** Reverting only `hermes_cli/model_normalize.py` to `main` turns **30** of them red, so the tests fail without the production change.
4. Negative controls (unchanged in both directions): `llama3:8b` on `ollama-cloud`, `kimi-k2.5:free` on `opencode-zen`, `custom:my-model` on `custom`, `openai/gpt-5.4` on `openai-codex`, `anthropic/claude-3.5-sonnet:beta` on `openai-codex`, and — for the catalogue branch — `nvidia/my-local-nim-container`, `nvidia/nemotron-3-ultra-550b-a55b`, `z-ai/glm-5.2`, `my-local-nim-container`, `nemotron-3-ultra-550b-a55b:beta`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

> Ran the affected slice rather than the whole suite: every test file that exercises `normalize_model_for_provider` / `model_normalize` (`test_codex_models`, `test_model_normalize`, `test_model_switch_configured_provider_routing`, the per-provider files for arcee/gemini/ollama-cloud/opencode-go/tencent-tokenhub/xiaomi, `test_cli_custom_provider_vision`, `test_user_providers_model_switch`, `test_hermes_constants`, and the three `tests/run_agent/` provider-fallback files), plus `tests/hermes_cli/test_config.py`. **371 passed, 0 failed** on `70c6cf8e7ef`. (`test_cli_provider_resolution.py`, named in an earlier revision of this list, no longer exists on `main`.)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on both touched helpers
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure string handling, no platform-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
