### PR TITLE
fix(conversation): rebuild the system prompt when the working directory drifts

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -540,15 +540,49 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
 
 
 def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
-    """Return False when the persisted Model/Provider lines are stale."""
+    """Return False when the persisted runtime-identity lines are stale."""
 
     def line_value(label: str) -> str:
+        """Last matching line wins.
+
+        Safe ONLY for fields emitted in the volatile tier at the very END of
+        the prompt (Model / Provider / Platform). User-supplied project
+        context (AGENTS.md / CLAUDE.md / .cursorrules) is embedded in the
+        middle context tier, so a last-match scan lets project prose shadow
+        any field emitted EARLIER — see ``host_info_value``.
+        """
         prefix = f"{label}:"
         value = ""
         for line in prompt.splitlines():
             if line.startswith(prefix):
                 value = line[len(prefix):].strip()
         return value
+
+    def host_info_value(label: str) -> str:
+        """Read a field from the prompt's own host-info block.
+
+        The host-info block (``build_environment_hints``) sits in the STABLE
+        tier, ahead of the embedded project context files. A bare scan of the
+        whole prompt would therefore match a user's ``AGENTS.md`` that merely
+        contains a line starting with the same label, comparing runtime state
+        against project prose. That mismatch never clears, so the check would
+        reject the stored prompt on EVERY turn — rebuilding the system prompt
+        each message and destroying the prefix cache for the whole session,
+        which is far worse than the staleness this function guards against.
+
+        Anchor on the ``User home directory:`` line that immediately precedes
+        the working-directory line in that block, and take the FIRST such
+        occurrence, so only Hermes' own emitted block can satisfy the read.
+        """
+        prefix = f"{label}:"
+        lines = prompt.splitlines()
+        for idx, line in enumerate(lines):
+            if not line.startswith("User home directory:"):
+                continue
+            for candidate in lines[idx + 1: idx + 4]:
+                if candidate.startswith(prefix):
+                    return candidate[len(prefix):].strip()
+        return ""
 
     stored_model = line_value("Model")
     current_model = str(getattr(agent, "model", "") or "").strip()
@@ -565,7 +599,7 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     # Compare against resolve_agent_cwd() — the SAME resolver used to build the
     # prompt — so gateway/TUI sessions that set TERMINAL_CWD are not falsely
     # rejected (they would always differ from the launch dir's os.getcwd()).
-    stored_cwd = line_value("Current working directory")
+    stored_cwd = host_info_value("Current working directory")
     if stored_cwd:
         if stored_cwd != str(resolve_agent_cwd()):
             return False

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -559,6 +559,20 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     if stored_provider and current_provider and stored_provider != current_provider:
         return False
 
+    # Detect cwd drift: if the stored prompt was built in a different working
+    # directory, reuse would silently inject a stale path into the prefix cache.
+    stored_cwd = line_value("Current working directory")
+    if stored_cwd:
+        import os as _os
+        if stored_cwd != _os.getcwd():
+            return False
+
+    # Detect runtime surface drift: desktop GUI vs non-desktop.
+    has_desktop_marker = "Runtime surface: you're running inside the Hermes desktop GUI app." in prompt
+    in_desktop = (os.environ.get("HERMES_DESKTOP", "").strip().lower() in {"1", "true", "yes"})
+    if has_desktop_marker != in_desktop:
+        return False
+
     return True
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -48,6 +48,7 @@ from agent.turn_context import (
     reanchor_current_turn_user_idx,
 )
 from agent.turn_retry_state import TurnRetryState
+from agent.runtime_cwd import resolve_agent_cwd
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
     _repair_tool_call_arguments,
@@ -561,16 +562,20 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
 
     # Detect cwd drift: if the stored prompt was built in a different working
     # directory, reuse would silently inject a stale path into the prefix cache.
+    # Compare against resolve_agent_cwd() — the SAME resolver used to build the
+    # prompt — so gateway/TUI sessions that set TERMINAL_CWD are not falsely
+    # rejected (they would always differ from the launch dir's os.getcwd()).
     stored_cwd = line_value("Current working directory")
     if stored_cwd:
-        import os as _os
-        if stored_cwd != _os.getcwd():
+        if stored_cwd != str(resolve_agent_cwd()):
             return False
 
-    # Detect runtime surface drift: desktop GUI vs non-desktop.
-    has_desktop_marker = "Runtime surface: you're running inside the Hermes desktop GUI app." in prompt
-    in_desktop = (os.environ.get("HERMES_DESKTOP", "").strip().lower() in {"1", "true", "yes"})
-    if has_desktop_marker != in_desktop:
+    # Detect runtime-surface drift: the stored prompt records which platform it
+    # was built for (e.g. "desktop" vs "cli"). Reusing a desktop-built prompt on
+    # a terminal session (or vice versa) would inject the wrong runtime hints.
+    stored_platform = line_value("Platform")
+    current_platform = str(getattr(agent, "platform", "") or "").strip()
+    if stored_platform and current_platform and stored_platform != current_platform:
         return False
 
     return True

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -532,6 +532,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         timestamp_line += f"\nModel: {agent.model}"
     if agent.provider:
         timestamp_line += f"\nProvider: {agent.provider}"
