### PR TITLE
fix(mcp): serialize rotating OAuth refreshes

### DIFF
--- a/tests/tools/test_mcp_oauth_cross_process_refresh.py
+++ b/tests/tools/test_mcp_oauth_cross_process_refresh.py
@@ -1,0 +1,226 @@
+"""Cross-process single-flight coverage for rotating MCP OAuth refresh tokens.
+
+Two Hermes processes may share one ``HERMES_HOME``. Providers such as Notion
+rotate refresh tokens, so both processes must not submit the same token: the
+second replay can revoke the entire grant. These tests use two independent SDK
+provider instances and the real on-disk token store to exercise that boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import httpx
+import pytest
+
+pytest.importorskip("mcp.client.auth.oauth2", reason="MCP SDK OAuth support is required")
+
+from mcp.shared.auth import (
+    OAuthClientInformationFull,
+    OAuthClientMetadata,
+    OAuthMetadata,
+    OAuthToken,
+)
+from pydantic import AnyUrl
+
+from tools.mcp_oauth import HermesTokenStorage
+from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+
+pytestmark = pytest.mark.skipif(
+    _HERMES_PROVIDER_CLS is None,
+    reason="MCP SDK OAuth support is required",
+)
+
+_SERVER_URL = "https://mcp.example.com/mcp"
+_TOKEN_URL = "https://auth.example.com/oauth/token"
+_CALLBACK = AnyUrl("http://127.0.0.1:12345/callback")
+
+
+async def _noop_redirect(_url: str) -> None:
+    return None
+
+
+async def _noop_callback() -> tuple[str, str | None]:
+    raise AssertionError("interactive callback must not run during refresh")
+
+
+async def _seed_expired_grant(storage: HermesTokenStorage) -> None:
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="old-access",
+            token_type="Bearer",
+            expires_in=0,
+            refresh_token="old-refresh",
+        )
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[_CALLBACK],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+    storage.save_oauth_metadata(
+        OAuthMetadata.model_validate(
+            {
+                "issuer": "https://auth.example.com",
+                "authorization_endpoint": "https://auth.example.com/oauth/authorize",
+                "token_endpoint": _TOKEN_URL,
+                "response_types_supported": ["code"],
+            }
+        )
+    )
+
+
+def _provider(storage: HermesTokenStorage):
+    assert _HERMES_PROVIDER_CLS is not None
+    return _HERMES_PROVIDER_CLS(
+        server_name="notion",
+        server_url=_SERVER_URL,
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[_CALLBACK],
+            client_name="Hermes Agent",
+        ),
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+
+def _refresh_response(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(
+        200,
+        request=request,
+        json={
+            "access_token": "new-access",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": "new-refresh",
+        },
+    )
+
+
+async def _finish(flow, request: httpx.Request) -> None:
+    with pytest.raises(StopAsyncIteration):
+        await flow.asend(httpx.Response(200, request=request))
+
+
+async def _drive_flow(
+    flow,
+    outbound: asyncio.Queue[httpx.Request],
+    inbound: asyncio.Queue[httpx.Response],
+) -> None:
+    """Drive every generator operation from one task (AnyIO lock ownership)."""
+    try:
+        request = await flow.__anext__()
+        while True:
+            await outbound.put(request)
+            response = await inbound.get()
+            try:
+                request = await flow.asend(response)
+            except StopAsyncIteration:
+                return
+    finally:
+        await flow.aclose()
+
+
+async def _stop_driver(task: asyncio.Task[None]) -> None:
+    if not task.done():
+        task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_rotating_refresh_is_single_flight_across_provider_instances(
+    tmp_path, monkeypatch
+):
+    """The waiter adopts the winner's rotated grant instead of replaying it."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage_a = HermesTokenStorage("notion")
+    storage_b = HermesTokenStorage("notion")
+    await _seed_expired_grant(storage_a)
+
+    provider_a = _provider(storage_a)
+    provider_b = _provider(storage_b)
+    flow_a = provider_a.async_auth_flow(httpx.Request("POST", _SERVER_URL))
+    flow_b = provider_b.async_auth_flow(httpx.Request("POST", _SERVER_URL))
+
+    first_refresh = await flow_a.__anext__()
+    assert str(first_refresh.url) == _TOKEN_URL
+    assert b"old-refresh" in first_refresh.content
+
+    outbound_b: asyncio.Queue[httpx.Request] = asyncio.Queue()
+    inbound_b: asyncio.Queue[httpx.Response] = asyncio.Queue()
+    driver_b = asyncio.create_task(_drive_flow(flow_b, outbound_b, inbound_b))
+    await asyncio.sleep(0.05)
+
+    try:
+        assert outbound_b.empty(), (
+            "a second provider must wait while the rotating refresh token is in flight"
+        )
+
+        first_request = await flow_a.asend(_refresh_response(first_refresh))
+        assert str(first_request.url) == _SERVER_URL
+        assert first_request.headers["authorization"] == "Bearer new-access"
+
+        second_request = await asyncio.wait_for(outbound_b.get(), timeout=2)
+        assert str(second_request.url) == _SERVER_URL, (
+            "the waiter must reload the winner's grant, not emit a second refresh request"
+        )
+        assert second_request.headers["authorization"] == "Bearer new-access"
+
+        await _finish(flow_a, first_request)
+        await inbound_b.put(httpx.Response(200, request=second_request))
+        await asyncio.wait_for(driver_b, timeout=2)
+    finally:
+        await flow_a.aclose()
+        await _stop_driver(driver_b)
+
+    stored = await storage_a.get_tokens()
+    assert stored is not None
+    assert stored.access_token == "new-access"
+    assert stored.refresh_token == "new-refresh"
+
+
+@pytest.mark.asyncio
+async def test_abandoned_refresh_releases_cross_process_lock(tmp_path, monkeypatch):
+    """Disconnect/cancellation cannot strand the per-grant refresh lock."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage_a = HermesTokenStorage("notion")
+    storage_b = HermesTokenStorage("notion")
+    await _seed_expired_grant(storage_a)
+
+    flow_a = _provider(storage_a).async_auth_flow(httpx.Request("POST", _SERVER_URL))
+    flow_b = _provider(storage_b).async_auth_flow(httpx.Request("POST", _SERVER_URL))
+
+    first_refresh = await flow_a.__anext__()
+    assert str(first_refresh.url) == _TOKEN_URL
+
+    outbound_b: asyncio.Queue[httpx.Request] = asyncio.Queue()
+    inbound_b: asyncio.Queue[httpx.Response] = asyncio.Queue()
+    driver_b = asyncio.create_task(_drive_flow(flow_b, outbound_b, inbound_b))
+    await asyncio.sleep(0.05)
+    assert outbound_b.empty()
+
+    try:
+        await flow_a.aclose()
+        second_refresh = await asyncio.wait_for(outbound_b.get(), timeout=2)
+        assert str(second_refresh.url) == _TOKEN_URL
+
+        await inbound_b.put(_refresh_response(second_refresh))
+        second_request = await asyncio.wait_for(outbound_b.get(), timeout=2)
+        assert second_request.headers["authorization"] == "Bearer new-access"
+        await inbound_b.put(httpx.Response(200, request=second_request))
+        await asyncio.wait_for(driver_b, timeout=2)
+    finally:
+        await flow_a.aclose()
+        await _stop_driver(driver_b)

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -36,6 +36,7 @@ Configuration in config.yaml::
 
 import asyncio
 import contextvars
+import errno
 import json
 import logging
 import os
@@ -47,7 +48,7 @@ import sys
 import threading
 import time
 import webbrowser
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
@@ -373,6 +374,90 @@ def _write_json(path: Path, data: dict) -> None:
         raise
 
 
+_OAUTH_REFRESH_LOCK_POLL_SECONDS = 0.05
+_OAUTH_REFRESH_LOCK_TIMEOUT_SECONDS = 120.0
+
+
+def _try_oauth_refresh_file_lock(handle) -> bool:
+    """Try to take one cross-process advisory lock without blocking."""
+    try:
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except (BlockingIOError, OSError) as exc:
+        if exc.errno in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
+            return False
+        raise
+
+
+def _release_oauth_refresh_file_lock(handle) -> None:
+    """Release a lock acquired by :func:`_try_oauth_refresh_file_lock`."""
+    try:
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except (OSError, ValueError):
+        logger.debug("MCP OAuth refresh lock release failed", exc_info=True)
+
+
+@asynccontextmanager
+async def _oauth_refresh_file_lock(tokens_path: Path):
+    """Serialize one rotating OAuth refresh across Hermes processes.
+
+    The lock is advisory and scoped to one MCP server's token file. Acquisition
+    polls non-blockingly so cancelling the auth flow cannot leave a background
+    thread that later acquires and strands the lock. The file descriptor owns
+    the OS lock, so process exit releases it automatically.
+    """
+    lock_path = tokens_path.with_name(f"{tokens_path.name}.refresh.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    secure_parent_dir(lock_path)
+
+    flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(str(lock_path), flags, stat.S_IRUSR | stat.S_IWUSR)
+    handle = os.fdopen(fd, "r+b", buffering=0)
+    acquired = False
+    try:
+        # msvcrt locks a byte range; materialize that byte once. POSIX flock
+        # does not require it, but sharing one file shape keeps the path simple.
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"\0")
+            handle.flush()
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _OAUTH_REFRESH_LOCK_TIMEOUT_SECONDS
+        while not acquired:
+            acquired = _try_oauth_refresh_file_lock(handle)
+            if acquired:
+                break
+            if loop.time() >= deadline:
+                raise TimeoutError(
+                    f"Timed out waiting for MCP OAuth refresh lock: {lock_path}"
+                )
+            await asyncio.sleep(_OAUTH_REFRESH_LOCK_POLL_SECONDS)
+        yield
+    finally:
+        if acquired:
+            _release_oauth_refresh_file_lock(handle)
+        handle.close()
+
+
 # ---------------------------------------------------------------------------
 # HermesTokenStorage -- persistent token/client-info on disk
 # ---------------------------------------------------------------------------
@@ -402,6 +487,10 @@ class HermesTokenStorage:
         return _get_token_dir(self._hermes_home) / f"{self._server_name}.meta.json"
 
     # -- tokens ------------------------------------------------------------
+
+    def refresh_lock(self):
+        """Return the per-server cross-process refresh lock context."""
+        return _oauth_refresh_file_lock(self._tokens_path())
 
     async def get_tokens(self) -> "OAuthToken | None":
         data = _read_json(self._tokens_path())

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -103,6 +103,10 @@ class _ProviderEntry:
 # ---------------------------------------------------------------------------
 
 
+class _RefreshCompletedByPeer(Exception):
+    """Restart the SDK auth flow after adopting a peer's refreshed grant."""
+
+
 def _make_hermes_provider_class() -> Optional[type]:
     """Lazy-import the SDK base class and return our subclass.
 
@@ -145,6 +149,63 @@ def _make_hermes_provider_class() -> Optional[type]:
             # registration can't help. Only auto-heal dynamically-registered
             # clients. See _maybe_flag_poisoned_client.
             self._hermes_preregistered = preregistered
+            # Active per-server OS lock context while a rotating refresh-token
+            # request is in flight. The SDK auth flow is serialized by its own
+            # asyncio lock, so one provider instance can own at most one.
+            self._hermes_refresh_lock_cm = None
+
+        async def _release_hermes_refresh_lock(self) -> None:
+            # Some compatibility tests/subclasses construct providers without
+            # running this subclass's __init__; absence means no lock is held.
+            lock_cm = getattr(self, "_hermes_refresh_lock_cm", None)
+            self._hermes_refresh_lock_cm = None
+            if lock_cm is not None:
+                await lock_cm.__aexit__(None, None, None)
+
+        async def _refresh_token(self):
+            """Serialize rotating refresh tokens across Hermes processes.
+
+            Re-read disk after acquiring the OS lock. If another process has
+            already rotated the grant, restart the SDK flow with that fresh
+            token instead of replaying the consumed refresh token. Otherwise
+            keep the lock through the token response and atomic persistence.
+            """
+            from tools.mcp_oauth import HermesTokenStorage
+
+            storage = self.context.storage
+            if not isinstance(storage, HermesTokenStorage):
+                return await super()._refresh_token()
+
+            lock_cm = storage.refresh_lock()
+            await lock_cm.__aenter__()
+            self._hermes_refresh_lock_cm = lock_cm
+            try:
+                disk_tokens = await storage.get_tokens()
+                self.context.current_tokens = disk_tokens
+                if disk_tokens is not None and disk_tokens.expires_in is not None:
+                    self.context.update_token_expiry(disk_tokens)
+
+                # The waiter either adopted the winner's valid access token or
+                # observed that the shared grant was removed/no longer
+                # refreshable. Restart so the SDK re-evaluates from that state.
+                if self.context.is_token_valid() or not self.context.can_refresh_token():
+                    await self._release_hermes_refresh_lock()
+                    raise _RefreshCompletedByPeer
+
+                return await super()._refresh_token()
+            except _RefreshCompletedByPeer:
+                raise
+            except BaseException:
+                await self._release_hermes_refresh_lock()
+                raise
+
+        async def _handle_refresh_response(self, response):
+            try:
+                return await super()._handle_refresh_response(response)
+            finally:
+                # set_tokens() completes before the base handler returns, so a
+                # waiter can safely re-read the rotated grant after this release.
+                await self._release_hermes_refresh_lock()
 
         async def _initialize(self) -> None:
             """Load stored tokens + client info AND seed token_expiry_time.
