### PR TITLE
fix(gateway): include .3gp in MEDIA_DELIVERY_EXTS

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1478,7 +1478,8 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     # Images (embed inline)
     ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".svg",
     # Video (embed inline where supported)
-    ".mp4", ".mov", ".avi", ".mkv", ".webm",
+    # Keep in parity with gateway local `_VIDEO_EXTS` sets (incl. .3gp).
+    ".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp",
     # Audio (delivered as voice/audio where supported)
     ".mp3", ".wav", ".ogg", ".opus", ".m4a", ".flac",
     # Documents (uploaded as file attachments)

--- a/tests/gateway/test_extract_local_files.py
+++ b/tests/gateway/test_extract_local_files.py
@@ -60,7 +60,7 @@ class TestBasicDetection:
         assert "~/photos/cat.jpg" not in cleaned
 
     def test_video_extensions(self):
-        for ext in (".mp4", ".mov", ".avi", ".mkv", ".webm"):
+        for ext in (".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"):
             text = f"Video at /tmp/clip{ext} here"
             paths, _ = _extract(text)
             assert len(paths) == 1, f"Failed for {ext}"

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -644,6 +644,35 @@ class TestMediaExtensionAllowlistParity:
         # that motivated the bug are present in the shared set.
         for ext in (".md", ".json", ".yaml", ".yml", ".xml", ".html", ".htm"):
             assert ext in MEDIA_DELIVERY_EXTS
+        # Video partition must match gateway peer `_VIDEO_EXTS` (incl. .3gp).
+        for ext in (".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"):
+            assert ext in MEDIA_DELIVERY_EXTS
+
+    def test_3gp_media_tag_extracts_and_is_stripped(self):
+        """`.3gp` drifted out of MEDIA_DELIVERY_EXTS while remaining in
+        dispatch `_VIDEO_EXTS` — MEDIA:/clip.3gp was neither extracted nor
+        cleaned, so the tag leaked as plain text and the file was not sent.
+        """
+        import tempfile
+        from pathlib import Path
+
+        from gateway.platforms.base import MEDIA_TAG_CLEANUP_RE
+
+        # Cleanup recognizes .3gp even when the path does not exist.
+        path = "/tmp/clip.3gp"
+        text = f"Clip: MEDIA:{path}"
+        stripped = MEDIA_TAG_CLEANUP_RE.sub("", text).strip()
+        assert "MEDIA:" not in stripped
+        assert path not in stripped
+        assert "Clip:" in stripped
+
+        # extract_media delivers when the file exists.
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "clip.3gp"
+            p.write_bytes(b"\x00" * 16)
+            media, cleaned = BasePlatformAdapter.extract_media(f"MEDIA:{p}")
+            assert media == [(str(p), False)]
+            assert "MEDIA:" not in cleaned
 
     def test_unknown_extension_not_black_holed_by_cleanup(self):
         """A MEDIA: tag with an unknown extension is NOT stripped from the


### PR DESCRIPTION
## Summary

- Add `.3gp` to `MEDIA_DELIVERY_EXTS` video partition (parity with gateway `_VIDEO_EXTS`)
- Without this, `MEDIA:/clip.3gp` is not extracted and the tag is not stripped from text
- Regression tests for allowlist parity + extract/cleanup

Fixes #71621

## Test plan

- [x] `bash scripts/run_tests.sh tests/gateway/test_platform_base.py tests/gateway/test_extract_local_files.py -- -k '3gp or video_ext or MediaExtension or share_one_extension'`
