### PR TITLE
fix(api-server): delay session stream agent start until SSE is ready

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3568,14 +3568,6 @@ class APIServerAdapter(BasePlatformAdapter):
                 await queue.put(_event_payload("done", {}))
                 await queue.put(None)
 
-        task = asyncio.create_task(_run_and_signal())
-        try:
-            self._background_tasks.add(task)
-        except TypeError:
-            pass
-        if hasattr(task, "add_done_callback"):
-            task.add_done_callback(self._background_tasks.discard)
-
         headers = {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
@@ -3586,6 +3578,15 @@ class APIServerAdapter(BasePlatformAdapter):
             headers["X-Hermes-Session-Key"] = gateway_session_key
         response = web.StreamResponse(status=200, headers=headers)
         await response.prepare(request)
+
+        task = asyncio.create_task(_run_and_signal())
+        try:
+            self._background_tasks.add(task)
+        except TypeError:
+            pass
+        if hasattr(task, "add_done_callback"):
+            task.add_done_callback(self._background_tasks.discard)
+
         last_write = time.monotonic()
         try:
             while True:

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,5 +1,6 @@
 """Focused tests for API server session-control endpoints."""
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -344,6 +345,44 @@ async def test_session_chat_stream_emits_lifecycle_events_and_keepalive_safe_sha
     assert "event: assistant.completed" in body
     assert "event: run.completed" in body
     assert "event: done" in body
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_does_not_start_agent_when_sse_prepare_fails(
+    adapter, session_db
+):
+    session_id = session_db.create_session("prepare-fails", "api_server")
+    started = asyncio.Event()
+
+    async def fake_run(**kwargs):
+        started.set()
+        return {"final_response": "should not run", "session_id": session_id}, {
+            "total_tokens": 1
+        }
+
+    class _PrepareFailsStreamResponse:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def prepare(self, request):
+            raise ConnectionResetError("client disconnected before SSE headers")
+
+    app = _create_session_app(adapter)
+    with (
+        patch.object(adapter, "_run_agent", side_effect=fake_run) as run_mock,
+        patch("gateway.platforms.api_server.web.StreamResponse", _PrepareFailsStreamResponse),
+    ):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "stream please"},
+            )
+            assert resp.status == 500
+
+        await asyncio.sleep(0)
+
+    assert not started.is_set()
+    run_mock.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This prevents `/api/sessions/{session_id}/chat/stream` from starting the agent task before the SSE response has been successfully prepared.

## Why

The handler created `_run_and_signal()` before `StreamResponse.prepare(request)`. If the client disconnected during SSE header preparation, the request failed, but the background agent task could still start and run without any connected client.

That leaves a path where a dropped streaming request can still consume model/tool work in the background.

## Changes

- Move `_run_and_signal()` task creation until after `response.prepare(request)` succeeds.
- Keep the existing background task tracking and done callback behavior unchanged.
- Add a regression test that simulates `StreamResponse.prepare()` failing and verifies `_run_agent` is never started.

## Validation

```text
python -m pytest tests/gateway/test_session_api.py -q
34 passed