### PR TITLE
fix(desktop): trust usable active runtime without bootstrap marker

### DIFF
--- a/apps/desktop/electron/active-runtime-state.test.ts
+++ b/apps/desktop/electron/active-runtime-state.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { classifyActiveRuntime, hasValidBootstrapMarker } from './active-runtime-state'
+
+const VALID_MARKER = {
+  pinnedCommit: '1234567890abcdef1234567890abcdef12345678',
+  schemaVersion: 1
+}
+
+test('hasValidBootstrapMarker accepts the current schema with a real-looking commit', () => {
+  assert.equal(hasValidBootstrapMarker(VALID_MARKER, 1), true)
+})
+
+test('hasValidBootstrapMarker rejects missing, wrong-schema, and too-short markers', () => {
+  assert.equal(hasValidBootstrapMarker(null, 1), false)
+  assert.equal(hasValidBootstrapMarker({ schemaVersion: 2, pinnedCommit: VALID_MARKER.pinnedCommit }, 1), false)
+  assert.equal(hasValidBootstrapMarker({ schemaVersion: 1, pinnedCommit: 'abc123' }, 1), false)
+})
+
+test('classifyActiveRuntime uses a healthy active runtime even when the bootstrap marker is missing', () => {
+  assert.deepEqual(classifyActiveRuntime(null, 1, true), {
+    hasValidMarker: false,
+    shouldUseActiveRuntime: true,
+    usabilityReason: 'usable'
+  })
+})
+
+test('classifyActiveRuntime uses a healthy active runtime even when the marker is stale or malformed', () => {
+  assert.deepEqual(classifyActiveRuntime({ schemaVersion: 999, pinnedCommit: 'abc1234' }, 1, true), {
+    hasValidMarker: false,
+    shouldUseActiveRuntime: true,
+    usabilityReason: 'usable'
+  })
+})
+
+test('classifyActiveRuntime refuses an unusable runtime even if a valid marker exists', () => {
+  assert.deepEqual(classifyActiveRuntime(VALID_MARKER, 1, false), {
+    hasValidMarker: true,
+    shouldUseActiveRuntime: false,
+    usabilityReason: 'unusable'
+  })
+})

