### PR TITLE
fix(web): recheck extract provider final URLs

### DIFF
--- a/tests/tools/test_web_tools_truncate.py
+++ b/tests/tools/test_web_tools_truncate.py
@@ -129,6 +129,41 @@ class TestEndToEnd:
         assert "para 0 " in content
         assert "para 2999 " in content
 
+    def test_web_extract_rechecks_provider_final_url_before_content(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        class RedirectedProvider:
+            name = "fake"
+            display_name = "Fake"
+
+            def supports_extract(self):
+                return True
+
+            async def extract(self, urls, **kwargs):
+                return [{
+                    "url": "http://169.254.169.254/latest/meta-data/",
+                    "title": "metadata",
+                    "content": "INSTANCE_SECRET=should-not-reach-model",
+                    "raw_content": "INSTANCE_SECRET=should-not-reach-model",
+                    "metadata": {"sourceURL": "http://169.254.169.254/latest/meta-data/"},
+                }]
+
+        safety = _AsyncSequence([True, False])
+        with patch("tools.web_tools._ensure_web_plugins_loaded"), \
+             patch("tools.web_tools._get_extract_backend", return_value="fake"), \
+             patch("tools.web_tools.async_is_safe_url", new=safety), \
+             patch("agent.web_search_registry.get_provider", return_value=RedirectedProvider()):
+            result = json.loads(asyncio.new_event_loop().run_until_complete(
+                wt.web_extract_tool(["https://public.example/redirect"])
+            ))
+
+        item = result["results"][0]
+        assert item["url"] == "http://169.254.169.254/latest/meta-data/"
+        assert "private or internal network" in item["error"]
+        assert item["content"] == ""
+        assert "INSTANCE_SECRET" not in json.dumps(result)
+        assert not list((tmp_path / ".hermes" / "cache" / "web").glob("*.md"))
+
 
 def _make_awaitable(value):
     async def _coro(*a, **k):
@@ -140,3 +175,14 @@ class _AsyncTrue:
     """Async callable that always returns True (re-awaitable per call)."""
     async def __call__(self, *a, **k):
         return True
+
+
+class _AsyncSequence:
+    """Async callable that returns the next configured value per call."""
+    def __init__(self, values):
+        self._values = list(values)
+
+    async def __call__(self, *a, **k):
+        if not self._values:
+            raise AssertionError("async sequence exhausted")
+        return self._values.pop(0)

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -963,6 +963,29 @@ async def web_extract_tool(
             by_index = {**safe_results, **ssrf_blocked, **invalid_urls}
             results = [by_index[index] for index in range(len(urls))]
 
+        for result in results:
+            if not isinstance(result, dict) or result.get("error"):
+                continue
+            final_url = (result.get("url") or "").strip()
+            if final_url and not await async_is_safe_url(final_url):
+                logger.info(
+                    "Blocked web_extract provider result for unsafe final URL: %s",
+                    final_url,
+                )
+                result.clear()
+                result.update(
+                    {
+                        "url": final_url,
+                        "title": "",
+                        "content": "",
+                        "raw_content": "",
+                        "error": (
+                            "Blocked: URL targets a private or internal "
+                            "network address"
+                        ),
+                    }
+                )
+
         response = {"results": results}
         
         pages_extracted = len(response.get('results', []))


### PR DESCRIPTION
## Summary

`web_extract` now re-checks each provider-returned final URL before returning or storing extracted content.

The dispatcher already blocks unsafe input URLs before calling an extract backend, and Firecrawl has its own redirect-aware final URL guard. However, other extract providers can return a different final URL in the result payload after backend-side redirects. Before this change, a result whose final URL pointed at a private/internal address could still have its content returned to the model and written into `cache/web`.

## Why

The SSRF invariant for `web_extract` is that private/internal targets must be blocked before their content reaches the agent.

Current flow:

1. User supplies a public URL.
2. `web_extract` preflights the input URL.
3. Provider fetches/extracts the page.
4. Provider returns `result["url"]` and content.
5. Hermes trusted that returned content without a central final URL re-check.

That left non-Firecrawl providers dependent on their own redirect behavior. A public URL that resolves safely at input time but is reported back as a metadata/private final URL should not be allowed to return content or write a cached full-text file.

## Changes

- Re-check successful provider results with `async_is_safe_url(result["url"])`.
- If the provider-returned final URL is private/internal, replace the result with a blocked error before truncate-and-store runs.
- Add regression coverage proving unsafe provider-returned content does not reach the model output and is not stored under `cache/web`.

## Tests

```text
python -m pytest tests/tools/test_web_tools_truncate.py -q --basetemp=.pytest_tmp\webextract-final-url
13 passed

python -m pytest tests/tools/test_web_providers.py tests/tools/test_web_tools_config.py -q --basetemp=.pytest_tmp\webextract-provider-adjacent
85 passed

python -m ruff check tools/web_tools.py tests/tools/test_web_tools_truncate.py