### PR TITLE
fix(tui): exclude cron runs from resumable history

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -25,6 +25,8 @@ from tools.ansi_strip import strip_ansi as _strip_ansi
 
 ConsoleStatus = Literal["ok", "error", "confirm_required", "exit", "clear"]
 
+_INTERACTIVE_HISTORY_EXCLUDE_SOURCES = ["cron", "tool"]
+
 
 class ConsoleCommandError(RuntimeError):
     """User-facing console command failure."""
@@ -1324,7 +1326,7 @@ def _sessions_list(_engine: HermesConsoleEngine, args: list[str]) -> str:
     db = SessionDB()
     try:
         sessions = db.list_sessions_rich(
-            exclude_sources=["tool"],
+            exclude_sources=_INTERACTIVE_HISTORY_EXCLUDE_SOURCES,
             limit=ns.limit,
             order_by_last_active=True,
         )
@@ -1340,7 +1342,10 @@ def _sessions_stats(_engine: HermesConsoleEngine, args: list[str]) -> str:
     db = SessionDB()
     try:
         total = db.session_count()
-        listable = db.session_count(exclude_children=True, exclude_sources=["tool"])
+        listable = db.session_count(
+            exclude_children=True,
+            exclude_sources=_INTERACTIVE_HISTORY_EXCLUDE_SOURCES,
+        )
         messages = db.message_count()
         lines = [
             f"Total sessions: {total}",

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -55,6 +55,9 @@ def _confirm_prompt(prompt: str) -> bool:
         return False
 
 
+_INTERACTIVE_HISTORY_EXCLUDE_SOURCES = ["cron", "tool"]
+
+
 def cmd_sessions(args, sessions_parser=None):
     import json as _json
 
@@ -232,9 +235,10 @@ def cmd_sessions(args, sessions_parser=None):
         print(f"Error: Could not open session database: {e}")
         return
 
-    # Hide third-party tool sessions by default, but honour explicit --source
+    # Hide noisy non-interactive sessions by default, but honour explicit
+    # --source so cron/tool history remains available when requested.
     _source = getattr(args, "source", None)
-    _exclude = None if _source else ["tool"]
+    _exclude = None if _source else _INTERACTIVE_HISTORY_EXCLUDE_SOURCES
 
     if action == "list":
         from hermes_state import workspace_key as _ws_key
@@ -983,7 +987,7 @@ def cmd_sessions(args, sessions_parser=None):
     elif action == "browse":
         limit = getattr(args, "limit", 500) or 500
         source = getattr(args, "source", None)
-        _browse_exclude = None if source else ["tool"]
+        _browse_exclude = None if source else _INTERACTIVE_HISTORY_EXCLUDE_SOURCES
         sessions = db.list_sessions_rich(
             source=source, exclude_sources=_browse_exclude, limit=limit
         )

--- a/tests/hermes_cli/test_sessions_history_filters.py
+++ b/tests/hermes_cli/test_sessions_history_filters.py
@@ -1,0 +1,115 @@
+"""Regression tests for interactive CLI session-history filtering."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import console_engine, sessions_cmd
+
+
+class _SessionDB:
+    def __init__(self) -> None:
+        self.list_calls: list[dict] = []
+        self.closed = False
+
+    def list_sessions_rich(self, **kwargs) -> list[dict]:
+        self.list_calls.append(kwargs)
+        return [
+            {
+                "id": "human",
+                "source": "tui",
+                "title": "Human chat",
+                "preview": "continue this",
+                "started_at": 1,
+                "last_active": 1,
+            }
+        ]
+
+    def session_count(self, *args, **kwargs) -> int:
+        self.list_calls.append({"session_count": True, **kwargs})
+        return 1
+
+    def message_count(self) -> int:
+        return 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture()
+def fake_session_db(monkeypatch):
+    import hermes_state
+
+    db = _SessionDB()
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: db)
+    return db
+
+
+def test_sessions_list_excludes_cron_and_tool_by_default(fake_session_db, capsys):
+    args = SimpleNamespace(
+        sessions_action="list",
+        source=None,
+        limit=10,
+        workspace=None,
+    )
+
+    sessions_cmd.cmd_sessions(args)
+
+    assert fake_session_db.list_calls[0]["exclude_sources"] == ["cron", "tool"]
+    assert "human" in capsys.readouterr().out
+
+
+def test_sessions_list_honors_explicit_cron_source(fake_session_db):
+    args = SimpleNamespace(
+        sessions_action="list",
+        source="cron",
+        limit=10,
+        workspace=None,
+    )
+
+    sessions_cmd.cmd_sessions(args)
+
+    assert fake_session_db.list_calls[0]["source"] == "cron"
+    assert fake_session_db.list_calls[0]["exclude_sources"] is None
+
+
+def test_sessions_browse_excludes_cron_and_tool_by_default(fake_session_db, monkeypatch, capsys):
+    monkeypatch.setattr(sessions_cmd, "_session_browse_picker", lambda sessions: "human")
+    relaunched: list[list[str]] = []
+
+    def fake_relaunch(argv):
+        relaunched.append(argv)
+
+    monkeypatch.setattr("hermes_cli.relaunch.relaunch", fake_relaunch)
+    args = SimpleNamespace(sessions_action="browse", source=None, limit=10)
+
+    sessions_cmd.cmd_sessions(args)
+
+    assert fake_session_db.list_calls[0]["exclude_sources"] == ["cron", "tool"]
+    assert relaunched == [["--resume", "human"]]
+    assert "Resuming session: human" in capsys.readouterr().out
+
+
+def test_console_sessions_list_excludes_cron_and_tool(fake_session_db, monkeypatch):
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: fake_session_db)
+
+    output = console_engine._sessions_list(None, ["--limit", "10"])
+
+    assert fake_session_db.list_calls[0]["exclude_sources"] == ["cron", "tool"]
+    assert "human" in output
+
+
+def test_console_sessions_stats_listable_excludes_cron_and_tool(fake_session_db, monkeypatch):
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: fake_session_db)
+
+    output = console_engine._sessions_stats(None, [])
+
+    listable_call = next(call for call in fake_session_db.list_calls if call.get("exclude_sources"))
+    assert listable_call["exclude_sources"] == ["cron", "tool"]
+    assert "Listable sessions: 1" in output

--- a/tests/tui_gateway/test_session_history.py
+++ b/tests/tui_gateway/test_session_history.py
@@ -1,0 +1,91 @@
+"""Regression tests for human-facing TUI session history."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def server():
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+            "hermes_state": MagicMock(),
+        },
+    ):
+        import importlib
+
+        mod = importlib.import_module("tui_gateway.server")
+
+    methods = dict(mod._methods)
+    yield mod
+    mod._methods.clear()
+    mod._methods.update(methods)
+
+
+class _SessionDB:
+    def __init__(self, rows: list[dict]) -> None:
+        self.rows = rows
+        self.calls: list[dict] = []
+
+    def list_sessions_rich(self, **kwargs) -> list[dict]:
+        self.calls.append(kwargs)
+        return self.rows
+
+
+def _with_db(monkeypatch, server, db: _SessionDB) -> None:
+    @contextmanager
+    def profile_db(_params: dict):
+        yield db
+
+    monkeypatch.setattr(server, "_profile_db", profile_db)
+
+
+def test_session_list_excludes_cron_and_tool_runs(server, monkeypatch):
+    db = _SessionDB(
+        [
+            {"id": "cron-newest", "source": "cron", "title": "cron", "preview": "", "started_at": 3},
+            {"id": "tool-newer", "source": "tool", "title": "tool", "preview": "", "started_at": 2},
+            {"id": "human", "source": "tui", "title": "Human chat", "preview": "continue this", "started_at": 1},
+        ]
+    )
+    _with_db(monkeypatch, server, db)
+
+    response = server._methods["session.list"]("request", {"limit": 10})
+
+    assert response["result"]["sessions"] == [
+        {
+            "id": "human",
+            "title": "Human chat",
+            "preview": "continue this",
+            "started_at": 1,
+            "message_count": 0,
+            "source": "tui",
+        }
+    ]
+
+
+def test_most_recent_skips_cron_and_tool_runs(server, monkeypatch):
+    db = _SessionDB(
+        [
+            {"id": "cron-newest", "source": "cron", "title": "cron", "started_at": 3},
+            {"id": "tool-newer", "source": "tool", "title": "tool", "started_at": 2},
+            {"id": "human", "source": "tui", "title": "Human chat", "started_at": 1},
+        ]
+    )
+    _with_db(monkeypatch, server, db)
+
+    response = server._methods["session.most_recent"]("request", {})
+
+    assert response["result"] == {
+        "session_id": "human",
+        "title": "Human chat",
+        "started_at": 1,
+        "source": "tui",
+    }

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -170,10 +170,11 @@ def _(rid, params: dict) -> dict:
             # ones not enumerated here), ACP adapter clients, webhook sessions,
             # custom `HERMES_SESSION_SOURCE` values, and older installs with
             # different source labels. We deny-list only the noisy internal
