### PR TITLE
fix(tools): close session_search-owned SessionDB handles

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -1216,6 +1216,65 @@ class TestRewindExclusion:
         assert result_rewind["count"] == 0
 
 
+class TestSessionSearchConnectionLifetime:
+    class _ClosableDB:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    def test_owned_default_db_closes_after_success(self, monkeypatch):
+        fake_db = self._ClosableDB()
+
+        import hermes_state
+        import tools.session_search_tool as session_search_mod
+
+        monkeypatch.setattr(hermes_state, "SessionDB", lambda: fake_db)
+        monkeypatch.setattr(
+            session_search_mod,
+            "_list_recent_sessions",
+            lambda *args, **kwargs: json.dumps({"success": True}),
+        )
+
+        assert json.loads(session_search())["success"] is True
+        assert fake_db.closed is True
+
+    def test_owned_default_db_closes_after_exception(self, monkeypatch):
+        fake_db = self._ClosableDB()
+
+        import hermes_state
+        import tools.session_search_tool as session_search_mod
+
+        monkeypatch.setattr(hermes_state, "SessionDB", lambda: fake_db)
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(session_search_mod, "_list_recent_sessions", boom)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            session_search()
+        assert fake_db.closed is True
+
+    def test_profile_db_closes_without_closing_caller_db(self, monkeypatch):
+        caller_db = self._ClosableDB()
+        profile_db = self._ClosableDB()
+
+        import tools.session_search_tool as session_search_mod
+
+        monkeypatch.setattr(session_search_mod, "_resolve_profile_db", lambda profile: profile_db)
+        monkeypatch.setattr(
+            session_search_mod,
+            "_list_recent_sessions",
+            lambda *args, **kwargs: json.dumps({"success": True}),
+        )
+
+        assert json.loads(session_search(db=caller_db, profile="work"))["success"] is True
+        assert caller_db.closed is False
+        assert profile_db.closed is True
+
+
 class TestCompressionEndedHelper:
     """Unit tests for _is_compression_ended."""
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -66,6 +66,14 @@ _COMPACTION_PREFIXES = (
 )
 
 
+def _close_session_search_dbs(dbs: List[Any]) -> None:
+    for db in reversed(dbs):
+        try:
+            db.close()
+        except Exception:
+            logging.debug("Failed to close session_search SessionDB", exc_info=True)
+
+
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
     """Convert a Unix timestamp (float/int) or ISO string to a human-readable date.
 
@@ -823,27 +831,60 @@ def session_search(
 
     Discovery: pass ``query``.
     Scroll:    pass ``session_id`` + ``around_message_id``.
-    Read:      pass ``session_id`` (no anchor) — dumps the whole session.
+    Read:      pass ``session_id`` (no anchor) - dumps the whole session.
     Browse:    pass nothing.
 
     Pass ``profile`` to read another profile's sessions (e.g. resolving an
     ``@session:<profile>/<id>`` link). Scroll wins over read/discovery when an
-    anchor is set — the agent has asked for a specific slice.
+    anchor is set - the agent has asked for a specific slice.
     """
+    owned_dbs: List[Any] = []
     if db is None:
         try:
             from hermes_state import SessionDB
             db = SessionDB()
+            owned_dbs.append(db)
         except Exception:
             logging.debug("SessionDB unavailable for session_search", exc_info=True)
             from hermes_state import format_session_db_unavailable
             return tool_error(format_session_db_unavailable(), success=False)
 
+    try:
+        return _session_search_with_db(
+            query=query,
+            role_filter=role_filter,
+            limit=limit,
+            db=db,
+            current_session_id=current_session_id,
+            session_id=session_id,
+            around_message_id=around_message_id,
+            window=window,
+            sort=sort,
+            profile=profile,
+            owned_dbs=owned_dbs,
+        )
+    finally:
+        _close_session_search_dbs(owned_dbs)
+
+
+def _session_search_with_db(
+    *,
+    query: str = "",
+    role_filter: str = None,
+    limit: int = 3,
+    db,
+    current_session_id: str = None,
+    session_id: str = None,
+    around_message_id: int = None,
+    window: int = 5,
+    sort: str = None,
+    profile: str = None,
+    owned_dbs: List[Any],
+) -> str:
     # Normalise a raw `@session:<profile>/<id>` link value passed as session_id.
