### PR TITLE
fix(gateway): re-check env for a late-resolved bot token on reconnect

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1776,6 +1776,19 @@ def _platform_has_bot_credential(platform: "Platform", platform_config: "Platfor
 
     Platforms that do not use ``PlatformConfig.token`` always return True so we
     never skip them here (Signal session paths, port-binding HTTP adapters, etc.).
+
+    Also re-checks ``os.environ`` for the platform's token env var and, if
+    found, backfills it onto ``platform_config.token`` in place. This covers
+    a startup race (#69XXX) where an external secret source (1Password,
+    Bitwarden, ...) is still resolving when the initial connect attempt is
+    made — the empty-token config gets queued for reconnect, the secret
+    finishes resolving into os.environ a few seconds later, but this queued
+    ``PlatformConfig`` snapshot never got the value and the platform was
+    otherwise permanently evicted from the retry queue on the very next
+    check without ever looking at the env var again. Re-reading env here is
+    cheap (a dict lookup) and does not touch the #64674 multiplex-safety
+    behavior: a token that is genuinely never configured anywhere still
+    correctly returns False and gets dropped.
     """
     from gateway.config import PLATFORM_TOKEN_ENV_NAMES
 
@@ -1787,6 +1800,16 @@ def _platform_has_bot_credential(platform: "Platform", platform_config: "Platfor
     # Some adapters also accept api_key as the primary credential.
     api_key = getattr(platform_config, "api_key", None) or ""
     if isinstance(api_key, str) and api_key.strip():
+        return True
+    # Fall back to a live env re-check: a secret source (1Password, etc.)
+    # may have finished resolving the token into os.environ after this
+    # PlatformConfig snapshot was built and queued.
+    env_token = os.environ.get(PLATFORM_TOKEN_ENV_NAMES[platform], "").strip()
+    if env_token:
+        try:
+            platform_config.token = env_token
+        except Exception:
+            pass
         return True
     return False
 

--- a/tests/gateway/test_64674_multiplex_primary_token_scope.py
+++ b/tests/gateway/test_64674_multiplex_primary_token_scope.py
@@ -97,6 +97,34 @@ class TestPlatformHasBotCredential:
             Platform.TELEGRAM, PlatformConfig(enabled=True, token="123:abc")
         ) is True
 
+    def test_backfills_from_env_when_config_empty(self, monkeypatch):
+        """Startup-race regression: a secret source (1Password, etc.) that
+        finishes resolving the token into os.environ AFTER a platform's
+        PlatformConfig snapshot was queued for reconnect must still be
+        picked up, instead of permanently evicting the platform from the
+        retry queue on the very next check."""
+        from gateway.config import PLATFORM_TOKEN_ENV_NAMES
+        from gateway.run import _platform_has_bot_credential
+
+        env_name = PLATFORM_TOKEN_ENV_NAMES[Platform.DISCORD]
+        monkeypatch.setenv(env_name, "late-resolved-token")
+        cfg = PlatformConfig(enabled=True, token="")
+
+        assert _platform_has_bot_credential(Platform.DISCORD, cfg) is True
+        # Also backfilled onto the config so the reconnect attempt actually
+        # uses the recovered token instead of dropping it again next cycle.
+        assert cfg.token == "late-resolved-token"
+
+    def test_still_false_when_env_also_empty(self, monkeypatch):
+        from gateway.config import PLATFORM_TOKEN_ENV_NAMES
+        from gateway.run import _platform_has_bot_credential
+
+        env_name = PLATFORM_TOKEN_ENV_NAMES[Platform.DISCORD]
+        monkeypatch.delenv(env_name, raising=False)
+        cfg = PlatformConfig(enabled=True, token="")
+
+        assert _platform_has_bot_credential(Platform.DISCORD, cfg) is False
+
     def test_non_token_platform_always_true(self):
         from gateway.run import _platform_has_bot_credential
 


### PR DESCRIPTION
## Problem

`_platform_has_bot_credential()` (gateway/run.py) gates whether a platform still has usable credentials before a reconnect attempt, reading only the queued `PlatformConfig` snapshot's `token` / `api_key`.

When an external secret source (1Password, Bitwarden, a keychain helper, …) is still resolving the bot token into `os.environ` at the moment the initial connect runs:

1. the `PlatformConfig` snapshot is built with an empty token and queued for reconnect;
2. the secret finishes resolving into `os.environ` a few seconds later;
3. but on the next reconnect check, #64674's empty-token guard sees the still-empty snapshot and **permanently evicts the platform from the retry queue** — it never looks at the env var again.

Net effect on a host that pulls its Discord/Telegram token from a secret manager: a slightly slow secret resolution on startup takes the bot offline until the next full gateway restart, with no error beyond the eviction.

## Fix

When the snapshot's token/api_key are empty, fall back to a live `os.environ` re-check keyed by `PLATFORM_TOKEN_ENV_NAMES[platform]`, and backfill the recovered value onto `platform_config.token` so the reconnect actually uses it rather than dropping it again next cycle.

This is a cheap dict lookup and does **not** weaken #64674's multiplex-safety behavior: a token that is genuinely configured nowhere still reads empty from the env and still returns `False`, so it is still correctly dropped.

## Tests

Two cases added to the existing `tests/gateway/test_64674_multiplex_primary_token_scope.py`:

- `test_backfills_from_env_when_config_empty` — empty config token + token present in env ⇒ returns `True` and backfills `cfg.token`. **Fails on `main`** (`assert False is True`) and passes with the fix.
- `test_still_false_when_env_also_empty` — empty config token + no env token ⇒ still `False`. Passes either way (the #64674 guard is preserved).
