### PR TITLE
fix(gateway,tools): add missing .3gp and .webm to video extension sets

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1478,7 +1478,7 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     # Images (embed inline)
     ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".svg",
     # Video (embed inline where supported)
-    ".mp4", ".mov", ".avi", ".mkv", ".webm",
+    ".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp",
     # Audio (delivered as voice/audio where supported)
     ".mp3", ".wav", ".ogg", ".opus", ".m4a", ".flac",
     # Documents (uploaded as file attachments)

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -5447,7 +5447,7 @@ def _qr_register_inner(
 # ──────────────────────────────────────────────────────────────────────────
 
 _MIGRATION_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
-_MIGRATION_VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
+_MIGRATION_VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
 _MIGRATION_AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
 _MIGRATION_VOICE_EXTS = {".ogg", ".opus"}
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -62,7 +62,7 @@ _EMAIL_TARGET_RE = re.compile(r"^\s*[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2
 # never read. Map the exceptions so the error guidance is actually actionable.
 _HOME_CHANNEL_ENV_OVERRIDES = {"email": "EMAIL_HOME_ADDRESS"}
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
-_VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
+_VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
 _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
 _VOICE_EXTS = {".ogg", ".opus"}
 # Telegram's Bot API sendAudio only accepts MP3 / M4A. Other audio


### PR DESCRIPTION
## Summary

- Add `.3gp` to `MEDIA_DELIVERY_EXTS` in `gateway/platforms/base.py` — the shared allowlist for media extraction and `MEDIA:` tag cleanup. Without it, `.3gp` files are not extracted for native video delivery and the `MEDIA:` tag leaks as plain text.
- Add `.webm` to `_VIDEO_EXTS` in `tools/send_message_tool.py` — without it, `.webm` files are classified as documents instead of video, causing Telegram (and other platforms) to use `sendDocument` instead of `sendVideo`.
- Add `.webm` to `_MIGRATION_VIDEO_EXTS` in `plugins/platforms/feishu/adapter.py` — same drift as send_message_tool.

All three extensions are already present in every gateway-side `_VIDEO_EXTS` definition (`run.py`, `kanban_watchers.py`, `weixin.py`, `base.py` local). This PR aligns the two outliers with the established canonical set.

## Change Plan

1. **Observed behavior**: `.3gp` MEDIA tags leak as plain text; `.webm` files delivered as documents instead of inline video
2. **Expected behavior**: Both extensions route through the video delivery path
3. **Root cause**: Constant-set drift — `MEDIA_DELIVERY_EXTS` missing `.3gp`, `send_message_tool._VIDEO_EXTS` and `feishu._MIGRATION_VIDEO_EXTS` missing `.webm`
4. **Safest seam**: Add the missing extensions to the respective constant definitions
5. **Risk surface**: Minimal — only extends existing sets, no logic changes

## Test plan

- [x] Existing `test_extract_media_and_local_files_share_one_extension_set` passes (checks document extensions, unaffected)
- [x] `.3gp` now in `MEDIA_DELIVERY_EXTS` — `extract_media` and `extract_local_files` will pick it up
- [x] `.webm` now in `_VIDEO_EXTS` — `send_message` will route `.webm` through video path
- [x] `_CAPTIONABLE_EXTS` inherits `_VIDEO_EXTS` change automatically

Closes #71621
Closes #71603