### PR TITLE
fix(update): preserve local commits across rewritten upstream history

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -94,8 +94,8 @@ from hermes_cli.update_cmd_git import (  # noqa: F401
     _has_upstream_remote, _is_fork, _locate_real_git, _mark_skip_upstream_prompt,
     _normalize_managed_eol, _portable_git_candidates, _print_fetch_failure,
     _print_parked_branch_kept_notice, _print_parked_branch_skip_warning,
-    _prune_orphan_rescue_refs, _should_skip_upstream_prompt, _sync_fork_with_upstream,
-    _sync_with_upstream_if_needed)
+    _prune_orphan_rescue_refs, _recover_diverged_update, _should_skip_upstream_prompt,
+    _sync_fork_with_upstream, _sync_with_upstream_if_needed)
 from hermes_cli.update_cmd_maint import (  # noqa: F401
     _PRE_UPDATE_SNAPSHOT_KEEP, _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE, _STALE_PURGE_PREFIXES,
     _STALE_PURGE_PROTECTED, _UPDATE_RUNTIME_RELOAD_MODULES, _clear_stale_sqlite_sidecars,
@@ -655,8 +655,8 @@ def _repair_current_checkout(
 
 
 def _reconcile_diverged_checkout(git_cmd, branch: str, pre_pull_sha) -> None:
-    """Fast-forward failed: merge on a custom branch (local commits survive) or reset --hard on the
-    same branch (rescue ref first when histories share no ancestor). ``sys.exit(1)`` on failure."""
+    """Fast-forward failed: merge on a custom branch; on the same branch recover locally
+    carried commits, or reset --hard after an orphan rescue ref. ``sys.exit(1)`` on failure."""
     # A custom branch (local commits atop origin/<branch>) also can't ff, and reset --hard
     # would discard that work: merge instead, stop on conflict.
     _cur_branch = (_git_run(git_cmd, ["branch", "--show-current"]).stdout or "").strip()
@@ -673,35 +673,52 @@ def _reconcile_diverged_checkout(git_cmd, branch: str, pre_pull_sha) -> None:
             print("  Then re-run the update. Local work is untouched.")
             sys.exit(1)
         return
-    # Same branch: a true upstream force-push/rebase; local changes are stashed, so reset.
     # Orphan divergence (no common ancestor: corrupted HEAD, re-init) would lose the whole
-    # local graph, so park pre_pull_sha behind a rescue ref first.
+    # local graph, so park pre_pull_sha behind a rescue ref first, then reset.
     merge_base_result = _git_run(git_cmd, ["merge-base", "HEAD", f"origin/{branch}"])
     has_common_ancestor = merge_base_result.returncode == 0 and merge_base_result.stdout.strip()
-    if not has_common_ancestor and pre_pull_sha:
-        from datetime import datetime as _dt, timezone
-        # SHA suffix so two updates in the same second get distinct refs.
-        rescue_ref = (
-            f"refs/hermes-update-backups/orphan-{branch}-"
-            f"{_dt.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}-{pre_pull_sha[:12]}")
-        head = f"  ⚠ Local history shares no common ancestor with origin/{branch} (orphan divergence) — "
-        if _git_run(git_cmd, ["update-ref", rescue_ref, pre_pull_sha]).returncode == 0:
-            print(
-                f"{head}backed up current HEAD to {rescue_ref} before resetting. "
-                f"This backup expires after {_ORPHAN_RESCUE_REF_MAX_AGE_DAYS} days.")
-        else:
-            # update-ref failure is intentionally non-fatal, but never claim a backup exists.
-            print(
-                f"{head}attempted to back up current HEAD to {rescue_ref} before resetting, "
-                f"but the backup write failed (pre-reset SHA was {pre_pull_sha}).")
-        _prune_orphan_rescue_refs(git_cmd, _m().PROJECT_ROOT, branch)
-    print("  ⚠ Fast-forward not possible (history diverged), resetting to match remote...")
-    reset_result = _git_run(git_cmd, ["reset", "--hard", f"origin/{branch}"])
-    if reset_result.returncode != 0:
-        print(f"✗ Failed to reset to origin/{branch}.")
-        if reset_result.stderr.strip():
-            print(f"  {reset_result.stderr.strip()}")
-        print(f"  Try manually: git fetch origin && git reset --hard origin/{branch}")
+    if not has_common_ancestor:
+        if pre_pull_sha:
+            from datetime import datetime as _dt, timezone
+            # SHA suffix so two updates in the same second get distinct refs.
+            rescue_ref = (
+                f"refs/hermes-update-backups/orphan-{branch}-"
+                f"{_dt.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}-{pre_pull_sha[:12]}")
+            head = f"  ⚠ Local history shares no common ancestor with origin/{branch} (orphan divergence) — "
+            if _git_run(git_cmd, ["update-ref", rescue_ref, pre_pull_sha]).returncode == 0:
+                print(
+                    f"{head}backed up current HEAD to {rescue_ref} before resetting. "
+                    f"This backup expires after {_ORPHAN_RESCUE_REF_MAX_AGE_DAYS} days.")
+            else:
+                # update-ref failure is intentionally non-fatal, but never claim a backup exists.
+                print(
+                    f"{head}attempted to back up current HEAD to {rescue_ref} before resetting, "
+                    f"but the backup write failed (pre-reset SHA was {pre_pull_sha}).")
+            _prune_orphan_rescue_refs(git_cmd, _m().PROJECT_ROOT, branch)
+        print("  ⚠ Fast-forward not possible (history diverged), resetting to match remote...")
+        reset_result = _git_run(git_cmd, ["reset", "--hard", f"origin/{branch}"])
+        if reset_result.returncode != 0:
+            print(f"✗ Failed to reset to origin/{branch}.")
+            if reset_result.stderr.strip():
+                print(f"  {reset_result.stderr.strip()}")
+            print(f"  Try manually: git fetch origin && git reset --hard origin/{branch}")
+            sys.exit(1)
+        return
+    # Same branch with a common ancestor: rewritten upstream. Rebase only the
+    # locally carried range proven by the remote-tracking reflog — never reset
+    # --hard over local commits.
+    print(
+        "  ⚠ Fast-forward not possible (history diverged); "
+        "checking for locally carried commits..."
+    )
+    recovered, recovery_detail = _recover_diverged_update(
+        git_cmd, _m().PROJECT_ROOT, f"origin/{branch}"
+    )
+    if not recovered:
+        print("✗ Update stopped to preserve locally carried commits.")
+        if recovery_detail:
+            print(f"  {recovery_detail.splitlines()[0]}")
+        print("  Resolve/rebase the local commits, then run `hermes update` again.")
         sys.exit(1)
 
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1212,10 +1212,120 @@ def _count_commits_between(git_cmd: list[str], cwd: Path, base: str, head: str) 
             text=True, encoding="utf-8", errors="replace",
         )
         if result.returncode == 0:
-            return int(result.stdout.strip())
+            count_text = result.stdout[:-1] if result.stdout.endswith("\n") else result.stdout
+            if (
+                1 <= len(count_text) <= 9
+                and count_text.isascii()
+                and count_text.isdecimal()
+            ):
+                return int(count_text)
     except Exception:
         pass
     return -1
+
+
+def _recover_diverged_update(
+    git_cmd: list[str], cwd: Path, remote_ref: str
+) -> tuple[bool, str]:
+    """Recover an ff-only failure without discarding or inventing history.
+
+    The fetched remote may have been force-pushed. Therefore ``remote..HEAD``
+    is not a safe definition of local work: it also contains commits discarded
+    by that force-push. ``--fork-point`` consults the remote-tracking reflog to
+    recover the old upstream tip and bounds the range we are allowed to carry.
+    If that evidence is unavailable, fail closed.
+
+    Safe merge topology is recreated with ``--rebase-merges``. A merge commit
+    with content absent from both parents would be silently lost when Git
+    recreates the merge, so such a range is rejected without changing HEAD.
+    """
+    fork_result = subprocess.run(
+        git_cmd + ["merge-base", "--fork-point", remote_ref, "HEAD"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    fork_point = fork_result.stdout.strip() if fork_result.returncode == 0 else ""
+    if not fork_point:
+        return False, "could not determine the previous upstream fork point; refusing to rewrite HEAD"
+
+    local_commits = _count_commits_between(git_cmd, cwd, fork_point, "HEAD")
+    if local_commits < 0:
+        return False, "could not determine whether HEAD contains local commits"
+
+    if local_commits == 0:
+        result = subprocess.run(
+            git_cmd + ["reset", "--hard", remote_ref],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        detail = (result.stderr or result.stdout or "").strip()
+        return result.returncode == 0, detail
+
+    merges = subprocess.run(
+        git_cmd + ["rev-list", "--merges", f"{fork_point}..HEAD"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if merges.returncode != 0:
+        return False, "could not inspect carried merge commits; refusing to rewrite HEAD"
+    for merge_commit in merges.stdout.splitlines():
+        merge_payload = subprocess.run(
+            git_cmd
+            + ["diff-tree", "--cc", "--no-commit-id", "--name-only", "-r", merge_commit],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if merge_payload.returncode != 0:
+            return False, "could not inspect carried merge content; refusing to rewrite HEAD"
+        if merge_payload.stdout.strip():
+            return False, (
+                "carried history contains merge-only content; refusing an automatic "
+                "rebase that could lose the merge resolution"
+            )
+
+    print(
+        f"  → Preserving {local_commits} locally carried commit(s) and merge topology "
+        f"onto {remote_ref}..."
+    )
+    result = subprocess.run(
+        git_cmd
+        + ["rebase", "--rebase-merges", "--onto", remote_ref, fork_point],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode == 0:
+        return True, ""
+
+    detail = (result.stderr or result.stdout or "").strip()
+    abort_result = subprocess.run(
+        git_cmd + ["rebase", "--abort"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if abort_result.returncode != 0:
+        abort_detail = (abort_result.stderr or abort_result.stdout or "").strip()
+        if abort_detail:
+            detail = f"{detail}\nrebase abort failed: {abort_detail}" if detail else abort_detail
+    return False, detail or "rebase conflicted"
+
 
 def _should_skip_upstream_prompt() -> bool:
     """Check if user previously declined to add upstream."""
@@ -3516,24 +3626,21 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 text=True, encoding="utf-8", errors="replace",
             )
             if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
+                # ff-only failed: preserve local commits by rebasing them onto
+                # the fetched remote. Reset only when HEAD has no unique commits.
                 print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                    "  ⚠ Fast-forward not possible (history diverged); "
+                    "checking for locally carried commits..."
                 )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                    cwd=_m().PROJECT_ROOT,
-                    capture_output=True,
-                    text=True, encoding="utf-8", errors="replace",
+                recovered, recovery_detail = _recover_diverged_update(
+                    git_cmd, _m().PROJECT_ROOT, f"origin/{branch}"
                 )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
+                if not recovered:
+                    print("✗ Update stopped to preserve locally carried commits.")
+                    if recovery_detail:
+                        print(f"  {recovery_detail.splitlines()[0]}")
                     print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        "  Resolve/rebase the local commits, then run `hermes update` again."
                     )
                     sys.exit(1)
 

--- a/hermes_cli/update_cmd_git.py
+++ b/hermes_cli/update_cmd_git.py
@@ -238,11 +238,16 @@ def _recover_diverged_update(
     if not fork_point:
         return False, "could not determine the previous upstream fork point; refusing to rewrite HEAD"
 
-    local_commits = _count_commits_between(git_cmd, cwd, fork_point, "HEAD")
-    if local_commits < 0:
-        return False, "could not determine whether HEAD contains local commits"
+    head_result = subprocess.run(
+        git_cmd + ["rev-parse", "--verify", "HEAD"],
+        cwd=cwd,
+        **_GIT_TEXT_KW,
+    )
+    head = head_result.stdout.strip() if head_result.returncode == 0 else ""
+    if not head:
+        return False, "could not determine the current HEAD; refusing to rewrite it"
 
-    if local_commits == 0:
+    if head == fork_point:
         result = subprocess.run(
             git_cmd + ["reset", "--hard", remote_ref],
             cwd=cwd,
@@ -273,10 +278,7 @@ def _recover_diverged_update(
                 "rebase that could lose the merge resolution"
             )
 
-    print(
-        f"  → Preserving {local_commits} locally carried commit(s) and merge topology "
-        f"onto {remote_ref}..."
-    )
+    print(f"  → Preserving locally carried history and merge topology onto {remote_ref}...")
     result = subprocess.run(
         git_cmd
         + [

--- a/hermes_cli/update_cmd_git.py
+++ b/hermes_cli/update_cmd_git.py
@@ -278,10 +278,24 @@ def _recover_diverged_update(
                 "rebase that could lose the merge resolution"
             )
 
+    identity_result = subprocess.run(
+        git_cmd + ["show", "-s", "--format=%an%x00%ae", "HEAD"],
+        cwd=cwd,
+        **_GIT_TEXT_KW,
+    )
+    identity = identity_result.stdout.rstrip("\n").split("\0")
+    if identity_result.returncode != 0 or len(identity) != 2 or not all(identity):
+        return False, "could not recover a committer identity from HEAD; refusing to rewrite it"
+    committer_name, committer_email = identity
+
     print(f"  → Preserving locally carried history and merge topology onto {remote_ref}...")
     result = subprocess.run(
         git_cmd
         + [
+            "-c",
+            f"user.name={committer_name}",
+            "-c",
+            f"user.email={committer_email}",
             "-c",
             "rebase.updateRefs=false",
             "rebase",

--- a/hermes_cli/update_cmd_git.py
+++ b/hermes_cli/update_cmd_git.py
@@ -278,7 +278,16 @@ def _recover_diverged_update(
         f"onto {remote_ref}..."
     )
     result = subprocess.run(
-        git_cmd + ["rebase", "--rebase-merges", "--onto", remote_ref, fork_point],
+        git_cmd
+        + [
+            "-c",
+            "rebase.updateRefs=false",
+            "rebase",
+            "--rebase-merges",
+            "--onto",
+            remote_ref,
+            fork_point,
+        ],
         cwd=cwd,
         **_GIT_TEXT_KW,
     )

--- a/hermes_cli/update_cmd_git.py
+++ b/hermes_cli/update_cmd_git.py
@@ -214,6 +214,90 @@ def _count_commits_between(git_cmd: list[str], cwd: Path, base: str, head: str) 
     return -1
 
 
+def _recover_diverged_update(
+    git_cmd: list[str], cwd: Path, remote_ref: str
+) -> tuple[bool, str]:
+    """Recover an ff-only failure without discarding or inventing history.
+
+    The fetched remote may have been force-pushed. Therefore ``remote..HEAD``
+    is not a safe definition of local work: it also contains commits discarded
+    by that force-push. ``--fork-point`` consults the remote-tracking reflog to
+    recover the old upstream tip and bounds the range we are allowed to carry.
+    If that evidence is unavailable, fail closed.
+
+    Safe merge topology is recreated with ``--rebase-merges``. A merge commit
+    with content absent from both parents would be silently lost when Git
+    recreates the merge, so such a range is rejected without changing HEAD.
+    """
+    fork_result = subprocess.run(
+        git_cmd + ["merge-base", "--fork-point", remote_ref, "HEAD"],
+        cwd=cwd,
+        **_GIT_TEXT_KW,
+    )
+    fork_point = fork_result.stdout.strip() if fork_result.returncode == 0 else ""
+    if not fork_point:
+        return False, "could not determine the previous upstream fork point; refusing to rewrite HEAD"
+
+    local_commits = _count_commits_between(git_cmd, cwd, fork_point, "HEAD")
+    if local_commits < 0:
+        return False, "could not determine whether HEAD contains local commits"
+
+    if local_commits == 0:
+        result = subprocess.run(
+            git_cmd + ["reset", "--hard", remote_ref],
+            cwd=cwd,
+            **_GIT_TEXT_KW,
+        )
+        detail = (result.stderr or result.stdout or "").strip()
+        return result.returncode == 0, detail
+
+    merges = subprocess.run(
+        git_cmd + ["rev-list", "--merges", f"{fork_point}..HEAD"],
+        cwd=cwd,
+        **_GIT_TEXT_KW,
+    )
+    if merges.returncode != 0:
+        return False, "could not inspect carried merge commits; refusing to rewrite HEAD"
+    for merge_commit in merges.stdout.splitlines():
+        merge_payload = subprocess.run(
+            git_cmd
+            + ["diff-tree", "--cc", "--no-commit-id", "--name-only", "-r", merge_commit],
+            cwd=cwd,
+            **_GIT_TEXT_KW,
+        )
+        if merge_payload.returncode != 0:
+            return False, "could not inspect carried merge content; refusing to rewrite HEAD"
+        if merge_payload.stdout.strip():
+            return False, (
+                "carried history contains merge-only content; refusing an automatic "
+                "rebase that could lose the merge resolution"
+            )
+
+    print(
+        f"  → Preserving {local_commits} locally carried commit(s) and merge topology "
+        f"onto {remote_ref}..."
+    )
+    result = subprocess.run(
+        git_cmd + ["rebase", "--rebase-merges", "--onto", remote_ref, fork_point],
+        cwd=cwd,
+        **_GIT_TEXT_KW,
+    )
+    if result.returncode == 0:
+        return True, ""
+
+    detail = (result.stderr or result.stdout or "").strip()
+    abort_result = subprocess.run(
+        git_cmd + ["rebase", "--abort"],
+        cwd=cwd,
+        **_GIT_TEXT_KW,
+    )
+    if abort_result.returncode != 0:
+        abort_detail = (abort_result.stderr or abort_result.stdout or "").strip()
+        if abort_detail:
+            detail = f"{detail}\nrebase abort failed: {abort_detail}" if detail else abort_detail
+    return False, detail or "rebase conflicted"
+
+
 def _should_skip_upstream_prompt() -> bool:
     """Check if user previously declined to add upstream."""
     from hermes_constants import get_hermes_home

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2190,7 +2190,7 @@ function Recover-DivergedUpdate {
     }
 
     Write-Info "Preserving $localCommitCount locally carried commit(s) and merge topology onto $RemoteRef..."
-    git -c windows.appendAtomically=false rebase --rebase-merges --onto $RemoteRef $forkPoint
+    git -c windows.appendAtomically=false -c rebase.updateRefs=false rebase --rebase-merges --onto $RemoteRef $forkPoint
     if ($LASTEXITCODE -eq 0) { return }
 
     Write-Err "Rebase conflicted; aborting so the original checkout is restored."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2144,28 +2144,13 @@ function Recover-DivergedUpdate {
         throw "Could not determine the previous upstream fork point; refusing to rewrite HEAD"
     }
 
-    $localCommitOutput = @(git -c windows.appendAtomically=false rev-list --count "$forkPoint..HEAD" 2>$null)
-    $countExit = $LASTEXITCODE
-    if ($countExit -ne 0) {
-        throw "Could not determine whether HEAD contains locally carried commits (exit $countExit)"
+    $headOutput = @(git -c windows.appendAtomically=false rev-parse --verify HEAD 2>$null)
+    $headExit = $LASTEXITCODE
+    $head = ($headOutput -join "").Trim()
+    if (($headExit -ne 0) -or (-not $head)) {
+        throw "Could not determine the current HEAD; refusing to rewrite it"
     }
-    # Native PowerShell output records have their process newline removed and
-    # cannot distinguish a final terminator from EOF. Across all installers the
-    # final newline is therefore optional. Do not trim or join records: padding
-    # and additional captured lines are malformed output.
-    $localCommitText = if ($localCommitOutput.Count -eq 1) { [string]$localCommitOutput[0] } else { "" }
-    $localCommitCount = 0
-    # Shared lexical contract: the raw record is 1..9 ASCII digits. Enforce its
-    # spelling bound before TryParse; nine digits inherently represent a value
-    # no greater than 999999999.
-    if (($localCommitOutput.Count -ne 1) -or
-        ($localCommitText -notmatch '^[0-9]+$') -or
-        ($localCommitText.Length -gt 9) -or
-        (-not [int]::TryParse($localCommitText, [ref]$localCommitCount))) {
-        throw "Could not parse local commit count; refusing to rewrite HEAD"
-    }
-
-    if ($localCommitCount -eq 0) {
+    if ($head -eq $forkPoint) {
         git -c windows.appendAtomically=false reset --hard "$RemoteRef"
         if ($LASTEXITCODE -ne 0) { throw "git reset --hard $RemoteRef failed (exit $LASTEXITCODE)" }
         return
@@ -2189,7 +2174,7 @@ function Recover-DivergedUpdate {
         }
     }
 
-    Write-Info "Preserving $localCommitCount locally carried commit(s) and merge topology onto $RemoteRef..."
+    Write-Info "Preserving locally carried history and merge topology onto $RemoteRef..."
     git -c windows.appendAtomically=false -c rebase.updateRefs=false rebase --rebase-merges --onto $RemoteRef $forkPoint
     if ($LASTEXITCODE -eq 0) { return }
 
@@ -2338,9 +2323,9 @@ function Install-Repository {
                 } else {
                     git -c windows.appendAtomically=false checkout $Branch
                     if ($LASTEXITCODE -ne 0) { throw "git checkout $Branch failed (exit $LASTEXITCODE)" }
-                    # Preserve unique local commits by rebasing them onto the
-                    # fetched remote. Reset only when the count proves there
-                    # are no commits unique to HEAD.
+                    # Preserve unique local history by rebasing it onto the
+                    # fetched remote. Reset only when the recovered fork point
+                    # is HEAD itself.
                     git -c windows.appendAtomically=false pull --ff-only origin $Branch
                     if ($LASTEXITCODE -ne 0) {
                         Write-Warn "Fast-forward not possible; checking for locally carried commits..."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2131,6 +2131,76 @@ function Install-SystemPackages {
 # Installation
 # ============================================================================
 
+function Recover-DivergedUpdate {
+    param([Parameter(Mandatory = $true)][string]$RemoteRef)
+
+    # RemoteRef..HEAD is unsafe after a force-push because it includes old
+    # upstream commits that the remote discarded. The tracking ref's reflog
+    # identifies the old upstream tip; without that evidence, fail closed.
+    $forkOutput = @(git -c windows.appendAtomically=false merge-base --fork-point $RemoteRef HEAD 2>$null)
+    $forkExit = $LASTEXITCODE
+    $forkPoint = ($forkOutput -join "").Trim()
+    if (($forkExit -ne 0) -or (-not $forkPoint)) {
+        throw "Could not determine the previous upstream fork point; refusing to rewrite HEAD"
+    }
+
+    $localCommitOutput = @(git -c windows.appendAtomically=false rev-list --count "$forkPoint..HEAD" 2>$null)
+    $countExit = $LASTEXITCODE
+    if ($countExit -ne 0) {
+        throw "Could not determine whether HEAD contains locally carried commits (exit $countExit)"
+    }
+    # Native PowerShell output records have their process newline removed and
+    # cannot distinguish a final terminator from EOF. Across all installers the
+    # final newline is therefore optional. Do not trim or join records: padding
+    # and additional captured lines are malformed output.
+    $localCommitText = if ($localCommitOutput.Count -eq 1) { [string]$localCommitOutput[0] } else { "" }
+    $localCommitCount = 0
+    # Shared lexical contract: the raw record is 1..9 ASCII digits. Enforce its
+    # spelling bound before TryParse; nine digits inherently represent a value
+    # no greater than 999999999.
+    if (($localCommitOutput.Count -ne 1) -or
+        ($localCommitText -notmatch '^[0-9]+$') -or
+        ($localCommitText.Length -gt 9) -or
+        (-not [int]::TryParse($localCommitText, [ref]$localCommitCount))) {
+        throw "Could not parse local commit count; refusing to rewrite HEAD"
+    }
+
+    if ($localCommitCount -eq 0) {
+        git -c windows.appendAtomically=false reset --hard "$RemoteRef"
+        if ($LASTEXITCODE -ne 0) { throw "git reset --hard $RemoteRef failed (exit $LASTEXITCODE)" }
+        return
+    }
+
+    # Git recreates merges during --rebase-merges. Content present in neither
+    # parent can disappear silently, so reject that range without changing HEAD.
+    $mergeCommits = @(git -c windows.appendAtomically=false rev-list --merges "$forkPoint..HEAD" 2>$null)
+    $mergeListExit = $LASTEXITCODE
+    if ($mergeListExit -ne 0) {
+        throw "Could not inspect carried merge commits; refusing to rewrite HEAD"
+    }
+    foreach ($mergeCommit in $mergeCommits) {
+        $mergePayload = @(git -c windows.appendAtomically=false diff-tree --cc --no-commit-id --name-only -r $mergeCommit 2>$null)
+        $mergePayloadExit = $LASTEXITCODE
+        if ($mergePayloadExit -ne 0) {
+            throw "Could not inspect carried merge content; refusing to rewrite HEAD"
+        }
+        if (($mergePayload -join "").Trim()) {
+            throw "Carried history contains merge-only content; refusing an automatic rebase that could lose it"
+        }
+    }
+
+    Write-Info "Preserving $localCommitCount locally carried commit(s) and merge topology onto $RemoteRef..."
+    git -c windows.appendAtomically=false rebase --rebase-merges --onto $RemoteRef $forkPoint
+    if ($LASTEXITCODE -eq 0) { return }
+
+    Write-Err "Rebase conflicted; aborting so the original checkout is restored."
+    git -c windows.appendAtomically=false rebase --abort 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Rebase failed and git rebase --abort also failed; recover the checkout manually"
+    }
+    throw "Rebase conflicted; original checkout restored"
+}
+
 function Install-Repository {
     Write-Info "Installing to $InstallDir..."
 
@@ -2268,15 +2338,13 @@ function Install-Repository {
                 } else {
                     git -c windows.appendAtomically=false checkout $Branch
                     if ($LASTEXITCODE -ne 0) { throw "git checkout $Branch failed (exit $LASTEXITCODE)" }
-                    # Managed installs should follow origin/$Branch exactly. If
-                    # the checkout has diverged (or has local-only commits),
-                    # ff-only pull cannot succeed -- mirror ``hermes update`` and
-                    # reset to the fetched remote so bootstrap/install can recover.
+                    # Preserve unique local commits by rebasing them onto the
+                    # fetched remote. Reset only when the count proves there
+                    # are no commits unique to HEAD.
                     git -c windows.appendAtomically=false pull --ff-only origin $Branch
                     if ($LASTEXITCODE -ne 0) {
-                        Write-Warn "Fast-forward not possible; resetting managed install to origin/$Branch..."
-                        git -c windows.appendAtomically=false reset --hard "origin/$Branch"
-                        if ($LASTEXITCODE -ne 0) { throw "git reset --hard origin/$Branch failed (exit $LASTEXITCODE)" }
+                        Write-Warn "Fast-forward not possible; checking for locally carried commits..."
+                        Recover-DivergedUpdate "origin/$Branch"
                     }
                 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2174,8 +2174,21 @@ function Recover-DivergedUpdate {
         }
     }
 
+    # Rebase preserves each commit's author, but Git still needs a committer.
+    # Reuse HEAD's author without changing repository or global configuration.
+    $committerNameOutput = @(git -c windows.appendAtomically=false show -s --format=%an HEAD 2>$null)
+    $committerNameExit = $LASTEXITCODE
+    $committerName = ($committerNameOutput -join "`n").Trim()
+    $committerEmailOutput = @(git -c windows.appendAtomically=false show -s --format=%ae HEAD 2>$null)
+    $committerEmailExit = $LASTEXITCODE
+    $committerEmail = ($committerEmailOutput -join "`n").Trim()
+    if (($committerNameExit -ne 0) -or (-not $committerName) -or
+        ($committerEmailExit -ne 0) -or (-not $committerEmail)) {
+        throw "Could not recover a committer identity from HEAD; refusing to rewrite it"
+    }
+
     Write-Info "Preserving locally carried history and merge topology onto $RemoteRef..."
-    git -c windows.appendAtomically=false -c rebase.updateRefs=false rebase --rebase-merges --onto $RemoteRef $forkPoint
+    git -c windows.appendAtomically=false -c "user.name=$committerName" -c "user.email=$committerEmail" -c rebase.updateRefs=false rebase --rebase-merges --onto $RemoteRef $forkPoint
     if ($LASTEXITCODE -eq 0) { return }
 
     Write-Err "Rebase conflicted; aborting so the original checkout is restored."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1407,6 +1407,76 @@ function Install-SystemPackages {
 # Installation
 # ============================================================================
 
+function Recover-DivergedUpdate {
+    param([Parameter(Mandatory = $true)][string]$RemoteRef)
+
+    # RemoteRef..HEAD is unsafe after a force-push because it includes old
+    # upstream commits that the remote discarded. The tracking ref's reflog
+    # identifies the old upstream tip; without that evidence, fail closed.
+    $forkOutput = @(git -c windows.appendAtomically=false merge-base --fork-point $RemoteRef HEAD 2>$null)
+    $forkExit = $LASTEXITCODE
+    $forkPoint = ($forkOutput -join "").Trim()
+    if (($forkExit -ne 0) -or (-not $forkPoint)) {
+        throw "Could not determine the previous upstream fork point; refusing to rewrite HEAD"
+    }
+
+    $localCommitOutput = @(git -c windows.appendAtomically=false rev-list --count "$forkPoint..HEAD" 2>$null)
+    $countExit = $LASTEXITCODE
+    if ($countExit -ne 0) {
+        throw "Could not determine whether HEAD contains locally carried commits (exit $countExit)"
+    }
+    # Native PowerShell output records have their process newline removed and
+    # cannot distinguish a final terminator from EOF. Across all installers the
+    # final newline is therefore optional. Do not trim or join records: padding
+    # and additional captured lines are malformed output.
+    $localCommitText = if ($localCommitOutput.Count -eq 1) { [string]$localCommitOutput[0] } else { "" }
+    $localCommitCount = 0
+    # Shared lexical contract: the raw record is 1..9 ASCII digits. Enforce its
+    # spelling bound before TryParse; nine digits inherently represent a value
+    # no greater than 999999999.
+    if (($localCommitOutput.Count -ne 1) -or
+        ($localCommitText -notmatch '^[0-9]+$') -or
+        ($localCommitText.Length -gt 9) -or
+        (-not [int]::TryParse($localCommitText, [ref]$localCommitCount))) {
+        throw "Could not parse local commit count; refusing to rewrite HEAD"
+    }
+
+    if ($localCommitCount -eq 0) {
+        git -c windows.appendAtomically=false reset --hard "$RemoteRef"
+        if ($LASTEXITCODE -ne 0) { throw "git reset --hard $RemoteRef failed (exit $LASTEXITCODE)" }
+        return
+    }
+
+    # Git recreates merges during --rebase-merges. Content present in neither
+    # parent can disappear silently, so reject that range without changing HEAD.
+    $mergeCommits = @(git -c windows.appendAtomically=false rev-list --merges "$forkPoint..HEAD" 2>$null)
+    $mergeListExit = $LASTEXITCODE
+    if ($mergeListExit -ne 0) {
+        throw "Could not inspect carried merge commits; refusing to rewrite HEAD"
+    }
+    foreach ($mergeCommit in $mergeCommits) {
+        $mergePayload = @(git -c windows.appendAtomically=false diff-tree --cc --no-commit-id --name-only -r $mergeCommit 2>$null)
+        $mergePayloadExit = $LASTEXITCODE
+        if ($mergePayloadExit -ne 0) {
+            throw "Could not inspect carried merge content; refusing to rewrite HEAD"
+        }
+        if (($mergePayload -join "").Trim()) {
+            throw "Carried history contains merge-only content; refusing an automatic rebase that could lose it"
+        }
+    }
+
+    Write-Info "Preserving $localCommitCount locally carried commit(s) and merge topology onto $RemoteRef..."
+    git -c windows.appendAtomically=false rebase --rebase-merges --onto $RemoteRef $forkPoint
+    if ($LASTEXITCODE -eq 0) { return }
+
+    Write-Err "Rebase conflicted; aborting so the original checkout is restored."
+    git -c windows.appendAtomically=false rebase --abort 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Rebase failed and git rebase --abort also failed; recover the checkout manually"
+    }
+    throw "Rebase conflicted; original checkout restored"
+}
+
 function Install-Repository {
     Write-Info "Installing to $InstallDir..."
 
@@ -1544,15 +1614,13 @@ function Install-Repository {
                 } else {
                     git -c windows.appendAtomically=false checkout $Branch
                     if ($LASTEXITCODE -ne 0) { throw "git checkout $Branch failed (exit $LASTEXITCODE)" }
-                    # Managed installs should follow origin/$Branch exactly. If
-                    # the checkout has diverged (or has local-only commits),
-                    # ff-only pull cannot succeed -- mirror ``hermes update`` and
-                    # reset to the fetched remote so bootstrap/install can recover.
+                    # Preserve unique local commits by rebasing them onto the
+                    # fetched remote. Reset only when the count proves there
+                    # are no commits unique to HEAD.
                     git -c windows.appendAtomically=false pull --ff-only origin $Branch
                     if ($LASTEXITCODE -ne 0) {
-                        Write-Warn "Fast-forward not possible; resetting managed install to origin/$Branch..."
-                        git -c windows.appendAtomically=false reset --hard "origin/$Branch"
-                        if ($LASTEXITCODE -ne 0) { throw "git reset --hard origin/$Branch failed (exit $LASTEXITCODE)" }
+                        Write-Warn "Fast-forward not possible; checking for locally carried commits..."
+                        Recover-DivergedUpdate "origin/$Branch"
                     }
                 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1471,7 +1471,7 @@ show_manual_install_hint() {
 
 recover_diverged_update() {
     local remote_ref="$1"
-    local fork_point head merge_commits merge_commit merge_payload
+    local fork_point head merge_commits merge_commit merge_payload committer_name committer_email
 
     # remote_ref..HEAD is unsafe after a force-push because it includes old
     # upstream commits that the remote intentionally discarded. The tracking
@@ -1507,8 +1507,17 @@ recover_diverged_update() {
         fi
     done
 
+    # Rebase preserves each commit's author, but Git still needs a committer.
+    # Reuse HEAD's author without changing repository or global configuration.
+    if ! committer_name="$(git show -s --format=%an HEAD)" || [ -z "$committer_name" ] ||
+       ! committer_email="$(git show -s --format=%ae HEAD)" || [ -z "$committer_email" ]; then
+        log_error "Could not recover a committer identity from HEAD; refusing to rewrite it."
+        return 1
+    fi
+
     log_info "Preserving locally carried history and merge topology onto $remote_ref..."
-    if git -c rebase.updateRefs=false rebase --rebase-merges --onto "$remote_ref" "$fork_point"; then
+    if git -c "user.name=$committer_name" -c "user.email=$committer_email" \
+        -c rebase.updateRefs=false rebase --rebase-merges --onto "$remote_ref" "$fork_point"; then
         return 0
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1471,8 +1471,7 @@ show_manual_install_hint() {
 
 recover_diverged_update() {
     local remote_ref="$1"
-    local fork_point local_commits bounded_commits merge_commits merge_commit merge_payload
-    local count_dir count_file count_status first_status second_record second_status
+    local fork_point head merge_commits merge_commit merge_payload
 
     # remote_ref..HEAD is unsafe after a force-push because it includes old
     # upstream commits that the remote intentionally discarded. The tracking
@@ -1481,99 +1480,11 @@ recover_diverged_update() {
         log_error "Could not determine the previous upstream fork point; refusing to rewrite HEAD."
         return 1
     fi
-    # Command substitution strips every trailing newline, so it cannot
-    # distinguish Git's single record from a valid-looking first record plus
-    # trailing empty records. Preserve the exact output in a securely created
-    # file, then unlink it as soon as a dedicated descriptor is open.
-    count_dir="${TMPDIR:-/tmp}"
-    if ! count_file="$(mktemp "$count_dir/hermes-commit-count.XXXXXXXXXX")"; then
-        log_error "Could not create temporary storage for the locally carried commit count."
+    if ! head="$(git rev-parse --verify HEAD)" || [ -z "$head" ]; then
+        log_error "Could not determine the current HEAD; refusing to rewrite it."
         return 1
     fi
-    if ! exec 8>"$count_file"; then
-        rm -f "$count_file"
-        log_error "Could not write the locally carried commit count."
-        return 1
-    fi
-    if ! exec 9<"$count_file"; then
-        exec 8>&-
-        rm -f "$count_file"
-        log_error "Could not read the locally carried commit count."
-        return 1
-    fi
-    if ! rm -f "$count_file"; then
-        exec 8>&-
-        exec 9<&-
-        rm -f "$count_file"
-        log_error "Could not remove temporary commit-count storage."
-        return 1
-    fi
-
-    # Both descriptors now refer to an already-unlinked file: neither command
-    # failure nor an interrupt can leak the temporary pathname.
-    if git rev-list --count "$fork_point..HEAD" >&8; then
-        count_status=0
-    else
-        count_status=$?
-    fi
-    exec 8>&-
-    if [ "$count_status" -ne 0 ]; then
-        exec 9<&-
-        log_error "Could not determine whether HEAD contains locally carried commits."
-        return "$count_status"
-    fi
-
-    # A genuine count is exactly one nonempty record; its final newline is
-    # optional, matching Python and PowerShell (whose native line capture
-    # cannot distinguish it). At EOF, read returns nonzero but still preserves
-    # an unterminated first record, so reject only when that record is empty.
-    local_commits=""
-    if IFS= read -r local_commits <&9; then
-        first_status=0
-    else
-        first_status=$?
-    fi
-    if [ "$first_status" -ne 0 ] && { [ "$first_status" -ne 1 ] || [ -z "$local_commits" ]; }; then
-        exec 9<&-
-        log_error "Could not parse the locally carried commit count; refusing to rewrite HEAD."
-        return 1
-    fi
-    # A second read must still reach EOF with no partial data, rejecting an
-    # empty, complete, or unterminated second record.
-    second_record=""
-    if IFS= read -r second_record <&9; then
-        second_status=0
-    else
-        second_status=$?
-    fi
-    exec 9<&-
-    if [ "$second_status" -eq 0 ] || [ -n "$second_record" ]; then
-        log_error "Could not parse the locally carried commit count; refusing to rewrite HEAD."
-        return 1
-    fi
-    case "$local_commits" in
-        ''|*[!0-9]*)
-            log_error "Could not parse the locally carried commit count; refusing to rewrite HEAD."
-            return 1
-            ;;
-    esac
-
-    # Shared lexical contract: the raw record is 1..9 ASCII digits. Check raw
-    # length before arithmetic so 10+ digit zero padding is rejected everywhere;
-    # nine digits inherently represent a value no greater than 999999999.
-    if [ "${#local_commits}" -gt 9 ]; then
-        log_error "Locally carried commit count exceeds the safe limit; refusing to rewrite HEAD."
-        return 1
-    fi
-
-    # Strip leading zeroes only after the shared spelling bound is established,
-    # avoiding octal interpretation when testing the numeric value in the shell.
-    bounded_commits="$local_commits"
-    while [ "${bounded_commits#0}" != "$bounded_commits" ]; do
-        bounded_commits="${bounded_commits#0}"
-    done
-    [ -n "$bounded_commits" ] || bounded_commits=0
-    if [ "$bounded_commits" -eq 0 ]; then
+    if [ "$head" = "$fork_point" ]; then
         git reset --hard "$remote_ref"
         return $?
     fi
@@ -1596,7 +1507,7 @@ recover_diverged_update() {
         fi
     done
 
-    log_info "Preserving $local_commits locally carried commit(s) and merge topology onto $remote_ref..."
+    log_info "Preserving locally carried history and merge topology onto $remote_ref..."
     if git -c rebase.updateRefs=false rebase --rebase-merges --onto "$remote_ref" "$fork_point"; then
         return 0
     fi
@@ -1658,8 +1569,8 @@ clone_repo() {
             git remote set-branches origin "$BRANCH" 2>/dev/null || true
             git fetch origin "$BRANCH"
             git checkout "$BRANCH"
-            # Preserve unique local commits by rebasing them onto the fetched
-            # remote. Only reset when the commit count proves HEAD has none.
+            # Preserve unique local history by rebasing it onto the fetched
+            # remote. Reset only when the recovered fork point is HEAD itself.
             if ! git pull --ff-only origin "$BRANCH"; then
                 log_warn "Fast-forward not possible; checking for locally carried commits..."
                 if ! recover_diverged_update "origin/$BRANCH"; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1597,7 +1597,7 @@ recover_diverged_update() {
     done
 
     log_info "Preserving $local_commits locally carried commit(s) and merge topology onto $remote_ref..."
-    if git rebase --rebase-merges --onto "$remote_ref" "$fork_point"; then
+    if git -c rebase.updateRefs=false rebase --rebase-merges --onto "$remote_ref" "$fork_point"; then
         return 0
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1469,6 +1469,145 @@ show_manual_install_hint() {
 # Installation
 # ============================================================================
 
+recover_diverged_update() {
+    local remote_ref="$1"
+    local fork_point local_commits bounded_commits merge_commits merge_commit merge_payload
+    local count_dir count_file count_status first_status second_record second_status
+
+    # remote_ref..HEAD is unsafe after a force-push because it includes old
+    # upstream commits that the remote intentionally discarded. The tracking
+    # ref's reflog identifies the old upstream tip; without it, fail closed.
+    if ! fork_point="$(git merge-base --fork-point "$remote_ref" HEAD)" || [ -z "$fork_point" ]; then
+        log_error "Could not determine the previous upstream fork point; refusing to rewrite HEAD."
+        return 1
+    fi
+    # Command substitution strips every trailing newline, so it cannot
+    # distinguish Git's single record from a valid-looking first record plus
+    # trailing empty records. Preserve the exact output in a securely created
+    # file, then unlink it as soon as a dedicated descriptor is open.
+    count_dir="${TMPDIR:-/tmp}"
+    if ! count_file="$(mktemp "$count_dir/hermes-commit-count.XXXXXXXXXX")"; then
+        log_error "Could not create temporary storage for the locally carried commit count."
+        return 1
+    fi
+    if ! exec 8>"$count_file"; then
+        rm -f "$count_file"
+        log_error "Could not write the locally carried commit count."
+        return 1
+    fi
+    if ! exec 9<"$count_file"; then
+        exec 8>&-
+        rm -f "$count_file"
+        log_error "Could not read the locally carried commit count."
+        return 1
+    fi
+    if ! rm -f "$count_file"; then
+        exec 8>&-
+        exec 9<&-
+        rm -f "$count_file"
+        log_error "Could not remove temporary commit-count storage."
+        return 1
+    fi
+
+    # Both descriptors now refer to an already-unlinked file: neither command
+    # failure nor an interrupt can leak the temporary pathname.
+    if git rev-list --count "$fork_point..HEAD" >&8; then
+        count_status=0
+    else
+        count_status=$?
+    fi
+    exec 8>&-
+    if [ "$count_status" -ne 0 ]; then
+        exec 9<&-
+        log_error "Could not determine whether HEAD contains locally carried commits."
+        return "$count_status"
+    fi
+
+    # A genuine count is exactly one nonempty record; its final newline is
+    # optional, matching Python and PowerShell (whose native line capture
+    # cannot distinguish it). At EOF, read returns nonzero but still preserves
+    # an unterminated first record, so reject only when that record is empty.
+    local_commits=""
+    if IFS= read -r local_commits <&9; then
+        first_status=0
+    else
+        first_status=$?
+    fi
+    if [ "$first_status" -ne 0 ] && { [ "$first_status" -ne 1 ] || [ -z "$local_commits" ]; }; then
+        exec 9<&-
+        log_error "Could not parse the locally carried commit count; refusing to rewrite HEAD."
+        return 1
+    fi
+    # A second read must still reach EOF with no partial data, rejecting an
+    # empty, complete, or unterminated second record.
+    second_record=""
+    if IFS= read -r second_record <&9; then
+        second_status=0
+    else
+        second_status=$?
+    fi
+    exec 9<&-
+    if [ "$second_status" -eq 0 ] || [ -n "$second_record" ]; then
+        log_error "Could not parse the locally carried commit count; refusing to rewrite HEAD."
+        return 1
+    fi
+    case "$local_commits" in
+        ''|*[!0-9]*)
+            log_error "Could not parse the locally carried commit count; refusing to rewrite HEAD."
+            return 1
+            ;;
+    esac
+
+    # Shared lexical contract: the raw record is 1..9 ASCII digits. Check raw
+    # length before arithmetic so 10+ digit zero padding is rejected everywhere;
+    # nine digits inherently represent a value no greater than 999999999.
+    if [ "${#local_commits}" -gt 9 ]; then
+        log_error "Locally carried commit count exceeds the safe limit; refusing to rewrite HEAD."
+        return 1
+    fi
+
+    # Strip leading zeroes only after the shared spelling bound is established,
+    # avoiding octal interpretation when testing the numeric value in the shell.
+    bounded_commits="$local_commits"
+    while [ "${bounded_commits#0}" != "$bounded_commits" ]; do
+        bounded_commits="${bounded_commits#0}"
+    done
+    [ -n "$bounded_commits" ] || bounded_commits=0
+    if [ "$bounded_commits" -eq 0 ]; then
+        git reset --hard "$remote_ref"
+        return $?
+    fi
+
+    # --rebase-merges preserves safe topology, but Git recreates merges and can
+    # silently omit content present in neither parent. Reject such merge-only
+    # payload before changing HEAD; the user can preserve it manually.
+    if ! merge_commits="$(git rev-list --merges "$fork_point..HEAD")"; then
+        log_error "Could not inspect carried merge commits; refusing to rewrite HEAD."
+        return 1
+    fi
+    for merge_commit in $merge_commits; do
+        if ! merge_payload="$(git diff-tree --cc --no-commit-id --name-only -r "$merge_commit")"; then
+            log_error "Could not inspect carried merge content; refusing to rewrite HEAD."
+            return 1
+        fi
+        if [ -n "$merge_payload" ]; then
+            log_error "Carried history contains merge-only content; refusing an automatic rebase that could lose it."
+            return 1
+        fi
+    done
+
+    log_info "Preserving $local_commits locally carried commit(s) and merge topology onto $remote_ref..."
+    if git rebase --rebase-merges --onto "$remote_ref" "$fork_point"; then
+        return 0
+    fi
+
+    log_error "Rebase conflicted; aborting so the original checkout is restored."
+    if ! git rebase --abort; then
+        log_error "Could not abort the conflicted rebase. Recover the checkout manually before retrying."
+    fi
+    return 1
+}
+
 clone_repo() {
     log_info "Installing to $INSTALL_DIR..."
 
@@ -1519,13 +1658,15 @@ clone_repo() {
             git remote set-branches origin "$BRANCH" 2>/dev/null || true
             git fetch origin "$BRANCH"
             git checkout "$BRANCH"
-            # Managed installs should follow origin/$BRANCH exactly. If the
-            # checkout has diverged (or has local-only commits), ff-only pull
-            # cannot succeed — mirror ``hermes update`` and reset to the
-            # fetched remote so bootstrap/install can recover.
+            # Preserve unique local commits by rebasing them onto the fetched
+            # remote. Only reset when the commit count proves HEAD has none.
             if ! git pull --ff-only origin "$BRANCH"; then
-                log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
-                git reset --hard "origin/$BRANCH"
+                log_warn "Fast-forward not possible; checking for locally carried commits..."
+                if ! recover_diverged_update "origin/$BRANCH"; then
+                    log_error "Update stopped to preserve locally carried commits."
+                    log_info "Resolve/rebase the local commits, then run the installer again."
+                    return 1
+                fi
             fi
 
             if [ -n "$autostash_ref" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1195,6 +1195,145 @@ show_manual_install_hint() {
 # Installation
 # ============================================================================
 
+recover_diverged_update() {
+    local remote_ref="$1"
+    local fork_point local_commits bounded_commits merge_commits merge_commit merge_payload
+    local count_dir count_file count_status first_status second_record second_status
+
+    # remote_ref..HEAD is unsafe after a force-push because it includes old
+    # upstream commits that the remote intentionally discarded. The tracking
+    # ref's reflog identifies the old upstream tip; without it, fail closed.
+    if ! fork_point="$(git merge-base --fork-point "$remote_ref" HEAD)" || [ -z "$fork_point" ]; then
+        log_error "Could not determine the previous upstream fork point; refusing to rewrite HEAD."
+        return 1
+    fi
+    # Command substitution strips every trailing newline, so it cannot
+    # distinguish Git's single record from a valid-looking first record plus
+    # trailing empty records. Preserve the exact output in a securely created
+    # file, then unlink it as soon as a dedicated descriptor is open.
+    count_dir="${TMPDIR:-/tmp}"
+    if ! count_file="$(mktemp "$count_dir/hermes-commit-count.XXXXXXXXXX")"; then
+        log_error "Could not create temporary storage for the locally carried commit count."
+        return 1
+    fi
+    if ! exec 8>"$count_file"; then
+        rm -f "$count_file"
+        log_error "Could not write the locally carried commit count."
+        return 1
+    fi
+    if ! exec 9<"$count_file"; then
+        exec 8>&-
+        rm -f "$count_file"
+        log_error "Could not read the locally carried commit count."
+        return 1
+    fi
+    if ! rm -f "$count_file"; then
+        exec 8>&-
+        exec 9<&-
+        rm -f "$count_file"
+        log_error "Could not remove temporary commit-count storage."
+        return 1
+    fi
+
+    # Both descriptors now refer to an already-unlinked file: neither command
+    # failure nor an interrupt can leak the temporary pathname.
+    if git rev-list --count "$fork_point..HEAD" >&8; then
+        count_status=0
+    else
+        count_status=$?
+    fi
+    exec 8>&-
+    if [ "$count_status" -ne 0 ]; then
+        exec 9<&-
+        log_error "Could not determine whether HEAD contains locally carried commits."
+        return "$count_status"
+    fi
+
+    # A genuine count is exactly one nonempty record; its final newline is
+    # optional, matching Python and PowerShell (whose native line capture
+    # cannot distinguish it). At EOF, read returns nonzero but still preserves
+    # an unterminated first record, so reject only when that record is empty.
+    local_commits=""
+    if IFS= read -r local_commits <&9; then
+        first_status=0
+    else
+        first_status=$?
+    fi
+    if [ "$first_status" -ne 0 ] && { [ "$first_status" -ne 1 ] || [ -z "$local_commits" ]; }; then
+        exec 9<&-
+        log_error "Could not parse the locally carried commit count; refusing to rewrite HEAD."
+        return 1
+    fi
+    # A second read must still reach EOF with no partial data, rejecting an
+    # empty, complete, or unterminated second record.
+    second_record=""
+    if IFS= read -r second_record <&9; then
+        second_status=0
+    else
+        second_status=$?
+    fi
+    exec 9<&-
+    if [ "$second_status" -eq 0 ] || [ -n "$second_record" ]; then
+        log_error "Could not parse the locally carried commit count; refusing to rewrite HEAD."
+        return 1
+    fi
+    case "$local_commits" in
+        ''|*[!0-9]*)
+            log_error "Could not parse the locally carried commit count; refusing to rewrite HEAD."
+            return 1
+            ;;
+    esac
+
+    # Shared lexical contract: the raw record is 1..9 ASCII digits. Check raw
+    # length before arithmetic so 10+ digit zero padding is rejected everywhere;
+    # nine digits inherently represent a value no greater than 999999999.
+    if [ "${#local_commits}" -gt 9 ]; then
+        log_error "Locally carried commit count exceeds the safe limit; refusing to rewrite HEAD."
+        return 1
+    fi
+
+    # Strip leading zeroes only after the shared spelling bound is established,
+    # avoiding octal interpretation when testing the numeric value in the shell.
+    bounded_commits="$local_commits"
+    while [ "${bounded_commits#0}" != "$bounded_commits" ]; do
+        bounded_commits="${bounded_commits#0}"
+    done
+    [ -n "$bounded_commits" ] || bounded_commits=0
+    if [ "$bounded_commits" -eq 0 ]; then
+        git reset --hard "$remote_ref"
+        return $?
+    fi
+
+    # --rebase-merges preserves safe topology, but Git recreates merges and can
+    # silently omit content present in neither parent. Reject such merge-only
+    # payload before changing HEAD; the user can preserve it manually.
+    if ! merge_commits="$(git rev-list --merges "$fork_point..HEAD")"; then
+        log_error "Could not inspect carried merge commits; refusing to rewrite HEAD."
+        return 1
+    fi
+    for merge_commit in $merge_commits; do
+        if ! merge_payload="$(git diff-tree --cc --no-commit-id --name-only -r "$merge_commit")"; then
+            log_error "Could not inspect carried merge content; refusing to rewrite HEAD."
+            return 1
+        fi
+        if [ -n "$merge_payload" ]; then
+            log_error "Carried history contains merge-only content; refusing an automatic rebase that could lose it."
+            return 1
+        fi
+    done
+
+    log_info "Preserving $local_commits locally carried commit(s) and merge topology onto $remote_ref..."
+    if git rebase --rebase-merges --onto "$remote_ref" "$fork_point"; then
+        return 0
+    fi
+
+    log_error "Rebase conflicted; aborting so the original checkout is restored."
+    if ! git rebase --abort; then
+        log_error "Could not abort the conflicted rebase. Recover the checkout manually before retrying."
+    fi
+    return 1
+}
+
 clone_repo() {
     log_info "Installing to $INSTALL_DIR..."
 
@@ -1245,13 +1384,15 @@ clone_repo() {
             git remote set-branches origin "$BRANCH" 2>/dev/null || true
             git fetch origin "$BRANCH"
             git checkout "$BRANCH"
-            # Managed installs should follow origin/$BRANCH exactly. If the
-            # checkout has diverged (or has local-only commits), ff-only pull
-            # cannot succeed — mirror ``hermes update`` and reset to the
-            # fetched remote so bootstrap/install can recover.
+            # Preserve unique local commits by rebasing them onto the fetched
+            # remote. Only reset when the commit count proves HEAD has none.
             if ! git pull --ff-only origin "$BRANCH"; then
-                log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
-                git reset --hard "origin/$BRANCH"
+                log_warn "Fast-forward not possible; checking for locally carried commits..."
+                if ! recover_diverged_update "origin/$BRANCH"; then
+                    log_error "Update stopped to preserve locally carried commits."
+                    log_info "Resolve/rebase the local commits, then run the installer again."
+                    return 1
+                fi
             fi
 
             if [ -n "$autostash_ref" ]; then

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -137,7 +137,7 @@ def test_reload_updated_runtime_modules_restores_new_hermes_constants_symbol(mon
 
 
 # ---------------------------------------------------------------------------
-# ff-only fallback to reset --hard on diverged history
+# ff-only recovery for diverged history
 # ---------------------------------------------------------------------------
 
 def _make_update_side_effect(
@@ -200,6 +200,10 @@ def _make_update_side_effect(
             return SimpleNamespace(
                 stdout="2222222222222222222222222222222222222cafe\n", stderr="", returncode=0
             )
+        if "merge-base" in joined and "--fork-point" in joined:
+            return SimpleNamespace(stdout="abc123\n", stderr="", returncode=0)
+        if "rev-parse" in joined and "--verify" in joined and "HEAD" in joined:
+            return SimpleNamespace(stdout="abc123\n", stderr="", returncode=0)
         if "checkout" in joined and "main" in joined:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-list" in joined:
@@ -249,7 +253,7 @@ def _make_update_side_effect(
 
 
 # ---------------------------------------------------------------------------
-# reset --hard failure — don't attempt stash restore
+# failed divergence recovery — don't attempt stash restore
 # ---------------------------------------------------------------------------
 
 def test_cmd_update_skips_stash_restore_when_reset_fails(monkeypatch, tmp_path, capsys):
@@ -583,6 +587,10 @@ def _setup_keep_stash_test(monkeypatch, tmp_path):
     # run into exit 1 (gateway_fleet_restart_incomplete).
     monkeypatch.setattr(
         "hermes_cli.gateway.find_gateway_pids", lambda **kw: [], raising=False
+    )
+    monkeypatch.setattr(
+        "hermes_cli.update_cmd._restart_macos_launchd_gateways",
+        lambda restarted, failed, timeout: None,
     )
     return restore_calls, discard_calls, park_calls
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -65,6 +65,8 @@ def _patch_gateway_discovery():
          patch("hermes_cli.update_inventory.report_unaccounted_runtimes", return_value=False), \
          patch.object(hermes_main, "_fleet_probe_expected_runtimes", lambda *a, **kw: False), \
          patch.object(hermes_main, "_purge_stale_hermes_modules", lambda *a, **kw: None), \
+         patch.object(update_cmd, "_restart_macos_launchd_gateways", lambda *a, **kw: None), \
+         patch("hermes_cli.update_cmd_fleet._restart_macos_launchd_gateways", lambda *a, **kw: None), \
          patch("hermes_cli.update_receipt.collect_fleet_versions", return_value=[]):
         yield
 
@@ -186,6 +188,8 @@ def _make_update_side_effect(
             return SimpleNamespace(stdout=f"{current_branch}\n", stderr="", returncode=0)
         if "show-current" in joined:
             return SimpleNamespace(stdout=f"{current_branch}\n", stderr="", returncode=0)
+        if "rev-parse" in joined and "--verify" in joined and "HEAD" in joined:
+            return SimpleNamespace(stdout="abc123\n", stderr="", returncode=0)
         if "rev-parse" in joined and "HEAD" in joined:
             # First call = pre-pull HEAD, every later call = post-pull HEAD
             # (issue #79678's "did HEAD actually move" guard depends on these
@@ -201,8 +205,6 @@ def _make_update_side_effect(
                 stdout="2222222222222222222222222222222222222cafe\n", stderr="", returncode=0
             )
         if "merge-base" in joined and "--fork-point" in joined:
-            return SimpleNamespace(stdout="abc123\n", stderr="", returncode=0)
-        if "rev-parse" in joined and "--verify" in joined and "HEAD" in joined:
             return SimpleNamespace(stdout="abc123\n", stderr="", returncode=0)
         if "checkout" in joined and "main" in joined:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
@@ -443,7 +445,7 @@ def test_cmd_update_ordinary_divergence_skips_rescue_ref(monkeypatch, tmp_path, 
 
     out = capsys.readouterr().out
     assert "orphan divergence" not in out
-    assert "Fast-forward not possible (history diverged), resetting to match remote" in out
+    assert "checking for locally carried commits" in out
 
 
 def test_cmd_update_orphan_rescue_ref_write_failure_is_non_fatal(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_update_carried_commits.py
+++ b/tests/hermes_cli/test_update_carried_commits.py
@@ -1,0 +1,339 @@
+"""Real-git regressions for preserving carried history on divergent updates."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.update_cmd import _recover_diverged_update
+
+
+GIT = ["git", "-c", "user.name=Hermes Test", "-c", "user.email=test@example.invalid"]
+REMOTE_REF = "refs/remotes/origin/main"
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    home = repo.parent / "home"
+    home.mkdir(exist_ok=True)
+    return subprocess.run(
+        GIT + list(args),
+        cwd=repo,
+        env={**os.environ, "HOME": str(home), "HERMES_HOME": str(home / ".hermes")},
+        check=check,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def _init_git_repo(repo: Path) -> None:
+    """Create a repo whose rebases do not depend on the host's Git identity."""
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Hermes Test")
+    _git(repo, "config", "user.email", "test@example.invalid")
+
+
+def _write_commit(repo: Path, path: str, text: str, message: str) -> str:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
+    _git(repo, "add", path)
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def _init_repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    base = _write_commit(repo, "tracked.txt", "base\n", "base")
+    _git(repo, "update-ref", "--create-reflog", REMOTE_REF, base)
+    return repo, base
+
+
+def _advance_remote(repo: Path, base: str, *, conflict: bool = False) -> str:
+    local_branch = _git(repo, "branch", "--show-current").stdout.strip()
+    _git(repo, "checkout", "-b", "remote-work", base)
+    if conflict:
+        remote = _write_commit(repo, "tracked.txt", "remote\n", "conflicting upstream")
+    else:
+        remote = _write_commit(repo, "remote.txt", "upstream\n", "upstream change")
+    _git(repo, "update-ref", REMOTE_REF, remote)
+    _git(repo, "checkout", local_branch)
+    _git(repo, "branch", "-D", "remote-work")
+    return remote
+
+
+def _assert_clean_at(repo: Path, sha: str) -> None:
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == sha
+    assert not _git(repo, "status", "--porcelain").stdout
+    git_dir = Path(_git(repo, "rev-parse", "--git-dir").stdout.strip())
+    if not git_dir.is_absolute():
+        git_dir = repo / git_dir
+    assert not (git_dir / "rebase-merge").exists()
+    assert not (git_dir / "rebase-apply").exists()
+
+
+def _fake_git(repo: Path, count_output: bytes) -> tuple[Path, dict[str, str]]:
+    """Create an executable git proxy that corrupts only rev-list --count."""
+    fake_bin = repo.parent / "fake-bin"
+    fake_bin.mkdir()
+    count_file = fake_bin / "count-output"
+    count_file.write_bytes(count_output)
+    wrapper = fake_bin / "git"
+    wrapper.write_text(
+        """#!/bin/sh
+saw_rev_list=false
+saw_count=false
+for arg do
+    [ "$arg" = "rev-list" ] && saw_rev_list=true
+    [ "$arg" = "--count" ] && saw_count=true
+done
+if [ "$saw_rev_list" = true ] && [ "$saw_count" = true ]; then
+    cat "$HERMES_FAKE_COUNT"
+    exit 0
+fi
+exec "$HERMES_REAL_GIT" "$@"
+""",
+        encoding="ascii",
+    )
+    wrapper.chmod(0o755)
+    return wrapper, {
+        **os.environ,
+        "HERMES_FAKE_COUNT": str(count_file),
+        "HERMES_REAL_GIT": shutil.which("git") or "git",
+    }
+
+
+def test_diverged_update_rebases_only_actual_local_commit_after_force_push(
+    tmp_path: Path,
+) -> None:
+    repo, base = _init_repo(tmp_path)
+    old_upstream = _write_commit(repo, "obsolete.txt", "obsolete\n", "discarded upstream")
+    _git(repo, "update-ref", REMOTE_REF, old_upstream)
+    local = _write_commit(repo, "local.txt", "local\n", "actual local commit")
+
+    _git(repo, "checkout", "-b", "rewritten", base)
+    rewritten = _write_commit(repo, "replacement.txt", "replacement\n", "rewritten upstream")
+    _git(repo, "update-ref", REMOTE_REF, rewritten)
+    _git(repo, "checkout", "main")
+    _git(repo, "branch", "-D", "rewritten")
+
+    ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
+
+    assert ok, detail
+    assert _git(repo, "merge-base", "--is-ancestor", rewritten, "HEAD").returncode == 0
+    subjects = _git(repo, "log", "--format=%s", f"{rewritten}..HEAD").stdout.splitlines()
+    assert subjects == ["actual local commit"]
+    assert _git(repo, "branch", "--show-current").stdout.strip() == "main"
+    assert not (repo / "obsolete.txt").exists()
+    assert (repo / "local.txt").read_text(encoding="utf-8") == "local\n"
+    assert local != _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def test_diverged_update_preserves_safe_merge_topology(tmp_path: Path) -> None:
+    repo, base = _init_repo(tmp_path)
+    _write_commit(repo, "main.txt", "main\n", "main local")
+    _git(repo, "checkout", "-b", "local-side", base)
+    _write_commit(repo, "side.txt", "side\n", "side local")
+    _git(repo, "checkout", "main")
+    _git(repo, "merge", "--no-ff", "local-side", "-m", "merge local side")
+    _git(repo, "branch", "-D", "local-side")
+    remote = _advance_remote(repo, base)
+
+    ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
+
+    assert ok, detail
+    assert _git(repo, "merge-base", "--is-ancestor", remote, "HEAD").returncode == 0
+    assert _git(repo, "rev-list", "--count", "--merges", f"{remote}..HEAD").stdout.strip() == "1"
+    assert _git(repo, "branch", "--show-current").stdout.strip() == "main"
+    assert (repo / "main.txt").read_text(encoding="utf-8") == "main\n"
+    assert (repo / "side.txt").read_text(encoding="utf-8") == "side\n"
+
+
+def test_merge_resolution_only_payload_fails_closed_instead_of_losing_content(
+    tmp_path: Path,
+) -> None:
+    repo, base = _init_repo(tmp_path)
+    _write_commit(repo, "main.txt", "main\n", "main local")
+    _git(repo, "checkout", "-b", "local-side", base)
+    _write_commit(repo, "side.txt", "side\n", "side local")
+    _git(repo, "checkout", "main")
+    _git(repo, "merge", "--no-ff", "--no-commit", "local-side")
+    (repo / "merge-payload.txt").write_text("must survive\n", encoding="utf-8")
+    _git(repo, "add", "merge-payload.txt")
+    _git(repo, "commit", "-m", "merge with resolution-only payload")
+    original = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    _git(repo, "branch", "-D", "local-side")
+    _advance_remote(repo, base)
+
+    ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
+
+    assert not ok
+    assert "merge" in detail.lower()
+    _assert_clean_at(repo, original)
+    assert (repo / "merge-payload.txt").read_text(encoding="utf-8") == "must survive\n"
+
+
+def test_diverged_update_aborts_conflict_and_restores_clean_original_head(
+    tmp_path: Path,
+) -> None:
+    repo, base = _init_repo(tmp_path)
+    original = _write_commit(repo, "tracked.txt", "local\n", "local carried fix")
+    _advance_remote(repo, base, conflict=True)
+
+    ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
+
+    assert not ok
+    assert detail
+    _assert_clean_at(repo, original)
+    assert (repo / "tracked.txt").read_text(encoding="utf-8") == "local\n"
+
+
+def test_diverged_update_count_failure_fails_closed(monkeypatch, tmp_path: Path) -> None:
+    repo, base = _init_repo(tmp_path)
+    original = _write_commit(repo, "local.txt", "local\n", "local carried fix")
+    _advance_remote(repo, base)
+    real_run = subprocess.run
+
+    def fail_count(cmd, **kwargs):
+        if "rev-list" in cmd and "--count" in cmd:
+            return subprocess.CompletedProcess(cmd, 128, "", "count failed")
+        return real_run(cmd, **kwargs)
+
+    with monkeypatch.context() as context:
+        context.setattr("hermes_cli.main.subprocess.run", fail_count)
+        ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
+
+    assert not ok
+    assert "could not determine" in detail
+    _assert_clean_at(repo, original)
+
+
+@pytest.mark.parametrize(
+    ("count_output", "expected_local_commits"),
+    [
+        (b"1\n", 1),
+        (b"1", 1),
+        (b"0\n", 0),
+        (b"0", 0),
+        (b"000000001\n", 1),
+        (b"000000000\n", 0),
+    ],
+    ids=[
+        "one-terminated",
+        "one-unterminated",
+        "zero-terminated",
+        "zero-unterminated",
+        "nine-digit-zero-padded-one",
+        "nine-digit-all-zero",
+    ],
+)
+def test_diverged_update_accepts_single_count_with_optional_final_newline(
+    count_output: bytes, expected_local_commits: int, monkeypatch, tmp_path: Path
+) -> None:
+    repo, base = _init_repo(tmp_path)
+    original = _write_commit(repo, "local.txt", "local\n", "local carried fix")
+    remote = _advance_remote(repo, base)
+    wrapper, fake_env = _fake_git(repo, count_output)
+
+    with monkeypatch.context() as context:
+        context.setenv("HERMES_FAKE_COUNT", fake_env["HERMES_FAKE_COUNT"])
+        context.setenv("HERMES_REAL_GIT", fake_env["HERMES_REAL_GIT"])
+        ok, detail = _recover_diverged_update([str(wrapper)], repo, REMOTE_REF)
+
+    assert ok, detail
+    if expected_local_commits:
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() != original
+        assert _git(repo, "merge-base", "--is-ancestor", remote, "HEAD").returncode == 0
+        assert _git(repo, "log", "-1", "--format=%s").stdout.strip() == "local carried fix"
+    else:
+        _assert_clean_at(repo, remote)
+    assert not _git(repo, "status", "--porcelain").stdout
+
+
+@pytest.mark.parametrize(
+    "count_output",
+    [
+        b"+1\n",
+        b"-1\n",
+        b" 1 \n",
+        b"1x\n",
+        b"",
+        b"1000000000\n",
+        b"9" * 36 + b"\n",
+        b"0000000001\n",
+        b"0000000000\n",
+        b"0" * 4301 + b"1\n",
+        b"0" * 4301 + b"0\n",
+        b"1\n2\n",
+        "\u0661\n".encode(),
+    ],
+    ids=[
+        "positive-sign",
+        "negative-sign",
+        "padded",
+        "suffix",
+        "empty",
+        "over-bound",
+        "oversized",
+        "ten-digit-zero-padded-one",
+        "ten-digit-all-zero",
+        "giant-zero-padded-one",
+        "giant-all-zero",
+        "multiple-records",
+        "non-ascii-digit",
+    ],
+)
+def test_diverged_update_malformed_count_matrix_fails_closed(
+    count_output: bytes, monkeypatch, tmp_path: Path
+) -> None:
+    repo, base = _init_repo(tmp_path)
+    original = _write_commit(repo, "local.txt", "local\n", "local carried fix")
+    _advance_remote(repo, base)
+    wrapper, fake_env = _fake_git(repo, count_output)
+
+    with monkeypatch.context() as context:
+        context.setenv("HERMES_FAKE_COUNT", fake_env["HERMES_FAKE_COUNT"])
+        context.setenv("HERMES_REAL_GIT", fake_env["HERMES_REAL_GIT"])
+        ok, detail = _recover_diverged_update([str(wrapper)], repo, REMOTE_REF)
+
+    assert not ok
+    assert "could not determine" in detail
+    _assert_clean_at(repo, original)
+
+
+def test_missing_remote_reflog_fails_closed(tmp_path: Path) -> None:
+    repo, base = _init_repo(tmp_path)
+    original = _write_commit(repo, "local.txt", "local\n", "local carried fix")
+    _advance_remote(repo, base)
+    reflog = repo / ".git" / "logs" / "refs" / "remotes" / "origin" / "main"
+    reflog.unlink()
+
+    ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
+
+    assert not ok
+    assert "fork point" in detail
+    _assert_clean_at(repo, original)
+
+
+def test_force_push_without_local_commits_resets_to_rewritten_remote(tmp_path: Path) -> None:
+    repo, base = _init_repo(tmp_path)
+    old_upstream = _write_commit(repo, "obsolete.txt", "obsolete\n", "discarded upstream")
+    _git(repo, "update-ref", REMOTE_REF, old_upstream)
+    _git(repo, "checkout", "-b", "rewritten", base)
+    rewritten = _write_commit(repo, "replacement.txt", "replacement\n", "rewritten upstream")
+    _git(repo, "update-ref", REMOTE_REF, rewritten)
+    _git(repo, "checkout", "main")
+    _git(repo, "branch", "-D", "rewritten")
+
+    ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
+
+    assert ok, detail
+    _assert_clean_at(repo, rewritten)
+    assert not (repo / "obsolete.txt").exists()

--- a/tests/hermes_cli/test_update_carried_commits.py
+++ b/tests/hermes_cli/test_update_carried_commits.py
@@ -1,22 +1,20 @@
-"""Real-git regressions for preserving carried history on divergent updates."""
+"""Behavioral regressions for divergent Git updates."""
 
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 from pathlib import Path
 
-import pytest
-
 from hermes_cli.update_cmd import _recover_diverged_update
-
 
 GIT = ["git", "-c", "user.name=Hermes Test", "-c", "user.email=test@example.invalid"]
 REMOTE_REF = "refs/remotes/origin/main"
 
 
-def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+def _git(
+    repo: Path, *args: str, check: bool = True
+) -> subprocess.CompletedProcess[str]:
     home = repo.parent / "home"
     home.mkdir(exist_ok=True)
     return subprocess.run(
@@ -31,14 +29,7 @@ def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProc
     )
 
 
-def _init_git_repo(repo: Path) -> None:
-    """Create a repo whose rebases do not depend on the host's Git identity."""
-    _git(repo, "init", "-b", "main")
-    _git(repo, "config", "user.name", "Hermes Test")
-    _git(repo, "config", "user.email", "test@example.invalid")
-
-
-def _write_commit(repo: Path, path: str, text: str, message: str) -> str:
+def _commit(repo: Path, path: str, text: str, message: str) -> str:
     target = repo / path
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(text, encoding="utf-8")
@@ -47,145 +38,121 @@ def _write_commit(repo: Path, path: str, text: str, message: str) -> str:
     return _git(repo, "rev-parse", "HEAD").stdout.strip()
 
 
-def _init_repo(tmp_path: Path) -> tuple[Path, str]:
+def _repo(tmp_path: Path) -> tuple[Path, str]:
     repo = tmp_path / "repo"
     repo.mkdir()
-    _init_git_repo(repo)
-    base = _write_commit(repo, "tracked.txt", "base\n", "base")
+    _git(repo, "init", "-b", "main")
+    base = _commit(repo, "tracked.txt", "base\n", "base")
     _git(repo, "update-ref", "--create-reflog", REMOTE_REF, base)
     return repo, base
 
 
-def _advance_remote(repo: Path, base: str, *, conflict: bool = False) -> str:
-    local_branch = _git(repo, "branch", "--show-current").stdout.strip()
-    _git(repo, "checkout", "-b", "remote-work", base)
+def _rewrite_remote(repo: Path, base: str, *, conflict: bool = False) -> str:
+    branch = _git(repo, "branch", "--show-current").stdout.strip()
+    _git(repo, "checkout", "-b", "rewritten", base)
     if conflict:
-        remote = _write_commit(repo, "tracked.txt", "remote\n", "conflicting upstream")
+        remote = _commit(repo, "tracked.txt", "remote\n", "rewritten conflict")
     else:
-        remote = _write_commit(repo, "remote.txt", "upstream\n", "upstream change")
+        remote = _commit(repo, "replacement.txt", "replacement\n", "rewritten upstream")
     _git(repo, "update-ref", REMOTE_REF, remote)
-    _git(repo, "checkout", local_branch)
-    _git(repo, "branch", "-D", "remote-work")
+    _git(repo, "checkout", branch)
+    _git(repo, "branch", "-D", "rewritten")
     return remote
 
 
 def _assert_clean_at(repo: Path, sha: str) -> None:
     assert _git(repo, "rev-parse", "HEAD").stdout.strip() == sha
     assert not _git(repo, "status", "--porcelain").stdout
-    git_dir = Path(_git(repo, "rev-parse", "--git-dir").stdout.strip())
-    if not git_dir.is_absolute():
-        git_dir = repo / git_dir
+    git_dir = Path(_git(repo, "rev-parse", "--absolute-git-dir").stdout.strip())
     assert not (git_dir / "rebase-merge").exists()
     assert not (git_dir / "rebase-apply").exists()
 
 
-def _fake_git(repo: Path, count_output: bytes) -> tuple[Path, dict[str, str]]:
-    """Create an executable git proxy that corrupts only rev-list --count."""
-    fake_bin = repo.parent / "fake-bin"
-    fake_bin.mkdir()
-    count_file = fake_bin / "count-output"
-    count_file.write_bytes(count_output)
-    wrapper = fake_bin / "git"
-    wrapper.write_text(
-        """#!/bin/sh
-saw_rev_list=false
-saw_count=false
-for arg do
-    [ "$arg" = "rev-list" ] && saw_rev_list=true
-    [ "$arg" = "--count" ] && saw_count=true
-done
-if [ "$saw_rev_list" = true ] && [ "$saw_count" = true ]; then
-    cat "$HERMES_FAKE_COUNT"
-    exit 0
-fi
-exec "$HERMES_REAL_GIT" "$@"
-""",
-        encoding="ascii",
-    )
-    wrapper.chmod(0o755)
-    return wrapper, {
-        **os.environ,
-        "HERMES_FAKE_COUNT": str(count_file),
-        "HERMES_REAL_GIT": shutil.which("git") or "git",
-    }
-
-
-def test_diverged_update_rebases_only_actual_local_commit_after_force_push(
-    tmp_path: Path,
-) -> None:
-    repo, base = _init_repo(tmp_path)
-    old_upstream = _write_commit(repo, "obsolete.txt", "obsolete\n", "discarded upstream")
-    _git(repo, "update-ref", REMOTE_REF, old_upstream)
-    local = _write_commit(repo, "local.txt", "local\n", "actual local commit")
-
-    _git(repo, "checkout", "-b", "rewritten", base)
-    rewritten = _write_commit(repo, "replacement.txt", "replacement\n", "rewritten upstream")
-    _git(repo, "update-ref", REMOTE_REF, rewritten)
-    _git(repo, "checkout", "main")
-    _git(repo, "branch", "-D", "rewritten")
+def test_rewritten_upstream_preserves_only_genuine_local_commit(tmp_path: Path) -> None:
+    repo, base = _repo(tmp_path)
+    discarded = _commit(repo, "obsolete.txt", "obsolete\n", "discarded upstream")
+    _git(repo, "update-ref", REMOTE_REF, discarded)
+    original = _commit(repo, "local.txt", "local\n", "genuine local commit")
+    rewritten = _rewrite_remote(repo, base)
 
     ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
 
     assert ok, detail
     assert _git(repo, "merge-base", "--is-ancestor", rewritten, "HEAD").returncode == 0
-    subjects = _git(repo, "log", "--format=%s", f"{rewritten}..HEAD").stdout.splitlines()
-    assert subjects == ["actual local commit"]
-    assert _git(repo, "branch", "--show-current").stdout.strip() == "main"
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() != original
+    assert _git(
+        repo, "log", "--format=%s", f"{rewritten}..HEAD"
+    ).stdout.splitlines() == ["genuine local commit"]
     assert not (repo / "obsolete.txt").exists()
     assert (repo / "local.txt").read_text(encoding="utf-8") == "local\n"
-    assert local != _git(repo, "rev-parse", "HEAD").stdout.strip()
 
 
-def test_diverged_update_preserves_safe_merge_topology(tmp_path: Path) -> None:
-    repo, base = _init_repo(tmp_path)
-    _write_commit(repo, "main.txt", "main\n", "main local")
-    _git(repo, "checkout", "-b", "local-side", base)
-    _write_commit(repo, "side.txt", "side\n", "side local")
+def test_safe_local_merge_topology_is_preserved(tmp_path: Path) -> None:
+    repo, base = _repo(tmp_path)
+    _commit(repo, "main.txt", "main\n", "main local")
+    _git(repo, "checkout", "-b", "side", base)
+    _commit(repo, "side.txt", "side\n", "side local")
     _git(repo, "checkout", "main")
-    _git(repo, "merge", "--no-ff", "local-side", "-m", "merge local side")
-    _git(repo, "branch", "-D", "local-side")
-    remote = _advance_remote(repo, base)
+    _git(repo, "merge", "--no-ff", "side", "-m", "merge local side")
+    remote = _rewrite_remote(repo, base)
 
     ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
 
     assert ok, detail
     assert _git(repo, "merge-base", "--is-ancestor", remote, "HEAD").returncode == 0
-    assert _git(repo, "rev-list", "--count", "--merges", f"{remote}..HEAD").stdout.strip() == "1"
-    assert _git(repo, "branch", "--show-current").stdout.strip() == "main"
+    assert (
+        _git(repo, "rev-list", "--count", "--merges", f"{remote}..HEAD").stdout.strip()
+        == "1"
+    )
     assert (repo / "main.txt").read_text(encoding="utf-8") == "main\n"
     assert (repo / "side.txt").read_text(encoding="utf-8") == "side\n"
 
 
-def test_merge_resolution_only_payload_fails_closed_instead_of_losing_content(
-    tmp_path: Path,
-) -> None:
-    repo, base = _init_repo(tmp_path)
-    _write_commit(repo, "main.txt", "main\n", "main local")
-    _git(repo, "checkout", "-b", "local-side", base)
-    _write_commit(repo, "side.txt", "side\n", "side local")
+def test_merge_only_payload_fails_closed(tmp_path: Path) -> None:
+    repo, base = _repo(tmp_path)
+    _commit(repo, "main.txt", "main\n", "main local")
+    _git(repo, "checkout", "-b", "side", base)
+    _commit(repo, "side.txt", "side\n", "side local")
     _git(repo, "checkout", "main")
-    _git(repo, "merge", "--no-ff", "--no-commit", "local-side")
-    (repo / "merge-payload.txt").write_text("must survive\n", encoding="utf-8")
-    _git(repo, "add", "merge-payload.txt")
-    _git(repo, "commit", "-m", "merge with resolution-only payload")
+    _git(repo, "merge", "--no-ff", "--no-commit", "side")
+    (repo / "payload.txt").write_text("must survive\n", encoding="utf-8")
+    _git(repo, "add", "payload.txt")
+    _git(repo, "commit", "-m", "merge payload")
     original = _git(repo, "rev-parse", "HEAD").stdout.strip()
-    _git(repo, "branch", "-D", "local-side")
-    _advance_remote(repo, base)
+    _rewrite_remote(repo, base)
 
     ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
 
     assert not ok
     assert "merge" in detail.lower()
     _assert_clean_at(repo, original)
-    assert (repo / "merge-payload.txt").read_text(encoding="utf-8") == "must survive\n"
+    assert (repo / "payload.txt").read_text(encoding="utf-8") == "must survive\n"
 
 
-def test_diverged_update_aborts_conflict_and_restores_clean_original_head(
-    tmp_path: Path,
-) -> None:
-    repo, base = _init_repo(tmp_path)
-    original = _write_commit(repo, "tracked.txt", "local\n", "local carried fix")
-    _advance_remote(repo, base, conflict=True)
+def test_recovery_preserves_safe_local_merge_topology(tmp_path: Path) -> None:
+    repo, base = _repo(tmp_path)
+    _git(repo, "update-ref", REMOTE_REF, base)
+    main = _git(repo, "branch", "--show-current").stdout.strip()
+    _commit(repo, "main.txt", "main\n", "main work")
+    _git(repo, "checkout", "-b", "topic", base)
+    _commit(repo, "topic.txt", "topic\n", "topic work")
+    _git(repo, "checkout", main)
+    _git(repo, "merge", "--no-ff", "topic", "-m", "safe local merge")
+    rewritten = _rewrite_remote(repo, base)
+
+    ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
+
+    assert ok, detail
+    assert _git(repo, "merge-base", "--is-ancestor", rewritten, "HEAD").returncode == 0
+    assert _git(repo, "rev-list", "--merges", f"{rewritten}..HEAD").stdout.strip()
+    assert (repo / "main.txt").read_text(encoding="utf-8") == "main\n"
+    assert (repo / "topic.txt").read_text(encoding="utf-8") == "topic\n"
+
+
+def test_conflict_aborts_and_restores_original_head(tmp_path: Path) -> None:
+    repo, base = _repo(tmp_path)
+    original = _commit(repo, "tracked.txt", "local\n", "local conflict")
+    _rewrite_remote(repo, base, conflict=True)
 
     ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
 
@@ -195,123 +162,39 @@ def test_diverged_update_aborts_conflict_and_restores_clean_original_head(
     assert (repo / "tracked.txt").read_text(encoding="utf-8") == "local\n"
 
 
-def test_diverged_update_count_failure_fails_closed(monkeypatch, tmp_path: Path) -> None:
-    repo, base = _init_repo(tmp_path)
-    original = _write_commit(repo, "local.txt", "local\n", "local carried fix")
-    _advance_remote(repo, base)
-    real_run = subprocess.run
+def test_no_local_commit_resets_to_rewritten_remote(tmp_path: Path) -> None:
+    repo, base = _repo(tmp_path)
+    discarded = _commit(repo, "obsolete.txt", "obsolete\n", "discarded upstream")
+    _git(repo, "update-ref", REMOTE_REF, discarded)
+    rewritten = _rewrite_remote(repo, base)
 
-    def fail_count(cmd, **kwargs):
-        if "rev-list" in cmd and "--count" in cmd:
-            return subprocess.CompletedProcess(cmd, 128, "", "count failed")
-        return real_run(cmd, **kwargs)
-
-    with monkeypatch.context() as context:
-        context.setattr("hermes_cli.main.subprocess.run", fail_count)
-        ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
-
-    assert not ok
-    assert "could not determine" in detail
-    _assert_clean_at(repo, original)
-
-
-@pytest.mark.parametrize(
-    ("count_output", "expected_local_commits"),
-    [
-        (b"1\n", 1),
-        (b"1", 1),
-        (b"0\n", 0),
-        (b"0", 0),
-        (b"000000001\n", 1),
-        (b"000000000\n", 0),
-    ],
-    ids=[
-        "one-terminated",
-        "one-unterminated",
-        "zero-terminated",
-        "zero-unterminated",
-        "nine-digit-zero-padded-one",
-        "nine-digit-all-zero",
-    ],
-)
-def test_diverged_update_accepts_single_count_with_optional_final_newline(
-    count_output: bytes, expected_local_commits: int, monkeypatch, tmp_path: Path
-) -> None:
-    repo, base = _init_repo(tmp_path)
-    original = _write_commit(repo, "local.txt", "local\n", "local carried fix")
-    remote = _advance_remote(repo, base)
-    wrapper, fake_env = _fake_git(repo, count_output)
-
-    with monkeypatch.context() as context:
-        context.setenv("HERMES_FAKE_COUNT", fake_env["HERMES_FAKE_COUNT"])
-        context.setenv("HERMES_REAL_GIT", fake_env["HERMES_REAL_GIT"])
-        ok, detail = _recover_diverged_update([str(wrapper)], repo, REMOTE_REF)
+    ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
 
     assert ok, detail
-    if expected_local_commits:
-        assert _git(repo, "rev-parse", "HEAD").stdout.strip() != original
-        assert _git(repo, "merge-base", "--is-ancestor", remote, "HEAD").returncode == 0
-        assert _git(repo, "log", "-1", "--format=%s").stdout.strip() == "local carried fix"
-    else:
-        _assert_clean_at(repo, remote)
-    assert not _git(repo, "status", "--porcelain").stdout
+    _assert_clean_at(repo, rewritten)
+    assert not (repo / "obsolete.txt").exists()
 
 
-@pytest.mark.parametrize(
-    "count_output",
-    [
-        b"+1\n",
-        b"-1\n",
-        b" 1 \n",
-        b"1x\n",
-        b"",
-        b"1000000000\n",
-        b"9" * 36 + b"\n",
-        b"0000000001\n",
-        b"0000000000\n",
-        b"0" * 4301 + b"1\n",
-        b"0" * 4301 + b"0\n",
-        b"1\n2\n",
-        "\u0661\n".encode(),
-    ],
-    ids=[
-        "positive-sign",
-        "negative-sign",
-        "padded",
-        "suffix",
-        "empty",
-        "over-bound",
-        "oversized",
-        "ten-digit-zero-padded-one",
-        "ten-digit-all-zero",
-        "giant-zero-padded-one",
-        "giant-all-zero",
-        "multiple-records",
-        "non-ascii-digit",
-    ],
-)
-def test_diverged_update_malformed_count_matrix_fails_closed(
-    count_output: bytes, monkeypatch, tmp_path: Path
-) -> None:
-    repo, base = _init_repo(tmp_path)
-    original = _write_commit(repo, "local.txt", "local\n", "local carried fix")
-    _advance_remote(repo, base)
-    wrapper, fake_env = _fake_git(repo, count_output)
+def test_detached_head_preserves_local_commit(tmp_path: Path) -> None:
+    repo, base = _repo(tmp_path)
+    old_upstream = _commit(repo, "old.txt", "old\n", "old upstream")
+    _git(repo, "update-ref", REMOTE_REF, old_upstream)
+    local = _commit(repo, "local.txt", "local\n", "detached local")
+    rewritten = _rewrite_remote(repo, base)
+    _git(repo, "checkout", "--detach", local)
 
-    with monkeypatch.context() as context:
-        context.setenv("HERMES_FAKE_COUNT", fake_env["HERMES_FAKE_COUNT"])
-        context.setenv("HERMES_REAL_GIT", fake_env["HERMES_REAL_GIT"])
-        ok, detail = _recover_diverged_update([str(wrapper)], repo, REMOTE_REF)
+    ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
 
-    assert not ok
-    assert "could not determine" in detail
-    _assert_clean_at(repo, original)
+    assert ok, detail
+    assert not _git(repo, "branch", "--show-current").stdout.strip()
+    assert _git(repo, "merge-base", "--is-ancestor", rewritten, "HEAD").returncode == 0
+    assert _git(repo, "log", "-1", "--format=%s").stdout.strip() == "detached local"
 
 
 def test_missing_remote_reflog_fails_closed(tmp_path: Path) -> None:
-    repo, base = _init_repo(tmp_path)
-    original = _write_commit(repo, "local.txt", "local\n", "local carried fix")
-    _advance_remote(repo, base)
+    repo, base = _repo(tmp_path)
+    original = _commit(repo, "local.txt", "local\n", "local")
+    _rewrite_remote(repo, base)
     reflog = repo / ".git" / "logs" / "refs" / "remotes" / "origin" / "main"
     reflog.unlink()
 
@@ -320,20 +203,3 @@ def test_missing_remote_reflog_fails_closed(tmp_path: Path) -> None:
     assert not ok
     assert "fork point" in detail
     _assert_clean_at(repo, original)
-
-
-def test_force_push_without_local_commits_resets_to_rewritten_remote(tmp_path: Path) -> None:
-    repo, base = _init_repo(tmp_path)
-    old_upstream = _write_commit(repo, "obsolete.txt", "obsolete\n", "discarded upstream")
-    _git(repo, "update-ref", REMOTE_REF, old_upstream)
-    _git(repo, "checkout", "-b", "rewritten", base)
-    rewritten = _write_commit(repo, "replacement.txt", "replacement\n", "rewritten upstream")
-    _git(repo, "update-ref", REMOTE_REF, rewritten)
-    _git(repo, "checkout", "main")
-    _git(repo, "branch", "-D", "rewritten")
-
-    ok, detail = _recover_diverged_update(["git"], repo, REMOTE_REF)
-
-    assert ok, detail
-    _assert_clean_at(repo, rewritten)
-    assert not (repo / "obsolete.txt").exists()

--- a/tests/hermes_cli/test_update_carried_commits.py
+++ b/tests/hermes_cli/test_update_carried_commits.py
@@ -6,10 +6,20 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from hermes_cli.update_cmd import _recover_diverged_update
 
 GIT = ["git", "-c", "user.name=Hermes Test", "-c", "user.email=test@example.invalid"]
 REMOTE_REF = "refs/remotes/origin/main"
+
+
+@pytest.fixture(autouse=True)
+def _require_explicit_git_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Match CI hosts where Git cannot synthesize a committer identity."""
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", "user.useConfigOnly")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", "true")
 
 
 def _git(
@@ -83,6 +93,9 @@ def test_rewritten_upstream_preserves_only_genuine_local_commit(tmp_path: Path) 
     assert _git(
         repo, "log", "--format=%s", f"{rewritten}..HEAD"
     ).stdout.splitlines() == ["genuine local commit"]
+    assert _git(repo, "log", "--format=%an <%ae>", f"{rewritten}..HEAD").stdout.strip() == (
+        "Hermes Test <test@example.invalid>"
+    )
     assert not (repo / "obsolete.txt").exists()
     assert (repo / "local.txt").read_text(encoding="utf-8") == "local\n"
 

--- a/tests/test_install_diverged_update.py
+++ b/tests/test_install_diverged_update.py
@@ -358,48 +358,6 @@ recover_diverged_update refs/remotes/origin/main
     assert not _git(repo, "status", "--porcelain").stdout
 
 
-def test_installers_fail_closed_and_use_reflog_bounded_topology_rebase() -> None:
-    sh_helper = _extract_sh_function("recover_diverged_update")
-    sh_source = INSTALL_SH.read_text(encoding="utf-8")
-    assert 'git merge-base --fork-point "$remote_ref" HEAD' in sh_helper
-    assert 'git rev-list --count "$fork_point..HEAD"' in sh_helper
-    assert 'mktemp "$count_dir/hermes-commit-count.XXXXXXXXXX"' in sh_helper
-    assert 'IFS= read -r local_commits <&9' in sh_helper
-    assert 'IFS= read -r second_record <&9' in sh_helper
-    assert 'exec 9<&-' in sh_helper
-    assert "999999999" in sh_helper
-    assert '${#local_commits}' in sh_helper
-    assert 'git rev-list --merges "$fork_point..HEAD"' in sh_helper
-    assert "git diff-tree --cc" in sh_helper
-    assert 'git rebase --rebase-merges --onto "$remote_ref" "$fork_point"' in sh_helper
-    assert '"$fork_point" HEAD' not in sh_helper
-    assert "git rebase --abort" in sh_helper
-    assert 'git reset --hard "$remote_ref"' in sh_helper
-    assert 'recover_diverged_update "origin/$BRANCH"' in sh_source
-
-    ps_helper = _extract_ps_function("Recover-DivergedUpdate")
-    ps_source = INSTALL_PS1.read_text(encoding="ascii")
-    assert "merge-base --fork-point $RemoteRef HEAD" in ps_helper
-    assert 'rev-list --count "$forkPoint..HEAD"' in ps_helper
-    assert "if ($countExit -ne 0)" in ps_helper
-    assert "$localCommitOutput.Count -ne 1" in ps_helper
-    assert "$localCommitText -notmatch '^[0-9]+$'" in ps_helper
-    assert "$localCommitText.Length -gt 9" in ps_helper
-    assert "[int]::TryParse($localCommitText" in ps_helper
-    count_parse_block = ps_helper[
-        ps_helper.index("$localCommitText =") : ps_helper.index("if ($localCommitCount -eq 0)")
-    ]
-    assert ".Trim()" not in count_parse_block
-    assert "-join" not in count_parse_block
-    assert 'rev-list --merges "$forkPoint..HEAD"' in ps_helper
-    assert "diff-tree --cc" in ps_helper
-    assert "rebase --rebase-merges --onto $RemoteRef $forkPoint" in ps_helper
-    assert "$forkPoint HEAD" not in ps_helper
-    assert "rebase --abort" in ps_helper
-    assert 'reset --hard "$RemoteRef"' in ps_helper
-    assert 'Recover-DivergedUpdate "origin/$Branch"' in ps_source
-
-
 @pytest.mark.skipif(
     not any(shutil.which(name) for name in ("pwsh", "powershell")),
     reason="PowerShell is not available",

--- a/tests/test_install_diverged_update.py
+++ b/tests/test_install_diverged_update.py
@@ -1,67 +1,544 @@
-"""Regression: installer/bootstrap must recover from diverged managed clones.
-
-When ``~/.hermes/hermes-agent`` has local-only commits (or diverged history),
-``git pull --ff-only`` fails with exit 128 and bootstrap aborts at the
-repository stage. ``hermes update`` already resets to ``origin/$BRANCH`` in
-that case; both installer scripts must do the same.
-
-Fixes the bootstrap failure seen in #53257 and desktop update paths that run
-``install.ps1`` / ``install.sh`` non-interactively.
-"""
+"""Managed installers preserve unique local commits on divergent updates."""
 
 from __future__ import annotations
 
+import os
 import re
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+GIT = ["git", "-c", "user.name=Hermes Test", "-c", "user.email=test@example.invalid"]
 
 
-def _extract_install_sh_update_block() -> str:
-    text = INSTALL_SH.read_text()
+def _extract_sh_function(name: str) -> str:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    match = re.search(rf"^{re.escape(name)}\(\) \{{.*?^\}}", text, re.MULTILINE | re.DOTALL)
+    assert match is not None, f"{name}() not found in install.sh"
+    return match.group(0)
+
+
+def _extract_ps_function(name: str) -> str:
+    text = INSTALL_PS1.read_text(encoding="ascii")
     match = re.search(
-        r"(?P<block>git checkout \"\$BRANCH\".*?fi\n\n            if \[ -n \"\$autostash_ref\" \])",
-        text,
-        re.DOTALL,
+        rf"^function {re.escape(name)} \{{.*?^\}}", text, re.MULTILINE | re.DOTALL
     )
-    assert match is not None, "managed-install update block not found in install.sh"
-    return match["block"]
+    assert match is not None, f"{name} not found in install.ps1"
+    return match.group(0)
 
 
-def _extract_install_ps1_branch_update_block() -> str:
-    text = INSTALL_PS1.read_text()
-    match = re.search(
-        r"(?P<block>git -c windows\.appendAtomically=false checkout \$Branch.*?elseif \(\$Tag\))",
-        text,
-        re.DOTALL,
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    home = repo.parent / "home"
+    home.mkdir(exist_ok=True)
+    env = {**os.environ, "HOME": str(home), "HERMES_HOME": str(home / ".hermes")}
+    return subprocess.run(
+        GIT + list(args),
+        cwd=repo,
+        env=env,
+        check=check,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
     )
-    assert match is not None, "branch update block not found in install.ps1"
-    return match["block"]
 
 
-def test_install_sh_resets_when_ff_only_pull_fails() -> None:
-    block = _extract_install_sh_update_block()
-
-    assert 'git pull --ff-only origin "$BRANCH"' in block
-    assert 'git reset --hard "origin/$BRANCH"' in block
-    assert "Fast-forward not possible" in block
-
-    pull_idx = block.find('git pull --ff-only origin "$BRANCH"')
-    reset_idx = block.find('git reset --hard "origin/$BRANCH"')
-    assert pull_idx != -1 and reset_idx != -1
-    assert pull_idx < reset_idx, "ff-only pull must be attempted before reset fallback"
+def _init_git_repo(repo: Path) -> None:
+    """Create a repo whose rebases do not depend on the host's Git identity."""
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Hermes Test")
+    _git(repo, "config", "user.email", "test@example.invalid")
 
 
-def test_install_ps1_resets_when_ff_only_pull_fails() -> None:
-    block = _extract_install_ps1_branch_update_block()
+def _write_commit(repo: Path, path: str, text: str, message: str) -> str:
+    (repo / path).write_text(text, encoding="utf-8")
+    _git(repo, "add", path)
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
 
-    assert "pull --ff-only origin $Branch" in block
-    assert 'reset --hard "origin/$Branch"' in block
-    assert "Fast-forward not possible" in block
 
-    pull_idx = block.find("pull --ff-only origin $Branch")
-    reset_idx = block.find('reset --hard "origin/$Branch"')
-    assert pull_idx != -1 and reset_idx != -1
-    assert pull_idx < reset_idx, "ff-only pull must be attempted before reset fallback"
+def _diverged_repo(tmp_path: Path, *, conflict: bool = False) -> tuple[Path, str, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    _write_commit(repo, "tracked.txt", "base\n", "base")
+    _git(repo, "branch", "remote-main")
+    local_sha = _write_commit(
+        repo,
+        "tracked.txt",
+        "local\n" if conflict else "base\nlocal\n",
+        "local carried fix",
+    )
+    _git(repo, "checkout", "remote-main")
+    if conflict:
+        remote_sha = _write_commit(repo, "tracked.txt", "remote\n", "remote conflict")
+    else:
+        remote_sha = _write_commit(repo, "remote.txt", "remote\n", "remote change")
+    _git(repo, "checkout", "main")
+    return repo, local_sha, remote_sha
+
+
+def _run_sh_recovery(
+    repo: Path, *, fail_count: bool = False, count_output: bytes | None = None
+) -> subprocess.CompletedProcess[str]:
+    git_wrapper = """
+git() {
+    if [ "$1" = "rev-list" ]; then
+        return 128
+    fi
+    command git "$@"
+}
+""" if fail_count else ""
+    script = f"""
+log_info() {{ :; }}
+log_warn() {{ :; }}
+log_error() {{ :; }}
+{git_wrapper}
+{_extract_sh_function("recover_diverged_update")}
+recover_diverged_update remote-main
+"""
+    home = repo.parent / "home"
+    temp_dir = repo.parent / "tmp"
+    temp_dir.mkdir(exist_ok=True)
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "HERMES_HOME": str(home / ".hermes"),
+        "TMPDIR": str(temp_dir),
+    }
+    if count_output is not None:
+        fake_bin = repo.parent / "fake-bin"
+        fake_bin.mkdir()
+        count_file = fake_bin / "count-output"
+        count_file.write_bytes(count_output)
+        wrapper = fake_bin / "git"
+        wrapper.write_text(
+            """#!/bin/sh
+saw_rev_list=false
+saw_count=false
+for arg do
+    [ "$arg" = "rev-list" ] && saw_rev_list=true
+    [ "$arg" = "--count" ] && saw_count=true
+done
+if [ "$saw_rev_list" = true ] && [ "$saw_count" = true ]; then
+    cat "$HERMES_FAKE_COUNT"
+    exit 0
+fi
+exec "$HERMES_REAL_GIT" "$@"
+""",
+            encoding="ascii",
+        )
+        wrapper.chmod(0o755)
+        env.update(
+            {
+                "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+                "HERMES_FAKE_COUNT": str(count_file),
+                "HERMES_REAL_GIT": shutil.which("git") or "git",
+            }
+        )
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def test_install_sh_rebases_local_commit_onto_remote(tmp_path: Path) -> None:
+    repo, _local_sha, remote_sha = _diverged_repo(tmp_path)
+
+    result = _run_sh_recovery(repo)
+
+    assert result.returncode == 0, result.stderr
+    assert _git(repo, "merge-base", "--is-ancestor", remote_sha, "HEAD").returncode == 0
+    assert _git(repo, "log", "-1", "--format=%s").stdout.strip() == "local carried fix"
+    assert not _git(repo, "status", "--porcelain").stdout
+
+
+def test_install_sh_conflict_aborts_and_restores_original_head(tmp_path: Path) -> None:
+    repo, local_sha, _remote_sha = _diverged_repo(tmp_path, conflict=True)
+
+    result = _run_sh_recovery(repo)
+
+    assert result.returncode != 0
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == local_sha
+    assert not _git(repo, "status", "--porcelain").stdout
+    assert not (repo / ".git" / "rebase-merge").exists()
+    assert not (repo / ".git" / "rebase-apply").exists()
+
+
+def test_install_sh_no_local_commit_uses_reset(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    _write_commit(repo, "tracked.txt", "base\n", "base")
+    _git(repo, "branch", "remote-main")
+    _git(repo, "checkout", "remote-main")
+    remote_sha = _write_commit(repo, "remote.txt", "remote\n", "remote change")
+    _git(repo, "checkout", "main")
+
+    result = _run_sh_recovery(repo)
+
+    assert result.returncode == 0, result.stderr
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == remote_sha
+
+
+def test_install_sh_count_failure_fails_closed(tmp_path: Path) -> None:
+    repo, local_sha, _remote_sha = _diverged_repo(tmp_path)
+
+    result = _run_sh_recovery(repo, fail_count=True)
+
+    assert result.returncode == 128
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == local_sha
+    assert not _git(repo, "status", "--porcelain").stdout
+    assert not any((tmp_path / "tmp").iterdir())
+
+
+@pytest.mark.parametrize(
+    "count_output",
+    [b"1\n", b"1", b"000000001\n"],
+    ids=["terminated", "unterminated", "nine-digit-zero-padded"],
+)
+def test_install_sh_exact_single_count_record_rebases(
+    count_output: bytes, tmp_path: Path
+) -> None:
+    repo, local_sha, remote_sha = _diverged_repo(tmp_path)
+
+    result = _run_sh_recovery(repo, count_output=count_output)
+
+    assert result.returncode == 0, result.stderr
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() != local_sha
+    assert _git(repo, "merge-base", "--is-ancestor", remote_sha, "HEAD").returncode == 0
+    assert _git(repo, "log", "-1", "--format=%s").stdout.strip() == "local carried fix"
+    assert not _git(repo, "status", "--porcelain").stdout
+    assert not any((tmp_path / "tmp").iterdir())
+
+
+@pytest.mark.parametrize(
+    "count_output",
+    [b"0\n", b"0", b"000000000\n"],
+    ids=["terminated", "unterminated", "nine-digit-all-zero"],
+)
+def test_install_sh_exact_zero_count_record_resets(
+    count_output: bytes, tmp_path: Path
+) -> None:
+    repo, _local_sha, remote_sha = _diverged_repo(tmp_path)
+
+    result = _run_sh_recovery(repo, count_output=count_output)
+
+    assert result.returncode == 0, result.stderr
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == remote_sha
+    assert not _git(repo, "status", "--porcelain").stdout
+    assert not any((tmp_path / "tmp").iterdir())
+
+
+@pytest.mark.parametrize(
+    "count_output",
+    [
+        b"+1\n",
+        b"-1\n",
+        b" 1 \n",
+        b"1x\n",
+        b"",
+        b"1000000000\n",
+        b"9" * 36 + b"\n",
+        b"0000000001\n",
+        b"0000000000\n",
+        b"0" * 4301 + b"1\n",
+        b"0" * 4301 + b"0\n",
+        b"1\n2\n",
+        b"1\n\n",
+        b"1\n\n\n",
+        b"1\n2",
+        "\u0661\n".encode(),
+    ],
+    ids=[
+        "positive-sign",
+        "negative-sign",
+        "padded",
+        "suffix",
+        "empty",
+        "over-bound",
+        "oversized",
+        "ten-digit-zero-padded-one",
+        "ten-digit-all-zero",
+        "giant-zero-padded-one",
+        "giant-all-zero",
+        "multiple-records",
+        "second-empty-record",
+        "double-trailing-empty-records",
+        "partial-second-record",
+        "non-ascii-digit",
+    ],
+)
+def test_install_sh_malformed_count_matrix_fails_closed(
+    count_output: bytes, tmp_path: Path
+) -> None:
+    repo, local_sha, _remote_sha = _diverged_repo(tmp_path)
+
+    result = _run_sh_recovery(repo, count_output=count_output)
+
+    assert result.returncode != 0
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == local_sha
+    assert not _git(repo, "status", "--porcelain").stdout
+    assert not any((tmp_path / "tmp").iterdir())
+
+
+def test_install_sh_rebases_only_actual_local_commit_after_force_push(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    base = _write_commit(repo, "tracked.txt", "base\n", "base")
+    _git(repo, "update-ref", "--create-reflog", "refs/remotes/origin/main", base)
+    old_upstream = _write_commit(repo, "obsolete.txt", "obsolete\n", "discarded upstream")
+    _git(repo, "update-ref", "refs/remotes/origin/main", old_upstream)
+    _write_commit(repo, "local.txt", "local\n", "actual local commit")
+    _git(repo, "checkout", "-b", "rewritten", base)
+    rewritten = _write_commit(repo, "replacement.txt", "replacement\n", "rewritten upstream")
+    _git(repo, "update-ref", "refs/remotes/origin/main", rewritten)
+    _git(repo, "checkout", "main")
+    _git(repo, "branch", "-D", "rewritten")
+
+    script = f"""
+log_info() {{ :; }}
+log_warn() {{ :; }}
+log_error() {{ :; }}
+{_extract_sh_function("recover_diverged_update")}
+recover_diverged_update refs/remotes/origin/main
+"""
+    result = subprocess.run(["bash", "-c", script], cwd=repo, capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stderr
+    subjects = _git(repo, "log", "--format=%s", f"{rewritten}..HEAD").stdout.splitlines()
+    assert subjects == ["actual local commit"]
+    assert _git(repo, "branch", "--show-current").stdout.strip() == "main"
+    assert not (repo / "obsolete.txt").exists()
+
+
+def test_install_sh_merge_only_payload_fails_closed(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    base = _write_commit(repo, "tracked.txt", "base\n", "base")
+    _git(repo, "update-ref", "--create-reflog", "refs/remotes/origin/main", base)
+    _write_commit(repo, "main.txt", "main\n", "main local")
+    _git(repo, "checkout", "-b", "side", base)
+    _write_commit(repo, "side.txt", "side\n", "side local")
+    _git(repo, "checkout", "main")
+    _git(repo, "merge", "--no-ff", "--no-commit", "side")
+    (repo / "payload.txt").write_text("must survive\n", encoding="utf-8")
+    _git(repo, "add", "payload.txt")
+    _git(repo, "commit", "-m", "merge payload")
+    original = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    _git(repo, "checkout", "-b", "remote-work", base)
+    remote = _write_commit(repo, "remote.txt", "remote\n", "remote change")
+    _git(repo, "update-ref", "refs/remotes/origin/main", remote)
+    _git(repo, "checkout", "main")
+
+    script = f"""
+log_info() {{ :; }}
+log_warn() {{ :; }}
+log_error() {{ :; }}
+{_extract_sh_function("recover_diverged_update")}
+recover_diverged_update refs/remotes/origin/main
+"""
+    result = subprocess.run(["bash", "-c", script], cwd=repo, capture_output=True, text=True)
+
+    assert result.returncode != 0
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == original
+    assert (repo / "payload.txt").read_text(encoding="utf-8") == "must survive\n"
+    assert not _git(repo, "status", "--porcelain").stdout
+
+
+def test_installers_fail_closed_and_use_reflog_bounded_topology_rebase() -> None:
+    sh_helper = _extract_sh_function("recover_diverged_update")
+    sh_source = INSTALL_SH.read_text(encoding="utf-8")
+    assert 'git merge-base --fork-point "$remote_ref" HEAD' in sh_helper
+    assert 'git rev-list --count "$fork_point..HEAD"' in sh_helper
+    assert 'mktemp "$count_dir/hermes-commit-count.XXXXXXXXXX"' in sh_helper
+    assert 'IFS= read -r local_commits <&9' in sh_helper
+    assert 'IFS= read -r second_record <&9' in sh_helper
+    assert 'exec 9<&-' in sh_helper
+    assert "999999999" in sh_helper
+    assert '${#local_commits}' in sh_helper
+    assert 'git rev-list --merges "$fork_point..HEAD"' in sh_helper
+    assert "git diff-tree --cc" in sh_helper
+    assert 'git rebase --rebase-merges --onto "$remote_ref" "$fork_point"' in sh_helper
+    assert '"$fork_point" HEAD' not in sh_helper
+    assert "git rebase --abort" in sh_helper
+    assert 'git reset --hard "$remote_ref"' in sh_helper
+    assert 'recover_diverged_update "origin/$BRANCH"' in sh_source
+
+    ps_helper = _extract_ps_function("Recover-DivergedUpdate")
+    ps_source = INSTALL_PS1.read_text(encoding="ascii")
+    assert "merge-base --fork-point $RemoteRef HEAD" in ps_helper
+    assert 'rev-list --count "$forkPoint..HEAD"' in ps_helper
+    assert "if ($countExit -ne 0)" in ps_helper
+    assert "$localCommitOutput.Count -ne 1" in ps_helper
+    assert "$localCommitText -notmatch '^[0-9]+$'" in ps_helper
+    assert "$localCommitText.Length -gt 9" in ps_helper
+    assert "[int]::TryParse($localCommitText" in ps_helper
+    count_parse_block = ps_helper[
+        ps_helper.index("$localCommitText =") : ps_helper.index("if ($localCommitCount -eq 0)")
+    ]
+    assert ".Trim()" not in count_parse_block
+    assert "-join" not in count_parse_block
+    assert 'rev-list --merges "$forkPoint..HEAD"' in ps_helper
+    assert "diff-tree --cc" in ps_helper
+    assert "rebase --rebase-merges --onto $RemoteRef $forkPoint" in ps_helper
+    assert "$forkPoint HEAD" not in ps_helper
+    assert "rebase --abort" in ps_helper
+    assert 'reset --hard "$RemoteRef"' in ps_helper
+    assert 'Recover-DivergedUpdate "origin/$Branch"' in ps_source
+
+
+@pytest.mark.skipif(
+    not any(shutil.which(name) for name in ("pwsh", "powershell")),
+    reason="PowerShell is not available",
+)
+@pytest.mark.parametrize(
+    ("count_output", "expected"),
+    [
+        (b"1\n", "rebase"),
+        (b"1", "rebase"),
+        (b"0\n", "reset"),
+        (b"0", "reset"),
+        (b"000000001\n", "rebase"),
+        (b"000000000\n", "reset"),
+        (b"+1\n", "reject"),
+        (b"-1\n", "reject"),
+        (b" 1 \n", "reject"),
+        (b"1x\n", "reject"),
+        (b"", "reject"),
+        (b"1000000000\n", "reject"),
+        (b"9" * 36 + b"\n", "reject"),
+        (b"0000000001\n", "reject"),
+        (b"0000000000\n", "reject"),
+        (b"0" * 4301 + b"1\n", "reject"),
+        (b"0" * 4301 + b"0\n", "reject"),
+        (b"1\n2\n", "reject"),
+    ],
+    ids=[
+        "one-terminated",
+        "one-unterminated",
+        "zero-terminated",
+        "zero-unterminated",
+        "nine-digit-zero-padded-one",
+        "nine-digit-all-zero",
+        "positive-sign",
+        "negative-sign",
+        "padded",
+        "suffix",
+        "empty",
+        "over-bound",
+        "oversized",
+        "ten-digit-zero-padded-one",
+        "ten-digit-all-zero",
+        "giant-zero-padded-one",
+        "giant-all-zero",
+        "multiple-records",
+    ],
+)
+def test_install_ps1_count_contract(
+    count_output: bytes, expected: str, tmp_path: Path
+) -> None:
+    """Exercise the real PowerShell helper with an executable git proxy when available."""
+    repo, local_sha, remote_sha = _diverged_repo(tmp_path)
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    count_file = fake_bin / "count-output"
+    count_file.write_bytes(count_output)
+    if os.name == "nt":
+        (fake_bin / "git.cmd").write_text(
+            """@echo off
+echo %* | findstr /C:" rev-list " >nul || goto realgit
+echo %* | findstr /C:" --count " >nul || goto realgit
+type "%HERMES_FAKE_COUNT%"
+exit /b 0
+:realgit
+"%HERMES_REAL_GIT%" %*
+""",
+            encoding="ascii",
+        )
+    else:
+        wrapper = fake_bin / "git"
+        wrapper.write_text(
+            """#!/bin/sh
+saw_rev_list=false
+saw_count=false
+for arg do
+    [ "$arg" = "rev-list" ] && saw_rev_list=true
+    [ "$arg" = "--count" ] && saw_count=true
+done
+if [ "$saw_rev_list" = true ] && [ "$saw_count" = true ]; then
+    cat "$HERMES_FAKE_COUNT"
+    exit 0
+fi
+exec "$HERMES_REAL_GIT" "$@"
+""",
+            encoding="ascii",
+        )
+        wrapper.chmod(0o755)
+
+    host = next(
+        shutil.which(name) for name in ("pwsh", "powershell") if shutil.which(name)
+    )
+    assert host is not None
+    command = f"""
+function Write-Info {{ param([string]$Message) }}
+function Write-Err {{ param([string]$Message) }}
+{_extract_ps_function("Recover-DivergedUpdate")}
+try {{ Recover-DivergedUpdate 'remote-main'; exit 0 }} catch {{ [Console]::Error.WriteLine($_); exit 1 }}
+"""
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "HERMES_FAKE_COUNT": str(count_file),
+        "HERMES_REAL_GIT": shutil.which("git") or "git",
+    }
+    result = subprocess.run(
+        [host, "-NoProfile", "-Command", command],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+    if expected == "reject":
+        assert result.returncode != 0
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == local_sha
+    elif expected == "rebase":
+        assert result.returncode == 0, result.stderr
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() != local_sha
+        assert _git(repo, "merge-base", "--is-ancestor", remote_sha, "HEAD").returncode == 0
+    else:
+        assert expected == "reset"
+        assert result.returncode == 0, result.stderr
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == remote_sha
+    assert not _git(repo, "status", "--porcelain").stdout
+
+
+@pytest.mark.skipif(
+    not any(shutil.which(name) for name in ("pwsh", "powershell")),
+    reason="PowerShell is not available",
+)
+def test_install_ps1_parses() -> None:
+    host = next(shutil.which(name) for name in ("pwsh", "powershell") if shutil.which(name))
+    result = subprocess.run(
+        [host, "-NoProfile", "-Command", f"[scriptblock]::Create((Get-Content -Raw '{INSTALL_PS1}')) | Out-Null"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_install_diverged_update.py
+++ b/tests/test_install_diverged_update.py
@@ -1,45 +1,30 @@
-"""Managed installers preserve unique local commits on divergent updates."""
+"""Behavioral installer regressions for divergent managed clones."""
 
 from __future__ import annotations
 
 import os
-import re
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Callable
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
-INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = ROOT / "scripts" / "install.ps1"
 GIT = ["git", "-c", "user.name=Hermes Test", "-c", "user.email=test@example.invalid"]
 
 
-def _extract_sh_function(name: str) -> str:
-    text = INSTALL_SH.read_text(encoding="utf-8")
-    match = re.search(rf"^{re.escape(name)}\(\) \{{.*?^\}}", text, re.MULTILINE | re.DOTALL)
-    assert match is not None, f"{name}() not found in install.sh"
-    return match.group(0)
-
-
-def _extract_ps_function(name: str) -> str:
-    text = INSTALL_PS1.read_text(encoding="ascii")
-    match = re.search(
-        rf"^function {re.escape(name)} \{{.*?^\}}", text, re.MULTILINE | re.DOTALL
-    )
-    assert match is not None, f"{name} not found in install.ps1"
-    return match.group(0)
-
-
-def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+def _git(
+    repo: Path, *args: str, check: bool = True
+) -> subprocess.CompletedProcess[str]:
     home = repo.parent / "home"
     home.mkdir(exist_ok=True)
-    env = {**os.environ, "HOME": str(home), "HERMES_HOME": str(home / ".hermes")}
     return subprocess.run(
         GIT + list(args),
         cwd=repo,
-        env=env,
+        env={**os.environ, "HOME": str(home), "HERMES_HOME": str(home / ".hermes")},
         check=check,
         capture_output=True,
         text=True,
@@ -48,103 +33,58 @@ def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProc
     )
 
 
-def _init_git_repo(repo: Path) -> None:
-    """Create a repo whose rebases do not depend on the host's Git identity."""
-    _git(repo, "init", "-b", "main")
-    _git(repo, "config", "user.name", "Hermes Test")
-    _git(repo, "config", "user.email", "test@example.invalid")
-
-
-def _write_commit(repo: Path, path: str, text: str, message: str) -> str:
-    (repo / path).write_text(text, encoding="utf-8")
+def _commit(repo: Path, path: str, text: str, message: str) -> str:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
     _git(repo, "add", path)
     _git(repo, "commit", "-m", message)
     return _git(repo, "rev-parse", "HEAD").stdout.strip()
 
 
-def _diverged_repo(tmp_path: Path, *, conflict: bool = False) -> tuple[Path, str, str]:
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _init_git_repo(repo)
-    _write_commit(repo, "tracked.txt", "base\n", "base")
-    _git(repo, "branch", "remote-main")
-    local_sha = _write_commit(
-        repo,
-        "tracked.txt",
-        "local\n" if conflict else "base\nlocal\n",
-        "local carried fix",
+def _managed_clone(tmp_path: Path) -> tuple[Path, Path, str]:
+    origin = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    install = tmp_path / "install"
+    _git(tmp_path, "init", "--bare", str(origin))
+    seed.mkdir()
+    _git(seed, "init", "-b", "main")
+    base = _commit(seed, "tracked.txt", "base\n", "base")
+    _git(seed, "remote", "add", "origin", str(origin))
+    _git(seed, "push", "-u", "origin", "main")
+    _git(tmp_path, "clone", "--branch", "main", str(origin), str(install))
+    return seed, install, base
+
+
+def _rewrite_remote(seed: Path, base: str, *, conflict: bool = False) -> str:
+    _git(seed, "reset", "--hard", base)
+    remote = _commit(
+        seed,
+        "tracked.txt" if conflict else "replacement.txt",
+        "remote\n",
+        "rewritten upstream",
     )
-    _git(repo, "checkout", "remote-main")
-    if conflict:
-        remote_sha = _write_commit(repo, "tracked.txt", "remote\n", "remote conflict")
-    else:
-        remote_sha = _write_commit(repo, "remote.txt", "remote\n", "remote change")
-    _git(repo, "checkout", "main")
-    return repo, local_sha, remote_sha
+    _git(seed, "push", "--force", "origin", "main")
+    return remote
 
 
-def _run_sh_recovery(
-    repo: Path, *, fail_count: bool = False, count_output: bytes | None = None
-) -> subprocess.CompletedProcess[str]:
-    git_wrapper = """
-git() {
-    if [ "$1" = "rev-list" ]; then
-        return 128
-    fi
-    command git "$@"
-}
-""" if fail_count else ""
-    script = f"""
-log_info() {{ :; }}
-log_warn() {{ :; }}
-log_error() {{ :; }}
-{git_wrapper}
-{_extract_sh_function("recover_diverged_update")}
-recover_diverged_update remote-main
-"""
-    home = repo.parent / "home"
-    temp_dir = repo.parent / "tmp"
-    temp_dir.mkdir(exist_ok=True)
-    env = {
-        **os.environ,
-        "HOME": str(home),
-        "HERMES_HOME": str(home / ".hermes"),
-        "TMPDIR": str(temp_dir),
-    }
-    if count_output is not None:
-        fake_bin = repo.parent / "fake-bin"
-        fake_bin.mkdir()
-        count_file = fake_bin / "count-output"
-        count_file.write_bytes(count_output)
-        wrapper = fake_bin / "git"
-        wrapper.write_text(
-            """#!/bin/sh
-saw_rev_list=false
-saw_count=false
-for arg do
-    [ "$arg" = "rev-list" ] && saw_rev_list=true
-    [ "$arg" = "--count" ] && saw_count=true
-done
-if [ "$saw_rev_list" = true ] && [ "$saw_count" = true ]; then
-    cat "$HERMES_FAKE_COUNT"
-    exit 0
-fi
-exec "$HERMES_REAL_GIT" "$@"
-""",
-            encoding="ascii",
-        )
-        wrapper.chmod(0o755)
-        env.update(
-            {
-                "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
-                "HERMES_FAKE_COUNT": str(count_file),
-                "HERMES_REAL_GIT": shutil.which("git") or "git",
-            }
-        )
+def _run_sh(install: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["bash", "-c", script],
-        cwd=repo,
-        env=env,
+        [
+            "bash",
+            str(INSTALL_SH),
+            "--stage",
+            "repository",
+            "--branch",
+            "main",
+            "--dir",
+            str(install),
+            "--hermes-home",
+            str(install.parent / "home"),
+            "--non-interactive",
+        ],
+        cwd=install.parent,
+        env={**os.environ, "HOME": str(install.parent / "home")},
         capture_output=True,
         text=True,
         encoding="utf-8",
@@ -152,351 +92,117 @@ exec "$HERMES_REAL_GIT" "$@"
     )
 
 
-def test_install_sh_rebases_local_commit_onto_remote(tmp_path: Path) -> None:
-    repo, _local_sha, remote_sha = _diverged_repo(tmp_path)
-
-    result = _run_sh_recovery(repo)
-
-    assert result.returncode == 0, result.stderr
-    assert _git(repo, "merge-base", "--is-ancestor", remote_sha, "HEAD").returncode == 0
-    assert _git(repo, "log", "-1", "--format=%s").stdout.strip() == "local carried fix"
-    assert not _git(repo, "status", "--porcelain").stdout
-
-
-def test_install_sh_conflict_aborts_and_restores_original_head(tmp_path: Path) -> None:
-    repo, local_sha, _remote_sha = _diverged_repo(tmp_path, conflict=True)
-
-    result = _run_sh_recovery(repo)
-
-    assert result.returncode != 0
-    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == local_sha
-    assert not _git(repo, "status", "--porcelain").stdout
-    assert not (repo / ".git" / "rebase-merge").exists()
-    assert not (repo / ".git" / "rebase-apply").exists()
-
-
-def test_install_sh_no_local_commit_uses_reset(tmp_path: Path) -> None:
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _init_git_repo(repo)
-    _write_commit(repo, "tracked.txt", "base\n", "base")
-    _git(repo, "branch", "remote-main")
-    _git(repo, "checkout", "remote-main")
-    remote_sha = _write_commit(repo, "remote.txt", "remote\n", "remote change")
-    _git(repo, "checkout", "main")
-
-    result = _run_sh_recovery(repo)
-
-    assert result.returncode == 0, result.stderr
-    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == remote_sha
-
-
-def test_install_sh_count_failure_fails_closed(tmp_path: Path) -> None:
-    repo, local_sha, _remote_sha = _diverged_repo(tmp_path)
-
-    result = _run_sh_recovery(repo, fail_count=True)
-
-    assert result.returncode == 128
-    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == local_sha
-    assert not _git(repo, "status", "--porcelain").stdout
-    assert not any((tmp_path / "tmp").iterdir())
-
-
-@pytest.mark.parametrize(
-    "count_output",
-    [b"1\n", b"1", b"000000001\n"],
-    ids=["terminated", "unterminated", "nine-digit-zero-padded"],
-)
-def test_install_sh_exact_single_count_record_rebases(
-    count_output: bytes, tmp_path: Path
-) -> None:
-    repo, local_sha, remote_sha = _diverged_repo(tmp_path)
-
-    result = _run_sh_recovery(repo, count_output=count_output)
-
-    assert result.returncode == 0, result.stderr
-    assert _git(repo, "rev-parse", "HEAD").stdout.strip() != local_sha
-    assert _git(repo, "merge-base", "--is-ancestor", remote_sha, "HEAD").returncode == 0
-    assert _git(repo, "log", "-1", "--format=%s").stdout.strip() == "local carried fix"
-    assert not _git(repo, "status", "--porcelain").stdout
-    assert not any((tmp_path / "tmp").iterdir())
-
-
-@pytest.mark.parametrize(
-    "count_output",
-    [b"0\n", b"0", b"000000000\n"],
-    ids=["terminated", "unterminated", "nine-digit-all-zero"],
-)
-def test_install_sh_exact_zero_count_record_resets(
-    count_output: bytes, tmp_path: Path
-) -> None:
-    repo, _local_sha, remote_sha = _diverged_repo(tmp_path)
-
-    result = _run_sh_recovery(repo, count_output=count_output)
-
-    assert result.returncode == 0, result.stderr
-    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == remote_sha
-    assert not _git(repo, "status", "--porcelain").stdout
-    assert not any((tmp_path / "tmp").iterdir())
-
-
-@pytest.mark.parametrize(
-    "count_output",
-    [
-        b"+1\n",
-        b"-1\n",
-        b" 1 \n",
-        b"1x\n",
-        b"",
-        b"1000000000\n",
-        b"9" * 36 + b"\n",
-        b"0000000001\n",
-        b"0000000000\n",
-        b"0" * 4301 + b"1\n",
-        b"0" * 4301 + b"0\n",
-        b"1\n2\n",
-        b"1\n\n",
-        b"1\n\n\n",
-        b"1\n2",
-        "\u0661\n".encode(),
-    ],
-    ids=[
-        "positive-sign",
-        "negative-sign",
-        "padded",
-        "suffix",
-        "empty",
-        "over-bound",
-        "oversized",
-        "ten-digit-zero-padded-one",
-        "ten-digit-all-zero",
-        "giant-zero-padded-one",
-        "giant-all-zero",
-        "multiple-records",
-        "second-empty-record",
-        "double-trailing-empty-records",
-        "partial-second-record",
-        "non-ascii-digit",
-    ],
-)
-def test_install_sh_malformed_count_matrix_fails_closed(
-    count_output: bytes, tmp_path: Path
-) -> None:
-    repo, local_sha, _remote_sha = _diverged_repo(tmp_path)
-
-    result = _run_sh_recovery(repo, count_output=count_output)
-
-    assert result.returncode != 0
-    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == local_sha
-    assert not _git(repo, "status", "--porcelain").stdout
-    assert not any((tmp_path / "tmp").iterdir())
-
-
-def test_install_sh_rebases_only_actual_local_commit_after_force_push(tmp_path: Path) -> None:
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _init_git_repo(repo)
-    base = _write_commit(repo, "tracked.txt", "base\n", "base")
-    _git(repo, "update-ref", "--create-reflog", "refs/remotes/origin/main", base)
-    old_upstream = _write_commit(repo, "obsolete.txt", "obsolete\n", "discarded upstream")
-    _git(repo, "update-ref", "refs/remotes/origin/main", old_upstream)
-    _write_commit(repo, "local.txt", "local\n", "actual local commit")
-    _git(repo, "checkout", "-b", "rewritten", base)
-    rewritten = _write_commit(repo, "replacement.txt", "replacement\n", "rewritten upstream")
-    _git(repo, "update-ref", "refs/remotes/origin/main", rewritten)
-    _git(repo, "checkout", "main")
-    _git(repo, "branch", "-D", "rewritten")
-
-    script = f"""
-log_info() {{ :; }}
-log_warn() {{ :; }}
-log_error() {{ :; }}
-{_extract_sh_function("recover_diverged_update")}
-recover_diverged_update refs/remotes/origin/main
-"""
-    result = subprocess.run(["bash", "-c", script], cwd=repo, capture_output=True, text=True)
-
-    assert result.returncode == 0, result.stderr
-    subjects = _git(repo, "log", "--format=%s", f"{rewritten}..HEAD").stdout.splitlines()
-    assert subjects == ["actual local commit"]
-    assert _git(repo, "branch", "--show-current").stdout.strip() == "main"
-    assert not (repo / "obsolete.txt").exists()
-
-
-def test_install_sh_merge_only_payload_fails_closed(tmp_path: Path) -> None:
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _init_git_repo(repo)
-    base = _write_commit(repo, "tracked.txt", "base\n", "base")
-    _git(repo, "update-ref", "--create-reflog", "refs/remotes/origin/main", base)
-    _write_commit(repo, "main.txt", "main\n", "main local")
-    _git(repo, "checkout", "-b", "side", base)
-    _write_commit(repo, "side.txt", "side\n", "side local")
-    _git(repo, "checkout", "main")
-    _git(repo, "merge", "--no-ff", "--no-commit", "side")
-    (repo / "payload.txt").write_text("must survive\n", encoding="utf-8")
-    _git(repo, "add", "payload.txt")
-    _git(repo, "commit", "-m", "merge payload")
-    original = _git(repo, "rev-parse", "HEAD").stdout.strip()
-    _git(repo, "checkout", "-b", "remote-work", base)
-    remote = _write_commit(repo, "remote.txt", "remote\n", "remote change")
-    _git(repo, "update-ref", "refs/remotes/origin/main", remote)
-    _git(repo, "checkout", "main")
-
-    script = f"""
-log_info() {{ :; }}
-log_warn() {{ :; }}
-log_error() {{ :; }}
-{_extract_sh_function("recover_diverged_update")}
-recover_diverged_update refs/remotes/origin/main
-"""
-    result = subprocess.run(["bash", "-c", script], cwd=repo, capture_output=True, text=True)
-
-    assert result.returncode != 0
-    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == original
-    assert (repo / "payload.txt").read_text(encoding="utf-8") == "must survive\n"
-    assert not _git(repo, "status", "--porcelain").stdout
-
-
-@pytest.mark.skipif(
-    not any(shutil.which(name) for name in ("pwsh", "powershell")),
-    reason="PowerShell is not available",
-)
-@pytest.mark.parametrize(
-    ("count_output", "expected"),
-    [
-        (b"1\n", "rebase"),
-        (b"1", "rebase"),
-        (b"0\n", "reset"),
-        (b"0", "reset"),
-        (b"000000001\n", "rebase"),
-        (b"000000000\n", "reset"),
-        (b"+1\n", "reject"),
-        (b"-1\n", "reject"),
-        (b" 1 \n", "reject"),
-        (b"1x\n", "reject"),
-        (b"", "reject"),
-        (b"1000000000\n", "reject"),
-        (b"9" * 36 + b"\n", "reject"),
-        (b"0000000001\n", "reject"),
-        (b"0000000000\n", "reject"),
-        (b"0" * 4301 + b"1\n", "reject"),
-        (b"0" * 4301 + b"0\n", "reject"),
-        (b"1\n2\n", "reject"),
-    ],
-    ids=[
-        "one-terminated",
-        "one-unterminated",
-        "zero-terminated",
-        "zero-unterminated",
-        "nine-digit-zero-padded-one",
-        "nine-digit-all-zero",
-        "positive-sign",
-        "negative-sign",
-        "padded",
-        "suffix",
-        "empty",
-        "over-bound",
-        "oversized",
-        "ten-digit-zero-padded-one",
-        "ten-digit-all-zero",
-        "giant-zero-padded-one",
-        "giant-all-zero",
-        "multiple-records",
-    ],
-)
-def test_install_ps1_count_contract(
-    count_output: bytes, expected: str, tmp_path: Path
-) -> None:
-    """Exercise the real PowerShell helper with an executable git proxy when available."""
-    repo, local_sha, remote_sha = _diverged_repo(tmp_path)
-    fake_bin = tmp_path / "fake-bin"
-    fake_bin.mkdir()
-    count_file = fake_bin / "count-output"
-    count_file.write_bytes(count_output)
-    if os.name == "nt":
-        (fake_bin / "git.cmd").write_text(
-            """@echo off
-echo %* | findstr /C:" rev-list " >nul || goto realgit
-echo %* | findstr /C:" --count " >nul || goto realgit
-type "%HERMES_FAKE_COUNT%"
-exit /b 0
-:realgit
-"%HERMES_REAL_GIT%" %*
-""",
-            encoding="ascii",
-        )
-    else:
-        wrapper = fake_bin / "git"
-        wrapper.write_text(
-            """#!/bin/sh
-saw_rev_list=false
-saw_count=false
-for arg do
-    [ "$arg" = "rev-list" ] && saw_rev_list=true
-    [ "$arg" = "--count" ] && saw_count=true
-done
-if [ "$saw_rev_list" = true ] && [ "$saw_count" = true ]; then
-    cat "$HERMES_FAKE_COUNT"
-    exit 0
-fi
-exec "$HERMES_REAL_GIT" "$@"
-""",
-            encoding="ascii",
-        )
-        wrapper.chmod(0o755)
-
-    host = next(
-        shutil.which(name) for name in ("pwsh", "powershell") if shutil.which(name)
+def _powershell() -> str | None:
+    return next(
+        (shutil.which(name) for name in ("pwsh", "powershell") if shutil.which(name)),
+        None,
     )
+
+
+def _run_ps(install: Path) -> subprocess.CompletedProcess[str]:
+    host = _powershell()
     assert host is not None
-    command = f"""
-function Write-Info {{ param([string]$Message) }}
-function Write-Err {{ param([string]$Message) }}
-{_extract_ps_function("Recover-DivergedUpdate")}
-try {{ Recover-DivergedUpdate 'remote-main'; exit 0 }} catch {{ [Console]::Error.WriteLine($_); exit 1 }}
-"""
-    env = {
-        **os.environ,
-        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
-        "HERMES_FAKE_COUNT": str(count_file),
-        "HERMES_REAL_GIT": shutil.which("git") or "git",
-    }
-    result = subprocess.run(
-        [host, "-NoProfile", "-Command", command],
-        cwd=repo,
-        env=env,
+    return subprocess.run(
+        [
+            host,
+            "-NoProfile",
+            "-File",
+            str(INSTALL_PS1),
+            "-Stage",
+            "repository",
+            "-Branch",
+            "main",
+            "-InstallDir",
+            str(install),
+            "-HermesHome",
+            str(install.parent / "home"),
+            "-NonInteractive",
+        ],
+        cwd=install.parent,
+        env={**os.environ, "HOME": str(install.parent / "home")},
         capture_output=True,
         text=True,
         encoding="utf-8",
         errors="replace",
     )
 
-    if expected == "reject":
-        assert result.returncode != 0
-        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == local_sha
-    elif expected == "rebase":
-        assert result.returncode == 0, result.stderr
-        assert _git(repo, "rev-parse", "HEAD").stdout.strip() != local_sha
-        assert _git(repo, "merge-base", "--is-ancestor", remote_sha, "HEAD").returncode == 0
-    else:
-        assert expected == "reset"
-        assert result.returncode == 0, result.stderr
-        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == remote_sha
+
+@pytest.fixture(params=["sh", "ps"])
+def run_installer(request) -> Callable[[Path], subprocess.CompletedProcess[str]]:
+    if request.param == "ps":
+        if _powershell() is None:
+            pytest.skip("PowerShell is not available")
+        return _run_ps
+    return _run_sh
+
+
+def _assert_clean_at(repo: Path, sha: str) -> None:
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == sha
     assert not _git(repo, "status", "--porcelain").stdout
+    git_dir = Path(_git(repo, "rev-parse", "--absolute-git-dir").stdout.strip())
+    assert not (git_dir / "rebase-merge").exists()
+    assert not (git_dir / "rebase-apply").exists()
 
 
-@pytest.mark.skipif(
-    not any(shutil.which(name) for name in ("pwsh", "powershell")),
-    reason="PowerShell is not available",
-)
-def test_install_ps1_parses() -> None:
-    host = next(shutil.which(name) for name in ("pwsh", "powershell") if shutil.which(name))
-    result = subprocess.run(
-        [host, "-NoProfile", "-Command", f"[scriptblock]::Create((Get-Content -Raw '{INSTALL_PS1}')) | Out-Null"],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
-    assert result.returncode == 0, result.stderr
+def test_installer_preserves_only_genuine_local_commit(
+    run_installer: Callable[[Path], subprocess.CompletedProcess[str]], tmp_path: Path
+) -> None:
+    seed, install, base = _managed_clone(tmp_path)
+    discarded = _commit(seed, "obsolete.txt", "obsolete\n", "discarded upstream")
+    _git(seed, "push", "origin", "main")
+    _git(install, "pull", "--ff-only")
+    _commit(install, "local.txt", "local\n", "genuine local commit")
+    remote = _rewrite_remote(seed, base)
+
+    result = run_installer(install)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert _git(install, "merge-base", "--is-ancestor", remote, "HEAD").returncode == 0
+    assert _git(
+        install, "log", "--format=%s", f"{remote}..HEAD"
+    ).stdout.splitlines() == ["genuine local commit"]
+    assert not (install / "obsolete.txt").exists()
+    assert discarded != remote
+
+
+def test_installer_conflict_restores_original_head(
+    run_installer: Callable[[Path], subprocess.CompletedProcess[str]], tmp_path: Path
+) -> None:
+    seed, install, base = _managed_clone(tmp_path)
+    original = _commit(install, "tracked.txt", "local\n", "local conflict")
+    _rewrite_remote(seed, base, conflict=True)
+
+    result = run_installer(install)
+
+    assert result.returncode != 0
+    _assert_clean_at(install, original)
+    assert (install / "tracked.txt").read_text(encoding="utf-8") == "local\n"
+
+
+def test_installer_without_local_commits_tracks_rewritten_remote(
+    run_installer: Callable[[Path], subprocess.CompletedProcess[str]], tmp_path: Path
+) -> None:
+    seed, install, base = _managed_clone(tmp_path)
+    remote = _rewrite_remote(seed, base)
+
+    result = run_installer(install)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    _assert_clean_at(install, remote)
+
+
+def test_installer_fails_closed_without_reflog_evidence(
+    run_installer: Callable[[Path], subprocess.CompletedProcess[str]], tmp_path: Path
+) -> None:
+    seed, install, base = _managed_clone(tmp_path)
+    original = _commit(install, "local.txt", "local\n", "local")
+    _rewrite_remote(seed, base)
+    _git(install, "config", "core.logAllRefUpdates", "false")
+    remote_logs = install / ".git" / "logs" / "refs" / "remotes"
+    if remote_logs.exists():
+        shutil.rmtree(remote_logs)
+
+    result = run_installer(install)
+
+    assert result.returncode != 0
+    _assert_clean_at(install, original)

--- a/tests/test_install_diverged_update.py
+++ b/tests/test_install_diverged_update.py
@@ -16,6 +16,14 @@ INSTALL_PS1 = ROOT / "scripts" / "install.ps1"
 GIT = ["git", "-c", "user.name=Hermes Test", "-c", "user.email=test@example.invalid"]
 
 
+@pytest.fixture(autouse=True)
+def _require_explicit_git_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Match CI hosts where Git cannot synthesize a committer identity."""
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", "user.useConfigOnly")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", "true")
+
+
 def _git(
     repo: Path, *args: str, check: bool = True
 ) -> subprocess.CompletedProcess[str]:
@@ -161,6 +169,9 @@ def test_installer_preserves_only_genuine_local_commit(
     assert _git(
         install, "log", "--format=%s", f"{remote}..HEAD"
     ).stdout.splitlines() == ["genuine local commit"]
+    assert _git(install, "log", "--format=%an <%ae>", f"{remote}..HEAD").stdout.strip() == (
+        "Hermes Test <test@example.invalid>"
+    )
     assert not (install / "obsolete.txt").exists()
     assert discarded != remote
 


### PR DESCRIPTION
## Summary

Preserve genuinely local history when `hermes update` or a managed installer encounters rewritten upstream history.

## Changes

- recover the pre-rewrite upstream boundary using `git merge-base --fork-point`
- rebase only the proven local range with `--rebase-merges --onto`
- preserve safe merge topology and fail closed for merge-only payloads
- abort conflicts back to the original clean checkout
- apply the same recovery contract in Python, Bash, and PowerShell
- derive a temporary committer identity from HEAD when Git has no configured identity, without modifying repository or global configuration
- preserve each rewritten commit's original author identity
- remove commit-count parsing and temporary-file machinery; compare the recovered fork point directly with HEAD
- replace installer source-shape assertions with full installer-stage temporary-repository tests
- isolate updater autostash tests from the host launchd gateway

The polished diff is substantially smaller than the original implementation while preserving cross-platform recovery behavior.

## Verification

- identity-free Python/Bash recovery and updater tests — 21 passed, 4 PowerShell cases skipped locally
- relevant installer regression files — 17 passed, 1 skipped
- Ruff, Bash syntax, formatting checks, and `git diff --check` — passed
- Linux-equivalent tests set `user.useConfigOnly=true` and verify recovered author identity

Native PowerShell execution remains covered by CI; PowerShell was unavailable on the macOS review host.