### PR TITLE
fix(gateway): expand ${VAR} env refs in _resolve_gateway_model (#71710)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2849,14 +2849,25 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     Without this, temporary AIAgent instances (e.g. /compress) fall
     back to the hardcoded default which fails when the active provider is
     openai-codex.
+
+    Env-var references (``${VAR}``) in the model value are expanded so that
+    callers that pass a fast-loaded (unexpanded) config still get a usable
+    model name.  See GH #71710.
     """
     cfg = config if config is not None else _load_gateway_config()
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, str):
-        return model_cfg
+        model = model_cfg
     elif isinstance(model_cfg, dict):
-        return model_cfg.get("default") or model_cfg.get("model") or ""
-    return ""
+        model = model_cfg.get("default") or model_cfg.get("model") or ""
+    else:
+        return ""
+    if isinstance(model, str) and "${" in model:
+        from hermes_cli.config import _expand_env_vars
+        expanded = _expand_env_vars(model)
+        if isinstance(expanded, str):
+            model = expanded
+    return model
 
 
 def _channel_override_lookup_keys(

--- a/tests/test_empty_model_fallback.py
+++ b/tests/test_empty_model_fallback.py
@@ -243,3 +243,23 @@ class TestResolveGatewayModel:
     def test_string_model_config(self):
         from gateway.run import _resolve_gateway_model
         assert _resolve_gateway_model({"model": "my-model"}) == "my-model"
+
+    def test_expands_env_var_in_default_key(self, monkeypatch):
+        """${VAR} references in model.default are expanded (#71710)."""
+        from gateway.run import _resolve_gateway_model
+        monkeypatch.setenv("MY_MODEL", "qwen3.6-27b-mtp@q8_k_xl")
+        result = _resolve_gateway_model({"model": {"default": "${MY_MODEL}"}})
+        assert result == "qwen3.6-27b-mtp@q8_k_xl"
+
+    def test_expands_env_var_in_string_model_config(self, monkeypatch):
+        """${VAR} references expanded when model config is a plain string."""
+        from gateway.run import _resolve_gateway_model
+        monkeypatch.setenv("LM_MODEL", "gpt-4.1")
+        result = _resolve_gateway_model({"model": "${LM_MODEL}"})
+        assert result == "gpt-4.1"
+
+    def test_undefined_env_var_kept_verbatim(self):
+        """Undefined env vars are preserved as-is per _expand_env_vars contract."""
+        from gateway.run import _resolve_gateway_model
+        result = _resolve_gateway_model({"model": {"default": "${TOTALLY_UNDEFINED_VAR_XYZ}"}})
+        assert result == "${TOTALLY_UNDEFINED_VAR_XYZ}"


### PR DESCRIPTION
## Summary

`_resolve_gateway_model()` reads the model name from `config.yaml` via the fast (unexpanded) config loader. When `model.default` contains an env-var reference like `${LM_MODEL}`, the literal string was passed as the model identifier — causing gateway sessions (Telegram, Discord, etc.) to fail with an unknown model.

The provider fields (`base_url`, `api_key`) don't have this bug because they go through `resolve_runtime_provider()` → `_load_gateway_runtime_config()` which calls `_expand_env_vars()`. Model resolution took a different, unexpanded path.

## Changes

- **`gateway/run.py`**: After extracting the model string in `_resolve_gateway_model()`, expand `${VAR}` references via `_expand_env_vars()` before returning. The `"${"` check is cheap so the fast path stays fast for plain model names.
- **`tests/test_empty_model_fallback.py`**: 3 new tests covering env-var expansion, string-form model config expansion, and undefined-var passthrough.

## Test Plan

- [x] `pytest tests/test_empty_model_fallback.py::TestResolveGatewayModel` — 8/8 passed
- [ ] Verify gateway resolves `${LM_MODEL}` correctly via Telegram/Discord

Fixes #71710