### PR TITLE
feat(desktop): make mouse-wheel zoom optional

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2331,6 +2331,7 @@ const schedulePersistWindowState = debounce(persistWindowState, 250)
 // recovered from a crash (#56726). JSON survives; localStorage is kept as a
 // secondary mirror so pre-JSON installs migrate transparently on first read.
 const DESKTOP_ZOOM_STATE_PATH = path.join(app.getPath('userData'), 'zoom-state.json')
+const DESKTOP_ZOOM_SCROLL_STATE_PATH = path.join(app.getPath('userData'), 'zoom-scroll.json')
 
 function readZoomState() {
   try {
@@ -2351,6 +2352,25 @@ function writeZoomState(zoomLevel) {
     rememberLog(`[zoom] json persist failed: ${error?.message || error}`)
   }
 }
+
+function readPersistedZoomScrollEnabled() {
+  try {
+    return JSON.parse(fs.readFileSync(DESKTOP_ZOOM_SCROLL_STATE_PATH, 'utf8')).enabled !== false
+  } catch {
+    return true
+  }
+}
+
+function writePersistedZoomScrollEnabled(enabled) {
+  try {
+    fs.mkdirSync(path.dirname(DESKTOP_ZOOM_SCROLL_STATE_PATH), { recursive: true })
+    writeFileAtomic(DESKTOP_ZOOM_SCROLL_STATE_PATH, JSON.stringify({ enabled }, null, 2))
+  } catch (error) {
+    rememberLog(`[zoom] scroll preference persist failed: ${error?.message || error}`)
+  }
+}
+
+let zoomScrollEnabled = readPersistedZoomScrollEnabled()
 
 // Match the backend's source resolution but bias toward a real git checkout.
 // Dev → SOURCE_REPO_ROOT. Packaged/CLI install → ACTIVE_HERMES_ROOT.
@@ -5426,6 +5446,7 @@ function installPreviewShortcut(window) {
 import {
   applyZoomLevel,
   DEFAULT_ZOOM_LEVEL,
+  handleZoomChanged,
   installZoomReassertOnWindowEvents,
   percentToZoomLevel,
   ZOOM_STEP,
@@ -5539,9 +5560,12 @@ function installZoomShortcuts(window) {
   // so wheel zoom survives restarts and the settings Scale control stays in
   // sync, and use the same half step for consistency.
   window.webContents.on('zoom-changed', (event, zoomDirection) => {
-    event.preventDefault()
-    const delta = zoomDirection === 'in' ? ZOOM_STEP : -ZOOM_STEP
-    setAndPersistZoomLevel(window, window.webContents.getZoomLevel() + delta)
+    handleZoomChanged(event, zoomDirection, {
+      currentLevel: window.webContents.getZoomLevel(),
+      enabled: zoomScrollEnabled,
+      onZoom: level => setAndPersistZoomLevel(window, level),
+      step: ZOOM_STEP
+    })
   })
 }
 
@@ -9469,6 +9493,11 @@ ipcMain.on('hermes:zoom:set-percent', (event, percent) => {
 
   setAndPersistZoomLevel(window, percentToZoomLevel(Number(percent)))
 })
+ipcMain.on('hermes:zoom:set-scroll-enabled', (_event, enabled) => {
+  zoomScrollEnabled = Boolean(enabled)
+  writePersistedZoomScrollEnabled(zoomScrollEnabled)
+})
+ipcMain.handle('hermes:zoom:get-scroll-enabled', () => zoomScrollEnabled)
 
 // --- Pet overlay (pop-out mascot) -----------------------------------------
 // `request` is `{ bounds, screen }`. A fresh pop-out passes viewport-space

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -140,6 +140,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     // Current zoom of this window, as { level, percent }.
     get: () => ipcRenderer.invoke('hermes:zoom:get'),
     setPercent: percent => ipcRenderer.send('hermes:zoom:set-percent', percent),
+    getScrollEnabled: () => ipcRenderer.invoke('hermes:zoom:get-scroll-enabled'),
+    setScrollEnabled: enabled => ipcRenderer.send('hermes:zoom:set-scroll-enabled', Boolean(enabled)),
     // Fires on every zoom change, including the Ctrl/Cmd +/-/0 shortcuts,
     // so the settings UI can stay in sync with the keyboard.
     onChanged: callback => {

--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -12,6 +12,7 @@ import {
   applyZoomLevel,
   clampZoomLevel,
   DEFAULT_ZOOM_LEVEL,
+  handleZoomChanged,
   installZoomReassertOnWindowEvents,
   percentToZoomLevel,
   ZOOM_RESIZE_REASSERT_DELAY_MS,
@@ -214,4 +215,34 @@ test('applyZoomLevel clamps garbage before applying and notifying', () => {
     ['setZoomLevel', clamped],
     ['send', 'hermes:zoom:changed', { level: clamped, percent: zoomLevelToPercent(clamped) }]
   ])
+})
+
+test('wheel zoom applies the configured half-step when enabled', () => {
+  const event = { preventDefault: vi.fn() }
+  const levels: number[] = []
+
+  const handled = handleZoomChanged(event, 'in', {
+    currentLevel: 2,
+    enabled: true,
+    onZoom: level => levels.push(level)
+  })
+
+  assert.equal(handled, true)
+  assert.equal(event.preventDefault.mock.calls.length, 1)
+  assert.deepEqual(levels, [2.1])
+})
+
+test('disabled wheel zoom consumes the gesture without changing scale', () => {
+  const event = { preventDefault: vi.fn() }
+  const levels: number[] = []
+
+  const handled = handleZoomChanged(event, 'out', {
+    currentLevel: 2,
+    enabled: false,
+    onZoom: level => levels.push(level)
+  })
+
+  assert.equal(handled, false)
+  assert.equal(event.preventDefault.mock.calls.length, 1)
+  assert.deepEqual(levels, [])
 })

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -57,6 +57,27 @@ export function applyZoomLevel(webContents, level) {
   return clamped
 }
 
+/**
+ * Consume Chromium's native Ctrl/Cmd+wheel zoom event.
+ *
+ * The event must always be prevented: when wheel zoom is disabled, letting the
+ * event fall through would re-enable Chromium's default 0.2-step page zoom.
+ * Keyboard shortcuts and the settings scale control use separate paths and
+ * remain available.
+ */
+export function handleZoomChanged(event, direction, { currentLevel, enabled, onZoom, step = 0.1 }) {
+  event.preventDefault()
+
+  if (!enabled) {
+    return false
+  }
+
+  const delta = direction === 'in' ? step : -step
+  onZoom(currentLevel + delta)
+
+  return true
+}
+
 // Chromium can drop webContents zoom when a BrowserWindow is resized, minimized
 // and restored, or crosses onto a monitor with different display scaling. macOS
 // and Windows provide trailing `resized`/`moved` events; Linux only provides the

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -19,6 +19,7 @@ import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enable
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $translucency, setTranslucency } from '@/store/translucency'
 import { $zoomPercent, setZoomPercent } from '@/store/zoom'
+import { $zoomScrollEnabled, setZoomScrollEnabled } from '@/store/zoom-scroll'
 import { getBaseColors, useTheme } from '@/themes/context'
 import { installVscodeThemeFromMarketplace } from '@/themes/install'
 import type { DesktopTheme } from '@/themes/types'
@@ -26,7 +27,7 @@ import { $marketplaceInstalls, isUserTheme, removeUserTheme } from '@/themes/use
 
 import { MODE_OPTIONS } from './constants'
 import { PetSettings } from './pet-settings'
-import { ListRow, SectionHeading, SettingsContent } from './primitives'
+import { ListRow, SectionHeading, SettingsContent, ToggleRow } from './primitives'
 
 function ThemePreview({ name, mode }: { name: string; mode: 'light' | 'dark' }) {
   // Preview in the *current* mode: the dark palette in Dark, and the light
@@ -248,6 +249,7 @@ export function AppearanceSettings() {
   const { themeName, mode, resolvedMode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
   const zoomPercent = useStore($zoomPercent)
+  const zoomScrollEnabled = useStore($zoomScrollEnabled)
   const embedMode = useStore($embedMode)
   const embedAllowed = useStore($embedAllowed)
   const translucency = useStore($translucency)
@@ -428,6 +430,13 @@ export function AppearanceSettings() {
             }
             description={a.uiScaleDesc(zoomPercent)}
             title={a.uiScaleTitle}
+          />
+
+          <ToggleRow
+            checked={zoomScrollEnabled}
+            description={a.zoomScrollDesc}
+            label={a.zoomScrollTitle}
+            onChange={setZoomScrollEnabled}
           />
 
           <ListRow

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -153,7 +153,9 @@ declare global {
       }
       zoom?: {
         get: () => Promise<{ level: number; percent: number }>
+        getScrollEnabled: () => Promise<boolean>
         setPercent: (percent: number) => void
+        setScrollEnabled: (enabled: boolean) => void
         onChanged: (callback: (payload: { level: number; percent: number }) => void) => () => void
       }
       revealLogs: () => Promise<{ ok: boolean; path: string; error?: string }>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -438,6 +438,8 @@ export const en: Translations = {
       uiScaleTitle: 'UI Scale',
       uiScaleDesc: (percent: number) =>
         `Scales text and controls across the whole app. Cmd/Ctrl with +, - and 0 also works. Current: ${percent}%.`,
+      zoomScrollTitle: 'Mouse Wheel Zoom',
+      zoomScrollDesc: 'Allow Cmd/Ctrl with the mouse wheel to change the app scale.',
       translucencyTitle: 'Window Translucency',
       translucencyDesc: 'See your desktop through the whole window. macOS and Windows only.',
       backdropTitle: 'Chat Backdrop',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -314,6 +314,8 @@ export const ja = defineLocale({
       uiScaleTitle: 'UI スケール',
       uiScaleDesc: (percent: number) =>
         `アプリ全体の文字と UI を拡大縮小します。Cmd/Ctrl と +、-、0 でも変更できます。現在: ${percent}%`,
+      zoomScrollTitle: 'マウスホイールでズーム',
+      zoomScrollDesc: 'Cmd/Ctrl とマウスホイールでアプリの表示倍率を変更できるようにします。',
       translucencyTitle: 'ウィンドウの透過',
       translucencyDesc: 'ウィンドウ全体を透過させてデスクトップを表示します。macOS と Windows のみ。',
       backdropTitle: 'チャット背景',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -347,6 +347,8 @@ export interface Translations {
       toolViewDesc: string
       uiScaleTitle: string
       uiScaleDesc: (percent: number) => string
+      zoomScrollTitle: string
+      zoomScrollDesc: string
       translucencyTitle: string
       translucencyDesc: string
       backdropTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -306,6 +306,8 @@ export const zhHant = defineLocale({
       uiScaleTitle: '介面縮放',
       uiScaleDesc: (percent: number) =>
         `縮放整個應用程式的文字與介面。也可使用 Cmd/Ctrl 加 +、- 或 0 調整。目前：${percent}%`,
+      zoomScrollTitle: '滑鼠滾輪縮放',
+      zoomScrollDesc: '允許使用 Cmd/Ctrl 加滑鼠滾輪調整應用程式介面縮放。',
       translucencyTitle: '視窗透明',
       translucencyDesc: '讓整個視窗透出桌面。僅支援 macOS 與 Windows。',
       backdropTitle: '聊天背景',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -430,6 +430,8 @@ export const zh: Translations = {
       uiScaleTitle: '界面缩放',
       uiScaleDesc: (percent: number) =>
         `缩放整个应用的文字和界面。也可使用 Cmd/Ctrl 加 +、- 或 0 调整。当前：${percent}%`,
+      zoomScrollTitle: '鼠标滚轮缩放',
+      zoomScrollDesc: '允许使用 Cmd/Ctrl 加鼠标滚轮调整应用界面缩放。',
       translucencyTitle: '窗口透明',
       translucencyDesc: '让整个窗口透出桌面。仅支持 macOS 和 Windows。',
       backdropTitle: '聊天背景',

--- a/apps/desktop/src/store/zoom-scroll.test.ts
+++ b/apps/desktop/src/store/zoom-scroll.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $zoomScrollEnabled, setZoomScrollEnabled } from './zoom-scroll'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+const setScrollEnabledBridge = vi.fn()
+const getScrollEnabledBridge = vi.fn().mockResolvedValue(true)
+
+beforeEach(() => {
+  desktopWindow.hermesDesktop = {
+    zoom: {
+      getScrollEnabled: getScrollEnabledBridge,
+      setScrollEnabled: setScrollEnabledBridge
+    }
+  } as unknown as Window['hermesDesktop']
+  setZoomScrollEnabled(true)
+  setScrollEnabledBridge.mockClear()
+})
+
+afterEach(() => {
+  desktopWindow.hermesDesktop = initialHermesDesktop
+})
+
+describe('zoom-scroll store', () => {
+  it('updates the preference and mirrors it to Electron', () => {
+    setZoomScrollEnabled(false)
+    expect($zoomScrollEnabled.get()).toBe(false)
+    expect(setScrollEnabledBridge).toHaveBeenLastCalledWith(false)
+
+    setZoomScrollEnabled(true)
+    expect($zoomScrollEnabled.get()).toBe(true)
+    expect(setScrollEnabledBridge).toHaveBeenLastCalledWith(true)
+  })
+})

--- a/apps/desktop/src/store/zoom-scroll.ts
+++ b/apps/desktop/src/store/zoom-scroll.ts
@@ -1,0 +1,21 @@
+/**
+ * Ctrl/Cmd+wheel window zoom preference.
+ *
+ * This is device-local presentation state, independent of the active Hermes
+ * profile. Electron owns and persists the setting so it is effective at cold
+ * launch, before the Appearance page has mounted; the renderer only mirrors
+ * the current value for the settings UI.
+ */
+
+import { atom } from 'nanostores'
+
+export const $zoomScrollEnabled = atom<boolean>(true)
+
+export function setZoomScrollEnabled(enabled: boolean): void {
+  $zoomScrollEnabled.set(enabled)
+  window.hermesDesktop?.zoom?.setScrollEnabled(enabled)
+}
+
+if (typeof window !== 'undefined' && window.hermesDesktop?.zoom) {
+  void window.hermesDesktop.zoom.getScrollEnabled().then(enabled => $zoomScrollEnabled.set(enabled))
+}


### PR DESCRIPTION
## What does this PR do?

Adds a setting to disable Cmd/Ctrl + mouse-wheel zoom in the desktop app.
On resource-constrained systems an accidental wheel-zoom triggers heavy
layout recalculation that can freeze the app, and there was no way to turn
the gesture off. This adds a toggle in Appearance settings, defaulting to
**on** so existing behaviour is unchanged.

Electron owns and persists the preference (`zoom-scroll.json` in userData)
so it takes effect at cold launch, before the settings page mounts; the
renderer only mirrors the value for the UI. Keyboard shortcuts
(Cmd/Ctrl +/-/0) and the Scale slider use separate code paths and stay
available when wheel zoom is off. The issue explicitly wanted keyboard zoom
preserved.

## Related Issue

Fixes #71421

## Help wanted: Windows / Linux verification 🙏

The limitation I am facing is that I could only verify this via unit tests,
since I'm on macOS. Chromium doesn't do scroll-wheel page zoom there
(Ctrl+scroll on a Mac is the OS accessibility screen zoom, which sits above
the app), so the in-app `zoom-changed` path isn't reachable to test end to
end. The handler is covered by platform-agnostic unit tests, but not a real
wheel gesture.

If you're on **Windows or Linux**, a quick check would be a big help:

1. Ctrl + mouse wheel zooms the app (toggle on, the default).
2. Settings → Appearance → turn **Mouse Wheel Zoom** off.
3. Ctrl + mouse wheel should now do nothing, and must **not** fall back to
   Chromium's default zoom step.
4. Keyboard zoom (Ctrl +/-/0) should still work either way.

A 👍 confirming steps 2 and 3 on your platform would be much appreciated.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/electron/zoom.ts`: `handleZoomChanged()` always
  `preventDefault()`s the native gesture, and applies the half-step only
  when enabled.
- `apps/desktop/electron/main.ts`: persist/read the preference, route the
  `zoom-changed` event through the helper, add
  `hermes:zoom:{get,set}-scroll-enabled` IPC.
- `apps/desktop/electron/preload.ts` and `src/global.d.ts`: expose
  `zoom.getScrollEnabled` / `setScrollEnabled` on the bridge.
- `apps/desktop/src/store/zoom-scroll.ts`: nanostore mirror of the setting.
- `apps/desktop/src/app/settings/appearance-settings.tsx`: `ToggleRow`
  under UI Scale.
- `apps/desktop/src/i18n/*`: `zoomScrollTitle` / `zoomScrollDesc` in en,
  ja, zh, zh-hant, and the shared type.
- Tests: `electron/zoom.test.ts` (handler enabled/disabled) and
  `src/store/zoom-scroll.test.ts` (store to bridge).

## Implementation note

The issue proposed a `desktop.disable_zoom_scroll` config key. This PR
instead exposes it as a UI toggle in Appearance settings (persisted by
Electron), which is discoverable in-app and doesn't require editing config.
Same effect, better discoverability; no `cli-config.yaml.example` key added.
Happy to switch to a config key instead if maintainers prefer.

## How to Test

> ⚠️ **Not visually verifiable on macOS** (see "Help wanted" above). Verify
> on Linux or Windows, or via the unit tests.

1. On Linux/Windows: Ctrl + mouse wheel zooms the app (default on).
2. Settings → Appearance → toggle **Mouse Wheel Zoom** off.
3. Ctrl + mouse wheel no longer changes scale, and does **not** fall back to
   Chromium's default zoom. Cmd/Ctrl +/-/0 and the Scale slider still work.
4. Restart, and the setting persists.
5. `npm test -- zoom` (in `apps/desktop`): 18 passing (handler + store
   logic, platform-agnostic).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the test suite. This is a desktop-only change (no Python
      touched); `npm test -- zoom` in `apps/desktop` passes (18). Any
      `ModuleNotFoundError: No module named 'acp'` seen locally is just the
      optional `acp` extra not being installed. After `uv sync --extra acp`,
      `tests/acp*` collect and pass (348/348). Unrelated to this PR.
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] Documentation (README, docs/, docstrings): N/A
- [x] `cli-config.yaml.example`: N/A (Electron-side persistence, no config key)
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered: no OS-specific APIs; macOS simply
      doesn't reach this gesture (documented above)
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

<!-- Drag the Appearance-settings screenshot into the GitHub PR editor here;
     GitHub uploads it and inserts the image markdown automatically. -->
<img width="857" height="48" alt="image" src="https://github.com/user-attachments/assets/87144857-e0bc-4cd5-b210-fc5877c9f07b" />

Appearance settings, new **Mouse Wheel Zoom** toggle:
