### PR TITLE
feat: add governed approvals and connector visibility

### DIFF
--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -6,11 +6,21 @@ import { test } from 'vitest'
 import {
   appendUniquePathEntries,
   buildDesktopBackendEnv,
+  buildDesktopParentEnv,
   buildDesktopBackendPath,
   normalizeHermesHomeRoot,
   pathEnvKey,
   POSIX_SANE_PATH_ENTRIES
 } from './backend-env'
+
+test('desktop parent supervision env is explicit and validated', () => {
+  assert.deepEqual(buildDesktopParentEnv({ pid: 4242, nonce: 'a'.repeat(32) }), {
+    HERMES_DESKTOP_PARENT_PID: '4242',
+    HERMES_DESKTOP_PARENT_NONCE: 'a'.repeat(32)
+  })
+  assert.throws(() => buildDesktopParentEnv({ pid: 1, nonce: 'a'.repeat(32) }), /PID/)
+  assert.throws(() => buildDesktopParentEnv({ pid: 4242, nonce: 'short' }), /nonce/)
+})
 
 test('desktop backend PATH adds Hermes-managed bins and missing POSIX sane entries', () => {
   const result = buildDesktopBackendPath({

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -121,9 +121,23 @@ function buildDesktopBackendEnv({
   }
 }
 
+function buildDesktopParentEnv({ pid = process.pid, nonce }: any = {}) {
+  if (!Number.isSafeInteger(pid) || pid <= 1) {
+    throw new Error('Desktop parent PID must be a positive process identifier')
+  }
+  if (!/^[A-Za-z0-9_-]{32,128}$/.test(String(nonce || ''))) {
+    throw new Error('Desktop parent nonce must be 32-128 URL-safe characters')
+  }
+  return {
+    HERMES_DESKTOP_PARENT_PID: String(pid),
+    HERMES_DESKTOP_PARENT_NONCE: String(nonce)
+  }
+}
+
 export {
   appendUniquePathEntries,
   buildDesktopBackendEnv,
+  buildDesktopParentEnv,
   buildDesktopBackendPath,
   delimiterForPlatform,
   normalizeHermesHomeRoot,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -33,7 +33,7 @@ import nodePty from 'node-pty'
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
-import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
+import { buildDesktopBackendEnv, buildDesktopParentEnv, normalizeHermesHomeRoot } from './backend-env'
 import { waitForHermesReady } from './backend-health'
 import { canImportHermesCli, shouldTrustHermesOverride, verifyHermesCli } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
@@ -555,6 +555,7 @@ const DESKTOP_WINDOW_STATE_PATH = path.join(app.getPath('userData'), 'window-sta
 // ~/.hermes/active_profile file. Unset (null) preserves the legacy behavior:
 // no --profile flag, so the backend honors active_profile / default.
 const DESKTOP_PROFILE_CONFIG_PATH = path.join(app.getPath('userData'), 'active-profile.json')
+const DESKTOP_PARENT_NONCE = crypto.randomBytes(24).toString('base64url')
 // Mirrors hermes_cli.profiles._PROFILE_ID_RE so we never hand the backend a
 // value its profile resolver would reject and exit on.
 const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
@@ -7777,6 +7778,7 @@ async function spawnPoolBackend(profile, entry) {
         // Marks this dashboard backend as desktop-spawned so it runs the cron
         // scheduler tick loop (the gateway isn't running under the app).
         HERMES_DESKTOP: '1',
+        ...buildDesktopParentEnv({ nonce: DESKTOP_PARENT_NONCE }),
         HERMES_WEB_DIST: webDist,
         ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
       },
@@ -8052,6 +8054,7 @@ async function startHermes() {
           // Marks this dashboard backend as desktop-spawned so it runs the cron
           // scheduler tick loop (the gateway isn't running under the app).
           HERMES_DESKTOP: '1',
+          ...buildDesktopParentEnv({ nonce: DESKTOP_PARENT_NONCE }),
           HERMES_WEB_DIST: webDist,
           ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
         },

--- a/apps/desktop/src/app/settings/governance-settings.test.tsx
+++ b/apps/desktop/src/app/settings/governance-settings.test.tsx
@@ -1,0 +1,63 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { GovernanceSettings } from './governance-settings'
+
+const decide = vi.fn()
+const revoke = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  decideGovernanceApproval: (...args: unknown[]) => decide(...args),
+  getGovernanceApprovals: vi.fn(async () => ({
+    count: 1,
+    approvals: [{
+      id: 'a1', session_key: 'cron:test', tool_name: 'send_message', risk_class: 'external',
+      target: 'discord:#ops', args_digest: 'abc', args_preview: '{"text":"daily"}',
+      reason: 'daily report', pattern_key: 'daily', status: 'pending', source: 'plugin',
+      created_at: 1, expires_at: 9999999999, integrity_ok: true
+    }]
+  })),
+  getGovernanceConnectors: vi.fn(async () => ({
+    count: 1,
+    connectors: [{ id: 'mcp-github', enabled: true, health: 'healthy', tool_count: 2,
+      available_tool_count: 2, tools: ['issues_get', 'issues_create'],
+      risk_classes: ['read', 'external'], highest_risk: 'external' }]
+  })),
+  getGovernanceRules: vi.fn(async () => ({
+    count: 1,
+    rules: [{ id: 'r1', tool_name: 'send_message', operation: '', target_pattern: 'discord:#ops',
+      risk_ceiling: 'external', profile: '', workspace: '', job_id: '', use_count: 1,
+      enabled: true, note: '', created_at: 1 }]
+  })),
+  revokeGovernanceRule: (...args: unknown[]) => revoke(...args)
+}))
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={client}><GovernanceSettings /></QueryClientProvider>)
+}
+
+describe('GovernanceSettings', () => {
+  beforeEach(() => { decide.mockReset(); revoke.mockReset(); decide.mockResolvedValue({ resolved: true }); revoke.mockResolvedValue({ revoked: true }) })
+
+  it('shows pending approvals, bounded rules, and connector health', async () => {
+    renderPage()
+    expect(await screen.findByText('daily report')).toBeTruthy()
+    expect(document.body.textContent).toContain('discord:#ops')
+    expect(screen.getByText('mcp-github')).toBeTruthy()
+    expect(screen.getByText('healthy')).toBeTruthy()
+  })
+
+  it('submits an exact one-time approval decision', async () => {
+    renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: 'Allow once' }))
+    await waitFor(() => expect(decide).toHaveBeenCalledWith('a1', 'allow-once'))
+  })
+
+  it('revokes a standing rule', async () => {
+    renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: 'Revoke' }))
+    await waitFor(() => expect(revoke.mock.calls[0]?.[0]).toBe('r1'))
+  })
+})

--- a/apps/desktop/src/app/settings/governance-settings.tsx
+++ b/apps/desktop/src/app/settings/governance-settings.tsx
@@ -1,0 +1,123 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  decideGovernanceApproval,
+  getGovernanceApprovals,
+  getGovernanceConnectors,
+  getGovernanceRules,
+  revokeGovernanceRule,
+  type GovernanceApproval
+} from '@/hermes'
+import { Clock, Link, Lock, RefreshCw } from '@/lib/icons'
+
+import { ListRow, SettingsContent, SettingsSection, SettingsSkeleton } from './primitives'
+
+function humanTime(value: number | null | undefined): string {
+  if (!value) return 'No expiry'
+  return new Date(value * 1000).toLocaleString()
+}
+
+function riskTone(risk: string): 'default' | 'muted' | 'warn' {
+  if (risk === 'privileged' || risk === 'destructive') return 'warn'
+  if (risk === 'external' || risk === 'exec') return 'default'
+  return 'muted'
+}
+
+function ApprovalActions({ approval, busy, onDecision }: {
+  approval: GovernanceApproval
+  busy: boolean
+  onDecision: (decision: 'allow-once' | 'allow-always' | 'deny') => void
+}) {
+  if (!approval.integrity_ok) {
+    return <Badge variant="warn">Integrity failed</Badge>
+  }
+  return (
+    <div className="flex flex-wrap justify-end gap-1.5">
+      <Button disabled={busy} onClick={() => onDecision('allow-once')} size="xs" variant="outline">Allow once</Button>
+      <Button disabled={busy || !approval.target} onClick={() => onDecision('allow-always')} size="xs" variant="outline">Allow for target</Button>
+      <Button className="text-destructive" disabled={busy} onClick={() => onDecision('deny')} size="xs" variant="ghost">Deny</Button>
+    </div>
+  )
+}
+
+export function GovernanceSettings() {
+  const queryClient = useQueryClient()
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const approvals = useQuery({ queryKey: ['governance', 'approvals'], queryFn: getGovernanceApprovals, refetchInterval: 10_000 })
+  const rules = useQuery({ queryKey: ['governance', 'rules'], queryFn: getGovernanceRules })
+  const connectors = useQuery({ queryKey: ['governance', 'connectors'], queryFn: getGovernanceConnectors })
+
+  const refresh = () => void queryClient.invalidateQueries({ queryKey: ['governance'] })
+  const decide = useMutation({
+    mutationFn: ({ id, decision }: { id: string; decision: 'allow-once' | 'allow-always' | 'deny' }) =>
+      decideGovernanceApproval(id, decision),
+    onMutate: ({ id }) => { setBusyId(id); setError(null) },
+    onError: err => setError(err instanceof Error ? err.message : String(err)),
+    onSettled: () => { setBusyId(null); refresh() }
+  })
+  const revoke = useMutation({
+    mutationFn: revokeGovernanceRule,
+    onMutate: id => { setBusyId(id); setError(null) },
+    onError: err => setError(err instanceof Error ? err.message : String(err)),
+    onSettled: () => { setBusyId(null); refresh() }
+  })
+
+  if (approvals.isPending || rules.isPending || connectors.isPending) {
+    return <SettingsSkeleton sections={[{ rows: 2 }, { rows: 2 }, { rows: 3 }]} />
+  }
+
+  return (
+    <SettingsContent>
+      <div className="flex items-center justify-between py-4">
+        <div>
+          <h2 className="text-base font-semibold">Governance</h2>
+          <p className="mt-1 text-xs text-muted-foreground">Durable approvals, bounded authority, and connector health.</p>
+        </div>
+        <Button aria-label="Refresh governance" onClick={refresh} size="sm" variant="ghost"><RefreshCw className="size-4" /></Button>
+      </div>
+
+      {error && <div className="mb-4 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">{error}</div>}
+
+      <SettingsSection icon={Clock} meta={String(approvals.data?.count ?? 0)} title="Approval inbox">
+        {(approvals.data?.approvals ?? []).length === 0 ? (
+          <p className="py-3 text-sm text-muted-foreground">No actions are waiting for approval.</p>
+        ) : approvals.data?.approvals.map(approval => (
+          <ListRow
+            action={<ApprovalActions approval={approval} busy={busyId === approval.id} onDecision={decision => decide.mutate({ id: approval.id, decision })} />}
+            description={<><span>{approval.reason}</span><span className="mt-1 block font-mono text-[0.68rem]">{approval.target || 'No target'} · expires {humanTime(approval.expires_at)}</span></>}
+            key={approval.id}
+            title={<span className="flex items-center gap-2"><span>{approval.tool_name}</span><Badge variant={riskTone(approval.risk_class)}>{approval.risk_class}</Badge></span>}
+          />
+        ))}
+      </SettingsSection>
+
+      <SettingsSection icon={Lock} meta={String(rules.data?.count ?? 0)} title="Standing approvals">
+        {(rules.data?.rules ?? []).length === 0 ? (
+          <p className="py-3 text-sm text-muted-foreground">No standing approvals. Create one only from an exact pending target.</p>
+        ) : rules.data?.rules.map(rule => (
+          <ListRow
+            action={<Button className="text-destructive" disabled={busyId === rule.id} onClick={() => revoke.mutate(rule.id)} size="xs" variant="ghost">Revoke</Button>}
+            description={`${rule.target_pattern} · ${rule.use_count}${rule.max_uses == null ? '' : `/${rule.max_uses}`} uses · ${humanTime(rule.expires_at)}`}
+            key={rule.id}
+            title={<span className="flex items-center gap-2"><span>{rule.tool_name}</span><Badge variant={riskTone(rule.risk_ceiling)}>{rule.risk_ceiling}</Badge></span>}
+          />
+        ))}
+      </SettingsSection>
+
+      <SettingsSection icon={Link} meta={String(connectors.data?.count ?? 0)} title="Connectors">
+        {(connectors.data?.connectors ?? []).map(connector => (
+          <ListRow
+            action={<Badge variant={connector.health === 'healthy' ? 'default' : 'muted'}>{connector.health}</Badge>}
+            description={`${connector.available_tool_count ?? connector.tool_count}/${connector.tool_count} tools available · ${connector.risk_classes.join(', ') || 'unclassified'}`}
+            key={connector.id}
+            title={connector.id}
+          />
+        ))}
+      </SettingsSection>
+    </SettingsContent>
+  )
+}

