### PR TITLE
fix(gateway): release hygiene lock after timeout

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -40,7 +40,7 @@ import uuid
 import threading
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from agent.context_engine import (
     automatic_compaction_status_message,
@@ -221,6 +221,9 @@ class CompressionCommitFence:
         self._lock = threading.Lock()
         self._cancelled = False
         self._commit_started = False
+        self._lock_release_guard = threading.Lock()
+        self._cancelled_lock_release: Optional[Callable[[], None]] = None
+        self._cancelled_lock_release_requested = False
         # Forward-progress telemetry: the compression worker touches this
         # whenever the streamed summary call produces a token (see
         # ContextCompressor._call_summary_llm). Waiters use it to distinguish
@@ -282,6 +285,58 @@ class CompressionCommitFence:
     def finish_commit(self) -> None:
         """Leave a commit boundary entered by :meth:`begin_commit`."""
         self._lock.release()
+
+    def begin_lock_setup(self) -> bool:
+        """Fence durable-lock acquisition and release-hook publication.
+
+        The caller keeps the fence until it has either published the exact
+        holder-qualified release hook or established that no lock was
+        acquired. A timeout cannot therefore win in the gap between acquiring
+        the durable lock and making its cancellation cleanup callable.
+        """
+        self._lock.acquire()
+        if self._cancelled:
+            self._lock.release()
+            return False
+        return True
+
+    def finish_lock_setup(self) -> None:
+        """Leave a lock setup boundary entered by :meth:`begin_lock_setup`."""
+        self._lock.release()
+
+    def register_cancelled_lock_release(
+        self, release: Callable[[], None]
+    ) -> bool:
+        """Publish the timed-out worker's holder-qualified lock release.
+
+        Returns whether cancellation cleanup was requested before publication.
+        In that race, the release runs synchronously before this method returns.
+        """
+        with self._lock_release_guard:
+            self._cancelled_lock_release = release
+            requested = self._cancelled_lock_release_requested
+        if requested:
+            release()
+        return requested
+
+    def clear_cancelled_lock_release(self, release: Callable[[], None]) -> None:
+        """Forget ``release`` after the worker's normal cleanup finishes."""
+        with self._lock_release_guard:
+            if self._cancelled_lock_release is release:
+                self._cancelled_lock_release = None
+
+    def release_cancelled_compression_lock(self) -> None:
+        """Release the cancelled worker's lock without finalizing its clients.
+
+        Callers invoke this only after :meth:`try_cancel_before_commit` returns
+        ``True``. A request that races ahead of lock-hook publication is retained
+        and fulfilled synchronously when the worker publishes the hook.
+        """
+        with self._lock_release_guard:
+            self._cancelled_lock_release_requested = True
+            release = self._cancelled_lock_release
+        if release is not None:
+            release()
 
 
 def _lock_api_is_absent_on_session_db(lock_db: Any) -> bool:
@@ -1492,6 +1547,15 @@ def compress_context(
         _lock_ttl = 300.0
     _lock_refresh_interval = getattr(agent, "_compression_lock_refresh_interval", None)
     _lock_refresher: Optional[_CompressionLockLeaseRefresher] = None
+    _lock_setup_entered = False
+
+    def _finish_lock_setup() -> None:
+        nonlocal _lock_setup_entered
+        if not _lock_setup_entered or commit_fence is None:
+            return
+        _lock_setup_entered = False
+        commit_fence.finish_lock_setup()
+
     if _lock_db is not None and _lock_sid:
         _lock_holder = _compression_lock_holder(agent)
         if _lock_lookup_error is not None:
@@ -1520,6 +1584,27 @@ def compress_context(
                 )
             _lock_acquired = True  # acquired-but-unlocked compatibility path
         else:
+            if commit_fence is not None:
+                _lock_setup_entered = commit_fence.begin_lock_setup()
+                if not _lock_setup_entered:
+                    logger.info(
+                        "Compression commit cancelled before lock acquisition "
+                        "(session=%s).",
+                        agent.session_id or "none",
+                    )
+                    agent._last_compaction_in_place = False
+                    _existing_sp = getattr(agent, "_cached_system_prompt", None)
+                    if not _existing_sp:
+                        _existing_sp = agent._build_system_prompt(system_message)
+                    _emit_compression_attempt_telemetry(
+                        agent,
+                        started_at=_attempt_started_at,
+                        commit_status="aborted",
+                        split_status="aborted",
+                        failure_class="commit_fence_cancelled",
+                    )
+                    _complete_compaction_lifecycle()
+                    return messages, _existing_sp
             try:
                 _lock_acquired = _try_acquire_lock(
                     _lock_sid, _lock_holder, ttl_seconds=_lock_ttl
@@ -1547,6 +1632,7 @@ def compress_context(
                 )
                 _lock_acquired = False
         if not _lock_acquired:
+            _finish_lock_setup()
             try:
                 existing = _lock_db.get_compression_lock_holder(_lock_sid)
             except Exception:
@@ -1591,29 +1677,74 @@ def compress_context(
             _complete_compaction_lifecycle()
             return messages, _existing_sp
     _lock_released = False
+    _lock_release_guard = threading.Lock()
+
+    def _release_lock_holder_only() -> None:
+        """Stop this holder's refresher and release only its durable lock."""
+        nonlocal _lock_released
+        with _lock_release_guard:
+            if _lock_released:
+                return
+            _lock_released = True
+            if getattr(agent, "_active_compression_lock_holder", None) == _lock_holder:
+                agent._active_compression_lock_holder = None
+            if _lock_refresher is not None:
+                try:
+                    _lock_refresher.stop()
+                except Exception as _stop_err:
+                    logger.debug("compression lock refresher stop failed: %s", _stop_err)
+            if _lock_db is not None and _lock_sid and _lock_holder:
+                try:
+                    _lock_db.release_compression_lock(_lock_sid, _lock_holder)
+                except Exception as _rel_err:
+                    logger.debug("compression lock release failed: %s", _rel_err)
 
     def _release_lock() -> None:
-        """Release the lock keyed on the OLD session_id (before rotation)."""
-        nonlocal _lock_released
-        _complete_compaction_lifecycle()
-        if _lock_released:
-            return
-        _lock_released = True
-        if getattr(agent, "_active_compression_lock_holder", None) == _lock_holder:
-            agent._active_compression_lock_holder = None
-        if _lock_refresher is not None:
+        """Finish lifecycle cleanup and release the OLD session lock once."""
+        try:
+            _complete_compaction_lifecycle()
+        finally:
             try:
-                _lock_refresher.stop()
-            except Exception as _stop_err:
-                logger.debug("compression lock refresher stop failed: %s", _stop_err)
-        if _lock_db is not None and _lock_sid and _lock_holder:
-            try:
-                _lock_db.release_compression_lock(_lock_sid, _lock_holder)
-            except Exception as _rel_err:
-                logger.debug("compression lock release failed: %s", _rel_err)
+                _release_lock_holder_only()
+            finally:
+                try:
+                    if commit_fence is not None:
+                        commit_fence.clear_cancelled_lock_release(
+                            _release_lock_holder_only
+                        )
+                finally:
+                    _finish_lock_setup()
 
     if _lock_holder is not None:
         agent._active_compression_lock_holder = _lock_holder
+        if (
+            commit_fence is not None
+            and commit_fence.register_cancelled_lock_release(
+                _release_lock_holder_only
+            )
+        ):
+            logger.info(
+                "Compression commit cancelled before summary dispatch "
+                "(session=%s).",
+                agent.session_id or "none",
+            )
+            agent._last_compaction_in_place = False
+            _existing_sp = getattr(agent, "_cached_system_prompt", None)
+            if not _existing_sp:
+                _existing_sp = agent._build_system_prompt(system_message)
+            _emit_compression_attempt_telemetry(
+                agent,
+                started_at=_attempt_started_at,
+                commit_status="aborted",
+                split_status="aborted",
+                failure_class="commit_fence_cancelled",
+            )
+            _release_lock()
+            return messages, _existing_sp
+
+    # Publish the holder-qualified release hook before a timeout can win the
+    # fence. If no durable lock was acquired there is no hook to publish.
+    _finish_lock_setup()
 
     # A delayed contender can acquire the parent lock after the winning path
     # has released it and completed rotation. The lock serializes work but does
@@ -1680,14 +1811,21 @@ def compress_context(
     _activity_heartbeat: Optional[_CompressionActivityHeartbeat] = None
     try:
         if _lock_holder is not None:
-            _lock_refresher = _CompressionLockLeaseRefresher(
+            _candidate_refresher = _CompressionLockLeaseRefresher(
                 _lock_db,
                 _lock_sid,
                 _lock_holder,
                 _lock_ttl,
                 _lock_refresh_interval,
             )
-            _lock_refresher.start()
+            # Cancellation may release the holder after hook publication but
+            # before this refresher starts. Serialize that check/start with the
+            # idempotent release path so a refresher is never started for an
+            # already-released lock.
+            with _lock_release_guard:
+                if not _lock_released:
+                    _lock_refresher = _candidate_refresher
+                    _lock_refresher.start()
 
         # The caller's history snapshot predates lease acquisition. Reload the
         # durable parent after the lease is live; MORE durable rows than the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3415,6 +3415,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._restart_task: Optional[asyncio.Task] = None
         self._executor_lock = threading.Lock()
         self._executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+        # Lock release after a hygiene timeout must not queue behind the
+        # potentially hung hygiene workers occupying the loop's default pool.
+        self._hygiene_lock_release_executor: Optional[
+            concurrent.futures.ThreadPoolExecutor
+        ] = None
         # Set on gateway stop so the recreate-on-shutdown path can't resurrect
         # the pool during a real shutdown.
         self._executor_closing = False
@@ -13532,6 +13537,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             # successful compaction as a timeout.
                                             _compressed, _ = await _hyg_future
                                         else:
+                                            # Cancellation won before mutation. Release only
+                                            # this worker's holder-qualified compression lock
+                                            # off-loop before the live agent starts; the
+                                            # synchronous summary call remains alive and owns
+                                            # its clients until deferred cleanup below.
+                                            await loop.run_in_executor(
+                                                self._get_hygiene_lock_release_executor(),
+                                                _hyg_commit_fence.release_cancelled_compression_lock,
+                                            )
                                             self._defer_agent_cleanup_until_future_done(
                                                 _hyg_future,
                                                 _hyg_agent,
@@ -17472,8 +17486,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._executor = executor
             return executor
 
+    def _get_hygiene_lock_release_executor(
+        self,
+    ) -> concurrent.futures.ThreadPoolExecutor:
+        """Return reserved capacity for timed-out hygiene lock releases.
+
+        Hygiene compression itself runs in the loop's default executor and may
+        remain blocked in a synchronous provider call after cancellation. Its
+        holder-qualified database release must therefore use an independent
+        pool or it can starve behind the workers whose locks it must release.
+        """
+        lock = getattr(self, "_executor_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._executor_lock = lock
+
+        with lock:
+            if getattr(self, "_executor_closing", False):
+                raise RuntimeError("Gateway is shutting down; executor unavailable")
+            executor = getattr(self, "_hygiene_lock_release_executor", None)
+            if executor is None or getattr(executor, "_shutdown", False):
+                executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=2,
+                    thread_name_prefix="hermes-hygiene-lock-release",
+                )
+                self._hygiene_lock_release_executor = executor
+            return executor
+
     def _shutdown_executor(self) -> None:
-        """Stop the gateway-owned executor without touching the loop default."""
+        """Stop gateway-owned executors without touching the loop default."""
         lock = getattr(self, "_executor_lock", None)
         if lock is None:
             return
@@ -17481,15 +17522,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         with lock:
             self._executor_closing = True
             executor = getattr(self, "_executor", None)
+            release_executor = getattr(
+                self, "_hygiene_lock_release_executor", None
+            )
             self._executor = None
+            self._hygiene_lock_release_executor = None
 
-        if executor is None:
-            return
-
-        try:
-            executor.shutdown(wait=False, cancel_futures=True)
-        except TypeError:
-            executor.shutdown(wait=False)
+        for owned_executor in (executor, release_executor):
+            if owned_executor is None:
+                continue
+            try:
+                owned_executor.shutdown(wait=False, cancel_futures=True)
+            except TypeError:
+                owned_executor.shutdown(wait=False)
 
     def _decide_image_input_mode(
         self,

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -9,6 +9,7 @@ so CLI and messaging platforms behave identically.
 """
 
 import asyncio
+import concurrent.futures
 import importlib
 import sys
 import threading
@@ -689,67 +690,115 @@ async def test_session_hygiene_skips_compression_during_failure_cooldown(monkeyp
 async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monkeypatch, tmp_path):
     """A timed-out SessionDB-bound worker cannot compact after the live turn starts.
 
-    The worker remains alive long enough to cross the old race window. The
-    timeout must fence its eventual commit, continue to the live agent, and
-    clean up the temporary agent only after the worker actually returns.
+    The worker pauses after its real durable acquire but before publishing the
+    release hook, then remains alive in the auxiliary call. Timeout cancellation
+    must wait for hook publication, release the old holder before continuing to
+    the live agent even when the default executor is saturated, fence the late
+    commit, and defer helper cleanup. Every barrier is unwound on assertion
+    failure so the RED run is deterministic and leaves no orphan future.
     """
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
+    from hermes_state import SessionDB
+    from run_agent import AIAgent as RealAIAgent
+
     worker_started = threading.Event()
+    worker_finished = threading.Event()
+    lock_acquired_before_hook = threading.Event()
+    allow_acquire_return = threading.Event()
+    cancel_attempted = threading.Event()
+    cancel_results = []
     release_worker = threading.Event()
     cleanup_done = threading.Event()
-    fake_db = MagicMock()
+    live_agent_started = threading.Event()
+    teardown_started = threading.Event()
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "sess-timeout"
+    live_holder = "live-turn-holder"
+    db.create_session(session_id, source="telegram")
+    real_try_acquire = db.try_acquire_compression_lock
 
-    class SlowCompressAgent:
+    def _gated_try_acquire(lock_session_id, holder, ttl_seconds=300.0):
+        acquired = real_try_acquire(
+            lock_session_id,
+            holder,
+            ttl_seconds=ttl_seconds,
+        )
+        if holder != live_holder and acquired:
+            lock_acquired_before_hook.set()
+            assert allow_acquire_return.wait(timeout=10)
+        return acquired
+
+    db.try_acquire_compression_lock = _gated_try_acquire
+    archive_spy = MagicMock(wraps=db.archive_and_compact)
+    db.archive_and_compact = archive_spy
+    live_lock_attempts = []
+
+    class SlowCompressAgent(RealAIAgent):
         last_instance = None
 
         def __init__(self, **kwargs):
-            self.session_id = kwargs.get("session_id", "fake-session")
-            self._session_db = kwargs.get("session_db")
-            self._last_compaction_in_place = False
-            self.context_compressor = SimpleNamespace(
-                bind_session_state=MagicMock(),
-                _last_compress_aborted=False,
-                _last_aux_model_failure_model=None,
-            )
+            super().__init__(**kwargs)
+            compressor = MagicMock()
+
+            def _slow_summary(*_args, **_kwargs):
+                worker_started.set()
+                try:
+                    assert release_worker.wait(timeout=10)
+                    return [
+                        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                        {"role": "user", "content": "tail"},
+                    ]
+                finally:
+                    worker_finished.set()
+
+            compressor.compress.side_effect = _slow_summary
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            compressor._last_aux_model_failure_model = None
+            compressor._last_aux_model_failure_error = None
+            compressor._last_compression_made_progress = True
+            compressor._last_summary_fallback_used = False
+            self.context_compressor = compressor
+            self._compression_feasibility_checked = True
+            self._cached_system_prompt = "sys"
             self.shutdown_memory_provider = MagicMock()
             self.close = MagicMock(side_effect=cleanup_done.set)
             type(self).last_instance = self
 
-        def _compress_context(
-            self, messages, *_args, commit_fence=None, **_kwargs
-        ):
-            worker_started.set()
-            assert release_worker.wait(timeout=2)
-            if commit_fence is not None and not commit_fence.begin_commit():
-                return (messages, None)
-            try:
-                self._session_db.archive_and_compact(
-                    self.session_id,
-                    [{"role": "assistant", "content": "too late"}],
-                )
-                self._last_compaction_in_place = True
-                return ([{"role": "assistant", "content": "too late"}], None)
-            finally:
-                if commit_fence is not None:
-                    commit_fence.finish_commit()
-
-    fake_run_agent = types.ModuleType("run_agent")
-    fake_run_agent.AIAgent = SlowCompressAgent
-    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    run_agent_module = sys.modules["run_agent"]
+    monkeypatch.setattr(run_agent_module, "AIAgent", SlowCompressAgent)
 
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text(
         "compression:\n"
         "  enabled: true\n"
-        "  hygiene_timeout_seconds: 0.01\n"
+        "  hygiene_timeout_seconds: 0.1\n"
         "  hygiene_failure_cooldown_seconds: 120\n"
     )
 
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
+    from agent.conversation_compression import CompressionCommitFence
+
+    original_try_cancel = CompressionCommitFence.try_cancel_before_commit
+
+    def _tracked_try_cancel(fence):
+        result = original_try_cancel(fence)
+        cancel_results.append(result)
+        cancel_attempted.set()
+        return result
+
+    monkeypatch.setattr(
+        CompressionCommitFence,
+        "try_cancel_before_commit",
+        _tracked_try_cancel,
+    )
 
     adapter = HygieneCaptureAdapter()
     runner = object.__new__(GatewayRunner)
@@ -775,18 +824,38 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
     runner._running_agents = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
-    runner._session_db = SimpleNamespace(_db=fake_db)
+    runner._session_db = SimpleNamespace(_db=db)
     runner._is_user_authorized = lambda _source: True
     runner._set_session_env = lambda _context: None
-    runner._run_agent = AsyncMock(
-        return_value={
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "test/model",
+        {
+            "api_key": "test-key",
+            "base_url": "https://openrouter.ai/api/v1",
+            "skip_context_files": True,
+        },
+    )
+
+    async def _run_live_agent(**_kwargs):
+        assert lock_acquired_before_hook.is_set()
+        if not teardown_started.is_set():
+            assert not worker_finished.is_set(), (
+                "the hygiene worker finished before the live agent started; this "
+                "does not exercise early cancellation lock release"
+            )
+            live_agent_started.set()
+        live_lock_attempts.append(
+            db.try_acquire_compression_lock(session_id, live_holder)
+        )
+        return {
             "final_response": "ok",
             "messages": [],
             "tools": [],
             "history_offset": 0,
             "last_prompt_tokens": 0,
         }
-    )
+
+    runner._run_agent = AsyncMock(side_effect=_run_live_agent)
 
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
@@ -806,32 +875,114 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
         message_id="1",
     )
 
-    started = time.monotonic()
-    result = await runner._handle_message(event)
-    elapsed = time.monotonic() - started
+    loop = asyncio.get_running_loop()
+    saturated_executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="hygiene-saturation-test",
+    )
+    real_run_in_executor = loop.run_in_executor
 
-    assert result == "ok"
-    # Loose wall-clock bound per flake policy: this asserts the handler did
-    # NOT block on the hygiene-compression timeout path (which would take
-    # multiple seconds), not a precise latency. 0.15s missed by ~1-8ms on
-    # busy CI shards twice on 2026-07-23.
-    assert elapsed < 2.0
-    assert worker_started.is_set()
-    assert runner._run_agent.await_count == 1
-    assert runner._hygiene_compression_failure_cooldowns["sess-timeout"] > time.time()
-    timeout_warnings = [s for s in adapter.sent if "Context compression timed out" in s["content"]]
-    assert len(timeout_warnings) == 1
-    fake_db.archive_and_compact.assert_not_called()
-    SlowCompressAgent.last_instance.close.assert_not_called()
+    def _route_default_executor(executor, func, *args):
+        return real_run_in_executor(
+            saturated_executor if executor is None else executor,
+            func,
+            *args,
+        )
 
-    release_worker.set()
-    await asyncio.wait_for(asyncio.to_thread(cleanup_done.wait), timeout=2)
+    monkeypatch.setattr(loop, "run_in_executor", _route_default_executor)
 
-    # The late worker observed cancellation at the commit fence, so it never
-    # mutated the live session after the new turn began. Cleanup still ran once
-    # it was safe to tear down the helper agent's clients/providers.
-    fake_db.archive_and_compact.assert_not_called()
-    SlowCompressAgent.last_instance.close.assert_called_once()
+    async def _wait_for_event(event, timeout):
+        deadline = loop.time() + timeout
+        while not event.is_set():
+            if loop.time() >= deadline:
+                return False
+            await asyncio.sleep(0.001)
+        return True
+
+    handler_task = None
+    try:
+        handler_task = asyncio.create_task(runner._handle_message(event))
+        assert await _wait_for_event(lock_acquired_before_hook, 15)
+        assert await _wait_for_event(cancel_attempted, 10)
+        assert cancel_results[0] is None
+        assert runner._run_agent.await_count == 0
+        allow_acquire_return.set()
+
+        assert await _wait_for_event(live_agent_started, 2), (
+            "holder-qualified release starved behind the blocked hygiene "
+            "worker in the saturated default executor"
+        )
+        assert await _wait_for_event(worker_started, 2)
+        assert not worker_finished.is_set()
+        assert runner._run_agent.await_count == 1
+        assert runner._hygiene_compression_failure_cooldowns["sess-timeout"] > time.time()
+        timeout_warnings = [
+            s for s in adapter.sent if "Context compression timed out" in s["content"]
+        ]
+        assert len(timeout_warnings) == 1
+        archive_spy.assert_not_called()
+        SlowCompressAgent.last_instance.close.assert_not_called()
+        assert live_lock_attempts == [True], (
+            "the timed-out hygiene worker still held the compression lock when "
+            "the live agent started"
+        )
+        assert db.get_compression_lock_holder(session_id) == live_holder
+
+        release_worker.set()
+        assert await _wait_for_event(cleanup_done, 10)
+        assert worker_finished.is_set()
+        result = await asyncio.wait_for(handler_task, timeout=15)
+        assert result == "ok"
+
+        # The late worker observed cancellation at the commit fence, so it never
+        # mutated the live session after the new turn began. Cleanup still ran once
+        # it was safe to tear down the helper agent's clients/providers. Its
+        # idempotent holder-qualified cleanup must not release the live turn's lock.
+        archive_spy.assert_not_called()
+        SlowCompressAgent.last_instance.close.assert_called_once()
+        assert db.get_compression_lock_holder(session_id) == live_holder
+    finally:
+        teardown_started.set()
+        allow_acquire_return.set()
+        release_worker.set()
+        if handler_task is not None:
+            if not handler_task.done():
+                try:
+                    await asyncio.wait_for(asyncio.shield(handler_task), timeout=15)
+                except Exception:
+                    handler_task.cancel()
+            try:
+                await handler_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        GatewayRunner._shutdown_executor(runner)
+        saturated_executor.shutdown(wait=True, cancel_futures=True)
+        if db.get_compression_lock_holder(session_id) == live_holder:
+            db.release_compression_lock(session_id, live_holder)
+        db.close()
+
+
+def test_compression_commit_fence_closes_lock_hook_publication_race():
+    """Timeout cancellation cannot win while lock cleanup is unpublished."""
+    from agent.conversation_compression import CompressionCommitFence
+
+    fence = CompressionCommitFence()
+    released = threading.Event()
+
+    assert fence.begin_lock_setup() is True
+    assert fence.try_cancel_before_commit() is None
+    assert fence.register_cancelled_lock_release(released.set) is False
+    fence.finish_lock_setup()
+
+    assert fence.try_cancel_before_commit() is True
+    fence.release_cancelled_compression_lock()
+    assert released.is_set()
+
+    # If cancellation wins before setup starts, the worker is fenced from
+    # acquiring a durable lock and therefore needs no late release hook.
+    early_cancel = CompressionCommitFence()
+    assert early_cancel.try_cancel_before_commit() is True
+    assert early_cancel.begin_lock_setup() is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway session-hygiene timeout race where cancellation prevented a late database commit but left the timed-out worker's durable per-session compression lock held until the synchronous auxiliary request returned. During that window the live turn could not compress and could send an oversized request.

Current `main` now uses progress-aware inactivity timeouts, which correctly protect slow-but-streaming summary models. Genuine inactivity and the total-ceiling path still cancel a live synchronous worker, however, and retain the same durable-lock race. This PR preserves the progress-aware wait unchanged and closes that remaining cancellation path.

The fix adds a narrow lock-setup boundary to `CompressionCommitFence`. Cancellation cannot win between durable lock acquisition and publication of the exact-holder cleanup callback. Once cancellation wins, the gateway releases that holder off the event loop before continuing to the live agent. Release uses a small gateway-owned executor independent of the default pool occupied by hygiene workers, so a blocked summary cannot starve its own mandatory cleanup. The worker's eventual cleanup remains idempotent and cannot release a newer holder's lock.

## Related Issue

No public issue; reproduced from a production gateway incident.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_compression.py`
  - publish an idempotent, holder-qualified cancellation cleanup callback;
  - fence durable lock acquisition through callback publication;
  - stop the timed-out holder's lease refresher and release only that holder;
  - preserve normal late lifecycle/client cleanup and commit-fence cancellation.
- `gateway/run.py`
  - after timeout cancellation wins, invoke the lock cleanup off-loop before continuing;
  - use gateway-owned release capacity independent of the potentially saturated default executor;
  - shut that release pool through the existing executor lifecycle;
  - preserve the existing wait path when commit has already started.
- `tests/gateway/test_session_hygiene.py`
  - add a deterministic production-path race regression that pauses after real durable acquire but before callback publication;
  - saturate `executor=None` work with the blocked hygiene worker and require live-agent entry plus exact lock reacquisition before releasing it;
  - verify cancellation initially defers, late database mutation is fenced, cleanup runs once, and late cleanup preserves the newer holder;
  - guarantee both worker barriers, handler task, executors, live-holder lock, and SessionDB unwind on every failure path.

## How to Test

1. On current `origin/main`, apply only the regression-test patch and run:
   `.venv/bin/python -m pytest tests/gateway/test_session_hygiene.py::test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown -q`
   It fails because `try_cancel_before_commit()` returns `True` while hook publication is still blocked.
2. On this branch, run:
   `scripts/run_tests.sh tests/gateway/test_session_hygiene.py tests/gateway/test_session_env.py tests/agent/test_compression_concurrent_fork.py tests/gateway/test_compression_concurrent_sessions.py tests/agent/test_aux_progress_streaming.py tests/agent/test_auxiliary_client.py tests/test_hermes_state_compression_locks.py tests/run_agent/test_compression_lock_defer.py -q`
   Expected: 504 passed, including current-main progress streaming, gateway executor lifecycle, and durable-lock coverage.
3. The production regression routes all default-executor work through one worker occupied by the blocked hygiene summary. It must enter the live agent and reacquire the exact session lock before that worker is released. Run the two race regressions repeatedly; the frozen candidate passed 10 consecutive iterations.
4. Run:
   `.venv/bin/python -m py_compile agent/conversation_compression.py gateway/run.py tests/gateway/test_session_hygiene.py`
   `.venv/bin/ruff check agent/conversation_compression.py gateway/run.py tests/gateway/test_session_hygiene.py`
   `git diff --check`
5. A repository-wide per-file sweep was also run on the pre-progress-timeout V3 candidate. On the contributor host, the monolithic sweep exposed ambient-config/dependency/root-permission failures and three per-file timeout caps outside the changed paths. Every affected file passed when rerun under its intended isolated condition; see the verification notes below. The all-tests-pass checkbox remains deliberately unchecked because the single monolithic invocation was not green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and documented in code
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — no platform-specific APIs added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Behavioral RED on the current compression-progress base (`32fd9d65cf091269709c5a6301b25aadac681aa8`) with only the final regression-test patch:

```text
assert cancel_results[0] is None
E assert True is None
```

The RED teardown consumed the handler and worker cleanly: no orphan future, destroyed task, secondary worker assertion, or gateway agent error.

Executor-starvation RED against the pre-V5 candidate:

```text
AssertionError: holder-qualified release starved behind the blocked hygiene worker in the saturated default executor
```

Publication-base compatibility GREEN (`78c06525e8e955e06a007b07b347c679f3977c3e`):

```text
=== Summary: 8 files, 504 tests passed, 0 failed ===
Full context-compressor file: 214 passed
Saturated race regressions: 10/10 consecutive runs passed
```

Repository-wide sweep and isolated reruns:

```text
Discovered 2,294 test files (~43,859 tests)
Ambient config/dependency/startup rerun: 636 passed
Permission-sensitive rerun as an unprivileged UID: 371 passed, 1 skipped
Context-compressor timeout rerun: 214 passed
Web-server timeout rerun: 516 passed
Browser-hardening timeout rerun: 29 passed
```

Review history: V4 was rejected for default-executor starvation and incomplete RED teardown; both findings are addressed in V5. Independent immutable V5 reviews all passed with no findings or over-scope: specification/blocker resolution, concurrency/starvation/shutdown lifecycle, and code/test quality/scope.
