### PR TITLE
fix(context-engine): host calls two methods missing from the ContextEngine ABC

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -122,6 +122,23 @@ class ContextEngine(ABC):
     protect_first_n: int = 3
     protect_last_n: int = 6
 
+    # Fraction of ``threshold_tokens`` a compaction pass aims to leave behind.
+    # The host multiplies this by ``threshold_tokens`` to derive the idle-
+    # compaction floor (``turn_context.py``: don't summarize a thread that is
+    # already smaller than what compaction would reduce it to). Engines with a
+    # different post-compaction target should override it; the default mirrors
+    # ContextCompressor's own ``summary_target_ratio`` default so host behaviour
+    # is unchanged for the built-in engine.
+    summary_target_ratio: float = 0.20
+
+    # Last provider-reported ``prompt_tokens`` that was a REAL reading, as
+    # opposed to the ``-1`` "compaction just ran, awaiting real usage" sentinel
+    # written into ``last_prompt_tokens``. The host reports this when it skips a
+    # preflight compaction because ``should_defer_preflight_to_real_usage()``
+    # returned True, so an engine that implements that hook should keep this
+    # field current. Engines that don't implement the hook can leave it at 0.
+    last_real_prompt_tokens: int = 0
+
     # User-visible lifecycle status for automatic host-triggered compaction.
     # Alternative engines that treat compaction as routine background
     # maintenance can set this false to keep successful automatic passes silent;

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -38,7 +38,10 @@ from agent.conversation_compression import (
     conversation_history_after_compression,
     recover_rotated_compression_session,
 )
-from agent.context_engine import automatic_compaction_status_message
+from agent.context_engine import (
+    ContextEngine as _ContextEngine,
+    automatic_compaction_status_message,
+)
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import build_memory_context_block
 from agent.memory_provider import is_trivial_prompt
@@ -889,10 +892,17 @@ def build_turn_context(
                 tools=agent.tools or None,
             )
             # Post-compression target size: don't summarise a thread already
