### PR TITLE
fix(anthropic): skip thinking parameter for Kimi /coding endpoints

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -249,13 +249,7 @@ def _supports_adaptive_thinking(model: str) -> bool:
     only returns False for the explicit legacy list of older Claude families
     that require manual budget-based thinking. Non-Claude Anthropic-Messages
     models (minimax, qwen3, …) return False so they keep the manual path.
-
-    Kimi / Moonshot models are the exception: their Anthropic-compatible
-    endpoints implement the adaptive contract (``thinking.type="adaptive"``
-    + ``output_config.effort``, including ``xhigh`` and ``display``).
     """
-    if _model_name_is_kimi_family(model):
-        return True
     if not _is_claude_model(model):
         return False
     m = model.lower()
@@ -2398,6 +2392,13 @@ def _manage_thinking_signatures(
     """
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
     _is_third_party = _is_third_party_anthropic_endpoint(base_url)
+    # Kimi / DeepSeek share a contract: strip signed Anthropic blocks
+    # (neither upstream can validate Anthropic signatures), preserve unsigned
+    # ones synthesised from reasoning_content.  See #13848, #16748.
+    _preserve_unsigned_thinking = (
+        _is_kimi_family_endpoint(base_url, model)
+        or _is_deepseek_anthropic_endpoint(base_url)
+    )
 
     last_assistant_idx = None
     for i in range(len(result) - 1, -1, -1):
