### PR TITLE
fix(webhook): honor [SILENT] when the agent explains its own silence

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -66,6 +66,40 @@ from gateway.platforms.webhook_filters import (
 
 logger = logging.getLogger(__name__)
 
+
+def _is_webhook_silence_response(content: Any) -> bool:
+    """Whether an agent response means "deliberately say nothing".
+
+    Webhook routes are autonomous background lanes: a subscription prompt tells
+    the agent to answer with ``[SILENT]`` when a tick produced nothing worth a
+    human's attention (a duplicate inbound, a stand-down because a sibling lane
+    already replied, a routine close).  Nobody is waiting on the other end, so
+    there is no reader for whom a "nothing happened" message is useful.
+
+    The reason this is cron's looser rule rather than the live gateway's is what
+    the two lanes optimise for.  In an interactive chat, swallowing a real answer
+    because it happens to open with a marker is much worse than showing a stray
+    marker, so ``is_intentional_silence_response`` demands the response be
+    EXACTLY a marker.  A webhook run has the opposite payoff: the cost of a
+    leaked non-story is a pointless notification on every tick, and models
+    reliably add a sentence explaining why they stayed quiet — which under the
+    strict rule flips the whole thing back to "deliver".  That is not a
+    hypothetical: it is why a Helper support lane kept messaging its owner to
+    report that it had nothing to report.
+
+    So reuse cron's matcher, which already treats a marker on its own first or
+    last line as silence while still delivering prose that merely mentions one
+    mid-sentence.  Sharing the function keeps the two autonomous lanes from
+    drifting apart, and keeps the interactive path untouched.
+    """
+    if not isinstance(content, str):
+        return False
+    try:
+        from cron.scheduler import _is_cron_silence_response
+    except Exception:  # pragma: no cover - cron package always ships with the gateway
+        return False
+    return _is_cron_silence_response(content)
+
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
 # (no prefix / multiplexing off → handle as the default profile).
@@ -336,6 +370,12 @@ class WebhookAdapter(BasePlatformAdapter):
         do not consume the entry and silently downgrade the final response
         to the ``log`` deliver type.  TTL cleanup happens on POST.
         """
+        if _is_webhook_silence_response(content):
+            logger.info(
+                "[webhook] Response for %s is a silence marker — not delivering", chat_id
+            )
+            return SendResult(success=True)
+
         delivery = self._delivery_info.get(chat_id, {})
         deliver_type = delivery.get("deliver", "log")
 

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -1297,6 +1297,117 @@ class TestSessionIsolation:
 
 
 # ===================================================================
+# Silence-marker suppression
+# ===================================================================
+
+
+class TestWebhookSilenceSuppression:
+    """A webhook route that answers ``[SILENT]`` must deliver nothing.
+
+    Webhook routes are autonomous lanes with nobody waiting on the other end,
+    so a subscription prompt tells the agent to reply ``[SILENT]`` on a tick
+    that produced no story.  Models routinely append a sentence saying WHY they
+    stayed quiet, and the live gateway's exact-whole-response rule then treats
+    that as a real report — which is how a Helper support lane ended up
+    repeatedly messaging its owner to say it had nothing to say.
+    """
+
+    def _adapter_with_mock_target(self):
+        adapter = _make_adapter()
+        mock_target = AsyncMock()
+        mock_target.send = AsyncMock(return_value=SendResult(success=True))
+        mock_runner = MagicMock()
+        mock_runner.adapters = {Platform("telegram"): mock_target}
+        mock_runner.config.get_home_channel.return_value = None
+        adapter.gateway_runner = mock_runner
+
+        chat_id = "webhook:helper-events:d-1"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "telegram",
+            "deliver_extra": {"chat_id": "-100123"},
+        }
+        adapter._delivery_info_created[chat_id] = time.time()
+        return adapter, mock_target, chat_id
+
+    @pytest.mark.asyncio
+    async def test_bare_marker_is_not_delivered(self):
+        adapter, target, chat_id = self._adapter_with_mock_target()
+
+        result = await adapter.send(chat_id, "[SILENT]")
+
+        assert result.success is True
+        target.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_marker_followed_by_prose_is_not_delivered(self):
+        """The regression this suppression exists for.
+
+        The agent explains its own silence on the lines after the marker.  The
+        strict interactive rule reads that as substantive prose and delivers the
+        whole thing, marker included.
+        """
+        adapter, target, chat_id = self._adapter_with_mock_target()
+
+        result = await adapter.send(
+            chat_id,
+            "[SILENT]\n\nThe new inbound was the same email quoted back a second "
+            "time, on a ticket we already answered. Nothing new to reply to, so I "
+            "closed it; it reopens by itself if they write back.",
+        )
+
+        assert result.success is True
+        target.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_marker_on_the_last_line_is_not_delivered(self):
+        adapter, target, chat_id = self._adapter_with_mock_target()
+
+        result = await adapter.send(chat_id, "Nothing to report this tick.\n\n[SILENT]")
+
+        assert result.success is True
+        target.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_real_report_is_still_delivered(self):
+        """Suppression must not swallow an actual story."""
+        adapter, target, chat_id = self._adapter_with_mock_target()
+
+        result = await adapter.send(
+            chat_id,
+            "Refunded $240 to the buyer and replied; the seller had already agreed.",
+        )
+
+        assert result.success is True
+        target.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_report_mentioning_the_marker_mid_sentence_is_delivered(self):
+        """A report that merely quotes a marker is not a silence request."""
+        adapter, target, chat_id = self._adapter_with_mock_target()
+
+        result = await adapter.send(
+            chat_id,
+            "I considered staying [SILENT] but this one moved money, so: refunded "
+            "$240 and replied to the buyer.",
+        )
+
+        assert result.success is True
+        target.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_suppression_precedes_log_delivery(self):
+        """A `log` route also suppresses, so the two lanes behave the same."""
+        adapter = _make_adapter()
+        chat_id = "webhook:helper-events:d-log"
+        adapter._delivery_info[chat_id] = {"deliver": "log", "deliver_extra": {}}
+        adapter._delivery_info_created[chat_id] = time.time()
+
+        result = await adapter.send(chat_id, "[SILENT]\n\nnothing happened")
+
+        assert result.success is True
+
+
+# ===================================================================
 # Delivery info cleanup
 # ===================================================================
 


### PR DESCRIPTION
## The symptom

A webhook route that answered `[SILENT]` still delivered its message, whenever the model added a sentence explaining why it was staying quiet:

```
[SILENT]

The new inbound was the same email quoted back a second time, on a ticket we
already answered. Nothing new to reply to, so I closed it.
```

This fires every tick that has nothing to report, which on a support-triage lane is most of them.

## Why it happens

Webhook subscription prompts tell the agent to answer `[SILENT]` when a tick produced no story — a duplicate inbound, a stand-down because a sibling lane already replied, a routine close. Nobody is waiting on the other end of a webhook, so a "nothing happened" message has no reader.

Delivery went through the live gateway's `is_intentional_silence_response` (`gateway/response_filters.py`), which requires the response to be **exactly** a marker:

> *Substantive prose that merely mentions `NO_REPLY` or `[SILENT]` must be delivered normally.*

**That rule is correct for an interactive chat** — swallowing a real answer because it happens to open with a marker is far worse than showing a stray marker. It is the wrong trade for an autonomous lane, where the cost of a leaked non-story is a pointless notification on every tick, and models reliably append the explanation that flips the check back to "deliver."

Cron already resolved this the other way: `cron/scheduler.py::_is_cron_silence_response` treats a marker on its own first or last line as silence, with a comment noting the cron contract is *"intentionally looser than the gateway's exact-whole-response rule."* So the two autonomous lanes disagreed, and webhook inherited the interactive rule.

## The fix

Suppress in `WebhookAdapter.send`, **before** the deliver-type switch, so every route behaves identically — `log`, `github_comment`, and cross-platform.

Reuses cron's `_is_cron_silence_response` rather than restating the rule, per *extend, don't duplicate* — the two autonomous lanes now cannot drift apart. Prose that merely mentions a marker mid-sentence still delivers. **The interactive gateway path is untouched.**

## What this does NOT change

- Interactive/gateway delivery keeps the strict exact-marker rule.
- No new config. The behaviour follows from the lane, not a knob.
- Empty responses are still the empty-response failure path, not silence.

## Tests

Six cases in `tests/gateway/test_webhook_adapter.py`:

| case | expected |
|---|---|
| bare `[SILENT]` | suppressed |
| `[SILENT]` + trailing prose (**the reported shape**) | suppressed |
| marker on the last line | suppressed |
| a real report | delivered |
| report quoting a marker mid-sentence | delivered |
| `log` route | suppressed |

**Verified red-first** — with the suppression block removed, the three silence cases fail (`AssertionError: Expected send to not have been awaited. Awaited 1 times.`) while the three delivery cases still pass. The tests assert the fix, not the framework.

Also green: `test_webhook_adapter.py`, `test_webhook_deliver_only.py`, `test_webhook_integration.py`, `test_response_filters.py` — 123 passed.

---

**AI disclosure:** authored by Gumclaw (claude-opus-5) after the bug fired repeatedly on a live Helper support-triage webhook lane.