+    if agent.platform:
+        timestamp_line += f"\nPlatform: {agent.platform}"
     volatile_parts.append(timestamp_line)
 
     return {

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -487,19 +487,61 @@ class TestStoredPromptCwdDrift:
             )
 
     def test_stored_prompt_stale_when_runtime_surface_differs(self):
-        """Desktop GUI marker in stored prompt must not be reused when running in terminal."""
-        from unittest.mock import patch
+        """A stored prompt built for a different platform must not be reused."""
         from agent.conversation_loop import _stored_prompt_matches_runtime
 
-        agent = self._make_agent()
         stored_prompt = (
-            "Runtime surface: you're running inside the Hermes desktop GUI app.\n"
+            "Platform: desktop\n"
             "Model: test/model\n"
             "Provider: openrouter\n"
         )
+        agent = self._make_agent()
+        agent.platform = "cli"
+        assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
+            "Expected False when stored prompt is for 'desktop' but the "
+            "current session runs on 'cli'"
+        )
 
-        # Current runtime is terminal/CLI: no desktop marker.
-        with patch.dict(os.environ, {"HERMES_DESKTOP": ""}, clear=False):
-            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
-                "Expected False when stored prompt claims desktop but HERMES_DESKTOP is unset"
+    def test_stored_prompt_fresh_when_platform_matches(self):
+        """Matching platform allows prompt reuse."""
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        agent.platform = "desktop"
+        stored_prompt = (
+            "Platform: desktop\n"
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+        assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
+            "Expected True when stored platform matches the current platform"
+        )
+
+    def test_built_prompt_contains_platform_line(self):
+        """The built system prompt must carry a Platform: line so drift detection works."""
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+        from hermes_state import SessionDB
+        from run_agent import AIAgent
+        from agent.system_prompt import build_system_prompt_parts
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+                agent = AIAgent(
+                    api_key="test-key",
+                    base_url="https://openrouter.ai/api/v1",
+                    model="test/model",
+                    provider="openrouter",
+                    quiet_mode=True,
+                    session_db=db,
+                    session_id="platform-test",
+                    skip_context_files=True,
+                    skip_memory=True,
+                )
+            agent.platform = "cli"
+            parts = build_system_prompt_parts(agent)
+            assert "Platform: cli" in parts["volatile"], (
+                "Built prompt missing 'Platform: cli' — drift detection cannot read it"
             )

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -485,3 +485,21 @@ class TestStoredPromptCwdDrift:
             assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
                 "Expected True when stored cwd matches current cwd"
             )
+
+    def test_stored_prompt_stale_when_runtime_surface_differs(self):
+        """Desktop GUI marker in stored prompt must not be reused when running in terminal."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        stored_prompt = (
+            "Runtime surface: you're running inside the Hermes desktop GUI app.\n"
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+
+        # Current runtime is terminal/CLI: no desktop marker.
+        with patch.dict(os.environ, {"HERMES_DESKTOP": ""}, clear=False):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
+                "Expected False when stored prompt claims desktop but HERMES_DESKTOP is unset"
+            )

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -517,6 +517,47 @@ class TestStoredPromptCwdDrift:
             "Expected True when stored platform matches the current platform"
         )
 
+    def test_stored_prompt_fresh_when_terminal_cwd_matches(self):
+        """Gateway: stored cwd equals TERMINAL_CWD -> reuse via resolve_agent_cwd.
+
+        The gateway sets TERMINAL_CWD to the configured project dir, which differs
+        from the process launch dir (os.getcwd()). Reuse must key off
+        resolve_agent_cwd(), not os.getcwd(), or every gateway turn would falsely
+        rebuild the system prompt.
+        """
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        with tempfile.TemporaryDirectory() as term_cwd:
+            stored_prompt = (
+                f"Current working directory: {term_cwd}\n"
+                "Model: test/model\n"
+                "Provider: openrouter\n"
+            )
+            with patch.dict(os.environ, {"TERMINAL_CWD": term_cwd}):
+                assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
+                    "Expected True when stored cwd equals TERMINAL_CWD "
+                    "(gateway launch dir differs from configured cwd)"
+                )
+
+    def test_stored_prompt_stale_when_terminal_cwd_differs(self):
+        """Gateway: stored cwd differs from TERMINAL_CWD -> rebuild."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        with tempfile.TemporaryDirectory() as term_cwd, tempfile.TemporaryDirectory() as other_cwd:
+            stored_prompt = (
+                f"Current working directory: {other_cwd}\n"
+                "Model: test/model\n"
+                "Provider: openrouter\n"
+            )
+            with patch.dict(os.environ, {"TERMINAL_CWD": term_cwd}):
+                assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
+                    "Expected False when stored cwd differs from TERMINAL_CWD"
+                )
+
     def test_built_prompt_contains_platform_line(self):
         """The built system prompt must carry a Platform: line so drift detection works."""
         import tempfile

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -451,6 +451,22 @@ class TestStoredPromptCwdDrift:
         agent.provider = provider
         return agent
 
