### PR TITLE
fix(dashboard): refresh plugin manifests automatically

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17780,17 +17780,8 @@ def _safe_plugin_api_relpath(api_field: Any, *, dashboard_dir: Path) -> Optional
     return api_field
 
 
-def _discover_dashboard_plugins() -> list:
-    """Scan plugins/*/dashboard/manifest.json for dashboard extensions.
-
-    Checks three plugin sources (same as hermes_cli.plugins):
-    1. User plugins:    ~/.hermes/plugins/<name>/dashboard/manifest.json
-    2. Bundled plugins: <repo>/plugins/<name>/dashboard/manifest.json  (memory/, etc.)
-    3. Project plugins: ./.hermes/plugins/  (only if HERMES_ENABLE_PROJECT_PLUGINS)
-    """
-    plugins = []
-    seen_names: set = set()
-
+def _dashboard_plugin_search_dirs() -> list[tuple[Path, str]]:
+    """Return dashboard plugin roots in discovery precedence order."""
     from hermes_cli.plugins import get_bundled_plugins_dir
     bundled_root = get_bundled_plugins_dir()
     # User dashboard plugins are a dashboard-owned asset (same category as
@@ -17830,12 +17821,59 @@ def _discover_dashboard_plugins() -> list:
     # ``hermes_cli/plugins.py`` and the documented user contract.
     if env_var_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
         search_dirs.append((Path.cwd() / ".hermes" / "plugins", "project"))
+    return search_dirs
 
-    for plugins_root, source in search_dirs:
+
+def _dashboard_plugins_fingerprint() -> tuple[tuple[str, int, int, int], ...]:
+    """Cheaply fingerprint every discoverable dashboard manifest.
+
+    The plugin list is cached because discovery also parses manifests.  The
+    cache still needs to notice plugins installed or updated after the
+    dashboard starts, so compare manifest path, nanosecond mtime and ctime, and
+    size on each read.  Ctime catches atomic replacements and same-size
+    rewrites even when a tool preserves mtime.  A set avoids duplicate entries
+    where a bundled plugin root is also visited through its parent directory.
+    """
+    manifests: set[tuple[str, int, int, int]] = set()
+    for plugins_root, _source in _dashboard_plugin_search_dirs():
         if not plugins_root.is_dir():
             continue
-        with os.scandir(plugins_root) as scan:
-            children = sorted((Path(e.path) for e in scan), key=lambda p: p.name)
+        try:
+            with os.scandir(plugins_root) as scan:
+                children = sorted((Path(e.path) for e in scan), key=lambda p: p.name)
+        except OSError:
+            continue
+        for child in children:
+            manifest_file = child / "dashboard" / "manifest.json"
+            try:
+                stat = manifest_file.stat()
+            except OSError:
+                continue
+            manifests.add(
+                (str(manifest_file), stat.st_mtime_ns, stat.st_ctime_ns, stat.st_size)
+            )
+    return tuple(sorted(manifests))
+
+
+def _discover_dashboard_plugins() -> list:
+    """Scan plugins/*/dashboard/manifest.json for dashboard extensions.
+
+    Checks three plugin sources (same as hermes_cli.plugins):
+    1. User plugins:    ~/.hermes/plugins/<name>/dashboard/manifest.json
+    2. Bundled plugins: <repo>/plugins/<name>/dashboard/manifest.json  (memory/, etc.)
+    3. Project plugins: ./.hermes/plugins/  (only if HERMES_ENABLE_PROJECT_PLUGINS)
+    """
+    plugins = []
+    seen_names: set = set()
+
+    for plugins_root, source in _dashboard_plugin_search_dirs():
+        if not plugins_root.is_dir():
+            continue
+        try:
+            with os.scandir(plugins_root) as scan:
+                children = sorted((Path(e.path) for e in scan), key=lambda p: p.name)
+        except OSError:
+            continue
         for child in children:
             if not child.is_dir():
                 continue
@@ -17907,17 +17945,30 @@ def _discover_dashboard_plugins() -> list:
     return plugins
 
 
-# Cache discovered plugins per-process (refresh on explicit re-scan).
+# Cache parsed dashboard manifests per process, with a cheap fingerprint so new,
+# removed, and edited frontend extensions become visible without a restart.
+# Backend plugin API routers have a separate process-start mount lifecycle.
 _dashboard_plugins_cache: Optional[list] = None
