### PR TITLE
fix(acp): pin the session cwd for the turn

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1761,7 +1761,16 @@ class HermesACPAgent(acp.Agent):
                     clear_session_vars,
                     set_session_vars,
                 )
-                session_tokens = set_session_vars(session_key=session_id)
+                # ``cwd`` pins the logical working directory for this context,
+                # which is what the system prompt's "Current working directory"
+                # line reports (agent/prompt_builder.py -> resolve_agent_cwd).
+                # Without it the prompt advertises the global Hermes workspace
+                # while the tools are rooted at the client's project, so the
+                # model emits absolute paths under ~/.hermes/workspace and the
+                # edit silently lands outside the editor's workspace.
+                session_tokens = set_session_vars(
+                    session_key=session_id, cwd=state.cwd,
+                )
             except Exception:
                 session_tokens = None
                 clear_session_vars = None  # type: ignore[assignment]

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1639,6 +1639,47 @@ class TestPrompt:
             text and "[plugin appended this]" in text for text in all_texts
         ), f"expected transformed final to be delivered, got: {all_texts!r}"
 
+    @pytest.mark.asyncio
+    async def test_prompt_pins_the_session_cwd_for_the_turn(self, agent, tmp_path):
+        """The turn must resolve the ACP client's cwd, not the Hermes workspace.
+
+        ``resolve_agent_cwd()`` is what the system prompt reports as "Current
+        working directory". When it is left unpinned it falls back to
+        TERMINAL_CWD / the launch dir, so the prompt advertises one root while
+        the tools are rooted at the editor's project. The model then emits
+        absolute paths under the advertised root and the edit silently lands
+        outside the workspace the client asked for.
+        """
+        workspace = tmp_path / "project"
+        workspace.mkdir()
+
+        new_resp = await agent.new_session(cwd=str(workspace))
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        observed = {}
+
+        def capture_cwd(*args, **kwargs):
+            from agent.runtime_cwd import resolve_agent_cwd
+
+            observed["cwd"] = str(resolve_agent_cwd())
+            return {"final_response": "ok", "messages": []}
+
+        state.agent.run_conversation = capture_cwd
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="hello")],
+            session_id=new_resp.session_id,
+        )
+
+        assert observed.get("cwd") == str(workspace), (
+            "the turn resolved "
+            f"{observed.get('cwd')!r} instead of the ACP client's cwd "
+            f"{str(workspace)!r}"
+        )
 
     @pytest.mark.asyncio
     async def test_prompt_auto_titles_session(self, agent):


### PR DESCRIPTION
## What does this PR do?

An ACP session pins the client's `cwd` for the **tools** but never for the **prompt**, so an edit can silently land outside the workspace the client asked for while the turn still reports success.

`agent/prompt_builder.py` reports `Current working directory: {resolve_agent_cwd()}`, and `resolve_agent_cwd()` reads the `_SESSION_CWD` contextvar. ACP never set it, so it fell back to `TERMINAL_CWD` / the launch dir. Meanwhile `_register_task_cwd()` → `register_task_env_overrides()` *did* root the tools at the client's project.

The result is a split brain: the system prompt advertises one root, the tools use another. When the model emits a **relative** path the tools resolve it correctly; when it emits an **absolute** path built from the root the prompt advertised, the write goes somewhere else entirely.

`_run_agent` already calls `set_session_vars(session_key=session_id)` inside its `contextvars.copy_context()`, and that helper's `cwd` argument exists precisely to "pin the logical working directory for this context" — it just wasn't passed. `gateway/session_context.py` and `tui_gateway/server.py` both already pass it; **ACP was the only surface that didn't.**

### Why this approach

The one-line change reuses the existing, intended mechanism at the site that already manages per-turn context, inside the `copy_context()` that isolates concurrent ACP sessions. `clear_session_vars` already handles teardown, so no new lifecycle is introduced.

### Related open PRs (not duplicates, as far as I can tell)

- #11570 (`fix(acp): use session cwd for project context discovery`) and #11490 thread cwd into `AIAgent` for **context-file discovery**. They don't set `_SESSION_CWD`, so `resolve_agent_cwd()` — and therefore the "Current working directory" prompt line — is still unpinned. I believe these are complementary; happy to rebase on top of either if a maintainer prefers one lands first.
- #54654 / #68994 concern Hermes acting as an ACP *client* toward Copilot — the opposite direction from this.
- #70759 adds a lock to `_task_env_overrides`, which is the tool-side registry, not the prompt side.

## Related Issue

No existing issue found for this specific split; happy to open one if you'd prefer it tracked that way.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/server.py` — pass `cwd=state.cwd` to `set_session_vars()` in `_run_agent`, with a comment explaining the prompt/tool split it prevents.
- `tests/acp/test_server.py` — add `test_prompt_pins_the_session_cwd_for_the_turn`, asserting the cwd resolved **during the turn** is the cwd the client passed to `session/new`.

## How to Test

Reproduction (before the fix), driving the adapter as an ACP client with a **brand-new** `cwd`:

1. `session/new` with `cwd` = an empty directory that has never been used as a Hermes session cwd.
2. `session/prompt`: *"Create a file called `cold.txt` containing the word COLD in the current directory, then read it back."*
3. The agent answers `Done. cold.txt says COLD.` — the client's directory is **empty**, and the file is at `~/.hermes/workspace/cold.txt`.

The intermittency is worth noting: once a session cwd record exists for that directory, later runs resolve correctly, so this looks flaky until you test a fresh workspace. Instrumenting the failing turn showed `write_file` receiving an already-absolute `/Users/<me>/.hermes/workspace/cold3.txt`.

The mechanism, in-process:

```
_resolve_path('foo.txt', <session-id>) -> <client cwd>/foo.txt        # correct
_resolve_path('foo.txt', 'default')    -> ~/.hermes/workspace/foo.txt # fallback
```

Verification (after the fix): 4 cold-start runs against brand-new workspaces all wrote to the client's cwd, with nothing leaking to `~/.hermes/workspace`.

The new test is a genuine regression test — without the change it fails, resolving the install tree instead of the client's project:

```
AssertionError: the turn resolved '/Users/vibex/.hermes/hermes-agent'
instead of the ACP client's cwd '/private/var/folders/.../project'
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Python 3.11.15

On the full-suite box: `pytest tests/acp/ -q` → **324 passed, 3 failed**. The 3 failures are in `tests/acp/test_edit_approval.py` and reproduce **identically on unmodified `main`** — they're a macOS-only artifact where pytest's `tmp_path` lives under `/private/var/...` and trips the sensitive-system-path guard in `file_tools`. Unrelated to this change. `pytest tests/ -k acp -q` → 411 passed with the same 3 pre-existing failures.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(N/A — the comment at the call site documents the constraint)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A — no config keys)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

Cross-platform note: `state.cwd` is already normalized by `_translate_acp_cwd()` (the WSL/Windows path bridge) in `create_session`/`update_cwd`, so the value passed here is the same one the tools already use — this doesn't introduce a second normalization path. `set_session_cwd()` guards on `is_dir()`, so a stale or missing cwd falls back to today's behavior rather than raising.

- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(N/A)*

## Screenshots / Logs

Streamed turn from the ACP client used for testing (post-fix), confirming a normal turn is unaffected:

```
initialize: OK   agentInfo=hermes-agent 0.19.0   protocolVersion=1
session/new: OK  models offered: 48
  [msg] ACP_OK
session/prompt -> stopReason=end_turn  usage: in=22842 out=6
```
