### PR TITLE
fix(cli): run plugin discovery before toolset validation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4281,9 +4281,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.disabled_toolsets = CLI_CONFIG["agent"].get("disabled_toolsets") or []
 
         if toolsets and "all" not in toolsets and "*" not in toolsets:
-            # Validate each toolset — MCP server names are resolved via
-            # live registry aliases (registered during discover_mcp_tools),
-            # but discovery hasn't run yet at this point, so exclude them.
+            # Validate each toolset — ensure plugins are loaded so
+            # plugin-registered toolsets are recognized. MCP server names
+            # are resolved via live registry aliases (registered during
+            # discover_mcp_tools), but discovery hasn't run yet either, so
+            # exclude them.
+            try:
+                from hermes_cli.plugins import discover_plugins
+                discover_plugins()
+            except Exception:
+                pass
             mcp_names = set((CLI_CONFIG.get("mcp_servers") or {}).keys())
             invalid = [t for t in toolsets if not validate_toolset(t) and t not in mcp_names]
             if invalid:


### PR DESCRIPTION
## Summary

`HermesCLI.__init__` called `validate_toolset()` before `discover_plugins()`, so plugin-registered toolsets (e.g. `beads`, `spotify`) were always flagged as `Warning: Unknown toolsets` on every startup — even though they worked correctly at runtime.

## Root Cause

`cli.py:4283-4290` — the validation block queries `tools.registry` via `validate_toolset() → _get_plugin_toolset_names()`, but the registry isn't populated with plugin toolsets until `discover_plugins()` runs. The comment already noted that "discovery hasn't run yet" (referring to MCP), but the same gap applied to plugin-registered toolsets.

## Fix

Run `discover_plugins()` (best-effort, exception-silenced) before the validation block so the tool registry reflects plugin entries.

## Live Proof

```
BEFORE — validate_toolset("spotify") = False
  (spotify plugin not loaded → registry doesn't know it)

AFTER — validate_toolset("spotify") = True
  (discover_plugins() runs first → registry contains spotify tools)
```

### Test run
```
$ .venv/bin/python -m pytest tests/hermes_cli/test_toolset_validation.py -v
13 passed
```

## Risk

Low. `discover_plugins()` is idempotent and already called elsewhere during startup. The call is exception-guarded so plugin discovery failure does not block CLI startup.