### PR TITLE
fix(tools): add native vision fast-path to camofox_vision

### DIFF
--- a/tests/tools/test_camofox_native_vision_fast_path.py
+++ b/tests/tools/test_camofox_native_vision_fast_path.py
@@ -65,6 +65,35 @@ class TestCamofoxVisionFastPath:
         assert "screenshot_path" in result.get("meta", {})
         assert "Screenshot path:" in result.get("text_summary", "")
 
+    def test_native_fast_path_preserves_annotation_context(self):
+        """annotate=True → element refs appear in the native envelope text."""
+        fake_snapshot = {"snapshot": "[@e1] button 'Submit'\n[@e2] link 'Home'"}
+        with (
+            patch.object(browser_camofox, "_get_session", return_value=_fake_session()),
+            patch.object(
+                browser_camofox, "_camofox_private_page_block", return_value=None
+            ),
+            patch.object(
+                browser_camofox, "_get_raw", return_value=_fake_response(_TINY_PNG)
+            ),
+            patch.object(browser_camofox, "_get", return_value=fake_snapshot),
+            patch(
+                "tools.vision_tools._should_use_native_vision_fast_path",
+                return_value=True,
+            ),
+        ):
+            result = camofox_vision("what buttons are there?", annotate=True)
+
+        assert isinstance(result, dict)
+        assert result.get("_multimodal") is True
+        text_part = next(
+            p["text"] for p in result["content"] if p.get("type") == "text"
+        )
+        # Annotation context must be present for element interaction.
+        assert "Accessibility tree" in text_part
+        assert "[@e1]" in text_part
+        assert "button 'Submit'" in text_part
+
     def test_text_only_model_falls_back_to_aux_llm(self):
         """No native vision → delegates to the auxiliary vision LLM."""
         fake_llm_response = SimpleNamespace(

--- a/tests/tools/test_camofox_native_vision_fast_path.py
+++ b/tests/tools/test_camofox_native_vision_fast_path.py
@@ -1,0 +1,95 @@
+"""Tests for the native-vision fast path inside camofox_vision.
+
+When the active main model supports native vision, ``camofox_vision`` must
+attach the screenshot directly as a multimodal tool-result envelope (so the
+main model sees the pixels on its next turn) instead of delegating to the
+auxiliary vision LLM.  This mirrors the fast path already present in
+``browser_tool.browser_vision`` and keeps the two backends consistent.
+"""
+
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tools import browser_camofox
+from tools.browser_camofox import camofox_vision
+
+
+# Minimal valid 1x1 PNG bytes.
+_TINY_PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+)
+
+
+def _fake_session():
+    return {"tab_id": "tab-123", "user_id": "ashu"}
+
+
+def _fake_response(content: bytes) -> SimpleNamespace:
+    return SimpleNamespace(content=content)
+
+
+class TestCamofoxVisionFastPath:
+    """Verify camofox_vision chooses fast-path vs aux-LLM correctly."""
+
+    def test_native_capable_model_returns_multimodal_envelope(self):
+        """Main model supports native vision → screenshot attached directly."""
+        with (
+            patch.object(browser_camofox, "_get_session", return_value=_fake_session()),
+            patch.object(
+                browser_camofox, "_camofox_private_page_block", return_value=None
+            ),
+            patch.object(
+                browser_camofox, "_get_raw", return_value=_fake_response(_TINY_PNG)
+            ),
+            patch(
+                "tools.vision_tools._should_use_native_vision_fast_path",
+                return_value=True,
+            ),
+        ):
+            result = camofox_vision("what does it say?")
+
+        # Fast path returns the multimodal envelope (dict), NOT a JSON string.
+        assert isinstance(result, dict)
+        assert result.get("_multimodal") is True
+        parts = result["content"]
+        assert any(p.get("type") == "image_url" for p in parts)
+        assert any(p.get("type") == "text" for p in parts)
+        url = next(
+            p["image_url"]["url"] for p in parts if p.get("type") == "image_url"
+        )
+        assert url.startswith("data:image/png;base64,")
+        # Screenshot path is surfaced in meta + text_summary for sharing.
+        assert "screenshot_path" in result.get("meta", {})
+        assert "Screenshot path:" in result.get("text_summary", "")
+
+    def test_text_only_model_falls_back_to_aux_llm(self):
+        """No native vision → delegates to the auxiliary vision LLM."""
+        fake_llm_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="a gray page"))]
+        )
+        with (
+            patch.object(browser_camofox, "_get_session", return_value=_fake_session()),
+            patch.object(
+                browser_camofox, "_camofox_private_page_block", return_value=None
+            ),
+            patch.object(
+                browser_camofox, "_get_raw", return_value=_fake_response(_TINY_PNG)
+            ),
+            patch(
+                "tools.vision_tools._should_use_native_vision_fast_path",
+                return_value=False,
+            ),
+            patch("agent.auxiliary_client.call_llm", return_value=fake_llm_response),
+        ):
+            result = camofox_vision("what does it say?")
+
+        # Aux path returns a JSON string with the analysis text.
+        import json
+
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert parsed.get("success") is True
+        assert parsed.get("analysis") == "a gray page"

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -894,6 +894,10 @@ def camofox_vision(question: str, annotate: bool = False,
                 image_data_url=data_url,
                 image_size_bytes=len(resp.content),
             )
