### PR TITLE
fix(send_message): route .webm as video, not document

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -683,6 +683,34 @@ class TestSendTelegramMediaDelivery:
         bot.send_audio.assert_awaited_once()
         bot.send_voice.assert_not_awaited()
 
+    def test_sends_video_for_webm(self, tmp_path, monkeypatch):
+        """`.webm` must route via send_video, not document (parity with gateway _VIDEO_EXTS)."""
+        video_path = tmp_path / "clip.webm"
+        video_path.write_bytes(b"\x1aE\xdf\xa3" + b"\x00" * 32)  # EBML/WebM header
+
+        bot = MagicMock()
+        bot.send_message = AsyncMock()
+        bot.send_photo = AsyncMock()
+        bot.send_video = AsyncMock(return_value=SimpleNamespace(message_id=9))
+        bot.send_voice = AsyncMock()
+        bot.send_audio = AsyncMock()
+        bot.send_document = AsyncMock()
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram(
+                "token",
+                "12345",
+                "",
+                media_files=[(str(video_path), False)],
+            )
+        )
+
+        assert result["success"] is True
+        assert result["message_id"] == "9"
+        bot.send_video.assert_awaited_once()
+        bot.send_document.assert_not_awaited()
+
     def test_missing_media_returns_error_without_leaking_raw_tag(self, monkeypatch):
         bot = MagicMock()
         bot.send_message = AsyncMock()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -62,7 +62,9 @@ _EMAIL_TARGET_RE = re.compile(r"^\s*[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2
 # never read. Map the exceptions so the error guidance is actually actionable.
 _HOME_CHANNEL_ENV_OVERRIDES = {"email": "EMAIL_HOME_ADDRESS"}
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
-_VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
+# Keep in sync with gateway/platforms/base.py _VIDEO_EXTS / MEDIA_DELIVERY_EXTS
+# video partition (.webm was missing here and fell through to document send).
+_VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
 _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
 _VOICE_EXTS = {".ogg", ".opus"}
 # Telegram's Bot API sendAudio only accepts MP3 / M4A. Other audio


### PR DESCRIPTION
## Summary

- Sync `tools/send_message_tool.py` `_VIDEO_EXTS` with gateway peers by adding `.webm`
- Without this, `.webm` files fall through to `send_document` instead of native `send_video`
- Add Telegram regression test covering WebM video routing

Fixes #71603

## Root cause

Constant-set drift: gateway `base.py` / `run.py` / `scheduler.py` include `.webm` in video partitions; `send_message_tool` did not.

## Test plan

- [x] `bash scripts/run_tests.sh tests/tools/test_send_message_tool.py -- -k 'webm or sends_audio_for_mp3'`
- [x] Confirmed `_describe_media_for_mirror` reports video for `.webm` after fix