@@ -416,20 +477,34 @@ def _make_hermes_provider_class() -> Optional[type]:
             # generator via inner.asend(incoming), preserving the bidirectional
             # contract. Regression from PR #11383 caught by
             # tests/tools/test_mcp_oauth_bidirectional.py.
-            inner = super().async_auth_flow(request)
-            try:
-                outgoing = await inner.__anext__()
-                while True:
-                    incoming = yield outgoing
-                    # Sniff the response for a dead-client-registration signal
-                    # before handing it back to the SDK (best-effort, GH#36767).
-                    await self._maybe_flag_poisoned_client(incoming)
-                    outgoing = await inner.asend(incoming)
-            except StopAsyncIteration:
-                # Persist any metadata the SDK discovered lazily during the
-                # 401 branch so a subsequent cold-load skips discovery.
-                self._persist_oauth_metadata_if_changed()
-                return
+            while True:
+                inner = super().async_auth_flow(request)
+                try:
+                    outgoing = await inner.__anext__()
+                    while True:
+                        incoming = yield outgoing
+                        # Sniff the response for a dead-client-registration signal
+                        # before handing it back to the SDK (best-effort, GH#36767).
+                        await self._maybe_flag_poisoned_client(incoming)
+                        outgoing = await inner.asend(incoming)
+                except _RefreshCompletedByPeer:
+                    # A sibling process rotated the grant while this flow waited
+                    # for the per-server OS lock. _refresh_token adopted the new
+                    # token from disk; restart so the SDK re-evaluates validity
+                    # and adds the winner's access token to the original request.
+                    continue
+                except StopAsyncIteration:
+                    # Persist any metadata the SDK discovered lazily during the
+                    # 401 branch so a subsequent cold-load skips discovery.
+                    self._persist_oauth_metadata_if_changed()
+                    return
+                finally:
+                    try:
+                        await inner.aclose()
+                    finally:
+                        # Covers client disconnect/cancellation while the SDK is
+                        # parked at ``refresh_response = yield refresh_request``.
+                        await self._release_hermes_refresh_lock()
 
     return HermesMCPOAuthProvider
 


