### PR TITLE
fix(desktop): silence elapsed timers inside live regions

### DIFF
--- a/apps/desktop/src/app/chat/composer/voice-activity.test.tsx
+++ b/apps/desktop/src/app/chat/composer/voice-activity.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+
+import { VoiceActivity } from './voice-activity'
+
+afterEach(cleanup)
+
+describe('VoiceActivity accessibility', () => {
+  it('keeps the dictation timer visible without announcing every tick', () => {
+    render(
+      <I18nProvider configClient={null} initialLocale="en">
+        <VoiceActivity state={{ elapsedSeconds: 65, level: 0.5, status: 'recording' }} />
+      </I18nProvider>
+    )
+
+    const status = screen.getByRole('status')
+    const timer = screen.getByText('1:05')
+
+    expect(status.getAttribute('aria-live')).toBe('polite')
+    expect(status.textContent).toContain('Dictating')
+    expect(status.textContent).toContain('1:05')
+    expect(timer.getAttribute('aria-hidden')).toBe('true')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/voice-activity.tsx
+++ b/apps/desktop/src/app/chat/composer/voice-activity.tsx
@@ -193,7 +193,7 @@ export function VoiceActivity({ state }: { state: VoiceActivityState }) {
 
       <div className="flex min-w-0 flex-1 items-center gap-2">
         <span className="truncate font-medium text-foreground/85">{title}</span>
-        <span className="font-mono text-[0.6875rem] text-muted-foreground/85">
+        <span aria-hidden="true" className="font-mono text-[0.6875rem] text-muted-foreground/85">
           {formatElapsed(state.elapsedSeconds)}
         </span>
       </div>

--- a/apps/desktop/src/components/assistant-ui/thread/status.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.test.tsx
@@ -5,7 +5,12 @@ import { __resetElapsedTimerRegistryForTests } from '@/components/chat/activity-
 import { I18nProvider } from '@/i18n'
 import { $activeSessionId, $turnStartedAt } from '@/store/session'
 
-import { ResponseLoadingIndicator } from './status'
+import { ResponseLoadingIndicator, StreamStallIndicator } from './status'
+
+vi.mock('@assistant-ui/react', () => ({
+  useAuiState: (selector: (state: { message: { content: unknown[] } }) => unknown) =>
+    selector({ message: { content: [] } })
+}))
 
 function renderIndicator() {
   return render(
@@ -30,6 +35,16 @@ describe('ResponseLoadingIndicator timer', () => {
     vi.useRealTimers()
   })
 
+  it('keeps the ticking timer visible but hidden from the live region accessibility tree', () => {
+    const { container } = renderIndicator()
+    const status = screen.getByRole('status')
+
+    expect(status.textContent).toContain('0s')
+    expect([...container.querySelectorAll('[aria-hidden="true"]')].some(element => element.textContent === '0s')).toBe(
+      true
+    )
+  })
+
   it('preserves each running session timer while switching between sessions', () => {
     $activeSessionId.set('session-a')
     $turnStartedAt.set(Date.now())
@@ -52,6 +67,25 @@ describe('ResponseLoadingIndicator timer', () => {
     renderIndicator()
 
     expect(screen.getAllByText((_, node) => node?.textContent === '8s').length).toBeGreaterThan(0)
+  })
+
+  it('keeps the stream-stall timer out of the live region accessibility tree', () => {
+    const { container } = render(
+      <I18nProvider configClient={null} initialLocale="en">
+        <StreamStallIndicator />
+      </I18nProvider>
+    )
+
+    act(() => vi.advanceTimersByTime(2_000))
+
+    const status = screen.getByRole('status')
+
+    const hiddenTimer = [...container.querySelectorAll('[aria-hidden="true"]')].find(element =>
+      element.textContent?.endsWith('s')
+    )
+
+    expect(status.getAttribute('aria-label')).toBe('Hermes is thinking')
+    expect(hiddenTimer).toBeDefined()
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/thread/status.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.tsx
@@ -132,7 +132,7 @@ export const ResponseLoadingIndicator: FC = () => {
     <StatusRow data-slot="aui_response-loading" label={hint || t.assistant.thread.loadingResponse}>
       <span aria-hidden="true" className="dither inline-block size-3 rounded-[2px] text-midground/80 animate-pulse" />
       {hint && <HintText>{hint}</HintText>}
-      <ActivityTimerText seconds={elapsed} />
+      <ActivityTimerText aria-hidden={true} seconds={elapsed} />
     </StatusRow>
   )
 }
@@ -238,7 +238,7 @@ export const StreamStallIndicator: FC = () => {
     <StatusRow data-slot="aui_stream-stall" label={hint || 'Hermes is thinking'}>
       <span aria-hidden="true" className="dither inline-block size-3 rounded-[2px] text-midground/80 animate-pulse" />
       {hint && <HintText>{hint}</HintText>}
-      <ActivityTimerText seconds={elapsed} />
+      <ActivityTimerText aria-hidden={true} seconds={elapsed} />
     </StatusRow>
   )
 }

--- a/apps/desktop/src/components/chat/activity-timer-text.tsx
+++ b/apps/desktop/src/components/chat/activity-timer-text.tsx
@@ -4,13 +4,15 @@ import { formatElapsed } from './activity-timer'
 import { StableText } from './stable-text'
 
 interface ActivityTimerTextProps {
+  'aria-hidden'?: boolean
   seconds: number
   className?: string
 }
 
-export function ActivityTimerText({ seconds, className }: ActivityTimerTextProps) {
+export function ActivityTimerText({ 'aria-hidden': ariaHidden, seconds, className }: ActivityTimerTextProps) {
   return (
     <StableText
+      aria-hidden={ariaHidden}
       className={cn(
         // Tinted with --dt-midground (very low alpha) so the timer reads
         // as part of the same "live signal" cluster as the dither block /

--- a/apps/desktop/src/components/chat/stable-text.tsx
+++ b/apps/desktop/src/components/chat/stable-text.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@/lib/utils'
 
 interface StableTextProps {
+  'aria-hidden'?: boolean
   children: string
   className?: string
 }
@@ -10,9 +11,9 @@ interface StableTextProps {
  * shift the layout as they change (e.g. digits in a ticking timer).
  * Works with any proportional font — no need for font-mono.
  */
-export function StableText({ children, className }: StableTextProps) {
+export function StableText({ 'aria-hidden': ariaHidden, children, className }: StableTextProps) {
   return (
-    <span className={cn('inline-flex', className)}>
+    <span aria-hidden={ariaHidden} className={cn('inline-flex', className)}>
       {children.split('').map((char, i) => (
         <span className="inline-block w-[1ch] text-center" key={i}>
           {char}


### PR DESCRIPTION
## What does this PR do?

Stops Desktop screen readers from announcing elapsed timers every second while preserving the visible timers for sighted users.

Two thread indicators and the dictation indicator render inside `aria-live="polite"` / `role="status"` regions. Their per-second counters were therefore treated as live status changes. This marks only those live-region timer instances as `aria-hidden`; other `ActivityTimerText` uses in agent rows, tool cards, and message parts remain accessible.

## Related Issue

Fixes #71657

Related but distinct from #46229/#46225: that work tracks repeated mounting of the stream-stall live region. This PR does not change mount/unmount behavior; it narrowly removes the ticking values from the accessibility tree across the current thread-status and dictation surfaces.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- allow `ActivityTimerText` / `StableText` to forward `aria-hidden` without changing their default accessibility behavior;
- hide the timers inside `ResponseLoadingIndicator` and `StreamStallIndicator` from assistive technology;
- hide the dictation elapsed counter inside `VoiceActivity` from assistive technology;
- keep the surrounding discrete labels (`Hermes is thinking`, loading state, `Dictating`) in their existing live regions;
- add component regressions proving the counters remain visually rendered while hidden from the accessibility tree.

## How to Test

```bash
npm ci --ignore-scripts
cd apps/desktop
npm run typecheck
npm run test:ui -- --run \
  src/components/assistant-ui/thread/status.test.tsx \
  src/app/chat/composer/voice-activity.test.tsx \
  src/components/chat/activity-timer.test.tsx
```

Expected focused result: **5 passed**.

Also run ESLint on the six changed TypeScript files and `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for this Desktop-only TypeScript change; the complete Desktop typecheck and focused UI regressions pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS Apple Silicon; regressions assert DOM accessibility semantics shared by NVDA, JAWS, and VoiceOver

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no configuration or workflow changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No visual change. Focused verification:

```text
Test Files  3 passed (3)
Tests       5 passed (5)
```
