### PR TITLE
fix(telegram): preserve command argument separator

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7584,7 +7584,12 @@ class TelegramAdapter(BasePlatformAdapter):
         if not text or not self._bot or not getattr(self._bot, "username", None):
             return text
         username = re.escape(self._bot.username)
-        cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
+        # Do not consume the whitespace after a command mention.  Telegram
+        # sends ``/title@bot_name My title`` as one command message; consuming
+        # that separator turns it into ``/titleMy title`` and makes the
+        # gateway report an unknown command.  ``strip()`` below still removes
+        # leading whitespace for ordinary ``@bot_name hello`` messages.
+        cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*", "", text).strip()
         return cleaned or text
 
     def _should_observe_unmentioned_group_message(self, message: Message) -> bool:

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -228,6 +228,16 @@ def test_observed_group_context_uses_shared_source_and_prompt_for_later_mentions
     asyncio.run(_run())
 
 
+def test_clean_bot_trigger_text_preserves_command_argument_separator():
+    adapter = _make_adapter(bot_username="marseilleclaudebot")
+
+    assert (
+        adapter._clean_bot_trigger_text("/title@marseilleclaudebot chat-telegram")
+        == "/title chat-telegram"
+    )
+    assert adapter._clean_bot_trigger_text("@marseilleclaudebot bonjour") == "bonjour"
+
+
 def test_observed_group_context_replays_as_current_message_context_not_user_turns():
     from gateway.run import (
         _build_gateway_agent_history,


### PR DESCRIPTION
## Summary
- preserve the separator in Telegram commands addressed with `@botname`
- fix `/title@botname chat-telegram` being parsed as `/titlechat-telegram`
- add regression coverage for command and ordinary mention messages

## Test plan
- `uv run --with pytest pytest tests/gateway/test_telegram_group_gating.py -q`
- 56 tests passed

This fixes a generic Telegram gateway parsing bug; no user configuration or secrets are involved.