### PR TITLE
fix(agent): fail over from codex app-server quota errors

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -87,6 +87,12 @@ from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
 
+_CODEX_RUNTIME_EAGER_FALLBACK_REASONS = frozenset({
+    FailoverReason.billing,
+    FailoverReason.rate_limit,
+    FailoverReason.upstream_rate_limit,
+})
+
 # Stable prefix of the local interrupt status string emitted when a turn is
 # cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
 # to treat it as cancellation metadata rather than assistant prose.
@@ -1029,12 +1035,53 @@ def run_conversation(
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
-        return agent._run_codex_app_server_turn(
+        codex_result = agent._run_codex_app_server_turn(
             user_message=user_message,
             original_user_message=original_user_message,
             messages=messages,
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
+        )
+        codex_error = codex_result.get("error")
+        if not codex_error or not agent._has_pending_fallback():
+            return codex_result
+
+        classified = classify_api_error(
+            RuntimeError(str(codex_error)),
+            provider=getattr(agent, "provider", "") or "",
+            model=getattr(agent, "model", "") or "",
+        )
+        if classified.reason not in _CODEX_RUNTIME_EAGER_FALLBACK_REASONS:
+            return codex_result
+
+        if classified.reason == FailoverReason.billing:
+            agent._buffer_status(
+                "⚠️ Codex billing or credits exhausted — "
+                "switching to fallback provider..."
+            )
+        elif classified.reason == FailoverReason.upstream_rate_limit:
+            agent._buffer_status(
+                "⚠️ Codex upstream rate-limited — switching to fallback provider..."
+            )
+        else:
+            agent._buffer_status(
+                "⚠️ Codex rate-limited — switching to fallback provider..."
+            )
+
+        if not agent._try_activate_fallback(reason=classified.reason):
+            return codex_result
+
+        # The fallback activation rewrites provider/model/api_mode and the
+        # cached prompt identity. Continue through the normal loop so the same
+        # user turn is retried by the newly selected runtime. Preserve any
+        # projected Codex messages and count the failed Codex call in this
+        # turn's accounting.
+        codex_messages = codex_result.get("messages")
+        if isinstance(codex_messages, list):
+            messages = codex_messages
+        api_call_count = int(codex_result.get("api_calls") or 0)
+        active_system_prompt = _sync_failover_system_message(
+            agent, None, active_system_prompt
         )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -86,6 +86,130 @@ class TestRunConversationCodexPath:
         assert result["codex_thread_id"] == "thread-stub-1"
         assert result["codex_turn_id"] == "turn-stub-1"
 
+    @pytest.mark.parametrize(
+        ("error_message", "expected_reason"),
+        [
+            (
+                "insufficient_quota: exceeded your current quota",
+                run_agent.FailoverReason.billing,
+            ),
+            (
+                "rate limit exceeded; try again in 60 seconds",
+                run_agent.FailoverReason.rate_limit,
+            ),
+        ],
+    )
+    def test_fallback_eligible_codex_error_retries_with_fallback_provider(
+        self,
+        error_message,
+        expected_reason,
+    ):
+        agent = _make_codex_agent()
+        agent._fallback_chain = [
+            {"provider": "openrouter", "model": "fallback/model"}
+        ]
+        agent._fallback_index = 0
+        agent._disable_streaming = True
+
+        def fail_codex_turn(**kwargs):
+            return {
+                "final_response": f"Codex app-server turn failed: {error_message}",
+                "messages": kwargs["messages"],
+                "api_calls": 1,
+                "completed": False,
+                "partial": True,
+                "error": error_message,
+                "agent_persisted": True,
+            }
+
+        def activate_fallback(*, reason):
+            assert reason == expected_reason
+            agent._fallback_index += 1
+            agent.api_mode = "chat_completions"
+            agent.provider = "openrouter"
+            agent.model = "fallback/model"
+            agent._fallback_activated = True
+            agent._rate_limited_until = float("inf")
+            agent._transport_cache.clear()
+            return True
+
+        message = SimpleNamespace(
+            content="fallback answer",
+            tool_calls=None,
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+        )
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=message,
+                    finish_reason="stop",
+                )
+            ],
+            model="fallback/model",
+            usage=None,
+        )
+
+        with (
+            patch.object(
+                agent,
+                "_run_codex_app_server_turn",
+                side_effect=fail_codex_turn,
+            ),
+            patch.object(
+                agent,
+                "_try_activate_fallback",
+                side_effect=activate_fallback,
+            ) as fallback,
+            patch.object(
+                agent,
+                "_interruptible_api_call",
+                return_value=response,
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        fallback.assert_called_once_with(reason=expected_reason)
+        assert result["completed"] is True
+        assert result["final_response"] == "fallback answer"
+        assert result["api_calls"] == 2
+
+    def test_unknown_codex_error_keeps_native_failure_result(self):
+        agent = _make_codex_agent()
+        agent._fallback_chain = [
+            {"provider": "openrouter", "model": "fallback/model"}
+        ]
+        agent._fallback_index = 0
+
+        def fail_codex_turn(**kwargs):
+            return {
+                "final_response": "Codex app-server turn failed: malformed event",
+                "messages": kwargs["messages"],
+                "api_calls": 1,
+                "completed": False,
+                "partial": True,
+                "error": "malformed event",
+                "agent_persisted": True,
+            }
+
+        with (
+            patch.object(
+                agent,
+                "_run_codex_app_server_turn",
+                side_effect=fail_codex_turn,
+            ),
+            patch.object(agent, "_try_activate_fallback") as fallback,
+        ):
+            result = agent.run_conversation("hello")
+
+        fallback.assert_not_called()
+        assert result["completed"] is False
+        assert result["error"] == "malformed event"
+
     def test_codex_app_server_token_usage_updates_session_accounting(self, monkeypatch):
         def fake_run_turn(self, user_input: str, **kwargs):
             return TurnResult(
@@ -786,4 +910,3 @@ class TestCodexToolProgressBridge:
 
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert ("tool.started", "exec_command", "pytest") in events
-


### PR DESCRIPTION
## What does this PR do?

The `codex_app_server` dispatch returned its result before Hermes' normal error-classification and provider-fallback path could run. A billing/quota/rate-limit failure therefore ended the turn even when `fallback_providers` was configured.

This keeps the native fast path for successful and non-fallback-eligible results. For billing, rate-limit, and upstream-rate-limit errors, it classifies the Codex result, activates the next configured fallback, refreshes the in-flight prompt identity, preserves projected messages, counts the failed Codex call, and continues the same user turn through the normal runtime loop.

## Related Issue

Fixes #71633

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/conversation_loop.py`: route fallback-eligible `codex_app_server` error results into the existing provider fallback mechanism instead of returning early.
- `tests/run_agent/test_codex_app_server_integration.py`: add failing-first coverage for billing and rate-limit recovery, API-call accounting, successful fallback completion, and unchanged handling of unknown errors.

## How to Test

1. Configure `codex_app_server` with at least one `fallback_providers` entry.
2. Force the Codex turn to return an `insufficient_quota` or transient rate-limit error.
3. Verify Hermes activates the fallback and completes the same user turn; force an unknown Codex error and verify the native failure result remains unchanged.

Commands run:

- `pytest -q tests/run_agent/test_codex_app_server_*.py tests/agent/test_codex_app_server_event_bridge.py tests/agent/test_codex_runtime_live_events.py tests/agent/transports/test_codex_app_server_runtime.py tests/tui_gateway/test_codex_app_server_live_events.py` — 121 passed
- `pytest -q tests/run_agent/test_codex_app_server_integration.py tests/run_agent/test_provider_fallback.py tests/run_agent/test_auth_provider_failover.py` — 64 passed
- `ruff check agent/conversation_loop.py tests/run_agent/test_codex_app_server_integration.py` — passed
- `python -m py_compile agent/conversation_loop.py tests/run_agent/test_codex_app_server_integration.py` — passed
- `git diff --check` — passed

Full-suite note: `scripts/run_tests.sh` reached 11,544 passes before I stopped it at 24%. It reported three `TestRunOauthSetupToken` failures that reproduce unchanged on a detached `origin/main` worktree (local credential/keychain mock returns `MagicMock` to `json.loads`), plus one macOS `/tmp` vs `/private/tmp` parallel-run failure that passes in isolation on both baseline and this branch. No failure touched the modified files or Codex/fallback suites.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — see documented baseline/environment failures above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing config or command changed
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; the change is provider/runtime control flow with no platform-specific APIs
- [x] Tool descriptions/schemas update — N/A; no tool surface changed
