### PR TITLE
test(computer-use): simulate Linux for GNOME helper selection

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1918,7 +1918,8 @@ class TestCaptureAppFilterNoMatch:
              "structuredContent": None},
         ]
 
-        backend.capture(mode="ax")
+        with patch("tools.computer_use.cua_backend.sys.platform", "linux"):
+            backend.capture(mode="ax")
 
         assert backend._active_pid == 200
         assert backend._active_window_id == 2


### PR DESCRIPTION
## Purpose

Make the GNOME/Linux helper-selection regression test deterministic on non-Linux developer and CI hosts.

## Change

- Patch `tools.computer_use.cua_backend.sys.platform` to `"linux"` only while `TestCaptureAppFilterNoMatch` calls `backend.capture()`.
- Keep the production implementation unchanged.

The test exercises Linux-specific GNOME app/window selection. Without the platform patch, macOS runs a different backend branch and the assertion does not test the intended code path.

## Validation

```text
python -m pytest tests/tools/test_computer_use.py -q
223 passed in 64.13s
```

## Risk

Low. This changes one test only and narrows its environment to the platform behavior it is intended to cover.
