### PR TITLE
fix(relay): block SSRF in media downloads

### DIFF
--- a/gateway/relay/media.py
+++ b/gateway/relay/media.py
@@ -41,7 +41,9 @@ import urllib.request
 from pathlib import Path
 from typing import Optional
 
+from gateway.platforms.base import safe_url_for_log
 from gateway.relay.auth import make_upgrade_token
+from tools.url_safety import is_safe_url
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +52,20 @@ logger = logging.getLogger(__name__)
 MEDIA_MAX_BYTES = 25 * 1024 * 1024
 
 _REQUEST_TIMEOUT_S = 30.0
+
+
+class _RelayMediaRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Apply the shared SSRF policy to every urllib-followed redirect."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[override]
+        if not is_safe_url(newurl):
+            raise ValueError(
+                f"Blocked relay media redirect to private/internal address: {safe_url_for_log(newurl)}"
+            )
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+_RELAY_MEDIA_OPENER = urllib.request.build_opener(_RelayMediaRedirectHandler)
 
 
 def media_base_url(relay_dial_url: str) -> str:
@@ -161,6 +177,9 @@ class RelayMediaClient:
         """
         if not url:
             return None
+        if not is_safe_url(url):
+            logger.warning("relay media download blocked unsafe URL: %s", safe_url_for_log(url))
+            return None
         needs_auth = self.is_relay_media_url(url)
         if needs_auth and not self.enabled:
             return None
@@ -171,7 +190,7 @@ class RelayMediaClient:
         def _get() -> Optional[str]:
             req = urllib.request.Request(url, headers=headers)
             try:
-                with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_S) as resp:
+                with _RELAY_MEDIA_OPENER.open(req, timeout=_REQUEST_TIMEOUT_S) as resp:
                     length = int(resp.headers.get("Content-Length") or 0)
                     if length > MEDIA_MAX_BYTES:
                         logger.warning("relay media download too large: %s", url)

--- a/tests/gateway/relay/test_relay_media.py
+++ b/tests/gateway/relay/test_relay_media.py
@@ -15,6 +15,7 @@ Covers:
 
 from __future__ import annotations
 
+import urllib.request
 from pathlib import Path
 from typing import Optional
 
@@ -23,6 +24,7 @@ import pytest
 from gateway.config import PlatformConfig
 from gateway.relay.adapter import RelayAdapter
 from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
+from gateway.relay import media as relay_media
 from gateway.relay.media import RelayMediaClient, media_base_url
 
 from tests.gateway.relay.stub_connector import StubConnector
@@ -270,6 +272,35 @@ def test_client_recognizes_rehost_urls():
     c = RelayMediaClient("https://c.example", "gw1", "sec")
     assert c.is_relay_media_url("https://c.example/relay/media/abc") is True
     assert c.is_relay_media_url("https://cdn.discordapp.com/a/b.png") is False
+
+
+@pytest.mark.asyncio
+async def test_client_download_blocks_private_url_before_network(monkeypatch):
+    c = RelayMediaClient("https://c.example", "gw1", "sec")
+
+    def fail_open(*args, **kwargs):
+        raise AssertionError("private relay media URL reached the network")
+
+    monkeypatch.setattr(relay_media._RELAY_MEDIA_OPENER, "open", fail_open)
+
+    result = await c.download("http://169.254.169.254/latest/meta-data/")
+
+    assert result is None
+
+
+def test_client_download_redirect_handler_blocks_private_location():
+    handler = relay_media._RelayMediaRedirectHandler()
+    request = urllib.request.Request("https://cdn.example/file.png")
+
+    with pytest.raises(ValueError, match="Blocked relay media redirect"):
+        handler.redirect_request(
+            request,
+            fp=None,
+            code=302,
+            msg="Found",
+            headers={},
+            newurl="http://169.254.169.254/latest/meta-data/",
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Relay inbound media downloads now enforce Hermes' shared URL safety policy before the gateway fetches connector-provided media URLs.

## Why

Relay Phase 2 localizes inbound `media_urls` by downloading them on the gateway host before handing local files to the agent. That path used `urllib.request.urlopen()` directly for both connector re-host URLs and public CDN URLs.

Because there was no `is_safe_url()` preflight and urllib followed redirects by default, a connector/platform-provided media URL could make the gateway fetch private/internal network locations such as cloud metadata endpoints.

This is different from the relay media bearer-origin issue: this patch is about blocking gateway-side SSRF fetches for inbound media bytes, including redirect targets.

## Changes

- Add a preflight `is_safe_url()` check before `RelayMediaClient.download()` opens any URL.
- Add a urllib redirect handler that re-validates every followed redirect target.
- Keep the existing best-effort media behavior: unsafe or failed downloads return `None`, so the inbound message can continue without localized media.
- Add regression coverage for:
  - direct metadata/private URLs being blocked before network access
  - redirects to metadata/private URLs being rejected before follow

## Validation

```text
python -m pytest -p no:cacheprovider tests/gateway/relay/test_relay_media.py -q --basetemp=.pytest_tmp\relay-media-ssrf
17 passed in 1.11s
```
