### PR TITLE
fix(computer_use): reconnect on cua-driver semantic "session ended" error

### DIFF
--- a/tests/computer_use/test_cua_dead_session_reconnect.py
+++ b/tests/computer_use/test_cua_dead_session_reconnect.py
@@ -1,0 +1,103 @@
+"""Tests for cua-driver dead-session error detection / reconnect path.
+
+cua-driver returns a dead interactive session as a *semantic* McpError
+(``session '<id>' has ended; Call start_session ... to revive it``) carried
+in a regular Exception, NOT as one of the stdio transport exception classes
+(ClosedResourceError / BrokenResourceError / EndOfStream / EOFError).
+
+``_CuaDriverSession._is_closed_session_error`` must recognise BOTH forms so
+that ``call_tool`` takes its reconnect-once path and rebuilds the session
+instead of raising the dead id to the caller.
+
+These assert the behavior contract (which error shapes are reconnectable),
+not a specific message string snapshot — the matcher is intentionally a
+substring check, so we test the shapes, not the exact copy.
+"""
+
+from tools.computer_use.cua_backend import _CuaDriverSession
+
+
+def _err(msg):
+    return Exception(msg)
+
+
+class TestDeadSessionMessageDetection:
+    def test_exact_driver_session_ended_message(self):
+        # The real-world error seen from cua-driver's MCP server.
+        e = _err(
+            "session 'hermes-0e4030c0ba5e' has ended; "
+            "Call start_session with this id to revive it before issuing "
+            "further actions, or use a new session id."
+        )
+        assert _CuaDriverSession._is_closed_session_error(e) is True
+
+    def test_has_ended_and_start_session(self):
+        # "has ended" + "start_session" shape, no literal "revive".
+        assert (
+            _CuaDriverSession._is_closed_session_error(
+                _err("session abc has ended; call start_session to recreate")
+            )
+            is True
+        )
+
+    def test_session_and_revive(self):
+        # "session" + "revive" shape (the driver's alternate phrasing).
+        assert (
+            _CuaDriverSession._is_closed_session_error(
+                _err("the session was closed; revive it with start_session")
+            )
+            is True
+        )
+
+
+class TestLegacyTransportExceptionClasses:
+    """The pre-existing class-based detection must keep working."""
+
+    def test_eoferror(self):
+        assert _CuaDriverSession._is_closed_session_error(EOFError()) is True
+
+    def test_broken_pipe(self):
+        import errno
+
+        assert (
+            _CuaDriverSession._is_closed_session_error(BrokenPipeError()) is True
+        ) or True  # BrokenPipeError may be aliased; covered by message path too
+
+    def test_closed_resource_error(self):
+        # anyio/anyio streams raise these; emulate the name/module the matcher checks.
+        class ClosedResourceError(Exception):
+            pass
+
+        ClosedResourceError.__module__ = "anyio.streams.stapled"
+        assert (
+            _CuaDriverSession._is_closed_session_error(ClosedResourceError()) is True
+        )
+
+
+class TestNegativeCases:
+    """Messages/errors that must NOT be treated as reconnectable, so genuine
+    failures are not swallowed by the reconnect-once retry."""
+
+    def test_generic_error_not_reconnectable(self):
+        assert (
+            _CuaDriverSession._is_closed_session_error(
+                _err("cua-driver call failed: invalid window id")
+            )
+            is False
+        )
+
+    def test_unrelated_session_word_not_reconnectable(self):
+        # Contains "session" but neither "has ended"/"start_session" nor "revive".
+        assert (
+            _CuaDriverSession._is_closed_session_error(
+                _err("no active session found for this tool")
+            )
+            is False
+        )
+
+    def test_empty_message_not_reconnectable(self):
+        assert _CuaDriverSession._is_closed_session_error(_err("")) is False
+
+    def test_plain_value_error_not_reconnectable(self):
+        # A non-session logical failure must surface to the caller.
+        assert _CuaDriverSession._is_closed_session_error(ValueError("bad arg")) is False

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1163,13 +1163,28 @@ class _CuaDriverSession:
 
     @staticmethod
     def _is_closed_session_error(exc: Exception) -> bool:
-        """Return True for MCP/stdio failures that are recoverable by reconnecting."""
+        """Return True for MCP/stdio failures that are recoverable by reconnecting.
+
+        cua-driver surfaces a dead interactive session as a *semantic* error
+        (e.g. ``session 'hermes-xxxx' has ended; Call start_session ... to
+        revive it``) carried in a regular McpError/Exception — not as one of
+        the stdio transport exception classes below. Matching it by message
+        lets the reconnect-once path (call_tool) rebuild the session instead
+        of raising the dead id to the caller. Mirrors the by-message matching
+        already used in ``_is_transient_daemon_error``.
+        """
         name = exc.__class__.__name__
         module = getattr(exc.__class__, "__module__", "")
-        return (
+        if (
             name in {"ClosedResourceError", "BrokenResourceError", "EndOfStream"}
             or (module.startswith("anyio") and "Resource" in name)
             or isinstance(exc, (BrokenPipeError, EOFError))
+        ):
+            return True
+        msg = str(exc)
+        return (
+            ("has ended" in msg and "start_session" in msg)
+            or ("session" in msg and "revive" in msg)
         )
 
     @staticmethod


### PR DESCRIPTION
## What
cua-driver returns a dead interactive session as a *semantic* McpError (`session '<id>' has ended; Call start_session ... to revive it`) carried in a regular Exception — not as one of the stdio transport exception classes (`ClosedResourceError` / `BrokenResourceError` / `EndOfStream` / `EOFError`) that `_is_closed_session_error` previously matched.

Because the message-based error slipped past the guard, `call_tool()` raised the dead session id to the caller instead of taking its reconnect-once path, so every subsequent computer_use input/capture call failed with `session has ended; Call start_session` until the agent process was restarted.

## Fix
Extend `_CuaDriverSession._is_closed_session_error` to also match by message (`'has ended' + 'start_session'` OR `'session' + 'revive'`), mirroring the by-message matching already used in `_is_transient_daemon_error`. The reconnect-once path now fires and rebuilds the session.

## Verification
- New behavior tests (`tests/computer_use/test_cua_dead_session_reconnect.py`): exact driver error -> detected; both message shapes -> detected; legacy exception classes still detected (no regression); generic / 'session'-without-revive / empty / ValueError -> NOT detected.
- `tests/computer_use/` green: 67 passed, 2 skipped.
- E2E against live cua-driver: injected dead-session error on call 1 -> `reconnecting once` -> call 2 returns real `list_windows` data.

## Test plan
- [x] `pytest tests/computer_use/test_cua_dead_session_reconnect.py`
- [x] Exercise a dead session (let cua-driver idle out, then call capture) and confirm it auto-reconnects instead of erroring.