### PR TITLE
fix(update): refuse local source work

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -354,8 +354,7 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   'tts.openai.model': ['gpt-4o-mini-tts', 'tts-1', 'tts-1-hd'],
   'tts.elevenlabs.model_id': ['eleven_multilingual_v2', 'eleven_turbo_v2_5', 'eleven_flash_v2_5'],
   // NeuTTS local inference device.
-  'tts.neutts.device': ['cpu', 'cuda', 'mps'],
-  'updates.non_interactive_local_changes': ['stash', 'discard']
+  'tts.neutts.device': ['cpu', 'cuda', 'mps']
 }
 
 // Voice/model name fields render as a free-input combobox (Input + datalist)
@@ -545,9 +544,6 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     maxConcurrentChildren: 'Parallel Subagents',
     childTimeoutSeconds: 'Subagent Timeout',
     reasoningEffort: 'Subagent Reasoning Effort'
-  },
-  updates: {
-    nonInteractiveLocalChanges: 'In-App Update Local Changes'
   }
 })
 
@@ -625,10 +621,6 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
     elevenlabs: {
       languageCode: 'Optional ISO-639-3 language code. Blank lets ElevenLabs auto-detect.'
     }
-  },
-  updates: {
-    nonInteractiveLocalChanges:
-      'When Hermes updates itself from the app (no terminal prompt), keep local source edits (stash) or throw them away (discard). Terminal updates always ask.'
   }
 })
 
