### PR TITLE
fix(gateway): route webhook approvals by delivery id 🩷

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -427,6 +427,51 @@ class WebhookAdapter(BasePlatformAdapter):
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         return {"name": chat_id, "type": "webhook"}
 
+    def approval_delivery_context(self, chat_id: str) -> Dict[str, str]:
+        """Describe the actual chat receiving an approval forwarded by this webhook."""
+        delivery = self._delivery_info.get(chat_id, {})
+        platform_name = str(delivery.get("deliver", "webhook"))
+        context = {
+            "platform": "webhook",
+            "chat_id": str(chat_id or ""),
+            "thread_id": "",
+            "typed_command_prefix": self.typed_command_prefix,
+        }
+        try:
+            target_platform = Platform(platform_name)
+        except ValueError:
+            return context
+        if not self.gateway_runner:
+            return context
+
+        adapter = self.gateway_runner.adapters.get(target_platform)
+        if not adapter:
+            for adapter_map in (
+                getattr(self.gateway_runner, "_profile_adapters", None) or {}
+            ).values():
+                if isinstance(adapter_map, dict) and adapter_map.get(target_platform):
+                    adapter = adapter_map[target_platform]
+                    break
+        if not adapter:
+            return context
+
+        extra = delivery.get("deliver_extra", {})
+        target_chat_id = extra.get("chat_id", "")
+        if not target_chat_id:
+            home = self.gateway_runner.config.get_home_channel(target_platform)
+            target_chat_id = home.chat_id if home else ""
+        if not target_chat_id:
+            return context
+
+        return {
+            "platform": target_platform.value,
+            "chat_id": str(target_chat_id),
+            "thread_id": str(
+                extra.get("message_thread_id") or extra.get("thread_id") or ""
+            ),
+            "typed_command_prefix": getattr(adapter, "typed_command_prefix", "/"),
+        }
+
     # ------------------------------------------------------------------
     # HTTP handlers
     # ------------------------------------------------------------------

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -452,6 +452,7 @@ def _format_exec_approval_fallback(
     description: str,
     command_prefix: str,
     *,
+    approval_id: str | None = None,
     allow_permanent: bool = True,
     allow_session: bool = True,
     smart_denied: bool = False,
@@ -462,14 +463,20 @@ def _format_exec_approval_fallback(
     if smart_denied:
         heading = "⚠️ **Smart DENY — owner override for one operation:**"
 
-    choices = [f"Reply `{command_prefix}approve` to execute this one operation"]
+    approve_target = (
+        f"{command_prefix}approve {approval_id}"
+        if approval_id
+        else f"{command_prefix}approve"
+    )
+    choices = [f"Reply `{approve_target}` to execute this one operation"]
     if not smart_denied and allow_session:
         choices.append(
-            f"`{command_prefix}approve session` to approve this pattern for the session"
+            f"`{approve_target} session` to approve this pattern for the session"
         )
         if allow_permanent:
-            choices.append(f"`{command_prefix}approve always` to approve permanently")
-    choices.append(f"`{command_prefix}deny` to cancel")
+            choices.append(f"`{approve_target} always` to approve permanently")
+    deny_target = f"{command_prefix}deny {approval_id}" if approval_id else f"{command_prefix}deny"
+    choices.append(f"`{deny_target}` to cancel")
     return (
         f"{heading}\n```\n{cmd_preview}\n```\nReason: {description}\n\n"
         + ", ".join(choices[:-1]) + f", or {choices[-1]}."
@@ -21961,6 +21968,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # The callback bridges sync→async to send the approval request
             # to the user immediately.
             from tools.approval import (
+                bind_gateway_approval_recipient,
                 register_gateway_notify,
                 reset_current_session_key,
                 set_current_session_key,
@@ -21986,6 +21994,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
+                approval_id = approval_data.get("approval_id")
+                approval_context = {
+                    "platform": source.platform.value,
+                    "chat_id": str(_status_chat_id or ""),
+                    "thread_id": str(getattr(source, "thread_id", None) or ""),
+                    "typed_command_prefix": getattr(
+                        _status_adapter, "typed_command_prefix", "/"
+                    ),
+                }
+                context_resolver = getattr(
+                    _status_adapter, "approval_delivery_context", None
+                )
+                if callable(context_resolver):
+                    resolved_context = context_resolver(_status_chat_id)
+                    if isinstance(resolved_context, dict):
+                        approval_context.update(resolved_context)
+                _p = str(approval_context.get("typed_command_prefix") or "/")
+                interactive_desc = desc
+                if approval_id:
+                    bind_gateway_approval_recipient(
+                        approval_id,
+                        str(approval_context.get("platform") or ""),
+                        str(approval_context.get("chat_id") or ""),
+                        str(approval_context.get("thread_id") or ""),
+                    )
+                    interactive_desc += (
+                        f"\n\nIf buttons are unavailable, reply "
+                        f"`{_p}approve {approval_id}` or `{_p}deny {approval_id}`."
+                    )
 
                 # Redact credentials from the command before displaying it in
                 # the approval prompt — Tirith's findings are already redacted,
@@ -22005,7 +22042,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 chat_id=_status_chat_id,
                                 command=cmd,
                                 session_key=_approval_session_key,
-                                description=desc,
+                                description=interactive_desc,
                                 metadata=_status_thread_metadata,
                                 allow_permanent=approval_data.get("allow_permanent", True),
                                 allow_session=approval_data.get("allow_session", True),
@@ -22033,11 +22070,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # typed prefix so Slack/Matrix users are told the form they
                 # can actually type (`!approve`) — typed "/" is blocked in
                 # Slack threads and reserved by Matrix clients.
-                _p = getattr(_status_adapter, "typed_command_prefix", "/")
                 msg = _format_exec_approval_fallback(
                     cmd,
                     desc,
                     _p,
+                    approval_id=approval_id,
                     allow_permanent=approval_data.get("allow_permanent", True),
                     allow_session=approval_data.get("allow_session", True),
                     smart_denied=approval_data.get("smart_denied", False),

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4765,19 +4765,42 @@ class GatewaySlashCommandsMixin:
         session_key = self._session_key_for_source(source)
 
         from tools.approval import (
-            resolve_gateway_approval, has_blocking_approval,
+            resolve_gateway_approval, resolve_gateway_approval_by_id,
+            has_blocking_approval, gateway_approval_recipient_matches,
         )
 
-        if not has_blocking_approval(session_key):
+        # Addressable approval ids let an operator answer from the delivery
+        # session when the guarded run belongs to a different session (e.g.
+        # webhook -> Telegram). Bare /approve retains same-session semantics.
+        args = event.get_command_args().strip().lower().split()
+        approval_id_candidate = (
+            args[0]
+            if args and len(args[0]) == 16
+            and all(c in "0123456789abcdef" for c in args[0])
+            else None
+        )
+        approval_id = (
+            approval_id_candidate
+            if approval_id_candidate and gateway_approval_recipient_matches(
+                approval_id_candidate,
+                source.platform.value,
+                source.chat_id,
+                getattr(source, "thread_id", None),
+            )
+            else None
+        )
+        has_pending = (
+            True if approval_id else has_blocking_approval(session_key)
+        )
+        if not has_pending:
             if session_key in self._pending_approvals:
                 self._pending_approvals.pop(session_key)
                 return t("gateway.approval_expired")
             return t("gateway.approve.no_pending")
 
         # Parse args: support "all", "all session", "all always", "session", "always"
-        args = event.get_command_args().strip().lower().split()
         resolve_all = "all" in args
-        remaining = [a for a in args if a != "all"]
+        remaining = [a for a in args if a != "all" and a != approval_id]
 
         if any(a in {"always", "permanent", "permanently"} for a in remaining):
             choice = "always"
@@ -4786,7 +4809,10 @@ class GatewaySlashCommandsMixin:
         else:
             choice = "once"
 
-        count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
+        if approval_id:
+            count = resolve_gateway_approval_by_id(approval_id, choice)
+        else:
+            count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
         if not count:
             return t("gateway.approve.no_pending")
 
@@ -4814,10 +4840,34 @@ class GatewaySlashCommandsMixin:
         session_key = self._session_key_for_source(source)
 
         from tools.approval import (
-            resolve_gateway_approval, has_blocking_approval,
+            resolve_gateway_approval, resolve_gateway_approval_by_id,
+            has_blocking_approval, gateway_approval_recipient_matches,
         )
 
-        if not has_blocking_approval(session_key):
+        # A 16-character hex token is an addressable approval id; other
+        # text remains a legacy free-form deny reason.
+        raw_args = event.get_command_args().strip()
+        tokens = raw_args.split()
+        approval_id_candidate = (
+            tokens[0].lower()
+            if tokens and len(tokens[0]) == 16
+            and all(c in "0123456789abcdef" for c in tokens[0].lower())
+            else None
+        )
+        approval_id = (
+            approval_id_candidate
+            if approval_id_candidate and gateway_approval_recipient_matches(
+                approval_id_candidate,
+                source.platform.value,
+                source.chat_id,
+                getattr(source, "thread_id", None),
+            )
+            else None
+        )
+        has_pending = (
+            True if approval_id else has_blocking_approval(session_key)
+        )
+        if not has_pending:
             if session_key in self._pending_approvals:
                 self._pending_approvals.pop(session_key)
                 return t("gateway.deny.stale")
@@ -4826,10 +4876,10 @@ class GatewaySlashCommandsMixin:
         # Parse args: a leading "all" token denies every pending command;
         # anything after it (or the whole arg string when "all" is absent) is
         # captured verbatim as the optional deny reason relayed to the agent.
-        raw_args = event.get_command_args().strip()
-        tokens = raw_args.split()
         resolve_all = bool(tokens) and tokens[0].lower() == "all"
-        if resolve_all:
+        if approval_id:
+            reason = " ".join(tokens[1:]).strip()
+        elif resolve_all:
             reason = raw_args[len(tokens[0]):].strip()
         else:
             reason = raw_args
@@ -4837,10 +4887,15 @@ class GatewaySlashCommandsMixin:
         if reason:
             reason = reason[:280].strip()
 
-        count = resolve_gateway_approval(
-            session_key, "deny", resolve_all=resolve_all,
-            reason=reason or None,
-        )
+        if approval_id:
+            count = resolve_gateway_approval_by_id(
+                approval_id, "deny", reason=reason or None,
+            )
+        else:
+            count = resolve_gateway_approval(
+                session_key, "deny", resolve_all=resolve_all,
+                reason=reason or None,
+            )
         if not count:
             return t("gateway.deny.no_pending")
 

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -186,3 +186,16 @@ class TestApprovalTextFallbackContract:
         )
         assert "`/approve session`" in text
         assert "`/approve always`" in text
+
+    def test_addressable_prompt_includes_id_for_cross_session_delivery(self):
+        from gateway.run import _format_exec_approval_fallback
+
+        text = _format_exec_approval_fallback(
+            "curl https://example.test | python3",
+            "pipe to interpreter",
+            "/",
+            approval_id="a1b2c3d4e5f60718",
+        )
+        assert "`/approve a1b2c3d4e5f60718`" in text
+        assert "`/approve a1b2c3d4e5f60718 session`" in text
+        assert "`/deny a1b2c3d4e5f60718`" in text

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -70,6 +70,7 @@ def _clear_approval_state():
     """Reset all module-level approval state between tests."""
     from tools import approval as mod
     mod._gateway_queues.clear()
+    mod._gateway_approval_ids.clear()
     mod._gateway_notify_cbs.clear()
     mod._session_approved.clear()
     mod._permanent_approved.clear()
@@ -261,6 +262,90 @@ class TestApproveCommand:
         assert "No pending command" in result
 
     @pytest.mark.asyncio
+    async def test_approve_id_resolves_cross_session_approval(self, monkeypatch):
+        from tools import approval as approval_mod
+
+        monkeypatch.setattr(approval_mod, "_get_approval_timeout", lambda: 2)
+        runner = _make_runner()
+        notified = []
+        result_holder = {}
+
+        def _notify(data):
+            approval_mod.bind_gateway_approval_recipient(
+                data["approval_id"], "telegram", "c1"
+            )
+            notified.append(data)
+
+        def _wait_for_decision():
+            result_holder["decision"] = approval_mod._await_gateway_decision(
+                "webhook:route:delivery-1",
+                _notify,
+                {
+                    "command": "rm -rf .git",
+                    "description": "recursive delete",
+                    "pattern_key": "rm_recursive",
+                },
+            )
+
+        t = threading.Thread(target=_wait_for_decision)
+        t.start()
+        for _ in range(50):
+            if notified:
+                break
+            time.sleep(0.02)
+        assert notified
+        approval_id = notified[0]["approval_id"]
+
+        result = await runner._handle_approve_command(
+            _make_event(f"/approve {approval_id}")
+        )
+        t.join(timeout=5)
+
+        assert result is not None
+        assert "approved" in result.lower()
+        assert result_holder["decision"]["resolved"] is True
+        assert result_holder["decision"]["choice"] == "once"
+
+    @pytest.mark.asyncio
+    async def test_approve_unknown_arg_keeps_legacy_same_session_behavior(self):
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        runner = _make_runner()
+        session_key = runner._session_key_for_source(_make_source())
+        entry = _ApprovalEntry({"command": "test"})
+        _gateway_queues[session_key] = [entry]
+
+        await runner._handle_approve_command(_make_event("/approve nonsense"))
+
+        assert entry.result == "once"
+        assert entry.event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_approve_id_rejects_a_different_delivery_chat(self):
+        from tools.approval import (
+            _ApprovalEntry,
+            _gateway_approval_ids,
+            _gateway_queues,
+            bind_gateway_approval_recipient,
+        )
+
+        runner = _make_runner()
+        origin_key = "webhook:route:delivery-other"
+        approval_id = "0123456789abcdef"
+        entry = _ApprovalEntry({"command": "test", "approval_id": approval_id})
+        _gateway_queues[origin_key] = [entry]
+        _gateway_approval_ids[approval_id] = (origin_key, entry)
+        bind_gateway_approval_recipient(approval_id, "telegram", "another-chat")
+
+        result = await runner._handle_approve_command(
+            _make_event(f"/approve {approval_id}")
+        )
+
+        assert result is not None
+        assert "No pending command" in result
+        assert not entry.event.is_set()
+
+    @pytest.mark.asyncio
     async def test_approve_stale_old_style_pending(self):
         """Old-style _pending_approvals without blocking event reports expired."""
         runner = _make_runner()
@@ -299,6 +384,33 @@ class TestDenyCommand:
         assert "denied" in result.lower()
         assert entry.event.is_set()
         assert entry.result == "deny"
+
+    @pytest.mark.asyncio
+    async def test_deny_id_resolves_cross_session_approval_with_reason(self):
+        from tools.approval import (
+            _ApprovalEntry,
+            _gateway_approval_ids,
+            _gateway_queues,
+            bind_gateway_approval_recipient,
+        )
+
+        runner = _make_runner()
+        origin_key = "webhook:route:delivery-2"
+        entry = _ApprovalEntry({"command": "test", "approval_id": "deadbeefcafefeed"})
+        _gateway_queues[origin_key] = [entry]
+        _gateway_approval_ids["deadbeefcafefeed"] = (origin_key, entry)
+        bind_gateway_approval_recipient("deadbeefcafefeed", "telegram", "c1")
+
+        result = await runner._handle_deny_command(
+            _make_event("/deny deadbeefcafefeed not authorized")
+        )
+
+        assert result is not None
+        assert "denied" in result.lower()
+        assert entry.result == "deny"
+        assert entry.reason == "not authorized"
+        assert entry.event.is_set()
+        assert origin_key not in _gateway_queues
 
     @pytest.mark.asyncio
     async def test_deny_all_resolves_all(self):

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -1497,6 +1497,26 @@ class TestDeliverCrossPlatformThreadId:
             "12345", "hello", metadata=None
         )
 
+    def test_approval_delivery_context_uses_forwarded_platform_prefix(self):
+        """Approval instructions must use the destination adapter's alias."""
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        mock_target.typed_command_prefix = "!"
+        getattr(adapter.gateway_runner, "adapters")[Platform("slack")] = mock_target
+        chat_id = "webhook:test:d-prefix"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "slack",
+            "deliver_extra": {"chat_id": "C1", "thread_id": "T1"},
+        }
+
+        context = adapter.approval_delivery_context(chat_id)
+
+        assert context == {
+            "platform": "slack",
+            "chat_id": "C1",
+            "thread_id": "T1",
+            "typed_command_prefix": "!",
+        }
+
 
 class TestInsecureNoAuthSafetyRail:
     """connect() refuses to start when INSECURE_NO_AUTH is combined with a

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -2252,6 +2252,7 @@ class TestApprovalTimeoutIsNotConsent:
         """Reset module state and force a tight approval timeout for fast tests."""
         from tools import approval as mod
         mod._gateway_queues.clear()
+        mod._gateway_approval_ids.clear()
         mod._gateway_notify_cbs.clear()
         mod._session_approved.clear()
         mod._permanent_approved.clear()
@@ -2275,6 +2276,7 @@ class TestApprovalTimeoutIsNotConsent:
     def teardown_method(self):
         from tools import approval as mod
         mod._gateway_queues.clear()
+        mod._gateway_approval_ids.clear()
         mod._gateway_notify_cbs.clear()
         for k, v in self._saved_env.items():
             if v is None:
@@ -2362,6 +2364,37 @@ class TestApprovalTimeoutIsNotConsent:
         assert "Silence is not consent" not in r["message"]  # this one IS denied, not timed-out
         assert "NOT consented" in r["message"]
         assert "rephrase" in r["message"].lower()
+
+    def test_addressable_approval_can_be_resolved_from_another_session(self, monkeypatch):
+        """Webhook-delivered approvals must not depend on the reply session key."""
+        from tools import approval as mod
+
+        self._force_short_timeout(monkeypatch, seconds=60)
+        notified = []
+        mod.register_gateway_notify("webhook:route:delivery", lambda data: notified.append(data))
+        result_holder = {}
+
+        def _check():
+            token = mod.set_current_session_key("webhook:route:delivery")
+            try:
+                result_holder["r"] = mod.check_all_command_guards(
+                    "rm -rf .git", "local"
+                )
+            finally:
+                mod.reset_current_session_key(token)
+
+        t = threading.Thread(target=_check)
+        t.start()
+        for _ in range(50):
+            if notified:
+                break
+            time.sleep(0.02)
+        assert notified and len(notified[0]["approval_id"]) == 16
+        approval_id = notified[0]["approval_id"]
+        assert mod.resolve_gateway_approval_by_id(approval_id, "once") == 1
+        t.join(timeout=5)
+        assert result_holder["r"]["approved"] is True
+        assert not mod.has_gateway_approval_id(approval_id)
 
     def test_timeout_emits_post_hook_with_timeout_outcome(self, monkeypatch):
         """Plugins must be able to distinguish timeout from explicit deny.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -15,6 +15,7 @@ import hashlib
 import logging
 import os
 import re
+import secrets
 import shlex
 import sys
 import tempfile
@@ -2042,6 +2043,7 @@ class _ApprovalEntry:
 
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
+_gateway_approval_ids: dict[str, tuple[str, _ApprovalEntry]] = {}
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
 
 
@@ -2066,6 +2068,10 @@ def unregister_gateway_notify(session_key: str) -> None:
     with _lock:
         _gateway_notify_cbs.pop(session_key, None)
         entries = _gateway_queues.pop(session_key, [])
+        for entry in entries:
+            approval_id = entry.data.get("approval_id")
+            if approval_id:
+                _gateway_approval_ids.pop(approval_id, None)
     for entry in entries:
         entry.event.set()
 
@@ -2097,6 +2103,10 @@ def resolve_gateway_approval(session_key: str, choice: str,
             targets = [queue.pop(0)]
         if not queue:
             _gateway_queues.pop(session_key, None)
+        for entry in targets:
+            approval_id = entry.data.get("approval_id")
+            if approval_id:
+                _gateway_approval_ids.pop(approval_id, None)
 
     for entry in targets:
         entry.result = choice
@@ -2104,6 +2114,76 @@ def resolve_gateway_approval(session_key: str, choice: str,
             entry.reason = reason
         entry.event.set()
     return len(targets)
+
+
+def has_gateway_approval_id(approval_id: str) -> bool:
+    """Return whether an addressable approval is still pending."""
+    with _lock:
+        return approval_id in _gateway_approval_ids
+
+
+def bind_gateway_approval_recipient(
+    approval_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+) -> bool:
+    """Bind an addressable approval to the chat where its prompt is delivered."""
+    with _lock:
+        target = _gateway_approval_ids.get(approval_id)
+        if target is None:
+            return False
+        target[1].data["approval_recipient"] = {
+            "platform": str(platform or ""),
+            "chat_id": str(chat_id or ""),
+            "thread_id": str(thread_id or ""),
+        }
+        return True
+
+
+def gateway_approval_recipient_matches(
+    approval_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+) -> bool:
+    """Return whether *approval_id* was delivered to this command surface."""
+    with _lock:
+        target = _gateway_approval_ids.get(approval_id)
+        if target is None:
+            return False
+        recipient = target[1].data.get("approval_recipient")
+        if not isinstance(recipient, dict):
+            return False
+        return recipient == {
+            "platform": str(platform or ""),
+            "chat_id": str(chat_id or ""),
+            "thread_id": str(thread_id or ""),
+        }
+
+
+def resolve_gateway_approval_by_id(
+    approval_id: str,
+    choice: str,
+    *,
+    reason: Optional[str] = None,
+) -> int:
+    """Resolve one pending approval from any authorized gateway session."""
+    with _lock:
+        target = _gateway_approval_ids.pop(approval_id, None)
+        if target is None:
+            return 0
+        session_key, entry = target
+        queue = _gateway_queues.get(session_key, [])
+        if entry in queue:
+            queue.remove(entry)
+        if not queue:
+            _gateway_queues.pop(session_key, None)
+    entry.result = choice
+    if reason:
+        entry.reason = reason
+    entry.event.set()
+    return 1
 
 
 def has_blocking_approval(session_key: str) -> bool:
@@ -2149,6 +2229,10 @@ def clear_session(session_key: str) -> None:
         _session_yolo.discard(session_key)
         _pending.pop(session_key, None)
         entries = _gateway_queues.pop(session_key, [])
+        for entry in entries:
+            approval_id = entry.data.get("approval_id")
+            if approval_id:
+                _gateway_approval_ids.pop(approval_id, None)
     for entry in entries:
         # Session-boundary cleanup should cancel any blocked approval waits
         # immediately so the old run can unwind instead of idling until timeout.
@@ -3082,15 +3166,21 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
 
+    approval_data = dict(approval_data)
+    approval_data.setdefault("approval_id", secrets.token_hex(8))
     entry = _ApprovalEntry(approval_data)
     with _lock:
         _gateway_queues.setdefault(session_key, []).append(entry)
+        _gateway_approval_ids[approval_data["approval_id"]] = (session_key, entry)
 
     def _drop_entry() -> None:
         with _lock:
             queue = _gateway_queues.get(session_key, [])
             if entry in queue:
                 queue.remove(entry)
+            approval_id = entry.data.get("approval_id")
+            if approval_id:
+                _gateway_approval_ids.pop(approval_id, None)
             if not queue:
                 _gateway_queues.pop(session_key, None)
 


### PR DESCRIPTION
## Summary

Fixes #71571.

Webhook-triggered agent runs can deliver approval prompts to another platform (for example Telegram), while the pending approval remains keyed by the webhook session. Bare `/approve` therefore looks in the delivery session and cannot unblock the waiting webhook run.

This change gives each gateway approval a cryptographically random 128-bit address, includes the address in typed fallback instructions, and binds it to the actual destination platform/chat/thread. `/approve <id>` and `/deny <id>` resolve the correct origin approval only when issued from the bound delivery surface. Same-session commands and legacy `/approve`, `/approve session`, `/approve always`, and `/deny <reason>` behavior remain unchanged.

Webhook forwarding also uses the destination adapter's command prefix, including `!approve` for Slack/Matrix contexts.

## Verification

- `scripts/run_tests.sh tests/gateway/test_approve_deny_commands.py tests/gateway/test_approval_prompt_redaction.py tests/gateway/test_webhook_adapter.py -q` — 142 passed
- Cross-session approval integration regression — passed
- Ruff, `py_compile`, and `git diff --check` — passed
- `tests/tools/test_approval.py` has one pre-existing macOS `/tmp` verification-artifact failure on clean `origin/main`; the same failure reproduces on the baseline and is unrelated to this patch.
