### PR TITLE
test: isolate delegated and Photon environment state

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,6 +214,10 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "HERMES_KANBAN_RUN_ID",
     "HERMES_KANBAN_CLAIM_LOCK",
     "HERMES_KANBAN_DISPATCH_IN_GATEWAY",
+    # Pytest is routinely launched from a delegated worker.  The worker
+    # lineage marker must not make parent-state tests run as delegated
+    # children; tests that exercise child behavior set it explicitly.
+    "HERMES_DELEGATED_CHILD_CONTEXT",
     "HERMES_TENANT",
     # Honcho host selection changes which nested config block wins. A local
     # shell override leaked "myhost" into the full suite and flipped 20
@@ -254,6 +258,7 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "DINGTALK_ALLOWED_USERS",
     "FEISHU_ALLOWED_USERS",
     "WECOM_ALLOWED_USERS",
+    "PHOTON_ALLOWED_USERS",
     "GATEWAY_ALLOWED_USERS",
     "GATEWAY_ALLOW_ALL_USERS",
     "TELEGRAM_ALLOW_ALL_USERS",
@@ -263,6 +268,7 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "SIGNAL_ALLOW_ALL_USERS",
     "EMAIL_ALLOW_ALL_USERS",
     "SMS_ALLOW_ALL_USERS",
+    "PHOTON_ALLOW_ALL_USERS",
     # Gateway home channels are set by /sethome in real profiles. Tests that
     # exercise dashboard notification toggles must opt in explicitly or they
     # can accidentally subscribe against a developer's real home channel.
@@ -303,6 +309,9 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "WECOM_HOME_CHANNEL",
     "WECOM_HOME_CHANNEL_THREAD_ID",
     "WECOM_HOME_CHANNEL_NAME",
+    "PHOTON_HOME_CHANNEL",
+    "PHOTON_HOME_CHANNEL_THREAD_ID",
+    "PHOTON_HOME_CHANNEL_NAME",
     # API server bind/auth settings are common in local gateway profiles and
     # change adapter defaults plus load_gateway_config() enablement. Tests that
     # need them set opt in explicitly with monkeypatch.

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -575,13 +575,27 @@ class TestRoutingIntents:
 
     def test_all_with_no_connected_channels_returns_empty(self, monkeypatch):
         """deliver='all' with nothing connected returns [] — delivery is recorded as failed upstream."""
-        from cron.scheduler import _resolve_delivery_targets
+        from cron.scheduler import (
+            _LEGACY_HOME_TARGET_ENV_VARS,
+            _iter_home_target_platforms,
+            _resolve_delivery_targets,
+            _resolve_home_env_var,
+        )
 
-        for var in ("TELEGRAM_HOME_CHANNEL", "DISCORD_HOME_CHANNEL", "SLACK_HOME_CHANNEL",
-                    "SIGNAL_HOME_CHANNEL", "MATRIX_HOME_ROOM", "MATTERMOST_HOME_CHANNEL",
-                    "SMS_HOME_CHANNEL", "EMAIL_HOME_ADDRESS", "DINGTALK_HOME_CHANNEL",
-                    "FEISHU_HOME_CHANNEL", "WECOM_HOME_CHANNEL", "WEIXIN_HOME_CHANNEL",
-                    "BLUEBUBBLES_HOME_CHANNEL", "QQBOT_HOME_CHANNEL", "QQ_HOME_CHANNEL"):
+        # Derive the quarantine from the same registry used by delivery
+        # resolution.  A newly registered platform must not require another
+        # hard-coded test list update.
+        env_vars = {
+            _resolve_home_env_var(platform)
+            for platform in _iter_home_target_platforms()
+        }
+        env_vars.discard("")
+        env_vars.update(
+            legacy
+            for current, legacy in _LEGACY_HOME_TARGET_ENV_VARS.items()
+            if current in env_vars
+        )
+        for var in env_vars:
             monkeypatch.delenv(var, raising=False)
 
         assert _resolve_delivery_targets({"deliver": "all", "origin": None}) == []


### PR DESCRIPTION
## Summary
- clear inherited `HERMES_DELEGATED_CHILD_CONTEXT` so parent-state tests remain hermetic when pytest is launched by a delegated worker
- quarantine Photon routing and auth environment variables alongside other platform variables
- derive the cron no-connected-channels cleanup from the registered platform specs instead of a stale hard-coded list

## Reproduction
Before this patch:
- `HERMES_DELEGATED_CHILD_CONTEXT=1` caused 8 failures in `test_delegate_kanban_isolation.py`
- `PHOTON_HOME_CHANNEL=...` made the no-connected-channels cron test discover the developer's real Photon destination

## Verification
- contaminated-environment regression: 17 passed
- combined relevant suite on current `origin/main`: 928 passed
- Ruff checks passed
- production code and plugin SDK unchanged