### PR TITLE
fix(agent): account for max-iteration summary requests

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1951,7 +1951,10 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
-    print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")
+    agent._last_max_iteration_api_calls = 0
+
+    def _record_summary_request_attempt() -> None:
+        agent._last_max_iteration_api_calls += 1
 
     summary_request = (
         "You've reached the maximum number of tool-calling iterations allowed. "
@@ -2069,6 +2072,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         if agent.api_mode == "codex_responses":
             codex_kwargs = agent._build_api_kwargs(api_messages)
             codex_kwargs.pop("tools", None)
+            _record_summary_request_attempt()
             summary_response = agent._run_codex_stream(codex_kwargs)
             _ct_sum = agent._get_transport()
             _cnr_sum = _ct_sum.normalize_response(summary_response)
@@ -2142,10 +2146,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                                max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
                                is_oauth=agent._is_anthropic_oauth,
                                preserve_dots=agent._anthropic_preserve_dots())
+                _record_summary_request_attempt()
                 summary_response = agent._anthropic_messages_create(_ant_kw)
                 _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=agent._is_anthropic_oauth)
                 final_response = (_summary_result.content or "").strip()
             else:
+                _record_summary_request_attempt()
                 summary_response = agent._ensure_primary_openai_client(reason="iteration_limit_summary").chat.completions.create(**summary_kwargs)
                 _summary_result = agent._get_transport().normalize_response(summary_response)
                 final_response = (_summary_result.content or "").strip()
@@ -2162,6 +2168,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             if agent.api_mode == "codex_responses":
                 codex_kwargs = agent._build_api_kwargs(api_messages)
                 codex_kwargs.pop("tools", None)
+                _record_summary_request_attempt()
                 retry_response = agent._run_codex_stream(codex_kwargs)
                 _ct_retry = agent._get_transport()
                 _cnr_retry = _ct_retry.normalize_response(retry_response)
@@ -2172,6 +2179,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                                 is_oauth=agent._is_anthropic_oauth,
                                 max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
                                 preserve_dots=agent._anthropic_preserve_dots())
+                _record_summary_request_attempt()
                 retry_response = agent._anthropic_messages_create(_ant_kw2)
                 _retry_result = _tretry.normalize_response(retry_response, strip_tool_prefix=agent._is_anthropic_oauth)
                 final_response = (_retry_result.content or "").strip()
@@ -2189,6 +2197,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 if summary_extra_body:
                     summary_kwargs["extra_body"] = summary_extra_body
 
