### PR TITLE
feat(secrets): support multi-account 1Password routing

### DIFF
--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -172,6 +172,12 @@ def _validate_references(
             structured = None
         elif isinstance(ref, dict):
             ref_map = cast(Dict[str, object], ref)
+            non_string_fields = [key for key in ref_map if not isinstance(key, str)]
+            if non_string_fields:
+                warnings.append(
+                    f"Skipping {name!r}: structured mapping field names must be strings"
+                )
+                continue
             unknown = sorted(
                 set(ref_map)
                 - {"reference", "account", "service_account_token_env"}

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -15,16 +15,18 @@ Design summary
           enabled: true
           env:
             OPENAI_API_KEY: "op://Private/OpenAI/api key"
-            ANTHROPIC_API_KEY: "op://Private/Anthropic/credential"
+            WORK_API_KEY:
+              reference: "op://Engineering/Internal API/credential"
+              account: work.1password.com
+              service_account_token_env: OP_SERVICE_ACCOUNT_TOKEN_WORK
 
 * After ``.env`` loads, each reference is resolved with a single
   ``op read -- <reference>`` call and injected into ``os.environ`` (the
   same point in startup as the Bitwarden source).
-* Authentication is whatever the user's ``op`` CLI already uses — a
-  service-account token (``OP_SERVICE_ACCOUNT_TOKEN``) for headless boxes,
-  or a desktop/interactive session (``OP_SESSION_*``).  Hermes never
-  authenticates on the user's behalf; it shells out to an already-trusted,
-  already-authenticated CLI.
+* Legacy string mappings use the profile defaults and preserve the historical
+  ``op`` authentication environment.  Structured mappings can select an
+  account and token env per reference; each read receives only that service
+  token, or a clean desktop-integration context when no token is available.
 * Failures NEVER block startup.  A missing ``op`` binary, expired auth, a
   bad reference, or a permission error each surface a one-line warning and
   Hermes continues with whatever credentials ``.env`` already had.
@@ -40,6 +42,7 @@ material is fingerprinted, never stored.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import re
@@ -47,7 +50,7 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Mapping, Optional, Tuple, Union, cast
 
 from agent.secret_sources._cache import (
     CachedFetch,
@@ -72,6 +75,11 @@ _OP_RUN_TIMEOUT = 30
 # the value to the child as OP_SERVICE_ACCOUNT_TOKEN, which is what `op` itself
 # looks for.
 _DEFAULT_TOKEN_ENV = "OP_SERVICE_ACCOUNT_TOKEN"
+
+# Backward-compatible reference values.  Existing configs store a plain
+# ``op://`` string.  A structured mapping can override the account and token
+# env for one reference without changing the legacy profile-wide defaults.
+ReferenceConfig = Union[str, Dict[str, str]]
 
 # Strip whole ANSI CSI sequences (colour, cursor moves, line erases) from any
 # `op` diagnostic we surface — not just the lone ESC byte — so a control
@@ -145,34 +153,112 @@ def _disk_cache_path(home_path: Optional[Path] = None) -> Path:
 
 
 def _validate_references(
-    references: Optional[Dict[str, str]],
-) -> Tuple[Dict[str, str], List[str]]:
+    references: Optional[Mapping[str, object]],
+) -> Tuple[Dict[str, ReferenceConfig], List[str]]:
     """Return ``(valid_refs, warnings)`` from an ``env`` mapping.
 
     A reference is kept only if its target env-var name is a valid POSIX
     name and the value is a stripped ``op://…`` reference string.  Everything
     else produces a warning and is dropped (never fatal).
     """
-    valid: Dict[str, str] = {}
+    valid: Dict[str, ReferenceConfig] = {}
     warnings: List[str] = []
     for name, ref in (references or {}).items():
         if not is_valid_env_name(name):
             warnings.append(f"Skipping {name!r}: not a valid env-var name")
             continue
-        if not isinstance(ref, str):
-            warnings.append(f"Skipping {name!r}: reference is not a string")
+        if isinstance(ref, str):
+            cleaned = ref.strip()
+            structured = None
+        elif isinstance(ref, dict):
+            ref_map = cast(Dict[str, object], ref)
+            unknown = sorted(
+                set(ref_map)
+                - {"reference", "account", "service_account_token_env"}
+            )
+            if unknown:
+                warnings.append(
+                    f"Skipping {name!r}: unknown field(s): {', '.join(unknown)}"
+                )
+                continue
+            raw_reference = ref_map.get("reference")
+            if not isinstance(raw_reference, str):
+                warnings.append(
+                    f"Skipping {name!r}: structured mapping requires a string reference"
+                )
+                continue
+            cleaned = raw_reference.strip()
+            structured = {"reference": cleaned}
+            raw_account = ref_map.get("account", "")
+            if not isinstance(raw_account, str):
+                warnings.append(f"Skipping {name!r}: account must be a string")
+                continue
+            account = raw_account.strip()
+            if account:
+                if account.startswith("-") or any(ord(ch) < 32 for ch in account):
+                    warnings.append(f"Skipping {name!r}: account contains invalid characters")
+                    continue
+            if "account" in ref_map:
+                structured["account"] = account
+            raw_token_env = ref_map.get("service_account_token_env", "")
+            if not isinstance(raw_token_env, str):
+                warnings.append(
+                    f"Skipping {name!r}: service_account_token_env must be a string"
+                )
+                continue
+            token_env = raw_token_env.strip()
+            if token_env:
+                if not is_valid_env_name(token_env):
+                    warnings.append(
+                        f"Skipping {name!r}: {token_env!r} is not a valid token env-var name"
+                    )
+                    continue
+            if "service_account_token_env" in ref_map:
+                structured["service_account_token_env"] = token_env
+        else:
+            warnings.append(
+                f"Skipping {name!r}: reference must be a string or structured mapping"
+            )
             continue
-        cleaned = ref.strip()
         if not cleaned.startswith("op://"):
             warnings.append(
                 f"Skipping {name!r}: {ref!r} is not an op:// secret reference"
             )
             continue
-        valid[name] = cleaned
+        valid[name] = structured if structured is not None else cleaned
     return valid, warnings
 
 
-def _auth_fingerprint(token_env: str) -> str:
+def _reference_route(
+    value: ReferenceConfig,
+    *,
+    default_account: str,
+    default_token_env: str,
+) -> Tuple[str, str, str]:
+    """Return ``(reference, account, token_env)`` for a validated mapping."""
+    if isinstance(value, str):
+        return value, default_account, default_token_env
+    return (
+        value["reference"],
+        value.get("account", default_account),
+        value.get("service_account_token_env", default_token_env),
+    )
+
+
+def _configured_token_envs(
+    references: Dict[str, ReferenceConfig], default_token_env: str
+) -> frozenset[str]:
+    """Return every bootstrap-token env var named by validated mappings."""
+    configured = frozenset(
+        _reference_route(
+            value, default_account="", default_token_env=default_token_env
+        )[2]
+        for value in references.values()
+    ) | frozenset({default_token_env, _DEFAULT_TOKEN_ENV})
+    return frozenset(name for name in configured if name)
+
+
+def _auth_fingerprint(token_envs: Union[str, List[str]]) -> str:
     """SHA-256 prefix over the auth material `op` would use.
 
     Folds in the service-account token, ``OP_ACCOUNT``, the 1Password Connect
@@ -183,8 +269,10 @@ def _auth_fingerprint(token_env: str) -> str:
     previous identity is never served under a new one.  Never logged or
     displayed; the raw token never leaves this hash.
     """
+    if isinstance(token_envs, str):
+        token_envs = [token_envs]
     parts: List[str] = [
-        f"token={os.environ.get(token_env, '')}",
+        *(f"token:{name}={os.environ.get(name, '')}" for name in sorted(set(token_envs))),
         f"account={os.environ.get('OP_ACCOUNT', '')}",
         f"connect_host={os.environ.get('OP_CONNECT_HOST', '')}",
         f"connect_token={os.environ.get('OP_CONNECT_TOKEN', '')}",
@@ -196,9 +284,12 @@ def _auth_fingerprint(token_env: str) -> str:
     return hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
 
 
-def _refs_fingerprint(references: Dict[str, str]) -> str:
+def _refs_fingerprint(references: Dict[str, ReferenceConfig]) -> str:
     """SHA-256 prefix over the configured name→reference mapping."""
-    material = "\n".join(f"{name}={references[name]}" for name in sorted(references))
+    material = "\n".join(
+        f"{name}={json.dumps(references[name], sort_keys=True, separators=(',', ':'))}"
+        for name in sorted(references)
+    )
     return hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
 
 
@@ -234,17 +325,30 @@ def _scrub(text: str) -> str:
     return _ANSI_CSI_RE.sub("", text).replace("\x1b", "").strip()
 
 
-def _op_child_env(token_value: str) -> Dict[str, str]:
-    """Build a minimal allowlisted environment for the ``op`` child process."""
+def _op_child_env(token_value: str, *, strict_auth: bool = False) -> Dict[str, str]:
+    """Build a minimal allowlisted environment for the ``op`` child process.
+
+    Structured account-bound mappings use ``strict_auth`` so a read receives
+    exactly its selected service token, or no inherited CLI auth material when
+    desktop-app authentication is intended.  Legacy scalar mappings retain the
+    historical session/Connect environment for backward compatibility.
+    """
     env: Dict[str, str] = {}
     for key in _OP_ENV_ALLOWLIST:
+        if strict_auth and key in {
+            "OP_ACCOUNT",
+            "OP_CONNECT_HOST",
+            "OP_CONNECT_TOKEN",
+        }:
+            continue
         val = os.environ.get(key)
         if val is not None:
             env[key] = val
     # Desktop / interactive session credentials.
-    for key, val in os.environ.items():
-        if key.startswith("OP_SESSION_"):
-            env[key] = val
+    if not strict_auth:
+        for key, val in os.environ.items():
+            if key.startswith("OP_SESSION_"):
+                env[key] = val
     # `op` reads OP_SERVICE_ACCOUNT_TOKEN regardless of which env var the user
     # configured Hermes to source it from, so normalize to that name here.
     if token_value:
@@ -259,6 +363,7 @@ def _run_op_read(
     *,
     account: str = "",
     token_value: str = "",
+    strict_auth: bool = False,
 ) -> str:
     """Resolve a single ``op://`` reference to its value.
 
@@ -276,7 +381,8 @@ def _run_op_read(
     try:
         proc = subprocess.run(  # noqa: S603 — op path is user-trusted, argv list
             cmd,
-            env=_op_child_env(token_value),
+            env=_op_child_env(token_value, strict_auth=strict_auth),
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
             encoding="utf-8",
@@ -291,7 +397,21 @@ def _run_op_read(
         raise RuntimeError(f"failed to invoke op: {exc}") from exc
 
     if proc.returncode != 0:
-        err = _scrub(proc.stderr or "")[:200]
+        err: str = str(proc.stderr or "")
+        auth_values: list[str] = [token_value] + [
+            str(value)
+            for key, value in os.environ.items()
+            if key == "OP_SERVICE_ACCOUNT_TOKEN"
+            or key == "OP_CONNECT_TOKEN"
+            or key.startswith("OP_SESSION_")
+        ]
+        for auth_value in sorted(auth_values, key=len, reverse=True):
+            auth_value_text: str = str(auth_value)
+            if auth_value_text:
+                err = re.sub(
+                    re.escape(auth_value_text), "[REDACTED]", err
+                )
+        err = _scrub(err)[:200]
         if err:
             raise RuntimeError(f"op read failed for {reference!r}: {err}")
         raise RuntimeError(
@@ -315,7 +435,7 @@ def _run_op_read(
 
 def fetch_onepassword_secrets(
     *,
-    references: Dict[str, str],
+    references: Mapping[str, object],
     account: str = "",
     token_env: str = _DEFAULT_TOKEN_ENV,
     binary: Optional[Path] = None,
@@ -335,18 +455,43 @@ def fetch_onepassword_secrets(
     isn't frozen in for the whole TTL window.
     """
     valid, warnings = _validate_references(references)
+    protected_token_envs = _configured_token_envs(valid, token_env)
+    for name in list(valid):
+        if name in protected_token_envs:
+            warnings.append(
+                f"Skipping {name!r}: target is a 1Password bootstrap token env var"
+            )
+            del valid[name]
     if not valid:
         return {}, warnings
 
-    token_value = os.environ.get(token_env, "").strip()
+    routes = {
+        name: _reference_route(
+            value, default_account=account, default_token_env=token_env
+        )
+        for name, value in valid.items()
+    }
+    token_envs = [route[2] for route in routes.values()]
     cache_key: _CacheKey = (
-        _auth_fingerprint(token_env),
-        account or "",
+        _auth_fingerprint(token_envs),
+        hashlib.sha256(
+            "\n".join(
+                f"{name}={routes[name][1]}|{routes[name][2]}"
+                for name in sorted(routes)
+            ).encode("utf-8")
+        ).hexdigest()[:16],
         str(home_path) if home_path is not None else "",
         _refs_fingerprint(valid),
     )
 
-    if use_cache:
+    # Desktop-app identity is not represented by a stable environment value.
+    # Do not persist/reuse values for routes that intentionally select desktop
+    # auth; otherwise switching identities can replay a prior account's secret.
+    cache_allowed = use_cache and all(
+        bool(token_env and os.environ.get(token_env, "").strip())
+        for _reference, _account, token_env in routes.values()
+    )
+    if cache_allowed:
         cached = _CACHE.get(cache_key)
         if cached and cached.is_fresh(cache_ttl_seconds):
             return dict(cached.secrets), warnings
@@ -367,15 +512,33 @@ def fetch_onepassword_secrets(
     secrets: Dict[str, str] = {}
     read_errors = 0
     for name in sorted(valid):
+        reference, selected_account, selected_token_env = routes[name]
+        token_value = os.environ.get(selected_token_env, "").strip()
+        route_cfg = valid[name]
+        token_is_explicit = (
+            isinstance(route_cfg, dict)
+            and "service_account_token_env" in route_cfg
+        ) or selected_token_env not in {"", _DEFAULT_TOKEN_ENV}
+        if selected_token_env and token_is_explicit and not token_value:
+            warnings.append(
+                f"Skipping {name!r}: selected token env var "
+                f"{selected_token_env!r} is unset"
+            )
+            read_errors += 1
+            continue
         try:
             secrets[name] = _run_op_read(
-                op, valid[name], account=account, token_value=token_value
+                op,
+                reference,
+                account=selected_account,
+                token_value=token_value,
+                strict_auth=isinstance(route_cfg, dict) or not selected_token_env,
             )
         except RuntimeError as exc:
             warnings.append(str(exc))
             read_errors += 1
 
-    if use_cache and not read_errors and secrets:
+    if cache_allowed and not read_errors and secrets:
         entry = CachedFetch(secrets=dict(secrets), fetched_at=time.time())
         _CACHE[cache_key] = entry
         _DISK_CACHE.write(cache_key, entry, cache_ttl_seconds, home_path)
@@ -391,7 +554,7 @@ def fetch_onepassword_secrets(
 def apply_onepassword_secrets(
     *,
     enabled: bool,
-    env: Optional[Dict[str, str]] = None,
+    env: Optional[Mapping[str, object]] = None,
     account: str = "",
     service_account_token_env: str = _DEFAULT_TOKEN_ENV,
     binary_path: str = "",
@@ -420,9 +583,10 @@ def apply_onepassword_secrets(
     result.warnings.extend(warnings)
 
     # Skip-before-fetch: never resolve a reference we'd only throw away.
-    refs_to_fetch: Dict[str, str] = {}
+    protected_token_envs = _configured_token_envs(valid, service_account_token_env)
+    refs_to_fetch: Dict[str, ReferenceConfig] = {}
     for name, ref in valid.items():
-        if name == service_account_token_env:
+        if name in protected_token_envs:
             # Never let a resolved secret clobber the very token used to auth.
             result.skipped.append(name)
             continue
@@ -470,7 +634,7 @@ def apply_onepassword_secrets(
     for name, value in secrets.items():
         # The token-var and override guards already filtered refs_to_fetch, but
         # re-check defensively in case the fetch layer ever returns extras.
-        if name == service_account_token_env:
+        if name in protected_token_envs:
             if name not in result.skipped:
                 result.skipped.append(name)
             continue
@@ -517,15 +681,22 @@ class OnePasswordSource(SecretSource):
 
     def protected_env_vars(self, cfg: dict):
         token_env = _DEFAULT_TOKEN_ENV
+        valid: Dict[str, ReferenceConfig] = {}
         if isinstance(cfg, dict):
-            token_env = str(cfg.get("service_account_token_env") or token_env)
-        return frozenset({token_env})
+            raw_token_env = cfg.get("service_account_token_env", token_env)
+            token_env = token_env if raw_token_env is None else str(raw_token_env).strip()
+            env_map = cfg.get("env")
+            valid, _warnings = _validate_references(
+                env_map if isinstance(env_map, dict) else None
+            )
+        return _configured_token_envs(valid, token_env)
 
     def config_schema(self) -> dict:
         return {
             "enabled": {"description": "Master switch", "default": False},
             "env": {
-                "description": "Map of ENV_VAR -> op://vault/item/field reference",
+                "description": "Map of ENV_VAR to an op:// reference string or "
+                               "{reference, account?, service_account_token_env?}",
                 "default": {},
             },
             "account": {
@@ -594,12 +765,18 @@ class OnePasswordSource(SecretSource):
             ttl = 300.0
 
         try:
+            raw_token_env = cfg.get(
+                "service_account_token_env", _DEFAULT_TOKEN_ENV
+            )
+            token_env = (
+                _DEFAULT_TOKEN_ENV
+                if raw_token_env is None
+                else str(raw_token_env).strip()
+            )
             secrets, fetch_warnings = fetch_onepassword_secrets(
                 references=valid,
                 account=str(cfg.get("account") or ""),
-                token_env=str(
-                    cfg.get("service_account_token_env") or _DEFAULT_TOKEN_ENV
-                ),
+                token_env=token_env,
                 binary=binary,
                 cache_ttl_seconds=ttl,
                 home_path=home_path,
@@ -617,7 +794,12 @@ class OnePasswordSource(SecretSource):
         if kind in (ErrorKind.AUTH_FAILED, ErrorKind.AUTH_EXPIRED):
             token_env = _DEFAULT_TOKEN_ENV
             if isinstance(cfg, dict):
-                token_env = str(cfg.get("service_account_token_env") or token_env)
+                raw_token_env = cfg.get("service_account_token_env", token_env)
+                token_env = (
+                    token_env if raw_token_env is None else str(raw_token_env).strip()
+                )
+            if not token_env:
+                return "Unlock 1Password and enable desktop app CLI integration."
             return (
                 "Run `hermes secrets onepassword token` to paste a fresh "
                 f"service-account token ({token_env}), or `op signin` for an "

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1591,13 +1591,16 @@ updates:
 #   # ---- 1Password (op CLI) -------------------------------------------------
 #   onepassword:
 #     enabled: false
-#     # Map env-var names to op:// secret references. Each is resolved with a
-#     # single `op read` at startup.
+#     # Map env-var names to op:// secret references. String mappings inherit
+#     # the defaults below; use the structured form for per-reference routing.
 #     env:
 #       OPENAI_API_KEY: "op://Private/OpenAI/api key"
-#       ANTHROPIC_API_KEY: "op://Private/Anthropic/credential"
-#     account: ""                                   # op --account shorthand; "" = default
-#     service_account_token_env: OP_SERVICE_ACCOUNT_TOKEN  # headless auth; unset = desktop session
+#       WORK_API_KEY:
+#         reference: "op://Engineering/Internal API/credential"
+#         account: work.1password.com
+#         service_account_token_env: OP_SERVICE_ACCOUNT_TOKEN_WORK
+#     account: ""                                   # default op --account; "" = op default
+#     service_account_token_env: OP_SERVICE_ACCOUNT_TOKEN  # default headless auth env
 #     binary_path: ""                               # "" = resolve op via PATH; else absolute path
 #     cache_ttl_seconds: 300                        # 0 disables BOTH cache layers
 #     override_existing: true                       # resolved values win over existing env

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -8,7 +8,7 @@ import os
 import sys
 from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values, load_dotenv
 from utils import atomic_replace, fast_safe_load
 
 
@@ -329,11 +329,23 @@ def load_hermes_dotenv(
     # committed .env file.
     # Users on systemd can alternatively use:
     #   EnvironmentFile=-/path/to/.hermes/.op.env
-    # in their gateway unit, which takes precedence (override=False below
-    # ensures .op.env never clobbers a token already in the environment).
+    # in their gateway unit, which takes precedence because `.op.env` never
+    # clobbers a token already present in the process environment.
+    # .op.env may hold one bootstrap variable per 1Password account. Load only
+    # token names selected by valid 1Password routes; this is not a general
+    # additive env file. Existing environment values keep precedence.
     op_env = home_path / ".op.env"
-    if op_env.exists() and not os.environ.get("OP_SERVICE_ACCOUNT_TOKEN"):
-        _load_dotenv_with_fallback(op_env, override=False)
+    if op_env.exists():
+        _sanitize_env_file_if_needed(op_env)
+        allowed = _configured_onepassword_token_envs(home_path)
+        try:
+            values = dotenv_values(op_env, encoding="utf-8", interpolate=False)
+        except UnicodeDecodeError:
+            values = dotenv_values(op_env, encoding="latin-1", interpolate=False)
+        for key in allowed:
+            value = values.get(key)
+            if value is not None and key not in os.environ:
+                os.environ[key] = value
 
     if project_env_path and project_env_path.exists():
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
@@ -343,6 +355,31 @@ def load_hermes_dotenv(
     _apply_managed_env()
 
     return loaded
+
+
+def _configured_onepassword_token_envs(home_path: Path) -> frozenset[str]:
+    """Return the bootstrap-token names that `.op.env` may populate."""
+    try:
+        from agent.secret_sources import onepassword as op_src
+
+        secrets_cfg = _load_secrets_config(home_path)
+        op_cfg = secrets_cfg.get("onepassword")
+        op_cfg = op_cfg if isinstance(op_cfg, dict) else {}
+        raw_default = op_cfg.get(
+            "service_account_token_env", op_src._DEFAULT_TOKEN_ENV
+        )
+        default_token_env = (
+            op_src._DEFAULT_TOKEN_ENV
+            if raw_default is None
+            else str(raw_default).strip()
+        )
+        raw_env = op_cfg.get("env")
+        valid, _warnings = op_src._validate_references(
+            raw_env if isinstance(raw_env, dict) else None
+        )
+        return op_src._configured_token_envs(valid, default_token_env)
+    except Exception:  # noqa: BLE001 — dotenv loading must never block startup
+        return frozenset({"OP_SERVICE_ACCOUNT_TOKEN"})
 
 
 def _apply_managed_env() -> None:
@@ -505,7 +542,7 @@ def _load_secrets_config(home_path: Path) -> dict:
     if not config_path.exists():
         return {}
     try:
-        import yaml  # type: ignore
+        import yaml
     except ImportError:
         return {}
     try:

--- a/hermes_cli/onepassword_secrets_cli.py
+++ b/hermes_cli/onepassword_secrets_cli.py
@@ -82,6 +82,14 @@ def register_cli(parent_parser: argparse.ArgumentParser) -> None:
         help="Provide the new token non-interactively (default: masked prompt)",
     )
     token.add_argument(
+        "--account",
+        help="Account shorthand/sign-in address to validate this token against",
+    )
+    token.add_argument(
+        "--token-env",
+        help="Env var in which to store this account's service-account token",
+    )
+    token.add_argument(
         "--no-verify",
         action="store_true",
         help="Store without probing 1Password first (not recommended)",
@@ -91,6 +99,14 @@ def register_cli(parent_parser: argparse.ArgumentParser) -> None:
     set_p = sub.add_parser("set", help="Map an env var to an op:// reference")
     set_p.add_argument("env_var", help="Environment variable name, e.g. OPENAI_API_KEY")
     set_p.add_argument("reference", help="1Password reference, e.g. op://Private/OpenAI/api key")
+    set_p.add_argument(
+        "--account",
+        help="Account shorthand/sign-in address for this reference",
+    )
+    set_p.add_argument(
+        "--token-env",
+        help="Env var holding this account's service-account token",
+    )
     set_p.set_defaults(func=cmd_set)
 
     remove = sub.add_parser("remove", help="Remove an env-var → reference mapping")
@@ -101,7 +117,7 @@ def register_cli(parent_parser: argparse.ArgumentParser) -> None:
     sync.add_argument(
         "--apply",
         action="store_true",
-        help="Actually export resolved values into the current shell (default: dry-run)",
+        help="Apply resolved values inside this validation process (default: dry-run)",
     )
     sync.set_defaults(func=cmd_sync)
 
@@ -204,7 +220,8 @@ def cmd_status(args: argparse.Namespace) -> int:
     account = str(op_cfg.get("account", "") or "").strip()
     token_env = op_cfg.get("service_account_token_env", _DEFAULT_TOKEN_ENV)
     binary_path = str(op_cfg.get("binary_path", "") or "").strip()
-    references = op_cfg.get("env") if isinstance(op_cfg.get("env"), dict) else {}
+    raw_references = op_cfg.get("env")
+    references: dict = raw_references if isinstance(raw_references, dict) else {}
     token_set = bool(os.environ.get(token_env))
 
     binary = op_src.find_op(binary_path)
@@ -213,8 +230,8 @@ def cmd_status(args: argparse.Namespace) -> int:
     table.add_column("", style="bold")
     table.add_column("")
     table.add_row("Enabled", _yn(enabled))
-    table.add_row("Account", account or "[dim]default[/dim]")
-    table.add_row("Token env var", token_env)
+    table.add_row("Default account", account or "[dim]op default[/dim]")
+    table.add_row("Default token env var", token_env)
     table.add_row("Token in env", _yn(token_set))
     table.add_row("Override existing", _yn(bool(op_cfg.get("override_existing", True))))
     table.add_row("Cache TTL (s)", str(op_cfg.get("cache_ttl_seconds", 300)))
@@ -226,26 +243,85 @@ def cmd_status(args: argparse.Namespace) -> int:
 
     console.print(Panel(table, title="1Password secret source", border_style="cyan"))
 
+    valid_references: dict = {}
+    effective_routes: dict[str, tuple[str, str, str]] = {}
     if references:
+        valid_references, reference_warnings = op_src._validate_references(references)
         ref_table = Table(show_header=True, header_style="bold")
         ref_table.add_column("Env var", style="cyan")
         ref_table.add_column("Reference")
-        for name in sorted(references):
-            ref_table.add_row(name, str(references[name]))
+        ref_table.add_column("Account")
+        ref_table.add_column("Token env")
+        ref_table.add_column("Token")
+        for name in sorted(valid_references):
+            route_cfg = valid_references[name]
+            route = op_src._reference_route(
+                route_cfg,
+                default_account=account,
+                default_token_env=token_env,
+            )
+            effective_routes[name] = route
+            reference, selected_account, selected_token_env = route
+            account_inherited = isinstance(route_cfg, str) or "account" not in route_cfg
+            token_inherited = (
+                isinstance(route_cfg, str)
+                or "service_account_token_env" not in route_cfg
+            )
+            ref_table.add_row(
+                name,
+                reference,
+                (selected_account or "op default")
+                + (" *" if account_inherited else ""),
+                (selected_token_env or "desktop")
+                + (" *" if token_inherited else ""),
+                _yn(bool(selected_token_env and os.environ.get(selected_token_env))),
+            )
         console.print(ref_table)
+        for warning in reference_warnings:
+            console.print(f"[yellow]warning:[/yellow] {warning}")
+        console.print("[dim]* inherited from profile defaults[/dim]")
 
     if not enabled:
         console.print("\n  Run [cyan]hermes secrets onepassword setup[/cyan] to enable.")
         return 0
-    if binary and not token_set:
-        who = _op_whoami(binary, account)
-        if who:
-            console.print(f"\n  [green]Active op session:[/green] {who}")
-        else:
+    if binary:
+        missing_token_routes: list[str] = []
+        desktop_routes: dict[tuple[str, bool], list[str]] = {}
+        for name, (_reference, selected_account, selected_token_env) in effective_routes.items():
+            route_cfg = valid_references[name]
+            token_is_explicit = (
+                isinstance(route_cfg, dict)
+                and "service_account_token_env" in route_cfg
+            ) or selected_token_env not in {"", _DEFAULT_TOKEN_ENV}
+            if selected_token_env and os.environ.get(selected_token_env):
+                continue
+            if selected_token_env and token_is_explicit:
+                missing_token_routes.append(name)
+                continue
+            strict_auth = isinstance(route_cfg, dict)
+            desktop_routes.setdefault((selected_account, strict_auth), []).append(name)
+
+        for name in missing_token_routes:
+            selected_token_env = effective_routes[name][2]
             console.print(
-                f"\n  [yellow]No active op session and {token_env} is unset — "
-                "Hermes will warn and skip 1Password on next startup.[/yellow]"
+                f"\n  [yellow]{name}: selected token env "
+                f"{selected_token_env} is unset; this mapping will be skipped.[/yellow]"
             )
+        for (selected_account, strict_auth), names in desktop_routes.items():
+            who = _op_whoami(
+                binary, selected_account, strict_auth=strict_auth
+            )
+            if who:
+                console.print(
+                    f"\n  [green]Active op session:[/green] {who} "
+                    f"([cyan]{', '.join(names)}[/cyan])"
+                )
+            else:
+                console.print(
+                    f"\n  [yellow]No active op session for "
+                    f"{selected_account or 'the op default account'}; mappings "
+                    f"{', '.join(names)} will be skipped.[/yellow]"
+                )
     if not references:
         console.print(
             "\n  [yellow]No references mapped yet.[/yellow]  Add one: "
@@ -259,7 +335,19 @@ def cmd_set(args: argparse.Namespace) -> int:
     # Reuse the backend validator so the CLI and startup paths agree on what a
     # valid reference is — and store the *validated/stripped* value, not the
     # raw arg (so trailing whitespace never lands in config.yaml).
-    valid, warnings = op_src._validate_references({args.env_var: args.reference})
+    account_arg = getattr(args, "account", None)
+    token_env_arg = getattr(args, "token_env", None)
+    account = str(account_arg or "").strip()
+    token_env = str(token_env_arg or "").strip()
+    candidate: object = args.reference
+    if account_arg is not None or token_env_arg is not None:
+        structured = {"reference": args.reference}
+        if account_arg is not None:
+            structured["account"] = account
+        if token_env_arg is not None:
+            structured["service_account_token_env"] = token_env
+        candidate = structured
+    valid, warnings = op_src._validate_references({args.env_var: candidate})
     if args.env_var not in valid:
         for w in warnings:
             console.print(f"[red]{w}[/red]")
@@ -273,9 +361,16 @@ def cmd_set(args: argparse.Namespace) -> int:
         op_cfg["env"] = env_map
     env_map[args.env_var] = valid[args.env_var]
     save_config(cfg)
+    reference, selected_account, selected_token_env = op_src._reference_route(
+        valid[args.env_var], default_account="", default_token_env=""
+    )
+    route = ""
+    if selected_account:
+        route += f" account={selected_account}"
+    if selected_token_env:
+        route += f" token-env={selected_token_env}"
     console.print(
-        f"[green]✓[/green] mapped [cyan]{args.env_var}[/cyan] → "
-        f"{valid[args.env_var]}"
+        f"[green]✓[/green] mapped [cyan]{args.env_var}[/cyan] → {reference}{route}"
     )
     if not op_cfg.get("enabled"):
         console.print(
@@ -309,8 +404,19 @@ def cmd_token(args: argparse.Namespace) -> int:
     console = Console()
     cfg = load_config()
     op_cfg = (cfg.get("secrets") or {}).get("onepassword") or {}
-    token_env = op_cfg.get("service_account_token_env", _DEFAULT_TOKEN_ENV)
-    account = str(op_cfg.get("account", "") or "").strip()
+    token_env_arg = getattr(args, "token_env", None)
+    raw_token_env = (
+        op_cfg.get("service_account_token_env", _DEFAULT_TOKEN_ENV)
+        if token_env_arg is None
+        else token_env_arg
+    )
+    token_env = str(raw_token_env).strip()
+    account_arg = getattr(args, "account", None)
+    raw_account = op_cfg.get("account", "") if account_arg is None else account_arg
+    account = str(raw_account or "").strip()
+    if not op_src.is_valid_env_name(token_env):
+        console.print(f"[red]{token_env!r} is not a valid token env-var name.[/red]")
+        return 1
     binary_path = str(op_cfg.get("binary_path", "") or "").strip()
 
     token = (args.token or "").strip()
@@ -403,17 +509,19 @@ def cmd_sync(args: argparse.Namespace) -> int:
         table.add_column("Env var", style="cyan")
         table.add_column("Action")
         for name in sorted(result.applied):
-            table.add_row(name, "[green]exported[/green]")
+            table.add_row(name, "[green]applied[/green]")
         for name in sorted(result.skipped):
             table.add_row(name, "[dim]skipped (already set / token var)[/dim]")
         console.print(table)
         for w in result.warnings:
             console.print(f"[yellow]warning:[/yellow] {w}")
         console.print(
-            f"\n  [green]Exported {len(result.applied)} secret(s) into current "
+            f"\n  [green]Applied {len(result.applied)} secret(s) inside this validation "
             "process.[/green]"
         )
         return 0
+
+    protected_token_envs = op_src.OnePasswordSource().protected_env_vars(op_cfg)
 
     # Dry-run: resolve fresh (no cache) and preview, mutating nothing.
     try:
@@ -433,7 +541,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
     table.add_column("Env var", style="cyan")
     table.add_column("Action")
     for name in sorted(references):
-        if name == token_env:
+        if name in protected_token_envs:
             table.add_row(name, "[dim]skip (token var)[/dim]")
         elif name not in secrets:
             table.add_row(name, "[red]unresolved (see warnings)[/red]")
@@ -499,24 +607,36 @@ def _op_version(binary: Path) -> str:
 
 
 def _op_whoami(
-    binary: Path, account: str, *, token_value: str = ""
+    binary: Path,
+    account: str,
+    *,
+    token_value: str = "",
+    strict_auth: bool = False,
 ) -> Optional[str]:
     """Return a short identity string if op is authenticated, else None.
 
     ``token_value``, when given, is passed to the child as
     ``OP_SERVICE_ACCOUNT_TOKEN`` so a candidate token can be probed
-    without touching the caller's environment.
+    without touching the caller's environment. ``strict_auth`` also isolates
+    desktop probes from unrelated ambient 1Password credentials.
     """
     cmd = [str(binary), "whoami"]
     if account:
         cmd += ["--account", account]
-    env = os.environ.copy()
+    if token_value or strict_auth:
+        # Candidate tokens and structured desktop routes are validated in
+        # isolation so unrelated sessions, Connect credentials, and provider
+        # secrets cannot authenticate the probe or leak into its environment.
+        env = op_src._op_child_env(token_value, strict_auth=True)
+    else:
+        # Preserve the historical interactive-session behavior for setup/status
+        # probes that are not validating a candidate token.
+        env = os.environ.copy()
     env.setdefault("NO_COLOR", "1")
-    if token_value:
-        env["OP_SERVICE_ACCOUNT_TOKEN"] = token_value
     try:
         res = subprocess.run(
-            cmd, env=env, capture_output=True, text=True,
+            cmd, env=env, stdin=subprocess.DEVNULL,
+            capture_output=True, text=True,
             encoding="utf-8", errors="replace", timeout=10
         )
     except (OSError, subprocess.TimeoutExpired):

--- a/hermes_cli/onepassword_secrets_cli.py
+++ b/hermes_cli/onepassword_secrets_cli.py
@@ -218,11 +218,16 @@ def cmd_status(args: argparse.Namespace) -> int:
 
     enabled = bool(op_cfg.get("enabled"))
     account = str(op_cfg.get("account", "") or "").strip()
-    token_env = op_cfg.get("service_account_token_env", _DEFAULT_TOKEN_ENV)
+    raw_token_env = op_cfg.get("service_account_token_env", _DEFAULT_TOKEN_ENV)
+    token_env = (
+        _DEFAULT_TOKEN_ENV
+        if raw_token_env is None
+        else str(raw_token_env).strip()
+    )
     binary_path = str(op_cfg.get("binary_path", "") or "").strip()
     raw_references = op_cfg.get("env")
     references: dict = raw_references if isinstance(raw_references, dict) else {}
-    token_set = bool(os.environ.get(token_env))
+    token_set = bool(token_env and os.environ.get(token_env))
 
     binary = op_src.find_op(binary_path)
 

--- a/tests/hermes_cli/test_onepassword_multi_account_cli.py
+++ b/tests/hermes_cli/test_onepassword_multi_account_cli.py
@@ -219,6 +219,31 @@ def test_status_checks_auth_readiness_per_effective_route(
     assert "skip 1Password" not in capsys.readouterr().out
 
 
+def test_status_normalizes_null_and_non_string_default_token_env(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(op_cli.op_src, "find_op", lambda binary_path="": None)
+    for raw_value, expected in (
+        (None, "OP_SERVICE_ACCOUNT_TOKEN"),
+        (123, "123"),
+    ):
+        monkeypatch.setattr(
+            op_cli,
+            "load_config",
+            lambda raw_value=raw_value: {
+                "secrets": {
+                    "onepassword": {
+                        "enabled": False,
+                        "service_account_token_env": raw_value,
+                    }
+                }
+            },
+        )
+
+        assert op_cli.cmd_status(argparse.Namespace()) == 0
+        assert expected in capsys.readouterr().out
+
+
 def test_status_marks_inherited_account_and_token_fields_independently(
     monkeypatch, capsys
 ):

--- a/tests/hermes_cli/test_onepassword_multi_account_cli.py
+++ b/tests/hermes_cli/test_onepassword_multi_account_cli.py
@@ -1,0 +1,293 @@
+"""CLI coverage for per-reference 1Password account routing."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from rich.console import Console
+
+from hermes_cli import onepassword_secrets_cli as op_cli
+
+
+def test_set_accepts_account_and_token_env_and_persists_structured_mapping(monkeypatch):
+    parser = argparse.ArgumentParser()
+    op_cli.register_cli(parser)
+    args = parser.parse_args(
+        [
+            "set",
+            "WORK_API_KEY",
+            "op://Work/Hermes/key",
+            "--account",
+            "work.1password.com",
+            "--token-env",
+            "OP_TOKEN_WORK",
+        ]
+    )
+    cfg = {"secrets": {"onepassword": {"enabled": True, "env": {}}}}
+    saved = []
+    monkeypatch.setattr(op_cli, "load_config", lambda: cfg)
+    monkeypatch.setattr(op_cli, "save_config", lambda value: saved.append(value))
+
+    assert args.func(args) == 0
+    assert saved == [cfg]
+    assert cfg["secrets"]["onepassword"]["env"]["WORK_API_KEY"] == {
+        "reference": "op://Work/Hermes/key",
+        "account": "work.1password.com",
+        "service_account_token_env": "OP_TOKEN_WORK",
+    }
+
+
+def test_set_explicit_empty_token_env_selects_desktop_auth(monkeypatch):
+    parser = argparse.ArgumentParser()
+    op_cli.register_cli(parser)
+    args = parser.parse_args(
+        [
+            "set",
+            "PERSONAL_API_KEY",
+            "op://Personal/Hermes/key",
+            "--account",
+            "personal.1password.com",
+            "--token-env",
+            "",
+        ]
+    )
+    cfg = {"secrets": {"onepassword": {"enabled": True, "env": {}}}}
+    monkeypatch.setattr(op_cli, "load_config", lambda: cfg)
+    monkeypatch.setattr(op_cli, "save_config", lambda value: None)
+
+    assert args.func(args) == 0
+    assert cfg["secrets"]["onepassword"]["env"]["PERSONAL_API_KEY"] == {
+        "reference": "op://Personal/Hermes/key",
+        "account": "personal.1password.com",
+        "service_account_token_env": "",
+    }
+
+
+def test_token_accepts_account_and_token_env_overrides(monkeypatch, tmp_path):
+    parser = argparse.ArgumentParser()
+    op_cli.register_cli(parser)
+    args = parser.parse_args(
+        [
+            "token",
+            "--account",
+            "work.1password.com",
+            "--token-env",
+            "OP_TOKEN_WORK",
+            "--token",
+            "candidate-token",
+        ]
+    )
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    saved_env = {}
+    seen = {}
+    monkeypatch.setattr(
+        op_cli,
+        "load_config",
+        lambda: {"secrets": {"onepassword": {"enabled": True}}},
+    )
+    monkeypatch.setattr(op_cli.op_src, "find_op", lambda binary_path="": fake_op)
+    monkeypatch.setattr(op_cli.op_src, "clear_caches", lambda *a, **k: None)
+    monkeypatch.setattr(
+        op_cli,
+        "save_env_value",
+        lambda name, value: saved_env.__setitem__(name, value),
+    )
+
+    def fake_whoami(binary, account, *, token_value=""):
+        seen.update(account=account, token_value=token_value)
+        return "authenticated"
+
+    monkeypatch.setattr(op_cli, "_op_whoami", fake_whoami)
+
+    assert args.func(args) == 0
+    assert saved_env == {"OP_TOKEN_WORK": "candidate-token"}
+    assert seen == {
+        "account": "work.1password.com",
+        "token_value": "candidate-token",
+    }
+
+
+def test_candidate_token_whoami_uses_isolated_auth_environment(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "provider-secret")
+    monkeypatch.setenv("OP_SESSION_personal", "personal-session")
+    monkeypatch.setenv("OP_ACCOUNT", "personal.1password.com")
+    monkeypatch.setenv("OP_CONNECT_HOST", "https://connect.invalid")
+    monkeypatch.setenv("OP_CONNECT_TOKEN", "connect-secret")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(cmd=cmd, env=kwargs["env"], stdin=kwargs["stdin"])
+        return subprocess.CompletedProcess(cmd, 0, stdout="work account\n", stderr="")
+
+    monkeypatch.setattr(op_cli.subprocess, "run", fake_run)
+
+    assert op_cli._op_whoami(
+        Path("/fake/op"),
+        "work.1password.com",
+        token_value="work-candidate",
+    ) == "work account"
+    assert captured["env"]["OP_SERVICE_ACCOUNT_TOKEN"] == "work-candidate"
+    assert "OPENAI_API_KEY" not in captured["env"]
+    assert "OP_SESSION_personal" not in captured["env"]
+    assert "OP_ACCOUNT" not in captured["env"]
+    assert "OP_CONNECT_HOST" not in captured["env"]
+    assert "OP_CONNECT_TOKEN" not in captured["env"]
+    assert captured["stdin"] is subprocess.DEVNULL
+
+
+def test_token_explicit_empty_account_overrides_profile_default(monkeypatch, tmp_path):
+    parser = argparse.ArgumentParser()
+    op_cli.register_cli(parser)
+    args = parser.parse_args(
+        [
+            "token",
+            "--account",
+            "",
+            "--token-env",
+            "OP_TOKEN_PERSONAL",
+            "--token",
+            "candidate-token",
+        ]
+    )
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    seen = {}
+    monkeypatch.setattr(
+        op_cli,
+        "load_config",
+        lambda: {
+            "secrets": {
+                "onepassword": {
+                    "enabled": True,
+                    "account": "work.1password.com",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(op_cli.op_src, "find_op", lambda binary_path="": fake_op)
+    monkeypatch.setattr(op_cli.op_src, "clear_caches", lambda: None)
+    monkeypatch.setattr(op_cli, "save_env_value", lambda name, value: None)
+
+    def fake_whoami(binary, account, *, token_value=""):
+        seen["account"] = account
+        return "authenticated"
+
+    monkeypatch.setattr(op_cli, "_op_whoami", fake_whoami)
+
+    assert args.func(args) == 0
+    assert seen["account"] == ""
+
+
+def test_status_checks_auth_readiness_per_effective_route(
+    monkeypatch, tmp_path, capsys
+):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    monkeypatch.setenv("OP_TOKEN_WORK", "configured")
+    monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN", raising=False)
+    monkeypatch.setattr(
+        op_cli,
+        "load_config",
+        lambda: {
+            "secrets": {
+                "onepassword": {
+                    "enabled": True,
+                    "env": {
+                        "WORK": {
+                            "reference": "op://Work/Service/credential",
+                            "account": "work.1password.com",
+                            "service_account_token_env": "OP_TOKEN_WORK",
+                        }
+                    },
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(op_cli.op_src, "find_op", lambda binary_path="": fake_op)
+    monkeypatch.setattr(
+        op_cli,
+        "_op_whoami",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("token-backed routes must not probe desktop auth")
+        ),
+    )
+
+    assert op_cli.cmd_status(argparse.Namespace()) == 0
+    assert "skip 1Password" not in capsys.readouterr().out
+
+
+def test_status_marks_inherited_account_and_token_fields_independently(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(op_cli, "Console", lambda: Console(width=180))
+    monkeypatch.setattr(
+        op_cli,
+        "load_config",
+        lambda: {
+            "secrets": {
+                "onepassword": {
+                    "enabled": False,
+                    "account": "default.1password.com",
+                    "service_account_token_env": "OP_TOKEN_DEFAULT",
+                    "env": {
+                        "ACCOUNT_ONLY": {
+                            "reference": "op://Work/Service/credential",
+                            "account": "work.1password.com",
+                        },
+                        "TOKEN_ONLY": {
+                            "reference": "op://Personal/Service/credential",
+                            "service_account_token_env": "OP_TOKEN_PERSONAL",
+                        },
+                    },
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(op_cli.op_src, "find_op", lambda binary_path="": None)
+
+    assert op_cli.cmd_status(argparse.Namespace()) == 0
+    output = capsys.readouterr().out
+    assert "OP_TOKEN_DEFAULT *" in output
+    assert "default.1password.com *" in output
+
+
+def test_status_probes_structured_desktop_route_with_strict_auth(
+    monkeypatch, capsys
+):
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "unrelated-token")
+    monkeypatch.setenv("OP_SESSION_unrelated", "unrelated-session")
+    monkeypatch.setattr(
+        op_cli,
+        "load_config",
+        lambda: {
+            "secrets": {
+                "onepassword": {
+                    "enabled": True,
+                    "env": {
+                        "DESKTOP": {
+                            "reference": "op://Vault/Item/field",
+                            "service_account_token_env": "",
+                        }
+                    },
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        op_cli.op_src, "find_op", lambda binary_path="": Path("/fake/op")
+    )
+    monkeypatch.setattr(op_cli, "_op_version", lambda _binary: "2.0")
+    calls = []
+
+    def fake_whoami(binary, account, *, token_value="", strict_auth=False):
+        calls.append((account, token_value, strict_auth))
+        return None
+
+    monkeypatch.setattr(op_cli, "_op_whoami", fake_whoami)
+
+    assert op_cli.cmd_status(argparse.Namespace()) == 0
+    capsys.readouterr()
+    assert calls == [("", "", True)]

--- a/tests/test_env_loader_op_bootstrap.py
+++ b/tests/test_env_loader_op_bootstrap.py
@@ -41,6 +41,7 @@ import agent.credential_pool as credential_pool  # noqa: E402
 def _isolate_op_token(monkeypatch):
     """Each test starts with OP_SERVICE_ACCOUNT_TOKEN unset and a clean cache."""
     monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN", raising=False)
+    monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN_WORK", raising=False)
     env_loader.reset_secret_source_cache()
     yield
     env_loader.reset_secret_source_cache()
@@ -84,6 +85,58 @@ def test_op_env_does_not_override_existing_token(tmp_path, monkeypatch):
 
     # override=False AND the explicit guard both protect the live token.
     assert os.environ["OP_SERVICE_ACCOUNT_TOKEN"] == "live-token"
+
+
+def test_op_env_loads_additional_account_tokens_without_overriding_existing(
+    tmp_path, monkeypatch
+):
+    """An existing default token must not suppress other account token vars."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / ".env").write_text("FOO=bar\n", encoding="utf-8")
+    (home / ".op.env").write_text(
+        "OP_SERVICE_ACCOUNT_TOKEN=file-default\n"
+        "OP_SERVICE_ACCOUNT_TOKEN_WORK=file-work\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "secrets:\n"
+        "  onepassword:\n"
+        "    service_account_token_env: OP_SERVICE_ACCOUNT_TOKEN\n"
+        "    env:\n"
+        "      WORK:\n"
+        "        reference: op://Work/Service/credential\n"
+        "        service_account_token_env: OP_SERVICE_ACCOUNT_TOKEN_WORK\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "live-default")
+
+    env_loader.load_hermes_dotenv(hermes_home=home)
+
+    assert os.environ["OP_SERVICE_ACCOUNT_TOKEN"] == "live-default"
+    assert os.environ["OP_SERVICE_ACCOUNT_TOKEN_WORK"] == "file-work"
+
+
+def test_op_env_ignores_variables_that_are_not_configured_token_names(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / ".op.env").write_text(
+        "OP_SERVICE_ACCOUNT_TOKEN=allowed\n"
+        "UNRELATED_PROVIDER_KEY=must-not-load\n"
+        "OP_CONNECT_TOKEN=must-not-load\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN", raising=False)
+    monkeypatch.delenv("UNRELATED_PROVIDER_KEY", raising=False)
+    monkeypatch.delenv("OP_CONNECT_TOKEN", raising=False)
+
+    env_loader.load_hermes_dotenv(hermes_home=home)
+
+    assert os.environ["OP_SERVICE_ACCOUNT_TOKEN"] == "allowed"
+    assert "UNRELATED_PROVIDER_KEY" not in os.environ
+    assert "OP_CONNECT_TOKEN" not in os.environ
 
 
 def test_missing_op_env_is_a_noop(tmp_path):

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -8,6 +8,7 @@ don't see an unexplained "credentials ✓" line when their .env is empty.
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -355,6 +356,62 @@ def test_apply_external_secret_sources_records_onepassword_origin(tmp_path, monk
         env_loader.format_secret_source_suffix("ANTHROPIC_API_KEY")
         == " (from 1Password)"
     )
+
+
+def test_real_onepassword_source_routes_two_accounts_through_startup(
+    tmp_path, monkeypatch
+):
+    """The real registry path preserves routing, provenance, and token isolation."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OP_TOKEN_WORK", "work-bootstrap")
+    monkeypatch.setenv("OP_TOKEN_PERSONAL", "personal-bootstrap")
+    monkeypatch.delenv("WORK_API_KEY", raising=False)
+    monkeypatch.delenv("PERSONAL_API_KEY", raising=False)
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  onepassword:\n"
+        "    enabled: true\n"
+        "    cache_ttl_seconds: 0\n"
+        "    env:\n"
+        "      WORK_API_KEY:\n"
+        "        reference: 'op://Work/Hermes/key'\n"
+        "        account: work.1password.com\n"
+        "        service_account_token_env: OP_TOKEN_WORK\n"
+        "      PERSONAL_API_KEY:\n"
+        "        reference: 'op://Personal/Hermes/key'\n"
+        "        account: personal.1password.com\n"
+        "        service_account_token_env: OP_TOKEN_PERSONAL\n",
+        encoding="utf-8",
+    )
+
+    import agent.secret_sources.onepassword as op_module
+    from agent.secret_sources import registry as reg_module
+
+    monkeypatch.setattr(op_module, "find_op", lambda *_a, **_kw: Path("/fake/op"))
+    calls = {}
+
+    def fake_run(cmd, **kwargs):
+        account = cmd[cmd.index("--account") + 1]
+        calls[account] = kwargs["env"]
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout=f"resolved-{account}\n", stderr=""
+        )
+
+    monkeypatch.setattr(op_module.subprocess, "run", fake_run)
+    reg_module._reset_registry_for_tests()
+
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert os.environ["WORK_API_KEY"] == "resolved-work.1password.com"
+    assert os.environ["PERSONAL_API_KEY"] == "resolved-personal.1password.com"
+    assert env_loader.get_secret_source("WORK_API_KEY") == "onepassword"
+    assert env_loader.get_secret_source("PERSONAL_API_KEY") == "onepassword"
+    assert calls["work.1password.com"]["OP_SERVICE_ACCOUNT_TOKEN"] == "work-bootstrap"
+    assert calls["personal.1password.com"]["OP_SERVICE_ACCOUNT_TOKEN"] == "personal-bootstrap"
+    assert "personal-bootstrap" not in calls["work.1password.com"].values()
+    assert "work-bootstrap" not in calls["personal.1password.com"].values()
+    assert os.environ["OP_TOKEN_WORK"] == "work-bootstrap"
+    assert os.environ["OP_TOKEN_PERSONAL"] == "personal-bootstrap"
 
 
 def test_apply_external_secret_sources_survives_non_dict_section(tmp_path, monkeypatch):

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -75,6 +75,38 @@ def test_validate_references_filters_bad_names_and_refs():
     assert len(warnings) == 3
 
 
+def test_validate_references_rejects_unknown_structured_keys():
+    valid, warnings = op._validate_references(
+        {
+            "WORK_KEY": {
+                "reference": "op://Work/Hermes/key",
+                "acount": "work.1password.com",
+            }
+        }
+    )
+
+    assert valid == {}
+    assert any("unknown field" in warning and "acount" in warning for warning in warnings)
+
+
+def test_structured_empty_routing_fields_override_profile_defaults():
+    valid, warnings = op._validate_references(
+        {
+            "DESKTOP_KEY": {
+                "reference": "op://Personal/Hermes/key",
+                "account": "",
+                "service_account_token_env": "",
+            }
+        }
+    )
+
+    assert warnings == []
+    assert op._reference_route(
+        valid["DESKTOP_KEY"],
+        default_account="work.1password.com",
+        default_token_env="OP_TOKEN_WORK",
+    ) == ("op://Personal/Hermes/key", "", "")
+
 # ---------------------------------------------------------------------------
 # fetch_onepassword_secrets
 # ---------------------------------------------------------------------------
@@ -130,6 +162,79 @@ def test_fetch_uses_option_terminator_and_account(monkeypatch, tmp_path):
     assert "--account" in cmd and "my.1password.com" in cmd
     # `--` must precede the positional reference.
     assert cmd[-2:] == ["--", "op://V/I/F"]
+
+
+def test_fetch_routes_each_reference_to_its_account_and_token(monkeypatch, tmp_path):
+    """Each structured mapping must use only its selected account credential."""
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    monkeypatch.setenv("OP_TOKEN_WORK", "work-token")
+    monkeypatch.setenv("OP_TOKEN_PERSONAL", "personal-token")
+    calls = {}
+
+    def fake_run(cmd, **kwargs):
+        reference = cmd[cmd.index("--") + 1]
+        calls[reference] = {"cmd": cmd, "env": kwargs["env"]}
+        return _ok(f"resolved:{reference}")
+
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+
+    secrets, warnings = op.fetch_onepassword_secrets(
+        references={
+            "WORK_KEY": {
+                "reference": "op://Work/Hermes/key",
+                "account": "work.1password.com",
+                "service_account_token_env": "OP_TOKEN_WORK",
+            },
+            "PERSONAL_KEY": {
+                "reference": "op://Personal/Hermes/key",
+                "account": "personal.1password.com",
+                "service_account_token_env": "OP_TOKEN_PERSONAL",
+            },
+        },
+        binary=fake_op,
+        use_cache=False,
+    )
+
+    assert warnings == []
+    assert set(secrets) == {"WORK_KEY", "PERSONAL_KEY"}
+    work = calls["op://Work/Hermes/key"]
+    personal = calls["op://Personal/Hermes/key"]
+    assert work["cmd"][-4:] == [
+        "--account", "work.1password.com", "--", "op://Work/Hermes/key"
+    ]
+    assert personal["cmd"][-4:] == [
+        "--account", "personal.1password.com", "--", "op://Personal/Hermes/key"
+    ]
+    assert work["env"]["OP_SERVICE_ACCOUNT_TOKEN"] == "work-token"
+    assert personal["env"]["OP_SERVICE_ACCOUNT_TOKEN"] == "personal-token"
+    assert "personal-token" not in work["env"].values()
+    assert "work-token" not in personal["env"].values()
+
+
+def test_fetch_never_resolves_into_any_configured_token_env(monkeypatch, tmp_path):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    monkeypatch.setenv("OP_TOKEN_PERSONAL", "original")
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("op must not run for a protected token target")
+
+    monkeypatch.setattr(op.subprocess, "run", fail_if_called)
+    secrets, warnings = op.fetch_onepassword_secrets(
+        references={
+            "OP_TOKEN_PERSONAL": {
+                "reference": "op://Personal/Hermes/token",
+                "account": "personal.1password.com",
+                "service_account_token_env": "OP_TOKEN_PERSONAL",
+            }
+        },
+        binary=fake_op,
+        use_cache=False,
+    )
+
+    assert secrets == {}
+    assert any("bootstrap token" in warning for warning in warnings)
 
 
 def test_fetch_empty_rc0_does_not_clobber(monkeypatch, tmp_path):
@@ -203,17 +308,57 @@ def test_fetch_child_env_is_allowlisted(monkeypatch, tmp_path):
 
     def fake_run(cmd, **kwargs):
         captured["env"] = kwargs["env"]
-        return _ok("v")
+        return _ok("value")
 
     monkeypatch.setattr(op.subprocess, "run", fake_run)
     op.fetch_onepassword_secrets(
-        references={"K": "op://V/I/F"}, binary=fake_op, use_cache=False
+        references={"K": "op://V/I/F"}, binary=fake_op, use_cache=False,
     )
     env = captured["env"]
     assert "OPENAI_API_KEY" not in env          # not inherited
     assert env["OP_SERVICE_ACCOUNT_TOKEN"] == "ops_tok"
     assert env["OP_SESSION_myacct"] == "sess123"
     assert env.get("NO_COLOR") == "1"
+
+
+def test_structured_mapping_uses_isolated_auth_environment(monkeypatch, tmp_path):
+    """Account-bound reads must not inherit another 1Password auth mode."""
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    monkeypatch.setenv("OP_TOKEN_WORK", "selected-token")
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "unrelated-token")
+    monkeypatch.setenv("OP_SESSION_personal", "unrelated-session")
+    monkeypatch.setenv("OP_ACCOUNT", "personal")
+    monkeypatch.setenv("OP_CONNECT_HOST", "https://connect.example.test")
+    monkeypatch.setenv("OP_CONNECT_TOKEN", "unrelated-connect-token")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        captured["stdin"] = kwargs.get("stdin")
+        return _ok("value")
+
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+    op.fetch_onepassword_secrets(
+        references={
+            "WORK_KEY": {
+                "reference": "op://Work/Hermes/key",
+                "account": "work.1password.com",
+                "service_account_token_env": "OP_TOKEN_WORK",
+            }
+        },
+        binary=fake_op,
+        use_cache=False,
+    )
+
+    env = captured["env"]
+    assert env["OP_SERVICE_ACCOUNT_TOKEN"] == "selected-token"
+    assert "OP_SESSION_personal" not in env
+    assert "OP_ACCOUNT" not in env
+    assert "OP_CONNECT_HOST" not in env
+    assert "OP_CONNECT_TOKEN" not in env
+    assert captured["stdin"] is subprocess.DEVNULL
 
 
 def test_fetch_child_env_passes_load_desktop_app_settings(monkeypatch, tmp_path):
@@ -249,6 +394,7 @@ def test_fetch_child_env_passes_load_desktop_app_settings(monkeypatch, tmp_path)
 def test_inprocess_cache_hit(monkeypatch, tmp_path):
     fake_op = tmp_path / "op"
     fake_op.write_text("")
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "test-token")
     calls = {"n": 0}
 
     def fake_run(*a, **k):
@@ -512,6 +658,37 @@ def test_apply_never_overrides_token_var(monkeypatch, tmp_path):
     assert calls["n"] == 0
 
 
+def test_apply_protects_every_structured_mapping_token_var(monkeypatch, tmp_path):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    monkeypatch.setattr(op, "find_op", lambda binary_path="": fake_op)
+    monkeypatch.setenv("OP_TOKEN_PERSONAL", "original")
+    calls = {"n": 0}
+
+    def fake_run(*a, **k):
+        calls["n"] += 1
+        return _ok("malicious")
+
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+
+    result = op.apply_onepassword_secrets(
+        enabled=True,
+        env={
+            "OP_TOKEN_PERSONAL": {
+                "reference": "op://Personal/Hermes/token",
+                "account": "personal.1password.com",
+                "service_account_token_env": "OP_TOKEN_PERSONAL",
+            }
+        },
+        override_existing=True,
+        cache_ttl_seconds=0,
+    )
+
+    assert "OP_TOKEN_PERSONAL" in result.skipped
+    assert os.environ["OP_TOKEN_PERSONAL"] == "original"
+    assert calls["n"] == 0
+
+
 def test_apply_never_raises_on_read_failure(monkeypatch, tmp_path):
     fake_op = tmp_path / "op"
     fake_op.write_text("")
@@ -538,3 +715,186 @@ def test_apply_no_valid_refs_is_noop(monkeypatch):
     assert result.ok
     assert result.applied == []
     assert result.warnings  # the bad mapping warned
+
+
+def test_source_protects_all_configured_token_env_vars():
+    protected = op.OnePasswordSource().protected_env_vars(
+        {
+            "service_account_token_env": "OP_TOKEN_DEFAULT",
+            "env": {
+                "WORK": {
+                    "reference": "op://Work/Hermes/key",
+                    "service_account_token_env": "OP_TOKEN_WORK",
+                },
+                "PERSONAL": {
+                    "reference": "op://Personal/Hermes/key",
+                    "service_account_token_env": "OP_TOKEN_PERSONAL",
+                },
+            },
+        }
+    )
+
+    assert protected == frozenset(
+        {
+            "OP_SERVICE_ACCOUNT_TOKEN",
+            "OP_TOKEN_DEFAULT",
+            "OP_TOKEN_WORK",
+            "OP_TOKEN_PERSONAL",
+        }
+    )
+
+
+def test_explicit_structured_token_route_fails_closed_when_token_is_missing(
+    monkeypatch, tmp_path
+):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    calls = {"n": 0}
+
+    def fake_run(*args, **kwargs):
+        calls["n"] += 1
+        return _ok("desktop-derived")
+
+    monkeypatch.delenv("OP_TOKEN_WORK", raising=False)
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+    secrets, warnings = op.fetch_onepassword_secrets(
+        references={
+            "WORK": {
+                "reference": "op://Work/Service/credential",
+                "account": "work.1password.com",
+                "service_account_token_env": "OP_TOKEN_WORK",
+            }
+        },
+        binary=fake_op,
+        use_cache=False,
+    )
+
+    assert secrets == {}
+    assert calls["n"] == 0
+    assert any("OP_TOKEN_WORK" in warning and "unset" in warning for warning in warnings)
+
+
+def test_top_level_empty_token_env_uses_strict_desktop_auth(monkeypatch, tmp_path):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs["env"])
+        return _ok("desktop-derived")
+
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "must-not-cross")
+    monkeypatch.setattr(op, "find_op", lambda binary_path="": fake_op)
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+    result = op.OnePasswordSource().fetch(
+        {
+            "service_account_token_env": "",
+            "env": {"DESKTOP": "op://Personal/Service/credential"},
+            "cache_ttl_seconds": 0,
+        },
+        tmp_path,
+    )
+
+    assert result.secrets == {"DESKTOP": "desktop-derived"}
+    assert "OP_SERVICE_ACCOUNT_TOKEN" not in captured
+
+
+def test_desktop_auth_routes_are_not_cached_across_identity_switches(
+    monkeypatch, tmp_path
+):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    calls = {"n": 0}
+
+    def fake_run(*args, **kwargs):
+        calls["n"] += 1
+        return _ok(f"identity-{calls['n']}")
+
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+    refs = {
+        "DESKTOP": {
+            "reference": "op://Personal/Service/credential",
+            "account": "",
+            "service_account_token_env": "",
+        }
+    }
+    first, _ = op.fetch_onepassword_secrets(
+        references=refs, binary=fake_op, home_path=tmp_path
+    )
+    second, _ = op.fetch_onepassword_secrets(
+        references=refs, binary=fake_op, home_path=tmp_path
+    )
+
+    assert first == {"DESKTOP": "identity-1"}
+    assert second == {"DESKTOP": "identity-2"}
+    assert calls["n"] == 2
+
+
+def test_implicit_desktop_fallback_is_not_cached_across_identity_switches(
+    monkeypatch, tmp_path
+):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    calls = {"n": 0}
+
+    def fake_run(*args, **kwargs):
+        calls["n"] += 1
+        return _ok(f"identity-{calls['n']}")
+
+    monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN", raising=False)
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+    refs = {"LEGACY": "op://Vault/Item/field"}
+    first, _ = op.fetch_onepassword_secrets(
+        references=refs, binary=fake_op, home_path=tmp_path
+    )
+    second, _ = op.fetch_onepassword_secrets(
+        references=refs, binary=fake_op, home_path=tmp_path
+    )
+
+    assert first == {"LEGACY": "identity-1"}
+    assert second == {"LEGACY": "identity-2"}
+    assert calls["n"] == 2
+
+
+def test_op_stderr_redacts_selected_token(monkeypatch, tmp_path):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    token = "selected-token-must-not-leak"
+    monkeypatch.setenv("OP_TOKEN_WORK", token)
+    monkeypatch.setattr(
+        op.subprocess,
+        "run",
+        lambda *args, **kwargs: _err(1, f"authentication failed for {token}"),
+    )
+    _secrets, warnings = op.fetch_onepassword_secrets(
+        references={
+            "WORK": {
+                "reference": "op://Work/Service/credential",
+                "service_account_token_env": "OP_TOKEN_WORK",
+            }
+        },
+        binary=fake_op,
+        use_cache=False,
+    )
+
+    rendered = "\n".join(warnings)
+    assert token not in rendered
+    assert "[REDACTED]" in rendered
+
+
+def test_all_reads_disable_stdin_to_prevent_interactive_fallback(
+    monkeypatch, tmp_path
+):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    stdins = []
+
+    def fake_run(*args, **kwargs):
+        stdins.append(kwargs.get("stdin"))
+        return _ok("resolved")
+
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+    op._run_op_read(fake_op, "op://V/I/F", strict_auth=False)
+    op._run_op_read(fake_op, "op://V/I/F", strict_auth=True)
+
+    assert stdins == [subprocess.DEVNULL, subprocess.DEVNULL]

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -89,6 +89,20 @@ def test_validate_references_rejects_unknown_structured_keys():
     assert any("unknown field" in warning and "acount" in warning for warning in warnings)
 
 
+def test_validate_references_rejects_non_string_structured_keys():
+    valid, warnings = op._validate_references(
+        {
+            "WORK_KEY": {
+                "reference": "op://Work/Hermes/key",
+                1: "valid YAML key, invalid schema",
+            }
+        }
+    )
+
+    assert valid == {}
+    assert any("field names must be strings" in warning for warning in warnings)
+
+
 def test_structured_empty_routing_fields_override_profile_defaults():
     valid, warnings = op._validate_references(
         {

--- a/website/docs/user-guide/secrets/onepassword.md
+++ b/website/docs/user-guide/secrets/onepassword.md
@@ -16,22 +16,22 @@ Hermes never authenticates on your behalf and never downloads `op`: it shells ou
 `op` supports two non-interactive-friendly modes; Hermes works with either:
 
 - **Service accounts** (recommended for servers/CI): create a service account in 1Password, grant it read access to the relevant vault, and export its token as `OP_SERVICE_ACCOUNT_TOKEN` in `~/.hermes/.env`. The token is the credential — treat it like any other bearer token.
-- **Desktop / interactive sessions** (laptops): run `op signin` (or enable CLI integration in the 1Password app). Hermes passes your `OP_SESSION_*` variables through to the `op` child process. The 1Password cache key includes those session variables, so signing into a different account never serves a value cached under the previous identity.
+- **Desktop / interactive sessions** (laptops): run `op signin` (or enable CLI integration in the 1Password app). Legacy string mappings retain support for inherited `OP_SESSION_*` variables. Structured, account-bound mappings use an isolated child environment and should use 1Password desktop-app integration; unrelated session, service-account, and Connect credentials are not inherited.
 
 ## Bootstrap token
 
 When you authenticate with a **service-account token**, that token is itself the bootstrap credential Hermes needs *before* it can resolve any `op://` reference. It must be present in `os.environ` of every process that resolves secrets — including cron jobs (`kanban.dispatch_in_gateway: false`), subprocess invocations, CLI runs, macOS launchd agents, and Docker containers — not just the interactive gateway. There are three ways to make it available, in order of precedence:
 
-1. **In `~/.hermes/.env` (recommended).** `hermes secrets onepassword setup --token <token>` writes the token to `~/.hermes/.env`, exactly like Bitwarden's `BWS_ACCESS_TOKEN`. Because `load_hermes_dotenv()` always loads `.env`, the token is available everywhere with zero extra setup. This is the simplest reliable option.
+1. **In `~/.hermes/.env` (recommended).** Run `hermes secrets onepassword token --account my.1password.com --token-env OP_SERVICE_ACCOUNT_TOKEN` and paste the token at the masked prompt. Hermes writes it to `~/.hermes/.env`, exactly like Bitwarden's `BWS_ACCESS_TOKEN`. Because `load_hermes_dotenv()` always loads `.env`, the token is available everywhere with zero extra setup. This is the simplest reliable option and avoids exposing the token in shell history or process arguments.
 
 2. **In `~/.hermes/.op.env` (gitignored).** If you'd rather keep the service-account token out of `.env` — for example so `.env` can be checked into a private dotfiles repo while the token stays out of version control — place it in `~/.hermes/.op.env`:
 
    ```bash
-   echo 'OP_SERVICE_ACCOUNT_TOKEN=ops_...' > ~/.hermes/.op.env
+   printf '%s\n' 'OP_SERVICE_ACCOUNT_TOKEN=[SERVICE_ACCOUNT_TOKEN]' > ~/.hermes/.op.env
    chmod 600 ~/.hermes/.op.env
    ```
 
-   Hermes auto-loads `.op.env` at startup, **after** `.env`, and **never** overrides a token already present in the environment. `.op.env` is gitignored so the token never enters a committed file.
+   Hermes auto-loads `.op.env` at startup, **after** `.env`, and **never** overrides a token already present in the environment. Only the canonical token and token-env names selected by valid 1Password routes are loaded; unrelated entries are ignored. The Hermes source repository ignores `.op.env`, but if your home directory is managed by a separate dotfiles repository, add `~/.hermes/.op.env` to that repository's ignore rules too.
 
 3. **Via systemd `EnvironmentFile` (Linux gateway).** If you run the gateway under systemd, you can inject the token directly into the service environment:
 
@@ -40,9 +40,9 @@ When you authenticate with a **service-account token**, that token is itself the
    EnvironmentFile=-/home/youruser/.hermes/.op.env
    ```
 
-   A token injected this way takes precedence — Hermes detects that `OP_SERVICE_ACCOUNT_TOKEN` is already set and skips loading `.op.env` entirely.
+   A token injected this way takes precedence. Hermes still loads additional configured account-token variables from `.op.env` without replacing values already injected by systemd.
 
-If the token is reachable only through an interactive shell (`op signin`, `OP_SESSION_*` exports in `.bashrc`, etc.), it will **not** be inherited by cron jobs or freshly spawned subprocesses, and those contexts will log a warning and fall back to whatever credentials `.env` already held. Use one of the three options above for any non-interactive workload.
+If authentication is reachable only through an interactive shell (`op signin`, `OP_SESSION_*` exports in `.bashrc`, etc.), it will **not** be available to cron jobs or freshly spawned subprocesses. An explicit nonempty token route whose selected variable is missing fails closed and skips that mapping; it never falls back to desktop credentials. Use one of the three options above for any non-interactive workload.
 
 ## Setup
 
@@ -60,13 +60,15 @@ op whoami
 hermes secrets onepassword setup
 ```
 
-This verifies `op` is on `PATH` (or use `--binary-path`), records your account/token settings, checks for an active session, and flips `secrets.onepassword.enabled: true`. Non-interactive flags:
+This verifies `op` is on `PATH` (or use `--binary-path`), records your account/token settings, checks for an active session, and flips `secrets.onepassword.enabled: true`. To preselect routing, enable the integration first, then store a service-account token through the separate masked-input command:
 
 ```bash
 hermes secrets onepassword setup \
   --account my.1password.com \
-  --token-env OP_SERVICE_ACCOUNT_TOKEN \
-  --token "$OP_SERVICE_ACCOUNT_TOKEN"
+  --token-env OP_SERVICE_ACCOUNT_TOKEN
+hermes secrets onepassword token \
+  --account my.1password.com \
+  --token-env OP_SERVICE_ACCOUNT_TOKEN
 ```
 
 ### 3. Map your credentials
@@ -77,6 +79,26 @@ The reference format is `op://<vault>/<item>/<field>`:
 hermes secrets onepassword set OPENAI_API_KEY    "op://Private/OpenAI/api key"
 hermes secrets onepassword set ANTHROPIC_API_KEY "op://Private/Anthropic/credential"
 ```
+
+To route references through different 1Password accounts in one Hermes profile,
+add `--account` and, for headless use, a distinct `--token-env`:
+
+```bash
+hermes secrets onepassword set WORK_API_KEY \
+  "op://Engineering/Internal API/credential" \
+  --account work.1password.com \
+  --token-env OP_SERVICE_ACCOUNT_TOKEN_WORK
+
+# Uses a masked prompt by default; the token value is stored outside config.yaml.
+hermes secrets onepassword token \
+  --account work.1password.com \
+  --token-env OP_SERVICE_ACCOUNT_TOKEN_WORK
+```
+
+Mappings without either flag keep the original string form and inherit the
+top-level defaults. Mappings with either flag use a structured form containing
+only the `op://` reference, account selector, and token **environment-variable
+name**—never the token value.
 
 ### 4. Preview and confirm
 
@@ -93,11 +115,11 @@ From now on, every `hermes` invocation resolves the references at startup. You'l
 |---|---|
 | `hermes secrets onepassword setup` | Verify `op`, set account / token env var, enable |
 | `hermes secrets onepassword status` | Show config, binary, auth, and configured references |
-| `hermes secrets onepassword token` | Rotate the service-account token: validate with `op whoami`, then store it in `.env` |
-| `hermes secrets onepassword set ENV_VAR "op://…"` | Map an env var to a reference (stored stripped + validated) |
+| `hermes secrets onepassword token [--account ACCOUNT] [--token-env ENV_VAR]` | Rotate the selected account's service-account token: validate with `op whoami`, then store it in `.env` |
+| `hermes secrets onepassword set ENV_VAR "op://…" [--account ACCOUNT] [--token-env ENV_VAR]` | Map an env var to a reference, optionally overriding the profile defaults |
 | `hermes secrets onepassword remove ENV_VAR` | Drop a mapping |
 | `hermes secrets onepassword sync` | Dry-run: resolve references now and show what would apply |
-| `hermes secrets onepassword sync --apply` | Resolve and export into the current shell's environment |
+| `hermes secrets onepassword sync --apply` | Resolve and apply inside the validation process (a child process cannot modify its parent shell) |
 | `hermes secrets onepassword disable` | Flip `enabled: false`; leaves mappings in place |
 
 `op` and `1password` are accepted as aliases for `onepassword`.
@@ -112,7 +134,10 @@ secrets:
     enabled: false
     env:
       OPENAI_API_KEY: "op://Private/OpenAI/api key"
-      ANTHROPIC_API_KEY: "op://Private/Anthropic/credential"
+      WORK_API_KEY:
+        reference: "op://Engineering/Internal API/credential"
+        account: work.1password.com
+        service_account_token_env: OP_SERVICE_ACCOUNT_TOKEN_WORK
     account: ""
     service_account_token_env: OP_SERVICE_ACCOUNT_TOKEN
     binary_path: ""
@@ -123,9 +148,9 @@ secrets:
 | Key | Default | What it does |
 |---|---|---|
 | `enabled` | `false` | Master switch. When false, `op` is never invoked. |
-| `env` | `{}` | Mapping of env-var name → `op://vault/item/field` reference. Entries whose name isn't a valid env-var name, or whose value isn't an `op://` reference, are skipped with a warning. |
-| `account` | `""` | Account shorthand / sign-in address passed as `op read --account`. Empty uses `op`'s default account. |
-| `service_account_token_env` | `OP_SERVICE_ACCOUNT_TOKEN` | Env var Hermes reads the service-account token from. Its value is exported to the `op` child as `OP_SERVICE_ACCOUNT_TOKEN` (the name `op` expects). Leave the var unset to use a desktop/interactive session. |
+| `env` | `{}` | Mapping of env-var name to either an `op://vault/item/field` string or `{reference, account?, service_account_token_env?}`. String entries inherit the defaults below. Unknown structured fields and invalid values warn and skip instead of silently falling back. |
+| `account` | `""` | Default account shorthand / sign-in address passed as `op read --account`. Empty uses `op`'s default account. Structured mappings can override it. |
+| `service_account_token_env` | `OP_SERVICE_ACCOUNT_TOKEN` | Default env var Hermes reads the service-account token from. Its value is supplied to the selected `op` child as `OP_SERVICE_ACCOUNT_TOKEN` (the name `op` expects). Structured mappings can select a different token env. An explicit nonempty selection is required and fails closed when unset; an explicit empty string selects desktop integration. |
 | `binary_path` | `""` | Absolute path to `op`. When set, it is used verbatim and `PATH` is **not** consulted — pin this to avoid trusting whatever `op` appears first on `PATH`. |
 | `cache_ttl_seconds` | `300` | How long resolved values are reused (in-process and on disk). Set to `0` to disable **both** cache layers — no values are written to disk at all. |
 | `override_existing` | `true` | When true, resolved values overwrite anything already in env (so rotation takes effect). Flip to `false` to let `.env` / shell exports win; those references are then skipped *before* `op` is invoked. |
@@ -149,15 +174,17 @@ Startup warnings now include a `→` remediation line telling you exactly which 
 Successful, complete pulls are cached in-process and on disk under `<hermes_home>/cache/op_cache.json` (written atomically, mode `0600`), so back-to-back short-lived `hermes` invocations don't re-shell `op` for every reference. The cache:
 
 - stores only resolved secret **values** — never the service-account token or any raw auth material (auth is fingerprinted into the cache key);
-- is invalidated when the token, account, `OP_SESSION_*` variables, or the set of references change;
+- is invalidated when any selected token, effective account, token-env routing, `OP_SESSION_*` identity, or reference mapping changes;
+- is bypassed for explicit desktop-auth routes because the desktop app's active identity has no stable environment fingerprint;
 - is **not** written when a pull had any per-reference error, so a transient auth failure isn't frozen in for the TTL;
 - is fully disabled — reads *and* writes — when `cache_ttl_seconds: 0`.
 
 ## Security notes
 
 - A 1Password service-account token can read every secret the account has access to. Store it in `~/.hermes/.env` (not `config.yaml`), and revoke + regenerate from 1Password if it leaks.
-- Hermes refuses to let a resolved value overwrite the token env var itself, even with `override_existing: true`.
-- The `op` child process gets a minimal allowlisted environment (auth/session vars + `PATH`/`HOME`), not a copy of the full `os.environ`, so post-dotenv provider credentials aren't all inherited by the child.
+- Hermes refuses to let a resolved value overwrite the canonical `OP_SERVICE_ACCOUNT_TOKEN` or **any configured token env var**, even with `override_existing: true`.
+- The `op` child process gets a minimal allowlisted environment, not a copy of the full `os.environ`. Structured mappings receive exactly their selected service token, or a clean desktop-integration context; unrelated `OP_SESSION_*`, `OP_ACCOUNT`, and Connect credentials are excluded.
+- Account selectors and token-env names participate in the cache key. Two identical `op://` references routed to different accounts cannot share a cache entry.
 - References are validated to start with `op://`, and the reference is passed after a `--` option terminator so a crafted value can't be parsed as an `op` flag.
 
 ## When NOT to use this

--- a/website/docs/user-guide/secrets/onepassword.md
+++ b/website/docs/user-guide/secrets/onepassword.md
@@ -175,7 +175,7 @@ Successful, complete pulls are cached in-process and on disk under `<hermes_home
 
 - stores only resolved secret **values** — never the service-account token or any raw auth material (auth is fingerprinted into the cache key);
 - is invalidated when any selected token, effective account, token-env routing, `OP_SESSION_*` identity, or reference mapping changes;
-- is bypassed for explicit desktop-auth routes because the desktop app's active identity has no stable environment fingerprint;
+- is bypassed whenever a route uses desktop authentication, including implicit fallback when a selected token variable is unset, because the desktop app's active identity has no stable environment fingerprint;
 - is **not** written when a pull had any per-reference error, so a transient auth failure isn't frozen in for the TTL;
 - is fully disabled — reads *and* writes — when `cache_ttl_seconds: 0`.
 


### PR DESCRIPTION
## What does this PR do?

Adds backward-compatible, per-reference account routing to Hermes' existing native 1Password secret source.

Existing string mappings remain unchanged and inherit profile defaults:

```yaml
OPENAI_API_KEY: "op://Private/OpenAI/api key"
```

Mappings that need a different account or authentication route can use a structured form:

```yaml
WORK_API_KEY:
  reference: "op://Engineering/Internal API/credential"
  account: work.1password.com
  service_account_token_env: OP_SERVICE_ACCOUNT_TOKEN_WORK
```

Omitted structured fields inherit profile defaults. Explicit empty `account` and `service_account_token_env` fields suppress their respective defaults; an empty token-env selection uses isolated desktop authentication.

The implementation keeps routing metadata outside the `op://` locator, rejects malformed/unknown structured fields, isolates every structured `op` child to the selected authentication context, protects all configured token variables from resolved-secret writes, and separates cache identities by account and token route. Routes using desktop authentication are not cached because the active desktop identity has no stable environment fingerprint.

This extends an existing core integration rather than adding a new third-party plugin.

## Related Issue

N/A — no matching open or closed issue/PR was found for per-reference multi-account 1Password routing.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/secret_sources/onepassword.py`
  - accepts legacy strings or strict structured references;
  - routes each reference by effective account and token-env selection;
  - rejects unknown fields, malformed account selectors, invalid token variable names, and token variables used as destinations;
  - isolates structured `op` children and supplies only the selected service token;
  - redacts authentication values from surfaced `op` errors;
  - disables stdin for all secret-resolution reads;
  - separates cache/auth fingerprints and bypasses caching for desktop-auth routes.
- `hermes_cli/onepassword_secrets_cli.py`
  - adds per-reference `--account` and `--token-env` configuration;
  - preserves omitted-versus-explicit-empty CLI semantics;
  - validates candidate tokens and structured desktop status probes in isolated environments;
  - reports route-specific authentication readiness and accurate process-local `sync --apply` behavior.
- `hermes_cli/env_loader.py`
  - loads multiple configured 1Password bootstrap-token variables without overriding existing process values;
  - ignores unrelated `.op.env` entries.
- Tests cover routing, malformed input, credential isolation, protected destinations, explicit-empty semantics, cache separation, desktop identity switching, error redaction, CLI persistence/status, bootstrap loading, and startup orchestration.
- Updated `cli-config.yaml.example` and the 1Password user guide with schema, migration, masked token intake, desktop/service-account behavior, caching, and security guidance.

## How to Test

1. Run the focused regression suite:
   ```bash
   scripts/run_tests.sh \
     tests/test_onepassword_secrets.py \
     tests/hermes_cli/test_onepassword_multi_account_cli.py \
     tests/hermes_cli/test_secrets_token_rotation.py \
     tests/test_env_loader_op_bootstrap.py \
     tests/test_env_loader_secret_sources.py -v --tb=short
   ```
   Expected: `81 passed, 0 failed`.
2. Run quality/security checks:
   ```bash
   .venv/bin/ruff check agent/secret_sources/onepassword.py hermes_cli/onepassword_secrets_cli.py hermes_cli/env_loader.py tests/test_onepassword_secrets.py tests/hermes_cli/test_onepassword_multi_account_cli.py tests/test_env_loader_op_bootstrap.py tests/test_env_loader_secret_sources.py
   .venv/bin/ty check agent/secret_sources/onepassword.py hermes_cli/onepassword_secrets_cli.py hermes_cli/env_loader.py
   .venv/bin/python scripts/check-windows-footguns.py agent/secret_sources/onepassword.py hermes_cli/onepassword_secrets_cli.py hermes_cli/env_loader.py
   ```
3. Build the documentation site:
   ```bash
   cd website && npm ci && npm run build
   ```
   Both English and Chinese static builds complete successfully. The build reports pre-existing unrelated broken-link warnings.

Automated tests use mocked `op` subprocesses and synthetic placeholder values; no real 1Password secret values are required or exposed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Focused feature suite: 81 passed. The broader project runner reproduces the same unrelated failure families on the pristine base commit (47 failed tests across 20 files plus 10 files with collection/import/time-limit failures); no changed 1Password path fails.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2, Python 3.11.15, 1Password CLI 2.35.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no contribution workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — explicit Windows footgun scan passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Focused suite:       81 passed, 0 failed
Ruff:                 All checks passed
Ty:                   All checks passed
Windows footguns:     No Windows footguns found (3 files scanned)
Documentation build:  English and zh-Hans generated successfully
Bounded artifact gate: high-confidence source, filesystem, and worktree scans passed
```

