### PR TITLE
feat(dashboard): expose real MCP/channel/key last-used timestamps

### DIFF
--- a/hermes_cli/context_usage.py
+++ b/hermes_cli/context_usage.py
@@ -1,0 +1,224 @@
+"""Best-effort "last used" timestamps for the Context dashboard/mobile view.
+
+Derives real usage recency for MCP servers, messaging channels, and API keys
+from ``state.db`` — never invents a timestamp. Everything here is read-only
+(a ``mode=ro`` SQLite URI via the tracked connection helper) and bounded (a
+row-count ``LIMIT`` on the message scan) so it stays cheap enough for mobile
+pull-to-refresh even against a large, long-lived database.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from tools.mcp_tool import (
+    MCP_TOOL_NAME_PREFIX,
+    _MCP_NAME_DELIM,
+    sanitize_mcp_name_component,
+)
+
+DEFAULT_LOOKBACK_MESSAGES = 50_000
+
+
+def _split_mcp_server(tool_name: str) -> Optional[str]:
+    """Return the *sanitized* server component from ``mcp__<server>__<tool>``.
+
+    Registration stores sanitized names (hyphens → underscores, see
+    :func:`tools.mcp_tool.sanitize_mcp_name_component`), so the value returned
+    here is the sanitized form, not the configured config key.
+    """
+    if not tool_name.startswith(MCP_TOOL_NAME_PREFIX):
+        return None
+    remainder = tool_name[len(MCP_TOOL_NAME_PREFIX) :]
+    server, sep, _tool = remainder.partition(_MCP_NAME_DELIM)
+    if not sep or not server:
+        return None
+    return server
+
+
+def _configured_name_lookup(
+    mcp_server_names: Optional[Iterable[str]],
+) -> Dict[str, str]:
+    """Map sanitized MCP server name → configured name.
+
+    Config may use ``github-enterprise`` while tool_calls persist
+    ``mcp__github_enterprise__…``. When two configured names sanitize to the
+    same key, prefer an already-sanitized identity match, else first-seen.
+    """
+    if not mcp_server_names:
+        return {}
+    out: Dict[str, str] = {}
+    for name in mcp_server_names:
+        if not isinstance(name, str) or not name:
+            continue
+        safe = sanitize_mcp_name_component(name)
+        if not safe:
+            continue
+        existing = out.get(safe)
+        if existing is None or (existing != safe and name == safe):
+            out[safe] = name
+    return out
+
+
+def _iter_tool_call_names(tool_calls_json: str) -> Iterable[str]:
+    """Yield each function name in a stored ``tool_calls`` JSON blob."""
+    try:
+        calls = json.loads(tool_calls_json)
+    except (TypeError, ValueError):
+        return
+    if not isinstance(calls, list):
+        return
+    for call in calls:
+        if not isinstance(call, dict):
+            continue
+        function = call.get("function")
+        name = function.get("name") if isinstance(function, dict) else call.get("name")
+        if isinstance(name, str) and name:
+            yield name
+
+
+def _tool_to_unique_env_key() -> Dict[str, str]:
+    """Map tool name -> env key, for tools backed by exactly one key.
+
+    Built from ``OPTIONAL_ENV_VARS``' existing ``tools`` lists so it tracks
+    that catalog automatically. Many tools (``web_search``, ``browser_navigate``,
+    ...) are served by whichever of several configured providers wins at
+    runtime — attributing those to any single key would be a guess, so they
+    are excluded here rather than guessed wrong.
+    """
+    from hermes_cli.config import OPTIONAL_ENV_VARS
+
+    tool_keys: Dict[str, list] = {}
+    for key, info in OPTIONAL_ENV_VARS.items():
+        for tool_name in info.get("tools") or ():
+            tool_keys.setdefault(tool_name, []).append(key)
+    return {tool: keys[0] for tool, keys in tool_keys.items() if len(keys) == 1}
+
+
+def _connect_state_db_ro(db_path: Path) -> sqlite3.Connection:
+    """Open ``state.db`` read-only through the tracked-connection guard.
+
+    Matches :class:`hermes_state.SessionDB` read-only attaches so concurrent
+    byte-probes cannot cancel POSIX advisory locks held by other state.db
+    connections in this process.
+    """
+    from hermes_cli.sqlite_safe_read import connect_tracked
+
+    return connect_tracked(
+        f"file:{db_path}?mode=ro",
+        tracking_path=db_path,
+        uri=True,
+        timeout=1.0,
+        isolation_level=None,
+    )
+
+
+def compute_context_last_used(
+    *,
+    home: Optional[Path] = None,
+    lookback_messages: int = DEFAULT_LOOKBACK_MESSAGES,
+    mcp_server_names: Optional[Iterable[str]] = None,
+) -> Dict[str, Any]:
+    """Compute real last-used timestamps from ``state.db``.
+
+    ``mcp_server_names``, when given, lets the message scan stop early once
+    every configured server already has a hit, and remaps sanitized tool-call
+    server components back to the configured names used in API responses
+    (e.g. ``github_enterprise`` → ``github-enterprise``).
+
+    Returns:
+        {
+          "mcp": {"<server_name>": <unix_ts>, ...},
+          "channels": {"<platform_id>": <unix_ts>, ...},
+          "keys": {"<ENV_VAR>": <unix_ts>, ...},
+          "computed_at": <unix_ts>,
+        }
+    """
+    from hermes_constants import get_hermes_home
+
+    resolved_home = Path(home) if home is not None else get_hermes_home()
+    db_path = resolved_home / "state.db"
+    result: Dict[str, Any] = {
+        "mcp": {},
+        "channels": {},
+        "keys": {},
+        "computed_at": time.time(),
+    }
+    if not db_path.exists():
+        return result
+
+    mcp_last: Dict[str, float] = {}
+    tool_last: Dict[str, float] = {}
+    channels: Dict[str, float] = {}
+    sanitized_to_configured = _configured_name_lookup(mcp_server_names)
+    # Early-exit tracks sanitized keys (what tool_calls actually store).
+    pending_servers = (
+        set(sanitized_to_configured.keys()) if sanitized_to_configured else None
+    )
+
+    conn = None
+    try:
+        conn = _connect_state_db_ro(db_path)
+        conn.row_factory = sqlite3.Row
+
+        # The inner LIMIT bounds rows actually scanned (not rows matched) to
+        # `lookback_messages`, walking newest-first via the rowid/PK order so
+        # a cold multi-GB history never triggers a full table scan.
+        cursor = conn.execute(
+            """
+            SELECT tool_calls, timestamp FROM (
+                SELECT tool_calls, timestamp, id FROM messages
+                ORDER BY id DESC
+                LIMIT ?
+            )
+            WHERE tool_calls IS NOT NULL
+            """,
+            (lookback_messages,),
+        )
+        for row in cursor:
+            ts = row["timestamp"]
+            if ts is None:
+                continue
+            for name in _iter_tool_call_names(row["tool_calls"]):
+                server = _split_mcp_server(name)
+                if server is not None:
+                    display = sanitized_to_configured.get(server, server)
+                    if ts > mcp_last.get(display, 0.0):
+                        mcp_last[display] = ts
+                    if pending_servers is not None:
+                        pending_servers.discard(server)
+                elif ts > tool_last.get(name, 0.0):
+                    tool_last[name] = ts
+            if pending_servers is not None and not pending_servers:
+                # Every configured MCP server already has a newest-first hit;
+                # older messages can only add earlier (non-newest) timestamps
+                # for MCP, so there's nothing left worth the extra scan.
+                break
+
+        for row in conn.execute(
+            "SELECT source, MAX(COALESCE(ended_at, started_at)) AS ts "
+            "FROM sessions GROUP BY source"
+        ):
+            if row["source"] and row["ts"] is not None:
+                channels[row["source"]] = row["ts"]
+    finally:
+        if conn is not None:
+            conn.close()
+
+    keys: Dict[str, float] = {}
+    for tool_name, env_key in _tool_to_unique_env_key().items():
+        ts = tool_last.get(tool_name)
+        if ts is not None:
+            # Keep the newest timestamp if several unique tools share one key.
+            prev = keys.get(env_key)
+            if prev is None or ts > prev:
+                keys[env_key] = ts
+
+    result["mcp"] = mcp_last
+    result["channels"] = channels
+    result["keys"] = keys
+    return result

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -57,15 +57,42 @@ _MAX_PENDING_MCP_OAUTH_FLOWS = LateState("_MAX_PENDING_MCP_OAUTH_FLOWS")
 
 @router.get("/api/mcp/servers")
 async def list_mcp_servers(profile: Optional[str] = None):
+    from hermes_cli.context_usage import compute_context_last_used
     from hermes_cli.mcp_config import _get_mcp_servers
+    from hermes_constants import get_hermes_home
 
-    with _profile_scope(profile):
+    with _profile_scope(profile) as scoped_dir:
         servers = _get_mcp_servers()
+        home = scoped_dir or get_hermes_home()
+    usage = compute_context_last_used(home=home, mcp_server_names=servers.keys())
+    mcp_last_used = usage["mcp"]
     return {
         "servers": [
-            _mcp_server_summary(name, cfg) for name, cfg in sorted(servers.items())
+            _mcp_server_summary(
+                name, cfg, last_used_at=mcp_last_used.get(name)
+            )
+            for name, cfg in sorted(servers.items())
         ]
     }
+
+
+@router.get("/api/context/last-used")
+async def get_context_last_used(profile: Optional[str] = None):
+    """One-shot batch of real last-used times, for mobile pull-to-refresh.
+
+    Wraps :func:`hermes_cli.context_usage.compute_context_last_used` so a
+    client can fetch MCP/channel/key recency in a single round trip instead
+    of hitting ``/api/mcp/servers`` + ``/api/messaging/platforms`` + ``/api/env``
+    separately. Same data, same "never fabricate a timestamp" contract.
+    """
+    from hermes_cli.context_usage import compute_context_last_used
+    from hermes_cli.mcp_config import _get_mcp_servers
+    from hermes_constants import get_hermes_home
+
+    with _profile_scope(profile) as scoped_dir:
+        servers = _get_mcp_servers()
+        home = scoped_dir or get_hermes_home()
+    return compute_context_last_used(home=home, mcp_server_names=servers.keys())
 
 
 @router.post("/api/mcp/servers")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6870,8 +6870,12 @@ def _catalog_provider_env_metadata() -> dict:
 
 @app.get("/api/env")
 async def get_env_vars(profile: Optional[str] = None):
-    with _profile_scope(profile):
+    from hermes_cli.context_usage import compute_context_last_used
+
+    with _profile_scope(profile) as scoped_dir:
         env_on_disk = load_env()
+        home = scoped_dir or get_hermes_home()
+    keys_last_used = compute_context_last_used(home=home)["keys"]
     channel_keys = _channel_managed_env_keys()
     catalog_meta = _catalog_provider_env_metadata()
 
@@ -6904,6 +6908,10 @@ async def get_env_vars(profile: Optional[str] = None):
             # Keys page can list (and let the user manage) them instead of
             # hiding everything it doesn't recognise.
             "custom": custom,
+            # Best-effort real last-used time from state.db tool calls —
+            # only set when this key is the sole provider of its tool(s), so
+            # it's never a guess among several configured alternatives.
+            "last_used_at": keys_last_used.get(var_name),
         }
 
     result = {}
@@ -8095,6 +8103,7 @@ def _messaging_platform_payload(
     runtime: dict | None,
     scoped: bool = False,
     profile_home: Optional[Path] = None,
+    last_used_at: Optional[float] = None,
 ) -> dict[str, Any]:
     platform_id = entry["id"]
     runtime_platforms = runtime.get("platforms") if runtime else {}
@@ -8253,6 +8262,9 @@ def _messaging_platform_payload(
         ),
         "home_channel": home_channel,
         "env_vars": env_vars,
+        # Real last-used time derived from state.db sessions for this
+        # platform's source id, or None when never used — never fabricated.
+        "last_used_at": last_used_at,
     }
     if whatsapp_setup is not None:
         payload["whatsapp_setup"] = whatsapp_setup
@@ -9125,6 +9137,8 @@ async def cancel_telegram_onboarding(pairing_id: str):
 
 @app.get("/api/messaging/platforms")
 async def get_messaging_platforms(profile: Optional[str] = None):
+    from hermes_cli.context_usage import compute_context_last_used
+
     # Profile-scoped so the dashboard's global profile switcher shows the
     # TARGET profile's channel credentials/state, not the root install's.
     # load_env() honors the HERMES_HOME contextvar override; the gateway
@@ -9137,6 +9151,8 @@ async def get_messaging_platforms(profile: Optional[str] = None):
             if scoped_dir is not None
             else read_runtime_status()
         )
+        home = scoped_dir or get_hermes_home()
+        channels_last_used = compute_context_last_used(home=home)["channels"]
         return {
             "env_path": str(get_env_path()),
             "gateway_start_command": _gateway_display_command(profile, "start"),
@@ -9147,6 +9163,7 @@ async def get_messaging_platforms(profile: Optional[str] = None):
                     runtime,
                     scoped=scoped_dir is not None,
                     profile_home=scoped_dir,
+                    last_used_at=channels_last_used.get(entry["id"]),
                 )
                 for entry in _messaging_platform_catalog()
             ]
@@ -11840,7 +11857,9 @@ def _redact_mcp_env(env: Dict[str, Any]) -> Dict[str, str]:
     return out
 
 
-def _mcp_server_summary(name: str, cfg: Dict[str, Any]) -> Dict[str, Any]:
+def _mcp_server_summary(
+    name: str, cfg: Dict[str, Any], *, last_used_at: Optional[float] = None
+) -> Dict[str, Any]:
     transport = "http" if cfg.get("url") else ("stdio" if cfg.get("command") else "unknown")
     auth = cfg.get("auth")
     headers = cfg.get("headers") or {}
@@ -11859,6 +11878,10 @@ def _mcp_server_summary(name: str, cfg: Dict[str, Any]) -> Dict[str, Any]:
         "enabled": cfg.get("enabled", True) is not False,
         # Tool selection: list of enabled tool names, or None = all.
         "tools": cfg.get("tools"),
+        # Real last-used time derived from state.db tool_calls, or None when
+        # the server has never been called (or history doesn't reach it) —
+        # never fabricated. See hermes_cli/context_usage.py.
+        "last_used_at": last_used_at,
     }
 
 
@@ -11867,6 +11890,7 @@ from hermes_cli.web_routers import mcp as _mcp_routes  # noqa: E402
 app.include_router(_mcp_routes.router)
 from hermes_cli.web_routers.mcp import (  # noqa: E402,F401 — legacy re-exports; tests call these via web_server.<name>
     list_mcp_servers,
+    get_context_last_used,
     add_mcp_server,
     replace_mcp_servers,
     remove_mcp_server,

--- a/tests/hermes_cli/test_context_last_used.py
+++ b/tests/hermes_cli/test_context_last_used.py
@@ -1,0 +1,383 @@
+"""Tests for hermes_cli/context_usage.py and the endpoints that surface it.
+
+Covers the "last used" derivation from state.db (MCP tool calls, channel
+sessions, best-effort key attribution) plus the /api/context/last-used,
+/api/mcp/servers, /api/messaging/platforms, and /api/env wiring. See the
+module docstring in context_usage.py for the "never fabricate a timestamp"
+contract these tests are pinning down.
+"""
+
+import time
+
+import pytest
+
+
+def _write_state_db(db_path, now, *, include_hyphenated_mcp: bool = False):
+    """Seed a temp state.db with sessions/messages at known timestamps."""
+    import hermes_state
+
+    db = hermes_state.SessionDB(db_path=db_path)
+    db.create_session("s1", "slack")
+    db.append_message(
+        "s1",
+        "assistant",
+        tool_calls=[
+            {"id": "c1", "function": {"name": "mcp__github__create_issue", "arguments": "{}"}}
+        ],
+        timestamp=now - 20,
+    )
+    db.append_message(
+        "s1",
+        "assistant",
+        tool_calls=[
+            {"id": "c2", "function": {"name": "mcp__github__list_issues", "arguments": "{}"}}
+        ],
+        timestamp=now - 10,
+    )
+    db.append_message(
+        "s1",
+        "assistant",
+        content="just talking, no tools",
+        timestamp=now - 9,
+    )
+    db.append_message(
+        "s1",
+        "assistant",
+        tool_calls=[{"id": "c3", "function": {"name": "elevenlabs_tts", "arguments": "{}"}}],
+        timestamp=now - 5,
+    )
+    db.append_message(
+        "s1",
+        "assistant",
+        tool_calls=[{"id": "c4", "function": {"name": "web_search", "arguments": "{}"}}],
+        timestamp=now - 3,
+    )
+    if include_hyphenated_mcp:
+        # Registration sanitizes configured "github-enterprise" → github_enterprise
+        # in the persisted tool name (tools.mcp_tool.sanitize_mcp_name_component).
+        db.append_message(
+            "s1",
+            "assistant",
+            tool_calls=[
+                {
+                    "id": "c5",
+                    "function": {
+                        "name": "mcp__github_enterprise__list_repos",
+                        "arguments": "{}",
+                    },
+                }
+            ],
+            timestamp=now - 2,
+        )
+    db.close()
+    return db
+
+
+class TestComputeContextLastUsed:
+    def test_mcp_tool_call_maps_to_server_max_timestamp(self, tmp_path):
+        from hermes_cli.context_usage import compute_context_last_used
+
+        now = time.time()
+        _write_state_db(tmp_path / "state.db", now)
+
+        result = compute_context_last_used(home=tmp_path)
+
+        assert result["mcp"]["github"] == pytest.approx(now - 10)
+
+    def test_hyphenated_configured_name_matches_sanitized_tool_call(self, tmp_path):
+        """Configured ``github-enterprise`` must match persisted
+        ``mcp__github_enterprise__…`` tool names."""
+        from hermes_cli.context_usage import compute_context_last_used
+
+        now = time.time()
+        _write_state_db(tmp_path / "state.db", now, include_hyphenated_mcp=True)
+
+        result = compute_context_last_used(
+            home=tmp_path, mcp_server_names=["github-enterprise", "github"]
+        )
+
+        assert result["mcp"]["github-enterprise"] == pytest.approx(now - 2)
+        assert result["mcp"]["github"] == pytest.approx(now - 10)
+        assert "github_enterprise" not in result["mcp"]
+
+    def test_non_mcp_tools_ignored_for_mcp_map(self, tmp_path):
+        from hermes_cli.context_usage import compute_context_last_used
+
+        now = time.time()
+        _write_state_db(tmp_path / "state.db", now)
+
+        result = compute_context_last_used(home=tmp_path)
+
+        assert set(result["mcp"].keys()) == {"github"}
+
+    def test_unique_provider_tool_attributes_to_its_key(self, tmp_path):
+        from hermes_cli.context_usage import compute_context_last_used
+
+        now = time.time()
+        _write_state_db(tmp_path / "state.db", now)
+
+        result = compute_context_last_used(home=tmp_path)
+
+        assert result["keys"]["ELEVENLABS_API_KEY"] == pytest.approx(now - 5)
+
+    def test_ambiguous_provider_tool_is_omitted_from_keys(self, tmp_path):
+        """web_search is served by several possible providers (Tavily, Exa,
+        Firecrawl, ...) — with no way to tell which one actually ran, no key
+        should claim it."""
+        from hermes_cli.context_usage import compute_context_last_used
+
+        now = time.time()
+        _write_state_db(tmp_path / "state.db", now)
+
+        result = compute_context_last_used(home=tmp_path)
+
+        assert "FIRECRAWL_API_KEY" not in result["keys"]
+        assert "TAVILY_API_KEY" not in result["keys"]
+        assert "EXA_API_KEY" not in result["keys"]
+
+    def test_channel_last_used_from_session_source(self, tmp_path):
+        from hermes_cli.context_usage import compute_context_last_used
+
+        now = time.time()
+        _write_state_db(tmp_path / "state.db", now)
+
+        result = compute_context_last_used(home=tmp_path)
+
+        assert result["channels"]["slack"] is not None
+
+    def test_empty_db_returns_empty_maps_without_throwing(self, tmp_path):
+        import hermes_state
+        from hermes_cli.context_usage import compute_context_last_used
+
+        hermes_state.SessionDB(db_path=tmp_path / "state.db").close()
+
+        result = compute_context_last_used(home=tmp_path)
+
+        assert result == {
+            "mcp": {},
+            "channels": {},
+            "keys": {},
+            "computed_at": result["computed_at"],
+        }
+
+    def test_missing_db_returns_empty_maps_without_throwing(self, tmp_path):
+        from hermes_cli.context_usage import compute_context_last_used
+
+        result = compute_context_last_used(home=tmp_path)
+
+        assert result["mcp"] == {}
+        assert result["channels"] == {}
+        assert result["keys"] == {}
+
+    def test_mcp_server_names_stops_scan_once_all_found(self, tmp_path):
+        """Passing the configured server set lets the scan stop early once
+        every server already has a hit — verified indirectly: it must still
+        find the newest (not an older, pre-early-exit) timestamp."""
+        from hermes_cli.context_usage import compute_context_last_used
+
+        now = time.time()
+        _write_state_db(tmp_path / "state.db", now)
+
+        result = compute_context_last_used(home=tmp_path, mcp_server_names=["github"])
+
+        assert result["mcp"]["github"] == pytest.approx(now - 10)
+
+    def test_lookback_limit_bounds_the_scan(self, tmp_path):
+        """A tiny lookback window means older tool calls fall outside it and
+        are honestly omitted rather than scanned in full every time."""
+        import hermes_state
+        from hermes_cli.context_usage import compute_context_last_used
+
+        now = time.time()
+        db_path = tmp_path / "state.db"
+        db = hermes_state.SessionDB(db_path=db_path)
+        db.create_session("s1", "slack")
+        # Many filler messages without tool_calls, then one MCP call buried
+        # near the oldest end.
+        db.append_message(
+            "s1",
+            "assistant",
+            tool_calls=[
+                {"id": "c0", "function": {"name": "mcp__github__create_issue", "arguments": "{}"}}
+            ],
+            timestamp=now - 1000,
+        )
+        for i in range(20):
+            db.append_message("s1", "user", content=f"msg {i}", timestamp=now - 900 + i)
+        db.close()
+
+        result = compute_context_last_used(home=tmp_path, lookback_messages=5)
+
+        assert result["mcp"] == {}
+
+    def test_opens_state_db_via_tracked_connection(self, tmp_path, monkeypatch):
+        """Review regression: must not raw-sqlite3.connect state.db."""
+        import hermes_cli.sqlite_safe_read as safe
+        from hermes_cli import context_usage
+
+        now = time.time()
+        _write_state_db(tmp_path / "state.db", now)
+
+        calls = []
+        real = safe.connect_tracked
+
+        def _spy(*args, **kwargs):
+            calls.append((args, kwargs))
+            return real(*args, **kwargs)
+
+        # Imported inside _connect_state_db_ro — patch the module attribute.
+        monkeypatch.setattr(safe, "connect_tracked", _spy)
+
+        result = context_usage.compute_context_last_used(home=tmp_path)
+
+        assert result["mcp"]["github"] == pytest.approx(now - 10)
+        assert calls, "expected connect_tracked to open state.db"
+        assert any(
+            kwargs.get("tracking_path") is not None or "mode=ro" in str(args)
+            for args, kwargs in calls
+        )
+
+
+def _client():
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    client = TestClient(app)
+    client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    hermes_state.DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+    return client
+
+
+class TestContextLastUsedEndpoint:
+    @pytest.fixture(autouse=True)
+    def _setup(self, _isolate_hermes_home):
+        self.client = _client()
+
+    def test_empty_state_returns_200_with_empty_maps(self):
+        response = self.client.get("/api/context/last-used")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["mcp"] == {}
+        assert body["channels"] == {}
+        assert body["keys"] == {}
+        assert "computed_at" in body
+
+    def test_reflects_configured_mcp_server_usage(self):
+        from hermes_constants import get_hermes_home
+
+        self.client.post(
+            "/api/mcp/servers", json={"name": "github", "url": "https://x/mcp"}
+        )
+
+        now = time.time()
+        _write_state_db(get_hermes_home() / "state.db", now)
+
+        response = self.client.get("/api/context/last-used")
+
+        assert response.status_code == 200
+        assert response.json()["mcp"]["github"] == pytest.approx(now - 10)
+
+    def test_hyphenated_server_name_on_batch_endpoint(self):
+        from hermes_constants import get_hermes_home
+
+        self.client.post(
+            "/api/mcp/servers",
+            json={"name": "github-enterprise", "url": "https://x/mcp"},
+        )
+
+        now = time.time()
+        _write_state_db(
+            get_hermes_home() / "state.db", now, include_hyphenated_mcp=True
+        )
+
+        body = self.client.get("/api/context/last-used").json()
+
+        assert body["mcp"]["github-enterprise"] == pytest.approx(now - 2)
+
+
+class TestMcpServersLastUsedField:
+    @pytest.fixture(autouse=True)
+    def _setup(self, _isolate_hermes_home):
+        self.client = _client()
+
+    def test_server_summary_includes_null_last_used_when_never_called(self):
+        self.client.post(
+            "/api/mcp/servers", json={"name": "unused-server", "url": "https://x/mcp"}
+        )
+
+        servers = self.client.get("/api/mcp/servers").json()["servers"]
+
+        assert servers[0]["name"] == "unused-server"
+        assert servers[0]["last_used_at"] is None
+
+    def test_server_summary_includes_real_last_used_when_called(self):
+        from hermes_constants import get_hermes_home
+
+        self.client.post(
+            "/api/mcp/servers", json={"name": "github", "url": "https://x/mcp"}
+        )
+
+        now = time.time()
+        _write_state_db(get_hermes_home() / "state.db", now)
+
+        servers = self.client.get("/api/mcp/servers").json()["servers"]
+
+        assert servers[0]["last_used_at"] == pytest.approx(now - 10)
+
+    def test_hyphenated_server_name_matches_sanitized_tool_calls(self):
+        from hermes_constants import get_hermes_home
+
+        self.client.post(
+            "/api/mcp/servers",
+            json={"name": "github-enterprise", "url": "https://x/mcp"},
+        )
+
+        now = time.time()
+        _write_state_db(
+            get_hermes_home() / "state.db", now, include_hyphenated_mcp=True
+        )
+
+        servers = self.client.get("/api/mcp/servers").json()["servers"]
+        assert servers[0]["name"] == "github-enterprise"
+        assert servers[0]["last_used_at"] == pytest.approx(now - 2)
+
+
+class TestChannelAndKeyLastUsedFields:
+    @pytest.fixture(autouse=True)
+    def _setup(self, _isolate_hermes_home):
+        self.client = _client()
+
+    def test_messaging_platforms_includes_channel_last_used(self):
+        from hermes_constants import get_hermes_home
+
+        now = time.time()
+        _write_state_db(get_hermes_home() / "state.db", now)
+
+        platforms = self.client.get("/api/messaging/platforms").json()["platforms"]
+        by_id = {p["id"]: p for p in platforms}
+
+        assert "slack" in by_id
+        assert by_id["slack"]["last_used_at"] is not None
+        # Platforms never used stay None rather than fabricated.
+        unused = next(p for p in platforms if p["id"] != "slack")
+        assert unused["last_used_at"] is None
+
+    def test_env_includes_unique_key_last_used(self):
+        from hermes_constants import get_hermes_home
+
+        now = time.time()
+        _write_state_db(get_hermes_home() / "state.db", now)
+
+        env = self.client.get("/api/env").json()
+
+        assert env["ELEVENLABS_API_KEY"]["last_used_at"] == pytest.approx(now - 5)
+        # Ambiguous multi-provider tools must not stamp any single key.
+        for key in ("FIRECRAWL_API_KEY", "TAVILY_API_KEY", "EXA_API_KEY"):
+            if key in env:
+                assert env[key]["last_used_at"] is None


### PR DESCRIPTION
## Summary
- Adds `hermes_cli/context_usage.py` to derive real last-used timestamps from `state.db` (read-only, bounded lookback)
- MCP servers from `mcp__{server}__{tool}` tool_calls; channels from session sources; keys only when a tool maps to exactly one env var (no guessing)
- Additive `last_used_at` on `GET /api/mcp/servers`, `GET /api/messaging/platforms`, `GET /api/env`
- Batch `GET /api/context/last-used` for Hermes Focus Context pull-to-refresh

## Why
Hermes Focus Context is replacing the green FULL badge with real recency + sort-by-last-touched. Timestamps must not be fabricated.

## Test plan
- [x] `pytest tests/hermes_cli/test_context_last_used.py` (13 passed on Python 3.12 venv)
- [ ] CI green
- [ ] Manual: authenticated `GET /api/context/last-used` returns mcp hits for any `mcp__*` tools in history

Closes #71749