### PR TITLE
fix(guardrails): update stale MCP tool names in idempotent allowlist

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -27,14 +27,14 @@ IDEMPOTENT_TOOL_NAMES = frozenset(
         "browser_snapshot",
         "browser_console",
         "browser_get_images",
-        "mcp_filesystem_read_file",
-        "mcp_filesystem_read_text_file",
-        "mcp_filesystem_read_multiple_files",
-        "mcp_filesystem_list_directory",
-        "mcp_filesystem_list_directory_with_sizes",
-        "mcp_filesystem_directory_tree",
-        "mcp_filesystem_get_file_info",
-        "mcp_filesystem_search_files",
+        "mcp__filesystem__read_file",
+        "mcp__filesystem__read_text_file",
+        "mcp__filesystem__read_multiple_files",
+        "mcp__filesystem__list_directory",
+        "mcp__filesystem__list_directory_with_sizes",
+        "mcp__filesystem__directory_tree",
+        "mcp__filesystem__get_file_info",
+        "mcp__filesystem__search_files",
     }
 )
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -240,6 +240,44 @@ def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_succes
         assert controller.after_call("custom_tool", {"x": 1}, "ok", failed=False).action == "allow"
 
 
+def test_mcp_filesystem_tools_are_classified_as_idempotent():
+    """MCP tools using the mcp__<server>__<tool> naming are in the idempotent set."""
+    from agent.tool_guardrails import IDEMPOTENT_TOOL_NAMES
+
+    mcp_read_tools = [
+        "mcp__filesystem__read_file",
+        "mcp__filesystem__read_text_file",
+        "mcp__filesystem__read_multiple_files",
+        "mcp__filesystem__list_directory",
+        "mcp__filesystem__list_directory_with_sizes",
+        "mcp__filesystem__directory_tree",
+        "mcp__filesystem__get_file_info",
+        "mcp__filesystem__search_files",
+    ]
+    for name in mcp_read_tools:
+        assert name in IDEMPOTENT_TOOL_NAMES, f"{name} should be in IDEMPOTENT_TOOL_NAMES"
+
+    # Old-style single-underscore names must NOT be present (they never match)
+    for name in [
+        "mcp_filesystem_read_file",
+        "mcp_filesystem_list_directory",
+    ]:
+        assert name not in IDEMPOTENT_TOOL_NAMES, f"{name} (old format) should NOT be in IDEMPOTENT_TOOL_NAMES"
+
+    # The guardrail controller actually fires for mcp__ tools
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)
+    )
+    args = {"path": "/tmp/same.txt"}
+    result = "same contents"
+    assert controller.before_call("mcp__filesystem__read_file", args).action == "allow"
+    assert controller.after_call("mcp__filesystem__read_file", args, result, failed=False).action == "allow"
+    assert controller.before_call("mcp__filesystem__read_file", args).action == "allow"
+    warn = controller.after_call("mcp__filesystem__read_file", args, result, failed=False)
+    assert warn.action == "warn"
+    assert warn.code == "idempotent_no_progress_warning"
+
+
 def test_reset_for_turn_clears_bounded_guardrail_state():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(hard_stop_enabled=True, exact_failure_block_after=2, no_progress_block_after=2)


### PR DESCRIPTION
## Summary

Fixes #[71585](https://github.com/NousResearch/hermes-agent/issues/71585) (naming portion).

The `IDEMPOTENT_TOOL_NAMES` frozenset in `agent/tool_guardrails.py` used the old single-underscore naming convention (`mcp_filesystem_read_file`) which predates the `mcp__<server>__<tool>` double-underscore migration in `tools/mcp_tool.py`. These entries could never match any actual MCP tool, making the `idempotent_no_progress` guardrail completely inert for all MCP servers.

From the issue reporter's logs: **397 of 982 tool invocations (40.4%) being exact repeats** over six days, while only **17 guardrail warnings** fired in total — because the allowlist entries used the wrong naming format.

### What changed

- **`agent/tool_guardrails.py`**: Updated all 8 `mcp_filesystem_*` entries to `mcp__filesystem__*` to match the current naming convention used by `mcp_prefixed_tool_name()` in `tools/mcp_tool.py`.
- **`tests/agent/test_tool_guardrails.py`**: Added regression test verifying:
  - All `mcp__filesystem__*` read tools are in `IDEMPOTENT_TOOL_NAMES`
  - Old-style single-underscore names are absent
  - The guardrail controller actually fires warnings for `mcp__`-prefixed tools

### Out of scope (separate PR)

Issue #[71585](https://github.com/NousResearch/hermes-agent/issues/71585) also notes that `idempotent_tools` / `mutating_tools` cannot be set from `config.yaml` (PR [\#45603](https://github.com/NousResearch/hermes-agent/pull/45603) addresses that). This PR only fixes the stale naming.

### Verification

- All 15 tests in `tests/agent/test_tool_guardrails.py` pass
