### PR TITLE
fix(kanban-dashboard): make /board identify the board it read

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -545,6 +545,11 @@
     const [taskEventTick, setTaskEventTick] = useState({});
 
     const cursorRef = useRef(0);
+    // Mirrors the `board` state so an in-flight /board response can be checked
+    // against the CURRENT selection at the moment it resolves, not against the
+    // selection captured when the closure was created.
+    const boardRef = useRef(board);
+    useEffect(function () { boardRef.current = board; }, [board]);
     const reloadTimerRef = useRef(null);
     const wsRef = useRef(null);
     const wsBackoffRef = useRef(1000);
@@ -571,8 +576,19 @@
       if (tenantFilter) qs.set("tenant", tenantFilter);
       if (includeArchived) qs.set("include_archived", "true");
       const url = qs.toString() ? `${API}/board?${qs}` : `${API}/board`;
+      // Capture the selection this request was issued for. The response can
+      // land after the user has switched boards (nothing aborts it), and the
+      // payload used to be board-anonymous, so a slow response for the PREVIOUS
+      // board would overwrite the new board's grid and leave one board's cards
+      // rendered under another board's label. The server now echoes the slug it
+      // actually read, so drop anything that no longer matches.
+      const requestedBoard = board;
       return SDK.fetchJSON(withBoard(url, board))
         .then(function (data) {
+          if (requestedBoard !== boardRef.current) return;
+          // Only meaningful once a board is explicitly selected; before that
+          // `requestedBoard` is null and the server resolves the active board.
+          if (requestedBoard && data && data.board && data.board !== requestedBoard) return;
           setBoardData(data);
           cursorRef.current = data.latest_event_id || 0;
           setError(null);
@@ -600,6 +616,11 @@
           if (board && board !== "default" && !boards.find(function (b) { return b.slug === board; })) {
             setBoard("default");
             writeSelectedBoard("default");
+            // Same contract switchBoard() honours: never leave the previous
+            // board's cards on screen under the new board's label while the
+            // replacement fetch is still in flight.
+            setBoardData(null);
+            setLoading(true);
           }
         })
         .catch(function () { /* non-fatal */ });

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -395,8 +395,16 @@ def get_board(
     ``board`` selects which board to read from. Omitting it falls
     through to the active board (``HERMES_KANBAN_BOARD`` env → on-disk
     ``current`` pointer → ``default``).
+
+    The resolved slug is echoed back as ``board`` so the caller can tell
+    which board these columns actually came from. Without it the payload
+    is board-anonymous and a response that arrives after the user has
+    switched boards is indistinguishable from a fresh one — the grid then
+    renders one board's cards under another board's label. ``/boards``
+    already publishes the active slug as ``current``; this mirrors that
+    contract for the endpoint that returns the cards themselves.
     """
-    board = _resolve_board(board)
+    board = _resolve_board(board) or kanban_db.get_current_board()
     conn = _conn(board=board)
     try:
         tasks = kanban_db.list_tasks(
@@ -498,6 +506,7 @@ def get_board(
         ]
 
         return {
+            "board": board,
             "columns": [
                 {"name": name, "tasks": columns[name]} for name in columns.keys()
             ],

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2545,3 +2545,69 @@ def test_dashboard_parent_notice_and_child_results_use_detail_links():
     assert "t.link_counts" not in detail
     assert "Child Results" in detail
     assert "props.data.child_results" in detail
+
+
+def test_board_response_echoes_the_board_it_read(client):
+    """``GET /board`` must identify which board its columns came from.
+
+    Without it the payload is board-anonymous: a response that resolves after
+    the user has switched boards is indistinguishable from a fresh one, so the
+    grid renders one board's cards under another board's label while the
+    replacement fetch is still in flight. ``/boards`` already publishes the
+    active slug as ``current``; this is the same contract for the endpoint that
+    returns the cards.
+    """
+    kb.create_board("other")
+
+    # Explicit slug is echoed verbatim.
+    for slug in ("default", "other"):
+        data = client.get(f"/api/plugins/kanban/board?board={slug}").json()
+        assert data["board"] == slug, slug
+
+    # Omitted param resolves concretely rather than reporting None, so the
+    # client can still compare it against its own selection.
+    kb.set_current_board("other")
+    assert client.get("/api/plugins/kanban/board").json()["board"] == "other"
+    kb.set_current_board("default")
+    assert client.get("/api/plugins/kanban/board").json()["board"] == "default"
+
+
+def test_board_echo_matches_the_cards_actually_returned(client):
+    """The echoed slug must agree with the payload, not just the request."""
+    default_task = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "default-only"},
+    ).json()["task"]
+
+    kb.create_board("other")
+    other_conn = kb.connect(board="other")
+    try:
+        other_task = kb.create_task(other_conn, title="other-only")
+    finally:
+        other_conn.close()
+
+    for slug, expected_id in (("default", default_task["id"]),
+                              ("other", getattr(other_task, "id", other_task))):
+        data = client.get(f"/api/plugins/kanban/board?board={slug}").json()
+        ids = {t["id"] for c in data["columns"] for t in c["tasks"]}
+        assert data["board"] == slug
+        assert ids == {expected_id}, (slug, ids)
+
+
+def test_client_drops_board_responses_for_a_stale_selection():
+    """The grid must never accept a /board response for a board that is no
+    longer selected, and the deleted-board reset must clear the grid like
+    switchBoard() does."""
+    bundle = (
+        Path(__file__).resolve().parents[2]
+        / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    ).read_text()
+    # request-scoped capture + both guards
+    assert "const requestedBoard = board;" in bundle
+    assert "if (requestedBoard !== boardRef.current) return;" in bundle
+    assert "data.board !== requestedBoard) return;" in bundle
+    # the ref the guard reads must exist and track `board`
+    assert "const boardRef = useRef(board);" in bundle
+    assert "boardRef.current = board;" in bundle
+    # the reset branch must clear the grid rather than leave stale cards
+    reset = bundle.split('writeSelectedBoard("default");')[1][:400]
+    assert "setBoardData(null);" in reset


### PR DESCRIPTION
## Problem

`GET /api/plugins/kanban/board` returns:

```python
return {
    "columns": [...],
    "tenants": tenants,
    "assignees": assignees,
    "latest_event_id": int(latest_event_id),
    "now": int(time.time()),
}
```

Nothing in that payload says **which board** those columns came from. `/boards` publishes the active slug as `current`, but the endpoint that actually returns the cards is board-anonymous.

That matters because nothing aborts an in-flight request. `loadBoard()` has no `AbortController`, no sequence guard, and its `useEffect` cleanup clears only the debounce timer — so a response issued for the previously-selected board can resolve *after* the user has switched, and the client has no way to distinguish it from a fresh one. It calls `setBoardData(data)` unconditionally.

We hit this on a 5-board install: a screenshot of the board switcher reading **`Default · 177`** above a card grid whose ids all belonged to a *different* board. The label, its task count and the `?board=` param all derive from the same React state, so they were mutually consistent and correct — only the grid was stale. Verified server-side that each `?board=` returns strictly its own board's cards, so this is purely a client-side staleness problem that the response shape makes undetectable.

There is a second, non-racy path to the same picture: the board-list reconciliation branch resets the selector to `default` when the stored slug is gone from `/boards`, but unlike `switchBoard()` it never calls `setBoardData(null)` — so the previous board's cards stay on screen under the `Default` label until the replacement fetch resolves.

## Fix

Additive and backward compatible — no existing key changes meaning:

- `get_board()` resolves the slug concretely (`_resolve_board(board) or kanban_db.get_current_board()`) instead of leaving it `None`, and echoes it back as `board`. Same contract `/boards` already honours with `current`. With the param present this is a pure addition; with it absent the endpoint now reports the board it fell through to instead of staying silent.
- `loadBoard()` captures the selection the request was issued for and drops the response if either the current selection has moved on or the echoed slug disagrees. A `boardRef` mirrors the `board` state so the check reads the selection *at resolve time*, not the one captured in the closure.
- The deleted-board reset branch now calls `setBoardData(null)` / `setLoading(true)`, matching `switchBoard()`.

The echo is what makes this robust rather than a patch over one race: any future path that lands a response for the wrong board is now self-detecting.

## Tests

`tests/plugins/test_kanban_dashboard_plugin.py`, 3 added:

- `test_board_response_echoes_the_board_it_read` — echo is correct for explicit slugs and for the omitted-param fall-through (both directions of `set_current_board`).
- `test_board_echo_matches_the_cards_actually_returned` — the echoed slug agrees with the payload, not merely with the request.
- `test_client_drops_board_responses_for_a_stale_selection` — the bundle carries the request-scoped capture, both guards, the tracking ref, and the reset-branch clear.

107 passed on this branch vs 104 on `main` (+3); the 10 pre-existing failures are identical on both and are unrelated optional-dependency gaps in the `home_subscribe`/`specify` fixtures.

Running on our fleet.