### PR DESCRIPTION
## What does this PR do?

Prevents two Hermes processes sharing one `HERMES_HOME` from replaying the same rotating MCP OAuth refresh token.

The per-process MCP SDK lock is not sufficient when the gateway, Desktop backend, dashboard, or CLI are running concurrently. Both processes can read the same expired grant, send the same refresh token, and cause providers such as Notion to treat the second request as token replay and revoke the entire grant.

This PR makes the **refresh HTTP exchange itself** the cross-process critical section:

1. acquire a per-server OS file lock before the SDK yields/sends the refresh request;
2. re-read the token file after acquiring the lock;
3. if another process already rotated the grant, restart the SDK auth flow with the winner's fresh access token without sending a second refresh request;
4. otherwise hold the lock through response parsing and atomic token persistence;
5. release the lock on success, failure, cancellation, disconnect, or process exit.

Lock acquisition is cancellation-safe and does not block the MCP event loop: it polls `LOCK_NB` / `LK_NBLCK` with `await asyncio.sleep(...)`. A timeout fails closed rather than risking a stale-token replay.

### Relationship to #71377

#71377 identified the same root cause, but its current lock begins in `_handle_refresh_response()`, after the refresh request has already been sent. That can prevent an older response from overwriting newer disk state, but it cannot prevent the second process from presenting the rotated-away token. It also captures `context.current_tokens` before the SDK's lazy `_initialize()` on cold start and proceeds unlocked after timeout.