+_dashboard_plugins_cache_fingerprint: Optional[
+    tuple[tuple[str, int, int, int], ...]
+] = None
 
 
 def _get_dashboard_plugins(force_rescan: bool = False) -> list:
-    global _dashboard_plugins_cache
-    if _dashboard_plugins_cache is None or force_rescan:
+    global _dashboard_plugins_cache, _dashboard_plugins_cache_fingerprint
+    fingerprint = _dashboard_plugins_fingerprint()
+    if (
+        _dashboard_plugins_cache is None
+        or force_rescan
+        or (
+            _dashboard_plugins_cache_fingerprint is not None
+            and fingerprint != _dashboard_plugins_cache_fingerprint
+        )
+    ):
         _dashboard_plugins_cache = _discover_dashboard_plugins()
-    elif _dashboard_plugins_cache:
-        if any(not Path(p["_dir"]).is_dir() for p in _dashboard_plugins_cache):
-            _dashboard_plugins_cache = _discover_dashboard_plugins()
+        # Pair the parsed result with the pre-read fingerprint. If a manifest
+        # changed during discovery, the next read will detect and rescan it.
+        _dashboard_plugins_cache_fingerprint = fingerprint
     return _dashboard_plugins_cache
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16672,17 +16672,8 @@ def _safe_plugin_api_relpath(api_field: Any, *, dashboard_dir: Path) -> Optional
     return api_field
 
 
-def _discover_dashboard_plugins() -> list:
-    """Scan plugins/*/dashboard/manifest.json for dashboard extensions.
-
-    Checks three plugin sources (same as hermes_cli.plugins):
-    1. User plugins:    ~/.hermes/plugins/<name>/dashboard/manifest.json
-    2. Bundled plugins: <repo>/plugins/<name>/dashboard/manifest.json  (memory/, etc.)
-    3. Project plugins: ./.hermes/plugins/  (only if HERMES_ENABLE_PROJECT_PLUGINS)
-    """
-    plugins = []
-    seen_names: set = set()
-
+def _dashboard_plugin_search_dirs() -> list[tuple[Path, str]]:
+    """Return dashboard plugin roots in discovery precedence order."""
     from hermes_cli.plugins import get_bundled_plugins_dir
     bundled_root = get_bundled_plugins_dir()
     # User dashboard plugins are a dashboard-owned asset (same category as
@@ -16705,11 +16696,58 @@ def _discover_dashboard_plugins() -> list:
     # ``hermes_cli/plugins.py`` and the documented user contract.
     if env_var_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
         search_dirs.append((Path.cwd() / ".hermes" / "plugins", "project"))
+    return search_dirs
 
-    for plugins_root, source in search_dirs:
+
+def _dashboard_plugins_fingerprint() -> tuple[tuple[str, int, int, int], ...]:
+    """Cheaply fingerprint every discoverable dashboard manifest.
+
+    The plugin list is cached because discovery also parses manifests.  The
+    cache still needs to notice plugins installed or updated after the
+    dashboard starts, so compare manifest path, nanosecond mtime and ctime, and
+    size on each read.  Ctime catches atomic replacements and same-size
+    rewrites even when a tool preserves mtime.  A set avoids duplicate entries
+    where a bundled plugin root is also visited through its parent directory.
+    """
+    manifests: set[tuple[str, int, int, int]] = set()
+    for plugins_root, _source in _dashboard_plugin_search_dirs():
         if not plugins_root.is_dir():
             continue
-        for child in sorted(plugins_root.iterdir()):
+        try:
+            children = list(plugins_root.iterdir())
+        except OSError:
+            continue
+        for child in children:
+            manifest_file = child / "dashboard" / "manifest.json"
+            try:
+                stat = manifest_file.stat()
+            except OSError:
+                continue
+            manifests.add(
+                (str(manifest_file), stat.st_mtime_ns, stat.st_ctime_ns, stat.st_size)
+            )
+    return tuple(sorted(manifests))
+
+
+def _discover_dashboard_plugins() -> list:
+    """Scan plugins/*/dashboard/manifest.json for dashboard extensions.
+
+    Checks three plugin sources (same as hermes_cli.plugins):
+    1. User plugins:    ~/.hermes/plugins/<name>/dashboard/manifest.json
+    2. Bundled plugins: <repo>/plugins/<name>/dashboard/manifest.json  (memory/, etc.)
+    3. Project plugins: ./.hermes/plugins/  (only if HERMES_ENABLE_PROJECT_PLUGINS)
+    """
+    plugins = []
+    seen_names: set = set()
+
+    for plugins_root, source in _dashboard_plugin_search_dirs():
+        if not plugins_root.is_dir():
+            continue
+        try:
+            children = sorted(plugins_root.iterdir())
+        except OSError:
+            continue
+        for child in children:
             if not child.is_dir():
                 continue
             manifest_file = child / "dashboard" / "manifest.json"