+    @staticmethod
+    def _host_block(cwd: str) -> str:
+        """A stored prompt fragment shaped like the real host-info block.
+
+        ``build_environment_hints`` always emits ``User home directory:``
+        immediately before the working-directory line, and the staleness check
+        anchors on that pair so user project files can't shadow the real value.
+        Fixtures must therefore include the anchor or they stop exercising the
+        cwd path at all.
+        """
+        return (
+            "Host: Linux (6.16.0)\n"
+            "User home directory: /home/tester\n"
+            f"Current working directory: {cwd}\n"
+        )
+
     def test_stored_prompt_stale_when_cwd_differs(self):
         """Different cwd should force a prompt rebuild."""
         from unittest.mock import patch
@@ -458,8 +474,8 @@ class TestStoredPromptCwdDrift:
 
         agent = self._make_agent()
         stored_prompt = (
-            "Current working directory: /project/old\n"
-            "Model: test/model\n"
+            self._host_block("/project/old")
+            + "Model: test/model\n"
             "Provider: openrouter\n"
         )
 
@@ -476,14 +492,73 @@ class TestStoredPromptCwdDrift:
         agent = self._make_agent()
         current_cwd = "/project/current"
         stored_prompt = (
-            f"Current working directory: {current_cwd}\n"
-            "Model: test/model\n"
+            self._host_block(current_cwd)
+            + "Model: test/model\n"
             "Provider: openrouter\n"
         )
 
         with patch("os.getcwd", return_value=current_cwd):
             assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
                 "Expected True when stored cwd matches current cwd"
+            )
+
+    def test_project_context_cannot_force_a_rebuild(self):
+        """🔴 CACHE INVARIANT: user project text must never invalidate the prompt.
+
+        The prompt embeds AGENTS.md / CLAUDE.md / .cursorrules in the context
+        tier, which sits AFTER the host-info block. A whole-prompt scan for
+        ``Current working directory:`` therefore matched the user's own file
+        and compared runtime state against project prose. That mismatch never
+        clears, so the check rejected the stored prompt on EVERY turn —
+        rebuilding the system prompt each message and destroying the prefix
+        cache for the entire session. Strictly worse than the staleness this
+        check exists to catch.
+        """
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        current_cwd = "/project/current"
+        stored_prompt = (
+            self._host_block(current_cwd)
+            + "\n# AGENTS.md\n\n"
+            "Our deploy convention:\n\n"
+            "Current working directory: /srv/decoy\n\n"
+            "Always run make before pushing.\n\n"
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+
+        with patch("os.getcwd", return_value=current_cwd):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
+                "A project file that merely MENTIONS 'Current working "
+                "directory:' must not invalidate the prompt — that would "
+                "rebuild every turn and break the prefix cache"
+            )
+
+    def test_project_context_cannot_mask_real_drift(self):
+        """The inverse: project text must not fake a match either.
+
+        A stored prompt built in /project/old whose embedded AGENTS.md happens
+        to name the NEW cwd must still be rejected — otherwise project prose
+        could suppress genuine drift detection.
+        """
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        stored_prompt = (
+            self._host_block("/project/old")
+            + "\n# AGENTS.md\n\n"
+            "Current working directory: /project/new\n\n"
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+
+        with patch("os.getcwd", return_value="/project/new"):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
+                "Embedded project text naming the new cwd must not mask real "
+                "drift in the host-info block"
             )
 
     def test_stored_prompt_stale_when_runtime_surface_differs(self):
@@ -531,8 +606,8 @@ class TestStoredPromptCwdDrift:
         agent = self._make_agent()
         with tempfile.TemporaryDirectory() as term_cwd:
             stored_prompt = (
-                f"Current working directory: {term_cwd}\n"
-                "Model: test/model\n"
+                self._host_block(term_cwd)
+                + "Model: test/model\n"
                 "Provider: openrouter\n"
             )
             with patch.dict(os.environ, {"TERMINAL_CWD": term_cwd}):