-            # below what compaction would reduce it to.
-            _idle_floor = int(
-                _compressor.threshold_tokens * _compressor.summary_target_ratio
+            # below what compaction would reduce it to. ``summary_target_ratio``
+            # is a ContextEngine field, but read it defensively: minimal
+            # compressor doubles and engines constructed before the field was
+            # declared on the ABC would otherwise raise AttributeError here and
+            # abort the turn.
+            _idle_ratio = getattr(
+                _compressor, "summary_target_ratio", _ContextEngine.summary_target_ratio
             )
+            if not isinstance(_idle_ratio, (int, float)) or isinstance(_idle_ratio, bool):
+                _idle_ratio = _ContextEngine.summary_target_ratio
+            _idle_floor = int(_compressor.threshold_tokens * _idle_ratio)
             _idle_cooldown = getattr(
                 _compressor, "get_active_compression_failure_cooldown", lambda: None
             )()
@@ -1028,7 +1038,12 @@ def build_turn_context(
                 "but last real provider prompt was %s after compression",
                 f"{_preflight_tokens:,}",
                 f"{_compressor.threshold_tokens:,}",
-                f"{_compressor.last_real_prompt_tokens:,}",
+                # ``last_real_prompt_tokens`` is a ContextEngine field, but an
+                # engine that implements ``should_defer_preflight_to_real_usage``
+                # without tracking it (or one constructed before the field was
+                # declared on the ABC) would otherwise raise AttributeError
+                # inside this log call and abort the turn.
+                f"{getattr(_compressor, 'last_real_prompt_tokens', 0) or 0:,}",
             )
         elif _compression_cooldown:
             logger.info(

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -38,7 +38,10 @@ from agent.conversation_compression import (
     conversation_history_after_compression,
     recover_rotated_compression_session,
 )
-from agent.context_engine import automatic_compaction_status_message
+from agent.context_engine import (
+    ContextEngine as _ContextEngine,
+    automatic_compaction_status_message,
+)
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import build_memory_context_block
 from agent.model_metadata import (
@@ -649,10 +652,17 @@ def build_turn_context(
                 tools=agent.tools or None,
             )
             # Post-compression target size: don't summarise a thread already
-            # below what compaction would reduce it to.
-            _idle_floor = int(
-                _compressor.threshold_tokens * _compressor.summary_target_ratio
+            # below what compaction would reduce it to. ``summary_target_ratio``
+            # is a ContextEngine field, but read it defensively: minimal
+            # compressor doubles and engines constructed before the field was
+            # declared on the ABC would otherwise raise AttributeError here and
+            # abort the turn.
+            _idle_ratio = getattr(
+                _compressor, "summary_target_ratio", _ContextEngine.summary_target_ratio
             )
+            if not isinstance(_idle_ratio, (int, float)) or isinstance(_idle_ratio, bool):
+                _idle_ratio = _ContextEngine.summary_target_ratio
+            _idle_floor = int(_compressor.threshold_tokens * _idle_ratio)
             _idle_cooldown = getattr(
                 _compressor, "get_active_compression_failure_cooldown", lambda: None
             )()
@@ -784,7 +794,12 @@ def build_turn_context(
                 "but last real provider prompt was %s after compression",
                 f"{_preflight_tokens:,}",
                 f"{_compressor.threshold_tokens:,}",
-                f"{_compressor.last_real_prompt_tokens:,}",
+                # ``last_real_prompt_tokens`` is a ContextEngine field, but an
+                # engine that implements ``should_defer_preflight_to_real_usage``
+                # without tracking it (or one constructed before the field was
+                # declared on the ABC) would otherwise raise AttributeError
+                # inside this log call and abort the turn.
+                f"{getattr(_compressor, 'last_real_prompt_tokens', 0) or 0:,}",
             )
         elif _compression_cooldown:
             logger.info(

--- a/tests/agent/test_context_engine_attr_contract.py
+++ b/tests/agent/test_context_engine_attr_contract.py
@@ -1,0 +1,243 @@
+"""The host must not read engine state that the ContextEngine ABC never declares.
+
+``plugins/context_engine/load_context_engine()`` advertises pluggable context
+engines, and ``ContextEngine`` is the published contract those engines
+implement. But two host sites read attributes that live only on the built-in
+``ContextCompressor``:
+
+* ``agent/turn_context.py`` idle-compaction floor — ``summary_target_ratio``
+* ``agent/turn_context.py`` deferred-preflight log — ``last_real_prompt_tokens``
+
+Neither was declared on the ABC and neither read was guarded, so an engine that
+implements exactly the four abstract members raises ``AttributeError`` mid-turn
+and the turn dies.
+
+These tests pin both halves of the fix:
+
+1. ``ContextEngine`` declares both fields with defaults that match the built-in
+   compressor, so the contract is honest about what the host reads.
+2. The two host reads are defensive, so an engine constructed before the fields
+   were declared (or a compressor double) still completes the turn.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.context_engine import ContextEngine
+from agent.turn_context import TurnContext, build_turn_context
+from tests.agent.test_turn_context import _FakeAgent
+
+
+@pytest.fixture(autouse=True)
+def _stub_runtime_main():
+    with patch("agent.auxiliary_client.set_runtime_main", lambda *a, **k: None):
+        yield
+
+
+class _MinimalEngine(ContextEngine):
+    """An engine implementing EXACTLY the ContextEngine abstract members."""
+
+    @property
+    def name(self) -> str:
+        return "minimal"
+
+    def update_from_response(self, usage: Dict[str, Any]) -> None:
+        return None
+
+    def should_compress(self, prompt_tokens: int = None) -> bool:
+        return False
+
+    def compress(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: Optional[int] = None,
+        focus_topic: Optional[str] = None,
+        force: bool = False,
+        memory_context: str = "",
+    ) -> List[Dict[str, Any]]:
+        return messages
+
+
+# ── 1. contract: the ABC declares what the host reads ──────────────────────
+
+
+def test_abc_declares_summary_target_ratio_with_builtin_default():
+    """The idle-compaction floor multiplier is part of the published contract."""
+    engine = _MinimalEngine()
+    assert isinstance(engine.summary_target_ratio, float)
+    # Pin the RELATION to the built-in engine's own default rather than a bare
+    # literal, so the two can never silently drift apart.
+    from agent.context_compressor import ContextCompressor
+    import inspect
+
+    builtin_default = inspect.signature(
+        ContextCompressor.__init__
+    ).parameters["summary_target_ratio"].default
+    assert engine.summary_target_ratio == builtin_default
+
+
+def test_abc_declares_last_real_prompt_tokens():
+    """The deferred-preflight log reads this; the ABC must declare it."""
+    engine = _MinimalEngine()
+    assert engine.last_real_prompt_tokens == 0
+
+
+def test_builtin_compressor_still_overrides_both_fields():
+    """The ABC defaults must not shadow ContextCompressor's real values."""
+    from agent.context_compressor import ContextCompressor
+
+    comp = ContextCompressor(model="test/model", summary_target_ratio=0.35)
+    assert comp.summary_target_ratio == 0.35
+    comp.last_real_prompt_tokens = 4321
+    assert comp.last_real_prompt_tokens == 4321
+
+
+# ── 2. host: both reads survive an engine that lacks the attributes ────────
+
+
+def _history(n_pairs: int = 6) -> list:
+    msgs = []
+    for i in range(n_pairs):
+        msgs.append({"role": "user", "content": f"q{i}"})
+        msgs.append({"role": "assistant", "content": f"a{i}"})
+    return msgs
+
+
+def _make_agent(compressor):
+    agent = _FakeAgent()
+    agent.compression_enabled = True
+    agent.context_compressor = compressor
+    agent._emit_status = MagicMock()
+    agent._compress_context = MagicMock(
+        side_effect=lambda messages, *_a, **_k: (messages, "SYSTEM")
+    )
+    return agent
+
+
+def _build(agent, **overrides):
+    kwargs = dict(
+        agent=agent,
+        user_message="hello",
+        system_message=None,
+        conversation_history=_history(),
+        task_id=None,
+        stream_callback=None,
+        persist_user_message=None,
+        restore_or_build_system_prompt=lambda *a, **k: None,
+        install_safe_stdio=lambda: None,
+        sanitize_surrogates=lambda s: s,
+        summarize_user_message_for_log=lambda s: s,
+        set_session_context=lambda _sid: None,
+        set_current_write_origin=lambda _o: None,
+        ra=lambda: types.SimpleNamespace(_set_interrupt=lambda *a, **k: None),
+    )
+    kwargs.update(overrides)
+    return build_turn_context(**kwargs)
+
+
+def _legacy_engine_stub(**extra):
+    """An engine-shaped double with NEITHER of the two attributes present.
+
+    This is what a plugin engine written against an older ContextEngine looks
+    like from the host's point of view: it satisfies every documented hook but
+    carries no ``summary_target_ratio`` / ``last_real_prompt_tokens``.
+    """
+    comp = types.SimpleNamespace(
+        protect_first_n=2,
+        protect_last_n=2,
+        threshold_tokens=1_000,
+        last_prompt_tokens=0,
+        should_compress=lambda _tokens=None: False,
+        should_compress_info=lambda _tokens=None: (False, None),
+        get_active_compression_failure_cooldown=lambda: None,
+    )
+    for k, v in extra.items():
+        setattr(comp, k, v)
+    assert not hasattr(comp, "summary_target_ratio")
+    assert not hasattr(comp, "last_real_prompt_tokens")
+    return comp
+
+
+def test_idle_compaction_survives_engine_without_summary_target_ratio():
+    """Idle compaction must not AttributeError on a minimal engine."""
+    comp = _legacy_engine_stub(
+        should_defer_preflight_to_real_usage=lambda _t: False,
+    )
+    agent = _make_agent(comp)
+    # Arm the opt-in idle path so the floor calculation actually runs.
+    agent.compression_idle_compact_after_seconds = 1
+    agent._last_activity_ts = 0.0  # epoch => a huge idle gap
+
+    ctx = _build(agent)
+
+    assert isinstance(ctx, TurnContext)
+
+
+def test_idle_floor_uses_abc_default_when_engine_omits_the_ratio():
+    """The fallback must be the ABC default, not 0 (which would floor at 0)."""
+    comp = _legacy_engine_stub(
+        should_defer_preflight_to_real_usage=lambda _t: False,
+    )
+    agent = _make_agent(comp)
+    agent.compression_idle_compact_after_seconds = 1
+    agent._last_activity_ts = 0.0
+
+    seen = {}
+
+    def _capture(*_a, **kw):
+        seen["floor"] = kw.get("floor_tokens")
+        return False
+
+    with patch("agent.turn_context._should_idle_compact", side_effect=_capture):
+        _build(agent)
+
+    assert seen["floor"] == int(
+        comp.threshold_tokens * ContextEngine.summary_target_ratio
+    )
+    assert seen["floor"] > 0
+
+
+def test_deferred_preflight_log_survives_engine_without_last_real_prompt_tokens():
+    """A deferring engine that never tracks the real count must not crash."""
+    comp = _legacy_engine_stub(
+        # Force the deferral branch that reads last_real_prompt_tokens.
+        should_defer_preflight_to_real_usage=lambda _t: True,
+    )
+    agent = _make_agent(comp)
+    # Push the rough estimate over the threshold so preflight actually runs.
+    comp.threshold_tokens = 1
+
+    ctx = _build(agent)
+
+    assert isinstance(ctx, TurnContext)
+    # The deferral means no compaction was attempted.
+    agent._compress_context.assert_not_called()
+
+
+def test_non_numeric_summary_target_ratio_falls_back_to_abc_default():
+    """A MagicMock-style engine double must not poison the floor arithmetic."""
+    comp = _legacy_engine_stub(
+        should_defer_preflight_to_real_usage=lambda _t: False,
+    )
+    comp.summary_target_ratio = MagicMock()  # truthy, non-numeric
+    agent = _make_agent(comp)
+    agent.compression_idle_compact_after_seconds = 1
+    agent._last_activity_ts = 0.0
+
+    seen = {}
+
+    def _capture(*_a, **kw):
+        seen["floor"] = kw.get("floor_tokens")
+        return False
+
+    with patch("agent.turn_context._should_idle_compact", side_effect=_capture):
+        _build(agent)
+
+    assert seen["floor"] == int(
+        comp.threshold_tokens * ContextEngine.summary_target_ratio
+    )

--- a/website/docs/developer-guide/context-engine-plugin.md
+++ b/website/docs/developer-guide/context-engine-plugin.md
@@ -81,7 +81,23 @@ last_total_tokens: int = 0
 threshold_tokens: int = 0        # when compression triggers
 context_length: int = 0          # model's full context window
 compression_count: int = 0       # how many times compress() has run
+summary_target_ratio: float = 0.20   # post-compaction target as a fraction of threshold_tokens
+last_real_prompt_tokens: int = 0     # last REAL provider prompt_tokens (not the -1 sentinel)
 ```
+
+`summary_target_ratio` is multiplied by `threshold_tokens` to derive the
+idle-compaction floor — the host will not summarize a thread that is already
+smaller than what compaction would reduce it to. Its default mirrors the
+built-in `ContextCompressor.summary_target_ratio`, so host behaviour is
+unchanged unless your engine deliberately overrides it.
+
+`last_real_prompt_tokens` holds the last provider-reported `prompt_tokens` that
+was a real reading, as opposed to the `-1` "compaction just ran, awaiting real
+usage" sentinel the host writes into `last_prompt_tokens`. The host reports it
+when it skips a preflight compaction because
+`should_defer_preflight_to_real_usage()` returned `True`; an engine that
+implements that hook should keep this field current, and an engine that does
+not can leave it at `0`.
 
 ### Optional methods
 


### PR DESCRIPTION
# fix(context-engine): declare the two engine fields the host reads unguarded

## Symptom

Load any context engine other than the built-in `ContextCompressor` — the
mechanism `plugins/context_engine/load_context_engine()` exists to support —
and a turn dies with:

```
AttributeError: 'MyEngine' object has no attribute 'summary_target_ratio'
```

…if `compression.idle_compact_after_seconds` is set, or:

```
AttributeError: 'MyEngine' object has no attribute 'last_real_prompt_tokens'
```

…the first time a preflight compaction is deferred.

An engine that implements *exactly* the `ContextEngine` abstract members
(`name`, `update_from_response`, `should_compress`, `compress`) — i.e. one
written strictly against the published contract — hits both.

## The exact lines

**`agent/turn_context.py:653-655`** — the idle-compaction floor:

```python
# Post-compression target size: don't summarise a thread already
# below what compaction would reduce it to.
_idle_floor = int(
    _compressor.threshold_tokens * _compressor.summary_target_ratio
)
```

**`agent/turn_context.py:787`** — the deferred-preflight log:

```python
f"{_compressor.last_real_prompt_tokens:,}",
```

Neither attribute is declared on `ContextEngine`
(`agent/context_engine.py:103-129`, which does declare `last_prompt_tokens`,
`threshold_tokens`, `context_length`, `threshold_percent`, `protect_first_n`,
`protect_last_n`, …). Both live only on `ContextCompressor`
(`agent/context_compressor.py:1976` and `:2045`).

Reproduce on current `main`:

```python
from agent.context_engine import ContextEngine

class MinimalEngine(ContextEngine):
    @property
    def name(self): return "minimal"
    def update_from_response(self, usage): pass
    def should_compress(self, prompt_tokens=None): return False
    def compress(self, messages, current_tokens=None, focus_topic=None,
                 force=False, memory_context=""): return messages

MinimalEngine().summary_target_ratio      # AttributeError
MinimalEngine().last_real_prompt_tokens   # AttributeError
```

## Root cause

The ABC is the published contract for pluggable engines, and this repo already
takes that seriously — every *optional method* the host calls on an engine is
either declared on the ABC or `getattr`-guarded at the call site
(`should_defer_preflight_to_real_usage` at `turn_context.py:746-750`,
`get_active_compression_failure_cooldown` at `:655`,
`should_compress_preflight` at `:950`, `prune_tool_results_only` at
`conversation_loop.py:5890`). An AST sweep of `agent/ gateway/ tui_gateway/
hermes_cli/ tools/ cli.py run_agent.py` for *unguarded method calls* on the
engine that are not ABC members returns **zero** hits — the method side of the
contract is already clean.

The same sweep for unguarded **attribute reads** returns exactly these two.
So the gap is precisely and only engine *state*: two `ContextCompressor`
implementation details leaked into the host and were never promoted to the
contract.

## The fix

Two halves, because either alone is incomplete:

1. **Declare both on the ABC** with defaults that match the built-in engine, so
   the contract is honest about what the host reads. `summary_target_ratio`
   defaults to `0.20` (the same default `ContextCompressor.__init__` takes) and
   `last_real_prompt_tokens` to `0`, so host behaviour for the built-in engine
   is byte-identical.

2. **Make the two host reads defensive** (`getattr` + type check), so an engine
   *already deployed* against the previous contract — which had no reason to
   define either field — still completes the turn. The type check matters for
   the arithmetic site: a `MagicMock`-shaped compressor double is truthy but
   non-numeric, and `int(threshold * mock)` raises `TypeError`.

## Whole bug class

Both sites the sweep found are fixed, in both directions (contract + call
site). The sweep method is included in the test file's docstring so the same
check is repeatable when the ABC grows.

## Test evidence

New file `tests/agent/test_context_engine_attr_contract.py` — 7 tests, all
passing; see `TEST-EVIDENCE.md` for the RED transcript. Both halves are
RED-proved independently (reverting the ABC declaration reddens 5; reverting
only the host guards reddens 4).

Neighbours re-run green: `tests/agent/test_turn_context.py`,
`test_engine_preflight_wire.py`, `test_context_engine.py`,
`test_context_engine_host_contract.py`, `test_context_engine_select_context.py`,
`test_context_engine_on_turn_complete_usage.py`, `test_preflight_lock_defer.py`
(94 passed), `test_idle_compaction.py` + `test_idle_compaction_lock_and_guards.py`
(16 passed), `test_context_compressor.py` (214 passed).

The ABC default is pinned by **relation** to `ContextCompressor.__init__`'s own
default via `inspect.signature`, not by a literal — so the two can never
silently drift, and a future retune of the built-in default does not redden
this test.

## Footprint

- No new core tool.
- No new `HERMES_*` env var.
- No new config key.
- No new dependency.
- Two ABC class attributes with defaults matching current behaviour; two
  defensive reads. Zero behaviour change for the built-in `ContextCompressor`.
