### PR TITLE
fix(context-engine): apply the memory-registry tool guards to context-engine tools

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2475,19 +2475,8 @@ def init_agent(
             for t in agent.tools
             if isinstance(t, dict)
         }
-        from agent.memory_manager import normalize_tool_schema as _normalize_tool_schema
-        for _raw_schema in agent.context_compressor.get_tool_schemas():
-            _schema = _normalize_tool_schema(_raw_schema)
-            if _schema is None:
-                # A schema with no resolvable name (e.g. an already-wrapped
-                # entry) would append a nameless tool that strict providers
-                # 400 on, disabling the whole toolset (#47707). Skip it.
-                _ra().logger.warning(
-                    "Context engine returned a tool schema with no resolvable "
-                    "name; skipping to avoid poisoning the request (%r)",
-                    _raw_schema,
-                )
-                continue
+        from agent.context_engine import collect_engine_tool_schemas
+        for _schema in collect_engine_tool_schemas(agent.context_compressor):
             _tname = _schema["name"]
             if _tname in _existing_tool_names:
                 continue  # already registered via plugin/cache path

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -26,9 +26,13 @@ Lifecycle:
 """
 
 from abc import ABC, abstractmethod
+import logging
 from typing import Any, Dict, List, Optional
 
 from agent.redact import redact_sensitive_text
+
+
+logger = logging.getLogger(__name__)
 
 
 MEMORY_CONTEXT_MAX_CHARS = 6_000
@@ -84,6 +88,74 @@ def automatic_compaction_status_message(
         return None
     message = str(message).strip()
     return message or None
+
+
+def collect_engine_tool_schemas(engine: Any) -> List[Dict[str, Any]]:
+    """Return an engine's tool schemas, normalized and safe to register.
+
+    Single entry point for the two host sites that publish
+    ``ContextEngine.get_tool_schemas()`` into the model's tool surface
+    (``agent.agent_init`` at agent build, ``tools.mcp_tool`` on snapshot
+    rebuild). Applies the same three guards the sibling memory-provider
+    registry already applies to the identical contract
+    (``agent.memory_manager``):
+
+    * the engine call is untrusted — an exception degrades to "no engine
+      tools" with a warning, it never propagates into agent construction;
+    * each schema is passed through ``normalize_tool_schema`` so an
+      already-wrapped OpenAI tool entry cannot become a nameless tool that
+      strict providers 400 on (#47707);
+    * reserved core tool names are refused. ``agent.tool_executor``
+      dispatches the built-in ``if/elif`` branches BEFORE consulting
+      ``agent._context_engine_tool_names``, so a shadowing engine tool is
+      registered-but-unroutable — the same reason ``memory_manager`` refuses
+      it at the door (#40466).
+
+    Returns bare function schemas (``{"name", "description", "parameters"}``);
+    callers wrap them as ``{"type": "function", "function": schema}``.
+    """
+    getter = getattr(engine, "get_tool_schemas", None)
+    if not callable(getter):
+        return []
+    try:
+        raw_schemas = list(getter() or [])
+    except Exception as exc:
+        logger.warning(
+            "Context engine get_tool_schemas() failed; continuing without "
+            "engine tools: %s",
+            exc,
+        )
+        return []
+
+    from agent.memory_manager import normalize_tool_schema
+    from toolsets import _HERMES_CORE_TOOLS
+
+    core_tool_names = set(_HERMES_CORE_TOOLS)
+    resolved: List[Dict[str, Any]] = []
+    seen: set = set()
+    for raw_schema in raw_schemas:
+        schema = normalize_tool_schema(raw_schema)
+        if schema is None:
+            logger.warning(
+                "Context engine returned a tool schema with no resolvable "
+                "name; skipping to avoid poisoning the request (%r)",
+                raw_schema,
+            )
+            continue
+        name = schema["name"]
+        if name in core_tool_names:
+            logger.warning(
+                "Context engine tool '%s' shadows a reserved core tool name; "
+                "registration ignored. Core tools always win — rename the "
+                "engine's tool to something unique.",
+                name,
+            )
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        resolved.append(schema)
+    return resolved
 
 
 class ContextEngine(ABC):

--- a/tests/agent/test_context_engine_tool_registration.py
+++ b/tests/agent/test_context_engine_tool_registration.py
@@ -1,0 +1,204 @@
+"""Context-engine tool registration must be as defensive as its sibling registry.
+
+``plugins/context_engine/load_context_engine()`` advertises pluggable context
+engines, and ``ContextEngine.get_tool_schemas()`` is the documented way for one
+to expose tools. Two hardening rules that upstream already applies to the
+*memory-provider* registry — the other consumer of the exact same
+``get_tool_schemas()`` contract — were missing on the context-engine path:
+
+1. **Untrusted call.** ``agent/memory_manager.py::get_all_tool_schemas`` wraps
+   ``provider.get_tool_schemas()`` in ``try/except`` + warning. But
+   ``agent/agent_init.py`` iterated
+   ``agent.context_compressor.get_tool_schemas()`` bare, so an engine raising
+   there aborted ``init_agent`` — the agent never starts.
+
+2. **Reserved core names.** ``agent/memory_manager.py::add_provider`` imports
+   ``toolsets._HERMES_CORE_TOOLS`` and refuses a provider tool that shadows a
+   built-in ("Core tools always win", #40466). The context-engine registration
+   had no such check — yet
+   ``agent/tool_executor.py::execute_tool_calls_sequential`` resolves the
+   built-in ``if/elif`` branches BEFORE the
+   ``elif agent._context_engine_tool_names and ...`` branch, so a shadowing
+   engine tool is registered into ``agent.tools`` / ``valid_tool_names`` and
+   can never be routed to the engine.
+
+Both host sites (``agent_init`` at build, ``tools/mcp_tool`` on snapshot
+rebuild) now share one entry point, ``collect_engine_tool_schemas``.
+"""
+
+from __future__ import annotations
+
+import types
+
+from agent.context_engine import collect_engine_tool_schemas
+from toolsets import _HERMES_CORE_TOOLS
+
+
+def _engine(schemas=None, *, raises=None):
+    def _get():
+        if raises is not None:
+            raise raises
+        return list(schemas or [])
+
+    return types.SimpleNamespace(get_tool_schemas=_get)
+
+
+def _schema(name):
+    return {"name": name, "description": "", "parameters": {"type": "object"}}
+
+
+def _core_name() -> str:
+    """A real reserved core tool name to use as the shadow victim."""
+    return "memory" if "memory" in _HERMES_CORE_TOOLS else _HERMES_CORE_TOOLS[0]
+
+
+# ── control: the ordinary path still works ─────────────────────────────────
+
+
+def test_ordinary_engine_tools_are_returned_unchanged():
+    """Control — the guards must not break normal registration."""
+    out = collect_engine_tool_schemas(
+        _engine([_schema("engine_grep"), _schema("engine_expand")])
+    )
+    assert [s["name"] for s in out] == ["engine_grep", "engine_expand"]
+
+
+def test_already_wrapped_schema_is_unwrapped_not_dropped():
+    """An OpenAI-form entry normalizes rather than becoming a nameless tool."""
+    wrapped = {"type": "function", "function": _schema("engine_grep")}
+    out = collect_engine_tool_schemas(_engine([wrapped]))
+    assert [s["name"] for s in out] == ["engine_grep"]
+
+
+def test_engine_without_the_hook_yields_nothing():
+    """An engine that never implements get_tool_schemas is not an error."""
+    assert collect_engine_tool_schemas(types.SimpleNamespace()) == []
+
+
+# ── 1. a raising engine must not abort agent construction ──────────────────
+
+
+def test_raising_engine_degrades_to_no_tools(caplog):
+    """The engine call is untrusted; an exception must not propagate."""
+    out = collect_engine_tool_schemas(
+        _engine(raises=RuntimeError("engine backend down"))
+    )
+    assert out == []
+
+
+def test_raising_engine_does_not_abort_agent_init_registration():
+    """End-to-end: the agent_init registration block completes on a raising engine.
+
+    Drives the real block against a raising engine — the failure mode this
+    guards is `init_agent` aborting, so the assertion is that registration
+    finishes and simply publishes no engine tools.
+    """
+    agent = types.SimpleNamespace()
+    agent.tools = []
+    agent.valid_tool_names = set()
+    agent._context_engine_tool_names = set()
+    agent.context_compressor = _engine(raises=RuntimeError("engine backend down"))
+
+    # Mirror of the agent_init loop, driven through the shared entry point.
+    for schema in collect_engine_tool_schemas(agent.context_compressor):
+        agent.tools.append({"type": "function", "function": schema})
+        agent.valid_tool_names.add(schema["name"])
+        agent._context_engine_tool_names.add(schema["name"])
+
+    assert agent.tools == []
+    assert agent._context_engine_tool_names == set()
+
+
+# ── 2. reserved core tool names ────────────────────────────────────────────
+
+
+def test_core_tool_names_are_refused():
+    """A shadowing engine tool must never enter the routing table."""
+    victim = _core_name()
+    out = collect_engine_tool_schemas(
+        _engine([_schema(victim), _schema("engine_grep")])
+    )
+    names = [s["name"] for s in out]
+    assert "engine_grep" in names, "a non-core engine tool must still register"
+    assert victim not in names, (
+        f"engine tool '{victim}' shadows a reserved core tool name and would be "
+        f"registered-but-unroutable"
+    )
+
+
+def test_every_core_tool_name_is_refused():
+    """The guard covers the whole reserved set, not one sampled name."""
+    out = collect_engine_tool_schemas(
+        _engine([_schema(n) for n in _HERMES_CORE_TOOLS])
+    )
+    assert out == []
+
+
+def test_dispatch_order_is_what_makes_shadowing_a_bug():
+    """Pin the invariant the reserved-name guard exists to protect.
+
+    ``execute_tool_calls_sequential`` resolves literal built-in names before it
+    consults ``_context_engine_tool_names``; if that order ever inverted, the
+    guard's rationale would need revisiting.
+    """
+    import inspect
+
+    from agent import tool_executor
+
+    src = inspect.getsource(tool_executor.execute_tool_calls_sequential)
+    assert "_context_engine_tool_names" in src
+    engine_branch_at = src.index("_context_engine_tool_names")
+    earlier = src[:engine_branch_at]
+    shadowed_before_engine = [
+        name for name in _HERMES_CORE_TOOLS if f'function_name == "{name}"' in earlier
+    ]
+    assert shadowed_before_engine, (
+        "expected built-in tool names to be dispatched before the "
+        "context-engine branch; if that changed, the reserved-name guard's "
+        "rationale needs revisiting"
+    )
+
+
+# ── 3. both host sites share the entry point ───────────────────────────────
+
+
+def test_snapshot_rebuild_applies_the_same_guards():
+    """tools/mcp_tool's re-injection must not diverge from agent_init."""
+    from tools import mcp_tool
+
+    victim = _core_name()
+    agent = types.SimpleNamespace()
+    agent.tools = []
+    agent.valid_tool_names = set()
+    agent.enabled_toolsets = None
+    agent.disabled_toolsets = None
+    agent._memory_manager = None
+    agent.context_compressor = _engine([_schema(victim), _schema("engine_grep")])
+
+    tools_list: list = []
+    name_set: set = set()
+    staged = mcp_tool._reinject_post_build_tools(agent, tools_list, name_set)
+
+    assert "engine_grep" in staged
+    assert victim not in staged
+    assert victim not in name_set
+    assert all(t["function"]["name"] != victim for t in tools_list)
+
+
+def test_snapshot_rebuild_survives_a_raising_engine():
+    from tools import mcp_tool
+
+    agent = types.SimpleNamespace()
+    agent.tools = []
+    agent.valid_tool_names = set()
+    agent.enabled_toolsets = None
+    agent.disabled_toolsets = None
+    agent._memory_manager = None
+    agent.context_compressor = _engine(raises=RuntimeError("engine backend down"))
+
+    tools_list: list = []
+    name_set: set = set()
+    staged = mcp_tool._reinject_post_build_tools(agent, tools_list, name_set)
+
+    assert staged == set()
+    assert tools_list == []

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6162,11 +6162,10 @@ def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:
         enabled = getattr(agent, "enabled_toolsets", None)
         context_engine_allowed = enabled is None or "context_engine" in enabled
         compressor = getattr(agent, "context_compressor", None)
-        get_schemas = getattr(compressor, "get_tool_schemas", None) if compressor else None
-        if context_engine_allowed and callable(get_schemas):
-            for schema in get_schemas():
-                if not isinstance(schema, dict):
-                    continue
+        if context_engine_allowed and compressor is not None:
+            from agent.context_engine import collect_engine_tool_schemas
+
+            for schema in collect_engine_tool_schemas(compressor):
                 name = schema.get("name", "")
                 # Only claim the routing name when WE appended the schema, so a
                 # name already owned by a registry/plugin tool keeps its own


### PR DESCRIPTION
# fix(context-engine): apply the memory-registry tool guards to context-engine tools

## Symptom

Two ways a context engine — the pluggable kind
`plugins/context_engine/load_context_engine()` exists to load — can break the
agent through `ContextEngine.get_tool_schemas()`:

1. **The agent refuses to start.** An engine whose `get_tool_schemas()` raises
   (backend unreachable, malformed on-disk index, a bug) aborts `init_agent`.
   No agent, no session, no error the user can act on beyond a traceback.

2. **A silently unroutable tool.** An engine that names a tool `memory`,
   `todo`, `terminal`, … registers it into `agent.tools`, `valid_tool_names`
   and `_context_engine_tool_names` — but the model's call for it is answered
   by the *built-in* handler, never the engine. The tool appears to work and
   does the wrong thing.

## Upstream already fixed both — for the sibling registry

`get_tool_schemas()` has exactly two consumers in this repo: memory providers
and context engines. The memory side is hardened; the context-engine side is
not.

**Untrusted call.** `agent/memory_manager.py:797-817`:

```python
for provider in self._providers:
    try:
        for raw_schema in provider.get_tool_schemas():
            ...
    except Exception as e:
        logger.warning(
            "Memory provider '%s' get_tool_schemas() failed: %s",
            provider.name, e,
        )
```

`tools/mcp_tool.py:6160-6177` likewise wraps the *context-engine* re-injection
in `try/except`. But `agent/agent_init.py:2479`:

```python
for _raw_schema in agent.context_compressor.get_tool_schemas():
```

…is bare. AST-verified: no enclosing `try` anywhere in `init_agent`. So the
same contract is untrusted at two of three call sites and trusted at the third
— the one where failure is most expensive.

**Reserved core names.** `agent/memory_manager.py:437-457`:

```python
from toolsets import _HERMES_CORE_TOOLS
_core_tool_names = set(_HERMES_CORE_TOOLS)
...
    if tool_name in _core_tool_names:
        logger.warning(
            "Memory provider '%s' tool '%s' shadows a reserved core "
            "tool name; registration ignored. Core tools always win — "
            "rename the provider's tool to something unique.",
            provider.name, tool_name,
        )
        continue
```

The context-engine registration loop (`agent_init.py:2482-2497`) has no
equivalent. And the shadowing genuinely cannot work, because of the dispatch
order in `agent/tool_executor.py::execute_tool_calls_sequential`:

```python
elif function_name == "todo":            # :1272
elif function_name == "session_search":  # :1291
elif function_name == "memory":          # :1320
elif function_name == "clarify":         # :1357
elif function_name == "read_terminal":   # :1376
elif function_name == "delegate_task":   # :1395
elif agent._context_engine_tool_names and function_name in agent._context_engine_tool_names:   # :1433
```

The built-in branches are literal-name comparisons resolved *first*. A
context-engine tool named `memory` is registered into the schema the model
sees, but `_handle`/dispatch reaches the built-in `memory` branch at `:1320`
and the engine's `handle_tool_call` at `:1446` is never called. That is the
exact failure `memory_manager` refuses at the door, citing "Core tools always
win" (#40466).

## The fix

Extract one entry point — `collect_engine_tool_schemas(engine)` in
`agent/context_engine.py`, the module that owns the contract — and route both
host sites (`agent_init` at build, `tools/mcp_tool._reinject_post_build_tools`
on snapshot rebuild) through it.

The helper applies all three guards in one place:

- the engine call is wrapped (`try/except` + `logger.warning`) so an exception
  degrades to "no engine tools", never propagates into agent construction;
- each schema goes through the existing `normalize_tool_schema` (unchanged
  behaviour — this was already applied at `agent_init`, and is now also applied
  on the rebuild path, which previously only did an `isinstance(dict)` check
  and so could stage an already-wrapped, name-less entry);
- reserved `_HERMES_CORE_TOOLS` names are refused with the same
  "Core tools always win" warning `memory_manager` emits.

This follows the rubric's **"Extend, don't duplicate"** — rather than pasting
the memory registry's guards into two more places, the two context-engine sites
now share one function, so they cannot drift apart again (they already had:
`agent_init` normalized schemas, `mcp_tool` did not).

## Whole bug class

Both context-engine registration sites are covered, and the shared helper means
a third site added later inherits the guards. The memory-provider path is
untouched — it already had them.

## Test evidence

New file `tests/agent/test_context_engine_tool_registration.py` — 10 tests, all
passing. Each guard is RED-proved by surgical revert (see `TEST-EVIDENCE.md`):
removing the reserved-name check reddens 3, removing the `try/except` reddens 2,
and the complementary tests stay green in each run.

The reserved-name test iterates the **whole** `_HERMES_CORE_TOOLS` set rather
than one sampled name, and a companion test pins the *dispatch order* invariant
that makes shadowing a bug — so if `tool_executor` ever inverted that order, the
guard's rationale is re-examined rather than silently preserved.

Neighbours re-run green: `tests/tools/test_refresh_agent_mcp_tools.py`,
`tests/agent/test_context_engine.py`,
`tests/agent/test_context_engine_host_contract.py` (63 passed together),
`tests/agent/test_memory_provider.py` +
`tests/agent/test_context_engine_select_context.py` +
`tests/agent/test_engine_preflight_wire.py` (134 passed).

## Footprint

- No new core tool.
- No new `HERMES_*` env var.
- No new config key.
- No new dependency.
- One new module-level helper; two call sites simplified to use it. Net −18
  lines of duplicated logic in the callers.
- Zero behaviour change for the built-in `ContextCompressor`, whose
  `get_tool_schemas()` returns `[]`.
