### PR TITLE
fix(hermes_cli): stop planted cwd PowerShell from running during managed-uv bootstrap

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -1080,13 +1080,22 @@ def _resolve_windows_powershell_host() -> str:
         raise FileNotFoundError(
             "Windows PowerShell host unresolved: SystemRoot/WINDIR is unset"
         )
+    root = Path(system_root)
+    if not root.is_absolute():
+        raise FileNotFoundError(
+            f"Windows PowerShell system root must be absolute: {system_root}"
+        )
     candidate = (
-        Path(system_root)
+        root
         / "System32"
         / "WindowsPowerShell"
         / "v1.0"
         / "powershell.exe"
     )
+    if not candidate.is_absolute():
+        raise FileNotFoundError(
+            f"Windows PowerShell host path must be absolute: {candidate}"
+        )
     if candidate.is_file():
         return str(candidate)
     raise FileNotFoundError(f"Windows PowerShell host not found at {candidate}")

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -1066,11 +1066,38 @@ def _install_uv_posix(env: dict[str, str]) -> None:
             pass
 
 
+def _resolve_windows_powershell_host() -> str:
+    """Return an absolute Windows PowerShell host path for managed-uv bootstrap.
+
+    A bare ``powershell`` argv lets CreateProcess search the process current
+    directory (and PATHEXT) before PATH, so an attacker-writable cwd can plant
+    ``powershell.exe`` / ``.cmd`` / ``.bat`` and run arbitrary code under
+    ``-ExecutionPolicy Bypass``. Prefer the well-known System32 host only —
+    never fall back to an unresolved bare name.
+    """
+    system_root = os.environ.get("SystemRoot") or os.environ.get("WINDIR")
+    if not system_root:
+        raise FileNotFoundError(
+            "Windows PowerShell host unresolved: SystemRoot/WINDIR is unset"
+        )
+    candidate = (
+        Path(system_root)
+        / "System32"
+        / "WindowsPowerShell"
+        / "v1.0"
+        / "powershell.exe"
+    )
+    if candidate.is_file():
+        return str(candidate)
+    raise FileNotFoundError(f"Windows PowerShell host not found at {candidate}")
+
+
 def _install_uv_windows(env: dict[str, str]) -> None:
-    """Invoke the PowerShell installer."""
+    """Invoke the PowerShell installer via a trusted absolute host path."""
     cmd = "irm https://astral.sh/uv/install.ps1 | iex"
