### PR TITLE
fix(gateway): forward model name in session override rehydration

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2115,14 +2115,20 @@ def _resolve_runtime_agent_kwargs() -> dict:
     }
 
 
-def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
-    """Resolve runtime credentials for a specific provider (e.g. from channel override)."""
+def _resolve_runtime_agent_kwargs_for_provider(provider: str, target_model: Optional[str] = None) -> dict:
+    """Resolve runtime credentials for a specific provider (e.g. from channel override).
+
+    target_model is forwarded to resolve_runtime_provider so that
+    per-model api_mode resolution works for aggregator providers (e.g.
+    opencode-zen/go where minimax-m3 uses anthropic_messages but
+    mimo-v2.5 uses chat_completions).  Refs #70153.
+    """
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
         format_runtime_provider_error,
     )
     try:
-        runtime = resolve_runtime_provider(requested=provider)
+        runtime = resolve_runtime_provider(requested=provider, target_model=target_model)
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
     return {
@@ -17497,13 +17503,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "base_url": persisted.get("base_url"),
         }
         provider = persisted.get("provider")
+        persisted_model = persisted.get("model")
         if provider:
             # Re-resolve credentials for the persisted provider. On failure
             # (e.g. credentials were removed since the switch) keep the
             # credential-less override — _resolve_session_agent_runtime falls
             # back to env-based resolution and applies model/provider on top.
             try:
-                runtime = _resolve_runtime_agent_kwargs_for_provider(provider)
+                runtime = _resolve_runtime_agent_kwargs_for_provider(
+                    provider, target_model=persisted_model,
+                )
                 override["api_key"] = runtime.get("api_key")
                 override["api_mode"] = runtime.get("api_mode")
                 override["credential_pool"] = runtime.get("credential_pool")

--- a/tests/gateway/test_session_model_override_persistence.py
+++ b/tests/gateway/test_session_model_override_persistence.py
@@ -223,6 +223,35 @@ def test_runner_rehydrate_survives_credential_resolution_failure(store_factory):
     assert override.get("api_key") is None
 
 
+def test_rehydrate_forwards_target_model_to_provider_resolution(store_factory):
+    """Regression: rehydration must pass the model name through so that
+    aggregator providers (e.g. opencode-zen/go) resolve the correct
+    per-model api_mode.  Refs #70153."""
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+    store.set_model_override(session_key, OVERRIDE)
+
+    runner = _make_runner(store_factory())
+    with patch(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        return_value={
+            "api_key": "sk-fresh",
+            "api_mode": "chat_completions",  # correct for this model
+            "base_url": "https://api.opencode.example/v1",
+            "provider": "opencode-go",
+        },
+    ) as mock_resolve:
+        runner._rehydrate_session_model_override(session_key)
+
+    # The model name must be forwarded as target_model so the provider
+    # resolver can select the right transport.
+    mock_resolve.assert_called_once_with("openai", target_model="gpt-5o")
+
+    override = runner._session_model_overrides[session_key]
+    assert override["api_mode"] == "chat_completions"
+
+
 def test_sanitize_model_override():
     assert sanitize_model_override(None) is None
     assert sanitize_model_override({}) is None


### PR DESCRIPTION
## Summary

Fixes #70153

When a gateway restarts, `_rehydrate_session_model_override()` re-resolves runtime credentials for the persisted provider but did **not** pass the model name through to the provider resolver. For aggregator providers (e.g. `opencode-zen`/`opencode-go`) where different models use different transports — `minimax-m3` needs `anthropic_messages` while `mimo-v2.5` needs `chat_completions` — the rehydrated `api_mode` was always the provider's default, not the model-specific one. This caused HTTP 400 on the next API call after a gateway restart.

## Changes

- **`gateway/run.py`**: Add `target_model` parameter to `_resolve_runtime_agent_kwargs_for_provider()` and forward it to `resolve_runtime_provider()`, which already accepts it for per-model `api_mode` selection.
- **`gateway/run.py`**: In `_rehydrate_session_model_override()`, pass the persisted model name as `target_model` when calling the credential resolver.
- **Test**: Add regression test verifying the model name is forwarded during rehydration.

## Verification

All 9 tests in `test_session_model_override_persistence.py` pass, including the new regression test.