### PR TITLE
fix(model): stop the shipped MoA "default" preset from hijacking /model default

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -735,7 +735,7 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
             # current provider (handled above) or the user explicitly wrote an
             # enabled MoA preset into config.yaml. Use raw config so the
             # DEFAULT_CONFIG preset does not make every desktop picker show MoA.
-            if _raw_config_has_enabled_moa_preset():
+            if raw_config_has_enabled_moa_preset():
                 kept.append(row)
             continue
         if _provider_is_keyless(slug):
@@ -767,7 +767,7 @@ def _provider_is_keyless(slug: str) -> bool:
         return False
 
 
-def _raw_config_has_enabled_moa_preset() -> bool:
+def raw_config_has_enabled_moa_preset() -> bool:
     """Return True when the user's raw config explicitly enables MoA.
 
     ``load_config()`` includes ``DEFAULT_CONFIG["moa"].presets.default`` for

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -433,7 +433,7 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
             # current provider (handled above) or the user explicitly wrote an
             # enabled MoA preset into config.yaml. Use raw config so the
             # DEFAULT_CONFIG preset does not make every desktop picker show MoA.
-            if _raw_config_has_enabled_moa_preset():
+            if raw_config_has_enabled_moa_preset():
                 kept.append(row)
             continue
         if is_provider_explicitly_configured(slug):
@@ -441,7 +441,7 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
     return kept
 
 
-def _raw_config_has_enabled_moa_preset() -> bool:
+def raw_config_has_enabled_moa_preset() -> bool:
     """Return True when the user's raw config explicitly enables MoA.
 
     ``load_config()`` includes ``DEFAULT_CONFIG["moa"].presets.default`` for

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1634,11 +1634,28 @@ def switch_model(
     # =================================================================
     else:
         try:
-            from hermes_cli.config import load_config
+            from hermes_cli.config import read_raw_config
+            from hermes_cli.inventory import raw_config_has_enabled_moa_preset
             from hermes_cli.moa_config import exact_moa_preset_name, normalize_moa_config
 
-            _moa_cfg = normalize_moa_config(load_config().get("moa") or {})
-            _moa_match = exact_moa_preset_name(_moa_cfg, raw_input)
+            # Only presets the user wrote into their own config.yaml are
+            # /model switch targets. DEFAULT_CONFIG ships an enabled preset
+            # literally named "default", and ``load_config()`` merges it in —
+            # so on a stock install "/model default", a user plainly asking
+            # for their default model, silently switched the session into MoA
+            # mode. ``inventory.raw_config_has_enabled_moa_preset()`` already
+            # draws exactly this line for the model pickers.
+            #
+            # The gate is load-bearing: reading from ``read_raw_config()``
+            # alone would not be enough, because ``normalize_moa_config({})``
+            # synthesizes a "default" preset for an empty config.
+            _moa_match = None
+            if raw_config_has_enabled_moa_preset():
+                _raw_moa = (read_raw_config() or {}).get("moa")
+                _moa_cfg = normalize_moa_config(
+                    _raw_moa if isinstance(_raw_moa, dict) else {},
+                )
+                _moa_match = exact_moa_preset_name(_moa_cfg, raw_input)
             if _moa_match:
                 target_provider = "moa"
                 new_model = _moa_match

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1188,11 +1188,28 @@ def switch_model(
     # =================================================================
     else:
         try:
-            from hermes_cli.config import load_config
+            from hermes_cli.config import read_raw_config
+            from hermes_cli.inventory import raw_config_has_enabled_moa_preset
             from hermes_cli.moa_config import exact_moa_preset_name, normalize_moa_config
 
-            _moa_cfg = normalize_moa_config(load_config().get("moa") or {})
-            _moa_match = exact_moa_preset_name(_moa_cfg, raw_input)
+            # Only presets the user wrote into their own config.yaml are
+            # /model switch targets. DEFAULT_CONFIG ships an enabled preset
+            # literally named "default", and ``load_config()`` merges it in —
+            # so on a stock install "/model default", a user plainly asking
+            # for their default model, silently switched the session into MoA
+            # mode. ``inventory.raw_config_has_enabled_moa_preset()`` already
+            # draws exactly this line for the model pickers.
+            #
+            # The gate is load-bearing: reading from ``read_raw_config()``
+            # alone would not be enough, because ``normalize_moa_config({})``
+            # synthesizes a "default" preset for an empty config.
+            _moa_match = None
+            if raw_config_has_enabled_moa_preset():
+                _raw_moa = (read_raw_config() or {}).get("moa")
+                _moa_cfg = normalize_moa_config(
+                    _raw_moa if isinstance(_raw_moa, dict) else {},
+                )
+                _moa_match = exact_moa_preset_name(_moa_cfg, raw_input)
             if _moa_match:
                 target_provider = "moa"
                 new_model = _moa_match

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3351,6 +3351,16 @@ def _openrouter_variant_base(model_id: str) -> Optional[str]:
 # away from the model's native vendor). None are currently defined.
 _BORROWED_MODEL_PROVIDERS: frozenset[str] = frozenset()
 
+# Virtual routing modes: entries in _PROVIDER_MODELS that are not real
+# providers with real model catalogs. Their "models" are user-defined preset
+# names, so they must never win static auto-detection — a preset name that
+# happens to collide with something the user typed would silently reroute the
+# session into that mode. ``_PROVIDER_MODELS["moa"]`` ships ``["default"]``,
+# which made ``/model default`` — a user asking for their default model —
+# switch into MoA on a stock install. Selecting one stays possible; it just
+# has to be deliberate (an exact configured-preset match, or --provider moa).
+_VIRTUAL_ROUTING_PROVIDERS = frozenset({"moa"})
+
 # Providers whose live /v1/models endpoint is the authoritative catalog, so the
 # curated list is a discovery-only fallback. For these, the picker merges
 # live-first (live entries lead, curated-only entries append). Every OTHER
@@ -3488,6 +3498,7 @@ def detect_static_provider_for_model(
             pid in current_keys
             or pid in _AGGREGATOR_PROVIDERS
             or pid in _BORROWED_MODEL_PROVIDERS
+            or pid in _VIRTUAL_ROUTING_PROVIDERS
         ):
             continue
         if _is_custom_current:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2103,6 +2103,16 @@ _AGGREGATOR_PROVIDERS = frozenset(
 # away from the model's native vendor). None are currently defined.
 _BORROWED_MODEL_PROVIDERS: frozenset[str] = frozenset()
 
+# Virtual routing modes: entries in _PROVIDER_MODELS that are not real
+# providers with real model catalogs. Their "models" are user-defined preset
+# names, so they must never win static auto-detection — a preset name that
+# happens to collide with something the user typed would silently reroute the
+# session into that mode. ``_PROVIDER_MODELS["moa"]`` ships ``["default"]``,
+# which made ``/model default`` — a user asking for their default model —
+# switch into MoA on a stock install. Selecting one stays possible; it just
+# has to be deliberate (an exact configured-preset match, or --provider moa).
+_VIRTUAL_ROUTING_PROVIDERS = frozenset({"moa"})
+
 # Providers whose live /v1/models endpoint is the authoritative catalog, so the
 # curated list is a discovery-only fallback. For these, the picker merges
 # live-first (live entries lead, curated-only entries append). Every OTHER
@@ -2240,6 +2250,7 @@ def detect_static_provider_for_model(
             pid in current_keys
             or pid in _AGGREGATOR_PROVIDERS
             or pid in _BORROWED_MODEL_PROVIDERS
+            or pid in _VIRTUAL_ROUTING_PROVIDERS
         ):
             continue
         if _is_custom_current:

--- a/tests/hermes_cli/test_model_switch_moa_preset_gating.py
+++ b/tests/hermes_cli/test_model_switch_moa_preset_gating.py
@@ -1,0 +1,117 @@
+"""``/model <name>`` must only match MoA presets the user actually configured.
+
+``DEFAULT_CONFIG["moa"]["presets"]`` ships an enabled preset literally named
+``default``, and ``switch_model`` resolved MoA preset names from
+``load_config()``, which merges DEFAULT_CONFIG. On a stock install
+``/model default`` therefore matched that shipped preset and silently switched
+the session into MoA mode, routing every later turn through the
+reference-model fan-out.
+
+``inventory.raw_config_has_enabled_moa_preset()`` already draws this line for
+the model pickers ("the DEFAULT_CONFIG preset is not a user choice"); these
+tests pin it for the switch path too.
+
+Note that reading from ``read_raw_config()`` is not sufficient on its own:
+``normalize_moa_config({})`` synthesizes a ``default`` preset for an empty
+config, so the gate is what actually does the work.
+
+The ``_switch`` helper patches both config seams so each test means the same
+thing before and after the fix: ``read_raw_config`` returns the user's raw
+config (what the fixed code reads), and ``load_config`` returns that config
+merged over the real shipped ``DEFAULT_CONFIG["moa"]`` (what the unfixed code
+reads). ``test_user_configured_preset_still_routes_into_moa`` is a regression
+guard and passes on unfixed code too; the other two demonstrate the bug and
+fail without the fix.
+"""
+
+import copy
+
+from unittest.mock import patch
+
+import pytest
+from hermes_cli.config import DEFAULT_CONFIG
+from hermes_cli.model_switch import switch_model
+
+
+_USER_RAW_CONFIG = {
+    "moa": {
+        "presets": {
+            "review": {
+                "enabled": True,
+                "reference_models": [
+                    {"provider": "openai-codex", "model": "gpt-5.5"},
+                ],
+                "aggregator": {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-opus-4.8",
+                },
+            },
+        },
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: {
+            "accepted": True, "persist": True, "recognized": True, "message": None,
+        },
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None,
+    )
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_catalog.get_catalog", lambda *a, **k: {})
+
+
+def _merged_config(raw_config):
+    """What ``load_config()`` would return: user config over DEFAULT_CONFIG.
+
+    Only the ``moa`` section matters to the code under test. Using the real
+    shipped DEFAULT_CONFIG keeps the pre-fix behaviour honest instead of
+    hand-writing a stand-in for the ``default`` preset.
+    """
+    moa = copy.deepcopy(DEFAULT_CONFIG.get("moa") or {})
+    user_moa = (raw_config or {}).get("moa") or {}
+    presets = dict(moa.get("presets") or {})
+    presets.update(user_moa.get("presets") or {})
+    moa.update({k: v for k, v in user_moa.items() if k != "presets"})
+    moa["presets"] = presets
+    return {"moa": moa}
+
+
+def _switch(raw_input, raw_config):
+    with patch("hermes_cli.config.read_raw_config", return_value=raw_config), \
+         patch("hermes_cli.config.load_config", return_value=_merged_config(raw_config)):
+        return switch_model(
+            raw_input=raw_input,
+            current_provider="openrouter",
+            current_model="anthropic/claude-opus-4.8",
+            user_providers={},
+            custom_providers=[],
+        )
+
+
+def test_stock_config_does_not_route_model_default_into_moa():
+    """The shipped DEFAULT_CONFIG preset is not a user-selectable switch target."""
+    result = _switch("default", {})
+
+    assert result.target_provider != "moa"
+
+
+def test_user_configured_preset_still_routes_into_moa():
+    """A preset the user did write in config.yaml keeps working (pre- and post-fix)."""
+    result = _switch("review", _USER_RAW_CONFIG)
+
+    assert result.target_provider == "moa"
+    assert result.new_model == "review"
+
+
+def test_model_default_does_not_match_when_user_configured_a_different_preset():
+    """Having *some* MoA config must not resurrect the shipped "default" preset."""
+    result = _switch("default", _USER_RAW_CONFIG)
+
+    assert result.target_provider != "moa"


### PR DESCRIPTION
## Problem

`DEFAULT_CONFIG["moa"]["presets"]` ships an enabled preset literally named `default`. On a stock install, `/model default` — a user plainly asking for their default model — silently switches the session into MoA mode and routes every later turn through the reference-model fan-out.

There are two independent routes, and closing either one alone leaves the bug in place:

1. `switch_model` resolved MoA preset names from `load_config()`, which merges DEFAULT_CONFIG, so `exact_moa_preset_name(..., "default")` matched.
2. `_PROVIDER_MODELS["moa"] == ["default"]`, so even with (1) closed, `detect_static_provider_for_model("default", ...)` matched MoA's entry in the static-catalog scan and returned `("moa", "default")`.

## Fix

For (1), read presets from `read_raw_config()` and gate the lookup on `inventory.raw_config_has_enabled_moa_preset()`. The gate is load-bearing: reading raw config alone is not enough, because `normalize_moa_config({})` synthesizes a `default` preset for an empty config. That helper already exists and already draws exactly this line for the model pickers ("the DEFAULT_CONFIG preset is not a user choice"); it is renamed from `_raw_config_has_...` to public since it now has a second caller.

For (2), add `_VIRTUAL_ROUTING_PROVIDERS` and skip it in the static-catalog scan. MoA is a virtual routing mode whose "models" are user-defined preset names, not a provider catalog — auto-detection must never route *into* it on a name collision. `inventory.py` already describes MoA in exactly these terms.

Selecting a preset is unaffected: an exact match against a preset the user configured still works, as does `--provider moa`.

## Tests

`tests/hermes_cli/test_model_switch_moa_preset_gating.py` — 3 tests. The two negative ones (`/model default` on a stock config, and with an unrelated user preset configured) fail on `main` with `target_provider == "moa"` and pass with the fix; each fails if either route is left open. The third is a regression guard — a preset the user actually wrote in config.yaml still routes into MoA — and passes both before and after the fix. The helper patches both config seams (`read_raw_config` and `load_config`, the latter built over the real shipped `DEFAULT_CONFIG["moa"]`) so every test means the same thing on both sides of the change, and the autouse fixture stubs model validation, capabilities, and the model-catalog fetch so nothing touches the network.
