### PR TITLE
feat(kanban): add lifetime idempotency keys

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -327,7 +327,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           help="Park in triage — a specifier will flesh out the spec and promote to todo")
     p_create.add_argument("--idempotency-key", default=None,
                           help="Dedup key. If a non-archived task with this key exists, "
-                               "its id is returned instead of creating a duplicate.")
+                               "its id is returned instead of creating a duplicate. "
+                               "Use lifetime-v1:<namespace>:<token> to retain uniqueness "
+                               "after terminal/archive states.")
     p_create.add_argument("--max-runtime", default=None,
                           help="Per-task runtime cap. Accepts seconds (300) or "
                                "durations (90s, 30m, 2h, 1d). When exceeded, "
@@ -398,7 +400,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_swarm.add_argument("--tenant", default=None, help="Tenant namespace")
     p_swarm.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
     p_swarm.add_argument("--created-by", default=None, help="Creator/anchor profile")
-    p_swarm.add_argument("--idempotency-key", default=None, help="Dedup key for the root card")
+    p_swarm.add_argument(
+        "--idempotency-key",
+        default=None,
+        help="Dedup key for the root card; lifetime-v1:<namespace>:<token> "
+        "retains uniqueness after terminal/archive states",
+    )
     p_swarm.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- list ---

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2989,11 +2989,8 @@ def create_task(
             )
         skills_list = cleaned
 
-    # Idempotency check — return the existing task instead of creating a
-    # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
+    # Idempotency fast path — avoid taking a write lock for ordinary retries.
+    # Concurrent creators must recheck after entering write_txn below.
     if idempotency_key:
         row = conn.execute(
             "SELECT id FROM tasks WHERE idempotency_key = ? "
@@ -3031,6 +3028,16 @@ def create_task(
         task_id = _new_task_id()
         try:
             with write_txn(conn):
+                if idempotency_key:
+                    row = conn.execute(
+                        "SELECT id FROM tasks WHERE idempotency_key = ? "
+                        "AND status != 'archived' "
+                        "ORDER BY created_at DESC LIMIT 1",
+                        (idempotency_key,),
+                    ).fetchone()
+                    if row:
+                        return row["id"]
+
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -133,6 +133,11 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+LIFETIME_IDEMPOTENCY_PREFIX = "lifetime-v1:"
+LIFETIME_IDEMPOTENCY_KEY_RE = re.compile(
+    r"^lifetime-v1:[a-z0-9][a-z0-9._-]{0,63}:[A-Za-z0-9._~-]{1,256}$"
+)
+LIFETIME_IDEMPOTENCY_INDEX = "idx_tasks_idempotency_lifetime"
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 KANBAN_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024
@@ -2383,6 +2388,30 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
     )
+    duplicate_lifetime_keys = conn.execute(
+        "SELECT idempotency_key, COUNT(*) AS duplicate_count FROM tasks "
+        "WHERE idempotency_key >= ? AND idempotency_key < ? "
+        "GROUP BY idempotency_key HAVING COUNT(*) > 1 "
+        "ORDER BY idempotency_key LIMIT 10",
+        (LIFETIME_IDEMPOTENCY_PREFIX, "lifetime-v1;"),
+    ).fetchall()
+    if duplicate_lifetime_keys:
+        keys = ", ".join(
+            f"{row['idempotency_key']!r} ({row['duplicate_count']} rows)"
+            for row in duplicate_lifetime_keys
+        )
+        raise RuntimeError(
+            "cannot enable lifetime idempotency: duplicate lifetime idempotency "
+            f"key(s) already exist: {keys}. Resolve the duplicate rows before retrying."
+        )
+    # Prefix-range predicate keeps legacy keys unchanged while making every
+    # lifetime-v1 key unique across all statuses, including archived rows.
+    conn.execute(
+        f"CREATE UNIQUE INDEX IF NOT EXISTS {LIFETIME_IDEMPOTENCY_INDEX} "
+        "ON tasks(idempotency_key) "
+        "WHERE idempotency_key >= 'lifetime-v1:' "
+        "AND idempotency_key < 'lifetime-v1;'"
+    )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
@@ -2770,6 +2799,54 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+def _is_lifetime_idempotency_key(key: Optional[str]) -> bool:
+    return isinstance(key, str) and key.startswith(LIFETIME_IDEMPOTENCY_PREFIX)
+
+
+def _validate_idempotency_key(key: Optional[str]) -> None:
+    if _is_lifetime_idempotency_key(key) and not LIFETIME_IDEMPOTENCY_KEY_RE.fullmatch(key):
+        raise ValueError(
+            "lifetime-v1 idempotency keys must use "
+            "lifetime-v1:<namespace>:<token> with a lowercase namespace and "
+            "a URL-safe token"
+        )
+
+
+def _find_idempotent_task_id(
+    conn: sqlite3.Connection,
+    key: str,
+    *,
+    lifetime: bool,
+) -> Optional[str]:
+    status_clause = "" if lifetime else "AND status != 'archived' "
+    row = conn.execute(
+        "SELECT id FROM tasks WHERE idempotency_key = ? "
+        f"{status_clause}ORDER BY created_at DESC LIMIT 1",
+        (key,),
+    ).fetchone()
+    return row["id"] if row else None
+
+
+def _record_duplicate_suppression(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    idempotency_key: str,
+    requested_title: str,
+    requested_by: Optional[str],
+) -> None:
+    _append_event(
+        conn,
+        task_id,
+        "duplicate_suppressed",
+        {
+            "idempotency_key": idempotency_key,
+            "requested_title": requested_title,
+            "requested_by": requested_by,
+        },
+    )
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -2808,8 +2885,9 @@ def create_task(
 
     If ``idempotency_key`` is provided and a non-archived task with the
     same key already exists, returns the existing task's id instead of
-    creating a duplicate. Useful for retried webhooks / automation that
-    should not double-write.
+    creating a duplicate. Keys using ``lifetime-v1:<namespace>:<token>``
+    remain unique across every status, including archived, and record a
+    ``duplicate_suppressed`` event on the canonical task.
 
     ``max_runtime_seconds`` caps how long a worker may run before the
     dispatcher SIGTERMs (then SIGKILLs after a grace window) and
@@ -2832,13 +2910,39 @@ def create_task(
     board can supply the repo and branch convention. Its literal worktree is
     never reused; the new task still gets its own task-id-keyed path.
     """
+    if not title or not title.strip():
+        raise ValueError("title is required")
+    _validate_idempotency_key(idempotency_key)
+    lifetime_idempotency = _is_lifetime_idempotency_key(idempotency_key)
+
+    # Lifetime identity wins over every optional route-shape field. A renamed or
+    # malformed replacement for an existing packet must converge on the
+    # canonical task before provider/assignee/status/worktree/project/skill
+    # validation can turn it into a fresh failure path. The insertion
+    # transaction below rechecks after this early miss, preserving race safety
+    # for first creation.
+    if lifetime_idempotency and idempotency_key:
+        with write_txn(conn):
+            existing_task_id = _find_idempotent_task_id(
+                conn,
+                idempotency_key,
+                lifetime=True,
+            )
+            if existing_task_id:
+                _record_duplicate_suppression(
+                    conn,
+                    existing_task_id,
+                    idempotency_key=idempotency_key,
+                    requested_title=title.strip(),
+                    requested_by=created_by,
+                )
+                return existing_task_id
+
     model_override = (model_override or "").strip() or None
     provider_override = (provider_override or "").strip() or None
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
     assignee = _canonical_assignee(assignee)
-    if not title or not title.strip():
-        raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
         raise ValueError(
             f"initial_status must be one of {sorted(VALID_INITIAL_STATUSES)}"
@@ -2990,16 +3094,16 @@ def create_task(
         skills_list = cleaned
 
     # Idempotency fast path — avoid taking a write lock for ordinary retries.
-    # Concurrent creators must recheck after entering write_txn below.
-    if idempotency_key:
-        row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
-            "AND status != 'archived' "
-            "ORDER BY created_at DESC LIMIT 1",
-            (idempotency_key,),
-        ).fetchone()
-        if row:
-            return row["id"]
+    # Lifetime keys always enter write_txn so duplicate_suppressed is durable.
+    # Concurrent creators recheck after entering write_txn below.
+    if idempotency_key and not lifetime_idempotency:
+        existing_task_id = _find_idempotent_task_id(
+            conn,
+            idempotency_key,
+            lifetime=False,
+        )
+        if existing_task_id:
+            return existing_task_id
 
     now = int(time.time())
 
@@ -3029,14 +3133,21 @@ def create_task(
         try:
             with write_txn(conn):
                 if idempotency_key:
-                    row = conn.execute(
-                        "SELECT id FROM tasks WHERE idempotency_key = ? "
-                        "AND status != 'archived' "
-                        "ORDER BY created_at DESC LIMIT 1",
-                        (idempotency_key,),
-                    ).fetchone()
-                    if row:
-                        return row["id"]
+                    existing_task_id = _find_idempotent_task_id(
+                        conn,
+                        idempotency_key,
+                        lifetime=lifetime_idempotency,
+                    )
+                    if existing_task_id:
+                        if lifetime_idempotency:
+                            _record_duplicate_suppression(
+                                conn,
+                                existing_task_id,
+                                idempotency_key=idempotency_key,
+                                requested_title=title.strip(),
+                                requested_by=created_by,
+                            )
+                        return existing_task_id
 
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
@@ -3149,10 +3260,34 @@ def create_task(
                     },
                 )
             return task_id
-        except sqlite3.IntegrityError:
+        except sqlite3.IntegrityError as exc:
+            if lifetime_idempotency and idempotency_key:
+                existing_task_id = _find_idempotent_task_id(
+                    conn,
+                    idempotency_key,
+                    lifetime=True,
+                )
+                if existing_task_id:
+                    with write_txn(conn):
+                        canonical_task_id = _find_idempotent_task_id(
+                            conn,
+                            idempotency_key,
+                            lifetime=True,
+                        )
+                        if canonical_task_id:
+                            _record_duplicate_suppression(
+                                conn,
+                                canonical_task_id,
+                                idempotency_key=idempotency_key,
+                                requested_title=title.strip(),
+                                requested_by=created_by,
+                            )
+                            return canonical_task_id
+            if str(exc) != "UNIQUE constraint failed: tasks.id":
+                raise
             if attempt == 1:
                 raise
-            # Retry with a fresh id.
+            # Retry only a genuine task-id collision with a fresh id.
             continue
     raise RuntimeError("unreachable")
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -68,6 +68,72 @@ def test_idempotency_key_returns_existing_task(kanban_home):
         conn.close()
 
 
+def test_idempotency_key_is_atomic_across_concurrent_creates(kanban_home):
+    key = "concurrent-create"
+    connections_ready = threading.Barrier(3)
+    start_create = threading.Event()
+    prechecks_complete = [threading.Event(), threading.Event()]
+    writes_attempted = [threading.Event(), threading.Event()]
+    results = [None, None]
+    errors = []
+
+    def create(index):
+        conn = kb.connect()
+        try:
+            def trace(statement):
+                normalized = " ".join(statement.lower().split())
+                if normalized.startswith(
+                    "select id from tasks where idempotency_key"
+                ):
+                    prechecks_complete[index].set()
+                elif normalized == "begin immediate":
+                    writes_attempted[index].set()
+
+            conn.set_trace_callback(trace)
+            connections_ready.wait(timeout=10)
+            if not start_create.wait(timeout=10):
+                raise TimeoutError("concurrent create was not released")
+            results[index] = kb.create_task(
+                conn,
+                title=f"concurrent attempt {index}",
+                idempotency_key=key,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            conn.close()
+
+    threads = [threading.Thread(target=create, args=(index,)) for index in range(2)]
+    for thread in threads:
+        thread.start()
+
+    connections_ready.wait(timeout=10)
+    blocker = kb.connect()
+    try:
+        blocker.execute("BEGIN IMMEDIATE")
+        start_create.set()
+        assert all(event.wait(timeout=10) for event in prechecks_complete)
+        assert all(event.wait(timeout=10) for event in writes_attempted)
+        blocker.execute("COMMIT")
+    finally:
+        if blocker.in_transaction:
+            blocker.execute("ROLLBACK")
+        blocker.close()
+
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert errors == []
+    assert results[0] == results[1]
+    with kb.connect() as conn:
+        task_count = conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = ?",
+            (key,),
+        ).fetchone()[0]
+    assert task_count == 1
+
+
 def test_idempotency_key_ignored_for_archived(kanban_home):
     conn = kb.connect()
     try:

--- a/tests/hermes_cli/test_kanban_lifetime_idempotency.py
+++ b/tests/hermes_cli/test_kanban_lifetime_idempotency.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import threading
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban import run_slash
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _meta_packet_key(mission_id: str, packet_id: str) -> str:
+    digest = hashlib.sha256(f"{mission_id}\0{packet_id}".encode()).hexdigest()
+    return f"lifetime-v1:meta-packet-v1:{digest}"
+
+
+def _event_rows(conn: sqlite3.Connection, task_id: str) -> list[sqlite3.Row]:
+    return conn.execute(
+        "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id",
+        (task_id,),
+    ).fetchall()
+
+
+@pytest.mark.parametrize(
+    "bad_key",
+    [
+        "lifetime-v1:",
+        "lifetime-v1:namespace",
+        "lifetime-v1:namespace:",
+        "lifetime-v1:bad namespace:token",
+        "lifetime-v1:namespace:token/with/slash",
+    ],
+)
+def test_lifetime_key_rejects_malformed_reserved_representation(kanban_home, bad_key):
+    with kb.connect() as conn, pytest.raises(ValueError, match="lifetime-v1"):
+        kb.create_task(conn, title="invalid lifetime key", idempotency_key=bad_key)
+
+
+@pytest.mark.parametrize("terminal_status", ["done", "blocked", "archived"])
+def test_lifetime_key_converges_after_terminal_and_archive(
+    kanban_home, terminal_status
+):
+    key = _meta_packet_key("mission-a", f"packet-{terminal_status}")
+    with kb.connect() as conn:
+        original = kb.create_task(conn, title="first owner", idempotency_key=key)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = ? WHERE id = ?",
+                (terminal_status, original),
+            )
+
+        duplicate = kb.create_task(
+            conn,
+            title="renamed retry must converge",
+            idempotency_key=key,
+        )
+
+        assert duplicate == original
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM tasks WHERE idempotency_key = ?", (key,)
+            ).fetchone()[0]
+            == 1
+        )
+        events = _event_rows(conn, original)
+        suppression = [row for row in events if row["kind"] == "duplicate_suppressed"]
+        assert len(suppression) == 1
+        payload = json.loads(suppression[0]["payload"])
+        assert payload["idempotency_key"] == key
+        assert payload["requested_title"] == "renamed retry must converge"
+
+
+@pytest.mark.parametrize(
+    "invalid_route",
+    [
+        {"skills": ["web"]},
+        {"provider_override": "provider-without-model"},
+        {"workspace_kind": "scratch", "branch_name": "wt/invalid"},
+    ],
+    ids=["skill-toolset", "provider-without-model", "branch-without-worktree"],
+)
+def test_lifetime_duplicate_suppresses_before_optional_route_validation(
+    kanban_home, invalid_route
+):
+    key = _meta_packet_key("mission-order", "packet-order")
+    with kb.connect() as conn:
+        original = kb.create_task(conn, title="canonical", idempotency_key=key)
+        duplicate = kb.create_task(
+            conn,
+            title="renamed invalid route",
+            idempotency_key=key,
+            **invalid_route,
+        )
+        assert duplicate == original
+        assert any(
+            row["kind"] == "duplicate_suppressed" for row in _event_rows(conn, original)
+        )
+
+
+def test_different_lifetime_key_creates_independent_packet(kanban_home):
+    with kb.connect() as conn:
+        first = kb.create_task(
+            conn,
+            title="packet one",
+            idempotency_key=_meta_packet_key("mission-a", "packet-1"),
+        )
+        second = kb.create_task(
+            conn,
+            title="packet two",
+            idempotency_key=_meta_packet_key("mission-a", "packet-2"),
+        )
+        assert first != second
+
+
+def test_lifetime_key_is_atomic_across_concurrent_creates(kanban_home):
+    key = _meta_packet_key("mission-race", "packet-race")
+    start = threading.Barrier(2)
+    results: list[str] = []
+    errors: list[BaseException] = []
+
+    def create(index: int) -> None:
+        conn = kb.connect()
+        try:
+            start.wait(timeout=10)
+            results.append(
+                kb.create_task(
+                    conn,
+                    title=f"race attempt {index}",
+                    idempotency_key=key,
+                )
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+        finally:
+            conn.close()
+
+    threads = [threading.Thread(target=create, args=(index,)) for index in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert errors == []
+    assert len(results) == 2
+    assert results[0] == results[1]
+    with kb.connect() as conn:
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM tasks WHERE idempotency_key = ?", (key,)
+            ).fetchone()[0]
+            == 1
+        )
+        assert any(
+            row["kind"] == "duplicate_suppressed"
+            for row in _event_rows(conn, results[0])
+        )
+
+
+def test_integrity_error_recovers_canonical_lifetime_task(kanban_home, monkeypatch):
+    key = _meta_packet_key("mission-recovery", "packet-recovery")
+    with kb.connect() as conn:
+        original = kb.create_task(conn, title="canonical", idempotency_key=key)
+
+        real_find = getattr(kb, "_find_idempotent_task_id")
+        calls = 0
+
+        def miss_once(connection, lookup_key, *, lifetime):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return None
+            return real_find(connection, lookup_key, lifetime=lifetime)
+
+        monkeypatch.setattr(kb, "_find_idempotent_task_id", miss_once)
+        recovered = kb.create_task(
+            conn,
+            title="forced unique-index conflict",
+            idempotency_key=key,
+        )
+
+        assert recovered == original
+        assert any(
+            row["kind"] == "duplicate_suppressed" for row in _event_rows(conn, original)
+        )
+
+
+def test_unique_partial_index_blocks_direct_lifetime_duplicate(kanban_home):
+    key = _meta_packet_key("mission-index", "packet-index")
+    with kb.connect() as conn:
+        first = kb.create_task(conn, title="first", idempotency_key=key)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'archived' WHERE id = ?", (first,))
+        other = kb.create_task(
+            conn, title="ordinary task", idempotency_key="legacy-key"
+        )
+
+        with pytest.raises(sqlite3.IntegrityError):
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET idempotency_key = ? WHERE id = ?",
+                    (key, other),
+                )
+
+
+def test_migration_fails_closed_on_preexisting_lifetime_duplicates(tmp_path):
+    db_path = tmp_path / "legacy-duplicate.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(kb.SCHEMA_SQL)
+        key = _meta_packet_key("legacy-mission", "legacy-packet")
+        conn.executemany(
+            "INSERT INTO tasks (id, title, status, created_at, idempotency_key) "
+            "VALUES (?, ?, 'archived', ?, ?)",
+            [("t_first", "first", 1, key), ("t_second", "second", 2, key)],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(RuntimeError, match="duplicate lifetime idempotency"):
+        kb.connect(db_path=db_path)
+
+
+def test_real_cli_returns_canonical_id_and_suppression_event(kanban_home):
+    key = _meta_packet_key("mission-cli", "packet-cli")
+    first = json.loads(run_slash(f"create CLI-first --idempotency-key {key} --json"))
+    task_id = first["id"]
+    run_slash(f"archive {task_id}")
+
+    duplicate = json.loads(
+        run_slash(f"create CLI-renamed --idempotency-key {key} --json")
+    )
+    assert duplicate["id"] == task_id
+
+    shown = json.loads(run_slash(f"show {task_id} --json"))
+    assert any(event["kind"] == "duplicate_suppressed" for event in shown["events"])
+
+
+def test_legacy_key_still_allows_reuse_after_archive(kanban_home):
+    with kb.connect() as conn:
+        first = kb.create_task(conn, title="legacy first", idempotency_key="legacy")
+        kb.archive_task(conn, first)
+        second = kb.create_task(conn, title="legacy second", idempotency_key="legacy")
+        assert second != first


### PR DESCRIPTION
## Summary

Add opt-in, self-describing lifetime idempotency keys for Kanban:

- ordinary keys keep their existing non-archived deduplication semantics
- `lifetime-v1:<namespace>:<token>` keys remain unique across every task status, including `archived`
- duplicate lifetime creates return the canonical task id and append a native `duplicate_suppressed` event
- same-key lookup is identity-first, rechecked inside `BEGIN IMMEDIATE`, and backed by a partial unique index
- migration fails closed if historical duplicate lifetime keys exist

Meta orchestration will use:

```text
lifetime-v1:meta-packet-v1:<sha256(mission_id NUL packet_id)>
```

## Attribution / prior work

This branch preserves JnyRoad's authored commit from #69017 (`fix(kanban): enforce idempotency keys atomically`) unchanged as the first commit. The lifetime extension builds on its in-transaction recheck. #57832 informed the partial-index review; this PR narrows uniqueness to explicitly opted-in lifetime keys so legacy archived-key reuse remains compatible.

## Safety properties

- sequential, concurrent, post-terminal, and post-archive duplicates converge on one task row
- malformed lifetime keys fail before creation
- direct SQL duplicates are rejected by `idx_tasks_idempotency_lifetime`
- `IntegrityError` recovery returns the canonical lifetime task; only exact `tasks.id` collisions retain id-retry behavior
- optional route-shape changes—including invalid provider, skill, or workspace fields—cannot bypass or block an existing lifetime identity
- different lifetime keys create independently
- ordinary keys retain current behavior

## Verification

Local:

- `469 passed` — complete W3 + Kanban core + DB + CLI matrix, no deselections
- Ruff check: pass
- added-line secret/high-risk scan: pass

Live-shape preflight used SQLite backups only; source DBs opened read-only. Each copy was first normalized by unmodified upstream `main`, then migrated with this candidate:

- default board: 3 tasks
- market-research: 330 tasks
- vps-control-plane: 228 tasks
- all: `PRAGMA quick_check = ok`, exact task rows, exact table counts, index present
- rollback `DROP INDEX IF EXISTS idx_tasks_idempotency_lifetime` restored the exact upstream-normalized schema on all three copies

No installed runtime, live board, gateway, scheduler, or prompt was changed.

## Rollback

Before any deployment: snapshot each live board and stop at the deployment approval edge.

If rolled back after deployment:

1. stop the gateway / Kanban writers
2. revert the lifetime-idempotency code commit
3. run `DROP INDEX IF EXISTS idx_tasks_idempotency_lifetime` on each migrated board
4. run `PRAGMA quick_check`, restart, and verify ordinary create/archive behavior

The migration adds only an index; it does not rewrite task rows.
