### PR TITLE
fix(gateway): keep malformed URL log fallback credential-safe

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -537,7 +537,14 @@ def safe_url_for_log(url: str, max_len: int = 80) -> str:
     try:
         parsed = urlsplit(raw)
     except Exception:
-        return raw[:max_len]
+        # urlsplit() can reject malformed bracketed hosts before we have a
+        # chance to strip userinfo. Keep the fallback log-safe too.
+        safe = re.sub(r"([A-Za-z][A-Za-z0-9+.-]*://)[^/\s@]+@", r"\1", raw)
+        if len(safe) <= max_len:
+            return safe
+        if max_len <= 3:
+            return "." * max_len
+        return f"{safe[:max_len - 3]}..."
 
     if parsed.scheme and parsed.netloc:
         # Strip potential embedded credentials (user:pass@host).

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -107,6 +107,11 @@ class TestSafeUrlForLog:
         assert "token=abc" not in result
         assert "user:pass@" not in result
 
+    def test_strips_userinfo_when_url_parse_fails(self):
+        result = safe_url_for_log("http://user:pass@[")
+        assert result == "http://["
+        assert "user:pass@" not in result
+
     def test_truncates_long_values(self):
         long_url = "https://example.com/" + ("a" * 300)
         result = safe_url_for_log(long_url, max_len=40)


### PR DESCRIPTION
## Summary

Make `safe_url_for_log()` keep its credential-stripping guarantee even when `urlsplit()` rejects a malformed URL.

## Why

`safe_url_for_log()` is used before writing URLs into gateway errors/log-facing messages. It already strips URL userinfo for normal parsed URLs, but the parse-error fallback returned the raw string truncated to `max_len`.

That means a malformed bracketed host can bypass the userinfo stripping path:

```text
safe_url_for_log("http://user:pass@[")
# before: "http://user:pass@["