### PR TITLE
fix(discord): keep triggering IDs out of transcript history

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -16,6 +16,7 @@ resolved through :func:`_ra` so those patches keep working.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -721,6 +722,30 @@ def _compression_deferred_result(
     }
 
 
+def _apply_transient_user_message_prefix(
+    current_content: Any,
+    prefix: Optional[str],
+) -> Any:
+    """Prepend current-turn-only text without mutating canonical content."""
+    if not prefix:
+        return copy.deepcopy(current_content)
+    if isinstance(current_content, str):
+        return prefix + current_content
+    if isinstance(current_content, list):
+        result = copy.deepcopy(current_content)
+        for part in result:
+            if (
+                isinstance(part, dict)
+                and part.get("type") == "text"
+                and isinstance(part.get("text"), str)
+            ):
+                part["text"] = prefix + part["text"]
+                return result
+        result.insert(0, {"type": "text", "text": prefix.rstrip()})
+        return result
+    return copy.deepcopy(current_content)
+
+
 def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     """Refresh the in-flight system message after a provider failover.
 
@@ -886,6 +911,7 @@ def run_conversation(
     stream_callback: Optional[callable] = None,
     persist_user_message: Optional[Any] = None,
     persist_user_timestamp: Optional[float] = None,
+    transient_user_message_prefix: Optional[str] = None,
     moa_config: Optional[dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
@@ -900,11 +926,11 @@ def run_conversation(
             Used by the TTS pipeline to start audio generation before the full response.
             When None (default), API calls use the standard non-streaming path.
         persist_user_message: Optional clean user message to store in
-            transcripts/history when user_message contains API-only
-            synthetic prefixes.
+            transcripts/history when the model input differs from authored content.
         persist_user_timestamp: Optional platform event timestamp to store
             as metadata on that persisted user message.
-                or queuing follow-up prefetch work.
+        transient_user_message_prefix: Optional current-turn-only text prepended
+            after compression when constructing the live provider request.
 
     Returns:
         Dict: Complete conversation result with final response and message history
@@ -946,6 +972,7 @@ def run_conversation(
         stream_callback,
         persist_user_message,
         persist_user_timestamp,
+        transient_user_message_prefix,
         restore_or_build_system_prompt=_restore_or_build_system_prompt,
         install_safe_stdio=_install_safe_stdio,
         sanitize_surrogates=_sanitize_surrogates,
@@ -959,6 +986,7 @@ def run_conversation(
     )
     user_message = _ctx.user_message
     original_user_message = _ctx.original_user_message
+    _transient_user_message_prefix = _ctx.transient_user_message_prefix
     messages = _ctx.messages
     conversation_history = _ctx.conversation_history
     active_system_prompt = _ctx.active_system_prompt
@@ -1029,8 +1057,12 @@ def run_conversation(
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
+        _codex_user_message = _apply_transient_user_message_prefix(
+            user_message,
+            _transient_user_message_prefix,
+        )
         return agent._run_codex_app_server_turn(
-            user_message=user_message,
+            user_message=_codex_user_message,
             original_user_message=original_user_message,
             messages=messages,
             effective_task_id=effective_task_id,
@@ -1221,7 +1253,25 @@ def run_conversation(
             # never mutated beyond the api_content stamp, so nothing leaks
             # into the clean transcript content.
             if idx == current_turn_user_idx and msg.get("role") == "user":
-                if isinstance(_api_content, str) and _api_content:
+                if _transient_user_message_prefix:
+                    # Current-turn-only routing metadata is composed onto this
+                    # request copy after preflight compression and persistence.
+                    # It never enters ``messages`` or replayable api_content.
+                    _request_user_content = _apply_transient_user_message_prefix(
+                        api_msg.get("content", ""),
+                        _transient_user_message_prefix,
+                    )
+                    _composed = compose_user_api_content(
+                        _request_user_content,
+                        _ext_prefetch_cache,
+                        _plugin_user_context,
+                    )
+                    api_msg["content"] = (
+                        _composed
+                        if _composed is not None
+                        else _request_user_content
+                    )
+                elif isinstance(_api_content, str) and _api_content:
                     # Stamped by the prologue from the same composition —
                     # reuse it so the persisted sidecar and the wire cannot
                     # drift, and so every pass this turn sends identical

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -16,6 +16,7 @@ resolved through :func:`_ra` so those patches keep working.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -1409,6 +1410,28 @@ def _rewrite_system_content_blocks(system_message: dict, effective: str) -> bool
                 content[1]["text"] = tail
                 return True
     return False
+def _apply_transient_user_message_prefix(
+    current_content: Any,
+    prefix: Optional[str],
+) -> Any:
+    """Prepend current-turn-only text without mutating canonical content."""
+    if not prefix:
+        return copy.deepcopy(current_content)
+    if isinstance(current_content, str):
+        return prefix + current_content
+    if isinstance(current_content, list):
+        result = copy.deepcopy(current_content)
+        for part in result:
+            if (
+                isinstance(part, dict)
+                and part.get("type") == "text"
+                and isinstance(part.get("text"), str)
+            ):
+                part["text"] = prefix + part["text"]
+                return result
+        result.insert(0, {"type": "text", "text": prefix.rstrip()})
+        return result
+    return copy.deepcopy(current_content)
 
 
 def _sync_failover_system_message(agent, api_messages, active_system_prompt):
@@ -1698,6 +1721,7 @@ def run_conversation(
     persist_user_timestamp: Optional[float] = None,
     persist_user_display_kind: Optional[str] = None,
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+    transient_user_message_prefix: Optional[str] = None,
     moa_config: Optional[dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
@@ -1712,8 +1736,7 @@ def run_conversation(
             Used by the TTS pipeline to start audio generation before the full response.
             When None (default), API calls use the standard non-streaming path.
         persist_user_message: Optional clean user message to store in
-            transcripts/history when user_message contains API-only
-            synthetic prefixes.
+            transcripts/history when the model input differs from authored content.
         persist_user_timestamp: Optional platform event timestamp to store
             as metadata on that persisted user message.
         persist_user_display_kind: Optional presentation type for a
@@ -1724,6 +1747,8 @@ def run_conversation(
         persist_user_display_metadata: Optional payload for that event
             (e.g. a delegation's task count).
                 or queuing follow-up prefetch work.
+        transient_user_message_prefix: Optional current-turn-only text prepended
+            after compression when constructing the live provider request.
 
     Returns:
         Dict: Complete conversation result with final response and message history
@@ -1798,6 +1823,7 @@ def run_conversation(
         stream_callback,
         persist_user_message,
         persist_user_timestamp,
+        transient_user_message_prefix,
         persist_user_display_kind=persist_user_display_kind,
         persist_user_display_metadata=persist_user_display_metadata,
         restore_or_build_system_prompt=_restore_or_build_system_prompt,
@@ -1813,6 +1839,7 @@ def run_conversation(
     )
     user_message = _ctx.user_message
     original_user_message = _ctx.original_user_message
+    _transient_user_message_prefix = _ctx.transient_user_message_prefix
     messages = _ctx.messages
     conversation_history = _ctx.conversation_history
     active_system_prompt = _ctx.active_system_prompt
@@ -1897,8 +1924,12 @@ def run_conversation(
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
+        _codex_user_message = _apply_transient_user_message_prefix(
+            user_message,
+            _transient_user_message_prefix,
+        )
         return agent._run_codex_app_server_turn(
-            user_message=user_message,
+            user_message=_codex_user_message,
             original_user_message=original_user_message,
             messages=messages,
             effective_task_id=effective_task_id,
@@ -2138,7 +2169,25 @@ def run_conversation(
             # never mutated beyond the api_content stamp, so nothing leaks
             # into the clean transcript content.
             if idx == current_turn_user_idx and msg.get("role") == "user":
-                if isinstance(_api_content, str) and _api_content:
+                if _transient_user_message_prefix:
+                    # Current-turn-only routing metadata is composed onto this
+                    # request copy after preflight compression and persistence.
+                    # It never enters ``messages`` or replayable api_content.
+                    _request_user_content = _apply_transient_user_message_prefix(
+                        api_msg.get("content", ""),
+                        _transient_user_message_prefix,
+                    )
+                    _composed = compose_user_api_content(
+                        _request_user_content,
+                        _ext_prefetch_cache,
+                        _plugin_user_context,
+                    )
+                    api_msg["content"] = (
+                        _composed
+                        if _composed is not None
+                        else _request_user_content
+                    )
+                elif isinstance(_api_content, str) and _api_content:
                     # Stamped by the prologue from the same composition —
                     # reuse it so the persisted sidecar and the wire cannot
                     # drift, and so every pass this turn sends identical

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -302,9 +302,11 @@ class TurnContext:
     """Values produced by the turn prologue and consumed by the turn loop."""
 
     # Sanitized inbound message (surrogates stripped).
-    user_message: str
+    user_message: Any
     # Clean message preserved for transcripts / memory queries (no nudge injection).
     original_user_message: Any
+    # API-only current-turn prefix, excluded from compression and persistence.
+    transient_user_message_prefix: Optional[str]
     # Working message list for this turn (loop appends to it).
     messages: List[Dict[str, Any]]
     # May be reset to None by preflight compression (new session created).
@@ -335,6 +337,7 @@ def build_turn_context(
     stream_callback,
     persist_user_message: Optional[Any],
     persist_user_timestamp: Optional[float] = None,
+    transient_user_message_prefix: Optional[str] = None,
     *,
     restore_or_build_system_prompt,
     install_safe_stdio,
@@ -428,11 +431,17 @@ def build_turn_context(
     if isinstance(persist_user_message, str):
         persist_user_message = sanitize_surrogates(persist_user_message)
 
+    if isinstance(transient_user_message_prefix, str):
+        transient_user_message_prefix = sanitize_surrogates(
+            transient_user_message_prefix
+        )
+
     # Store stream callback for _interruptible_api_call to pick up.
     agent._stream_callback = stream_callback
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = persist_user_message
     agent._persist_user_message_timestamp = persist_user_timestamp
+
     # Generate unique task_id if not provided to isolate VMs between tasks.
     effective_task_id = task_id or str(uuid.uuid4())
     agent._current_task_id = effective_task_id
@@ -1228,6 +1237,7 @@ def build_turn_context(
     return TurnContext(
         user_message=user_message,
         original_user_message=original_user_message,
+        transient_user_message_prefix=transient_user_message_prefix,
         messages=messages,
         conversation_history=conversation_history,
         active_system_prompt=active_system_prompt,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -404,9 +404,11 @@ class TurnContext:
     """Values produced by the turn prologue and consumed by the turn loop."""
 
     # Sanitized inbound message (surrogates stripped).
-    user_message: str
+    user_message: Any
     # Clean message preserved for transcripts / memory queries (no nudge injection).
     original_user_message: Any
+    # API-only current-turn prefix, excluded from compression and persistence.
+    transient_user_message_prefix: Optional[str]
     # Working message list for this turn (loop appends to it).
     messages: List[Dict[str, Any]]
     # May be reset to None by preflight compression (new session created).
@@ -437,6 +439,7 @@ def build_turn_context(
     stream_callback,
     persist_user_message: Optional[Any],
     persist_user_timestamp: Optional[float] = None,
+    transient_user_message_prefix: Optional[str] = None,
     *,
     persist_user_display_kind: Optional[str] = None,
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
@@ -545,11 +548,17 @@ def build_turn_context(
     if isinstance(persist_user_message, str):
         persist_user_message = sanitize_surrogates(persist_user_message)
 
+    if isinstance(transient_user_message_prefix, str):
+        transient_user_message_prefix = sanitize_surrogates(
+            transient_user_message_prefix
+        )
+
     # Store stream callback for _interruptible_api_call to pick up.
     agent._stream_callback = stream_callback
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = persist_user_message
     agent._persist_user_message_timestamp = persist_user_timestamp
+
     # Generate unique task_id if not provided to isolate VMs between tasks.
     effective_task_id = task_id or str(uuid.uuid4())
     agent._current_task_id = effective_task_id
@@ -1395,6 +1404,7 @@ def build_turn_context(
     return TurnContext(
         user_message=user_message,
         original_user_message=original_user_message,
+        transient_user_message_prefix=transient_user_message_prefix,
         messages=messages,
         conversation_history=conversation_history,
         active_system_prompt=active_system_prompt,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3708,6 +3708,57 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
+        # Authenticated gateway proxies may preserve a clean user-authored value
+        # for transcript storage and attach current-turn-only routing context as
+        # a separate prefix. Never expose these hidden controls on an
+        # unauthenticated API server.
+        persist_user_message = body.get("hermes_persist_user_message")
+        if persist_user_message is not None:
+            if not self._api_key:
+                return web.json_response(
+                    _openai_error(
+                        "hermes_persist_user_message requires API authentication",
+                        param="hermes_persist_user_message",
+                    ),
+                    status=400,
+                )
+            if not isinstance(persist_user_message, str):
+                return web.json_response(
+                    _openai_error(
+                        "hermes_persist_user_message must be a string",
+                        param="hermes_persist_user_message",
+                    ),
+                    status=400,
+                )
+        transient_user_message_prefix = body.get(
+            "hermes_transient_user_message_prefix"
+        )
+        if transient_user_message_prefix is not None:
+            if not self._api_key:
+                return web.json_response(
+                    _openai_error(
+                        "hermes_transient_user_message_prefix requires API authentication",
+                        param="hermes_transient_user_message_prefix",
+                    ),
+                    status=400,
+                )
+            if not isinstance(transient_user_message_prefix, str):
+                return web.json_response(
+                    _openai_error(
+                        "hermes_transient_user_message_prefix must be a string",
+                        param="hermes_transient_user_message_prefix",
+                    ),
+                    status=400,
+                )
+            if persist_user_message is None:
+                return web.json_response(
+                    _openai_error(
+                        "hermes_transient_user_message_prefix requires hermes_persist_user_message",
+                        param="hermes_transient_user_message_prefix",
+                    ),
+                    status=400,
+                )
+
         # Allow caller to scope long-term memory (e.g. Honcho) with a
         # stable per-channel identifier via X-Hermes-Session-Key.  This
         # is independent of X-Hermes-Session-Id: the key persists across
@@ -3881,6 +3932,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                persist_user_message=persist_user_message,
+                **(
+                    {"transient_user_message_prefix": transient_user_message_prefix}
+                    if transient_user_message_prefix is not None
+                    else {}
+                ),
                 **agent_overrides,
                 route=route,
             ))
@@ -3902,6 +3959,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                persist_user_message=persist_user_message,
+                **(
+                    {"transient_user_message_prefix": transient_user_message_prefix}
+                    if transient_user_message_prefix is not None
+                    else {}
+                ),
                 **agent_overrides,
                 route=route,
             )
@@ -3910,7 +3973,17 @@ class APIServerAdapter(BasePlatformAdapter):
         if idempotency_key:
             fp = _make_request_fingerprint(
                 body,
-                keys=["model", "provider", "model_options", "messages", "tools", "tool_choice", "stream"],
+                keys=[
+                    "model",
+                    "provider",
+                    "model_options",
+                    "messages",
+                    "tools",
+                    "tool_choice",
+                    "stream",
+                    "hermes_persist_user_message",
+                    "hermes_transient_user_message_prefix",
+                ],
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
@@ -5712,6 +5785,8 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
+        persist_user_message: Optional[str] = None,
+        transient_user_message_prefix: Optional[str] = None,
         requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None,
         model_options: Optional[Dict[str, Any]] = None,
@@ -5780,11 +5855,18 @@ class APIServerAdapter(BasePlatformAdapter):
                     if agent_ref is not None:
                         agent_ref[0] = agent
                     effective_task_id = session_id or str(uuid.uuid4())
-                    result = agent.run_conversation(
-                        user_message=user_message,
-                        conversation_history=conversation_history,
-                        task_id=effective_task_id,
-                    )
+                    _conversation_kwargs = {
+                        "user_message": user_message,
+                        "conversation_history": conversation_history,
+                        "task_id": effective_task_id,
+                    }
+                    if persist_user_message is not None:
+                        _conversation_kwargs["persist_user_message"] = persist_user_message
+                    if transient_user_message_prefix is not None:
+                        _conversation_kwargs["transient_user_message_prefix"] = (
+                            transient_user_message_prefix
+                        )
+                    result = agent.run_conversation(**_conversation_kwargs)
                     usage = {
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4182,6 +4182,57 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
+        # Authenticated gateway proxies may preserve a clean user-authored value
+        # for transcript storage and attach current-turn-only routing context as
+        # a separate prefix. Never expose these hidden controls on an
+        # unauthenticated API server.
+        persist_user_message = body.get("hermes_persist_user_message")
+        if persist_user_message is not None:
+            if not self._api_key:
+                return web.json_response(
+                    _openai_error(
+                        "hermes_persist_user_message requires API authentication",
+                        param="hermes_persist_user_message",
+                    ),
+                    status=400,
+                )
+            if not isinstance(persist_user_message, str):
+                return web.json_response(
+                    _openai_error(
+                        "hermes_persist_user_message must be a string",
+                        param="hermes_persist_user_message",
+                    ),
+                    status=400,
+                )
+        transient_user_message_prefix = body.get(
+            "hermes_transient_user_message_prefix"
+        )
+        if transient_user_message_prefix is not None:
+            if not self._api_key:
+                return web.json_response(
+                    _openai_error(
+                        "hermes_transient_user_message_prefix requires API authentication",
+                        param="hermes_transient_user_message_prefix",
+                    ),
+                    status=400,
+                )
+            if not isinstance(transient_user_message_prefix, str):
+                return web.json_response(
+                    _openai_error(
+                        "hermes_transient_user_message_prefix must be a string",
+                        param="hermes_transient_user_message_prefix",
+                    ),
+                    status=400,
+                )
+            if persist_user_message is None:
+                return web.json_response(
+                    _openai_error(
+                        "hermes_transient_user_message_prefix requires hermes_persist_user_message",
+                        param="hermes_transient_user_message_prefix",
+                    ),
+                    status=400,
+                )
+
         # Allow caller to scope long-term memory (e.g. Honcho) with a
         # stable per-channel identifier via X-Hermes-Session-Key.  This
         # is independent of X-Hermes-Session-Id: the key persists across
@@ -4356,6 +4407,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                persist_user_message=persist_user_message,
+                **(
+                    {"transient_user_message_prefix": transient_user_message_prefix}
+                    if transient_user_message_prefix is not None
+                    else {}
+                ),
                 **agent_overrides,
                 route=route,
             ))
@@ -4377,6 +4434,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                persist_user_message=persist_user_message,
+                **(
+                    {"transient_user_message_prefix": transient_user_message_prefix}
+                    if transient_user_message_prefix is not None
+                    else {}
+                ),
                 **agent_overrides,
                 route=route,
             )
@@ -4385,7 +4448,17 @@ class APIServerAdapter(BasePlatformAdapter):
         if idempotency_key:
             fp = _make_request_fingerprint(
                 body,
-                keys=["model", "provider", "model_options", "messages", "tools", "tool_choice", "stream"],
+                keys=[
+                    "model",
+                    "provider",
+                    "model_options",
+                    "messages",
+                    "tools",
+                    "tool_choice",
+                    "stream",
+                    "hermes_persist_user_message",
+                    "hermes_transient_user_message_prefix",
+                ],
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
@@ -6285,6 +6358,8 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_ref: Optional[list] = None,
         active_run_id: Optional[str] = None,
         gateway_session_key: Optional[str] = None,
+        persist_user_message: Optional[str] = None,
+        transient_user_message_prefix: Optional[str] = None,
         requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None,
         model_options: Optional[Dict[str, Any]] = None,
@@ -6373,11 +6448,18 @@ class APIServerAdapter(BasePlatformAdapter):
                     # ``agent_ref``, and only /v1/runs has a run_id, so neither
                     # is a usable hook for the rest.
                     self._shutdown_interruptible_agents[id(agent)] = agent
-                    result = agent.run_conversation(
-                        user_message=user_message,
-                        conversation_history=conversation_history,
-                        task_id=effective_task_id,
-                    )
+                    _conversation_kwargs = {
+                        "user_message": user_message,
+                        "conversation_history": conversation_history,
+                        "task_id": effective_task_id,
+                    }
+                    if persist_user_message is not None:
+                        _conversation_kwargs["persist_user_message"] = persist_user_message
+                    if transient_user_message_prefix is not None:
+                        _conversation_kwargs["transient_user_message_prefix"] = (
+                            transient_user_message_prefix
+                        )
+                    result = agent.run_conversation(**_conversation_kwargs)
                     usage = {
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12620,25 +12620,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 context_note = _build_document_context_note(display_name, agent_path, mtype)
                 message_text = f"{context_note}\n\n{message_text}"
 
-        # Discord: surface the triggering message id per-turn on the user
-        # message rather than in the cached system prompt. message_id changes
-        # every turn, so baking it into build_session_context_prompt() would
-        # bust the agent-cache signature and rebuild the AIAgent every message
-        # (destroying prompt caching). The static IDs block points the agent
-        # here; the volatile id rides the per-turn user content.
-        if (
-            source is not None
-            and getattr(source, "platform", None) == Platform.DISCORD
-            and getattr(event, "message_id", None)
-        ):
-            from gateway.session import _discord_tools_loaded as _disc_tools_loaded
-            if _disc_tools_loaded():
-                message_text = (
-                    f"[Triggering message id: `{event.message_id}` — use as "
-                    f"`message_id` for reply/react/pin via the discord tools.]\n\n"
-                    f"{message_text}"
-                )
-
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
             # Always inject the reply-to pointer — even when the quoted text
             # already appears in history. The prefix isn't deduplication, it's
@@ -12784,6 +12765,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             history=history,
             session_key=session_key,
         )
+
+    def _discord_tools_loaded_for_source(self, source: SessionSource) -> bool:
+        """Check Discord tool availability under the routed profile scope."""
+        from gateway.session import _discord_tools_loaded
+
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
+                return _discord_tools_loaded()
+        return _discord_tools_loaded()
 
     def _consume_pending_native_image_paths(self, session_key: str) -> List[str]:
         pending_native = getattr(self, "_pending_native_image_paths_by_session", None)
@@ -12984,6 +12974,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _redact_pii = False
         persist_user_message = None
         persist_user_timestamp = None
+        transient_user_message_prefix = None
         try:
             _pcfg = _load_gateway_config()
             _redact_pii = bool((_pcfg.get("privacy") or {}).get("redact_pii", False))
@@ -13829,6 +13820,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if message_text is None:
             return
 
+        # Capture the clean authored representation before exception-prone
+        # timestamp preprocessing. The Discord routing prefix is transported
+        # separately and is never inserted into this canonical message.
+        if isinstance(message_text, str):
+            persist_user_message = message_text
+
         # Capture the platform event time as message metadata and keep the
         # persisted transcript clean (strip any leading timestamp prefix).
         # This runs regardless of the toggle so storage stays clean and the
@@ -13844,7 +13841,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             _evt_tz = _get_evt_tz()
             _evt_ts = getattr(event, "timestamp", None)
-            if message_text and isinstance(message_text, str):
+            if isinstance(message_text, str):
                 _clean_message_text, _embedded_ts = _strip_msg_ts(
                     message_text, tz=_evt_tz)
                 persist_user_message = _clean_message_text
@@ -13864,6 +13861,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     message_text = _clean_message_text
         except Exception as _ts_err:
             logger.debug("Message timestamp injection failed (non-fatal): %s", _ts_err)
+
+        # Discord: surface the volatile triggering message id on the model's
+        # current user message only after capturing the clean persistence
+        # override above. Keeping it in a separate transient prefix preserves
+        # prompt caching and keeps it out of canonical transcript state.
+        if (
+            source is not None
+            and source.platform == Platform.DISCORD
+            and getattr(event, "message_id", None)
+        ):
+            if self._discord_tools_loaded_for_source(source):
+                transient_user_message_prefix = (
+                    f"[Triggering message id: `{event.message_id}` — use as "
+                    "`message_id` for reply/react/pin via the discord tools.]\n\n"
+                )
 
         # Stage the collected must-deliver notes for this turn's agent run
         # (one-shot; consumed in run_sync).  Staged AFTER the message_text
@@ -13912,6 +13924,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                transient_user_message_prefix=transient_user_message_prefix,
             )
 
             # Stop persistent typing indicator now that the agent is done.
@@ -19657,6 +19670,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key: str = None,
         run_generation: Optional[int] = None,
         event_message_id: Optional[str] = None,
+        persist_user_message: Optional[str] = None,
+        transient_user_message_prefix: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Forward the message to a remote Hermes API server instead of
         running a local AIAgent.
@@ -19690,6 +19705,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             }
 
         proxy_key = os.getenv("GATEWAY_PROXY_KEY", "").strip()
+        if transient_user_message_prefix is not None and not proxy_key:
+            return {
+                "final_response": (
+                    "⚠️ Proxy mode requires GATEWAY_PROXY_KEY and a matching "
+                    "API_SERVER_KEY on the remote server to forward transient "
+                    "routing metadata safely."
+                ),
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+            }
 
         def _run_still_current() -> bool:
             if run_generation is None or not session_key:
@@ -19732,6 +19758,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "messages": api_messages,
             "stream": True,
         }
+        if proxy_key and persist_user_message is not None:
+            # Internal proxy extension: the final user message remains clean.
+            # The remote agent applies any transient routing prefix only while
+            # constructing the current provider request.
+            body["hermes_persist_user_message"] = persist_user_message
+            if transient_user_message_prefix is not None:
+                body["hermes_transient_user_message_prefix"] = (
+                    transient_user_message_prefix
+                )
 
         # Set up platform streaming if available -------------------------
         _stream_consumer = None
@@ -19961,6 +19996,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        transient_user_message_prefix: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -19979,6 +20015,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                transient_user_message_prefix=transient_user_message_prefix,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -19990,6 +20027,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                transient_user_message_prefix=transient_user_message_prefix,
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -20111,6 +20149,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        transient_user_message_prefix: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -20135,6 +20174,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key=session_key,
                 run_generation=run_generation,
                 event_message_id=event_message_id,
+                persist_user_message=persist_user_message,
+                transient_user_message_prefix=transient_user_message_prefix,
             )
 
         from run_agent import AIAgent
@@ -22173,6 +22214,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                         if any(p.get("type") == "image_url" for p in _parts):
                             _run_message: Any = _parts
+                            if isinstance(_persist_user_message_override, str):
+                                # A string override cannot replace multimodal
+                                # content at the persistence boundary. Preserve
+                                # the image parts and their replay hints while
+                                # replacing only the model-facing text prefix.
+                                _persist_parts = [dict(part) for part in _parts]
+                                _model_base = (
+                                    (message or "").strip()
+                                    or "What do you see in this image?"
+                                )
+                                _clean_base = (
+                                    _persist_user_message_override.strip()
+                                    or "What do you see in this image?"
+                                )
+                                _model_text = _persist_parts[0].get("text")
+                                if (
+                                    _persist_parts[0].get("type") == "text"
+                                    and isinstance(_model_text, str)
+                                    and _model_text.startswith(_model_base)
+                                ):
+                                    _persist_parts[0]["text"] = (
+                                        _clean_base + _model_text[len(_model_base):]
+                                    )
+                                    _persist_user_message_override = _persist_parts
                         else:
                             # All images failed to read — fall back to plain text.
                             _run_message = message
@@ -22197,6 +22262,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["persist_user_message"] = _persist_user_message_override
                 elif observed_group_context:
                     _conversation_kwargs["persist_user_message"] = message
+                if transient_user_message_prefix is not None:
+                    _conversation_kwargs["transient_user_message_prefix"] = (
+                        transient_user_message_prefix
+                    )
                 if moa_config is not None:
                     _conversation_kwargs["moa_config"] = moa_config
                 if _persist_user_timestamp_override is not None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6105,6 +6105,30 @@ class TurnRunner:
                         )
                     if any(p.get("type") == "image_url" for p in _parts):
                         _run_message: Any = _parts
+                        if isinstance(_persist_user_message_override, str):
+                            # A string override cannot replace multimodal
+                            # content at the persistence boundary. Preserve
+                            # the image parts while replacing only the
+                            # model-facing text with the clean authored text.
+                            _persist_parts = [dict(part) for part in _parts]
+                            _model_base = (
+                                (ctx.message or "").strip()
+                                or "What do you see in this image?"
+                            )
+                            _clean_base = (
+                                _persist_user_message_override.strip()
+                                or "What do you see in this image?"
+                            )
+                            _model_text = _persist_parts[0].get("text")
+                            if (
+                                _persist_parts[0].get("type") == "text"
+                                and isinstance(_model_text, str)
+                                and _model_text.startswith(_model_base)
+                            ):
+                                _persist_parts[0]["text"] = (
+                                    _clean_base + _model_text[len(_model_base):]
+                                )
+                                _persist_user_message_override = _persist_parts
                     else:
                         # All images failed to read — fall back to plain text.
                         _run_message = ctx.message
@@ -6141,6 +6165,10 @@ class TurnRunner:
                 _conversation_kwargs["moa_config"] = ctx.moa_config
             if _persist_user_timestamp_override is not None:
                 _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
+            if ctx.transient_user_message_prefix is not None:
+                _conversation_kwargs["transient_user_message_prefix"] = (
+                    ctx.transient_user_message_prefix
+                )
             result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
         finally:
             unregister_gateway_notify(_approval_session_key)
@@ -17873,25 +17901,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 context_note = _build_document_context_note(display_name, agent_path, mtype)
                 message_text = f"{context_note}\n\n{message_text}"
 
-        # Discord: surface the triggering message id per-turn on the user
-        # message rather than in the cached system prompt. message_id changes
-        # every turn, so baking it into build_session_context_prompt() would
-        # bust the agent-cache signature and rebuild the AIAgent every message
-        # (destroying prompt caching). The static IDs block points the agent
-        # here; the volatile id rides the per-turn user content.
-        if (
-            source is not None
-            and getattr(source, "platform", None) == Platform.DISCORD
-            and getattr(event, "message_id", None)
-        ):
-            from gateway.session import _discord_tools_loaded as _disc_tools_loaded
-            if _disc_tools_loaded():
-                message_text = (
-                    f"[Triggering message id: `{event.message_id}` — use as "
-                    f"`message_id` for reply/react/pin via the discord tools.]\n\n"
-                    f"{message_text}"
-                )
-
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
             # Always inject the reply-to pointer — even when the quoted text
             # already appears in history. The prefix isn't deduplication, it's
@@ -18051,6 +18060,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             for transcript in successful_transcripts
             if transcript.strip()
         )
+    def _discord_tools_loaded_for_source(self, source: SessionSource) -> bool:
+        """Check Discord tool availability under the routed profile scope."""
+        from gateway.session import _discord_tools_loaded
+
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
+                return _discord_tools_loaded()
+        return _discord_tools_loaded()
 
     def _consume_pending_native_image_paths(self, session_key: str) -> List[str]:
         state = self._peek_session_state(session_key)
@@ -18518,6 +18535,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_display_kind = (
             "internal_notification" if getattr(event, "internal", False) else None
         )
+        transient_user_message_prefix = None
         try:
             _pcfg = _load_gateway_config()
             _redact_pii = bool((_pcfg.get("privacy") or {}).get("redact_pii", False))
@@ -19611,6 +19629,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if message_text is None:
             return
 
+        # Capture the clean authored representation before exception-prone
+        # timestamp preprocessing. The Discord routing prefix is transported
+        # separately and is never inserted into this canonical message.
+        if isinstance(message_text, str):
+            persist_user_message = message_text
+
         # Capture the platform event time as message metadata and keep the
         # persisted transcript clean (strip any leading timestamp prefix).
         # This runs regardless of the toggle so storage stays clean and the
@@ -19626,7 +19650,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             _evt_tz = _get_evt_tz()
             _evt_ts = getattr(event, "timestamp", None)
-            if message_text and isinstance(message_text, str):
+            if isinstance(message_text, str):
                 _clean_message_text, _embedded_ts = _strip_msg_ts(
                     message_text, tz=_evt_tz)
                 persist_user_message = _clean_message_text
@@ -19646,6 +19670,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     message_text = _clean_message_text
         except Exception as _ts_err:
             logger.debug("Message timestamp injection failed (non-fatal): %s", _ts_err)
+
+        # Discord: surface the volatile triggering message id on the model's
+        # current user message only after capturing the clean persistence
+        # override above. Keeping it in a separate transient prefix preserves
+        # prompt caching and keeps it out of canonical transcript state.
+        if (
+            source is not None
+            and source.platform == Platform.DISCORD
+            and getattr(event, "message_id", None)
+        ):
+            if self._discord_tools_loaded_for_source(source):
+                transient_user_message_prefix = (
+                    f"[Triggering message id: `{event.message_id}` — use as "
+                    "`message_id` for reply/react/pin via the discord tools.]\n\n"
+                )
 
         # Stage the collected must-deliver notes for this turn's agent run
         # (one-shot; consumed in run_sync).  Staged AFTER the message_text
@@ -19697,6 +19736,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
                 message_type=event.message_type,
+                transient_user_message_prefix=transient_user_message_prefix,
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
 
@@ -27008,6 +27048,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key: str = None,
         run_generation: Optional[int] = None,
         event_message_id: Optional[str] = None,
+        persist_user_message: Optional[str] = None,
+        transient_user_message_prefix: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Forward the message to a remote Hermes API server instead of
         running a local AIAgent.
@@ -27052,6 +27094,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 proxy_key = os.getenv("GATEWAY_PROXY_KEY", "").strip()
         except Exception:
             proxy_key = os.getenv("GATEWAY_PROXY_KEY", "").strip()
+        if transient_user_message_prefix is not None and not proxy_key:
+            return {
+                "final_response": (
+                    "⚠️ Proxy mode requires GATEWAY_PROXY_KEY and a matching "
+                    "API_SERVER_KEY on the remote server to forward transient "
+                    "routing metadata safely."
+                ),
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+            }
 
         def _run_still_current() -> bool:
             if run_generation is None or not session_key:
@@ -27094,6 +27147,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "messages": api_messages,
             "stream": True,
         }
+        if proxy_key and persist_user_message is not None:
+            # Internal proxy extension: the final user message remains clean.
+            # The remote agent applies any transient routing prefix only while
+            # constructing the current provider request.
+            body["hermes_persist_user_message"] = persist_user_message
+            if transient_user_message_prefix is not None:
+                body["hermes_transient_user_message_prefix"] = (
+                    transient_user_message_prefix
+                )
 
         # Set up platform streaming if available -------------------------
         _stream_consumer = None
@@ -27300,6 +27362,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
         message_type: Optional[str] = None,
+        transient_user_message_prefix: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -27320,6 +27383,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
                 message_type=message_type,
+                transient_user_message_prefix=transient_user_message_prefix,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -27333,6 +27397,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
                 message_type=message_type,
+                transient_user_message_prefix=transient_user_message_prefix,
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -27476,6 +27541,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
         message_type: Optional[str] = None,
+        transient_user_message_prefix: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -27500,6 +27566,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key=session_key,
                 run_generation=run_generation,
                 event_message_id=event_message_id,
+                persist_user_message=persist_user_message,
+                transient_user_message_prefix=transient_user_message_prefix,
             )
 
         from run_agent import AIAgent
@@ -27784,6 +27852,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             moa_config=moa_config,
             persist_user_message=persist_user_message,
             persist_user_timestamp=persist_user_timestamp,
+            transient_user_message_prefix=transient_user_message_prefix,
             persist_user_display_kind=persist_user_display_kind,
         )
         turn_runner = TurnRunner(self, turn_ctx)

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -91,6 +91,8 @@ class TurnContext:
     moa_config: Optional[dict] = None
     persist_user_message: Optional[Any] = None
     persist_user_timestamp: Optional[float] = None
+    # API-only current-turn prefix, excluded from canonical persistence.
+    transient_user_message_prefix: Optional[str] = None
     # display_kind stamped on the persisted user row at turn start when this
     # turn was self-injected (MessageEvent.internal), e.g.
     # "internal_notification" for async-delegation/background notifications

--- a/run_agent.py
+++ b/run_agent.py
@@ -6681,6 +6681,7 @@ class AIAgent:
         stream_callback: Optional[callable] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        transient_user_message_prefix: Optional[str] = None,
         moa_config: Optional[dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
@@ -6723,6 +6724,7 @@ class AIAgent:
                     stream_callback,
                     persist_user_message,
                     persist_user_timestamp=persist_user_timestamp,
+                    transient_user_message_prefix=transient_user_message_prefix,
                     moa_config=moa_config,
                 )
             finally:

--- a/run_agent.py
+++ b/run_agent.py
@@ -8331,6 +8331,7 @@ class AIAgent:
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+        transient_user_message_prefix: Optional[str] = None,
         moa_config: Optional[dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
@@ -8696,6 +8697,7 @@ class AIAgent:
                         persist_user_timestamp=persist_user_timestamp,
                         persist_user_display_kind=persist_user_display_kind,
                         persist_user_display_metadata=persist_user_display_metadata,
+                        transient_user_message_prefix=transient_user_message_prefix,
                         moa_config=moa_config,
                     )
                 finally:

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -29,6 +29,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent.conversation_loop import _apply_transient_user_message_prefix
 from agent.memory_manager import build_memory_context_block
 from agent.turn_context import build_turn_context, compose_user_api_content
 from hermes_state import SessionDB
@@ -49,6 +50,15 @@ class TestComposeUserApiContent:
         assert out == "hello" + "\n\n" + fenced + "\n\n" + "PLUGIN-CTX"
 
 
+
+    def test_transient_prefix_preserves_compaction_merged_content(self):
+        routing_note = "[Triggering message id: `message-1`]"
+        merged = "[prior context]\ncompaction summary\n\nhello"
+
+        assert _apply_transient_user_message_prefix(
+            merged,
+            f"{routing_note}\n\n",
+        ) == f"{routing_note}\n\n{merged}"
 
 
 # ---------------------------------------------------------------------------
@@ -546,6 +556,146 @@ class TestWireInvariant:
         current = _user_messages(_chat_requests(handler)[0])[-1]
         assert current["content"] == "second question\n\nPLUGIN-CTX"
 
+    def test_transient_prefix_reaches_current_turn_but_not_replay(self, wire_env):
+        """Current-turn routing metadata must never become replayable history."""
+        make_agent, handler, db, sid = wire_env
+        routing_note = "[Triggering message id: `message-1`]"
+        routing_prefix = f"{routing_note}\n\n"
+        stable_model_message = "MODEL-SWITCH\n\nhello please"
+
+        agent1 = make_agent()
+        agent1.run_conversation(
+            stable_model_message,
+            conversation_history=[],
+            task_id="t1",
+            persist_user_message="hello please",
+            transient_user_message_prefix=routing_prefix,
+        )
+
+        current_turn = _user_messages(_chat_requests(handler)[0])[0]["content"]
+        assert current_turn.startswith(routing_prefix)
+        assert "MODEL-SWITCH" in current_turn
+
+        history = db.get_messages_as_conversation(sid)
+        assert history[0]["content"] == "hello please"
+        assert history[0]["api_content"] == (
+            "MODEL-SWITCH\n\nhello please\n\nPLUGIN-CTX"
+        )
+        assert routing_note not in json.dumps(history[0])
+
+        handler.captured_requests = []
+        agent2 = make_agent()
+        agent2.run_conversation(
+            "second question",
+            conversation_history=history,
+            task_id="t2",
+        )
+
+        replayed_history = _user_messages(_chat_requests(handler)[0])[0]["content"]
+        assert replayed_history == "MODEL-SWITCH\n\nhello please\n\nPLUGIN-CTX"
+        assert routing_note not in replayed_history
+
+    @pytest.mark.parametrize("caption", ["describe this", ""])
+    def test_transient_multimodal_prefix_is_wire_only(self, wire_env, caption):
+        """Native image payloads keep routing context on the wire, never in SQLite."""
+        make_agent, handler, db, sid = wire_env
+        routing_note = "[Triggering message id: `message-1`]"
+        routing_prefix = f"{routing_note}\n\n"
+        clean_text = caption or "What do you see in this image?"
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,AAAA"},
+        }
+        clean_content = [
+            {"type": "text", "text": clean_text},
+            image_part,
+        ]
+
+        agent = make_agent()
+        setattr(agent, "_model_supports_vision", lambda: True)
+        agent.run_conversation(
+            clean_content,
+            conversation_history=[],
+            task_id="t-image",
+            persist_user_message=clean_content,
+            transient_user_message_prefix=routing_prefix,
+        )
+
+        sent = _user_messages(_chat_requests(handler)[0])[0]["content"]
+        assert sent[0]["text"].startswith(routing_prefix)
+        assert clean_text in sent[0]["text"]
+        assert sent[1] == clean_content[1]
+        rows = db.get_messages(sid)
+        replay = db.get_messages_as_conversation(sid)
+        assert routing_note not in json.dumps(rows)
+        assert routing_note not in json.dumps(replay)
+        assert clean_text in rows[0]["content"]
+
+    @pytest.mark.parametrize("caption", ["describe this", ""])
+    def test_transient_multimodal_prefix_preserves_preflight_merge(
+        self, wire_env, caption
+    ):
+        """Compression output, image parts, and routing prefix all reach the wire."""
+        make_agent, handler, db, sid = wire_env
+        routing_note = "[Triggering message id: `message-1`]"
+        routing_prefix = f"{routing_note}\n\n"
+        clean_text = caption or "What do you see in this image?"
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,AAAA"},
+        }
+        clean_content = [
+            {"type": "text", "text": clean_text},
+            image_part,
+        ]
+        seen = {}
+        calls = {"n": 0}
+
+        agent = make_agent()
+        setattr(agent, "_model_supports_vision", lambda: True)
+        agent.compression_enabled = True
+
+        def _should_compress(_tokens):
+            calls["n"] += 1
+            return calls["n"] == 1
+
+        agent.context_compressor = types.SimpleNamespace(
+            protect_first_n=0,
+            protect_last_n=0,
+            threshold_tokens=1,
+            context_length=1000,
+            last_prompt_tokens=-1,
+            should_compress=_should_compress,
+            should_defer_preflight_to_real_usage=lambda _t: False,
+            get_active_compression_failure_cooldown=lambda: None,
+        )
+
+        def _compress(messages, _system, approx_tokens=None, task_id=None):
+            seen["messages"] = json.loads(json.dumps(messages))
+            current = json.loads(json.dumps(messages[-1]))
+            current["content"][0]["text"] = (
+                "[Prior context]\nSUMMARY\n" + current["content"][0]["text"]
+            )
+            return [current], "SYSTEM"
+
+        setattr(agent, "_compress_context", _compress)
+        agent.run_conversation(
+            clean_content,
+            conversation_history=[],
+            task_id="t-image-merge",
+            persist_user_message=clean_content,
+            transient_user_message_prefix=routing_prefix,
+        )
+
+        assert routing_note not in json.dumps(seen["messages"])
+        sent = _user_messages(_chat_requests(handler)[0])[0]["content"]
+        assert sent[0]["text"].startswith(routing_prefix)
+        assert "[Prior context]\nSUMMARY" in sent[0]["text"]
+        assert clean_text in sent[0]["text"]
+        assert sent[1] == image_part
+        assert routing_note not in json.dumps(db.get_messages(sid))
+        assert routing_note not in json.dumps(db.get_messages_as_conversation(sid))
+
 
 # ---------------------------------------------------------------------------
 # Review fixes: re-anchoring, MoA, in-place compaction backfill, override
@@ -932,17 +1082,25 @@ class TestSessionRowExistsBeforePreflightCompaction:
             return calls["n"] == 1  # compress once, then stop
 
         seen = {}
-        compacted = [
-            {"role": "assistant", "content": "[CONTEXT COMPACTION] summary"},
-            {"role": "user", "content": "hello"},
-        ]
-
         def _compress(_messages, **_kwargs):
             # The ordering invariant under test: the row must already exist
             # when compression starts — the DB writes right after this call
             # (archive_and_compact / child create_session) reference it.
             seen["row_at_compress"] = db.get_session(sid)
-            return compacted
+            seen["messages_at_compress"] = json.loads(json.dumps(_messages))
+            serialized = json.dumps(_messages)
+            leaked_note = (
+                "\n[Triggering message id: `message-1`]"
+                if "message-1" in serialized
+                else ""
+            )
+            return [
+                {
+                    "role": "assistant",
+                    "content": f"[CONTEXT COMPACTION] summary{leaked_note}",
+                },
+                {"role": "user", "content": _messages[-1]["content"]},
+            ]
 
         compressor = MagicMock()
         compressor.protect_first_n = 0
@@ -975,8 +1133,15 @@ class TestSessionRowExistsBeforePreflightCompaction:
         sid = "sess-fresh-inplace"
         try:
             agent, seen = self._make_agent(db, sid, in_place=True)
+            routing_note = "[Triggering message id: `message-1`]"
             with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
-                ctx = _build(agent, conversation_history=self._oversized_history())
+                ctx = _build(
+                    agent,
+                    conversation_history=self._oversized_history(),
+                    user_message="hello",
+                    persist_user_message="hello",
+                    transient_user_message_prefix=f"{routing_note}\n\n",
+                )
 
             # The row was created before compression started — without it the
             # FK on messages.session_id rejects the compacted rows and the
@@ -986,8 +1151,12 @@ class TestSessionRowExistsBeforePreflightCompaction:
             assert agent._last_compaction_in_place is True
             contents = [m["content"] for m in db.get_messages(sid)]
             assert "[CONTEXT COMPACTION] summary" in contents
+            assert routing_note not in json.dumps(seen["messages_at_compress"])
+            assert routing_note not in json.dumps(db.get_messages(sid))
+            assert routing_note not in json.dumps(db.get_messages_as_conversation(sid))
             # And the live context is the compacted set.
             assert ctx.messages[ctx.current_turn_user_idx]["content"] == "hello"
+            assert ctx.transient_user_message_prefix == f"{routing_note}\n\n"
         finally:
             db.close()
 
@@ -996,8 +1165,15 @@ class TestSessionRowExistsBeforePreflightCompaction:
         sid = "sess-fresh-rot"
         try:
             agent, seen = self._make_agent(db, sid, in_place=False)
+            routing_note = "[Triggering message id: `message-1`]"
             with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
-                _build(agent, conversation_history=self._oversized_history())
+                ctx = _build(
+                    agent,
+                    conversation_history=self._oversized_history(),
+                    user_message="hello",
+                    persist_user_message="hello",
+                    transient_user_message_prefix=f"{routing_note}\n\n",
+                )
 
             # The parent row existed before compression started — the child
             # INSERT's parent_session_id FK needs it; without it
@@ -1012,6 +1188,12 @@ class TestSessionRowExistsBeforePreflightCompaction:
             parent_row = db.get_session(sid)
             assert parent_row is not None
             assert parent_row["end_reason"] == "compression"
+            assert routing_note not in json.dumps(seen["messages_at_compress"])
+            assert routing_note not in json.dumps(db.get_messages(child))
+            assert routing_note not in json.dumps(
+                db.get_messages_as_conversation(child)
+            )
+            assert ctx.transient_user_message_prefix == f"{routing_note}\n\n"
         finally:
             db.close()
 

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -29,6 +29,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent.conversation_loop import _apply_transient_user_message_prefix
 from agent.memory_manager import build_memory_context_block
 from agent.turn_context import build_turn_context, compose_user_api_content
 from hermes_state import SessionDB
@@ -58,6 +59,15 @@ class TestComposeUserApiContent:
         a = compose_user_api_content("hello", "likes tea", "CTX")
         b = compose_user_api_content("hello", "likes tea", "CTX")
         assert a == b
+
+    def test_transient_prefix_preserves_compaction_merged_content(self):
+        routing_note = "[Triggering message id: `message-1`]"
+        merged = "[prior context]\ncompaction summary\n\nhello"
+
+        assert _apply_transient_user_message_prefix(
+            merged,
+            f"{routing_note}\n\n",
+        ) == f"{routing_note}\n\n{merged}"
 
 
 # ---------------------------------------------------------------------------
@@ -580,6 +590,146 @@ class TestWireInvariant:
         current = _user_messages(_chat_requests(handler)[0])[-1]
         assert current["content"] == "second question\n\nPLUGIN-CTX"
 
+    def test_transient_prefix_reaches_current_turn_but_not_replay(self, wire_env):
+        """Current-turn routing metadata must never become replayable history."""
+        make_agent, handler, db, sid = wire_env
+        routing_note = "[Triggering message id: `message-1`]"
+        routing_prefix = f"{routing_note}\n\n"
+        stable_model_message = "MODEL-SWITCH\n\nhello please"
+
+        agent1 = make_agent()
+        agent1.run_conversation(
+            stable_model_message,
+            conversation_history=[],
+            task_id="t1",
+            persist_user_message="hello please",
+            transient_user_message_prefix=routing_prefix,
+        )
+
+        current_turn = _user_messages(_chat_requests(handler)[0])[0]["content"]
+        assert current_turn.startswith(routing_prefix)
+        assert "MODEL-SWITCH" in current_turn
+
+        history = db.get_messages_as_conversation(sid)
+        assert history[0]["content"] == "hello please"
+        assert history[0]["api_content"] == (
+            "MODEL-SWITCH\n\nhello please\n\nPLUGIN-CTX"
+        )
+        assert routing_note not in json.dumps(history[0])
+
+        handler.captured_requests = []
+        agent2 = make_agent()
+        agent2.run_conversation(
+            "second question",
+            conversation_history=history,
+            task_id="t2",
+        )
+
+        replayed_history = _user_messages(_chat_requests(handler)[0])[0]["content"]
+        assert replayed_history == "MODEL-SWITCH\n\nhello please\n\nPLUGIN-CTX"
+        assert routing_note not in replayed_history
+
+    @pytest.mark.parametrize("caption", ["describe this", ""])
+    def test_transient_multimodal_prefix_is_wire_only(self, wire_env, caption):
+        """Native image payloads keep routing context on the wire, never in SQLite."""
+        make_agent, handler, db, sid = wire_env
+        routing_note = "[Triggering message id: `message-1`]"
+        routing_prefix = f"{routing_note}\n\n"
+        clean_text = caption or "What do you see in this image?"
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,AAAA"},
+        }
+        clean_content = [
+            {"type": "text", "text": clean_text},
+            image_part,
+        ]
+
+        agent = make_agent()
+        setattr(agent, "_model_supports_vision", lambda: True)
+        agent.run_conversation(
+            clean_content,
+            conversation_history=[],
+            task_id="t-image",
+            persist_user_message=clean_content,
+            transient_user_message_prefix=routing_prefix,
+        )
+
+        sent = _user_messages(_chat_requests(handler)[0])[0]["content"]
+        assert sent[0]["text"].startswith(routing_prefix)
+        assert clean_text in sent[0]["text"]
+        assert sent[1] == clean_content[1]
+        rows = db.get_messages(sid)
+        replay = db.get_messages_as_conversation(sid)
+        assert routing_note not in json.dumps(rows)
+        assert routing_note not in json.dumps(replay)
+        assert clean_text in rows[0]["content"]
+
+    @pytest.mark.parametrize("caption", ["describe this", ""])
+    def test_transient_multimodal_prefix_preserves_preflight_merge(
+        self, wire_env, caption
+    ):
+        """Compression output, image parts, and routing prefix all reach the wire."""
+        make_agent, handler, db, sid = wire_env
+        routing_note = "[Triggering message id: `message-1`]"
+        routing_prefix = f"{routing_note}\n\n"
+        clean_text = caption or "What do you see in this image?"
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,AAAA"},
+        }
+        clean_content = [
+            {"type": "text", "text": clean_text},
+            image_part,
+        ]
+        seen = {}
+        calls = {"n": 0}
+
+        agent = make_agent()
+        setattr(agent, "_model_supports_vision", lambda: True)
+        agent.compression_enabled = True
+
+        def _should_compress(_tokens):
+            calls["n"] += 1
+            return calls["n"] == 1
+
+        agent.context_compressor = types.SimpleNamespace(
+            protect_first_n=0,
+            protect_last_n=0,
+            threshold_tokens=1,
+            context_length=1000,
+            last_prompt_tokens=-1,
+            should_compress=_should_compress,
+            should_defer_preflight_to_real_usage=lambda _t: False,
+            get_active_compression_failure_cooldown=lambda: None,
+        )
+
+        def _compress(messages, _system, approx_tokens=None, task_id=None):
+            seen["messages"] = json.loads(json.dumps(messages))
+            current = json.loads(json.dumps(messages[-1]))
+            current["content"][0]["text"] = (
+                "[Prior context]\nSUMMARY\n" + current["content"][0]["text"]
+            )
+            return [current], "SYSTEM"
+
+        setattr(agent, "_compress_context", _compress)
+        agent.run_conversation(
+            clean_content,
+            conversation_history=[],
+            task_id="t-image-merge",
+            persist_user_message=clean_content,
+            transient_user_message_prefix=routing_prefix,
+        )
+
+        assert routing_note not in json.dumps(seen["messages"])
+        sent = _user_messages(_chat_requests(handler)[0])[0]["content"]
+        assert sent[0]["text"].startswith(routing_prefix)
+        assert "[Prior context]\nSUMMARY" in sent[0]["text"]
+        assert clean_text in sent[0]["text"]
+        assert sent[1] == image_part
+        assert routing_note not in json.dumps(db.get_messages(sid))
+        assert routing_note not in json.dumps(db.get_messages_as_conversation(sid))
+
 
 # ---------------------------------------------------------------------------
 # Review fixes: re-anchoring, MoA, in-place compaction backfill, override
@@ -929,17 +1079,25 @@ class TestSessionRowExistsBeforePreflightCompaction:
             return calls["n"] == 1  # compress once, then stop
 
         seen = {}
-        compacted = [
-            {"role": "assistant", "content": "[CONTEXT COMPACTION] summary"},
-            {"role": "user", "content": "hello"},
-        ]
-
         def _compress(_messages, **_kwargs):
             # The ordering invariant under test: the row must already exist
             # when compression starts — the DB writes right after this call
             # (archive_and_compact / child create_session) reference it.
             seen["row_at_compress"] = db.get_session(sid)
-            return compacted
+            seen["messages_at_compress"] = json.loads(json.dumps(_messages))
+            serialized = json.dumps(_messages)
+            leaked_note = (
+                "\n[Triggering message id: `message-1`]"
+                if "message-1" in serialized
+                else ""
+            )
+            return [
+                {
+                    "role": "assistant",
+                    "content": f"[CONTEXT COMPACTION] summary{leaked_note}",
+                },
+                {"role": "user", "content": _messages[-1]["content"]},
+            ]
 
         compressor = MagicMock()
         compressor.protect_first_n = 0
@@ -972,8 +1130,15 @@ class TestSessionRowExistsBeforePreflightCompaction:
         sid = "sess-fresh-inplace"
         try:
             agent, seen = self._make_agent(db, sid, in_place=True)
+            routing_note = "[Triggering message id: `message-1`]"
             with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
-                ctx = _build(agent, conversation_history=self._oversized_history())
+                ctx = _build(
+                    agent,
+                    conversation_history=self._oversized_history(),
+                    user_message="hello",
+                    persist_user_message="hello",
+                    transient_user_message_prefix=f"{routing_note}\n\n",
+                )
 
             # The row was created before compression started — without it the
             # FK on messages.session_id rejects the compacted rows and the
@@ -983,8 +1148,12 @@ class TestSessionRowExistsBeforePreflightCompaction:
             assert agent._last_compaction_in_place is True
             contents = [m["content"] for m in db.get_messages(sid)]
             assert "[CONTEXT COMPACTION] summary" in contents
+            assert routing_note not in json.dumps(seen["messages_at_compress"])
+            assert routing_note not in json.dumps(db.get_messages(sid))
+            assert routing_note not in json.dumps(db.get_messages_as_conversation(sid))
             # And the live context is the compacted set.
             assert ctx.messages[ctx.current_turn_user_idx]["content"] == "hello"
+            assert ctx.transient_user_message_prefix == f"{routing_note}\n\n"
         finally:
             db.close()
 
@@ -993,8 +1162,15 @@ class TestSessionRowExistsBeforePreflightCompaction:
         sid = "sess-fresh-rot"
         try:
             agent, seen = self._make_agent(db, sid, in_place=False)
+            routing_note = "[Triggering message id: `message-1`]"
             with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
-                _build(agent, conversation_history=self._oversized_history())
+                ctx = _build(
+                    agent,
+                    conversation_history=self._oversized_history(),
+                    user_message="hello",
+                    persist_user_message="hello",
+                    transient_user_message_prefix=f"{routing_note}\n\n",
+                )
 
             # The parent row existed before compression started — the child
             # INSERT's parent_session_id FK needs it; without it
@@ -1009,6 +1185,12 @@ class TestSessionRowExistsBeforePreflightCompaction:
             parent_row = db.get_session(sid)
             assert parent_row is not None
             assert parent_row["end_reason"] == "compression"
+            assert routing_note not in json.dumps(seen["messages_at_compress"])
+            assert routing_note not in json.dumps(db.get_messages(child))
+            assert routing_note not in json.dumps(
+                db.get_messages_as_conversation(child)
+            )
+            assert ctx.transient_user_message_prefix == f"{routing_note}\n\n"
         finally:
             db.close()
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -428,6 +428,31 @@ class TestAgentExecution:
         assert mock_agent._gateway_turn_process_task_id == ""
         assert mock_agent._gateway_turn_process_baseline == frozenset()
 
+    @pytest.mark.asyncio
+    async def test_run_agent_forwards_transient_user_message_prefix(self, adapter):
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id="session-123",
+                persist_user_message="hello",
+                transient_user_message_prefix="[routing note]\n\n",
+            )
+
+        mock_agent.run_conversation.assert_called_once_with(
+            user_message="hello",
+            conversation_history=[],
+            task_id="session-123",
+            persist_user_message="hello",
+            transient_user_message_prefix="[routing note]\n\n",
+        )
+
 
 class TestDisconnectedAgentReap:
     """#76188 review: SSE disconnect handlers must reap only the background
