### PR TITLE
Add x402engine MCP and payments skill

### DIFF
--- a/optional-mcps/x402engine/manifest.yaml
+++ b/optional-mcps/x402engine/manifest.yaml
@@ -19,6 +19,10 @@ transport:
     X402_BASE_URL: "https://x402-gateway-production.up.railway.app"
     X402_PAYMENT_NETWORK: "auto"
     X402_MAX_PAYMENT_USD: "1.00"
+    # Keep references in config.yaml; Hermes resolves them from its secret
+    # scope only when constructing the MCP subprocess environment.
+    X402_EVM_PRIVATE_KEY: "${X402_EVM_PRIVATE_KEY}"
+    X402_SOLANA_PRIVATE_KEY: "${X402_SOLANA_PRIVATE_KEY}"
 
 auth:
   type: api_key

--- a/optional-mcps/x402engine/manifest.yaml
+++ b/optional-mcps/x402engine/manifest.yaml
@@ -1,0 +1,56 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: x402engine
+description: Discover and buy pay-per-call AI, data, code, media, and web APIs with USDC.
+source: https://github.com/agentc22/x402engine-mcp
+
+transport:
+  type: stdio
+  command: "npx"
+  # Exact pin. x402engine-mcp 1.1.0 adds local wallet signing and a hard
+  # per-request spend cap; the catalog never auto-updates this version.
+  args:
+    - "-y"
+    - "x402engine-mcp@1.1.0"
+  version: "1.1.0"
+  env:
+    X402_BASE_URL: "https://x402-gateway-production.up.railway.app"
+    X402_PAYMENT_NETWORK: "auto"
+    X402_MAX_PAYMENT_USD: "1.00"
+
+auth:
+  type: api_key
+  env:
+    - name: X402_EVM_PRIVATE_KEY
+      prompt: "Dedicated Base payer private key (optional; press Enter to skip)"
+      required: false
+      secret: true
+    - name: X402_SOLANA_PRIVATE_KEY
+      prompt: "Dedicated Solana payer private key (optional; press Enter to skip)"
+      required: false
+      secret: true
+
+# Discovery and health are free. Paid tools stay off until the user reviews
+# their descriptions and prices in the configure checklist.
+tools:
+  default_enabled:
+    - discover_services
+    - service_health
+
+post_install: |
+  Discovery and health are enabled without a wallet. To buy API calls:
+
+    1. Fund a dedicated low-balance wallet with USDC on Base or Solana.
+    2. Set its private key in ~/.hermes/.env as X402_EVM_PRIVATE_KEY or
+       X402_SOLANA_PRIVATE_KEY. Never use a primary wallet.
+    3. Review and enable paid tools with:
+         hermes mcp configure x402engine
+
+  Automatic payment accepts only canonical USDC on Base and Solana and
+  rejects any single payment above X402_MAX_PAYMENT_USD (default $1.00).
+  Change X402_PAYMENT_NETWORK or X402_MAX_PAYMENT_USD in the x402engine
+  server env block in ~/.hermes/config.yaml when you need a tighter policy.
+
+  Start a new Hermes session after changing MCP configuration.

--- a/optional-skills/payments/x402engine/SKILL.md
+++ b/optional-skills/payments/x402engine/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: x402engine
-description: Discover and buy x402 pay-per-call APIs through the x402engine MCP.
+description: Discover and buy pay-per-call APIs with USDC.
 version: 0.1.0
-author: x402engine, Hermes Agent
+author: __agentc1__ (@agentc22), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:

