### PR TITLE
fix(cli): declare stateless channel for single-query chat (-q) path

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16409,6 +16409,15 @@ def main(
         if not cli._claim_active_session("cli", stderr=bool(quiet)):
             sys.exit(1)
         try:
+            # Single-query (including chat -q) prints one response and exits:
+            # there is no later turn for a detached subagent's completion to
+            # re-enter, and nothing here drains the completion queue. Left
+            # unset, async_delivery_supported() defaults True, delegate_task is
+            # forced background, and every subagent result is discarded. The
+            # oneshot path already does this (herses_cli/oneshot.py:231);
+            # single-query chat was missed. See declare_stateless_channel().
+            from gateway.session_context import declare_stateless_channel
+            declare_stateless_channel()
             query, single_query_images = _collect_query_images(query, image)
             # Kanban workers spawn with ``hermes chat -q "work kanban task <id>"``;
             # the actual task description lives in the task body. Mirror the

--- a/cli.py
+++ b/cli.py
@@ -16414,7 +16414,7 @@ def main(
             # re-enter, and nothing here drains the completion queue. Left
             # unset, async_delivery_supported() defaults True, delegate_task is
             # forced background, and every subagent result is discarded. The
-            # oneshot path already does this (herses_cli/oneshot.py:231);
+            # oneshot path already does this (hermes_cli/oneshot.py:231);
             # single-query chat was missed. See declare_stateless_channel().
             from gateway.session_context import declare_stateless_channel
             declare_stateless_channel()


### PR DESCRIPTION
## What does this PR do?

`hermes chat -q` was missing `declare_stateless_channel()`, so `async_delivery_supported()` returned `True` and top-level `delegate_task` was dispatched **asynchronously** — then `_run_cleanup()` killed the child on exit with `status=interrupted`.

The oneshot path already does this (`hermes_cli/oneshot.py:231`); the single-query chat path was missed. After this change, top-level `delegate_task` in `chat -q` runs **inline/synchronous**, matching the oneshot/cron behavior from #66617.

## Related Issue

Fixes #71453

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `cli.py` — `main()`: call `declare_stateless_channel()` in the single-query path (before both the `quiet` and non-quiet branches), mirroring the oneshot pattern.

## Why here specifically

Every `chat -q` entry point converges on `cli.main()` (`hermes_cli/main.py:cmd_chat()` → `cli_main(**kwargs)`), so a single call at the top of the single-query branch covers all variants:
- `hermes chat -q "..."` (human-facing)
- `hermes chat -Q "..."` / `--quiet` (machine-readable)
- `hermes chat -q "..." --cli`
- Kanban worker spawns (already guarded by `HERMES_KANBAN_TASK` env check in `async_delivery_supported()`, so no change in behavior)

## How to Test

1. Existing tests: `pytest tests/gateway/test_async_delivery_capability.py -v` — the `TestStatelessChannelForcesSyncDelegation` class already validates the behavioral contract (stateless channel → sync delegation).
2. Manual: `hermes chat -q 'Use delegate_task to read README.md and report its first line.'` — before this fix the child gets `status=interrupted`; after, the inline result is returned within the turn.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] Existing tests in `tests/gateway/test_async_delivery_capability.py` cover the behavioral contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)