### PR TITLE
fix(mcp-oauth): escape callback error responses

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -440,6 +440,26 @@ class TestCallbackHandlerIsolation:
         assert result["auth_code"] is None
         assert result["error"] == "access_denied"
 
+    def test_handler_escapes_error_in_html_response(self):
+        HandlerClass, _ = _make_callback_handler()
+
+        handler = HandlerClass.__new__(HandlerClass)
+        handler.path = "/callback?error=%3Cscript%3Ealert%281%29%3C%2Fscript%3E"
+        handler.wfile = BytesIO()
+        handler.send_response = MagicMock()
+        handler.send_header = MagicMock()
+        handler.end_headers = MagicMock()
+        handler.do_GET()
+
+        body = handler.wfile.getvalue().decode()
+        assert "<script>" not in body
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in body
+        handler.send_header.assert_any_call(
+            "Content-Security-Policy",
+            "default-src 'none'; frame-ancestors 'none'",
+        )
+        handler.send_header.assert_any_call("X-Content-Type-Options", "nosniff")
+
 
 # ---------------------------------------------------------------------------
 # Port sharing

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -36,6 +36,7 @@ Configuration in config.yaml::
 
 import asyncio
 import contextvars
+import html
 import json
 import logging
 import os
@@ -617,17 +618,23 @@ def _make_callback_handler() -> tuple[type, dict]:
             result["state"] = state
             result["error"] = error
 
+            safe_error = html.escape(str(error or "unknown"))
             body = (
                 "<html><body><h2>Authorization Successful</h2>"
                 "<p>You can close this tab and return to Hermes.</p></body></html>"
             ) if code else (
                 "<html><body><h2>Authorization Failed</h2>"
-                f"<p>Error: {error or 'unknown'}</p></body></html>"
+                f"<p>Error: {safe_error}</p></body></html>"
             )
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header(
+                "Content-Security-Policy",
+                "default-src 'none'; frame-ancestors 'none'",
+            )
+            self.send_header("X-Content-Type-Options", "nosniff")
             self.end_headers()
-            self.wfile.write(body.encode())
+            self.wfile.write(body.encode("utf-8"))
 
         def log_message(self, fmt: str, *args: Any) -> None:
             logger.debug("OAuth callback: %s", fmt % args)


### PR DESCRIPTION
## What

Escape OAuth callback error text before rendering it in the local HTML response.

Add a restrictive Content Security Policy and `X-Content-Type-Options: nosniff` to both callback outcomes, and encode the response explicitly as UTF-8.

## Why

The callback handler parsed the OAuth provider's `error` query parameter and interpolated it directly into a `text/html` response. A provider-controlled error value could therefore be interpreted as markup by the browser before the OAuth flow rejected the callback.

## Impact

- Provider error strings remain visible to the user as inert text.
- The successful callback experience is unchanged.
- CSP and MIME sniffing protection reduce the impact of future accidental markup regressions in this tiny local response surface.

## Validation

- `scripts/run_tests.sh tests/tools/test_mcp_oauth.py -q` — 106 passed
- `ruff check tools/mcp_oauth.py tests/tools/test_mcp_oauth.py` — passed
- `python scripts/check-windows-footguns.py tools/mcp_oauth.py tests/tools/test_mcp_oauth.py` — passed
- `git diff --check` — passed

Tested on macOS; the change uses Python standard-library escaping and is platform-neutral.