### PR TITLE
fix(doctor): recognize secret-source credentials

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -262,8 +262,10 @@ def _termux_install_all_fallback_notes() -> list[str]:
 
 
 def _has_provider_env_config(content: str) -> bool:
-    """Return True when ~/.hermes/.env contains provider auth/base URL settings."""
-    return any(key in content for key in _PROVIDER_ENV_HINTS)
+    """Return True when resolved provider auth or endpoint settings exist."""
+    return any(key in content for key in _PROVIDER_ENV_HINTS) or any(
+        str(os.environ.get(key) or "").strip() for key in _PROVIDER_ENV_HINTS
+    )
 
 
 def _honcho_is_configured_for_doctor() -> bool:
@@ -1242,7 +1244,9 @@ def run_doctor(args):
     managed_scope_check()
     # Check ~/.hermes/.env (primary location for user config)
     env_path = HERMES_HOME / '.env'
-    if env_path.exists():
+    env_file_exists = env_path.exists()
+    content = ""
+    if env_file_exists:
         check_ok(f"{_DHH}/.env file exists")
         
         # Prefer UTF-8 (.env is written as UTF-8 elsewhere). Fall back to
@@ -1252,17 +1256,14 @@ def run_doctor(args):
             content = env_path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             content = env_path.read_text(encoding="latin-1")
-        if _has_provider_env_config(content):
-            check_ok("API key or custom endpoint configured")
-        else:
-            check_warn(f"No API key found in {_DHH}/.env")
-            issues.append("Run 'hermes setup' to configure API keys")
-    else:
+
+    has_provider_env_config = _has_provider_env_config(content)
+    if not env_file_exists:
         # Also check project root as fallback
         fallback_env = PROJECT_ROOT / '.env'
         if fallback_env.exists():
             check_ok(".env file exists (in project directory)")
-        else:
+        elif not has_provider_env_config:
             check_fail(f"{_DHH}/.env file missing")
             if should_fix:
                 env_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1280,6 +1281,16 @@ def run_doctor(args):
             else:
                 check_info("Run 'hermes setup' to create one")
                 issues.append("Run 'hermes setup' to create .env")
+        else:
+            check_info(
+                f"{_DHH}/.env not present (credentials resolved from environment)"
+            )
+
+    if has_provider_env_config:
+        check_ok("API key or custom endpoint configured")
+    elif env_file_exists:
+        check_warn(f"No API key found in {_DHH}/.env")
+        issues.append("Run 'hermes setup' to configure API keys")
     
     # Check ~/.hermes/config.yaml (primary) or project cli-config.yaml (fallback)
     config_path = HERMES_HOME / 'config.yaml'

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -101,8 +101,10 @@ def _termux_install_all_fallback_notes() -> list[str]:
 
 
 def _has_provider_env_config(content: str) -> bool:
-    """Return True when ~/.hermes/.env contains provider auth/base URL settings."""
-    return any(key in content for key in _PROVIDER_ENV_HINTS)
+    """Return True when resolved provider auth or endpoint settings exist."""
+    return any(key in content for key in _PROVIDER_ENV_HINTS) or any(
+        str(os.environ.get(key) or "").strip() for key in _PROVIDER_ENV_HINTS
+    )
 
 
 def _honcho_is_configured_for_doctor() -> bool:
@@ -884,7 +886,9 @@ def run_doctor(args):
     managed_scope_check()
     # Check ~/.hermes/.env (primary location for user config)
     env_path = HERMES_HOME / '.env'
-    if env_path.exists():
+    env_file_exists = env_path.exists()
+    content = ""
+    if env_file_exists:
         check_ok(f"{_DHH}/.env file exists")
         
         # Prefer UTF-8 (.env is written as UTF-8 elsewhere). Fall back to
@@ -894,17 +898,14 @@ def run_doctor(args):
             content = env_path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             content = env_path.read_text(encoding="latin-1")
-        if _has_provider_env_config(content):
-            check_ok("API key or custom endpoint configured")
-        else:
-            check_warn(f"No API key found in {_DHH}/.env")
-            issues.append("Run 'hermes setup' to configure API keys")
-    else:
+
+    has_provider_env_config = _has_provider_env_config(content)
+    if not env_file_exists:
         # Also check project root as fallback
         fallback_env = PROJECT_ROOT / '.env'
         if fallback_env.exists():
             check_ok(".env file exists (in project directory)")
-        else:
+        elif not has_provider_env_config:
             check_fail(f"{_DHH}/.env file missing")
             if should_fix:
                 env_path.parent.mkdir(parents=True, exist_ok=True)
@@ -922,6 +923,16 @@ def run_doctor(args):
             else:
                 check_info("Run 'hermes setup' to create one")
                 issues.append("Run 'hermes setup' to create .env")
