### PR TITLE
fix(pricing): estimate xAI Grok session costs

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -862,6 +862,24 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
             pricing["completion"] = str(float(novita_output) / 10_000 / 1_000_000)
         return pricing
 
+    # xAI ships integer prices as 1/10_000 USD per 1M tokens on the models
+    # endpoint (e.g. prompt_text_token_price=20000 → $2.00/MTok). Same scale
+    # as Novita's input_token_price_per_m. Long-context tier fields exist
+    # (*_long_context) but the generic cost path has no context-tier switch,
+    # so we map the base rates only.
+    xai_prompt = payload.get("prompt_text_token_price")
+    xai_completion = payload.get("completion_text_token_price")
+    xai_cache = payload.get("cached_prompt_text_token_price")
+    if xai_prompt is not None or xai_completion is not None:
+        pricing = {}
+        if xai_prompt is not None:
+            pricing["prompt"] = str(float(xai_prompt) / 10_000 / 1_000_000)
+        if xai_completion is not None:
+            pricing["completion"] = str(float(xai_completion) / 10_000 / 1_000_000)
+        if xai_cache is not None:
+            pricing["cache_read"] = str(float(xai_cache) / 10_000 / 1_000_000)
+        return pricing
+
     # DeepInfra ships pricing under ``metadata.pricing`` with $/MTok values:
     # ``input_tokens``, ``output_tokens``, ``cache_read_tokens``. Convert to
     # per-token strings so the generic cost machinery (usage_pricing.py)

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -14,6 +14,7 @@ DEFAULT_PRICING = {"input": 0.0, "output": 0.0}
 _ZERO = Decimal("0")
 _ONE_MILLION = Decimal("1000000")
 _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
+_XAI_DEFAULT_BASE_URL = "https://api.x.ai/v1"
 
 CostStatus = Literal["actual", "estimated", "included", "unknown"]
 CostSource = Literal[
@@ -867,6 +868,34 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://docs.fireworks.ai/serverless/pricing",
         pricing_version="fireworks-pricing-2026-07",
     ),
+    # ── xAI Grok ─────────────────────────────────────────────────────────
+    # Base (< long-context threshold) rates from docs.x.ai + live
+    # GET /v1/models fields (prompt_text_token_price etc., unit 1/10_000 $/M).
+    # Long-context tier is ~2x; estimate_usage_cost has no tier switch yet, so
+    # fat sessions can understate until that lands. Verified 2026-07-25.
+    # Source: https://docs.x.ai/developers/models
+    (
+        "xai",
+        "grok-4.5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("2.00"),
+        output_cost_per_million=Decimal("6.00"),
+        cache_read_cost_per_million=Decimal("0.30"),
+        source="official_docs_snapshot",
+        source_url="https://docs.x.ai/developers/models",
+        pricing_version="xai-pricing-2026-07",
+    ),
+    (
+        "xai",
+        "grok-4.3",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.25"),
+        output_cost_per_million=Decimal("2.50"),
+        cache_read_cost_per_million=Decimal("0.20"),
+        source="official_docs_snapshot",
+        source_url="https://docs.x.ai/developers/models",
+        pricing_version="xai-pricing-2026-07",
+    ),
 }
 
 # GPT-5.6 "-pro" high-effort variants bill at the same per-token rates as