+    host = _resolve_windows_powershell_host()
     subprocess.run(
-        ["powershell", "-ExecutionPolicy", "Bypass", "-c", cmd],
+        [host, "-ExecutionPolicy", "Bypass", "-c", cmd],
         env=env,
         check=True,
         capture_output=True,

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -1073,7 +1073,9 @@ def _resolve_windows_powershell_host() -> str:
     directory (and PATHEXT) before PATH, so an attacker-writable cwd can plant
     ``powershell.exe`` / ``.cmd`` / ``.bat`` and run arbitrary code under
     ``-ExecutionPolicy Bypass``. Prefer the well-known System32 host only —
-    never fall back to an unresolved bare name.
+    never fall back to an unresolved bare name. This closes cwd/PATHEXT host
+    planting; like other Windows process launches, it trusts the inherited
+    OS environment to provide the genuine ``SystemRoot`` / ``WINDIR``.
     """
     system_root = os.environ.get("SystemRoot") or os.environ.get("WINDIR")
     if not system_root:

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -748,6 +748,28 @@ class TestWindowsPowershellHostResolution:
         with pytest.raises(FileNotFoundError, match="Windows PowerShell host"):
             _resolve_windows_powershell_host()
 
+    def test_resolve_rejects_relative_systemroot(self, tmp_path, monkeypatch):
+        from hermes_cli.managed_uv import _resolve_windows_powershell_host
+
+        self._fake_system_powershell(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("SystemRoot", "Windows")
+        monkeypatch.delenv("WINDIR", raising=False)
+
+        with pytest.raises(FileNotFoundError, match="must be absolute"):
+            _resolve_windows_powershell_host()
+
+    def test_resolve_rejects_relative_windir(self, tmp_path, monkeypatch):
+        from hermes_cli.managed_uv import _resolve_windows_powershell_host
+
+        self._fake_system_powershell(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("SystemRoot", raising=False)
+        monkeypatch.setenv("WINDIR", "Windows")
+
+        with pytest.raises(FileNotFoundError, match="must be absolute"):
+            _resolve_windows_powershell_host()
+
     def test_install_uv_windows_uses_absolute_host_not_bare_name(
         self, tmp_path, monkeypatch
     ):

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -699,6 +699,81 @@ class TestInstallUvInternals:
             assert call_env["UV_INSTALL_DIR"] == str(tmp_path / "bin")
 
 
+class TestWindowsPowershellHostResolution:
+    """Managed-uv Windows bootstrap must not spawn a bare ``powershell`` name.
+
+    CreateProcess resolves extension-less names via PATHEXT and searches the
+    process cwd before PATH, so a planted host in an untrusted directory would
+    win under ``-ExecutionPolicy Bypass``.
+    """
+
+    @staticmethod
+    def _fake_system_powershell(tmp_path: Path) -> Path:
+        host = (
+            tmp_path
+            / "Windows"
+            / "System32"
+            / "WindowsPowerShell"
+            / "v1.0"
+            / "powershell.exe"
+        )
+        host.parent.mkdir(parents=True, exist_ok=True)
+        host.write_bytes(b"MZ")
+        return host
+
+    def test_resolve_uses_systemroot_absolute_path(self, tmp_path, monkeypatch):
+        from hermes_cli.managed_uv import _resolve_windows_powershell_host
+
+        host = self._fake_system_powershell(tmp_path)
+        monkeypatch.setenv("SystemRoot", str(tmp_path / "Windows"))
+        monkeypatch.delenv("WINDIR", raising=False)
+
+        assert _resolve_windows_powershell_host() == str(host)
+
+    def test_resolve_falls_back_to_windir(self, tmp_path, monkeypatch):
+        from hermes_cli.managed_uv import _resolve_windows_powershell_host
+
+        host = self._fake_system_powershell(tmp_path)
+        monkeypatch.delenv("SystemRoot", raising=False)
+        monkeypatch.setenv("WINDIR", str(tmp_path / "Windows"))
+
+        assert _resolve_windows_powershell_host() == str(host)
+
+    def test_resolve_missing_host_fails_closed(self, tmp_path, monkeypatch):
+        from hermes_cli.managed_uv import _resolve_windows_powershell_host
+
+        monkeypatch.setenv("SystemRoot", str(tmp_path / "Windows"))
+        monkeypatch.delenv("WINDIR", raising=False)
+
+        with pytest.raises(FileNotFoundError, match="Windows PowerShell host"):
+            _resolve_windows_powershell_host()
+
+    def test_install_uv_windows_uses_absolute_host_not_bare_name(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import managed_uv
+
+        host = self._fake_system_powershell(tmp_path)
+        monkeypatch.setenv("SystemRoot", str(tmp_path / "Windows"))
+        # Plant a cwd decoy that CreateProcess would prefer for a bare name.
+        decoy = tmp_path / "cwd" / "powershell.exe"
+        decoy.parent.mkdir(parents=True, exist_ok=True)
+        decoy.write_bytes(b"MZ")
+        monkeypatch.chdir(decoy.parent)
+
+        with patch.object(managed_uv.subprocess, "run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=0)
+            managed_uv._install_uv_windows({"UV_INSTALL_DIR": str(tmp_path / "bin")})
+
+        mock_run.assert_called_once()
+        argv = mock_run.call_args[0][0]
+        assert argv[0] == str(host)
+        assert argv[0] != "powershell"
+        assert Path(argv[0]).is_absolute()
+        assert argv[1:4] == ["-ExecutionPolicy", "Bypass", "-c"]
+        assert "astral.sh/uv/install.ps1" in argv[4]
+
+
 class TestRuntimeRequestMinorLine:
     """The repair must request the CPython minor line, not the exact patch.
 


### PR DESCRIPTION
## What does this PR do?

On Windows, managed-uv bootstrap no longer spawns a bare `powershell` name. It resolves the absolute System32 Windows PowerShell host so an attacker-writable current directory cannot plant `powershell.exe` / `.cmd` / `.bat` and gain arbitrary code execution under `-ExecutionPolicy Bypass` when Hermes installs missing managed uv.

### Bug Cause

`_install_uv_windows` called `subprocess.run(["powershell", "-ExecutionPolicy", "Bypass", "-c", "irm ... | iex"], ...)`. On Windows, CreateProcess resolves extension-less names via PATHEXT and searches the process cwd before PATH, so a planted host wins. This path is reached from `ensure_uv()` when `$HERMES_HOME/bin/uv.exe` is missing (first bootstrap / deleted binary), including `hermes update` recovery.

### Reproduction Steps

1. Remove or rename `%USERPROFILE%\.hermes\bin\uv.exe` (or the active profile's `HERMES_HOME\bin\uv.exe`).
2. In an untrusted project directory, plant `powershell.cmd` or `powershell.exe` that only creates a marker file.
3. From that directory, run a command that calls `ensure_uv()` (for example `hermes update`).

Expected: only `%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe` is spawned.
Before fix: the planted cwd host runs as the Hermes user before any Astral installer integrity check.

### Fix

Add `_resolve_windows_powershell_host()` that returns the absolute System32 PowerShell path from `SystemRoot` / `WINDIR`, and raises `FileNotFoundError` if missing (no bare-name fallback). `_install_uv_windows` uses that path. Tests cover SystemRoot/WINDIR resolution, missing-host fail-closed, and a cwd decoy that must not win.

## Related Issue

No issue

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/managed_uv.py` - resolve absolute System32 PowerShell for Windows managed-uv install; refuse bare-name fallback
- `tests/hermes_cli/test_managed_uv.py` - lock host resolution and cwd-decoy behavior

## How to Test

1. Manual (Windows): remove managed `uv.exe`, plant a cwd `powershell` decoy, run a path that calls `ensure_uv()`, confirm only System32 PowerShell is used.
2. Automated (already run locally, 53 passed):

```bash
scripts/run_tests.sh tests/hermes_cli/test_managed_uv.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (WSL-backed test runner for the suite)

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact - Windows-only host resolution; POSIX path unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
