### PR TITLE
fix(config): let a deployment mark a config file owner-managed and unwritable at runtime

### DIFF
--- a/hermes_cli/xai_retirement.py
+++ b/hermes_cli/xai_retirement.py
@@ -243,10 +243,10 @@ def apply_migration(
         shutil.copy2(config_path, backup_path)
 
     from hermes_cli.config import require_readable_config_before_write
+    from utils import atomic_roundtrip_yaml_write
 
     require_readable_config_before_write(config_path)
-    with config_path.open("w", encoding="utf-8") as fh:
-        yaml.dump(doc, fh)
+    atomic_roundtrip_yaml_write(config_path, doc)
 
     return ApplyResult(
         file_path=config_path,

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -141,10 +141,11 @@ class HolographicMemoryProvider(MemoryProvider):
                     existing = yaml.safe_load(f) or {}
             existing.setdefault("plugins", {})
             existing["plugins"]["hermes-memory-store"] = values
-            with open(config_path, "w", encoding="utf-8") as f:
-                yaml.dump(existing, f, default_flow_style=False)
-        except Exception:
-            pass
+            from utils import atomic_yaml_write
+
+            atomic_yaml_write(config_path, existing)
+        except Exception as exc:
+            logger.warning("Failed to save holographic memory config: %s", exc)
 
     def get_config_schema(self):
         from hermes_constants import display_hermes_home

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -126,6 +126,56 @@ def test_atomic_yaml_write_preserves_symlink(tmp_path: Path) -> None:
     assert data == {"model": {"provider": "openrouter"}}
 
 
+def test_atomic_yaml_write_refuses_explicitly_protected_config(tmp_path: Path) -> None:
+    config = tmp_path / "config.yaml"
+    sentinel = tmp_path / ".config.yaml.write-protected"
+    original = b"owner: canonical\n"
+    config.write_bytes(original)
+    sentinel.write_text("owner-managed\n", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="owner-managed and write-protected"):
+        atomic_yaml_write(config, {"owner": "rewritten"})
+
+    assert config.read_bytes() == original
+
+
+def test_atomic_yaml_write_remains_mutable_without_protection_sentinel(
+    tmp_path: Path,
+) -> None:
+    profile = tmp_path / "profiles" / "reviewer"
+    profile.mkdir(parents=True)
+    config = profile / "config.yaml"
+    config.write_text("owner: profile\n", encoding="utf-8")
+
+    atomic_yaml_write(config, {"owner": "profile-updated"})
+
+    assert yaml.safe_load(config.read_text(encoding="utf-8")) == {
+        "owner": "profile-updated"
+    }
+
+
+def test_atomic_yaml_write_refuses_symlink_to_protected_real_config(
+    tmp_path: Path,
+) -> None:
+    owner = tmp_path / "owner"
+    profile = tmp_path / "profile"
+    owner.mkdir()
+    profile.mkdir()
+    real = owner / "config.yaml"
+    real.write_text("owner: canonical\n", encoding="utf-8")
+    (owner / ".config.yaml.write-protected").write_text(
+        "owner-managed\n", encoding="utf-8"
+    )
+    link = profile / "config.yaml"
+    link.symlink_to(real)
+
+    with pytest.raises(PermissionError, match="owner-managed and write-protected"):
+        atomic_yaml_write(link, {"owner": "rewritten-through-profile"})
+
+    assert link.is_symlink()
+    assert real.read_text(encoding="utf-8") == "owner: canonical\n"
+
+
 def test_atomic_json_write_preserves_symlink_permissions(tmp_path: Path) -> None:
     """Symlinked targets keep the real file's permission bits."""
     if os.name != "posix":

--- a/utils.py
+++ b/utils.py
@@ -88,6 +88,28 @@ def _restore_file_mode(path: Path, mode: "int | None") -> None:
         pass
 
 
+def _raise_if_owner_write_protected(target: Union[str, Path]) -> None:
+    """Refuse an atomic replacement when the target has an owner sentinel.
+
+    A sibling named ``.<filename>.write-protected`` is an explicit ownership
+    contract used by managed deployments.  Profiles and ordinary installs are
+    unchanged unless an operator deliberately creates the sentinel.
+    """
+
+    target_path = Path(target)
+    sentinel = target_path.parent / f".{target_path.name}.write-protected"
+    try:
+        sentinel_mode = sentinel.lstat().st_mode
+    except OSError:
+        return
+    if not stat.S_ISREG(sentinel_mode):
+        return
+    raise PermissionError(
+        f"{target_path} is owner-managed and write-protected by {sentinel}; "
+        "reconcile it through its owner source instead of a runtime config writer"
+    )
+
+
 def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     """Atomically move *tmp_path* onto *target*, preserving symlinks.
 
@@ -108,8 +130,11 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     Returns the resolved real path used for the replace, so callers that
     need to re-apply permissions can target it instead of the symlink.
     """
+    _raise_if_owner_write_protected(target)
     target_str = str(target)
     real_path = os.path.realpath(target_str) if os.path.islink(target_str) else target_str
+    if real_path != target_str:
+        _raise_if_owner_write_protected(real_path)
     tmp_str = str(tmp_path)
     try:
         os.replace(tmp_str, real_path)
@@ -327,6 +352,43 @@ def atomic_yaml_write(
     except BaseException:
         # Match atomic_json_write: cleanup must also happen for process-level
         # interruptions before we re-raise them.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def atomic_roundtrip_yaml_write(path: Union[str, Path], data: Any) -> None:
+    """Atomically write ruamel round-trip YAML while preserving file metadata."""
+
+    from ruamel.yaml import YAML
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    yaml_rt = YAML(typ="rt")
+    yaml_rt.preserve_quotes = True
+    yaml_rt.allow_unicode = True
+    yaml_rt.default_flow_style = False
+    yaml_rt.indent(mapping=2, sequence=4, offset=2)
+
+    original_mode = _preserve_file_mode(path)
+    original_owner = _preserve_file_owner(path)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.stem}_",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml_rt.dump(data, f)
+            f.flush()
+            os.fsync(f.fileno())
+        real_path = atomic_replace(tmp_path, path)
+        real_path_obj = Path(real_path)
+        _restore_file_owner(real_path_obj, original_owner)
+        _restore_file_mode(real_path_obj, original_mode)
+    except BaseException:
         try:
             os.unlink(tmp_path)
         except OSError:


### PR DESCRIPTION
## Problem

Two related ways a runtime config writer can silently destroy an operator-managed file.

**1. `atomic_replace()` writes through a symlink into whatever it points at.** It resolves the link and `os.replace()`s onto the real path. That is the right behaviour for an ordinary install, but it means any config writer can rewrite a file that a deployment considers its own — there is no way for the operator to say "this file is managed elsewhere, do not rewrite it at runtime."

On our fleet this showed up as a config file being periodically re-serialized by an unidentified writer, dropping the operator's ordering and comments each time. The file was owner-managed and reconciled from a deployment source; nothing in the process was doing anything illegitimate by its own lights, and nothing could be told to stop.

**2. Round-trip YAML writes lost file metadata.** Callers that need ruamel round-trip semantics (to preserve comments/quoting) had no atomic helper that also restored mode and ownership, so a rewrite could silently change permissions or owner on a root-managed file.

## Fix

**Opt-in ownership sentinel.** `atomic_replace()` now refuses when a sibling file named `.<filename>.write-protected` exists, raising `PermissionError` naming both the target and the sentinel. The check runs on the requested path *and*, when that path is a symlink, on the resolved real path — otherwise the protection is trivially bypassed by writing through a link.

It is deliberately inert by default: no sentinel, no behaviour change. Ordinary installs and profile configs are completely unaffected unless an operator creates the file. Only a regular file counts as a sentinel (a dangling or directory entry is ignored), so a stray symlink cannot brick writes.

**`atomic_roundtrip_yaml_write()`** — an atomic ruamel round-trip writer that preserves quotes/unicode/indent and restores the original mode and owner, so a round-trip rewrite of a root-owned config cannot silently change its metadata.

Two callers that were rewriting managed files are moved onto the protected path (`hermes_cli/xai_retirement.py`, `plugins/memory/holographic/__init__.py`).

## Tests

`tests/test_atomic_replace_symlinks.py`: the sentinel blocks a direct replace and a replace through a symlink; absence of the sentinel leaves behaviour identical; a non-regular sentinel is ignored; and `atomic_roundtrip_yaml_update` restores owner and mode.

20 tests pass on this branch.

Running on our fleet.