@@ -549,8 +624,8 @@ class TestStoredPromptCwdDrift:
         agent = self._make_agent()
         with tempfile.TemporaryDirectory() as term_cwd, tempfile.TemporaryDirectory() as other_cwd:
             stored_prompt = (
-                f"Current working directory: {other_cwd}\n"
-                "Model: test/model\n"
+                self._host_block(other_cwd)
+                + "Model: test/model\n"
                 "Provider: openrouter\n"
             )
             with patch.dict(os.environ, {"TERMINAL_CWD": term_cwd}):

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -437,3 +437,51 @@ class TestGatewayHistoryOffsetAfterSplit:
         assert len(new_messages) == 0, (
             "Expected 0 messages with stale offset=200 (demonstrates the bug)"
         )
+
+
+class TestStoredPromptCwdDrift:
+    """Verify that stored system prompts are rejected when cwd changed."""
+
+    def _make_agent(self, model="test/model", provider="openrouter"):
+        class _Agent:
+            pass
+
+        agent = _Agent()
+        agent.model = model
+        agent.provider = provider
+        return agent
+
+    def test_stored_prompt_stale_when_cwd_differs(self):
+        """Different cwd should force a prompt rebuild."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        stored_prompt = (
+            "Current working directory: /project/old\n"
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+
+        with patch("os.getcwd", return_value="/project/new"):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
+                "Expected False when stored cwd differs from current cwd"
+            )
+
+    def test_stored_prompt_fresh_when_cwd_matches(self):
+        """Matching cwd should allow prompt reuse."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        current_cwd = "/project/current"
+        stored_prompt = (
+            f"Current working directory: {current_cwd}\n"
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+
+        with patch("os.getcwd", return_value=current_cwd):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
+                "Expected True when stored cwd matches current cwd"
+            )


### PR DESCRIPTION
## Summary

Switching your project mid-session now updates what the agent thinks its working directory is. Salvages @MorAlekss's fix in #47915.

`_stored_prompt_matches_runtime()` decides whether a continuing session may reuse its persisted system prompt verbatim (the prefix-cache reuse path). It compared the `Model` and `Provider` lines but **not** the `Current working directory` line — so after a mid-session workspace change the restored prompt kept advertising the *old* directory for the rest of the session, while the tools ran in the new one.

Same split-brain class as #71644, one layer up: that fix pins the cwd correctly per turn, but a *cached* prompt from an earlier turn still won on the restore path.

## Changes

- `agent/conversation_loop.py` — reject a stored prompt when its `Current working directory` line no longer matches `resolve_agent_cwd()`. Compares against the same resolver that built the line, so gateway/TUI sessions setting `TERMINAL_CWD` aren't falsely rejected.
- `agent/conversation_loop.py` — also reject on `Platform` drift (a desktop-built prompt reused on a CLI session injects the wrong runtime hints).
- `agent/system_prompt.py` — emit a `Platform:` line in the volatile tier so the above has something to compare.
- `tests/run_agent/test_compression_persistence.py` — cwd-drift and runtime-surface-drift coverage, incl. the `TERMINAL_CWD` gateway case.

## Validation

E2E through the real restore path (`_restore_or_build_system_prompt` with a persisted prompt and a switched cwd):

| | Before | After |
|---|---|---|
| Stored prompt judged reusable after switch | yes | no |
| Turn 2 prompt cwd (switched A→B) | `/ws/A` (stale) | `/ws/B` |
| Prompt rebuilt on drift | no | yes |

**Cache-safety control** — the risk with a staleness check is rejecting on every turn (rebuild each turn = prompt-cache miss each turn, worse than the bug). Verified a *stable* cwd still reuses the prompt byte-for-byte with **0 rebuilds** across all five resolution paths:

| Scenario | Reused | Rebuilds |
|---|---|---|
| Pinned contextvar (ACP/TUI) | yes | 0 |
| `TERMINAL_CWD` (gateway) | yes | 0 |
| Launch dir (CLI) | yes | 0 |
| Symlinked workspace | yes | 0 |
| Trailing-slash cwd | yes | 0 |

`scripts/run_tests.sh tests/run_agent/test_compression_persistence.py tests/agent/test_system_prompt.py tests/agent/test_runtime_cwd.py tests/acp/` → **372 passed, 0 failed**. Ruff clean.

## Also resolves

- #11515 — *"ACP session cwd is used for tool execution but not for project context file discovery."* The write-path half landed in #71644; this closes the cached-prompt half.
- #11570 — the designated fix PR for #11515, via a separate `working_dir` kwarg threaded through `AIAgent`. Superseded: `_SESSION_CWD` (#71644) already reaches context discovery, and this PR covers #11570's cache-invalidation half generically for every surface rather than ACP alone.

## Infographic

![stored-prompt-cwd-drift](https://v3b.fal.media/files/b/0aa3bd28/SicyA8A1zkwOR0453mFRN_EJMWYBbZ.png)
