### PR TITLE
gateway: three small fixes from a production deployment

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -666,11 +666,17 @@ def _summarize_bws_stderr(raw: str) -> str:
 def _run_bws_list(
     bws: Path, access_token: str, project_id: str, server_url: str = ""
 ) -> Tuple[Dict[str, str], List[str]]:
-    cmd = [str(bws), "secret", "list", project_id, "--output", "json"]
+    cmd = [str(bws), "secret", "list", project_id, "--output", "json", "--color", "no"]
     env = os.environ.copy()
     env["BWS_ACCESS_TOKEN"] = access_token
     # Make sure we're not echoing telemetry / colour codes into json.
-    env.setdefault("NO_COLOR", "1")
+    # NO_COLOR alone is insufficient: an inherited FORCE_COLOR / CLICOLOR_FORCE
+    # overrides it in bws 2.x, which then syntax-highlights the JSON with ANSI
+    # escapes and breaks json.loads at char 0.  Force colour off via the CLI
+    # flag above AND scrub the forcing vars from the child environment.
+    env["NO_COLOR"] = "1"
+    for _cvar in ("FORCE_COLOR", "CLICOLOR_FORCE", "CLICOLOR"):
+        env.pop(_cvar, None)
     # Region / self-hosted support.  bws defaults to https://vault.bitwarden.com
     # (US Cloud); EU Cloud users need https://vault.bitwarden.eu, and
     # self-hosted users need their own URL.  When unset, fall back to whatever

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1624,6 +1624,11 @@ def load_gateway_config() -> GatewayConfig:
                             for cid, ov_data in raw_overrides.items()
                             if isinstance(ov_data, dict)
                         }
+                # WhatsApp bridge-specific keys; the adapter reads these from config.extra.
+                if plat == Platform.WHATSAPP and "bridge_port" in platform_cfg:
+                    bridged["bridge_port"] = platform_cfg["bridge_port"]
+                if plat == Platform.WHATSAPP and "session_path" in platform_cfg:
+                    bridged["session_path"] = platform_cfg["session_path"]
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit and not has_channel_overrides:
                     continue

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -28,6 +28,8 @@ import { mkdirSync, readFileSync, existsSync, readdirSync, unlinkSync } from 'fs
 import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
 import { execFileSync } from 'child_process';
+
+const QR_PNG_PATH = '/tmp/whatsapp-qr.png';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
@@ -419,6 +421,13 @@ async function startSocket() {
         console.log('\n📱 Scan this QR code with WhatsApp on your phone:\n');
         qrcode.generate(qr, { small: true });
         console.log('\nWaiting for scan...\n');
+        // Also write a PNG for easier scanning on mobile
+        try {
+          execFileSync('qrencode', ['-t', 'PNG', '-o', QR_PNG_PATH, '-s', '10', '-m', '2', qr]);
+          console.log(`🖼 QR image saved: ${QR_PNG_PATH}`);
+        } catch (e) {
+          console.log('⚠ Could not write QR PNG:', e.message);
+        }
       }
     }
 


### PR DESCRIPTION
Three small fixes we have been carrying as local patches on a production deployment (Ubuntu VPS, Discord+Telegram gateway) since ~v0.18. All three apply cleanly on current main and are independent — happy to split into separate PRs if preferred.

**1. `fix(secrets)`: force colorless bws JSON output even under FORCE_COLOR**
`bws secret list --output json` syntax-highlights its JSON with ANSI escapes when `FORCE_COLOR`/`CLICOLOR_FORCE` is inherited from the parent environment (both override `NO_COLOR` in bws 2.x), which breaks `json.loads` at char 0. Notably, some agent harnesses export `FORCE_COLOR=3`, so any gateway restarted from such a session lost all its bws secrets. Fix: pass `--color no` explicitly and scrub the forcing vars from the child env.

**2. `fix(gateway)`: bridge WhatsApp `bridge_port`/`session_path` YAML keys to config.extra**
The WhatsApp adapter reads these from `config.extra`, but the YAML bridging pass dropped them, so `whatsapp.bridge_port` / `whatsapp.session_path` in config.yaml silently fell back to defaults.

**3. `feat(whatsapp)`: also write the pairing QR to a PNG when `qrencode` is available**
Terminal QR rendering is unusable over some remote shells (no OSC support, broken glyphs). Best-effort write of `/tmp/whatsapp-qr.png` via `qrencode`, wrapped in try/catch — degrades gracefully when the binary is absent.

All three run in production since May–July 2026 without issues.
