### PR TITLE
fix(kanban): let an audited resume clear the active_pr respawn guard

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7909,26 +7909,40 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     #    "closed") cannot authorize a retry, and no network/API failure can
     #    silently turn an unresolved PR into a closed one.  The strict
     #    timestamp comparison stays fail-closed when ordering is ambiguous.
+    #
+    #    Comments and resume events must come from one SQLite statement.  The
+    #    connection runs in autocommit mode, so separate SELECTs would open
+    #    separate snapshots and let a newer unresolved PR commit between them
+    #    while an older resume event incorrectly authorizes another worker.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    latest_pr_comment_at: Optional[int] = None
-    for c in conn.execute(
-        "SELECT body, created_at FROM task_comments "
+    pr_inputs = conn.execute(
+        "SELECT 'comment' AS record_type, id AS record_id, body, created_at, "
+        "NULL AS kind, NULL AS payload "
+        "FROM task_comments WHERE task_id = ? AND created_at >= ? "
+        "UNION ALL "
+        "SELECT 'event' AS record_type, id AS record_id, NULL AS body, "
+        "created_at, kind, payload FROM task_events "
         "WHERE task_id = ? AND created_at >= ? "
-        "ORDER BY created_at DESC, id DESC",
-        (task_id, pr_cutoff),
-    ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            latest_pr_comment_at = int(c["created_at"])
+        "AND kind IN ('status', 'unblocked', 'promoted_manual') "
+        "ORDER BY record_type, created_at DESC, record_id DESC",
+        (task_id, pr_cutoff, task_id, pr_cutoff),
+    ).fetchall()
+
+    latest_pr_comment_at: Optional[int] = None
+    for record in pr_inputs:
+        if record["record_type"] != "comment":
+            continue
+        if record["body"] and _RESPAWN_GUARD_PR_URL_RE.search(record["body"]):
+            latest_pr_comment_at = int(record["created_at"])
             break
 
     if latest_pr_comment_at is not None:
-        for event in conn.execute(
-            "SELECT kind, payload FROM task_events "
-            "WHERE task_id = ? "
-            "AND kind IN ('status', 'unblocked', 'promoted_manual') "
-            "AND created_at > ?",
-            (task_id, latest_pr_comment_at),
-        ).fetchall():
+        for event in pr_inputs:
+            if (
+                event["record_type"] != "event"
+                or int(event["created_at"]) <= latest_pr_comment_at
+            ):
+                continue
             if event["kind"] == "unblocked":
                 return None
             try:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7818,6 +7818,9 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         A GitHub PR URL appears in a recent task comment (within
         ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
         opened a PR; re-spawning risks a duplicate PR on the same task.
+        An audited, deliberate ready/unblock/manual-promote event after the
+        newest PR-bearing comment overrides this guard.  Comment prose alone
+        never does, so an offline or unresolved PR remains fail-closed.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -7900,13 +7903,48 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    A later audited status-to-ready, unblock, or actor-bound manual
+    #    promotion is an explicit duplicate-PR override.  This deliberately
+    #    relies only on durable local board state: comment claims (including
+    #    "closed") cannot authorize a retry, and no network/API failure can
+    #    silently turn an unresolved PR into a closed one.  The strict
+    #    timestamp comparison stays fail-closed when ordering is ambiguous.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+    latest_pr_comment_at: Optional[int] = None
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT body, created_at FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ? "
+        "ORDER BY created_at DESC, id DESC",
         (task_id, pr_cutoff),
     ).fetchall():
         if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+            latest_pr_comment_at = int(c["created_at"])
+            break
+
+    if latest_pr_comment_at is not None:
+        for event in conn.execute(
+            "SELECT kind, payload FROM task_events "
+            "WHERE task_id = ? "
+            "AND kind IN ('status', 'unblocked', 'promoted_manual') "
+            "AND created_at > ?",
+            (task_id, latest_pr_comment_at),
+        ).fetchall():
+            if event["kind"] == "unblocked":
+                return None
+            try:
+                payload = json.loads(event["payload"] or "{}")
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            if event["kind"] == "status" and payload.get("status") == "ready":
+                return None
+            if (
+                event["kind"] == "promoted_manual"
+                and str(payload.get("actor") or "").strip()
+            ):
+                return None
+        return "active_pr"
 
     return None
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1929,6 +1929,162 @@ def test_respawn_guard_active_pr_in_comment(kanban_home):
     assert reason == "active_pr"
 
 
+def test_respawn_guard_closed_pr_evidence_then_deliberate_requeue(kanban_home):
+    """A post-evidence ready transition is an audited duplicate-PR override."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="closed-pr", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'operator', ?, ?)",
+            (
+                t,
+                "gh pr view https://github.com/acme/widget/pull/42 "
+                "--json state => CLOSED",
+                now - 2,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'status', ?, ?)",
+            (t, '{"status": "ready"}', now - 1),
+        )
+
+        reason = kb.check_respawn_guard(conn, t)
+
+    assert reason is None
+
+
+def test_respawn_guard_explicit_unblock_after_pr_evidence(kanban_home):
+    """An audited unblock after PR evidence authorizes a fresh worker."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="resume-pr", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'operator', ?, ?)",
+            (
+                t,
+                "PR verified merged: https://github.com/acme/widget/pull/43",
+                now - 2,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'unblocked', NULL, ?)",
+            (t, now - 1),
+        )
+
+        reason = kb.check_respawn_guard(conn, t)
+
+    assert reason is None
+
+
+def test_respawn_guard_manual_promotion_after_pr_evidence(kanban_home):
+    """Manual promote carries the actor audit needed to override the guard."""
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn,
+            title="promote-pr",
+            assignee="alice",
+            initial_status="blocked",
+        )
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'operator', ?, ?)",
+            (
+                t,
+                "Merged https://github.com/acme/widget/pull/44",
+                now - 2,
+            ),
+        )
+        promoted, error = kb.promote_task(
+            conn,
+            t,
+            actor="orchestrator",
+            reason="closed PR verified",
+        )
+        assert promoted is True
+        assert error is None
+
+        reason = kb.check_respawn_guard(conn, t)
+
+    assert reason is None
+
+
+def test_respawn_guard_unresolved_pr_and_spoofed_closure_stay_guarded(kanban_home):
+    """Comment prose alone cannot impersonate an authoritative resume event."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="unresolved-pr", assignee="alice")
+        kb.add_comment(
+            conn,
+            t,
+            "worker",
+            "CLOSED (trust me): https://github.com/acme/widget/pull/45; "
+            "GitHub lookup failed offline",
+        )
+
+        reason = kb.check_respawn_guard(conn, t)
+
+    assert reason == "active_pr"
+
+
+def test_respawn_guard_latest_pr_comment_requires_newer_resume(kanban_home):
+    """A resume only clears PR evidence that predates that audited action."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="multiple-prs", assignee="alice")
+        now = int(time.time())
+        conn.executemany(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'worker', ?, ?)",
+            [
+                (t, "https://github.com/acme/widget/pull/46 CLOSED", now - 5),
+                (t, "https://github.com/acme/widget/pull/47 unresolved", now - 1),
+            ],
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'status', ?, ?)",
+            (t, '{"status": "ready"}', now - 3),
+        )
+
+        assert kb.check_respawn_guard(conn, t) == "active_pr"
+
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'status', ?, ?)",
+            (t, '{"status": "ready"}', now),
+        )
+        assert kb.check_respawn_guard(conn, t) is None
+
+
+def test_respawn_guard_ambiguous_or_automatic_events_fail_closed(kanban_home):
+    """Same-second, malformed, and automatic promotions are not overrides."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="ambiguous-resume", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'worker', ?, ?)",
+            (t, "https://github.com/acme/widget/pull/48", now - 1),
+        )
+        conn.executemany(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            [
+                (t, "status", '{"status": "ready"}', now - 1),
+                (t, "status", "not-json", now),
+                (t, "promoted", None, now),
+                (t, "promoted_manual", '{"actor": ""}', now),
+            ],
+        )
+
+        reason = kb.check_respawn_guard(conn, t)
+
+    assert reason == "active_pr"
+
+
 def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
     """A GitHub PR URL in a comment older than the PR window does not block."""
     with kb.connect() as conn:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -11,6 +11,7 @@ import time
 import types
 import unittest.mock
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -2057,6 +2058,84 @@ def test_respawn_guard_latest_pr_comment_requires_newer_resume(kanban_home):
             (t, '{"status": "ready"}', now),
         )
         assert kb.check_respawn_guard(conn, t) is None
+
+
+def test_respawn_guard_comment_event_scan_uses_one_snapshot(kanban_home):
+    """A newer PR at the old comment/event boundary stays fail-closed."""
+
+    class _CommitAfterFetch:
+        def __init__(self, cursor, commit_new_comment):
+            self._cursor = cursor
+            self._commit_new_comment = commit_new_comment
+
+        def fetchall(self):
+            rows = self._cursor.fetchall()
+            self._commit_new_comment()
+            return rows
+
+        def __getattr__(self, name):
+            return getattr(self._cursor, name)
+
+    class _InterleavingConnection:
+        def __init__(self, reader, commit_new_comment):
+            self._reader = reader
+            self._commit_new_comment = commit_new_comment
+
+        def execute(self, sql, parameters=()):
+            reads_comments = "FROM task_comments" in sql
+            reads_events = "FROM task_events" in sql
+            if reads_comments and reads_events:
+                # A single statement has no comment/event gap. Commit at the
+                # former boundary, immediately before its snapshot is opened.
+                self._commit_new_comment()
+            cursor = self._reader.execute(sql, parameters)
+            if reads_comments and not reads_events:
+                # Reproduce the rejected implementation exactly: its first
+                # statement returned old comments before the writer committed.
+                return _CommitAfterFetch(cursor, self._commit_new_comment)
+            return cursor
+
+        def __getattr__(self, name):
+            return getattr(self._reader, name)
+
+    with kb.connect() as reader, kb.connect() as writer:
+        t = kb.create_task(reader, title="snapshot-race", assignee="alice")
+        now = int(time.time())
+        reader.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'worker', ?, ?)",
+            (t, "https://github.com/acme/widget/pull/49 CLOSED", now - 5),
+        )
+        reader.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'status', ?, ?)",
+            (t, '{"status": "ready"}', now - 3),
+        )
+        committed = False
+
+        def commit_new_comment():
+            nonlocal committed
+            if committed:
+                return
+            writer.execute(
+                "INSERT INTO task_comments (task_id, author, body, created_at) "
+                "VALUES (?, 'worker', ?, ?)",
+                (t, "https://github.com/acme/widget/pull/50 unresolved", now - 1),
+            )
+            writer.commit()
+            committed = True
+
+        interleaved = _InterleavingConnection(reader, commit_new_comment)
+        reason = kb.check_respawn_guard(cast(sqlite3.Connection, interleaved), t)
+        newest = writer.execute(
+            "SELECT body FROM task_comments WHERE task_id = ? "
+            "ORDER BY created_at DESC, id DESC LIMIT 1",
+            (t,),
+        ).fetchone()["body"]
+
+    assert committed is True
+    assert newest.endswith("/pull/50 unresolved")
+    assert reason == "active_pr"
 
 
 def test_respawn_guard_ambiguous_or_automatic_events_fail_closed(kanban_home):


### PR DESCRIPTION
## Problem

`check_respawn_guard()` returns `"active_pr"` as soon as *any* GitHub PR URL appears in a task comment within `_RESPAWN_GUARD_PR_WINDOW` (24h):

```python
for c in conn.execute(
    "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
    (task_id, pr_cutoff),
).fetchall():
    if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
        return "active_pr"
```

The guard is right to be fail-closed about duplicate PRs, but as written it has no escape hatch at all, and it is self-sustaining: **any comment that merely mentions a PR URL re-arms it for another 24 hours** — including a comment written to record that the PR is already closed.

On our fleet this parks cards permanently. Two examples from one board today: a card whose orchestrator audit comment read *"PRs #1, #10 and #54 are CLOSED"* was held by this guard **452 times** in 24 hours, and a second card **344 times**, both never dispatched. Every audit pass that re-confirmed the PRs were closed pushed the release 24h further out. The only way out was to stop commenting for a full day.

An operator who has *already* looked at the PR and deliberately re-queued the card has no way to say so.

## Fix

Keep the fail-closed default, but honour a **durable, audited resume event that happened after the newest PR-bearing comment**:

- `unblocked`
- `status` → `ready`
- `promoted_manual` with a non-empty `actor`

These are exactly the events the board already records for a deliberate human/operator re-queue, and they are the same set the `recent_success` guard above already trusts for the identical purpose. Comment prose still authorizes nothing — a comment claiming "the PR is closed" cannot clear the guard, so an offline or unresolved PR stays fail-closed and no network/API failure can silently turn an unresolved PR into a closed one. Ordering is compared strictly, so an ambiguous timestamp stays blocked.

The second commit folds the comment scan and the event scan into a **single SQLite statement**. The connection runs in autocommit mode, so two separate `SELECT`s open two separate snapshots — a newer unresolved PR comment could commit between them and be authorized by an older resume event. One statement, one snapshot.

## Tests

`tests/hermes_cli/test_kanban_db.py` adds coverage for: each of the three resume kinds clearing the guard; a resume *before* the newest PR comment not clearing it; `promoted_manual` with an empty/missing actor not clearing it; prose claiming the PR is closed not clearing it; and the single-snapshot ordering guarantee.

236 tests in `tests/hermes_cli/test_kanban_db.py` pass on this branch.

Running on our fleet since 2026-07-25.
