### PR TITLE
fix(terminal): preserve local identity across environment snapshots

### DIFF
--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -106,3 +106,55 @@ def test_shared_snapshot_no_cross_session_leak(tmp_path):
                 assert "HERMES_SESSION_ID" not in f.read()
     finally:
         env.cleanup()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_shared_snapshot_does_not_persist_profile_identity(tmp_path):
+    """A command in one profile must not redirect later local commands."""
+    from agent import secret_scope
+    from tools.environments.local import LocalEnvironment
+
+    canonical_home = tmp_path / "owner-home"
+    canonical_hermes = canonical_home / ".hermes"
+    canonical_real_home = tmp_path / "owner-real-home"
+    canonical_hermes.mkdir(parents=True)
+    canonical_real_home.mkdir()
+
+    previous_multiplex = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    env = LocalEnvironment(
+        cwd=str(tmp_path),
+        timeout=30,
+        env={
+            "HOME": str(canonical_home),
+            "HERMES_HOME": str(canonical_hermes),
+            "HERMES_REAL_HOME": str(canonical_real_home),
+        },
+    )
+    try:
+        poisoned_home = tmp_path / "foreign-home"
+        poisoned_hermes = poisoned_home / ".hermes"
+        poisoned_real_home = tmp_path / "foreign-real-home"
+        result = env.execute(
+            f'export HOME="{poisoned_home}"; '
+            f'export HERMES_HOME="{poisoned_hermes}"; '
+            f'export HERMES_REAL_HOME="{poisoned_real_home}"; true'
+        )
+        assert result.get("returncode") == 0
+
+        observed = env.execute(
+            'printf "%s\\n%s\\n%s\\n" "$HOME" "$HERMES_HOME" "$HERMES_REAL_HOME"'
+        )
+        assert observed.get("returncode") == 0
+        assert observed.get("output", "").splitlines()[:3] == [
+            str(canonical_home),
+            str(canonical_hermes),
+            str(canonical_real_home),
+        ]
+
+        snapshot = open(env._snapshot_path, encoding="utf-8").read()
+        assert "foreign-home" not in snapshot
+        assert "foreign-real-home" not in snapshot
+    finally:
+        env.cleanup()
+        secret_scope.set_multiplex_active(previous_multiplex)

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -129,6 +129,7 @@ def test_shared_snapshot_does_not_persist_profile_identity(tmp_path):
             "HOME": str(canonical_home),
             "HERMES_HOME": str(canonical_hermes),
             "HERMES_REAL_HOME": str(canonical_real_home),
+            "HERMES_HOME_BACKUP": "owner-backup",
         },
     )
     try:
@@ -138,23 +139,27 @@ def test_shared_snapshot_does_not_persist_profile_identity(tmp_path):
         result = env.execute(
             f'export HOME="{poisoned_home}"; '
             f'export HERMES_HOME="{poisoned_hermes}"; '
-            f'export HERMES_REAL_HOME="{poisoned_real_home}"; true'
+            f'export HERMES_REAL_HOME="{poisoned_real_home}"; '
+            'export HERMES_HOME_BACKUP="foreign-backup"; true'
         )
         assert result.get("returncode") == 0
 
         observed = env.execute(
-            'printf "%s\\n%s\\n%s\\n" "$HOME" "$HERMES_HOME" "$HERMES_REAL_HOME"'
+            'printf "%s\\n%s\\n%s\\n%s\\n" '
+            '"$HOME" "$HERMES_HOME" "$HERMES_REAL_HOME" "$HERMES_HOME_BACKUP"'
         )
         assert observed.get("returncode") == 0
-        assert observed.get("output", "").splitlines()[:3] == [
+        assert observed.get("output", "").splitlines()[:4] == [
             str(canonical_home),
             str(canonical_hermes),
             str(canonical_real_home),
+            "foreign-backup",
         ]
 
         snapshot = open(env._snapshot_path, encoding="utf-8").read()
         assert "foreign-home" not in snapshot
         assert "foreign-real-home" not in snapshot
+        assert "foreign-backup" in snapshot
     finally:
         env.cleanup()
         secret_scope.set_multiplex_active(previous_multiplex)

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -130,6 +130,7 @@ def test_shared_snapshot_does_not_persist_profile_identity(tmp_path):
             "HOME": str(canonical_home),
             "HERMES_HOME": str(canonical_hermes),
             "HERMES_REAL_HOME": str(canonical_real_home),
+            "HERMES_HOME_BACKUP": "owner-backup",
         },
     )
     try:
@@ -139,23 +140,27 @@ def test_shared_snapshot_does_not_persist_profile_identity(tmp_path):
         result = env.execute(
             f'export HOME="{poisoned_home}"; '
             f'export HERMES_HOME="{poisoned_hermes}"; '
-            f'export HERMES_REAL_HOME="{poisoned_real_home}"; true'
+            f'export HERMES_REAL_HOME="{poisoned_real_home}"; '
+            'export HERMES_HOME_BACKUP="foreign-backup"; true'
         )
         assert result.get("returncode") == 0
 
         observed = env.execute(
-            'printf "%s\\n%s\\n%s\\n" "$HOME" "$HERMES_HOME" "$HERMES_REAL_HOME"'
+            'printf "%s\\n%s\\n%s\\n%s\\n" '
+            '"$HOME" "$HERMES_HOME" "$HERMES_REAL_HOME" "$HERMES_HOME_BACKUP"'
         )
         assert observed.get("returncode") == 0
