### PR TITLE
fix(codex): resolve codex CLI to a launchable path on Windows (#48510)

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 import queue
+import shutil
 import subprocess
 import threading
 import time
@@ -45,14 +46,23 @@ def resolve_codex_bin(codex_bin: str = DEFAULT_CODEX_BIN) -> str:
     so a bare ``"codex"`` raises ``FileNotFoundError`` even though the CLI is
     installed and ``shutil.which("codex")`` finds it (#48510).
 
-    ``find_hermes_node_executable`` searches the Hermes-managed Node dirs
-    directly (not just inherited ``PATH``) and its candidate order —
-    ``["codex.cmd", "codex.exe", "codex"]`` — deliberately excludes ``.ps1``,
-    which PowerShell's execution policy blocks by default. That also fixes
-    gateway/service/Kanban-worker contexts where ``PATH`` is minimal (#61360).
+    Resolution order for the default (only the ``DEFAULT_CODEX_BIN`` sentinel
+    is resolved — an explicit path is always returned untouched):
 
-    An explicitly supplied path is returned untouched. Falls back to the input
-    when nothing resolves, so the caller still gets the original error message.
+    1. ``find_hermes_node_executable`` — searches the Hermes-managed Node dirs
+       directly (not just inherited ``PATH``). Its candidate order
+       ``["codex.cmd", "codex.exe", "codex"]`` deliberately excludes ``.ps1``.
+       Covers Hermes-managed npm installs and minimal-``PATH`` gateway /
+       service / Kanban-worker contexts where ``PATH`` is sanitized (#61360).
+    2. ``shutil.which`` — covers a system-Node global install where the shim
+       lives in e.g. ``%APPDATA%\\npm`` (the exact layout in the #48510 report),
+       which is on ``PATH`` but outside the Hermes node dirs. A ``.ps1`` hit is
+       rejected: PowerShell blocks it under the default execution policy and
+       ``CreateProcess`` cannot launch a bare ``.ps1``, so accepting it would
+       just trade one spawn failure for another. (Windows' default ``PATHEXT``
+       excludes ``.PS1``, but a user can add it, so the guard is defensive.)
+    3. Fall back to the input, so the caller still gets the actionable
+       "codex CLI not found ... npm i -g @openai/codex" message.
     """
     if codex_bin != DEFAULT_CODEX_BIN:
         return codex_bin
@@ -62,6 +72,12 @@ def resolve_codex_bin(codex_bin: str = DEFAULT_CODEX_BIN) -> str:
         resolved = find_hermes_node_executable(codex_bin)
         if resolved:
             return resolved
+    except Exception:  # pragma: no cover - defensive, never block spawn
+        pass
+    try:
+        which_hit = shutil.which(codex_bin)
+        if which_hit and not which_hit.lower().endswith(".ps1"):
+            return which_hit
     except Exception:  # pragma: no cover - defensive, never block spawn
         pass
     return codex_bin

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -31,6 +31,41 @@ from tools.environments.local import hermes_subprocess_env
 # `codex --version` parsed at install time; bumping is a one-line change here.
 MIN_CODEX_VERSION = (0, 125, 0)
 
+# Sentinel for "caller did not specify a binary". Distinguishes an explicit
+# ``codex_bin="codex"`` (respect it verbatim) from the default (resolve it).
+DEFAULT_CODEX_BIN = "codex"
+
+
+def resolve_codex_bin(codex_bin: str = DEFAULT_CODEX_BIN) -> str:
+    """Resolve the codex CLI to a launchable path.
+
+    ``npm i -g @openai/codex`` installs ``codex``/``codex.cmd``/``codex.ps1``
+    on Windows and no bare ``codex.exe``. ``subprocess.run``/``Popen`` with a
+    list argument call ``CreateProcess``, which does NOT consult ``PATHEXT``,
+    so a bare ``"codex"`` raises ``FileNotFoundError`` even though the CLI is
+    installed and ``shutil.which("codex")`` finds it (#48510).
+
+    ``find_hermes_node_executable`` searches the Hermes-managed Node dirs
+    directly (not just inherited ``PATH``) and its candidate order —
+    ``["codex.cmd", "codex.exe", "codex"]`` — deliberately excludes ``.ps1``,
+    which PowerShell's execution policy blocks by default. That also fixes
+    gateway/service/Kanban-worker contexts where ``PATH`` is minimal (#61360).
+
+    An explicitly supplied path is returned untouched. Falls back to the input
+    when nothing resolves, so the caller still gets the original error message.
+    """
+    if codex_bin != DEFAULT_CODEX_BIN:
+        return codex_bin
+    try:
+        from hermes_constants import find_hermes_node_executable
+
+        resolved = find_hermes_node_executable(codex_bin)
+        if resolved:
+            return resolved
+    except Exception:  # pragma: no cover - defensive, never block spawn
+        pass
+    return codex_bin
+
 
 @dataclass
 class CodexAppServerError(RuntimeError):
@@ -70,12 +105,12 @@ class CodexAppServerClient:
 
     def __init__(
         self,
-        codex_bin: str = "codex",
+        codex_bin: str = DEFAULT_CODEX_BIN,
         codex_home: Optional[str] = None,
         extra_args: Optional[list[str]] = None,
         env: Optional[dict[str, str]] = None,
     ) -> None:
-        self._codex_bin = codex_bin
+        self._codex_bin = codex_bin = resolve_codex_bin(codex_bin)
         # codex app-server is a model-driving CLI executor: it runs a
         # model-chosen agentic loop that executes shell commands, so it
         # legitimately needs LLM provider credentials (inherit_credentials=True)
@@ -385,11 +420,13 @@ def parse_codex_version(output: str) -> Optional[tuple[int, int, int]]:
 
 
 def check_codex_binary(
-    codex_bin: str = "codex", min_version: tuple[int, int, int] = MIN_CODEX_VERSION
+    codex_bin: str = DEFAULT_CODEX_BIN,
+    min_version: tuple[int, int, int] = MIN_CODEX_VERSION,
 ) -> tuple[bool, str]:
     """Verify codex CLI is installed and meets minimum version.
 
     Returns (ok, message). Used by setup wizard and runtime startup."""
+    codex_bin = resolve_codex_bin(codex_bin)
     try:
         proc = subprocess.run(
             [codex_bin, "--version"],

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -34,8 +34,10 @@ from typing import Any, Callable, Optional
 from agent.codex_responses_adapter import _format_responses_error
 from agent.redact import redact_sensitive_text
 from agent.transports.codex_app_server import (
+    DEFAULT_CODEX_BIN,
     CodexAppServerClient,
     CodexAppServerError,
+    resolve_codex_bin,
 )
 from agent.transports.codex_event_projector import CodexEventProjector
 
@@ -275,7 +277,7 @@ class CodexAppServerSession:
         self,
         *,
         cwd: Optional[str] = None,
-        codex_bin: str = "codex",
+        codex_bin: str = DEFAULT_CODEX_BIN,
         codex_home: Optional[str] = None,
         permission_profile: Optional[str] = None,
         approval_callback: Optional[Callable[..., str]] = None,
@@ -284,7 +286,7 @@ class CodexAppServerSession:
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
     ) -> None:
         self._cwd = cwd or os.getcwd()
-        self._codex_bin = codex_bin
+        self._codex_bin = resolve_codex_bin(codex_bin)
         self._codex_home = codex_home
         self._permission_profile = (
             permission_profile or _HERMES_TO_CODEX_PERMISSION_PROFILE.get(

--- a/tests/run_agent/test_codex_bin_resolution.py
+++ b/tests/run_agent/test_codex_bin_resolution.py
@@ -58,19 +58,71 @@ class TestResolveCodexBin:
 
     def test_falls_back_to_input_when_nothing_resolves(self, monkeypatch):
         """No discoverable binary → return the original so the caller still
-        gets the actionable 'not found, install with npm i -g' message."""
+        gets the actionable 'not found, install with npm i -g' message.
+        Both resolver tiers must miss."""
         monkeypatch.setattr(
             "hermes_constants.find_hermes_node_executable", lambda name: None
         )
+        monkeypatch.setattr(cas.shutil, "which", lambda name: None)
         assert cas.resolve_codex_bin() == cas.DEFAULT_CODEX_BIN
 
     def test_resolver_failure_does_not_block_spawn(self, monkeypatch):
-        """A broken resolver must degrade to the old behaviour, not raise."""
+        """A broken tier-1 resolver must degrade, not raise. Tier-2 also
+        misses here so the final fallback is exercised."""
 
         def boom(name):
             raise RuntimeError("resolver exploded")
 
         monkeypatch.setattr("hermes_constants.find_hermes_node_executable", boom)
+        monkeypatch.setattr(cas.shutil, "which", lambda name: None)
+        assert cas.resolve_codex_bin() == cas.DEFAULT_CODEX_BIN
+
+    def test_tier2_which_covers_system_npm_when_hermes_dirs_miss(self, monkeypatch):
+        """The #48510 reporter's layout: codex.cmd in %APPDATA%\\npm, on PATH
+        but outside the Hermes node dirs. Tier 1 misses; tier 2 (shutil.which)
+        must find the launchable .cmd — otherwise the reported bug is unfixed."""
+        monkeypatch.setattr(
+            "hermes_constants.find_hermes_node_executable", lambda name: None
+        )
+        appdata_cmd = r"C:\Users\x\AppData\Roaming\npm\codex.CMD"
+        monkeypatch.setattr(cas.shutil, "which", lambda name: appdata_cmd)
+        assert cas.resolve_codex_bin() == appdata_cmd
+
+    def test_tier2_rejects_ps1_hit(self, monkeypatch):
+        """shutil.which can resolve to codex.ps1 if a user added .PS1 to
+        PATHEXT. PowerShell blocks it and CreateProcess can't launch a bare
+        .ps1, so it must be rejected and the bare-name fallback returned."""
+        monkeypatch.setattr(
+            "hermes_constants.find_hermes_node_executable", lambda name: None
+        )
+        monkeypatch.setattr(
+            cas.shutil, "which", lambda name: r"C:\Users\x\AppData\Roaming\npm\codex.ps1"
+        )
+        assert cas.resolve_codex_bin() == cas.DEFAULT_CODEX_BIN
+
+    def test_tier1_wins_over_tier2(self, monkeypatch):
+        """When the Hermes-managed resolver finds a binary, tier 2 is never
+        consulted — the managed path is authoritative."""
+        managed = r"C:\hermes\node\codex.cmd"
+        monkeypatch.setattr(
+            "hermes_constants.find_hermes_node_executable", lambda name: managed
+        )
+        monkeypatch.setattr(
+            cas.shutil, "which",
+            lambda name: pytest.fail("tier 2 must not run when tier 1 hits"),
+        )
+        assert cas.resolve_codex_bin() == managed
+
+    def test_tier2_failure_does_not_block_spawn(self, monkeypatch):
+        """A broken shutil.which must degrade to the bare-name fallback."""
+        monkeypatch.setattr(
+            "hermes_constants.find_hermes_node_executable", lambda name: None
+        )
+
+        def boom(name):
+            raise RuntimeError("which exploded")
+
+        monkeypatch.setattr(cas.shutil, "which", boom)
         assert cas.resolve_codex_bin() == cas.DEFAULT_CODEX_BIN
 
 
@@ -114,6 +166,7 @@ class TestCheckCodexBinaryUsesResolver:
         monkeypatch.setattr(
             "hermes_constants.find_hermes_node_executable", lambda name: None
         )
+        monkeypatch.setattr(cas.shutil, "which", lambda name: None)
 
         def fake_run(cmd, **kwargs):
             raise FileNotFoundError(2, "not found")

--- a/tests/run_agent/test_codex_bin_resolution.py
+++ b/tests/run_agent/test_codex_bin_resolution.py
@@ -1,0 +1,170 @@
+"""Regression tests for #48510 — Windows codex.cmd resolution.
+
+`npm i -g @openai/codex` on Windows installs `codex`, `codex.cmd` and
+`codex.ps1` but no bare `codex.exe`. `subprocess.run`/`Popen` with a list
+argument call `CreateProcess`, which does NOT consult `PATHEXT`, so a bare
+`"codex"` raises FileNotFoundError even though the CLI is installed.
+
+These are behaviour contracts, not snapshots: they assert the relationship
+"whatever the default resolves to must be launchable", and that an explicit
+caller-supplied path is never rewritten.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from agent.transports import codex_app_server as cas
+
+
+class TestResolveCodexBin:
+    def test_explicit_path_is_never_rewritten(self):
+        """A caller who passes a real path must get it back verbatim."""
+        explicit = r"C:\custom\codex.exe" if sys.platform == "win32" else "/opt/codex"
+        assert cas.resolve_codex_bin(explicit) == explicit
+
+    def test_default_resolves_when_only_cmd_shim_exists(self, tmp_path, monkeypatch):
+        """The .cmd-only install (the #48510 repro) must resolve, not fall
+        back to the bare name that CreateProcess cannot launch."""
+        node_dir = tmp_path / "node"
+        node_dir.mkdir()
+        # Stock Windows npm layout: shims only, no bare .exe.
+        (node_dir / "codex").write_text("#!/bin/sh\n")
+        (node_dir / "codex.cmd").write_text("@echo off\n")
+        (node_dir / "codex.ps1").write_text("# ps shim\n")
+
+        shim = node_dir / "codex.cmd"
+        monkeypatch.setattr(
+            "hermes_constants.find_hermes_node_executable",
+            lambda name: str(shim) if name == "codex" else None,
+        )
+
+        resolved = cas.resolve_codex_bin()
+        assert resolved == str(shim)
+        # The contract that actually matters: never hand CreateProcess a bare
+        # name when a concrete path was discoverable.
+        assert resolved != cas.DEFAULT_CODEX_BIN
+
+    def test_ps1_is_never_selected(self, tmp_path, monkeypatch):
+        """PowerShell blocks .ps1 under the default execution policy, so the
+        resolver must not choose it (hermes_constants excludes it by design)."""
+        import hermes_constants as hc
+
+        candidates = hc._candidate_node_command_names("codex")
+        assert not any(c.lower().endswith(".ps1") for c in candidates), candidates
+        if sys.platform == "win32":
+            assert candidates[0].lower().endswith(".cmd")
+
+    def test_falls_back_to_input_when_nothing_resolves(self, monkeypatch):
+        """No discoverable binary → return the original so the caller still
+        gets the actionable 'not found, install with npm i -g' message."""
+        monkeypatch.setattr(
+            "hermes_constants.find_hermes_node_executable", lambda name: None
+        )
+        assert cas.resolve_codex_bin() == cas.DEFAULT_CODEX_BIN
+
+    def test_resolver_failure_does_not_block_spawn(self, monkeypatch):
+        """A broken resolver must degrade to the old behaviour, not raise."""
+
+        def boom(name):
+            raise RuntimeError("resolver exploded")
+
+        monkeypatch.setattr("hermes_constants.find_hermes_node_executable", boom)
+        assert cas.resolve_codex_bin() == cas.DEFAULT_CODEX_BIN
+
+
+class TestCheckCodexBinaryUsesResolver:
+    def test_default_call_spawns_resolved_path_not_bare_name(self, monkeypatch):
+        """check_codex_binary() must hand subprocess the resolved path."""
+        monkeypatch.setattr(
+            "hermes_constants.find_hermes_node_executable",
+            lambda name: r"C:\hermes\node\codex.cmd",
+        )
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen["argv0"] = cmd[0]
+            return subprocess.CompletedProcess(cmd, 0, "codex-cli 0.145.0\n", "")
+
+        monkeypatch.setattr(cas.subprocess, "run", fake_run)
+
+        ok, ver = cas.check_codex_binary()
+        assert ok, ver
+        assert seen["argv0"] == r"C:\hermes\node\codex.cmd"
+
+    def test_explicit_bin_is_passed_through_unchanged(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_constants.find_hermes_node_executable",
+            lambda name: r"C:\should\not\be\used.cmd",
+        )
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen["argv0"] = cmd[0]
+            return subprocess.CompletedProcess(cmd, 0, "codex-cli 0.145.0\n", "")
+
+        monkeypatch.setattr(cas.subprocess, "run", fake_run)
+
+        ok, _ = cas.check_codex_binary(codex_bin="/usr/local/bin/codex")
+        assert ok
+        assert seen["argv0"] == "/usr/local/bin/codex"
+
+    def test_missing_binary_still_reports_actionable_error(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_constants.find_hermes_node_executable", lambda name: None
+        )
+
+        def fake_run(cmd, **kwargs):
+            raise FileNotFoundError(2, "not found")
+
+        monkeypatch.setattr(cas.subprocess, "run", fake_run)
+
+        ok, msg = cas.check_codex_binary()
+        assert not ok
+        assert "npm i -g @openai/codex" in msg
+
+
+class TestSessionUsesResolver:
+    def test_session_default_bin_is_resolved(self, monkeypatch):
+        """CodexAppServerSession must resolve at construction time so the
+        spawn in ensure_started() never sees a bare name."""
+        from agent.transports import codex_app_server_session as cass
+
+        monkeypatch.setattr(
+            "hermes_constants.find_hermes_node_executable",
+            lambda name: r"C:\hermes\node\codex.cmd",
+        )
+        sess = cass.CodexAppServerSession(cwd=".")
+        assert sess._codex_bin == r"C:\hermes\node\codex.cmd"
+
+    def test_session_explicit_bin_wins(self, monkeypatch):
+        from agent.transports import codex_app_server_session as cass
+
+        monkeypatch.setattr(
+            "hermes_constants.find_hermes_node_executable",
+            lambda name: r"C:\should\not\be\used.cmd",
+        )
+        sess = cass.CodexAppServerSession(cwd=".", codex_bin="/opt/codex/bin/codex")
+        assert sess._codex_bin == "/opt/codex/bin/codex"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows PATHEXT behaviour")
+class TestWindowsCreateProcessContract:
+    def test_bare_cmd_name_is_unlaunchable_by_createprocess(self, tmp_path, monkeypatch):
+        """Documents the root cause: shutil.which finds a .cmd that
+        subprocess cannot launch by bare name. If CPython ever changes this,
+        the test fails loudly and the workaround can be revisited."""
+        import shutil
+
+        d = tmp_path / "shimdir"
+        d.mkdir()
+        (d / "hermestestshim.cmd").write_text("@echo off\r\necho ok\r\n")
+        monkeypatch.setenv("PATH", str(d), prepend=False)
+
+        assert shutil.which("hermestestshim") is not None
+        with pytest.raises(FileNotFoundError):
+            subprocess.run(
+                ["hermestestshim"], capture_output=True, timeout=10,
+                stdin=subprocess.DEVNULL,
+            )


### PR DESCRIPTION
Fixes #48510.

## Problem

`npm i -g @openai/codex` installs `codex`, `codex.cmd` and `codex.ps1` on Windows — and **no bare `codex.exe`**. `subprocess.run`/`Popen` with a list argument go through `CreateProcess`, which does not consult `PATHEXT`, so the bare `"codex"` default raises `FileNotFoundError` even though the CLI is installed:

```python
shutil.which("codex")                      # -> ...\hermes\node\codex.CMD   ✓ found
subprocess.run(["codex", "--version"])     # -> FileNotFoundError            ✗
subprocess.run(["codex.cmd", "--version"]) # -> ok                           ✓
```

Symptom: `/codex-runtime` reports `codex CLI not found` and the `codex_app_server` runtime fails at spawn.

## Fix

Adds `resolve_codex_bin()` and calls it at the three spawn sites named in the issue:

| Site | File |
|---|---|
| `check_codex_binary()` | `agent/transports/codex_app_server.py` |
| `CodexAppServerClient.__init__` | `agent/transports/codex_app_server.py` |
| `CodexAppServerSession.__init__` | `agent/transports/codex_app_server_session.py` |

It delegates to the **existing** `hermes_constants.find_hermes_node_executable`, which already solves this exact problem for `node`/`npm`/`npx` — extending existing infrastructure rather than adding a parallel mechanism.

### Why not `shutil.which()` (the fix suggested in the issue)

`shutil.which` is PATHEXT-aware and can resolve bare `codex` to **`codex.ps1`**, which PowerShell blocks under the default execution policy:

```
codex : File ...\hermes\node\codex.ps1 cannot be loaded because running scripts
is disabled on this system.
    + CategoryInfo : SecurityError: (:) [], PSSecurityException
```

`_candidate_node_command_names()` returns `["codex.cmd", "codex.exe", "codex"]` — `.ps1` is excluded **by design**, with the rationale already documented at `hermes_constants.py:294`: *"PowerShell may block npm.ps1 by execution policy, and CreateProcess cannot launch a bare .ps1 the way it can launch .cmd."*

It also searches the Hermes-managed Node dirs directly instead of relying on inherited `PATH`, which additionally helps the minimal-PATH gateway / service / Kanban-worker contexts described in #61360.

## Behaviour preserved

- **POSIX**: unchanged — `_candidate_node_command_names` returns `[base]` off-Windows.
- **Explicit paths**: never rewritten. Only the `DEFAULT_CODEX_BIN` sentinel is resolved, so `codex_bin="/opt/codex/bin/codex"` is passed through verbatim.
- **Unresolvable**: falls back to the original name so the actionable `codex CLI not found ... npm i -g @openai/codex` message survives.
- **Resolver failure**: wrapped in `try/except` — a broken resolver degrades to today's behaviour instead of blocking spawn.

## Tests

11 new cases in `tests/run_agent/test_codex_bin_resolution.py`, written as behaviour contracts rather than snapshots (no frozen paths or version literals).

```
tests/run_agent/test_codex_bin_resolution.py ...........   [100%]
11 passed
```

**Verified the tests actually catch the bug** — neutering the `resolve_codex_bin` body fails exactly 3, one per spawn site:

```
FAILED ...::TestResolveCodexBin::test_default_resolves_when_only_cmd_shim_exists
FAILED ...::TestCheckCodexBinaryUsesResolver::test_default_call_spawns_resolved_path_not_bare_name
FAILED ...::TestSessionUsesResolver::test_session_default_bin_is_resolved
3 failed, 8 passed
```

No regressions in the existing suite:

```
tests/run_agent/test_codex_app_server_integration.py
tests/run_agent/test_codex_app_server_compaction.py
36 passed in 21.29s
```

One test is Windows-gated and documents the root cause directly: it asserts that a `.cmd` found by `shutil.which` is *not* launchable by bare name via `subprocess`. If CPython ever changes that, it fails loudly and the workaround can be revisited.

## Manual verification

Windows 10 (19045), codex-cli 0.145.0, Hermes v0.19.0. Simulating a stock `.cmd`-only install:

```
=== BEFORE ===
shutil.which('codex')     = ...\hermes\node\codex.CMD
check_codex_binary()      = (False, "codex CLI not found at 'codex'. ...")

=== AFTER ===
find_hermes_node_executable('codex') = ...\hermes\node\codex.cmd
check_codex_binary()                 = (True, '0.145.0')
```

End-to-end with `model.openai_runtime: codex_app_server`, real repo, `gpt-5.6-terra`:

```
COMMAND EXECUTIONS
  status=completed exit=0   cmd=powershell.exe -Command 'git rev-parse --short HEAD'
                            out=3333617          (matches real HEAD)
  status=completed          cmd=<fileChange>
                            diff=@@ -1 +1 @@ -STAGE = pending +STAGE = hardened
SANDBOX ERRORS: 0
```

## Note for anyone hitting this before the fix lands

Do **not** work around it by hardlinking/copying `codex.exe` out of its vendor directory. Codex resolves helper binaries relative to its own image path, so that orphans `codex-resources/codex-windows-sandbox-setup.exe` and every execution fails with:

```
windows sandbox: orchestrator_helper_launch_failed: setup refresh failed to launch
helper=codex-windows-sandbox-setup.exe, error=program not found
```

Nasty to diagnose because Codex silently retries unsandboxed and the turn's final text still looks correct — only `status: "failed"` in the event stream reveals it. Detail in https://github.com/NousResearch/hermes-agent/issues/48510#issuecomment-5081549795
