### PR TITLE
feat(dispatcher): shared-tree serialization guard for git-repo default_workdirs

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6605,6 +6605,14 @@ class DispatchResult:
     (EX_TEMPFAIL sentinel exit) and were released back to ``ready`` WITHOUT
     counting a failure. These never trip the circuit breaker — a long quota
     window just makes the task bounce cheaply until the window clears."""
+    skipped_shared_tree: list[tuple[str, list[str]]] = field(default_factory=list)
+    """Tasks deferred this tick because another scratch task is running on
+    the same shared source tree (board default_workdir). Each entry is
+    ``(task_id, running_scratch_task_ids)``. Scratch tasks serialize when
+    the board has a git-repo default_workdir, preventing concurrent edits to
+    the same checkout. NOT an operator-actionable failure — the task will be
+    picked up on a subsequent tick when the running scratch worker finishes.
+    Worktree tasks are always exempt (they have their own isolated checkout)."""
     skipped_locked: bool = False
     """True when this tick was skipped because another process already held
     the board's dispatch lock (issue #35240). A losing dispatcher does no
@@ -8125,7 +8133,7 @@ def _dispatch_once_locked(
         )
 
     ready_rows = conn.execute(
-        "SELECT id, assignee FROM tasks "
+        "SELECT id, assignee, workspace_kind FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
@@ -8164,6 +8172,33 @@ def _dispatch_once_locked(
             "GROUP BY assignee"
         ):
             _per_profile_running[prow["assignee"]] = int(prow["n"])
+
+    # Shared-tree serialization guard: when the board has a git-repo
+    # default_workdir, at most ONE scratch task may run at a time. Scratch
+    # workers routinely cd into the shared checkout and edit files
+    # concurrently — without this guard, two sibling scratch tasks race on
+    # the same files and the first to commit sweeps the other's
+    # half-finished work into their commit (shared-tree collision, see
+    # audit 2026-07-26 / kanban-worker pitfall #13). Worktree tasks are
+    # exempt: they each get an isolated checkout at <repo>/.worktrees/<id>.
+    _shared_tree_root: Optional[str] = None
+    _running_scratch_ids: list[str] = []
+    _board_slug = board if board else get_current_board()
+    if _board_slug:
+        try:
+            _board_meta = read_board_metadata(_board_slug)
+            _bd = (_board_meta.get("default_workdir") or "").strip()
+            if _bd and Path(_bd).expanduser().is_dir():
+                _shared_tree_root = _bd
+        except Exception:
+            pass
+    if _shared_tree_root:
+        _running_scratch_ids = [
+            r["id"] for r in conn.execute(
+                "SELECT id FROM tasks "
+                "WHERE status = 'running' AND workspace_kind = 'scratch'"
+            ).fetchall()
+        ]
     # Normalize default_assignee once: empty/whitespace string → None so the
     # rest of the loop can use ``if default_assignee:`` as a single check.
     # We also resolve profile_exists once here for the same reason.
@@ -8263,6 +8298,35 @@ def _dispatch_once_locked(
                     (row["id"], row_assignee, current)
                 )
                 continue
+        # Shared-tree serialization guard: if this board has a git-repo
+        # default_workdir and this is a scratch task, defer it when another
+        # scratch task is already running. Prevents concurrent edits to the
+        # same shared checkout (shared-tree collision, audit 2026-07-26).
+        # Worktree tasks are exempt — each gets an isolated checkout.
+        row_workspace_kind = row["workspace_kind"] or "scratch"
+        if (
+            _shared_tree_root
+            and row_workspace_kind == "scratch"
+            and _running_scratch_ids
+        ):
+            result.skipped_shared_tree.append(
+                (row["id"], list(_running_scratch_ids))
+            )
+            if not dry_run:
+                with write_txn(conn):
+                    _append_event(
+                        conn, row["id"], "shared_tree_deferred",
+                        {
+                            "blocked_by": list(_running_scratch_ids),
+                            "board_workdir": _shared_tree_root,
+                            "message": (
+                                "Deferred: another scratch task is running on "
+                                "the same shared tree. Use workspace_kind=worktree "
+                                "for parallel tasks on the same repo."
+                            ),
+                        },
+                    )
+            continue
         # Respawn guard: refuse to re-spawn when useful work is already
         # in-flight/recent, or when the last failure is a deterministic
         # blocker (quota / auth). The guard defers the spawn this tick so
@@ -8294,6 +8358,10 @@ def _dispatch_once_locked(
                 _per_profile_running[row_assignee] = (
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
+            # Same for the shared-tree guard: a dry_run spawn still
+            # "occupies" the scratch slot for the rest of this tick.
+            if _shared_tree_root and row_workspace_kind == "scratch":
+                _running_scratch_ids.append(row["id"])
             continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
@@ -8349,6 +8417,13 @@ def _dispatch_once_locked(
                 _per_profile_running[claimed.assignee] = (
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
+            # Track spawned scratch tasks so the shared-tree guard
+            # correctly defers a second scratch task in the same tick.
+            if (
+                _shared_tree_root
+                and (claimed.workspace_kind or "scratch") == "scratch"
+            ):
+                _running_scratch_ids.append(claimed.id)
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),

--- a/tests/hermes_cli/test_kanban_shared_tree_serialization.py
+++ b/tests/hermes_cli/test_kanban_shared_tree_serialization.py
@@ -1,0 +1,225 @@
+"""Regression tests for shared-tree commit isolation (audit 2026-07-26).
+
+When a board has a git-repo ``default_workdir``, at most ONE scratch task
+may run at a time. Prevents concurrent scratch workers from editing the
+same shared checkout simultaneously — the shared-tree collision that
+intermixed 3 tasks' uncommitted work in ~/projects/NOESIS.
+
+Worktree tasks are always exempt (they get isolated checkouts at
+``<repo>/.worktrees/<id>``).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_kanban_home_with_profiles(monkeypatch):
+    """Spin up a fresh HERMES_HOME with kanban DB + alpha/beta profiles."""
+    test_home = tempfile.mkdtemp(prefix="kanban_shared_tree_test_")
+    for prof in ("alpha", "beta", "default"):
+        os.makedirs(os.path.join(test_home, "profiles", prof), exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+    yield kanban_db
+
+
+def _make_git_repo(tmp_path) -> str:
+    """Create a minimal git repo and return its absolute path."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(
+        [
+            "git", "init", "-b", "main", str(repo),
+        ],
+        check=True, capture_output=True, text=True,
+    )
+    subprocess.run(
+        [
+            "git", "-C", str(repo),
+            "-c", "user.name=Test",
+            "-c", "user.email=test@example.com",
+            "-c", "commit.gpgsign=false",
+            "commit", "--allow-empty", "-m", "init",
+        ],
+        check=True, capture_output=True, text=True,
+    )
+    return str(repo)
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+def test_no_default_workdir_no_guard(isolated_kanban_home_with_profiles):
+    """Without a board default_workdir, all scratch tasks dispatch freely."""
+    kb = isolated_kanban_home_with_profiles
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        kb.create_task(conn, title="pre-running", assignee="alpha")
+        # Set first task to running to simulate in-flight scratch worker
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'running', claim_lock = 'test:1'"
+            )
+        for i in range(3):
+            kb.create_task(conn, title=f"task-{i}", assignee="alpha")
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    assert len(res.spawned) == 3
+    assert not res.skipped_shared_tree
+
+
+def test_scratch_serialized_when_default_workdir_set(
+    isolated_kanban_home_with_profiles, tmp_path
+):
+    """With a git-repo default_workdir, a pre-running scratch task defers
+    all other scratch tasks."""
+    kb = isolated_kanban_home_with_profiles
+    repo = _make_git_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test", default_workdir=repo)
+        # One scratch task already running
+        running_id = kb.create_task(conn, title="running", assignee="alpha")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'running', claim_lock = 'test:1' "
+                "WHERE id = ?",
+                (running_id,),
+            )
+        # Two more scratch tasks ready
+        t1 = kb.create_task(conn, title="ready-1", assignee="alpha")
+        t2 = kb.create_task(conn, title="ready-2", assignee="beta")
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    assert len(res.spawned) == 0
+    assert len(res.skipped_shared_tree) == 2
+    deferred_ids = {entry[0] for entry in res.skipped_shared_tree}
+    assert deferred_ids == {t1, t2}
+
+
+def test_worktree_tasks_exempt_from_guard(
+    isolated_kanban_home_with_profiles, tmp_path
+):
+    """Worktree tasks dispatch freely even when a scratch task is running
+    on the same shared tree."""
+    kb = isolated_kanban_home_with_profiles
+    repo = _make_git_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test", default_workdir=repo)
+        # Scratch task already running
+        running_id = kb.create_task(conn, title="running-scratch", assignee="alpha")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'running', claim_lock = 'test:1' "
+                "WHERE id = ?",
+                (running_id,),
+            )
+        # Worktree task ready — should NOT be deferred
+        wt_task = kb.create_task(
+            conn, title="worktree-task", assignee="beta",
+            workspace_kind="worktree",
+        )
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    assert len(res.spawned) == 1
+    assert res.spawned[0][0] == wt_task
+    assert not res.skipped_shared_tree
+
+
+def test_first_scratch_dispatches_second_defers(
+    isolated_kanban_home_with_profiles, tmp_path
+):
+    """No pre-running tasks: first scratch task dispatches, second is
+    deferred in the SAME tick (intra-tick tracking)."""
+    kb = isolated_kanban_home_with_profiles
+    repo = _make_git_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test", default_workdir=repo)
+        t1 = kb.create_task(conn, title="first", assignee="alpha")
+        t2 = kb.create_task(conn, title="second", assignee="beta")
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    assert len(res.spawned) == 1
+    assert res.spawned[0][0] == t1
+    assert len(res.skipped_shared_tree) == 1
+    assert res.skipped_shared_tree[0][0] == t2
+
+
+def test_deferred_task_dispatches_after_running_completes(
+    isolated_kanban_home_with_profiles, tmp_path
+):
+    """A deferred scratch task should dispatch on the next tick once the
+    running scratch worker completes."""
+    kb = isolated_kanban_home_with_profiles
+    repo = _make_git_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test", default_workdir=repo)
+        running_id = kb.create_task(conn, title="running", assignee="alpha")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'running', claim_lock = 'test:1' "
+                "WHERE id = ?",
+                (running_id,),
+            )
+        ready_id = kb.create_task(conn, title="ready", assignee="alpha")
+    # Tick 1: ready task deferred
+    with kb.connect_closing() as conn:
+        res1 = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    assert len(res1.skipped_shared_tree) == 1
+    # Simulate running task completing
+    with kb.connect_closing() as conn:
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'done', claim_lock = NULL "
+                "WHERE id = ?",
+                (running_id,),
+            )
+    # Tick 2: previously deferred task now dispatches
+    with kb.connect_closing() as conn:
+        res2 = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    assert len(res2.spawned) == 1
+    assert res2.spawned[0][0] == ready_id
+    assert not res2.skipped_shared_tree
+
+
+def test_dispatch_result_has_skipped_shared_tree_field():
+    """Schema-level invariant: DispatchResult exposes the
+    skipped_shared_tree field as a list of (task_id, running_ids) tuples."""
+    from hermes_cli.kanban_db import DispatchResult
+    r = DispatchResult()
+    assert hasattr(r, "skipped_shared_tree")
+    assert r.skipped_shared_tree == []
+
+
+def test_nonexistent_default_workdir_no_guard(
+    isolated_kanban_home_with_profiles
+):
+    """A board default_workdir that doesn't exist on disk should NOT trigger
+    the guard (fails open — no serialization)."""
+    kb = isolated_kanban_home_with_profiles
+    with kb.connect_closing() as conn:
+        kb.create_board(
+            slug="default", name="Test",
+            default_workdir="/nonexistent/path/that/does/not/exist",
+        )
+        running_id = kb.create_task(conn, title="running", assignee="alpha")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'running', claim_lock = 'test:1' "
+                "WHERE id = ?",
+                (running_id,),
+            )
+        t1 = kb.create_task(conn, title="ready", assignee="beta")
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    assert len(res.spawned) == 1
+    assert not res.skipped_shared_tree


