### PR TITLE
fix(dashboard): reuse built TUI and report launch failures

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -431,12 +431,13 @@ import shutil
 import stat
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import NoReturn, Optional
 
 
 import functools as _functools
 
 from hermes_cli.sessions_cmd import cmd_sessions  # noqa: F401
+from hermes_cli.tui_launch import TuiLaunchError
 from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_hooks_flag
 from hermes_cli.subcommands.cron import build_cron_parser
 from hermes_cli.subcommands.sync import build_sync_parser
@@ -1902,7 +1903,24 @@ def _restore_tui_workspace(tui_dir: Path) -> bool:
     return tui_dir.is_dir()
 
 
-def _ensure_tui_workspace(tui_dir: Path) -> None:
+def _fail_tui_launch(
+    message: str,
+    *,
+    raise_launch_errors: bool,
+    stderr: bool = True,
+) -> NoReturn:
+    """Raise for embedded callers, or preserve the CLI's exit-1 contract."""
+    if raise_launch_errors:
+        raise TuiLaunchError(message)
+    print(message, file=sys.stderr if stderr else sys.stdout)
+    raise SystemExit(1)
+
+
+def _ensure_tui_workspace(
+    tui_dir: Path,
+    *,
+    raise_launch_errors: bool = False,
+) -> None:
     """Ensure ``ui-tui/`` exists before any npm/node subprocess uses it as cwd.
 
     Without this, a missing workspace falls through to ``subprocess.run(...,
@@ -1919,7 +1937,7 @@ def _ensure_tui_workspace(tui_dir: Path) -> None:
             print(f"Restored missing TUI workspace: {tui_dir}")
         return
 
-    print(
+    _fail_tui_launch(
         "Error: the TUI workspace is missing from this Hermes checkout.\n"
         f"Expected directory: {tui_dir}\n"
         "This usually means `hermes update` left tracked ui-tui files deleted.\n"
@@ -1928,13 +1946,28 @@ def _ensure_tui_workspace(tui_dir: Path) -> None:
         "  2. Run `npm install --silent --no-fund --no-audit --progress=false`\n"
         "  3. Retry `hermes --tui`\n"
         "If the checkout is still inconsistent, run `hermes update --force`.",
-        file=sys.stderr,
+        raise_launch_errors=raise_launch_errors,
     )
-    sys.exit(1)
 
 
-def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
-    """TUI: --dev → tsx src; else node dist (HERMES_TUI_DIR prebuilt or esbuild)."""
+def _make_tui_argv(
+    tui_dir: Path,
+    tui_dev: bool,
+    *,
+    prefer_existing_bundle: bool = False,
+    raise_launch_errors: bool = False,
+) -> tuple[list[str], Path]:
+    """Build or select the TUI command for CLI and embedded runtime callers.
+
+    ``prefer_existing_bundle`` is for long-lived runtime surfaces such as the
+    dashboard PTY. They should execute an already-fresh ``dist/entry.js``
+    instead of requiring npm and rebuilding on every browser connection.
+    Ordinary CLI launches retain the historical always-build behavior.
+
+    ``raise_launch_errors`` preserves actionable preparation failures for an
+    embedding caller. The default CLI contract still prints the message and
+    exits with status 1.
+    """
     _ensure_tui_node()
 
     def _node_bin(bin: str) -> str:
@@ -1957,20 +1990,22 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             except Exception:
                 pass
         if not path:
-            print(f"{bin} not found — install Node.js to use the TUI.")
-            sys.exit(1)
+            _fail_tui_launch(
+                f"{bin} not found — install Node.js to use the TUI.",
+                raise_launch_errors=raise_launch_errors,
+            )
         return path
 
     # Footgun: --dev against a prebuilt bundle that has no source/node_modules.
     ext_dir = os.environ.get("HERMES_TUI_DIR")
     if tui_dev and ext_dir:
-        print(
+        _fail_tui_launch(
             f"Error: --dev is incompatible with HERMES_TUI_DIR={ext_dir}\n"
-            f"The prebuilt TUI has no source code to hot-reload.\n"
-            f"Unset HERMES_TUI_DIR (e.g. `unset HERMES_TUI_DIR`) to use --dev from a checkout.",
-            file=sys.stderr,
+            "The prebuilt TUI has no source code to hot-reload.\n"
+            "Unset HERMES_TUI_DIR (e.g. `unset HERMES_TUI_DIR`) to use "
+            "--dev from a checkout.",
+            raise_launch_errors=raise_launch_errors,
         )
-        sys.exit(1)
 
     # 1. Prebuilt bundle (nix / packaged release / Docker image): just run it.
     #
@@ -1997,7 +2032,10 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
     # No prebuilt bundle available (or --dev, which never uses one) — we're
     # about to npm install/build from source, so the workspace must exist.
     if not ext_dir:
-        _ensure_tui_workspace(tui_dir)
+        _ensure_tui_workspace(
+            tui_dir,
+            raise_launch_errors=raise_launch_errors,
+        )
 
     # 2. Normal flow: npm install if needed, always esbuild, then node dist/entry.js.
     #    --dev flow: npm install if needed, then tsx src/entry.tsx.
@@ -2006,17 +2044,20 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
     #    dependencies into the hot path.
     did_install = False
     termux_startup = _is_termux_startup_environment()
-    termux_need_rebuild = False
-    if termux_startup and not tui_dev:
-        termux_need_rebuild = _tui_need_rebuild(tui_dir)
-
-    skip_install_for_fresh_termux_bundle = (
-        termux_startup and not tui_dev and not termux_need_rebuild
+    runtime_bundle_mode = (
+        not tui_dev and (termux_startup or prefer_existing_bundle)
     )
-    if (
-        not skip_install_for_fresh_termux_bundle
-        and _tui_need_npm_install(tui_dir)
-    ):
+    runtime_need_rebuild = (
+        _tui_need_rebuild(tui_dir) if runtime_bundle_mode else True
+    )
+
+    # Termux and the dashboard are runtime surfaces. A fresh bundle is
+    # sufficient to start; missing node_modules/npm are build-time concerns
+    # and must not make a working browser chat fail during connection setup.
+    skip_install_for_fresh_bundle = (
+        runtime_bundle_mode and not runtime_need_rebuild
+    )
+    if not skip_install_for_fresh_bundle and _tui_need_npm_install(tui_dir):
         npm = _node_bin("npm")
         if not os.environ.get("HERMES_QUIET"):
             print("Installing TUI dependencies…")
@@ -2083,10 +2124,14 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         if result.returncode != 0:
             combined = f"{result.stdout or ''}\n{result.stderr or ''}".strip()
             preview = "\n".join(combined.splitlines()[-30:])
-            print("npm install failed.")
+            message = "npm install failed."
             if preview:
-                print(preview)
-            sys.exit(1)
+                message = f"{message}\n{preview}"
+            _fail_tui_launch(
+                message,
+                raise_launch_errors=raise_launch_errors,
+                stderr=False,
+            )
         did_install = True
 
     if tui_dev:
@@ -2108,22 +2153,26 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         if result.returncode != 0:
             combined = f"{result.stdout or ''}{result.stderr or ''}".strip()
             preview = "\n".join(combined.splitlines()[-30:])
-            print("TUI dev prebuild failed.")
+            message = "TUI dev prebuild failed."
             if preview:
-                print(preview)
-            sys.exit(1)
+                message = f"{message}\n{preview}"
+            _fail_tui_launch(
+                message,
+                raise_launch_errors=raise_launch_errors,
+                stderr=False,
+            )
 
         tsx = tui_dir / "node_modules" / ".bin" / "tsx"
         if tsx.exists():
             return [str(tsx), "src/entry.tsx"], tui_dir
         return [npm, "start"], tui_dir
 
-    # Desktop/dev launches retain the historical "always rebuild" behaviour.
-    # Termux cold starts use the freshness check because esbuild startup is
-    # expensive on old mobile CPUs.
+    # Ordinary CLI launches retain the historical always-build behavior.
+    # Runtime surfaces reuse a fresh bundle and rebuild only when source or
+    # build inputs are newer (or an install just changed dependencies).
     should_build = True
-    if termux_startup:
-        should_build = did_install or termux_need_rebuild
+    if runtime_bundle_mode:
+        should_build = did_install or runtime_need_rebuild
 
     if should_build:
         npm = _node_bin("npm")
@@ -2138,10 +2187,14 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         if result.returncode != 0:
             combined = f"{result.stdout or ''}{result.stderr or ''}".strip()
             preview = "\n".join(combined.splitlines()[-30:])
-            print("TUI build failed.")
+            message = "TUI build failed."
             if preview:
-                print(preview)
-            sys.exit(1)
+                message = f"{message}\n{preview}"
+            _fail_tui_launch(
+                message,
+                raise_launch_errors=raise_launch_errors,
+                stderr=False,
+            )
 
     node = _node_bin("node")
     return [node, "--expose-gc", str(tui_dir / "dist" / "entry.js")], tui_dir

--- a/hermes_cli/tui_launch.py
+++ b/hermes_cli/tui_launch.py
@@ -1,0 +1,16 @@
+"""Shared failure type for preparing the Node TUI runtime."""
+
+from __future__ import annotations
+
+
+class TuiLaunchError(RuntimeError):
+    """Actionable TUI preparation failure for non-CLI callers.
+
+    The ordinary CLI surface still prints the message and exits with status 1.
+    Long-lived callers such as the dashboard raise this exception instead so
+    the real npm/node/workspace failure can be logged and returned over the
+    WebSocket rather than collapsing to the opaque string ``SystemExit(1)``.
+    """
+
+
+__all__ = ["TuiLaunchError"]

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -57,6 +57,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from hermes_cli import __version__, __release_date__
+from hermes_cli.tui_launch import TuiLaunchError
 from hermes_cli.config import (
     cfg_get,
     DEFAULT_CONFIG,
@@ -14817,7 +14818,12 @@ def _resolve_chat_argv(
     if requested and requested.lower() != "current":
         profile_dir = _resolve_profile_dir(requested)
 
-    argv, cwd = _make_tui_argv(PROJECT_ROOT / "ui-tui", tui_dev=False)
+    argv, cwd = _make_tui_argv(
+        PROJECT_ROOT / "ui-tui",
+        tui_dev=False,
+        prefer_existing_bundle=True,
+        raise_launch_errors=True,
+    )
     # Hermes TUI child: build via the single spawn-env factory (profile-home
     # contract applied; secrets kept — the spawned agent needs provider creds).
     # An explicit profile scope below still overrides HERMES_HOME afterwards.
@@ -15742,10 +15748,37 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc.detail}\x1b[0m\r\n")
         await ws.close(code=1011)
         return
+    except TuiLaunchError as exc:
+        # Embedded callers request an exception instead of the CLI's
+        # print+SystemExit contract so the real node/npm/build failure reaches
+        # both server logs and the browser. This is the #71349 path that used
+        # to collapse every failure into the opaque "Chat unavailable: 1".
+        detail = str(exc).strip() or "TUI launch failed"
+        _log.error(
+            "pty TUI launch failed peer=%s profile=%s: %s",
+            peer,
+            profile or "current",
+            detail,
+        )
+        await ws.send_text(
+            f"\r\n\x1b[31mChat unavailable: {detail}\x1b[0m\r\n"
+        )
+        await ws.close(code=1011, reason=_ws_close_reason(detail))
+        return
     except SystemExit as exc:
-        # _make_tui_argv calls sys.exit(1) when node/npm is missing.
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
+        # Compatibility guard for external/monkeypatched resolvers that still
+        # use the historical CLI exit contract.
+        detail = str(exc).strip() or "TUI launch exited"
+        _log.error(
+            "pty TUI launch exited peer=%s profile=%s: %s",
+            peer,
+            profile or "current",
+            detail,
+        )
+        await ws.send_text(
+            f"\r\n\x1b[31mChat unavailable: {detail}\x1b[0m\r\n"
+        )
+        await ws.close(code=1011, reason=_ws_close_reason(detail))
         return
 
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -32,6 +32,79 @@ def _assert_utf8_replace_capture(kwargs: dict) -> None:
     assert kwargs["errors"] == "replace"
 
 
+def test_make_tui_argv_dashboard_reuses_fresh_workspace_bundle_without_npm(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """Dashboard PTY startup reuses a fresh source-workspace bundle."""
+    _touch_tui_entry(tmp_path)
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: None)
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
+
+    def which(name: str) -> str | None:
+        if name == "node":
+            return "/usr/bin/node"
+        raise AssertionError(f"fresh dashboard bundle must not require {name}")
+
+    monkeypatch.setattr(main_mod.shutil, "which", which)
+    monkeypatch.setattr(
+        main_mod.subprocess,
+        "run",
+        lambda *_a, **_kw: (_ for _ in ()).throw(
+            AssertionError("fresh dashboard bundle must not run npm")
+        ),
+    )
+
+    argv, cwd = main_mod._make_tui_argv(
+        tmp_path,
+        tui_dev=False,
+        prefer_existing_bundle=True,
+        raise_launch_errors=True,
+    )
+
+    assert argv == [
+        "/usr/bin/node",
+        "--expose-gc",
+        str(tmp_path / "dist" / "entry.js"),
+    ]
+    assert cwd == tmp_path
+
+
+def test_make_tui_argv_dashboard_build_failure_preserves_actionable_detail(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """Dashboard callers receive the actual build failure."""
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: None)
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        main_mod.subprocess,
+        "run",
+        lambda *_a, **_kw: types.SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="sh: esbuild: command not found\n",
+        ),
+    )
+
+    from hermes_cli.tui_launch import TuiLaunchError
+
+    with pytest.raises(
+        TuiLaunchError,
+        match=r"(?s)TUI build failed.*esbuild: command not found",
+    ):
+        main_mod._make_tui_argv(
+            tmp_path,
+            tui_dev=False,
+            prefer_existing_bundle=True,
+            raise_launch_errors=True,
+        )
 
 
 
@@ -42,6 +115,36 @@ def _assert_utf8_replace_capture(kwargs: dict) -> None:
 
 
 
+
+
+
+
+def test_make_tui_argv_cli_build_failure_preserves_exit_contract(
+    tmp_path: Path, main_mod, monkeypatch, capsys
+) -> None:
+    """Ordinary CLI launches still print the build error and exit with code 1."""
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: None)
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        main_mod.subprocess,
+        "run",
+        lambda *_a, **_kw: types.SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="sh: esbuild: command not found\n",
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._make_tui_argv(tmp_path, tui_dev=False)
+
+    assert exc.value.code == 1
+    output = capsys.readouterr().out
+    assert "TUI build failed" in output
+    assert "esbuild: command not found" in output
 
 
 def test_make_tui_argv_uses_bundled_tui_when_workspace_missing(

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3630,6 +3630,29 @@ class TestPtyWebSocket:
             assert expect_detail in notice
 
 
+    def test_pty_ws_surfaces_actionable_tui_launch_error(self, monkeypatch):
+        """A failed TUI launch must not collapse to ``Chat unavailable: 1``."""
+        from hermes_cli.tui_launch import TuiLaunchError
+        from starlette.websockets import WebSocketDisconnect
+
+        def boom(resume=None, sidecar_url=None, profile=None):
+            raise TuiLaunchError(
+                "TUI build failed.\nsh: esbuild: command not found"
+            )
+
+        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv", boom)
+
+        with self.client.websocket_connect(self._url()) as conn:
+            notice = conn.receive_text()
+            with pytest.raises(WebSocketDisconnect) as exc:
+                conn.receive_text()
+
+        assert "TUI build failed" in notice
+        assert "esbuild: command not found" in notice
+        assert exc.value.code == 1011
+        assert "TUI build failed" in exc.value.reason
+
+
 
 
 
@@ -3733,6 +3756,29 @@ def test_resolve_chat_argv_injects_gateway_ws_url(monkeypatch):
     gateway_url = env.get("HERMES_TUI_GATEWAY_URL", "")
     assert gateway_url.startswith("ws://127.0.0.1:9119/api/ws?")
     assert "token=" in gateway_url
+
+
+def test_resolve_chat_argv_uses_runtime_bundle_and_actionable_errors(monkeypatch):
+    """The browser PTY must not rebuild a fresh TUI on every connection."""
+    import hermes_cli.main as main_mod
+    import hermes_cli.web_server as ws
+
+    captured: dict = {}
+
+    def fake_make_tui_argv(project_root, tui_dev=False, **kwargs):
+        captured["project_root"] = project_root
+        captured["tui_dev"] = tui_dev
+        captured["kwargs"] = kwargs
+        return (["node", "dist/entry.js"], "/tmp/ui-tui")
+
+    monkeypatch.setattr(main_mod, "_make_tui_argv", fake_make_tui_argv)
+
+    ws._resolve_chat_argv()
+
+    assert captured["kwargs"] == {
+        "prefer_existing_bundle": True,
+        "raise_launch_errors": True,
+    }
 
 
 class TestDashboardPluginStaticAssetAllowlist:

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -398,7 +398,7 @@ class TestProfileScopedChatPty:
 
         monkeypatch.setattr(
             "hermes_cli.main._make_tui_argv",
-            lambda root, tui_dev=False: (["cat"], None),
+            lambda root, tui_dev=False, **_kwargs: (["cat"], None),
             raising=False,
         )
         argv, cwd, env = web_server._resolve_chat_argv(profile="worker_beta")


### PR DESCRIPTION
## What does this PR do?

Fixes browser dashboard chat startup when the embedded PTY cannot prepare its Node TUI runtime.

The reported `Chat unavailable: 1` is the string form of `SystemExit(1)` from `_make_tui_argv()`. Node, npm, workspace, and build failures were therefore reduced to an integer before reaching the browser or server logs. The dashboard also rebuilt the source-tree TUI on every PTY connection, so a headless service could reject chat even when a fresh, runnable `ui-tui/dist/entry.js` already existed.

This PR gives `_make_tui_argv()` two explicit caller policies:

- ordinary CLI launches retain the historical install/build behavior and print plus exit-1 failure contract
- embedded runtime launches reuse a fresh bundle, rebuild only when inputs are newer, and raise an actionable `TuiLaunchError` for the WebSocket layer

`/api/pty` now logs the real preparation failure, writes it to the terminal, and includes a bounded diagnostic in its 1011 close reason.

This is complementary to #54306's immutable/read-only cache fallback and #61462's dependency-lock scope work. It changes dashboard runtime selection and error propagation; it does not add a cache or change dependency-freshness parsing.

## Related issue

Fixes #71349.

## Changes made

- `hermes_cli/main.py`
  - add explicit embedded-caller policy flags to `_make_tui_argv()`
  - reuse a fresh source bundle for dashboard runtime launches
  - preserve the ordinary CLI contract while raising detailed failures for embedded callers
- `hermes_cli/tui_launch.py`
  - add the shared `TuiLaunchError` type without importing the CLI entrypoint
- `hermes_cli/web_server.py`
  - select the runtime-bundle policy for `/api/pty`
  - log and surface the actual launch error through the terminal and close reason
- tests
  - prove a fresh bundle starts without npm
  - prove embedded build errors retain actionable detail
  - prove ordinary CLI build failures still print and exit with code 1
  - preserve profile, resume, reconnect, npm-engine-repair, and PTY contracts

## Validation

Fresh verification after rebasing onto current `main`:

```text
TUI, npm-engine, PTY, profile, and reconnect slice: 190 passed, 1 skipped
Ruff:                                                   passed
py_compile -Werror:                                     passed
Windows-footgun comparison:                             no new finding vs current main
Diff/conflict hygiene:                                  passed
GitHub CI:                                              passed
```