-        assert observed.get("output", "").splitlines()[:3] == [
+        assert observed.get("output", "").splitlines()[:4] == [
             str(canonical_home),
             str(canonical_hermes),
             str(canonical_real_home),
+            "foreign-backup",
         ]
 
         snapshot = open(env._snapshot_path, encoding="utf-8").read()
         assert "foreign-home" not in snapshot
         assert "foreign-real-home" not in snapshot
+        assert "foreign-backup" in snapshot
     finally:
         env.cleanup()
         secret_scope.set_multiplex_active(previous_multiplex)

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -107,3 +107,55 @@ def test_shared_snapshot_no_cross_session_leak(tmp_path):
                 assert "HERMES_SESSION_ID" not in f.read()
     finally:
         env.cleanup()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_shared_snapshot_does_not_persist_profile_identity(tmp_path):
+    """A command in one profile must not redirect later local commands."""
+    from agent import secret_scope
+    from tools.environments.local import LocalEnvironment
+
+    canonical_home = tmp_path / "owner-home"
+    canonical_hermes = canonical_home / ".hermes"
+    canonical_real_home = tmp_path / "owner-real-home"
+    canonical_hermes.mkdir(parents=True)
+    canonical_real_home.mkdir()
+
+    previous_multiplex = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    env = LocalEnvironment(
+        cwd=str(tmp_path),
+        timeout=30,
+        env={
+            "HOME": str(canonical_home),
+            "HERMES_HOME": str(canonical_hermes),
+            "HERMES_REAL_HOME": str(canonical_real_home),
+        },
+    )
+    try:
+        poisoned_home = tmp_path / "foreign-home"
+        poisoned_hermes = poisoned_home / ".hermes"
+        poisoned_real_home = tmp_path / "foreign-real-home"
+        result = env.execute(
+            f'export HOME="{poisoned_home}"; '
+            f'export HERMES_HOME="{poisoned_hermes}"; '
+            f'export HERMES_REAL_HOME="{poisoned_real_home}"; true'
+        )
+        assert result.get("returncode") == 0
+
+        observed = env.execute(
+            'printf "%s\\n%s\\n%s\\n" "$HOME" "$HERMES_HOME" "$HERMES_REAL_HOME"'
+        )
+        assert observed.get("returncode") == 0
+        assert observed.get("output", "").splitlines()[:3] == [
+            str(canonical_home),
+            str(canonical_hermes),
+            str(canonical_real_home),
+        ]
+
+        snapshot = open(env._snapshot_path, encoding="utf-8").read()
+        assert "foreign-home" not in snapshot
+        assert "foreign-real-home" not in snapshot
+    finally:
+        env.cleanup()
+        secret_scope.set_multiplex_active(previous_multiplex)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1421,6 +1421,10 @@ class LocalEnvironment(BaseEnvironment):
 
     _profile_scoped_passthrough = True
 
+    def _additional_profile_scoped_passthrough_names(self) -> tuple[str, ...]:
+        """Keep process/profile identity out of shared local snapshots."""
+        return ("HOME", "HERMES_HOME", "HERMES_REAL_HOME")
+
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         cwd = _resolve_local_initial_cwd(cwd)
         super().__init__(cwd=cwd, timeout=timeout, env=env)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -693,15 +693,20 @@ class LocalEnvironment(BaseEnvironment):
     is_local = True
 
     def _additional_profile_scoped_passthrough_names(self) -> tuple[str, ...]:
-        """First-party ``BUZZ_*`` names present in the env, excluded from the shared
-        session snapshot. env_passthrough can never list them (it refuses blocklisted
-        names), so under a multiplexed gateway profile A's BUZZ_PRIVATE_KEY would land
-        in the snapshot and be sourced by profile B. Prefix-only and monotonic on
-        purpose: conservative even when the context-gated carve-out is inactive."""
+        """First-party ``BUZZ_*`` names and local identity vars, excluded from the
+        shared session snapshot. env_passthrough can never list them (it refuses
+        blocklisted names), so under a multiplexed gateway profile A's
+        BUZZ_PRIVATE_KEY or HOME would land in the snapshot and be sourced by
+        profile B. Prefix-only and monotonic on purpose: conservative even when
+        the context-gated carve-out is inactive. Identity names are exact
+        (``HOME`` / ``HERMES_HOME`` / ``HERMES_REAL_HOME``) so similarly
+        prefixed vars still persist across snapshots."""
         merged = dict(os.environ | self.env)
-        return tuple(sorted(
+        names = {"HOME", "HERMES_HOME", "HERMES_REAL_HOME"}
+        names.update(
             name for name in merged
-            if isinstance(name, str) and _matches_terminal_first_party_prefix(name)))
+            if isinstance(name, str) and _matches_terminal_first_party_prefix(name))
+        return tuple(sorted(names))
 
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         super().__init__(cwd=_resolve_local_initial_cwd(cwd), timeout=timeout, env=env)


### PR DESCRIPTION
## Summary

- keep `HOME`, `HERMES_HOME`, and `HERMES_REAL_HOME` tied to the active local process/profile instead of persisting them into shared environment snapshots
- prevent one profile's exported identity from redirecting later local commands
- preserve similarly prefixed ordinary variables such as `HERMES_HOME_BACKUP`
- add a real cross-command regression covering the shared snapshot path

## Related work

#76527 overlaps on `HERMES_HOME` and adds separate delegated-child and Kanban exclusions. This PR retains the unique `HOME` and `HERMES_REAL_HOME` behavior and prefix-boundary regression so maintainers can consolidate without losing those cases. Current main already publishes environment snapshots atomically; this branch does not duplicate that mechanism.

## Verification

- focused snapshot tests — 8 passed
- broader local environment tests — 35 passed
- Ruff and `git diff --check` — passed