### PR TITLE
fix(desktop): distinguish measured context usage

### DIFF
--- a/agent/context_breakdown.py
+++ b/agent/context_breakdown.py
@@ -151,6 +151,7 @@ def compute_session_context_breakdown(
         "context_max": context_max,
         "context_percent": context_percent,
         "context_used": context_used,
+        "context_used_is_estimate": measured_used <= 0,
         "estimated_total": estimated_total,
         "model": getattr(agent, "model", "") or "",
     }

--- a/apps/desktop/src/app/shell/context-usage-panel.test.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -21,6 +21,7 @@ const breakdown: ContextBreakdown = {
   context_max: 272_000,
   context_percent: 89,
   context_used: 241_400,
+  context_used_is_estimate: false,
   estimated_total: 286_600,
   model: 'test-model'
 }
@@ -89,5 +90,30 @@ describe('ContextUsagePanel', () => {
     rerender(<ContextUsagePanel currentUsage={initialUsage} requestGateway={secondGateway} sessionId="runtime-2" />)
 
     await waitFor(() => expect(secondGateway).toHaveBeenCalledTimes(1))
+  })
+
+  it('distinguishes the measured total from the estimated category breakdown', async () => {
+    const requestGateway = vi.fn().mockResolvedValue(breakdown)
+
+    render(<ContextUsagePanel currentUsage={initialUsage} requestGateway={requestGateway} sessionId="runtime-1" />)
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledTimes(1))
+
+    expect(screen.getByText('Estimated breakdown')).toBeTruthy()
+    expect(screen.getByText(/Category values are approximate/)).toBeTruthy()
+    expect(document.querySelector('[data-slot="context-usage-total"]')?.textContent).not.toContain('~')
+  })
+
+  it('marks the total as approximate when no provider measurement exists', async () => {
+    const requestGateway = vi.fn().mockResolvedValue({
+      ...breakdown,
+      context_used_is_estimate: true
+    })
+
+    render(<ContextUsagePanel currentUsage={initialUsage} requestGateway={requestGateway} sessionId="runtime-1" />)
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledTimes(1))
+
+    expect(document.querySelector('[data-slot="context-usage-total"]')?.textContent).toContain('~')
   })
 })