@@ -905,8 +934,8 @@ def resolve_billing_route(
     model = (model_name or "").strip()
     if not provider_name and "/" in model:
         inferred_provider, bare_model = model.split("/", 1)
-        if inferred_provider in {"anthropic", "openai", "google"}:
-            provider_name = inferred_provider
+        if inferred_provider in {"anthropic", "openai", "google", "xai", "x-ai"}:
+            provider_name = "xai" if inferred_provider in {"xai", "x-ai"} else inferred_provider
             model = bare_model
 
     if provider_name == "openai-codex":
@@ -925,6 +954,21 @@ def resolve_billing_route(
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"minimax", "minimax-cn"}:
         return BillingRoute(provider=provider_name, model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    # xAI API-key and SuperGrok OAuth both bill at the same published Grok
+    # rates. Prefer live /v1/models when base_url+key work; snapshot is the
+    # offline/insights fallback (see get_pricing_entry).
+    if (
+        provider_name in {"xai", "xai-oauth", "x-ai"}
+        or base_url_host_matches(base_url or "", "api.x.ai")
+        or base_url_host_matches(base_url or "", "x.ai")
+    ):
+        bare = model.split("/")[-1]
+        return BillingRoute(
+            provider="xai",
+            model=bare,
+            base_url=base_url or _XAI_DEFAULT_BASE_URL,
+            billing_mode="official_docs_snapshot",
+        )
     # Vertex AI hosts the same Gemini models as Google AI Studio; price them
     # off the gemini official-docs snapshot. Strip the "google/" vendor prefix
     # the OpenAI-compat endpoint requires so the pricing key matches.

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -636,3 +636,69 @@ def test_deepseek_v4_flash_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $0.14/M + 500K output × $0.28/M = $0.14 + $0.14 = $0.28
     assert float(result.amount_usd) == 0.28
+
+def test_xai_grok_snapshot_pricing_when_models_api_empty(monkeypatch):
+    """xAI Grok sessions must not stay cost_status=unknown.
+
+    Before this fix, resolve_billing_route left provider xai on
+    billing_mode=unknown with no snapshot row, so every xAI session
+    wrote estimated_cost_usd=0 / cost_status=unknown.
+    """
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda base_url, api_key=None: {},
+    )
+
+    entry = get_pricing_entry("grok-4.5", provider="xai")
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 2.0
+    assert float(entry.output_cost_per_million) == 6.0
+    assert float(entry.cache_read_cost_per_million) == 0.30
+
+    entry43 = get_pricing_entry("xai/grok-4.3", provider="xai")
+    assert entry43 is not None
+    assert float(entry43.input_cost_per_million) == 1.25
+    assert float(entry43.cache_read_cost_per_million) == 0.20
+
+    # Prefixed model id with no explicit provider still resolves.
+    entry_inferred = get_pricing_entry("xai/grok-4.5")
+    assert entry_inferred is not None
+    assert float(entry_inferred.input_cost_per_million) == 2.0
+
+
+def test_xai_grok_cached_session_estimates_not_unknown(monkeypatch):
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda base_url, api_key=None: {},
+    )
+    result = estimate_usage_cost(
+        "grok-4.5",
+        CanonicalUsage(
+            input_tokens=100_000,
+            output_tokens=10_000,
+            cache_read_tokens=500_000,
+        ),
+        provider="xai",
+        base_url="https://api.x.ai/v1",
+    )
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # 100k*$2 + 10k*$6 + 500k*$0.30 per 1M = 0.20 + 0.06 + 0.15 = 0.41
+    assert abs(float(result.amount_usd) - 0.41) < 1e-9
+
+
+def test_xai_models_api_price_fields_are_extracted():
+    from agent.model_metadata import _extract_pricing
+
+    pricing = _extract_pricing(
+        {
+            "id": "grok-4.5",
+            "prompt_text_token_price": 20000,
+            "cached_prompt_text_token_price": 3000,
+            "completion_text_token_price": 60000,
+        }
+    )
+    # Unit is 1/10_000 USD per 1M tokens → per-token strings for usage_pricing.
+    assert float(pricing["prompt"]) == 2.0 / 1_000_000
+    assert float(pricing["cache_read"]) == 0.30 / 1_000_000
+    assert float(pricing["completion"]) == 6.0 / 1_000_000


### PR DESCRIPTION
## What does this PR do?

Fixes cost tracking for xAI Grok sessions. Today, any session routed through xAI (API key or SuperGrok OAuth) writes `estimated_cost_usd = 0`, `cost_status = unknown`, `cost_source = none`, so `hermes insights` and the session DB show zero cost for Grok usage even though token counts are correct.

