### PR TITLE
fix(sessions): show FTS results outside the current page

### DIFF
--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -36,6 +36,7 @@ import {
   importSummary,
   parseImportSessions,
 } from "@/lib/session-import";
+import { sessionsForSearchResults } from "./session-search";
 import type {
   SessionInfo,
   SessionMessage,
@@ -1246,10 +1247,11 @@ export default function SessionsPage() {
     }
   }
 
-  // When searching, filter sessions to those with FTS matches;
-  // when not searching, show all sessions
+  // FTS searches the entire store while `sessions` only holds the current
+  // pagination page. Render the FTS rows directly so an older matching session
+  // remains discoverable instead of being silently filtered out.
   const filtered = searchResults
-    ? sessions.filter((s) => snippetMap.has(s.id))
+    ? sessionsForSearchResults(sessions, searchResults)
     : sessions;
 
   const platformEntries = status

--- a/web/src/pages/session-search.test.ts
+++ b/web/src/pages/session-search.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionInfo, SessionSearchResult } from "@/lib/api";
+import { sessionsForSearchResults } from "./session-search";
+
+const archivedSearchHit: SessionSearchResult = {
+  session_id: "20260722_185815_27a418",
+  snippet: "Automação CRM Bonus → WhatsApp",
+  role: "assistant",
+  source: "tui",
+  model: "deepseek/deepseek-v4-pro",
+  session_started: 1784746695,
+};
+
+describe("sessionsForSearchResults", () => {
+  it("renders a matching session even when it is outside the loaded page", () => {
+    const currentPage: SessionInfo[] = [];
+
+    expect(sessionsForSearchResults(currentPage, [archivedSearchHit])).toEqual([
+      {
+        id: "20260722_185815_27a418",
+        source: "tui",
+        model: "deepseek/deepseek-v4-pro",
+        title: null,
+        started_at: 1784746695,
+        ended_at: null,
+        last_active: 1784746695,
+        is_active: false,
+        message_count: 0,
+        tool_call_count: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        preview: "Automação CRM Bonus → WhatsApp",
+      },
+    ]);
+  });
+});

--- a/web/src/pages/session-search.ts
+++ b/web/src/pages/session-search.ts
@@ -1,0 +1,34 @@
+import type { SessionInfo, SessionSearchResult } from "@/lib/api";
+
+/**
+ * Turn FTS hits into rows the Sessions page can render. Search queries span the
+ * whole session store, while `sessions` only holds the current pagination page.
+ */
+export function sessionsForSearchResults(
+  sessions: SessionInfo[],
+  results: SessionSearchResult[],
+): SessionInfo[] {
+  const loadedById = new Map(sessions.map((session) => [session.id, session]));
+
+  return results.map((result) => {
+    const loaded = loadedById.get(result.session_id);
+    if (loaded) return loaded;
+
+    const startedAt = result.session_started ?? 0;
+    return {
+      id: result.session_id,
+      source: result.source,
+      model: result.model,
+      title: null,
+      started_at: startedAt,
+      ended_at: null,
+      last_active: startedAt,
+      is_active: false,
+      message_count: 0,
+      tool_call_count: 0,
+      input_tokens: 0,
+      output_tokens: 0,
+      preview: result.snippet,
+    };
+  });
+}


### PR DESCRIPTION
## Summary

The Sessions page searches the entire session store, but then filtered its rendered rows against only the currently loaded pagination page. As a result, valid matches in older sessions were returned by FTS but rendered as no results.

Render the FTS result set directly, preserving full metadata for any result already present on the loaded page and providing a renderable fallback for off-page matches.

## Test plan

- `npm run test --workspace web` (98 tests)
- `npm run typecheck --workspace web`
- `npm run lint --workspace web` (existing warnings only)