### PR TITLE
fix(delegation): honor inherit_mcp_toolsets=false on full parent inherit

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1249,7 +1249,7 @@ delegation:
                                               # or auto-approve "once" (true) instead of blocking on stdin.
                                               # The parent TUI owns stdin, so blocking would deadlock; non-interactive resolution is required.
                                               # Both choices emit a logger.warning audit line. Flip to true only for cron/batch pipelines.
-  # inherit_mcp_toolsets: true                # When explicit child toolsets are narrowed, also keep the parent's MCP toolsets (default: true). Set false for strict intersection.
+  # inherit_mcp_toolsets: true                # Whether children receive parent MCP toolsets (default: true). Set false to strip mcp-* on every child-build path, including normal delegate_task (toolsets unset).
   # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -856,6 +856,74 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
             ["web", "browser"],
         )
 
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={"inherit_mcp_toolsets": False},
+    )
+    def test_build_child_agent_strips_mcp_on_full_parent_inherit(self, mock_cfg):
+        """inherit_mcp_toolsets=false must apply when toolsets=None (normal delegate_task)."""
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = [
+            "terminal",
+            "file",
+            "web",
+            "mcp-trello",
+            "mcp-hound",
+            "mcp-agentmail",
+        ]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Test default full inherit path",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        enabled = MockAgent.call_args[1]["enabled_toolsets"]
+        self.assertNotIn("mcp-trello", enabled)
+        self.assertNotIn("mcp-hound", enabled)
+        self.assertNotIn("mcp-agentmail", enabled)
+        for name in ("terminal", "file", "web"):
+            self.assertIn(name, enabled)
+        disabled = MockAgent.call_args[1]["disabled_toolsets"]
+        self.assertIn("mcp-trello", disabled)
+        self.assertIn("mcp-hound", disabled)
+        self.assertIn("mcp-agentmail", disabled)
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_build_child_agent_keeps_mcp_on_full_parent_inherit_by_default(
+        self, mock_cfg
+    ):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["terminal", "file", "mcp-trello"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Test default full inherit keeps MCP",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        enabled = MockAgent.call_args[1]["enabled_toolsets"]
+        self.assertIn("mcp-trello", enabled)
+        self.assertIn("terminal", enabled)
+
 
 class TestChildCredentialLeasing(unittest.TestCase):
     def test_run_single_child_acquires_and_releases_lease(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -647,9 +647,26 @@ def _get_orchestrator_enabled() -> bool:
 
 
 def _get_inherit_mcp_toolsets() -> bool:
-    """Whether narrowed child toolsets should keep the parent's MCP toolsets."""
+    """Whether child agents should receive the parent's MCP toolsets.
+
+    Default True preserves historical behavior: children keep parent MCP on
+    full inherit, and narrowed children also re-add parent MCP via
+    ``_preserve_parent_mcp_toolsets``.
+
+    When False, MCP toolsets are stripped on **every** child-build path —
+    including the common case where ``toolsets`` is unset and the child would
+    otherwise copy the parent's full enabled set. The previous implementation
+    only consulted this flag on the narrowed-``toolsets`` branch, so
+    ``delegation.inherit_mcp_toolsets: false`` had no effect on normal
+    ``delegate_task`` calls (both call sites pass ``toolsets=None``).
+    """
     cfg = _load_config()
     return is_truthy_value(cfg.get("inherit_mcp_toolsets"), default=True)
+
+
+def _strip_mcp_toolsets(toolsets: List[str]) -> List[str]:
+    """Drop canonical MCP toolsets (and registered MCP aliases) from a list."""
+    return [t for t in toolsets if not _is_mcp_toolset_name(t)]
 
 
 def _is_mcp_toolset_name(name: str) -> bool:
@@ -1284,6 +1301,16 @@ def _build_child_agent(
     else:
         child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
 
+    # Apply inherit_mcp_toolsets=false on *all* paths. The narrowed-toolsets
+    # branch already skips _preserve_parent_mcp_toolsets when false; full
+    # parent inherit still carried mcp-* toolsets until this strip.
+    mcp_denies: List[str] = []
+    if not _get_inherit_mcp_toolsets():
+        child_toolsets = _strip_mcp_toolsets(child_toolsets)
+        # Also subtract via disabled_toolsets so composite/platform bundles
+        # cannot reintroduce MCP tools after expansion (#17309 pattern).
+        mcp_denies = sorted(t for t in parent_toolsets if _is_mcp_toolset_name(t))
+
     # Blocked tools also live inside mixed platform bundles (hermes-cli,
     # hermes-telegram, etc.) that _strip_blocked_tools must keep because they
     # carry useful tools too. Pass exact one-tool deny toolsets through to the
@@ -1302,7 +1329,10 @@ def _build_child_agent(
         ]
     child_disabled_toolsets = list(
         dict.fromkeys(
-            inherited_disabled + _blocked_toolsets_for_role(effective_role) + ["kanban"]
+            inherited_disabled
+            + _blocked_toolsets_for_role(effective_role)
+            + ["kanban"]
+            + mcp_denies
         )
     )
 


### PR DESCRIPTION
## Summary

`delegation.inherit_mcp_toolsets: false` did not affect normal `delegate_task` children.

Both `_build_child_agent` call sites pass `toolsets=None`. On that path children copy the parent's full enabled toolsets (including `mcp-*`). The flag only gated the **narrowed** `toolsets=[...]` branch (whether to re-add parent MCP via `_preserve_parent_mcp_toolsets`).

Operators who set the flag expecting Tony/article-style "subagents don't get parent MCP" got a silent no-op. Confirmed live on Windows with Trello + Hound still callable from a leaf child after config was `false` and process restarted.

## Fix

When `inherit_mcp_toolsets` is false:

1. Strip MCP toolsets (`mcp-*` + registered MCP aliases) from the child's `enabled_toolsets` on **every** path, including full parent inherit.
2. Add those MCP toolset names to `disabled_toolsets` so composite/platform bundles cannot reintroduce them after expansion (same pattern as #17309).

Default remains `true` (no behavior change for unset configs).

## Related open work (not duplicates)

| PR | Relationship |
|----|----------------|
| #66277 | Makes operator `child_toolsets` narrowing reachable so the old flag path can fire; **does not** strip MCP when toolsets stay unset. Complementary. |
| #68440 | Granular MCP keep-list when model/caller narrows toolsets. Different axis. |
| #65136 / #66570 | Per-server scope (`parent` / `delegation` / `subagent_only`). Broader design; does not fix the existing flag's full-inherit hole. |

Happy to rebase or fold into #66277 if maintainers prefer one landing vehicle.

## Test plan

- [x] `pytest tests/tools/test_delegate.py -k "preserves_mcp or strict_intersection or strips_mcp or keeps_mcp_on_full" -o addopts=` → 4 passed
- [x] New: full inherit + `inherit_mcp_toolsets: false` drops `mcp-*` from enabled and lists them in disabled
- [x] New: default full inherit still keeps `mcp-*`
- [x] Existing narrowed preserve / strict intersection cases still pass
- [ ] After merge: live smoke with `inherit_mcp_toolsets: false` — leaf child must not see `mcp__*` tools; parent still can

## Type of Change

- [x] 🐛 Bug fix (non-breaking; makes existing config key do what its name implies on the common path)