--- a/apps/desktop/src/app/settings/index.tsx
+++ b/apps/desktop/src/app/settings/index.tsx
@@ -15,6 +15,7 @@ import {
   Info,
   Keyboard,
   KeyRound,
+  Lock,
   Package,
   RefreshCw,
   Settings2,
@@ -36,6 +37,7 @@ import { BillingSettings } from './billing'
 import { ConfigSettings } from './config-settings'
 import { SECTIONS } from './constants'
 import { GatewaySettings } from './gateway-settings'
+import { GovernanceSettings } from './governance-settings'
 import { KeybindSettings } from './keybind-settings'
 import { KEYS_VIEWS, KeysSettings, type KeysView } from './keys-settings'
 import { NotificationsSettings } from './notifications-settings'
@@ -48,6 +50,7 @@ const SETTINGS_VIEWS: readonly SettingsViewId[] = [
   ...SECTIONS.map(s => `config:${s.id}` as SettingsViewId),
   'providers',
   'gateway',
+  'governance',
   'keybinds',
   'keys',
   'notifications',
@@ -199,6 +202,13 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
       onSelect: () => setActiveView('gateway')
     },
     {
+      active: activeView === 'governance',
+      icon: Lock,
+      id: 'governance',
+      label: 'Governance',
+      onSelect: () => setActiveView('governance')
+    },
+    {
       active: activeView === 'keybinds',
       icon: Keyboard,
       id: 'keybinds',
@@ -295,6 +305,8 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
             <AboutSettings />
           ) : activeView === 'gateway' ? (
             <GatewaySettings />
+          ) : activeView === 'governance' ? (
+            <GovernanceSettings />
           ) : activeView === 'keybinds' ? (
             <KeybindSettings />
           ) : activeView.startsWith('config:') ? (

--- a/apps/desktop/src/app/settings/types.ts
+++ b/apps/desktop/src/app/settings/types.ts
@@ -8,6 +8,7 @@ export type SettingsView =
   | 'about'
   | 'billing'
   | 'gateway'
+  | 'governance'
   | 'keybinds'
   | 'keys'
   | 'notifications'

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -22,6 +22,9 @@ import type {
   DebugShareResponse,
   ElevenLabsVoicesResponse,
   EnvVarInfo,
+  GovernanceApprovalList,
+  GovernanceConnectorList,
+  GovernanceRuleList,
   HermesConfig,
   HermesConfigRecord,
   LogsResponse,
@@ -156,6 +159,12 @@ export type {
   ElevenLabsVoicesResponse,
   EnvVarInfo,
   GatewayReadyPayload,
+  GovernanceApproval,
+  GovernanceApprovalList,
+  GovernanceConnector,
+  GovernanceConnectorList,
+  GovernanceRule,
+  GovernanceRuleList,
   HermesConfig,
   HermesConfigRecord,
   LogsResponse,
@@ -994,6 +1003,48 @@ export function getMcpOAuthFlow(flowId: string): Promise<McpOAuthFlow> {
   return window.hermesDesktop.api<McpOAuthFlow>({
     ...profileScoped(),
     path: `/api/mcp/oauth/flows/${encodeURIComponent(flowId)}`
+  })
+}
+
+export function getGovernanceApprovals(): Promise<GovernanceApprovalList> {
+  return window.hermesDesktop.api<GovernanceApprovalList>({
+    ...profileScoped(),
+    path: '/api/governance/approvals'
+  })
+}
+
+export function decideGovernanceApproval(
+  id: string,
+  decision: 'allow-once' | 'allow-always' | 'deny',
+  reason = ''
+): Promise<{ resolved: boolean; status: string; standing_rule_id?: string | null }> {
+  return window.hermesDesktop.api({
+    ...profileScoped(),
+    path: `/api/governance/approvals/${encodeURIComponent(id)}/decision`,
+    method: 'POST',
+    body: { decision, reason }
+  })
+}
+
+export function getGovernanceRules(): Promise<GovernanceRuleList> {
+  return window.hermesDesktop.api<GovernanceRuleList>({
+    ...profileScoped(),
+    path: '/api/governance/rules'
+  })
+}
+
+export function revokeGovernanceRule(id: string): Promise<{ revoked: boolean; id: string }> {
+  return window.hermesDesktop.api({
+    ...profileScoped(),
+    path: `/api/governance/rules/${encodeURIComponent(id)}`,
+    method: 'DELETE'
+  })
+}
+
+export function getGovernanceConnectors(): Promise<GovernanceConnectorList> {
+  return window.hermesDesktop.api<GovernanceConnectorList>({
+    ...profileScoped(),
+    path: '/api/governance/connectors'
   })
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -856,6 +856,70 @@ export interface SkillInfo {
   provenance?: 'agent' | 'bundled' | 'hub'
 }
 
+export interface GovernanceApproval {
+  id: string
+  session_key: string
+  tool_name: string
+  risk_class: string
+  target: string
+  args_digest: string
+  args_preview: string
+  reason: string
+  pattern_key: string
+  status: 'pending' | 'approved' | 'denied' | 'expired' | 'consumed'
+  source: string
+  created_at: number
+  expires_at: number
+  integrity_ok: boolean
+  decided_at?: number | null
+  decision_reason?: string
+  decided_by?: string
+}
+
+export interface GovernanceApprovalList {
+  count: number
+  approvals: GovernanceApproval[]
+}
+
+export interface GovernanceRule {
+  id: string
+  tool_name: string
+  operation: string
+  target_pattern: string
+  match_mode: 'exact'
+  risk_ceiling: string
+  profile: string
+  workspace: string
+  job_id: string
+  expires_at?: number | null
+  max_uses?: number | null
+  use_count: number
+  enabled: boolean
+  note: string
+  created_at: number
+}
+
+export interface GovernanceRuleList {
+  count: number
+  rules: GovernanceRule[]
+}
+
+export interface GovernanceConnector {
+  id: string
+  enabled: boolean
+  health: string
+  tool_count: number
+  available_tool_count?: number
+  tools: string[]
+  risk_classes: string[]
+  highest_risk?: string | null
+}
+
+export interface GovernanceConnectorList {
+  count: number
+  connectors: GovernanceConnector[]
+}
+
 export interface ToolsetInfo {
   configured: boolean
   description: string

--- a/hermes_cli/desktop_parent_monitor.py
+++ b/hermes_cli/desktop_parent_monitor.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import errno
+import os
+import re
+from dataclasses import dataclass
+from typing import Callable, Mapping, Protocol
+
+_NONCE_RE = re.compile(r"^[A-Za-z0-9_-]{32,128}$")
+_STILL_ACTIVE = 259
+_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+
+
+@dataclass(frozen=True)
+class DesktopParentContract:
+    pid: int
+    nonce: str
+
+
+class _Server(Protocol):
+    should_exit: bool
+
+
+def parse_desktop_parent_contract(
+    env: Mapping[str, str] | None = None,
+    *,
+    current_pid: int | None = None,
+) -> DesktopParentContract | None:
+    """Parse the optional Desktop parent-liveness contract.
+
+    Older Desktop releases set only ``HERMES_DESKTOP=1``.  Absence of both
+    contract fields therefore preserves compatibility; a partially supplied or
+    malformed new contract fails closed instead of silently disabling the
+    monitor.
+    """
+    values = os.environ if env is None else env
+    if values.get("HERMES_DESKTOP") != "1":
+        return None
+    raw_pid = values.get("HERMES_DESKTOP_PARENT_PID", "")
+    nonce = values.get("HERMES_DESKTOP_PARENT_NONCE", "")
+    if not raw_pid and not nonce:
+        return None
+    if not raw_pid or not nonce:
+        raise ValueError("incomplete Desktop parent-liveness contract")
+    try:
+        pid = int(raw_pid)
+    except ValueError as exc:
+        raise ValueError("invalid Desktop parent PID") from exc
+    own_pid = os.getpid() if current_pid is None else current_pid
+    if pid <= 1 or pid == own_pid:
+        raise ValueError("invalid Desktop parent PID")
+    if not _NONCE_RE.fullmatch(nonce):
+        raise ValueError("invalid Desktop parent nonce")
+    return DesktopParentContract(pid=pid, nonce=nonce)
+
+
+def is_process_alive(pid: int) -> bool:
+    """Return whether *pid* still identifies a live process without signalling it."""
+    if os.name == "nt":
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        handle = kernel32.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return False
+        try:
+            exit_code = ctypes.c_ulong()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return False
+            return exit_code.value == _STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError as exc:
+        return exc.errno == errno.EPERM
+    return True
+
+
+async def monitor_desktop_parent(
+    server: _Server,
+    contract: DesktopParentContract,
+    *,
+    check_alive: Callable[[int], bool] = is_process_alive,
+    interval_seconds: float = 3.0,
+    missed_checks: int = 2,
+) -> None:
+    """Request graceful server shutdown after consecutive parent-liveness misses."""
+    required_misses = max(1, int(missed_checks))
+    misses = 0
+    while not server.should_exit:
+        try:
+            alive = check_alive(contract.pid)
+        except Exception:
+            alive = False
+        if alive:
+            misses = 0
+        else:
+            misses += 1
+            if misses >= required_misses:
+                server.should_exit = True
+                return
+        await asyncio.sleep(max(0.0, float(interval_seconds)))

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -399,6 +399,9 @@ class PluginContext:
         is_async: bool = False,
         description: str = "",
         emoji: str = "",
+        risk_class=None,
+        connector_id: str = "",
+        target_resolver: Callable | None = None,
         override: bool = False,
     ) -> None:
         """Register a tool in the global registry **and** track it as plugin-provided.
@@ -437,6 +440,9 @@ class PluginContext:
             is_async=is_async,
             description=description,
             emoji=emoji,
+            risk_class=risk_class,
+            connector_id=connector_id,
+            target_resolver=target_resolver,
             override=override,
         )
         self._manager._plugin_tool_names.add(name)
@@ -2263,6 +2269,7 @@ def resolve_pre_tool_block(
                 tool_name,
                 details.message or "",
                 rule_key=details.rule_key or tool_name,
+                args=args or {},
             )
         except Exception:
             # Fail-closed: if the gate itself errors, block rather than

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15639,6 +15639,179 @@ async def update_skill_content(body: SkillContentUpdate):
     return result
 
 
+# ---------------------------------------------------------------------------
+# Governance — durable approvals, bounded standing rules, connector inventory
+# ---------------------------------------------------------------------------
+
+
+class GovernanceDecision(BaseModel):
+    decision: str
+    reason: str = ""
+
+
+class GovernanceRuleCreate(BaseModel):
+    tool_name: str
+    target_pattern: str
+    match_mode: Literal["exact"] = "exact"
+    risk_ceiling: str
+    operation: str = ""
+    profile: str = ""
+    workspace: str = ""
+    job_id: str = ""
+    expires_at: Optional[float] = None
+    max_uses: Optional[int] = None
+    note: str = ""
+
+
+def _governance_store(profile: Optional[str]):
+    from tools.approval_store import ApprovalStore
+
+    with _profile_scope(profile):
+        return ApprovalStore()
+
+
+@app.get("/api/governance/approvals")
+async def governance_list_approvals(
+    status: str = "pending",
+    session_key: Optional[str] = None,
+    profile: Optional[str] = None,
+):
+    """List durable approval requests without exposing raw tool arguments."""
+    allowed = {"pending", "approved", "denied", "expired", "consumed"}
+    if status not in allowed:
+        raise HTTPException(status_code=400, detail="Invalid approval status")
+    approvals = _governance_store(profile).list_requests(
+        status=status, session_key=session_key
+    )
+    return {"count": len(approvals), "approvals": approvals}
+
+
+@app.post("/api/governance/approvals/{approval_id}/decision")
+async def governance_decide_approval(
+    approval_id: str,
+    body: GovernanceDecision,
+    profile: Optional[str] = None,
+):
+    """Resolve one immutable approval envelope or create its exact standing rule."""
+    store = _governance_store(profile)
+    request = store.get_request(approval_id)
+    if request is None:
+        raise HTTPException(status_code=404, detail="Approval request not found")
+    if body.decision not in {"allow-once", "allow-always", "deny"}:
+        raise HTTPException(status_code=400, detail="Invalid decision")
+
+    standing_rule = None
+    try:
+        if body.decision == "allow-always":
+            resolved, standing_rule = store.resolve_request_with_standing_rule(
+                approval_id,
+                expires_at=time.time() + (30 * 24 * 60 * 60),
+                max_uses=100,
+                decision_reason=body.reason,
+                decided_by="desktop",
+                note=f"Bounded rule created from approval {approval_id}",
+            )
+        else:
+            resolved = store.resolve_request(
+                approval_id,
+                "denied" if body.decision == "deny" else "approved",
+                decision_reason=body.reason,
+                decided_by="desktop",
+            )
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    return {
+        "resolved": True,
+        "approval_id": approval_id,
+        "decision": body.decision,
+        "status": resolved["status"],
+        "standing_rule_id": standing_rule["id"] if standing_rule else None,
+    }
+
+
+@app.get("/api/governance/rules")
+async def governance_list_rules(active_only: bool = True, profile: Optional[str] = None):
+    rules = _governance_store(profile).list_standing_rules(active_only=active_only)
+    return {"count": len(rules), "rules": rules}
+
+
+@app.post("/api/governance/rules")
+async def governance_create_rule(
+    body: GovernanceRuleCreate,
+    profile: Optional[str] = None,
+):
+    try:
+        rule = _governance_store(profile).add_standing_rule(
+            tool_name=body.tool_name,
+            target_pattern=body.target_pattern,
+            match_mode=body.match_mode,
+            risk_ceiling=body.risk_ceiling,
+            operation=body.operation,
+            profile=body.profile,
+            workspace=body.workspace,
+            job_id=body.job_id,
+            expires_at=body.expires_at,
+            max_uses=body.max_uses,
+            note=body.note,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"created": True, "rule": rule}
+
+
+@app.delete("/api/governance/rules/{rule_id}")
+async def governance_revoke_rule(rule_id: str, profile: Optional[str] = None):
+    return {
+        "revoked": _governance_store(profile).revoke_standing_rule(rule_id),
+        "id": rule_id,
+    }
+
+
+@app.get("/api/governance/connectors")
+async def governance_connector_inventory(profile: Optional[str] = None):
+    """Return live connector/tool health without configuration secrets."""
+    from tools.registry import discover_builtin_tools, registry
+
+    discover_builtin_tools()
+    connectors = registry.get_connector_report()
+    by_id = {
+        row["connector_id"]: {
+            "id": row["connector_id"],
+            "enabled": True,
+            "health": "healthy" if row["healthy"] else "degraded",
+            "tool_count": row["tool_count"],
+            "available_tool_count": row["available_tool_count"],
+            "tools": row["tools"],
+            "risk_classes": row["risk_classes"],
+            "highest_risk": row["max_risk_class"],
+        }
+        for row in connectors
+    }
+
+    # Configured MCP servers may not have registered tools in the web process.
+    # Include their enablement state without returning commands, headers, or env.
+    with _profile_scope(profile):
+        cfg = load_config()
+    for name, server in (cfg.get("mcp_servers", {}) or {}).items():
+        connector_id = f"mcp-{name}"
+        if connector_id in by_id:
+            continue
+        enabled = bool(server.get("enabled", True)) if isinstance(server, dict) else True
+        by_id[connector_id] = {
+            "id": connector_id,
+            "enabled": enabled,
+            "health": "configured" if enabled else "disabled",
+            "tool_count": 0,
+            "tools": [],
+            "risk_classes": [],
+            "highest_risk": None,
+        }
+
+    rows = sorted(by_id.values(), key=lambda row: row["id"])
+    return {"count": len(rows), "connectors": rows}
+
+
 @app.get("/api/tools/toolsets")
 async def get_toolsets(profile: Optional[str] = None):
     from hermes_cli.tools_config import (
@@ -20097,6 +20270,12 @@ def start_server(
         ws_ping_timeout=None if _is_loopback else 20.0,
     )
     server = uvicorn.Server(config)
+    from hermes_cli.desktop_parent_monitor import (
+        monitor_desktop_parent,
+        parse_desktop_parent_contract,
+    )
+
+    desktop_parent = parse_desktop_parent_contract()
 
     async def _serve():
         # Split startup from main_loop so we can read the bound port
@@ -20168,7 +20347,19 @@ def start_server(
                 _hb_interval, _loop_heartbeat, _hb_loop.time() + _hb_interval
             )
 
-            await server.main_loop()
+            parent_monitor_task = None
+            if desktop_parent is not None:
+                parent_monitor_task = asyncio.create_task(
+                    monitor_desktop_parent(server, desktop_parent),
+                    name="desktop-parent-monitor",
+                )
+            try:
+                await server.main_loop()
+            finally:
+                if parent_monitor_task is not None:
+                    parent_monitor_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await parent_monitor_task
             if server.started:
                 await server.shutdown()
 

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -915,13 +915,18 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
 
     @mcp.tool()
     def permissions_list_open() -> str:
-        """List pending approval requests observed during this bridge session.
+        """List durable and live pending approval requests.
 
-        Returns exec and plugin approval requests that the bridge has seen
-        since it started. Approvals are live-session only — older approvals
-        from before the bridge connected are not included.
+        Durable requests survive bridge, gateway, and desktop restarts.  Live
+        bridge-only requests are merged for backwards compatibility.
         """
-        approvals = bridge.list_pending_approvals()
+        from tools.approval_store import ApprovalStore
+
+        durable = ApprovalStore().list_requests(status="pending")
+        by_id = {item["id"]: item for item in durable}
+        for item in bridge.list_pending_approvals():
+            by_id.setdefault(item.get("id", ""), item)
+        approvals = sorted(by_id.values(), key=lambda item: item.get("created_at", 0))
         return json.dumps({
             "count": len(approvals),
             "approvals": approvals,
@@ -934,11 +939,11 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
         id: str,
         decision: str,
     ) -> str:
-        """Respond to a pending approval request.
+        """Resolve a durable or live approval request.
 
-        Args:
-            id: The approval ID from permissions_list_open
-            decision: One of "allow-once", "allow-always", or "deny"
+        ``allow-always`` creates a standing rule bound to the request's exact
+        tool, target, and risk ceiling.  Targetless requests cannot become
+        standing rules because that would amount to a blanket tool approval.
         """
         if decision not in {"allow-once", "allow-always", "deny"}:
             return json.dumps({
@@ -946,8 +951,102 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
                          f"Must be allow-once, allow-always, or deny"
             })
 
+        from tools.approval_store import ApprovalStore
+
+        store = ApprovalStore()
+        durable = store.get_request(id)
+        if durable is not None:
+            try:
+                if decision == "allow-always":
+                    resolved, rule = store.resolve_request_with_standing_rule(
+                        id,
+                        expires_at=time.time() + (30 * 24 * 60 * 60),
+                        max_uses=100,
+                        decided_by="mcp",
+                        note=f"Bounded rule created from approval {id}",
+                    )
+                else:
+                    rule = None
+                    resolved = store.resolve_request(
+                        id,
+                        "denied" if decision == "deny" else "approved",
+                        decided_by="mcp",
+                    )
+                return json.dumps({
+                    "resolved": True,
+                    "approval_id": id,
+                    "decision": decision,
+                    "status": resolved["status"],
+                    "standing_rule_id": rule["id"] if rule else None,
+                }, indent=2)
+            except (KeyError, ValueError) as exc:
+                return json.dumps({"error": str(exc)})
+
         result = bridge.respond_to_approval(id, decision)
         return json.dumps(result, indent=2)
+
+    # -- permissions standing rules ----------------------------------------
+
+    @mcp.tool()
+    def permissions_rules_list(active_only: bool = True) -> str:
+        """List target-scoped standing approval rules."""
+        from tools.approval_store import ApprovalStore
+
+        rules = ApprovalStore().list_standing_rules(active_only=active_only)
+        return json.dumps({"count": len(rules), "rules": rules}, indent=2)
+
+    @mcp.tool()
+    def permissions_rules_create(
+        tool_name: str,
+        target_pattern: str,
+        risk_ceiling: str,
+        operation: str = "",
+        profile: str = "",
+        workspace: str = "",
+        job_id: str = "",
+        expires_at: float | None = None,
+        max_uses: int | None = None,
+        note: str = "",
+    ) -> str:
+        """Create a bounded standing approval for one tool and target pattern."""
+        from tools.approval_store import ApprovalStore
+
+        try:
+            rule = ApprovalStore().add_standing_rule(
+                tool_name=tool_name,
+                target_pattern=target_pattern,
+                risk_ceiling=risk_ceiling,
+                match_mode="exact",
+                operation=operation,
+                profile=profile,
+                workspace=workspace,
+                job_id=job_id,
+                expires_at=expires_at,
+                max_uses=max_uses,
+                note=note,
+            )
+            return json.dumps({"created": True, "rule": rule}, indent=2)
+        except ValueError as exc:
+            return json.dumps({"error": str(exc)})
+
+    @mcp.tool()
+    def permissions_rules_revoke(id: str) -> str:
+        """Revoke a standing approval rule."""
+        from tools.approval_store import ApprovalStore
+
+        revoked = ApprovalStore().revoke_standing_rule(id)
+        return json.dumps({"revoked": revoked, "id": id}, indent=2)
+
+    # -- connector inventory ------------------------------------------------
+
+    @mcp.tool()
+    def connectors_list() -> str:
+        """Return connector health, exposed tools, and declared risk classes."""
+        from tools.registry import discover_builtin_tools, registry
+
+        discover_builtin_tools()
+        connectors = registry.get_connector_report()
+        return json.dumps({"count": len(connectors), "connectors": connectors}, indent=2)
 
     return mcp
 

--- a/tests/hermes_cli/test_desktop_parent_monitor.py
+++ b/tests/hermes_cli/test_desktop_parent_monitor.py
@@ -1,0 +1,56 @@
+import asyncio
+
+import pytest
+
+from hermes_cli.desktop_parent_monitor import (
+    DesktopParentContract,
+    monitor_desktop_parent,
+    parse_desktop_parent_contract,
+)
+
+
+def test_parent_contract_is_desktop_only_and_backwards_compatible():
+    assert parse_desktop_parent_contract({}, current_pid=99) is None
+    assert parse_desktop_parent_contract({"HERMES_DESKTOP": "1"}, current_pid=99) is None
+
+
+def test_parent_contract_validates_pid_and_nonce():
+    env = {
+        "HERMES_DESKTOP": "1",
+        "HERMES_DESKTOP_PARENT_PID": "42",
+        "HERMES_DESKTOP_PARENT_NONCE": "a" * 32,
+    }
+    assert parse_desktop_parent_contract(env, current_pid=99) == DesktopParentContract(
+        pid=42, nonce="a" * 32
+    )
+    with pytest.raises(ValueError, match="incomplete"):
+        parse_desktop_parent_contract(
+            {"HERMES_DESKTOP": "1", "HERMES_DESKTOP_PARENT_PID": "42"},
+            current_pid=99,
+        )
+    with pytest.raises(ValueError, match="PID"):
+        parse_desktop_parent_contract(
+            {**env, "HERMES_DESKTOP_PARENT_PID": "99"}, current_pid=99
+        )
+    with pytest.raises(ValueError, match="nonce"):
+        parse_desktop_parent_contract(
+            {**env, "HERMES_DESKTOP_PARENT_NONCE": "short"}, current_pid=99
+        )
+
+
+def test_monitor_requests_shutdown_only_after_consecutive_misses():
+    class Server:
+        should_exit = False
+
+    outcomes = iter([False, True, False, False])
+    server = Server()
+    asyncio.run(
+        monitor_desktop_parent(
+            server,
+            DesktopParentContract(pid=42, nonce="a" * 32),
+            check_alive=lambda _pid: next(outcomes),
+            interval_seconds=0,
+            missed_checks=2,
+        )
+    )
+    assert server.should_exit is True

--- a/tests/hermes_cli/test_web_server_governance.py
+++ b/tests/hermes_cli/test_web_server_governance.py
@@ -1,0 +1,68 @@
+from fastapi.testclient import TestClient
+
+from tools.approval_store import ApprovalStore
+from tools.governance import build_tool_call_envelope
+
+
+def _client():
+    from hermes_cli import web_server
+
+    client = TestClient(web_server.app, base_url="http://127.0.0.1")
+    client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    return client
+
+
+def _request():
+    return ApprovalStore().create_request(
+        session_key="cron:daily",
+        envelope=build_tool_call_envelope(
+            "send_message", {"target": "discord:#ops", "text": "daily"},
+            risk_class="external",
+        ),
+        reason="daily report",
+        pattern_key="daily",
+    )
+
+
+def test_governance_inbox_approve_once(_isolate_hermes_home):
+    request = _request()
+    client = _client()
+    listed = client.get("/api/governance/approvals")
+    assert listed.status_code == 200
+    assert listed.json()["approvals"][0]["id"] == request["id"]
+    resolved = client.post(
+        f"/api/governance/approvals/{request['id']}/decision",
+        json={"decision": "allow-once"},
+    )
+    assert resolved.status_code == 200
+    stored = ApprovalStore().get_request(request["id"])
+    assert stored is not None
+    assert stored["status"] == "approved"
+
+
+def test_allow_for_target_is_atomic_bounded_and_secret_free(_isolate_hermes_home):
+    request = _request()
+    client = _client()
+    path = f"/api/governance/approvals/{request['id']}/decision"
+    first = client.post(path, json={"decision": "allow-always"})
+    second = client.post(path, json={"decision": "allow-always"})
+    assert first.status_code == 200
+    assert second.status_code == 409
+    rules = ApprovalStore().list_standing_rules()
+    assert len(rules) == 1
+    assert rules[0]["target_pattern"] == "discord:#ops"
+    assert rules[0]["max_uses"] == 100
+    assert rules[0]["expires_at"] is not None
+
+
+def test_connector_inventory_does_not_expose_config_secrets(_isolate_hermes_home, monkeypatch):
+    from hermes_cli import web_server
+
+    monkeypatch.setattr(web_server, "load_config", lambda: {
+        "mcp_servers": {"github": {"url": "https://mcp.test", "headers": {"token": "secret"}}}
+    })
+    response = _client().get("/api/governance/connectors")
+    assert response.status_code == 200
+    payload = response.json()
+    assert any(row["id"] == "mcp-github" for row in payload["connectors"])
+    assert "secret" not in response.text

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -244,6 +244,7 @@ class _FakeFastMCP:
 def fake_mcp_server(populated_sessions_dir, mock_session_db, monkeypatch):
     import mcp_serve
 
+    monkeypatch.setenv("HERMES_HOME", str(populated_sessions_dir.parent / "hermes-home"))
     monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: populated_sessions_dir)
     monkeypatch.setattr(mcp_serve, "_get_session_db", lambda: mock_session_db)
     monkeypatch.setattr(mcp_serve, "_load_channel_directory", lambda: {})
@@ -500,6 +501,8 @@ def mcp_server_e2e(populated_sessions_dir, mock_session_db, monkeypatch):
     """Create a fully wired MCP server for E2E testing."""
     mcp = pytest.importorskip("mcp", reason="MCP SDK not installed")
     import mcp_serve
+
+    monkeypatch.setenv("HERMES_HOME", str(populated_sessions_dir.parent / "hermes-home-e2e"))
     monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: populated_sessions_dir)
     monkeypatch.setattr(mcp_serve, "_get_session_db", lambda: mock_session_db)
     monkeypatch.setattr(mcp_serve, "_load_channel_directory", lambda: {})
@@ -918,9 +921,32 @@ class TestE2EPermissions:
                           {"id": "nope", "decision": "deny"})
         assert "error" in result
 
+    def test_durable_request_can_be_listed_and_approved(self, mcp_server_e2e, _event_loop):
+        from tools.approval_store import ApprovalStore
+        from tools.governance import build_tool_call_envelope
+
+        server, _ = mcp_server_e2e
+        store = ApprovalStore()
+        request = store.create_request(
+            session_key="cron:daily",
+            envelope=build_tool_call_envelope(
+                "send_message",
+                {"target": "discord:#ops", "text": "daily"},
+                risk_class="external",
+            ),
+            reason="daily",
+            pattern_key="daily",
+        )
+        listed = _run_tool(server, "permissions_list_open")
+        assert request["id"] in {item["id"] for item in listed["approvals"]}
+        resolved = _run_tool(server, "permissions_respond", {
+            "id": request["id"], "decision": "allow-once",
+        })
+        assert resolved["status"] == "approved"
+
 
 # ---------------------------------------------------------------------------
-# 4. TOOL LISTING — verify all 10 tools are registered
+# 4. TOOL LISTING — verify all bridge and governance tools are registered
 # ---------------------------------------------------------------------------
 
 class TestToolRegistration:
@@ -934,6 +960,8 @@ class TestToolRegistration:
             "attachments_fetch", "events_poll", "events_wait",
             "messages_send", "channels_list",
             "permissions_list_open", "permissions_respond",
+            "permissions_rules_list", "permissions_rules_create",
+            "permissions_rules_revoke", "connectors_list",
         }
         assert expected == tool_names, f"Missing: {expected - tool_names}, Extra: {tool_names - expected}"
 

--- a/tests/tools/test_governance_persistence.py
+++ b/tests/tools/test_governance_persistence.py
@@ -1,0 +1,165 @@
+import json
+import sqlite3
+
+import pytest
+
+import tools.approval as approval
+from tools.approval_store import ApprovalStore
+from tools.governance import RiskClass, build_tool_call_envelope, infer_risk_class
+from tools.registry import ToolRegistry
+
+
+def _envelope(text="hello", target="discord:#ops", risk="external"):
+    return build_tool_call_envelope(
+        "send_message", {"target": target, "text": text}, risk_class=risk
+    )
+
+
+def test_risk_inference_and_secret_free_envelope():
+    assert infer_risk_class("read_file") is RiskClass.READ
+    assert infer_risk_class("terminal") is RiskClass.EXEC
+    assert infer_risk_class("delete_project", "mcp-stitch") is RiskClass.DESTRUCTIVE
+    assert infer_risk_class("mystery", "third-party") is RiskClass.PRIVILEGED
+    env = build_tool_call_envelope(
+        "browser_navigate",
+        {"url": "https://user:pass@example.test/?token=secret", "api_key": "sk-x"},
+        risk_class="external",
+    )
+    assert "pass" not in env.target
+    assert "secret" not in env.target
+    assert "sk-x" not in env.args_preview
+    assert json.loads(env.args_preview)["api_key"] == "***REDACTED***"
+
+
+def test_registry_exposes_explicit_and_inferred_governance():
+    registry = ToolRegistry()
+    schema = lambda name: {"name": name, "description": "x", "parameters": {"type": "object"}}
+    handler = lambda args, **kwargs: "ok"
+    registry.register(
+        name="send_message", toolset="discord", schema=schema("send_message"),
+        handler=handler, risk_class="external",
+        check_fn=lambda: True,
+    )
+    entry = registry.get_entry("send_message")
+    assert entry is not None
+    assert entry.risk_class is RiskClass.EXTERNAL
+    assert entry.risk_source == "explicit"
+    report = registry.get_connector_report()[0]
+    assert report["connector_id"] == "discord"
+    assert report["healthy"] is True
+
+
+def test_durable_exact_approval_is_single_use_and_argument_bound(tmp_path):
+    store = ApprovalStore(tmp_path / "state.db", clock=lambda: 1000.0)
+    request = store.create_request(
+        session_key="cron:daily", envelope=_envelope(), reason="daily",
+        pattern_key="daily",
+    )
+    store.resolve_request(request["id"], "approved")
+    consumed = store.consume_matching_approval(
+        _envelope(), pattern_key="daily", session_key="cron:daily"
+    )
+    assert consumed is not None
+    assert consumed["status"] == "consumed"
+    assert store.consume_matching_approval(
+        _envelope(), pattern_key="daily", session_key="cron:daily"
+    ) is None
+    assert store.consume_matching_approval(
+        _envelope("changed"), pattern_key="daily", session_key="cron:daily"
+    ) is None
+
+
+def test_allow_always_resolution_is_atomic_and_bounded(tmp_path):
+    store = ApprovalStore(tmp_path / "state.db", clock=lambda: 1000.0)
+    request = store.create_request(
+        session_key="cron:daily", envelope=_envelope(), reason="daily",
+        pattern_key="daily",
+    )
+    resolved, rule = store.resolve_request_with_standing_rule(
+        request["id"], expires_at=2000.0, max_uses=3
+    )
+    assert resolved["status"] == "approved"
+    assert rule["target_pattern"] == "discord:#ops"
+    assert rule["max_uses"] == 3
+    with pytest.raises(ValueError):
+        store.resolve_request_with_standing_rule(
+            request["id"], expires_at=2000.0, max_uses=3
+        )
+    assert len(store.list_standing_rules()) == 1
+
+
+def test_standing_rule_exact_targets_do_not_become_accidental_globs(tmp_path):
+    store = ApprovalStore(tmp_path / "state.db", clock=lambda: 1000.0)
+    store.add_standing_rule(
+        tool_name="send_message", target_pattern="discord:#ops*",
+        risk_ceiling="external", max_uses=2,
+    )
+    assert store.consume_standing_rule(_envelope(target="discord:#ops-secret")) is None
+    assert store.consume_standing_rule(_envelope(target="discord:#ops*")) is not None
+
+    with pytest.raises(ValueError, match="exact"):
+        store.add_standing_rule(
+            tool_name="send_message", target_pattern="discord:#ops*",
+            risk_ceiling="external", max_uses=1, match_mode="glob",
+        )
+
+
+def test_tampered_approval_envelope_cannot_be_resolved(tmp_path):
+    db_path = tmp_path / "state.db"
+    store = ApprovalStore(db_path, clock=lambda: 1000.0)
+    request = store.create_request(
+        session_key="cron:daily", envelope=_envelope(), reason="daily",
+        pattern_key="daily",
+    )
+    assert request["envelope_sha256"]
+    assert request["integrity_ok"] is True
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE approval_requests SET target=? WHERE id=?",
+            ("discord:#attacker", request["id"]),
+        )
+
+    with pytest.raises(ValueError, match="integrity"):
+        store.resolve_request(request["id"], "approved")
+    listed = store.list_requests(status="pending")
+    assert listed[0]["integrity_ok"] is False
+
+
+def test_standing_rule_is_target_risk_scope_and_use_bound(tmp_path):
+    now = [1000.0]
+    store = ApprovalStore(tmp_path / "state.db", clock=lambda: now[0])
+    store.add_standing_rule(
+        tool_name="send_message", target_pattern="discord:#ops",
+        risk_ceiling="external", profile="default", max_uses=1,
+        expires_at=1100.0,
+    )
+    assert store.consume_standing_rule(_envelope(), profile="default") is not None
+    assert store.consume_standing_rule(_envelope(), profile="default") is None
+    assert store.consume_standing_rule(_envelope(target="discord:#other"), profile="default") is None
+
+
+@pytest.fixture
+def unattended(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(approval, "get_current_session_key", lambda default="default": "cron:daily")
+    monkeypatch.setattr(approval, "is_approved", lambda *args: False)
+    monkeypatch.setattr(approval, "is_current_session_yolo_enabled", lambda: False)
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", False, raising=False)
+    monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+    monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+    monkeypatch.setattr(approval, "env_var_enabled", lambda name: name == "HERMES_CRON_SESSION")
+    monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "deny")
+
+
+def test_unattended_tool_and_terminal_requests_are_parked(unattended):
+    tool = approval.request_tool_approval(
+        "send_message", "daily", rule_key="daily",
+        args={"target": "discord:#ops", "text": "hello"}, risk_class="external",
+    )
+    command = approval.check_dangerous_command("rm -rf ./cache", "local")
+    assert tool["status"] == command["status"] == "approval_required"
+    rows = ApprovalStore().list_requests(status="pending")
+    assert {(row["tool_name"], row["source"]) for row in rows} == {
+        ("send_message", "plugin"), ("terminal", "terminal")
+    }

--- a/tests/tools/test_governance_persistence.py
+++ b/tests/tools/test_governance_persistence.py
@@ -152,13 +152,15 @@ def unattended(monkeypatch, tmp_path):
     monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "deny")
 
 
-def test_unattended_tool_and_terminal_requests_are_parked(unattended):
+def test_cron_denials_are_blocked_and_left_reviewable(unattended):
     tool = approval.request_tool_approval(
         "send_message", "daily", rule_key="daily",
         args={"target": "discord:#ops", "text": "hello"}, risk_class="external",
     )
     command = approval.check_dangerous_command("rm -rf ./cache", "local")
-    assert tool["status"] == command["status"] == "approval_required"
+    assert tool.get("status") != "approval_required"
+    assert command.get("status") != "approval_required"
+    assert tool["approved"] is command["approved"] is False
     rows = ApprovalStore().list_requests(status="pending")
     assert {(row["tool_name"], row["source"]) for row in rows} == {
         ("send_message", "plugin"), ("terminal", "terminal")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2926,16 +2926,20 @@ def check_dangerous_command(command: str, env_type: str,
     if not is_dangerous:
         return {"approved": True, "message": None}
 
-    return _run_approval_gate(
-        pattern_key=pattern_key,
-        description=description,
-        display_target=command,
+    return request_tool_approval(
+        "terminal",
+        description,
+        rule_key=pattern_key,
         approval_callback=approval_callback,
+        args={"command": command, "env_type": env_type},
+        risk_class="exec",
+        source="terminal",
+        fail_closed_when_no_human=False,
         cron_deny_message=(
             f"BLOCKED: Command flagged as dangerous ({description}) "
             "but cron jobs run without a user present to approve it. "
-            "Find an alternative approach that avoids this command. "
-            "To allow dangerous commands in cron jobs, set "
+            "The exact command has been parked in the durable approval inbox. "
+            "To pre-authorise dangerous commands in cron jobs, set "
             "approvals.cron_mode: approve in config.yaml."
         ),
         autoapprove_log_prefix=(
@@ -2950,6 +2954,15 @@ def request_tool_approval(
     *,
     rule_key: str = "",
     approval_callback=None,
+    args: Optional[dict] = None,
+    risk_class=None,
+    profile: str = "",
+    workspace: str = "",
+    job_id: str = "",
+    source: str = "plugin",
+    fail_closed_when_no_human: bool = True,
+    cron_deny_message: str = "",
+    autoapprove_log_prefix: str = "AUTO-APPROVED plugin tool request",
 ) -> dict:
     """Escalate an arbitrary tool call to the human-approval gate.
 
@@ -2992,43 +3005,128 @@ def request_tool_approval(
     description = reason or f"Plugin requires approval for {tool_name}"
     # Allowlist grain: an explicit plugin rule_key wins; otherwise derive from
     # tool + a short hash of the reason so distinct reasons on the same tool
-    # get independent [a]lways entries (Finding: rule_key=tool_name alone was
-    # too coarse — one "always" would blanket every rule on that tool).
+    # get independent [a]lways entries.
     if rule_key:
         key_suffix = rule_key
     else:
         _reason_hash = hashlib.sha256(description.encode("utf-8")).hexdigest()[:12]
         key_suffix = f"{tool_name}:{_reason_hash}"
-    # Synthetic pattern key so plugin-rule approvals live in the same
-    # session/permanent allowlist machinery as command patterns, namespaced
-    # to avoid ever colliding with a real command pattern key.
     pattern_key = f"plugin_rule:{key_suffix}"
-    # A synthetic "command" string for the display/allowlist layer. It never
-    # executes; it only labels the gate. Namespaced identically.
     display_target = f"<{tool_name}> (plugin approval rule)"
 
-    return _run_approval_gate(
+    # Calls made through the central resolver include arguments.  Bind durable
+    # and standing approvals to the exact canonical arguments and target.  The
+    # legacy direct API (args=None) retains its historical in-memory behaviour.
+    store = None
+    envelope = None
+    request_id = None
+    session_key = get_current_session_key()
+    if args is not None:
+        try:
+            from tools.approval_store import ApprovalStore
+            from tools.governance import build_tool_call_envelope, infer_risk_class
+            from tools.registry import registry
+
+            entry = registry.get_entry(tool_name)
+            resolved_risk = risk_class or (
+                entry.risk_class if entry is not None else infer_risk_class(tool_name)
+            )
+            target_resolver = entry.target_resolver if entry is not None else None
+            envelope = build_tool_call_envelope(
+                tool_name,
+                args,
+                risk_class=resolved_risk,
+                target_resolver=target_resolver,
+            )
+            if envelope.target:
+                display_target = f"<{tool_name}> target={envelope.target}"
+
+            # Preserve yolo/session-cache semantics before creating inbox noise.
+            if not (_YOLO_MODE_FROZEN or is_current_session_yolo_enabled()) and not is_approved(
+                session_key, pattern_key
+            ):
+                store = ApprovalStore()
+                exact = store.consume_matching_approval(
+                    envelope,
+                    pattern_key=pattern_key,
+                    session_key=session_key,
+                )
+                if exact is not None:
+                    return {
+                        "approved": True,
+                        "message": None,
+                        "approval_id": exact["id"],
+                        "approval_source": "durable_once",
+                    }
+                standing = store.consume_standing_rule(
+                    envelope,
+                    profile=profile,
+                    workspace=workspace,
+                    job_id=job_id,
+                )
+                if standing is not None:
+                    return {
+                        "approved": True,
+                        "message": None,
+                        "approval_source": "standing_rule",
+                        "standing_rule_id": standing["id"],
+                    }
+                pending = store.create_request(
+                    session_key=session_key,
+                    envelope=envelope,
+                    reason=description,
+                    pattern_key=pattern_key,
+                    source=source,
+                )
+                request_id = pending["id"]
+        except Exception as exc:
+            # The live human gate remains authoritative.  A persistence failure
+            # must never turn a denied action into an allowed action.
+            logger.warning("Durable approval preparation failed for %s: %s", tool_name, exc)
+
+    result = _run_approval_gate(
         pattern_key=pattern_key,
         description=description,
         display_target=display_target,
         approval_callback=approval_callback,
-        cron_deny_message=(
+        cron_deny_message=cron_deny_message or (
             f"BLOCKED: Tool '{tool_name}' requires approval ({description}) "
-            "but cron jobs run without a user present to approve it. Find an "
-            "alternative approach. To allow flagged actions in cron jobs, set "
-            "approvals.cron_mode: approve in config.yaml."
+            "but cron jobs run without a user present to approve it. The action "
+            "has been parked in the durable approval inbox when available."
         ),
-        autoapprove_log_prefix=(
-            f"plugin-escalated tool call '{tool_name}' in "
-            "non-interactive non-gateway context"
-        ),
-        fail_closed_when_no_human=True,
+        autoapprove_log_prefix=autoapprove_log_prefix,
+        fail_closed_when_no_human=fail_closed_when_no_human,
         no_human_block_message=(
             f"BLOCKED: Tool '{tool_name}' requires approval ({description}) "
             "but no interactive user or gateway is present to approve it. "
-            "A plugin flagged this action for human confirmation."
+            "The action has been parked in the durable approval inbox when available."
         ),
     )
+
+    if store is not None and envelope is not None and request_id is not None:
+        result = dict(result)
+        result["approval_id"] = request_id
+        if result.get("approved"):
+            try:
+                store.resolve_request(request_id, "approved", decided_by="live_gate")
+                store.consume_matching_approval(
+                    envelope,
+                    pattern_key=pattern_key,
+                    session_key=session_key,
+                )
+            except (KeyError, ValueError):
+                pass
+        elif result.get("status") == "approval_required" or (
+            not _is_interactive_cli() and not _is_gateway_approval_context()
+        ):
+            # Unattended calls are parked, not recorded as definitive denials.
+            result["status"] = "approval_required"
+        else:
+            try:
+                store.resolve_request(request_id, "denied", decided_by="live_gate")
+            except (KeyError, ValueError):
+                pass
+    return result
 
 
 # =========================================================================

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3116,6 +3116,12 @@ def request_tool_approval(
                 )
             except (KeyError, ValueError):
                 pass
+        elif env_var_enabled("HERMES_CRON_SESSION"):
+            # cron_mode: deny is a terminal block for this invocation, even
+            # though its durable inbox row remains pending for later review.
+            # Do not advertise approval_required: there is no listener waiting
+            # to resume this cron run.
+            pass
         elif result.get("status") == "approval_required" or (
             not _is_interactive_cli() and not _is_gateway_approval_context()
         ):

--- a/tools/approval_store.py
+++ b/tools/approval_store.py
@@ -1,0 +1,545 @@
+"""Durable approval inbox and target-scoped standing approval rules."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Callable, Optional
+
+from hermes_constants import get_hermes_home
+from tools.governance import RiskClass, ToolCallEnvelope, risk_at_most
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS approval_requests (
+    id TEXT PRIMARY KEY,
+    session_key TEXT NOT NULL DEFAULT '',
+    tool_name TEXT NOT NULL,
+    risk_class TEXT NOT NULL,
+    target TEXT NOT NULL DEFAULT '',
+    args_digest TEXT NOT NULL,
+    args_preview TEXT NOT NULL DEFAULT '{}',
+    reason TEXT NOT NULL DEFAULT '',
+    pattern_key TEXT NOT NULL DEFAULT '',
+    source TEXT NOT NULL DEFAULT 'tool',
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at REAL NOT NULL,
+    expires_at REAL NOT NULL,
+    decided_at REAL,
+    decision_reason TEXT NOT NULL DEFAULT '',
+    decided_by TEXT NOT NULL DEFAULT '',
+    consumed_at REAL,
+    envelope_json TEXT NOT NULL DEFAULT '',
+    envelope_sha256 TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_approval_requests_status_created
+    ON approval_requests(status, created_at);
+CREATE INDEX IF NOT EXISTS idx_approval_requests_exact_call
+    ON approval_requests(session_key, tool_name, args_digest, pattern_key, status);
+
+CREATE TABLE IF NOT EXISTS standing_approval_rules (
+    id TEXT PRIMARY KEY,
+    tool_name TEXT NOT NULL,
+    target_pattern TEXT NOT NULL,
+    match_mode TEXT NOT NULL DEFAULT 'exact',
+    risk_ceiling TEXT NOT NULL,
+    operation TEXT NOT NULL DEFAULT '',
+    profile TEXT NOT NULL DEFAULT '',
+    workspace TEXT NOT NULL DEFAULT '',
+    job_id TEXT NOT NULL DEFAULT '',
+    expires_at REAL,
+    max_uses INTEGER,
+    use_count INTEGER NOT NULL DEFAULT 0,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    note TEXT NOT NULL DEFAULT '',
+    created_at REAL NOT NULL,
+    last_used_at REAL
+);
+CREATE INDEX IF NOT EXISTS idx_standing_approval_rules_tool_enabled
+    ON standing_approval_rules(tool_name, enabled);
+"""
+
+
+class ApprovalStore:
+    """Small SQLite facade intentionally independent of ``SessionDB`` lifetimes."""
+
+    def __init__(
+        self,
+        db_path: str | Path | None = None,
+        *,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self.db_path = Path(db_path) if db_path is not None else get_hermes_home() / "state.db"
+        self.clock = clock
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.executescript(_SCHEMA)
+            columns = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(standing_approval_rules)").fetchall()
+            }
+            if "match_mode" not in columns:
+                conn.execute(
+                    "ALTER TABLE standing_approval_rules "
+                    "ADD COLUMN match_mode TEXT NOT NULL DEFAULT 'exact'"
+                )
+            request_columns = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(approval_requests)").fetchall()
+            }
+            if "envelope_json" not in request_columns:
+                conn.execute(
+                    "ALTER TABLE approval_requests "
+                    "ADD COLUMN envelope_json TEXT NOT NULL DEFAULT ''"
+                )
+            if "envelope_sha256" not in request_columns:
+                conn.execute(
+                    "ALTER TABLE approval_requests "
+                    "ADD COLUMN envelope_sha256 TEXT NOT NULL DEFAULT ''"
+                )
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path, timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA busy_timeout=10000")
+        return conn
+
+    @staticmethod
+    def _row(row: sqlite3.Row | None) -> Optional[dict]:
+        return dict(row) if row is not None else None
+
+    @staticmethod
+    def _approval_envelope_json(data: dict) -> str:
+        immutable = {
+            key: data[key]
+            for key in (
+                "id", "session_key", "tool_name", "risk_class", "target",
+                "args_digest", "args_preview", "reason", "pattern_key", "source",
+                "created_at", "expires_at",
+            )
+        }
+        return json.dumps(
+            {"schema_version": 1, **immutable},
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    def _request_row(
+        self,
+        row: sqlite3.Row | None,
+        *,
+        require_integrity: bool = False,
+    ) -> Optional[dict]:
+        if row is None:
+            return None
+        data = dict(row)
+        envelope_json = data.get("envelope_json", "")
+        stored_digest = data.get("envelope_sha256", "")
+        expected_json = self._approval_envelope_json(data)
+        expected_digest = hashlib.sha256(expected_json.encode("utf-8")).hexdigest()
+        integrity_ok = bool(envelope_json and stored_digest) and hmac.compare_digest(
+            envelope_json.encode("utf-8"), expected_json.encode("utf-8")
+        ) and hmac.compare_digest(stored_digest, expected_digest)
+        data.pop("envelope_json", None)
+        data["integrity_ok"] = integrity_ok
+        if require_integrity and not integrity_ok:
+            raise ValueError(f"Approval {data['id']} failed envelope integrity verification")
+        return data
+
+    def _expire(self, conn: sqlite3.Connection, now: float) -> None:
+        conn.execute(
+            "UPDATE approval_requests SET status='expired' "
+            "WHERE status IN ('pending', 'approved') AND expires_at <= ?",
+            (now,),
+        )
+
+    def create_request(
+        self,
+        *,
+        session_key: str,
+        envelope: ToolCallEnvelope,
+        reason: str,
+        pattern_key: str,
+        source: str = "tool",
+        expires_in: float = 86400.0,
+    ) -> dict:
+        now = float(self.clock())
+        expires_at = now + max(float(expires_in), 1.0)
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            self._expire(conn, now)
+            existing = conn.execute(
+                "SELECT * FROM approval_requests WHERE session_key=? AND tool_name=? "
+                "AND args_digest=? AND pattern_key=? AND status='pending' "
+                "AND expires_at>? ORDER BY created_at DESC LIMIT 1",
+                (
+                    session_key,
+                    envelope.tool_name,
+                    envelope.args_digest,
+                    pattern_key,
+                    now,
+                ),
+            ).fetchone()
+            if existing is not None:
+                existing_data = self._request_row(existing)
+                if existing_data and existing_data["integrity_ok"]:
+                    conn.commit()
+                    return existing_data
+            request_id = uuid.uuid4().hex
+            immutable = {
+                "id": request_id,
+                "session_key": session_key,
+                "tool_name": envelope.tool_name,
+                "risk_class": envelope.risk_class,
+                "target": envelope.target,
+                "args_digest": envelope.args_digest,
+                "args_preview": envelope.args_preview,
+                "reason": reason,
+                "pattern_key": pattern_key,
+                "source": source,
+                "created_at": now,
+                "expires_at": expires_at,
+            }
+            envelope_json = self._approval_envelope_json(immutable)
+            envelope_sha256 = hashlib.sha256(envelope_json.encode("utf-8")).hexdigest()
+            conn.execute(
+                "INSERT INTO approval_requests "
+                "(id, session_key, tool_name, risk_class, target, args_digest, "
+                "args_preview, reason, pattern_key, source, status, created_at, expires_at, "
+                "envelope_json, envelope_sha256) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?)",
+                (
+                    request_id,
+                    session_key,
+                    envelope.tool_name,
+                    envelope.risk_class,
+                    envelope.target,
+                    envelope.args_digest,
+                    envelope.args_preview,
+                    reason,
+                    pattern_key,
+                    source,
+                    now,
+                    expires_at,
+                    envelope_json,
+                    envelope_sha256,
+                ),
+            )
+            row = conn.execute(
+                "SELECT * FROM approval_requests WHERE id=?", (request_id,)
+            ).fetchone()
+            conn.commit()
+            verified = self._request_row(row, require_integrity=True)
+            assert verified is not None
+            return verified
+
+    def get_request(self, request_id: str) -> Optional[dict]:
+        now = float(self.clock())
+        with self._connect() as conn:
+            self._expire(conn, now)
+            row = conn.execute(
+                "SELECT * FROM approval_requests WHERE id=?", (request_id,)
+            ).fetchone()
+            return self._request_row(row)
+
+    def list_requests(
+        self,
+        *,
+        status: str | None = None,
+        session_key: str | None = None,
+        limit: int = 200,
+    ) -> list[dict]:
+        now = float(self.clock())
+        clauses: list[str] = []
+        params: list[object] = []
+        if status:
+            clauses.append("status=?")
+            params.append(status)
+        if session_key:
+            clauses.append("session_key=?")
+            params.append(session_key)
+        where = " WHERE " + " AND ".join(clauses) if clauses else ""
+        params.append(max(1, min(int(limit), 1000)))
+        with self._connect() as conn:
+            self._expire(conn, now)
+            rows = conn.execute(
+                f"SELECT * FROM approval_requests{where} ORDER BY created_at ASC LIMIT ?",
+                params,
+            ).fetchall()
+            return [data for row in rows if (data := self._request_row(row)) is not None]
+
+    def resolve_request(
+        self,
+        request_id: str,
+        decision: str,
+        *,
+        decision_reason: str = "",
+        decided_by: str = "operator",
+    ) -> dict:
+        normalized = str(decision).strip().lower()
+        if normalized in {"approve", "approved", "allow", "once"}:
+            status = "approved"
+        elif normalized in {"deny", "denied", "reject"}:
+            status = "denied"
+        else:
+            raise ValueError("decision must be approved or denied")
+        now = float(self.clock())
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            self._expire(conn, now)
+            current = conn.execute(
+                "SELECT * FROM approval_requests WHERE id=?", (request_id,)
+            ).fetchone()
+            if current is None:
+                raise KeyError(f"Approval not found: {request_id}")
+            self._request_row(current, require_integrity=True)
+            if current["status"] != "pending":
+                raise ValueError(
+                    f"Approval {request_id} is already {current['status']}"
+                )
+            conn.execute(
+                "UPDATE approval_requests SET status=?, decided_at=?, "
+                "decision_reason=?, decided_by=? WHERE id=?",
+                (status, now, decision_reason, decided_by, request_id),
+            )
+            row = conn.execute(
+                "SELECT * FROM approval_requests WHERE id=?", (request_id,)
+            ).fetchone()
+            conn.commit()
+            verified = self._request_row(row, require_integrity=True)
+            assert verified is not None
+            return verified
+
+    def consume_matching_approval(
+        self,
+        envelope: ToolCallEnvelope,
+        *,
+        pattern_key: str,
+        session_key: str,
+    ) -> Optional[dict]:
+        now = float(self.clock())
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            self._expire(conn, now)
+            row = conn.execute(
+                "SELECT * FROM approval_requests WHERE session_key=? AND tool_name=? "
+                "AND args_digest=? AND target=? AND risk_class=? AND pattern_key=? "
+                "AND status='approved' AND expires_at>? "
+                "ORDER BY decided_at ASC LIMIT 1",
+                (
+                    session_key,
+                    envelope.tool_name,
+                    envelope.args_digest,
+                    envelope.target,
+                    envelope.risk_class,
+                    pattern_key,
+                    now,
+                ),
+            ).fetchone()
+            if row is None:
+                conn.commit()
+                return None
+            self._request_row(row, require_integrity=True)
+            conn.execute(
+                "UPDATE approval_requests SET status='consumed', consumed_at=? "
+                "WHERE id=? AND status='approved'",
+                (now, row["id"]),
+            )
+            consumed = conn.execute(
+                "SELECT * FROM approval_requests WHERE id=?", (row["id"],)
+            ).fetchone()
+            conn.commit()
+            verified = self._request_row(consumed, require_integrity=True)
+            assert verified is not None
+            return verified
+
+    def resolve_request_with_standing_rule(
+        self,
+        request_id: str,
+        *,
+        expires_at: float,
+        max_uses: int,
+        decision_reason: str = "",
+        decided_by: str = "operator",
+        note: str = "",
+    ) -> tuple[dict, dict]:
+        """Atomically approve a pending request and create its exact bounded rule."""
+        if int(max_uses) < 1:
+            raise ValueError("max_uses must be at least 1")
+        now = float(self.clock())
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            self._expire(conn, now)
+            current = conn.execute(
+                "SELECT * FROM approval_requests WHERE id=?", (request_id,)
+            ).fetchone()
+            if current is None:
+                raise KeyError(f"Approval not found: {request_id}")
+            self._request_row(current, require_integrity=True)
+            if current["status"] != "pending":
+                raise ValueError(f"Approval {request_id} is already {current['status']}")
+            if not current["target"]:
+                raise ValueError("Targetless approvals cannot become standing rules")
+
+            rule_id = uuid.uuid4().hex
+            conn.execute(
+                "INSERT INTO standing_approval_rules "
+                "(id, tool_name, target_pattern, match_mode, risk_ceiling, expires_at, "
+                "max_uses, note, created_at) VALUES (?, ?, ?, 'exact', ?, ?, ?, ?, ?)",
+                (
+                    rule_id,
+                    current["tool_name"],
+                    current["target"],
+                    current["risk_class"],
+                    float(expires_at),
+                    int(max_uses),
+                    note,
+                    now,
+                ),
+            )
+            conn.execute(
+                "UPDATE approval_requests SET status='approved', decided_at=?, "
+                "decision_reason=?, decided_by=? WHERE id=? AND status='pending'",
+                (now, decision_reason, decided_by, request_id),
+            )
+            resolved = conn.execute(
+                "SELECT * FROM approval_requests WHERE id=?", (request_id,)
+            ).fetchone()
+            rule = conn.execute(
+                "SELECT * FROM standing_approval_rules WHERE id=?", (rule_id,)
+            ).fetchone()
+            conn.commit()
+            verified = self._request_row(resolved, require_integrity=True)
+            assert verified is not None
+            return verified, dict(rule)
+
+    def add_standing_rule(
+        self,
+        *,
+        tool_name: str,
+        target_pattern: str,
+        risk_ceiling: RiskClass | str,
+        operation: str = "",
+        profile: str = "",
+        workspace: str = "",
+        job_id: str = "",
+        expires_at: float | None = None,
+        max_uses: int | None = None,
+        note: str = "",
+        match_mode: str = "exact",
+    ) -> dict:
+        if not tool_name.strip():
+            raise ValueError("tool_name is required")
+        if not target_pattern.strip():
+            raise ValueError("target_pattern is required")
+        if max_uses is not None and int(max_uses) < 1:
+            raise ValueError("max_uses must be at least 1")
+        if match_mode != "exact":
+            raise ValueError("standing approval rules must use exact target matching")
+        now = float(self.clock())
+        rule_id = uuid.uuid4().hex
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO standing_approval_rules "
+                "(id, tool_name, target_pattern, match_mode, risk_ceiling, operation, profile, "
+                "workspace, job_id, expires_at, max_uses, note, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    rule_id,
+                    tool_name,
+                    target_pattern,
+                    match_mode,
+                    RiskClass.parse(risk_ceiling).value,
+                    operation,
+                    profile,
+                    workspace,
+                    job_id,
+                    expires_at,
+                    int(max_uses) if max_uses is not None else None,
+                    note,
+                    now,
+                ),
+            )
+            row = conn.execute(
+                "SELECT * FROM standing_approval_rules WHERE id=?", (rule_id,)
+            ).fetchone()
+            return dict(row)
+
+    def consume_standing_rule(
+        self,
+        envelope: ToolCallEnvelope,
+        *,
+        operation: str = "",
+        profile: str = "",
+        workspace: str = "",
+        job_id: str = "",
+    ) -> Optional[dict]:
+        now = float(self.clock())
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            candidates = conn.execute(
+                "SELECT * FROM standing_approval_rules WHERE enabled=1 "
+                "AND tool_name=? AND (expires_at IS NULL OR expires_at>?) "
+                "AND (max_uses IS NULL OR use_count<max_uses) "
+                "ORDER BY created_at ASC",
+                (envelope.tool_name, now),
+            ).fetchall()
+            for row in candidates:
+                if row["operation"] and row["operation"] != operation:
+                    continue
+                if row["profile"] and row["profile"] != profile:
+                    continue
+                if row["workspace"] and row["workspace"] != workspace:
+                    continue
+                if row["job_id"] and row["job_id"] != job_id:
+                    continue
+                if row["match_mode"] != "exact":
+                    continue
+                target_matches = envelope.target == row["target_pattern"]
+                if not target_matches:
+                    continue
+                if not risk_at_most(envelope.risk_class, row["risk_ceiling"]):
+                    continue
+                conn.execute(
+                    "UPDATE standing_approval_rules SET use_count=use_count+1, "
+                    "last_used_at=? WHERE id=? AND enabled=1",
+                    (now, row["id"]),
+                )
+                used = conn.execute(
+                    "SELECT * FROM standing_approval_rules WHERE id=?", (row["id"],)
+                ).fetchone()
+                conn.commit()
+                return dict(used)
+            conn.commit()
+            return None
+
+    def list_standing_rules(self, *, active_only: bool = False) -> list[dict]:
+        now = float(self.clock())
+        where = ""
+        params: tuple[object, ...] = ()
+        if active_only:
+            where = (
+                " WHERE enabled=1 AND (expires_at IS NULL OR expires_at>?) "
+                "AND (max_uses IS NULL OR use_count<max_uses)"
+            )
+            params = (now,)
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM standing_approval_rules" + where + " ORDER BY created_at ASC",
+                params,
+            ).fetchall()
+            return [dict(row) for row in rows]
+
+    def revoke_standing_rule(self, rule_id: str) -> bool:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "UPDATE standing_approval_rules SET enabled=0 WHERE id=? AND enabled=1",
+                (rule_id,),
+            )
+            return cursor.rowcount == 1

--- a/tools/governance.py
+++ b/tools/governance.py
@@ -1,0 +1,251 @@
+"""Cross-tool governance primitives.
+
+The registry and approval layer use this module to describe a tool call without
+persisting its raw arguments.  The argument digest binds an approval to the
+exact call; the preview is recursively redacted for operator-facing UIs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Callable, Mapping
+
+
+class RiskClass(str, Enum):
+    """Ordered risk classes shared by built-in, plugin, and MCP tools."""
+
+    READ = "read"
+    WRITE = "write"
+    EXEC = "exec"
+    EXTERNAL = "external"
+    DESTRUCTIVE = "destructive"
+    PRIVILEGED = "privileged"
+
+    @property
+    def level(self) -> int:
+        return _RISK_ORDER[self]
+
+    @classmethod
+    def parse(cls, value: "RiskClass | str") -> "RiskClass":
+        if isinstance(value, cls):
+            return value
+        try:
+            return cls(str(value).strip().lower())
+        except ValueError as exc:
+            allowed = ", ".join(item.value for item in cls)
+            raise ValueError(f"Unknown risk class {value!r}; expected one of: {allowed}") from exc
+
+
+_RISK_ORDER = {
+    RiskClass.READ: 0,
+    RiskClass.WRITE: 1,
+    RiskClass.EXEC: 2,
+    RiskClass.EXTERNAL: 3,
+    RiskClass.DESTRUCTIVE: 4,
+    RiskClass.PRIVILEGED: 5,
+}
+
+
+def risk_at_most(actual: RiskClass | str, ceiling: RiskClass | str) -> bool:
+    return RiskClass.parse(actual).level <= RiskClass.parse(ceiling).level
+
+
+_PRIVILEGED_TOKENS = (
+    "submit_filing",
+    "file_with_court",
+    "issue_invoice",
+    "publish_release",
+    "deploy_production",
+    "rotate_secret",
+    "grant_role",
+    "iam_",
+)
+_DESTRUCTIVE_TOKENS = (
+    "delete",
+    "destroy",
+    "remove",
+    "revoke",
+    "purge",
+    "drop_",
+    "reset_",
+)
+_EXEC_NAMES = {
+    "terminal",
+    "execute_code",
+    "process",
+    "computer_use",
+    "browser_press",
+    "browser_click",
+    "browser_type",
+}
+_EXTERNAL_TOKENS = (
+    "send_",
+    "publish",
+    "upload",
+    "create_issue",
+    "create_pull",
+    "comment",
+    "browser_navigate",
+    "web_search",
+    "web_extract",
+)
+_WRITE_NAMES = {
+    "write_file",
+    "patch",
+    "skill_manage",
+    "memory",
+}
+_READ_PREFIXES = ("read_", "search_", "list_", "get_", "locate_", "map_")
+
+
+def infer_risk_class(tool_name: str, toolset: str = "") -> RiskClass:
+    """Return a conservative default for tools without explicit metadata.
+
+    Explicit metadata always wins in the registry. Unknown MCP tools default to
+    ``external`` because they may mutate a remote service; other unrecognised
+    tools default to ``privileged`` so new plugins cannot silently inherit a
+    read-only classification.
+    """
+
+    name = (tool_name or "").strip().lower()
+    toolset_name = (toolset or "").strip().lower()
+    if any(token in name for token in _PRIVILEGED_TOKENS):
+        return RiskClass.PRIVILEGED
+    if any(token in name for token in _DESTRUCTIVE_TOKENS):
+        return RiskClass.DESTRUCTIVE
+    if name in _EXEC_NAMES or name.startswith("terminal_"):
+        return RiskClass.EXEC
+    if name in _WRITE_NAMES or name.startswith(("write_", "patch_", "update_")):
+        return RiskClass.WRITE
+    if any(token in name for token in _EXTERNAL_TOKENS) or toolset_name in {
+        "messaging",
+        "browser",
+    }:
+        return RiskClass.EXTERNAL
+    if name.startswith(_READ_PREFIXES):
+        return RiskClass.READ
+    if toolset_name.startswith("mcp-"):
+        return RiskClass.EXTERNAL
+    # Unknown plugin/tool names fail conservative: metadata must never silently
+    # downgrade an unrecognised side-effecting tool to read-only.
+    return RiskClass.PRIVILEGED
+
+
+_SENSITIVE_KEYS = {
+    "api_key",
+    "apikey",
+    "authorization",
+    "credential",
+    "credentials",
+    "password",
+    "secret",
+    "token",
+    "access_token",
+    "refresh_token",
+    "private_key",
+}
+_TARGET_KEYS = (
+    "target",
+    "recipient",
+    "destination",
+    "destination_path",
+    "path",
+    "url",
+    "channel",
+    "chat_id",
+    "repo",
+    "repository",
+    "project_id",
+    "name",
+)
+_QUERY_SECRET_RE = re.compile(
+    r"(?i)([?&](?:access_token|api_key|apikey|authorization|credential|password|secret|token)=)[^&#\s]+"
+)
+_URL_USERINFO_RE = re.compile(r"(?i)(https?://)[^/@\s]+@")
+
+
+def _redact_scalar(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    try:
+        from agent.redact import redact_sensitive_text
+
+        value = redact_sensitive_text(value)
+    except Exception:
+        pass
+    value = _QUERY_SECRET_RE.sub(r"\1<redacted>", value)
+    return _URL_USERINFO_RE.sub(r"\1<redacted>@", value)
+
+
+def _redacted_copy(value: Any, *, key: str = "") -> Any:
+    if key.strip().lower() in _SENSITIVE_KEYS:
+        return "***REDACTED***"
+    if isinstance(value, Mapping):
+        return {str(k): _redacted_copy(v, key=str(k)) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_redacted_copy(item) for item in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return _redact_scalar(value)
+    return repr(value)
+
+
+def _canonical_json(args: Mapping[str, Any] | None) -> str:
+    return json.dumps(args or {}, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=repr)
+
+
+def infer_target(args: Mapping[str, Any] | None) -> str:
+    if not isinstance(args, Mapping):
+        return ""
+    for key in _TARGET_KEYS:
+        value = args.get(key)
+        if value is not None and value != "":
+            if isinstance(value, (dict, list, tuple)):
+                return json.dumps(_redacted_copy(value), sort_keys=True, ensure_ascii=False)
+            return str(_redact_scalar(value))
+    command = args.get("command")
+    if command:
+        return str(_redact_scalar(command))[:240]
+    return ""
+
+
+@dataclass(frozen=True)
+class ToolCallEnvelope:
+    tool_name: str
+    risk_class: str
+    target: str
+    args_digest: str
+    args_preview: str
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+def build_tool_call_envelope(
+    tool_name: str,
+    args: Mapping[str, Any] | None,
+    *,
+    risk_class: RiskClass | str,
+    target_resolver: Callable[[Mapping[str, Any]], str] | None = None,
+) -> ToolCallEnvelope:
+    canonical = _canonical_json(args)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    redacted = _redacted_copy(args or {})
+    preview = json.dumps(redacted, sort_keys=True, ensure_ascii=False, default=repr)
+    if len(preview) > 4096:
+        preview = preview[:4080] + "…<truncated>"
+    if target_resolver is not None:
+        target = str(target_resolver(args or {}))
+        target = str(_redact_scalar(target))
+    else:
+        target = str(_redact_scalar(infer_target(args)))
+    return ToolCallEnvelope(
+        tool_name=tool_name,
+        risk_class=RiskClass.parse(risk_class).value,
+        target=target,
+        args_digest=digest,
+        args_preview=preview,
+    )

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -24,6 +24,8 @@ import time
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set
 
+from tools.governance import RiskClass, infer_risk_class
+
 logger = logging.getLogger(__name__)
 
 
@@ -91,11 +93,14 @@ class ToolEntry:
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
         "max_result_size_chars", "dynamic_schema_overrides",
+        "risk_class", "risk_source", "connector_id", "target_resolver",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 risk_class=RiskClass.READ, risk_source="inferred",
+                 connector_id="", target_resolver=None):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -114,6 +119,10 @@ class ToolEntry:
         # on every get_definitions() call; results are merged shallow on top
         # of the base schema before the {"type": "function", ...} wrap.
         self.dynamic_schema_overrides = dynamic_schema_overrides
+        self.risk_class = RiskClass.parse(risk_class)
+        self.risk_source = risk_source
+        self.connector_id = connector_id
+        self.target_resolver = target_resolver
 
 
 # ---------------------------------------------------------------------------
@@ -375,6 +384,9 @@ class ToolRegistry:
         emoji: str = "",
         max_result_size_chars: int | float | None = None,
         dynamic_schema_overrides: Callable = None,
+        risk_class: RiskClass | str | None = None,
+        connector_id: str = "",
+        target_resolver: Optional[Callable] = None,
         override: bool = False,
     ):
         """Register a tool.  Called at module-import time by each tool file.
@@ -385,6 +397,47 @@ class ToolRegistry:
         registrations that would shadow an existing tool from a different
         toolset are rejected to prevent accidental overwrites.
         """
+        resolved_risk = (
+            RiskClass.parse(risk_class)
+            if risk_class is not None
+            else infer_risk_class(name, toolset)
+        )
+        risk_source = "explicit" if risk_class is not None else "inferred"
+        resolved_connector = connector_id
+        if not resolved_connector and (
+            toolset.startswith("mcp-")
+            or toolset
+            in {
+                "browser",
+                "browser-cdp",
+                "cloudflare",
+                "computer_use",
+                "discord",
+                "discord_admin",
+                "feishu_doc",
+                "feishu_drive",
+                "github",
+                "hermes-yuanbao",
+                "homeassistant",
+                "image_gen",
+                "messaging",
+                "spotify",
+                "tts",
+                "video",
+                "video_gen",
+                "vision",
+                "web",
+                "x_search",
+            }
+        ):
+            connector_aliases = {
+                "browser-cdp": "browser",
+                "discord_admin": "discord",
+                "feishu_doc": "feishu",
+                "feishu_drive": "feishu",
+            }
+            resolved_connector = connector_aliases.get(toolset, toolset)
+
         with self._lock:
             existing = self._tools.get(name)
             if existing and existing.toolset != toolset:
@@ -445,6 +498,10 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                risk_class=resolved_risk,
+                risk_source=risk_source,
+                connector_id=resolved_connector,
+                target_resolver=target_resolver,
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by
@@ -575,6 +632,37 @@ class ToolRegistry:
                     )
             result.append({"type": "function", "function": schema_with_name})
         return result
+
+    def get_connector_report(self) -> List[dict]:
+        """Return a live, secret-free inventory for connector management UIs."""
+        grouped: Dict[str, List[ToolEntry]] = {}
+        for entry in self._snapshot_entries():
+            if entry.connector_id:
+                grouped.setdefault(entry.connector_id, []).append(entry)
+
+        report = []
+        for connector_id in sorted(grouped):
+            entries = grouped[connector_id]
+            available = [
+                entry
+                for entry in entries
+                if entry.check_fn is None or _check_fn_cached(entry.check_fn)
+            ]
+            risks = sorted(
+                {entry.risk_class for entry in entries},
+                key=lambda risk: risk.level,
+            )
+            report.append({
+                "connector_id": connector_id,
+                "toolsets": sorted({entry.toolset for entry in entries}),
+                "tool_count": len(entries),
+                "available_tool_count": len(available),
+                "healthy": len(available) == len(entries),
+                "risk_classes": [risk.value for risk in risks],
+                "max_risk_class": risks[-1].value if risks else RiskClass.READ.value,
+                "tools": sorted(entry.name for entry in entries),
+            })
+        return report
 
     # ------------------------------------------------------------------
     # Dispatch

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -65,6 +65,7 @@ import { SidebarStatusStrip, gatewayLine } from "@/components/SidebarStatusStrip
 import { useBelowBreakpoint } from "@nous-research/ui/hooks/use-below-breakpoint";
 import { useSidebarStatus } from "@/hooks/useSidebarStatus";
 import { AuthWidget } from "@/components/AuthWidget";
+import { GovernancePendingBadge } from "@/components/GovernancePendingBadge";
 import { PageHeaderProvider } from "@/contexts/PageHeaderProvider";
 import { ProfileProvider } from "@/contexts/ProfileProvider";
 import { useProfileScope } from "@/contexts/useProfileScope";
@@ -871,6 +872,10 @@ function SidebarNavLink({
             >
               {navLabel}
             </span>
+
+            {path === "/governance" && (
+              <GovernancePendingBadge collapsed={collapsed} />
+            )}
 
             <span
               aria-hidden

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -86,6 +86,7 @@ import ProfileBuilderPage from "@/pages/ProfileBuilderPage";
 import SkillsPage from "@/pages/SkillsPage";
 import PluginsPage from "@/pages/PluginsPage";
 import McpPage from "@/pages/McpPage";
+import GovernancePage from "@/pages/GovernancePage";
 import PairingPage from "@/pages/PairingPage";
 import ChannelsPage from "@/pages/ChannelsPage";
 import WebhooksPage from "@/pages/WebhooksPage";
@@ -141,6 +142,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/skills": SkillsPage,
   "/plugins": PluginsPage,
   "/mcp": McpPage,
+  "/governance": GovernancePage,
   "/pairing": PairingPage,
   "/channels": ChannelsPage,
   "/webhooks": WebhooksPage,
@@ -185,6 +187,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
   { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },
   { path: "/mcp", label: "MCP", icon: Plug },
+  { path: "/governance", label: "Governance", icon: Shield },
   { path: "/channels", label: "Channels", icon: Radio },
   { path: "/webhooks", label: "Webhooks", icon: Webhook },
   { path: "/pairing", label: "Pairing", icon: ShieldCheck },

--- a/web/src/components/GovernancePendingBadge.tsx
+++ b/web/src/components/GovernancePendingBadge.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+
+import { useProfileScope } from "@/contexts/useProfileScope";
+import { api } from "@/lib/api";
+import { startPendingApprovalPolling } from "@/lib/governance-pending";
+import { cn } from "@/lib/utils";
+
+export function GovernancePendingBadge({ collapsed }: { collapsed: boolean }) {
+  const { profile } = useProfileScope();
+  const [snapshot, setSnapshot] = useState({ profile, count: 0 });
+  const count = snapshot.profile === profile ? snapshot.count : 0;
+
+  useEffect(() => {
+    const polling = startPendingApprovalPolling({
+      load: api.getGovernanceApprovals,
+      onCount: (nextCount) => setSnapshot({ profile, count: nextCount }),
+    });
+    return polling.stop;
+  }, [profile]);
+
+  if (count < 1) return null;
+
+  const displayCount = count > 99 ? "99+" : String(count);
+  const label = `${count} pending approval${count === 1 ? "" : "s"}`;
+
+  return (
+    <span
+      aria-label={label}
+      title={label}
+      className={cn(
+        "ml-auto inline-flex min-w-5 shrink-0 items-center justify-center rounded-full bg-warning px-1.5 py-0.5 font-sans text-[0.625rem] font-bold leading-none tracking-normal text-black",
+        collapsed && "lg:absolute lg:right-1 lg:top-1 lg:min-w-3.5 lg:px-1 lg:py-px lg:text-[0.5rem]",
+      )}
+    >
+      {displayCount}
+    </span>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -72,6 +72,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/config",
   "/api/env",
   "/api/mcp",
+  "/api/governance",
   "/api/messaging/platforms",
   "/api/messaging/telegram/onboarding",
   "/api/messaging/whatsapp/onboarding",
@@ -987,6 +988,35 @@ export const api = {
       body: JSON.stringify({ font }),
     }),
 
+  // ── Governance: approvals, exact standing rules, connector health ──
+  getGovernanceApprovals: () =>
+    fetchJSON<GovernanceApprovalList>(
+      "/api/governance/approvals?status=pending",
+    ),
+  decideGovernanceApproval: (
+    id: string,
+    decision: GovernanceDecision,
+  ) =>
+    fetchJSON<GovernanceDecisionResponse>(
+      `/api/governance/approvals/${encodeURIComponent(id)}/decision`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision }),
+      },
+    ),
+  getGovernanceRules: () =>
+    fetchJSON<GovernanceRuleList>(
+      "/api/governance/rules?active_only=true",
+    ),
+  revokeGovernanceRule: (id: string) =>
+    fetchJSON<{ revoked: boolean; id: string }>(
+      `/api/governance/rules/${encodeURIComponent(id)}`,
+      { method: "DELETE" },
+    ),
+  getGovernanceConnectors: () =>
+    fetchJSON<GovernanceConnectorList>("/api/governance/connectors"),
+
   // ── Admin: MCP servers ──────────────────────────────────────────────
   getMcpServers: () => fetchJSON<{ servers: McpServer[] }>("/api/mcp/servers"),
   addMcpServer: (body: McpServerCreate) =>
@@ -1408,6 +1438,81 @@ export interface SkillHubScan {
 }
 
 // ── Admin types ───────────────────────────────────────────────────────
+
+export type GovernanceDecision = "allow-once" | "allow-always" | "deny";
+
+export interface GovernanceApproval {
+  id: string;
+  session_key: string;
+  tool_name: string;
+  risk_class: string;
+  target: string;
+  args_digest: string;
+  args_preview: string;
+  reason: string;
+  pattern_key: string;
+  status: "pending" | "approved" | "denied" | "expired" | "consumed";
+  source: string;
+  created_at: number;
+  expires_at: number;
+  integrity_ok: boolean;
+  decided_at?: number | null;
+  decision_reason?: string;
+  decided_by?: string;
+}
+
+export interface GovernanceApprovalList {
+  count: number;
+  approvals: GovernanceApproval[];
+}
+
+export interface GovernanceDecisionResponse {
+  resolved: boolean;
+  approval_id: string;
+  decision: GovernanceDecision;
+  status: GovernanceApproval["status"];
+  standing_rule_id: string | null;
+}
+
+export interface GovernanceRule {
+  id: string;
+  tool_name: string;
+  operation: string;
+  target_pattern: string;
+  match_mode: "exact";
+  risk_ceiling: string;
+  profile: string;
+  workspace: string;
+  job_id: string;
+  expires_at?: number | null;
+  max_uses?: number | null;
+  use_count: number;
+  enabled: boolean;
+  note: string;
+  created_at: number;
+  last_used_at?: number | null;
+}
+
+export interface GovernanceRuleList {
+  count: number;
+  rules: GovernanceRule[];
+}
+
+export interface GovernanceConnector {
+  id: string;
+  enabled: boolean;
+  health: string;
+  tool_count: number;
+  available_tool_count?: number;
+  tools: string[];
+  risk_classes: string[];
+  highest_risk?: string | null;
+}
+
+export interface GovernanceConnectorList {
+  count: number;
+  connectors: GovernanceConnector[];
+}
 
 export interface McpServer {
   name: string;

--- a/web/src/lib/governance-dashboard.test.ts
+++ b/web/src/lib/governance-dashboard.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import appSource from "../App.tsx?raw";
+import badgeSource from "../components/GovernancePendingBadge.tsx?raw";
 import pageSource from "../pages/GovernancePage.tsx?raw";
 import { api, setManagementProfile } from "./api";
+import {
+  PENDING_APPROVAL_REFRESH_MS,
+  startPendingApprovalPolling,
+} from "./governance-pending";
 
 function jsonFetchMock(body: unknown = { ok: true }) {
   return vi.fn<typeof fetch>(
@@ -66,6 +71,59 @@ describe("governance dashboard API", () => {
   });
 });
 
+describe("governance pending-approval polling", () => {
+  it("loads immediately, refreshes every 10 seconds, and stops cleanly", async () => {
+    const load = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 2 })
+      .mockResolvedValueOnce({ count: 0 });
+    const onCount = vi.fn();
+    const onError = vi.fn();
+    let scheduledRefresh: (() => void) | undefined;
+    const clearIntervalFn = vi.fn();
+    const handle = startPendingApprovalPolling({
+      load,
+      onCount,
+      onError,
+      setIntervalFn: (callback, delay) => {
+        expect(delay).toBe(PENDING_APPROVAL_REFRESH_MS);
+        scheduledRefresh = callback;
+        return 73;
+      },
+      clearIntervalFn,
+    });
+
+    await handle.initial;
+    expect(onCount).toHaveBeenLastCalledWith(2);
+    expect(scheduledRefresh).toBeTypeOf("function");
+
+    scheduledRefresh?.();
+    await vi.waitFor(() => expect(onCount).toHaveBeenLastCalledWith(0));
+
+    handle.stop();
+    expect(clearIntervalFn).toHaveBeenCalledWith(73);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("reports refresh failures without inventing a pending count", async () => {
+    const onCount = vi.fn();
+    const onError = vi.fn();
+    const expectedError = new Error("offline");
+    const handle = startPendingApprovalPolling({
+      load: vi.fn().mockRejectedValue(expectedError),
+      onCount,
+      onError,
+      setIntervalFn: vi.fn(() => 91),
+      clearIntervalFn: vi.fn(),
+    });
+
+    await handle.initial;
+    expect(onCount).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(expectedError);
+    handle.stop();
+  });
+});
+
 describe("governance dashboard route", () => {
   it("is a first-class sidebar route with the required operator controls", () => {
     expect(appSource).toContain(
@@ -73,6 +131,10 @@ describe("governance dashboard route", () => {
     );
     expect(appSource).toContain('"/governance": GovernancePage');
     expect(appSource).toContain('path: "/governance"');
+    expect(appSource).toContain(
+      "<GovernancePendingBadge collapsed={collapsed} />",
+    );
+    expect(badgeSource).toContain("pending approval");
     expect(pageSource).toContain("Approval inbox");
     expect(pageSource).toContain("Allow once");
     expect(pageSource).toContain("Allow for target");

--- a/web/src/lib/governance-dashboard.test.ts
+++ b/web/src/lib/governance-dashboard.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import appSource from "../App.tsx?raw";
+import pageSource from "../pages/GovernancePage.tsx?raw";
+import { api, setManagementProfile } from "./api";
+
+function jsonFetchMock(body: unknown = { ok: true }) {
+  return vi.fn<typeof fetch>(
+    async () =>
+      new Response(JSON.stringify(body), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      }),
+  );
+}
+
+afterEach(() => {
+  setManagementProfile("");
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("governance dashboard API", () => {
+  it("loads all governance panels in the selected profile", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock({ count: 0 });
+    vi.stubGlobal("fetch", fetchMock);
+    setManagementProfile("work");
+
+    await Promise.all([
+      api.getGovernanceApprovals(),
+      api.getGovernanceRules(),
+      api.getGovernanceConnectors(),
+    ]);
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "/api/governance/approvals?status=pending&profile=work",
+      "/api/governance/rules?active_only=true&profile=work",
+      "/api/governance/connectors?profile=work",
+    ]);
+  });
+
+  it("sends approval decisions and rule revocations to their exact targets", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.decideGovernanceApproval("approval/id", "allow-always");
+    await api.revokeGovernanceRule("rule/id");
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/api/governance/approvals/approval%2Fid/decision",
+    );
+    expect(fetchMock.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ decision: "allow-always" }),
+      }),
+    );
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      "/api/governance/rules/rule%2Fid",
+    );
+    expect(fetchMock.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});
+
+describe("governance dashboard route", () => {
+  it("is a first-class sidebar route with the required operator controls", () => {
+    expect(appSource).toContain(
+      'import GovernancePage from "@/pages/GovernancePage";',
+    );
+    expect(appSource).toContain('"/governance": GovernancePage');
+    expect(appSource).toContain('path: "/governance"');
+    expect(pageSource).toContain("Approval inbox");
+    expect(pageSource).toContain("Allow once");
+    expect(pageSource).toContain("Allow for target");
+    expect(pageSource).toContain("Integrity failed");
+    expect(pageSource).toContain("Standing approvals");
+    expect(pageSource).toContain("Revoke");
+    expect(pageSource).toContain("Connector health");
+  });
+});

--- a/web/src/lib/governance-pending.ts
+++ b/web/src/lib/governance-pending.ts
@@ -1,0 +1,72 @@
+export const PENDING_APPROVAL_REFRESH_MS = 10_000;
+
+type PendingApprovalResult = {
+  count: number;
+};
+
+type IntervalHandle = unknown;
+
+interface PendingApprovalPollingOptions {
+  load: () => Promise<PendingApprovalResult>;
+  onCount: (count: number) => void;
+  onError?: (error: unknown) => void;
+  setIntervalFn?: (
+    callback: () => void,
+    delay: number,
+  ) => IntervalHandle;
+  clearIntervalFn?: (handle: IntervalHandle) => void;
+}
+
+export interface PendingApprovalPollingHandle {
+  initial: Promise<void>;
+  refresh: () => Promise<void>;
+  stop: () => void;
+}
+
+/**
+ * Start bounded polling for the profile-scoped pending approval count.
+ * Failures leave the last known value untouched; stopping suppresses late
+ * promise resolutions so profile switches cannot paint stale counts.
+ */
+export function startPendingApprovalPolling({
+  load,
+  onCount,
+  onError,
+  setIntervalFn = (callback, delay) => globalThis.setInterval(callback, delay),
+  clearIntervalFn = (handle) =>
+    globalThis.clearInterval(
+      handle as ReturnType<typeof globalThis.setInterval>,
+    ),
+}: PendingApprovalPollingOptions): PendingApprovalPollingHandle {
+  let active = true;
+  let loading = false;
+
+  const refresh = async () => {
+    if (!active || loading) return;
+    loading = true;
+    try {
+      const result = await load();
+      if (active) onCount(Math.max(0, result.count));
+    } catch (error) {
+      if (active) onError?.(error);
+    } finally {
+      loading = false;
+    }
+  };
+
+  const initial = refresh();
+  const interval = setIntervalFn(
+    () => void refresh(),
+    PENDING_APPROVAL_REFRESH_MS,
+  );
+
+  return {
+    initial,
+    refresh,
+    stop: () => {
+      if (!active) return;
+      active = false;
+      clearIntervalFn(interval);
+    },
+  };
+}

--- a/web/src/pages/GovernancePage.tsx
+++ b/web/src/pages/GovernancePage.tsx
@@ -1,0 +1,510 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  ExternalLink,
+  Link2,
+  LockKeyhole,
+  RefreshCw,
+  ShieldCheck,
+  ShieldX,
+} from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@nous-research/ui/ui/components/card";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Toast } from "@nous-research/ui/ui/components/toast";
+import { useToast } from "@nous-research/ui/hooks/use-toast";
+
+import { api } from "@/lib/api";
+import type {
+  GovernanceApproval,
+  GovernanceConnector,
+  GovernanceDecision,
+  GovernanceRule,
+} from "@/lib/api";
+
+const REFRESH_INTERVAL_MS = 10_000;
+
+type BadgeTone =
+  | "destructive"
+  | "outline"
+  | "secondary"
+  | "success"
+  | "warning";
+
+function humanTime(value: number | null | undefined): string {
+  if (!value) return "No expiry";
+  return new Date(value * 1000).toLocaleString();
+}
+
+function riskTone(risk: string | null | undefined): BadgeTone {
+  if (risk === "destructive") return "destructive";
+  if (risk === "privileged" || risk === "exec") return "warning";
+  if (risk === "external") return "outline";
+  return "secondary";
+}
+
+function healthTone(health: string): BadgeTone {
+  if (health === "healthy") return "success";
+  if (health === "degraded") return "destructive";
+  if (health === "disabled") return "secondary";
+  return "outline";
+}
+
+function EmptyState({ children }: { children: string }) {
+  return (
+    <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+function LoadingCard({ title }: { title: string }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
+        <Spinner /> Loading…
+      </CardContent>
+    </Card>
+  );
+}
+
+function ApprovalRow({
+  approval,
+  busy,
+  onDecision,
+}: {
+  approval: GovernanceApproval;
+  busy: boolean;
+  onDecision: (decision: GovernanceDecision) => void;
+}) {
+  return (
+    <article className="flex flex-col gap-3 px-4 py-4">
+      <div className="min-w-0 space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium">{approval.tool_name}</span>
+          <Badge tone={riskTone(approval.risk_class)}>{approval.risk_class}</Badge>
+          {!approval.integrity_ok && (
+            <Badge tone="destructive">
+              <ShieldX className="mr-1 size-3" /> Integrity failed
+            </Badge>
+          )}
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {approval.reason || "This action requires operator approval."}
+        </p>
+        <code
+          className="block max-w-full break-all border border-border bg-background/50 px-2 py-1 text-xs text-foreground"
+          title={approval.target || "No target"}
+        >
+          {approval.target || "No target"}
+        </code>
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          <span>Source: {approval.source || "tool"}</span>
+          <span>Created: {humanTime(approval.created_at)}</span>
+          <span>Expires: {humanTime(approval.expires_at)}</span>
+        </div>
+      </div>
+
+      <div className="flex shrink-0 flex-wrap gap-2 lg:justify-end">
+        {approval.integrity_ok ? (
+          <>
+            <Button
+              size="sm"
+              outlined
+              disabled={busy}
+              onClick={() => onDecision("allow-once")}
+            >
+              Allow once
+            </Button>
+            <Button
+              size="sm"
+              outlined
+              disabled={busy || !approval.target}
+              title={
+                approval.target
+                  ? "Create an exact-target rule, bounded to 30 days and 100 uses"
+                  : "Targetless requests cannot become standing approvals"
+              }
+              onClick={() => onDecision("allow-always")}
+            >
+              Allow for target
+            </Button>
+            <Button
+              size="sm"
+              ghost
+              className="text-destructive hover:text-destructive"
+              disabled={busy}
+              onClick={() => onDecision("deny")}
+            >
+              Deny
+            </Button>
+          </>
+        ) : (
+          <span className="text-xs text-destructive">
+            Decisions are blocked because the stored envelope failed verification.
+          </span>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function RuleRow({
+  rule,
+  busy,
+  onRevoke,
+}: {
+  rule: GovernanceRule;
+  busy: boolean;
+  onRevoke: () => void;
+}) {
+  const useLabel =
+    rule.max_uses == null
+      ? `${rule.use_count} uses`
+      : `${rule.use_count}/${rule.max_uses} uses`;
+
+  return (
+    <article className="flex flex-col gap-3 px-4 py-4 md:flex-row md:items-start md:justify-between">
+      <div className="min-w-0 space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium">{rule.tool_name}</span>
+          <Badge tone={riskTone(rule.risk_ceiling)}>{rule.risk_ceiling}</Badge>
+          <Badge tone="outline">exact target</Badge>
+        </div>
+        <code
+          className="block max-w-full break-all border border-border bg-background/50 px-2 py-1 text-xs text-foreground"
+          title={rule.target_pattern}
+        >
+          {rule.target_pattern}
+        </code>
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          <span>{useLabel}</span>
+          <span>Expires: {humanTime(rule.expires_at)}</span>
+          {rule.last_used_at ? (
+            <span>Last used: {humanTime(rule.last_used_at)}</span>
+          ) : null}
+        </div>
+      </div>
+      <Button
+        size="sm"
+        ghost
+        className="shrink-0 text-destructive hover:text-destructive"
+        disabled={busy}
+        onClick={onRevoke}
+      >
+        Revoke
+      </Button>
+    </article>
+  );
+}
+
+function ConnectorRow({ connector }: { connector: GovernanceConnector }) {
+  const available = connector.available_tool_count ?? connector.tool_count;
+  return (
+    <article className="flex flex-col gap-3 px-4 py-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0 space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium">{connector.id}</span>
+          <Badge tone={healthTone(connector.health)}>{connector.health}</Badge>
+          {!connector.enabled && <Badge tone="secondary">disabled</Badge>}
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {available}/{connector.tool_count} tools available
+          {connector.risk_classes.length
+            ? ` · ${connector.risk_classes.join(", ")}`
+            : " · unclassified"}
+        </p>
+        {connector.tools.length > 0 && (
+          <p className="break-words font-mono text-xs text-muted-foreground">
+            {connector.tools.join(", ")}
+          </p>
+        )}
+      </div>
+      {connector.highest_risk ? (
+        <Badge tone={riskTone(connector.highest_risk)}>
+          highest: {connector.highest_risk}
+        </Badge>
+      ) : null}
+    </article>
+  );
+}
+
+export default function GovernancePage() {
+  const navigate = useNavigate();
+  const [approvals, setApprovals] = useState<GovernanceApproval[]>([]);
+  const [rules, setRules] = useState<GovernanceRule[]>([]);
+  const [connectors, setConnectors] = useState<GovernanceConnector[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const { toast, showToast } = useToast();
+
+  const loadGovernance = useCallback(async () => {
+    const results = await Promise.allSettled([
+      api.getGovernanceApprovals(),
+      api.getGovernanceRules(),
+      api.getGovernanceConnectors(),
+    ]);
+    const failures: string[] = [];
+
+    if (results[0].status === "fulfilled") {
+      setApprovals(results[0].value.approvals);
+    } else failures.push("approvals");
+    if (results[1].status === "fulfilled") {
+      setRules(results[1].value.rules);
+    } else failures.push("standing approvals");
+    if (results[2].status === "fulfilled") {
+      setConnectors(results[2].value.connectors);
+    } else failures.push("connectors");
+
+    setLoadError(
+      failures.length
+        ? `Could not refresh ${failures.join(", ")}. Previously loaded data is retained.`
+        : null,
+    );
+    setLoading(false);
+    setRefreshing(false);
+  }, []);
+
+  useEffect(() => {
+    const initialTimer = window.setTimeout(() => void loadGovernance(), 0);
+    const refreshTimer = window.setInterval(
+      () => void loadGovernance(),
+      REFRESH_INTERVAL_MS,
+    );
+    return () => {
+      window.clearTimeout(initialTimer);
+      window.clearInterval(refreshTimer);
+    };
+  }, [loadGovernance]);
+
+  const decide = async (
+    approval: GovernanceApproval,
+    decision: GovernanceDecision,
+  ) => {
+    setBusyId(approval.id);
+    try {
+      await api.decideGovernanceApproval(approval.id, decision);
+      showToast(
+        decision === "deny"
+          ? "Approval denied"
+          : decision === "allow-always"
+            ? "Approved and bounded exact-target rule created"
+            : "Approved once",
+        "success",
+      );
+      await loadGovernance();
+    } catch (error) {
+      showToast(`Decision failed: ${String(error)}`, "error");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const revoke = async (rule: GovernanceRule) => {
+    setBusyId(rule.id);
+    try {
+      const result = await api.revokeGovernanceRule(rule.id);
+      if (!result.revoked) throw new Error("Rule was already inactive or not found");
+      showToast("Standing approval revoked", "success");
+      await loadGovernance();
+    } catch (error) {
+      showToast(`Revoke failed: ${String(error)}`, "error");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const degradedConnectors = connectors.filter(
+    (connector) => connector.health === "degraded",
+  ).length;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Toast toast={toast} />
+
+      <Card className="border-border">
+        <CardContent className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-3">
+            <ShieldCheck className="mt-0.5 size-5 shrink-0 text-primary" />
+            <div>
+              <h2 className="font-medium">Governed authority</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Review durable requests, manage exact-target standing approvals, and
+                inspect connector health. Standing approvals created here expire after
+                30 days or 100 uses.
+              </p>
+            </div>
+          </div>
+          <Button
+            size="sm"
+            outlined
+            className="shrink-0"
+            disabled={refreshing}
+            prefix={refreshing ? <Spinner /> : <RefreshCw />}
+            onClick={() => {
+              setRefreshing(true);
+              void loadGovernance();
+            }}
+          >
+            Refresh
+          </Button>
+        </CardContent>
+      </Card>
+
+      {loadError && (
+        <div className="flex items-start gap-2 border border-warning/50 bg-warning/10 px-4 py-3 text-sm">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-warning" />
+          <span>{loadError}</span>
+        </div>
+      )}
+
+      {!loading && (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <Card>
+            <CardContent className="flex items-center justify-between p-4">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                  Pending approvals
+                </p>
+                <p className="mt-1 text-2xl font-semibold">{approvals.length}</p>
+              </div>
+              <Clock3 className="size-5 text-muted-foreground" />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="flex items-center justify-between p-4">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                  Active rules
+                </p>
+                <p className="mt-1 text-2xl font-semibold">{rules.length}</p>
+              </div>
+              <LockKeyhole className="size-5 text-muted-foreground" />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="flex items-center justify-between p-4">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                  Degraded connectors
+                </p>
+                <p className="mt-1 text-2xl font-semibold">{degradedConnectors}</p>
+              </div>
+              {degradedConnectors ? (
+                <AlertTriangle className="size-5 text-warning" />
+              ) : (
+                <CheckCircle2 className="size-5 text-success" />
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+          <LoadingCard title="Approval inbox" />
+          <LoadingCard title="Standing approvals" />
+          <div className="xl:col-span-2">
+            <LoadingCard title="Connector health" />
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+          <Card className="min-w-0">
+            <CardHeader className="flex-row items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <Clock3 className="size-4 text-muted-foreground" />
+                <CardTitle className="text-base">Approval inbox</CardTitle>
+              </div>
+              <Badge tone={approvals.length ? "warning" : "secondary"}>
+                {approvals.length}
+              </Badge>
+            </CardHeader>
+            <CardContent className="p-0">
+              {approvals.length === 0 ? (
+                <EmptyState>No actions are waiting for approval.</EmptyState>
+              ) : (
+                <div className="max-h-[400px] divide-y divide-border overflow-y-auto">
+                  {approvals.map((approval) => (
+                    <ApprovalRow
+                      key={approval.id}
+                      approval={approval}
+                      busy={busyId === approval.id}
+                      onDecision={(decision) => void decide(approval, decision)}
+                    />
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="min-w-0">
+            <CardHeader className="flex-row items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <LockKeyhole className="size-4 text-muted-foreground" />
+                <CardTitle className="text-base">Standing approvals</CardTitle>
+              </div>
+              <Badge tone="secondary">{rules.length}</Badge>
+            </CardHeader>
+            <CardContent className="p-0">
+              {rules.length === 0 ? (
+                <EmptyState>
+                  No standing approvals. Create one only from an exact pending target.
+                </EmptyState>
+              ) : (
+                <div className="max-h-[400px] divide-y divide-border overflow-y-auto">
+                  {rules.map((rule) => (
+                    <RuleRow
+                      key={rule.id}
+                      rule={rule}
+                      busy={busyId === rule.id}
+                      onRevoke={() => void revoke(rule)}
+                    />
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="min-w-0 xl:col-span-2">
+            <CardHeader className="flex-row items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <Link2 className="size-4 text-muted-foreground" />
+                <CardTitle className="text-base">Connector health</CardTitle>
+                <Badge tone="secondary">{connectors.length}</Badge>
+              </div>
+              <Button size="sm" ghost onClick={() => navigate("/mcp")}>
+                Manage MCP <ExternalLink className="ml-1 size-3" />
+              </Button>
+            </CardHeader>
+            <CardContent className="p-0">
+              {connectors.length === 0 ? (
+                <EmptyState>No connectors are registered for this profile.</EmptyState>
+              ) : (
+                <div className="max-h-[400px] divide-y divide-border overflow-y-auto">
+                  {connectors.map((connector) => (
+                    <ConnectorRow key={connector.id} connector={connector} />
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- add durable, profile-scoped approval requests and exact-target standing approvals
- expose connector health and governed approval APIs
- add Governance settings to Hermes Desktop
- add a first-class `/governance` page to the existing web dashboard
- show a profile-scoped pending-approval count in expanded and collapsed navigation
- keep cron `deny` responses terminal while preserving durable requests for later review

## Safety and authority model

- execution remains fail-closed
- standing approvals are exact-target, risk-bounded, expiring and use-limited
- unresolved requests are integrity-checked and profile-scoped
- cron denials do not masquerade as resumable `approval_required` responses
- the navigation badge reads pending state only and fails quietly if the API is unavailable

## Verification

- Web: 18 files, 102 tests passed
- Web production build and TypeScript project build passed
- Targeted ESLint: 0 errors; 1 unrelated pre-existing `App.tsx` warning
- Backend governance/approval matrix: 578 tests passed
- Ruff: passed
- Desktop governance/backend-env: 11 tests passed
- Desktop TypeScript checks: passed
- `git diff --check`: passed
- Live `/governance` browser verification: passed
- Pending badge: verified expanded, collapsed and post-resolution states
- Browser console and JavaScript errors: none

## Notes

The web experience reuses the existing dashboard shell and backend governance APIs; it does not add a separate application or model-facing core tool.