@@ -983,6 +1008,312 @@ class TestChatCompletionsEndpoint:
             data = await resp.json()
             assert "messages" in data["error"]["message"]
 
+    @pytest.mark.asyncio
+    async def test_empty_messages_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/chat/completions", json={"model": "test", "messages": []})
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("stream", [False, True])
+    async def test_authenticated_proxy_can_preserve_clean_user_content(
+        self,
+        auth_adapter,
+        stream,
+    ):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "test",
+                        "messages": [
+                            {"role": "user", "content": "hello"},
+                        ],
+                        "hermes_persist_user_message": "hello",
+                        "hermes_transient_user_message_prefix": "[routing note]\n\n",
+                        "stream": stream,
+                    },
+                )
+                if stream:
+                    await resp.text()
+
+        assert resp.status == 200
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["user_message"] == "hello"
+        assert kwargs["persist_user_message"] == "hello"
+        assert kwargs["transient_user_message_prefix"] == "[routing note]\n\n"
+
+    @pytest.mark.asyncio
+    async def test_transient_prefix_participates_in_idempotency_fingerprint(
+        self, auth_adapter
+    ):
+        app = _create_app(auth_adapter)
+        request_body = {
+            "model": "test",
+            "messages": [{"role": "user", "content": "hello"}],
+            "hermes_persist_user_message": "hello",
+        }
+        headers = {
+            "Authorization": "Bearer sk-secret",
+            "Idempotency-Key": "transient-prefix",
+        }
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                first = await cli.post(
+                    "/v1/chat/completions",
+                    headers=headers,
+                    json=request_body,
+                )
+                second = await cli.post(
+                    "/v1/chat/completions",
+                    headers=headers,
+                    json={
+                        **request_body,
+                        "hermes_transient_user_message_prefix": "[routing note]\n\n",
+                    },
+                )
+
+        assert first.status == 200
+        assert second.status == 200
+        assert mock_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_persist_override_participates_in_idempotency_fingerprint(
+        self, auth_adapter
+    ):
+        app = _create_app(auth_adapter)
+        request_body = {
+            "model": "test",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        headers = {
+            "Authorization": "Bearer sk-secret",
+            "Idempotency-Key": "persist-content",
+        }
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                first = await cli.post(
+                    "/v1/chat/completions",
+                    headers=headers,
+                    json={**request_body, "hermes_persist_user_message": "hello"},
+                )
+                second = await cli.post(
+                    "/v1/chat/completions",
+                    headers=headers,
+                    json={**request_body, "hermes_persist_user_message": "goodbye"},
+                )
+
+        assert first.status == 200
+        assert second.status == 200
+        assert mock_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_persist_override_requires_configured_authentication(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "hermes_persist_user_message": "hello",
+                },
+            )
+            data = await resp.json()
+
+        assert resp.status == 400
+        assert data["error"]["param"] == "hermes_persist_user_message"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("invalid_value", [True, 1, [], {}])
+    async def test_persist_override_rejects_non_string_content(
+        self,
+        auth_adapter,
+        invalid_value,
+    ):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hello"}],
+                        "hermes_persist_user_message": invalid_value,
+                    },
+                )
+            data = await resp.json()
+
+        assert resp.status == 400
+        assert data["error"]["param"] == "hermes_persist_user_message"
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("authorization", [None, "Bearer wrong"])
+    async def test_persist_override_rejects_missing_or_invalid_credentials(
+        self,
+        auth_adapter,
+        authorization,
+    ):
+        app = _create_app(auth_adapter)
+        headers = {"Authorization": authorization} if authorization else {}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers=headers,
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hello"}],
+                        "hermes_persist_user_message": "hello",
+                    },
+                )
+
+        assert resp.status == 401
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("persist_value", "expect_forwarded"),
+        [(None, False), ("", True)],
+    )
+    async def test_persist_override_defines_null_and_empty_string_semantics(
+        self,
+        auth_adapter,
+        persist_value,
+        expect_forwarded,
+    ):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hello"}],
+                        "hermes_persist_user_message": persist_value,
+                    },
+                )
+
+        assert resp.status == 200
+        kwargs = mock_run.call_args.kwargs
+        if expect_forwarded:
+            assert kwargs["persist_user_message"] == ""
+        else:
+            assert kwargs["persist_user_message"] is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("adapter_fixture", "body", "expected_param"),
+        [
+            (
+                "adapter",
+                {
+                    "hermes_persist_user_message": "hello",
+                    "hermes_transient_user_message_prefix": "[routing note]\n\n",
+                },
+                "hermes_persist_user_message",
+            ),
+            (
+                "auth_adapter",
+                {
+                    "hermes_persist_user_message": "hello",
+                    "hermes_transient_user_message_prefix": False,
+                },
+                "hermes_transient_user_message_prefix",
+            ),
+            (
+                "auth_adapter",
+                {"hermes_transient_user_message_prefix": "[routing note]\n\n"},
+                "hermes_transient_user_message_prefix",
+            ),
+        ],
+    )
+    async def test_transient_prefix_rejects_invalid_boundary_combinations(
+        self,
+        request,
+        adapter_fixture,
+        body,
+        expected_param,
+    ):
+        target_adapter = request.getfixturevalue(adapter_fixture)
+        app = _create_app(target_adapter)
+        headers = (
+            {"Authorization": "Bearer sk-secret"}
+            if adapter_fixture == "auth_adapter"
+            else {}
+        )
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(target_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers=headers,
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hello"}],
+                        **body,
+                    },
+                )
+                data = await resp.json()
+
+        assert resp.status == 400
+        assert data["error"]["param"] == expected_param
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_passes_request_model_provider_options(self, adapter):
+        app = _create_app(adapter)
+        model_options = {
+            "reasoning": {"enabled": True, "effort": "high"},
+            "reasoning_effort": "high",
+            "service_tier": "priority",
+            "fast": True,
+        }
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "MiniMax-M3",
+                        "provider": "minimax",
+                        "model_options": model_options,
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                )
+
+        assert resp.status == 200
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["requested_model"] == "MiniMax-M3"
+        assert kwargs["requested_provider"] == "minimax"
+        assert kwargs["model_options"] == model_options
 
     @pytest.mark.asyncio
     async def test_chat_completions_stream_passes_request_model_provider_options(self, adapter):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -745,6 +745,31 @@ class TestAgentExecution:
             task_id="session-123",
         )
 
