### PR TITLE
fix(context-engine): log register() construction failures at WARNING with traceback

### DIFF
--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -180,7 +180,17 @@ def _load_engine_from_dir(engine_dir: Path) -> Optional["ContextEngine"]:
             if collector.engine:
                 return collector.engine
         except Exception as e:
-            logger.debug("register() failed for %s: %s", name, e)
+            # WARNING with traceback, not debug: when engine construction
+            # fails, every session silently falls back to the built-in
+            # compressor and this log line is the only breadcrumb. At debug
+            # level the real exception (e.g. a SQLite schema error in the
+            # engine's storage init) is invisible in production, so the
+            # degradation looks like a mystery instead of pointing at the
+            # actual cause.
+            logger.warning(
+                "register() failed for context engine %r: %s", name, e,
+                exc_info=True,
+            )
 
     # Fallback: find a ContextEngine subclass and instantiate it
     from agent.context_engine import ContextEngine

--- a/tests/run_agent/test_context_engine_loader_visibility.py
+++ b/tests/run_agent/test_context_engine_loader_visibility.py
@@ -1,0 +1,85 @@
+"""Loader visibility for context-engine construction failures.
+
+Regression test: when a context engine's ``register(ctx)`` raises during
+construction, the loader must log at WARNING with the traceback — not
+``debug``. A failed construction silently downgrades every session to the
+built-in compressor, and this log line is the only breadcrumb pointing at
+the real cause (e.g. a SQLite schema error in the engine's storage init).
+At debug level the exception is invisible in production and the degradation
+presents as an unexplained behavior change.
+"""
+
+import logging
+
+import plugins.context_engine as ce_loader
+
+
+def _write_failing_engine(plugin_dir, name="boomengine"):
+    engine_dir = plugin_dir / name
+    engine_dir.mkdir(parents=True)
+    (engine_dir / "__init__.py").write_text(
+        "def register(ctx):\n"
+        "    raise RuntimeError('storage init exploded: no such column: search_content')\n",
+        encoding="utf-8",
+    )
+    return engine_dir
+
+
+def test_register_failure_logs_warning_with_traceback(tmp_path, monkeypatch, caplog):
+    """A register() crash must surface at WARNING with the real exception."""
+    plugin_dir = tmp_path / "context_engine_plugins"
+    _write_failing_engine(plugin_dir)
+    monkeypatch.setattr(ce_loader, "_CONTEXT_ENGINE_PLUGINS_DIR", plugin_dir)
+
+    with caplog.at_level(logging.DEBUG, logger="plugins.context_engine"):
+        engine = ce_loader.load_context_engine("boomengine")
+
+    assert engine is None
+    warning_records = [
+        r for r in caplog.records
+        if r.levelno >= logging.WARNING and "register() failed" in r.getMessage()
+    ]
+    assert warning_records, (
+        "register() construction failure must be logged at WARNING+ "
+        f"(records seen: {[(r.levelname, r.getMessage()) for r in caplog.records]})"
+    )
+    rec = warning_records[0]
+    # The real exception message must be present so operators can act on it.
+    assert "storage init exploded" in rec.getMessage()
+    # And the traceback must ride along (exc_info), not just the str(e).
+    assert rec.exc_info is not None
+
+
+def test_healthy_engine_still_loads_without_warning(tmp_path, monkeypatch, caplog):
+    """A working register() path must not emit the failure warning."""
+    plugin_dir = tmp_path / "context_engine_plugins"
+    engine_dir = plugin_dir / "okengine"
+    engine_dir.mkdir(parents=True)
+    (engine_dir / "__init__.py").write_text(
+        "from agent.context_engine import ContextEngine\n"
+        "\n"
+        "class _OkEngine(ContextEngine):\n"
+        "    @property\n"
+        "    def name(self):\n"
+        "        return 'okengine'\n"
+        "    def update_from_response(self, usage):\n"
+        "        pass\n"
+        "    def should_compress(self, prompt_tokens=None):\n"
+        "        return False\n"
+        "    def compress(self, messages, current_tokens=None):\n"
+        "        return messages\n"
+        "\n"
+        "def register(ctx):\n"
+        "    ctx.register_context_engine(_OkEngine())\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ce_loader, "_CONTEXT_ENGINE_PLUGINS_DIR", plugin_dir)
+
+    with caplog.at_level(logging.DEBUG, logger="plugins.context_engine"):
+        engine = ce_loader.load_context_engine("okengine")
+
+    assert engine is not None
+    assert not [
+        r for r in caplog.records
+        if r.levelno >= logging.WARNING and "register() failed" in r.getMessage()
+    ]


### PR DESCRIPTION
## Problem

When a plugin context engine's `register(ctx)` raises during construction, `_load_engine_from_dir_locked` catches the exception and logs it at **DEBUG**:

```python
except Exception as e:
    logger.debug("register() failed for %s: %s", name, e)
```

The loader then returns `None` and every session silently falls back to the built-in compressor. At production log levels the real exception never appears anywhere — the only observable symptoms are downstream behavior changes from the degraded compressor, which look like provider or harness bugs rather than pointing at the engine.

The two sibling failure paths in the same module already log at WARNING (`"Context engine '%s' loaded but no engine instance found"`, `"Failed to load context engine '%s'"`); the register() path is the odd one out, and it's the one that carries the actual root cause.

## Real-world impact (how this bit us, 2026-07-25)

A SQLite schema drift in an engine's storage init made `register()` raise. The debug-level log hid the cause; all sessions degraded to the built-in compressor; the degraded compressor emitted a malformed message that was rejected with an identical HTTP 400 by every provider in the fallback chain — presenting as a total provider outage across ~30 minutes and multiple sessions. Root-causing required log archaeology that a single WARNING line with the traceback would have made a one-grep diagnosis.

## Fix

Log at WARNING with `exc_info=True` so the traceback rides along. No behavior change beyond log level — load flow, fallback semantics, and return values are untouched.

## Tests

`tests/run_agent/test_context_engine_loader_visibility.py`:
- a failing-`register()` engine fixture must surface at WARNING+ containing the real exception message, with `exc_info` attached — **red on current main** (the record only exists at DEBUG), green with the fix
- a healthy engine loads with no failure warning (no new noise on the happy path)

Verified against this base: the new file 2/2, plus `tests/run_agent/test_plugin_context_engine_init.py` and `tests/test_plugin_utils.py` (16 passed total).