@@ -16780,17 +16818,30 @@ def _discover_dashboard_plugins() -> list:
     return plugins
 
 
-# Cache discovered plugins per-process (refresh on explicit re-scan).
+# Cache parsed dashboard manifests per process, with a cheap fingerprint so new,
+# removed, and edited frontend extensions become visible without a restart.
+# Backend plugin API routers have a separate process-start mount lifecycle.
 _dashboard_plugins_cache: Optional[list] = None
+_dashboard_plugins_cache_fingerprint: Optional[
+    tuple[tuple[str, int, int, int], ...]
+] = None
 
 
 def _get_dashboard_plugins(force_rescan: bool = False) -> list:
-    global _dashboard_plugins_cache
-    if _dashboard_plugins_cache is None or force_rescan:
+    global _dashboard_plugins_cache, _dashboard_plugins_cache_fingerprint
+    fingerprint = _dashboard_plugins_fingerprint()
+    if (
+        _dashboard_plugins_cache is None
+        or force_rescan
+        or (
+            _dashboard_plugins_cache_fingerprint is not None
+            and fingerprint != _dashboard_plugins_cache_fingerprint
+        )
+    ):
         _dashboard_plugins_cache = _discover_dashboard_plugins()
-    elif _dashboard_plugins_cache:
-        if any(not Path(p["_dir"]).is_dir() for p in _dashboard_plugins_cache):
-            _dashboard_plugins_cache = _discover_dashboard_plugins()
+        # Pair the parsed result with the pre-read fingerprint. If a manifest
+        # changed during discovery, the next read will detect and rescan it.
+        _dashboard_plugins_cache_fingerprint = fingerprint
     return _dashboard_plugins_cache
 
 

--- a/tests/hermes_cli/test_project_plugin_rce_bypass.py
+++ b/tests/hermes_cli/test_project_plugin_rce_bypass.py
@@ -47,8 +47,10 @@ def _reset_plugin_cache(monkeypatch):
     mask a regression — and so the production cache the import-time
     ``_mount_plugin_api_routes()`` populated doesn't bleed in."""
     web_server._dashboard_plugins_cache = None
+    web_server._dashboard_plugins_cache_fingerprint = None
     yield
     web_server._dashboard_plugins_cache = None
+    web_server._dashboard_plugins_cache_fingerprint = None
 
 
 def _write_plugin_manifest(root: Path, name: str, manifest: dict) -> Path:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4135,7 +4135,37 @@ class TestDashboardPluginManifestExtensions:
         assert entries[0]["tab"]["path"] == "/from-profile"
 
 
+    def test_plugin_cache_refreshes_when_manifests_change(self, tmp_path, monkeypatch):
+        """Installed, edited, and removed plugins appear without a restart."""
+        import json
+        import shutil
 
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli import web_server
+
+        web_server._dashboard_plugins_cache = None
+        web_server._dashboard_plugins_cache_fingerprint = None
+        initial = web_server._get_dashboard_plugins(force_rescan=True)
+        assert not any(p["name"] == "hot-plugin" for p in initial)
+
+        plug_dir = self._write_plugin(tmp_path, "hot-plugin", {
+            "name": "hot-plugin",
+            "label": "Hot",
+            "tab": {"path": "/hot"},
+        })
+        added = web_server._get_dashboard_plugins()
+        assert next(p for p in added if p["name"] == "hot-plugin")["label"] == "Hot"
+
+        manifest_file = plug_dir / "manifest.json"
+        manifest = json.loads(manifest_file.read_text())
+        manifest["label"] = "Hot Reloaded"
+        manifest_file.write_text(json.dumps(manifest))
+        updated = web_server._get_dashboard_plugins()
+        assert next(p for p in updated if p["name"] == "hot-plugin")["label"] == "Hot Reloaded"
+
+        shutil.rmtree(plug_dir.parent)
+        removed = web_server._get_dashboard_plugins()
+        assert not any(p["name"] == "hot-plugin" for p in removed)
 
 # ---------------------------------------------------------------------------
 # /api/pty WebSocket — terminal bridge for the dashboard "Chat" tab.

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3601,7 +3601,37 @@ class TestDashboardPluginManifestExtensions:
         assert any(p["name"] == "skin-home" for p in plugins)
 
 