+        else:
+            check_info(
+                f"{_DHH}/.env not present (credentials resolved from environment)"
+            )
+
+    if has_provider_env_config:
+        check_ok("API key or custom endpoint configured")
+    elif env_file_exists:
+        check_warn(f"No API key found in {_DHH}/.env")
+        issues.append("Run 'hermes setup' to configure API keys")
     
     # Check ~/.hermes/config.yaml (primary) or project cli-config.yaml (fallback)
     config_path = HERMES_HOME / 'config.yaml'

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -60,9 +60,128 @@ class TestProviderEnvDetection:
         assert _has_provider_env_config(content)
 
 
-    def test_returns_false_when_no_provider_settings(self):
+    def test_detects_provider_setting_from_process_environment(self, monkeypatch):
+        for key in doctor._PROVIDER_ENV_HINTS:
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-from-secret-source")
+
+        assert _has_provider_env_config("")
+
+    def test_ignores_empty_provider_setting_in_process_environment(self, monkeypatch):
+        for key in doctor._PROVIDER_ENV_HINTS:
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "   ")
+
+        assert not _has_provider_env_config("")
+
+    def test_returns_false_when_no_provider_settings(self, monkeypatch):
+        for key in doctor._PROVIDER_ENV_HINTS:
+            monkeypatch.delenv(key, raising=False)
         content = "TERMINAL_ENV=local\n"
         assert not _has_provider_env_config(content)
+
+
+class TestDoctorSecretSourceConfiguration:
+    @staticmethod
+    def _run_until_tool_availability(monkeypatch, home, project):
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+        def no_network(*args, **kwargs):
+            raise RuntimeError("network disabled in doctor configuration test")
+
+        monkeypatch.setattr("httpx.get", no_network)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: (_ for _ in ()).throw(
+                SystemExit(0)
+            ),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            with pytest.raises(SystemExit):
+                doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue()
+
+    @pytest.mark.parametrize("create_env_file", [True, False])
+    def test_secret_source_credentials_are_reported_as_configured(
+        self, monkeypatch, tmp_path, create_env_file
+    ):
+        from agent.secret_sources import registry
+        from agent.secret_sources.base import FetchResult, SecretSource
+        from hermes_cli import env_loader
+
+        class DoctorStubSource(SecretSource):
+            name = "doctorstub"
+            label = "Doctor Stub"
+            shape = "bulk"
+
+            def fetch(self, cfg, home_path):
+                return FetchResult(
+                    secrets={"OPENROUTER_API_KEY": "sk-from-secret-source"}
+                )
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        if create_env_file:
+            (home / ".env").write_text("", encoding="utf-8")
+        (home / "config.yaml").write_text(
+            "secrets:\n"
+            "  doctorstub:\n"
+            "    enabled: true\n"
+            "memory: {}\n",
+            encoding="utf-8",
+        )
+        project = tmp_path / "project"
+        project.mkdir()
+
+        for key in doctor._PROVIDER_ENV_HINTS:
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setattr(registry, "_ensure_builtin_sources", lambda: None)
+        registry._reset_registry_for_tests()
+        env_loader.reset_secret_source_cache()
+        try:
+            assert registry.register_source(DoctorStubSource())
+            env_loader.load_hermes_dotenv(hermes_home=home)
+            assert env_loader.get_secret_source("OPENROUTER_API_KEY") == "doctorstub"
+
+            out = self._run_until_tool_availability(monkeypatch, home, project)
+        finally:
+            os.environ.pop("OPENROUTER_API_KEY", None)
+            registry._reset_registry_for_tests()
+            env_loader.reset_secret_source_cache()
+
+        assert "API key or custom endpoint configured" in out
+        assert f"No API key found in {home}/.env" not in out
+        assert f"{home}/.env file missing" not in out
+        if create_env_file:
+            assert f"{home}/.env not present" not in out
+        else:
+            assert (
+                f"{home}/.env not present (credentials resolved from environment)"
+                in out
+            )
+
+    def test_empty_env_without_resolved_credentials_still_warns(
+        self, monkeypatch, tmp_path
+    ):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / ".env").write_text("", encoding="utf-8")
+        (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+        project = tmp_path / "project"
+        project.mkdir()
+
+        for key in doctor._PROVIDER_ENV_HINTS:
+            monkeypatch.delenv(key, raising=False)
+
+        out = self._run_until_tool_availability(monkeypatch, home, project)
+
+        assert f"No API key found in {home}/.env" in out
 
 
 class TestDoctorToolAvailabilitySummary:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -46,9 +46,128 @@ class TestProviderEnvDetection:
         content = "KIMI_CN_API_KEY=sk-test\n"
         assert _has_provider_env_config(content)
 
-    def test_returns_false_when_no_provider_settings(self):
+    def test_detects_provider_setting_from_process_environment(self, monkeypatch):
+        for key in doctor._PROVIDER_ENV_HINTS:
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-from-secret-source")
+
+        assert _has_provider_env_config("")
+
+    def test_ignores_empty_provider_setting_in_process_environment(self, monkeypatch):
+        for key in doctor._PROVIDER_ENV_HINTS:
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "   ")
+
+        assert not _has_provider_env_config("")
+
+    def test_returns_false_when_no_provider_settings(self, monkeypatch):
+        for key in doctor._PROVIDER_ENV_HINTS:
+            monkeypatch.delenv(key, raising=False)
         content = "TERMINAL_ENV=local\n"
         assert not _has_provider_env_config(content)