--- a/apps/desktop/src/app/shell/context-usage-panel.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.tsx
@@ -65,6 +65,8 @@ export function ContextUsagePanel({
 
   const contextMax = breakdown?.context_max ?? currentUsage.context_max ?? 0
   const contextUsed = breakdown?.context_used ?? currentUsage.context_used ?? 0
+  const contextUsedIsEstimate = breakdown ? breakdown.context_used_is_estimate !== false : false
+  const contextUsedLabel = `${contextUsedIsEstimate ? '~' : ''}${compactNumber(contextUsed)}`
 
   const contextPercent = Math.max(
     0,
@@ -87,14 +89,23 @@ export function ContextUsagePanel({
       <div className="flex items-baseline justify-between gap-2">
         <p className="font-medium text-foreground">{copy.title}</p>
 
-        <span className="text-[0.6875rem] text-muted-foreground">
-          {copy.tokenSummary(`~${compactNumber(contextUsed)}`, compactNumber(contextMax))}
+        <span className="text-[0.6875rem] text-muted-foreground" data-slot="context-usage-total">
+          {copy.tokenSummary(contextUsedLabel, compactNumber(contextMax))}
         </span>
       </div>
 
       <p className="text-[0.6875rem] text-foreground">{copy.percentFull(contextPercent)}</p>
 
       <ContextUsageBar categories={categories} segmentTotal={segmentTotal} />
+
+      {!!categories.length && (
+        <div className="flex flex-col gap-0.5">
+          <p className="font-medium text-foreground">{copy.estimatedBreakdown}</p>
+          <p className="text-[0.6875rem] leading-relaxed text-muted-foreground">
+            {copy.estimatedBreakdownHint}
+          </p>
+        </div>
+      )}
 
       <ul className="flex flex-col gap-1.5">
         {categories.map(category => (

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2408,6 +2408,8 @@ export const en: Translations = {
           tool_definitions: 'Tool definitions'
         },
         empty: 'No context data yet',
+        estimatedBreakdown: 'Estimated breakdown',
+        estimatedBreakdownHint: 'Category values are approximate and may not add up to the measured total.',
         loading: 'Loading breakdown…',
         percentFull: percent => `${percent}% Full`,
         title: 'Context Usage',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2278,6 +2278,8 @@ export const ja = defineLocale({
           tool_definitions: 'ツール定義'
         },
         empty: 'コンテキストデータはまだありません',
+        estimatedBreakdown: '推定内訳',
+        estimatedBreakdownHint: 'カテゴリの値は概算であり、合計が測定値と一致しない場合があります。',
         loading: '内訳を読み込み中…',
         percentFull: percent => `${percent}% 使用中`,
         title: 'コンテキスト使用状況',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2016,6 +2016,8 @@ export interface Translations {
           tool_definitions: string
         }
         empty: string
+        estimatedBreakdown: string
+        estimatedBreakdownHint: string
         loading: string
         percentFull: (percent: number) => string
         title: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2205,6 +2205,8 @@ export const zhHant = defineLocale({
           tool_definitions: '工具定義'
         },
         empty: '尚無上下文資料',
+        estimatedBreakdown: '估算明細',
+        estimatedBreakdownHint: '分類數值為近似值，其總和可能與實測總數不同。',
         loading: '正在載入明細…',
         percentFull: percent => `已用 ${percent}%`,
         title: '上下文使用量',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2585,6 +2585,8 @@ export const zh: Translations = {
           tool_definitions: '工具定义'
         },
         empty: '暂无上下文数据',
+        estimatedBreakdown: '估算明细',
+        estimatedBreakdownHint: '分类数值为近似值，其总和可能与实测总数不同。',
         loading: '正在加载明细…',
         percentFull: percent => `已用 ${percent}%`,
         title: '上下文用量',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -631,6 +631,7 @@ export interface ContextBreakdown {
   context_max: number
   context_percent: number
   context_used: number
+  context_used_is_estimate?: boolean
   estimated_total: number
   model?: string
 }

--- a/tests/agent/test_context_breakdown.py
+++ b/tests/agent/test_context_breakdown.py
@@ -48,6 +48,7 @@ def test_breakdown_includes_major_categories():
     assert {"system_prompt", "tool_definitions", "rules", "skills", "mcp", "subagent_definitions", "conversation"} <= ids
     assert data["context_max"] == 200_000
     assert data["estimated_total"] > 0
+    assert data["context_used_is_estimate"] is True
 
 
 def test_breakdown_uses_measured_context_when_available():
@@ -58,3 +59,4 @@ def test_breakdown_uses_measured_context_when_available():
 
     assert data["context_used"] == 42_000
     assert data["context_percent"] == 21
+    assert data["context_used_is_estimate"] is False

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8162,14 +8162,16 @@ def _(rid, params: dict) -> dict:
     agent = session.get("agent")
     if agent is None:
         usage = _session_usage_snapshot(session) or _get_usage(None)
+        context_used = usage.get("context_used", 0) or 0
         return _ok(
             rid,
             {
                 "categories": [],
                 "context_max": usage.get("context_max", 0) or 0,
                 "context_percent": usage.get("context_percent", 0) or 0,
-                "context_used": usage.get("context_used", 0) or 0,
-                "estimated_total": usage.get("context_used", 0) or usage.get("total", 0) or 0,
+                "context_used": context_used,
+                "context_used_is_estimate": not bool(context_used),
+                "estimated_total": context_used or usage.get("total", 0) or 0,
                 "model": _metadata_mirror(session).get("model", ""),
             },
         )


### PR DESCRIPTION
## Do not merge yet

This draft overlaps the context-usage panel files changed by #71420. It should be rebased after #71420 lands so the two fixes compose cleanly.

## Problem

The Desktop context popover mixes two different kinds of numbers without identifying their provenance:

- `context_used` comes from the provider's latest prompt-token measurement when one is available.
- Every category in the breakdown is independently estimated with a `chars / 4` heuristic.

The UI currently prefixes the measured total with `~`, while the genuinely approximate categories are presented without any qualification. Their sum can differ substantially from the measured total, so the panel makes the exact value look approximate and the approximate values look exact.

## Solution

- Add `context_used_is_estimate` to the gateway payload so the renderer does not have to infer provenance from numeric equality.
- Remove the approximation marker only when the backend confirms the total was provider-measured.
- Preserve the marker for the estimator fallback and for older backends that do not expose the new field.
- Label the category list as an estimated breakdown and explain that its sum may differ from the measured total.
- Add the new copy to every existing Desktop locale.

The categories are intentionally **not** scaled to match the provider total. A single proportional correction would manufacture per-category precision that the underlying heuristic does not provide, because JSON schemas and conversational prose do not share a uniform token-to-character ratio.

## Compatibility and scope

- The new payload field is additive.
- The TypeScript field is optional so Desktop remains compatible with older gateways.
- Older gateways retain the previous conservative `~` marker.
- This does not change token accounting, compaction, context limits, or the existing category estimates.
- This deliberately does not change the bar scaling addressed by #71420.

## Tests

- `scripts/run_tests.sh tests/agent/test_context_breakdown.py tests/test_tui_gateway_server.py` — 465 passed
- `npm --prefix apps/desktop run test:ui -- src/app/shell/context-usage-panel.test.tsx` — 4 passed
- `npm --prefix apps/desktop run typecheck` — passed
- `npm --prefix apps/desktop run lint -- --quiet` — passed
- `git diff --check` — passed

The UI tests cover both provider-measured totals (no `~`) and estimator fallbacks (`~` retained).

## Cross-check

An adversarial Claude Opus 4.8 review independently traced the provider measurement and category-estimation paths. It confirmed that the total is provider-measured when available, the categories are rough estimates, and proportional rescaling would create false precision. The review recommended exposing provenance explicitly and labeling the category list as estimated.

Designed by Marsu — Refined by Codex.

Co-Authored-By: Codex <codex@openai.com>
