### PR TITLE
fix(telegram): release fallback transport pools on connect failure

### DIFF
--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -58,17 +58,49 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
     ``curl --resolve api.telegram.org:443:<ip>``.
     """
 
+    # Bound every pool. httpx defaults to 100 connections per pool, so a wedged
+    # endpoint plus the seed IPs can outgrow the process file-descriptor limit
+    # on its own (#63311).
+    _POOL_LIMITS = httpx.Limits(max_connections=8, max_keepalive_connections=4)
+
     def __init__(self, fallback_ips: Iterable[str], **transport_kwargs):
         self._fallback_ips = list(dict.fromkeys(_normalize_fallback_ips(fallback_ips)))
         proxy_url = _resolve_proxy_url(target_hosts=[_TELEGRAM_API_HOST, *self._fallback_ips])
         if proxy_url and "proxy" not in transport_kwargs:
             transport_kwargs["proxy"] = proxy_url
+        transport_kwargs.setdefault("limits", self._POOL_LIMITS)
+        self._transport_kwargs = transport_kwargs
         self._primary = httpx.AsyncHTTPTransport(**transport_kwargs)
-        self._fallbacks = {
-            ip: httpx.AsyncHTTPTransport(**transport_kwargs) for ip in self._fallback_ips
-        }
+        # Built on demand and discarded on failure — see _reset_fallback.
+        self._fallbacks: dict[str, httpx.AsyncHTTPTransport] = {}
+        self._fallback_lock = asyncio.Lock()
         self._sticky_ip: Optional[str] = None
         self._sticky_lock = asyncio.Lock()
+
+    async def _get_fallback(self, ip: str) -> httpx.AsyncHTTPTransport:
+        async with self._fallback_lock:
+            transport = self._fallbacks.get(ip)
+            if transport is None:
+                transport = httpx.AsyncHTTPTransport(**self._transport_kwargs)
+                self._fallbacks[ip] = transport
+            return transport
+
+    async def _reset_fallback(self, ip: str) -> None:
+        """Discard a failed fallback pool so its dead sockets are released.
+
+        A connect that reaches ESTABLISHED and is then closed by the peer leaves
+        its socket in CLOSE_WAIT inside the pool. Retaining the poisoned pool
+        leaks one descriptor per retry until the process hits its file limit and
+        can no longer accept connections or resolve DNS (#63311).
+        """
+        async with self._fallback_lock:
+            transport = self._fallbacks.pop(ip, None)
+        if transport is None:
+            return
+        try:
+            await transport.aclose()
+        except Exception as exc:  # closing a broken pool must never mask the real error
+            logger.debug("[Telegram] Error closing fallback transport %s: %s", ip, exc)
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         if request.url.host != _TELEGRAM_API_HOST or not self._fallback_ips:
@@ -85,7 +117,7 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
         last_error: Exception | None = None
         for ip in attempt_order:
             candidate = request if ip is None else _rewrite_request_for_ip(request, ip)
-            transport = self._primary if ip is None else self._fallbacks[ip]
+            transport = self._primary if ip is None else await self._get_fallback(ip)
             try:
                 response = await transport.handle_async_request(candidate)
                 if ip is not None and self._sticky_ip != ip:
@@ -117,6 +149,7 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
                     )
                     continue
                 logger.warning("[Telegram] Fallback IP %s failed: %s", ip, exc)
+                await self._reset_fallback(ip)
                 continue
 
         if last_error is None:
@@ -125,7 +158,10 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
 
     async def aclose(self) -> None:
         await self._primary.aclose()
-        for transport in self._fallbacks.values():
+        async with self._fallback_lock:
+            transports = list(self._fallbacks.values())
+            self._fallbacks.clear()
+        for transport in transports:
             await transport.aclose()
 
 


### PR DESCRIPTION
## Summary

`TelegramFallbackTransport` leaks a file descriptor on every failed fallback connect. On a host where `api.telegram.org` became unreachable, this exhausted the gateway's descriptor limit and wedged the whole process.

The per-IP `httpx.AsyncHTTPTransport` pools are built once in `__init__` and never torn down. A connect that reaches ESTABLISHED and is then closed by the peer leaves its socket in `CLOSE_WAIT` inside the pool, and the failure path only logs and `continue`s — so the poisoned pool is retained and leaks one descriptor per retry.

Two changes:

- Build fallback transports lazily and discard them on a retryable connect failure (`_reset_fallback` pops the pool and `aclose()`s it, releasing its sockets).
- Bound every pool at `max_connections=8`. httpx defaults to 100 per pool, so the two seed IPs plus primary could alone exceed a default file limit.

## Impact observed

The bot gateway accumulated **177 sockets in `CLOSE_WAIT`** to `149.154.166.110` (`_SEED_FALLBACK_IPS[0]`) against launchd's 256 soft limit. Once exhausted, the failure cascaded well beyond Telegram:

```
ERROR asyncio: socket.accept() out of system resource
socket: <asyncio.TransportSocket fd=36, laddr=('127.0.0.1', 8643)>
OSError: [Errno 24] Too many open files
```

- `accept()` on the gateway port failed, so the gateway stopped answering entirely
- config reads failed (`failed to read .drain_request.json: [Errno 24]`)
- DNS resolution failed (`nodename nor servname provided`), which made the *primary* path fail too and fed more traffic into the leaking fallback path
- MCP servers could not connect (`tempo` parked after 5 attempts)

The DNS symptom is what makes this self-reinforcing: descriptor exhaustion breaks the resolver, which forces every subsequent request down the fallback path, which leaks faster.

## Test plan

Regression test drives 50 consecutive retryable connect failures through the transport:

- **before:** 1 pool retained indefinitely, 0 closes
- **after:** 0 pools retained, 50 `aclose()` calls, `max_connections=8` applied

```
ok  pools bounded: max_connections=8
ok  no pools retained after 50 failed attempts (was: 1 held forever)
ok  every failed pool was closed (50 aclose calls)
ok  aclose() clean
```

Also verified in production: after applying this the gateway holds ~113 descriptors with **0** in `CLOSE_WAIT`, `/health` returns 200, and Telegram reconnects cleanly (`set_my_commands OK, 60 cmds`).

Note for operators: steady-state usage is ~113 descriptors, so a 256 soft limit leaves little headroom even without a leak. Raising `NumberOfFiles` on the service is worthwhile independently of this fix.

Generated with [Claude Code](https://claude.com/claude-code)