+    @pytest.mark.asyncio
+    async def test_run_agent_forwards_transient_user_message_prefix(self, adapter):
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id="session-123",
+                persist_user_message="hello",
+                transient_user_message_prefix="[routing note]\n\n",
+            )
+
+        mock_agent.run_conversation.assert_called_once_with(
+            user_message="hello",
+            conversation_history=[],
+            task_id="session-123",
+            persist_user_message="hello",
+            transient_user_message_prefix="[routing note]\n\n",
+        )
+
     def test_create_agent_honors_request_model_provider_and_options(self, adapter, monkeypatch):
         import gateway.run as gateway_run
         import hermes_cli.runtime_provider as runtime_provider
@@ -1461,6 +1486,275 @@ class TestChatCompletionsEndpoint:
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.post("/v1/chat/completions", json={"model": "test", "messages": []})
             assert resp.status == 400
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("stream", [False, True])
+    async def test_authenticated_proxy_can_preserve_clean_user_content(
+        self,
+        auth_adapter,
+        stream,
+    ):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "test",
+                        "messages": [
+                            {"role": "user", "content": "hello"},
+                        ],
+                        "hermes_persist_user_message": "hello",
+                        "hermes_transient_user_message_prefix": "[routing note]\n\n",
+                        "stream": stream,
+                    },
+                )
+                if stream:
+                    await resp.text()
+
+        assert resp.status == 200
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["user_message"] == "hello"
+        assert kwargs["persist_user_message"] == "hello"
+        assert kwargs["transient_user_message_prefix"] == "[routing note]\n\n"
+
+    @pytest.mark.asyncio
+    async def test_transient_prefix_participates_in_idempotency_fingerprint(
+        self, auth_adapter
+    ):
+        app = _create_app(auth_adapter)
+        request_body = {
+            "model": "test",
+            "messages": [{"role": "user", "content": "hello"}],
+            "hermes_persist_user_message": "hello",
+        }
+        headers = {
+            "Authorization": "Bearer sk-secret",
+            "Idempotency-Key": "transient-prefix",
+        }
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                first = await cli.post(
+                    "/v1/chat/completions",
+                    headers=headers,
+                    json=request_body,
+                )
+                second = await cli.post(
+                    "/v1/chat/completions",
+                    headers=headers,
+                    json={
+                        **request_body,
+                        "hermes_transient_user_message_prefix": "[routing note]\n\n",
+                    },
+                )
+
+        assert first.status == 200
+        assert second.status == 200
+        assert mock_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_persist_override_participates_in_idempotency_fingerprint(
+        self, auth_adapter
+    ):
+        app = _create_app(auth_adapter)
+        request_body = {
+            "model": "test",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        headers = {
+            "Authorization": "Bearer sk-secret",
+            "Idempotency-Key": "persist-content",
+        }
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                first = await cli.post(
+                    "/v1/chat/completions",
+                    headers=headers,
+                    json={**request_body, "hermes_persist_user_message": "hello"},
+                )
+                second = await cli.post(
+                    "/v1/chat/completions",
+                    headers=headers,
+                    json={**request_body, "hermes_persist_user_message": "goodbye"},
+                )
+
+        assert first.status == 200
+        assert second.status == 200
+        assert mock_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_persist_override_requires_configured_authentication(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "hermes_persist_user_message": "hello",
+                },
+            )
+            data = await resp.json()
+
+        assert resp.status == 400
+        assert data["error"]["param"] == "hermes_persist_user_message"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("invalid_value", [True, 1, [], {}])
+    async def test_persist_override_rejects_non_string_content(
+        self,
+        auth_adapter,
+        invalid_value,
+    ):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hello"}],
+                        "hermes_persist_user_message": invalid_value,
+                    },
+                )
+            data = await resp.json()
+
+        assert resp.status == 400
+        assert data["error"]["param"] == "hermes_persist_user_message"
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("authorization", [None, "Bearer wrong"])
+    async def test_persist_override_rejects_missing_or_invalid_credentials(
+        self,
+        auth_adapter,
+        authorization,
+    ):
+        app = _create_app(auth_adapter)
+        headers = {"Authorization": authorization} if authorization else {}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers=headers,
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hello"}],
+                        "hermes_persist_user_message": "hello",
+                    },
+                )
+
+        assert resp.status == 401
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("persist_value", "expect_forwarded"),
+        [(None, False), ("", True)],
+    )
+    async def test_persist_override_defines_null_and_empty_string_semantics(
+        self,
+        auth_adapter,
+        persist_value,
+        expect_forwarded,
+    ):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hello"}],
+                        "hermes_persist_user_message": persist_value,
+                    },
+                )
+
+        assert resp.status == 200
+        kwargs = mock_run.call_args.kwargs
+        if expect_forwarded:
+            assert kwargs["persist_user_message"] == ""
+        else:
+            assert kwargs["persist_user_message"] is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("adapter_fixture", "body", "expected_param"),
+        [
+            (
+                "adapter",
+                {
+                    "hermes_persist_user_message": "hello",
+                    "hermes_transient_user_message_prefix": "[routing note]\n\n",
+                },
+                "hermes_persist_user_message",
+            ),
+            (
+                "auth_adapter",
+                {
+                    "hermes_persist_user_message": "hello",
+                    "hermes_transient_user_message_prefix": False,
+                },
+                "hermes_transient_user_message_prefix",
+            ),
+            (
+                "auth_adapter",
+                {"hermes_transient_user_message_prefix": "[routing note]\n\n"},
+                "hermes_transient_user_message_prefix",
+            ),
+        ],
+    )
+    async def test_transient_prefix_rejects_invalid_boundary_combinations(
+        self,
+        request,
+        adapter_fixture,
+        body,
+        expected_param,
+    ):
+        target_adapter = request.getfixturevalue(adapter_fixture)
+        app = _create_app(target_adapter)
+        headers = (
+            {"Authorization": "Bearer sk-secret"}
+            if adapter_fixture == "auth_adapter"
+            else {}
+        )
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(target_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers=headers,
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hello"}],
+                        **body,
+                    },
+                )
+                data = await resp.json()
+
+        assert resp.status == 400
+        assert data["error"]["param"] == expected_param
+        mock_run.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_chat_completions_passes_request_model_provider_options(self, adapter):

