### PR TITLE
fix(pairing): fail closed on approved store read errors

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -281,10 +281,11 @@ class PairingStore:
     def _rate_limit_path(self) -> Path:
         return self._dir / "_rate_limits.json"
 
-    def _load_json(self, path: Path) -> dict:
+    def _load_json_checked(self, path: Path) -> tuple[dict, bool]:
         if path.exists():
             try:
-                return json.loads(path.read_text(encoding="utf-8"))
+                data = json.loads(path.read_text(encoding="utf-8"))
+                return (data if isinstance(data, dict) else {}), True
             except PermissionError as e:
                 # Surface this loudly: a 0600 file owned by a different user
                 # (classic Docker symptom: `docker exec` runs as root and writes
@@ -308,10 +309,25 @@ class PairingStore:
                     "container so the entrypoint can fix ownership.",
                     path, euid, owner_info, e,
                 )
-                return {}
+                return {}, False
             except (json.JSONDecodeError, OSError):
-                return {}
-        return {}
+                return {}, False
+        return {}, True
+
+    def _load_json(self, path: Path) -> dict:
+        data, _ok = self._load_json_checked(path)
+        return data
+
+    def _load_json_for_write(self, path: Path) -> Optional[dict]:
+        data, ok = self._load_json_checked(path)
+        if not ok:
+            logger.warning(
+                "Refusing to update pairing store %s because the existing file "
+                "could not be read; retry after the file is readable",
+                path,
+            )
+            return None
+        return data
 
     def _save_json(self, path: Path, data: dict) -> None:
         _secure_write(path, json.dumps(data, indent=2, ensure_ascii=False))
@@ -361,9 +377,11 @@ class PairingStore:
                 results.append({"platform": p, "user_id": uid, **info})
         return results
 
-    def _approve_user(self, platform: str, user_id: str, user_name: str = "") -> None:
+    def _approve_user(self, platform: str, user_id: str, user_name: str = "") -> bool:
         """Add a user to the approved list. Must be called under self._lock."""