### PR DESCRIPTION
## Problem

When a kanban board has a git repository set as its `default_workdir`, multiple concurrent scratch workers that cd into the shared checkout race on the same files. Observed live on 2026-07-26 in ~/projects/NOESIS: 3 parallel scratch tasks' uncommitted work intermixed in the same tree — each worker committed half-finished state from the others.

This is adjacent to the concurrency issue described in #71650 (toolset validation ordering), but is a distinct runtime collision.

## Solution

Introduce a **shared-tree serialization guard** in _dispatch_once_locked():

- **When** a board's default_workdir is a directory on disk (git repo detection via Path check)
- **Then** at most ONE scratch task may run at a time
- **Extra** scratch tasks get a shared_tree_deferred event logged to their history and wait in ready
- **Worktree** tasks are always exempt (each has its own isolated checkout at <repo>/.worktrees/<id>)
- **Intra-tick** tracking: both dry_run spawns and real claims occupy the scratch slot for the current tick

### Detection approach

The guard checks whether default_workdir resolves to an existing directory on disk. If the path doesn't exist (e.g. unconfigured or removed), the guard fails open — all tasks dispatch normally.

### New field: DispatchResult.skipped_shared_tree

A new field on DispatchResult tracks which tasks were deferred and why, parallel to the existing skipped_locked field.

## Testing

7 regression tests added covering all edge cases:

| Test | Scenario |
|------|----------|
| test_no_default_workdir_no_guard | No default_workdir → all dispatch freely |
| test_scratch_serialized_when_default_workdir_set | Pre-running scratch defers others |
| test_worktree_tasks_exempt_from_guard | Worktree tasks bypass the guard |
| test_first_scratch_dispatches_second_defers | Intra-tick: first dispatches, second defers |
| test_deferred_task_dispatches_after_running_completes | Next-tick promotion on completion |
| test_dispatch_result_has_skipped_shared_tree_field | Schema invariant |
| test_nonexistent_default_workdir_no_guard | Nonexistent path fails open |

```
$ python3 -m pytest tests/hermes_cli/test_kanban_shared_tree_serialization.py -v
============================= 7 passed in 3.43s ==============================
```

## Related

- Kanban issue #71650 (adjacent concurrency topic)
- Real-world incident 2026-07-26: 3 scratch tasks intermixed in ~/projects/NOESIS