+
+
+class TestDoctorSecretSourceConfiguration:
+    @staticmethod
+    def _run_until_tool_availability(monkeypatch, home, project):
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+        def no_network(*args, **kwargs):
+            raise RuntimeError("network disabled in doctor configuration test")
+
+        monkeypatch.setattr("httpx.get", no_network)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: (_ for _ in ()).throw(
+                SystemExit(0)
+            ),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            with pytest.raises(SystemExit):
+                doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue()
+
+    @pytest.mark.parametrize("create_env_file", [True, False])
+    def test_secret_source_credentials_are_reported_as_configured(
+        self, monkeypatch, tmp_path, create_env_file
+    ):
+        from agent.secret_sources import registry
+        from agent.secret_sources.base import FetchResult, SecretSource
+        from hermes_cli import env_loader
+
+        class DoctorStubSource(SecretSource):
+            name = "doctorstub"
+            label = "Doctor Stub"
+            shape = "bulk"
+
+            def fetch(self, cfg, home_path):
+                return FetchResult(
+                    secrets={"OPENROUTER_API_KEY": "sk-from-secret-source"}
+                )
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        if create_env_file:
+            (home / ".env").write_text("", encoding="utf-8")
+        (home / "config.yaml").write_text(
+            "secrets:\n"
+            "  doctorstub:\n"
+            "    enabled: true\n"
+            "memory: {}\n",
+            encoding="utf-8",
+        )
+        project = tmp_path / "project"
+        project.mkdir()
+
+        for key in doctor._PROVIDER_ENV_HINTS:
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setattr(registry, "_ensure_builtin_sources", lambda: None)
+        registry._reset_registry_for_tests()
+        env_loader.reset_secret_source_cache()
+        try:
+            assert registry.register_source(DoctorStubSource())
+            env_loader.load_hermes_dotenv(hermes_home=home)
+            assert env_loader.get_secret_source("OPENROUTER_API_KEY") == "doctorstub"
+
+            out = self._run_until_tool_availability(monkeypatch, home, project)
+        finally:
+            os.environ.pop("OPENROUTER_API_KEY", None)
+            registry._reset_registry_for_tests()
+            env_loader.reset_secret_source_cache()
+
+        assert "API key or custom endpoint configured" in out
+        assert f"No API key found in {home}/.env" not in out
+        assert f"{home}/.env file missing" not in out
+        if create_env_file:
+            assert f"{home}/.env not present" not in out
+        else:
+            assert (
+                f"{home}/.env not present (credentials resolved from environment)"
+                in out
+            )
+
+    def test_empty_env_without_resolved_credentials_still_warns(
+        self, monkeypatch, tmp_path
+    ):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / ".env").write_text("", encoding="utf-8")
+        (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+        project = tmp_path / "project"
+        project.mkdir()
+
+        for key in doctor._PROVIDER_ENV_HINTS:
+            monkeypatch.delenv(key, raising=False)
+
+        out = self._run_until_tool_availability(monkeypatch, home, project)
+
+        assert f"No API key found in {home}/.env" in out
 
 
 class TestDoctorToolAvailabilitySummary:


### PR DESCRIPTION
## Why

`hermes doctor` inspected the raw `~/.hermes/.env` text even though `load_hermes_dotenv()` had already resolved external secret sources into `os.environ`. Users with Bitwarden, 1Password, command, or plugin-provided credentials could therefore be told that no API key existed and directed back to plaintext setup.

This is a focused alternative to #45218: it credits and preserves that PR's environment-aware detection while avoiding its unrelated connectivity-reporting changes.

## What changed

- Recognize non-empty resolved provider credentials and endpoint settings.
- Treat an absent `.env` as valid when credentials were resolved elsewhere, while explaining that state in Doctor output.
- Preserve the existing warning and setup guidance for genuinely unconfigured homes.
- Exercise the real `SecretSource` registration, load, environment, and Doctor reporting path, including explicit environment cleanup.

The named-profile `no .env` annotation remains a literal informational file-state label; source configuration alone is not treated as proof that an inactive profile fetched credentials successfully.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_doctor.py tests/test_env_loader_secret_sources.py -q` — 96 passed
- `ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`
- `python -m compileall -q hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`
- `git diff --check upstream/main...HEAD`
