### PR TITLE
feat(conformance): vector generator — native renderers as executable spec

### DIFF
--- a/scripts/generate_conformance_vectors.py
+++ b/scripts/generate_conformance_vectors.py
@@ -240,7 +240,10 @@ def generate(out_dir: Path) -> Dict[str, Any]:
             "vectors": vectors,
         }
         path = out_dir / f"{platform}.json"
-        path.write_text(json.dumps(doc, ensure_ascii=False, indent=2) + "\n")
+        path.write_text(
+            json.dumps(doc, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
         summary[platform] = len(vectors)
     return summary
 

--- a/scripts/generate_conformance_vectors.py
+++ b/scripts/generate_conformance_vectors.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Conformance-vector generator — the native adapters as executable spec.
+
+Renders a shared corpus (markdown grid + scar tissue + adversarial agent
+output) through the NATIVE platform renderers and dumps input→output JSON
+vectors, stamped with the oracle commit. The gateway-gateway connector
+commits these under conformance/vectors/ and its vitest runner asserts the
+CONNECTOR's constructed REST payloads against them — so cross-repo renderer
+drift breaks a test instead of a user's formatting.
+
+Oracles (all imported, never reimplemented):
+  telegram  plugins.platforms.telegram.adapter.TelegramAdapter.format_message
+            (standard markdown → Telegram MarkdownV2)
+  slack     plugins.platforms.slack.adapter.SlackAdapter.format_message
+            (standard markdown → Slack mrkdwn)
+  whatsapp  gateway.platforms.whatsapp_common.WhatsAppBehaviorMixin
+            .format_message (standard markdown → WhatsApp formatting)
+  discord   plugins.platforms.discord.adapter.DiscordAdapter.format_message
+            (GFM tables → bullet groups; otherwise identity)
+
+Expect semantics (consumed by the gg runner):
+  parity    connector render must BYTE-EQUAL native_output
+            (Slack / WhatsApp — same-dialect ports; most Discord).
+  semantic  connector renders a DIFFERENT representation on purpose
+            (Telegram: connector sends HTML, native sends MarkdownV2);
+            the runner asserts plain-text content equivalence instead.
+  divergent documented no-parity (e.g. Discord tables: native converts to
+            bullets, connector passes raw markdown through). The runner
+            asserts the DOCUMENTED connector behavior named in `note`.
+
+Run:  python scripts/generate_conformance_vectors.py [--out DIR]
+Determinism is covered by tests/conformance/test_vector_generator.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+GENERATOR_VERSION = 1
+
+# ── corpus ───────────────────────────────────────────────────────────────
+# Every entry: (id, category, input). Categories: grid | scar | adversarial.
+# Ids are STABLE API — the runner and divergence notes key on them.
+
+GRID: List[tuple] = [
+    ("plain-text", "Just a plain sentence."),
+    ("bold", "This is **bold** text."),
+    ("italic", "This is *italic* text."),
+    ("bold-italic", "Mix of **bold** and *italic* in one line."),
+    ("strikethrough", "This is ~~struck~~ text."),
+    ("inline-code", "Run `pip install hermes` to start."),
+    ("fenced-code", "```\nprint('hello')\n```"),
+    ("fenced-code-lang", "```python\ndef f(x):\n    return x * 2\n```"),
+    ("link", "See [the docs](https://example.com/docs) for more."),
+    ("link-parens-url", "See [spec](https://example.com/a_(b)) here."),
+    ("header-h1", "# Big Title\nBody follows."),
+    ("header-h2", "## Section\nBody follows."),
+    ("header-h3", "### Sub-section\nBody follows."),
+    ("ul-list", "- first\n- second\n- third"),
+    ("ol-list", "1. first\n2. second\n3. third"),
+    ("nested-list", "- outer\n  - inner one\n  - inner two\n- outer two"),
+    ("blockquote", "> quoted wisdom\nregular line"),
+    ("hrule", "above\n\n---\n\nbelow"),
+    (
+        "table-simple",
+        "| name | value |\n|------|-------|\n| a    | 1     |\n| b    | 2     |",
+    ),
+    ("emoji", "Done ✅ with 🎉 emoji 👀 test."),
+    ("cjk", "中文测试：**粗体** 和 `代码` 混排。"),
+    ("bare-url", "Visit https://example.com/path?q=1&r=2 today."),
+    (
+        "mixed-document",
+        "## Report\n\nStatus: **green**. Details in `runbook.md`.\n\n"
+        "- item *one*\n- item **two**\n\n```sh\nmake deploy\n```\n\n"
+        "See [dashboard](https://grafana.example.com/d/x).",
+    ),
+]
+
+SCAR: List[tuple] = [
+    # MarkdownV2 reserved characters in prose — the classic Telegram 400.
+    ("mdv2-reserved-chars", "Price is 3.50 (was 4.00) — save ~12%! #deal +tax = win."),
+    ("mdv2-underscores", "snake_case_name and file_name.py in prose."),
+    ("mdv2-brackets", "Array[0] and dict{key} and (parens) live here."),
+    # Slack: **bold** must become *bold*; [t](u) must become <u|t>.
+    ("slack-bold-conversion", "**important** word"),
+    ("slack-link-conversion", "[click here](https://example.com)"),
+    # Slack broadcast-mention escape (model output must not ping @everyone).
+    ("slack-broadcast-mention", "Hey <!everyone> and <!channel> and <!here>!"),
+    # Fence language tag handling (Slack renders the tag literally).
+    ("fence-lang-tag-slack", "```text\nliteral first line issue\n```"),
+    # Backslashes inside code must survive doubling rules.
+    ("backslash-in-code", "`C:\\Users\\ben\\file.txt` and ```\npath = \"a\\\\b\"\n```"),
+    ("backtick-in-fence", "```\nuse `inline` inside fence\n```"),
+    # Headers containing bold markers (native strips redundant **).
+    ("header-with-bold", "## The **Real** Deal"),
+    # Table with CJK cells (display-width alignment scar in Slack).
+    (
+        "table-cjk",
+        "| 名前 | 値 |\n|------|----|\n| 中文 | 42 |\n| b    | 2  |",
+    ),
+    # Link display text that itself needs escaping.
+    ("link-display-escapes", "[v2.0 (beta)](https://example.com/v2)"),
+]
+
+ADVERSARIAL: List[tuple] = [
+    ("media-tag", "Here you go\nMEDIA:/tmp/output.png\ndone"),
+    ("unclosed-fence", "```python\nprint('never closed')"),
+    ("pathological-nesting", "**bold *italic ~~struck `code` struck~~ italic* bold**"),
+    ("placeholder-injection", "sneaky \x00PH0\x00 token and \x00SL1\x00 too"),
+    ("triple-markers", "***what is this*** and ____that____"),
+    ("empty-string", ""),
+    ("whitespace-only", "   \n\t\n   "),
+    ("long-line", "word " * 500),
+    ("many-fences", "```\na\n```\nmid\n```\nb\n```\nend ```inline``` tail"),
+]
+
+
+def corpus() -> List[Dict[str, str]]:
+    rows: List[Dict[str, str]] = []
+    for cid, text in GRID:
+        rows.append({"id": cid, "category": "grid", "input": text})
+    for cid, text in SCAR:
+        rows.append({"id": cid, "category": "scar", "input": text})
+    for cid, text in ADVERSARIAL:
+        rows.append({"id": cid, "category": "adversarial", "input": text})
+    return rows
+
+
+# ── oracles ──────────────────────────────────────────────────────────────
+
+
+def _oracles() -> Dict[str, Callable[[str], str]]:
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+    from plugins.platforms.slack.adapter import SlackAdapter
+    from plugins.platforms.discord.adapter import DiscordAdapter
+    from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+
+    wa = object.__new__(WhatsAppBehaviorMixin)  # format_message needs no __init__
+
+    return {
+        # These format_message implementations are self-free (asserted by
+        # tests/conformance/test_vector_generator.py) — invoked unbound.
+        "telegram": lambda s: TelegramAdapter.format_message(None, s),  # type: ignore[arg-type]
+        "slack": lambda s: SlackAdapter.format_message(None, s),  # type: ignore[arg-type]
+        "discord": lambda s: DiscordAdapter.format_message(None, s),  # type: ignore[arg-type]
+        "whatsapp": wa.format_message,
+    }
+
+
+# Per-platform expect overrides (default: parity, except telegram=semantic).
+# Keyed by vector id; value = (expect, note).
+_EXPECT_OVERRIDES: Dict[str, Dict[str, tuple]] = {
+    "telegram": {
+        # Native wraps pipe tables into row groups; the connector's HTML lane
+        # renders tables as <pre>. Same content, structurally different enough
+        # that plain-text comparison is noise — documented divergence.
+        "table-simple": ("divergent", "native wraps tables into row groups; connector renders <pre> — content preserved, layout differs"),
+        "table-cjk": ("divergent", "same as table-simple (CJK width alignment is native-only)"),
+        "unclosed-fence": ("divergent", "unterminated fence: native escapes as prose, connector HTML may close the block — degraded either way, never a 400"),
+        "placeholder-injection": ("divergent", "NUL placeholder tokens are renderer-internal; each side neutralizes its own pattern"),
+        "whitespace-only": ("divergent", "native collapses to empty-ish prose, connector HTML preserves — cosmetic"),
+    },
+    "slack": {
+        "placeholder-injection": ("divergent", "\\x00SL tokens are the native renderer's own placeholder alphabet; connector uses a different scheme"),
+        "unclosed-fence": ("divergent", "unterminated fence handling differs; both degrade without dropping content"),
+    },
+    "whatsapp": {
+        "placeholder-injection": ("divergent", "placeholder alphabets are renderer-internal"),
+        "unclosed-fence": ("divergent", "unterminated fence handling differs; both degrade without dropping content"),
+    },
+    "discord": {
+        "table-simple": ("divergent", "native converts GFM tables to bullet groups; connector passes raw markdown through (port deferred — parity report Phase 4/oracle section)"),
+        "table-cjk": ("divergent", "same as table-simple"),
+    },
+}
+
+
+def _expect_for(platform: str, vector_id: str) -> tuple:
+    default = ("semantic", "") if platform == "telegram" else ("parity", "")
+    return _EXPECT_OVERRIDES.get(platform, {}).get(vector_id, default)
+
+
+def _oracle_commit() -> str:
+    try:
+        return (
+            subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+        )
+    except Exception:
+        return "unknown"
+
+
+def generate(out_dir: Path) -> Dict[str, Any]:
+    """Render the corpus through every oracle; write one JSON per platform."""
+    oracles = _oracles()
+    commit = _oracle_commit()
+    rows = corpus()
+    summary: Dict[str, Any] = {}
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for platform, render in sorted(oracles.items()):
+        vectors = []
+        for row in rows:
+            expect, note = _expect_for(platform, row["id"])
+            entry: Dict[str, Any] = {
+                "id": row["id"],
+                "category": row["category"],
+                "expect": expect,
+                "input": row["input"],
+                "native_output": render(row["input"]),
+            }
+            if note:
+                entry["note"] = note
+            vectors.append(entry)
+        doc = {
+            "$comment": (
+                "GENERATED — do not hand-edit. Regenerate with "
+                "hermes-agent scripts/generate_conformance_vectors.py; the "
+                "native renderers are the oracle (executable spec)."
+            ),
+            "oracle": {
+                "repo": "NousResearch/hermes-agent",
+                "commit": commit,
+                "generator": "scripts/generate_conformance_vectors.py",
+                "generator_version": GENERATOR_VERSION,
+            },
+            "platform": platform,
+            "vectors": vectors,
+        }
+        path = out_dir / f"{platform}.json"
+        path.write_text(json.dumps(doc, ensure_ascii=False, indent=2) + "\n")
+        summary[platform] = len(vectors)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        default=str(REPO_ROOT / "tests" / "conformance" / "vectors"),
+        help="Output directory for <platform>.json vector files",
+    )
+    args = parser.parse_args()
+    summary = generate(Path(args.out))
+    for platform, count in sorted(summary.items()):
+        print(f"{platform}: {count} vectors")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conformance/test_vector_generator.py
+++ b/tests/conformance/test_vector_generator.py
@@ -1,0 +1,129 @@
+"""Conformance vector generator tests (Phase 5 oracle workstream).
+
+Behavior contracts, not change-detectors: determinism, corpus invariants,
+oracle-import health (the generator calls format_message UNBOUND — these
+tests fail loudly if a refactor gives those renderers instance state), and
+vector-file shape. Native outputs themselves are NOT snapshotted here — the
+connector's conformance runner is the consumer that asserts them.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from generate_conformance_vectors import (  # noqa: E402
+    ADVERSARIAL,
+    GRID,
+    SCAR,
+    _oracles,
+    corpus,
+    generate,
+)
+
+PLATFORMS = ("discord", "slack", "telegram", "whatsapp")
+
+
+def test_corpus_ids_unique_and_categorized():
+    rows = corpus()
+    ids = [r["id"] for r in rows]
+    assert len(ids) == len(set(ids)), "vector ids must be unique (runner keys on them)"
+    assert {r["category"] for r in rows} == {"grid", "scar", "adversarial"}
+    assert len(GRID) >= 20 and len(SCAR) >= 10 and len(ADVERSARIAL) >= 8
+
+
+def test_oracles_importable_and_self_free():
+    """The generator invokes format_message unbound (self=None) — verify every
+    oracle actually renders under that calling convention. A refactor that
+    adds instance state to a renderer must update the generator too."""
+    oracles = _oracles()
+    assert set(oracles) == set(PLATFORMS)
+    for platform, render in oracles.items():
+        out = render("**bold** and `code`")
+        assert isinstance(out, str) and out, platform
+
+
+def test_generation_is_deterministic(tmp_path):
+    a, b = tmp_path / "a", tmp_path / "b"
+    generate(a)
+    generate(b)
+    for platform in PLATFORMS:
+        va = (a / f"{platform}.json").read_text()
+        vb = (b / f"{platform}.json").read_text()
+        # The oracle commit is identical within one checkout; whole file must be.
+        assert va == vb, f"{platform} vectors are nondeterministic"
+
+
+def test_vector_files_shape(tmp_path):
+    generate(tmp_path)
+    for platform in PLATFORMS:
+        doc = json.loads((tmp_path / f"{platform}.json").read_text())
+        assert doc["platform"] == platform
+        assert doc["oracle"]["repo"] == "NousResearch/hermes-agent"
+        assert re.match(r"^[0-9a-f]{40}$|^unknown$", doc["oracle"]["commit"])
+        assert doc["oracle"]["generator_version"] >= 1
+        ids = set()
+        for v in doc["vectors"]:
+            assert v["expect"] in ("parity", "semantic", "divergent"), v["id"]
+            assert isinstance(v["native_output"], str)
+            if v["expect"] == "divergent":
+                assert v.get("note"), f"{platform}/{v['id']}: divergent needs a note"
+            ids.add(v["id"])
+        assert len(ids) == len(doc["vectors"])
+
+
+def test_default_expectations_per_platform(tmp_path):
+    """Telegram defaults to semantic (connector speaks HTML, native speaks
+    MarkdownV2); every other platform defaults to parity (same dialect)."""
+    generate(tmp_path)
+    tg = json.loads((tmp_path / "telegram.json").read_text())
+    assert all(v["expect"] != "parity" for v in tg["vectors"]), (
+        "telegram byte-parity is impossible across dialects — semantic/divergent only"
+    )
+    for platform in ("slack", "whatsapp"):
+        doc = json.loads((tmp_path / f"{platform}.json").read_text())
+        parity = [v for v in doc["vectors"] if v["expect"] == "parity"]
+        assert len(parity) > len(doc["vectors"]) * 0.7, f"{platform} should be mostly parity"
+
+
+def test_scar_vectors_exercise_the_named_bugs(tmp_path):
+    """The scar corpus must actually trigger the behaviors it memorializes."""
+    generate(tmp_path)
+    tg = {v["id"]: v for v in json.loads((tmp_path / "telegram.json").read_text())["vectors"]}
+    # MarkdownV2 reserved chars actually get escaped by the oracle.
+    assert "\\." in tg["mdv2-reserved-chars"]["native_output"] or "\\(" in tg["mdv2-reserved-chars"]["native_output"]
+    assert "\\_" in tg["mdv2-underscores"]["native_output"]
+    sl = {v["id"]: v for v in json.loads((tmp_path / "slack.json").read_text())["vectors"]}
+    assert sl["slack-bold-conversion"]["native_output"] == "*important* word"
+    assert sl["slack-link-conversion"]["native_output"] == "<https://example.com|click here>"
+    assert "&lt;!everyone&gt;" in sl["slack-broadcast-mention"]["native_output"]
+    wa = {v["id"]: v for v in json.loads((tmp_path / "whatsapp.json").read_text())["vectors"]}
+    assert wa["bold"]["native_output"] == "This is *bold* text."
+
+
+def test_committed_vectors_match_regeneration(tmp_path):
+    """The committed tests/conformance/vectors/ must reproduce from the
+    current oracle — the same lockstep discipline as openapi.json (drift
+    means someone changed a renderer without regenerating)."""
+    committed_dir = REPO_ROOT / "tests" / "conformance" / "vectors"
+    if not committed_dir.exists():
+        pytest.skip("no committed vectors in this checkout")
+    generate(tmp_path)
+    for platform in PLATFORMS:
+        fresh = json.loads((tmp_path / f"{platform}.json").read_text())
+        committed = json.loads((committed_dir / f"{platform}.json").read_text())
+        # Compare everything except the commit stamp (committed file may be
+        # one commit behind HEAD in a dirty working tree).
+        fresh["oracle"].pop("commit")
+        committed["oracle"].pop("commit")
+        assert fresh == committed, (
+            f"{platform} vectors drifted — run "
+            "`python scripts/generate_conformance_vectors.py` and commit"
+        )

--- a/tests/conformance/test_vector_generator.py
+++ b/tests/conformance/test_vector_generator.py
@@ -55,8 +55,8 @@ def test_generation_is_deterministic(tmp_path):
     generate(a)
     generate(b)
     for platform in PLATFORMS:
-        va = (a / f"{platform}.json").read_text()
-        vb = (b / f"{platform}.json").read_text()
+        va = (a / f"{platform}.json").read_text(encoding="utf-8")
+        vb = (b / f"{platform}.json").read_text(encoding="utf-8")
         # The oracle commit is identical within one checkout; whole file must be.
         assert va == vb, f"{platform} vectors are nondeterministic"
 
@@ -64,7 +64,7 @@ def test_generation_is_deterministic(tmp_path):
 def test_vector_files_shape(tmp_path):
     generate(tmp_path)
     for platform in PLATFORMS:
-        doc = json.loads((tmp_path / f"{platform}.json").read_text())
+        doc = json.loads((tmp_path / f"{platform}.json").read_text(encoding="utf-8"))
         assert doc["platform"] == platform
         assert doc["oracle"]["repo"] == "NousResearch/hermes-agent"
         assert re.match(r"^[0-9a-f]{40}$|^unknown$", doc["oracle"]["commit"])
@@ -83,12 +83,12 @@ def test_default_expectations_per_platform(tmp_path):
     """Telegram defaults to semantic (connector speaks HTML, native speaks
     MarkdownV2); every other platform defaults to parity (same dialect)."""
     generate(tmp_path)
-    tg = json.loads((tmp_path / "telegram.json").read_text())
+    tg = json.loads((tmp_path / "telegram.json").read_text(encoding="utf-8"))
     assert all(v["expect"] != "parity" for v in tg["vectors"]), (
         "telegram byte-parity is impossible across dialects — semantic/divergent only"
     )
     for platform in ("slack", "whatsapp"):
-        doc = json.loads((tmp_path / f"{platform}.json").read_text())
+        doc = json.loads((tmp_path / f"{platform}.json").read_text(encoding="utf-8"))
         parity = [v for v in doc["vectors"] if v["expect"] == "parity"]
         assert len(parity) > len(doc["vectors"]) * 0.7, f"{platform} should be mostly parity"
 
@@ -96,15 +96,15 @@ def test_default_expectations_per_platform(tmp_path):
 def test_scar_vectors_exercise_the_named_bugs(tmp_path):
     """The scar corpus must actually trigger the behaviors it memorializes."""
     generate(tmp_path)
-    tg = {v["id"]: v for v in json.loads((tmp_path / "telegram.json").read_text())["vectors"]}
+    tg = {v["id"]: v for v in json.loads((tmp_path / "telegram.json").read_text(encoding="utf-8"))["vectors"]}
     # MarkdownV2 reserved chars actually get escaped by the oracle.
     assert "\\." in tg["mdv2-reserved-chars"]["native_output"] or "\\(" in tg["mdv2-reserved-chars"]["native_output"]
     assert "\\_" in tg["mdv2-underscores"]["native_output"]
-    sl = {v["id"]: v for v in json.loads((tmp_path / "slack.json").read_text())["vectors"]}
+    sl = {v["id"]: v for v in json.loads((tmp_path / "slack.json").read_text(encoding="utf-8"))["vectors"]}
     assert sl["slack-bold-conversion"]["native_output"] == "*important* word"
     assert sl["slack-link-conversion"]["native_output"] == "<https://example.com|click here>"
     assert "&lt;!everyone&gt;" in sl["slack-broadcast-mention"]["native_output"]
-    wa = {v["id"]: v for v in json.loads((tmp_path / "whatsapp.json").read_text())["vectors"]}
+    wa = {v["id"]: v for v in json.loads((tmp_path / "whatsapp.json").read_text(encoding="utf-8"))["vectors"]}
     assert wa["bold"]["native_output"] == "This is *bold* text."
 
 
@@ -117,8 +117,8 @@ def test_committed_vectors_match_regeneration(tmp_path):
         pytest.skip("no committed vectors in this checkout")
     generate(tmp_path)
     for platform in PLATFORMS:
-        fresh = json.loads((tmp_path / f"{platform}.json").read_text())
-        committed = json.loads((committed_dir / f"{platform}.json").read_text())
+        fresh = json.loads((tmp_path / f"{platform}.json").read_text(encoding="utf-8"))
+        committed = json.loads((committed_dir / f"{platform}.json").read_text(encoding="utf-8"))
         # Compare everything except the commit stamp (committed file may be
         # one commit behind HEAD in a dirty working tree).
         fresh["oracle"].pop("commit")

--- a/tests/conformance/vectors/discord.json
+++ b/tests/conformance/vectors/discord.json
@@ -1,0 +1,322 @@
+{
+  "$comment": "GENERATED — do not hand-edit. Regenerate with hermes-agent scripts/generate_conformance_vectors.py; the native renderers are the oracle (executable spec).",
+  "oracle": {
+    "repo": "NousResearch/hermes-agent",
+    "commit": "40eebc7d70f3d8e95c429c8aa482f31ba6c867f6",
+    "generator": "scripts/generate_conformance_vectors.py",
+    "generator_version": 1
+  },
+  "platform": "discord",
+  "vectors": [
+    {
+      "id": "plain-text",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Just a plain sentence.",
+      "native_output": "Just a plain sentence."
+    },
+    {
+      "id": "bold",
+      "category": "grid",
+      "expect": "parity",
+      "input": "This is **bold** text.",
+      "native_output": "This is **bold** text."
+    },
+    {
+      "id": "italic",
+      "category": "grid",
+      "expect": "parity",
+      "input": "This is *italic* text.",
+      "native_output": "This is *italic* text."
+    },
+    {
+      "id": "bold-italic",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Mix of **bold** and *italic* in one line.",
+      "native_output": "Mix of **bold** and *italic* in one line."
+    },
+    {
+      "id": "strikethrough",
+      "category": "grid",
+      "expect": "parity",
+      "input": "This is ~~struck~~ text.",
+      "native_output": "This is ~~struck~~ text."
+    },
+    {
+      "id": "inline-code",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Run `pip install hermes` to start.",
+      "native_output": "Run `pip install hermes` to start."
+    },
+    {
+      "id": "fenced-code",
+      "category": "grid",
+      "expect": "parity",
+      "input": "```\nprint('hello')\n```",
+      "native_output": "```\nprint('hello')\n```"
+    },
+    {
+      "id": "fenced-code-lang",
+      "category": "grid",
+      "expect": "parity",
+      "input": "```python\ndef f(x):\n    return x * 2\n```",
+      "native_output": "```python\ndef f(x):\n    return x * 2\n```"
+    },
+    {
+      "id": "link",
+      "category": "grid",
+      "expect": "parity",
+      "input": "See [the docs](https://example.com/docs) for more.",
+      "native_output": "See [the docs](https://example.com/docs) for more."
+    },
+    {
+      "id": "link-parens-url",
+      "category": "grid",
+      "expect": "parity",
+      "input": "See [spec](https://example.com/a_(b)) here.",
+      "native_output": "See [spec](https://example.com/a_(b)) here."
+    },
+    {
+      "id": "header-h1",
+      "category": "grid",
+      "expect": "parity",
+      "input": "# Big Title\nBody follows.",
+      "native_output": "# Big Title\nBody follows."
+    },
+    {
+      "id": "header-h2",
+      "category": "grid",
+      "expect": "parity",
+      "input": "## Section\nBody follows.",
+      "native_output": "## Section\nBody follows."
+    },
+    {
+      "id": "header-h3",
+      "category": "grid",
+      "expect": "parity",
+      "input": "### Sub-section\nBody follows.",
+      "native_output": "### Sub-section\nBody follows."
+    },
+    {
+      "id": "ul-list",
+      "category": "grid",
+      "expect": "parity",
+      "input": "- first\n- second\n- third",
+      "native_output": "- first\n- second\n- third"
+    },
+    {
+      "id": "ol-list",
+      "category": "grid",
+      "expect": "parity",
+      "input": "1. first\n2. second\n3. third",
+      "native_output": "1. first\n2. second\n3. third"
+    },
+    {
+      "id": "nested-list",
+      "category": "grid",
+      "expect": "parity",
+      "input": "- outer\n  - inner one\n  - inner two\n- outer two",
+      "native_output": "- outer\n  - inner one\n  - inner two\n- outer two"
+    },
+    {
+      "id": "blockquote",
+      "category": "grid",
+      "expect": "parity",
+      "input": "> quoted wisdom\nregular line",
+      "native_output": "> quoted wisdom\nregular line"
+    },
+    {
+      "id": "hrule",
+      "category": "grid",
+      "expect": "parity",
+      "input": "above\n\n---\n\nbelow",
+      "native_output": "above\n\n---\n\nbelow"
+    },
+    {
+      "id": "table-simple",
+      "category": "grid",
+      "expect": "divergent",
+      "input": "| name | value |\n|------|-------|\n| a    | 1     |\n| b    | 2     |",
+      "native_output": "**a**\n• value: 1\n\n**b**\n• value: 2",
+      "note": "native converts GFM tables to bullet groups; connector passes raw markdown through (port deferred — parity report Phase 4/oracle section)"
+    },
+    {
+      "id": "emoji",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Done ✅ with 🎉 emoji 👀 test.",
+      "native_output": "Done ✅ with 🎉 emoji 👀 test."
+    },
+    {
+      "id": "cjk",
+      "category": "grid",
+      "expect": "parity",
+      "input": "中文测试：**粗体** 和 `代码` 混排。",
+      "native_output": "中文测试：**粗体** 和 `代码` 混排。"
+    },
+    {
+      "id": "bare-url",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Visit https://example.com/path?q=1&r=2 today.",
+      "native_output": "Visit https://example.com/path?q=1&r=2 today."
+    },
+    {
+      "id": "mixed-document",
+      "category": "grid",
+      "expect": "parity",
+      "input": "## Report\n\nStatus: **green**. Details in `runbook.md`.\n\n- item *one*\n- item **two**\n\n```sh\nmake deploy\n```\n\nSee [dashboard](https://grafana.example.com/d/x).",
+      "native_output": "## Report\n\nStatus: **green**. Details in `runbook.md`.\n\n- item *one*\n- item **two**\n\n```sh\nmake deploy\n```\n\nSee [dashboard](https://grafana.example.com/d/x)."
+    },
+    {
+      "id": "mdv2-reserved-chars",
+      "category": "scar",
+      "expect": "parity",
+      "input": "Price is 3.50 (was 4.00) — save ~12%! #deal +tax = win.",
+      "native_output": "Price is 3.50 (was 4.00) — save ~12%! #deal +tax = win."
+    },
+    {
+      "id": "mdv2-underscores",
+      "category": "scar",
+      "expect": "parity",
+      "input": "snake_case_name and file_name.py in prose.",
+      "native_output": "snake_case_name and file_name.py in prose."
+    },
+    {
+      "id": "mdv2-brackets",
+      "category": "scar",
+      "expect": "parity",
+      "input": "Array[0] and dict{key} and (parens) live here.",
+      "native_output": "Array[0] and dict{key} and (parens) live here."
+    },
+    {
+      "id": "slack-bold-conversion",
+      "category": "scar",
+      "expect": "parity",
+      "input": "**important** word",
+      "native_output": "**important** word"
+    },
+    {
+      "id": "slack-link-conversion",
+      "category": "scar",
+      "expect": "parity",
+      "input": "[click here](https://example.com)",
+      "native_output": "[click here](https://example.com)"
+    },
+    {
+      "id": "slack-broadcast-mention",
+      "category": "scar",
+      "expect": "parity",
+      "input": "Hey <!everyone> and <!channel> and <!here>!",
+      "native_output": "Hey <!everyone> and <!channel> and <!here>!"
+    },
+    {
+      "id": "fence-lang-tag-slack",
+      "category": "scar",
+      "expect": "parity",
+      "input": "```text\nliteral first line issue\n```",
+      "native_output": "```text\nliteral first line issue\n```"
+    },
+    {
+      "id": "backslash-in-code",
+      "category": "scar",
+      "expect": "parity",
+      "input": "`C:\\Users\\ben\\file.txt` and ```\npath = \"a\\\\b\"\n```",
+      "native_output": "`C:\\Users\\ben\\file.txt` and ```\npath = \"a\\\\b\"\n```"
+    },
+    {
+      "id": "backtick-in-fence",
+      "category": "scar",
+      "expect": "parity",
+      "input": "```\nuse `inline` inside fence\n```",
+      "native_output": "```\nuse `inline` inside fence\n```"
+    },
+    {
+      "id": "header-with-bold",
+      "category": "scar",
+      "expect": "parity",
+      "input": "## The **Real** Deal",
+      "native_output": "## The **Real** Deal"
+    },
+    {
+      "id": "table-cjk",
+      "category": "scar",
+      "expect": "divergent",
+      "input": "| 名前 | 値 |\n|------|----|\n| 中文 | 42 |\n| b    | 2  |",
+      "native_output": "**中文**\n• 値: 42\n\n**b**\n• 値: 2",
+      "note": "same as table-simple"
+    },
+    {
+      "id": "link-display-escapes",
+      "category": "scar",
+      "expect": "parity",
+      "input": "[v2.0 (beta)](https://example.com/v2)",
+      "native_output": "[v2.0 (beta)](https://example.com/v2)"
+    },
+    {
+      "id": "media-tag",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "Here you go\nMEDIA:/tmp/output.png\ndone",
+      "native_output": "Here you go\nMEDIA:/tmp/output.png\ndone"
+    },
+    {
+      "id": "unclosed-fence",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "```python\nprint('never closed')",
+      "native_output": "```python\nprint('never closed')"
+    },
+    {
+      "id": "pathological-nesting",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "**bold *italic ~~struck `code` struck~~ italic* bold**",
+      "native_output": "**bold *italic ~~struck `code` struck~~ italic* bold**"
+    },
+    {
+      "id": "placeholder-injection",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "sneaky \u0000PH0\u0000 token and \u0000SL1\u0000 too",
+      "native_output": "sneaky \u0000PH0\u0000 token and \u0000SL1\u0000 too"
+    },
+    {
+      "id": "triple-markers",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "***what is this*** and ____that____",
+      "native_output": "***what is this*** and ____that____"
+    },
+    {
+      "id": "empty-string",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "",
+      "native_output": ""
+    },
+    {
+      "id": "whitespace-only",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "   \n\t\n   ",
+      "native_output": "   \n\t\n   "
+    },
+    {
+      "id": "long-line",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word ",
+      "native_output": "word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word "
+    },
+    {
+      "id": "many-fences",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "```\na\n```\nmid\n```\nb\n```\nend ```inline``` tail",
+      "native_output": "```\na\n```\nmid\n```\nb\n```\nend ```inline``` tail"
+    }
+  ]
+}

--- a/tests/conformance/vectors/slack.json
+++ b/tests/conformance/vectors/slack.json
@@ -1,0 +1,322 @@
+{
+  "$comment": "GENERATED — do not hand-edit. Regenerate with hermes-agent scripts/generate_conformance_vectors.py; the native renderers are the oracle (executable spec).",
+  "oracle": {
+    "repo": "NousResearch/hermes-agent",
+    "commit": "40eebc7d70f3d8e95c429c8aa482f31ba6c867f6",
+    "generator": "scripts/generate_conformance_vectors.py",
+    "generator_version": 1
+  },
+  "platform": "slack",
+  "vectors": [
+    {
+      "id": "plain-text",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Just a plain sentence.",
+      "native_output": "Just a plain sentence."
+    },
+    {
+      "id": "bold",
+      "category": "grid",
+      "expect": "parity",
+      "input": "This is **bold** text.",
+      "native_output": "This is *bold* text."
+    },
+    {
+      "id": "italic",
+      "category": "grid",
+      "expect": "parity",
+      "input": "This is *italic* text.",
+      "native_output": "This is _italic_ text."
+    },
+    {
+      "id": "bold-italic",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Mix of **bold** and *italic* in one line.",
+      "native_output": "Mix of *bold* and _italic_ in one line."
+    },
+    {
+      "id": "strikethrough",
+      "category": "grid",
+      "expect": "parity",
+      "input": "This is ~~struck~~ text.",
+      "native_output": "This is ~struck~ text."
+    },
+    {
+      "id": "inline-code",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Run `pip install hermes` to start.",
+      "native_output": "Run `pip install hermes` to start."
+    },
+    {
+      "id": "fenced-code",
+      "category": "grid",
+      "expect": "parity",
+      "input": "```\nprint('hello')\n```",
+      "native_output": "```\nprint('hello')\n```"
+    },
+    {
+      "id": "fenced-code-lang",
+      "category": "grid",
+      "expect": "parity",
+      "input": "```python\ndef f(x):\n    return x * 2\n```",
+      "native_output": "```\ndef f(x):\n    return x * 2\n```"
+    },
+    {
+      "id": "link",
+      "category": "grid",
+      "expect": "parity",
+      "input": "See [the docs](https://example.com/docs) for more.",
+      "native_output": "See <https://example.com/docs|the docs> for more."
+    },
+    {
+      "id": "link-parens-url",
+      "category": "grid",
+      "expect": "parity",
+      "input": "See [spec](https://example.com/a_(b)) here.",
+      "native_output": "See <https://example.com/a_(b)|spec> here."
+    },
+    {
+      "id": "header-h1",
+      "category": "grid",
+      "expect": "parity",
+      "input": "# Big Title\nBody follows.",
+      "native_output": "*Big Title*\nBody follows."
+    },
+    {
+      "id": "header-h2",
+      "category": "grid",
+      "expect": "parity",
+      "input": "## Section\nBody follows.",
+      "native_output": "*Section*\nBody follows."
+    },
+    {
+      "id": "header-h3",
+      "category": "grid",
+      "expect": "parity",
+      "input": "### Sub-section\nBody follows.",
+      "native_output": "*Sub-section*\nBody follows."
+    },
+    {
+      "id": "ul-list",
+      "category": "grid",
+      "expect": "parity",
+      "input": "- first\n- second\n- third",
+      "native_output": "- first\n- second\n- third"
+    },
+    {
+      "id": "ol-list",
+      "category": "grid",
+      "expect": "parity",
+      "input": "1. first\n2. second\n3. third",
+      "native_output": "1. first\n2. second\n3. third"
+    },
+    {
+      "id": "nested-list",
+      "category": "grid",
+      "expect": "parity",
+      "input": "- outer\n  - inner one\n  - inner two\n- outer two",
+      "native_output": "- outer\n  - inner one\n  - inner two\n- outer two"
+    },
+    {
+      "id": "blockquote",
+      "category": "grid",
+      "expect": "parity",
+      "input": "> quoted wisdom\nregular line",
+      "native_output": "> quoted wisdom\nregular line"
+    },
+    {
+      "id": "hrule",
+      "category": "grid",
+      "expect": "parity",
+      "input": "above\n\n---\n\nbelow",
+      "native_output": "above\n\n---\n\nbelow"
+    },
+    {
+      "id": "table-simple",
+      "category": "grid",
+      "expect": "parity",
+      "input": "| name | value |\n|------|-------|\n| a    | 1     |\n| b    | 2     |",
+      "native_output": "```\n| name | value |\n| ---- | ----- |\n| a    | 1     |\n| b    | 2     |\n```"
+    },
+    {
+      "id": "emoji",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Done ✅ with 🎉 emoji 👀 test.",
+      "native_output": "Done ✅ with 🎉 emoji 👀 test."
+    },
+    {
+      "id": "cjk",
+      "category": "grid",
+      "expect": "parity",
+      "input": "中文测试：**粗体** 和 `代码` 混排。",
+      "native_output": "中文测试：*粗体* 和 `代码` 混排。"
+    },
+    {
+      "id": "bare-url",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Visit https://example.com/path?q=1&r=2 today.",
+      "native_output": "Visit https://example.com/path?q=1&amp;r=2 today."
+    },
+    {
+      "id": "mixed-document",
+      "category": "grid",
+      "expect": "parity",
+      "input": "## Report\n\nStatus: **green**. Details in `runbook.md`.\n\n- item *one*\n- item **two**\n\n```sh\nmake deploy\n```\n\nSee [dashboard](https://grafana.example.com/d/x).",
+      "native_output": "*Report*\n\nStatus: *green*. Details in `runbook.md`.\n\n- item _one_\n- item *two*\n\n```\nmake deploy\n```\n\nSee <https://grafana.example.com/d/x|dashboard>."
+    },
+    {
+      "id": "mdv2-reserved-chars",
+      "category": "scar",
+      "expect": "parity",
+      "input": "Price is 3.50 (was 4.00) — save ~12%! #deal +tax = win.",
+      "native_output": "Price is 3.50 (was 4.00) — save ~12%! #deal +tax = win."
+    },
+    {
+      "id": "mdv2-underscores",
+      "category": "scar",
+      "expect": "parity",
+      "input": "snake_case_name and file_name.py in prose.",
+      "native_output": "snake_case_name and file_name.py in prose."
+    },
+    {
+      "id": "mdv2-brackets",
+      "category": "scar",
+      "expect": "parity",
+      "input": "Array[0] and dict{key} and (parens) live here.",
+      "native_output": "Array[0] and dict{key} and (parens) live here."
+    },
+    {
+      "id": "slack-bold-conversion",
+      "category": "scar",
+      "expect": "parity",
+      "input": "**important** word",
+      "native_output": "*important* word"
+    },
+    {
+      "id": "slack-link-conversion",
+      "category": "scar",
+      "expect": "parity",
+      "input": "[click here](https://example.com)",
+      "native_output": "<https://example.com|click here>"
+    },
+    {
+      "id": "slack-broadcast-mention",
+      "category": "scar",
+      "expect": "parity",
+      "input": "Hey <!everyone> and <!channel> and <!here>!",
+      "native_output": "Hey &lt;!everyone&gt; and &lt;!channel&gt; and &lt;!here&gt;!"
+    },
+    {
+      "id": "fence-lang-tag-slack",
+      "category": "scar",
+      "expect": "parity",
+      "input": "```text\nliteral first line issue\n```",
+      "native_output": "```\nliteral first line issue\n```"
+    },
+    {
+      "id": "backslash-in-code",
+      "category": "scar",
+      "expect": "parity",
+      "input": "`C:\\Users\\ben\\file.txt` and ```\npath = \"a\\\\b\"\n```",
+      "native_output": "`C:\\Users\\ben\\file.txt` and ```\npath = \"a\\\\b\"\n```"
+    },
+    {
+      "id": "backtick-in-fence",
+      "category": "scar",
+      "expect": "parity",
+      "input": "```\nuse `inline` inside fence\n```",
+      "native_output": "```\nuse `inline` inside fence\n```"
+    },
+    {
+      "id": "header-with-bold",
+      "category": "scar",
+      "expect": "parity",
+      "input": "## The **Real** Deal",
+      "native_output": "*The Real Deal*"
+    },
+    {
+      "id": "table-cjk",
+      "category": "scar",
+      "expect": "parity",
+      "input": "| 名前 | 値 |\n|------|----|\n| 中文 | 42 |\n| b    | 2  |",
+      "native_output": "```\n| 名前 | 値  |\n| ---- | --- |\n| 中文 | 42  |\n| b    | 2   |\n```"
+    },
+    {
+      "id": "link-display-escapes",
+      "category": "scar",
+      "expect": "parity",
+      "input": "[v2.0 (beta)](https://example.com/v2)",
+      "native_output": "<https://example.com/v2|v2.0 (beta)>"
+    },
+    {
+      "id": "media-tag",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "Here you go\nMEDIA:/tmp/output.png\ndone",
+      "native_output": "Here you go\nMEDIA:/tmp/output.png\ndone"
+    },
+    {
+      "id": "unclosed-fence",
+      "category": "adversarial",
+      "expect": "divergent",
+      "input": "```python\nprint('never closed')",
+      "native_output": "```python\nprint('never closed')",
+      "note": "unterminated fence handling differs; both degrade without dropping content"
+    },
+    {
+      "id": "pathological-nesting",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "**bold *italic ~~struck `code` struck~~ italic* bold**",
+      "native_output": "*bold *italic ~~struck `code` struck~~ italic* bold*"
+    },
+    {
+      "id": "placeholder-injection",
+      "category": "adversarial",
+      "expect": "divergent",
+      "input": "sneaky \u0000PH0\u0000 token and \u0000SL1\u0000 too",
+      "native_output": "sneaky \u0000PH0\u0000 token and \u0000SL1\u0000 too",
+      "note": "\\x00SL tokens are the native renderer's own placeholder alphabet; connector uses a different scheme"
+    },
+    {
+      "id": "triple-markers",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "***what is this*** and ____that____",
+      "native_output": "*_what is this_* and ____that____"
+    },
+    {
+      "id": "empty-string",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "",
+      "native_output": ""
+    },
+    {
+      "id": "whitespace-only",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "   \n\t\n   ",
+      "native_output": "   \n\t\n   "
+    },
+    {
+      "id": "long-line",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word ",
+      "native_output": "word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word "
+    },
+    {
+      "id": "many-fences",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "```\na\n```\nmid\n```\nb\n```\nend ```inline``` tail",
+      "native_output": "```\na\n```\nmid\n```\nb\n```\nend ```inline``` tail"
+    }
+  ]
+}

--- a/tests/conformance/vectors/telegram.json
+++ b/tests/conformance/vectors/telegram.json
@@ -1,0 +1,325 @@
+{
+  "$comment": "GENERATED — do not hand-edit. Regenerate with hermes-agent scripts/generate_conformance_vectors.py; the native renderers are the oracle (executable spec).",
+  "oracle": {
+    "repo": "NousResearch/hermes-agent",
+    "commit": "40eebc7d70f3d8e95c429c8aa482f31ba6c867f6",
+    "generator": "scripts/generate_conformance_vectors.py",
+    "generator_version": 1
+  },
+  "platform": "telegram",
+  "vectors": [
+    {
+      "id": "plain-text",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "Just a plain sentence.",
+      "native_output": "Just a plain sentence\\."
+    },
+    {
+      "id": "bold",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "This is **bold** text.",
+      "native_output": "This is *bold* text\\."
+    },
+    {
+      "id": "italic",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "This is *italic* text.",
+      "native_output": "This is _italic_ text\\."
+    },
+    {
+      "id": "bold-italic",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "Mix of **bold** and *italic* in one line.",
+      "native_output": "Mix of *bold* and _italic_ in one line\\."
+    },
+    {
+      "id": "strikethrough",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "This is ~~struck~~ text.",
+      "native_output": "This is ~struck~ text\\."
+    },
+    {
+      "id": "inline-code",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "Run `pip install hermes` to start.",
+      "native_output": "Run `pip install hermes` to start\\."
+    },
+    {
+      "id": "fenced-code",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "```\nprint('hello')\n```",
+      "native_output": "```\nprint('hello')\n```"
+    },
+    {
+      "id": "fenced-code-lang",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "```python\ndef f(x):\n    return x * 2\n```",
+      "native_output": "```python\ndef f(x):\n    return x * 2\n```"
+    },
+    {
+      "id": "link",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "See [the docs](https://example.com/docs) for more.",
+      "native_output": "See [the docs](https://example.com/docs) for more\\."
+    },
+    {
+      "id": "link-parens-url",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "See [spec](https://example.com/a_(b)) here.",
+      "native_output": "See [spec](https://example.com/a_\\(b\\)) here\\."
+    },
+    {
+      "id": "header-h1",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "# Big Title\nBody follows.",
+      "native_output": "*Big Title*\nBody follows\\."
+    },
+    {
+      "id": "header-h2",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "## Section\nBody follows.",
+      "native_output": "*Section*\nBody follows\\."
+    },
+    {
+      "id": "header-h3",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "### Sub-section\nBody follows.",
+      "native_output": "*Sub\\-section*\nBody follows\\."
+    },
+    {
+      "id": "ul-list",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "- first\n- second\n- third",
+      "native_output": "\\- first\n\\- second\n\\- third"
+    },
+    {
+      "id": "ol-list",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "1. first\n2. second\n3. third",
+      "native_output": "1\\. first\n2\\. second\n3\\. third"
+    },
+    {
+      "id": "nested-list",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "- outer\n  - inner one\n  - inner two\n- outer two",
+      "native_output": "\\- outer\n  \\- inner one\n  \\- inner two\n\\- outer two"
+    },
+    {
+      "id": "blockquote",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "> quoted wisdom\nregular line",
+      "native_output": "> quoted wisdom\nregular line"
+    },
+    {
+      "id": "hrule",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "above\n\n---\n\nbelow",
+      "native_output": "above\n\n\\-\\-\\-\n\nbelow"
+    },
+    {
+      "id": "table-simple",
+      "category": "grid",
+      "expect": "divergent",
+      "input": "| name | value |\n|------|-------|\n| a    | 1     |\n| b    | 2     |",
+      "native_output": "*a*\n• value: 1\n\n*b*\n• value: 2",
+      "note": "native wraps tables into row groups; connector renders <pre> — content preserved, layout differs"
+    },
+    {
+      "id": "emoji",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "Done ✅ with 🎉 emoji 👀 test.",
+      "native_output": "Done ✅ with 🎉 emoji 👀 test\\."
+    },
+    {
+      "id": "cjk",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "中文测试：**粗体** 和 `代码` 混排。",
+      "native_output": "中文测试：*粗体* 和 `代码` 混排。"
+    },
+    {
+      "id": "bare-url",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "Visit https://example.com/path?q=1&r=2 today.",
+      "native_output": "Visit https://example\\.com/path?q\\=1&r\\=2 today\\."
+    },
+    {
+      "id": "mixed-document",
+      "category": "grid",
+      "expect": "semantic",
+      "input": "## Report\n\nStatus: **green**. Details in `runbook.md`.\n\n- item *one*\n- item **two**\n\n```sh\nmake deploy\n```\n\nSee [dashboard](https://grafana.example.com/d/x).",
+      "native_output": "*Report*\n\nStatus: *green*\\. Details in `runbook.md`\\.\n\n\\- item _one_\n\\- item *two*\n\n```sh\nmake deploy\n```\n\nSee [dashboard](https://grafana.example.com/d/x)\\."
+    },
+    {
+      "id": "mdv2-reserved-chars",
+      "category": "scar",
+      "expect": "semantic",
+      "input": "Price is 3.50 (was 4.00) — save ~12%! #deal +tax = win.",
+      "native_output": "Price is 3\\.50 \\(was 4\\.00\\) — save \\~12%\\! \\#deal \\+tax \\= win\\."
+    },
+    {
+      "id": "mdv2-underscores",
+      "category": "scar",
+      "expect": "semantic",
+      "input": "snake_case_name and file_name.py in prose.",
+      "native_output": "snake\\_case\\_name and file\\_name\\.py in prose\\."
+    },
+    {
+      "id": "mdv2-brackets",
+      "category": "scar",
+      "expect": "semantic",
+      "input": "Array[0] and dict{key} and (parens) live here.",
+      "native_output": "Array\\[0\\] and dict\\{key\\} and \\(parens\\) live here\\."
+    },
+    {
+      "id": "slack-bold-conversion",
+      "category": "scar",
+      "expect": "semantic",
+      "input": "**important** word",
+      "native_output": "*important* word"
+    },
+    {
+      "id": "slack-link-conversion",
+      "category": "scar",
+      "expect": "semantic",
+      "input": "[click here](https://example.com)",
+      "native_output": "[click here](https://example.com)"
+    },
+    {
+      "id": "slack-broadcast-mention",
+      "category": "scar",
+      "expect": "semantic",
+      "input": "Hey <!everyone> and <!channel> and <!here>!",
+      "native_output": "Hey <\\!everyone\\> and <\\!channel\\> and <\\!here\\>\\!"
+    },
+    {
+      "id": "fence-lang-tag-slack",
+      "category": "scar",
+      "expect": "semantic",
+      "input": "```text\nliteral first line issue\n```",
+      "native_output": "```text\nliteral first line issue\n```"
+    },
+    {
+      "id": "backslash-in-code",
+      "category": "scar",
+      "expect": "semantic",
+      "input": "`C:\\Users\\ben\\file.txt` and ```\npath = \"a\\\\b\"\n```",
+      "native_output": "`C:\\\\Users\\\\ben\\\\file.txt` and ```\npath = \"a\\\\\\\\b\"\n```"
+    },
+    {
+      "id": "backtick-in-fence",
+      "category": "scar",
+      "expect": "semantic",
+      "input": "```\nuse `inline` inside fence\n```",
+      "native_output": "```\nuse \\`inline\\` inside fence\n```"
+    },
+    {
+      "id": "header-with-bold",
+      "category": "scar",
+      "expect": "semantic",
+      "input": "## The **Real** Deal",
+      "native_output": "*The Real Deal*"
+    },
+    {
+      "id": "table-cjk",
+      "category": "scar",
+      "expect": "divergent",
+      "input": "| 名前 | 値 |\n|------|----|\n| 中文 | 42 |\n| b    | 2  |",
+      "native_output": "*中文*\n• 値: 42\n\n*b*\n• 値: 2",
+      "note": "same as table-simple (CJK width alignment is native-only)"
+    },
+    {
+      "id": "link-display-escapes",
+      "category": "scar",
+      "expect": "semantic",
+      "input": "[v2.0 (beta)](https://example.com/v2)",
+      "native_output": "[v2\\.0 \\(beta\\)](https://example.com/v2)"
+    },
+    {
+      "id": "media-tag",
+      "category": "adversarial",
+      "expect": "semantic",
+      "input": "Here you go\nMEDIA:/tmp/output.png\ndone",
+      "native_output": "Here you go\nMEDIA:/tmp/output\\.png\ndone"
+    },
+    {
+      "id": "unclosed-fence",
+      "category": "adversarial",
+      "expect": "divergent",
+      "input": "```python\nprint('never closed')",
+      "native_output": "\\`\\`\\`python\nprint\\('never closed'\\)",
+      "note": "unterminated fence: native escapes as prose, connector HTML may close the block — degraded either way, never a 400"
+    },
+    {
+      "id": "pathological-nesting",
+      "category": "adversarial",
+      "expect": "semantic",
+      "input": "**bold *italic ~~struck `code` struck~~ italic* bold**",
+      "native_output": "*bold \\*italic \\~\\~struck `code` struck\\~\\~ italic\\* bold*"
+    },
+    {
+      "id": "placeholder-injection",
+      "category": "adversarial",
+      "expect": "divergent",
+      "input": "sneaky \u0000PH0\u0000 token and \u0000SL1\u0000 too",
+      "native_output": "sneaky \u0000PH0\u0000 token and \u0000SL1\u0000 too",
+      "note": "NUL placeholder tokens are renderer-internal; each side neutralizes its own pattern"
+    },
+    {
+      "id": "triple-markers",
+      "category": "adversarial",
+      "expect": "semantic",
+      "input": "***what is this*** and ____that____",
+      "native_output": "*\\*what is this*\\* and \\_\\_\\_\\_that\\_\\_\\_\\_"
+    },
+    {
+      "id": "empty-string",
+      "category": "adversarial",
+      "expect": "semantic",
+      "input": "",
+      "native_output": ""
+    },
+    {
+      "id": "whitespace-only",
+      "category": "adversarial",
+      "expect": "divergent",
+      "input": "   \n\t\n   ",
+      "native_output": "   \n\t\n   ",
+      "note": "native collapses to empty-ish prose, connector HTML preserves — cosmetic"
+    },
+    {
+      "id": "long-line",
+      "category": "adversarial",
+      "expect": "semantic",
+      "input": "word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word ",
+      "native_output": "word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word "
+    },
+    {
+      "id": "many-fences",
+      "category": "adversarial",
+      "expect": "semantic",
+      "input": "```\na\n```\nmid\n```\nb\n```\nend ```inline``` tail",
+      "native_output": "```\na\n```\nmid\n```\nb\n```\nend ```inline``` tail"
+    }
+  ]
+}

--- a/tests/conformance/vectors/whatsapp.json
+++ b/tests/conformance/vectors/whatsapp.json
@@ -1,0 +1,322 @@
+{
+  "$comment": "GENERATED — do not hand-edit. Regenerate with hermes-agent scripts/generate_conformance_vectors.py; the native renderers are the oracle (executable spec).",
+  "oracle": {
+    "repo": "NousResearch/hermes-agent",
+    "commit": "40eebc7d70f3d8e95c429c8aa482f31ba6c867f6",
+    "generator": "scripts/generate_conformance_vectors.py",
+    "generator_version": 1
+  },
+  "platform": "whatsapp",
+  "vectors": [
+    {
+      "id": "plain-text",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Just a plain sentence.",
+      "native_output": "Just a plain sentence."
+    },
+    {
+      "id": "bold",
+      "category": "grid",
+      "expect": "parity",
+      "input": "This is **bold** text.",
+      "native_output": "This is *bold* text."
+    },
+    {
+      "id": "italic",
+      "category": "grid",
+      "expect": "parity",
+      "input": "This is *italic* text.",
+      "native_output": "This is _italic_ text."
+    },
+    {
+      "id": "bold-italic",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Mix of **bold** and *italic* in one line.",
+      "native_output": "Mix of *bold* and _italic_ in one line."
+    },
+    {
+      "id": "strikethrough",
+      "category": "grid",
+      "expect": "parity",
+      "input": "This is ~~struck~~ text.",
+      "native_output": "This is ~struck~ text."
+    },
+    {
+      "id": "inline-code",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Run `pip install hermes` to start.",
+      "native_output": "Run `pip install hermes` to start."
+    },
+    {
+      "id": "fenced-code",
+      "category": "grid",
+      "expect": "parity",
+      "input": "```\nprint('hello')\n```",
+      "native_output": "```\nprint('hello')\n```"
+    },
+    {
+      "id": "fenced-code-lang",
+      "category": "grid",
+      "expect": "parity",
+      "input": "```python\ndef f(x):\n    return x * 2\n```",
+      "native_output": "```python\ndef f(x):\n    return x * 2\n```"
+    },
+    {
+      "id": "link",
+      "category": "grid",
+      "expect": "parity",
+      "input": "See [the docs](https://example.com/docs) for more.",
+      "native_output": "See the docs (https://example.com/docs) for more."
+    },
+    {
+      "id": "link-parens-url",
+      "category": "grid",
+      "expect": "parity",
+      "input": "See [spec](https://example.com/a_(b)) here.",
+      "native_output": "See spec (https://example.com/a_(b)) here."
+    },
+    {
+      "id": "header-h1",
+      "category": "grid",
+      "expect": "parity",
+      "input": "# Big Title\nBody follows.",
+      "native_output": "*Big Title*\nBody follows."
+    },
+    {
+      "id": "header-h2",
+      "category": "grid",
+      "expect": "parity",
+      "input": "## Section\nBody follows.",
+      "native_output": "*Section*\nBody follows."
+    },
+    {
+      "id": "header-h3",
+      "category": "grid",
+      "expect": "parity",
+      "input": "### Sub-section\nBody follows.",
+      "native_output": "*Sub-section*\nBody follows."
+    },
+    {
+      "id": "ul-list",
+      "category": "grid",
+      "expect": "parity",
+      "input": "- first\n- second\n- third",
+      "native_output": "- first\n- second\n- third"
+    },
+    {
+      "id": "ol-list",
+      "category": "grid",
+      "expect": "parity",
+      "input": "1. first\n2. second\n3. third",
+      "native_output": "1. first\n2. second\n3. third"
+    },
+    {
+      "id": "nested-list",
+      "category": "grid",
+      "expect": "parity",
+      "input": "- outer\n  - inner one\n  - inner two\n- outer two",
+      "native_output": "- outer\n  - inner one\n  - inner two\n- outer two"
+    },
+    {
+      "id": "blockquote",
+      "category": "grid",
+      "expect": "parity",
+      "input": "> quoted wisdom\nregular line",
+      "native_output": "> quoted wisdom\nregular line"
+    },
+    {
+      "id": "hrule",
+      "category": "grid",
+      "expect": "parity",
+      "input": "above\n\n---\n\nbelow",
+      "native_output": "above\n\n---\n\nbelow"
+    },
+    {
+      "id": "table-simple",
+      "category": "grid",
+      "expect": "parity",
+      "input": "| name | value |\n|------|-------|\n| a    | 1     |\n| b    | 2     |",
+      "native_output": "| name | value |\n|------|-------|\n| a    | 1     |\n| b    | 2     |"
+    },
+    {
+      "id": "emoji",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Done ✅ with 🎉 emoji 👀 test.",
+      "native_output": "Done ✅ with 🎉 emoji 👀 test."
+    },
+    {
+      "id": "cjk",
+      "category": "grid",
+      "expect": "parity",
+      "input": "中文测试：**粗体** 和 `代码` 混排。",
+      "native_output": "中文测试：*粗体* 和 `代码` 混排。"
+    },
+    {
+      "id": "bare-url",
+      "category": "grid",
+      "expect": "parity",
+      "input": "Visit https://example.com/path?q=1&r=2 today.",
+      "native_output": "Visit https://example.com/path?q=1&r=2 today."
+    },
+    {
+      "id": "mixed-document",
+      "category": "grid",
+      "expect": "parity",
+      "input": "## Report\n\nStatus: **green**. Details in `runbook.md`.\n\n- item *one*\n- item **two**\n\n```sh\nmake deploy\n```\n\nSee [dashboard](https://grafana.example.com/d/x).",
+      "native_output": "*Report*\n\nStatus: *green*. Details in `runbook.md`.\n\n- item _one_\n- item *two*\n\n```sh\nmake deploy\n```\n\nSee dashboard (https://grafana.example.com/d/x)."
+    },
+    {
+      "id": "mdv2-reserved-chars",
+      "category": "scar",
+      "expect": "parity",
+      "input": "Price is 3.50 (was 4.00) — save ~12%! #deal +tax = win.",
+      "native_output": "Price is 3.50 (was 4.00) — save ~12%! #deal +tax = win."
+    },
+    {
+      "id": "mdv2-underscores",
+      "category": "scar",
+      "expect": "parity",
+      "input": "snake_case_name and file_name.py in prose.",
+      "native_output": "snake_case_name and file_name.py in prose."
+    },
+    {
+      "id": "mdv2-brackets",
+      "category": "scar",
+      "expect": "parity",
+      "input": "Array[0] and dict{key} and (parens) live here.",
+      "native_output": "Array[0] and dict{key} and (parens) live here."
+    },
+    {
+      "id": "slack-bold-conversion",
+      "category": "scar",
+      "expect": "parity",
+      "input": "**important** word",
+      "native_output": "*important* word"
+    },
+    {
+      "id": "slack-link-conversion",
+      "category": "scar",
+      "expect": "parity",
+      "input": "[click here](https://example.com)",
+      "native_output": "click here (https://example.com)"
+    },
+    {
+      "id": "slack-broadcast-mention",
+      "category": "scar",
+      "expect": "parity",
+      "input": "Hey <!everyone> and <!channel> and <!here>!",
+      "native_output": "Hey <!everyone> and <!channel> and <!here>!"
+    },
+    {
+      "id": "fence-lang-tag-slack",
+      "category": "scar",
+      "expect": "parity",
+      "input": "```text\nliteral first line issue\n```",
+      "native_output": "```text\nliteral first line issue\n```"
+    },
+    {
+      "id": "backslash-in-code",
+      "category": "scar",
+      "expect": "parity",
+      "input": "`C:\\Users\\ben\\file.txt` and ```\npath = \"a\\\\b\"\n```",
+      "native_output": "`C:\\Users\\ben\\file.txt` and ```\npath = \"a\\\\b\"\n```"
+    },
+    {
+      "id": "backtick-in-fence",
+      "category": "scar",
+      "expect": "parity",
+      "input": "```\nuse `inline` inside fence\n```",
+      "native_output": "```\nuse `inline` inside fence\n```"
+    },
+    {
+      "id": "header-with-bold",
+      "category": "scar",
+      "expect": "parity",
+      "input": "## The **Real** Deal",
+      "native_output": "*The *Real* Deal*"
+    },
+    {
+      "id": "table-cjk",
+      "category": "scar",
+      "expect": "parity",
+      "input": "| 名前 | 値 |\n|------|----|\n| 中文 | 42 |\n| b    | 2  |",
+      "native_output": "| 名前 | 値 |\n|------|----|\n| 中文 | 42 |\n| b    | 2  |"
+    },
+    {
+      "id": "link-display-escapes",
+      "category": "scar",
+      "expect": "parity",
+      "input": "[v2.0 (beta)](https://example.com/v2)",
+      "native_output": "v2.0 (beta) (https://example.com/v2)"
+    },
+    {
+      "id": "media-tag",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "Here you go\nMEDIA:/tmp/output.png\ndone",
+      "native_output": "Here you go\nMEDIA:/tmp/output.png\ndone"
+    },
+    {
+      "id": "unclosed-fence",
+      "category": "adversarial",
+      "expect": "divergent",
+      "input": "```python\nprint('never closed')",
+      "native_output": "```python\nprint('never closed')",
+      "note": "unterminated fence handling differs; both degrade without dropping content"
+    },
+    {
+      "id": "pathological-nesting",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "**bold *italic ~~struck `code` struck~~ italic* bold**",
+      "native_output": "*bold _italic ~struck `code` struck~ italic_ bold*"
+    },
+    {
+      "id": "placeholder-injection",
+      "category": "adversarial",
+      "expect": "divergent",
+      "input": "sneaky \u0000PH0\u0000 token and \u0000SL1\u0000 too",
+      "native_output": "sneaky \u0000PH0\u0000 token and \u0000SL1\u0000 too",
+      "note": "placeholder alphabets are renderer-internal"
+    },
+    {
+      "id": "triple-markers",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "***what is this*** and ____that____",
+      "native_output": "**what is this** and *__that*__"
+    },
+    {
+      "id": "empty-string",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "",
+      "native_output": ""
+    },
+    {
+      "id": "whitespace-only",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "   \n\t\n   ",
+      "native_output": "   \n\t\n   "
+    },
+    {
+      "id": "long-line",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word ",
+      "native_output": "word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word "
+    },
+    {
+      "id": "many-fences",
+      "category": "adversarial",
+      "expect": "parity",
+      "input": "```\na\n```\nmid\n```\nb\n```\nend ```inline``` tail",
+      "native_output": "```\na\n```\nmid\n```\nb\n```\nend ```inline``` tail"
+    }
+  ]
+}


### PR DESCRIPTION
![Vector generator](https://v3b.fal.media/files/b/0aa3bca1/RwLhAvKSCfZLrb9skrVm-_CRABLZDE.png)

## Conformance oracle — vector generator (gateway side)

Gateway half of the conformance-oracle pair: NousResearch/gateway-gateway#179. The native renderers become the **executable specification** for the connector's egress lanes; what crosses the repo boundary is test data, not code.

### `scripts/generate_conformance_vectors.py`
Renders a 44-case corpus through the four NATIVE renderers and emits per-platform JSON vectors:
- **Corpus**: markdown grid (23) + scar tissue (12 — each a named vector memorializing a real fixed formatting bug) + adversarial agent output (9 — MEDIA: tags, unclosed fences, placeholder-alphabet injection, pathological nesting).
- **Oracles, imported never reimplemented**: `TelegramAdapter.format_message` (MarkdownV2), `SlackAdapter.format_message` (mrkdwn), `WhatsAppBehaviorMixin.format_message`, `DiscordAdapter.format_message`. All four are self-free and invoked unbound — a test guards that calling convention so a future refactor that adds instance state fails loudly here, not silently downstream.
- **Expect semantics** consumed by the connector runner: `parity` (byte-equal), `semantic` (Telegram: the connector speaks HTML, native speaks MarkdownV2 — content equivalence), `divergent` (documented no-parity, note required, asserted as the degraded behavior).
- Output stamped with oracle commit + generator version.

### `tests/conformance/` (7 tests + committed vectors)
Behavior contracts, not change-detectors: corpus id uniqueness, oracle importability/self-freeness, byte determinism, file shape (divergent ⇒ note), per-platform expect defaults (Telegram never claims byte parity), scar vectors actually exercising their named bugs, and **committed-vectors-reproduce lockstep** — the `openapi.json` discipline: change a renderer without regenerating and HA's own CI fails, before the drift ever reaches the connector.

### Consumers (connector side)
gateway-gateway commits a copy under `conformance/vectors/`, runs 179 sender-level payload assertions against them, and a weekly workflow regenerates from this repo's `main` and auto-PRs on drift. The suite found two real connector bugs on day one (Slack table wrapping missing; Telegram single-line fence content swallowed) — fixed in the paired PR.

### Tests
`pytest tests/conformance/` — 7 passed; ruff clean. No gateway/agent runtime changes (scripts + tests + committed vectors only).
