### PR TITLE
feat(webhook): per-route session mode — allow shared persistent sessions

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -798,9 +798,19 @@ class WebhookAdapter(BasePlatformAdapter):
                 status=502,
             )
 
-        # Use delivery_id in session key so concurrent webhooks on the
-        # same route get independent agent runs (not queued/interrupted).
-        session_chat_id = f"webhook:{route_name}:{delivery_id}"
+        # Session scope is per-route configurable:
+        #   * "per-delivery" (default) — delivery_id in the key: concurrent
+        #     webhooks on the same route get independent agent runs
+        #     (not queued/interrupted). Right for independent event streams.
+        #   * "shared" — one persistent session per route: deliveries
+        #     serialize into a single ongoing conversation with memory.
+        #     Right for workflow/relay routes where each event continues
+        #     the same collaboration.
+        session_scope = str(route_config.get("session") or "per-delivery").strip().lower()
+        if session_scope == "shared":
+            session_chat_id = f"webhook:{route_name}"
+        else:
+            session_chat_id = f"webhook:{route_name}:{delivery_id}"
 
         # Store delivery info for send().  Read by every send() invocation
         # for this chat_id (interim status messages and the final response),


### PR DESCRIPTION
## Problem

Webhook routes derive the agent session key from the delivery id (`gateway/platforms/webhook.py`):

```python
session_chat_id = f"webhook:{route_name}:{delivery_id}"
```

so **every delivery spawns a brand-new, zero-context session**. That is the right default for independent event streams (CI pings, monitoring alerts), but the wrong isolation granularity for *conversational/workflow* webhook consumers — e.g. an agent-to-agent relay where each message continues one ongoing collaboration.

Observed in production use (multi-agent setup, one route, serial messages):

- every delivery cold-starts: the session re-reads project state and searches past sessions to rebuild context (slow, token-expensive, and the reconstruction is fallibly lossy);
- decisions/approvals given to the agent on a chat platform are invisible to webhook-spawned sessions, which then re-request them from the operator;
- behavioural consistency (rules adopted mid-conversation) resets per delivery.

## Change

Opt-in, backward-compatible per-route setting in the webhook subscription:

```json
"session": "shared"
```

Default `"per-delivery"` preserves current behaviour exactly. With `"shared"`, the session key omits the delivery id (`webhook:{route_name}`), so all deliveries on that route continue one persistent session. Deliveries on a shared route serialize into that session's queue rather than running concurrently — which is the desired semantics for workflow routes.

Delivery-id dedup, HMAC verification, and delivery-info bookkeeping are unchanged (delivery info is keyed by the session chat id; on a shared route later deliveries refresh the same entry — same route, same target, no behavioural change to `send()`).

## Related

Filing a separate issue for an adjacent defect this surfaced: `/approve` is session-scoped while approval requests are delivered cross-platform, making dangerous-command gates in webhook sessions unapprovable. This PR reduces its blast radius (a shared session keeps pending state reachable across deliveries) but does not fix the routing itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)