-            # sources (``tool`` sub-agent runs) rather than allow-listing a
+            # sources (``tool`` sub-agent and ``cron`` job runs) rather than
+            # allow-listing a
             # fixed set of platform names that goes stale whenever a new
             # platform is added or a user names their own source.
-            deny = frozenset({"tool"})
+            deny = frozenset({"cron", "tool"})
 
             limit = int(params.get("limit", 200) or 200)
             # Over-fetch modestly so per-source filtering doesn't leave us
@@ -215,7 +216,7 @@ def _(rid, params: dict) -> dict:
     """Return the most recent human-facing session id, or ``None``.
 
     Mirrors ``session.list``'s deny-list behaviour (drops ``tool``
-    sub-agent rows).  Used by TUI auto-resume when
+    sub-agent and ``cron`` job rows). Used by TUI auto-resume when
     ``display.tui_auto_resume_recent`` is on; the field is also handy
     for any CLI tooling that wants "latest session" without paginating
     the full list.
@@ -232,9 +233,9 @@ def _(rid, params: dict) -> dict:
         if db is None:
             return _ok(rid, {"session_id": None})
         try:
-            deny = frozenset({"tool"})
+            deny = frozenset({"cron", "tool"})
             # Over-fetch by a generous bounded amount so heavy sub-agent
-            # users (lots of recent ``tool`` rows) don't get a false
+            # users (lots of recent ``tool``/``cron`` rows) don't get a false
             # "no eligible session" answer.  ``session.list`` uses a
             # similar over-fetch strategy.
             rows = db.list_sessions_rich(


### PR DESCRIPTION
## Summary
- omit `cron` runs from the TUI resume picker alongside internal `tool` sessions
- make automatic resume select the most recent human-facing conversation
- add regression coverage for both `session.list` and `session.most_recent`

## Test plan
- `scripts/run_tests.sh tests/tui_gateway/test_session_history.py tests/tui_gateway/test_protocol.py`

Cron runs remain persisted and available to the dedicated cron-management surfaces; this only removes them from the resumable chat history.