+            # Preserve annotation context (element refs) in the native
+            # envelope so the model can still interact with annotated elements.
+            if annotation_context:
+                native_result["content"][0]["text"] += annotation_context
             meta = native_result.setdefault("meta", {})
             meta["screenshot_path"] = screenshot_path
             native_result["text_summary"] = (

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -31,7 +31,7 @@ import logging
 import os
 import threading
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 import requests
@@ -833,7 +833,7 @@ def camofox_get_images(task_id: Optional[str] = None) -> str:
 
 
 def camofox_vision(question: str, annotate: bool = False,
-                   task_id: Optional[str] = None) -> str:
+                   task_id: Optional[str] = None) -> Union[str, Dict[str, Any]]:
     """Take a screenshot and analyze it with vision AI via Camofox."""
     try:
         session = _get_session(task_id)
@@ -879,6 +879,28 @@ def camofox_vision(question: str, annotate: bool = False,
         # text-based accessibility tree snippet won't leak secret values.
         from agent.redact import redact_sensitive_text
         annotation_context = redact_sensitive_text(annotation_context)
+
+        # Native fast-path: attach screenshot directly when the main model
+        # supports vision, bypassing the auxiliary LLM entirely.
+        from tools.vision_tools import (
+            _build_native_vision_tool_result,
+            _should_use_native_vision_fast_path,
+        )
+        if _should_use_native_vision_fast_path():
+            data_url = f"data:image/png;base64,{img_b64}"
+            native_result = _build_native_vision_tool_result(
+                image_url=screenshot_path,
+                question=question,
+                image_data_url=data_url,
+                image_size_bytes=len(resp.content),
+            )
+            meta = native_result.setdefault("meta", {})
+            meta["screenshot_path"] = screenshot_path
+            native_result["text_summary"] = (
+                f"{native_result.get('text_summary', '')} "
+                f"Screenshot path: {screenshot_path}"
+            ).strip()
+            return native_result
 
         # Send to vision LLM
         from agent.auxiliary_client import call_llm


### PR DESCRIPTION
## What does this PR do?

When `CAMOFOX_URL` is set, `browser_vision()` early-returns to `camofox_vision()` (line 4053 of `browser_tool.py`). Unlike the main `browser_vision()` path (lines 4211–4233), `camofox_vision()` has **no native vision fast-path** — it always delegates screenshot analysis to the auxiliary vision LLM via `call_llm()`, even when the active main model supports native vision (`supports_vision: true`).

This means users with vision-capable models still get auxiliary-LLM delegation when using the Camofox backend, resulting in:
- Extra latency (an auxiliary round-trip on every screenshot)
- Information loss (a text description instead of the raw pixels)
- Inconsistent behavior versus the main browser path

This PR adds the same `_should_use_native_vision_fast_path()` check to `camofox_vision()` that `browser_vision()` already uses. When the main model is vision-capable, the screenshot is attached directly as a multimodal tool-result envelope — no auxiliary call, no information loss, and consistent behavior across both browser backends.

## Related Issue

<!-- No existing issue found for this specific gap. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/browser_camofox.py`: Added the native vision fast-path to `camofox_vision()` before the `call_llm()` fallback, mirroring `browser_tool.browser_vision()`.
- `tools/browser_camofox.py`: Updated the return type annotation to `Union[str, Dict[str, Any]]` (the native path returns a multimodal dict envelope) and added `Union` to the typing imports.
- `tests/tools/test_camofox_native_vision_fast_path.py`: New tests covering both the fast-path (multimodal envelope) and the aux-LLM fallback.

## How to Test

1. Configure a vision-capable main model via a custom provider with `supports_vision: true`, and set `CAMOFOX_URL` so the browser tools route through Camofox.
2. Call `browser_navigate` to any page, then `browser_vision`.
3. **Before:** the tool returns `{"success": true, "analysis": "..."}` (auxiliary LLM text, ~15s).
4. **After:** the tool returns a multimodal envelope (`_multimodal: true`) with the screenshot attached directly, and the main model inspects the pixels on its next turn (~2s).

Unit tests:
```bash
pytest tests/tools/test_camofox_native_vision_fast_path.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Debian-based LXC), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Test run:
```
tests/tools/test_camofox_native_vision_fast_path.py::TestCamofoxVisionFastPath::test_native_capable_model_returns_multimodal_envelope PASSED
tests/tools/test_camofox_native_vision_fast_path.py::TestCamofoxVisionFastPath::test_text_only_model_falls_back_to_aux_llm PASSED
2 passed in 0.13s
```

Existing vision fast-path tests still pass: `21 passed in 3.40s`.