+                _record_summary_request_attempt()
                 summary_response = agent._ensure_primary_openai_client(reason="iteration_limit_summary_retry").chat.completions.create(**summary_kwargs)
                 _retry_result = agent._get_transport().normalize_response(summary_response)
                 final_response = (_retry_result.content or "").strip()

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -91,6 +91,7 @@ def finalize_turn(
     """
     from agent.conversation_loop import logger
 
+    _summary_api_call_count = 0
     budget_exhausted = (
         api_call_count >= agent.max_iterations
         or agent.iteration_budget.remaining <= 0
@@ -125,9 +126,9 @@ def finalize_turn(
         iteration_limit_fallback = True
         preserved_verification_fallback = True
     elif final_response is None and budget_fallback_eligible:
-        # Budget exhausted — ask the model for a summary via one extra
-        # API call with tools stripped.  _handle_max_iterations injects a
-        # user message and makes a single toolless request.
+        # Budget exhausted — ask the model for a summary with tools stripped.
+        # _handle_max_iterations injects a user message and makes one toolless
+        # request, with one retry when the first summary is empty.
         _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
         agent._emit_status(
             f"⚠️ Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
@@ -139,6 +140,9 @@ def finalize_turn(
                 "— requesting summary..."
             )
         final_response = agent._handle_max_iterations(messages, api_call_count)
+        _summary_api_call_count = getattr(
+            agent, "_last_max_iteration_api_calls", 0
+        ) or 0
         iteration_limit_fallback = True
 
     if iteration_limit_fallback:
@@ -189,6 +193,12 @@ def finalize_turn(
                     _kanban_task,
                     exc_info=True,
                 )
+
+    # Keep Kanban's budget_used bound to tool iterations, then include any
+    # post-budget summary requests in the turn's actual provider-call count.
+    if _summary_api_call_count:
+        api_call_count += _summary_api_call_count
+        agent._api_call_count = api_call_count
 
     # Determine if conversation completed successfully
     normal_text_response = str(_turn_exit_reason).startswith("text_response(")

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -82,6 +82,7 @@ class _StubAgent:
         pass
 
     def _handle_max_iterations(self, messages, n):
+        self._last_max_iteration_api_calls = 1
         return "PARTIAL SUMMARY FROM MODEL"
 
     def _file_mutation_verifier_enabled(self):
@@ -143,6 +144,15 @@ def test_all_cleanup_steps_raise_response_still_returned():
     assert result["final_response"] == "PARTIAL SUMMARY FROM MODEL"
     labels = [e.split(":")[0] for e in result["cleanup_errors"]]
     assert labels == ["save_trajectory", "cleanup_task_resources", "persist_session"]
+
+
+def test_summary_request_attempt_is_included_in_api_call_count():
+    agent = _StubAgent(raise_in=())
+
+    result = _run(agent, api_call_count=3)
+
+    assert result["api_calls"] == 4
+    assert agent._api_call_count == 4
 
 
 @pytest.mark.parametrize(

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -132,6 +132,22 @@ def test_pending_verify_response_is_preserved_for_cron_delivery(monkeypatch):
     assert agent._handle_max_iterations_called is False
 
 
+def test_preserved_response_does_not_reuse_stale_summary_request_count(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = _LimitAgent()
+    agent._last_max_iteration_api_calls = 2
+
+    result = _finalize(
+        agent,
+        final_response=None,
+        exit_reason="unknown",
+        pending_verification_response="complete report",
+    )
+
+    assert result["api_calls"] == 60
+    assert agent._handle_max_iterations_called is False
+
+
 def test_pending_pre_verify_response_is_preserved_on_budget_exhaustion(monkeypatch):
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     agent = _LimitAgent()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3861,6 +3861,46 @@ class TestMcpParallelToolBatch:
 
 
 class TestHandleMaxIterations:
+    def test_records_one_summary_request_attempt(self, agent):
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}],
+            60,
+        )
+
+        assert result == "Summary"
+        assert agent._last_max_iteration_api_calls == 1
+
+    def test_records_retry_after_empty_summary_as_second_request_attempt(self, agent):
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content=""),
+            _mock_response(content="Summary"),
+        ]
+        agent._cached_system_prompt = "You are helpful."
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}],
+            60,
+        )
+
+        assert result == "Summary"
+        assert agent._last_max_iteration_api_calls == 2
+
+    def test_quiet_mode_suppresses_iteration_warning(self, agent, capsys):
+        agent.quiet_mode = True
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}],
+            60,
+        )
+
+        assert result == "Summary"
+        assert capsys.readouterr().out == ""
+
     def test_returns_summary(self, agent):
         resp = _mock_response(content="Here is a summary of what I did.")
         agent.client.chat.completions.create.return_value = resp


### PR DESCRIPTION
## Summary
- keep max-iteration diagnostics out of quiet-mode stdout
- count forced-summary provider requests, including the empty-summary retry, in returned `api_calls` and live `_api_call_count`
- preserve current-main verification-response fallback semantics without reusing stale summary-call counts

## Why
The post-loop max-iteration path could issue one or two additional provider requests while reporting only tool-loop calls. Its unconditional warning also contaminated `--quiet` machine-readable output.

## Testing
- `scripts/run_tests.sh` on the complete run-agent file and all four turn-finalizer regression files: **483 passed, 0 failed**
- `ruff check` on all changed Python files
- Python compilation and `git diff --check`

## Scope
This corrects forced-summary turn/activity accounting. It does not redefine `--max-turns`, change Kanban's tool-iteration budget, or add a universal transport-attempt cap for retries/fallbacks.