+    def test_plugin_cache_refreshes_when_manifests_change(self, tmp_path, monkeypatch):
+        """Installed, edited, and removed plugins appear without a restart."""
+        import json
+        import shutil
 
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli import web_server
+
+        web_server._dashboard_plugins_cache = None
+        web_server._dashboard_plugins_cache_fingerprint = None
+        initial = web_server._get_dashboard_plugins(force_rescan=True)
+        assert not any(p["name"] == "hot-plugin" for p in initial)
+
+        plug_dir = self._write_plugin(tmp_path, "hot-plugin", {
+            "name": "hot-plugin",
+            "label": "Hot",
+            "tab": {"path": "/hot"},
+        })
+        added = web_server._get_dashboard_plugins()
+        assert next(p for p in added if p["name"] == "hot-plugin")["label"] == "Hot"
+
+        manifest_file = plug_dir / "manifest.json"
+        manifest = json.loads(manifest_file.read_text())
+        manifest["label"] = "Hot Reloaded"
+        manifest_file.write_text(json.dumps(manifest))
+        updated = web_server._get_dashboard_plugins()
+        assert next(p for p in updated if p["name"] == "hot-plugin")["label"] == "Hot Reloaded"
+
+        shutil.rmtree(plug_dir.parent)
+        removed = web_server._get_dashboard_plugins()
+        assert not any(p["name"] == "hot-plugin" for p in removed)
 
 # ---------------------------------------------------------------------------
 # /api/pty WebSocket — terminal bridge for the dashboard "Chat" tab.

--- a/website/docs/user-guide/features/extending-the-dashboard.md
+++ b/website/docs/user-guide/features/extending-the-dashboard.md
@@ -813,14 +813,15 @@ The dashboard scans three directories for `dashboard/manifest.json`:
 | 2 | `<repo>/plugins/<name>/dashboard/` | `bundled` |
 | 3 | `./.hermes/plugins/<name>/dashboard/` | `project` — only when `HERMES_ENABLE_PROJECT_PLUGINS` is set |
 
-Discovery results are cached per dashboard process. After adding a new plugin, either:
+Discovery results are cached per dashboard process, but the cache fingerprints every discoverable `manifest.json` on each plugin-list request. Adding, editing, or removing a frontend dashboard extension is picked up automatically the next time the dashboard fetches `GET /api/dashboard/plugins` (the browser also refreshes its session cache in the background).
+
+You can still force an immediate manifest rescan:
 
 ```bash
-# Force a rescan without restart
 curl http://127.0.0.1:9119/api/dashboard/plugins/rescan
 ```
 
-…or restart `hermes dashboard`.
+Backend plugin API routes are different: they are mounted when the dashboard backend process starts. If you add, remove, or change a plugin's `api` module, restart `hermes dashboard` so the FastAPI routes are remounted.
 
 #### Plugin load lifecycle
 


### PR DESCRIPTION
## Why

Dashboard extension manifests are cached for the lifetime of the web-server process. Installing, editing, or removing a frontend-only dashboard extension after the cache is populated leaves `GET /api/dashboard/plugins` stale until an explicit rescan or process restart.

## What changed

- Factor dashboard plugin search-root discovery into a shared helper.
- Fingerprint manifest path, mtime, ctime, and size before serving the cached manifest list.
- Re-discover frontend extension manifests when one is added, edited, or removed.
- Document automatic frontend refresh and the backend API-route restart boundary.
- Add current-main regression coverage for manifest add/update/removal.

## Scope

This refreshes dashboard manifests only. Static plugin assets retain stable URLs and the existing `Cache-Control: no-store, no-cache, must-revalidate` response. Backend plugin API routers retain their process-start mount lifecycle; this PR does not hot-load or unload Python routes or model tools.

No user-specific plugin content is included.

## Verification

- focused dashboard/plugin tests — **24 passed**
- Ruff on changed Python files — passed
- Python compile checks — passed
- `git diff --check` — passed

## Risk

Low. The backend adds a small directory/stat fingerprint before returning the cached dashboard manifest list. Existing manifest validation, source precedence, enable/disable filtering, static-asset allowlisting, and API-route trust gates are unchanged.

## Related issue

Related to #71595. Frontend dashboard manifests refresh automatically; process-global Python plugin/tool enablement remains restart-bound.