### PR TITLE
fix(desktop): request window controls overlay on WSLg (#57614)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -159,7 +159,7 @@ import {
   redactSecrets,
   SshConnection
 } from './ssh-connection'
-import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
+import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight, shouldSuppressWcoOnWsl } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
@@ -744,10 +744,10 @@ function getTitleBarOverlayOptions() {
     return { height: macTitleBarOverlayHeight({ darwinMajor: DARWIN_MAJOR, titlebarHeight: TITLEBAR_HEIGHT }) }
   }
 
-  // WSLg paints WCO via the RDP host's own min/max/close, so requesting
-  // an Electron overlay there just leaves a dead gap. Plain Linux (KDE,
-  // GNOME) can use the native overlay — let it through.
-  if (!IS_WINDOWS && IS_WSL) {
+  // WSLg: the overlay is requested by default (#57614 — common WSLg builds
+  // paint NO RDP-host controls, leaving a dead frameless window).
+  // HERMES_DESKTOP_WSL_NO_WCO=1 opts back out. See shouldSuppressWcoOnWsl.
+  if (shouldSuppressWcoOnWsl({ isWindows: IS_WINDOWS, isWsl: IS_WSL, wslNoWcoEnv: process.env.HERMES_DESKTOP_WSL_NO_WCO })) {
     return false
   }
 

--- a/apps/desktop/electron/titlebar-overlay-width.test.ts
+++ b/apps/desktop/electron/titlebar-overlay-width.test.ts
@@ -6,7 +6,8 @@ import {
   MACOS_TAHOE_DARWIN_MAJOR,
   macTitleBarOverlayHeight,
   nativeOverlayWidth,
-  OVERLAY_FALLBACK_WIDTH
+  OVERLAY_FALLBACK_WIDTH,
+  shouldSuppressWcoOnWsl
 } from './titlebar-overlay-width'
 
 // This static reservation is only the pre-layout FALLBACK. Once laid out the
@@ -52,4 +53,27 @@ test('Tahoe (Darwin 25+) drops the overlay height to 0 to avoid electron#49183',
 
 test('macTitleBarOverlayHeight tolerates missing args (unknown platform → 0)', () => {
   assert.equal(macTitleBarOverlayHeight(), 0)
+})
+
+test('WSL requests the overlay by default (#57614)', () => {
+  // The bug: WSLg was assumed to paint RDP-host min/max/close, so the overlay
+  // was suppressed — but common WSLg builds paint nothing, leaving a dead
+  // frameless window. The overlay must NOT be suppressed by default.
+  assert.equal(shouldSuppressWcoOnWsl({ isWsl: true }), false)
+})
+
+test('HERMES_DESKTOP_WSL_NO_WCO=1 restores the old WSL suppression', () => {
+  assert.equal(shouldSuppressWcoOnWsl({ isWsl: true, wslNoWcoEnv: '1' }), true)
+  // Any other value is not an opt-out
+  assert.equal(shouldSuppressWcoOnWsl({ isWsl: true, wslNoWcoEnv: 'true' }), false)
+  assert.equal(shouldSuppressWcoOnWsl({ isWsl: true, wslNoWcoEnv: '0' }), false)
+})
+
+test('native Windows never suppresses, even with the env set', () => {
+  assert.equal(shouldSuppressWcoOnWsl({ isWindows: true, isWsl: true, wslNoWcoEnv: '1' }), false)
+})
+
+test('plain Linux never suppresses', () => {
+  assert.equal(shouldSuppressWcoOnWsl({}), false)
+  assert.equal(shouldSuppressWcoOnWsl({ wslNoWcoEnv: '1' }), false)
 })

--- a/apps/desktop/electron/titlebar-overlay-width.ts
+++ b/apps/desktop/electron/titlebar-overlay-width.ts
@@ -1,6 +1,24 @@
 export const OVERLAY_FALLBACK_WIDTH = 144
 
 /**
+ * Whether the WSL special case should SUPPRESS the Window Controls Overlay.
+ *
+ * WSLg was assumed to paint min/max/close via the RDP host's own frame, so the
+ * overlay was suppressed on WSL — but in practice common WSLg builds (e.g.
+ * 1.0.65) paint NO controls at all, leaving a dead frameless window with no
+ * way to minimize, maximize, or close it (#57614). The overlay is therefore
+ * requested on WSL by default; HERMES_DESKTOP_WSL_NO_WCO=1 restores the old
+ * suppression if some WSLg build ever double-paints controls.
+ *
+ * Native Windows never suppresses — only Linux-on-WSL is the special case.
+ *
+ * @param {{ isWindows?: boolean, isWsl?: boolean, wslNoWcoEnv?: string }} opts
+ */
+export function shouldSuppressWcoOnWsl({ isWindows = false, isWsl = false, wslNoWcoEnv = '' } = {}) {
+  return !isWindows && isWsl && wslNoWcoEnv === '1'
+}
+
+/**
  * Static pre-layout reservation (px) for the right-side native window-controls
  * overlay (min/max/close). Only a FALLBACK — once laid out the renderer reads
  * the exact width from navigator.windowControlsOverlay


### PR DESCRIPTION
## Problem

On WSL (WSLg), the desktop app's windows are created with `titleBarStyle: 'hidden'` and `titleBarOverlay: false`, leaving a frameless window with **no minimize, maximize, or close buttons**. The code assumed the WSLg RDP host paints its own window controls on top of frameless windows — in practice, common WSLg builds (e.g. 1.0.65) paint nothing, so users get the worst of both worlds: no native frame AND no WCO. Only Alt+F4 or killing the process closes the app.

Fixes #57614 — the WSL counterpart of the plain-Linux regression resolved by #53989.

## Fix

Request the Window Controls Overlay on WSL too, exactly as plain Linux (KDE/GNOME) already does post-#53989. The old WSL suppression becomes **opt-out** via `HERMES_DESKTOP_WSL_NO_WCO=1`, in case some WSLg build ever double-paints controls.

The decision is extracted to a pure, tested `shouldSuppressWcoOnWsl()` in `titlebar-overlay-width.ts`, matching that module's existing pattern (`nativeOverlayWidth`, `macTitleBarOverlayHeight`).

## Changes

- `apps/desktop/electron/main.ts` — `getTitleBarOverlayOptions()` delegates the WSL decision to `shouldSuppressWcoOnWsl()`
- `apps/desktop/electron/titlebar-overlay-width.ts` — new pure `shouldSuppressWcoOnWsl()`
- `apps/desktop/electron/titlebar-overlay-width.test.ts` — 4 new vitest cases: WSL default (no suppression), env opt-out, native Windows never suppressed, plain Linux never suppressed

## Verification

- **Real hardware:** WSL2 ARM64 (Ubuntu, Windows 11 Snapdragon laptop, WSLg) — before: frameless window, no controls; after: min/max/close render correctly in the app titlebar
- `npx tsc --build tsconfig.electron.json` — clean
- `npx vitest run apps/desktop/electron/titlebar-overlay-width.test.ts` — 12/12 pass