--- a/tests/gateway/test_discord_triggering_message_persistence.py
+++ b/tests/gateway/test_discord_triggering_message_persistence.py
@@ -1,0 +1,461 @@
+"""Regression coverage for Discord triggering-message routing metadata.
+
+The current Discord message id is model-only routing context.
+It must reach the model when Discord tools are loaded without becoming user-authored transcript content.
+"""
+
+import base64
+import sys
+import types
+from contextlib import contextmanager
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+SESSION_KEY = "agent:main:discord:channel:channel-123:user-456"
+MESSAGE_ID = "synthetic-discord-message-id"
+USER_TEXT = "hello world"
+ROUTING_NOTE = (
+    f"[Triggering message id: `{MESSAGE_ID}` \u2014 use as `message_id` "
+    "for reply/react/pin via the discord tools.]"
+)
+ROUTING_PREFIX = f"{ROUTING_NOTE}\n\n"
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="channel-123",
+        chat_type="group",
+        user_id="user-456",
+    )
+
+
+def _event() -> MessageEvent:
+    return MessageEvent(
+        text=USER_TEXT,
+        source=_source(),
+        message_id=MESSAGE_ID,
+    )
+
+
+def _runner(monkeypatch, tmp_path) -> gateway_run.GatewayRunner:
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner = gateway_run.GatewayRunner(
+        GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(enabled=True, token="fake"),
+            }
+        )
+    )
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner._session_db = MagicMock()
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._get_guild_id = lambda _event: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    runner.session_store = MagicMock()
+    # _run_agent reads this mapping directly to detect resume-pending turns.
+    runner.session_store._entries = {}
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key=SESSION_KEY,
+        session_id="session-discord-routing",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.DISCORD,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.has_platform_message_id.return_value = False
+    runner.session_store.update_session = MagicMock()
+
+    runner._async_session_store = MagicMock()
+    runner._async_session_store._store = runner.session_store
+    runner._async_session_store.get_or_create_session = AsyncMock(
+        return_value=runner.session_store.get_or_create_session.return_value
+    )
+    runner._async_session_store.load_transcript = AsyncMock(return_value=[])
+    runner._async_session_store.has_any_sessions = AsyncMock(return_value=True)
+    runner._async_session_store.append_to_transcript = AsyncMock()
+    runner._async_session_store.update_session = AsyncMock()
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "fake"},
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+    return runner
+
+
+@pytest.mark.parametrize("routed_tools_loaded", [True, False])
+def test_discord_tool_gate_uses_routed_profile_scope(
+    monkeypatch,
+    tmp_path,
+    routed_tools_loaded,
+):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    setattr(runner, "config", GatewayConfig(multiplex_profiles=True))
+    setattr(
+        runner,
+        "_resolve_profile_home_for_source",
+        lambda source: tmp_path / "routed",
+    )
+    active_home = None
+
+    @contextmanager
+    def fake_scope(home):
+        nonlocal active_home
+        previous = active_home
+        active_home = home
+        try:
+            yield
+        finally:
+            active_home = previous
+
+    monkeypatch.setattr(gateway_run, "_profile_runtime_scope", fake_scope)
+    monkeypatch.setattr(
+        "gateway.session._discord_tools_loaded",
+        lambda: (
+            routed_tools_loaded
+            if active_home == tmp_path / "routed"
+            else not routed_tools_loaded
+        ),
+    )
+
+    assert runner._discord_tools_loaded_for_source(_source()) is routed_tools_loaded
+    assert active_home is None
+
+
+def _persist_turn(
+    tmp_path,
+    *,
+    content: Any,
+    api_content: Any | None,
+    override: Any,
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session(session_id="session-1", source="discord")
+        agent = object.__new__(AIAgent)
+        agent._session_db = db
+        agent._session_db_created = True
+        agent.session_id = "session-1"
+        agent._last_flushed_db_idx = 0
+        agent._flushed_db_message_ids = set()
+        agent._flushed_db_message_session_id = None
+        agent._persist_user_message_idx = 0
+        agent._persist_user_message_override = override
+        agent._persist_user_message_timestamp = None
+        agent._persist_disabled = False
+        agent._session_persist_lock = None
+
+        message = {"role": "user", "content": content}
+        if api_content is not None:
+            message["api_content"] = api_content
+        agent._flush_messages_to_session_db([message], [])
+        return (
+            db.get_messages("session-1"),
+            db.get_messages_as_conversation("session-1"),
+        )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("discord_tools_loaded", [True, False])
+async def test_triggering_message_metadata_is_model_only(
+    monkeypatch,
+    tmp_path,
+    discord_tools_loaded,
+):
+    runner = _runner(monkeypatch, tmp_path)
+    captured = {}
+
+    async def fake_run_agent(*, message, session_key, **kwargs):
+        notes = runner._consume_pending_turn_sidecar_notes(session_key)
+        captured.update(message=message, notes=notes, kwargs=kwargs)
+        return {
+            "final_response": "ok",
+            "messages": [
+                {"role": "user", "content": message},
+                {"role": "assistant", "content": "ok"},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+
+    monkeypatch.setattr(runner, "_run_agent", fake_run_agent)
+
+    with patch(
+        "gateway.session._discord_tools_loaded",
+        return_value=discord_tools_loaded,
+    ):
+        await runner._handle_message_with_agent(
+            _event(),
+            _source(),
+            SESSION_KEY,
+            1,
+        )
+
+    assert captured["kwargs"]["persist_user_message"] == USER_TEXT
+    assert captured["kwargs"]["transient_user_message_prefix"] == (
+        ROUTING_PREFIX if discord_tools_loaded else None
+    )
+
+    notes = captured["notes"]
+    assert notes == []
+    model_content = captured["message"]
+    assert model_content == USER_TEXT
+
+    rows, replay_history = _persist_turn(
+        tmp_path,
+        content=model_content,
+        api_content=None,
+        override=captured["kwargs"]["persist_user_message"],
+    )
+    user_rows = [row for row in rows if row["role"] == "user"]
+    assert len(user_rows) == 1
+    assert user_rows[0]["content"] == USER_TEXT
+    assert user_rows[0].get("api_content") is None
+    assert "api_content" not in replay_history[0]
+    replayed_content = replay_history[0]["content"]
+    assert MESSAGE_ID not in replayed_content
+
+
+@pytest.mark.asyncio
+async def test_timestamp_failure_keeps_routing_prefix_out_of_canonical_message(
+    monkeypatch,
+    tmp_path,
+):
+    runner = _runner(monkeypatch, tmp_path)
+    captured = {}
+
+    async def fake_run_agent(**kwargs):
+        captured.update(kwargs)
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+
+    monkeypatch.setattr(runner, "_run_agent", fake_run_agent)
+    monkeypatch.setattr(
+        "hermes_time.get_timezone",
+        MagicMock(side_effect=RuntimeError("synthetic timezone failure")),
+    )
+    with patch("gateway.session._discord_tools_loaded", return_value=True):
+        await runner._handle_message_with_agent(
+            _event(),
+            _source(),
+            SESSION_KEY,
+            1,
+        )
+
+    assert captured["message"] == USER_TEXT
+    assert captured["persist_user_message"] == USER_TEXT
+    assert captured["transient_user_message_prefix"] == ROUTING_PREFIX
+    assert MESSAGE_ID not in captured["message"]
+    assert MESSAGE_ID not in captured["persist_user_message"]
+
+    rows, replay_history = _persist_turn(
+        tmp_path,
+        content=captured["message"],
+        api_content=None,
+        override=captured["persist_user_message"],
+    )
+    assert MESSAGE_ID not in str(rows)
+    assert MESSAGE_ID not in str(replay_history)
+
+
+@pytest.mark.asyncio
+async def test_captionless_turn_preserves_explicit_empty_persistence_override(
+    monkeypatch,
+    tmp_path,
+):
+    runner = _runner(monkeypatch, tmp_path)
+    captured = {}
+    monkeypatch.setattr(
+        runner,
+        "_prepare_profile_scoped_inbound_message_text",
+        AsyncMock(return_value=""),
+    )
+
+    async def fake_run_agent(**kwargs):
+        captured.update(kwargs)
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+
+    monkeypatch.setattr(runner, "_run_agent", fake_run_agent)
+    with patch("gateway.session._discord_tools_loaded", return_value=True):
+        await runner._handle_message_with_agent(
+            _event(),
+            _source(),
+            SESSION_KEY,
+            1,
+        )
+
+    assert captured["persist_user_message"] == ""
+    assert captured["transient_user_message_prefix"] == ROUTING_PREFIX
+    assert captured["message"] == ""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("caption", [USER_TEXT, ""])
+async def test_native_image_keeps_routing_note_out_of_persisted_content(
+    monkeypatch,
+    tmp_path,
+    caption,
+):
+    runner = _runner(monkeypatch, tmp_path)
+    native_session_key = f"{SESSION_KEY}:native"
+    image_path = tmp_path / "image.png"
+    image_path.write_bytes(
+        base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+            "/x8AAusB9Y9ZP14AAAAASUVORK5CYII="
+        )
+    )
+    runner._pending_native_image_paths_by_session[native_session_key] = [str(image_path)]
+    captured = {}
+
+    fake_agent = MagicMock()
+    fake_agent.provider = "openai"
+    fake_agent.model = "test-model"
+    fake_agent.run_conversation.side_effect = lambda message, **kwargs: (
+        captured.update(message=message, kwargs=kwargs)
+        or {
+            "final_response": "ok",
+            "messages": [
+                {"role": "user", "content": message},
+                {"role": "assistant", "content": "ok"},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.delenv("GATEWAY_PROXY_URL", raising=False)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda *_args, **_kwargs: "test-model")
+    with patch("run_agent.AIAgent", return_value=fake_agent):
+        await runner._run_agent(
+            message=caption,
+            context_prompt="",
+            history=[],
+            source=_source(),
+            session_id="session-discord-routing",
+            session_key=native_session_key,
+            persist_user_message=caption,
+            transient_user_message_prefix=ROUTING_PREFIX,
+        )
+
+    assert "message" in captured
+    model_content = captured["message"]
+    persist_content = captured["kwargs"]["persist_user_message"]
+    assert captured["kwargs"]["transient_user_message_prefix"] == ROUTING_PREFIX
+    assert isinstance(model_content, list)
+    assert ROUTING_NOTE not in model_content[0]["text"]
+    assert isinstance(persist_content, list)
+    expected_clean_text = caption or "What do you see in this image?"
+    assert persist_content[0]["text"].startswith(expected_clean_text)
+    assert ROUTING_NOTE not in persist_content[0]["text"]
+    assert persist_content[1] == model_content[1]
+
+    rows, replay_history = _persist_turn(
+        tmp_path,
+        content=model_content,
+        api_content=None,
+        override=persist_content,
+    )
+    user_rows = [row for row in rows if row["role"] == "user"]
+    assert len(user_rows) == 1
+    assert user_rows[0]["content"].startswith(expected_clean_text)
+    assert ROUTING_NOTE not in user_rows[0]["content"]
+    assert user_rows[0].get("api_content") is None
+    assert "api_content" not in replay_history[0]
+    assert ROUTING_NOTE not in replay_history[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_aborted_turn_cannot_leak_routing_note_to_next_turn(monkeypatch, tmp_path):
+    runner = _runner(monkeypatch, tmp_path)
+
+    async def abort_run(**_kwargs):
+        raise RuntimeError("synthetic abort")
+
+    monkeypatch.setattr(runner, "_run_agent", abort_run)
+    with patch("gateway.session._discord_tools_loaded", return_value=True):
+        await runner._handle_message_with_agent(
+            _event(),
+            _source(),
+            SESSION_KEY,
+            1,
+        )
+
+    assert runner._consume_pending_turn_sidecar_notes(SESSION_KEY) == []
+    assert runner._release_turn_lease(SESSION_KEY, 1)
+
+    captured = {}
+
+    async def capture_run(**kwargs):
+        captured.update(kwargs)
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+
+    monkeypatch.setattr(runner, "_run_agent", capture_run)
+    with patch("gateway.session._discord_tools_loaded", return_value=False):
+        await runner._handle_message_with_agent(
+            _event(),
+            _source(),
+            SESSION_KEY,
+            2,
+        )
+
+    assert captured["message"] == USER_TEXT
+    assert MESSAGE_ID not in captured["message"]

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -159,11 +159,77 @@ class TestRunAgentProxyDispatch:
             session_id="test-session-123",
             session_key="test-key",
             run_generation=7,
+            persist_user_message="hi",
+            transient_user_message_prefix="[routing note]\n\n",
         )
 
         assert result["final_response"] == "Hello from remote!"
         runner._run_agent_via_proxy.assert_called_once()
         assert runner._run_agent_via_proxy.call_args.kwargs["run_generation"] == 7
+        assert runner._run_agent_via_proxy.call_args.kwargs["persist_user_message"] == "hi"
+        assert runner._run_agent_via_proxy.call_args.kwargs[
+            "transient_user_message_prefix"
+        ] == "[routing note]\n\n"
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_proxy_preserves_legacy_request_body(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        response = _FakeSSEResponse(
+            status=200,
+            sse_chunks=[
+                'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+                "data: [DONE]\n\n"
+            ],
+        )
+        session = _FakeSession(response)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session), patch("aiohttp.ClientTimeout"):
+                result = await runner._run_agent(
+                    message="hi",
+                    context_prompt="",
+                    history=[],
+                    source=_make_source(),
+                    session_id="test-session",
+                    persist_user_message="hi",
+                )
+
+        assert result["final_response"] == "ok"
+        assert session.captured_headers is not None
+        assert session.captured_json is not None
+        assert "Authorization" not in session.captured_headers
+        assert "hermes_persist_user_message" not in session.captured_json
+        assert "hermes_transient_user_message_prefix" not in session.captured_json
+
+    @pytest.mark.asyncio
+    async def test_transient_prefix_requires_authenticated_proxy(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        session = _FakeSession(_FakeSSEResponse(status=200))
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session), patch("aiohttp.ClientTimeout"):
+                result = await runner._run_agent(
+                    message="hi",
+                    context_prompt="",
+                    history=[],
+                    source=_make_source(Platform.DISCORD),
+                    session_id="test-session",
+                    persist_user_message="hi",
+                    transient_user_message_prefix="[routing note]\n\n",
+                )
+
+        assert result["api_calls"] == 0
+        assert "GATEWAY_PROXY_KEY" in result["final_response"]
+        assert "API_SERVER_KEY" in result["final_response"]
+        assert session.captured_url is None
 
 
 class TestRunAgentViaProxy:
@@ -198,6 +264,8 @@ class TestRunAgentViaProxy:
                         ],
                         source=source,
                         session_id="session-abc",
+                        persist_user_message="How are you?",
+                        transient_user_message_prefix="[routing note]\n\n",
                     )
 
         # Verify request URL
@@ -214,7 +282,14 @@ class TestRunAgentViaProxy:
         assert messages[0] == {"role": "system", "content": "You are helpful."}
         assert messages[1] == {"role": "user", "content": "Hello"}
         assert messages[2] == {"role": "assistant", "content": "Hi there!"}
-        assert messages[3] == {"role": "user", "content": "How are you?"}
+        assert messages[3] == {
+            "role": "user",
+            "content": "How are you?",
+        }
+        assert session.captured_json["hermes_persist_user_message"] == "How are you?"
+        assert session.captured_json["hermes_transient_user_message_prefix"] == (
+            "[routing note]\n\n"
+        )
 
         # Verify streaming is requested
         assert session.captured_json["stream"] is True

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -196,11 +196,77 @@ class TestRunAgentProxyDispatch:
             session_id="test-session-123",
             session_key="test-key",
             run_generation=7,
+            persist_user_message="hi",
+            transient_user_message_prefix="[routing note]\n\n",
         )
 
         assert result["final_response"] == "Hello from remote!"
         runner._run_agent_via_proxy.assert_called_once()
         assert runner._run_agent_via_proxy.call_args.kwargs["run_generation"] == 7
+        assert runner._run_agent_via_proxy.call_args.kwargs["persist_user_message"] == "hi"
+        assert runner._run_agent_via_proxy.call_args.kwargs[
+            "transient_user_message_prefix"
+        ] == "[routing note]\n\n"
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_proxy_preserves_legacy_request_body(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        response = _FakeSSEResponse(
+            status=200,
+            sse_chunks=[
+                'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+                "data: [DONE]\n\n"
+            ],
+        )
+        session = _FakeSession(response)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session), patch("aiohttp.ClientTimeout"):
+                result = await runner._run_agent(
+                    message="hi",
+                    context_prompt="",
+                    history=[],
+                    source=_make_source(),
+                    session_id="test-session",
+                    persist_user_message="hi",
+                )
+
+        assert result["final_response"] == "ok"
+        assert session.captured_headers is not None
+        assert session.captured_json is not None
+        assert "Authorization" not in session.captured_headers
+        assert "hermes_persist_user_message" not in session.captured_json
+        assert "hermes_transient_user_message_prefix" not in session.captured_json
+
+    @pytest.mark.asyncio
+    async def test_transient_prefix_requires_authenticated_proxy(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        session = _FakeSession(_FakeSSEResponse(status=200))
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session), patch("aiohttp.ClientTimeout"):
+                result = await runner._run_agent(
+                    message="hi",
+                    context_prompt="",
+                    history=[],
+                    source=_make_source(Platform.DISCORD),
+                    session_id="test-session",
+                    persist_user_message="hi",
+                    transient_user_message_prefix="[routing note]\n\n",
+                )
+
+        assert result["api_calls"] == 0
+        assert "GATEWAY_PROXY_KEY" in result["final_response"]
+        assert "API_SERVER_KEY" in result["final_response"]
+        assert session.captured_url is None
 
     @pytest.mark.asyncio
     async def test_run_agent_skips_proxy_when_not_configured(self, monkeypatch):
@@ -256,6 +322,8 @@ class TestRunAgentViaProxy:
                         ],
                         source=source,
                         session_id="session-abc",