--- a/apps/desktop/electron/active-runtime-state.ts
+++ b/apps/desktop/electron/active-runtime-state.ts
@@ -1,0 +1,58 @@
+export interface BootstrapMarkerLike {
+  pinnedCommit?: unknown
+  schemaVersion?: unknown
+}
+
+export interface ActiveRuntimeState {
+  hasValidMarker: boolean
+  shouldUseActiveRuntime: boolean
+  usabilityReason: 'usable' | 'unusable'
+}
+
+export function hasValidBootstrapMarker(
+  marker: BootstrapMarkerLike | null | undefined,
+  schemaVersion: number
+): boolean {
+  if (!marker || typeof marker !== 'object') {
+    return false
+  }
+
+  if (marker.schemaVersion !== schemaVersion) {
+    return false
+  }
+
+  if (typeof marker.pinnedCommit !== 'string' || marker.pinnedCommit.length < 7) {
+    return false
+  }
+
+  return true
+}
+
+// The active install at ~/.hermes/hermes-agent can be real and runnable even if
+// Desktop never wrote its first-run bootstrap marker (for example when Hermes
+// was installed by the CLI first, or when a past desktop build forgot the
+// marker). Runtime usability is authoritative for "can we launch local Hermes
+// right now?"; the marker is only provenance about how that install was
+// created. A missing/stale marker must never force a healthy local install into
+// the first-run bootstrap UI.
+export function classifyActiveRuntime(
+  marker: BootstrapMarkerLike | null | undefined,
+  schemaVersion: number,
+  runtimeUsable: boolean
+): ActiveRuntimeState {
+  const hasValidMarker = hasValidBootstrapMarker(marker, schemaVersion)
+
+  if (!runtimeUsable) {
+    return {
+      hasValidMarker,
+      shouldUseActiveRuntime: false,
+      usabilityReason: 'unusable'
+    }
+  }
+
+  return {
+    hasValidMarker,
+    shouldUseActiveRuntime: true,
+    usabilityReason: 'usable'
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -40,6 +40,7 @@ import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { shouldLatchBackendStartFailure } from './backend-start-failure'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
 import { runBootstrap } from './bootstrap-runner'
+import { classifyActiveRuntime } from './active-runtime-state'
 import { applyConnectionChange, resolveTerminalConnection } from './connection-apply'
 import {
   authModeFromStatus,
@@ -3407,21 +3408,15 @@ function isActiveRuntimeUsable() {
   )
 }
 
+function activeRuntimeState() {
+  return classifyActiveRuntime(
+    readBootstrapMarker(),
+    BOOTSTRAP_MARKER_SCHEMA_VERSION,
+    isActiveRuntimeUsable()
+  )
+}
+
 function isBootstrapComplete() {
-  const marker = readBootstrapMarker()
-
-  if (!marker || typeof marker !== 'object') {
-    return false
-  }
-
-  if (marker.schemaVersion !== BOOTSTRAP_MARKER_SCHEMA_VERSION) {
-    return false
-  }
-
-  if (typeof marker.pinnedCommit !== 'string' || marker.pinnedCommit.length < 7) {
-    return false
-  }
-
   // We DELIBERATELY do NOT verify that the checkout is currently at the
   // pinned commit -- users update via the in-app update path or `hermes
   // update`, which moves HEAD legitimately. The marker just attests "we
@@ -3429,7 +3424,7 @@ function isBootstrapComplete() {
   // a runnable venv: an interrupted or split-home install can leave the marker
   // + checkout without a venv, and trusting that spawns a dead backend
   // ("gateway offline") instead of re-running bootstrap to repair it.
-  return isActiveRuntimeUsable()
+  return activeRuntimeState().hasValidMarker
 }
 
 function writeBootstrapMarker(payload) {
@@ -3689,13 +3684,23 @@ function resolveHermesBackend(backendArgs) {
     }
   }
 
-  // 3. Bootstrap-complete ACTIVE_HERMES_ROOT -- the canonical install at
-  //    %LOCALAPPDATA%\hermes\hermes-agent (Windows) or ~/.hermes/hermes-agent.
-  //    The bootstrap marker means install.ps1 stages finished and the user
-  //    completed initial configuration; we trust the install and go straight
-  //    to spawning hermes. Updates flow through the in-app update path
-  //    (applyUpdates -> git pull) or `hermes update` from the CLI.
-  if (isBootstrapComplete()) {
+  // 3. ACTIVE_HERMES_ROOT — the canonical install at
+  //    %LOCALAPPDATA%\\hermes\\hermes-agent (Windows) or ~/.hermes/hermes-agent.
+  //    A valid bootstrap marker proves Desktop finished the first-run install
+  //    flow, but marker provenance is NOT the same thing as runtime usability:
+  //    the CLI can create the exact same repo+venv layout, and older desktop
+  //    builds could leave a healthy install behind without the marker. If the
+  //    active runtime is usable, launch it directly; only fall through to
+  //    bootstrap when the runtime itself is unusable.
+  const activeRuntime = activeRuntimeState()
+
+  if (activeRuntime.shouldUseActiveRuntime) {
+    if (!activeRuntime.hasValidMarker) {
+      rememberLog(
+        `[bootstrap] Active Hermes runtime at ${ACTIVE_HERMES_ROOT} is usable but the bootstrap marker is missing or stale; skipping first-run bootstrap.`
+      )
+    }
+
     return createActiveBackend(backendArgs)
   }
 


### PR DESCRIPTION
## Summary
- stop treating the desktop bootstrap marker as the sole signal that the active local runtime is installed
- trust a usable `~/.hermes/hermes-agent` runtime even when `.hermes-bootstrap-complete` is missing or stale
- add regression tests for runtime-vs-marker classification

## Problem
Desktop could fall through to `bootstrap-needed` and show the large first-run install UI even when the canonical local runtime was already valid and runnable. This happened when the active runtime existed but the desktop bootstrap marker was missing or stale.

That made a healthy install look uninstalled.

## Fix
- factor active-runtime classification into a small pure helper
- keep the bootstrap marker as provenance about desktop-managed first-run completion
- use runtime usability as the authoritative launch gate for `ACTIVE_HERMES_ROOT`
- log when Desktop skips bootstrap because the runtime is healthy but the marker is missing/stale

## Test Plan
- `npm --workspace apps/desktop run test:desktop:platforms -- active-runtime-state.test.ts primary-backend-startup.test.ts first-run-setup-main-process.test.ts windows-hermes-path.test.ts`
- `git diff --check -- apps/desktop/electron/main.ts apps/desktop/electron/active-runtime-state.ts apps/desktop/electron/active-runtime-state.test.ts`