@@ -773,8 +765,7 @@ export const SECTIONS: DesktopConfigSection[] = [
       'delegation.max_iterations',
       'delegation.max_concurrent_children',
       'delegation.child_timeout_seconds',
-      'delegation.reasoning_effort',
-      'updates.non_interactive_local_changes'
+      'delegation.reasoning_effort'
     ]
   }
 ]

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -84,9 +84,6 @@ describe('settings helpers', () => {
       expect(schemaKeyToFieldCopyKey('model_context_length')).toBe('modelContextLength')
       expect(schemaKeyToFieldCopyKey('display.show_reasoning')).toBe('display.showReasoning')
       expect(schemaKeyToFieldCopyKey('tool_output.max_line_length')).toBe('toolOutput.maxLineLength')
-      expect(schemaKeyToFieldCopyKey('updates.non_interactive_local_changes')).toBe(
-        'updates.nonInteractiveLocalChanges'
-      )
     })
 
     it('looks up camelCase field copy by schema key with legacy fallback', () => {

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -541,8 +541,7 @@ export const ar = defineLocale({
       'delegation.maxIterations': 'حد دورات الوكيل الفرعي',
       'delegation.maxConcurrentChildren': 'الوكلاء الفرعيون المتوازيون',
       'delegation.childTimeoutSeconds': 'مهلة الوكيل الفرعي',
-      'delegation.reasoningEffort': 'جهد تفكير الوكيل الفرعي',
-      'updates.nonInteractiveLocalChanges': 'تغييرات التحديث داخل التطبيق'
+      'delegation.reasoningEffort': 'جهد تفكير الوكيل الفرعي'
     },
     fieldDescriptions: {
       model: 'يستخدم في المحادثات الجديدة ما لم تختر نموذجاً مختلفاً من محرر الرسائل.',
@@ -575,9 +574,7 @@ export const ar = defineLocale({
       'tts.xai.language': 'رمز لغة النطق، مثل en.',
       'tts.neutts.device': 'جهاز الاستدلال المحلي لـ NeuTTS.',
       'stt.enabled': 'يفعل التفريغ الصوتي المحلي أو عبر مزود.',
-      'stt.elevenlabs.languageCode': 'رمز لغة ISO-639-3 اختياري. اتركه فارغاً للاكتشاف التلقائي.',
-      'updates.nonInteractiveLocalChanges':
-        'عندما يحدّث Hermes نفسه من التطبيق دون موجه طرفية، احتفظ بتعديلات المصدر المحلية أو تجاهلها.'
+      'stt.elevenlabs.languageCode': 'رمز لغة ISO-639-3 اختياري. اتركه فارغاً للاكتشاف التلقائي.'
     },
     about: {
       heading: 'حول Hermes',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -540,9 +540,6 @@ export const ja = defineLocale({
         maxConcurrentChildren: '並列サブエージェント',
         childTimeoutSeconds: 'サブエージェントタイムアウト',
         reasoningEffort: 'サブエージェント推論強度'
-      },
-      updates: {
-        nonInteractiveLocalChanges: 'アプリ内更新時のローカル変更'
       }
     }),
     fieldDescriptions: defineFieldCopy({
@@ -601,10 +598,6 @@ export const ja = defineLocale({
         elevenlabs: {
           languageCode: '任意の ISO-639-3 言語コードです。空欄なら ElevenLabs が自動検出します。'
         }
-      },
-      updates: {
-        nonInteractiveLocalChanges:
-          'アプリから Hermes 自身を更新するとき、ローカルのソース変更を保持するか破棄するかを選びます。ターミナル更新では常に確認されます。'
       }
     }),
     about: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -529,9 +529,6 @@ export const zhHant = defineLocale({
         maxConcurrentChildren: '平行子代理',
         childTimeoutSeconds: '子代理逾時',
         reasoningEffort: '子代理推理強度'
-      },
-      updates: {
-        nonInteractiveLocalChanges: '應用程式內更新的本機變更'
       }
     }),
     fieldDescriptions: defineFieldCopy({
@@ -589,10 +586,6 @@ export const zhHant = defineLocale({
         elevenlabs: {
           languageCode: '可選的 ISO-639-3 語言代碼。留空讓 ElevenLabs 自動偵測。'
         }
-      },
-      updates: {
-        nonInteractiveLocalChanges:
-          'Hermes 從應用程式內更新自身時，保留本機原始碼變更（stash）或丟棄（discard）。終端機更新一律會詢問。'
       }
     }),
     about: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -641,9 +641,6 @@ export const zh: Translations = {
         maxConcurrentChildren: '并行子智能体',
         childTimeoutSeconds: '子智能体超时',
         reasoningEffort: '子智能体推理强度'
-      },
-      updates: {
-        nonInteractiveLocalChanges: '应用内更新本地更改'
       }
     }),
     fieldDescriptions: defineFieldCopy({
@@ -701,10 +698,6 @@ export const zh: Translations = {
         elevenlabs: {
           languageCode: '可选的 ISO-639-3 语言代码。留空让 ElevenLabs 自动检测。'
         }
-      },
-      updates: {
-        nonInteractiveLocalChanges:
-          'Hermes 从应用内更新时（无终端提示），保留本地源码修改（暂存）或丢弃（放弃）。通过终端更新时始终会询问。'
       }
     }),
     about: {

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1471,14 +1471,6 @@ updates:
   # Number of pre-update backup zips to retain.
   backup_keep: 5
 
-  # What non-interactive updates do with local source edits in the Hermes repo.
-  # Interactive terminal updates always prompt before restoring the autostash.
-  #
-  #   stash   - auto-stash before pull, then auto-restore after success (default)
-  #   discard - drop the update-created stash after success; use only on managed
-  #             installs where local source edits should not persist
-  non_interactive_local_changes: "stash"
-
 
 # =============================================================================
 # Web Dashboard

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3363,22 +3363,6 @@ DEFAULT_CONFIG = {
         # Values below 1 are floored to 1 — the backup just created is
         # always preserved. The quick snapshot always keeps exactly 1.
         "backup_keep": 5,
-        # What `hermes update` does with uncommitted local changes to the
-        # source tree when it runs NON-interactively — i.e. triggered from
-        # the desktop/chat app or the gateway, where there's no TTY to answer
-        # a restore prompt. Interactive (terminal) updates are unaffected:
-        # they always stash the changes and ask whether to restore, exactly
-        # as they always have.
-        #   "stash"   — auto-stash the changes, pull, then auto-restore them
-        #               on top of the updated code (the safe default; nothing
-        #               is ever lost — conflicts are preserved in a git stash).
-        #   "discard" — auto-stash the changes and throw the stash away after
-        #               the pull. Use this only if you never intend to keep
-        #               local edits to the source tree on this machine.
-        #               Stash-and-drop (not `reset --hard` + `clean -fd`) so
-        #               ignored paths — node_modules, venv, build outputs —
-        #               are never touched.
-        "non_interactive_local_changes": "stash",
         # Refresh an already-installed cua-driver during `hermes update`.
         # The refresh is best-effort and macOS-only. Turn this off if the
         # upstream installer is not appropriate for the machine, for example

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4795,8 +4795,8 @@ def _gateway_prompt(prompt_text: str, default: str = "", timeout: float = 300.0)
     Writes a prompt marker file so the gateway can forward the question to the
     user, then polls for a response file.  Falls back to *default* on timeout.
 
-    Used by ``hermes update --gateway`` so interactive prompts (stash restore,
-    config migration) are forwarded to the messenger instead of being silently
+    Used by ``hermes update --gateway`` so remaining interactive prompts such as
+    config migration are forwarded to the messenger instead of being silently
     skipped.
     """
     import json as _json
@@ -7488,336 +7488,6 @@ def _update_via_zip(args):
         _kill_stale_dashboard_processes(restart_managed=True)
 
 
-def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
-    status = subprocess.run(
-        git_cmd + ["status", "--porcelain"],
-        cwd=cwd,
-        capture_output=True,
-        text=True, encoding="utf-8", errors="replace",
-        check=True,
-    )
-    if not status.stdout.strip():
-        return None
-
-    # If the index has unmerged entries (e.g. from an interrupted merge/rebase),
-    # git stash will fail with "needs merge / could not write index".  Clear the
-    # conflict state with `git reset` so the stash can proceed.  Working-tree
-    # changes are preserved; only the index conflict markers are dropped.
-    unmerged = subprocess.run(
-        git_cmd + ["ls-files", "--unmerged"],
-        cwd=cwd,
-        capture_output=True,
-        text=True, encoding="utf-8", errors="replace",
-    )
-    if unmerged.stdout.strip():
-        print("→ Clearing unmerged index entries from a previous conflict...")
-        subprocess.run(git_cmd + ["reset"], cwd=cwd, capture_output=True)
-
-    from datetime import datetime, timezone
-
-    stash_name = datetime.now(timezone.utc).strftime(
-        "hermes-update-autostash-%Y%m%d-%H%M%S"
-    )
-    print("→ Local changes detected — stashing before update...")
-    prev_stash = subprocess.run(
-        git_cmd + ["rev-parse", "--verify", "refs/stash"],
-        cwd=cwd,
-        capture_output=True,
-        text=True, encoding="utf-8", errors="replace",
-    ).stdout.strip()
-    push = subprocess.run(
-        git_cmd + ["stash", "push", "--include-untracked", "-m", stash_name],
-        cwd=cwd,
-        capture_output=True,
-        text=True, encoding="utf-8", errors="replace",
-    )
-    if push.stdout.strip():
-        print(push.stdout.strip())
-    stash_probe = subprocess.run(
-        git_cmd + ["rev-parse", "--verify", "refs/stash"],
-        cwd=cwd,
-        capture_output=True,
-        text=True, encoding="utf-8", errors="replace",
-    )
-    stash_ref = stash_probe.stdout.strip()
-    stash_created = (
-        stash_probe.returncode == 0 and bool(stash_ref) and stash_ref != prev_stash
-    )
-
-    if push.returncode != 0:
-        if stash_created:
-            # git stash push exits non-zero when it saved everything but could
-            # not delete some swept untracked files from the working tree
-            # (e.g. a root-owned directory: "warning: failed to remove ...:
-            # Permission denied").  The stash entry is complete — the changes
-            # are safe — so this is not a failure.  Leave the undeletable
-            # files in place and continue the update.
-            if push.stderr.strip():
-                print(push.stderr.strip())
-            print(
-                "  ⚠ Some untracked files could not be removed from the "
-                "working tree (permission denied)."
-            )
-            print(
-                "    They were still saved to the stash and were left in "
-                "place — the update will continue."
-            )
-            # A partially-failed stash push also aborts its working-tree
-            # cleanup for TRACKED modifications — they are saved in the stash
-            # but still dirty the tree, which would break the checkout/pull
-            # that follows. Safe to reset: everything is in the stash entry.
-            subprocess.run(
-                git_cmd + ["reset", "--hard", "HEAD"],
-                cwd=cwd,
-                capture_output=True,
-            )
-        else:
-            # No stash entry was created: the changes were NOT saved.  This
-            # is a real failure — bail out before the update touches HEAD.
-            print("✗ Could not stash local changes — update aborted.")
-            if push.stderr.strip():
-                print(f"  {push.stderr.strip().splitlines()[0]}")
-            print(
-                "  Commit, stash, or clean up your local changes manually, "
-                "then re-run `hermes update`."
-            )
-            raise subprocess.CalledProcessError(
-                push.returncode, push.args, output=push.stdout, stderr=push.stderr
-            )
-
-    return stash_ref
-
-
-def _resolve_stash_selector(
-    git_cmd: list[str], cwd: Path, stash_ref: str
-) -> Optional[str]:
-    stash_list = subprocess.run(
-        git_cmd + ["stash", "list", "--format=%gd %H"],
-        cwd=cwd,
-        capture_output=True,
-        text=True, encoding="utf-8", errors="replace",
-        check=True,
-    )
-    for line in stash_list.stdout.splitlines():
-        selector, _, commit = line.partition(" ")
-        if commit.strip() == stash_ref:
-            return selector.strip()
-    return None
-
-
-def _print_stash_cleanup_guidance(
-    stash_ref: str, stash_selector: Optional[str] = None
-) -> None:
-    print(
-        "  Check `git status` first so you don't accidentally reapply the same change twice."
-    )
-    print("  Find the saved entry with: git stash list --format='%gd %H %s'")
-    if stash_selector:
-        print(f"  Remove it with: git stash drop {stash_selector}")
-    else:
-        print(
-            f"  Look for commit {stash_ref}, then drop its selector with: git stash drop stash@{{N}}"
-        )
-
-
-def _stash_apply_failed_only_on_existing_untracked(stderr: str) -> bool:
-    """True when a ``git stash apply`` failure is ONLY about untracked files
-    that already exist in the working tree.
-
-    This is the tail end of the permission-denied autostash class: ``git stash
-    push --include-untracked`` swept undeletable files (e.g. a root-owned
-    ``packaging/`` directory) into the stash but could not remove them from
-    disk.  On restore, git applies all tracked changes, then refuses to
-    overwrite those still-present files (``already exists, no checkout`` /
-    ``could not restore untracked files from stash``) and exits non-zero even
-    though nothing was lost.  Any other error line (e.g. ``would be
-    overwritten by merge`` / ``Aborting``) means the tracked apply itself
-    failed and this returns False.
-    """
-    lines = [ln.strip() for ln in (stderr or "").splitlines() if ln.strip()]
-    if not lines:
-        return False
-    saw_untracked_error = False
-    for ln in lines:
-        if "already exists, no checkout" in ln:
-            saw_untracked_error = True
-        elif "could not restore untracked files from stash" in ln:
-            saw_untracked_error = True
-        elif ln.startswith(("warning:", "hint:")):
-            continue
-        else:
-            return False
-    return saw_untracked_error
-
-
-def _restore_stashed_changes(
-    git_cmd: list[str],
-    cwd: Path,
-    stash_ref: str,
-    prompt_user: bool = False,
-    input_fn=None,
-) -> bool:
-    if prompt_user:
-        print()
-        print("⚠ Local changes were stashed before updating.")
-        print(
-            "  Restoring them may reapply local customizations onto the updated codebase."
-        )
-        print("  Review the result afterward if Hermes behaves unexpectedly.")
-        print("Restore local changes now? [Y/n]")
-        if input_fn is not None:
-            response = input_fn("Restore local changes now? [Y/n]", "y")
-        else:
-            response = input().strip().lower()
-        if response not in {"", "y", "yes"}:
-            print("Skipped restoring local changes.")
-            print("Your changes are still preserved in git stash.")
-            print(f"Restore manually with: git stash apply {stash_ref}")
-            return False
-
-    print("→ Restoring local changes...")
-    restore = subprocess.run(
-        git_cmd + ["stash", "apply", stash_ref],
-        cwd=cwd,
-        capture_output=True,
-        text=True, encoding="utf-8", errors="replace",
-    )
-
-    # Check for unmerged (conflicted) files — can happen even when returncode is 0
-    unmerged = subprocess.run(
-        git_cmd + ["diff", "--name-only", "--diff-filter=U"],
-        cwd=cwd,
-        capture_output=True,
-        text=True, encoding="utf-8", errors="replace",
-    )
-    has_conflicts = bool(unmerged.stdout.strip())
-
-    if restore.returncode != 0 and not has_conflicts and (
-        _stash_apply_failed_only_on_existing_untracked(restore.stderr)
-    ):
-        # Permission-denied autostash tail end: the tracked changes applied
-        # cleanly; the only "failure" is untracked files that never left the
-        # working tree (git could not delete them at stash time, so it now
-        # refuses to overwrite them). Their content was never touched —
-        # nothing is lost. Treat as restored.
-        print(
-            "  ⚠ Some stashed untracked files already exist in the working "
-            "tree and were kept as-is."
-        )
-    elif restore.returncode != 0 or has_conflicts:
-        print("✗ Update pulled new code, but restoring local changes hit conflicts.")
-        if restore.stdout.strip():
-            print(restore.stdout.strip())
-        if restore.stderr.strip():
-            print(restore.stderr.strip())
-
-        # Show which files conflicted
-        conflicted_files = unmerged.stdout.strip()
-        if conflicted_files:
-            print("\nConflicted files:")
-            for f in conflicted_files.splitlines():
-                print(f"  • {f}")
-
-        print("\nYour stashed changes are preserved — nothing is lost.")
-        print(f"  Stash ref: {stash_ref}")
-
-        # Always reset to clean state — leaving conflict markers in source
-        # files makes hermes completely unrunnable (SyntaxError on import).
-        # The user's changes are safe in the stash for manual recovery.
-        subprocess.run(
-            git_cmd + ["reset", "--hard", "HEAD"],
-            cwd=cwd,
-            capture_output=True,
-        )
-        print("Working tree reset to clean state.")
-        print(f"Restore your changes later with: git stash apply {stash_ref}")
-        # Don't sys.exit — the code update itself succeeded, only the stash
-        # restore had conflicts.  Let cmd_update continue with pip install,
-        # skill sync, and gateway restart.
-        return False
-
-    stash_selector = _resolve_stash_selector(git_cmd, cwd, stash_ref)
-    if stash_selector is None:
-        print(
-            "⚠ Local changes were restored, but Hermes couldn't find the stash entry to drop."
-        )
-        print(
-            "  The stash was left in place. You can remove it manually after checking the result."
-        )
-        _print_stash_cleanup_guidance(stash_ref)
-    else:
-        drop = subprocess.run(
-            git_cmd + ["stash", "drop", stash_selector],
-            cwd=cwd,
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
-        )
-        if drop.returncode != 0:
-            print(
-                "⚠ Local changes were restored, but Hermes couldn't drop the saved stash entry."
-            )
-            if drop.stdout.strip():
-                print(drop.stdout.strip())
-            if drop.stderr.strip():
-                print(drop.stderr.strip())
-            print(
-                "  The stash was left in place. You can remove it manually after checking the result."
-            )
-            _print_stash_cleanup_guidance(stash_ref, stash_selector)
-
-    print("⚠ Local changes were restored on top of the updated codebase.")
-    print("  Review `git diff` / `git status` if Hermes behaves unexpectedly.")
-    return True
-
-
-def _discard_stashed_changes(
-    git_cmd: list[str],
-    cwd: Path,
-    stash_ref: str,
-) -> bool:
-    """Throw away a stash created before an update, without applying it.
-
-    Used only on a NON-interactive update when the user has set
-    ``updates.non_interactive_local_changes: discard`` — i.e. they've opted out
-    of keeping local source edits on this machine. Drops the stash entry
-    instead of re-applying it, so the working tree stays clean at the freshly
-    pulled HEAD. Unlike ``git reset --hard`` + ``git clean -fd``, this only
-    affects what was stashed (tracked changes + the untracked files we
-    explicitly captured) — ignored paths like node_modules/venv/build outputs
-    are never touched, since they were never stashed.
-
-    Returns True if the stash was dropped, False on a git failure (in which
-    case the stash is left in place for safety).
-    """
-    stash_selector = _resolve_stash_selector(git_cmd, cwd, stash_ref)
-    if stash_selector is None:
-        print(
-            "⚠ Configured to discard local changes on non-interactive update, "
-            "but Hermes couldn't find the stash entry to drop."
-        )
-        _print_stash_cleanup_guidance(stash_ref)
-        return False
-
-    drop = subprocess.run(
-        git_cmd + ["stash", "drop", stash_selector],
-        cwd=cwd,
-        capture_output=True,
-        text=True, encoding="utf-8", errors="replace",
-    )
-    if drop.returncode != 0:
-        print(
-            "⚠ Configured to discard local changes, but Hermes couldn't drop "
-            "the saved stash entry."
-        )
-        if drop.stderr.strip():
-            print(f"  {drop.stderr.strip().splitlines()[0]}")
-        _print_stash_cleanup_guidance(stash_ref, stash_selector)
-        return False
-
-    print("→ Discarded local source changes (updates.non_interactive_local_changes=discard).")
-    return True
-
-
 # =========================================================================
 # Fork detection and upstream management for `hermes update`
 # =========================================================================
@@ -8035,6 +7705,7 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
     print("→ Pulling from upstream...")
 
     try:
+        _guard_update_local_work(git_cmd, cwd, "main")
         subprocess.run(
             git_cmd + ["pull", "--ff-only", "upstream", "main"],
             cwd=cwd,
@@ -11140,47 +10811,159 @@ def _resume_windows_gateways_after_update(token: dict | None) -> None:
         )
 
 
-def _discard_lockfile_churn(git_cmd, repo_root):
-    """Restore tracked ``package-lock.json`` files that npm dirtied locally.
+def _guard_update_local_work(
+    git_cmd, repo_root, branch, *, update_already_pulled=False
+):
+    """Stop an update before it can mutate a checkout with local work."""
 
-    npm rewrites lockfiles non-deterministically at install/build time. On a
-    managed install those diffs are never intentional, so we discard them so
-    ``hermes update`` sees a clean tree instead of autostashing every run.
-    Best-effort; only ever touches files named ``package-lock.json``.
-    """
-    try:
-        diff = subprocess.run(
-            git_cmd + ["diff", "--name-only"],
+    def explain_preservation():
+        if update_already_pulled:
+            print("  Hermes did not reset the checkout; late local work was preserved.")
+        else:
+            print("  No source files were cleaned, stashed, switched, pulled, or reset.")
+
+    status = subprocess.run(
+        git_cmd
+        + [
+            "status",
+            "--porcelain",
+            "--",
+            ".",
+            ":(exclude).update-incomplete",
+            ":(exclude).lazy-refresh-incomplete",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if status.returncode != 0:
+        print("✗ Update stopped: Hermes could not verify local work.")
+        explain_preservation()
+        sys.exit(2)
+
+    current = subprocess.run(
+        git_cmd + ["rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if current.returncode != 0:
+        print("✗ Update stopped: Hermes could not identify the current branch.")
+        explain_preservation()
+        sys.exit(2)
+    current_branch = current.stdout.strip()
+    comparison_branch = branch if current_branch == "HEAD" else current_branch
+    comparison_ref = f"origin/{comparison_branch}"
+
+    if comparison_branch != branch:
+        comparison_refspec = (
+            f"+refs/heads/{comparison_branch}:"
+            f"refs/remotes/origin/{comparison_branch}"
+        )
+        refresh = subprocess.run(
+            git_cmd + ["fetch", "origin", comparison_refspec],
             cwd=repo_root,
             capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
+            text=True,
+            encoding="utf-8",
+            errors="replace",
         )
-        if diff.returncode != 0:
-            return
-        dirty_package_dirs = {
-            Path(line.strip()).parent
-            for line in diff.stdout.splitlines()
-            if line.strip().endswith("package.json")
-        }
-        dirty = [
-            line.strip()
-            for line in diff.stdout.splitlines()
-            if line.strip().endswith("package-lock.json")
-            and Path(line.strip()).parent not in dirty_package_dirs
-        ]
-        if not dirty:
-            return
-        subprocess.run(
-            git_cmd + ["checkout", "--", *dirty],
+        if refresh.returncode != 0:
+            print(
+                "✗ Update stopped: Hermes could not refresh the current branch safely."
+            )
+            explain_preservation()
+            sys.exit(2)
+
+    def count_local_commits(local_ref, remote_ref):
+        ancestry = subprocess.run(
+            git_cmd + ["merge-base", "--is-ancestor", local_ref, remote_ref],
             cwd=repo_root,
             capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
-            check=False,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
         )
-        print(f"→ Discarded npm lockfile churn ({len(dirty)} file(s))")
-    except Exception:
-        # Never let lockfile cleanup block an update.
-        pass
+        if ancestry.returncode == 0:
+            return 0
+        if ancestry.returncode != 1:
+            print("✗ Update stopped: Hermes could not verify local commit safety.")
+            explain_preservation()
+            sys.exit(2)
+
+        local_commits = subprocess.run(
+            git_cmd + ["rev-list", "--count", f"{remote_ref}..{local_ref}"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        try:
+            count = int(local_commits.stdout.strip())
+        except (TypeError, ValueError):
+            count = -1
+        if local_commits.returncode != 0 or count < 0:
+            print("✗ Update stopped: Hermes could not count local commits safely.")
+            explain_preservation()
+            sys.exit(2)
+        return count
+
+    local_commit_count = count_local_commits("HEAD", comparison_ref)
+    target_commit_count = 0
+    target_local_ref = f"refs/heads/{branch}"
+    if current_branch != branch:
+        target_exists = subprocess.run(
+            git_cmd + ["show-ref", "--verify", "--quiet", target_local_ref],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if target_exists.returncode == 0:
+            target_commit_count = count_local_commits(
+                target_local_ref, f"origin/{branch}"
+            )
+        elif target_exists.returncode != 1:
+            print("✗ Update stopped: Hermes could not inspect the target branch safely.")
+            explain_preservation()
+            sys.exit(2)
+
+    has_uncommitted_work = bool(status.stdout.strip())
+    if (
+        not has_uncommitted_work
+        and local_commit_count == 0
+        and target_commit_count == 0
+    ):
+        return current_branch
+
+    print("✗ Update stopped: this checkout contains local work.")
+    if local_commit_count:
+        suffix = "" if local_commit_count == 1 else "s"
+        print(f"  Committed work: {local_commit_count} local commit{suffix}")
+    if target_commit_count:
+        suffix = "" if target_commit_count == 1 else "s"
+        print(
+            f"  Committed work on target '{branch}': "
+            f"{target_commit_count} local commit{suffix}"
+        )
+    if has_uncommitted_work:
+        print("  Uncommitted work: tracked or untracked files are present")
+    explain_preservation()
+    print("  Review it with: git status --short")
+    print(f"  Review commits with: git log --oneline {comparison_ref}..HEAD")
+    if target_commit_count:
+        print(
+            "  Review target commits with: "
+            f"git log --oneline origin/{branch}..{target_local_ref}"
+        )
+    print(f"  Then update from a clean checkout of origin/{branch}.")
+    sys.exit(2)
 
 
 def cmd_update(args):
@@ -11249,30 +11032,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
         else None
     )
     assume_yes = bool(getattr(args, "yes", False))
-
-    # Whether this update is running without a human at the keyboard.
-    # Interactive terminal updates always stash-and-ask (unchanged behavior);
-    # only non-interactive updates (desktop/chat app, gateway, `--yes`) consult
-    # the `updates.non_interactive_local_changes` config setting to decide
-    # whether to auto-restore stashed local source changes or throw them away.
-    _non_interactive_update = (
-        gateway_mode
-        or assume_yes
-        or not (sys.stdin.isatty() and sys.stdout.isatty())
-    )
-    discard_local_changes = False
-    if _non_interactive_update:
-        try:
-            from hermes_cli.config import load_config
-
-            _update_cfg = (load_config() or {}).get("updates", {})
-            if isinstance(_update_cfg, dict):
-                _mode = str(_update_cfg.get("non_interactive_local_changes", "stash")).lower()
-                discard_local_changes = _mode == "discard"
-        except Exception as exc:
-            # Never let a config read failure change the safe default.
-            logger.debug("Could not read updates.non_interactive_local_changes: %s", exc)
-            discard_local_changes = False
 
     print("⚕ Updating Hermes Agent...")
     print()
@@ -11358,15 +11117,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
     if sys.platform == "win32":
         git_cmd = ["git", "-c", "windows.appendAtomically=false"]
 
-    # Discard npm lockfile churn before any stash/branch logic. npm rewrites
-    # tracked package-lock.json files non-deterministically at install/build
-    # time (platform-specific optional deps, ideallyInert annotations, etc.),
-    # which is never an intentional edit on a managed install but leaves the
-    # tree dirty — forcing an autostash on every update and making branch
-    # switches fragile. Restoring them first lets the common case (only
-    # lockfile churn) update with a clean tree.
-    _discard_lockfile_churn(git_cmd, PROJECT_ROOT)
-
     # Detect if we're updating from a fork (before any branch logic)
     origin_url = _get_origin_url(git_cmd, PROJECT_ROOT)
     is_fork = _is_fork(origin_url)
@@ -11393,10 +11143,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # minutes on a non-single-branch checkout. Fetch only what we update
         # against.
         branch = _resolve_update_branch(args)
+        branch_check = subprocess.run(
+            git_cmd + ["check-ref-format", "--branch", branch],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if branch_check.returncode != 0:
+            print(f"✗ Invalid update branch: {branch}")
+            sys.exit(2)
 
         print("→ Fetching updates...")
+        target_refspec = f"+refs/heads/{branch}:refs/remotes/origin/{branch}"
         fetch_result = subprocess.run(
-            git_cmd + ["fetch", "origin", branch],
+            git_cmd + ["fetch", "origin", target_refspec],
             cwd=PROJECT_ROOT,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
@@ -11418,15 +11180,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print(f"  {stderr.splitlines()[0]}")
             sys.exit(1)
 
-        # Get current branch (returns literal "HEAD" when detached)
-        result = subprocess.run(
-            git_cmd + ["rev-parse", "--abbrev-ref", "HEAD"],
-            cwd=PROJECT_ROOT,
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
-            check=True,
+        # Fetching only refreshes remote refs. Before the updater switches
+        # branches, pulls, or resets, refuse local source work so the user's
+        # checkout remains byte-for-byte intact.
+        current_branch = _guard_update_local_work(git_cmd, PROJECT_ROOT, branch)
+        original_detached_sha = (
+            _capture_head_sha(git_cmd, PROJECT_ROOT)
+            if current_branch == "HEAD"
+            else None
         )
-        current_branch = result.stdout.strip()
+        if current_branch == "HEAD" and not original_detached_sha:
+            print("✗ Update stopped: Hermes could not preserve the detached HEAD.")
+            sys.exit(2)
 
         # If user is on a different branch than the update target, switch
         # to the target. When the target is "main" this is the historical
@@ -11440,8 +11205,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 else f"branch '{current_branch}'"
             )
             print(f"  ⚠ Currently on {label} — switching to {branch} for update...")
-            # Stash before checkout so uncommitted work isn't lost
-            auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
+            # Recheck immediately before checkout. Git itself also refuses to
+            # overwrite a late uncommitted edit; Hermes never auto-stashes it.
+            _guard_update_local_work(git_cmd, PROJECT_ROOT, branch)
             checkout_result = subprocess.run(
                 git_cmd + ["checkout", branch],
                 cwd=PROJECT_ROOT,
@@ -11449,39 +11215,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 text=True, encoding="utf-8", errors="replace",
             )
             if checkout_result.returncode != 0:
-                # Local checkout doesn't have this branch yet. Try to set
-                # it up as a tracking branch of origin/<branch>. This is
-                # the common case when the requested branch exists upstream
-                # but was never checked out locally.
+                # Recheck before creating a missing local tracking branch. If
+                # the first checkout failed because work appeared after the
+                # previous guard, this stops instead of trying another checkout.
+                _guard_update_local_work(git_cmd, PROJECT_ROOT, branch)
                 track_result = subprocess.run(
-                    git_cmd + ["checkout", "-B", branch, f"origin/{branch}"],
+                    git_cmd
+                    + ["checkout", "--track", "-b", branch, f"origin/{branch}"],
                     cwd=PROJECT_ROOT,
                     capture_output=True,
                     text=True, encoding="utf-8", errors="replace",
                 )
                 if track_result.returncode != 0:
-                    # Restore the user's prior branch + stash before bailing
-                    # so we don't leave them stranded in a weird state.
-                    if auto_stash_ref is not None:
-                        _restore_stashed_changes(
-                            git_cmd,
-                            PROJECT_ROOT,
-                            auto_stash_ref,
-                            prompt_user=False,
-                            input_fn=gw_input_fn,
-                        )
-                    print(f"✗ Branch '{branch}' does not exist locally or on origin.")
+                    print(f"✗ Could not check out branch '{branch}' safely.")
                     if track_result.stderr.strip():
                         print(f"  {track_result.stderr.strip().splitlines()[0]}")
                     sys.exit(1)
-        else:
-            auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
-
-        prompt_for_restore = (
-            auto_stash_ref is not None
-            and not assume_yes
-            and (gateway_mode or (sys.stdin.isatty() and sys.stdout.isatty()))
-        )
 
         # Check if there are updates
         result = subprocess.run(
@@ -11500,23 +11249,34 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if is_fork and branch == "main":
                 _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
 
-            # Restore stash and switch back to original branch if we moved
-            if auto_stash_ref is not None:
-                _restore_stashed_changes(
+            # Switch back to the user's original clean branch or detached
+            # commit if we moved only to discover there was nothing to update.
+            if current_branch != branch:
+                restore_target = (
+                    original_detached_sha
+                    if current_branch == "HEAD"
+                    else current_branch
+                )
+                _guard_update_local_work(
                     git_cmd,
                     PROJECT_ROOT,
-                    auto_stash_ref,
-                    prompt_user=prompt_for_restore,
-                    input_fn=gw_input_fn,
+                    branch if current_branch == "HEAD" else current_branch,
                 )
-            if current_branch not in {branch, "HEAD"}:
-                subprocess.run(
-                    git_cmd + ["checkout", current_branch],
+                restore_cmd = ["checkout"]
+                if current_branch == "HEAD":
+                    restore_cmd.append("--detach")
+                restore_cmd.append(restore_target)
+                restore_result = subprocess.run(
+                    git_cmd + restore_cmd,
                     cwd=PROJECT_ROOT,
                     capture_output=True,
                     text=True, encoding="utf-8", errors="replace",
                     check=False,
                 )
+                if restore_result.returncode != 0:
+                    print("✗ Update check finished, but Hermes could not restore")
+                    print(f"  the original checkout: {restore_target}")
+                    sys.exit(1)
 
             # "No new commits" does not mean the managed interpreter is safe.
             # uv can retain the same CPython patch while python-build-standalone
@@ -11605,110 +11365,78 @@ def _cmd_update_impl(args, gateway_mode: bool):
         print(f"→ Found {commit_count} new commit(s)")
 
         print("→ Pulling updates...")
-        update_succeeded = False
         # Capture the pre-pull SHA so we can auto-roll-back if the new code
         # has a syntax error in a critical-path file (PR #28452 incident:
         # orphan merge-conflict markers in hermes_cli/config.py bricked
         # every user who ran ``hermes update`` for the 7 minutes between
         # the bad commit and the fix landing).
         pre_pull_sha = _capture_head_sha(git_cmd, PROJECT_ROOT)
-        try:
-            pull_result = subprocess.run(
-                git_cmd + ["pull", "--ff-only", "origin", branch],
-                cwd=PROJECT_ROOT,
-                capture_output=True,
-                text=True, encoding="utf-8", errors="replace",
-            )
-            if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+        # This is the final operation before pull: work created after the
+        # earlier preflight stops here, while Git itself refuses conflicts
+        # that race the check.
+        _guard_update_local_work(git_cmd, PROJECT_ROOT, branch)
+        pull_result = subprocess.run(
+            git_cmd + ["pull", "--ff-only", "origin", branch],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+        )
+        if pull_result.returncode != 0:
+            print("✗ Fast-forward update failed; Hermes did not reset the checkout.")
+            if pull_result.stderr.strip():
+                print(f"  {pull_result.stderr.strip().splitlines()[0]}")
+            print("  Review the branch with git status and git log, then retry.")
+            sys.exit(1)
+
+        # Post-pull syntax guard: validate critical-path files actually
+        # parse before declaring the update successful. If a bad commit
+        # made it through CI (e.g. admin-merge bypass of a failing
+        # ruff check), this catches it on the user side and rolls back
+        # so the CLI stays bootable. The user can then retry ``hermes
+        # update`` later once a fix lands upstream.
+        syntax_ok, failing_path, syntax_error = _validate_critical_files_syntax(
+            PROJECT_ROOT
+        )
+        if not syntax_ok:
+            print()
+            print("✗ Pulled code has a syntax error in a critical file:")
+            print(f"  {failing_path}")
+            if syntax_error:
+                # py_compile errors can be multi-line; show the first
+                # ~6 lines so the user sees the actual SyntaxError text.
+                for line in str(syntax_error).splitlines()[:6]:
+                    print(f"    {line}")
+            if pre_pull_sha:
+                # Refuse rollback if work appeared after the pull. --keep is
+                # a second safeguard: Git aborts rather than overwriting a
+                # late uncommitted edit.
+                _guard_update_local_work(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    branch,
+                    update_already_pulled=True,
                 )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                print()
+                print(f"→ Rolling back to {pre_pull_sha[:10]}...")
+                rollback_result = subprocess.run(
+                    git_cmd + ["reset", "--keep", pre_pull_sha],
                     cwd=PROJECT_ROOT,
                     capture_output=True,
                     text=True, encoding="utf-8", errors="replace",
                 )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
-                    print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
-                    )
-                    sys.exit(1)
-
-            # Post-pull syntax guard: validate critical-path files actually
-            # parse before declaring the update successful. If a bad commit
-            # made it through CI (e.g. admin-merge bypass of a failing
-            # ruff check), this catches it on the user side and rolls back
-            # so the CLI stays bootable. The user can then retry ``hermes
-            # update`` later once a fix lands upstream.
-            syntax_ok, failing_path, syntax_error = _validate_critical_files_syntax(
-                PROJECT_ROOT
-            )
-            if not syntax_ok:
+                if rollback_result.returncode == 0:
+                    print("  ✓ Rollback complete — your install is unchanged.")
+                    print("  Try ``hermes update`` again later once a fix lands.")
+                else:
+                    print("  ✗ Rollback failed. Recover manually with:")
+                    print(f"    cd {PROJECT_ROOT} && git reset --keep {pre_pull_sha}")
+                    if rollback_result.stderr.strip():
+                        print(f"    ({rollback_result.stderr.strip().splitlines()[0]})")
+            else:
                 print()
-                print("✗ Pulled code has a syntax error in a critical file:")
-                print(f"  {failing_path}")
-                if syntax_error:
-                    # py_compile errors can be multi-line; show the first
-                    # ~6 lines so the user sees the actual SyntaxError text.
-                    for line in str(syntax_error).splitlines()[:6]:
-                        print(f"    {line}")
-                if pre_pull_sha:
-                    print()
-                    print(f"→ Rolling back to {pre_pull_sha[:10]}...")
-                    rollback_result = subprocess.run(
-                        git_cmd + ["reset", "--hard", pre_pull_sha],
-                        cwd=PROJECT_ROOT,
-                        capture_output=True,
-                        text=True, encoding="utf-8", errors="replace",
-                    )
-                    if rollback_result.returncode == 0:
-                        print("  ✓ Rollback complete — your install is unchanged.")
-                        print("  Try ``hermes update`` again later once a fix lands.")
-                    else:
-                        print("  ✗ Rollback failed. Recover manually with:")
-                        print(f"    cd {PROJECT_ROOT} && git reset --hard {pre_pull_sha}")
-                        if rollback_result.stderr.strip():
-                            print(f"    ({rollback_result.stderr.strip().splitlines()[0]})")
-                else:
-                    print()
-                    print("  Could not capture pre-pull SHA — recover manually with:")
-                    print(f"    cd {PROJECT_ROOT} && git reflog && git reset --hard <prev-sha>")
-                sys.exit(1)
-
-            update_succeeded = True
-        finally:
-            if auto_stash_ref is not None:
-                # Don't attempt stash restore if the code update itself failed —
-                # working tree is in an unknown state.
-                if not update_succeeded:
-                    print(
-                        f"  ℹ️  Local changes preserved in stash (ref: {auto_stash_ref})"
-                    )
-                    print("  Restore manually with: git stash apply")
-                elif discard_local_changes:
-                    # Non-interactive update + user opted into discarding local
-                    # source edits (updates.non_interactive_local_changes:
-                    # discard). Throw the stash away instead of re-applying it.
-                    _discard_stashed_changes(
-                        git_cmd,
-                        PROJECT_ROOT,
-                        auto_stash_ref,
-                    )
-                else:
-                    _restore_stashed_changes(
-                        git_cmd,
-                        PROJECT_ROOT,
-                        auto_stash_ref,
-                        prompt_user=prompt_for_restore,
-                        input_fn=gw_input_fn,
-                    )
+                print("  Could not capture pre-pull SHA — recover manually with:")
+                print(f"    cd {PROJECT_ROOT} && git reflog && git reset --keep <prev-sha>")
+            sys.exit(1)
 
         _invalidate_update_cache()
 

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -48,7 +48,7 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         "-y",
         action="store_true",
         default=False,
-        help="Assume yes for interactive prompts (config migration, stash restore). API-key entry is skipped; run 'hermes config migrate' separately for those.",
+        help="Assume yes for interactive prompts such as config migration. Local source work still stops the update. API-key entry is skipped; run 'hermes config migrate' separately for those.",
     )
     update_parser.add_argument(
         "--branch",
@@ -57,8 +57,8 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         help=(
             "Update against this branch instead of the default (main). "
             "If the local checkout is on a different branch, hermes will "
-            "switch to the requested branch first (auto-stashing any "
-            "uncommitted changes)."
+            "switch to the requested branch only after confirming that no "
+            "local source work would be left behind."
         ),
     )
     update_parser.add_argument(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -910,16 +910,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Reasoning effort for delegated subagents",
         "options": ["", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"],
     },
-    "updates.non_interactive_local_changes": {
-        "type": "select",
-        "description": (
-            "When the chat app / gateway updates Hermes (no terminal prompt), "
-            "what to do with uncommitted local source edits. 'stash' keeps them "
-            "and re-applies them after the update; 'discard' throws them away. "
-            "Terminal updates always ask, regardless of this setting."
-        ),
-        "options": ["stash", "discard"],
-    },
+
     "updates.refresh_cua_driver": {
         "type": "bool",
         "description": (

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -4,7 +4,6 @@ Tests the new --gateway mode for hermes update, including:
 - _gateway_prompt() file-based IPC
 - _watch_update_progress() output streaming and prompt detection
 - Message interception for update prompt responses
-- _restore_stashed_changes() with input_fn parameter
 """
 
 import json
@@ -142,63 +141,6 @@ class TestGatewayPrompt:
             result = _gateway_prompt("test?", "default_val", timeout=2.0)
 
         assert result == "default_val"
-
-
-# ---------------------------------------------------------------------------
-# _restore_stashed_changes with input_fn
-# ---------------------------------------------------------------------------
-
-
-class TestRestoreStashWithInputFn:
-    """Tests for _restore_stashed_changes with the input_fn parameter."""
-
-    def test_uses_input_fn_when_provided(self, tmp_path):
-        """When input_fn is provided, it's called instead of input()."""
-        from hermes_cli.main import _restore_stashed_changes
-
-        captured_args = []
-
-        def fake_input_fn(prompt, default=""):
-            captured_args.append((prompt, default))
-            return "n"
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0, stdout="", stderr=""
-            )
-            result = _restore_stashed_changes(
-                ["git"], tmp_path, "abc123",
-                prompt_user=True,
-                input_fn=fake_input_fn,
-            )
-
-        assert len(captured_args) == 1
-        assert "Restore" in captured_args[0][0]
-        assert result is False  # user declined
-
-    def test_input_fn_yes_proceeds_with_restore(self, tmp_path):
-        """When input_fn returns 'y', stash apply is attempted."""
-        from hermes_cli.main import _restore_stashed_changes
-
-        call_count = [0]
-
-        def fake_run(*args, **kwargs):
-            call_count[0] += 1
-            mock = MagicMock()
-            mock.returncode = 0
-            mock.stdout = ""
-            mock.stderr = ""
-            return mock
-
-        with patch("subprocess.run", side_effect=fake_run):
-            _restore_stashed_changes(
-                ["git"], tmp_path, "abc123",
-                prompt_user=True,
-                input_fn=lambda p, d="": "y",
-            )
-
-        # Should have called git stash apply + git diff --name-only
-        assert call_count[0] >= 2
 
 
 # ---------------------------------------------------------------------------
@@ -727,28 +669,6 @@ class TestUpdatePromptInterception:
 
 class TestCmdUpdateGatewayMode:
     """Tests for cmd_update with --gateway flag."""
-
-    def test_gateway_flag_enables_gateway_prompt_for_stash(self, tmp_path):
-        """With --gateway, stash restore uses _gateway_prompt instead of input()."""
-        from hermes_cli.main import _restore_stashed_changes
-
-        # Use input_fn to verify the gateway path is taken
-        calls = []
-
-        def fake_input(prompt, default=""):
-            calls.append(prompt)
-            return "n"
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
-            _restore_stashed_changes(
-                ["git"], tmp_path, "abc123",
-                prompt_user=True,
-                input_fn=fake_input,
-            )
-
-        assert len(calls) == 1
-        assert "Restore" in calls[0]
 
     def test_gateway_flag_parsed(self):
         """The --gateway flag is accepted by the update subparser."""

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -742,8 +742,8 @@ class TestCmdUpdateBranchFlag:
         - ``current_branch``  what ``git rev-parse --abbrev-ref HEAD`` returns
         - ``target_branch``   passed via --branch; what we expect the code to switch to
         - ``checkout_fails``  if True, ``git checkout <target>`` returns non-zero
-                              (simulates branch absent locally; code should retry with -B)
-        - ``track_fails``     if True, ``git checkout -B <target> origin/<target>`` ALSO fails
+                              (simulates branch absent locally; code should create a tracking branch)
+        - ``track_fails``     if True, ``git checkout --track -b <target> origin/<target>`` also fails
                               (simulates branch absent on origin too)
         - ``commit_count``    rev-list count returned (0 = up-to-date, >0 = behind)
         """
@@ -754,12 +754,12 @@ class TestCmdUpdateBranchFlag:
             if "rev-parse" in joined and "--abbrev-ref" in joined:
                 return subprocess.CompletedProcess(cmd, 0, stdout=f"{current_branch}\n", stderr="")
 
-            if "checkout" in joined and "-B" in joined:
+            if "checkout" in joined and "--track" in joined:
                 rc = 128 if track_fails else 0
                 err = f"fatal: '{target_branch}' did not match any file(s) known to git\n" if track_fails else ""
                 return subprocess.CompletedProcess(cmd, rc, stdout="", stderr=err)
 
-            if "checkout" in joined and "-B" not in joined and "rev-parse" not in joined:
+            if "checkout" in joined and "--track" not in joined and "rev-parse" not in joined:
                 rc = 128 if checkout_fails else 0
                 err = f"error: pathspec '{target_branch}' did not match\n" if checkout_fails else ""
                 return subprocess.CompletedProcess(cmd, rc, stdout="", stderr=err)
@@ -831,12 +831,12 @@ class TestCmdUpdateBranchFlag:
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
     def test_branch_flag_tracks_remote_when_branch_absent_locally(self, mock_run, _mock_which, capsys):
-        """If local lacks the branch but origin has it, fall back to ``checkout -B``."""
+        """If local lacks the branch but origin has it, create a tracking branch."""
         mock_run.side_effect = self._branch_side_effect(
             current_branch="main",
             target_branch="bb/gui",
             checkout_fails=True,  # plain checkout fails
-            track_fails=False,    # -B from origin/bb/gui succeeds
+            track_fails=False,    # tracking origin/bb/gui succeeds
             commit_count="2",
         )
         args = SimpleNamespace(branch="bb/gui")
@@ -844,8 +844,8 @@ class TestCmdUpdateBranchFlag:
         cmd_update(args)
 
         commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
-        # Should have BOTH a failed `checkout bb/gui` AND a successful `checkout -B bb/gui origin/bb/gui`
-        track_cmds = [c for c in commands if "checkout" in c and "-B" in c]
+        # Should have both a failed checkout and a new tracking-branch checkout.
+        track_cmds = [c for c in commands if "checkout" in c and "--track" in c]
         assert len(track_cmds) == 1
         assert "bb/gui" in track_cmds[0]
         assert "origin/bb/gui" in track_cmds[0]
@@ -868,7 +868,7 @@ class TestCmdUpdateBranchFlag:
         assert exc_info.value.code == 1
 
         out = capsys.readouterr().out
-        assert "does not exist locally or on origin" in out
+        assert "Could not check out branch" in out
         assert "nonexistent" in out
 
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from subprocess import CalledProcessError
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -39,360 +38,10 @@ def _patch_managed_uv(request):
          patch("hermes_cli.managed_uv.update_managed_uv", side_effect=_fake_update_managed_uv):
         yield
 
-def test_stash_local_changes_if_needed_returns_none_when_tree_clean(monkeypatch, tmp_path):
-    calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        if cmd[-2:] == ["status", "--porcelain"]:
-            return SimpleNamespace(stdout="", returncode=0)
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-
-    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
-
-    assert stash_ref is None
-    assert [cmd[-2:] for cmd, _ in calls] == [["status", "--porcelain"]]
-
-
-def test_stash_local_changes_if_needed_returns_specific_stash_commit(monkeypatch, tmp_path):
-    calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        if cmd[-2:] == ["status", "--porcelain"]:
-            return SimpleNamespace(stdout=" M hermes_cli/main.py\n?? notes.txt\n", returncode=0)
-        if cmd[-2:] == ["ls-files", "--unmerged"]:
-            return SimpleNamespace(stdout="", returncode=0)
-        if cmd[1:4] == ["stash", "push", "--include-untracked"]:
-            return SimpleNamespace(stdout="Saved working directory\n", returncode=0)
-        if cmd[-3:] == ["rev-parse", "--verify", "refs/stash"]:
-            return SimpleNamespace(stdout="abc123\n", returncode=0)
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-
-    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
-
-    assert stash_ref == "abc123"
-    assert calls[1][0][-2:] == ["ls-files", "--unmerged"]
-    # Pre-push probe of refs/stash (baseline for detecting a fresh entry),
-    # then the push, then the post-push probe.
-    assert calls[2][0][-3:] == ["rev-parse", "--verify", "refs/stash"]
-    assert calls[3][0][1:4] == ["stash", "push", "--include-untracked"]
-    assert calls[4][0][-3:] == ["rev-parse", "--verify", "refs/stash"]
-
-
-def test_resolve_stash_selector_returns_matching_entry(monkeypatch, tmp_path):
-    def fake_run(cmd, **kwargs):
-        assert cmd == ["git", "stash", "list", "--format=%gd %H"]
-        return SimpleNamespace(
-            stdout="stash@{0} def456\nstash@{1} abc123\n",
-            returncode=0,
-        )
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-
-    assert hermes_main._resolve_stash_selector(["git"], tmp_path, "abc123") == "stash@{1}"
-
-
-
-def test_restore_stashed_changes_prompts_before_applying(monkeypatch, tmp_path, capsys):
-    calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        if cmd[1:3] == ["stash", "apply"]:
-            return SimpleNamespace(stdout="applied\n", stderr="", returncode=0)
-        if cmd[1:3] == ["diff", "--name-only"]:
-            return SimpleNamespace(stdout="", stderr="", returncode=0)
-        if cmd[1:3] == ["stash", "list"]:
-            return SimpleNamespace(stdout="stash@{1} abc123\n", stderr="", returncode=0)
-        if cmd[1:3] == ["stash", "drop"]:
-            return SimpleNamespace(stdout="dropped\n", stderr="", returncode=0)
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-    monkeypatch.setattr("builtins.input", lambda: "")
-
-    restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
-
-    assert restored is True
-    assert calls[0][0] == ["git", "stash", "apply", "abc123"]
-    assert calls[1][0] == ["git", "diff", "--name-only", "--diff-filter=U"]
-    assert calls[2][0] == ["git", "stash", "list", "--format=%gd %H"]
-    assert calls[3][0] == ["git", "stash", "drop", "stash@{1}"]
-    out = capsys.readouterr().out
-    assert "Restore local changes now? [Y/n]" in out
-    assert "restored on top of the updated codebase" in out
-    assert "git diff" in out
-    assert "git status" in out
-
-
-def test_restore_stashed_changes_can_skip_restore_and_keep_stash(monkeypatch, tmp_path, capsys):
-    calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-    monkeypatch.setattr("builtins.input", lambda: "n")
-
-    restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
-
-    assert restored is False
-    assert calls == []
-    out = capsys.readouterr().out
-    assert "Restore local changes now? [Y/n]" in out
-    assert "Your changes are still preserved in git stash." in out
-    assert "git stash apply abc123" in out
-
-
-def test_restore_stashed_changes_applies_without_prompt_when_disabled(monkeypatch, tmp_path, capsys):
-    calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        if cmd[1:3] == ["stash", "apply"]:
-            return SimpleNamespace(stdout="applied\n", stderr="", returncode=0)
-        if cmd[1:3] == ["diff", "--name-only"]:
-            return SimpleNamespace(stdout="", stderr="", returncode=0)
-        if cmd[1:3] == ["stash", "list"]:
-            return SimpleNamespace(stdout="stash@{0} abc123\n", stderr="", returncode=0)
-        if cmd[1:3] == ["stash", "drop"]:
-            return SimpleNamespace(stdout="dropped\n", stderr="", returncode=0)
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-
-    restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=False)
-
-    assert restored is True
-    assert calls[0][0] == ["git", "stash", "apply", "abc123"]
-    assert calls[1][0] == ["git", "diff", "--name-only", "--diff-filter=U"]
-    assert calls[2][0] == ["git", "stash", "list", "--format=%gd %H"]
-    assert calls[3][0] == ["git", "stash", "drop", "stash@{0}"]
-    assert "Restore local changes now?" not in capsys.readouterr().out
-
-
-
-def test_print_stash_cleanup_guidance_with_selector(capsys):
-    hermes_main._print_stash_cleanup_guidance("abc123", "stash@{2}")
-
-    out = capsys.readouterr().out
-    assert "Check `git status` first" in out
-    assert "git stash list --format='%gd %H %s'" in out
-    assert "git stash drop stash@{2}" in out
-
-
-
-def test_restore_stashed_changes_keeps_going_when_stash_entry_cannot_be_resolved(monkeypatch, tmp_path, capsys):
-    calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        if cmd[1:3] == ["stash", "apply"]:
-            return SimpleNamespace(stdout="applied\n", stderr="", returncode=0)
-        if cmd[1:3] == ["diff", "--name-only"]:
-            return SimpleNamespace(stdout="", stderr="", returncode=0)
-        if cmd[1:3] == ["stash", "list"]:
-            return SimpleNamespace(stdout="stash@{0} def456\n", stderr="", returncode=0)
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-
-    restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=False)
-
-    assert restored is True
-    _utf8 = {"encoding": "utf-8", "errors": "replace"}
-    assert calls[0] == (["git", "stash", "apply", "abc123"], {"cwd": tmp_path, "capture_output": True, "text": True, **_utf8})
-    assert calls[1] == (["git", "diff", "--name-only", "--diff-filter=U"], {"cwd": tmp_path, "capture_output": True, "text": True, **_utf8})
-    assert calls[2] == (["git", "stash", "list", "--format=%gd %H"], {"cwd": tmp_path, "capture_output": True, "text": True, **_utf8, "check": True})
-    out = capsys.readouterr().out
-    assert "couldn't find the stash entry to drop" in out
-    assert "stash was left in place" in out
-    assert "Check `git status` first" in out
-    assert "git stash list --format='%gd %H %s'" in out
-    assert "Look for commit abc123" in out
-
-
-
-def test_restore_stashed_changes_keeps_going_when_drop_fails(monkeypatch, tmp_path, capsys):
-    calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        if cmd[1:3] == ["stash", "apply"]:
-            return SimpleNamespace(stdout="applied\n", stderr="", returncode=0)
-        if cmd[1:3] == ["diff", "--name-only"]:
-            return SimpleNamespace(stdout="", stderr="", returncode=0)
-        if cmd[1:3] == ["stash", "list"]:
-            return SimpleNamespace(stdout="stash@{0} abc123\n", stderr="", returncode=0)
-        if cmd[1:3] == ["stash", "drop"]:
-            return SimpleNamespace(stdout="", stderr="drop failed\n", returncode=1)
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-
-    restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=False)
-
-    assert restored is True
-    assert calls[3][0] == ["git", "stash", "drop", "stash@{0}"]
-    out = capsys.readouterr().out
-    assert "couldn't drop the saved stash entry" in out
-    assert "drop failed" in out
-    assert "Check `git status` first" in out
-    assert "git stash list --format='%gd %H %s'" in out
-    assert "git stash drop stash@{0}" in out
-
-
-def test_restore_stashed_changes_always_resets_on_conflict(monkeypatch, tmp_path, capsys):
-    """Conflicts always auto-reset (no prompt) and return False, even interactively.
-
-    Leaving conflict markers in source files makes hermes unrunnable (SyntaxError).
-    The stash is preserved for manual recovery; cmd_update continues normally.
-    """
-    calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        if cmd[1:3] == ["stash", "apply"]:
-            return SimpleNamespace(stdout="conflict output\n", stderr="conflict stderr\n", returncode=1)
-        if cmd[1:3] == ["diff", "--name-only"]:
-            return SimpleNamespace(stdout="hermes_cli/main.py\n", stderr="", returncode=0)
-        if cmd[1:3] == ["reset", "--hard"]:
-            return SimpleNamespace(stdout="", stderr="", returncode=0)
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-    monkeypatch.setattr("builtins.input", lambda: "y")
-
-    result = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
-
-    assert result is False
-    out = capsys.readouterr().out
-    assert "Conflicted files:" in out
-    assert "hermes_cli/main.py" in out
-    assert "stashed changes are preserved" in out
-    assert "Working tree reset to clean state" in out
-    assert "git stash apply abc123" in out
-    reset_calls = [c for c, _ in calls if c[1:3] == ["reset", "--hard"]]
-    assert len(reset_calls) == 1
-
-
-def test_restore_stashed_changes_auto_resets_non_interactive(monkeypatch, tmp_path, capsys):
-    """Non-interactive mode auto-resets without prompting and returns False
-    instead of sys.exit(1) so the update can continue (gateway /update path)."""
-    calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        if cmd[1:3] == ["stash", "apply"]:
-            return SimpleNamespace(stdout="applied\n", stderr="", returncode=0)
-        if cmd[1:3] == ["diff", "--name-only"]:
-            return SimpleNamespace(stdout="cli.py\n", stderr="", returncode=0)
-        if cmd[1:3] == ["reset", "--hard"]:
-            return SimpleNamespace(stdout="", stderr="", returncode=0)
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-
-    result = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=False)
-
-    assert result is False
-    out = capsys.readouterr().out
-    assert "Working tree reset to clean state" in out
-    reset_calls = [c for c, _ in calls if c[1:3] == ["reset", "--hard"]]
-    assert len(reset_calls) == 1
-
-
-def test_stash_local_changes_if_needed_raises_when_stash_ref_missing(monkeypatch, tmp_path):
-    def fake_run(cmd, **kwargs):
-        if cmd[-2:] == ["status", "--porcelain"]:
-            return SimpleNamespace(stdout=" M hermes_cli/main.py\n", returncode=0)
-        if cmd[-2:] == ["ls-files", "--unmerged"]:
-            return SimpleNamespace(stdout="", returncode=0)
-        if cmd[1:4] == ["stash", "push", "--include-untracked"]:
-            return SimpleNamespace(stdout="Saved working directory\n", returncode=0)
-        if cmd[-3:] == ["rev-parse", "--verify", "refs/stash"]:
-            raise CalledProcessError(returncode=128, cmd=cmd)
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-
-    with pytest.raises(CalledProcessError):
-        hermes_main._stash_local_changes_if_needed(["git"], Path(tmp_path))
-
-
-def test_discard_lockfile_churn_skips_lock_when_package_json_dirty(tmp_path):
-    """Intentional dependency edits update package.json and lockfile together."""
-    import shutil
-    import subprocess
-
-    if shutil.which("git") is None:
-        pytest.skip("git not available")
-
-    def git(*args):
-        return subprocess.run(
-            ["git", *args], cwd=tmp_path, capture_output=True, text=True, check=True
-        )
-
-    git("init", "-q")
-    git("config", "user.email", "t@example.com")
-    git("config", "user.name", "t")
-    (tmp_path / "package.json").write_text('{"dependencies":{"a":"1"}}\n')
-    (tmp_path / "package-lock.json").write_text('{"lock":"old"}\n')
-    git("add", "package.json", "package-lock.json")
-    git("commit", "-qm", "init")
-
-    (tmp_path / "package.json").write_text('{"dependencies":{"a":"2"}}\n')
-    (tmp_path / "package-lock.json").write_text('{"lock":"new"}\n')
-
-    hermes_main._discard_lockfile_churn(["git"], tmp_path)
-
-    assert (tmp_path / "package-lock.json").read_text() == '{"lock":"new"}\n'
-
-
-def test_discard_lockfile_churn_restores_lock_when_package_json_clean(tmp_path):
-    """Runtime npm lockfile rewrites are still discarded on managed updates."""
-    import shutil
-    import subprocess
-
-    if shutil.which("git") is None:
-        pytest.skip("git not available")
-
-    def git(*args):
-        return subprocess.run(
-            ["git", *args], cwd=tmp_path, capture_output=True, text=True, check=True
-        )
-
-    git("init", "-q")
-    git("config", "user.email", "t@example.com")
-    git("config", "user.name", "t")
-    (tmp_path / "package.json").write_text('{"dependencies":{"a":"1"}}\n')
-    (tmp_path / "package-lock.json").write_text('{"lock":"old"}\n')
-    git("add", "package.json", "package-lock.json")
-    git("commit", "-qm", "init")
-
-    (tmp_path / "package-lock.json").write_text('{"lock":"runtime-churn"}\n')
-
-    hermes_main._discard_lockfile_churn(["git"], tmp_path)
-
-    assert (tmp_path / "package-lock.json").read_text() == '{"lock":"old"}\n'
-
-
-# ---------------------------------------------------------------------------
-# Update uses .[all] with fallback to .
-# ---------------------------------------------------------------------------
-
 def _setup_update_mocks(monkeypatch, tmp_path):
     """Common setup for cmd_update tests."""
     (tmp_path / ".git").mkdir()
     monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
-    monkeypatch.setattr(hermes_main, "_stash_local_changes_if_needed", lambda *a, **kw: None)
-    monkeypatch.setattr(hermes_main, "_restore_stashed_changes", lambda *a, **kw: True)
     monkeypatch.setattr(hermes_config, "get_missing_env_vars", lambda required_only=True: [])
     monkeypatch.setattr(hermes_config, "get_missing_config_fields", lambda: [])
     monkeypatch.setattr(hermes_config, "check_config_version", lambda: (5, 5))
@@ -412,7 +61,12 @@ def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypa
 
     def fake_run(cmd, **kwargs):
         recorded.append(cmd)
-        if cmd == ["git", "fetch", "origin", "main"]:
+        if cmd == [
+            "git",
+            "fetch",
+            "origin",
+            "+refs/heads/main:refs/remotes/origin/main",
+        ]:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
             return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
@@ -461,7 +115,12 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
 
     def fake_run(cmd, **kwargs):
         recorded.append(cmd)
-        if cmd == ["git", "fetch", "origin", "main"]:
+        if cmd == [
+            "git",
+            "fetch",
+            "origin",
+            "+refs/heads/main:refs/remotes/origin/main",
+        ]:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
             return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
@@ -552,6 +211,12 @@ def _make_update_side_effect(
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-parse" in joined and "--abbrev-ref" in joined:
             return SimpleNamespace(stdout=f"{current_branch}\n", stderr="", returncode=0)
+        if cmd[-2:] == ["rev-parse", "HEAD"]:
+            return SimpleNamespace(
+                stdout="0123456789abcdef0123456789abcdef01234567\n",
+                stderr="",
+                returncode=0,
+            )
         if "checkout" in joined and "main" in joined:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-list" in joined:
@@ -573,22 +238,22 @@ def _make_update_side_effect(
     return side_effect, recorded
 
 
-def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path, capsys):
-    """When --ff-only fails (diverged history), update resets to origin/{branch}."""
+def test_cmd_update_does_not_reset_when_ff_only_fails(monkeypatch, tmp_path, capsys):
+    """A failed fast-forward preserves the checkout instead of hard-resetting it."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
     side_effect, recorded = _make_update_side_effect(ff_only_fails=True)
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
-    hermes_main.cmd_update(SimpleNamespace())
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
 
-    reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
-    assert len(reset_calls) == 1
-    assert reset_calls[0] == ["git", "reset", "--hard", "origin/main"]
+    reset_calls = [c for c in recorded if "reset" in c]
+    assert reset_calls == []
 
     out = capsys.readouterr().out
-    assert "Fast-forward not possible" in out
+    assert "did not reset the checkout" in out
 
 
 def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):
@@ -601,8 +266,8 @@ def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):
 
     hermes_main.cmd_update(SimpleNamespace())
 
-    reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
-    assert len(reset_calls) == 0
+    reset_calls = [c for c in recorded if "reset" in c]
+    assert reset_calls == []
 
 
 # ---------------------------------------------------------------------------
@@ -644,21 +309,11 @@ def test_cmd_update_switches_to_main_from_detached_head(monkeypatch, tmp_path, c
     assert "detached HEAD" in out
 
 
-def test_cmd_update_restores_stash_and_branch_when_already_up_to_date(monkeypatch, tmp_path, capsys):
-    """When on a feature branch with no updates, stash is restored and branch switched back."""
+def test_cmd_update_restores_branch_when_already_up_to_date(monkeypatch, tmp_path, capsys):
+    """A clean feature branch is restored after checking an up-to-date main."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
-    # Enable stash so it returns a ref
-    monkeypatch.setattr(
-        hermes_main, "_stash_local_changes_if_needed",
-        lambda *a, **kw: "abc123deadbeef",
-    )
-    restore_calls = []
-    monkeypatch.setattr(
-        hermes_main, "_restore_stashed_changes",
-        lambda *a, **kw: restore_calls.append(1) or True,
-    )
 
     side_effect, recorded = _make_update_side_effect(
         current_branch="fix/something", commit_count="0",
@@ -666,9 +321,6 @@ def test_cmd_update_restores_stash_and_branch_when_already_up_to_date(monkeypatc
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
     hermes_main.cmd_update(SimpleNamespace())
-
-    # Stash should have been restored
-    assert len(restore_calls) == 1
 
     # Should have checked out back to the original branch
     checkout_back = [c for c in recorded if "checkout" in c and "fix/something" in c]
@@ -705,7 +357,14 @@ def test_cmd_update_fetch_is_scoped_to_target_branch(monkeypatch, tmp_path):
     hermes_main.cmd_update(SimpleNamespace())
 
     fetch_calls = [c for c in recorded if "fetch" in c]
-    assert fetch_calls == [["git", "fetch", "origin", "main"]]
+    assert fetch_calls == [
+        [
+            "git",
+            "fetch",
+            "origin",
+            "+refs/heads/main:refs/remotes/origin/main",
+        ]
+    ]
     assert ["git", "fetch", "origin"] not in recorded
 
 
@@ -745,420 +404,3 @@ def test_cmd_update_auth_error_shows_friendly_message(monkeypatch, tmp_path, cap
 
     out = capsys.readouterr().out
     assert "Authentication failed" in out
-
-
-# ---------------------------------------------------------------------------
-# reset --hard failure — don't attempt stash restore
-# ---------------------------------------------------------------------------
-
-def test_cmd_update_skips_stash_restore_when_reset_fails(monkeypatch, tmp_path, capsys):
-    """When reset --hard fails, stash restore is skipped with a helpful message."""
-    _setup_update_mocks(monkeypatch, tmp_path)
-    # Re-enable stash so it actually returns a ref
-    monkeypatch.setattr(
-        hermes_main, "_stash_local_changes_if_needed",
-        lambda *a, **kw: "abc123deadbeef",
-    )
-    restore_calls = []
-    monkeypatch.setattr(
-        hermes_main, "_restore_stashed_changes",
-        lambda *a, **kw: restore_calls.append(1) or True,
-    )
-
-    side_effect, _ = _make_update_side_effect(ff_only_fails=True, reset_fails=True)
-    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
-
-    with pytest.raises(SystemExit, match="1"):
-        hermes_main.cmd_update(SimpleNamespace())
-
-    # Stash restore should NOT have been called
-    assert len(restore_calls) == 0
-
-    out = capsys.readouterr().out
-    assert "preserved in stash" in out
-
-
-# ---------------------------------------------------------------------------
-# Non-interactive update.non_interactive_local_changes setting
-# (chat app / gateway): "discard" throws stashed changes away, "stash"
-# (default) restores them. Interactive terminal updates ignore the setting
-# and always go through the restore path.
-# ---------------------------------------------------------------------------
-
-def _setup_setting_test(monkeypatch, tmp_path, mode):
-    """Common wiring: real stash returns a ref, restore + discard are
-    recorded, and load_config reports the given non_interactive_local_changes
-    mode."""
-    _setup_update_mocks(monkeypatch, tmp_path)
-    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
-    monkeypatch.setattr(
-        hermes_main, "_stash_local_changes_if_needed",
-        lambda *a, **kw: "abc123deadbeef",
-    )
-    restore_calls = []
-    discard_calls = []
-    monkeypatch.setattr(
-        hermes_main, "_restore_stashed_changes",
-        lambda *a, **kw: restore_calls.append(1) or True,
-    )
-    monkeypatch.setattr(
-        hermes_main, "_discard_stashed_changes",
-        lambda *a, **kw: discard_calls.append(1) or True,
-    )
-    monkeypatch.setattr(
-        hermes_config, "load_config",
-        lambda *a, **kw: {"updates": {"non_interactive_local_changes": mode}},
-    )
-    side_effect, recorded = _make_update_side_effect()
-    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
-    return restore_calls, discard_calls, recorded
-
-
-def test_non_interactive_discard_throws_changes_away(monkeypatch, tmp_path):
-    """Gateway/chat-app update with discard mode drops the stash, never restores."""
-    restore_calls, discard_calls, _ = _setup_setting_test(monkeypatch, tmp_path, "discard")
-
-    hermes_main.cmd_update(SimpleNamespace(gateway=True))
-
-    assert len(discard_calls) == 1
-    assert len(restore_calls) == 0
-
-
-def test_non_interactive_stash_restores_changes(monkeypatch, tmp_path):
-    """Gateway/chat-app update with the default stash mode restores, never discards."""
-    restore_calls, discard_calls, _ = _setup_setting_test(monkeypatch, tmp_path, "stash")
-
-    hermes_main.cmd_update(SimpleNamespace(gateway=True))
-
-    assert len(restore_calls) == 1
-    assert len(discard_calls) == 0
-
-
-def test_interactive_update_ignores_discard_setting(monkeypatch, tmp_path):
-    """An interactive (TTY) terminal update always restores — the discard
-    setting only governs non-interactive updates."""
-    restore_calls, discard_calls, _ = _setup_setting_test(monkeypatch, tmp_path, "discard")
-    # Force an interactive TTY so _non_interactive_update is False even though
-    # the config says discard.
-    monkeypatch.setattr(hermes_main.sys.stdin, "isatty", lambda: True)
-    monkeypatch.setattr(hermes_main.sys.stdout, "isatty", lambda: True)
-
-    hermes_main.cmd_update(SimpleNamespace())  # no gateway, no --yes
-
-    assert len(restore_calls) == 1
-    assert len(discard_calls) == 0
-
-
-def test_non_interactive_defaults_to_stash_when_setting_absent(monkeypatch, tmp_path):
-    """A config with no update section falls back to stash (safe default)."""
-    restore_calls, discard_calls, _ = _setup_setting_test(monkeypatch, tmp_path, "stash")
-    # Override load_config to return a config with NO update section at all.
-    monkeypatch.setattr(hermes_config, "load_config", lambda *a, **kw: {"model": {}})
-
-    hermes_main.cmd_update(SimpleNamespace(gateway=True))
-
-    assert len(restore_calls) == 1
-    assert len(discard_calls) == 0
-
-
-def test_bootstrap_marker_not_autostashed_by_update(tmp_path):
-    """#38529: the Desktop bootstrap marker must be git-ignored so that
-    ``hermes update``'s ``git stash push --include-untracked`` does not sweep it
-    into an autostash on every run.
-
-    Behavioral + hermetic: build a throwaway repo that adopts the project's real
-    ``.gitignore`` (the contract under test), drop the marker, and confirm the
-    same stash invocation the updater uses leaves it untouched.
-    """
-    import shutil
-    import subprocess
-
-    if shutil.which("git") is None:
-        pytest.skip("git not available")
-
-    repo_gitignore = Path(hermes_main.__file__).resolve().parents[1] / ".gitignore"
-
-    def git(*args):
-        return subprocess.run(
-            ["git", *args], cwd=tmp_path, capture_output=True, text=True, check=True
-        )
-
-    git("init", "-q")
-    git("config", "user.email", "t@example.com")
-    git("config", "user.name", "t")
-    (tmp_path / ".gitignore").write_text(repo_gitignore.read_text())
-    (tmp_path / "tracked.txt").write_text("x\n")
-    git("add", "-A")
-    git("commit", "-qm", "init")
-
-    marker = tmp_path / ".hermes-bootstrap-complete"
-    marker.write_text("")
-
-    # Exact flags used by hermes update (hermes_cli/main.py).
-    git("stash", "push", "--include-untracked", "-m", "hermes-update-autostash")
-
-    assert marker.exists(), (
-        ".hermes-bootstrap-complete was swept into the update autostash — it must "
-        "be listed in .gitignore so `git stash -u` skips it (#38529)."
-    )
-    # It must not even register as a dirty/untracked change.
-    status = subprocess.run(
-        ["git", "status", "--porcelain"], cwd=tmp_path, capture_output=True, text=True
-    ).stdout
-    assert ".hermes-bootstrap-complete" not in status
-
-
-def test_install_method_marker_not_autostashed_by_update(tmp_path):
-    """#66189: the installer ``.install_method`` stamp must be git-ignored so
-    ``hermes update``'s ``git stash push --include-untracked`` does not sweep it
-    into an autostash on every run.
-
-    ``scripts/install.sh`` writes ``$INSTALL_DIR/.install_method`` as runtime
-    metadata; it is a sibling of ``.hermes-bootstrap-complete`` /
-    ``.update-incomplete`` and must be ignored the same way. Behavioral +
-    hermetic: adopt the project's real ``.gitignore`` (the contract under test),
-    drop the marker, and confirm the exact stash invocation the updater uses
-    leaves it untouched.
-    """
-    import shutil
-    import subprocess
-
-    if shutil.which("git") is None:
-        pytest.skip("git not available")
-
-    repo_gitignore = Path(hermes_main.__file__).resolve().parents[1] / ".gitignore"
-
-    def git(*args):
-        return subprocess.run(
-            ["git", *args], cwd=tmp_path, capture_output=True, text=True, check=True
-        )
-
-    git("init", "-q")
-    git("config", "user.email", "t@example.com")
-    git("config", "user.name", "t")
-    (tmp_path / ".gitignore").write_text(repo_gitignore.read_text())
-    (tmp_path / "tracked.txt").write_text("x\n")
-    git("add", "-A")
-    git("commit", "-qm", "init")
-
-    marker = tmp_path / ".install_method"
-    marker.write_text("managed\n")
-
-    # Exact flags used by hermes update (hermes_cli/main.py).
-    git("stash", "push", "--include-untracked", "-m", "hermes-update-autostash")
-
-    assert marker.exists(), (
-        ".install_method was swept into the update autostash — it must be listed "
-        "in .gitignore so `git stash -u` skips it (#66189)."
-    )
-    # It must not even register as a dirty/untracked change.
-    status = subprocess.run(
-        ["git", "status", "--porcelain"], cwd=tmp_path, capture_output=True, text=True
-    ).stdout
-    assert ".install_method" not in status
-
-
-# ---------------------------------------------------------------------------
-# Permission-denied autostash class: undeletable untracked files (root-owned
-# packaging/ etc.) must not abort the update when the stash entry was created.
-# ---------------------------------------------------------------------------
-
-
-def test_stash_push_partial_removal_failure_continues_when_stash_created(
-    monkeypatch, tmp_path, capsys
-):
-    """git stash push exits 1 ("failed to remove ...: Permission denied") but
-    the stash entry exists → treat as success, return the new ref."""
-    calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        if cmd[-2:] == ["status", "--porcelain"]:
-            return SimpleNamespace(stdout=" M x.py\n?? packaging/\n", returncode=0)
-        if cmd[-2:] == ["ls-files", "--unmerged"]:
-            return SimpleNamespace(stdout="", returncode=0)
-        if cmd[-3:] == ["rev-parse", "--verify", "refs/stash"]:
-            # Before push: no stash. After push: new entry.
-            probes = [c for c, _ in calls if c[-3:] == ["rev-parse", "--verify", "refs/stash"]]
-            if len(probes) == 1:
-                return SimpleNamespace(stdout="", returncode=1)
-            return SimpleNamespace(stdout="newref123\n", returncode=0)
-        if cmd[1:4] == ["stash", "push", "--include-untracked"]:
-            return SimpleNamespace(
-                stdout="Saved working directory and index state\n",
-                stderr=(
-                    "warning: failed to remove packaging/homebrew/hermes-agent.rb: "
-                    "Permission denied\n"
-                ),
-                returncode=1,
-            )
-        if cmd[1:3] == ["reset", "--hard"]:
-            return SimpleNamespace(stdout="", stderr="", returncode=0)
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-
-    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
-
-    assert stash_ref == "newref123"
-    # Tracked mods are saved in the stash but the failed push leaves them in
-    # the tree — the follow-up reset must run so the checkout/pull can proceed.
-    assert any(c[1:3] == ["reset", "--hard"] for c, _ in calls)
-    out = capsys.readouterr().out
-    assert "could not be removed" in out
-    assert "update will continue" in out
-
-
-def test_stash_push_failure_without_stash_entry_still_raises(monkeypatch, tmp_path, capsys):
-    """git stash push fails AND no stash entry was created → real failure."""
-
-    def fake_run(cmd, **kwargs):
-        if cmd[-2:] == ["status", "--porcelain"]:
-            return SimpleNamespace(stdout=" M x.py\n", returncode=0)
-        if cmd[-2:] == ["ls-files", "--unmerged"]:
-            return SimpleNamespace(stdout="", returncode=0)
-        if cmd[-3:] == ["rev-parse", "--verify", "refs/stash"]:
-            return SimpleNamespace(stdout="", returncode=1)
-        if cmd[1:4] == ["stash", "push", "--include-untracked"]:
-            return SimpleNamespace(
-                stdout="", stderr="fatal: unable to write new index file\n",
-                returncode=1, args=cmd,
-            )
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-
-    with pytest.raises(CalledProcessError):
-        hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
-    out = capsys.readouterr().out
-    assert "update aborted" in out
-
-
-def test_stash_push_failure_with_preexisting_stash_unchanged_still_raises(
-    monkeypatch, tmp_path
-):
-    """A pre-existing stash entry must not be mistaken for a fresh save."""
-
-    def fake_run(cmd, **kwargs):
-        if cmd[-2:] == ["status", "--porcelain"]:
-            return SimpleNamespace(stdout=" M x.py\n", returncode=0)
-        if cmd[-2:] == ["ls-files", "--unmerged"]:
-            return SimpleNamespace(stdout="", returncode=0)
-        if cmd[-3:] == ["rev-parse", "--verify", "refs/stash"]:
-            return SimpleNamespace(stdout="oldref456\n", returncode=0)
-        if cmd[1:4] == ["stash", "push", "--include-untracked"]:
-            return SimpleNamespace(stdout="", stderr="boom\n", returncode=1, args=cmd)
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-
-    with pytest.raises(CalledProcessError):
-        hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
-
-
-def test_stash_apply_untracked_only_failure_detector():
-    fn = hermes_main._stash_apply_failed_only_on_existing_untracked
-    assert fn(
-        "packaging/homebrew/hermes-agent.rb already exists, no checkout\n"
-        "error: could not restore untracked files from stash\n"
-    ) is True
-    # Tracked-apply failure lines must NOT be classified as benign.
-    assert fn(
-        "error: Your local changes to the following files would be overwritten by merge:\n"
-        "\ttracked.txt\n"
-        "Please commit your changes or stash them before you merge.\n"
-        "Aborting\n"
-        "packaging/homebrew/hermes-agent.rb already exists, no checkout\n"
-        "error: could not restore untracked files from stash\n"
-    ) is False
-    assert fn("") is False
-    assert fn("warning: something harmless\n") is False
-
-
-def test_restore_treats_existing_untracked_only_failure_as_restored(
-    monkeypatch, tmp_path, capsys
-):
-    """stash apply rc=1 purely from already-present untracked files → restored,
-    stash dropped, no destructive reset."""
-    calls = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        if cmd[1:3] == ["stash", "apply"]:
-            return SimpleNamespace(
-                stdout="",
-                stderr=(
-                    "packaging/homebrew/hermes-agent.rb already exists, no checkout\n"
-                    "error: could not restore untracked files from stash\n"
-                ),
-                returncode=1,
-            )
-        if cmd[1:3] == ["diff", "--name-only"]:
-            return SimpleNamespace(stdout="", stderr="", returncode=0)
-        if cmd[1:3] == ["stash", "list"]:
-            return SimpleNamespace(stdout="stash@{0} abc123\n", stderr="", returncode=0)
-        if cmd[1:3] == ["stash", "drop"]:
-            return SimpleNamespace(stdout="dropped\n", stderr="", returncode=0)
-        raise AssertionError(f"unexpected command: {cmd}")
-
-    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
-
-    restored = hermes_main._restore_stashed_changes(
-        ["git"], tmp_path, "abc123", prompt_user=False
-    )
-
-    assert restored is True
-    # No reset --hard in the command stream.
-    assert not any("reset" in c for c, _ in calls)
-    out = capsys.readouterr().out
-    assert "kept as-is" in out
-    assert "hit conflicts" not in out
-
-
-def test_update_autostash_survives_undeletable_untracked_dir(tmp_path):
-    """Behavioral E2E of the whole permission-denied class with real git:
-    root-owned-style undeletable untracked dir → stash succeeds, update-style
-    reset works, restore round-trips, nothing lost. (#70127 follow-up)"""
-    import os
-    import shutil
-    import subprocess
-
-    if shutil.which("git") is None:
-        pytest.skip("git not available")
-    if os.name == "nt":
-        pytest.skip("POSIX permission semantics")
-    if os.geteuid() == 0:
-        pytest.skip("root ignores directory write bits")
-
-    def git(*args, check=True):
-        return subprocess.run(
-            ["git", *args], cwd=tmp_path, capture_output=True, text=True, check=check
-        )
-
-    git("init", "-q", "-b", "main")
-    git("config", "user.email", "t@example.com")
-    git("config", "user.name", "t")
-    (tmp_path / "tracked.txt").write_text("v1\n")
-    git("add", "-A")
-    git("commit", "-qm", "init")
-
-    (tmp_path / "tracked.txt").write_text("v2 local change\n")
-    pkg = tmp_path / "packaging" / "homebrew"
-    pkg.mkdir(parents=True)
-    (pkg / "hermes-agent.rb").write_text("formula\n")
-    os.chmod(pkg, 0o555)  # undeletable contents, like a root-owned dir
-    try:
-        stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
-        assert stash_ref
-
-        # The tracked change is stashed; simulate the updater's checkout window.
-        assert (tmp_path / "tracked.txt").read_text() == "v1\n"
-
-        restored = hermes_main._restore_stashed_changes(
-            ["git"], tmp_path, stash_ref, prompt_user=False
-        )
-        assert restored is True
-        assert (tmp_path / "tracked.txt").read_text() == "v2 local change\n"
-        assert (pkg / "hermes-agent.rb").read_text() == "formula\n"
-    finally:
-        os.chmod(pkg, 0o755)

--- a/tests/hermes_cli/test_update_local_work_guard.py
+++ b/tests/hermes_cli/test_update_local_work_guard.py
@@ -1,0 +1,398 @@
+"""No-destroy preflight for ``hermes update``.
+
+A fetch may refresh remote refs, but local committed or uncommitted source work
+must stop the update before lockfile cleanup, stash, checkout, pull, or reset.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import main as cli_main
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-c", "user.email=test@example.com", "-c", "user.name=Test", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _checkout_with_remote(tmp_path: Path, *, single_branch: bool = False) -> Path:
+    remote = tmp_path / "remote.git"
+    seed = tmp_path / "seed"
+    checkout = tmp_path / "checkout"
+
+    _git(tmp_path, "init", "--bare", str(remote))
+    _git(tmp_path, "init", "-b", "main", str(seed))
+    (seed / "tracked.txt").write_text("upstream\n")
+    (seed / "package-lock.json").write_text('{"lock":"upstream"}\n')
+    _git(seed, "add", "tracked.txt", "package-lock.json")
+    _git(seed, "commit", "-m", "initial")
+    _git(seed, "remote", "add", "origin", str(remote))
+    _git(seed, "push", "-u", "origin", "main")
+    clone_args = ["clone", "--branch", "main"]
+    if single_branch:
+        clone_args.append("--single-branch")
+    _git(tmp_path, *clone_args, str(remote), str(checkout))
+    return checkout
+
+
+def _update_args(*, yes: bool = False, gateway: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        backup=False,
+        branch=None,
+        force=False,
+        force_venv=False,
+        gateway=gateway,
+        yes=yes,
+    )
+
+
+@pytest.mark.parametrize(
+    ("yes", "gateway"),
+    [(False, False), (True, False), (False, True)],
+    ids=["interactive", "yes", "gateway"],
+)
+def test_uncommitted_work_stops_before_cleanup_stash_checkout_pull_or_reset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    yes: bool,
+    gateway: bool,
+) -> None:
+    checkout = _checkout_with_remote(tmp_path)
+    tracked = checkout / "tracked.txt"
+    tracked.write_text("local edit\n")
+    lockfile = checkout / "package-lock.json"
+    lockfile.write_text('{"lock":"local edit"}\n')
+    untracked = checkout / "notes.txt"
+    untracked.write_text("keep me\n")
+
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", checkout)
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: False)
+    monkeypatch.setattr(cli_main, "_run_pre_update_backup", lambda _args: None)
+    monkeypatch.setattr(cli_main, "_pause_windows_gateways_for_update", lambda: None)
+
+    with (
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        cli_main._cmd_update_impl(
+            _update_args(yes=yes, gateway=gateway), gateway_mode=gateway
+        )
+
+    assert excinfo.value.code == 2
+    assert tracked.read_text() == "local edit\n"
+    assert lockfile.read_text() == '{"lock":"local edit"}\n'
+    assert untracked.read_text() == "keep me\n"
+    assert _git(checkout, "status", "--porcelain").stdout
+    output = capsys.readouterr().out
+    assert "local work" in output.lower()
+    assert "update stopped" in output.lower()
+
+
+@pytest.mark.parametrize(
+    ("yes", "gateway"),
+    [(False, False), (True, False), (False, True)],
+    ids=["interactive", "yes", "gateway"],
+)
+def test_committed_work_stops_before_cleanup_stash_checkout_pull_or_reset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    yes: bool,
+    gateway: bool,
+) -> None:
+    checkout = _checkout_with_remote(tmp_path)
+    tracked = checkout / "tracked.txt"
+    tracked.write_text("local commit\n")
+    _git(checkout, "add", "tracked.txt")
+    _git(checkout, "commit", "-m", "local work")
+    local_head = _git(checkout, "rev-parse", "HEAD").stdout.strip()
+
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", checkout)
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: False)
+    monkeypatch.setattr(cli_main, "_run_pre_update_backup", lambda _args: None)
+    monkeypatch.setattr(cli_main, "_pause_windows_gateways_for_update", lambda: None)
+
+    with (
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        cli_main._cmd_update_impl(
+            _update_args(yes=yes, gateway=gateway), gateway_mode=gateway
+        )
+
+    assert excinfo.value.code == 2
+    assert _git(checkout, "rev-parse", "HEAD").stdout.strip() == local_head
+    assert tracked.read_text() == "local commit\n"
+    output = capsys.readouterr().out
+    assert "local work" in output.lower()
+    assert "update stopped" in output.lower()
+
+
+def test_pushed_commit_on_current_branch_is_not_treated_as_local(
+    tmp_path: Path,
+) -> None:
+    checkout = _checkout_with_remote(tmp_path)
+    _git(checkout, "checkout", "-b", "feature")
+    (checkout / "feature.txt").write_text("published\n")
+    _git(checkout, "add", "feature.txt")
+    _git(checkout, "commit", "-m", "published feature")
+    _git(checkout, "push", "-u", "origin", "feature")
+
+    current_branch = cli_main._guard_update_local_work(["git"], checkout, "main")
+
+    assert current_branch == "feature"
+
+
+def test_pushed_branch_is_refreshed_in_a_single_branch_clone(tmp_path: Path) -> None:
+    checkout = _checkout_with_remote(tmp_path, single_branch=True)
+    _git(checkout, "checkout", "-b", "feature")
+    (checkout / "feature.txt").write_text("published\n")
+    _git(checkout, "add", "feature.txt")
+    _git(checkout, "commit", "-m", "published feature")
+    _git(checkout, "push", "-u", "origin", "feature")
+
+    missing_ref = subprocess.run(
+        ["git", "rev-parse", "--verify", "origin/feature"],
+        cwd=checkout,
+        capture_output=True,
+        text=True,
+    )
+    assert missing_ref.returncode != 0
+
+    current_branch = cli_main._guard_update_local_work(["git"], checkout, "main")
+
+    assert current_branch == "feature"
+    assert _git(checkout, "rev-parse", "origin/feature").stdout.strip() == _git(
+        checkout, "rev-parse", "HEAD"
+    ).stdout.strip()
+
+
+def test_local_commit_on_target_branch_blocks_before_checkout(tmp_path: Path) -> None:
+    checkout = _checkout_with_remote(tmp_path)
+    _git(checkout, "checkout", "-b", "feature")
+    _git(checkout, "push", "-u", "origin", "feature")
+    (checkout / "feature.txt").write_text("local target commit\n")
+    _git(checkout, "add", "feature.txt")
+    _git(checkout, "commit", "-m", "local target work")
+    target_head = _git(checkout, "rev-parse", "HEAD").stdout.strip()
+    _git(checkout, "checkout", "main")
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main._guard_update_local_work(["git"], checkout, "feature")
+
+    assert excinfo.value.code == 2
+    assert _git(checkout, "branch", "--show-current").stdout.strip() == "main"
+    assert _git(checkout, "rev-parse", "feature").stdout.strip() == target_head
+
+
+def test_updater_recovery_markers_do_not_block_clean_checkout(tmp_path: Path) -> None:
+    checkout = _checkout_with_remote(tmp_path)
+    (checkout / ".update-incomplete").write_text("started=1\n")
+    (checkout / ".lazy-refresh-incomplete").write_text("started=1\n")
+
+    current_branch = cli_main._guard_update_local_work(["git"], checkout, "main")
+
+    assert current_branch == "main"
+
+
+def test_status_probe_failure_stops_before_any_followup_git_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
+        calls.append(cmd)
+        if cmd[1:3] == ["status", "--porcelain"]:
+            return SimpleNamespace(returncode=128, stdout="", stderr="broken repo")
+        raise AssertionError(f"unexpected command after failed status probe: {cmd}")
+
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main._guard_update_local_work(["git"], tmp_path, "main")
+
+    assert excinfo.value.code == 2
+    assert len(calls) == 1
+    assert calls[0][1:3] == ["status", "--porcelain"]
+    assert "could not verify local work" in capsys.readouterr().out.lower()
+
+
+def test_guard_refreshes_current_branch_before_trusting_remote_ref(tmp_path: Path) -> None:
+    checkout = _checkout_with_remote(tmp_path)
+    _git(checkout, "checkout", "-b", "feature")
+    (checkout / "feature.txt").write_text("published\n")
+    _git(checkout, "add", "feature.txt")
+    _git(checkout, "commit", "-m", "published feature")
+    _git(checkout, "push", "-u", "origin", "feature")
+    stale_remote_head = _git(checkout, "rev-parse", "origin/feature").stdout.strip()
+
+    replacement = tmp_path / "replacement"
+    _git(tmp_path, "clone", "--branch", "feature", str(tmp_path / "remote.git"), str(replacement))
+    _git(replacement, "checkout", "--orphan", "replacement")
+    _git(replacement, "rm", "-rf", ".")
+    (replacement / "replacement.txt").write_text("rewritten\n")
+    _git(replacement, "add", "replacement.txt")
+    _git(replacement, "commit", "-m", "rewrite feature")
+    _git(replacement, "push", "--force", "origin", "HEAD:feature")
+
+    assert _git(checkout, "rev-parse", "origin/feature").stdout.strip() == stale_remote_head
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main._guard_update_local_work(["git"], checkout, "main")
+
+    assert excinfo.value.code == 2
+    assert _git(checkout, "rev-parse", "origin/feature").stdout.strip() != stale_remote_head
+
+
+def test_work_created_after_first_preflight_stops_before_cleanup_stash_or_pull(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkout = _checkout_with_remote(tmp_path)
+    seed = tmp_path / "seed"
+    (seed / "tracked.txt").write_text("upstream update\n")
+    _git(seed, "add", "tracked.txt")
+    _git(seed, "commit", "-m", "upstream update")
+    _git(seed, "push", "origin", "main")
+
+    lockfile = checkout / "package-lock.json"
+    real_guard = cli_main._guard_update_local_work
+    guard_calls = 0
+
+    def guard_then_create_work(git_cmd, repo_root, branch):
+        nonlocal guard_calls
+        guard_calls += 1
+        current_branch = real_guard(git_cmd, repo_root, branch)
+        if guard_calls == 1:
+            lockfile.write_text('{"lock":"late local edit"}\n')
+        return current_branch
+
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", checkout)
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: False)
+    monkeypatch.setattr(cli_main, "_run_pre_update_backup", lambda _args: None)
+    monkeypatch.setattr(cli_main, "_pause_windows_gateways_for_update", lambda: None)
+    monkeypatch.setattr(cli_main, "_guard_update_local_work", guard_then_create_work)
+
+    with (
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        cli_main._cmd_update_impl(_update_args(), gateway_mode=False)
+
+    assert excinfo.value.code == 2
+    assert guard_calls >= 2
+    assert lockfile.read_text() == '{"lock":"late local edit"}\n'
+    assert _git(checkout, "rev-parse", "HEAD").stdout.strip() != _git(
+        checkout, "rev-parse", "origin/main"
+    ).stdout.strip()
+
+
+def test_noop_update_restores_original_detached_head(
+    tmp_path: Path, monkeypatch
+) -> None:
+    checkout = _checkout_with_remote(tmp_path)
+    original_head = _git(checkout, "rev-parse", "HEAD").stdout.strip()
+    _git(checkout, "checkout", "--detach", original_head)
+
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", checkout)
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: False)
+    monkeypatch.setattr(cli_main, "_is_fork", lambda origin_url: False)
+    monkeypatch.setattr(cli_main, "_run_pre_update_backup", lambda args: None)
+    monkeypatch.setattr(cli_main, "_pause_windows_gateways_for_update", lambda: None)
+    monkeypatch.setattr(cli_main, "_resume_windows_gateways_after_update", lambda *a: None)
+    monkeypatch.setattr(cli_main, "_invalidate_update_cache", lambda: None)
+    monkeypatch.setattr(cli_main, "_venv_core_imports_healthy", lambda: (True, ""))
+    monkeypatch.setattr(
+        "hermes_cli.managed_uv.update_managed_uv", lambda **kwargs: None
+    )
+    monkeypatch.setattr("hermes_cli.managed_uv.ensure_uv", lambda **kwargs: None)
+
+    cli_main._cmd_update_impl(_update_args(), gateway_mode=False)
+
+    assert _git(checkout, "branch", "--show-current").stdout.strip() == ""
+    assert _git(checkout, "rev-parse", "HEAD").stdout.strip() == original_head
+
+
+def test_syntax_rollback_uses_reset_keep_on_a_clean_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkout = _checkout_with_remote(tmp_path)
+    old_head = _git(checkout, "rev-parse", "HEAD").stdout.strip()
+    seed = tmp_path / "seed"
+    (seed / "tracked.txt").write_text("upstream update\n")
+    _git(seed, "add", "tracked.txt")
+    _git(seed, "commit", "-m", "upstream update")
+    _git(seed, "push", "origin", "main")
+
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", checkout)
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: False)
+    monkeypatch.setattr(cli_main, "_run_pre_update_backup", lambda _args: None)
+    monkeypatch.setattr(cli_main, "_pause_windows_gateways_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli_main,
+        "_validate_critical_files_syntax",
+        lambda _root: (False, "hermes_cli/main.py", "bad syntax"),
+    )
+    real_run = subprocess.run
+    calls: list[list[str]] = []
+
+    def recording_run(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(cli_main.subprocess, "run", recording_run)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main._cmd_update_impl(_update_args(), gateway_mode=False)
+
+    assert excinfo.value.code == 1
+    assert _git(checkout, "rev-parse", "HEAD").stdout.strip() == old_head
+    assert any(command[1:3] == ["reset", "--keep"] for command in calls)
+    assert not any("--hard" in command for command in calls)
+
+
+def test_syntax_rollback_refuses_to_reset_late_local_work(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkout = _checkout_with_remote(tmp_path)
+    seed = tmp_path / "seed"
+    (seed / "tracked.txt").write_text("upstream update\n")
+    _git(seed, "add", "tracked.txt")
+    _git(seed, "commit", "-m", "upstream update")
+    _git(seed, "push", "origin", "main")
+    remote_head = _git(seed, "rev-parse", "HEAD").stdout.strip()
+    lockfile = checkout / "package-lock.json"
+
+    def fail_syntax_after_local_edit(_root):
+        lockfile.write_text('{"lock":"late local edit"}\n')
+        return False, "hermes_cli/main.py", "bad syntax"
+
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", checkout)
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: False)
+    monkeypatch.setattr(cli_main, "_run_pre_update_backup", lambda _args: None)
+    monkeypatch.setattr(cli_main, "_pause_windows_gateways_for_update", lambda: None)
+    monkeypatch.setattr(cli_main, "_validate_critical_files_syntax", fail_syntax_after_local_edit)
+    real_run = subprocess.run
+    calls: list[list[str]] = []
+
+    def recording_run(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(cli_main.subprocess, "run", recording_run)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main._cmd_update_impl(_update_args(), gateway_mode=False)
+
+    assert excinfo.value.code == 2
+    assert lockfile.read_text() == '{"lock":"late local edit"}\n'
+    assert _git(checkout, "rev-parse", "HEAD").stdout.strip() == remote_head
+    assert not any("reset" in command for command in calls)

--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -4,8 +4,6 @@ Covers:
   1. argparse parses the flag
   2. Config-migration prompt is auto-answered (no input() call) and migrate_config
      runs with interactive=False so API-key prompts are skipped
-  3. Autostash restore prompt is auto-answered (prompt_for_restore == False, no
-     input() call) and the stash is applied automatically
 """
 
 import subprocess
@@ -15,9 +13,7 @@ from unittest.mock import patch
 from hermes_cli.main import cmd_update
 
 
-def _make_run_side_effect(
-    branch="main", verify_ok=True, commit_count="1", dirty=False
-):
+def _make_run_side_effect(branch="main", verify_ok=True, commit_count="1"):
     """Minimal subprocess.run side_effect for the update flow."""
 
     def side_effect(cmd, **kwargs):
@@ -33,14 +29,8 @@ def _make_run_side_effect(
             return subprocess.CompletedProcess(
                 cmd, 0, stdout=f"{commit_count}\n", stderr=""
             )
-        # `git status --porcelain` for dirty-tree detection during autostash.
+        # Clean local-work guard result.
         if "status" in joined and "--porcelain" in joined:
-            out = " M hermes_cli/main.py\n" if dirty else ""
-            return subprocess.CompletedProcess(cmd, 0, stdout=out, stderr="")
-        # `git stash list` — return a stash ref when dirty (so _stash_local_changes
-        # gets something to return). _stash_local_changes_if_needed is what we
-        # actually patch in tests that exercise restore, so this is a catch-all.
-        if "stash" in joined and "list" in joined:
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
@@ -130,8 +120,3 @@ class TestUpdateYesConfigMigration:
             assert mock_input.called
             prompts = [c.args[0] if c.args else "" for c in mock_input.call_args_list]
             assert any("configure them now" in p for p in prompts)
-
-
-class TestUpdateYesStashRestore:
-    """--yes auto-restores the pre-update autostash without prompting."""
-

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -25,11 +25,12 @@ This pulls the latest code from `main`, updates dependencies, and prompts you to
 When you run `hermes update`, the following steps occur:
 
 1. **Pre-update snapshot** — a lightweight state snapshot is saved by default (covers pairing data, cron jobs, `config.yaml`, `.env`, `auth.json`, and other state files that get modified at runtime; individual files over 1 GiB are skipped so a large sessions DB never slows the update down). Controlled by `updates.pre_update_backup` (`quick` by default, `full` for a zip of all of `HERMES_HOME`, `off` to disable). Recoverable via the snapshot restore flow described under [Snapshots and rollback](../user-guide/checkpoints-and-rollback.md).
-2. **Git pull** — pulls the latest code from the `main` branch and updates submodules
-3. **Post-pull syntax validation + auto-rollback** — after the pull, Hermes compiles the eight critical files every `hermes` invocation imports at startup. If any fails to parse (e.g. an orphan merge-conflict marker, an accidentally truncated file), Hermes runs `git reset --hard <pre-pull-sha>` to roll the install back so your shell stays bootable. Re-run `hermes update` once the upstream fix lands.
-4. **Dependency install** — runs `uv pip install -e ".[all]"` to pick up new or changed dependencies
-5. **Config migration** — detects new config options added since your version and prompts you to set them
-6. **Gateway auto-restart** — running gateways are refreshed after the update completes so the new code takes effect immediately. Service-managed gateways (systemd on Linux, launchd on macOS) are restarted through the service manager. Manual gateways are relaunched automatically when Hermes can map the running PID back to a profile.
+2. **Local-work preflight (Git installs)** — refreshes the target and current branch refs, then stops if the checkout has uncommitted files or if either the current branch or requested target branch has commits absent from its matching `origin/` branch. This happens before branch checkout, pull, or reset; Hermes does not clean or auto-stash source changes.
+3. **Git pull** — pulls the latest code from the `main` branch and updates submodules
+4. **Post-pull syntax validation + safe rollback** — after the pull, Hermes compiles the eight critical files every `hermes` invocation imports at startup. If any fails to parse (e.g. an orphan merge-conflict marker, an accidentally truncated file), Hermes rechecks for local work and uses `git reset --keep <pre-pull-sha>` so Git refuses to overwrite a late edit. Re-run `hermes update` once the upstream fix lands.
+5. **Dependency install** — runs `uv pip install -e ".[all]"` to pick up new or changed dependencies
+6. **Config migration** — detects new config options added since your version and prompts you to set them
+7. **Gateway auto-restart** — running gateways are refreshed after the update completes so the new code takes effect immediately. Service-managed gateways (systemd on Linux, launchd on macOS) are restarted through the service manager. Manual gateways are relaunched automatically when Hermes can map the running PID back to a profile.
 
 ### Updating against a non-default branch: `--branch`
 
@@ -40,25 +41,19 @@ hermes update --branch release-candidate
 hermes update --check --branch experimental   # preview behindness only
 ```
 
-If your local checkout is on a different branch, Hermes auto-stashes any uncommitted work, switches HEAD to the target branch, and then pulls. Branches that don't exist locally are auto-tracked from `origin/<name>` (`git checkout -B <name> origin/<name>`). Branches that don't exist anywhere fail cleanly — your stashed changes are restored before exit so you're never stranded in a weird state. The `main`-only fork-upstream sync logic is automatically skipped on non-`main` branches.
+If your local checkout is on a different branch, Hermes first verifies that it has no uncommitted files and that neither the current branch nor the requested target branch has commits absent from its matching `origin/` branch. Local work stops the update with exit code 2. A clean checkout can switch to the target branch and pull. Branches that don't exist locally are created as tracking branches from `origin/<name>` (`git checkout --track -b <name> origin/<name>`). The `main`-only fork-upstream sync logic is automatically skipped on non-`main` branches.
 
-### Local changes on non-interactive updates
+### Local source work
 
-When you run `hermes update` in a terminal, Hermes stashes any uncommitted source-tree changes, pulls, then **asks** whether to restore them — exactly as it always has. Nothing changes for interactive updates.
+For Git installs, terminal, `--yes`, desktop, and gateway-triggered updates use the same guard. After refreshing the target and current remote branch refs, Hermes checks for both forms of local work:
 
-When the update runs **without a terminal** — from the desktop/chat app's "Update" button or a gateway-triggered update — there's no prompt to answer. The `updates.non_interactive_local_changes` setting decides what happens to your stashed changes:
+- dirty tracked files or untracked files;
+- commits in `HEAD` that are absent from the current branch's matching `origin/` branch (or the update target when HEAD is detached);
+- commits on the requested local target branch that are absent from `origin/<target>`.
 
-```yaml
-# ~/.hermes/config.yaml
-updates:
-  non_interactive_local_changes: stash   # default: keep + auto-restore
-  # non_interactive_local_changes: discard  # throw local source edits away
-```
+Either condition stops the update before branch checkout, pull, or reset. Hermes does not clean or auto-stash source changes. Review the paths with `git status --short` and use the exact `git log` command Hermes prints for local commits. Preserve or move that work, then update from a clean checkout.
 
-- `stash` (default) — auto-stash, pull, then auto-restore your changes on top of the updated code. Nothing is lost; if a restore hits conflicts they're preserved in a git stash for manual recovery.
-- `discard` — auto-stash and drop the stash after the pull, so the update always lands on a clean tree. Use this only on machines where you never intend to keep local edits to the Hermes source. It stash-drops (not `git reset --hard` + `git clean -fd`), so ignored paths like `node_modules`, `venv`, and build outputs are never touched.
-
-In the desktop app this is **Settings → Advanced → In-App Update Local Changes**.
+Windows ZIP installs do not have Git history and use the separate ZIP replacement updater, so this Git preflight does not apply to them.
 
 ### Preview-only: `hermes update --check`
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1622,7 +1622,7 @@ hermes update [--gateway] [--check] [--no-backup] [--backup] [--yes]
 
 Pulls the latest `hermes-agent` code and reinstalls dependencies in the managed venv, then re-runs the post-install hooks (MCP servers, skills sync, completion install). Safe to run on a live install. Use `--check` to see whether your checkout is behind `origin/main` without installing.
 
-`hermes update` pulls the configured update branch (default: `main`). If your checkout is on another branch, Hermes may check out the update branch before pulling. Commit branch work before updating when you want to keep it outside the update autostash flow.
+`hermes update` pulls the configured update branch (default: `main`). If your checkout is on another branch, Hermes may check out the update branch before pulling. The checkout must be clean, and neither the current branch nor the requested target branch may contain commits absent from its matching `origin/` branch.
 
 | Option | Description |
 |--------|-------------|
@@ -1630,16 +1630,16 @@ Pulls the latest `hermes-agent` code and reinstalls dependencies in the managed 
 | `--check` | Check whether an update is available without pulling, installing dependencies, or restarting anything. |
 | `--no-backup` | Skip all pre-update backups for this run (both the quick state snapshot and the full zip), regardless of `updates.pre_update_backup`. |
 | `--backup` | Force a **full** pre-update backup for this run: the quick state snapshot plus a complete zip of `HERMES_HOME` (config, auth, sessions, skills, pairing data). The default mode is `quick` — a lightweight state snapshot only. Set the permanent mode via `updates.pre_update_backup: quick | full | off` in `config.yaml`. |
-| `--yes`, `-y` | Assume yes for interactive prompts such as config migration and stash restore. API-key entry is skipped; run `hermes config migrate` separately for those. |
+| `--yes`, `-y` | Assume yes for interactive prompts such as config migration. API-key entry is skipped; run `hermes config migrate` separately for those. |
 
 Additional behavior:
 
 - **Gateway restart.** After a successful update, Hermes attempts to restart all running gateway profiles automatically so they pick up the new code. Use `hermes gateway restart` when you want to restart a gateway without applying an update.
-- **Local source changes.** For git installs, dirty tracked files and untracked files are auto-stashed before branch checkout or pull (`git stash push --include-untracked`). Interactive terminal updates ask before restoring the stash. Non-interactive updates restore it by default; set `updates.non_interactive_local_changes: discard` only on managed installs where local source edits should be thrown away after a successful pull. If stash restore conflicts or the pull fails, the stash is left in place for manual recovery.
-- **npm lockfile churn.** Before stashing or switching branches, Hermes makes a best-effort cleanup of tracked `package-lock.json` diffs produced by npm install/build steps. Commit or manually stash intentional lockfile edits before running `hermes update`.
+- **Local source work (Git installs).** After refreshing the target and current branch refs, Hermes refuses the update when the checkout has dirty tracked files, untracked files, or commits on either the current branch or requested target branch that are absent from its matching `origin/` branch. Detached HEAD compares against the update target. It exits before branch checkout, pull, or reset; Hermes does not clean or auto-stash source changes. Terminal, `--yes`, desktop, and gateway `/update` use the same Git guard. Windows ZIP installs use a separate ZIP replacement path and are not covered by this Git preflight.
+- **npm lockfile churn.** A modified `package-lock.json` is treated as local work and is not discarded automatically. Review or restore it yourself, then rerun the update from a clean checkout.
 - **Pairing data snapshot.** Even when `--backup` is off, `hermes update` takes a lightweight snapshot of `~/.hermes/pairing/` and the Feishu comment rules before `git pull`. You can roll it back with `hermes backup restore --state pre-update` if a pull rewrites a file you were editing.
 - **Legacy `hermes.service` warning.** If Hermes detects a pre-rename `hermes.service` systemd unit (instead of the current `hermes-gateway.service`), it prints a one-time migration hint so you can avoid flap-loop issues.
-- **Exit codes.** `0` on success, `1` on pull/install/post-install errors, `2` on unexpected working-tree changes that block `git pull`.
+- **Exit codes.** `0` on success, `1` on pull/install/post-install errors, `2` when local work or an unverifiable Git state blocks the update.
 
 ## Maintenance commands
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -103,14 +103,11 @@ Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERM
 updates:
   pre_update_backup: quick       # quick (state snapshot, default) | full (snapshot + HERMES_HOME zip) | off
   backup_keep: 5                 # Keep this many full pre-update backup zips
-  non_interactive_local_changes: stash  # stash | discard
 ```
 
 `pre_update_backup` is the single pre-update safety knob: `quick` (default) snapshots critical state files (pairing data, cron jobs, config, auth; files over 1 GiB are skipped) into `state-snapshots/`; `full` additionally zips all of `HERMES_HOME` into `backups/` and can add minutes on large homes; `off` disables both. Legacy booleans are honored (`true` → `full`, `false` → `off`).
 
-For git installs, Hermes auto-stashes dirty tracked files and untracked files before checking out the update branch or pulling. Interactive terminal updates prompt before restoring that stash. Non-interactive updates (desktop/chat app, gateway, or `--yes`) use `updates.non_interactive_local_changes`: `stash` restores local source edits after a successful pull, while `discard` drops the update-created stash after a successful pull. Use `discard` only on managed installs where local source edits are never meant to persist.
-
-Before that stash step, Hermes also restores tracked `package-lock.json` diffs left by npm install/build churn. Commit or manually stash intentional lockfile edits before updating.
+For Git installs, Hermes refuses to update when the source checkout contains uncommitted files or when either the current branch or requested target branch has commits absent from its matching `origin/` branch. It does not clean lockfiles, auto-stash edits, or discard local source work. Preserve or move that work yourself, then rerun the update from a clean checkout.
 
 ## Terminal Backend Configuration
 


### PR DESCRIPTION
## What does this PR do?

Makes the Git-based `hermes update` path fail closed when the checkout contains local source work.

Before any branch checkout, pull, or syntax rollback, the updater now refuses:

- dirty tracked or untracked files;
- commits on the current branch that are absent from its matching `origin/` branch;
- commits on the requested target branch that are absent from `origin/<target>`.

This is intentionally narrower than the open rebase and immutable-ref proposals: it does not try to move, replay, stash, or discard local work. It stops and tells the user how to inspect it. Missing local target branches are created with `checkout --track -b`; existing branches are never reset or force-recreated.

Windows ZIP installs do not have Git history and remain a separate replacement path, which the docs now state explicitly.

## Related Issue

Related: #63578, #68244

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a fail-closed local-work preflight in `hermes_cli/main.py` for the current and requested target branches.
- Run the guard before target checkout, tracking-branch creation, origin/upstream pulls, no-op branch restoration, and `reset --keep` syntax rollback.
- Replace the destructive `checkout -B` fallback with `checkout --track -b` and reject invalid branch names.
- Restore the original detached HEAD after a no-op update check.
- Remove update auto-stash/discard helpers, the obsolete `updates.non_interactive_local_changes` setting, and its desktop/config surface.
- Treat modified lockfiles as local work instead of cleaning them automatically.
- Update CLI, gateway, desktop, configuration, and documentation text.
- Add real temporary-repository regression tests for committed, uncommitted, target-branch, single-branch-clone, stale-ref, late-work, detached-HEAD, and rollback cases.

## How to Test

1. Run the focused update/config/gateway/install suite:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_update_*.py tests/hermes_cli/test_cmd_update*.py tests/hermes_cli/test_config*.py tests/gateway/test_update_streaming.py tests/test_install_diverged_update.py tests/test_install_lockfile_churn.py -q
   ```

   Expected: `509 passed, 0 failed`.

2. Run Python checks on changed files:

   ```bash
   python3 -m py_compile <changed Python files>
   ruff check <changed Python files>
   git diff origin/main...HEAD --check
   ```

3. In a Git install with a local commit or dirty file, run `hermes update`; expect exit code 2 before checkout, pull, stash, clean, or reset.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused affected suite passed 509 tests; full suite left to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows Git routes use the same guard; ZIP installs are documented separately
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
509 tests passed, 0 failed
Python compile: passed
Ruff: passed
TypeScript syntax: passed (6 changed files)
git diff --check: passed
Independent code review: PASS from two reviewer model families
```