+                        persist_user_message="How are you?",
+                        transient_user_message_prefix="[routing note]\n\n",
                     )
 
         # Verify request URL
@@ -272,7 +340,14 @@ class TestRunAgentViaProxy:
         assert messages[0] == {"role": "system", "content": "You are helpful."}
         assert messages[1] == {"role": "user", "content": "Hello"}
         assert messages[2] == {"role": "assistant", "content": "Hi there!"}
-        assert messages[3] == {"role": "user", "content": "How are you?"}
+        assert messages[3] == {
+            "role": "user",
+            "content": "How are you?",
+        }
+        assert session.captured_json["hermes_persist_user_message"] == "How are you?"
+        assert session.captured_json["hermes_transient_user_message_prefix"] == (
+            "[routing note]\n\n"
+        )
 
         # Verify streaming is requested
         assert session.captured_json["stream"] is True


### PR DESCRIPTION
## What does this PR do?

Discord triggering-message IDs remain available to the current model turn for reply, react, and pin routing, while transcripts, replay state, compression input, and external memory receive only user-authored content.

The routing instruction is applied as current-turn-only metadata after compression rather than being written into canonical conversation history.
This preserves prompt-cache stability and covers local text, native multimodal, routed-profile, and authenticated proxy/API paths.

This is a broader alternative to #71309, opened after coordinating on that PR.
#71309 identified the immediate strip-before-persist path; this implementation also covers replayable sidecars, preflight compression, captionless images, proxy transport, and stale-turn boundaries.

## Related Issue

Fixes #71304

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Keep canonical user content clean and apply the Discord routing prefix only to a copied current provider request (`gateway/run.py`, `agent/conversation_loop.py`, `agent/turn_context.py`).
- Carry persistence content and transient routing metadata through authenticated proxy/API boundaries without changing legacy unauthenticated requests (`gateway/platforms/api_server.py`, `gateway/run.py`, `run_agent.py`).
- Add regression coverage for SQLite/readback/replay, compression, captioned and captionless images, tools-disabled turns, timestamp failures, stale turns, profile routing, and proxy authentication boundaries.

## How to Test

1. Run the focused sidecar, Discord, multimodal, and proxy regressions. The reviewed snapshot passed 73 tests.
2. Run the API-server and run-agent suites. The reviewed snapshot passed 270 API-server tests with one known environment-health test deselected, plus 445 run-agent tests.
3. Run the PII, timestamp, prompt-cache, multiplexing, and profile suites. The reviewed snapshot passed 114 tests; `py_compile` and `git diff --check` also passed.

An independent fail-closed review of the frozen snapshot reported no security concerns or logic errors. One non-blocking P2 suggestion remains for additional Codex app-server coverage.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable. This is an internal persistence-boundary fix; validation evidence is listed above.