--- a/optional-skills/payments/x402engine/SKILL.md
+++ b/optional-skills/payments/x402engine/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: x402engine
+description: Discover and buy x402 pay-per-call APIs through the x402engine MCP.
+version: 0.1.0
+author: x402engine, Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Payments, x402, HTTP-402, USDC, Base, Solana, APIs]
+    related_skills: [mpp-agent]
+---
+
+# x402engine Skill
+
+Use the `x402engine` MCP when a user wants an agent to buy an API result per request with USDC. Its curated tools cover crypto and wallet data, code execution, image generation, transcription, travel, and IPFS. Free live discovery reports the broader gateway catalog, prices, and payment networks.
+
+## When to Use
+
+- The user asks for an x402 API, pay-per-call API, or software-paid API result.
+- A task needs a one-off external API and the user prefers per-request USDC payment.
+- The user wants to inspect x402engine services, pricing, or service health.
+
+This skill is for Coinbase x402-style `PAYMENT-REQUIRED` challenges. For Machine Payments Protocol challenges using `WWW-Authenticate`, use the `mpp-agent` skill.
+
+## Prerequisites
+
+Install the official MCP catalog entry:
+
+```bash
+hermes mcp install x402engine
+```
+
+Free discovery works without credentials. Paid calls require one dedicated payer wallet:
+
+- `X402_EVM_PRIVATE_KEY`: Base wallet funded with USDC
+- `X402_SOLANA_PRIVATE_KEY`: Solana wallet funded with USDC and a small SOL balance
+
+Keys belong in `~/.hermes/.env`. Never print, read back, or paste a wallet key into the conversation. Use a low-balance wallet created for agent purchases, never a primary wallet.
+
+## Spending Policy
+
+`X402_MAX_PAYMENT_USD` is a hard per-request cap and defaults to `1.00`. The MCP rejects unknown assets, unsupported networks, and prices above this cap before signing.
+
+Before a paid call:
+
+1. Confirm the requested outcome.
+2. Read the tool description or live discovery price.
+3. Use the least expensive tool that satisfies the request.
+4. Do not split or repeat calls to evade the configured cap.
+5. Surface the expected price before unusually expensive or repeated operations.
+
+Base is preferred when both wallets exist. Set `X402_PAYMENT_NETWORK` to `base` or `solana` in the MCP server configuration to force one rail.
+
+## Procedure
+
+### 1. Discover the live catalog
+
+Call `discover_services`. It is free and returns current routes, prices, and supported payment networks.
+
+### 2. Check service health
+
+Call `service_health`, optionally with a service ID. It is free. Avoid unhealthy services when an equivalent healthy option exists.
+
+### 3. Enable the required paid tool
+
+The catalog install enables only `discover_services` and `service_health` by default. Enable paid tools after reviewing their descriptions:
+
+```bash
+hermes mcp configure x402engine
+```
+
+Start a new Hermes session after changing the tool selection.
+
+### 4. Make the call once
+
+Call the selected MCP tool with the smallest sufficient request. The MCP requests the resource, validates the x402 challenge against its network, asset, and spending policy, signs locally, retries, and returns the API response.
+
+Do not retry a paid tool automatically after an ambiguous timeout. Check the returned error and service health first because settlement may already have occurred.
+
+## Common Failures
+
+- `Payment required`: no payer key is configured. Add one wallet key to `~/.hermes/.env` and restart Hermes.
+- `exceeds X402_MAX_PAYMENT_USD`: the route costs more than the cap. Report the price and ask before raising the limit.
+- `No supported ... USDC payment option`: the challenge offered a network or asset this MCP intentionally does not sign.
+- Insufficient funds: fund the dedicated wallet with the correct chain's USDC; Solana also needs SOL for fees.
+- Tool unavailable: run `hermes mcp configure x402engine`, enable it, and restart the session.
+
+## Verification
+
+```bash
+hermes mcp test x402engine
+```
+
+Then call `discover_services` and `service_health`. A paid verification should use `get_crypto_price`, currently the lowest-cost curated tool, only when the user has authorized a real payment.

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -895,3 +895,32 @@ class TestShippedCatalog:
                     )
 
         assert not problems, "unpinned catalog entries:\n" + "\n".join(problems)
+
+    def test_x402engine_wallet_secrets_are_forwarded_by_reference(self, monkeypatch):
+        """Wallet values reach the child env without entering saved config."""
+        monkeypatch.delenv("HERMES_OPTIONAL_MCPS", raising=False)
+        evm_secret = "0xnot-a-real-private-key"
+        solana_secret = "not-a-real-solana-private-key"
+        monkeypatch.setenv("X402_EVM_PRIVATE_KEY", evm_secret)
+        monkeypatch.setenv("X402_SOLANA_PRIVATE_KEY", solana_secret)
+
+        from hermes_cli.mcp_catalog import (
+            _build_server_config,
+            _catalog_root,
+            _parse_manifest,
+        )
+        from tools.mcp_tool import _build_safe_env, _interpolate_env_vars
+
+        entry = _parse_manifest(_catalog_root() / "x402engine" / "manifest.yaml")
+        saved_config = _build_server_config(entry, None)
+        saved_env = saved_config["env"]
+
+        assert saved_env["X402_EVM_PRIVATE_KEY"] == "${X402_EVM_PRIVATE_KEY}"
+        assert saved_env["X402_SOLANA_PRIVATE_KEY"] == "${X402_SOLANA_PRIVATE_KEY}"
+        assert evm_secret not in repr(saved_config)
+        assert solana_secret not in repr(saved_config)
+
+        runtime_config = _interpolate_env_vars(saved_config)
+        child_env = _build_safe_env(runtime_config["env"])
+        assert child_env["X402_EVM_PRIVATE_KEY"] == evm_secret
+        assert child_env["X402_SOLANA_PRIVATE_KEY"] == solana_secret


### PR DESCRIPTION
## Summary

- add a pinned x402engine MCP catalog entry using x402engine-mcp@1.1.0
- prompt for optional Base or Solana payer wallets without requiring credentials for free discovery
- default to free discovery and health tools; paid tools require explicit selection
- add an optional payments skill covering spend policy, safe wallet handling, and failure recovery

## Safety

- automatic payment accepts only canonical USDC on Base and Solana
- X402_MAX_PAYMENT_USD defaults to a hard USD 1.00 per-request cap
- unknown assets, unsupported networks, and over-cap challenges are rejected before signing
- no wallet secret is included in the manifest, config defaults, or skill

## Validation

- Hermes manifest parser: passed
- shipped manifest exact-pin contract tests: 2 passed
- x402engine MCP unit tests: 7 passed
- MCP build and clean npm tarball install: passed
- registry-installed MCP smoke: 22 tools; live discovery passed
- npm 1.1.0 published through trusted GitHub OIDC with provenance

## Supply-chain cooldown

x402engine-mcp@1.1.0 was published on 2026-07-25 because it is the first release with local wallet signing and the spend cap required by this entry. I am opening the PR now for review, but it should remain unmerged until the catalog's two-week package cooldown is satisfied (2026-08-08), unless maintainers explicitly waive that policy for this security-focused release.
