### PR TITLE
fix(gateway): survive faulthandler.enable() when sys.stderr is None

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7815,10 +7815,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Returns True if at least one adapter connected successfully.
         """
         logger.info("Starting Hermes Gateway...")
-        # Enable faulthandler at gateway start so that SIGUSR2 (or an
-        # internal watchdog) can dump all thread and task stacks to stderr
-        # for post-mortem diagnosis of event-loop freezes (#70344).
-        faulthandler.enable()
+        # Enable faulthandler for stack dumps on freezes/crashes (#70344).
+        # Falls back to a log file when sys.stderr is None (Windows VBS /
+        # pythonw / detached service) — otherwise the gateway would die
+        # here and take every adapter offline. See #71671.
+        try:
+            faulthandler.enable()
+        except (RuntimeError, ValueError, OSError):
+            try:
+                _fh_log_dir = getattr(self.config, "log_dir", None) or os.path.join(
+                    os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")),
+                    "logs",
+                )
+                os.makedirs(_fh_log_dir, exist_ok=True)
+                _fh_enable_path = os.path.join(_fh_log_dir, "gateway_faulthandler.log")
+                _fh_enable_file = open(_fh_enable_path, "a", encoding="utf-8")
+                faulthandler.enable(file=_fh_enable_file, all_threads=True)
+            except Exception:
+                logger.debug("faulthandler.enable() unavailable", exc_info=True)
         # Also dump stacks to a rotating file for off-line analysis when
         # the gateway is running under a service manager that doesn't
         # capture stderr.

--- a/tests/gateway/test_71671_faulthandler_no_stderr.py
+++ b/tests/gateway/test_71671_faulthandler_no_stderr.py
@@ -1,0 +1,47 @@
+"""Regression: #71671 — gateway must survive faulthandler.enable() with sys.stderr=None."""
+
+from __future__ import annotations
+
+import faulthandler
+import os
+import sys
+
+import pytest
+
+
+def test_faulthandler_enable_falls_back_when_stderr_is_none(tmp_path):
+    was_enabled = faulthandler.is_enabled()
+    if was_enabled:
+        faulthandler.disable()
+
+    real_stderr = sys.stderr
+    sys.stderr = None
+    try:
+        with pytest.raises(RuntimeError, match="sys.stderr is None"):
+            faulthandler.enable()
+
+        log_path = tmp_path / "gateway_faulthandler.log"
+        fh = open(log_path, "a", encoding="utf-8")
+        try:
+            faulthandler.enable(file=fh, all_threads=True)
+            assert faulthandler.is_enabled()
+            assert log_path.exists()
+        finally:
+            faulthandler.disable()
+            fh.close()
+    finally:
+        sys.stderr = real_stderr
+        if was_enabled:
+            faulthandler.enable()
+
+
+def test_gateway_run_keeps_faulthandler_guard():
+    src = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "gateway", "run.py",
+    )
+    with open(src, encoding="utf-8") as f:
+        text = f.read()
+    assert "try:\n            faulthandler.enable()\n        except (RuntimeError, ValueError, OSError):" in text, (
+        "gateway/run.py must keep the try/except guard around faulthandler.enable() (see #71671)"
+    )


### PR DESCRIPTION
## Symptom

When the Hermes gateway is launched with no console attached — e.g. via the Windows Startup `Hermes_Gateway.vbs` shim, `pythonw.exe`, a detached service, or any parent that redirects stderr to `DEVNULL` — it crashes on its very first line of `GatewayRunner.start()` and every configured platform adapter (Discord bot, Telegram, Slack, …) silently goes offline. The user only finds out much later when someone notices their bot has a grey dot next to it.

## Repro

Real traceback from `~/AppData/Local/hermes/logs/gateway-exit-diag.log` on a Windows box where the Startup VBS launched the gateway with `stdin_is_tty=false`:

```
{"tag": "asyncio.run.exception", "exc_type": "RuntimeError",
 "exc_repr": "RuntimeError('sys.stderr is None')",
 "traceback": "...
    File \"gateway/run.py\", line 7821, in start
        faulthandler.enable()
    RuntimeError: sys.stderr is None
"}
```

`faulthandler.enable()` writes to `sys.stderr` by default, which is `None` under the conditions above — so the call raises and bubbles all the way out of `asyncio.run(...)`, killing the gateway before a single adapter connects.

## Fix

Wrap `faulthandler.enable()` and, on failure, fall back to a log-file file descriptor (`<log_dir>/gateway_faulthandler.log`) so fatal-error stack dumps still land somewhere useful. If even the fallback fails we log-and-continue rather than crash — losing the fault-dump-on-abort niceness is much better than losing the whole gateway (and every messaging platform bound to it).

The fix is intentionally minimal and stays within the existing `start()` prologue; the surrounding `SIGUSR2` file-based `faulthandler.register()` block (which was already best-effort/try-except) is untouched.

## Why this bug class matters

Any adapter that lives inside the gateway process (Discord, Telegram, Slack, WhatsApp, etc.) shares its lifecycle. A single unhandled exception in `start()` = every user-facing bot goes dark at once. Making startup best-effort for observability shims (faulthandler, watchdogs, telemetry hooks) protects the whole product surface.

## Test

- Syntax check on `gateway/run.py` passes.
- Local run: launched the gateway on Windows with the same detached-VBS command line that used to reproduce the crash; it now starts cleanly and the Discord adapter comes back online.

## Related

Regression relative to `#70344` (which introduced the `faulthandler.enable()` line for event-loop-freeze diagnosis) and follow-up `dee0b5bf6` (which POSIX-gated the SIGUSR2 registration but did not consider the console-less-stderr case for `enable()` itself).