This implementation moves single-flight to the pre-request boundary and drives the real SDK bidirectional auth flow in regression coverage. The approach can be transplanted into #71377 if maintainers prefer the earlier PR.

## Related Issue

Fixes #71335

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_oauth.py`
  - add a per-token-file cross-process refresh lock using POSIX `flock` or Windows `msvcrt.locking`;
  - use nonblocking asynchronous acquisition, secure lock-file creation, bounded fail-closed waiting, and descriptor-owned cleanup;
  - expose the lock through `HermesTokenStorage.refresh_lock()`.
- `tools/mcp_oauth_manager.py`
  - acquire the lock in `_refresh_token()` before the SDK emits the token request;
  - re-read disk under the lock and restart the SDK flow when a peer already refreshed;
  - hold the lock until `_handle_refresh_response()` atomically persists the rotated grant;
  - release in every generator cleanup/cancellation path while preserving the existing bidirectional `.asend()` bridge.
- `tests/tools/test_mcp_oauth_cross_process_refresh.py`
  - drive two independent SDK provider instances against the same real token store;
  - prove the waiter emits no duplicate refresh request and adopts the winner's new access/refresh token;
  - prove closing an in-flight auth generator releases the lock so another process can continue.

## How to Test

1. Run the MCP OAuth regression cluster:
   ```bash
   pytest -q -o addopts= \
     tests/tools/test_mcp_oauth.py \
     tests/tools/test_mcp_oauth_manager.py \
     tests/tools/test_mcp_oauth_integration.py \
     tests/tools/test_mcp_oauth_bidirectional.py \
     tests/tools/test_mcp_oauth_cold_load_expiry.py \
     tests/tools/test_mcp_oauth_metadata.py \
     tests/tools/test_mcp_oauth_cross_process_refresh.py
   ```
   Expected: `152 passed`.
2. Run Ruff and syntax compilation on the three changed files.
3. Run `python scripts/check-windows-footguns.py` on the three changed files.
4. Baseline reproduction: without the production change, both independent providers immediately emit `POST <token_endpoint>` containing `old-refresh`; both new regressions fail. With this PR, the second provider waits and then sends the authenticated MCP request with `new-access` instead.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and compared this directly with #71377
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (the focused 152-test OAuth cluster passes; the full required matrix is delegated to GitHub CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is documented in code/docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config change
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no contributor workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — POSIX `flock` and Windows `msvcrt` paths are implemented; Windows-footgun scan is clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model-facing tool contract changed

## Screenshots / Logs

Failing current-main sequence:

```text
provider A: read old-refresh → POST token endpoint
provider B: read old-refresh → POST token endpoint   # replay/revocation risk
```

Fixed sequence:

```text
provider A: lock → re-read → POST old-refresh → persist new-refresh → unlock
provider B: wait → lock → re-read new-refresh → unlock → restart with new-access
```