-        approved = self._load_json(self._approved_path(platform))
+        approved = self._load_json_for_write(self._approved_path(platform))
+        if approved is None:
+            return False
         normalized_user_id = self._normalize_user_id(platform, user_id)
         duplicate_ids = [
             approved_user_id
@@ -383,12 +401,15 @@ class PairingStore:
         # (option i), so the pairing store and the allowlist stay a single
         # visible source of truth. No-op on open gateways.
         _sync_allowlist_add(platform, normalized_user_id)
+        return True
 
     def revoke(self, platform: str, user_id: str) -> bool:
         """Remove a user from the approved list. Returns True if found."""
         path = self._approved_path(platform)
         with self._lock:
-            approved = self._load_json(path)
+            approved = self._load_json_for_write(path)
+            if approved is None:
+                return False
             matching_ids = [
                 approved_user_id
                 for approved_user_id in approved
@@ -439,7 +460,10 @@ class PairingStore:
                 return None
 
             # Check max pending
-            pending = self._load_json(self._pending_path(platform))
+            pending_path = self._pending_path(platform)
+            pending = self._load_json_for_write(pending_path)
+            if pending is None:
+                return None
             if len(pending) >= MAX_PENDING_PER_PLATFORM:
                 return None
 
@@ -495,7 +519,10 @@ class PairingStore:
             if self._is_locked_out(platform):
                 return None
 
-            pending = self._load_json(self._pending_path(platform))
+            pending_path = self._pending_path(platform)
+            pending = self._load_json_for_write(pending_path)
+            if pending is None:
+                return None
 
             # Find the entry whose hash matches the provided code.
             # Tolerate legacy plaintext-key entries (no salt/hash) and
@@ -524,12 +551,16 @@ class PairingStore:
                 self._record_failed_attempt(platform)
                 return None
 
-            del pending[matched_key]
-            self._save_json(self._pending_path(platform), pending)
-
             # Add to approved list
-            self._approve_user(platform, matched_entry["user_id"],
-                               matched_entry.get("user_name", ""))
+            if not self._approve_user(
+                platform,
+                matched_entry["user_id"],
+                matched_entry.get("user_name", ""),
+            ):
+                return None
+
+            del pending[matched_key]
+            self._save_json(pending_path, pending)
 
             return {
                 "user_id": matched_entry["user_id"],

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -418,6 +418,68 @@ class TestApprovalFlow:
         assert result["user_id"] == "user1"
         assert result["user_name"] == "Alice"
 
+    def test_approve_code_does_not_clobber_existing_approved_on_read_failure(
+        self, tmp_path
+    ):
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+            store = PairingStore()
+            code = store.generate_code("discord", "carol", "Carol")
+            approved_path = store._approved_path("discord")
+            approved_path.write_text(
+                json.dumps(
+                    {
+                        "alice": {"user_name": "Alice", "approved_at": 1},
+                        "bob": {"user_name": "Bob", "approved_at": 2},
+                    },
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+            before_approved = approved_path.read_text(encoding="utf-8")
+            pending_path = store._pending_path("discord")
+            before_pending = pending_path.read_text(encoding="utf-8")
+            original_read_text = Path.read_text
+
+            def flaky_read_text(self, *args, **kwargs):
+                if Path(self) == approved_path:
+                    raise OSError("simulated transient read failure")
+                return original_read_text(self, *args, **kwargs)
+
+            with patch.object(Path, "read_text", flaky_read_text):
+                result = store.approve_code("discord", code)
+
+            assert result is None
+            assert approved_path.read_text(encoding="utf-8") == before_approved
+            assert pending_path.read_text(encoding="utf-8") == before_pending
+
+    def test_direct_approve_user_does_not_clobber_on_read_failure(self, tmp_path):
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+            store = PairingStore()
+            approved_path = store._approved_path("discord")
+            approved_path.write_text(
+                json.dumps(
+                    {
+                        "alice": {"user_name": "Alice", "approved_at": 1},
+                        "bob": {"user_name": "Bob", "approved_at": 2},
+                    },
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+            before_approved = approved_path.read_text(encoding="utf-8")
+            original_read_text = Path.read_text
+
+            def flaky_read_text(self, *args, **kwargs):
+                if Path(self) == approved_path:
+                    raise OSError("simulated transient read failure")
+                return original_read_text(self, *args, **kwargs)
+
+            with patch.object(Path, "read_text", flaky_read_text):
+                result = store._approve_user("discord", "carol", "Carol")
+
+            assert result is False
+            assert approved_path.read_text(encoding="utf-8") == before_approved
+
     def test_approved_user_is_approved(self, tmp_path):
         with patch("gateway.pairing.PAIRING_DIR", tmp_path):
             store = PairingStore()


### PR DESCRIPTION
## Summary

Prevents PairingStore write paths from treating an unreadable existing JSON store as an empty store.

`PairingStore._load_json()` intentionally returns `{}` for read-only auth checks so an unreadable pairing file does not crash the gateway. However, the same helper was also used by read-modify-write paths such as `approve_code()`, `_approve_user()`, `revoke()`, and `generate_code()`.

That means a transient read failure on `<platform>-approved.json` could be interpreted as "no approved users", and the next approval would rewrite the approved-user file with only the newly approved user. Existing paired users would be silently removed.

## Impact

This can silently clobber gateway pairing authorization state. A platform with multiple paired users can lose the existing approved-user list during a transient read failure or ownership/readability issue, causing previously paired users to become unauthorized until manually re-approved.

## Changes

- Split pairing JSON loads into:
  - read-only load: keeps the existing `{}` fallback for auth checks
  - write-intent load: returns failure when an existing file cannot be read
- Make write paths fail closed instead of rewriting from an empty fallback.
- Keep pending approval codes intact if approval cannot safely update the approved-user store.
- Add regression coverage for both public `approve_code()` and direct `_approve_user()` write paths.

## Validation

```text
python -m pytest tests/gateway/test_pairing.py -q
53 passed, 1 skipped in 5.39s