-    # Session ids never contain "/", so a slash unambiguously means profile/id —
-    # always strip the prefix off the id, and adopt the embedded profile only
-    # when one wasn't passed explicitly. Handles every permutation the model
-    # might send (full value as id, with or without a separate profile=).
+    # Session ids never contain "/", so a slash unambiguously means profile/id.
+    # Always strip the prefix off the id, and adopt the embedded profile only
+    # when one was not passed explicitly.
     if isinstance(session_id, str) and "/" in session_id:
         emb_profile, _, emb_id = session_id.partition("/")
         if emb_id:
@@ -861,9 +902,10 @@ def session_search(
             return tool_error(f"profile '{profile}': {e}", success=False)
         if profile_db is not None:
             db = profile_db
+            owned_dbs.append(profile_db)
             current_session_id = None
 
-    # Scroll shape takes precedence — explicit anchor beats any query.
+    # Scroll shape takes precedence - explicit anchor beats any query.
     if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
         return _scroll(
             db=db,
@@ -873,14 +915,14 @@ def session_search(
             current_session_id=current_session_id,
         )
 
-    # Read shape: a session_id with no anchor → dump the whole session.
+    # Read shape: a session_id with no anchor -> dump the whole session.
     if isinstance(session_id, str) and session_id.strip():
         sid = session_id.strip()
         result = _read_session(db, sid, link_profile=profile)
         if json.loads(result).get("success"):
             return result
 
-        # Miss in the target profile — the model may have dropped the owning
+        # Miss in the target profile - the model may have dropped the owning
         # profile from the link. Scan every profile and read it from wherever
         # it lives, tagging the profile it was found in.
         located, owner = _locate_session_db(sid)
@@ -902,7 +944,7 @@ def session_search(
             limit = 3
     limit = max(1, min(limit, 10))
 
-    # Browse shape: no query → recent sessions.
+    # Browse shape: no query -> recent sessions.
     if not query or not isinstance(query, str) or not query.strip():
         return _list_recent_sessions(db, limit, current_session_id, link_profile=profile)
 
@@ -927,7 +969,6 @@ def session_search(
         current_session_id=current_session_id,
         link_profile=profile,
     )
-
 
 def check_session_search_requirements() -> bool:
     """Requires the SQLite state database."""


### PR DESCRIPTION
## Summary

`session_search` now closes the `SessionDB` handles it opens internally.

## Why

`session_search()` opens a fresh `SessionDB()` whenever the caller does not provide one. That path is used by the model-facing `session_search` tool, so repeated recall calls inside long-running agent/gateway processes can accumulate SQLite file descriptors.

The same function also swaps to a read-only profile database when `profile=` is supplied. That profile-owned DB was likewise not closed on the normal return paths.

## Changes

- Track only the database handles owned by `session_search`.
- Close owned handles in a `finally` block across success and exception paths.
- Preserve the existing caller-owned `db=` contract: externally supplied DB objects are not closed.
- Close profile DB handles opened through the cross-profile lookup path.
- Add regression coverage for:
  - default owned DB closes after success
  - default owned DB closes after exceptions
  - profile DB closes while caller-supplied DB remains open

## Validation

```text
python -m pytest tests/tools/test_session_search.py -k "ConnectionLifetime" -q
3 passed, 92 deselected

python -m pytest tests/tools/test_session_search.py -q
95 passed

python -m py_compile tools/session_search_tool.py tests/tools/test_session_search.py
ruff check tools/session_search_tool.py tests/tools/test_session_search.py