Three gaps, three fixes:

1. **`resolve_billing_route()` had no xAI branch.** Providers `xai`, `xai-oauth`, and `x-ai` (and any base_url on `api.x.ai` / `x.ai`) now route to provider `xai` with default base `https://api.x.ai/v1`, instead of falling through to `billing_mode=unknown`.
2. **`_extract_pricing()` ignored xAI's models-endpoint price fields.** xAI's `GET /v1/models` publishes prices as integers in 1/10,000 USD per 1M tokens (same scale as Novita), under `prompt_text_token_price`, `cached_prompt_text_token_price`, and `completion_text_token_price` (e.g. `20000` means $2.00/MTok input). These are now mapped, so live provider prices are preferred when the endpoint is reachable.
3. **`_OFFICIAL_DOCS_PRICING` had no Grok rows.** Added snapshot entries for `grok-4.5` ($2.00 / $0.30 cache read / $6.00 per MTok) and `grok-4.3` ($1.25 / $0.20 / $2.50) from https://docs.x.ai/developers/models, as the offline/insights fallback.

Known limitation (noted in a code comment): xAI's long-context tier (~2x above roughly 200k tokens) is not modelled because the generic cost path has no context-tier switch. Base rates only, so very large sessions can understate. Same limitation as other snapshot providers.

This is the xAI analogue of #32400 (Gemini sessions always $0.00 for the same class of reason: missing billing route branch plus missing pricing entries).

## Authorship note

Full disclosure on how this fix came about: it was diagnosed and written by an AI agent, specifically a Hermes Agent instance running on xAI Grok 4.5, which noticed its own sessions logging `cost_status=unknown`, traced the cause through `resolve_billing_route()` and `_extract_pricing()`, and wrote the fix and tests for its own runtime. Upstream preparation (rebase onto current main, resolving the merge with the new Fireworks pricing entries, re-running the suite, and this PR text) was done by Claude (Anthropic). Both steps were human-directed and the result human-reviewed before submission. We're happy to adjust anything to fit project conventions.

## Related Issue

No existing issue covers xAI; #32400 tracks the same bug class for Gemini. Happy to file a matching issue if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/usage_pricing.py`: xAI branch in `resolve_billing_route()` (providers `xai` / `xai-oauth` / `x-ai`, base_url match on `api.x.ai` / `x.ai`); `_XAI_DEFAULT_BASE_URL`; snapshot `PricingEntry` rows for grok-4.5 and grok-4.3.
- `agent/model_metadata.py`: `_extract_pricing()` maps xAI's `*_text_token_price` fields (1/10,000 USD per 1M token units) to per-token pricing strings.
- `tests/agent/test_usage_pricing.py`: three new tests covering snapshot fallback (models API empty), a cached-session cost estimate with exact expected dollar value, and models-API field extraction.

## How to Test

1. `pytest tests/agent/test_usage_pricing.py -q` (3 new tests; whole file passes).
2. Live check: configure an xAI provider (`xai/grok-4.5` or similar), run a short session, then inspect the sessions table: `estimated_cost_usd` is non-zero with `cost_status=estimated` and `cost_source=provider_models_api` (or `official_docs_snapshot` if the models endpoint is unreachable).
3. Before this change, the same session writes `cost_status=unknown` / `cost_source=none`.

Verified in production on our own gateway (Linux/aarch64): first scheduled runs after deploying this change priced correctly from the live models endpoint (`provider_models_api`), e.g. a grok-4.5 session at $0.20 and a grok-4.3 session at $0.10.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(pricing): ...`)
- [x] I searched existing PRs for duplicates (none for xAI; #32400 is the Gemini analogue)
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (aarch64) VM, Python 3.11

### Documentation & Housekeeping

- [x] Relevant documentation updated — N/A (code comments document the xAI price-field units and long-context caveat)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure-Python pricing tables and routing, no platform-specific code
- [x] Tool descriptions/schemas — N/A
