### PR TITLE
feat(telegram): closed em: approval-callback routing to a deterministic operator plugin

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6157,6 +6157,18 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return
 
+        # --- Email-manager per-item approval callbacks (em:verb:ref[:action]) ---
+        if data.startswith("em:"):
+            await self._handle_email_manager_callback(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
+            return
+
         # --- Exec approval callbacks (ea:choice:id) ---
         if data.startswith("ea:"):
             parts = data.split(":", 2)
@@ -6609,6 +6621,123 @@ class TelegramAdapter(BasePlatformAdapter):
                 await query.edit_message_text(text=appended, reply_markup=None)
         except Exception:
             pass
+
+    # Closed `em:` callback contract for email-manager per-item approvals.
+    # Canonical contract: email-manager repo, docs/decisions/ws-t-telegram-approvals.md
+    # ("em: callback payload contract"), minted by email_manager.control
+    # encode_email_callback and mirrored — never re-parsed loosely — here. Any
+    # payload outside the closed grammar decodes to None and is dropped before
+    # the plugin is ever invoked.
+    _EM_CALLBACK_MAX_BYTES = 64
+    _EM_PROPOSAL_REF = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+    _EM_APPROVAL_ACTIONS = frozenset(
+        {"archive", "mark_read", "archive_document", "unsubscribe_oneclick"}
+    )
+
+    @classmethod
+    def _decode_email_callback(cls, data) -> Optional[tuple]:
+        """Decode closed `em:` callback_data into fixed /email argv, or None.
+
+        Mirrors email_manager.control.decode_email_callback: fail-closed on
+        non-string, oversized, wrong prefix, unknown verb, wrong arity, or a
+        reference/action outside the closed grammar. A successful decode is
+        exactly the argv of the equivalent typed command (`/email tg-approve
+        <ref> <action>` / `/email tg-dismiss <ref>`), so the button and text
+        paths cannot diverge.
+        """
+        if not isinstance(data, str):
+            return None
+        if len(data.encode("utf-8")) > cls._EM_CALLBACK_MAX_BYTES:
+            return None
+        parts = data.split(":")
+        if len(parts) < 3 or parts[0] != "em":
+            return None
+        verb = parts[1]
+        if verb == "approve":
+            if len(parts) != 4:
+                return None
+            ref, action = parts[2], parts[3]
+            if not cls._EM_PROPOSAL_REF.fullmatch(ref):
+                return None
+            if action not in cls._EM_APPROVAL_ACTIONS:
+                return None
+            return ("tg-approve", ref, action)
+        if verb == "dismiss":
+            if len(parts) != 3:
+                return None
+            ref = parts[2]
+            if not cls._EM_PROPOSAL_REF.fullmatch(ref):
+                return None
+            return ("tg-dismiss", ref)
+        return None
+
+    async def _handle_email_manager_callback(
+        self,
+        query,
+        data: str,
+        *,
+        query_chat_id,
+        query_chat_type,
+        query_thread_id,
+        query_user_name,
+    ) -> None:
+        """Dispatch an email-manager approval callback (em:verb:ref[:action]).
+
+        The press is only a carrier for the closed /email grammar: decode
+        fail-closed, authenticate the presser with the same check as ea:/gt:
+        callbacks, then dispatch the email-manager-operator plugin with argv
+        identical to the typed command — never through the model loop.
+        """
+        argv = self._decode_email_callback(data)
+        if argv is None:
+            await query.answer(text="Invalid email approval data.")
+            return
+
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ You are not authorized to act on this proposal.")
+            return
+
+        try:
+            from hermes_cli.plugins import get_plugin_command_handler
+            plugin_handler = get_plugin_command_handler("email")
+        except Exception:
+            plugin_handler = None
+        if not callable(plugin_handler):
+            await query.answer(text="❌ email-manager-operator plugin unavailable")
+            logger.error(
+                "[%s] email callback dropped: /email plugin command not registered",
+                self.name,
+            )
+            return
+
+        raw_args = " ".join(argv)
+        try:
+            # The plugin handler runs a bounded subprocess synchronously; keep
+            # it off the event loop.
+            result = await asyncio.to_thread(plugin_handler, raw_args)
+            if asyncio.iscoroutine(result):
+                result = await result
+            label = str(result).strip() if result else "Done."
+            logger.info(
+                "[%s] email callback dispatched: /email %s", self.name, raw_args,
+            )
+        except Exception as exc:
+            label = "❌ email command failed"
+            logger.error(
+                "[%s] email callback exception: args=%s err=%s",
+                self.name, raw_args, exc, exc_info=True,
+            )
+
+        # answerCallbackQuery caps text at 200 chars; the plugin result is
+        # already bounded, human-readable text.
+        await query.answer(text=label[:200])
 
     def _missing_media_path_error(self, label: str, path: str) -> str:
         """Build an actionable file-not-found error for gateway MEDIA delivery.

--- a/tests/gateway/test_telegram_email_callback.py
+++ b/tests/gateway/test_telegram_email_callback.py
@@ -1,0 +1,262 @@
+"""Tests for the Telegram adapter's `em:` email-manager approval callbacks.
+
+The `em:` payload contract is canonical in the email-manager repo
+(docs/decisions/ws-t-telegram-approvals.md, "em: callback payload contract",
+mirrored by email_manager.control.encode_email_callback/decode_email_callback):
+closed grammar `em:approve:<ref>:<action>` / `em:dismiss:<ref>`, <=64 bytes,
+fail-closed decode, the same authorization check as ea:/gt: callbacks, and
+dispatch of the email-manager-operator plugin with argv identical to the typed
+`/email tg-approve <ref> <action>` / `/email tg-dismiss <ref>` command — never
+through the model loop.
+"""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+def _adapter_class():
+    try:
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+    except ModuleNotFoundError:  # PR branch before Telegram plugin extraction
+        from gateway.platforms.telegram import TelegramAdapter
+    return TelegramAdapter
+
+
+def _make_adapter(callback_auth=None):
+    TelegramAdapter = _adapter_class()
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="fake-token", extra={})
+    if callback_auth is not None:
+        adapter._is_callback_user_authorized = callback_auth
+    return adapter
+
+
+def _make_query(data, *, user_id=111, chat_id=-100, chat_type="group"):
+    return SimpleNamespace(
+        data=data,
+        from_user=SimpleNamespace(id=user_id, first_name="Test"),
+        message=SimpleNamespace(
+            chat_id=chat_id,
+            chat=SimpleNamespace(id=chat_id, type=chat_type),
+            message_thread_id=None,
+            text="proposal",
+        ),
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+    )
+
+
+def _make_update(query):
+    return SimpleNamespace(callback_query=query)
+
+
+# --- decode: mirrors email_manager.control.decode_email_callback -------------
+
+
+def test_decode_approve_yields_typed_command_argv():
+    decode = _adapter_class()._decode_email_callback
+    assert decode("em:approve:tg-123:archive") == ("tg-approve", "tg-123", "archive")
+
+
+@pytest.mark.parametrize(
+    "action", ["archive", "mark_read", "archive_document", "unsubscribe_oneclick"]
+)
+def test_decode_accepts_every_closed_action(action):
+    decode = _adapter_class()._decode_email_callback
+    assert decode(f"em:approve:tg-9:{action}") == ("tg-approve", "tg-9", action)
+
+
+def test_decode_dismiss_yields_typed_command_argv():
+    decode = _adapter_class()._decode_email_callback
+    assert decode("em:dismiss:tg-123") == ("tg-dismiss", "tg-123")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        123,
+        "",
+        "em",
+        "em:",
+        "em:approve",
+        "em:approve:tg-123",  # approve missing action
+        "em:approve:tg-123:archive:extra",  # approve wrong arity
+        "em:dismiss:tg-123:archive",  # dismiss wrong arity
+        "em:execute:tg-123",  # unknown verb
+        "EM:approve:tg-123:archive",  # wrong prefix case
+        "ea:once:42",  # other prefix
+        "em:approve:tg-123:trash",  # action outside the closed set
+        "em:approve:tg-123:ARCHIVE",  # action case outside the closed set
+        "em:approve:.bad-ref:archive",  # ref outside identifier grammar
+        "em:approve::archive",  # empty ref
+        "em:dismiss:",  # empty ref
+        "em:approve:tg-123:" + "a" * 64,  # oversized (>64 bytes)
+    ],
+)
+def test_decode_fails_closed(payload):
+    decode = _adapter_class()._decode_email_callback
+    assert decode(payload) is None
+
+
+def test_decode_64_byte_boundary():
+    decode = _adapter_class()._decode_email_callback
+    ref = "r" * (64 - len("em:dismiss:"))
+    exactly_64 = f"em:dismiss:{ref}"
+    assert len(exactly_64.encode("utf-8")) == 64
+    assert decode(exactly_64) == ("tg-dismiss", ref)
+    assert decode(exactly_64 + "r") is None
+
+
+# --- routing + authorization + dispatch ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_approve_press_dispatches_plugin_with_typed_command_argv():
+    """An authorized approve press runs /email tg-approve <ref> <action>."""
+    adapter = _make_adapter(callback_auth=lambda uid, **_kw: uid == "111")
+    query = _make_query("em:approve:tg-123:archive", user_id=111)
+
+    calls = []
+
+    def fake_handler(raw_args):
+        calls.append(raw_args)
+        return "tg-approve: state=EXECUTING"
+
+    with patch(
+        "hermes_cli.plugins.get_plugin_command_handler", return_value=fake_handler
+    ) as get_handler:
+        await adapter._handle_callback_query(_make_update(query), SimpleNamespace())
+
+    get_handler.assert_called_once_with("email")
+    assert calls == ["tg-approve tg-123 archive"]
+    query.answer.assert_awaited_once_with(text="tg-approve: state=EXECUTING")
+
+
+@pytest.mark.asyncio
+async def test_dismiss_press_dispatches_plugin_with_typed_command_argv():
+    adapter = _make_adapter(callback_auth=lambda uid, **_kw: uid == "111")
+    query = _make_query("em:dismiss:tg-123", user_id=111)
+
+    calls = []
+
+    def fake_handler(raw_args):
+        calls.append(raw_args)
+        return "tg-dismiss: state=DISMISSED"
+
+    with patch("hermes_cli.plugins.get_plugin_command_handler", return_value=fake_handler):
+        await adapter._handle_callback_query(_make_update(query), SimpleNamespace())
+
+    assert calls == ["tg-dismiss tg-123"]
+    query.answer.assert_awaited_once_with(text="tg-dismiss: state=DISMISSED")
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_press_answered_and_dropped_before_dispatch():
+    """A valid payload from an unauthorized presser must never reach the plugin."""
+    seen = []
+    adapter = _make_adapter(
+        callback_auth=lambda uid, **kw: seen.append((uid, kw)) or False
+    )
+    query = _make_query("em:approve:tg-123:archive", user_id=666)
+
+    with patch("hermes_cli.plugins.get_plugin_command_handler") as get_handler:
+        await adapter._handle_callback_query(_make_update(query), SimpleNamespace())
+
+    get_handler.assert_not_called()
+    query.answer.assert_awaited_once()
+    # The same callback authorization check as ea:/gt: sees the full context.
+    assert seen == [
+        (
+            "666",
+            {
+                "chat_id": -100,
+                "chat_type": "group",
+                "thread_id": None,
+                "user_name": "Test",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_answered_and_dropped_without_dispatch():
+    """Fail closed: bad em: data is answered and dropped before auth or dispatch."""
+    auth_calls = []
+    adapter = _make_adapter(
+        callback_auth=lambda uid, **_kw: auth_calls.append(uid) or True
+    )
+    query = _make_query("em:approve:tg-123:trash", user_id=111)
+
+    with patch("hermes_cli.plugins.get_plugin_command_handler") as get_handler:
+        await adapter._handle_callback_query(_make_update(query), SimpleNamespace())
+
+    get_handler.assert_not_called()
+    assert auth_calls == []
+    query.answer.assert_awaited_once_with(text="Invalid email approval data.")
+
+
+@pytest.mark.asyncio
+async def test_missing_plugin_answered_without_crash():
+    adapter = _make_adapter(callback_auth=lambda uid, **_kw: True)
+    query = _make_query("em:dismiss:tg-123", user_id=111)
+
+    with patch("hermes_cli.plugins.get_plugin_command_handler", return_value=None):
+        await adapter._handle_callback_query(_make_update(query), SimpleNamespace())
+
+    query.answer.assert_awaited_once_with(
+        text="❌ email-manager-operator plugin unavailable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_plugin_exception_answered_bounded():
+    adapter = _make_adapter(callback_auth=lambda uid, **_kw: True)
+    query = _make_query("em:dismiss:tg-123", user_id=111)
+
+    def exploding_handler(raw_args):
+        raise RuntimeError("boom")
+
+    with patch(
+        "hermes_cli.plugins.get_plugin_command_handler", return_value=exploding_handler
+    ):
+        await adapter._handle_callback_query(_make_update(query), SimpleNamespace())
+
+    query.answer.assert_awaited_once_with(text="❌ email command failed")
+
+
+@pytest.mark.asyncio
+async def test_plugin_result_bounded_to_callback_answer_limit():
+    """answerCallbackQuery caps text at 200 chars; the answer must fit."""
+    adapter = _make_adapter(callback_auth=lambda uid, **_kw: True)
+    query = _make_query("em:dismiss:tg-123", user_id=111)
+
+    with patch(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        return_value=lambda raw_args: "x" * 5000,
+    ):
+        await adapter._handle_callback_query(_make_update(query), SimpleNamespace())
+
+    query.answer.assert_awaited_once()
+    assert len(query.answer.await_args.kwargs["text"]) <= 200
+
+
+@pytest.mark.asyncio
+async def test_async_plugin_handler_result_awaited():
+    """Plugin command handlers may be coroutines, like the typed /email path."""
+    adapter = _make_adapter(callback_auth=lambda uid, **_kw: True)
+    query = _make_query("em:dismiss:tg-123", user_id=111)
+
+    async def async_handler(raw_args):
+        await asyncio.sleep(0)
+        return f"ran: {raw_args}"
+
+    with patch("hermes_cli.plugins.get_plugin_command_handler", return_value=async_handler):
+        await adapter._handle_callback_query(_make_update(query), SimpleNamespace())
+
+    query.answer.assert_awaited_once_with(text="ran: tg-dismiss tg-123")


### PR DESCRIPTION
## What

Adds an `em:` callback prefix to the Telegram adapter's `_handle_callback_query`, alongside the existing `ea:` (exec approvals) and `gt:` (gmail triage) prefixes. It routes inline-button presses for per-item email approvals to a deterministic operator plugin (`email-manager-operator`, dispatched through the `/email` slash-command handler) with argv identical to the equivalent typed command — never through the model loop.

## Why

I run a deterministic email-triage data plane next to hermes; approvals arrive as Telegram inline buttons on the single hermes bot. The adapter is the only `getUpdates` consumer, so button callbacks must be routed here. The pattern is exactly the one `ea:` already implements: authenticate the presser, then dispatch a closed, pre-validated action.

## Security properties

- **Fail-closed decode:** payload grammar is closed (`em:approve:<ref>:<action>` / `em:dismiss:<ref>`, ≤64 bytes, closed action set, strict ref regex). Anything else answers the callback and drops before auth or dispatch — the plugin is never invoked.
- **Same authorization as `ea:`:** `_is_callback_user_authorized` runs before any action.
- **No model in the path:** the dispatch is a fixed-argv plugin command; free text cannot reach it.
- **Bounded answer:** the callback answer is capped (200 chars); no raw plugin output is relayed.

## Tests

`tests/gateway/test_telegram_email_callback.py` (262 lines): valid approve/dismiss dispatch, every malformed-payload class dropped without dispatch, unauthorized press refused, oversized payload, bounded answers.

## Note on generalization

If you'd rather not carry product-specific prefixes in the adapter, I'm happy to rework this into a generic "plugins register callback prefixes" API (with `ea:`/`gt:` as internal clients and this as the first external one) — say the word and I'll follow up with that PR instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
