### PR TITLE
fix: defer toolset validation to after plugin discovery (#71650)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6034,6 +6034,26 @@ def _persist_migration(config: Dict[str, Any]) -> None:
     save_config(config)
 
 
+# ── Deferred toolset warnings ──
+# When migrate_config() runs before plugin discovery, plugin-registered
+# toolsets trigger false-positive "unknown toolset" warnings.  Those warnings
+# are stored here so the startup path can re-emit (or suppress) them after
+# discover_plugins() completes.  See #71650.
+_deferred_toolset_warnings: List[str] = []
+
+
+def get_deferred_toolset_warnings() -> List[str]:
+    """Return toolset warnings deferred from migrate_config().
+
+    After calling this, the internal buffer is cleared so warnings are only
+    emitted once.
+    """
+    global _deferred_toolset_warnings
+    warnings = list(_deferred_toolset_warnings)
+    _deferred_toolset_warnings = []
+    return warnings
+
+
 def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, Any]:
     """
     Migrate config to latest version, prompting for new required fields.
@@ -6645,6 +6665,12 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
     # platform_toolsets silently disables the affected tools — resolve_toolset()
     # returns [] for an unknown name, so the agent quietly loses tools with no
     # error or warning. Surface it loudly instead. See #38798.
+    #
+    # However, plugin-registered toolsets are only known AFTER discover_plugins()
+    # runs. When migrate_config() fires during early startup (before plugins
+    # load), any plugin-registered toolset triggers a false-positive "unknown
+    # toolset" warning.  Defer warnings to a module-level list so the caller
+    # can re-emit them after plugin discovery.  (#71650)
     try:
         from toolsets import validate_toolset
         from hermes_cli.toolset_validation import validate_platform_toolsets
@@ -6652,10 +6678,30 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         ts_warnings = validate_platform_toolsets(
             read_raw_config().get("platform_toolsets"), validate_toolset
         )
-        for w in ts_warnings:
-            results["warnings"].append(w)
-            if not quiet:
-                print(f"  ⚠ {w}")
+        if ts_warnings:
+            # Check whether the tool registry already has plugin toolsets
+            # (i.e. plugins were already discovered).  If so, these warnings
+            # are real and should be emitted immediately.
+            _has_plugin_toolsets = False
+            try:
+                from toolsets import _get_plugin_toolset_names
+                _has_plugin_toolsets = bool(_get_plugin_toolset_names())
+            except Exception:
+                pass
+
+            if _has_plugin_toolsets:
+                # Plugins already loaded — emit inline (original behavior)
+                for w in ts_warnings:
+                    results["warnings"].append(w)
+                    if not quiet:
+                        print(f"  ⚠ {w}")
+            else:
+                # Plugins not yet loaded — defer for post-discovery check
+                _deferred_toolset_warnings.extend(ts_warnings)
+                logger.debug(
+                    "Deferring %d toolset warning(s) until after plugin "
+                    "discovery: %s", len(ts_warnings), ts_warnings
+                )
     except Exception as _ts_val_err:
         # best-effort; never block migration on validation
         logger.debug("platform_toolsets validation skipped: %s", _ts_val_err)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14643,6 +14643,28 @@ def _prepare_agent_startup(args) -> None:
             "plugin discovery failed at CLI startup",
             exc_info=True,
         )
+
+    # ── Emit deferred toolset warnings after plugin discovery ──
+    # migrate_config() fires before plugins load, so plugin-registered
+    # toolsets trigger false-positive "unknown" warnings.  Now that
+    # discover_plugins() has populated the registry, re-validate and
+    # emit only the truly invalid ones.  (#71650)
+    try:
+        from hermes_cli.config import get_deferred_toolset_warnings
+        from hermes_cli.toolset_validation import validate_platform_toolsets
+        from toolsets import validate_toolset
+        from hermes_cli.config import read_raw_config
+
+        # Re-run validation with the now-populated plugin registry
+        fresh_warnings = validate_platform_toolsets(
+            read_raw_config().get("platform_toolsets"), validate_toolset
+        )
+        for w in fresh_warnings:
+            print(f"  ⚠ {w}")
+        # Clear the deferred buffer (we re-validated above)
+        get_deferred_toolset_warnings()
+    except Exception:
+        logger.debug("post-discovery toolset validation skipped", exc_info=True)
     _run_inline_mcp_discovery = True
     if _is_tui_chat_launch(args):
         # The TUI launcher hands off to a dedicated startup path that already


### PR DESCRIPTION
## Summary

`validate_platform_toolsets()` runs inside `migrate_config()` during early startup, before `discover_plugins()` populates the tool registry. Plugin-registered toolsets (e.g. `beads` from a third-party plugin) always trigger a false-positive "unknown toolset" warning on every startup.

Fixes #71650

## Root Cause

The startup sequence is:
1. `migrate_config()` → calls `validate_platform_toolsets()` → checks `validate_toolset()` → `_get_plugin_toolset_names()` returns empty set (plugins not loaded yet)
2. `discover_plugins()` → plugins register their toolsets in the registry

Any plugin-registered toolset listed in `platform_toolsets` config triggers the warning at step 1 because the registry is empty at that point.

## Fix

- **`hermes_cli/config.py`**: When `migrate_config()` detects that the tool registry has no plugin toolsets yet, store warnings in a module-level deferred buffer (`_deferred_toolset_warnings`) instead of printing them. When plugins are already loaded (e.g. standalone `hermes config migrate`), emit inline as before.
- **`hermes_cli/main.py`**: In `_prepare_agent_startup()`, after `discover_plugins()` completes, re-validate `platform_toolsets` with the now-populated plugin registry and emit only truly invalid toolset names.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Plugin toolset in config, startup | ⚠ false-positive warning | No warning (deferred, then re-validated clean) |
| Invalid toolset in config, startup | ⚠ warning (at migration time) | ⚠ warning (after plugin discovery) |
| `hermes config migrate` (plugins loaded) | ⚠ warning if invalid | Same (inline path, plugins already loaded) |

## Test Plan

- [x] 13 existing `test_toolset_validation.py` tests pass
- [x] Syntax check passes on both modified files
- [ ] Manual test: add a plugin toolset to `platform_toolsets` config, verify no false-positive warning on startup