### PR TITLE
fix(auth): harden Windows atomic store races

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -51,7 +51,15 @@ from hermes_cli.config import (
 )
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
-from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value
+from utils import (
+    _WINDOWS_FILE_RETRY_ATTEMPTS,
+    _is_windows_sharing_error,
+    _sleep_before_windows_file_retry,
+    atomic_replace,
+    atomic_yaml_write,
+    env_float,
+    is_truthy_value,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +78,12 @@ except Exception:
 
 AUTH_STORE_VERSION = 1
 AUTH_LOCK_TIMEOUT_SECONDS = 15.0
+_AUTH_STORE_LOAD_FAILED_KEY = "_auth_store_load_failed"
+_AUTH_STORE_CORRUPT_COPY_KEY = "_auth_store_corrupt_copy"
+_AUTH_STORE_METADATA_KEYS = frozenset({"version", "updated_at", "active_provider"})
+_AUTH_STORE_TOP_LEVEL_KEYS = _AUTH_STORE_METADATA_KEYS | frozenset(
+    {"providers", "credential_pool", "suppressed_sources", "systems"}
+)
 
 # Nous Portal defaults
 DEFAULT_NOUS_PORTAL_URL = "https://portal.nousresearch.com"
@@ -1117,38 +1131,228 @@ def _auth_store_lock(
         yield
 
 
+def _read_auth_store_bytes(auth_file: Path) -> Optional[bytes]:
+    """Read an auth store without misclassifying Windows sharing races.
+
+    ``None`` means the store does not exist. Persistent I/O failures propagate
+    so callers cannot silently overwrite an inaccessible credential store with
+    an empty one.
+    """
+    for attempt in range(1, _WINDOWS_FILE_RETRY_ATTEMPTS + 1):
+        try:
+            return auth_file.read_bytes()
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            if (
+                not _is_windows_sharing_error(exc)
+                or attempt == _WINDOWS_FILE_RETRY_ATTEMPTS
+            ):
+                raise
+            logger.debug(
+                "auth: transient Windows file-sharing failure while reading %s "
+                "(attempt %d/%d); retrying",
+                auth_file,
+                attempt,
+                _WINDOWS_FILE_RETRY_ATTEMPTS,
+            )
+            _sleep_before_windows_file_retry(attempt)
+    raise AssertionError("auth store retry loop exhausted without returning or raising")
+
+
+def _windows_corrupt_sidecar_security_attributes():
+    """Build a protected current-user + SYSTEM DACL for a forensic sidecar."""
+    import ntsecuritycon
+    import win32api
+    import win32con
+    import win32security
+
+    token = win32security.OpenProcessToken(
+        win32api.GetCurrentProcess(), win32con.TOKEN_QUERY
+    )
+    try:
+        current_sid = win32security.GetTokenInformation(
+            token, win32security.TokenUser
+        )[0]
+    finally:
+        token.Close()
+    system_sid = win32security.ConvertStringSidToSid("S-1-5-18")
+    acl = win32security.ACL()
+    for sid in (current_sid, system_sid):
+        acl.AddAccessAllowedAceEx(
+            win32security.ACL_REVISION,
+            0,
+            ntsecuritycon.FILE_ALL_ACCESS,
+            sid,
+        )
+    descriptor = win32security.SECURITY_DESCRIPTOR()
+    descriptor.SetSecurityDescriptorOwner(current_sid, False)
+    descriptor.SetSecurityDescriptorDacl(True, acl, False)
+    descriptor.SetSecurityDescriptorControl(
+        win32security.SE_DACL_PROTECTED,
+        win32security.SE_DACL_PROTECTED,
+    )
+    attributes = win32security.SECURITY_ATTRIBUTES()
+    attributes.SECURITY_DESCRIPTOR = descriptor
+    return attributes
+
+
+def _write_new_corrupt_sidecar_windows(corrupt_path: Path, payload: bytes) -> None:
+    """Create a Windows sidecar with its restrictive DACL applied atomically."""
+    import ntsecuritycon
+    import pywintypes
+    import win32file
+
+    try:
+        handle = win32file.CreateFile(
+            str(corrupt_path),
+            ntsecuritycon.GENERIC_WRITE,
+            0,
+            _windows_corrupt_sidecar_security_attributes(),
+            win32file.CREATE_NEW,
+            win32file.FILE_ATTRIBUTE_NORMAL,
+            None,
+        )
+    except pywintypes.error as exc:
+        if getattr(exc, "winerror", None) in {80, 183}:
+            raise FileExistsError(str(corrupt_path)) from exc
+        raise
+    try:
+        _error, written = win32file.WriteFile(handle, payload)
+        if written != len(payload):
+            raise OSError(f"short write preserving corrupt auth store: {written}/{len(payload)}")
+        win32file.FlushFileBuffers(handle)
+    except Exception:
+        win32file.CloseHandle(handle)
+        handle = None
+        try:
+            corrupt_path.unlink()
+        except OSError:
+            pass
+        raise
+    finally:
+        if handle is not None:
+            win32file.CloseHandle(handle)
+
+
+def _write_new_corrupt_sidecar(corrupt_path: Path, payload: bytes) -> None:
+    """Create one protected forensic sidecar without exposing its payload."""
+    if os.name == "nt":
+        _write_new_corrupt_sidecar_windows(corrupt_path, payload)
+        return
+
+    fd = os.open(
+        str(corrupt_path),
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        stat.S_IRUSR | stat.S_IWUSR,
+    )
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            fd = -1
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except Exception:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            corrupt_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _preserve_corrupt_auth_payload(auth_file: Path, payload: bytes) -> Path:
+    """Preserve exact invalid bytes once, keyed by their SHA-256 digest."""
+    digest = hashlib.sha256(payload).hexdigest()
+    corrupt_path = auth_file.with_name(f"{auth_file.name}.corrupt.sha256.{digest}")
+    try:
+        _write_new_corrupt_sidecar(corrupt_path, payload)
+        return corrupt_path
+    except FileExistsError:
+        existing = _read_auth_store_bytes(corrupt_path)
+        if existing == payload:
+            return corrupt_path
+        raise OSError(
+            f"corrupt auth sidecar digest collision or incomplete write: {corrupt_path}"
+        )
+
+
+def _auth_store_load_failure(
+    auth_file: Path,
+    payload: bytes,
+    exc: Exception,
+) -> Dict[str, Any]:
+    """Return a fail-closed sentinel after preserving invalid auth bytes."""
+    corrupt_path: Optional[Path] = None
+    try:
+        corrupt_path = _preserve_corrupt_auth_payload(auth_file, payload)
+        preservation_status = f"Corrupt file preserved at {corrupt_path}"
+    except Exception as preserve_exc:
+        logger.debug(
+            "auth: could not preserve invalid store %s: %s",
+            auth_file,
+            preserve_exc,
+        )
+        preservation_status = "Could not safely preserve corrupt file"
+    logger.warning(
+        "auth: invalid store %s (%s) — bounded recovery refused to overwrite it. %s",
+        auth_file,
+        exc,
+        preservation_status,
+    )
+    return {
+        "version": AUTH_STORE_VERSION,
+        "providers": {},
+        _AUTH_STORE_LOAD_FAILED_KEY: str(exc),
+        _AUTH_STORE_CORRUPT_COPY_KEY: str(corrupt_path) if corrupt_path else None,
+    }
+
+
+def _auth_store_structure_error(raw: Any) -> Optional[ValueError]:
+    """Return why parsed JSON is not a recognized auth-store structure."""
+    if not isinstance(raw, dict):
+        return ValueError("auth store top level must be an object")
+    unknown_keys = set(raw) - _AUTH_STORE_TOP_LEVEL_KEYS
+    if unknown_keys:
+        return ValueError(
+            "auth store has unrecognized top-level fields: "
+            + ", ".join(sorted(str(key) for key in unknown_keys))
+        )
+    for key in ("providers", "credential_pool", "suppressed_sources", "systems"):
+        if key in raw and not isinstance(raw[key], dict):
+            return ValueError(f"auth store field {key!r} must be an object")
+    if set(raw) <= _AUTH_STORE_METADATA_KEYS:
+        return None
+    if "systems" in raw:
+        nous_portal = raw["systems"].get("nous_portal")
+        if nous_portal is not None and not isinstance(nous_portal, dict):
+            return ValueError("auth store systems.nous_portal must be an object")
+    return None
+
+
 def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     auth_file = auth_file or _auth_file_path()
-    if not auth_file.exists():
+    payload = _read_auth_store_bytes(auth_file)
+    if payload is None:
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 
     try:
-        raw = json.loads(auth_file.read_text(encoding="utf-8"))
-    except Exception as exc:
-        corrupt_path = auth_file.with_suffix(".json.corrupt")
-        try:
-            import shutil
-            shutil.copy2(auth_file, corrupt_path)
-        except Exception:
-            pass
-        logger.warning(
-            "auth: failed to parse %s (%s) — starting with empty store. "
-            "Corrupt file preserved at %s",
-            auth_file, exc, corrupt_path,
-        )
-        return {"version": AUTH_STORE_VERSION, "providers": {}}
+        raw = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return _auth_store_load_failure(auth_file, payload, exc)
 
-    if isinstance(raw, dict) and (
-        isinstance(raw.get("providers"), dict)
-        or isinstance(raw.get("credential_pool"), dict)
-    ):
+    structure_error = _auth_store_structure_error(raw)
+    if structure_error is not None:
+        return _auth_store_load_failure(auth_file, payload, structure_error)
+
+    if "providers" in raw or "credential_pool" in raw or "systems" not in raw:
         raw.setdefault("providers", {})
-        if isinstance(raw.get("providers"), dict):
-            _migrate_stale_nous_portal_url(raw["providers"])
+        _migrate_stale_nous_portal_url(raw["providers"])
         return raw
 
     # Migrate from PR's "systems" format if present
-    if isinstance(raw, dict) and isinstance(raw.get("systems"), dict):
+    if "systems" in raw:
         systems = raw["systems"]
         providers = {}
         if "nous_portal" in systems:
@@ -1156,10 +1360,19 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
         return {"version": AUTH_STORE_VERSION, "providers": providers,
                 "active_provider": "nous" if providers else None}
 
-    return {"version": AUTH_STORE_VERSION, "providers": {}}
+    raise AssertionError("recognized auth store was not handled")
 
 
 def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = None) -> Path:
+    if auth_store.get(_AUTH_STORE_LOAD_FAILED_KEY):
+        corrupt_copy = auth_store.get(_AUTH_STORE_CORRUPT_COPY_KEY)
+        raise RuntimeError(
+            "Refusing to overwrite auth.json because it was loaded after a parse "
+            "or structure validation failure. "
+            "Recover or remove the existing auth.json first. "
+            f"Preserved copy: {corrupt_copy}"
+        )
+
     # target_path=None preserves the existing contract (write the active
     # store at _auth_file_path()). An explicit path lets callers persist a
     # specific store — e.g. the global-root write-through for rotating xAI

--- a/tests/hermes_cli/test_auth_store_read_races.py
+++ b/tests/hermes_cli/test_auth_store_read_races.py
@@ -1,0 +1,456 @@
+"""Regression tests for transient Windows auth.json sharing failures."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import json
+import multiprocessing
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import auth as auth_mod
+
+
+def _valid_store_bytes() -> bytes:
+    return json.dumps(
+        {
+            "version": 1,
+            "providers": {"test-provider": {"configured": True}},
+            "credential_pool": {"test-provider": [{"id": "slot-1"}]},
+        }
+    ).encode("utf-8")
+
+
+def _load_corrupt_store_worker(
+    auth_path: str,
+    start_event,
+    result_queue,
+) -> None:
+    """Load one shared corrupt store from an isolated spawned process."""
+    start_event.wait(timeout=10)
+    store = auth_mod._load_auth_store(Path(auth_path))
+    result_queue.put(store.get(auth_mod._AUTH_STORE_CORRUPT_COPY_KEY))
+
+
+def test_load_auth_store_retries_transient_windows_read_without_corrupt_backup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_bytes(_valid_store_bytes())
+    real_read_bytes = Path.read_bytes
+    attempts = 0
+    sleeps: list[int] = []
+
+    def locked_then_read(path: Path) -> bytes:
+        nonlocal attempts
+        attempts += 1
+        if attempts <= 2:
+            exc = OSError(errno.EACCES, "sharing violation", str(path))
+            exc.winerror = 32
+            raise exc
+        return real_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", locked_then_read)
+    monkeypatch.setattr(auth_mod, "_is_windows_sharing_error", lambda _exc: True)
+    monkeypatch.setattr(
+        auth_mod, "_sleep_before_windows_file_retry", sleeps.append
+    )
+
+    store = auth_mod._load_auth_store(auth_file)
+
+    assert attempts == 3
+    assert sleeps == [1, 2]
+    assert store["providers"]["test-provider"]["configured"] is True
+    assert store["credential_pool"]["test-provider"][0]["id"] == "slot-1"
+    assert not list(tmp_path.glob("auth.json.corrupt.*"))
+
+
+def test_load_auth_store_propagates_persistent_windows_read_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_bytes(_valid_store_bytes())
+    attempts = 0
+
+    def always_locked(_path: Path) -> bytes:
+        nonlocal attempts
+        attempts += 1
+        exc = OSError(errno.EACCES, "sharing violation", str(auth_file))
+        exc.winerror = 32
+        raise exc
+
+    monkeypatch.setattr(Path, "read_bytes", always_locked)
+    monkeypatch.setattr(auth_mod, "_is_windows_sharing_error", lambda _exc: True)
+    monkeypatch.setattr(
+        auth_mod, "_sleep_before_windows_file_retry", lambda _attempt: None
+    )
+
+    with pytest.raises(OSError) as excinfo:
+        auth_mod._load_auth_store(auth_file)
+
+    assert excinfo.value.winerror == 32
+    assert attempts == 6
+    assert not list(tmp_path.glob("auth.json.corrupt.*"))
+
+
+def test_load_auth_store_does_not_retry_permanent_io_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_bytes(_valid_store_bytes())
+    attempts = 0
+
+    def permanent_failure(_path: Path) -> bytes:
+        nonlocal attempts
+        attempts += 1
+        raise OSError(errno.EIO, "device error", str(auth_file))
+
+    monkeypatch.setattr(Path, "read_bytes", permanent_failure)
+    monkeypatch.setattr(auth_mod, "_is_windows_sharing_error", lambda _exc: False)
+
+    with pytest.raises(OSError) as excinfo:
+        auth_mod._load_auth_store(auth_file)
+
+    assert excinfo.value.errno == errno.EIO
+    assert attempts == 1
+    assert not list(tmp_path.glob("auth.json.corrupt.*"))
+
+
+@pytest.mark.parametrize("payload", [b"{not-json", b'{"providers":{"x":"\xff"}}'])
+def test_load_auth_store_preserves_exact_genuinely_invalid_payload(
+    tmp_path: Path, payload: bytes
+) -> None:
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_bytes(payload)
+
+    store = auth_mod._load_auth_store(auth_file)
+
+    assert store["version"] == auth_mod.AUTH_STORE_VERSION
+    assert store["providers"] == {}
+    assert store[auth_mod._AUTH_STORE_LOAD_FAILED_KEY]
+    backups = list(tmp_path.glob("auth.json.corrupt.*"))
+    assert len(backups) == 1
+    assert backups[0].read_bytes() == payload
+    assert store[auth_mod._AUTH_STORE_CORRUPT_COPY_KEY] == str(backups[0])
+    if os.name == "posix":
+        assert stat.S_IMODE(backups[0].stat().st_mode) == 0o600
+
+
+def test_corrupt_sidecar_is_unique_and_does_not_clobber_existing_copy(
+    tmp_path: Path,
+) -> None:
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_bytes(b"{not-json")
+    legacy_copy = tmp_path / "auth.json.corrupt.existing"
+    legacy_copy.write_bytes(b"earlier-forensic-copy")
+
+    auth_mod._load_auth_store(auth_file)
+
+    assert legacy_copy.read_bytes() == b"earlier-forensic-copy"
+    backups = list(tmp_path.glob("auth.json.corrupt.*"))
+    assert len(backups) == 2
+    assert any(path.read_bytes() == b"{not-json" for path in backups)
+
+
+def test_repeated_load_deduplicates_identical_corrupt_payload(tmp_path: Path) -> None:
+    auth_file = tmp_path / "auth.json"
+    payload = b"{same-invalid-payload"
+    auth_file.write_bytes(payload)
+    expected = tmp_path / (
+        f"auth.json.corrupt.sha256.{hashlib.sha256(payload).hexdigest()}"
+    )
+
+    first = auth_mod._load_auth_store(auth_file)
+    second = auth_mod._load_auth_store(auth_file)
+
+    assert first[auth_mod._AUTH_STORE_CORRUPT_COPY_KEY] == str(expected)
+    assert second[auth_mod._AUTH_STORE_CORRUPT_COPY_KEY] == str(expected)
+    assert list(tmp_path.glob("auth.json.corrupt.sha256.*")) == [expected]
+    assert expected.read_bytes() == payload
+
+
+def test_multiprocess_corrupt_load_deduplicates_to_one_sidecar(tmp_path: Path) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows-only O_EXCL sidecar stress")
+
+    auth_file = tmp_path / "auth.json"
+    payload = b"{" + (b"invalid-secret-material" * 32768)
+    auth_file.write_bytes(payload)
+    expected = tmp_path / (
+        f"auth.json.corrupt.sha256.{hashlib.sha256(payload).hexdigest()}"
+    )
+    context = multiprocessing.get_context("spawn")
+    start_event = context.Event()
+    result_queue = context.Queue()
+    processes = [
+        context.Process(
+            target=_load_corrupt_store_worker,
+            args=(str(auth_file), start_event, result_queue),
+        )
+        for _ in range(4)
+    ]
+    try:
+        for process in processes:
+            process.start()
+        start_event.set()
+        for process in processes:
+            process.join(timeout=20)
+
+        assert all(not process.is_alive() for process in processes)
+        assert [process.exitcode for process in processes] == [0, 0, 0, 0]
+        copies = [result_queue.get(timeout=2) for _ in processes]
+        assert copies == [str(expected)] * len(processes)
+        assert list(tmp_path.glob("auth.json.corrupt.sha256.*")) == [expected]
+        assert expected.read_bytes() == payload
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+        for process in processes:
+            process.join(timeout=5)
+        result_queue.close()
+        result_queue.join_thread()
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        [],
+        {"providers": []},
+        {"providers": {}, "credential_pool": []},
+        {"credential_pool": "invalid"},
+        {"systems": []},
+        {"systems": {"nous_portal": []}},
+        {"version": 1, "unrecognized": {}},
+    ],
+)
+def test_incompatible_json_structure_uses_same_fail_closed_sentinel(
+    tmp_path: Path, raw: object
+) -> None:
+    auth_file = tmp_path / "auth.json"
+    payload = json.dumps(raw).encode("utf-8")
+    auth_file.write_bytes(payload)
+
+    store = auth_mod._load_auth_store(auth_file)
+
+    assert store[auth_mod._AUTH_STORE_LOAD_FAILED_KEY]
+    sidecar = Path(store[auth_mod._AUTH_STORE_CORRUPT_COPY_KEY])
+    assert sidecar.read_bytes() == payload
+    with pytest.raises(RuntimeError, match="Refusing to overwrite auth.json"):
+        auth_mod._save_auth_store(store, target_path=auth_file)
+    assert auth_file.read_bytes() == payload
+
+
+def test_valid_legacy_systems_store_still_migrates(tmp_path: Path) -> None:
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(
+        json.dumps(
+            {
+                "systems": {
+                    "nous_portal": {
+                        "access_token": "test-access",
+                        "refresh_token": "test-refresh",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    store = auth_mod._load_auth_store(auth_file)
+
+    assert auth_mod._AUTH_STORE_LOAD_FAILED_KEY not in store
+    assert store["active_provider"] == "nous"
+    assert store["providers"]["nous"]["access_token"] == "test-access"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {},
+        {"version": 1},
+        {
+            "version": 1,
+            "updated_at": "2026-07-25T00:00:00+00:00",
+            "active_provider": None,
+        },
+    ],
+)
+def test_metadata_only_store_is_valid_and_normalizes_providers(
+    tmp_path: Path, raw: dict[str, object]
+) -> None:
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(json.dumps(raw), encoding="utf-8")
+
+    store = auth_mod._load_auth_store(auth_file)
+
+    assert auth_mod._AUTH_STORE_LOAD_FAILED_KEY not in store
+    assert store["providers"] == {}
+    for key, value in raw.items():
+        assert store[key] == value
+    assert not list(tmp_path.glob("auth.json.corrupt.sha256.*"))
+
+
+def test_corrupt_sidecar_has_real_protected_windows_dacl(tmp_path: Path) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows-only DACL contract")
+
+    import ntsecuritycon
+    import win32api
+    import win32con
+    import win32security
+
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_bytes(b"{invalid-with-secret-material")
+    store = auth_mod._load_auth_store(auth_file)
+    sidecar = Path(store[auth_mod._AUTH_STORE_CORRUPT_COPY_KEY])
+
+    descriptor = win32security.GetFileSecurity(
+        str(sidecar),
+        win32security.OWNER_SECURITY_INFORMATION
+        | win32security.DACL_SECURITY_INFORMATION,
+    )
+    control, _revision = descriptor.GetSecurityDescriptorControl()
+    assert control & win32security.SE_DACL_PROTECTED
+    token = win32security.OpenProcessToken(
+        win32api.GetCurrentProcess(), win32con.TOKEN_QUERY
+    )
+    try:
+        current_sid = win32security.GetTokenInformation(
+            token, win32security.TokenUser
+        )[0]
+    finally:
+        token.Close()
+    allowed = {
+        win32security.ConvertSidToStringSid(current_sid),
+        "S-1-5-18",
+    }
+    dacl = descriptor.GetSecurityDescriptorDacl()
+    assert dacl is not None
+    assert dacl.GetAceCount() == 2
+    for index in range(dacl.GetAceCount()):
+        ace = dacl.GetAce(index)
+        assert ace[0][0] == win32security.ACCESS_ALLOWED_ACE_TYPE
+        assert ace[1] == ntsecuritycon.FILE_ALL_ACCESS
+        assert win32security.ConvertSidToStringSid(ace[-1]) in allowed
+
+
+def test_windows_dacl_failure_never_writes_sidecar_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows-only DACL contract")
+
+    sidecar = tmp_path / "auth.json.corrupt.sha256.test"
+    monkeypatch.setattr(
+        auth_mod,
+        "_windows_corrupt_sidecar_security_attributes",
+        lambda: (_ for _ in ()).throw(PermissionError("DACL unavailable")),
+    )
+
+    with pytest.raises(PermissionError, match="DACL unavailable"):
+        auth_mod._write_new_corrupt_sidecar_windows(sidecar, b"credential-bytes")
+
+    assert not sidecar.exists()
+
+
+def test_load_auth_store_real_windows_handle_without_read_share(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows-only sharing semantics")
+
+    import ctypes
+    from ctypes import wintypes
+
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_bytes(_valid_store_bytes())
+    create_file = ctypes.windll.kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    close_handle = ctypes.windll.kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+    handle = create_file(
+        str(auth_file),
+        0x80000000,  # GENERIC_READ
+        0x00000002 | 0x00000004,  # FILE_SHARE_WRITE | FILE_SHARE_DELETE
+        None,
+        3,  # OPEN_EXISTING
+        0,
+        None,
+    )
+    assert handle != wintypes.HANDLE(-1).value
+    released = False
+
+    def release_lock(_attempt: int) -> None:
+        nonlocal released
+        if released:
+            return
+        assert close_handle(handle)
+        released = True
+
+    monkeypatch.setattr(auth_mod, "_sleep_before_windows_file_retry", release_lock)
+    try:
+        store = auth_mod._load_auth_store(auth_file)
+    finally:
+        if not released:
+            close_handle(handle)
+
+    assert released, "the first real read must observe the exclusive handle"
+    assert store["providers"]["test-provider"]["configured"] is True
+
+
+def test_save_auth_store_refuses_active_store_loaded_after_parse_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth_file = tmp_path / "auth.json"
+    monkeypatch.setattr(auth_mod, "_auth_file_path", lambda: auth_file)
+    original = b"{not-json"
+    auth_file.write_bytes(original)
+    store = auth_mod._load_auth_store()
+    store.setdefault("credential_pool", {})["test-provider"] = [{"id": "new"}]
+
+    with pytest.raises(RuntimeError, match="Refusing to overwrite auth.json"):
+        auth_mod._save_auth_store(store)
+
+    assert auth_file.read_bytes() == original
+
+
+def test_save_auth_store_refuses_explicit_target_loaded_after_parse_failure(
+    tmp_path: Path,
+) -> None:
+    auth_file = tmp_path / "global-auth.json"
+    original = b"{not-json"
+    auth_file.write_bytes(original)
+    store = auth_mod._load_auth_store(auth_file)
+    store.setdefault("credential_pool", {})["test-provider"] = [{"id": "new"}]
+
+    with pytest.raises(RuntimeError, match="Refusing to overwrite auth.json"):
+        auth_mod._save_auth_store(store, target_path=auth_file)
+
+    assert auth_file.read_bytes() == original
+
+
+def test_load_auth_store_missing_file_is_empty_without_corrupt_backup(
+    tmp_path: Path,
+) -> None:
+    auth_file = tmp_path / "auth.json"
+
+    assert auth_mod._load_auth_store(auth_file) == {
+        "version": auth_mod.AUTH_STORE_VERSION,
+        "providers": {},
+    }
+    assert not list(tmp_path.glob("auth.json.corrupt.*"))

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import errno
 import json
+import multiprocessing
 import os
 import sys
 from pathlib import Path
@@ -41,6 +42,12 @@ def _write_tmp(dir_: Path, content: str) -> Path:
     tmp = dir_ / ".src.tmp"
     tmp.write_text(content, encoding="utf-8")
     return tmp
+
+
+def _atomic_write_worker(path: str, worker_id: int, iterations: int) -> None:
+    """Exercise the real atomic writer from a spawned Windows process."""
+    for sequence in range(iterations):
+        atomic_json_write(path, {"worker": worker_id, "sequence": sequence})
 
 
 def test_atomic_replace_preserves_symlink(tmp_path: Path) -> None:
@@ -309,16 +316,194 @@ def test_atomic_replace_other_oserror_propagates(
     target.write_text("old\n", encoding="utf-8")
     tmp = _write_tmp(tmp_path, "new\n")
 
+    replace_calls = 0
+
     def fail_replace(src: str, dst: str) -> None:
+        nonlocal replace_calls
+        replace_calls += 1
         raise OSError(errno.EACCES, os.strerror(errno.EACCES), src, None, dst)
 
     monkeypatch.setattr("utils.os.replace", fail_replace)
+    monkeypatch.setattr("utils._is_windows", lambda: False)
 
     with pytest.raises(OSError) as excinfo:
         atomic_replace(tmp, target)
     assert excinfo.value.errno == errno.EACCES
+    assert replace_calls == 1
     assert target.read_text(encoding="utf-8") == "old\n"
     assert tmp.exists()
+
+
+def test_atomic_replace_retries_two_windows_sharing_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "auth.json"
+    target.write_text("old", encoding="utf-8")
+    tmp = _write_tmp(tmp_path, "new")
+    real_replace = os.replace
+    attempts = 0
+    sleeps: list[int] = []
+
+    def sharing_then_success(src: str, dst: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts <= 2:
+            exc = OSError(errno.EACCES, "sharing violation", src, None, dst)
+            exc.winerror = 32
+            raise exc
+        real_replace(src, dst)
+
+    monkeypatch.setattr("utils._is_windows", lambda: True)
+    monkeypatch.setattr("utils.os.replace", sharing_then_success)
+    monkeypatch.setattr(
+        "utils._sleep_before_windows_file_retry", sleeps.append
+    )
+
+    assert Path(atomic_replace(tmp, target)) == target
+    assert attempts == 3
+    assert sleeps == [1, 2]
+    assert target.read_text(encoding="utf-8") == "new"
+    assert not tmp.exists()
+
+
+@pytest.mark.parametrize("winerror", [5, 32, 33])
+def test_atomic_replace_exhausts_windows_sharing_retries_without_touching_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, winerror: int
+) -> None:
+    target = tmp_path / "auth.json"
+    target.write_text("preserve-me", encoding="utf-8")
+    tmp = _write_tmp(tmp_path, "replacement")
+    attempts = 0
+
+    def always_locked(src: str, dst: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        exc = OSError(errno.EACCES, "locked", src, None, dst)
+        exc.winerror = winerror
+        raise exc
+
+    monkeypatch.setattr("utils._is_windows", lambda: True)
+    monkeypatch.setattr("utils.os.replace", always_locked)
+    monkeypatch.setattr("utils._sleep_before_windows_file_retry", lambda _attempt: None)
+
+    with pytest.raises(OSError) as excinfo:
+        atomic_replace(tmp, target)
+
+    assert excinfo.value.winerror == winerror
+    assert attempts == 6
+    assert target.read_text(encoding="utf-8") == "preserve-me"
+    assert tmp.read_text(encoding="utf-8") == "replacement"
+
+
+@pytest.mark.parametrize("fail_errno", [errno.EACCES, errno.EPERM])
+def test_atomic_replace_retries_windows_errno_fallbacks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fail_errno: int
+) -> None:
+    target = tmp_path / "state.json"
+    target.write_text("old", encoding="utf-8")
+    tmp = _write_tmp(tmp_path, "new")
+    attempts = 0
+
+    def always_denied(src: str, dst: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise OSError(fail_errno, os.strerror(fail_errno), src, None, dst)
+
+    monkeypatch.setattr("utils._is_windows", lambda: True)
+    monkeypatch.setattr("utils.os.replace", always_denied)
+    monkeypatch.setattr("utils._sleep_before_windows_file_retry", lambda _attempt: None)
+
+    with pytest.raises(OSError):
+        atomic_replace(tmp, target)
+    assert attempts == 6
+    assert target.read_text(encoding="utf-8") == "old"
+
+
+def test_atomic_replace_real_windows_handle_without_delete_share(tmp_path: Path) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows-only sharing semantics")
+
+    import ctypes
+    from ctypes import wintypes
+    from unittest.mock import patch
+
+    target = tmp_path / "auth.json"
+    target.write_text("old", encoding="utf-8")
+    tmp = _write_tmp(tmp_path, "new")
+
+    create_file = ctypes.windll.kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    close_handle = ctypes.windll.kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+
+    handle = create_file(
+        str(target),
+        0x80000000,  # GENERIC_READ
+        0x00000001 | 0x00000002,  # FILE_SHARE_READ | FILE_SHARE_WRITE
+        None,
+        3,  # OPEN_EXISTING
+        0,
+        None,
+    )
+    assert handle != wintypes.HANDLE(-1).value
+
+    released = False
+
+    def release_lock(_attempt: int) -> None:
+        nonlocal released
+        if released:
+            return
+        assert close_handle(handle)
+        released = True
+
+    try:
+        with patch("utils._sleep_before_windows_file_retry", release_lock):
+            atomic_replace(tmp, target)
+    finally:
+        if not released:
+            close_handle(handle)
+
+    assert released, "the first real replace must observe the exclusive handle"
+    assert target.read_text(encoding="utf-8") == "new"
+
+
+def test_atomic_json_write_windows_multiprocess_stress(tmp_path: Path) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows-only sharing stress")
+
+    target = tmp_path / "shared.json"
+    target.write_text("{}", encoding="utf-8")
+    context = multiprocessing.get_context("spawn")
+    processes = [
+        context.Process(target=_atomic_write_worker, args=(str(target), worker_id, 25))
+        for worker_id in range(4)
+    ]
+    try:
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=20)
+
+        assert all(not process.is_alive() for process in processes)
+        assert [process.exitcode for process in processes] == [0, 0, 0, 0]
+        final = json.loads(target.read_text(encoding="utf-8"))
+        assert set(final) == {"worker", "sequence"}
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+        for process in processes:
+            process.join(timeout=5)
 
 
 def test_atomic_replace_real_cross_device(tmp_path: Path) -> None:

--- a/utils.py
+++ b/utils.py
@@ -4,9 +4,11 @@ import errno
 import json
 import logging
 import os
+import random
 import shutil
 import stat
 import tempfile
+import time
 from pathlib import Path
 from typing import Any, Union
 from urllib.parse import urlparse
@@ -17,6 +19,44 @@ logger = logging.getLogger(__name__)
 
 
 TRUTHY_STRINGS = frozenset({"1", "true", "yes", "on"})
+
+_WINDOWS_FILE_RETRY_ATTEMPTS = 6
+_WINDOWS_FILE_RETRY_BASE_DELAY_SECONDS = 0.025
+_WINDOWS_FILE_RETRY_MAX_DELAY_SECONDS = 0.4
+_WINDOWS_SHARING_WINERRORS = frozenset({5, 32, 33})
+_WINDOWS_SHARING_ERRNOS = frozenset({errno.EACCES, errno.EPERM})
+
+
+def _is_windows() -> bool:
+    """Return whether Windows file-sharing semantics apply."""
+    return os.name == "nt"
+
+
+def _is_windows_sharing_error(exc: OSError) -> bool:
+    """Identify transient Windows access and sharing violations.
+
+    CPython exposes native Windows failures through ``winerror`` when
+    available, while some filesystems and wrappers only populate ``errno``.
+    Restricting the errno fallback to Windows avoids retrying ordinary POSIX
+    permission failures. WinError 5 is included for real-world filter-driver
+    behavior, but callers bound it to six attempts because access denial can
+    also be permanent.
+    """
+    if not _is_windows():
+        return False
+    return (
+        getattr(exc, "winerror", None) in _WINDOWS_SHARING_WINERRORS
+        or exc.errno in _WINDOWS_SHARING_ERRNOS
+    )
+
+
+def _sleep_before_windows_file_retry(failed_attempt: int) -> None:
+    """Apply bounded exponential backoff with a small collision jitter."""
+    delay = min(
+        _WINDOWS_FILE_RETRY_BASE_DELAY_SECONDS * (2 ** (failed_attempt - 1)),
+        _WINDOWS_FILE_RETRY_MAX_DELAY_SECONDS,
+    )
+    time.sleep(delay + random.uniform(0.0, delay * 0.25))
 
 
 def is_truthy_value(value: Any, default: bool = False) -> bool:
@@ -101,9 +141,10 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     This helper resolves the symlink first so ``os.replace`` writes to
     the real file in-place while the symlink survives.  For non-symlink
     and non-existent paths the behavior is identical to a plain
-    ``os.replace`` call unless the rename fails with ``EXDEV`` or ``EBUSY``;
-    those cases fall back to copy/fsync/unlink for cross-device, bind-mount,
-    and busy-file deployments.
+    ``os.replace`` call. On Windows, transient access/sharing violations are
+    retried with bounded backoff. ``EXDEV`` and ``EBUSY`` retain their existing
+    copy/fsync/unlink fallback for cross-device, bind-mount, and busy-file
+    deployments.
 
     Returns the resolved real path used for the replace, so callers that
     need to re-apply permissions can target it instead of the symlink.
@@ -111,16 +152,35 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     target_str = str(target)
     real_path = os.path.realpath(target_str) if os.path.islink(target_str) else target_str
     tmp_str = str(tmp_path)
-    try:
-        os.replace(tmp_str, real_path)
-    except OSError as exc:
-        if exc.errno not in (errno.EXDEV, errno.EBUSY):
-            raise
+    fallback_exc: OSError | None = None
+    for attempt in range(1, _WINDOWS_FILE_RETRY_ATTEMPTS + 1):
+        try:
+            os.replace(tmp_str, real_path)
+            return real_path
+        except OSError as exc:
+            # Preserve the established cross-device/busy-file fallback. EBUSY
+            # is intentionally not part of the Windows sharing retry class.
+            if exc.errno in (errno.EXDEV, errno.EBUSY):
+                fallback_exc = exc
+                break
+            if not _is_windows_sharing_error(exc) or attempt == _WINDOWS_FILE_RETRY_ATTEMPTS:
+                raise
+            logger.debug(
+                "atomic_replace: transient Windows file-sharing failure "
+                "for %s -> %s (attempt %d/%d); retrying",
+                tmp_str,
+                real_path,
+                attempt,
+                _WINDOWS_FILE_RETRY_ATTEMPTS,
+            )
+            _sleep_before_windows_file_retry(attempt)
+
+    if fallback_exc is not None:
         logger.debug(
             "atomic_replace: %s -> %s failed with %s; falling back to copy",
             tmp_str,
             real_path,
-            errno.errorcode.get(exc.errno, exc.errno),
+            errno.errorcode.get(fallback_exc.errno, fallback_exc.errno),
         )
         shutil.copyfile(tmp_str, real_path)
         try:


### PR DESCRIPTION
## Summary

Fix two coupled Windows auth-store failure modes:

- retry bounded access/sharing failures around `atomic_replace()` without changing POSIX, symlink, `EXDEV`, or `EBUSY` behavior;
- stop `_load_auth_store()` from treating transient I/O as JSON corruption and returning an empty credential store.

The auth loader now reads bytes with the same bounded Windows policy, propagates persistent I/O failures, preserves genuinely invalid payloads once in a content-addressed private sidecar, and marks the in-memory store so later active-path or explicit `target_path` saves fail closed.

## Why

On Windows, replacing or moving an open destination requires compatible sharing. A short-lived handle held by Desktop, gateway, cron, antivirus, or an indexer can otherwise surface as `WinError 5`, `32`, or `33`. Microsoft documents the applicable sharing requirement for open destinations: https://learn.microsoft.com/en-us/windows/win32/fileio/moving-and-replacing-files

The previous broad exception handler in `_load_auth_store()` then compounded that write race: any read error was labeled corruption, copied to a fixed `.corrupt` path, and converted into an empty store. That could make `setup.status` and `setup.runtime_check` disagree and expose a later destructive rewrite path.

## Behavior

- Six attempts on Windows only for the observed bounded access/sharing class, with exponential backoff and jitter under one second total.
- Permanent non-matching errors and all POSIX permission errors propagate immediately.
- Existing symlink resolution and `EXDEV`/`EBUSY` copy fallback are preserved.
- Persistent auth-store I/O propagates; it never becomes an empty store or a corruption sidecar.
- Malformed or structurally incompatible JSON is preserved byte-for-byte in one SHA-256-addressed sidecar.
- Windows sidecars are created with a protected current-user + SYSTEM DACL before any credential bytes are written; POSIX remains `0600`.
- Parse/structure failure adds an in-memory sentinel that blocks both regular and explicit-target saves.
- Existing empty/metadata-only stores and legacy `systems` migration remain compatible.

## Validation

- Official runner, focused Windows coverage: 44 passed after rebasing on current `main`.
- Applicable matrix: atomic JSON/YAML, auth/xAI OAuth, credential pool/write-through, cron jobs/cross-process locking, and runtime provider resolution all pass; the final compatibility rerun was 125/125.
- Real Windows handle tests cover replacement without `FILE_SHARE_DELETE` and auth reads without `FILE_SHARE_READ`.
- Multiprocess stress covers concurrent atomic writes and content-addressed sidecar deduplication.
- Fresh-eyes security review: 0 critical, high, medium, or low findings.
- `ruff`, `compileall`, `git diff --check`, and `pip check` pass.

## Provenance

This integrates and extends prior work rather than hiding it:

- builds on the first reported retry patch in #36921;
- incorporates the Windows-only jitter/test matrix from #45022 while retaining #43852's current `EXDEV`/`EBUSY` flow;
- extends the fail-closed auth-store work in #46421 with bounded Windows read retries, structural validation, content-addressed deduplication, and a Windows DACL created before payload write.

The corresponding authors are credited as co-authors in the commit. Maintainers can close or retain the earlier PRs as they prefer.
