### PR TITLE
fix(acp): pin the session cwd for the turn and for slash commands

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1761,7 +1761,16 @@ class HermesACPAgent(acp.Agent):
                     clear_session_vars,
                     set_session_vars,
                 )
-                session_tokens = set_session_vars(session_key=session_id)
+                # ``cwd`` pins the logical working directory for this context,
+                # which is what the system prompt's "Current working directory"
+                # line reports (agent/prompt_builder.py -> resolve_agent_cwd).
+                # Without it the prompt advertises the global Hermes workspace
+                # while the tools are rooted at the client's project, so the
+                # model emits absolute paths under ~/.hermes/workspace and the
+                # edit silently lands outside the editor's workspace.
+                session_tokens = set_session_vars(
+                    session_key=session_id, cwd=state.cwd,
+                )
             except Exception:
                 session_tokens = None
                 clear_session_vars = None  # type: ignore[assignment]

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2057,8 +2057,26 @@ class HermesACPAgent(acp.Agent):
         if handler is None:
             return None  # not a known command — let the LLM handle it
 
-        try:
+        # Slash handlers run on the event-loop thread, OUTSIDE the per-turn
+        # contextvars.copy_context() that pins the session cwd for the agent
+        # call. ``/compress`` and ``/model`` reach code that REBUILDS the
+        # system prompt (agent._build_system_prompt -> resolve_agent_cwd), so
+        # an unpinned handler bakes the Hermes install tree into the session's
+        # cached prompt — persisted, and therefore poisoning every later turn
+        # even though the turn itself is pinned. Pin inside a fresh context so
+        # the write can't leak into other concurrent ACP sessions and needs no
+        # teardown.
+        def _dispatch() -> str | None:
+            try:
+                from agent.runtime_cwd import set_session_cwd
+
+                set_session_cwd(state.cwd)
+            except Exception:
+                logger.debug("Could not pin ACP session cwd for slash command", exc_info=True)
             return handler(args, state)
+
+        try:
+            return contextvars.copy_context().run(_dispatch)
         except Exception as e:
             logger.error("Slash command /%s error: %s", cmd, e, exc_info=True)
             return f"Error executing /{cmd}: {e}"

--- a/contributors/emails/steve.darlow@gmail.com
+++ b/contributors/emails/steve.darlow@gmail.com
@@ -1,0 +1,1 @@
+kerpopule

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -2041,6 +2041,77 @@ class TestSlashCommands:
         result = agent._handle_slash_command("/nonexistent", state)
         assert result is None
 
+    def test_slash_handler_pins_the_session_cwd(self, agent, mock_manager, tmp_path):
+        """A slash handler must resolve the client's cwd, not the install tree.
+
+        Slash commands run on the event-loop thread, outside the per-turn
+        ``copy_context()`` that pins the cwd for the agent call. ``/compress``
+        reaches ``agent._build_system_prompt()``, whose "Current working
+        directory" line comes from ``resolve_agent_cwd()`` — and the rebuilt
+        prompt is PERSISTED as the session's cached prompt, so an unpinned
+        handler poisons every later turn even though the turn is pinned.
+        """
+        workspace = tmp_path / "project"
+        workspace.mkdir()
+        state = mock_manager.create_session(cwd=str(workspace))
+        state.cwd = str(workspace)
+        state.agent.model = "test-model"
+        state.agent.provider = "openrouter"
+        state.history = [
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+        ]
+        state.agent.compression_enabled = True
+        state.agent._cached_system_prompt = "system"
+        state.agent.tools = None
+        state.agent._session_db = None
+
+        observed = {}
+
+        def _compress(messages, system_prompt, **kwargs):
+            from agent.runtime_cwd import resolve_agent_cwd
+
+            observed["cwd"] = str(resolve_agent_cwd())
+            return [{"role": "user", "content": "summary"}], "new-system"
+
+        state.agent._compress_context = _compress
+
+        with (
+            patch.object(agent.session_manager, "save_session"),
+            patch(
+                "agent.model_metadata.estimate_request_tokens_rough",
+                side_effect=[40, 12],
+            ),
+        ):
+            agent._handle_slash_command("/compress", state)
+
+        assert observed.get("cwd") == str(workspace), (
+            "the slash handler resolved "
+            f"{observed.get('cwd')!r} instead of the ACP client's cwd "
+            f"{str(workspace)!r}"
+        )
+
+    def test_slash_handler_cwd_pin_does_not_leak(self, agent, mock_manager, tmp_path):
+        """The pin is scoped to the handler's own context copy.
+
+        Concurrent ACP sessions share the event loop, so a handler that pinned
+        the ambient context would leave its workspace bound for whatever runs
+        next. Asserting the ambient value is unchanged after dispatch keeps the
+        fix from trading one cross-session leak for another.
+        """
+        from agent.runtime_cwd import resolve_agent_cwd
+
+        workspace = tmp_path / "project"
+        workspace.mkdir()
+        state = mock_manager.create_session(cwd=str(workspace))
+        state.cwd = str(workspace)
+        state.agent.model = "test-model"
+        state.agent.provider = "openrouter"
+
+        before = str(resolve_agent_cwd())
+        agent._handle_slash_command("/help", state)
+        assert str(resolve_agent_cwd()) == before
+
     @pytest.mark.asyncio
     async def test_slash_command_intercepted_in_prompt(self, agent, mock_manager):
         """Slash commands should be handled without calling the LLM."""

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1639,6 +1639,47 @@ class TestPrompt:
             text and "[plugin appended this]" in text for text in all_texts
         ), f"expected transformed final to be delivered, got: {all_texts!r}"
 
