### PR TITLE
fix(gateway): shield secondary profile fatal reconnect

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10270,7 +10270,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     ) -> Callable[[BasePlatformAdapter], Awaitable[None]]:
         """Route a secondary-profile fatal error to that profile's reconnect slot."""
         async def _handler(adapter: BasePlatformAdapter) -> None:
-            await self._handle_profile_adapter_fatal_error(profile_name, platform, adapter)
+            tasks = getattr(self, "_profile_fatal_handler_tasks", None)
+            if tasks is None:
+                tasks = self._profile_fatal_handler_tasks = set()
+            task = asyncio.create_task(
+                self._handle_profile_adapter_fatal_error(
+                    profile_name, platform, adapter
+                ),
+                name=f"secondary-fatal:{profile_name}:{platform.value}",
+            )
+            tasks.add(task)
+            task.add_done_callback(tasks.discard)
+            await asyncio.shield(task)
 
         return _handler
 

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -260,6 +260,58 @@ class TestSecondaryProfileFatalRecovery:
         assert all(path == Path("/profiles/reviewer") for path in scoped_homes)
 
     @pytest.mark.asyncio
+    async def test_secondary_fatal_callback_survives_caller_cancellation(
+        self, monkeypatch
+    ):
+        runner = _secondary_recovery_runner()
+        stale = _SecondaryRecoveryAdapter()
+        replacement = _SecondaryRecoveryAdapter()
+        runner._profile_adapters["reviewer"] = {Platform.DISCORD: stale}
+        _install_secondary_reconnect_context(monkeypatch, runner, replacement)
+
+        disconnect_started = asyncio.Event()
+        release_disconnect = asyncio.Event()
+
+        async def slow_disconnect():
+            disconnect_started.set()
+            await release_disconnect.wait()
+            stale.disconnected = True
+
+        async def connect(adapter, platform, *, is_reconnect=False):
+            assert adapter is replacement
+            assert platform is Platform.DISCORD
+            assert is_reconnect is True
+            replacement.connected = True
+            return True
+
+        stale.disconnect = slow_disconnect
+        monkeypatch.setattr(runner, "_connect_adapter_with_timeout", connect)
+        handler = runner._make_profile_fatal_error_handler(
+            "reviewer", Platform.DISCORD
+        )
+
+        caller_task = asyncio.create_task(handler(stale))
+        await disconnect_started.wait()
+        caller_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await caller_task
+
+        assert Platform.DISCORD not in runner._profile_adapters["reviewer"]
+        assert runner._background_tasks == set()
+
+        release_disconnect.set()
+        for _ in range(10):
+            await asyncio.sleep(0)
+            if not getattr(runner, "_profile_fatal_handler_tasks", set()):
+                break
+
+        assert stale.disconnected is True
+        tasks = list(runner._background_tasks)
+        assert len(tasks) == 1
+        await tasks[0]
+        assert runner._profile_adapters["reviewer"][Platform.DISCORD] is replacement
+
+    @pytest.mark.asyncio
     async def test_secondary_reconnect_cancellation_disposes_partial_adapter(
         self, monkeypatch
     ):


### PR DESCRIPTION
## Summary

Secondary-profile gateway adapters can still be silently lost when their fatal-error callback is cancelled while adapter teardown is in progress.

The primary adapter fatal handler already detaches and shields its reconnect handoff so adapter teardown cannot cancel the path before the platform is queued for recovery. The secondary-profile fatal handler did not have the same protection: it removed the failed adapter from `_profile_adapters`, awaited `_safe_adapter_disconnect()`, and only then scheduled the profile-scoped reconnect.

If the caller task is cancelled during that disconnect await, the secondary adapter is removed, no reconnect task is scheduled, and the profile's messaging platform stays dark until process restart.

## Changes

- Wrap secondary-profile fatal-error callbacks in a runner-owned task.
- Await that task through `asyncio.shield()` so caller cancellation does not cancel the reconnect handoff.
- Keep the existing direct helper behavior unchanged for tests and internal callers.
- Add regression coverage proving a cancelled secondary fatal callback still reaches the profile-scoped reconnect path.

## Impact

This affects multiplexed gateway profiles. A retryable fatal adapter event can remove a secondary profile's platform adapter without entering `_profile_failed_platforms` or scheduling `_run_secondary_profile_reconnect()`. The gateway remains alive, but that profile stops receiving messages.

## Validation

```text
python -m pytest tests/gateway/test_multiplex_adapter_registry.py -q
33 passed in 1.72s