### PR TITLE
fix(test): prevent os._exit from killing pytest process in gateway test (#71719)

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -239,6 +239,15 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr("gateway.run.start_gateway", fake_start_gateway)
 
+        # Prevent os._exit() from killing the pytest process (#71719).
+        # run_gateway() calls _hard_exit_after_gateway_teardown() on every
+        # exit path, which routes to gateway.run._exit_after_graceful_shutdown
+        # -> os._exit().  In a test, we just want run_gateway() to return.
+        monkeypatch.setattr(
+            "gateway.run._exit_after_graceful_shutdown",
+            lambda code=0: None,
+        )
+
         gateway_cli.run_gateway()
 
         assert unit_path.read_text(encoding="utf-8") == "new unit\n"


### PR DESCRIPTION
## Summary

Fixes #71719 — `tests/hermes_cli` suite aborts silently (exit 0, no summary) because `test_run_gateway_refreshes_outdated_unit_on_boot` calls `run_gateway()` which invokes `os._exit()` on every exit path, killing the pytest process mid-run.

## Root Cause

`run_gateway()` ends every path in `_hard_exit_after_gateway_teardown()` -> `gateway.run._exit_after_graceful_shutdown()` -> `os._exit(exit_code)`. In a test, this terminates the interpreter immediately. `pytest-xdist` hides this because each test runs in a worker subprocess.

## Fix

Monkeypatch `gateway.run._exit_after_graceful_shutdown` to a no-op in the test so `run_gateway()` returns normally instead of terminating the interpreter.

## Changes

- `tests/hermes_cli/test_gateway_service.py`: Add monkeypatch for `_exit_after_graceful_shutdown` (9 lines)

## Test Results

```
tests/hermes_cli/test_gateway_service.py::TestSystemdServiceRefresh::test_run_gateway_refreshes_outdated_unit_on_boot PASSED
1 passed in 1.41s
```

Previously this test would silently kill the pytest process with exit code 0.