### PR TITLE
fix(desktop): make English number formatting deterministic

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -1,5 +1,5 @@
 import type { AppendMessage } from '@assistant-ui/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
 
@@ -205,6 +205,18 @@ describe('renderRpcResult', () => {
       expect(renderRpcResult({ calls: 12, input: 1_234_567, output: 89_012, total: 1_323_579 }, 'usage')).toBe(
         'Usage: 12 calls · 1,234,567 in / 89,012 out · 1,323,579 total'
       )
+    })
+
+    it('pins English usage copy to en-US number formatting', () => {
+      const localeSpy = vi.spyOn(Number.prototype, 'toLocaleString').mockImplementation(function (this: number) {
+        return String(this)
+      })
+
+      renderRpcResult({ calls: 12, input: 1_234, output: 56, total: 1_290 }, 'usage')
+
+      expect(localeSpy).toHaveBeenCalledTimes(4)
+      expect(localeSpy.mock.calls).toEqual([['en-US'], ['en-US'], ['en-US'], ['en-US']])
+      localeSpy.mockRestore()
     })
 
     it('appends credits_lines when present', () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -271,7 +271,7 @@ export function renderRpcResult(response: unknown, name: string): string {
     const total = Number(r.total ?? 0)
 
     const lines: string[] = [
-      `Usage: ${calls.toLocaleString()} calls · ${input.toLocaleString()} in / ${output.toLocaleString()} out · ${total.toLocaleString()} total`
+      `Usage: ${calls.toLocaleString('en-US')} calls · ${input.toLocaleString('en-US')} in / ${output.toLocaleString('en-US')} out · ${total.toLocaleString('en-US')} total`
     ]
 
     if (Array.isArray(r.credits_lines)) {

--- a/apps/desktop/src/app/settings/billing/billing-amounts.test.ts
+++ b/apps/desktop/src/app/settings/billing/billing-amounts.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { formatMoney } from './billing-amounts'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('formatMoney', () => {
+  it('pins hard-coded USD copy to en-US formatting', () => {
+    const OriginalNumberFormat = Intl.NumberFormat
+    const seenLocales: Array<Intl.LocalesArgument | undefined> = []
+
+    vi.spyOn(Intl, 'NumberFormat').mockImplementation(
+      class {
+        constructor(locales?: Intl.LocalesArgument, options?: Intl.NumberFormatOptions) {
+          seenLocales.push(locales)
+
+          return new OriginalNumberFormat(locales ?? 'en-DE', options)
+        }
+      } as typeof Intl.NumberFormat
+    )
+
+    expect(formatMoney(25)).toBe('$25')
+    expect(seenLocales).toEqual(['en-US'])
+  })
+})

--- a/apps/desktop/src/app/settings/billing/billing-amounts.ts
+++ b/apps/desktop/src/app/settings/billing/billing-amounts.ts
@@ -114,7 +114,7 @@ export function formatMoney(value?: null | number | string): string {
     return EMPTY_BILLING_VALUE
   }
 
-  return new Intl.NumberFormat(undefined, {
+  return new Intl.NumberFormat('en-US', {
     currency: 'USD',
     maximumFractionDigits: amount % 1 === 0 ? 0 : 2,
     minimumFractionDigits: amount % 1 === 0 ? 0 : 2,

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { setRuntimeI18nLocale } from '@/i18n'
 
@@ -371,6 +371,15 @@ describe('clampForDisplay', () => {
     expect(clamped.startsWith('x'.repeat(MAX_TOOL_RENDER_CHARS))).toBe(true)
     expect(clamped).toContain('5,000 more characters truncated')
     expect(clamped).toContain('Copy')
+  })
+
+  it('pins the English truncation copy to en-US number formatting', () => {
+    const localeSpy = vi.spyOn(Number.prototype, 'toLocaleString').mockReturnValue('5,000')
+
+    clampForDisplay('x'.repeat(MAX_TOOL_RENDER_CHARS + 5_000))
+
+    expect(localeSpy).toHaveBeenCalledWith('en-US')
+    localeSpy.mockRestore()
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
@@ -55,7 +55,7 @@ export function clampForDisplay(value: string, max = MAX_TOOL_RENDER_CHARS): str
 
   const omitted = value.length - max
 
-  return `${value.slice(0, max)}\n\n… ${omitted.toLocaleString()} more characters truncated — use Copy for the full output.`
+  return `${value.slice(0, max)}\n\n… ${omitted.toLocaleString('en-US')} more characters truncated — use Copy for the full output.`
 }
 
 export function prettyJson(value: unknown): string {


### PR DESCRIPTION
## What does this PR do?

Makes the Desktop's hard-coded English number and USD strings deterministic across host locales.

On native Windows with an `en-DE` ICU locale, the current formatters produce `5.000` and `US$25`, while the surrounding English copy, existing billing formatter, and tests require `5,000` and `$25`. This pins the three outlier formatting sites to `en-US`, matching the explicit contract already used by `use-billing-state.ts` for USD display strings.

The change is intentionally scoped to copy that is currently hard-coded English. It does not change user-locale-aware UI formatting elsewhere.

## Related Issue

Fixes #71659

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts`
  - format the hard-coded English truncation count with `en-US` grouping.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts`
  - format usage call/token counts with stable `en-US` grouping.
- `apps/desktop/src/app/settings/billing/billing-amounts.ts`
  - use the same `en-US` USD contract as the existing billing-state formatter.
- focused regressions
  - assert the two English number paths pass `en-US` explicitly;
  - simulate a non-US default locale for the billing formatter and require `$25`.

## How to Test

1. Install the locked JavaScript dependencies with `npm ci --ignore-scripts`.
2. Run the Desktop type checker:
   ```bash
   cd apps/desktop
   npm run typecheck
   ```
3. Run the focused locale regressions:
   ```bash
   npm run test:ui -- --run \
     src/components/assistant-ui/tool/fallback-model.test.ts \
     src/app/session/hooks/use-prompt-actions/utils.test.ts \
     src/app/settings/billing/billing-amounts.test.ts
   ```
   Expected: **62 passed**.
4. Run ESLint on the six changed TypeScript files and `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for this Desktop-only TypeScript change; focused UI tests and the complete Desktop typecheck pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS Apple Silicon, with the host-locale behavior reproduced through adversarial formatter mocks

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration or workflow changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this removes host-locale variance across supported platforms
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No visual layout changes. Focused result:

```text
Test Files  3 passed (3)
Tests       62 passed (62)
```
