### PR TITLE
fix: report launchd supervision accurately in gateway status and shutdown forensics

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -108,7 +108,7 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
 
     * The signal number/name (so SIGINT vs SIGTERM is visible)
     * Our own PID/ppid + parent process info from /proc (Linux)
-    * Whether systemd is our parent (``ppid==1`` or ``INVOCATION_ID`` set)
+    * Which supervisor launched us (systemd, launchd, generic PID 1, or none)
     * Whether takeover/planned-stop markers exist (consumed lazily by the caller)
     * /proc/self limits + load average (1-min)
     * Wall-clock and monotonic timestamps for cross-correlating later phases
@@ -131,16 +131,33 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
         "self": _proc_summary(pid),
     }
 
-    # systemd context.  If we were started by a systemd unit, INVOCATION_ID
-    # is set in our env.  ppid==1 (init) is also a strong signal that
-    # systemd reaped+forwarded the SIGTERM.
+    # Supervisor context. PID 1 is launchd on macOS and may be systemd, s6,
+    # tini, or another init on Linux, so PPID alone must not be labelled
+    # systemd. systemd provides explicit invocation/journal markers; launchd
+    # provides XPC_SERVICE_NAME and reparents daemon jobs to PID 1.
     invocation_id = os.environ.get("INVOCATION_ID")
     if invocation_id:
         ctx["systemd_invocation_id"] = invocation_id
     journal_stream = os.environ.get("JOURNAL_STREAM")
     if journal_stream:
         ctx["systemd_journal_stream"] = journal_stream
-    ctx["under_systemd"] = bool(invocation_id) or ppid == 1
+    xpc_service_name = os.environ.get("XPC_SERVICE_NAME")
+    under_systemd = bool(invocation_id or journal_stream)
+    if under_systemd:
+        supervisor = "systemd"
+    elif sys.platform == "darwin" and (
+        ppid == 1 or xpc_service_name not in (None, "", "0")
+    ):
+        supervisor = "launchd"
+        if xpc_service_name not in (None, "", "0"):
+            ctx["launchd_service_name"] = xpc_service_name
+    elif ppid == 1:
+        supervisor = "pid1"
+    else:
+        supervisor = "none"
+    ctx["supervisor"] = supervisor
+    # Retain the machine-readable compatibility field, but make it truthful.
+    ctx["under_systemd"] = under_systemd
 
     # Load average — high load points the finger at "something else
     # crushing the box" rather than "external killer".
@@ -285,7 +302,9 @@ def format_context_for_log(ctx: Dict[str, Any]) -> str:
     parent_cmd = parent.get("cmdline", "(unknown)")
     parent_name = parent.get("name") or "?"
     parent_pid = parent.get("pid") or "?"
-    under_systemd = "yes" if ctx.get("under_systemd") else "no"
+    supervisor = ctx.get("supervisor") or (
+        "systemd" if ctx.get("under_systemd") else "none"
+    )
     load = ctx.get("loadavg_1m")
     load_str = f"{load:.2f}" if isinstance(load, (int, float)) else "?"
     extras: List[str] = []