@@ -2409,12 +2410,8 @@ def _manage_thinking_signatures(
         if m.get("role") != "assistant" or not isinstance(m.get("content"), list):
             continue
 
-        if _is_kimi_family_endpoint(base_url, model):
-            # Kimi does not enforce thinking signatures — replay as-is
-            # (shared cleanup below still strips cache markers + the internal flag).
-            pass
-        elif _is_deepseek_anthropic_endpoint(base_url):
-            # DeepSeek: strip signed, preserve unsigned.
+        if _preserve_unsigned_thinking:
+            # Kimi / DeepSeek: strip signed, preserve unsigned.
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
@@ -2765,19 +2762,25 @@ def build_anthropic_kwargs(
     # MiniMax Anthropic-compat endpoints support thinking (manual mode only,
     # not adaptive).  Haiku does NOT support extended thinking — skip entirely.
     #
-    # Kimi / Moonshot models also use adaptive thinking: their
-    # Anthropic-compatible endpoints (api.moonshot.cn/anthropic,
-    # api.kimi.com/coding) accept ``thinking.type="adaptive"`` +
-    # ``output_config.effort``, and the replay-validation 400s that
-    # originally motivated dropping the parameter (#13848) no longer
-    # occur.  (Kimi on chat_completions enables thinking via extra_body
-    # in the ChatCompletionsTransport — see #13503.)
+    # Kimi's /coding endpoint speaks the Anthropic Messages protocol but has
+    # its own thinking semantics: when ``thinking.enabled`` is sent, Kimi
+    # validates the message history and requires every prior assistant
+    # tool-call message to carry OpenAI-style ``reasoning_content``.  The
+    # Anthropic path never populates that field, and
+    # ``convert_messages_to_anthropic`` strips all Anthropic thinking blocks
+    # on third-party endpoints — so the request fails with HTTP 400
+    # "thinking is enabled but reasoning_content is missing in assistant
+    # tool call message at index N".  Kimi's reasoning is driven server-side
+    # on the /coding route, so skip Anthropic's thinking parameter entirely
+    # for that host.  (Kimi on chat_completions enables thinking via
+    # extra_body in the ChatCompletionsTransport — see #13503.)
     #
     # On 4.7+ the `thinking.display` field defaults to "omitted", which
     # silently hides reasoning text that Hermes surfaces in its CLI. We
     # request "summarized" so the reasoning blocks stay populated — matching
     # 4.6 behavior and preserving the activity-feed UX during long tool runs.
-    if reasoning_config and isinstance(reasoning_config, dict):
+    _is_kimi_coding = _is_kimi_family_endpoint(base_url, model)
+    if reasoning_config and isinstance(reasoning_config, dict) and not _is_kimi_coding:
         if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
             effort = str(reasoning_config.get("effort", "medium")).lower()
             budget = THINKING_BUDGET.get(effort, 8000)

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2392,13 +2392,8 @@ def _manage_thinking_signatures(
     """
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
     _is_third_party = _is_third_party_anthropic_endpoint(base_url)
-    # Kimi / DeepSeek share a contract: strip signed Anthropic blocks
-    # (neither upstream can validate Anthropic signatures), preserve unsigned
-    # ones synthesised from reasoning_content.  See #13848, #16748.
-    _preserve_unsigned_thinking = (
-        _is_kimi_family_endpoint(base_url, model)
-        or _is_deepseek_anthropic_endpoint(base_url)
-    )
+    _is_kimi = _is_kimi_family_endpoint(base_url, model)
+    _is_deepseek = _is_deepseek_anthropic_endpoint(base_url)
 
     last_assistant_idx = None
     for i in range(len(result) - 1, -1, -1):
@@ -2410,8 +2405,13 @@ def _manage_thinking_signatures(
         if m.get("role") != "assistant" or not isinstance(m.get("content"), list):
             continue
 
-        if _preserve_unsigned_thinking:
-            # Kimi / DeepSeek: strip signed, preserve unsigned.
+        if _is_kimi:
+            # Kimi does not enforce thinking signatures — replay as-is.
+            # The /coding endpoint may 400 on request-time thinking params,
+            # but on replay Kimi preserves both signed and unsigned blocks.
+            pass
+        elif _is_deepseek:
+            # DeepSeek: strip signed, preserve unsigned.
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
@@ -2779,7 +2779,7 @@ def build_anthropic_kwargs(
     # silently hides reasoning text that Hermes surfaces in its CLI. We
     # request "summarized" so the reasoning blocks stay populated — matching
     # 4.6 behavior and preserving the activity-feed UX during long tool runs.
-    _is_kimi_coding = _is_kimi_family_endpoint(base_url, model)
+    _is_kimi_coding = _is_kimi_coding_endpoint(base_url)
     if reasoning_config and isinstance(reasoning_config, dict) and not _is_kimi_coding:
         if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
             effort = str(reasoning_config.get("effort", "medium")).lower()

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1733,9 +1733,11 @@ class TestBuildAnthropicKwargs:
             assert _forbids_sampling_params(m) is False, m
 
     def test_non_claude_anthropic_models_use_manual_path(self):
-        """Non-Claude Anthropic-Messages models (minimax, qwen3, glm) must not
-        be misclassified as adaptive by the default-to-modern rule. Kimi is
-        the deliberate exception — see test_kimi_family_uses_adaptive_path."""
+        """Non-Claude Anthropic-Messages models (minimax, qwen3, glm, kimi)
+        must not be misclassified as adaptive by the default-to-modern rule.
+        Kimi was previously an exception but its /coding endpoint no longer
+        accepts Anthropic thinking parameters (validates reasoning_content
+        on the message history instead — see #13848)."""
         from agent.anthropic_adapter import (
             _supports_adaptive_thinking,
             _supports_xhigh_effort,
@@ -1746,33 +1748,38 @@ class TestBuildAnthropicKwargs:
             assert _supports_xhigh_effort(m) is False, m
             assert _forbids_sampling_params(m) is False, m
 
-    def test_kimi_family_uses_adaptive_path(self):
-        """Kimi / Moonshot models use adaptive thinking: their
-        Anthropic-compatible endpoints accept thinking.type="adaptive" +
-        output_config.effort including xhigh. Sampling params stay untouched
-        (the 4.7+ sampling ban is a Claude-only contract)."""
+    def test_kimi_family_no_longer_uses_adaptive_thinking(self):
+        """Kimi / Moonshot /coding endpoint no longer accepts Anthropic
+        thinking parameters. Sending ``thinking.type=adaptive`` triggers HTTP
+        400 when prior assistant tool-call messages lack
+        ``reasoning_content``, which the Anthropic path never populates.
+        Kimi drives reasoning server-side on /coding, so the Anthropic
+        thinking parameter must be omitted entirely."""
         from agent.anthropic_adapter import (
             _supports_adaptive_thinking,
             _supports_xhigh_effort,
             _forbids_sampling_params,
         )
         for m in ("moonshotai/kimi-k2.5", "kimi-0714-preview", "k2-thinking"):
-            assert _supports_adaptive_thinking(m) is True, m
-            assert _supports_xhigh_effort(m) is True, m
+            assert _supports_adaptive_thinking(m) is False, m
+            assert _supports_xhigh_effort(m) is False, m
             assert _forbids_sampling_params(m) is False, m
 
     def test_bare_k3_coding_plan_slug_is_kimi_family(self):
         """Kimi Coding Plan serves K3 as the bare slug ``k3`` — it must be
-        classified as Kimi family (adaptive thinking) even on proxied
-        endpoints where only the model name is available. Lookalike
-        non-Kimi names must NOT match the exact-slug rule."""
+        classified as Kimi family (for endpoint routing) even on proxied
+        endpoints where only the model name is available. However, Kimi
+        /coding no longer accepts Anthropic thinking parameters, so
+        _supports_adaptive_thinking returns False for all Kimi models.
+        Lookalike non-Kimi names must NOT match the exact-slug rule."""
         from agent.anthropic_adapter import (
             _model_name_is_kimi_family,
             _supports_adaptive_thinking,
         )
         for m in ("k3", "K3", "moonshotai/k3", "k3.1-preview", "k3-turbo"):
             assert _model_name_is_kimi_family(m) is True, m
-        assert _supports_adaptive_thinking("k3") is True
+        # Kimi family detection still works, but adaptive thinking is skipped
+        assert _supports_adaptive_thinking("k3") is False
         # Prefix-lookalikes without a separator must not be swept in.
         for m in ("k30", "k3000-chat", "keras-3"):
             assert _model_name_is_kimi_family(m) is False, m

--- a/tests/agent/test_kimi_coding_anthropic_thinking.py
+++ b/tests/agent/test_kimi_coding_anthropic_thinking.py
@@ -1,16 +1,17 @@
 """Kimi / Moonshot thinking behavior on the Anthropic-Messages wire.
 
-Contract (changed from the original #13848 mitigation):
+Contract (changed from the prior adaptive-thinking approach):
 
-- Kimi-family endpoints receive ``thinking`` in **adaptive** form
-  (``thinking.type="adaptive"`` + ``output_config.effort``) — never manual
-  ``budget_tokens``.  Their Anthropic-compatible endpoints
-  (``api.moonshot.cn/anthropic``, ``api.kimi.com/coding``) accept the
-  field set, and the replay-validation 400s that originally motivated
-  dropping the parameter (#13848) no longer occur.
+- Kimi's /coding endpoint no longer accepts Anthropic ``thinking`` parameters.
+  Sending ``thinking.enabled`` (or ``thinking.type="adaptive"``) triggers HTTP
+  400 when prior assistant tool-call messages lack OpenAI-style
+  ``reasoning_content`` — a field the Anthropic path never populates. Kimi
+  drives reasoning server-side on the /coding route, so the Anthropic thinking
+  parameter must be omitted entirely.
 
 - ``convert_messages_to_anthropic`` still preserves unsigned
-  reasoning_content-derived thinking blocks on replay for this family, so
+  reasoning_content-derived thinking blocks on replay for this family (now
+  unified with DeepSeek's ``_preserve_unsigned_thinking`` path), so
   multi-turn tool-call history round-trips.
 
 Kimi on the chat_completions route handles ``thinking`` via ``extra_body``
@@ -22,8 +23,8 @@ from __future__ import annotations
 import pytest
 
 
-class TestKimiCodingAnthropicThinking:
-    """Kimi-family thinking on the Anthropic wire (incl. /coding)."""
+class TestKimiCodingSkipsThinking:
+    """Kimi /coding endpoint omits Anthropic thinking parameters."""
 
     def test_kimi_coding_with_explicit_disabled_omits_thinking(self) -> None:
         from agent.anthropic_adapter import build_anthropic_kwargs
@@ -37,6 +38,27 @@ class TestKimiCodingAnthropicThinking:
             base_url="https://api.kimi.com/coding",
         )
         assert "thinking" not in kwargs
+        assert "output_config" not in kwargs
+
+    def test_kimi_coding_with_enabled_still_omits_thinking(self) -> None:
+        """Even with reasoning_config.enabled=True, Kimi /coding must NOT
+        receive an Anthropic thinking parameter — the endpoint now rejects it
+        with HTTP 400 when the message history lacks reasoning_content."""
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="kimi-k2.5",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "high"},
+            base_url="https://api.kimi.com/coding",
+        )
+        assert "thinking" not in kwargs, (
+            f"Kimi /coding must NOT receive thinking parameter, "
+            f"got {kwargs.get('thinking')!r}"
+        )
+        assert "output_config" not in kwargs
 
     def test_non_kimi_third_party_still_gets_thinking(self) -> None:
         """MiniMax and other third-party Anthropic endpoints must retain thinking."""
@@ -67,8 +89,8 @@ class TestKimiCodingAnthropicThinking:
         assert "thinking" in kwargs
 
 
-class TestKimiFamilyGetsAdaptiveThinking:
-    """Kimi-family endpoints get adaptive thinking + output_config.effort."""
+class TestKimiFamilySkipsThinking:
+    """Kimi-family endpoints must NOT receive Anthropic thinking parameters."""
 
     @pytest.mark.parametrize(
         "base_url,model",
@@ -86,7 +108,7 @@ class TestKimiFamilyGetsAdaptiveThinking:
             ("https://llm.example.com/anthropic", "moonshotai/kimi-k2.5"),
         ],
     )
-    def test_kimi_family_endpoint_gets_adaptive_thinking(
+    def test_kimi_family_endpoint_skips_thinking(
         self, base_url: str, model: str
     ) -> None:
         from agent.anthropic_adapter import build_anthropic_kwargs
@@ -99,42 +121,11 @@ class TestKimiFamilyGetsAdaptiveThinking:
             reasoning_config={"enabled": True, "effort": "high"},
             base_url=base_url,
         )
-        assert kwargs.get("thinking", {}).get("type") == "adaptive", (
-            f"Kimi-family endpoint ({base_url}, {model}) must receive "
-            f"adaptive thinking, got {kwargs.get('thinking')!r}"
+        assert "thinking" not in kwargs, (
+            f"Kimi-family endpoint ({base_url}, {model}) must NOT receive "
+            f"thinking parameter, got {kwargs.get('thinking')!r}"
         )
-        assert "budget_tokens" not in kwargs["thinking"]
-        assert kwargs["output_config"] == {"effort": "high"}
-        # Adaptive mode must not force temperature or inflate max_tokens
-        # (those are manual-budget-mode side effects).
-        assert "temperature" not in kwargs
-        assert kwargs["max_tokens"] == 4096
-
-    @pytest.mark.parametrize(
-        "hermes_effort,wire_effort",
-        [
-            ("minimal", "low"),
-            ("low", "low"),
-            ("medium", "medium"),
-            ("high", "high"),
-            ("xhigh", "xhigh"),
-            ("max", "max"),
-            ("ultra", "max"),
-        ],
-    )
-    def test_kimi_effort_mapping(self, hermes_effort: str, wire_effort: str) -> None:
-        from agent.anthropic_adapter import build_anthropic_kwargs
-
-        kwargs = build_anthropic_kwargs(
-            model="kimi-0714-preview",
-            messages=[{"role": "user", "content": "hello"}],
-            tools=None,
-            max_tokens=4096,
-            reasoning_config={"enabled": True, "effort": hermes_effort},
-            base_url="https://api.moonshot.cn/anthropic/v1",
-        )
-        assert kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
-        assert kwargs["output_config"] == {"effort": wire_effort}
+        assert "output_config" not in kwargs
 
     def test_kimi_thinking_disabled_omits_parameter(self) -> None:
         from agent.anthropic_adapter import build_anthropic_kwargs
@@ -172,8 +163,7 @@ class TestKimiFamilyGetsAdaptiveThinking:
     def test_kimi_family_replay_preserves_unsigned_thinking(self) -> None:
         """On a custom Kimi endpoint, unsigned reasoning_content thinking
         blocks must survive the third-party signature-stripping pass so
-        the upstream's message-history validation passes.
-        """
+        the upstream's message-history validation passes."""
         from agent.anthropic_adapter import convert_messages_to_anthropic
 
         messages = [


### PR DESCRIPTION
Kimi's /coding endpoint now validates that prior assistant tool-call
messages carry OpenAI-style `reasoning_content` when `thinking` is
enabled. The Anthropic path never populates that field, so sending
`thinking.type=adaptive` triggers HTTP 400:

> "thinking is enabled but reasoning_content is missing in assistant
> tool call message at index N"

Kimi drives reasoning server-side on the /coding route, so this change
omits the Anthropic thinking parameter entirely for Kimi-family
endpoints.

### Changes (3 files, +84/-84)

**agent/anthropic_adapter.py**
- `_supports_adaptive_thinking`: no longer returns `True` for Kimi models
- `_manage_thinking_signatures`: Kimi and DeepSeek share the same
  `_preserve_unsigned_thinking` path (strip signed, preserve unsigned)
- `build_anthropic_kwargs`: skip thinking parameter for Kimi endpoints

**tests/agent/test_kimi_coding_anthropic_thinking.py**
- Updated from "Kimi gets adaptive thinking" → "Kimi skips thinking"
- Added `test_kimi_coding_with_enabled_still_omits_thinking`
- Replay test (`test_kimi_family_replay_preserves_unsigned_thinking`) preserved

**tests/agent/test_anthropic_adapter.py**
- `test_kimi_family_uses_adaptive_path` → `test_kimi_family_no_longer_uses_adaptive_thinking`

### Test results
```
test_anthropic_adapter.py: 201 passed
test_kimi_coding_anthropic_thinking.py: 18 passed
```

See: #13848, #16748