+    @pytest.mark.asyncio
+    async def test_prompt_pins_the_session_cwd_for_the_turn(self, agent, tmp_path):
+        """The turn must resolve the ACP client's cwd, not the Hermes workspace.
+
+        ``resolve_agent_cwd()`` is what the system prompt reports as "Current
+        working directory". When it is left unpinned it falls back to
+        TERMINAL_CWD / the launch dir, so the prompt advertises one root while
+        the tools are rooted at the editor's project. The model then emits
+        absolute paths under the advertised root and the edit silently lands
+        outside the workspace the client asked for.
+        """
+        workspace = tmp_path / "project"
+        workspace.mkdir()
+
+        new_resp = await agent.new_session(cwd=str(workspace))
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        observed = {}
+
+        def capture_cwd(*args, **kwargs):
+            from agent.runtime_cwd import resolve_agent_cwd
+
+            observed["cwd"] = str(resolve_agent_cwd())
+            return {"final_response": "ok", "messages": []}
+
+        state.agent.run_conversation = capture_cwd
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="hello")],
+            session_id=new_resp.session_id,
+        )
+
+        assert observed.get("cwd") == str(workspace), (
+            "the turn resolved "
+            f"{observed.get('cwd')!r} instead of the ACP client's cwd "
+            f"{str(workspace)!r}"
+        )
 
     @pytest.mark.asyncio
     async def test_prompt_auto_titles_session(self, agent):


### PR DESCRIPTION
## Summary

ACP edits now land in the project the editor asked for. Salvages @kerpopule's fix in #71611 and widens it to the slash-command path.

An ACP session pinned the client's `cwd` for the **tools** but never for the **prompt**. `agent/prompt_builder.py` reports `Current working directory: {resolve_agent_cwd()}`, which reads the `_SESSION_CWD` contextvar — ACP never set it, so it fell back to `TERMINAL_CWD` / the launch dir while `_register_task_cwd()` correctly rooted the tools at the editor's project. Split brain: relative paths resolved correctly, but an **absolute** path built from the root the prompt advertised wrote to `~/.hermes/workspace/` and the turn still reported success.

`set_session_vars()` already takes a `cwd` argument for exactly this ("pin the logical working directory for this context"). `gateway/session_context.py` and `tui_gateway/server.py` both pass it. ACP was the only surface that didn't.

## Changes

- `acp_adapter/server.py` — pass `cwd=state.cwd` to `set_session_vars()` in `_run_agent`, inside the existing `contextvars.copy_context()` that isolates concurrent ACP sessions. (@kerpopule)
- `acp_adapter/server.py` — **sibling site:** pin the cwd for slash-command handlers too. Slash commands run on the event-loop thread, *outside* the per-turn context copy. `/compress` reaches `agent._build_system_prompt()` and that rebuild is **persisted** as the session's cached prompt, so an unpinned handler re-poisoned every later turn even with the turn itself pinned. Pinned inside a fresh context copy so the write can't leak into other concurrent ACP sessions and needs no teardown.
- `tests/acp/test_server.py` — 3 regression tests: the turn resolves the client's cwd (@kerpopule); a slash handler resolves the client's cwd; the slash pin does **not** leak into the ambient context.

## Validation

E2E through the real `HermesACPAgent.prompt()` chain against a temp `HERMES_HOME`, driving both consumers of the contextvar from inside the turn:

| | Before | After |
|---|---|---|
| `resolve_agent_cwd()` (prompt line) | install tree | client's cwd |
| `resolve_context_cwd()` (AGENTS.md discovery) | `None` | client's cwd |
| Workspace `AGENTS.md` discovered | no | yes |
| `/compress` prompt rebuild | install tree | client's cwd |

Sabotage-verified: reverting each fix makes its regression test fail with the install-tree path, so neither test passes vacuously.

`scripts/run_tests.sh tests/acp/ tests/agent/test_runtime_cwd.py tests/agent/test_system_prompt.py tests/tools/test_file_tools_cwd_resolution.py` → **386 passed, 0 failed**. Ruff clean.

## Not duplicates

- #11570 / #11490 thread cwd for context-file *discovery* through a separate `working_dir` kwarg and never set `_SESSION_CWD`, so the prompt line stays unpinned.
- #70759 locks the tool-side `_task_env_overrides` registry — the other half of the split.
- #54654 / #68994 concern Hermes acting as an ACP *client*, the opposite direction.

Closes #71611.

## Infographic

![acp-session-cwd-pin](https://v3b.fal.media/files/b/0aa3baa9/3FpH5CdjGPNZf72xU3MwL_vWou1JU8.png)