@@ -302,7 +321,7 @@ def format_context_for_log(ctx: Dict[str, Any]) -> str:
     # Parent cmdline is the most useful single signal — log it prominently.
     return (
         f"signal={sig} "
-        f"under_systemd={under_systemd} "
+        f"supervisor={supervisor} "
         f"parent_pid={parent_pid} "
         f"parent_name={parent_name} "
         f"loadavg_1m={load_str}"

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -77,6 +77,7 @@ class GatewayRuntimeSnapshot:
     service_running: bool = False
     gateway_pids: tuple[int, ...] = ()
     service_scope: str | None = None
+    service_name: str | None = None
 
     @property
     def running(self) -> bool:
@@ -1274,6 +1275,52 @@ def _parse_launchd_pid_from_list_output(output: str) -> int | None:
     return None
 
 
+def _parse_launchd_job_for_gateway_pids(
+    output: str, gateway_pids: tuple[int, ...]
+) -> tuple[int, str] | None:
+    """Find a launchd job whose live PID is one of *gateway_pids*.
+
+    ``launchctl list`` without a label emits a tabular ``PID Status Label``
+    view.  Operator-managed LaunchDaemons are allowed to use labels other than
+    Hermes' generated ``ai.hermes.gateway`` label, so PID ownership is the
+    reliable bridge between the process scan and launchd's registry.
+    """
+    wanted = set(gateway_pids)
+    if not wanted:
+        return None
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+        except ValueError:
+            continue
+        if pid in wanted:
+            return pid, parts[2]
+    return None
+
+
+def _probe_launchd_gateway_supervisor(
+    gateway_pids: tuple[int, ...],
+) -> tuple[int, str] | None:
+    """Return ``(pid, label)`` when launchd owns a discovered gateway PID."""
+    if not gateway_pids:
+        return None
+    try:
+        result = subprocess.run(
+            ["launchctl", "list"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return _parse_launchd_job_for_gateway_pids(result.stdout, gateway_pids)
+
+
 def _probe_launchd_service_running() -> bool:
     """Return True when launchd is actively supervising the gateway process.
 
@@ -1358,10 +1405,35 @@ def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot
         )
 
     if is_macos():
+        plist_exists = get_launchd_plist_path().exists()
+        generated_service_running = (
+            _probe_launchd_service_running() if plist_exists else False
+        )
+        if generated_service_running:
+            return GatewayRuntimeSnapshot(
+                manager="launchd",
+                service_installed=True,
+                service_running=True,
+                gateway_pids=gateway_pids,
+                service_scope="launchd",
+            )
+
+        external_job = _probe_launchd_gateway_supervisor(gateway_pids)
+        if external_job is not None:
+            _pid, label = external_job
+            return GatewayRuntimeSnapshot(
+                manager="launchd (external service)",
+                service_installed=True,
+                service_running=True,
+                gateway_pids=gateway_pids,
+                service_scope="launchd",
+                service_name=label,
+            )
+
         return GatewayRuntimeSnapshot(
             manager="launchd",
-            service_installed=get_launchd_plist_path().exists(),
-            service_running=_probe_launchd_service_running(),
+            service_installed=plist_exists,
+            service_running=False,
             gateway_pids=gateway_pids,
             service_scope="launchd",
         )
@@ -7250,6 +7322,17 @@ def _gateway_command_inner(args):
         ):
             systemd_status(deep, system=system, full=full)
             _print_gateway_process_mismatch(snapshot)
+        elif is_macos() and snapshot.service_running and snapshot.service_name:
+            pids = ", ".join(map(str, snapshot.gateway_pids))
+            print(f"✓ Gateway is running, supervised by launchd (PID: {pids})")
+            print(f"  Service: {snapshot.service_name}")
+            print("  (Externally managed launchd service; no duplicate install needed)")
+            runtime_lines = _runtime_health_lines()
+            if runtime_lines:
+                print()
+                print("Recent gateway health:")
+                for line in runtime_lines:
+                    print(f"  {line}")
         elif is_macos() and get_launchd_plist_path().exists():
             launchd_status(deep)
             _print_gateway_process_mismatch(snapshot)

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -67,7 +67,31 @@ class TestSnapshotShutdownContext:
         monkeypatch.setenv("INVOCATION_ID", "abc123")
         ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
         assert ctx["under_systemd"] is True
+        assert ctx["supervisor"] == "systemd"
         assert ctx["systemd_invocation_id"] == "abc123"
+
+    def test_ppid_one_on_macos_is_launchd_not_systemd(self, monkeypatch):
+        monkeypatch.setattr(sf.sys, "platform", "darwin")
+        monkeypatch.setattr(sf.os, "getppid", lambda: 1)
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.setenv("XPC_SERVICE_NAME", "pt.dias.hermes-gateway")
+
+        ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
+
+        assert ctx["supervisor"] == "launchd"
+        assert ctx["launchd_service_name"] == "pt.dias.hermes-gateway"
+        assert ctx["under_systemd"] is False
+
+    def test_ppid_one_without_platform_marker_is_generic_pid1(self, monkeypatch):
+        monkeypatch.setattr(sf.sys, "platform", "linux")
+        monkeypatch.setattr(sf.os, "getppid", lambda: 1)
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+
+        ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
+
+        assert ctx["supervisor"] == "pid1"
+        assert ctx["under_systemd"] is False
 
     def test_under_systemd_false_without_invocation_id_and_normal_ppid(
         self, monkeypatch
@@ -127,6 +151,8 @@ class TestFormatters:
         ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
         line = sf.format_context_for_log(ctx)
         assert "signal=SIGTERM" in line
+        assert "supervisor=" in line
+        assert "under_systemd=" not in line
         assert "parent_pid=" in line
         assert "parent_cmdline=" in line
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1239,6 +1239,42 @@ class TestLaunchdServiceRecovery:
         output = '{\n    "PID" = -1;\n    "Label" = "ai.hermes.gateway";\n}'
         assert gateway_cli._parse_launchd_pid_from_list_output(output) is None
 
+    def test_parse_launchd_job_for_gateway_pid_accepts_custom_label(self):
+        """A system LaunchDaemon may supervise Hermes under an operator label."""
+        output = (
+            "PID\tStatus\tLabel\n"
+            "-\t0\tcom.apple.unrelated\n"
+            "40495\t0\tpt.dias.hermes-gateway\n"
+        )
+
+        assert gateway_cli._parse_launchd_job_for_gateway_pids(
+            output, (40495,)
+        ) == (40495, "pt.dias.hermes-gateway")
+
+    def test_runtime_snapshot_detects_external_launchd_supervisor(
+        self, tmp_path, monkeypatch
+    ):
+        """Do not report a launchd-owned gateway as a manual process."""
+        missing_plist = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: missing_plist)
+        monkeypatch.setattr(gateway_cli, "find_gateway_pids", lambda: [40495])
+        monkeypatch.setattr(
+            gateway_cli,
+            "_probe_launchd_gateway_supervisor",
+            lambda pids: (40495, "pt.dias.hermes-gateway"),
+        )
+
+        snapshot = gateway_cli.get_gateway_runtime_snapshot()
+
+        assert snapshot.manager == "launchd (external service)"
+        assert snapshot.service_installed is True
+        assert snapshot.service_running is True
+        assert snapshot.service_name == "pt.dias.hermes-gateway"
+        assert snapshot.gateway_pids == (40495,)
+
     # ── Probe requires PID ───────────────────────────────────────────────
 
     def test_probe_launchd_service_running_false_without_pid_in_output(self, tmp_path, monkeypatch):
@@ -1813,6 +1849,44 @@ class TestGatewaySystemServiceRouting:
         )
 
         assert calls == [(False, False, True)]
+
+    def test_gateway_status_reports_external_launchd_supervisor(
+        self, monkeypatch, capsys
+    ):
+        missing_plist = SimpleNamespace(exists=lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: missing_plist)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_runtime_snapshot",
+            lambda system=False: gateway_cli.GatewayRuntimeSnapshot(
+                manager="launchd (external service)",
+                service_installed=True,
+                service_running=True,
+                gateway_pids=(40495,),
+                service_scope="launchd",
+                service_name="pt.dias.hermes-gateway",
+            ),
+        )
+        monkeypatch.setattr(gateway_cli, "_runtime_health_lines", lambda: [])
+        monkeypatch.setattr(
+            gateway_cli, "_print_other_profiles_gateway_status", lambda: None
+        )
+
+        gateway_cli.gateway_command(
+            SimpleNamespace(
+                gateway_command="status", deep=False, system=False, full=False
+            )
+        )
+
+        out = capsys.readouterr().out
+        assert "supervised by launchd" in out
+        assert "pt.dias.hermes-gateway" in out
+        assert "Running manually" not in out
+        assert "gateway install" not in out
 
     def test_gateway_install_reports_termux_manual_mode(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: True)


### PR DESCRIPTION
## What

Makes gateway supervision reporting accurate when the gateway runs under launchd: `hermes_cli/gateway.py` now detects and reports the actual launchd supervision state instead of assuming self-supervision, and `gateway/shutdown_forensics.py` records the supervisor in shutdown diagnostics.

## Why

On macOS deployments where the gateway is a LaunchAgent, status/diagnostics previously reported it as unsupervised, which sends an operator down the wrong path during incident triage (e.g. assuming a crash won't be restarted when launchd will in fact restart it — or the inverse).

## Tests

- `tests/gateway/test_shutdown_forensics.py`: supervisor recorded in forensics payloads.
- `tests/hermes_cli/test_gateway_service.py`: launchd detection and reporting paths (74 added lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
