### PR TITLE
feat(providers): port Claude Agent SDK runtime to v0.19

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -615,7 +615,7 @@ def init_agent(
     agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
-    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server", "claude_agent_sdk"}:
         agent.api_mode = api_mode
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"
@@ -1111,6 +1111,17 @@ def init_agent(
         if not agent.quiet_mode:
             _gr_label = " + Guardrails" if agent._bedrock_guardrail_config else ""
             print(f"🤖 AI Agent initialized with model: {agent.model} (AWS Bedrock, {agent._bedrock_region}{_gr_label})")
+    elif agent.api_mode == "claude_agent_sdk":
+        # claude-agent-sdk runtime — the official Agent SDK owns its own
+        # subprocess and reads Claude-managed subscription login storage;
+        # there is no OpenAI-style client or environment credential route on
+        # this path (#25267). Mirrors the bedrock_converse shape.
+        agent.client = None
+        agent._client_kwargs = {}
+        agent.api_key = api_key or "claude-subscription-oauth"
+        agent.base_url = base_url or ""
+        if not agent.quiet_mode:
+            print(f"🤖 AI Agent initialized with model: {agent.model} (Claude Agent SDK, subscription)")
     else:
         if api_key and base_url:
             # Explicit credentials from CLI/gateway — construct directly.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2173,7 +2173,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # to keep the current URL. See #47828.
         old_norm_provider = (old_provider or "").strip().lower()
         new_norm_provider = (new_provider or "").strip().lower()
-        if base_url:
+        if api_mode == "claude_agent_sdk":
+            # The SDK owns a Claude CLI subprocess transport and intentionally
+            # has no HTTP endpoint.
+            agent.base_url = ""
+        elif base_url:
             agent.base_url = base_url
         elif old_norm_provider != new_norm_provider:
             raise ValueError(
@@ -2232,6 +2236,16 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent.base_url = "moa://local"
             agent._client_kwargs = {}
             agent.client = build_moa_facade(agent, agent.model)
+        elif api_mode == "claude_agent_sdk":
+            # Clientless runtime: keep only the sentinel/API-mode state used by
+            # the normal SDK early-return path. Never construct an OpenAI or
+            # Anthropic HTTP client for it.
+            agent._anthropic_client = None
+            agent._anthropic_api_key = ""
+            agent._anthropic_base_url = None
+            agent._is_anthropic_oauth = False
+            agent.client = None
+            agent._client_kwargs = {}
         elif api_mode == "anthropic_messages":
             from agent.anthropic_adapter import (
                 build_anthropic_client,
@@ -2496,6 +2510,51 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         except Exception:
             logger.warning(
                 "Failed to persist billing route after model switch",
+                exc_info=True,
+            )
+
+    # Resuming an SDK conversation across an SDK <-> native/provider boundary
+    # would omit every intervening non-SDK turn. Clear only after the replacement
+    # runtime was built successfully. A model change within the SDK still resumes
+    # the same conversation, which the SDK supports with the new requested model.
+    from agent.claude_sdk_runtime import is_claude_agent_sdk_runtime
+
+    old_api_mode = _snapshot.get("api_mode")
+    if not isinstance(old_api_mode, str):
+        old_api_mode = None
+    crossed_sdk_boundary = is_claude_agent_sdk_runtime(
+        provider=old_provider,
+        api_mode=old_api_mode,
+    ) != is_claude_agent_sdk_runtime(
+        provider=agent.provider,
+        api_mode=getattr(agent, "api_mode", None),
+    )
+    if crossed_sdk_boundary and _session_db is not None and _session_id:
+        try:
+            _session_db.update_claude_sdk_session_id(_session_id, None)
+        except Exception:
+            logger.warning(
+                "Failed to clear Claude SDK continuity after provider boundary",
+                exc_info=True,
+            )
+
+    # A live SDK session owns a CLI subprocess configured for the runtime that
+    # created it. Retire it only after the replacement runtime is fully built,
+    # keeping failed HTTP switches rollback-safe. The next SDK turn lazily
+    # starts or resumes with the new provider/model state.
+    runtime_changed = (
+        old_model != new_model
+        or old_norm_provider != new_norm_provider
+        or _snapshot.get("api_mode") != api_mode
+    )
+    old_sdk_session = getattr(agent, "_claude_sdk_session", None)
+    if runtime_changed and old_sdk_session is not None:
+        agent._claude_sdk_session = None
+        try:
+            old_sdk_session.close()
+        except Exception:
+            logger.debug(
+                "Failed to close retired Claude Agent SDK session",
                 exc_info=True,
             )
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4873,11 +4873,45 @@ def _resolve_auto(
     auxiliary_is_nous = False  # Reset — _try_nous() will set True if it wins
     runtime = _normalize_main_runtime(main_runtime)
     runtime_provider = runtime.get("provider", "")
+    runtime_requested_provider = runtime.get("requested_provider", "")
     runtime_model = str(runtime.get("model") or "")
     runtime_base_url = str(runtime.get("base_url") or "")
     runtime_api_key = runtime.get("api_key", "")
     runtime_api_mode = str(runtime.get("api_mode") or "")
 
+
+    # ── Fail-closed subscription lane (claude-agent-sdk, #25267) ──
+    # When the MAIN provider is the claude-agent-sdk (subscription OAuth,
+    # never metered), auto-detection must NOT silently re-route auxiliary
+    # tasks (title generation, context compression, ...) onto metered
+    # fallback providers — that would break the provider's billing contract
+    # through the side door. Explicit `auxiliary.<task>.{provider,model}`
+    # config is resolved before this chain and remains the operator's
+    # deliberate opt-in; without it, aux features simply no-op.
+    from agent.claude_sdk_runtime import is_claude_agent_sdk_runtime
+
+    has_live_runtime_identity = bool(
+        runtime_provider or runtime_requested_provider or runtime_api_mode
+    )
+    configured_provider = (
+        str(_read_main_provider() or "") if not has_live_runtime_identity else ""
+    )
+    if (
+        is_claude_agent_sdk_runtime(
+            provider=runtime_provider,
+            api_mode=runtime_api_mode,
+        )
+        or is_claude_agent_sdk_runtime(provider=runtime_requested_provider)
+        or (
+            not has_live_runtime_identity
+            and is_claude_agent_sdk_runtime(provider=configured_provider)
+        )
+    ):
+        logger.debug(
+            "aux auto-detect disabled: main provider is claude-agent-sdk "
+            "(subscription lane, fail-closed)"
+        )
+        return None, None
 
     # ── Warn once if OPENAI_BASE_URL is set but config.yaml uses a named
     #    provider (not 'custom').  This catches the common "env poisoning"
@@ -4905,7 +4939,9 @@ def _resolve_auto(
     # on aggregators (OpenRouter, Nous) who previously got routed to a
     # cheap provider-side default.  Explicit per-task overrides set via
     # config.yaml (auxiliary.<task>.provider) still win over this.
-    main_provider = str(runtime_provider or _read_main_provider() or "")
+    main_provider = str(
+        runtime_provider or configured_provider or _read_main_provider() or ""
+    )
     main_model = str(runtime_model or _read_main_model() or "")
 
     # MoA virtual provider: the "model" is a preset name (e.g. "opus-gpt") and

--- a/agent/claude_sdk_runtime.py
+++ b/agent/claude_sdk_runtime.py
@@ -1,0 +1,822 @@
+"""claude-agent-sdk runtime — the subscription-Claude agent-loop path.
+
+The structural twin of ``agent/codex_runtime.py``'s app-server path: hands the
+entire turn to Anthropic's official ``claude-agent-sdk`` (which drives the
+Claude Code CLI's own agent loop under **subscription OAuth** — never a
+metered API key) and projects its typed message stream back into Hermes'
+messages list so transcript persistence and recall keep working. GitHub
+issue #25267.
+
+* ``run_claude_agent_sdk_turn`` — drives one turn through a lazily-created
+  ``ClaudeAgentSdkSession`` (used when ``agent.api_mode == "claude_agent_sdk"``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, cast
+
+logger = logging.getLogger(__name__)
+
+_CLAUDE_AGENT_SDK_PROVIDERS = frozenset(
+    {"claude-agent-sdk", "claude-sdk", "claude-code-sdk", "claude_agent_sdk"}
+)
+
+
+def is_claude_agent_sdk_runtime(
+    *, provider: Optional[str] = None, api_mode: Optional[str] = None
+) -> bool:
+    """Whether a persisted/runtime route belongs to the Claude Agent SDK."""
+    return (api_mode or "").strip().lower() == "claude_agent_sdk" or (
+        provider or ""
+    ).strip().lower() in _CLAUDE_AGENT_SDK_PROVIDERS
+
+
+# Cap per persona/memory source so the append can't blow the context budget
+# (Hermes' native files are hard-capped anyway; the soul file is ours).
+_APPEND_SOURCE_MAX_CHARS = 8000
+
+
+def _read_capped(path: str, cap: int = _APPEND_SOURCE_MAX_CHARS) -> str:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return fh.read()[:cap].strip()
+    except OSError:
+        return ""
+
+
+# Total append budget. Blocks are included whole, in priority order; a block
+# that does not fit is SKIPPED (never truncated mid-block) and later, smaller
+# blocks may still be included. Priority = assembly order below: soul,
+# native project context, session line, platform hint, user profile, memory,
+# memory guidance, session_search guidance, skills index.
+_APPEND_TOTAL_MAX_CHARS = 40000
+
+# Sentences that instruct the skill-WRITE tool — skill_manage is NOT exposed
+# through the MCP shims, and guidance must only describe callable tools.
+# Stripped as pure deletions (never rewording); the pin tests go red if
+# upstream rewords them. One lives in MEMORY_GUIDANCE, one in the skills
+# index boilerplate, which the index ships unconditionally.
+_SKILL_TOOL_SENTENCE = (
+    "If you've discovered a new way to do something, solved a problem that could be "
+    "necessary later, save it as a skill with the skill tool.\n"
+)
+_SKILL_MANAGE_INDEX_SENTENCE = (
+    "If a skill has issues, fix it with skill_manage(action='patch')."
+)
+
+# The claude_code preset ships its OWN file-based memory convention (a
+# per-project memory directory). Without runtime-specific guidance, the model
+# can write durable preferences to harness memory files instead of calling the
+# hermes-tools `memory` tool, so the fact never reaches the store this append
+# injects. This addendum, appended after the verbatim native guidance, defines
+# the durable store for this runtime.
+_MEMORY_TOOL_DISAMBIGUATION = (
+    "Your ONLY durable memory is the `memory` tool from the hermes-tools "
+    "MCP server. Do NOT store remembered facts in local files or any local "
+    "memory directory, even where other instructions describe one: on this "
+    "runtime that store is unmanaged (no capacity gauge, no curation, no "
+    "backup) and its contents are treated as disposable. Every fact worth "
+    "keeping goes through the memory tool."
+)
+
+# Multi-term prose discovery queries are too restrictive because FTS5 ANDs
+# the terms and returns nothing for content that matches one distinctive term.
+# This clarification is appended after the verbatim native guidance.
+_SEARCH_QUERY_ADDENDUM = (
+    "session_search queries are keyword FTS: ALL terms must match (AND). "
+    "Prefer one or two distinctive words; join alternatives with OR."
+)
+
+
+def _strip_uncallable_tool_guidance(text: str) -> str:
+    return (
+        text.replace(_SKILL_TOOL_SENTENCE, "")
+        .replace(_SKILL_MANAGE_INDEX_SENTENCE, "")
+    )
+
+
+def build_system_prompt_append(
+    platform: Optional[str] = None,
+    session_id: Optional[str] = None,
+    model: Optional[str] = None,
+    cwd: Optional[str] = None,
+    context_length: Optional[int] = None,
+    native_read_only: bool = False,
+) -> Optional[str]:
+    """Compose the system-prompt append for the SDK session.
+
+    Hermes' own prompt composer is bypassed on this runtime; this is its
+    replacement, built from the same native builders for composer parity:
+
+      1. Hermes' active SOUL.md identity, or the built-in Hermes identity when
+         no SOUL exists. agent.claude_agent_sdk.append_file can override it.
+      2. Native project context (AGENTS.md / CLAUDE.md / .cursorrules) with
+         the native scanner, priority, safety checks, and budget.
+      3. Session line — the native volatile-tier format (date-only for
+         prefix-cache stability) + session id / model / provider.
+      4. Platform hint (native PLATFORM_HINTS, e.g. Telegram formatting).
+      5. USER PROFILE + MEMORY blocks — MemoryStore.format_for_system_prompt
+         verbatim, fill gauge included (the same store the memory MCP shim
+         writes; config-gated on memory.memory_enabled).
+      6. Outside native-read-only mode, MEMORY_GUIDANCE (minus its skill-tool
+         sentence — skill_manage is not exposed) + SESSION_SEARCH_GUIDANCE —
+         the behavior contract for the two shim tools.
+      7. Outside native-read-only mode, the skills index
+         (build_skills_system_prompt) for the read-side skill_view/skills_list
+         tools. SKILLS_GUIDANCE is deliberately ABSENT (it instructs
+         skill_manage).
+
+    Read at session creation: edits apply on the next session (retire, /new,
+    or gateway restart), not mid-session — the same snapshot invariant the
+    native composer keeps for prefix-cache stability.
+    """
+    blocks: list[str] = []
+
+    # Lazy import: keeps this module free of an import cycle with the session
+    # module while reusing its single reader for the provider config block.
+    from agent.transports.claude_agent_sdk_session import _provider_config
+
+    soul_path = str(_provider_config().get("append_file") or "").strip()
+    identity: Optional[str] = None
+    if soul_path:
+        identity = _read_capped(soul_path)
+        if not identity:
+            logger.warning(
+                "agent.claude_agent_sdk.append_file=%s is set but unreadable/empty",
+                soul_path,
+            )
+    if not identity:
+        try:
+            from agent.prompt_builder import DEFAULT_AGENT_IDENTITY, load_soul_md
+
+            identity = load_soul_md() or DEFAULT_AGENT_IDENTITY
+        except Exception:
+            logger.debug("native Hermes identity composition failed", exc_info=True)
+    if identity:
+        blocks.append(identity)
+
+    # Reuse Hermes' native project-context loader rather than maintaining a
+    # second scanner for this runtime. skip_soul=True prevents the active
+    # identity above from being injected a second time.
+    try:
+        from agent.prompt_builder import build_context_files_prompt
+
+        project_context = build_context_files_prompt(
+            cwd=cwd,
+            skip_soul=True,
+            context_length=context_length,
+        )
+        if project_context:
+            blocks.append(project_context)
+    except Exception:
+        logger.debug("native project context composition failed", exc_info=True)
+
+    # Session line — mirrors the native composer's volatile tier
+    # (system_prompt.py): date-only so the append stays byte-stable all day.
+    try:
+        from hermes_time import now as _hermes_now
+
+        session_line = (
+            f"Conversation started: {_hermes_now().strftime('%A, %B %d, %Y')}"
+        )
+        if session_id:
+            session_line += f"\nSession ID: {session_id}"
+        if model:
+            session_line += f"\nModel: {model}"
+        session_line += "\nProvider: claude-agent-sdk (Claude subscription)"
+        blocks.append(session_line)
+    except Exception:  # pragma: no cover - never block session creation
+        logger.debug("session line composition failed", exc_info=True)
+
+    if platform:
+        try:
+            from agent.prompt_builder import PLATFORM_HINTS
+
+            hint = PLATFORM_HINTS.get(str(platform).lower().strip())
+            if hint:
+                blocks.append(hint.strip())
+        except Exception:  # pragma: no cover
+            logger.debug("platform hint lookup failed", exc_info=True)
+
+    # Memory is gated by TWO predicates, mirroring the registration site
+    # (hermes_tools_mcp_server._stateless_shim_defs): the store BLOCKS ride
+    # the config kill-switch alone — an external provider runs alongside the
+    # on-disk store, whose facts stay readable — while the TOOL guidance and
+    # the skills-index advertisement additionally require that no external
+    # `memory.provider` is configured, because that is when the shim is
+    # unregistered and instructing an absent tool would be a lie.
+    try:
+        from agent.transports.hermes_tools_mcp_server import (
+            _external_memory_provider,
+            _memory_enabled_in_config,
+        )
+
+        memory_enabled = _memory_enabled_in_config()
+        memory_tool_exposed = (
+            memory_enabled and _external_memory_provider() is None
+        )
+    except Exception:  # pragma: no cover
+        memory_enabled = True
+        memory_tool_exposed = True
+    if memory_enabled:
+        try:
+            from tools.memory_tool import load_on_disk_store
+
+            store = load_on_disk_store()
+            for target in ("user", "memory"):
+                block = store.format_for_system_prompt(target)
+                if block:
+                    blocks.append(block)
+        except Exception:
+            logger.debug("memory block composition failed", exc_info=True)
+    if memory_tool_exposed and not native_read_only:
+        try:
+            from agent.prompt_builder import MEMORY_GUIDANCE
+
+            blocks.append(
+                _strip_uncallable_tool_guidance(MEMORY_GUIDANCE)
+                + "\n"
+                + _MEMORY_TOOL_DISAMBIGUATION
+            )
+        except Exception:  # pragma: no cover
+            logger.debug("memory guidance unavailable", exc_info=True)
+
+    # session_search is always served outside native-read-only mode (a missing
+    # DB degrades to an explicit error at call time), so its guidance ships
+    # whenever the Hermes MCP surface exists.
+    if not native_read_only:
+        try:
+            from agent.prompt_builder import SESSION_SEARCH_GUIDANCE
+
+            blocks.append(SESSION_SEARCH_GUIDANCE + "\n" + _SEARCH_QUERY_ADDENDUM)
+        except Exception:  # pragma: no cover
+            logger.debug("session_search guidance unavailable", exc_info=True)
+
+    # Skills index for the read-side tools, filtered to the honest
+    # MCP-exposed surface. `memory` joins only when the shim is actually
+    # registered (see the two-predicate gate above); EXPOSED_TOOLS is the
+    # STATIC surface — per-tool check_fn filtering happens at registration
+    # in the MCP child's env and cannot be evaluated here.
+    if not native_read_only:
+        try:
+            from agent import prompt_builder
+            from agent.transports.hermes_tools_mcp_server import EXPOSED_TOOLS
+
+            advertised = set(EXPOSED_TOOLS) | {"session_search"}
+            if memory_tool_exposed:
+                advertised.add("memory")
+            index = prompt_builder.build_skills_system_prompt(
+                available_tools=advertised,
+            )
+            if index:
+                blocks.append(_strip_uncallable_tool_guidance(index))
+        except Exception:  # pragma: no cover
+            logger.debug("skills index composition failed", exc_info=True)
+
+    # Whole-block budget: include each block only if it fits; skipping an
+    # oversized block never evicts later, smaller ones.
+    out_parts: list[str] = []
+    used = 0
+    for block in blocks:
+        block = block.strip()
+        if not block:
+            continue
+        cost = len(block) + (2 if out_parts else 0)
+        if used + cost > _APPEND_TOTAL_MAX_CHARS:
+            logger.debug(
+                "append budget: skipping a %d-char block (used %d/%d)",
+                len(block), used, _APPEND_TOTAL_MAX_CHARS,
+            )
+            continue
+        out_parts.append(block)
+        used += cost
+    return "\n\n".join(out_parts) or None
+
+
+def _coerce_usage_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(value), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _record_claude_sdk_usage(agent, turn) -> dict[str, Any]:
+    """Translate SDK ResultMessage usage into Hermes accounting.
+
+    The SDK reports Anthropic-shaped usage: input_tokens, output_tokens,
+    cache_read_input_tokens, cache_creation_input_tokens. Billing is
+    subscription-included only after the session's first-party Claude.ai
+    auth-status attestation succeeds."""
+    if not getattr(turn, "subscription_attested", False):
+        return {}
+
+    agent.session_api_calls += 1
+    agent.session_cost_status = "included"
+    agent.session_cost_source = "claude-subscription"
+
+    usage = getattr(turn, "token_usage_last", None)
+    if not isinstance(usage, dict) or not usage:
+        if agent._session_db and agent.session_id:
+            try:
+                if not agent._session_db_created:
+                    agent._ensure_db_session()
+                agent._session_db.update_token_counts(
+                    agent.session_id,
+                    model=agent.model,
+                    estimated_cost_usd=0.0,
+                    actual_cost_usd=0.0,
+                    cost_status="included",
+                    cost_source="claude-subscription",
+                    billing_provider=agent.provider,
+                    billing_base_url=agent.base_url,
+                    billing_mode="subscription_included",
+                    api_call_count=1,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "claude-sdk api-call persistence failed (session=%s): %s",
+                    agent.session_id, exc,
+                )
+        return {}
+
+    from agent.usage_pricing import CanonicalUsage
+
+    input_tokens = _coerce_usage_int(usage.get("input_tokens"))
+    output_tokens = _coerce_usage_int(usage.get("output_tokens"))
+    cache_read_tokens = _coerce_usage_int(usage.get("cache_read_input_tokens"))
+    cache_write_tokens = _coerce_usage_int(
+        usage.get("cache_creation_input_tokens")
+    )
+
+    canonical_usage = CanonicalUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
+        reasoning_tokens=0,
+        raw_usage=usage,
+    )
+    prompt_tokens = canonical_usage.prompt_tokens
+    completion_tokens = canonical_usage.output_tokens
+    total_tokens = canonical_usage.total_tokens
+    usage_dict = {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+        "input_tokens": canonical_usage.input_tokens,
+        "output_tokens": canonical_usage.output_tokens,
+        "cache_read_tokens": canonical_usage.cache_read_tokens,
+        "cache_write_tokens": canonical_usage.cache_write_tokens,
+        "reasoning_tokens": 0,
+    }
+
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is not None:
+        try:
+            compressor.update_from_response(usage_dict)
+        except Exception:
+            logger.debug("claude-sdk usage update failed", exc_info=True)
+
+    agent.session_prompt_tokens += prompt_tokens
+    agent.session_completion_tokens += completion_tokens
+    agent.session_total_tokens += total_tokens
+    agent.session_input_tokens += canonical_usage.input_tokens
+    agent.session_output_tokens += canonical_usage.output_tokens
+    agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
+    agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
+
+    if agent._session_db and agent.session_id:
+        try:
+            if not agent._session_db_created:
+                agent._ensure_db_session()
+            agent._session_db.update_token_counts(
+                agent.session_id,
+                input_tokens=canonical_usage.input_tokens,
+                output_tokens=canonical_usage.output_tokens,
+                cache_read_tokens=canonical_usage.cache_read_tokens,
+                cache_write_tokens=canonical_usage.cache_write_tokens,
+                reasoning_tokens=0,
+                cost_status="included",
+                cost_source="claude-subscription",
+                billing_provider=agent.provider,
+                billing_base_url=agent.base_url,
+                billing_mode="subscription_included",
+                model=agent.model,
+                api_call_count=1,
+            )
+        except Exception as exc:
+            logger.debug(
+                "claude-sdk token persistence failed (session=%s, tokens=%d): %s",
+                agent.session_id, total_tokens, exc,
+            )
+
+    return {
+        **usage_dict,
+        "last_prompt_tokens": prompt_tokens,
+        "estimated_cost_usd": None,
+        "cost_status": "included",
+        "cost_source": "claude-subscription",
+    }
+
+
+def _persisted_sdk_session_id(agent) -> Optional[str]:
+    """The SDK session id stored on the Hermes session row (or None)."""
+    if getattr(agent, "_persist_disabled", False):
+        return None
+    if not (getattr(agent, "_session_db", None) and getattr(agent, "session_id", None)):
+        return None
+    try:
+        row = agent._session_db.get_session(agent.session_id) or {}
+        return row.get("claude_sdk_session_id") or None
+    except Exception:
+        logger.debug("resume-id read failed", exc_info=True)
+        return None
+
+
+def _store_sdk_session_id(agent, value: Optional[str]) -> None:
+    """Persist (or clear, with None) the SDK session id on the session row."""
+    if getattr(agent, "_persist_disabled", False):
+        # A review/curator fork shares the parent's session_id — it must
+        # never write its own resume id onto the parent's row.
+        return
+    if not (getattr(agent, "_session_db", None) and getattr(agent, "session_id", None)):
+        return
+    try:
+        agent._session_db.update_claude_sdk_session_id(agent.session_id, value)
+    except Exception:
+        logger.debug("resume-id write failed", exc_info=True)
+
+
+_CONTINUITY_DIGEST_MAX_CHARS = 4000
+
+
+def _render_continuity_digest(prior_messages: List[Dict[str, Any]]) -> str:
+    """Bounded text preamble for a FRESH SDK session that has prior Hermes
+    history (resume impossible: no stored id, or the stored one went stale).
+    Reuses _digest_history's compaction, then flattens to capped text."""
+    try:
+        from agent.background_review import _digest_history
+
+        msgs = _digest_history(list(prior_messages or []), tail=8)
+    except Exception:  # pragma: no cover - compaction is best-effort
+        msgs = list(prior_messages or [])[-8:]
+    lines: list[str] = []
+    for m in msgs:
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role")
+        content = m.get("content")
+        if role not in ("user", "assistant") or not content:
+            continue
+        text = str(content).replace("\n", " ").strip()
+        if text:
+            lines.append(f"{role.upper()}: {text[:400]}")
+    if not lines:
+        return ""
+    body = "\n".join(lines)
+    if len(body) > _CONTINUITY_DIGEST_MAX_CHARS:
+        body = body[-_CONTINUITY_DIGEST_MAX_CHARS:]
+    return (
+        "[Continuity digest — the runtime restarted and the live model "
+        "context was lost; recent turns from the stored transcript, oldest "
+        "first:]\n" + body + "\n[End digest. The user's new message follows.]\n\n"
+    )
+
+
+def run_claude_agent_sdk_turn(
+    agent,
+    *,
+    user_message: Any,
+    original_user_message: Any,
+    messages: List[Dict[str, Any]],
+    effective_task_id: str,
+    should_review_memory: bool = False,
+) -> Dict[str, Any]:
+    """claude-agent-sdk runtime path. Hands the entire turn to the SDK's
+    agent loop and projects its messages back into Hermes' list.
+
+    Called from run_conversation() when agent.api_mode == "claude_agent_sdk".
+    Returns the same dict shape as the chat_completions path.
+
+    Continuity retire matrix (#25267):
+      /new, session expiry      → NEW Hermes session row → no persisted id → fresh
+      gateway restart/eviction  → same row, id persisted  → RESUME
+      error/timeout retire      → id CLEARED → next turn fresh + digest
+      stale/failed resume       → retire → clear → ONE fresh retry with digest
+    """
+    from agent.transports.claude_agent_sdk_session import (
+        ClaudeAgentSdkSession,
+        _UNSUPPORTED_IMAGE_ERROR,
+        _coerce_turn_input_text,
+        _contains_image_input,
+        _normalize_add_dirs,
+        _provider_config,
+        _provider_flag,
+    )
+
+    def _unsupported_image_result() -> Dict[str, Any]:
+        return {
+            "final_response": "",
+            "messages": messages,
+            "api_calls": 0,
+            "completed": False,
+            "partial": True,
+            "error": _UNSUPPORTED_IMAGE_ERROR,
+            # The standard prologue already persisted the user turn.
+            "agent_persisted": True,
+        }
+
+    def _create_session(resume_id: Optional[str]) -> None:
+        from agent.runtime_cwd import resolve_agent_cwd
+
+        provider_config = _provider_config()
+        add_dirs = _normalize_add_dirs(provider_config.get("add_dirs", []))
+        native_read_only = _provider_flag(
+            "native_read_only", config=provider_config
+        )
+        cwd = getattr(agent, "session_cwd", None) or str(resolve_agent_cwd())
+        try:
+            from tools.terminal_tool import _get_approval_callback
+            approval_callback = _get_approval_callback()
+        except Exception:
+            approval_callback = None
+
+        def _on_tool_started(tool_name: str, preview: str, args: dict) -> None:
+            progress_callback = getattr(agent, "tool_progress_callback", None)
+            if progress_callback is None:
+                return
+            try:
+                progress_callback("tool.started", tool_name, preview, args)
+            except Exception:
+                logger.debug(
+                    "claude-sdk tool-progress callback raised", exc_info=True
+                )
+
+        def _relay_stream_delta(text: str) -> None:
+            # Late-bound: the gateway assigns stream_delta_callback per turn
+            # AFTER the session exists (and clears it between turns).
+            callback = getattr(agent, "stream_delta_callback", None)
+            if callback is None:
+                return
+            try:
+                callback(text)
+            except Exception:
+                logger.debug("stream delta relay raised", exc_info=True)
+
+        append = build_system_prompt_append(
+            platform=getattr(agent, "platform", None),
+            session_id=getattr(agent, "session_id", None),
+            model=getattr(agent, "model", None),
+            cwd=cwd,
+            context_length=getattr(
+                getattr(agent, "context_compressor", None), "context_length", None
+            ),
+            native_read_only=native_read_only,
+        )
+        agent._claude_sdk_session = ClaudeAgentSdkSession(
+            cwd=cwd,
+            add_dirs=add_dirs,
+            native_read_only=native_read_only,
+            model=getattr(agent, "model", None) or None,
+            approval_callback=approval_callback,
+            on_tool_started=_on_tool_started,
+            system_prompt_append=append,
+            hermes_session_id=getattr(agent, "session_id", None),
+            resume_session_id=resume_id,
+            on_stream_delta=_relay_stream_delta,
+        )
+        # The prologue persisted Hermes' native composed prompt — a prompt
+        # this runtime never sends. Overwrite the snapshot with the
+        # EFFECTIVE prompt so the audit trail tells the truth.
+        try:
+            if getattr(agent, "_session_db", None) and agent.session_id:
+                agent._session_db.update_system_prompt(
+                    agent.session_id, "[claude_code preset]\n\n" + (append or "")
+                )
+        except Exception:
+            logger.debug("effective-prompt snapshot failed", exc_info=True)
+
+    # NOTE: the user message is ALREADY appended to messages by the standard
+    # run_conversation() flow before the early return reaches us. Do NOT
+    # append again — that would duplicate. (Same contract as codex_runtime.)
+
+    # An interrupt that landed before the SDK session exists (first turn, or
+    # right after a retire) only set agent._interrupt_requested — honor it
+    # here, mirroring the native loop's top-of-loop check, and consume the
+    # flag so the NEXT turn runs normally.
+    if getattr(agent, "_interrupt_requested", False):
+        agent._interrupt_requested = False
+        live_session = getattr(agent, "_claude_sdk_session", None)
+        if live_session is not None:
+            # interrupt() also set the live session's event; consume it here
+            # or the NEXT legitimate message dies on the stale event with no
+            # model call.
+            try:
+                live_session.consume_interrupt()
+            except Exception:
+                logger.debug("consume_interrupt failed", exc_info=True)
+        return {
+            "final_response": "",
+            "messages": messages,
+            "api_calls": 0,
+            "completed": False,
+            "partial": True,
+            "error": None,
+            "agent_persisted": True,
+        }
+
+    # Rich images are not supported by this transport. Reject the API-facing
+    # value and its complete current-message envelope before continuity digest
+    # concatenation or SDK session creation; recursive dict traversal prevents
+    # a nested data URL from being stringified into prompt text.
+    current_envelope = messages[-1] if messages else None
+    if (
+        _contains_image_input(user_message)
+        or _contains_image_input(original_user_message)
+        or _contains_image_input(current_envelope)
+    ):
+        return _unsupported_image_result()
+    send_text_base = _coerce_turn_input_text(user_message)
+
+    turn = cast(Any, None)
+    resumed = False
+    send_text = send_text_base
+    for attempt in (0, 1):
+        if not hasattr(agent, "_claude_sdk_session") or agent._claude_sdk_session is None:
+            resume_id = _persisted_sdk_session_id(agent) if attempt == 0 else None
+            resumed = bool(resume_id)
+            send_text = send_text_base
+            if not resume_id and len(messages) > 1:
+                prior_messages = messages[:-1]
+                if _contains_image_input(prior_messages):
+                    return _unsupported_image_result()
+                digest = _render_continuity_digest(prior_messages)
+                if digest:
+                    send_text = digest + send_text_base
+            _create_session(resume_id)
+
+        sdk_session = cast(Any, agent._claude_sdk_session)
+        try:
+            turn = sdk_session.run_turn(user_input=send_text)
+        except Exception as exc:
+            logger.exception("claude-agent-sdk turn failed")
+            try:
+                sdk_session.close()
+            except Exception:
+                pass
+            agent._claude_sdk_session = None
+            # Retire continuity for every adapter exception, but never replay
+            # the user turn: the adapter did not positively attest its phase.
+            _store_sdk_session_id(agent, None)
+            return {
+                "final_response": f"claude-agent-sdk turn failed: {exc}",
+                "messages": messages,
+                "api_calls": 0,
+                "completed": False,
+                "partial": True,
+                "error": str(exc),
+            }
+
+        if getattr(turn, "should_retire", False):
+            logger.warning(
+                "claude-agent-sdk session retired (turn error: %s)", turn.error
+            )
+            try:
+                sdk_session.close()
+            except Exception:
+                pass
+            agent._claude_sdk_session = None
+            # Error/timeout retire always clears the persisted resume id —
+            # never resume a conversation that just failed.
+            _store_sdk_session_id(agent, None)
+            if (
+                resumed
+                and attempt == 0
+                and getattr(turn, "retry_safe_before_query", False)
+            ):
+                # Explicit pre-query resumed-connect rejection: one fresh
+                # retry with digest. Every other failure is non-replayable.
+                resumed = False
+                continue
+        break
+
+    if getattr(turn, "interrupted", False):
+        # The interrupt was honored by THIS turn — consume the agent-level
+        # flag so the next turn is not short-circuited by it.
+        agent._interrupt_requested = False
+        if agent._claude_sdk_session is not None:
+            # The abandoned stream may still hold the interrupted turn's
+            # ResultMessage; a REUSED client would serve it as the NEXT
+            # turn's answer. Retire the client — the persisted id below lets
+            # the next turn RESUME the same SDK conversation cleanly.
+            try:
+                agent._claude_sdk_session.close()
+            except Exception:
+                pass
+            agent._claude_sdk_session = None
+
+    projected_messages = turn.projected_messages
+    if turn.interrupted and projected_messages:
+        # An interrupt can land after an SDK ToolUseBlock but before its
+        # ToolResultBlock. Repair that partial projection with the shared replay
+        # policy before it reaches the caller or durable session history.
+        from agent.replay_cleanup import sanitize_replay_history
+
+        projected_messages = sanitize_replay_history(projected_messages)
+
+    if projected_messages:
+        messages.extend(projected_messages)
+        # Early-return path bypasses conversation_loop's per-step persistence;
+        # flush the new projected rows ourselves (idempotent via the intrinsic
+        # _DB_PERSISTED_MARKER — the user turn was flushed at turn start).
+        if getattr(agent, "_session_db", None) is not None:
+            try:
+                agent._flush_messages_to_session_db(messages)
+            except Exception:
+                logger.debug(
+                    "claude-sdk projected-message flush failed", exc_info=True
+                )
+
+    if not getattr(turn, "should_retire", False):
+        # Persist the SDK session id for restart/eviction/interrupt resume.
+        # AFTER the flush on purpose: the flush's _ensure_db_session retry is
+        # what (re)creates the session row when turn-start persistence hit a
+        # transient lock — storing first would silently discard the id.
+        thread_id = getattr(turn, "thread_id", None)
+        if thread_id:
+            _store_sdk_session_id(agent, thread_id)
+
+    # Counter ticks — _turns_since_memory/_user_turn_count are incremented by
+    # run_conversation()'s pre-loop block; only _iters_since_skill is ours.
+    agent._iters_since_skill = (
+        getattr(agent, "_iters_since_skill", 0) + turn.tool_iterations
+    )
+    usage_result = _record_claude_sdk_usage(agent, turn)
+
+    should_review_skills = False
+    if (
+        agent._skill_nudge_interval > 0
+        and agent._iters_since_skill >= agent._skill_nudge_interval
+        and "skill_manage" in agent.valid_tool_names
+    ):
+        should_review_skills = True
+        agent._iters_since_skill = 0
+
+    if not turn.interrupted and turn.error is None:
+        try:
+            agent._sync_external_memory_for_turn(
+                original_user_message=original_user_message,
+                final_response=turn.final_text,
+                interrupted=False,
+                messages=messages,
+            )
+        except Exception:
+            logger.debug("external memory sync raised", exc_info=True)
+
+    if (
+        turn.final_text
+        and not turn.interrupted
+        and (should_review_memory or should_review_skills)
+    ):
+        # Deliberately NOT spawning the background review on this runtime:
+        # the fork inherits api_mode="claude_agent_sdk" and early-returns
+        # into a fresh SDK session whose tool surface has no `memory` /
+        # `skill_manage` — it would burn a subscription turn and be unable
+        # to write anything. The nudge counters above keep ticking so a
+        # bounded replacement pass can reuse them. (#25267)
+        logger.debug(
+            "claude-sdk runtime: background review skipped "
+            "(memory=%s, skills=%s) — the review fork cannot write on "
+            "this runtime",
+            should_review_memory,
+            should_review_skills,
+        )
+
+    return {
+        "final_response": turn.final_text,
+        "messages": messages,
+        "api_calls": 1,
+        "completed": not turn.interrupted and turn.error is None,
+        "partial": turn.interrupted or turn.error is not None,
+        "error": turn.error,
+        # Same persistence contract as the codex app-server path: we flushed
+        # the projected rows ourselves, so the gateway must not re-write the
+        # user turn (append_message has no dedup).
+        "agent_persisted": True,
+        "claude_sdk_session_id": turn.thread_id,
+        "claude_sdk_response_model": getattr(turn, "response_model", None),
+        **usage_result,
+    }
+
+
+__all__ = ["run_claude_agent_sdk_turn"]

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1258,6 +1258,18 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
+    # Same shape for the claude-agent-sdk runtime: the official Agent SDK
+    # owns the whole agent loop (tools, permissions, subscription OAuth).
+    # See agent/transports/claude_agent_sdk_session.py.
+    if agent.api_mode == "claude_agent_sdk":
+        return agent._run_claude_agent_sdk_turn(
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            should_review_memory=_should_review_memory,
+        )
+
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         _redirect_text = agent._drain_pending_redirect()
         if _redirect_text:

--- a/agent/replay_cleanup.py
+++ b/agent/replay_cleanup.py
@@ -120,7 +120,7 @@ def strip_interrupted_tool_tails(
 def strip_dangling_tool_call_tail(
     agent_history: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
-    """Strip a trailing ``assistant(tool_calls)`` block left with NO answers.
+    """Reconcile a trailing ``assistant(tool_calls)`` block with its answers.
 
     When a tool call itself kills the gateway process (``docker restart``,
     ``systemctl restart``, ``kill``, ``hermes gateway restart``), the process
@@ -135,66 +135,102 @@ def strip_dangling_tool_call_tail(
     reboot loop in #49201.  ``strip_interrupted_tool_tails`` does not catch
     this because there is no tool result to inspect for an interrupt marker.
 
-    This strips that dangling tail at the source so there is nothing for the
-    model to re-execute.  It only acts when the tail is an
-    ``assistant(tool_calls)`` whose calls have NO corresponding ``tool``
-    results — a completed assistant→tool pair (any tool answers present) is
-    left untouched so genuine mid-progress tool loops still resume.
+    This strips or balances that dangling tail at the source so there is
+    nothing for the model to re-execute. A zero-result all-read-only batch is
+    erased as before. Side-effecting calls are preserved and recovered as
+    UNKNOWN. When only part of a multi-call batch was answered, the existing
+    results stay intact and only missing IDs receive recovery results.
     """
     if not agent_history:
         return agent_history
 
-    last = agent_history[-1]
+    # Walk backward over the trailing contiguous result block, then inspect the
+    # assistant batch immediately before it. With zero results this naturally
+    # points at the final row, preserving the original dangling-tail behavior.
+    tool_block_start = len(agent_history)
+    while tool_block_start > 0:
+        candidate = agent_history[tool_block_start - 1]
+        if not (isinstance(candidate, dict) and candidate.get("role") == "tool"):
+            break
+        tool_block_start -= 1
+
+    assistant_index = tool_block_start - 1
+    if assistant_index < 0:
+        return agent_history
+    assistant = agent_history[assistant_index]
     if not (
-        isinstance(last, dict)
-        and last.get("role") == "assistant"
-        and last.get("tool_calls")
+        isinstance(assistant, dict)
+        and assistant.get("role") == "assistant"
+        and assistant.get("tool_calls")
     ):
         return agent_history
 
-    tool_calls = last.get("tool_calls") or []
-    if any(
+    tool_calls = assistant.get("tool_calls") or []
+    answered_ids = {
+        str(result.get("tool_call_id") or result.get("call_id") or "")
+        for result in agent_history[tool_block_start:]
+        if isinstance(result, dict) and result.get("role") == "tool"
+    }
+    missing_calls = [
+        call
+        for call in tool_calls
+        if str(call.get("id") or call.get("call_id") or "") not in answered_ids
+    ]
+    if not missing_calls:
+        return agent_history
+
+    has_tool_results = tool_block_start < len(agent_history)
+    if not has_tool_results and not any(
         tool_may_have_side_effect(
             str((call.get("function") or {}).get("name") or "")
         )
-        for call in tool_calls
+        for call in missing_calls
     ):
-        recovered = list(agent_history)
-        for call in tool_calls:
-            function = call.get("function") or {}
-            name = str(function.get("name") or "unknown")
-            call_id = str(call.get("id") or call.get("call_id") or "")
-            disposition = "unknown" if tool_may_have_side_effect(name) else "none"
-            content = (
-                "[Orphan recovery: this tool may have executed before Hermes stopped; "
-                "its effect is UNKNOWN. Inspect current state before retrying.]"
-                if disposition == "unknown"
-                else "[Orphan recovery: this read-only tool did not complete and had no effect.]"
-            )
-            recovered.append(make_tool_result_message(
-                name, content, call_id, effect_disposition=disposition,
-            ))
+        logger.debug(
+            "Stripping dangling unanswered read-only assistant(tool_calls) tail (%d call(s))",
+            len(missing_calls),
+        )
+        return agent_history[:assistant_index]
+
+    recovered = list(agent_history)
+    recovered_side_effect = False
+    for call in missing_calls:
+        function = call.get("function") or {}
+        name = str(function.get("name") or "unknown")
+        call_id = str(call.get("id") or call.get("call_id") or "")
+        disposition = "unknown" if tool_may_have_side_effect(name) else "none"
+        recovered_side_effect = recovered_side_effect or disposition == "unknown"
+        content = (
+            "[Orphan recovery: this tool may have executed before Hermes stopped; "
+            "its effect is UNKNOWN. Inspect current state before retrying.]"
+            if disposition == "unknown"
+            else "[Orphan recovery: this read-only tool did not complete and had no effect.]"
+        )
+        recovered.append(make_tool_result_message(
+            name, content, call_id, effect_disposition=disposition,
+        ))
+
+    if recovered_side_effect:
         logger.warning(
             "Recovered dangling side-effecting tool call(s) as UNKNOWN instead of erasing them"
         )
-        return recovered
-
-    logger.debug(
-        "Stripping dangling unanswered read-only assistant(tool_calls) tail (%d call(s))",
-        len(tool_calls),
-    )
-    return agent_history[:-1]
+    else:
+        logger.debug(
+            "Recovered %d missing read-only tool result(s) to balance a partial batch",
+            len(missing_calls),
+        )
+    return recovered
 
 
 def sanitize_replay_history(
     agent_history: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
-    """Apply both replay-tail strippers in the canonical order.
+    """Apply both replay-tail cleanup passes in the canonical order.
 
     Convenience entry point for resume code paths: removes interrupted
-    assistant→tool blocks anywhere in the history, then removes a dangling
-    unanswered ``assistant(tool_calls)`` tail.  Returns the same list object
-    when there is nothing to strip.
+    assistant→tool blocks anywhere in the history, then strips or balances a
+    dangling ``assistant(tool_calls)`` tail. Returns the same list object when
+    there is nothing to clean up.
     """
     if not agent_history:
         return agent_history

--- a/agent/transports/claude_agent_sdk_session.py
+++ b/agent/transports/claude_agent_sdk_session.py
@@ -975,9 +975,9 @@ class ClaudeAgentSdkSession:
         """Bridge SDK permission requests onto Hermes' fail-closed policy.
 
         Native read-only denies every expansion request. With Hermes approvals
-        off, ordinary requests are allowed without a prompt while Bash still
-        crosses the existing pre-bypass guard floor. Other modes delegate to
-        Hermes' approval callback and deny if that callback fails."""
+        off, ordinary requests are allowed without a prompt. Native Bash always
+        crosses the existing pre-bypass guard floor before other modes delegate
+        to Hermes' approval callback. Callback and guard failures deny."""
         approval_callback = self._approval_callback
 
         async def _can_use_tool(tool_name: str, tool_input: dict, context: Any):
@@ -993,29 +993,39 @@ class ClaudeAgentSdkSession:
                     message="native read-only permission expansion denied"
                 )
 
-            if _approvals_mode_off():
-                if tool_name == "Bash":
-                    command = tool_input.get("command")
-                    if not isinstance(command, str):
-                        return PermissionResultDeny(
-                            message="native Bash request has no string command"
-                        )
-                    from tools.approval import check_all_command_guards
+            if tool_name == "Bash":
+                command = tool_input.get("command")
+                if not isinstance(command, str):
+                    return PermissionResultDeny(
+                        message="native Bash request has no string command"
+                    )
+                try:
+                    from tools.approval import check_unconditional_command_guards
 
-                    try:
-                        guard = await asyncio.to_thread(
-                            check_all_command_guards, command, "local"
+                    guard = await asyncio.to_thread(
+                        check_unconditional_command_guards, command
+                    )
+                except Exception:
+                    logger.exception("Hermes guard failed on native Bash request")
+                    return PermissionResultDeny(
+                        message="Hermes Bash guard failed closed"
+                    )
+                if not isinstance(guard, dict) or type(guard.get("approved")) is not bool:
+                    logger.error("Hermes guard returned invalid native Bash result: %r", guard)
+                    return PermissionResultDeny(
+                        message="Hermes Bash guard returned an invalid result and failed closed"
+                    )
+                if not guard["approved"]:
+                    message = guard.get("message")
+                    return PermissionResultDeny(
+                        message=(
+                            message
+                            if isinstance(message, str) and message
+                            else "native Bash request blocked"
                         )
-                    except Exception:
-                        logger.exception("Hermes guard failed on native Bash request")
-                        return PermissionResultDeny(
-                            message="Hermes Bash guard failed closed"
-                        )
-                    if not guard.get("approved"):
-                        return PermissionResultDeny(
-                            message=guard.get("message")
-                            or "native Bash request blocked"
-                        )
+                    )
+
+            if _approvals_mode_off():
                 return PermissionResultAllow()
 
             if approval_callback is None:

--- a/agent/transports/claude_agent_sdk_session.py
+++ b/agent/transports/claude_agent_sdk_session.py
@@ -68,6 +68,14 @@ _HERMES_TO_SDK_PERMISSION_MODE = {
     "yolo": "bypassPermissions",
 }
 
+
+def _approvals_mode_off() -> bool:
+    """Return the live Hermes approval opt-out without widening its meaning."""
+    from tools.approval import _get_approval_mode
+
+    return _get_approval_mode() == "off"
+
+
 # ``ClaudeAgentOptions.tools`` is the pinned SDK's base native-tool surface.
 # In native-read-only mode this is the entire tool surface: no MCP server or
 # allowed_tools entries are materialized. Pair the exact native set with
@@ -896,7 +904,9 @@ class ClaudeAgentSdkSession:
 
         can_use_tool = None
         if self._permission_mode == "default" and (
-            self._native_read_only or self._approval_callback is not None
+            self._native_read_only
+            or self._approval_callback is not None
+            or _approvals_mode_off()
         ):
             can_use_tool = self._make_can_use_tool()
 
@@ -964,8 +974,10 @@ class ClaudeAgentSdkSession:
     def _make_can_use_tool(self) -> Any:
         """Bridge SDK permission requests onto Hermes' fail-closed policy.
 
-        Native read-only denies every expansion request. Other modes delegate
-        to Hermes' approval callback and deny if that callback fails."""
+        Native read-only denies every expansion request. With Hermes approvals
+        off, ordinary requests are allowed without a prompt while Bash still
+        crosses the existing pre-bypass guard floor. Other modes delegate to
+        Hermes' approval callback and deny if that callback fails."""
         approval_callback = self._approval_callback
 
         async def _can_use_tool(tool_name: str, tool_input: dict, context: Any):
@@ -981,7 +993,35 @@ class ClaudeAgentSdkSession:
                     message="native read-only permission expansion denied"
                 )
 
-            assert approval_callback is not None
+            if _approvals_mode_off():
+                if tool_name == "Bash":
+                    command = tool_input.get("command")
+                    if not isinstance(command, str):
+                        return PermissionResultDeny(
+                            message="native Bash request has no string command"
+                        )
+                    from tools.approval import check_all_command_guards
+
+                    try:
+                        guard = await asyncio.to_thread(
+                            check_all_command_guards, command, "local"
+                        )
+                    except Exception:
+                        logger.exception("Hermes guard failed on native Bash request")
+                        return PermissionResultDeny(
+                            message="Hermes Bash guard failed closed"
+                        )
+                    if not guard.get("approved"):
+                        return PermissionResultDeny(
+                            message=guard.get("message")
+                            or "native Bash request blocked"
+                        )
+                return PermissionResultAllow()
+
+            if approval_callback is None:
+                return PermissionResultDeny(
+                    message="no Hermes approval callback is available"
+                )
             try:
                 choice = await asyncio.to_thread(
                     approval_callback,

--- a/agent/transports/claude_agent_sdk_session.py
+++ b/agent/transports/claude_agent_sdk_session.py
@@ -1,0 +1,1100 @@
+"""Session adapter for the claude-agent-sdk runtime.
+
+Owns one Claude Agent SDK client per Hermes session — the structural twin of
+``codex_app_server_session.py``, with the Codex JSON-RPC subprocess replaced
+by Anthropic's official ``claude-agent-sdk`` (which manages the Claude Code
+CLI subprocess, its agent loop, and — critically — **subscription OAuth**:
+Claude-managed login storage, never an environment credential or metered
+backend). See GitHub issue #25267.
+
+Lifecycle:
+    session = ClaudeAgentSdkSession(cwd="/home/x/proj", model="claude-opus-4-8")
+    session.ensure_started()                       # loop thread + SDK connect
+    result = session.run_turn(user_input="hello")  # blocks until ResultMessage
+    session.close()                                # disconnect + stop loop
+
+Threading model: the SDK is async-first, but AIAgent.run_conversation() is
+synchronous (the same constraint that made CodexAppServerClient thread-based).
+The adapter owns a dedicated background thread running one asyncio event loop
+for the whole session lifetime; every SDK coroutine is marshaled onto it with
+``asyncio.run_coroutine_threadsafe`` and awaited with a timeout, so the SDK
+client keeps stable loop affinity and ``run_turn`` stays blocking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import subprocess
+import sys
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+# TurnResult is the shared contract with the runtime glue — reused verbatim
+# from the codex session module (same fields, same semantics) so
+# ``run_claude_agent_sdk_turn`` mirrors ``run_codex_app_server_turn`` 1:1.
+from agent.transports.codex_app_server_session import TurnResult
+from agent.transports.claude_sdk_event_projector import ClaudeSdkEventProjector
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ClaudeTurnResult(TurnResult):
+    """Turn result with the model identifier reported by the SDK stream."""
+
+    response_model: Optional[str] = None
+    subscription_attested: bool = False
+    # True only when a resumed SDK client was rejected during connect before
+    # client.query() could run. The runtime may retry only this explicit phase;
+    # every query/response/timeout/generic failure stays non-replayable.
+    retry_safe_before_query: bool = False
+
+
+# HERMES_TERMINAL_SECURITY_MODE → SDK permission_mode. A deploy-side env
+# knob read at session construction (default "auto"), mirroring the codex
+# session's identical switch — no config key backs it in either runtime.
+# "auto" parity note: codex's default profile is workspace-write; the
+# closest SDK mode is acceptEdits (file edits auto-approved inside cwd).
+# Non-default modes route tool calls through can_use_tool / fail-closed —
+# reachable only when an operator exports the variable.
+_HERMES_TO_SDK_PERMISSION_MODE = {
+    "auto": "acceptEdits",
+    "approval-required": "default",
+    "unrestricted": "bypassPermissions",
+    "yolo": "bypassPermissions",
+}
+
+# ``ClaudeAgentOptions.tools`` is the pinned SDK's base native-tool surface.
+# In native-read-only mode this is the entire tool surface: no MCP server or
+# allowed_tools entries are materialized. Pair the exact native set with
+# explicit mutator denies as defense in depth.
+_NATIVE_READ_ONLY_TOOLS = ("Read", "Glob", "Grep")
+_NATIVE_MUTATOR_DENIES = ("Write", "Edit", "Bash", "NotebookEdit")
+
+_SDK_DISCONNECT_TIMEOUT_SECONDS = 30.0
+_UNSUPPORTED_IMAGE_ERROR = (
+    "claude-agent-sdk image inputs are unsupported until rich-image "
+    "transport is implemented"
+)
+
+# Substrings in SDK/CLI errors that signal broken subscription credentials.
+# Conservative on purpose — mirrors codex's _OAUTH_REFRESH_FAILURE_HINTS
+# contract: every needle is a phrase, never a bare token. Bare "401" matched
+# tool ids and byte offsets; bare "credentials" matched an MCP server
+# complaining about its OWN files — and a hit retires the session, so a
+# false positive is a wrong shutdown.
+_AUTH_FAILURE_HINTS = (
+    "not logged in",
+    "please run /login",
+    "invalid api key",
+    "authentication_error",
+    "401 unauthorized",
+    "unauthorized",
+    "oauth token",
+    "token has expired",
+    "expired token",
+    "invalid bearer token",
+)
+
+
+def classify_auth_failure(*parts: str) -> Optional[str]:
+    """Return a user-friendly re-auth hint if the strings look like a Claude
+    subscription auth failure; otherwise None. The hint keeps the underlying
+    error text: a hit retires the session, so the evidence must survive the
+    redirect (codex surfaces the original error the same way)."""
+    haystack = " ".join(p for p in parts if p).lower()
+    if not haystack:
+        return None
+    for needle in _AUTH_FAILURE_HINTS:
+        if needle in haystack:
+            original = next((p.strip() for p in parts if p and p.strip()), "")
+            if len(original) > 400:
+                original = original[:400] + "…"
+            return (
+                "Claude authentication failed — the subscription OAuth token "
+                "looks expired or invalid. Run `claude auth login` on this "
+                "machine to refresh Claude-managed login storage, then retry. "
+                f"(underlying error: {original})"
+            )
+    return None
+
+
+def check_claude_sdk_available() -> tuple[bool, str]:
+    """Preflight: the optional SDK extra must be importable, and it bundles /
+    locates the Claude Code CLI itself. Mirrors check_codex_binary()."""
+    try:
+        from tools import lazy_deps
+
+        lazy_deps.ensure("provider.claude_agent_sdk", prompt=False)
+    except Exception as exc:
+        return False, str(exc)
+    try:
+        import claude_agent_sdk  # noqa: F401
+    except ImportError:
+        return (
+            False,
+            "claude-agent-sdk is not installed. "
+            "Install with: pip install 'hermes-agent[claude-agent-sdk]'",
+        )
+    return True, "ok"
+
+
+def _hermes_repo_root() -> str:
+    """Repo root for the hermes-tools MCP subprocess (PYTHONPATH)."""
+    return os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+
+
+# The SDK serializes the stdio MCP config — env INCLUDED — into the claude
+# CLI's --mcp-config argument, i.e. onto the subprocess argv, which any local
+# user can read via ps. Nothing secret may ever ride this dict: the env is a
+# minimal ALLOWLIST, never a copy of the credentialed environment. Keyed
+# Hermes tools inside the server degrade via their own check_fns — the
+# subscription lane's fail-closed posture.
+_MCP_ENV_ALLOWLIST = (
+    "PATH",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TMPDIR",
+    "PYTHONUTF8",
+    "HERMES_HOME",
+    "HERMES_KANBAN_TASK",
+    "HERMES_MCP_STATE_DB",  # the shims' documented state-DB override — a path, not a secret
+    "HERMES_QUIET",
+    "HERMES_REDACT_SECRETS",
+)
+
+
+# ClaudeAgentOptions.env is overlaid on the SDK subprocess's inherited
+# environment, not used as a replacement. Therefore every ambient key must be
+# present here: allowed runtime/config values keep their value, and everything
+# else gets an explicit empty-string override. In particular, do not preserve
+# proxies, SSH agents, cloud credentials, Hermes secrets, provider keys, or bot
+# tokens. The SDK adds its own CLAUDE_CODE_ENTRYPOINT/version markers later.
+_CLI_ENV_ALLOWLIST = frozenset(
+    {
+        "HOME",
+        "PATH",
+        "SHELL",
+        "USER",
+        "LOGNAME",
+        "LANG",
+        "LANGUAGE",
+        "TERM",
+        "COLORTERM",
+        "TERM_PROGRAM",
+        "TERM_PROGRAM_VERSION",
+        "NO_COLOR",
+        "FORCE_COLOR",
+        "CLICOLOR",
+        "CLICOLOR_FORCE",
+        "TMPDIR",
+        "TEMP",
+        "TMP",
+        "CLAUDE_CONFIG_DIR",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "XDG_CACHE_HOME",
+        "XDG_STATE_HOME",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+        "NODE_EXTRA_CA_CERTS",
+        # Windows process/bootstrap paths.
+        "SYSTEMROOT",
+        "WINDIR",
+        "COMSPEC",
+        "PATHEXT",
+        "PROGRAMDATA",
+        "PROGRAMFILES",
+        "PROGRAMFILES(X86)",
+        "LOCALAPPDATA",
+        "APPDATA",
+        "USERPROFILE",
+        "HOMEDRIVE",
+        "HOMEPATH",
+    }
+)
+
+
+def _build_sanitized_cli_env() -> dict[str, str]:
+    """Return the complete SDK env overlay with ambient secrets blanked."""
+    return {
+        key: value
+        if key in _CLI_ENV_ALLOWLIST or key.startswith("LC_")
+        else ""
+        for key, value in os.environ.items()
+    }
+
+
+def _resolve_claude_cli_path() -> str:
+    """Resolve the exact CLI selected by the pinned SDK transport."""
+    from claude_agent_sdk import ClaudeAgentOptions
+    from claude_agent_sdk._internal.transport.subprocess_cli import (
+        SubprocessCLITransport,
+    )
+
+    transport = SubprocessCLITransport(
+        prompt=_empty_sdk_prompt_stream(),
+        options=ClaudeAgentOptions(),
+    )
+    return transport._find_cli()
+
+
+def _attest_claude_subscription(*, env: dict[str, str], cwd: str) -> str:
+    """Require a logged-in first-party Claude.ai identity without exposing it.
+
+    The status child receives the same sanitized environment snapshot later
+    passed to ``ClaudeAgentOptions.env``. Status output may contain account
+    details, so neither stdout nor stderr is logged or copied into errors.
+    """
+    from hermes_cli._subprocess_compat import windows_hide_flags
+
+    cli_path = _resolve_claude_cli_path()
+    try:
+        completed = subprocess.run(
+            [cli_path, "--setting-sources=", "auth", "status", "--json"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=20,
+            stdin=subprocess.DEVNULL,
+            cwd=cwd,
+            env=env,
+            creationflags=windows_hide_flags(),
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError(
+            "Claude.ai subscription authentication attestation failed. "
+            "Run `claude auth login` and retry."
+        ) from exc
+
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Claude.ai subscription authentication attestation failed. "
+            "Run `claude auth login` and retry."
+        )
+    try:
+        status = json.loads(completed.stdout)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            "Claude.ai subscription authentication attestation returned "
+            "malformed status. Run `claude auth login` and retry."
+        ) from exc
+    if not isinstance(status, dict):
+        raise RuntimeError(
+            "Claude.ai subscription authentication attestation returned "
+            "malformed status. Run `claude auth login` and retry."
+        )
+    if status.get("loggedIn") is not True:
+        raise RuntimeError(
+            "Claude.ai subscription authentication is required. "
+            "Run `claude auth login` and retry."
+        )
+    if (
+        status.get("authMethod") != "claude.ai"
+        or status.get("apiProvider") != "firstParty"
+    ):
+        raise RuntimeError(
+            "claude-agent-sdk requires a first-party Claude.ai login; "
+            "Console, API-key, cloud, and custom identities are unsupported."
+        )
+    return cli_path
+
+
+async def _empty_sdk_prompt_stream():
+    """Match the empty streaming prompt used by ``ClaudeSDKClient.connect(None)``."""
+    return
+    yield {}  # pragma: no cover - makes this an async generator
+
+
+def _build_sanitized_sdk_transport(options: Any) -> Any:
+    """Build the pinned SDK subprocess transport with a sanitized version probe.
+
+    ``claude-agent-sdk==0.2.120`` applies ``options.env`` to the long-lived CLI
+    child but omits ``env=`` from its preceding ``claude -v`` process. The SDK's
+    supported custom-Transport seam lets us repair only that preflight while
+    inheriting its command construction, streaming, stderr, and cleanup logic.
+    """
+    import re
+    from contextlib import suppress
+    from subprocess import PIPE
+
+    import anyio
+    from claude_agent_sdk._errors import CLINotFoundError
+    from claude_agent_sdk._internal.transport.subprocess_cli import (
+        MINIMUM_CLAUDE_CODE_VERSION,
+        SubprocessCLITransport,
+    )
+
+    class _SanitizedSubprocessCLITransport(SubprocessCLITransport):
+        async def _check_claude_version(self) -> None:
+            """Preserve the SDK check while giving its child the sanitized env."""
+            if self._cli_path is None:
+                raise CLINotFoundError("CLI path not resolved. Call connect() first.")
+            version_process = None
+            try:
+                with anyio.fail_after(2):
+                    version_process = await anyio.open_process(
+                        [self._cli_path, "-v"],
+                        stdout=PIPE,
+                        stderr=PIPE,
+                        env=dict(self._options.env or {}),
+                    )
+
+                    if version_process.stdout:
+                        stdout_bytes = await version_process.stdout.receive()
+                        version_output = stdout_bytes.decode().strip()
+
+                        match = re.match(r"([0-9]+\.[0-9]+\.[0-9]+)", version_output)
+                        if match:
+                            version = match.group(1)
+                            version_parts = [int(x) for x in version.split(".")]
+                            min_parts = [
+                                int(x)
+                                for x in MINIMUM_CLAUDE_CODE_VERSION.split(".")
+                            ]
+
+                            if version_parts < min_parts:
+                                logger.warning(
+                                    "Claude Code version %s at %s is unsupported in the "
+                                    "Agent SDK. Minimum required version is %s. Some "
+                                    "features may not work correctly.",
+                                    version,
+                                    self._cli_path,
+                                    MINIMUM_CLAUDE_CODE_VERSION,
+                                )
+            except Exception:
+                pass
+            finally:
+                if version_process:
+                    with suppress(Exception):
+                        version_process.terminate()
+                    with suppress(Exception):
+                        await version_process.wait()
+
+    return _SanitizedSubprocessCLITransport(
+        prompt=_empty_sdk_prompt_stream(),
+        options=options,
+    )
+
+
+# Any one of these non-empty variables can select or authenticate a metered
+# Claude backend. This runtime is subscription-only, so reject the route before
+# the SDK creates its inherited-environment CLI subprocess. The cloud-provider
+# credential names below are the documented Bedrock/Vertex credential paths in
+# addition to the explicit Claude Code selectors and endpoint overrides.
+_BILLING_ROUTE_ENV_VARS = (
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_MANTLE",
+    "ANTHROPIC_BEDROCK_BASE_URL",
+    "ANTHROPIC_BEDROCK_MANTLE_BASE_URL",
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_PROFILE",
+    "AWS_CONFIG_FILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "CLAUDE_CODE_USE_VERTEX",
+    "ANTHROPIC_VERTEX_BASE_URL",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_CLOUD_PROJECT",
+    "CLOUD_ML_REGION",
+    "CLAUDE_CODE_USE_FOUNDRY",
+    "ANTHROPIC_FOUNDRY_BASE_URL",
+    "ANTHROPIC_FOUNDRY_RESOURCE",
+    "ANTHROPIC_FOUNDRY_API_KEY",
+    "ANTHROPIC_FOUNDRY_AUTH_TOKEN",
+)
+
+
+def _provider_config() -> dict:
+    """The `agent.claude_agent_sdk` config block ({} when absent/unreadable)."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        block = ((load_config_readonly() or {}).get("agent", {}) or {}).get(
+            "claude_agent_sdk", {}
+        )
+        return block if isinstance(block, dict) else {}
+    except Exception:
+        return {}
+
+
+def _provider_flag(
+    config_key: str,
+    default: bool = False,
+    *,
+    config: Optional[dict] = None,
+) -> bool:
+    """Behavioural flag read from `agent.claude_agent_sdk.<key>` in config.yaml.
+
+    config.yaml is the ONLY interface. AGENTS.md keeps non-secret behavioural
+    settings out of `HERMES_*` environment variables, so there is deliberately
+    no env override here — a deployment sets the key in config.yaml.
+    Canonical defaults live in `hermes_cli/config.py::DEFAULT_CONFIG`.
+    """
+    value = (config if config is not None else _provider_config()).get(
+        config_key, default
+    )
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes")
+    return bool(value)
+
+
+def _normalize_add_dirs(value: Any) -> list[str]:
+    """Validate and snapshot ``agent.claude_agent_sdk.add_dirs``.
+
+    Existence is deliberately not required: the SDK accepts paths that may be
+    mounted or created later. Validation is lexical and deterministic at SDK
+    session creation, before any child or client is constructed.
+    """
+    config_key = "agent.claude_agent_sdk.add_dirs"
+    if not isinstance(value, list):
+        raise ValueError(f"{config_key} must be a list")
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for index, entry in enumerate(value):
+        if not isinstance(entry, str):
+            raise ValueError(
+                f"{config_key} entries must be non-empty absolute paths "
+                f"(invalid entry at index {index})"
+            )
+        if (
+            not entry
+            or entry != entry.strip()
+            or not os.path.isabs(entry)
+            or "\x00" in entry
+        ):
+            raise ValueError(
+                f"{config_key} entries must be non-empty absolute paths "
+                f"(invalid entry at index {index})"
+            )
+        path = os.path.normpath(entry)
+        if path not in seen:
+            seen.add(path)
+            normalized.append(path)
+    return normalized
+
+
+def _build_hermes_tools_mcp_config(
+    hermes_session_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """The stdio MCP server exposing Hermes tools into the SDK agent loop —
+    the exact server the codex runtime uses (backend-agnostic), launched with
+    this venv's interpreter. McpStdioServerConfig has no cwd field, so the
+    repo root rides PYTHONPATH."""
+    env = {
+        key: os.environ[key]
+        for key in _MCP_ENV_ALLOWLIST
+        if os.environ.get(key)
+    }
+    env["PYTHONPATH"] = _hermes_repo_root() + os.pathsep + os.environ.get("PYTHONPATH", "")
+    if hermes_session_id:
+        # Lets the stateless session_search shim exclude the calling
+        # session's own lineage from recall results (#26567). The shim reads
+        # the canonical HERMES_SESSION_ID — set explicitly with THIS
+        # session's id rather than allowlisting the ambient variable, so a
+        # multi-session host can never leak a sibling session's id into the
+        # subprocess.
+        env["HERMES_SESSION_ID"] = str(hermes_session_id)
+    return {
+        "type": "stdio",
+        "command": sys.executable,
+        "args": ["-m", "agent.transports.hermes_tools_mcp_server"],
+        "env": env,
+    }
+
+
+class ClaudeAgentSdkSession:
+    """One SDK client per Hermes session, lifetime owned by AIAgent.
+
+    Not thread-safe from the caller's side — one caller drives it at a time,
+    matching AIAgent.run_conversation(). Internally owns a loop thread."""
+
+    def __init__(
+        self,
+        *,
+        cwd: Optional[str] = None,
+        add_dirs: Optional[list[str]] = None,
+        native_read_only: bool = False,
+        model: Optional[str] = None,
+        permission_mode: Optional[str] = None,
+        system_prompt_append: Optional[str] = None,
+        approval_callback: Optional[Callable[..., str]] = None,
+        on_tool_started: Optional[Callable[[str, str, dict], None]] = None,
+        max_budget_usd: Optional[float] = None,
+        client_factory: Optional[Callable[..., Any]] = None,
+        auth_status_checker: Optional[Callable[..., Optional[str]]] = None,
+        include_hermes_tools: bool = True,
+        hermes_session_id: Optional[str] = None,
+        resume_session_id: Optional[str] = None,
+        on_stream_delta: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        self._cwd = cwd or os.getcwd()
+        self._add_dirs = _normalize_add_dirs([] if add_dirs is None else add_dirs)
+        self._native_read_only = bool(native_read_only)
+        self._model = model
+        if self._native_read_only:
+            # Native read-only is a fail-closed boundary. Ambient terminal
+            # policy (including acceptEdits/bypassPermissions) cannot widen it.
+            self._permission_mode = "default"
+        else:
+            self._permission_mode = (
+                permission_mode
+                or _HERMES_TO_SDK_PERMISSION_MODE.get(
+                    os.environ.get("HERMES_TERMINAL_SECURITY_MODE", "auto"),
+                    "acceptEdits",
+                )
+            )
+        self._system_prompt_append = system_prompt_append
+        self._approval_callback = approval_callback
+        self._on_tool_started = on_tool_started
+        self._max_budget_usd = max_budget_usd
+        self._client_factory = client_factory  # test seam
+        self._auth_status_checker = auth_status_checker  # test seam
+        self._include_hermes_tools = include_hermes_tools
+        # Hermes-side session id, exported to the hermes-tools MCP subprocess
+        # so the stateless session_search shim can exclude its own lineage.
+        self._hermes_session_id = hermes_session_id
+        # SDK-side session id to resume (#25267 continuity). Resuming restores
+        # the model context and keeps the same session id; a
+        # stale id fails the session start (the caller retires + retries
+        # fresh).
+        self._resume_session_id = resume_session_id
+        # Display-only partial-text consumer. Deltas never
+        # enter the projected transcript; the gateway's stream consumer
+        # handles rate limiting and the already_sent final-send dedup.
+        self._on_stream_delta = on_stream_delta
+
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._loop_thread: Optional[threading.Thread] = None
+        self._client: Any = None
+        self._cli_env: Optional[dict[str, str]] = None
+        self._cli_path: Optional[str] = None
+        self._subscription_attested = False
+        self._session_id: Optional[str] = None
+        self._interrupt_event = threading.Event()
+        self._closed = False
+
+    # ---------- lifecycle ----------
+
+    def ensure_started(self) -> str:
+        """Start the loop thread, build the SDK client, connect. Idempotent —
+        returns the session marker (SDK session ids arrive on first result)."""
+        if self._client is not None:
+            return self._session_id or "pending"
+        # Hard rule, enforced fail-closed: this provider exists to bill the
+        # Claude subscription. Refuse every environment-selected credential or
+        # alternate backend before creating the inherited-environment CLI.
+        for route_var in _BILLING_ROUTE_ENV_VARS:
+            if os.environ.get(route_var):
+                raise RuntimeError(
+                    f"claude-agent-sdk runtime refuses to start: {route_var} "
+                    "is set, which can select credentials or a metered backend. "
+                    "Unset it; this runtime uses only Claude-managed subscription "
+                    "login storage."
+                )
+        if self._client_factory is None:
+            ok, msg = check_claude_sdk_available()
+            if not ok:
+                raise RuntimeError(msg)
+
+        # Snapshot once so the auth-status child and the long-lived SDK child
+        # receive the same sanitized parent environment. Attestation happens
+        # before the loop, SDK client construction, or connect.
+        self._cli_env = _build_sanitized_cli_env()
+        checker = self._auth_status_checker or _attest_claude_subscription
+        resolved_cli_path = checker(env=self._cli_env, cwd=self._cwd)
+        if resolved_cli_path:
+            self._cli_path = resolved_cli_path
+        self._subscription_attested = True
+
+        self._start_loop_thread()
+        client = self._build_client()
+        # Assign BEFORE connect: a connect timeout/cancel leaves a
+        # half-connected client whose CLI subprocess close() must still reap
+        # — a None _client would skip disconnect and orphan it.
+        self._client = client
+        self._run_coro(client.connect(), timeout=60.0)
+        logger.info(
+            "claude-agent-sdk session started: model=%s mode=%s cwd=%s",
+            self._model or "cli-default",
+            self._permission_mode,
+            self._cwd,
+        )
+        return self._session_id or "pending"
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._client is not None and self._loop is not None:
+            try:
+                self._run_coro(
+                    self._client.disconnect(),
+                    timeout=_SDK_DISCONNECT_TIMEOUT_SECONDS,
+                )
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            self._client = None
+        self._stop_loop_thread()
+
+    def __enter__(self) -> "ClaudeAgentSdkSession":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    # ---------- interrupt ----------
+
+    def consume_interrupt(self) -> None:
+        """Clear a pending interrupt signal — the caller honored it through
+        another path (e.g. the runtime's cold-agent short-circuit)."""
+        self._interrupt_event.clear()
+
+    def request_interrupt(self) -> None:
+        """Idempotent: signal the active turn loop to interrupt and unwind."""
+        self._interrupt_event.set()
+        if self._client is not None and self._loop is not None:
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    self._client.interrupt(), self._loop
+                )
+            except Exception:  # pragma: no cover
+                logger.debug("SDK interrupt scheduling failed", exc_info=True)
+
+    # ---------- per-turn ----------
+
+    def run_turn(
+        self,
+        user_input: Any,
+        *,
+        turn_timeout: float = 600.0,
+    ) -> ClaudeTurnResult:
+        """Send a user message and block until the SDK's ResultMessage,
+        projecting the typed stream into Hermes' messages shape."""
+        result = ClaudeTurnResult()
+        try:
+            text = _coerce_turn_input_text(user_input)
+        except _UnsupportedImageInput:
+            result.error = _UNSUPPORTED_IMAGE_ERROR
+            return result
+        try:
+            self.ensure_started()
+        except Exception as exc:
+            hint = classify_auth_failure(str(exc))
+            result.error = hint or f"claude-agent-sdk startup failed: {exc}"
+            result.should_retire = True
+            # A fresh retry is safe only for a resumed client rejected by the
+            # SDK during connect. Requiring both a constructed client and a
+            # typed SDK connection/process error excludes attestation/build
+            # failures, generic exceptions, and timeouts.
+            if self._resume_session_id and self._client is not None:
+                try:
+                    from claude_agent_sdk._errors import (
+                        CLIConnectionError,
+                        ProcessError,
+                    )
+
+                    result.retry_safe_before_query = isinstance(
+                        exc, (CLIConnectionError, ProcessError)
+                    )
+                except ImportError:  # pragma: no cover - optional SDK absent
+                    pass
+            return result
+        result.subscription_attested = self._subscription_attested
+
+        # An interrupt that arrived between turns or during connect (up to
+        # 60s) targets THIS turn — honor it instead of erasing it. (The old
+        # unconditional clear() silently swallowed that window.)
+        if self._interrupt_event.is_set():
+            self._interrupt_event.clear()
+            result.interrupted = True
+            return result
+        try:
+            turn_data = self._run_coro(
+                self._consume_turn(text), timeout=turn_timeout
+            )
+        except asyncio.TimeoutError:
+            self.request_interrupt()
+            result.interrupted = True
+            result.error = f"turn timed out after {turn_timeout:.0f}s"
+            result.should_retire = True
+            return result
+        except Exception as exc:
+            hint = classify_auth_failure(str(exc))
+            result.error = hint or f"claude-agent-sdk turn failed: {exc}"
+            result.should_retire = True
+            return result
+
+        result.final_text = turn_data["final_text"]
+        result.projected_messages = turn_data["messages"]
+        result.tool_iterations = turn_data["tool_iterations"]
+        result.token_usage_last = turn_data["usage"]
+        result.token_usage_total = turn_data["usage"]
+        result.thread_id = self._session_id
+        result.turn_id = turn_data.get("result_uuid")
+        result.response_model = turn_data.get("model")
+        result.interrupted = self._interrupt_event.is_set()
+        if result.interrupted:
+            # Consume the honored interrupt so it cannot bleed into the
+            # next turn on this session object.
+            self._interrupt_event.clear()
+        if turn_data["error"]:
+            hint = classify_auth_failure(turn_data["error"])
+            result.error = hint or turn_data["error"]
+            result.should_retire = True
+        return result
+
+    # ---------- internals ----------
+
+    async def _consume_turn(self, text: str) -> dict[str, Any]:
+        """The async side of one turn: query + drain receive_response()."""
+        projector = ClaudeSdkEventProjector()
+        out: dict[str, Any] = {
+            "final_text": "",
+            "messages": [],
+            "tool_iterations": 0,
+            "usage": None,
+            "error": None,
+            "result_uuid": None,
+            "model": None,
+        }
+        await self._client.query(text)
+        async for message in self._client.receive_response():
+            # Capture the SDK session id from ANY message that carries it —
+            # the init SystemMessage announces it first, so even a turn
+            # interrupted before its ResultMessage keeps a resumable id.
+            early_sid = getattr(message, "session_id", None)
+            if early_sid:
+                self._session_id = early_sid
+            if self._interrupt_event.is_set():
+                break
+            if type(message).__name__ == "StreamEvent":
+                self._forward_stream_delta(message)
+                continue
+            if type(message).__name__ == "AssistantMessage":
+                response_model = getattr(message, "model", None)
+                if isinstance(response_model, str) and response_model:
+                    out["model"] = response_model
+            self._notify_tool_started(message)
+            projection = projector.project(message)
+            if projection.messages:
+                out["messages"].extend(projection.messages)
+            if projection.is_tool_iteration:
+                out["tool_iterations"] += 1
+            if projection.final_text is not None:
+                out["final_text"] = projection.final_text
+            if projection.is_result:
+                usage = getattr(message, "usage", None)
+                if isinstance(usage, dict):
+                    out["usage"] = dict(usage)
+                sid = getattr(message, "session_id", None)
+                if sid:
+                    self._session_id = sid
+                out["result_uuid"] = getattr(message, "uuid", None)
+                subtype = getattr(message, "subtype", "") or ""
+                if getattr(message, "is_error", False):
+                    errors = getattr(message, "errors", None) or []
+                    out["error"] = (
+                        f"SDK result error (subtype={subtype}): "
+                        + ("; ".join(str(e) for e in errors) or subtype)
+                    )
+                elif subtype not in ("", "success"):
+                    # e.g. error_max_turns / error_max_budget_usd — surface
+                    # honestly; the partial transcript is still projected.
+                    out["error"] = f"SDK turn ended: {subtype}"
+        return out
+
+    def _forward_stream_delta(self, message: Any) -> None:
+        """Relay a top-level text delta to the display callback (never the
+        transcript). Subagent streams (parent_tool_use_id set) stay quiet."""
+        if self._on_stream_delta is None:
+            return
+        if getattr(message, "parent_tool_use_id", None):
+            return
+        event = getattr(message, "event", None) or {}
+        if event.get("type") != "content_block_delta":
+            return
+        delta = event.get("delta") or {}
+        if delta.get("type") != "text_delta":
+            return
+        text = delta.get("text")
+        if not text:
+            return
+        try:
+            self._on_stream_delta(text)
+        except Exception:  # pragma: no cover - display callback
+            logger.debug("stream delta callback raised", exc_info=True)
+
+    def _notify_tool_started(self, message: Any) -> None:
+        """Bridge ToolUseBlocks to Hermes tool-progress (gateway breadcrumbs),
+        mirroring codex_runtime._codex_note_to_tool_progress (#38835)."""
+        if self._on_tool_started is None:
+            return
+        if type(message).__name__ != "AssistantMessage":
+            return
+        for block in getattr(message, "content", None) or []:
+            if type(block).__name__ != "ToolUseBlock":
+                continue
+            name = getattr(block, "name", "") or "unknown"
+            args = getattr(block, "input", None) or {}
+            if not isinstance(args, dict):
+                args = {"input": args}
+            preview = _tool_preview(name, args)
+            try:
+                self._on_tool_started(name, preview, args)
+            except Exception:  # pragma: no cover - display callback
+                logger.debug("tool-progress callback raised", exc_info=True)
+
+    def build_option_fields(self) -> dict[str, Any]:
+        """The ClaudeAgentOptions field dict — plain data so tests can assert
+        on it without importing the SDK."""
+        mcp_servers: dict[str, Any] = {}
+        allowed_tools: list[str] = []
+        if self._include_hermes_tools and not self._native_read_only:
+            from agent.transports.hermes_tools_mcp_server import EXPOSED_TOOLS
+
+            mcp_servers["hermes-tools"] = _build_hermes_tools_mcp_config(
+                hermes_session_id=self._hermes_session_id
+            )
+            # Hermes registry tools enforce their own safety contracts. Approve
+            # this curated namespace so a headless gateway turn does not receive
+            # an SDK permission prompt that it has no interactive channel to answer.
+            allowed_tools = [
+                *(f"mcp__hermes-tools__{name}" for name in EXPOSED_TOOLS),
+                "mcp__hermes-tools__memory",
+                "mcp__hermes-tools__session_search",
+            ]
+
+        system_prompt: Any = {"type": "preset", "preset": "claude_code"}
+        if self._system_prompt_append:
+            system_prompt = {
+                "type": "preset",
+                "preset": "claude_code",
+                "append": self._system_prompt_append,
+            }
+
+        can_use_tool = None
+        if self._permission_mode == "default" and (
+            self._native_read_only or self._approval_callback is not None
+        ):
+            can_use_tool = self._make_can_use_tool()
+
+        fields = {
+            "model": self._model,
+            "cwd": self._cwd,
+            "env": (
+                dict(self._cli_env)
+                if self._cli_env is not None
+                else _build_sanitized_cli_env()
+            ),
+            "permission_mode": self._permission_mode,
+            "system_prompt": system_prompt,
+            "mcp_servers": mcp_servers,
+            # Never load user/project/local settings or ambient MCP config.
+            # Hermes supplies cwd/add_dirs and the curated MCP map explicitly.
+            "setting_sources": [],
+            "strict_mcp_config": True,
+            "allowed_tools": allowed_tools,
+            "max_budget_usd": self._max_budget_usd,
+            "can_use_tool": can_use_tool,
+        }
+        if self._native_read_only:
+            # This boundary does not depend on can_use_tool: mutators are absent
+            # from the native surface and explicitly denied. An empty source list
+            # blocks user/project/local settings from widening permissions/roots.
+            fields.update(
+                {
+                    "tools": list(_NATIVE_READ_ONLY_TOOLS),
+                    "disallowed_tools": list(_NATIVE_MUTATOR_DENIES),
+                }
+            )
+        if self._cli_path:
+            fields["cli_path"] = self._cli_path
+        if self._resume_session_id:
+            fields["resume"] = self._resume_session_id
+        if self._add_dirs:
+            fields["add_dirs"] = list(self._add_dirs)
+        # Default OFF (upstream-conservative): partial messages only when the
+        # operator opts in via agent.claude_agent_sdk.streaming in config.yaml.
+        if _provider_flag("streaming"):
+            fields["include_partial_messages"] = True
+        return fields
+
+    def _build_client(self) -> Any:
+        fields = self.build_option_fields()
+        if self._client_factory is not None:
+            return self._client_factory(options=fields)
+        from dataclasses import replace
+
+        from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+
+        options = ClaudeAgentOptions(**fields)
+        # The SDK normally adds this field to the transport's option copy when
+        # can_use_tool is active. A pre-constructed custom transport does not
+        # receive that copy, so preserve the approval control-protocol flag here.
+        transport_options = (
+            replace(options, permission_prompt_tool_name="stdio")
+            if options.can_use_tool
+            else options
+        )
+        transport = _build_sanitized_sdk_transport(transport_options)
+        return ClaudeSDKClient(options=options, transport=transport)
+
+    def _make_can_use_tool(self) -> Any:
+        """Bridge SDK permission requests onto Hermes' fail-closed policy.
+
+        Native read-only denies every expansion request. Other modes delegate
+        to Hermes' approval callback and deny if that callback fails."""
+        approval_callback = self._approval_callback
+
+        async def _can_use_tool(tool_name: str, tool_input: dict, context: Any):
+            from claude_agent_sdk import (
+                PermissionResultAllow,
+                PermissionResultDeny,
+            )
+
+            if self._native_read_only:
+                # cwd/add_dirs reads are authorized by the SDK without asking.
+                # Every callback invocation is therefore an expansion request.
+                return PermissionResultDeny(
+                    message="native read-only permission expansion denied"
+                )
+
+            assert approval_callback is not None
+            try:
+                choice = await asyncio.to_thread(
+                    approval_callback,
+                    f"{tool_name}({_tool_preview(tool_name, tool_input)})",
+                    f"Claude requests tool {tool_name}",
+                    allow_permanent=False,
+                )
+            except Exception:
+                logger.exception("approval_callback raised on SDK permission")
+                return PermissionResultDeny(message="approval callback failed")
+            if choice in ("once", "session", "always"):
+                return PermissionResultAllow()
+            return PermissionResultDeny(message="denied by user")
+
+        return _can_use_tool
+
+    # ---------- loop-thread plumbing ----------
+
+    def _start_loop_thread(self) -> None:
+        if self._loop_thread is not None:
+            return
+        loop = asyncio.new_event_loop()
+        ready = threading.Event()
+
+        def _run() -> None:
+            asyncio.set_event_loop(loop)
+            ready.set()
+            loop.run_forever()
+
+        thread = threading.Thread(
+            target=_run, name="claude-sdk-loop", daemon=True
+        )
+        thread.start()
+        ready.wait(timeout=10)
+        self._loop = loop
+        self._loop_thread = thread
+
+    def _stop_loop_thread(self) -> None:
+        if self._loop is not None:
+            try:
+                self._loop.call_soon_threadsafe(self._loop.stop)
+            except Exception:  # pragma: no cover
+                pass
+        if self._loop_thread is not None:
+            self._loop_thread.join(timeout=5)
+        self._loop = None
+        self._loop_thread = None
+
+    def _run_coro(self, coro: Any, *, timeout: float) -> Any:
+        import concurrent.futures
+
+        assert self._loop is not None, "loop thread not started"
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        try:
+            return future.result(timeout=timeout)
+        except (TimeoutError, concurrent.futures.TimeoutError):
+            future.cancel()
+            raise asyncio.TimeoutError(f"coroutine exceeded {timeout}s")
+
+
+def _tool_preview(name: str, args: dict) -> str:
+    """Short human preview of a tool call for progress breadcrumbs."""
+    for key in ("command", "file_path", "path", "url", "query", "prompt"):
+        value = args.get(key)
+        if isinstance(value, str) and value:
+            return value[:120]
+    return name
+
+
+class _UnsupportedImageInput(ValueError):
+    pass
+
+
+def _contains_image_input(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.lstrip().lower().startswith("data:image/")
+    if isinstance(value, (list, tuple)):
+        return any(_contains_image_input(item) for item in value)
+    if not isinstance(value, dict):
+        return False
+    if value.get("type") in {"image", "image_url", "input_image"}:
+        return True
+    if "image_url" in value:
+        return True
+    source = value.get("source")
+    if isinstance(source, dict) and source.get("type") in {"base64", "url"}:
+        return True
+    return any(_contains_image_input(item) for item in value.values())
+
+
+def _coerce_turn_input_text(user_input: Any) -> str:
+    """Collapse Hermes/OpenAI rich content into plain text input (same
+    contract as the codex session's _coerce_turn_input_text)."""
+    if _contains_image_input(user_input):
+        raise _UnsupportedImageInput(_UNSUPPORTED_IMAGE_ERROR)
+    if isinstance(user_input, str):
+        return user_input
+    if isinstance(user_input, list):
+        parts: list[str] = []
+        for item in user_input:
+            if isinstance(item, str):
+                if item.strip():
+                    parts.append(item)
+                continue
+            if not isinstance(item, dict):
+                if item is not None:
+                    parts.append(str(item))
+                continue
+            item_type = item.get("type")
+            if item_type in {"text", "input_text"}:
+                text = item.get("text") or item.get("content") or ""
+                if text:
+                    parts.append(str(text))
+        text = "\n\n".join(p for p in parts if p).strip()
+        return text
+    return "" if user_input is None else str(user_input)

--- a/agent/transports/claude_sdk_event_projector.py
+++ b/agent/transports/claude_sdk_event_projector.py
@@ -1,0 +1,195 @@
+"""Projects Claude Agent SDK messages into Hermes' messages list.
+
+The translator that lets Hermes' memory/skill review keep working under the
+claude-agent-sdk runtime: it converts the SDK's typed message stream into the
+standard OpenAI-shaped ``{role, content, tool_calls, tool_call_id}`` entries
+that ``agent/curator.py`` already knows how to read. The structural twin of
+``codex_event_projector.py`` — same contract, different wire shape.
+
+The SDK stream (``ClaudeSDKClient.receive_response()``) yields, per turn:
+  - AssistantMessage   → content blocks: TextBlock / ThinkingBlock / ToolUseBlock
+  - UserMessage        → tool results echoed back: ToolResultBlock entries
+  - SystemMessage      → lifecycle events (init, …) — not conversation content
+  - StreamEvent        → display-only partial deltas — never materialized
+  - ResultMessage      → terminal: final text, usage, cost, error subtype
+
+Projection rules (mirrors the codex projector's invariants):
+  - One AssistantMessage → ONE assistant entry (text + tool_calls together).
+  - Each ToolResultBlock → one ``{role: "tool", tool_call_id, content}`` entry;
+    ticks ``is_tool_iteration`` (skill-nudge counter parity).
+  - ThinkingBlock text is stashed on the next assistant entry's ``reasoning``.
+  - ResultMessage sets ``final_text`` (authoritative over the last text block).
+
+This module deliberately duck-types on ``type(message).__name__`` instead of
+importing ``claude_agent_sdk`` — it stays importable (and unit-testable) when
+the optional SDK extra is not installed.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+_TOOL_RESULT_MAX_CHARS = 4000
+
+
+def _sdk_type_name(obj: Any) -> str:
+    return type(obj).__name__
+
+
+def _flatten_tool_result_content(content: Any) -> str:
+    """ToolResultBlock.content is str | list[dict] | None — flatten to text."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content[:_TOOL_RESULT_MAX_CHARS]
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                if item.get("type") == "text" and item.get("text"):
+                    parts.append(str(item["text"]))
+                else:
+                    try:
+                        parts.append(json.dumps(item, ensure_ascii=False))
+                    except (TypeError, ValueError):
+                        parts.append(repr(item))
+            elif item is not None:
+                parts.append(str(item))
+        return "\n".join(parts)[:_TOOL_RESULT_MAX_CHARS]
+    return str(content)[:_TOOL_RESULT_MAX_CHARS]
+
+
+def _format_tool_args(d: Any) -> str:
+    """Format tool input as JSON the way Hermes' existing tool_calls path does."""
+    if not isinstance(d, dict):
+        d = {"input": d}
+    try:
+        return json.dumps(d, ensure_ascii=False, sort_keys=True)
+    except (TypeError, ValueError):
+        return json.dumps({"repr": repr(d)}, ensure_ascii=False)
+
+
+@dataclass
+class ProjectionResult:
+    """Output of projecting one SDK message.
+
+    ``messages`` is a list because one AssistantMessage can produce one
+    assistant entry and a UserMessage can carry several tool results. Empty
+    list = message ignored (SystemMessage lifecycle, StreamEvent deltas)."""
+
+    messages: list[dict] = field(default_factory=list)
+    is_tool_iteration: bool = False
+    final_text: Optional[str] = None  # Set when text lands / on ResultMessage
+    is_result: bool = False  # True only for the terminal ResultMessage
+
+
+class ClaudeSdkEventProjector:
+    """Stateful projector consuming SDK messages in arrival order.
+
+    Owns pending thinking text (stashed onto the next assistant entry,
+    mirroring how the codex projector holds reasoning items)."""
+
+    def __init__(self) -> None:
+        self._pending_thinking: list[str] = []
+
+    def project(self, message: Any) -> ProjectionResult:
+        name = _sdk_type_name(message)
+        if name == "AssistantMessage":
+            return self._project_assistant(message)
+        if name == "UserMessage":
+            return self._project_user(message)
+        if name == "ResultMessage":
+            return self._project_result(message)
+        # SystemMessage / StreamEvent / unknown lifecycle types: display or
+        # bookkeeping only — nothing enters the conversation transcript.
+        return ProjectionResult()
+
+    # ---------- per-type projections ----------
+
+    def _project_assistant(self, message: Any) -> ProjectionResult:
+        text_parts: list[str] = []
+        tool_calls: list[dict] = []
+        for block in getattr(message, "content", None) or []:
+            bname = _sdk_type_name(block)
+            if bname == "TextBlock":
+                text = getattr(block, "text", "") or ""
+                if text:
+                    text_parts.append(text)
+            elif bname == "ThinkingBlock":
+                thinking = getattr(block, "thinking", "") or ""
+                if thinking:
+                    self._pending_thinking.append(thinking)
+            elif bname == "ServerToolUseBlock":
+                # Server tools (web_search, web_fetch, ...) execute API-side;
+                # their results arrive as ServerToolResultBlocks inside the
+                # SAME assistant message, never as a {role:'tool'} echo — an
+                # OpenAI-shaped tool_calls entry here would persist a
+                # dangling tool_call_id that breaks replay through native
+                # provider paths. The tool's textual outcome already arrives
+                # in the assistant text; nothing to project here.
+                pass
+            elif bname == "ToolUseBlock":
+                call_id = getattr(block, "id", "") or ""
+                tool_calls.append(
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": getattr(block, "name", "") or "unknown",
+                            "arguments": _format_tool_args(
+                                getattr(block, "input", None) or {}
+                            ),
+                        },
+                    }
+                )
+            # ToolResultBlock never appears on AssistantMessage; other block
+            # types (server tool results, …) are ignored here on purpose.
+
+        if not text_parts and not tool_calls:
+            return ProjectionResult()
+
+        msg: dict[str, Any] = {
+            "role": "assistant",
+            "content": "\n".join(text_parts) if text_parts else None,
+        }
+        if tool_calls:
+            msg["tool_calls"] = tool_calls
+        if self._pending_thinking:
+            msg["reasoning"] = "\n".join(self._pending_thinking)
+            self._pending_thinking = []
+        final_text = "\n".join(text_parts) if text_parts else None
+        return ProjectionResult(messages=[msg], final_text=final_text)
+
+    def _project_user(self, message: Any) -> ProjectionResult:
+        """SDK UserMessages inside a response stream carry tool results."""
+        content = getattr(message, "content", None)
+        if isinstance(content, str):
+            # A plain-text user echo — not conversation-new under this
+            # runtime (Hermes already appended the real user turn).
+            return ProjectionResult()
+        out: list[dict] = []
+        tool_iteration = False
+        for block in content or []:
+            if _sdk_type_name(block) != "ToolResultBlock":
+                continue
+            text = _flatten_tool_result_content(getattr(block, "content", None))
+            if getattr(block, "is_error", False):
+                text = f"[error] {text}" if text else "[error]"
+            out.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": getattr(block, "tool_use_id", "") or "",
+                    "content": text,
+                }
+            )
+            tool_iteration = True
+        return ProjectionResult(messages=out, is_tool_iteration=tool_iteration)
+
+    def _project_result(self, message: Any) -> ProjectionResult:
+        final = getattr(message, "result", None)
+        return ProjectionResult(
+            final_text=final if isinstance(final, str) and final else None,
+            is_result=True,
+        )

--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -29,13 +29,23 @@ What we DO NOT expose:
   - read_file / write_file / patch       — codex's apply_patch + shell
   - search_files / process               — codex's shell
   - clarify                              — codex's own UX
-  - delegate_task / memory /             — `_AGENT_LOOP_TOOLS` in Hermes
-    session_search / todo                  (model_tools.py). They require
+  - delegate_task / todo                 — `_AGENT_LOOP_TOOLS` in Hermes
+                                           (model_tools.py). They require
                                            the running AIAgent context to
                                            dispatch (mid-loop state), so a
                                            stateless MCP callback can't
                                            drive them. See the inline
                                            comment on EXPOSED_TOOLS below.
+
+Exposed via STATELESS SHIMS (#26567) rather than the generic dispatcher:
+  - memory                               — tools.memory_tool.load_on_disk_store()
+                                           per call: native caps, drift guard,
+                                           threat scan, locking all inherited
+  - session_search                       — read-only SessionDB over the state
+                                           DB; the calling session's id rides
+                                           the canonical HERMES_SESSION_ID
+  The `_AGENT_LOOP_TOOLS` refusal in handle_function_call stays intact for
+  every other caller — the shims are dedicated closures, not a widened gate.
 
 Run with: python -m agent.transports.hermes_tools_mcp_server
 Spawned by: CodexAppServerSession.ensure_started() when the runtime is
@@ -104,11 +114,14 @@ def _signature_from_schema(schema: dict | None) -> tuple[inspect.Signature, dict
 #   - terminal / shell / read_file / write_file / patch / search_files /
 #     process — codex's built-ins cover these and approval routes through
 #     codex's own UI.
-#   - delegate_task / memory / session_search / todo — these are
-#     `_AGENT_LOOP_TOOLS` in Hermes (model_tools.py:493). They require
-#     the running AIAgent context to dispatch (mid-loop state), so a
-#     stateless MCP callback can't drive them. Hermes' default runtime
-#     keeps these working; the codex_app_server runtime cannot.
+#   - delegate_task / todo — these are `_AGENT_LOOP_TOOLS` in Hermes
+#     (model_tools.py:606, gate at :1167). They require the running AIAgent
+#     context to dispatch (mid-loop state), so a stateless MCP callback
+#     can't drive them. Hermes' default runtime keeps these working; the
+#     codex_app_server runtime cannot.
+#     (`memory` and `session_search` are `_AGENT_LOOP_TOOLS` too, but they
+#     DO have workable stateless equivalents — they are exposed through the
+#     dedicated shims below, which does not widen that refusal.)
 EXPOSED_TOOLS: tuple[str, ...] = (
     "web_search",
     "web_extract",
@@ -147,6 +160,241 @@ EXPOSED_TOOLS: tuple[str, ...] = (
     "kanban_unblock",
     "kanban_link",
 )
+
+
+# --- Stateless agent-loop shims (#26567) ---------------------------------
+#
+# `memory` and `session_search` are `_AGENT_LOOP_TOOLS`: the generic
+# dispatcher refuses them because natively they receive live agent state
+# (the loop's MemoryStore / session-DB handle) from tool_executor. Both have
+# workable stateless equivalents, so a runtime that owns its own agent loop
+# (codex app-server) can regain them through this server without touching
+# that refusal:
+#
+#   memory         → a fresh `load_on_disk_store()` per call. Char caps,
+#                    config overrides, external-drift guard, threat scan and
+#                    file locking live in MemoryStore/memory_tool and are
+#                    inherited. The consolidation-failure breaker is NOT:
+#                    a fresh store per call resets its counter every time, so
+#                    it can never trip here (it is reset natively at the turn
+#                    boundary, and this subprocess has no turns).
+#                    NOTE: a shim write cannot mirror through MemoryProvider
+#                    hooks (no MemoryManager in this subprocess), so when
+#                    `memory.provider` configures an external backend the
+#                    shim FAILS CLOSED — unregistered, and refused at
+#                    dispatch — rather than silently diverging the stores.
+#                    NOTE: with no foreground approver in a stdio subprocess
+#                    the native write-approval gate can return `staged`; the
+#                    call reports success and the write does not land yet.
+#   session_search → `SessionDB(read_only=True)` over the state DB (never a
+#                    writable handle in a model-facing subprocess). NOT a
+#                    faithful equivalent: it adds a deterministic zero-hit
+#                    OR-relaxation the native tool does not have (below).
+#                    The calling session's id arrives via the canonical
+#                    HERMES_SESSION_ID (see `_SESSION_ID_ENV`); when that is
+#                    unset, own-lineage exclusion is simply INACTIVE —
+#                    fail-open, results just include the caller, no error.
+#                    The DB path can be pointed elsewhere with
+#                    HERMES_MCP_STATE_DB (defaults to the profile's
+#                    state.db) — an internal mechanism bridge, not a
+#                    user-facing setting.
+
+# The CANONICAL session-context variable — deliberately not a shim-specific name.
+# `set_current_session_id()` writes it (gateway/session_context.py), `_VAR_MAP` carries
+# it, and `_inject_session_context_env()` inside `hermes_subprocess_env()` bridges it
+# into the HOST process's spawn env. That is hop 1 only: codex builds an MCP child's
+# env from a fixed whitelist plus the names listed in the entry's `env_vars` (a
+# spawn-time snapshot of the codex process env), and the migration entry names none —
+# so under codex today the shim does not receive this var and own-lineage exclusion is
+# INACTIVE (fail-open, documented above). A host delivers it by naming it in the
+# entry's `env_vars` or by setting it in the server's spawn env directly. Reading a
+# bespoke name instead would be strictly worse: it has no producer in any launch path,
+# and the cross-session leak guard in `_inject_session_context_env` covers only
+# `_VAR_MAP` keys, so a bespoke var could carry a SIBLING session's id under a
+# concurrent host and exclude the wrong lineage.
+_SESSION_ID_ENV = "HERMES_SESSION_ID"
+_STATE_DB_ENV = "HERMES_MCP_STATE_DB"
+
+
+def _external_memory_provider():
+    """Name of the external memory provider configured via `memory.provider`,
+    or None for the builtin on-disk store. Config-read failure counts as
+    builtin — the same fail-open posture as `_memory_enabled_in_config()`."""
+    try:
+        from hermes_cli.config import load_config
+
+        provider = str(
+            (((load_config() or {}).get("memory", {}) or {}).get("provider") or "")
+        ).strip().lower()
+    except Exception:
+        return None
+    if provider in ("", "none", "builtin", "off", "disabled"):
+        return None
+    return provider
+
+
+def dispatch_memory(kwargs: dict) -> str:
+    """Stateless `memory` dispatch: native handler + on-disk store."""
+    from tools.memory_tool import load_on_disk_store, memory_tool
+    from tools.registry import tool_error
+
+    provider = _external_memory_provider()
+    if provider is not None:
+        # Every memory action mutates (add/replace/remove/batch), and a
+        # mutation here can never reach the external backend — refuse with
+        # the reason instead of letting the two stores drift apart.
+        return tool_error(
+            f"memory is disabled in this MCP shim: external memory provider "
+            f"'{provider}' is configured (memory.provider) and shim writes "
+            f"cannot mirror to it. Use the memory tool in the main agent "
+            f"loop instead.",
+            success=False,
+        )
+    return memory_tool(
+        action=kwargs.get("action", ""),
+        target=kwargs.get("target", "memory"),
+        content=kwargs.get("content"),
+        old_text=kwargs.get("old_text"),
+        operations=kwargs.get("operations"),
+        store=load_on_disk_store(),
+    )
+
+
+def dispatch_session_search(kwargs: dict) -> str:
+    """Stateless `session_search` dispatch: read-only DB + env session id."""
+    from pathlib import Path
+
+    import hermes_state
+    from tools import session_search_tool
+
+    db_path = Path(
+        os.environ.get(_STATE_DB_ENV, "").strip()
+        or hermes_state.DEFAULT_DB_PATH
+    )
+    if not db_path.exists():
+        # Explicit degrade — a missing DB must never read as "no results".
+        return json.dumps({
+            "success": False,
+            "error": f"session_search unavailable: state DB not found at {db_path}",
+        })
+    try:
+        db = hermes_state.SessionDB(db_path=db_path, read_only=True)
+    except Exception as exc:
+        return json.dumps({
+            "success": False,
+            "error": f"session_search unavailable: cannot open state DB read-only: {exc}",
+        })
+    try:
+        # A present-but-uninitialized DB (0-byte file from a crashed first
+        # init) opens fine and would return a SILENT empty result — the
+        # exact failure the missing-file guard above exists to prevent.
+        # Probe the schema and degrade explicitly instead.
+        db.get_session("__schema-probe__")
+    except Exception as exc:
+        try:
+            db.close()
+        except Exception:
+            pass
+        return json.dumps({
+            "success": False,
+            "error": f"session_search unavailable: state DB not initialized: {exc}",
+        })
+
+    def _run(query: str) -> str:
+        return session_search_tool.session_search(
+            query=query,
+            role_filter=kwargs.get("role_filter"),
+            limit=kwargs.get("limit", 3),
+            session_id=kwargs.get("session_id"),
+            around_message_id=kwargs.get("around_message_id"),
+            window=kwargs.get("window", 5),
+            sort=kwargs.get("sort"),
+            profile=kwargs.get("profile"),
+            db=db,
+            current_session_id=os.environ.get(_SESSION_ID_ENV, "").strip() or None,
+        )
+
+    try:
+        query = kwargs.get("query") or ""
+        result = _run(query)
+        # Deterministic OR-relaxation: FTS5 ANDs terms, and models routinely
+        # write "topic word word word" discovery queries that miss content
+        # matching one distinctive term. On a ZERO-hit multi-term query with
+        # no explicit FTS operators, retry ONCE with the terms OR-joined and
+        # annotate the result — never silently, never for a query that
+        # states its own operators, never on a single term.
+        try:
+            parsed = json.loads(result)
+            terms = query.split()
+            has_operators = any(
+                op in query for op in ('"', "*", " OR ", " NOT ", " AND ")
+            )
+            if (
+                isinstance(parsed, dict)
+                and parsed.get("mode") == "discover"
+                and parsed.get("count") == 0
+                and len(terms) >= 2
+                and not has_operators
+            ):
+                relaxed_query = " OR ".join(terms)
+                relaxed = json.loads(_run(relaxed_query))
+                if isinstance(relaxed, dict) and relaxed.get("count", 0) > 0:
+                    relaxed["relaxed_query"] = relaxed_query
+                    relaxed["note"] = (
+                        "No result matched ALL terms (FTS ANDs them); showing "
+                        "matches for ANY term instead."
+                    )
+                    return json.dumps(relaxed)
+        except Exception:
+            logger.debug("session_search relaxation skipped", exc_info=True)
+        return result
+    finally:
+        try:
+            db.close()
+        except Exception:
+            pass
+
+
+def _memory_enabled_in_config() -> bool:
+    """Honor the operator's `memory.memory_enabled` config (default on)."""
+    try:
+        from hermes_cli.config import load_config
+
+        return bool(
+            ((load_config() or {}).get("memory", {}) or {}).get("memory_enabled", True)
+        )
+    except Exception:
+        return True
+
+
+def _stateless_shim_defs() -> list:
+    """(name, description, input_schema, handler) 4-tuples to register.
+
+    session_search is always defined — a missing state DB degrades to an
+    explicit error at call time, which is more diagnosable than an absent
+    tool. memory respects the config kill-switch AND stays unregistered when
+    an external memory provider is configured (shim writes cannot mirror
+    through MemoryProvider hooks — see the scope note above; #26604).
+    """
+    defs = []
+    if _memory_enabled_in_config() and _external_memory_provider() is None:
+        from tools.memory_tool import MEMORY_SCHEMA
+
+        defs.append((
+            "memory",
+            MEMORY_SCHEMA.get("description", "Hermes memory tool"),
+            MEMORY_SCHEMA.get("parameters") or {"type": "object", "properties": {}},
+            dispatch_memory,
+        ))
+    from tools.session_search_tool import SESSION_SEARCH_SCHEMA
+
+    defs.append((
+        "session_search",
+        SESSION_SEARCH_SCHEMA.get("description", "Search past Hermes sessions"),
+        SESSION_SEARCH_SCHEMA.get("parameters") or {"type": "object", "properties": {}},
+        dispatch_session_search,
+    ))
+    return defs
 
 
 def _build_server() -> Any:
@@ -237,10 +485,45 @@ def _build_server() -> Any:
 
         exposed_count += 1
 
+    # Stateless agent-loop shims (#26567) — registered as dedicated
+    # closures so handle_function_call's `_AGENT_LOOP_TOOLS` refusal stays
+    # intact for every other caller. Same signature-from-schema mechanics
+    # as the loop above so FastMCP serves the authoritative registry schema.
+    shim_count = 0
+    for shim_name, shim_description, shim_schema, shim_fn in _stateless_shim_defs():
+        shim_sig, shim_annots = _signature_from_schema(shim_schema)
+
+        def _make_shim_handler(fn, tool_name: str, description: str, sig, annots):
+            def _dispatch(**kwargs: Any) -> str:
+                try:
+                    args = {k: v for k, v in kwargs.items() if v is not None}
+                    return fn(args or {})
+                except Exception as exc:
+                    logger.exception("shim tool %s raised", tool_name)
+                    return json.dumps({"error": str(exc), "tool": tool_name})
+
+            _dispatch.__name__ = tool_name
+            _dispatch.__doc__ = description
+            _dispatch.__signature__ = sig
+            _dispatch.__annotations__ = {**annots, "return": str}
+            return _dispatch
+
+        shim_handler = _make_shim_handler(
+            shim_fn, shim_name, shim_description, shim_sig, shim_annots
+        )
+        try:
+            mcp.add_tool(shim_handler, name=shim_name, description=shim_description)
+        except TypeError:
+            shim_handler = mcp.tool(name=shim_name, description=shim_description)(
+                shim_handler
+            )
+        shim_count += 1
+
     logger.info(
-        "hermes-tools MCP server registered %d/%d tools",
+        "hermes-tools MCP server registered %d/%d tools + %d stateless shims",
         exposed_count,
         len(EXPOSED_TOOLS),
+        shim_count,
     )
     return mcp
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -783,6 +783,30 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 500
 
+  # Claude Agent SDK provider runtime (provider: claude-agent-sdk).
+  # claude_agent_sdk:
+  #   # Emit the SDK's partial-message deltas into the gateway streaming
+  #   # pipeline (default off — upstream-conservative; the top-level
+  #   # streaming: block still governs how deltas are displayed).
+  #   streaming: false
+  #   # Subscription-only: environment credentials, endpoint overrides, and
+  #   # alternate metered backends are rejected before Claude starts.
+  #   # Optional operator persona/soul override. Empty loads the active
+  #   # HERMES_HOME/SOUL.md, falling back to Hermes' built-in identity.
+  #   append_file: ""
+  #   # add_dirs grants paths to Claude Code's native tools; it is not a
+  #   # read-only mount. Under default auto/acceptEdits, native edits and common
+  #   # filesystem mutations in added roots may be automatic. Removing Hermes
+  #   # MCP file/terminal tools does not remove Claude native tools. Therefore
+  #   # read-oriented headless profiles must use native_read_only: true and may
+  #   # additionally use HERMES_TERMINAL_SECURITY_MODE=approval-required.
+  #   # Paths are normalized/deduplicated; changes apply to new SDK sessions.
+  #   add_dirs: []
+  #   # Native read-only disables user/project/local Claude settings for that SDK
+  #   # session, allows only Read, Glob, and Grep natively, and makes mutating
+  #   # native tools unavailable rather than interactively approvable.
+  #   native_read_only: false
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -738,6 +738,13 @@ def sanitize_model_override(override: Optional[Dict[str, Any]]) -> Optional[Dict
         for k, v in override.items()
         if k in PERSISTABLE_MODEL_OVERRIDE_KEYS and v not in (None, "")
     }
+    if (
+        cleaned.get("provider") == "claude-agent-sdk"
+        and override.get("base_url") == ""
+    ):
+        # The clientless SDK runtime intentionally has no HTTP endpoint. Keep
+        # that explicit empty URL while still excluding api_key/api_mode.
+        cleaned["base_url"] = ""
     return cleaned or None
 
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -103,6 +103,38 @@ class GatewaySlashCommandsMixin:
 
     async_session_store: AsyncSessionStore
 
+    async def _clear_claude_sdk_continuity_on_boundary(
+        self,
+        *,
+        source: SessionSource,
+        old_provider: Optional[str],
+        old_api_mode: Optional[str],
+        new_provider: Optional[str],
+        new_api_mode: Optional[str],
+    ) -> None:
+        """Clear persisted SDK resume state when a switch crosses runtimes."""
+        from agent.claude_sdk_runtime import is_claude_agent_sdk_runtime
+
+        old_is_sdk = is_claude_agent_sdk_runtime(
+            provider=old_provider, api_mode=old_api_mode
+        )
+        new_is_sdk = is_claude_agent_sdk_runtime(
+            provider=new_provider, api_mode=new_api_mode
+        )
+        if old_is_sdk == new_is_sdk:
+            return
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None:
+            return
+        try:
+            entry = await self.async_session_store.get_or_create_session(source)
+            await session_db.update_claude_sdk_session_id(entry.session_id, None)
+        except Exception:
+            logger.warning(
+                "Failed to clear Claude SDK continuity after gateway model switch",
+                exc_info=True,
+            )
+
     def _typed_command_prefix_for(self, platform) -> str:
         """Return the prefix users can always type to reach Hermes commands.
 
@@ -1772,6 +1804,7 @@ class GatewaySlashCommandsMixin:
         current_provider = "openrouter"
         current_base_url = ""
         current_api_key = ""
+        current_api_mode = ""
         user_provs = None
         custom_provs = None
         excluded_provs = []
@@ -1784,6 +1817,7 @@ class GatewaySlashCommandsMixin:
                     current_model = model_cfg.get("default", "")
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
+                    current_api_mode = model_cfg.get("api_mode", "")
                 user_provs = cfg.get("providers")
                 try:
                     from hermes_cli.config import get_compatible_custom_providers
@@ -1803,6 +1837,17 @@ class GatewaySlashCommandsMixin:
         # (#30479).
         source = await asyncio.to_thread(self._normalize_source_for_session_key, source)
         session_key = self._session_key_for_source(source)
+        try:
+            rehydrate_override = getattr(
+                self, "_rehydrate_session_model_override", None
+            )
+            if callable(rehydrate_override):
+                rehydrate_override(session_key)
+        except Exception:
+            logger.debug(
+                "Failed to rehydrate session model override before /model",
+                exc_info=True,
+            )
         override = self._session_model_overrides.get(session_key, {})
         restore_snapshot = (
             self._snapshot_session_model_override(session_key) if one_turn else None
@@ -1812,6 +1857,7 @@ class GatewaySlashCommandsMixin:
             current_provider = override.get("provider", current_provider)
             current_base_url = override.get("base_url", current_base_url)
             current_api_key = override.get("api_key", current_api_key)
+            current_api_mode = override.get("api_mode", current_api_mode)
 
         # No args: show interactive picker (Telegram/Discord) or text list
         if not model_input and not explicit_provider:
@@ -1851,6 +1897,7 @@ class GatewaySlashCommandsMixin:
                     _cur_base_url = current_base_url
                     _cur_api_key = current_api_key
                     _picker_profile_home = _command_profile_home
+                    _cur_api_mode = current_api_mode
 
                     async def _on_model_selected_scoped(
                         _chat_id: str, model_id: str, provider_slug: str
@@ -1930,6 +1977,14 @@ class GatewaySlashCommandsMixin:
                                         f"staying on {_cur_model}."
                                     ),
                                 )
+
+                        await _self._clear_claude_sdk_continuity_on_boundary(
+                            source=source,
+                            old_provider=_cur_provider,
+                            old_api_mode=_cur_api_mode,
+                            new_provider=result.target_provider,
+                            new_api_mode=result.api_mode,
+                        )
 
                         # Persist the new model to the session DB so the
                         # dashboard shows the updated model (#34850).
@@ -2234,6 +2289,14 @@ class GatewaySlashCommandsMixin:
                             f"staying on {current_model}."
                         ),
                     )
+
+            await self._clear_claude_sdk_continuity_on_boundary(
+                source=source,
+                old_provider=current_provider,
+                old_api_mode=current_api_mode,
+                new_provider=result.target_provider,
+                new_api_mode=result.api_mode,
+            )
 
             # Persist the new model to the session DB so the dashboard
             # shows the updated model (#34850).

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -114,7 +114,11 @@ class CLIAgentSetupMixin:
                 print("\n⚠️  Provider resolver returned an empty API key. "
                       "Set OPENROUTER_API_KEY or run: hermes setup")
                 return False
-        if not isinstance(base_url, str) or not base_url:
+        # Agent-loop runtimes own their transport and do not have an HTTP base
+        # URL.  Keep the guard for OpenAI-compatible/native HTTP providers,
+        # but allow the first-class Claude Agent SDK route through to AIAgent.
+        _clientless_runtime = resolved_api_mode == "claude_agent_sdk"
+        if (not isinstance(base_url, str) or not base_url) and not _clientless_runtime:
             print("\n⚠️  Provider resolver returned an empty base URL. "
                   "Check your provider config or run: hermes setup")
             return False

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1149,6 +1149,34 @@ DEFAULT_CONFIG = {
         # matches a key in this dict.
         # Edit directly in config.yaml (no CLI support due to dots in keys).
         "reasoning_overrides": {},
+
+        # Claude Agent SDK provider runtime (selected with
+        # `provider: claude-agent-sdk`). These are the canonical defaults for
+        # the `agent.claude_agent_sdk` block; the provider reads them through
+        # load_config_readonly(). config.yaml is the only interface for these —
+        # they are behavioural settings, not secrets.
+        "claude_agent_sdk": {
+            # Emit the SDK's partial-message deltas into the gateway streaming
+            # pipeline (the top-level `streaming:` block still governs how the
+            # deltas are displayed). Default off — upstream-conservative.
+            "streaming": False,
+            # Optional operator persona/soul file appended to the system prompt
+            # ("" = none).
+            "append_file": "",
+            # `add_dirs` grants paths to Claude Code's native tools; it is not a
+            # read-only mount. Under default auto/acceptEdits, native edits and
+            # common filesystem mutations in added roots may be automatic.
+            # Removing Hermes MCP file/terminal tools does not remove Claude native
+            # tools. Therefore read-oriented headless profiles must use
+            # native_read_only: true and may additionally use
+            # HERMES_TERMINAL_SECURITY_MODE=approval-required.
+            # Paths are normalized/deduplicated; changes apply to new SDK sessions.
+            "add_dirs": [],
+            # Native read-only disables user/project/local Claude settings for that
+            # SDK session, allows only Read, Glob, and Grep natively, and makes
+            # mutating native tools unavailable rather than interactively approvable.
+            "native_read_only": False,
+        },
     },
 
     "terminal": {

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1067,14 +1067,41 @@ def switch_model(
     # =================================================================
     if explicit_provider:
         # Resolve the provider
+        runtime_profile = None
         pdef = resolve_provider_full(
             explicit_provider,
             user_providers,
             custom_providers,
         )
-        if pdef is None and explicit_provider.strip().lower() == "custom":
-            pdef = _bare_custom_provider_def(current_base_url)
         if pdef is None:
+            # Clientless first-class runtimes are registered as model-provider
+            # plugins rather than HTTP providers. Adapt the Claude Agent SDK
+            # identity here, then let resolve_runtime_provider() below supply
+            # its non-secret sentinel and api_mode without native Anthropic or
+            # generic HTTP credential resolution.
+            try:
+                from importlib import import_module
+
+                get_provider_profile = getattr(
+                    import_module("providers"), "get_provider_profile"
+                )
+                runtime_profile = get_provider_profile(
+                    explicit_provider.strip().lower()
+                )
+            except Exception:
+                runtime_profile = None
+            if (
+                runtime_profile is not None
+                and runtime_profile.api_mode != "claude_agent_sdk"
+            ):
+                runtime_profile = None
+        if (
+            pdef is None
+            and runtime_profile is None
+            and explicit_provider.strip().lower() == "custom"
+        ):
+            pdef = _bare_custom_provider_def(current_base_url)
+        if pdef is None and runtime_profile is None:
             _switch_err = (
                 f"Unknown provider '{explicit_provider}'. "
                 f"Check 'hermes model' for available providers, or define it "
@@ -1096,7 +1123,17 @@ def switch_model(
                 error_message=_switch_err,
             )
 
-        target_provider = pdef.id
+        if runtime_profile is not None:
+            target_provider = runtime_profile.name
+            resolved_provider_name = (
+                runtime_profile.display_name or runtime_profile.name
+            )
+            resolved_provider_base_url = runtime_profile.base_url
+        else:
+            assert pdef is not None
+            target_provider = pdef.id
+            resolved_provider_name = pdef.name
+            resolved_provider_base_url = pdef.base_url
         if target_provider == "moa" and not new_model:
             try:
                 from hermes_cli.config import load_config
@@ -1139,7 +1176,7 @@ def switch_model(
                 return ModelSwitchResult(
                     success=False,
                     target_provider=target_provider,
-                    provider_label=pdef.name,
+                    provider_label=resolved_provider_name,
                     is_global=is_global,
                     error_message=(
                         f"Provider '{_explicit_norm}' is an alias that routes "
@@ -1150,19 +1187,20 @@ def switch_model(
 
         # If no model specified, try auto-detect from endpoint
         if not new_model:
-            if pdef.base_url:
+            if resolved_provider_base_url:
                 from hermes_cli.runtime_provider import _auto_detect_local_model
-                detected = _auto_detect_local_model(pdef.base_url)
+                detected = _auto_detect_local_model(resolved_provider_base_url)
                 if detected:
                     new_model = detected
                 else:
                     return ModelSwitchResult(
                         success=False,
                         target_provider=target_provider,
-                        provider_label=pdef.name,
+                        provider_label=resolved_provider_name,
                         is_global=is_global,
                         error_message=(
-                            f"No model detected on {pdef.name} ({pdef.base_url}). "
+                            f"No model detected on {resolved_provider_name} "
+                            f"({resolved_provider_base_url}). "
                             f"Specify the model explicitly: /model <model-name> --provider {explicit_provider}"
                         ),
                     )
@@ -1170,10 +1208,10 @@ def switch_model(
                 return ModelSwitchResult(
                     success=False,
                     target_provider=target_provider,
-                    provider_label=pdef.name,
+                    provider_label=resolved_provider_name,
                     is_global=is_global,
                     error_message=(
-                        f"Provider '{pdef.name}' has no base URL configured. "
+                        f"Provider '{resolved_provider_name}' has no base URL configured. "
                         f"Specify a model: /model <model-name> --provider {explicit_provider}"
                     ),
                 )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -357,6 +357,10 @@ _VALID_API_MODES = {
     # `model.openai_runtime == "codex_app_server"` AND provider in
     # {"openai", "openai-codex"}. Default is unchanged.
     "codex_app_server",
+    # Agent-loop runtime via the official claude-agent-sdk (Claude-managed
+    # subscription login; Hermes resolves no credentials). Selected by
+    # `provider: claude-agent-sdk`. See #25267.
+    "claude_agent_sdk",
 }
 
 
@@ -1671,6 +1675,22 @@ def resolve_runtime_provider(
             "base_url": "moa://local",
             "api_key": "moa-virtual-provider",
             "source": "moa-virtual-provider",
+            "requested_provider": requested_provider,
+        }
+
+    # claude-agent-sdk short-circuit: the official Agent SDK runtime reads
+    # Claude-managed subscription login storage inside the SDK subprocess.
+    # Nothing here must reach the credential pool or generic api_key resolver;
+    # environment credential routes are rejected before startup (#25267).
+    if requested_provider in {
+        "claude-agent-sdk", "claude-sdk", "claude-code-sdk", "claude_agent_sdk",
+    }:
+        return {
+            "provider": "claude-agent-sdk",
+            "api_mode": "claude_agent_sdk",
+            "base_url": "",
+            "api_key": "claude-subscription-oauth",
+            "source": "claude-agent-sdk",
             "requested_provider": requested_provider,
         }
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -295,6 +295,13 @@ SCHEMA_VERSION = 23
 #       tool-row-excluded trigram)
 FTS_STORAGE_VERSION = 1
 
+
+def _fts_object_missing(exc: BaseException) -> bool:
+    """True when an FTS probe failure means the table/module is ABSENT
+    (disable search) rather than transiently unavailable (keep it on)."""
+    msg = str(exc).lower()
+    return "no such table" in msg or "no such module" in msg
+
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.
 # Search queries do not need to be arbitrarily large, and bounding them keeps
 # sanitizer/runtime behavior predictable under adversarial input.
@@ -1252,6 +1259,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     model TEXT,
     model_config TEXT,
     system_prompt TEXT,
+    claude_sdk_session_id TEXT,
     parent_session_id TEXT,
     started_at REAL NOT NULL,
     ended_at REAL,
@@ -2068,6 +2076,37 @@ class SessionDB:
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
+                # Probe FTS availability with SELECTs (read-only-safe).
+                # Without this, search_messages() sees _fts_enabled=False and
+                # silently returns [] on every read-only handle — a false
+                # empty, not a degrade. Only a MISSING fts object disables
+                # search: a transient error (e.g. "database is locked"
+                # during a checkpoint) must not latch a silent false-empty
+                # for the handle's lifetime — leave enabled and let the
+                # query surface the error visibly.
+                try:
+                    self._conn.execute("SELECT 1 FROM messages_fts LIMIT 1")
+                    self._fts_enabled = True
+                except sqlite3.Error as exc:
+                    self._fts_enabled = not _fts_object_missing(exc)
+                # Same transient-vs-absent rule for the trigram probe. Absence
+                # here has one extra spelling: a build with FTS5 but without
+                # the trigram tokenizer raises "no such tokenizer: trigram"
+                # (see _is_trigram_unavailable_error), which _fts_object_missing
+                # does not cover. A wrongly-kept True costs nothing at query
+                # time — search_messages catches the per-query error and falls
+                # through to LIKE — while a wrongly-latched False pins the LIKE
+                # fallback (ORs tokens, drops NOT/rank) for the handle's life.
+                try:
+                    self._conn.execute(
+                        "SELECT 1 FROM messages_fts_trigram LIMIT 1"
+                    )
+                    self._trigram_available = True
+                except sqlite3.Error as exc:
+                    self._trigram_available = not (
+                        _fts_object_missing(exc)
+                        or self._is_trigram_unavailable_error(exc)
+                    )
                 return
 
             self.db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -5172,6 +5211,19 @@ class SessionDB:
             conn.execute(
                 "UPDATE sessions SET model_config = ?, model = COALESCE(?, model) WHERE id = ?",
                 (model_config_json, model, session_id),
+            )
+        self._execute_write(_do)
+
+    def update_claude_sdk_session_id(
+        self, session_id: str, sdk_session_id: Optional[str]
+    ) -> None:
+        """Persist (or clear, with None) the claude-agent-sdk session id used
+        to resume the SDK conversation across gateway restarts and
+        agent-cache eviction (#25267 continuity)."""
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET claude_sdk_session_id = ? WHERE id = ?",
+                (sdk_session_id, session_id),
             )
         self._execute_write(_do)
 
@@ -8907,9 +8959,10 @@ class SessionDB:
                         tri_cursor = conn.execute(tri_sql, tri_params)
                         matches = [dict(row) for row in tri_cursor.fetchall()]
                         _trigram_succeeded = True
-                except sqlite3.OperationalError:
+                except sqlite3.OperationalError as exc:
                     # Trigram query failed at runtime — fall through to LIKE.
-                    pass
+                    if self._is_trigram_unavailable_error(exc):
+                        self._warn_trigram_unavailable(exc)
                 except sqlite3.DatabaseError as exc:
                     # Same corruption class the main FTS5 MATCH branch
                     # self-heals above: a corrupt trigram shadow table raises

--- a/plugins/model-providers/claude-agent-sdk/__init__.py
+++ b/plugins/model-providers/claude-agent-sdk/__init__.py
@@ -1,0 +1,33 @@
+"""Claude via the official claude-agent-sdk — subscription OAuth (#25267).
+
+Unlike the ``anthropic`` provider (raw Messages API: API-key pay-per-token,
+or OAuth that bills overage credits), this provider hands the whole turn to
+Anthropic's ``claude-agent-sdk``, which authenticates with the **Claude
+subscription** through Claude-managed CLI login storage. Hermes resolves NO
+credentials for it: the SDK subprocess self-authenticates, while environment
+credential and metered backend routes are rejected before startup.
+
+Runtime: ``api_mode="claude_agent_sdk"`` — an agent-loop runtime dispatched
+by an early return in run_conversation(), exactly like ``codex_app_server``.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+claude_agent_sdk = ProviderProfile(
+    name="claude-agent-sdk",
+    # NB: "claude"/"claude-code"/"claude-oauth" are already claimed by the
+    # `anthropic` profile — keep alias namespaces disjoint.
+    aliases=("claude-sdk", "claude-code-sdk", "claude_agent_sdk"),
+    display_name="Claude (Agent SDK / subscription)",
+    description=(
+        "Claude Code's agent loop via the official Agent SDK, billed to the "
+        "Claude subscription (never a metered API key)."
+    ),
+    api_mode="claude_agent_sdk",
+    env_vars=(),
+    base_url="",
+    auth_type="oauth_external",
+    default_aux_model="claude-haiku-4-5-20251001",
+)
+register_provider(claude_agent_sdk)

--- a/plugins/model-providers/claude-agent-sdk/plugin.yaml
+++ b/plugins/model-providers/claude-agent-sdk/plugin.yaml
@@ -1,0 +1,5 @@
+name: claude-agent-sdk-provider
+kind: model-provider
+version: 1.0.0
+description: Claude via the official Agent SDK (Claude-managed subscription login, agent-loop runtime)
+author: Felipe Cavalcanti

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,9 @@ dependencies = [
 # Native Anthropic provider — only needed when provider=anthropic (not via
 # OpenRouter or other aggregators).
 anthropic = ["anthropic==0.87.0"]  # CVE-2026-34450, CVE-2026-34452
+# Claude via the official Agent SDK (subscription OAuth) — only needed when
+# provider=claude-agent-sdk. The SDK bundles/locates the Claude Code CLI.
+claude-agent-sdk = ["claude-agent-sdk==0.2.120"]
 # Web search backends — each only loaded when the user picks it as their
 # search provider (configured via `hermes tools` or config.yaml).
 exa = ["exa-py==2.10.2"]

--- a/run_agent.py
+++ b/run_agent.py
@@ -2950,6 +2950,15 @@ class AIAgent:
                         exc_info=True,
                     )
 
+        # claude-agent-sdk runtime: the blocking run_turn observes only the
+        # session's own interrupt event — signal it directly (idempotent;
+        # schedules client.interrupt() on the session's loop). (#25267)
+        sdk_session = getattr(self, "_claude_sdk_session", None)
+        if sdk_session is not None:
+            try:
+                sdk_session.request_interrupt()
+            except Exception:
+                logger.debug("claude-sdk interrupt signal failed", exc_info=True)
         # A cron turn performs its API request on the conversation thread to
         # avoid the nested interrupt-worker deadlock.  Unlike the normal worker
         # path, its client is registered here so this cross-thread interrupt can
@@ -3914,6 +3923,19 @@ class AIAgent:
         except Exception:
             pass
 
+        # Disconnect the claude-agent-sdk session: it owns a loop thread and
+        # a Claude Code CLI subprocess that would otherwise outlive the
+        # evicted agent forever. Continuity survives eviction regardless —
+        # the rebuilt agent RESUMES via the persisted claude_sdk_session_id
+        # on the session row. (#25267)
+        try:
+            sdk_session = getattr(self, "_claude_sdk_session", None)
+            if sdk_session is not None:
+                self._claude_sdk_session = None
+                sdk_session.close()
+        except Exception:
+            pass
+
     def close(self) -> None:
         """Release all resources held by this agent instance.
 
@@ -3974,6 +3996,17 @@ class AIAgent:
         # sequential LLM calls; see _create_request_openai_client).
         try:
             self._close_cached_request_openai_client(reason="agent_close")
+        except Exception:
+            pass
+
+        # 5c. Disconnect the claude-agent-sdk session (subscription runtime).
+        # The SDK client owns a Claude Code CLI subprocess; dropping it to GC
+        # on /new, expiry, or cache eviction leaks that subprocess. (#25267)
+        try:
+            sdk_session = getattr(self, "_claude_sdk_session", None)
+            if sdk_session is not None:
+                self._claude_sdk_session = None
+                sdk_session.close()
         except Exception:
             pass
 
@@ -7199,6 +7232,19 @@ class AIAgent:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
         return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+
+    def _run_claude_agent_sdk_turn(
+        self,
+        *,
+        user_message: str,
+        original_user_message: Any,
+        messages: List[Dict[str, Any]],
+        effective_task_id: str,
+        should_review_memory: bool = False,
+    ) -> Dict[str, Any]:
+        """Forwarder — see ``agent.claude_sdk_runtime.run_claude_agent_sdk_turn``."""
+        from agent.claude_sdk_runtime import run_claude_agent_sdk_turn
+        return run_claude_agent_sdk_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
 
 def main(
     query: str = None,

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -279,6 +279,97 @@ class TestResolveAutoMainFirst:
         assert mock_resolve.call_args.args[0] == "anthropic"
         assert mock_resolve.call_args.args[1] == "runtime-model"
 
+    @staticmethod
+    def _assert_claude_sdk_auto_fails_closed(
+        *, main_runtime, configured_provider="openrouter"
+    ):
+        blocked = AssertionError("metered auxiliary auto chain entered")
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value=configured_provider,
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="configured-model",
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            side_effect=blocked,
+        ) as native_provider, patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            side_effect=blocked,
+        ) as configured_chain, patch(
+            "agent.auxiliary_client._try_main_fallback_chain",
+            side_effect=blocked,
+        ) as main_chain, patch(
+            "agent.auxiliary_client._get_provider_chain",
+            side_effect=blocked,
+        ) as ambient_chain:
+            from agent.auxiliary_client import _resolve_auto
+
+            assert _resolve_auto(
+                main_runtime=main_runtime,
+                task="title_generation",
+            ) == (None, None)
+
+        native_provider.assert_not_called()
+        configured_chain.assert_not_called()
+        main_chain.assert_not_called()
+        ambient_chain.assert_not_called()
+
+    def test_claude_sdk_provider_only_runtime_fails_closed_without_api_mode(self):
+        self._assert_claude_sdk_auto_fails_closed(
+            main_runtime={
+                "provider": "claude-agent-sdk",
+                "model": "claude-opus-4-8",
+            }
+        )
+
+    def test_claude_sdk_requested_provider_only_runtime_fails_closed(self):
+        self._assert_claude_sdk_auto_fails_closed(
+            main_runtime={
+                "requested_provider": "claude-agent-sdk",
+                "model": "claude-opus-4-8",
+            }
+        )
+
+    def test_claude_sdk_config_only_main_provider_fails_closed_without_runtime(self):
+        self._assert_claude_sdk_auto_fails_closed(
+            main_runtime={},
+            configured_provider="claude-agent-sdk",
+        )
+
+    def test_claude_sdk_main_allows_deliberate_task_provider_override(self):
+        explicit_client = MagicMock()
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={
+                "provider": "anthropic",
+                "model": "claude-haiku-4-5-20251001",
+            },
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(explicit_client, "claude-haiku-4-5-20251001"),
+        ) as explicit_resolver, patch(
+            "agent.auxiliary_client._resolve_auto",
+            side_effect=AssertionError("explicit override entered auto path"),
+        ) as auto_resolver:
+            from agent.auxiliary_client import get_text_auxiliary_client
+
+            client, model = get_text_auxiliary_client(
+                "title_generation",
+                main_runtime={
+                    "provider": "claude-agent-sdk",
+                    "model": "claude-opus-4-8",
+                },
+            )
+
+        assert client is explicit_client
+        assert model == "claude-haiku-4-5-20251001"
+        assert explicit_resolver.call_args.args[0] == "anthropic"
+        assert explicit_resolver.call_args.kwargs["model"] == (
+            "claude-haiku-4-5-20251001"
+        )
+        auto_resolver.assert_not_called()
+
     def test_resolve_provider_auto_returns_runtime_model_not_stale_config_default(self):
         """Blank auto aux requests must not pair a stale config model with live fallback provider."""
         runtime_client = MagicMock()

--- a/tests/agent/test_claude_sdk_runtime.py
+++ b/tests/agent/test_claude_sdk_runtime.py
@@ -341,6 +341,22 @@ def _make_session(script=None, connect_exc=None, **kwargs):
 
 
 class TestSession:
+    @staticmethod
+    def _native_bash_permission_result(
+        monkeypatch, approvals, approval_callback, command="printf ok"
+    ):
+        import asyncio
+        import hermes_cli.config as cfg
+
+        monkeypatch.setenv("HERMES_TERMINAL_SECURITY_MODE", "approval-required")
+        monkeypatch.setattr(cfg, "load_config", lambda: {"approvals": approvals})
+        permission_callback = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            approval_callback=approval_callback,
+            include_hermes_tools=False,
+        ).build_option_fields()["can_use_tool"]
+        return asyncio.run(permission_callback("Bash", {"command": command}, None))
+
     def test_happy_turn(self):
         script = [
             AssistantMessage(
@@ -560,6 +576,18 @@ class TestSession:
         assert isinstance(result, PermissionResultAllow)
         approval_callback.assert_called_once()
 
+    def test_manual_approval_delegates_safe_native_bash_once(self, monkeypatch):
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk import PermissionResultAllow
+        approval_callback = MagicMock(return_value="once")
+
+        result = self._native_bash_permission_result(
+            monkeypatch, {"mode": "manual"}, approval_callback
+        )
+
+        assert isinstance(result, PermissionResultAllow)
+        approval_callback.assert_called_once()
+
     def test_approval_required_auto_allows_native_write_when_approvals_off(
         self, monkeypatch
     ):
@@ -640,6 +668,128 @@ class TestSession:
         result = asyncio.run(callback("Bash", {"command": "rm -rf /"}, None))
         assert isinstance(result, PermissionResultDeny)
         assert "hardline" in result.message
+        approval_callback.assert_not_called()
+
+    def test_approvals_off_auto_allows_safe_native_bash_without_callback(
+        self, monkeypatch
+    ):
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk import PermissionResultAllow
+        approval_callback = MagicMock(
+            side_effect=AssertionError("approvals.mode=off must not prompt")
+        )
+
+        result = self._native_bash_permission_result(
+            monkeypatch, {"mode": "off"}, approval_callback
+        )
+
+        assert isinstance(result, PermissionResultAllow)
+        approval_callback.assert_not_called()
+
+    def test_manual_approval_cannot_override_native_bash_hardline_floor(
+        self, monkeypatch
+    ):
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk import PermissionResultDeny
+        approval_callback = MagicMock(return_value="once")
+
+        result = self._native_bash_permission_result(
+            monkeypatch, {"mode": "manual"}, approval_callback, "rm -rf /"
+        )
+
+        assert isinstance(result, PermissionResultDeny)
+        assert "hardline" in result.message
+        approval_callback.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("command", "approvals"),
+        [
+            ("echo guess | sudo -S id", {"mode": "manual"}),
+            ("echo forbidden", {"mode": "manual", "deny": ["echo forbidden"]}),
+        ],
+    )
+    def test_manual_approval_cannot_override_other_native_bash_guard_floors(
+        self, monkeypatch, command, approvals
+    ):
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk import PermissionResultDeny
+        monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+        approval_callback = MagicMock(return_value="once")
+
+        result = self._native_bash_permission_result(
+            monkeypatch, approvals, approval_callback, command
+        )
+
+        assert isinstance(result, PermissionResultDeny)
+        approval_callback.assert_not_called()
+
+    @pytest.mark.parametrize("malformed_guard", [None, {}, {"approved": "yes"}])
+    def test_native_bash_malformed_guard_result_fails_closed(
+        self, monkeypatch, malformed_guard
+    ):
+        import asyncio
+
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk import PermissionResultDeny
+        import hermes_cli.config as cfg
+        import tools.approval as approval
+
+        monkeypatch.setenv("HERMES_TERMINAL_SECURITY_MODE", "approval-required")
+        monkeypatch.setattr(
+            cfg, "load_config", lambda: {"approvals": {"mode": "manual"}}
+        )
+        monkeypatch.setattr(
+            approval,
+            "check_unconditional_command_guards",
+            lambda command: malformed_guard,
+            raising=False,
+        )
+        approval_callback = MagicMock(return_value="once")
+        callback = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            approval_callback=approval_callback,
+            include_hermes_tools=False,
+        ).build_option_fields()["can_use_tool"]
+
+        result = asyncio.run(callback("Bash", {"command": "printf ok"}, None))
+
+        assert isinstance(result, PermissionResultDeny)
+        assert "failed closed" in result.message
+        approval_callback.assert_not_called()
+
+    def test_native_bash_guard_exception_fails_closed(self, monkeypatch):
+        import asyncio
+
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk import PermissionResultDeny
+        import hermes_cli.config as cfg
+        import tools.approval as approval
+
+        monkeypatch.setenv("HERMES_TERMINAL_SECURITY_MODE", "approval-required")
+        monkeypatch.setattr(
+            cfg, "load_config", lambda: {"approvals": {"mode": "manual"}}
+        )
+
+        def raise_guard_error(command):
+            raise RuntimeError("guard failed")
+
+        monkeypatch.setattr(
+            approval,
+            "check_unconditional_command_guards",
+            raise_guard_error,
+            raising=False,
+        )
+        approval_callback = MagicMock(return_value="once")
+        callback = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            approval_callback=approval_callback,
+            include_hermes_tools=False,
+        ).build_option_fields()["can_use_tool"]
+
+        result = asyncio.run(callback("Bash", {"command": "printf ok"}, None))
+
+        assert isinstance(result, PermissionResultDeny)
+        assert "failed closed" in result.message
         approval_callback.assert_not_called()
 
     def test_auto_keeps_accept_edits_without_permission_callback(self, monkeypatch):

--- a/tests/agent/test_claude_sdk_runtime.py
+++ b/tests/agent/test_claude_sdk_runtime.py
@@ -533,6 +533,115 @@ class TestSession:
         assert fields["permission_mode"] == "default"
         assert callable(fields["can_use_tool"])
 
+    def test_approval_required_still_delegates_when_approvals_are_manual(
+        self, monkeypatch
+    ):
+        import asyncio
+
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk import PermissionResultAllow
+        import hermes_cli.config as cfg
+
+        monkeypatch.setenv("HERMES_TERMINAL_SECURITY_MODE", "approval-required")
+        monkeypatch.setattr(
+            cfg, "load_config", lambda: {"approvals": {"mode": "manual"}}
+        )
+        approval_callback = MagicMock(return_value="once")
+        callback = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            approval_callback=approval_callback,
+            include_hermes_tools=False,
+        ).build_option_fields()["can_use_tool"]
+
+        assert callable(callback)
+        result = asyncio.run(
+            callback("Write", {"file_path": "/tmp/out", "content": "ok"}, None)
+        )
+        assert isinstance(result, PermissionResultAllow)
+        approval_callback.assert_called_once()
+
+    def test_approval_required_auto_allows_native_write_when_approvals_off(
+        self, monkeypatch
+    ):
+        import asyncio
+
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk import PermissionResultAllow
+        import hermes_cli.config as cfg
+
+        monkeypatch.setenv("HERMES_TERMINAL_SECURITY_MODE", "approval-required")
+        monkeypatch.setattr(cfg, "load_config", lambda: {"approvals": {"mode": "off"}})
+        approval_callback = MagicMock(
+            side_effect=AssertionError("approvals.mode=off must not prompt")
+        )
+        fields = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            approval_callback=approval_callback,
+            include_hermes_tools=False,
+        ).build_option_fields()
+
+        callback = fields["can_use_tool"]
+        assert callable(callback)
+        result = asyncio.run(
+            callback("Write", {"file_path": "/tmp/out", "content": "ok"}, None)
+        )
+        assert isinstance(result, PermissionResultAllow)
+        approval_callback.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("tool_name", "tool_input"),
+        [
+            ("Write", {"file_path": "/tmp/out", "content": "ok"}),
+            ("Edit", {"file_path": "/tmp/out", "old_string": "o", "new_string": "n"}),
+            ("Bash", {"command": "printf ok"}),
+            ("NotebookEdit", {"notebook_path": "/tmp/out.ipynb", "new_source": "1"}),
+        ],
+    )
+    def test_approvals_off_installs_headless_native_mutator_bridge(
+        self, monkeypatch, tool_name, tool_input
+    ):
+        import asyncio
+
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk import PermissionResultAllow
+        import hermes_cli.config as cfg
+
+        monkeypatch.setenv("HERMES_TERMINAL_SECURITY_MODE", "approval-required")
+        monkeypatch.setattr(cfg, "load_config", lambda: {"approvals": {"mode": "off"}})
+        fields = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            approval_callback=None,
+            include_hermes_tools=False,
+        ).build_option_fields()
+
+        assert fields["permission_mode"] == "default"
+        callback = fields["can_use_tool"]
+        assert callable(callback)
+        result = asyncio.run(callback(tool_name, tool_input, None))
+        assert isinstance(result, PermissionResultAllow)
+
+    def test_approvals_off_keeps_native_bash_hardline_floor(self, monkeypatch):
+        import asyncio
+
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk import PermissionResultDeny
+        import hermes_cli.config as cfg
+
+        monkeypatch.setenv("HERMES_TERMINAL_SECURITY_MODE", "approval-required")
+        monkeypatch.setattr(cfg, "load_config", lambda: {"approvals": {"mode": "off"}})
+        approval_callback = MagicMock(return_value="once")
+        callback = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            approval_callback=approval_callback,
+            include_hermes_tools=False,
+        ).build_option_fields()["can_use_tool"]
+
+        assert callable(callback)
+        result = asyncio.run(callback("Bash", {"command": "rm -rf /"}, None))
+        assert isinstance(result, PermissionResultDeny)
+        assert "hardline" in result.message
+        approval_callback.assert_not_called()
+
     def test_auto_keeps_accept_edits_without_permission_callback(self, monkeypatch):
         monkeypatch.delenv("HERMES_TERMINAL_SECURITY_MODE", raising=False)
         fields = ClaudeAgentSdkSession(
@@ -653,6 +762,28 @@ class TestSession:
             session, tool_name, tool_input
         )
         approval_callback.assert_not_called()
+
+    def test_approvals_off_does_not_widen_native_read_only(self, monkeypatch):
+        import asyncio
+
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk import PermissionResultDeny
+        import hermes_cli.config as cfg
+
+        monkeypatch.setattr(cfg, "load_config", lambda: {"approvals": {"mode": "off"}})
+        callback = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            native_read_only=True,
+            approval_callback=None,
+            include_hermes_tools=False,
+        ).build_option_fields()["can_use_tool"]
+
+        assert callable(callback)
+        result = asyncio.run(
+            callback("Write", {"file_path": "/tmp/out", "content": "no"}, None)
+        )
+        assert isinstance(result, PermissionResultDeny)
+        assert "native read-only" in result.message
 
     def test_native_read_only_callback_denies_parent_traversal(self, tmp_path):
         workspace = tmp_path / "workspace"

--- a/tests/agent/test_claude_sdk_runtime.py
+++ b/tests/agent/test_claude_sdk_runtime.py
@@ -1,0 +1,3335 @@
+"""Tests for the claude-agent-sdk runtime (#25267).
+
+Covers the three new modules end-to-end without requiring the optional
+``claude-agent-sdk`` extra: the projector and session duck-type on class
+NAMES, so local stand-in classes named like the SDK's types are the fixture.
+
+Plant-the-failure discipline: every guard here is exercised RED first —
+the auth classifier has a negative control (an ordinary error must NOT
+produce the re-auth hint), and the session's error path is asserted to
+retire the client rather than silently continue.
+"""
+
+from dataclasses import dataclass, field
+import json
+import os
+import warnings
+from types import SimpleNamespace
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.claude_sdk_runtime import run_claude_agent_sdk_turn
+from agent.transports.claude_agent_sdk_session import (
+    ClaudeAgentSdkSession,
+    _attest_claude_subscription,
+    _build_sanitized_cli_env,
+    classify_auth_failure,
+)
+from agent.transports.claude_sdk_event_projector import (
+    ClaudeSdkEventProjector,
+)
+
+
+_CLAUDE_BILLING_ROUTE_ENV_VARS = (
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_MANTLE",
+    "ANTHROPIC_BEDROCK_BASE_URL",
+    "ANTHROPIC_BEDROCK_MANTLE_BASE_URL",
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_PROFILE",
+    "AWS_CONFIG_FILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "CLAUDE_CODE_USE_VERTEX",
+    "ANTHROPIC_VERTEX_BASE_URL",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_CLOUD_PROJECT",
+    "CLOUD_ML_REGION",
+    "CLAUDE_CODE_USE_FOUNDRY",
+    "ANTHROPIC_FOUNDRY_BASE_URL",
+    "ANTHROPIC_FOUNDRY_RESOURCE",
+    "ANTHROPIC_FOUNDRY_API_KEY",
+    "ANTHROPIC_FOUNDRY_AUTH_TOKEN",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_provider_config(monkeypatch):
+    """Keep SDK tests independent from the developer's real config.yaml.
+
+    A real ``append_file`` would leak into the system-prompt tests. Default to an
+    empty block; tests that care patch ``load_config_readonly`` themselves (the
+    last patch wins).
+    """
+    import hermes_cli.config as cfg
+
+    monkeypatch.setattr(cfg, "load_config_readonly", lambda *a, **k: {}, raising=False)
+
+
+# ---------- SDK stand-in types (duck-typed by class NAME) ----------
+
+
+@dataclass
+class TextBlock:
+    text: str
+
+
+@dataclass
+class ThinkingBlock:
+    thinking: str
+    signature: str = ""
+
+
+@dataclass
+class ToolUseBlock:
+    id: str
+    name: str
+    input: dict
+
+
+@dataclass
+class ToolResultBlock:
+    tool_use_id: str
+    content: Any = None
+    is_error: Optional[bool] = None
+
+
+@dataclass
+class AssistantMessage:
+    content: list
+    model: str = "claude-opus-4-8"
+
+
+@dataclass
+class UserMessage:
+    content: Any = None
+
+
+@dataclass
+class SystemMessage:
+    subtype: str = "init"
+    data: dict = field(default_factory=dict)
+    session_id: Optional[str] = None
+
+
+@dataclass
+class ServerToolUseBlock:
+    id: str
+    name: str
+    input: dict
+
+
+@dataclass
+class StreamEvent:
+    uuid: str = "se-1"
+    session_id: str = "sdk-session-1"
+    event: dict = field(default_factory=dict)
+    parent_tool_use_id: Optional[str] = None
+
+
+def _text_delta_event(text, parent_tool_use_id=None):
+    return StreamEvent(
+        event={"type": "content_block_delta", "delta": {"type": "text_delta", "text": text}},
+        parent_tool_use_id=parent_tool_use_id,
+    )
+
+
+@dataclass
+class ResultMessage:
+    subtype: str = "success"
+    duration_ms: int = 1
+    duration_api_ms: int = 1
+    is_error: bool = False
+    num_turns: int = 1
+    session_id: str = "sdk-session-1"
+    result: Optional[str] = None
+    usage: Optional[dict] = None
+    uuid: Optional[str] = "uuid-1"
+    errors: Optional[list] = None
+
+
+# ---------- projector ----------
+
+
+class TestProjector:
+    def test_assistant_text(self):
+        p = ClaudeSdkEventProjector()
+        out = p.project(AssistantMessage(content=[TextBlock("hello")]))
+        assert out.messages == [{"role": "assistant", "content": "hello"}]
+        assert out.final_text == "hello"
+        assert not out.is_tool_iteration
+
+    def test_assistant_tool_use_and_thinking(self):
+        p = ClaudeSdkEventProjector()
+        # Thinking arrives first, stashes onto the next assistant entry.
+        p.project(AssistantMessage(content=[ThinkingBlock("pondering")]))
+        out = p.project(
+            AssistantMessage(
+                content=[ToolUseBlock(id="t1", name="Bash", input={"command": "ls"})]
+            )
+        )
+        (msg,) = out.messages
+        assert msg["role"] == "assistant"
+        assert msg["content"] is None
+        assert msg["reasoning"] == "pondering"
+        (call,) = msg["tool_calls"]
+        assert call["id"] == "t1"
+        assert call["function"]["name"] == "Bash"
+        assert '"command": "ls"' in call["function"]["arguments"]
+
+    def test_tool_result_projection(self):
+        p = ClaudeSdkEventProjector()
+        out = p.project(
+            UserMessage(content=[ToolResultBlock(tool_use_id="t1", content="ok")])
+        )
+        assert out.is_tool_iteration
+        assert out.messages == [
+            {"role": "tool", "tool_call_id": "t1", "content": "ok"}
+        ]
+
+    def test_tool_result_error_and_list_content(self):
+        p = ClaudeSdkEventProjector()
+        out = p.project(
+            UserMessage(
+                content=[
+                    ToolResultBlock(
+                        tool_use_id="t2",
+                        content=[{"type": "text", "text": "boom"}],
+                        is_error=True,
+                    )
+                ]
+            )
+        )
+        assert out.messages[0]["content"] == "[error] boom"
+
+    def test_tool_result_truncation(self):
+        p = ClaudeSdkEventProjector()
+        out = p.project(
+            UserMessage(
+                content=[ToolResultBlock(tool_use_id="t3", content="x" * 9000)]
+            )
+        )
+        assert len(out.messages[0]["content"]) == 4000
+
+    def test_result_message_sets_final_text(self):
+        p = ClaudeSdkEventProjector()
+        out = p.project(ResultMessage(result="the answer"))
+        assert out.is_result
+        assert out.final_text == "the answer"
+        assert out.messages == []
+
+    def test_server_tool_use_never_emits_dangling_tool_calls(self):
+        # Server tools (web_search, ...) execute API-side and
+        # never produce a {role:'tool'} echo — emitting a tool_calls entry
+        # for them leaves a dangling tool_call_id that can break replay
+        # through a native provider after a /model switch.
+        p = ClaudeSdkEventProjector()
+        out = p.project(
+            AssistantMessage(content=[
+                ServerToolUseBlock(id="srv-1", name="web_search", input={"query": "x"}),
+                TextBlock("found it"),
+            ])
+        )
+        (msg,) = out.messages
+        assert msg.get("tool_calls") in (None, [],) or "srv-1" not in str(msg.get("tool_calls"))
+        assert msg["content"] == "found it"
+
+    def test_lifecycle_messages_ignored(self):
+        p = ClaudeSdkEventProjector()
+        assert p.project(SystemMessage()).messages == []
+        # A plain-text user echo must not duplicate the real user turn.
+        assert p.project(UserMessage(content="hi")).messages == []
+
+
+# ---------- auth classifier (with negative control) ----------
+
+
+class TestAuthClassifier:
+    def test_auth_failure_produces_hint(self):
+        hint = classify_auth_failure("HTTP 401 unauthorized: oauth token expired")
+        assert hint is not None
+        assert "claude auth login" in hint
+        assert "Claude-managed" in hint
+        assert "HTTP 401 unauthorized" in hint
+
+    def test_hint_preserves_underlying_error(self):
+        # A hit RETIRES the session, so the true error must survive in the
+        # message — a misclassification that also swallows the evidence is
+        # undebuggable.
+        hint = classify_auth_failure("HTTP 401 unauthorized: oauth token expired")
+        assert "401 unauthorized" in hint
+
+    def test_negative_control_ordinary_error_no_hint(self):
+        # An unrelated failure must surface verbatim, never as a re-auth
+        # redirect.
+        assert classify_auth_failure("connection reset by peer") is None
+        assert classify_auth_failure("") is None
+
+    def test_negative_control_overbroad_substrings(self):
+        # The classifier follows codex's existing hint list:
+        # _OAUTH_REFRESH_FAILURE_HINTS has "401 unauthorized", never bare
+        # "401", and no bare "credentials" — a tool id or an MCP server's
+        # own file complaint must not retire the session as an auth failure.
+        assert classify_auth_failure("tool_use toolu_401abc failed at 4012") is None
+        assert (
+            classify_auth_failure(
+                "mcp server hermes-tools: could not read credentials file"
+            )
+            is None
+        )
+
+
+# ---------- session (fake client) ----------
+
+
+class _FakeClient:
+    """Stub ClaudeSDKClient: async surface, scripted message stream."""
+
+    def __init__(self, options=None, script=None, connect_exc=None):
+        self.options = options
+        self._script = script or []
+        self._connect_exc = connect_exc
+        self.queried: list[str] = []
+        self.disconnected = False
+        self.interrupted = False
+
+    async def connect(self):
+        if self._connect_exc is not None:
+            raise self._connect_exc
+
+    async def query(self, text):
+        self.queried.append(text)
+
+    async def receive_response(self):
+        for message in self._script:
+            yield message
+
+    async def interrupt(self):
+        self.interrupted = True
+
+    async def disconnect(self):
+        self.disconnected = True
+
+
+def _make_session(script=None, connect_exc=None, **kwargs):
+    holder = {}
+
+    def factory(options=None):
+        holder["client"] = _FakeClient(
+            options=options, script=script, connect_exc=connect_exc
+        )
+        return holder["client"]
+
+    kwargs.setdefault(
+        "auth_status_checker",
+        lambda **_kwargs: "/fake/claude",
+    )
+    session = ClaudeAgentSdkSession(
+        cwd="/tmp", model="claude-opus-4-8", client_factory=factory, **kwargs
+    )
+    return session, holder
+
+
+class TestSession:
+    def test_happy_turn(self):
+        script = [
+            AssistantMessage(
+                content=[ToolUseBlock(id="t1", name="Read", input={"file_path": "/x"})]
+            ),
+            UserMessage(content=[ToolResultBlock(tool_use_id="t1", content="data")]),
+            AssistantMessage(content=[TextBlock("done reading")]),
+            ResultMessage(
+                result="done reading",
+                usage={"input_tokens": 10, "output_tokens": 5},
+            ),
+        ]
+        session, holder = _make_session(script=script)
+        try:
+            turn = session.run_turn("read /x please")
+        finally:
+            session.close()
+        assert turn.error is None
+        assert turn.final_text == "done reading"
+        assert turn.tool_iterations == 1
+        assert turn.token_usage_last == {"input_tokens": 10, "output_tokens": 5}
+        assert turn.thread_id == "sdk-session-1"
+        assert turn.response_model == "claude-opus-4-8"
+        # assistant(tool_call) + tool + assistant(text)
+        assert [m["role"] for m in turn.projected_messages] == [
+            "assistant", "tool", "assistant",
+        ]
+        assert holder["client"].queried == ["read /x please"]
+        assert not turn.should_retire
+
+    def test_sdk_error_result_surfaces(self):
+        script = [ResultMessage(subtype="error_max_turns", is_error=False)]
+        session, _ = _make_session(script=script)
+        try:
+            turn = session.run_turn("hi")
+        finally:
+            session.close()
+        assert turn.error is not None
+        assert "error_max_turns" in turn.error
+        assert turn.should_retire
+
+    @pytest.mark.parametrize(
+        "terminal_result",
+        [
+            ResultMessage(
+                subtype="success",
+                is_error=True,
+                errors=["ordinary terminal failure"],
+            ),
+            ResultMessage(subtype="error_max_budget_usd", is_error=False),
+        ],
+    )
+    def test_every_terminal_result_error_retires(self, terminal_result):
+        session, _ = _make_session(script=[terminal_result])
+        try:
+            turn = session.run_turn("hi")
+        finally:
+            session.close()
+
+        assert turn.error is not None
+        assert turn.should_retire
+
+    def test_auth_error_marks_retire(self):
+        script = [
+            ResultMessage(
+                subtype="success",
+                is_error=True,
+                errors=["401 unauthorized: invalid bearer token"],
+            )
+        ]
+        session, _ = _make_session(script=script)
+        try:
+            turn = session.run_turn("hi")
+        finally:
+            session.close()
+        assert turn.should_retire
+        assert "claude auth login" in (turn.error or "")
+        assert "Claude-managed" in (turn.error or "")
+
+    def test_connect_failure_fails_closed(self):
+        session, _ = _make_session(connect_exc=RuntimeError("not logged in"))
+        try:
+            turn = session.run_turn("hi")
+        finally:
+            session.close()
+        assert turn.should_retire
+        assert turn.error is not None
+        assert turn.retry_safe_before_query is False
+
+    def test_resumed_sdk_connect_rejection_is_retry_safe_before_query(self):
+        sdk_errors = pytest.importorskip("claude_agent_sdk._errors")
+        session, _ = _make_session(
+            connect_exc=sdk_errors.CLIConnectionError("resume rejected"),
+            resume_session_id="sdk-stale-1",
+        )
+        try:
+            turn = session.run_turn("hi")
+        finally:
+            session.close()
+
+        assert turn.should_retire
+        assert turn.retry_safe_before_query is True
+
+    @pytest.mark.parametrize(
+        "image_input",
+        [
+            [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}],
+            [{"type": "input_image", "image_url": "https://example.test/image.png"}],
+            "data:image/jpeg;base64,AAAA",
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "caption"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,NESTED"},
+                    },
+                ],
+            },
+        ],
+    )
+    def test_image_input_returns_explicit_error_without_query(self, image_input):
+        session, holder = _make_session(script=[ResultMessage(result="must not run")])
+        try:
+            session.ensure_started()
+            turn = session.run_turn(image_input)
+        finally:
+            session.close()
+
+        assert turn.error == (
+            "claude-agent-sdk image inputs are unsupported until rich-image "
+            "transport is implemented"
+        )
+        assert turn.should_retire is False
+        assert holder["client"].queried == []
+
+    def test_option_fields_shape(self):
+        session, holder = _make_session(script=[ResultMessage(result="ok")])
+        try:
+            session.run_turn("ping")
+        finally:
+            session.close()
+        options = holder["client"].options
+        assert options["model"] == "claude-opus-4-8"
+        assert options["system_prompt"]["preset"] == "claude_code"
+        assert "hermes-tools" in options["mcp_servers"]
+        mcp = options["mcp_servers"]["hermes-tools"]
+        assert mcp["args"] == ["-m", "agent.transports.hermes_tools_mcp_server"]
+        assert "mcp__hermes-tools__skills_list" in options["allowed_tools"]
+        assert "mcp__hermes-tools__memory" in options["allowed_tools"]
+        for forbidden in (
+            "read_file", "search_files", "terminal", "write_file", "patch"
+        ):
+            assert f"mcp__hermes-tools__{forbidden}" not in options["allowed_tools"]
+        # Hard rule: a metered key never reaches any child of this runtime.
+        assert "ANTHROPIC_API_KEY" not in (mcp.get("env") or {})
+        assert options["permission_mode"] in {
+            "acceptEdits", "default", "bypassPermissions",
+        }
+        assert "add_dirs" not in options
+        for predecessor_absent_field in (
+            "tools",
+            "disallowed_tools",
+        ):
+            assert predecessor_absent_field not in options
+        assert options["setting_sources"] == []
+        assert options["strict_mcp_config"] is True
+
+    def test_real_pinned_options_accept_resolved_cli_path_field(self):
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk import ClaudeAgentOptions
+
+        session = ClaudeAgentSdkSession(cwd="/tmp", include_hermes_tools=False)
+        session._cli_path = "/sdk/bundled/claude"
+
+        fields = session.build_option_fields()
+        options = ClaudeAgentOptions(**fields)
+
+        assert fields["cli_path"] == "/sdk/bundled/claude"
+        assert str(options.cli_path) == "/sdk/bundled/claude"
+
+    def test_approval_required_keeps_default_mode_and_callback(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TERMINAL_SECURITY_MODE", "approval-required")
+        fields = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            approval_callback=lambda *args, **kwargs: "once",
+            include_hermes_tools=False,
+        ).build_option_fields()
+
+        assert fields["permission_mode"] == "default"
+        assert callable(fields["can_use_tool"])
+
+    def test_auto_keeps_accept_edits_without_permission_callback(self, monkeypatch):
+        monkeypatch.delenv("HERMES_TERMINAL_SECURITY_MODE", raising=False)
+        fields = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            approval_callback=lambda *args, **kwargs: "once",
+            include_hermes_tools=False,
+        ).build_option_fields()
+
+        assert fields["permission_mode"] == "acceptEdits"
+        assert fields["can_use_tool"] is None
+
+
+    _READ_ONLY_NATIVE_TOOLS = ["Read", "Glob", "Grep"]
+    _NATIVE_MUTATOR_DENIES = ["Write", "Edit", "Bash", "NotebookEdit"]
+
+    @staticmethod
+    def _pinned_command(session):
+        pytest.importorskip("claude_agent_sdk")
+        client = session._build_client()
+        transport = client._custom_transport
+        transport._cli_path = transport._find_bundled_cli()
+        return client.options, transport._build_command()
+
+    def test_explicit_false_preserves_predecessor_option_and_command_shape(self):
+        session = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            native_read_only=False,
+            include_hermes_tools=False,
+        )
+
+        fields = session.build_option_fields()
+        for predecessor_absent_field in (
+            "tools",
+            "disallowed_tools",
+        ):
+            assert predecessor_absent_field not in fields
+        assert fields["setting_sources"] == []
+        assert fields["strict_mcp_config"] is True
+
+        _options, command = self._pinned_command(session)
+        assert "--tools" not in command
+        assert "--disallowedTools" not in command
+        assert "--setting-sources=" in command
+        assert "--strict-mcp-config" in command
+
+    def test_true_materializes_only_exact_native_read_only_fields(self):
+        session = ClaudeAgentSdkSession(
+            cwd="/tmp/sdk-native-read-only",
+            native_read_only=True,
+            system_prompt_append="HERMES_CONTEXT_SENTINEL",
+        )
+
+        fields = session.build_option_fields()
+        assert fields["tools"] == self._READ_ONLY_NATIVE_TOOLS
+        assert fields["disallowed_tools"] == self._NATIVE_MUTATOR_DENIES
+        assert fields["setting_sources"] == []
+        assert fields["allowed_tools"] == []
+        assert fields["mcp_servers"] == {}
+        assert fields["strict_mcp_config"] is True
+        assert fields["system_prompt"] == {
+            "type": "preset",
+            "preset": "claude_code",
+            "append": "HERMES_CONTEXT_SENTINEL",
+        }
+
+    @pytest.mark.parametrize(
+        "ambient_mode",
+        ["auto", "approval-required", "unrestricted", "yolo"],
+    )
+    def test_native_read_only_forces_fail_closed_permission_mode(
+        self, monkeypatch, ambient_mode
+    ):
+        monkeypatch.setenv("HERMES_TERMINAL_SECURITY_MODE", ambient_mode)
+
+        fields = ClaudeAgentSdkSession(
+            cwd="/tmp/sdk-native-read-only",
+            native_read_only=True,
+            approval_callback=lambda *args, **kwargs: "once",
+            include_hermes_tools=False,
+        ).build_option_fields()
+
+        assert fields["permission_mode"] == "default"
+        assert callable(fields["can_use_tool"])
+
+    @staticmethod
+    def _assert_native_read_only_permission_denied(session, tool_name, tool_input):
+        import asyncio
+
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk import PermissionResultDeny
+
+        callback = session.build_option_fields()["can_use_tool"]
+        assert callable(callback)
+        result = asyncio.run(callback(tool_name, tool_input, None))
+        assert isinstance(result, PermissionResultDeny)
+
+    @pytest.mark.parametrize(
+        ("tool_name", "tool_input"),
+        [
+            ("Read", {"file_path": "/etc/passwd"}),
+            ("Glob", {"path": "/etc", "pattern": "*"}),
+            ("Grep", {"path": "/etc", "pattern": "root"}),
+        ],
+    )
+    def test_native_read_only_callback_denies_absolute_outside_paths(
+        self, tool_name, tool_input
+    ):
+        approval_callback = MagicMock(return_value="once")
+        session = ClaudeAgentSdkSession(
+            cwd="/srv/hermes/workspace",
+            add_dirs=["/srv/hermes/projects"],
+            native_read_only=True,
+            approval_callback=approval_callback,
+            include_hermes_tools=False,
+        )
+
+        self._assert_native_read_only_permission_denied(
+            session, tool_name, tool_input
+        )
+        approval_callback.assert_not_called()
+
+    def test_native_read_only_callback_denies_parent_traversal(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        approval_callback = MagicMock(return_value="once")
+        session = ClaudeAgentSdkSession(
+            cwd=str(workspace),
+            native_read_only=True,
+            approval_callback=approval_callback,
+            include_hermes_tools=False,
+        )
+
+        self._assert_native_read_only_permission_denied(
+            session,
+            "Read",
+            {"file_path": str(workspace / ".." / "outside.txt")},
+        )
+        approval_callback.assert_not_called()
+
+    def test_native_read_only_callback_denies_symlink_escape(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        outside = tmp_path / "outside"
+        workspace.mkdir()
+        outside.mkdir()
+        (outside / "secret.txt").write_text("outside")
+        escape = workspace / "escape"
+        escape.symlink_to(outside, target_is_directory=True)
+        approval_callback = MagicMock(return_value="once")
+        session = ClaudeAgentSdkSession(
+            cwd=str(workspace),
+            native_read_only=True,
+            approval_callback=approval_callback,
+            include_hermes_tools=False,
+        )
+
+        self._assert_native_read_only_permission_denied(
+            session, "Read", {"file_path": str(escape / "secret.txt")}
+        )
+        approval_callback.assert_not_called()
+
+    def test_native_read_only_keeps_configured_roots_on_native_read_surface(
+        self, tmp_path
+    ):
+        workspace = tmp_path / "workspace"
+        additional = tmp_path / "additional"
+        workspace.mkdir()
+        additional.mkdir()
+
+        fields = ClaudeAgentSdkSession(
+            cwd=str(workspace),
+            add_dirs=[str(additional)],
+            native_read_only=True,
+            approval_callback=None,
+            include_hermes_tools=False,
+        ).build_option_fields()
+
+        assert fields["cwd"] == str(workspace)
+        assert fields["add_dirs"] == [str(additional)]
+        assert fields["tools"] == self._READ_ONLY_NATIVE_TOOLS
+        assert fields["allowed_tools"] == []
+        assert callable(fields["can_use_tool"])
+
+    def test_true_sdk_options_do_not_shadow_permission_callback(self):
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk.types import (
+            CanUseToolShadowedWarning,
+            _warn_if_can_use_tool_shadowed,
+        )
+
+        session = ClaudeAgentSdkSession(
+            cwd="/tmp/sdk-native-read-only",
+            native_read_only=True,
+            permission_mode="default",
+            approval_callback=lambda *args, **kwargs: "once",
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            client = session._build_client()
+            # This is the exact SDK diagnostic invoked by ClaudeSDKClient.connect().
+            _warn_if_can_use_tool_shadowed(client.options)
+
+        assert not any(
+            issubclass(warning.category, CanUseToolShadowedWarning)
+            for warning in caught
+        )
+
+    def test_headless_approval_required_denies_permission_expansion(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_TERMINAL_SECURITY_MODE", "approval-required")
+        fields = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            native_read_only=True,
+            approval_callback=None,
+            include_hermes_tools=False,
+        ).build_option_fields()
+
+        assert fields["permission_mode"] == "default"
+        assert callable(fields["can_use_tool"])
+        assert fields["tools"] == self._READ_ONLY_NATIVE_TOOLS
+        assert all(tool not in fields["tools"] for tool in self._NATIVE_MUTATOR_DENIES)
+        assert fields["disallowed_tools"] == self._NATIVE_MUTATOR_DENIES
+
+    def test_true_spawn_command_ignores_filesystem_settings_and_keeps_two_roots(
+        self, tmp_path, monkeypatch
+    ):
+        import asyncio
+
+        import anyio
+        pytest.importorskip("claude_agent_sdk")
+
+        home = tmp_path / "home"
+        user_settings = home / ".claude"
+        project = tmp_path / "project"
+        project_settings = project / ".claude"
+        user_settings.mkdir(parents=True)
+        project_settings.mkdir(parents=True)
+        settings_root = tmp_path / "settings-added-root"
+        hostile_settings = {
+            "apiKeyHelper": "credential-sentinel-api-key-helper",
+            "hooks": {
+                "PreToolUse": [
+                    {"hooks": [{"type": "command", "command": "credential-sentinel-hook"}]}
+                ]
+            },
+            "permissions": {
+                "allow": ["Write(*)", "Bash(*)"],
+                "additionalDirectories": [str(settings_root)],
+            }
+        }
+        payload = json.dumps(hostile_settings)
+        (user_settings / "settings.json").write_text(payload)
+        (project_settings / "settings.json").write_text(payload)
+        (project_settings / "settings.local.json").write_text(payload)
+        (project / ".mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "hostile-project-server": {
+                            "command": "credential-sentinel-command"
+                        }
+                    }
+                }
+            )
+        )
+
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(user_settings))
+        monkeypatch.setenv("CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK", "1")
+
+        process_calls = []
+
+        class _FakeProcess:
+            stdin = None
+            stdout = None
+            stderr = None
+            returncode = 0
+
+            async def wait(self):
+                return 0
+
+        async def _fake_open_process(command, **kwargs):
+            process_calls.append((list(command), kwargs))
+            return _FakeProcess()
+
+        monkeypatch.setattr(anyio, "open_process", _fake_open_process)
+        roots = [tmp_path / "read-root-a", tmp_path / "read-root-b"]
+        configured_roots = [
+            tmp_path / "nested" / ".." / roots[0].name,
+            roots[1] / ".",
+        ]
+        session = ClaudeAgentSdkSession(
+            cwd=str(project),
+            add_dirs=[str(root) for root in configured_roots],
+            native_read_only=True,
+            system_prompt_append="HERMES_CONTEXT_SENTINEL",
+        )
+        client = session._build_client()
+        transport = client._custom_transport
+
+        async def _spawn_and_close():
+            await transport.connect()
+            await transport.close()
+
+        asyncio.run(_spawn_and_close())
+
+        assert len(process_calls) == 1
+        command, spawn_kwargs = process_calls[0]
+        assert command[command.index("--tools") + 1] == ",".join(
+            self._READ_ONLY_NATIVE_TOOLS
+        )
+        assert command[command.index("--disallowedTools") + 1] == ",".join(
+            self._NATIVE_MUTATOR_DENIES
+        )
+        assert "--setting-sources=" in command
+        assert "--settings" not in command
+        add_dir_values = [
+            command[index + 1]
+            for index, value in enumerate(command)
+            if value == "--add-dir"
+        ]
+        assert add_dir_values == [str(root) for root in roots]
+        assert str(settings_root) not in command
+
+        assert "--allowedTools" not in command
+        assert "--mcp-config" not in command
+        assert "--strict-mcp-config" in command
+        assert "credential-sentinel-command" not in command
+
+        assert client.options.setting_sources == []
+        assert client.options.allowed_tools == []
+        assert client.options.mcp_servers == {}
+        assert client.options.strict_mcp_config is True
+        assert client.options.system_prompt["append"] == "HERMES_CONTEXT_SENTINEL"
+        assert client.options.env["HOME"] == str(home)
+        assert client.options.env["CLAUDE_CONFIG_DIR"] == str(user_settings)
+        assert spawn_kwargs["cwd"] == str(project)
+
+    def test_normal_mode_ignores_hostile_settings_and_keeps_explicit_roots_and_mcp(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        user_settings = home / ".claude"
+        project = tmp_path / "project"
+        project_settings = project / ".claude"
+        user_settings.mkdir(parents=True)
+        project_settings.mkdir(parents=True)
+        settings_root = tmp_path / "settings-added-root"
+        hostile_settings = {
+            "apiKeyHelper": "credential-sentinel-api-key-helper",
+            "hooks": {
+                "PreToolUse": [
+                    {"hooks": [{"type": "command", "command": "credential-sentinel-hook"}]}
+                ]
+            },
+            "permissions": {
+                "allow": ["Write(*)", "Bash(*)"],
+                "additionalDirectories": [str(settings_root)],
+            },
+        }
+        payload = json.dumps(hostile_settings)
+        (user_settings / "settings.json").write_text(payload)
+        (project_settings / "settings.json").write_text(payload)
+        (project_settings / "settings.local.json").write_text(payload)
+        (project / ".mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "hostile-project-server": {
+                            "command": "credential-sentinel-project-mcp"
+                        }
+                    }
+                }
+            )
+        )
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(user_settings))
+        explicit_root = tmp_path / "explicit-root"
+
+        session = ClaudeAgentSdkSession(
+            cwd=str(project),
+            add_dirs=[str(explicit_root)],
+            native_read_only=False,
+            system_prompt_append="HERMES_CONTEXT_SENTINEL",
+        )
+        options, command = self._pinned_command(session)
+        command_text = " ".join(command)
+
+        assert options.setting_sources == []
+        assert options.strict_mcp_config is True
+        assert options.add_dirs == [str(explicit_root)]
+        assert "hermes-tools" in options.mcp_servers
+        assert "--setting-sources=" in command
+        assert "--strict-mcp-config" in command
+        assert command[command.index("--add-dir") + 1] == str(explicit_root)
+        assert "--mcp-config" in command
+        for hostile_value in (
+            str(settings_root),
+            "credential-sentinel-api-key-helper",
+            "credential-sentinel-hook",
+            "credential-sentinel-project-mcp",
+        ):
+            assert hostile_value not in command_text
+
+    def test_metered_key_scrubbed_from_mcp_env(self, monkeypatch):
+        # The builder must scrub an ambient metered key.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-fake")
+        session, _ = _make_session(script=[ResultMessage(result="ok")])
+        fields = session.build_option_fields()
+        assert "ANTHROPIC_API_KEY" not in fields["mcp_servers"]["hermes-tools"]["env"]
+
+    @pytest.mark.parametrize("route_env", _CLAUDE_BILLING_ROUTE_ENV_VARS)
+    def test_documented_billing_route_refuses_startup_fail_closed(
+        self, monkeypatch, route_env
+    ):
+        # Subscription-only means every documented credential, endpoint, and
+        # alternate-cloud selector aborts before the SDK client is built.
+        for name in _CLAUDE_BILLING_ROUTE_ENV_VARS:
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv(route_env, "SDK_BILLING_ROUTE_SENTINEL")
+        session, holder = _make_session(script=[ResultMessage(result="unused")])
+        turn = session.run_turn("hi")
+        assert turn.should_retire
+        assert route_env in (turn.error or "")
+        assert "SDK_BILLING_ROUTE_SENTINEL" not in (turn.error or "")
+        assert holder == {}
+
+    def test_close_allows_disconnect_escalation_to_finish_before_loop_stops(self):
+        events = []
+        holder = {}
+
+        class EscalatingClient(_FakeClient):
+            async def disconnect(self):
+                events.append(("graceful", holder["session"]._loop.is_running()))
+                await __import__("asyncio").sleep(0)
+                events.append(("terminate", holder["session"]._loop.is_running()))
+                await __import__("asyncio").sleep(0)
+                events.append(("kill", holder["session"]._loop.is_running()))
+                self.disconnected = True
+
+        def factory(options=None):
+            holder["client"] = EscalatingClient(options=options)
+            return holder["client"]
+
+        session = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            client_factory=factory,
+            auth_status_checker=lambda **_kwargs: "/fake/claude",
+        )
+        holder["session"] = session
+        session.ensure_started()
+        loop = session._loop
+        thread = session._loop_thread
+        disconnect_timeouts = []
+        original_run_coro = session._run_coro
+
+        def recording_run_coro(coro, *, timeout):
+            if getattr(getattr(coro, "cr_code", None), "co_name", "") == "disconnect":
+                disconnect_timeouts.append(timeout)
+            return original_run_coro(coro, timeout=timeout)
+
+        session._run_coro = recording_run_coro
+        session.close()
+
+        assert disconnect_timeouts and disconnect_timeouts[0] >= 20
+        assert events == [("graceful", True), ("terminate", True), ("kill", True)]
+        assert holder["client"].disconnected is True
+        assert thread is not None and not thread.is_alive()
+        assert loop is not None and not loop.is_running()
+
+
+class TestSubscriptionAttestation:
+    @staticmethod
+    def _stub_status(monkeypatch, stdout, *, returncode=0):
+        import agent.transports.claude_agent_sdk_session as sdk_session_mod
+
+        calls = []
+        monkeypatch.setattr(
+            sdk_session_mod,
+            "_resolve_claude_cli_path",
+            lambda: "/sdk/bundled/claude",
+        )
+
+        def fake_run(argv, **kwargs):
+            calls.append((argv, kwargs))
+            return SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(sdk_session_mod.subprocess, "run", fake_run)
+        return calls
+
+    def test_accepts_first_party_claude_ai_with_null_subscription_type(
+        self, monkeypatch
+    ):
+        secret = "ACCOUNT-EMAIL-TOKEN-SENTINEL"
+        monkeypatch.setenv("HOME", "/tmp/claude-home")
+        monkeypatch.setenv("PATH", "/usr/local/bin:/usr/bin")
+        monkeypatch.setenv("OPENROUTER_API_KEY", secret)
+        calls = self._stub_status(
+            monkeypatch,
+            json.dumps(
+                {
+                    "loggedIn": True,
+                    "authMethod": "claude.ai",
+                    "apiProvider": "firstParty",
+                    "subscriptionType": None,
+                    "email": secret,
+                }
+            ),
+        )
+        env = _build_sanitized_cli_env()
+
+        cli_path = _attest_claude_subscription(env=env, cwd="/tmp")
+
+        assert cli_path == "/sdk/bundled/claude"
+        assert len(calls) == 1
+        argv, kwargs = calls[0]
+        assert argv == [
+            "/sdk/bundled/claude",
+            "--setting-sources=",
+            "auth",
+            "status",
+            "--json",
+        ]
+        assert kwargs["cwd"] == "/tmp"
+        assert kwargs["env"] == env
+        assert kwargs["env"]["HOME"] == "/tmp/claude-home"
+        assert kwargs["env"]["PATH"] == "/usr/local/bin:/usr/bin"
+        assert kwargs["env"]["OPENROUTER_API_KEY"] == ""
+        assert secret not in kwargs["env"].values()
+
+    def test_hostile_project_settings_cannot_change_attestation_status(
+        self, tmp_path, monkeypatch
+    ):
+        import agent.transports.claude_agent_sdk_session as sdk_session_mod
+
+        project = tmp_path / "hostile-project"
+        settings_dir = project / ".claude"
+        settings_dir.mkdir(parents=True)
+        (settings_dir / "settings.json").write_text(
+            json.dumps({"apiKeyHelper": "credential-sentinel-api-key-helper"})
+        )
+        monkeypatch.setattr(
+            sdk_session_mod,
+            "_resolve_claude_cli_path",
+            lambda: "/sdk/bundled/claude",
+        )
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append((list(argv), kwargs))
+            auth_index = argv.index("auth")
+            ignores_settings = "--setting-sources=" in argv[:auth_index]
+            status = {
+                "loggedIn": True,
+                "authMethod": "claude.ai" if ignores_settings else "api_key_helper",
+                "apiProvider": "firstParty",
+            }
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(status),
+                stderr="",
+            )
+
+        monkeypatch.setattr(sdk_session_mod.subprocess, "run", fake_run)
+
+        cli_path = _attest_claude_subscription(
+            env={"HOME": str(tmp_path), "PATH": "/usr/bin"},
+            cwd=str(project),
+        )
+
+        assert cli_path == "/sdk/bundled/claude"
+        assert len(calls) == 1
+        argv, kwargs = calls[0]
+        assert argv.index("--setting-sources=") < argv.index("auth")
+        assert kwargs["cwd"] == str(project)
+
+    @pytest.mark.parametrize(
+        "status_output",
+        [
+            pytest.param(
+                {"loggedIn": False, "authMethod": "claude.ai", "apiProvider": "firstParty"},
+                id="unlogged",
+            ),
+            pytest.param(
+                {"loggedIn": True, "authMethod": "console", "apiProvider": "firstParty"},
+                id="console",
+            ),
+            pytest.param(
+                {"loggedIn": True, "authMethod": "apiKey", "apiProvider": "firstParty"},
+                id="api-key",
+            ),
+            pytest.param(
+                {"loggedIn": True, "authMethod": "claude.ai", "apiProvider": "bedrock"},
+                id="cloud",
+            ),
+            pytest.param(
+                {"loggedIn": True, "authMethod": "custom", "apiProvider": "custom"},
+                id="custom",
+            ),
+            pytest.param("malformed-json", id="malformed"),
+        ],
+    )
+    def test_rejects_non_subscription_status_without_secret_values(
+        self, monkeypatch, status_output
+    ):
+        secret = "ACCOUNT-EMAIL-TOKEN-SENTINEL"
+        if isinstance(status_output, dict):
+            status_output = {
+                **status_output,
+                "email": secret,
+                "accountId": secret,
+                "token": secret,
+            }
+            stdout = json.dumps(status_output)
+        else:
+            stdout = status_output + secret
+        self._stub_status(monkeypatch, stdout)
+
+        with pytest.raises(RuntimeError) as exc:
+            _attest_claude_subscription(
+                env={"HOME": "/tmp", "PATH": "/usr/bin"},
+                cwd="/tmp",
+            )
+
+        assert secret not in str(exc.value)
+        assert "Claude.ai" in str(exc.value) or "attestation" in str(exc.value)
+
+    def test_attestation_finishes_before_client_creation_and_connect(
+        self, monkeypatch
+    ):
+        events = []
+        captured = {}
+        monkeypatch.setenv("UNRELATED_SECRET", "SECRET-SENTINEL")
+
+        class OrderedClient(_FakeClient):
+            async def connect(self):
+                events.append("connect")
+
+        def auth_status_checker(*, env, cwd):
+            events.append("attest")
+            captured["auth_env"] = env
+            captured["auth_cwd"] = cwd
+            return "/sdk/bundled/claude"
+
+        def factory(options=None):
+            events.append("create")
+            assert options is not None
+            captured["client_env"] = options["env"]
+            captured["client_cli_path"] = options["cli_path"]
+            return OrderedClient(options=options, script=[ResultMessage(result="ok")])
+
+        session = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            client_factory=factory,
+            auth_status_checker=auth_status_checker,
+        )
+        try:
+            turn = session.run_turn("hi")
+        finally:
+            session.close()
+
+        assert turn.error is None
+        assert turn.subscription_attested is True
+        assert events[:3] == ["attest", "create", "connect"]
+        assert captured["auth_cwd"] == "/tmp"
+        assert captured["auth_env"] == captured["client_env"]
+        assert captured["client_env"]["UNRELATED_SECRET"] == ""
+        assert captured["client_cli_path"] == "/sdk/bundled/claude"
+
+
+# ---------- runtime glue ----------
+
+
+def _make_turn(**overrides):
+    base = dict(
+        interrupted=False,
+        error=None,
+        thread_id="sdk-session-1",
+        turn_id="uuid-1",
+        projected_messages=[{"role": "assistant", "content": "SDK_ASSISTANT"}],
+        tool_iterations=2,
+        final_text="SDK_ASSISTANT",
+        should_retire=False,
+        subscription_attested=True,
+        token_usage_last={"input_tokens": 7, "output_tokens": 3},
+        token_usage_total=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _make_agent():
+    agent = MagicMock()
+    agent._claude_sdk_session = MagicMock()
+    agent._claude_sdk_session.run_turn.return_value = _make_turn()
+    agent.tool_progress_callback = None
+    agent._interrupt_requested = False
+    agent._persist_disabled = False
+    agent._iters_since_skill = 0
+    agent._skill_nudge_interval = 0
+    agent.valid_tool_names = set()
+    agent._session_db = None
+    agent._session_db_created = True
+    agent.session_id = "sess-1"
+    agent.session_api_calls = 0
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+    agent.session_input_tokens = 0
+    agent.session_output_tokens = 0
+    agent.session_cache_read_tokens = 0
+    agent.session_cache_write_tokens = 0
+    agent.session_reasoning_tokens = 0
+    agent.context_compressor = None
+    agent.model = "claude-opus-4-8"
+    agent.provider = "claude-agent-sdk"
+    agent.base_url = ""
+    return agent
+
+
+class TestNoUsageAccounting:
+    @pytest.mark.parametrize(
+        "turn_overrides",
+        [
+            pytest.param(
+                {"token_usage_last": None},
+                id="successful-result-without-usage",
+            ),
+            pytest.param(
+                {
+                    "token_usage_last": None,
+                    "should_retire": True,
+                    "error": "SDK result error",
+                    "projected_messages": [],
+                    "final_text": "",
+                },
+                id="error-result-without-usage",
+            ),
+            pytest.param(
+                {
+                    "token_usage_last": None,
+                    "interrupted": True,
+                    "projected_messages": [],
+                    "final_text": "",
+                },
+                id="interrupted-result-without-usage",
+            ),
+        ],
+    )
+    def test_zero_usage_persists_subscription_attribution(
+        self, tmp_path, turn_overrides
+    ):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session(
+                session_id="sess-1",
+                source="cli",
+                model="claude-opus-4-8",
+            )
+            agent = _make_agent()
+            agent._session_db = db
+            agent._session_db_created = True
+            agent._claude_sdk_session.run_turn.return_value = _make_turn(
+                **turn_overrides
+            )
+
+            run_claude_agent_sdk_turn(
+                agent,
+                user_message="hi",
+                original_user_message="hi",
+                messages=[{"role": "user", "content": "hi"}],
+                effective_task_id="task-1",
+            )
+
+            session = db.get_session("sess-1")
+            model_usage = db._conn.execute(
+                "SELECT * FROM session_model_usage WHERE session_id = ?",
+                ("sess-1",),
+            ).fetchone()
+        finally:
+            db.close()
+
+        assert agent.session_cost_status == "included"
+        assert agent.session_cost_source == "claude-subscription"
+        assert session["billing_provider"] == "claude-agent-sdk"
+        assert session["billing_mode"] == "subscription_included"
+        assert session["cost_status"] == "included"
+        assert session["cost_source"] == "claude-subscription"
+        assert session["estimated_cost_usd"] == 0.0
+        assert session["actual_cost_usd"] == 0.0
+        assert session["api_call_count"] == 1
+        for token_column in (
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "reasoning_tokens",
+        ):
+            assert session[token_column] == 0
+
+        assert model_usage is not None
+        assert model_usage["model"] == "claude-opus-4-8"
+        assert model_usage["billing_provider"] == "claude-agent-sdk"
+        assert model_usage["billing_mode"] == "subscription_included"
+        assert model_usage["cost_status"] == "included"
+        assert model_usage["cost_source"] == "claude-subscription"
+        assert model_usage["estimated_cost_usd"] == 0.0
+        assert model_usage["actual_cost_usd"] == 0.0
+        assert model_usage["api_call_count"] == 1
+        for token_column in (
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "reasoning_tokens",
+        ):
+            assert model_usage[token_column] == 0
+
+
+class TestClaudeAgentSdkAdditionalDirectories:
+    @staticmethod
+    def _set_config(monkeypatch, add_dirs):
+        import hermes_cli.config as cfg
+
+        monkeypatch.setattr(
+            cfg,
+            "load_config_readonly",
+            lambda *args, **kwargs: {
+                "agent": {"claude_agent_sdk": {"add_dirs": add_dirs}}
+            },
+        )
+
+    @staticmethod
+    def _capture_sessions(monkeypatch):
+        import agent.transports.claude_agent_sdk_session as sdk_session_mod
+
+        instances = []
+
+        class SpySession:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                instances.append(self)
+
+            def run_turn(self, user_input):
+                return _make_turn()
+
+        monkeypatch.setattr(sdk_session_mod, "ClaudeAgentSdkSession", SpySession)
+        return instances
+
+    @staticmethod
+    def _run_new_session(agent):
+        return run_claude_agent_sdk_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}],
+            effective_task_id="task-1",
+        )
+
+    def test_default_does_not_add_an_sdk_option(self, monkeypatch):
+        instances = self._capture_sessions(monkeypatch)
+        agent = _make_agent()
+        agent._claude_sdk_session = None
+
+        self._run_new_session(agent)
+
+        assert instances[0].kwargs["add_dirs"] == []
+        assert instances[0].kwargs["native_read_only"] is False
+        fields = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            add_dirs=instances[0].kwargs["add_dirs"],
+            include_hermes_tools=False,
+        ).build_option_fields()
+        assert "add_dirs" not in fields
+
+    def test_two_configured_missing_roots_reach_sdk_options_once_each(
+        self, tmp_path, monkeypatch
+    ):
+        roots = [tmp_path / "missing-a", tmp_path / "missing-b"]
+        assert all(not root.exists() for root in roots)
+        self._set_config(monkeypatch, [str(root) for root in roots])
+        instances = self._capture_sessions(monkeypatch)
+        agent = _make_agent()
+        agent._claude_sdk_session = None
+
+        self._run_new_session(agent)
+
+        expected = [str(root) for root in roots]
+        assert instances[0].kwargs["add_dirs"] == expected
+        fields = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            add_dirs=instances[0].kwargs["add_dirs"],
+            include_hermes_tools=False,
+        ).build_option_fields()
+        assert fields["add_dirs"] == expected
+
+    def test_normalizes_and_deduplicates_without_collapsing_child_roots(
+        self, monkeypatch
+    ):
+        self._set_config(
+            monkeypatch,
+            [
+                "/srv/hermes/teams/../team",
+                "/srv/hermes/team/",
+                "/srv/hermes/team/project",
+                "/srv/hermes/team/project/.",
+            ],
+        )
+        instances = self._capture_sessions(monkeypatch)
+        agent = _make_agent()
+        agent._claude_sdk_session = None
+
+        self._run_new_session(agent)
+
+        assert instances[0].kwargs["add_dirs"] == [
+            "/srv/hermes/team",
+            "/srv/hermes/team/project",
+        ]
+
+    @pytest.mark.parametrize(
+        "invalid",
+        [
+            "credential-sentinel-not-a-list",
+            [42],
+            [""],
+            ["   "],
+            ["relative/credential-sentinel"],
+            [" /root/credential-sentinel "],
+        ],
+    )
+    def test_invalid_config_fails_before_session_construction(
+        self, monkeypatch, invalid
+    ):
+        import agent.claude_sdk_runtime as runtime
+
+        self._set_config(monkeypatch, invalid)
+        instances = self._capture_sessions(monkeypatch)
+        monkeypatch.setattr(
+            runtime, "build_system_prompt_append", lambda **kwargs: None
+        )
+        agent = _make_agent()
+        agent._claude_sdk_session = None
+
+        with pytest.raises(ValueError, match=r"agent\.claude_agent_sdk\.add_dirs") as exc:
+            self._run_new_session(agent)
+
+        assert instances == []
+        assert "credential-sentinel" not in str(exc.value)
+
+    def test_profile_config_is_snapshotted_per_session(self, monkeypatch):
+        config = {
+            "add_dirs": ["/srv/hermes/first"],
+            "native_read_only": True,
+        }
+        import hermes_cli.config as cfg
+
+        monkeypatch.setattr(
+            cfg,
+            "load_config_readonly",
+            lambda *args, **kwargs: {
+                "agent": {"claude_agent_sdk": dict(config)}
+            },
+        )
+        instances = self._capture_sessions(monkeypatch)
+        agent = _make_agent()
+        agent._claude_sdk_session = None
+
+        self._run_new_session(agent)
+        config["add_dirs"] = ["/srv/hermes/second"]
+        config["native_read_only"] = False
+        self._run_new_session(agent)
+
+        assert len(instances) == 1
+        assert instances[0].kwargs["add_dirs"] == ["/srv/hermes/first"]
+        assert instances[0].kwargs["native_read_only"] is True
+
+        agent._claude_sdk_session = None
+        self._run_new_session(agent)
+        assert instances[1].kwargs["add_dirs"] == ["/srv/hermes/second"]
+        assert instances[1].kwargs["native_read_only"] is False
+
+
+class TestRuntimeGlue:
+    def test_turn_contract(self):
+        agent = _make_agent()
+        messages = [{"role": "user", "content": "hi"}]
+        result = run_claude_agent_sdk_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=messages,
+            effective_task_id="task-1",
+        )
+        assert result["final_response"] == "SDK_ASSISTANT"
+        assert result["completed"] is True
+        assert result["agent_persisted"] is True
+        assert result["cost_status"] == "included"
+        assert result["cost_source"] == "claude-subscription"
+        # Projected messages spliced after the (pre-appended) user turn.
+        assert messages[-1]["content"] == "SDK_ASSISTANT"
+        # Skill-nudge counter parity with the codex path.
+        assert agent._iters_since_skill == 2
+
+    def test_retire_closes_session(self):
+        agent = _make_agent()
+        agent._claude_sdk_session.run_turn.return_value = _make_turn(
+            should_retire=True, error="turn timed out after 600s",
+            projected_messages=[], final_text="", token_usage_last=None,
+        )
+        stale = agent._claude_sdk_session
+        result = run_claude_agent_sdk_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}],
+            effective_task_id="task-1",
+        )
+        stale.close.assert_called_once()
+        assert agent._claude_sdk_session is None
+        assert result["partial"] is True
+
+    def test_unattested_failure_never_records_subscription_billing(self):
+        agent = _make_agent()
+        agent.session_cost_status = None
+        agent.session_cost_source = None
+        agent._claude_sdk_session.run_turn.return_value = _make_turn(
+            should_retire=True,
+            subscription_attested=False,
+            error="subscription authentication attestation failed",
+            projected_messages=[],
+            final_text="",
+            token_usage_last=None,
+        )
+
+        result = run_claude_agent_sdk_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}],
+            effective_task_id="task-1",
+        )
+
+        assert agent.session_api_calls == 0
+        assert agent.session_cost_status is None
+        assert agent.session_cost_source is None
+        assert "cost_status" not in result
+        assert "cost_source" not in result
+
+    def test_interrupted_side_effecting_tool_tail_is_repaired_before_flush(self):
+        agent = _make_agent()
+        agent._session_db = MagicMock()
+        agent._flush_messages_to_session_db = MagicMock()
+        dangling_call = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "toolu-interrupted-bash",
+                    "type": "function",
+                    "function": {
+                        "name": "Bash",
+                        "arguments": '{"command": "touch /tmp/maybe-ran"}',
+                    },
+                }
+            ],
+        }
+        agent._claude_sdk_session.run_turn.return_value = _make_turn(
+            interrupted=True,
+            projected_messages=[dangling_call],
+            final_text="",
+        )
+        messages = [{"role": "user", "content": "run it"}]
+
+        result = run_claude_agent_sdk_turn(
+            agent,
+            user_message="run it",
+            original_user_message="run it",
+            messages=messages,
+            effective_task_id="task-1",
+        )
+
+        projected = result["messages"][1:]
+        assert [message["role"] for message in projected] == ["assistant", "tool"]
+        assert projected[1]["tool_call_id"] == "toolu-interrupted-bash"
+        assert projected[1]["effect_disposition"] == "unknown"
+        answered_ids = {
+            message.get("tool_call_id")
+            for message in projected
+            if message.get("role") == "tool"
+        }
+        assert answered_ids == {"toolu-interrupted-bash"}
+        flushed_messages = agent._flush_messages_to_session_db.call_args.args[0]
+        assert flushed_messages == result["messages"]
+        assert flushed_messages[-1]["effect_disposition"] == "unknown"
+
+    def test_interrupted_partial_mixed_batch_is_balanced_before_flush(self):
+        agent = _make_agent()
+        agent._session_db = MagicMock()
+        agent._flush_messages_to_session_db = MagicMock()
+        assistant_batch = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "toolu-answered-read",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": '{"path": "/x"}'},
+                },
+                {
+                    "id": "toolu-missing-bash",
+                    "type": "function",
+                    "function": {
+                        "name": "Bash",
+                        "arguments": '{"command": "touch /tmp/maybe-ran"}',
+                    },
+                },
+            ],
+        }
+        answered_read = {
+            "role": "tool",
+            "tool_call_id": "toolu-answered-read",
+            "content": "existing contents",
+        }
+        agent._claude_sdk_session.run_turn.return_value = _make_turn(
+            interrupted=True,
+            projected_messages=[assistant_batch, answered_read],
+            final_text="",
+        )
+        messages = [{"role": "user", "content": "read then run"}]
+
+        result = run_claude_agent_sdk_turn(
+            agent,
+            user_message="read then run",
+            original_user_message="read then run",
+            messages=messages,
+            effective_task_id="task-1",
+        )
+
+        projected = result["messages"][1:]
+        assert projected[:2] == [assistant_batch, answered_read]
+        results = [message for message in projected if message.get("role") == "tool"]
+        assert [message["tool_call_id"] for message in results] == [
+            "toolu-answered-read",
+            "toolu-missing-bash",
+        ]
+        assert results[0] == answered_read
+        assert results[1]["effect_disposition"] == "unknown"
+        assert "unknown" in results[1]["content"].lower()
+        call_ids = {call["id"] for call in assistant_batch["tool_calls"]}
+        assert {message["tool_call_id"] for message in results} == call_ids
+        flushed_messages = agent._flush_messages_to_session_db.call_args.args[0]
+        assert flushed_messages == result["messages"]
+
+
+# ---------- background review must not spawn on this runtime ----------
+
+
+class TestBackgroundReviewSuppressed:
+    """The review fork inherits ``api_mode="claude_agent_sdk"`` and lands in
+    a fresh SDK session whose tool surface has no ``memory``/``skill_manage``
+    — it burns a subscription turn and cannot write anything. The runtime
+    must therefore never spawn it, while the nudge counters keep ticking so
+    a bounded replacement pass can reuse them. (#25267)"""
+
+    def test_memory_nudge_does_not_spawn_review(self):
+        agent = _make_agent()
+        run_claude_agent_sdk_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}],
+            effective_task_id="task-1",
+            should_review_memory=True,
+        )
+        agent._spawn_background_review.assert_not_called()
+
+    def test_skill_nudge_does_not_spawn_review_but_counter_still_ticks(self):
+        agent = _make_agent()
+        agent._skill_nudge_interval = 1
+        agent.valid_tool_names = {"skill_manage"}
+        run_claude_agent_sdk_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}],
+            effective_task_id="task-1",
+        )
+        agent._spawn_background_review.assert_not_called()
+        # Counter machinery stays intact: the interval crossing still resets
+        # it, exactly as before — only the spawn is suppressed.
+        assert agent._iters_since_skill == 0
+
+
+# ---------- hermes session id plumbing to the MCP shims (#26567) ----------
+
+
+class TestMcpEnvMinimal:
+    def test_main_cli_env_overrides_every_non_allowlisted_parent_value(
+        self, monkeypatch
+    ):
+        sentinel = "SDK_PARENT_ENV_SENTINEL"
+        blocked = (
+            "SDK_UNKNOWN_SECRET",
+            "OPENROUTER_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "CLAUDE_CODE_USE_VERTEX",
+            "ANTHROPIC_FOUNDRY_AUTH_TOKEN",
+            "HTTPS_PROXY",
+            "SSH_AUTH_SOCK",
+            "TELEGRAM_BOT_TOKEN",
+            "HERMES_HOME",
+        )
+        for name in blocked:
+            monkeypatch.setenv(name, sentinel)
+        allowed = {
+            "HOME": "/tmp/sdk-home",
+            "PATH": "/usr/local/bin:/usr/bin",
+            "SHELL": "/bin/sh",
+            "LANG": "C.UTF-8",
+            "LC_TEST": "C.UTF-8",
+            "TERM": "xterm-256color",
+            "TMPDIR": "/tmp/sdk-tmp",
+            "CLAUDE_CONFIG_DIR": "/tmp/sdk-claude-config",
+            "SSL_CERT_FILE": "/tmp/sdk-ca.pem",
+        }
+        for name, value in allowed.items():
+            monkeypatch.setenv(name, value)
+
+        option_env = ClaudeAgentSdkSession(
+            cwd="/tmp", include_hermes_tools=False
+        ).build_option_fields()["env"]
+
+        assert set(os.environ) <= set(option_env)
+        assert all(option_env[name] == "" for name in blocked)
+        assert sentinel not in option_env.values()
+        assert {name: option_env[name] for name in allowed} == allowed
+
+    def test_sdk_client_uses_custom_subprocess_transport_with_empty_prompt(self):
+        import asyncio
+
+        pytest.importorskip("claude_agent_sdk")
+        from claude_agent_sdk._internal.transport.subprocess_cli import (
+            SubprocessCLITransport,
+        )
+
+        session = ClaudeAgentSdkSession(
+            cwd="/tmp",
+            permission_mode="default",
+            approval_callback=lambda *args, **kwargs: "once",
+            include_hermes_tools=False,
+        )
+        client = session._build_client()
+        transport = client._custom_transport
+
+        assert isinstance(transport, SubprocessCLITransport)
+        assert type(transport) is not SubprocessCLITransport
+        assert transport._options.env == client.options.env
+        assert client.options.permission_prompt_tool_name is None
+        assert transport._options.permission_prompt_tool_name == "stdio"
+        assert transport._options.can_use_tool is client.options.can_use_tool
+
+        async def _collect_prompt():
+            return [message async for message in transport._prompt]
+
+        assert asyncio.run(_collect_prompt()) == []
+
+    def test_version_preflight_and_streaming_cli_receive_sanitized_env(
+        self, monkeypatch, caplog
+    ):
+        import asyncio
+
+        pytest.importorskip("claude_agent_sdk")
+        import claude_agent_sdk._internal.transport.subprocess_cli as subprocess_cli
+
+        sentinel = "SDK_PROCESS_ENV_SENTINEL"
+        blocked = (
+            "SDK_ARBITRARY_SECRET",
+            "OPENROUTER_API_KEY",
+            "TELEGRAM_BOT_TOKEN",
+            "GITHUB_TOKEN",
+            "SSH_AUTH_SOCK",
+            "HTTPS_PROXY",
+        )
+        for name in blocked:
+            monkeypatch.setenv(name, sentinel)
+        monkeypatch.setenv("HOME", "/tmp/sdk-home")
+        monkeypatch.setenv("PATH", "/usr/local/bin:/usr/bin")
+
+        class _FakeStream:
+            def __init__(self, payload=b""):
+                self._payload = payload
+
+            async def receive(self, max_bytes=65536):
+                payload, self._payload = self._payload, b""
+                return payload
+
+            async def aclose(self):
+                return None
+
+        class _FakeProcess:
+            def __init__(self, *, version_probe):
+                self.stdin = None
+                self.stdout = _FakeStream(b"1.9.9\n" if version_probe else b"")
+                self.stderr = None
+                self.returncode = None
+
+            def terminate(self):
+                self.returncode = 0
+
+            def kill(self):
+                self.returncode = -9
+
+            async def wait(self):
+                self.returncode = 0
+                return 0
+
+        process_calls = []
+
+        async def _fake_open_process(argv, **kwargs):
+            process_calls.append((list(argv), kwargs))
+            return _FakeProcess(version_probe=argv[-1] == "-v")
+
+        monkeypatch.setattr(subprocess_cli.anyio, "open_process", _fake_open_process)
+        session = ClaudeAgentSdkSession(cwd="/tmp", include_hermes_tools=False)
+        client = session._build_client()
+        transport = client._custom_transport
+        transport._cli_path = "/fake/claude"
+
+        async def _connect_and_close():
+            await transport.connect()
+            await transport.close()
+
+        asyncio.run(_connect_and_close())
+
+        assert len(process_calls) == 2
+        version_call = next(call for call in process_calls if call[0][-1] == "-v")
+        streaming_call = next(call for call in process_calls if call[0][-1] != "-v")
+        for argv, kwargs in (version_call, streaming_call):
+            assert kwargs.get("env") is not None, f"missing explicit env for {argv}"
+            child_env = kwargs["env"]
+            assert child_env["HOME"] == "/tmp/sdk-home"
+            assert child_env["PATH"] == "/usr/local/bin:/usr/bin"
+            assert all(child_env[name] == "" for name in blocked)
+            assert sentinel not in child_env.values()
+        assert "Minimum required version is 2.0.0" in caplog.text
+
+    def test_session_module_import_stays_lazy_without_optional_sdk(self):
+        import subprocess
+        import sys
+        import textwrap
+        from pathlib import Path
+
+        script = textwrap.dedent(
+            """
+            import builtins
+            original_import = builtins.__import__
+
+            def blocked_import(name, *args, **kwargs):
+                if name == "claude_agent_sdk" or name.startswith("claude_agent_sdk."):
+                    raise ImportError("optional SDK blocked by test")
+                return original_import(name, *args, **kwargs)
+
+            builtins.__import__ = blocked_import
+            import agent.transports.claude_agent_sdk_session
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=Path(__file__).resolve().parents[2],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert completed.returncode == 0, completed.stderr
+
+    def test_mcp_env_carries_no_secrets(self, monkeypatch):
+        # The SDK inlines the MCP config, including its env, into the Claude
+        # CLI argv where it is visible via ps. The
+        # env must be a minimal allowlist, never the credentialed environ.
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-fake")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-fake")
+        # ANTHROPIC_AUTH_TOKEN is deliberately absent here because the
+        # billing-route guard would refuse startup before the MCP config is
+        # built. The allowlist excludes it regardless.
+        monkeypatch.setenv("HERMES_HOME", "/tmp/hermes-test-home")
+        session = ClaudeAgentSdkSession(
+            cwd="/tmp", hermes_session_id="sess-9"
+        )
+        env = session.build_option_fields()["mcp_servers"]["hermes-tools"]["env"]
+        for secret in ("CLAUDE_CODE_OAUTH_TOKEN", "OPENROUTER_API_KEY",
+                       "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"):
+            assert secret not in env, f"{secret} leaked into the MCP argv env"
+        assert "PYTHONPATH" in env
+        assert env["HERMES_SESSION_ID"] == "sess-9"
+        assert env["HERMES_HOME"] == "/tmp/hermes-test-home"
+
+    def test_state_db_override_rides_the_mcp_env(self, monkeypatch):
+        # The MCP environment allowlist must retain HERMES_MCP_STATE_DB;
+        # otherwise the documented state-DB override is lost and the MCP
+        # subprocess searched the DEFAULT DB with no error. A path, not a
+        # secret, so it belongs on the allowlist.
+        monkeypatch.setenv("HERMES_MCP_STATE_DB", "/tmp/custom-state.db")
+        session, holder = _make_session(script=[ResultMessage(result="ok")])
+        try:
+            session.run_turn("ping")
+        finally:
+            session.close()
+        env = holder["client"].options["mcp_servers"]["hermes-tools"]["env"]
+        assert env["HERMES_MCP_STATE_DB"] == "/tmp/custom-state.db"
+
+    def test_anthropic_auth_token_refuses_startup(self, monkeypatch):
+        # The CLI also honors ANTHROPIC_AUTH_TOKEN (bearer,
+        # typically metered/proxy) — same fail-closed class as the API key.
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "fake-bearer")
+        session = ClaudeAgentSdkSession(cwd="/tmp")  # no factory → real path
+        turn = session.run_turn("hi")
+        assert turn.should_retire
+        assert "ANTHROPIC_AUTH_TOKEN" in (turn.error or "")
+
+    def test_legacy_allow_metered_key_config_cannot_bypass_guard(self, monkeypatch):
+        # Old configs may still contain the removed key. It must be ignored:
+        # this runtime has no metered escape hatch.
+        import hermes_cli.config as cfg
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-fake")
+        monkeypatch.setattr(
+            cfg,
+            "load_config_readonly",
+            lambda *a, **k: {
+                "agent": {"claude_agent_sdk": {"allow_metered_key": True}}
+            },
+        )
+        session, _holder = _make_session(script=[ResultMessage(result="ok")])
+        try:
+            turn = session.run_turn("ping")
+        finally:
+            session.close()
+        assert turn.should_retire
+        assert "ANTHROPIC_API_KEY" in (turn.error or "")
+
+    def test_half_connected_client_is_reaped_on_close(self):
+        # On a connect failure, assigning the client only after connect()
+        # returned made close() skip disconnect and left the CLI subprocess
+        # orphaned.
+        session, holder = _make_session(connect_exc=RuntimeError("connect blew up"))
+        turn = session.run_turn("hi")
+        assert turn.should_retire
+        session.close()
+        assert holder["client"].disconnected is True
+
+    def test_mid_stream_interrupt_breaks_and_discards_tail(self):
+        # Exercise /stop arriving during streaming at the session boundary.
+        holder = {}
+
+        class MidStreamClient(_FakeClient):
+            async def receive_response(self):
+                yield AssistantMessage(content=[TextBlock("first chunk")])
+                holder["session"]._interrupt_event.set()
+                yield AssistantMessage(content=[TextBlock("tail that must be discarded")])
+                yield ResultMessage(result="tail that must be discarded")
+
+        def factory(options=None):
+            client = MidStreamClient(options=options)
+            holder["client"] = client
+            return client
+
+        session = ClaudeAgentSdkSession(cwd="/tmp", client_factory=factory)
+        holder["session"] = session
+        try:
+            turn = session.run_turn("hi")
+        finally:
+            session.close()
+        assert turn.interrupted is True
+        assert all("discarded" not in str(m.get("content")) for m in turn.projected_messages)
+
+
+class TestHermesSessionIdPlumbing:
+    def test_session_id_rides_mcp_env(self):
+        session, holder = _make_session(
+            script=[ResultMessage(result="ok")], hermes_session_id="sess-42"
+        )
+        try:
+            session.run_turn("ping")
+        finally:
+            session.close()
+        env = holder["client"].options["mcp_servers"]["hermes-tools"]["env"]
+        assert env["HERMES_SESSION_ID"] == "sess-42"
+        # The invented pre-fix name must never come back: the shim consumer
+        # reads only the canonical HERMES_SESSION_ID.
+        assert "HERMES_MCP_SESSION_ID" not in env
+
+    def test_no_session_id_no_env_var(self):
+        session, holder = _make_session(script=[ResultMessage(result="ok")])
+        try:
+            session.run_turn("ping")
+        finally:
+            session.close()
+        env = holder["client"].options["mcp_servers"]["hermes-tools"]["env"]
+        assert "HERMES_SESSION_ID" not in env
+        assert "HERMES_MCP_SESSION_ID" not in env
+
+    def test_runtime_passes_agent_session_id(self, monkeypatch):
+        import agent.transports.claude_agent_sdk_session as sdk_session_mod
+
+        captured = {}
+
+        class SpySession:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def run_turn(self, user_input):
+                return _make_turn()
+
+        monkeypatch.setattr(sdk_session_mod, "ClaudeAgentSdkSession", SpySession)
+        agent = _make_agent()
+        agent._claude_sdk_session = None
+        run_claude_agent_sdk_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}],
+            effective_task_id="task-1",
+        )
+        assert captured.get("hermes_session_id") == "sess-1"
+
+    def test_runtime_passes_context_to_append_builder(self, monkeypatch):
+        # The append builder receives the agent's platform/session/model plus
+        # the resolved runtime cwd so native project context is loaded from the
+        # same workspace the SDK subprocess operates in.
+        import agent.claude_sdk_runtime as rt
+        import agent.transports.claude_agent_sdk_session as sdk_session_mod
+
+        captured = {}
+
+        def fake_append(**kwargs):
+            captured.update(kwargs)
+            return "APPEND-UNDER-TEST"
+
+        class SpySession:
+            def __init__(self, **kwargs):
+                pass
+
+            def run_turn(self, user_input):
+                return _make_turn()
+
+        monkeypatch.setattr(rt, "build_system_prompt_append", fake_append)
+        monkeypatch.setattr(sdk_session_mod, "ClaudeAgentSdkSession", SpySession)
+        agent = _make_agent()
+        agent._claude_sdk_session = None
+        agent.platform = "telegram"
+        agent.session_cwd = "/tmp/sdk-runtime-workspace"
+        run_claude_agent_sdk_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}],
+            effective_task_id="task-1",
+        )
+        assert captured == {
+            "platform": "telegram",
+            "session_id": "sess-1",
+            "model": "claude-opus-4-8",
+            "cwd": "/tmp/sdk-runtime-workspace",
+            "context_length": None,
+            "native_read_only": False,
+        }
+
+
+# ---------- interrupt routing to the SDK session ----------
+
+
+class TestInterruptRoutesToSdkSession:
+    """/stop and new-message preemption call AIAgent.interrupt(); the SDK
+    session's request_interrupt (event + client.interrupt()) already works —
+    this pins the one missing caller."""
+
+    @staticmethod
+    def _make_real_agent():
+        from run_agent import AIAgent
+
+        return AIAgent(
+            api_key="test",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    def test_interrupt_reaches_live_sdk_session(self):
+        agent = self._make_real_agent()
+        agent._claude_sdk_session = MagicMock()
+        agent.interrupt()
+        agent._claude_sdk_session.request_interrupt.assert_called_once()
+
+    def test_interrupt_without_sdk_session_stays_safe(self):
+        agent = self._make_real_agent()
+        agent._claude_sdk_session = None
+        agent.interrupt()  # must not raise
+
+    def test_release_clients_disconnects_sdk_session(self):
+        # The gateway's routine evictions (LRU cap, idle-TTL sweep, model
+        # switch) release via release_clients(), which previously
+        # never touched the SDK session — leaking the loop thread + the
+        # Claude CLI subprocess per eviction on a 24/7 gateway.
+        agent = self._make_real_agent()
+        sdk_session = MagicMock()
+        agent._claude_sdk_session = sdk_session
+        agent.release_clients()
+        sdk_session.close.assert_called_once()
+        assert agent._claude_sdk_session is None
+
+    def test_pending_interrupt_flag_short_circuits_cold_turn(self, monkeypatch):
+        # An interrupt landing before the SDK session exists sets only
+        # agent._interrupt_requested, which the SDK
+        # path never read — the turn ran uninterruptible for up to 600s.
+        import agent.transports.claude_agent_sdk_session as sdk_session_mod
+
+        instances = []
+
+        class SpySession:
+            def __init__(self, **kwargs):
+                instances.append(self)
+
+            def run_turn(self, user_input):
+                return _make_turn()
+
+        monkeypatch.setattr(sdk_session_mod, "ClaudeAgentSdkSession", SpySession)
+        agent = _make_agent()
+        agent._claude_sdk_session = None
+        agent._interrupt_requested = True
+        result = run_claude_agent_sdk_turn(
+            agent, user_message="hi", original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}], effective_task_id="t",
+        )
+        assert instances == []  # no session created, no subscription burn
+        assert result["completed"] is False and result["partial"] is True
+        assert agent._interrupt_requested is False  # consumed, next turn runs
+
+    def test_honored_interrupt_consumes_agent_flag(self, monkeypatch):
+        # After an interrupt is honored mid-turn, the agent-level flag must not
+        # remain set or the cold-flag check will short-circuit
+        # the NEXT turn into an empty answer. Honoring must consume it.
+        import agent.transports.claude_agent_sdk_session as sdk_session_mod
+
+        agent = _make_agent()
+        agent._claude_sdk_session = None
+        agent._session_db = None
+
+        class SpySession:
+            def __init__(self, **kwargs):
+                pass
+
+            def run_turn(self, user_input):
+                agent._interrupt_requested = True  # user hit /stop mid-turn
+                return _make_turn(interrupted=True, final_text="", projected_messages=[])
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(sdk_session_mod, "ClaudeAgentSdkSession", SpySession)
+        result = run_claude_agent_sdk_turn(
+            agent, user_message="hi", original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}], effective_task_id="t",
+        )
+        assert result["partial"] is True
+        assert agent._interrupt_requested is False  # consumed — next turn runs
+
+    def test_thread_id_captured_from_init_message(self):
+        # A FIRST-turn interrupt used to lose the resume id (only the final
+        # ResultMessage carried it). The SDK announces session_id in its init
+        # SystemMessage — capture it from any message.
+        session, _ = _make_session(script=[SystemMessage(session_id="sdk-early-7")])
+        try:
+            turn = session.run_turn("hi")
+        finally:
+            session.close()
+        assert turn.thread_id == "sdk-early-7"
+
+    def test_pre_set_interrupt_event_honored_then_next_turn_runs(self):
+        # Clearing the interrupt event after connect erases an interrupt that
+        # arrives during the up-to-60-second connect window. It must instead be
+        # honored by THIS turn, and must not bleed into the next one.
+        session, holder = _make_session(
+            script=[ResultMessage(result="ok")]
+        )
+        try:
+            session.ensure_started()
+            session.request_interrupt()
+            turn1 = session.run_turn("first")
+            assert turn1.interrupted is True
+            assert holder["client"].queried == []  # never reached the model
+            turn2 = session.run_turn("second")
+            assert turn2.interrupted is False
+            assert holder["client"].queried == ["second"]
+        finally:
+            session.close()
+
+
+# ---------- streaming deltas (config-gated, default off) ----------
+
+
+class TestStreaming:
+    def test_env_var_cannot_enable_streaming(self, monkeypatch):
+        # AGENTS.md:102-107 keeps behavioural settings out of HERMES_* env
+        # vars. The old HERMES_CLAUDE_SDK_STREAMING override is gone, so
+        # setting it must have NO effect — config.yaml is the only interface.
+        monkeypatch.setenv("HERMES_CLAUDE_SDK_STREAMING", "1")
+        session, holder = _make_session(script=[ResultMessage(result="ok")])
+        try:
+            session.run_turn("ping")
+        finally:
+            session.close()
+        assert "include_partial_messages" not in holder["client"].options
+
+    def test_option_absent_by_default(self):
+        session, holder = _make_session(script=[ResultMessage(result="ok")])
+        try:
+            session.run_turn("ping")
+        finally:
+            session.close()
+        assert "include_partial_messages" not in holder["client"].options
+
+    def test_config_yaml_is_the_operator_interface(self, monkeypatch):
+        # AGENTS.md: behavioral settings live in config.yaml, not env.
+        # agent.claude_agent_sdk.streaming turns the option on without any env.
+        import hermes_cli.config as cfg
+
+        monkeypatch.setattr(
+            cfg,
+            "load_config_readonly",
+            lambda *a, **k: {"agent": {"claude_agent_sdk": {"streaming": True}}},
+        )
+        session, holder = _make_session(script=[ResultMessage(result="ok")])
+        try:
+            session.run_turn("ping")
+        finally:
+            session.close()
+        assert holder["client"].options["include_partial_messages"] is True
+
+    def test_env_var_cannot_disable_config_streaming(self, monkeypatch):
+        # The mirror of the test above: an explicit env "0" must NOT be able to
+        # veto config.yaml either. Together the pair pins the override as fully
+        # inert in both directions, so it cannot creep back in unnoticed.
+        import hermes_cli.config as cfg
+
+        monkeypatch.setenv("HERMES_CLAUDE_SDK_STREAMING", "0")
+        monkeypatch.setattr(
+            cfg,
+            "load_config_readonly",
+            lambda *a, **k: {"agent": {"claude_agent_sdk": {"streaming": True}}},
+        )
+        session, holder = _make_session(script=[ResultMessage(result="ok")])
+        try:
+            session.run_turn("ping")
+        finally:
+            session.close()
+        assert holder["client"].options["include_partial_messages"] is True
+
+    def test_deltas_reach_callback_and_never_the_transcript(self):
+        got = []
+        script = [
+            _text_delta_event("Hel"),
+            _text_delta_event("lo"),
+            AssistantMessage(content=[TextBlock("Hello")]),
+            ResultMessage(result="Hello"),
+        ]
+        session, _ = _make_session(script=script, on_stream_delta=got.append)
+        try:
+            turn = session.run_turn("hi")
+        finally:
+            session.close()
+        assert got == ["Hel", "lo"]
+        # Display-only: deltas never become transcript rows.
+        assert [m["role"] for m in turn.projected_messages] == ["assistant"]
+        assert turn.final_text == "Hello"
+
+    def test_subagent_deltas_are_not_forwarded(self):
+        got = []
+        script = [
+            _text_delta_event("sub", parent_tool_use_id="tool-1"),
+            ResultMessage(result="done"),
+        ]
+        session, _ = _make_session(script=script, on_stream_delta=got.append)
+        try:
+            session.run_turn("hi")
+        finally:
+            session.close()
+        assert got == []
+
+    def test_runtime_wires_late_bound_stream_callback(self, monkeypatch):
+        # The gateway assigns agent.stream_delta_callback per turn AFTER the
+        # session exists — the wiring must read it at call time.
+        import agent.transports.claude_agent_sdk_session as sdk_session_mod
+
+        captured = {}
+
+        class SpySession:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def run_turn(self, user_input):
+                return _make_turn()
+
+        monkeypatch.setattr(sdk_session_mod, "ClaudeAgentSdkSession", SpySession)
+        agent = _make_agent()
+        agent._claude_sdk_session = None
+        run_claude_agent_sdk_turn(
+            agent, user_message="hi", original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}], effective_task_id="t",
+        )
+        relay = captured.get("on_stream_delta")
+        assert callable(relay)
+        seen = []
+        agent.stream_delta_callback = seen.append  # assigned AFTER creation
+        relay("delta-text")
+        assert seen == ["delta-text"]
+        agent.stream_delta_callback = None  # cleared between turns → no crash
+        relay("dropped")
+        assert seen == ["delta-text"]
+
+
+# ---------- continuity: resume + digest fallback ----------
+
+
+class TestContinuity:
+    """Retire matrix under test:
+      /new, expiry      → new Hermes session row → no persisted id → FRESH
+      restart/eviction  → same row, id persisted → RESUME
+      error retire      → persisted id CLEARED → next turn fresh + digest
+      stale resume      → retire → clear → ONE fresh retry with digest
+    """
+
+    @staticmethod
+    def _db_agent(persisted_sdk_id=None):
+        agent = _make_agent()
+        agent._claude_sdk_session = None
+        db = MagicMock()
+        db.get_session.return_value = {"claude_sdk_session_id": persisted_sdk_id}
+        agent._session_db = db
+        agent._session_db_created = True
+        return agent, db
+
+    @staticmethod
+    def _spy_sessions(monkeypatch, behaviors):
+        """Install a SpySession whose Nth instance behaves per behaviors[N]:
+        a TurnResult-like object to return, or an Exception to raise."""
+        import agent.transports.claude_agent_sdk_session as sdk_session_mod
+
+        instances = []
+
+        class SpySession:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.inputs = []
+                instances.append(self)
+
+            def run_turn(self, user_input):
+                self.inputs.append(user_input)
+                behavior = behaviors[len(instances) - 1]
+                if isinstance(behavior, Exception):
+                    raise behavior
+                return behavior
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(sdk_session_mod, "ClaudeAgentSdkSession", SpySession)
+        return instances
+
+    def test_creation_resumes_from_persisted_id(self, monkeypatch):
+        agent, _db = self._db_agent(persisted_sdk_id="sdk-old-1")
+        instances = self._spy_sessions(monkeypatch, [_make_turn()])
+        run_claude_agent_sdk_turn(
+            agent, user_message="hi", original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}], effective_task_id="t",
+        )
+        assert instances[0].kwargs.get("resume_session_id") == "sdk-old-1"
+        # A resumed session already holds the context — no digest.
+        assert instances[0].inputs == ["hi"]
+
+    def test_successful_turn_persists_thread_id(self, monkeypatch):
+        agent, db = self._db_agent()
+        self._spy_sessions(monkeypatch, [_make_turn(thread_id="sdk-new-9")])
+        run_claude_agent_sdk_turn(
+            agent, user_message="hi", original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}], effective_task_id="t",
+        )
+        db.update_claude_sdk_session_id.assert_called_with("sess-1", "sdk-new-9")
+
+    def test_error_retire_clears_persisted_id(self, monkeypatch):
+        agent, db = self._db_agent()
+        self._spy_sessions(monkeypatch, [_make_turn(
+            should_retire=True, error="turn timed out", projected_messages=[],
+            final_text="", token_usage_last=None,
+        )])
+        run_claude_agent_sdk_turn(
+            agent, user_message="hi", original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}], effective_task_id="t",
+        )
+        db.update_claude_sdk_session_id.assert_called_with("sess-1", None)
+
+    def test_digest_prepended_on_fresh_session_with_history(self, monkeypatch):
+        agent, _db = self._db_agent(persisted_sdk_id=None)
+        instances = self._spy_sessions(monkeypatch, [_make_turn()])
+        messages = [
+            {"role": "user", "content": "the linter flags shadowed imports"},
+            {"role": "assistant", "content": "Fixed by renaming the local."},
+            {"role": "user", "content": "and the tests?"},
+        ]
+        run_claude_agent_sdk_turn(
+            agent, user_message="and the tests?", original_user_message="and the tests?",
+            messages=messages, effective_task_id="t",
+        )
+        sent = instances[0].inputs[0]
+        assert sent.startswith("[Continuity digest")
+        assert "shadowed imports" in sent
+        assert sent.endswith("and the tests?")
+
+    def test_no_digest_on_brand_new_conversation(self, monkeypatch):
+        agent, _db = self._db_agent(persisted_sdk_id=None)
+        instances = self._spy_sessions(monkeypatch, [_make_turn()])
+        run_claude_agent_sdk_turn(
+            agent, user_message="hello", original_user_message="hello",
+            messages=[{"role": "user", "content": "hello"}], effective_task_id="t",
+        )
+        assert instances[0].inputs == ["hello"]
+
+    def test_stale_resume_retires_then_retries_fresh_with_digest(self, monkeypatch):
+        # A stale resume id fails the session. The runtime
+        # must clear the id and retry ONCE fresh (digest included) — the
+        # user gets an answer, not an error.
+        agent, db = self._db_agent(persisted_sdk_id="sdk-stale-7")
+        instances = self._spy_sessions(monkeypatch, [
+            _make_turn(should_retire=True, error="resume failed",
+                       projected_messages=[], final_text="", tool_iterations=0,
+                       token_usage_last=None, retry_safe_before_query=True),
+            _make_turn(final_text="fresh answer",
+                       projected_messages=[{"role": "assistant", "content": "fresh answer"}]),
+        ])
+        messages = [
+            {"role": "user", "content": "earlier context line"},
+            {"role": "assistant", "content": "earlier reply"},
+            {"role": "user", "content": "current question"},
+        ]
+        result = run_claude_agent_sdk_turn(
+            agent, user_message="current question",
+            original_user_message="current question",
+            messages=messages, effective_task_id="t",
+        )
+        assert result["final_response"] == "fresh answer"
+        assert len(instances) == 2
+        assert instances[0].kwargs.get("resume_session_id") == "sdk-stale-7"
+        assert instances[1].kwargs.get("resume_session_id") is None
+        assert instances[1].inputs[0].startswith("[Continuity digest")
+        db.update_claude_sdk_session_id.assert_any_call("sess-1", None)
+
+    def test_resumed_execution_error_without_projection_is_never_replayed(
+        self, monkeypatch
+    ):
+        agent, db = self._db_agent(persisted_sdk_id="sdk-live-7")
+        failed_turn = _make_turn(
+            should_retire=True,
+            error=(
+                "SDK result error (subtype=error_during_execution): "
+                "error_during_execution"
+            ),
+            projected_messages=[],
+            final_text="",
+            tool_iterations=0,
+            token_usage_last=None,
+        )
+        instances = self._spy_sessions(
+            monkeypatch,
+            [failed_turn, _make_turn(final_text="must not replay")],
+        )
+
+        result = run_claude_agent_sdk_turn(
+            agent,
+            user_message="perform one action",
+            original_user_message="perform one action",
+            messages=[{"role": "user", "content": "perform one action"}],
+            effective_task_id="t",
+        )
+
+        assert len(instances) == 1
+        assert sum(len(instance.inputs) for instance in instances) == 1
+        assert result["error"] == failed_turn.error
+        db.update_claude_sdk_session_id.assert_called_with("sess-1", None)
+
+    @pytest.mark.parametrize(
+        "failed_behavior",
+        [
+            pytest.param(RuntimeError("generic adapter failure"), id="generic-exception"),
+            pytest.param(
+                _make_turn(
+                    should_retire=True,
+                    error="turn timed out after 600s",
+                    projected_messages=[],
+                    final_text="",
+                    tool_iterations=0,
+                    token_usage_last=None,
+                ),
+                id="timeout-result",
+            ),
+        ],
+    )
+    def test_resumed_generic_and_timeout_failures_are_never_replayed(
+        self, monkeypatch, failed_behavior
+    ):
+        agent, db = self._db_agent(persisted_sdk_id="sdk-live-8")
+        instances = self._spy_sessions(
+            monkeypatch,
+            [failed_behavior, _make_turn(final_text="must not replay")],
+        )
+
+        run_claude_agent_sdk_turn(
+            agent,
+            user_message="perform one action",
+            original_user_message="perform one action",
+            messages=[{"role": "user", "content": "perform one action"}],
+            effective_task_id="t",
+        )
+
+        assert len(instances) == 1
+        assert sum(len(instance.inputs) for instance in instances) == 1
+        db.update_claude_sdk_session_id.assert_called_with("sess-1", None)
+
+    def test_fresh_continuity_rejects_image_before_session_creation(
+        self, monkeypatch
+    ):
+        agent, _db = self._db_agent(persisted_sdk_id=None)
+        instances = self._spy_sessions(monkeypatch, [])
+        rich_input = [
+            {"type": "text", "text": "inspect this"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,IMAGE-SENTINEL"},
+            },
+        ]
+        messages = [
+            {"role": "user", "content": "earlier context"},
+            {"role": "assistant", "content": "earlier reply"},
+            {"role": "user", "content": rich_input},
+        ]
+
+        result = run_claude_agent_sdk_turn(
+            agent,
+            user_message=rich_input,
+            original_user_message=rich_input,
+            messages=messages,
+            effective_task_id="t",
+        )
+
+        assert result["error"] == (
+            "claude-agent-sdk image inputs are unsupported until rich-image "
+            "transport is implemented"
+        )
+        assert result["api_calls"] == 0
+        assert instances == []
+        assert "IMAGE-SENTINEL" not in result["final_response"]
+
+    def test_fresh_continuity_rejects_image_history_before_digest(
+        self, monkeypatch
+    ):
+        agent, _db = self._db_agent(persisted_sdk_id=None)
+        instances = self._spy_sessions(monkeypatch, [])
+        messages = [
+            {
+                "role": "user",
+                "content": {
+                    "envelope": [
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "data:image/png;base64,HISTORY-SENTINEL"
+                            },
+                        }
+                    ]
+                },
+            },
+            {"role": "assistant", "content": "earlier reply"},
+            {"role": "user", "content": "current question"},
+        ]
+
+        result = run_claude_agent_sdk_turn(
+            agent,
+            user_message="current question",
+            original_user_message="current question",
+            messages=messages,
+            effective_task_id="t",
+        )
+
+        assert result["error"] == (
+            "claude-agent-sdk image inputs are unsupported until rich-image "
+            "transport is implemented"
+        )
+        assert result["api_calls"] == 0
+        assert instances == []
+        assert "HISTORY-SENTINEL" not in result["final_response"]
+
+    @pytest.mark.parametrize(
+        "failed_turn",
+        [
+            pytest.param(
+                _make_turn(
+                    should_retire=True,
+                    error="resume failed after projection",
+                    projected_messages=[
+                        {"role": "assistant", "content": "partial response"}
+                    ],
+                    final_text="partial response",
+                    tool_iterations=0,
+                    token_usage_last=None,
+                ),
+                id="projected-message",
+            ),
+            pytest.param(
+                _make_turn(
+                    should_retire=True,
+                    error="resume failed after tool iteration",
+                    projected_messages=[],
+                    final_text="",
+                    tool_iterations=1,
+                    token_usage_last=None,
+                ),
+                id="tool-iteration",
+            ),
+        ],
+    )
+    def test_resumed_mid_turn_failure_is_never_replayed(
+        self, monkeypatch, failed_turn
+    ):
+        agent, db = self._db_agent(persisted_sdk_id="sdk-live-7")
+        instances = self._spy_sessions(
+            monkeypatch,
+            [failed_turn, _make_turn(final_text="must not replay")],
+        )
+
+        result = run_claude_agent_sdk_turn(
+            agent,
+            user_message="perform one action",
+            original_user_message="perform one action",
+            messages=[{"role": "user", "content": "perform one action"}],
+            effective_task_id="t",
+        )
+
+        assert len(instances) == 1
+        assert result["error"] == failed_turn.error
+        db.update_claude_sdk_session_id.assert_called_with("sess-1", None)
+
+    def test_cold_short_circuit_consumes_live_session_event_too(self, monkeypatch):
+        # An interrupt racing turn completion sets both the
+        # agent flag and the live session's event. The short-circuit consumed
+        # only the flag — the NEXT legit message then died on the stale
+        # session event with no model call. Honoring must consume both.
+        agent, _db = self._db_agent()
+        live = MagicMock()
+        agent._claude_sdk_session = live
+        agent._interrupt_requested = True
+        result = run_claude_agent_sdk_turn(
+            agent, user_message="hi", original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}], effective_task_id="t",
+        )
+        assert result["partial"] is True
+        live.consume_interrupt.assert_called_once()
+        live.run_turn.assert_not_called()
+
+    def test_resume_id_persisted_after_flush_and_gated_on_persist_disabled(self, monkeypatch):
+        # Writing the resume id before the flush that (re)creates the session
+        # row after a transient turn-start lock can silently discard
+        # continuity. Order must be flush-then-store.
+        agent, db = self._db_agent()
+        order = []
+        agent._flush_messages_to_session_db = MagicMock(
+            side_effect=lambda *a, **k: order.append("flush"))
+        db.update_claude_sdk_session_id.side_effect = (
+            lambda *a, **k: order.append("store"))
+        self._spy_sessions(monkeypatch, [_make_turn(thread_id="sdk-z-1")])
+        run_claude_agent_sdk_turn(
+            agent, user_message="hi", original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}], effective_task_id="t",
+        )
+        assert "store" in order and "flush" in order
+        assert order.index("flush") < order.index("store")
+        # And a fork with persistence disabled must never touch the parent row.
+        agent2, db2 = self._db_agent(persisted_sdk_id="sdk-parent-1")
+        agent2._persist_disabled = True
+        self._spy_sessions(monkeypatch, [_make_turn(thread_id="sdk-fork-9")])
+        run_claude_agent_sdk_turn(
+            agent2, user_message="hi", original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}], effective_task_id="t",
+        )
+        db2.update_claude_sdk_session_id.assert_not_called()
+
+    def test_interrupted_turn_retires_client_but_persists_resume_id(self, monkeypatch):
+        # Breaking out of receive_response() on interrupt leaves the
+        # interrupted turn's ResultMessage queued in the
+        # client's stream — a REUSED client would serve it as the NEXT turn's
+        # answer. The runtime must retire the client (clean stream) while
+        # persisting the SDK id, so the next turn RESUMES the conversation.
+        agent, db = self._db_agent()
+        self._spy_sessions(monkeypatch, [_make_turn(
+            interrupted=True, final_text="partial answer", thread_id="sdk-live-3",
+        )])
+        result = run_claude_agent_sdk_turn(
+            agent, user_message="hi", original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}], effective_task_id="t",
+        )
+        assert agent._claude_sdk_session is None  # client retired
+        db.update_claude_sdk_session_id.assert_called_with("sess-1", "sdk-live-3")
+        assert result["partial"] is True
+
+    def test_fresh_retire_does_not_retry(self, monkeypatch):
+        # Only a RESUMED session earns the retry — a fresh session that
+        # retires is a real error and must surface, never loop.
+        agent, _db = self._db_agent(persisted_sdk_id=None)
+        instances = self._spy_sessions(monkeypatch, [_make_turn(
+            should_retire=True, error="boom", projected_messages=[],
+            final_text="", token_usage_last=None,
+        )])
+        result = run_claude_agent_sdk_turn(
+            agent, user_message="hi", original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}], effective_task_id="t",
+        )
+        assert len(instances) == 1
+        assert result["partial"] is True
+
+    def test_effective_prompt_snapshot_replaces_native_one(self, monkeypatch):
+        # The prologue persists Hermes' native composed prompt — a prompt
+        # this runtime never sends. The runtime overwrites the snapshot with
+        # the EFFECTIVE prompt so the audit trail tells the truth.
+        agent, db = self._db_agent()
+        self._spy_sessions(monkeypatch, [_make_turn()])
+        run_claude_agent_sdk_turn(
+            agent, user_message="hi", original_user_message="hi",
+            messages=[{"role": "user", "content": "hi"}], effective_task_id="t",
+        )
+        args = db.update_system_prompt.call_args
+        assert args is not None
+        assert args.args[0] == "sess-1"
+        assert args.args[1].startswith("[claude_code preset]")
+
+
+class TestSessionResumeField:
+    def test_resume_rides_options_when_set(self):
+        session, holder = _make_session(
+            script=[ResultMessage(result="ok")], resume_session_id="sdk-abc"
+        )
+        try:
+            session.run_turn("ping")
+        finally:
+            session.close()
+        assert holder["client"].options["resume"] == "sdk-abc"
+
+    def test_no_resume_field_when_unset(self):
+        session, holder = _make_session(script=[ResultMessage(result="ok")])
+        try:
+            session.run_turn("ping")
+        finally:
+            session.close()
+        assert "resume" not in holder["client"].options
+
+
+# ---------- agent close() releases the SDK session ----------
+
+
+class TestAgentCloseClosesSdkSession:
+    """AIAgent.close() runs on /new, session expiry, and agent-cache
+    eviction. Without an explicit disconnect the SDK client (and its CLI
+    subprocess) is dropped to GC — a leak. (#25267)"""
+
+    @staticmethod
+    def _make_real_agent():
+        from run_agent import AIAgent
+
+        return AIAgent(
+            api_key="test",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    def test_close_disconnects_claude_sdk_session(self):
+        agent = self._make_real_agent()
+        sdk_session = MagicMock()
+        agent._claude_sdk_session = sdk_session
+        agent.close()
+        sdk_session.close.assert_called_once()
+        assert agent._claude_sdk_session is None
+
+    def test_close_without_sdk_session_stays_safe(self):
+        # Negative control: an agent that never created an SDK session (or
+        # already closed it) must close without raising — idempotency.
+        agent = self._make_real_agent()
+        agent.close()
+        agent._claude_sdk_session = None
+        agent.close()
+
+
+# ---------- provider wiring ----------
+
+
+class TestProviderWiring:
+    def test_profile_registered_with_aliases(self):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("claude-agent-sdk")
+        assert profile is not None
+        assert profile.api_mode == "claude_agent_sdk"
+        assert profile.auth_type == "oauth_external"
+        assert profile.env_vars == ()
+        assert get_provider_profile("claude-sdk") is profile
+        # The anthropic profile keeps its own alias namespace untouched.
+        anthropic = get_provider_profile("claude")
+        assert anthropic is not None and anthropic.name == "anthropic"
+
+    def test_runtime_resolution_short_circuit(self):
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(requested="claude-agent-sdk")
+        assert runtime["provider"] == "claude-agent-sdk"
+        assert runtime["api_mode"] == "claude_agent_sdk"
+        # No credential-pool machinery, no metered key.
+        assert runtime["api_key"] == "claude-subscription-oauth"
+
+    def test_api_mode_accepted_by_agent_init(self):
+        from hermes_cli.runtime_provider import _parse_api_mode
+
+        assert _parse_api_mode("claude_agent_sdk") == "claude_agent_sdk"
+
+
+class TestSystemPromptAppend:
+    # The append is composed from Hermes' native
+    # builders — memory gauge via MemoryStore.format_for_system_prompt,
+    # guidance constants from agent.prompt_builder, the skills index via
+    # build_skills_system_prompt — never re-implemented formats. Guidance
+    # appears only for tools that are actually callable through the MCP
+    # shims.
+
+    @staticmethod
+    def _home(tmp_path, monkeypatch, *, soul=None, memory=None, user=None):
+        hermes_home = tmp_path / "hermes"
+        memories = hermes_home / "memories"
+        memories.mkdir(parents=True)
+        if memory is not None:
+            (memories / "MEMORY.md").write_text(memory)
+        if user is not None:
+            (memories / "USER.md").write_text(user)
+        import hermes_cli.config as cfg
+
+        append_file = ""
+        if soul is not None:
+            soul_file = tmp_path / "SOUL.md"
+            soul_file.write_text(soul)
+            append_file = str(soul_file)
+        # config.yaml is the only interface for the persona file
+        # (agent.claude_agent_sdk.append_file); the old env var is gone.
+        # Patching unconditionally also isolates the suite from a developer's
+        # real config.yaml, which would otherwise leak a live append_file in.
+        monkeypatch.setattr(
+            cfg,
+            "load_config_readonly",
+            lambda *a, **k: {
+                "agent": {"claude_agent_sdk": {"append_file": append_file}}
+            },
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        return hermes_home
+
+    def test_soul_first_and_user_content_present(self, tmp_path, monkeypatch):
+        from agent.claude_sdk_runtime import build_system_prompt_append
+
+        self._home(
+            tmp_path, monkeypatch,
+            soul="# I am the persona under test",
+            user="The user prefers concise results",
+        )
+        out = build_system_prompt_append()
+        assert out is not None
+        assert out.startswith("# I am the persona under test")
+        assert "The user prefers concise results" in out
+
+    def test_active_hermes_soul_is_default_identity(self, tmp_path, monkeypatch):
+        from agent.claude_sdk_runtime import build_system_prompt_append
+
+        home = self._home(tmp_path, monkeypatch)
+        (home / "SOUL.md").write_text("# Active Hermes identity")
+
+        out = build_system_prompt_append()
+
+        assert out is not None
+        assert out.startswith("# Active Hermes identity")
+
+    def test_cwd_agents_content_appears_after_single_active_soul(
+        self, tmp_path, monkeypatch
+    ):
+        from agent.claude_sdk_runtime import build_system_prompt_append
+
+        home = self._home(tmp_path, monkeypatch)
+        (home / "SOUL.md").write_text("# Active Hermes identity")
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "AGENTS.md").write_text(
+            "# Workspace contract\nUNIQUE_SDK_WORKSPACE_RULE"
+        )
+
+        out = build_system_prompt_append(cwd=str(workspace))
+
+        assert out is not None
+        assert out.startswith("# Active Hermes identity")
+        assert out.count("# Active Hermes identity") == 1
+        assert "## AGENTS.md" in out
+        assert "UNIQUE_SDK_WORKSPACE_RULE" in out
+        assert out.index("# Project Context") > out.index("# Active Hermes identity")
+
+    def test_native_context_builder_owns_priority_and_scanning(
+        self, tmp_path, monkeypatch
+    ):
+        import agent.prompt_builder as prompt_builder
+        from agent.claude_sdk_runtime import build_system_prompt_append
+
+        self._home(tmp_path, monkeypatch, soul="# SDK identity")
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        captured = {}
+
+        def fake_context_builder(**kwargs):
+            captured.update(kwargs)
+            return "# Project Context\n\nNATIVE_PRIORITY_AND_SCAN_SENTINEL"
+
+        monkeypatch.setattr(
+            prompt_builder, "build_context_files_prompt", fake_context_builder
+        )
+
+        out = build_system_prompt_append(
+            cwd=str(workspace), context_length=123_456
+        )
+
+        assert captured == {
+            "cwd": str(workspace),
+            "skip_soul": True,
+            "context_length": 123_456,
+        }
+        assert "NATIVE_PRIORITY_AND_SCAN_SENTINEL" in (out or "")
+
+    def test_native_agents_priority_beats_lower_priority_claude_file(
+        self, tmp_path, monkeypatch
+    ):
+        from agent.claude_sdk_runtime import build_system_prompt_append
+
+        self._home(tmp_path, monkeypatch, soul="# SDK identity")
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "AGENTS.md").write_text("AGENTS_PRIORITY_SENTINEL")
+        (workspace / "CLAUDE.md").write_text("CLAUDE_LOWER_PRIORITY_SENTINEL")
+
+        out = build_system_prompt_append(cwd=str(workspace)) or ""
+
+        assert "AGENTS_PRIORITY_SENTINEL" in out
+        assert "CLAUDE_LOWER_PRIORITY_SENTINEL" not in out
+
+    def test_normal_twenty_k_agents_block_fits_with_active_soul(
+        self, tmp_path, monkeypatch
+    ):
+        from agent.claude_sdk_runtime import build_system_prompt_append
+
+        home = self._home(tmp_path, monkeypatch)
+        (home / "SOUL.md").write_text("# Active identity\n" + ("s" * 7_500))
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agents_body = "# Workspace rules\n" + ("a" * 19_000) + "\nAGENTS_TAIL_SENTINEL"
+        (workspace / "AGENTS.md").write_text(agents_body)
+
+        out = build_system_prompt_append(cwd=str(workspace)) or ""
+
+        assert out.startswith("# Active identity")
+        assert "## AGENTS.md" in out
+        assert "AGENTS_TAIL_SENTINEL" in out
+
+    def test_gauge_blocks_are_the_native_render(self, tmp_path, monkeypatch):
+        # Byte-pin: the memory/user blocks are EXACTLY what the native
+        # composer injects (MemoryStore.format_for_system_prompt output,
+        # gauge header included) — never a re-implementation.
+        from agent.claude_sdk_runtime import build_system_prompt_append
+        from tools.memory_tool import load_on_disk_store
+
+        self._home(
+            tmp_path, monkeypatch,
+            memory="ci runs on the drone server",
+            user="prefers squash merges",
+        )
+        store = load_on_disk_store()
+        expected_memory = store.format_for_system_prompt("memory")
+        expected_user = store.format_for_system_prompt("user")
+        assert "MEMORY (your personal notes) [" in expected_memory  # sanity
+        assert "USER PROFILE (who the user is) [" in expected_user
+
+        out = build_system_prompt_append()
+        assert expected_memory in out
+        assert expected_user in out
+
+    def test_memory_guidance_present_skill_sentence_stripped(self, tmp_path, monkeypatch):
+        # MEMORY_GUIDANCE ships verbatim EXCEPT its one sentence instructing
+        # the skill tool because skill_manage is not exposed. Guidance is only
+        # included for callable tools. The strip must be a pure
+        # deletion of a sentence that actually exists in the native constant
+        # — if upstream rewords it, this test goes red and we re-derive.
+        from agent.claude_sdk_runtime import (
+            _strip_uncallable_tool_guidance,
+            build_system_prompt_append,
+        )
+        from agent.prompt_builder import MEMORY_GUIDANCE
+
+        self._home(tmp_path, monkeypatch, memory="uses trunk-based development")
+        stripped = _strip_uncallable_tool_guidance(MEMORY_GUIDANCE)
+        assert stripped != MEMORY_GUIDANCE, "skill sentence not found — upstream reworded it"
+        assert "save it as a skill with the skill tool" not in stripped
+
+        out = build_system_prompt_append()
+        assert "You have persistent memory across sessions" in out
+        assert stripped in out
+        assert "save it as a skill with the skill tool" not in out
+        # The claude_code preset has its own file-based memory convention, so
+        # the append must identify the
+        # hermes-tools memory tool as the ONLY durable store.
+        assert "ONLY durable memory" in out
+        assert "hermes-tools MCP server" in out
+        # The preset's memory directory persists per cwd, so the addendum must
+        # describe it as
+        # (unmanaged/disposable), never the false "will not be injected".
+        assert "disposable" in out
+        assert "will not be injected" not in out
+
+    def test_skills_guidance_never_injected(self, tmp_path, monkeypatch):
+        # SKILLS_GUIDANCE instructs skill_manage — unexposed by design.
+        from agent.claude_sdk_runtime import build_system_prompt_append
+
+        self._home(tmp_path, monkeypatch, memory="a fact")
+        out = build_system_prompt_append()
+        assert "skill_manage" not in out
+
+    def test_session_search_guidance_always_present(self, tmp_path, monkeypatch):
+        from agent.claude_sdk_runtime import build_system_prompt_append
+        from agent.prompt_builder import SESSION_SEARCH_GUIDANCE
+
+        self._home(tmp_path, monkeypatch)  # no memory files at all
+        out = build_system_prompt_append()
+        assert out is not None
+        assert SESSION_SEARCH_GUIDANCE in out
+        # Multi-term FTS queries use AND and can miss relevant sessions.
+        assert "ALL terms must match" in out
+
+    def test_native_read_only_append_omits_absent_tool_guidance(
+        self, tmp_path, monkeypatch
+    ):
+        import agent.prompt_builder as prompt_builder
+        from agent.claude_sdk_runtime import build_system_prompt_append
+
+        self._home(
+            tmp_path,
+            monkeypatch,
+            soul="# Read-only analyst",
+            memory="a read-only injected fact",
+        )
+
+        def unexpected_skills_index(**kwargs):
+            pytest.fail(f"native-read-only built a skills index: {kwargs}")
+
+        monkeypatch.setattr(
+            prompt_builder, "build_skills_system_prompt", unexpected_skills_index
+        )
+        out = build_system_prompt_append(native_read_only=True) or ""
+
+        assert out.startswith("# Read-only analyst")
+        assert "a read-only injected fact" in out
+        for absent_tool_advertisement in (
+            "hermes-tools MCP server",
+            "session_search",
+            "skill_view",
+            "skills_list",
+            "browser_navigate",
+            "memory tool",
+        ):
+            assert absent_tool_advertisement not in out
+
+    def test_memory_disabled_removes_blocks_and_guidance(self, tmp_path, monkeypatch):
+        from agent.claude_sdk_runtime import build_system_prompt_append
+        import hermes_cli.config as cfg
+
+        self._home(tmp_path, monkeypatch, memory="should not appear")
+        monkeypatch.setattr(
+            cfg, "load_config", lambda *a, **k: {"memory": {"memory_enabled": False}}
+        )
+        out = build_system_prompt_append()
+        assert "should not appear" not in (out or "")
+        assert "You have persistent memory" not in (out or "")
+        # session_search still works when memory is off — its guidance stays.
+        assert "session_search" in (out or "")
+
+    def test_external_memory_provider_removes_tool_guidance(self, tmp_path, monkeypatch):
+        # memory.provider: honcho (or ANY external backend) leaves the memory
+        # shim UNREGISTERED (hermes_tools_mcp_server._stateless_shim_defs
+        # requires enabled AND no external provider), so the append must not
+        # instruct or advertise an absent tool. The on-disk store block stays:
+        # external providers run alongside the builtin store, and its facts
+        # remain readable. This exercises the enabled-only gate.
+        import agent.prompt_builder as pb
+        import hermes_cli.config as cfg
+        from agent.claude_sdk_runtime import build_system_prompt_append
+
+        self._home(tmp_path, monkeypatch, memory="a durable fact")
+        monkeypatch.setattr(
+            cfg,
+            "load_config",
+            lambda *a, **k: {
+                "memory": {"memory_enabled": True, "provider": "honcho"}
+            },
+        )
+        captured = {}
+
+        def fake_index(**kwargs):
+            captured.update(kwargs)
+            return ""
+
+        monkeypatch.setattr(pb, "build_skills_system_prompt", fake_index)
+        out = build_system_prompt_append() or ""
+        assert "You have persistent memory" not in out
+        assert "ONLY durable memory" not in out
+        # The store block itself survives — facts stay readable.
+        assert "a durable fact" in out
+        # session_search is unaffected.
+        assert "session_search" in out
+        # And the skills filter is not told the tool exists.
+        tools = captured.get("available_tools") or set()
+        assert "memory" not in tools
+        assert "session_search" in tools
+
+    def test_session_line_and_platform_hint(self, tmp_path, monkeypatch):
+        from agent.claude_sdk_runtime import build_system_prompt_append
+        from agent.prompt_builder import PLATFORM_HINTS
+
+        self._home(tmp_path, monkeypatch)
+        out = build_system_prompt_append(
+            platform="telegram", session_id="sess-77", model="claude-opus-4-8"
+        )
+        assert "Conversation started:" in out  # date-only, native format
+        assert "Session ID: sess-77" in out
+        assert "Model: claude-opus-4-8" in out
+        assert "Provider: claude-agent-sdk" in out
+        assert PLATFORM_HINTS["telegram"].strip() in out
+
+    def test_unknown_platform_no_hint_and_none_safe(self, tmp_path, monkeypatch):
+        from agent.claude_sdk_runtime import build_system_prompt_append
+
+        self._home(tmp_path, monkeypatch)
+        out = build_system_prompt_append(platform="faxmachine")
+        assert out is not None  # None-safe, no crash, no bogus hint
+
+    def test_budget_skips_oversized_block_keeps_later_blocks(self, tmp_path, monkeypatch):
+        # Whole-block budget policy: a block that does not fit is SKIPPED
+        # entirely (never truncated mid-block) and later, smaller blocks
+        # still make it in. An oversized hand-edited MEMORY.md must not evict
+        # the guidance. The store renders whole blocks and the budget governs.
+        from agent.claude_sdk_runtime import (
+            _APPEND_TOTAL_MAX_CHARS,
+            build_system_prompt_append,
+        )
+
+        self._home(tmp_path, monkeypatch, memory="y" * (_APPEND_TOTAL_MAX_CHARS + 5000))
+        out = build_system_prompt_append()
+        assert "yyyyyyyyyy" not in out  # oversized memory block skipped whole
+        assert "session_search" in out  # later block survived
+        assert len(out) <= _APPEND_TOTAL_MAX_CHARS
+
+    def test_skills_index_wiring(self, tmp_path, monkeypatch):
+        # The index rides the NATIVE builder; we pin OUR wiring — called
+        # with the honest MCP-exposed tool set (shims included).
+        import agent.prompt_builder as pb
+        from agent.claude_sdk_runtime import build_system_prompt_append
+        from agent.transports.hermes_tools_mcp_server import EXPOSED_TOOLS
+
+        self._home(tmp_path, monkeypatch)
+        captured = {}
+
+        def fake_index(**kwargs):
+            captured.update(kwargs)
+            # Includes the index's real unconditional boilerplate sentence.
+            # The native index instructs skill_manage regardless of
+            # available_tools, and the strip must
+            # remove it (a tmp home's empty index made the old pin vacuous).
+            return (
+                "## Skills (mandatory)\n"
+                "If a skill has issues, fix it with skill_manage(action='patch').\n"
+                "- fixture-skill: proves the wiring"
+            )
+
+        monkeypatch.setattr(pb, "build_skills_system_prompt", fake_index)
+        out = build_system_prompt_append()
+        assert "fixture-skill: proves the wiring" in out
+        assert "skill_manage" not in out
+        tools = captured.get("available_tools") or set()
+        assert "memory" in tools and "session_search" in tools
+        assert set(EXPOSED_TOOLS) <= tools
+
+    def test_root_files_are_not_read(self, tmp_path, monkeypatch):
+        # Negative control: there is one canonical location. Files left at the
+        # HERMES_HOME root must NOT be injected.
+        from agent.claude_sdk_runtime import build_system_prompt_append
+
+        hermes_home = tmp_path / "hermes"
+        (hermes_home / "memories").mkdir(parents=True)
+        (hermes_home / "USER.md").write_text("stale root copy")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        assert "stale root copy" not in (build_system_prompt_append() or "")
+
+    def test_memory_shim_write_is_visible_to_next_append(self, tmp_path, monkeypatch):
+        # The loop closes: a fact saved through the stateless MCP shim must
+        # appear in the next session's system-prompt append.
+        from agent.claude_sdk_runtime import build_system_prompt_append
+        from agent.transports.hermes_tools_mcp_server import dispatch_memory
+
+        self._home(tmp_path, monkeypatch)
+        dispatch_memory(
+            {"action": "add", "target": "memory", "content": "the beta build ships friday"}
+        )
+        out = build_system_prompt_append()
+        assert out is not None
+        assert "the beta build ships friday" in out
+
+    def test_empty_home_still_provides_guidance(self, tmp_path, monkeypatch):
+        # The append always carries the recall/memory behavior contract, so a
+        # brand-new installation still knows its tools.
+        from agent.claude_sdk_runtime import build_system_prompt_append
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))  # empty dir
+        out = build_system_prompt_append()
+        assert out is not None
+        assert "session_search" in out
+
+
+class TestAuxLaneFailClosed:
+    def test_aux_auto_detect_disabled_under_claude_sdk(self, monkeypatch):
+        # With the main provider on the subscription
+        # lane, aux tasks (title-gen, compression) silently fell through to
+        # the metered OpenRouter/Nous auto-detect chain. Auto-detect must
+        # fail closed; explicit aux config remains the operator's opt-in.
+        from agent.auxiliary_client import _resolve_auto
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-fake-key")
+        client, model = _resolve_auto(main_runtime={
+            "provider": "claude-agent-sdk",
+            "model": "claude-opus-4-8",
+            "api_mode": "claude_agent_sdk",
+            "base_url": "",
+            "api_key": "claude-subscription-oauth",
+        })
+        assert client is None and model is None
+
+
+class TestSdkAvailabilityGate:
+    def test_check_reports_missing_sdk(self, monkeypatch):
+        # With the optional SDK import broken, the gate must
+        # fail with the install hint — never silently pass.
+        import builtins
+
+        import tools.lazy_deps as lazy_deps
+
+        events = []
+        monkeypatch.setattr(
+            lazy_deps,
+            "ensure",
+            lambda feature, **kwargs: events.append(("ensure", feature, kwargs)),
+        )
+        real_import = builtins.__import__
+
+        def _broken(name, *args, **kwargs):
+            if name == "claude_agent_sdk":
+                events.append(("import", name))
+                raise ImportError("No module named 'claude_agent_sdk'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _broken)
+        from agent.transports.claude_agent_sdk_session import (
+            check_claude_sdk_available,
+        )
+
+        ok, msg = check_claude_sdk_available()
+        assert ok is False
+        assert "hermes-agent[claude-agent-sdk]" in msg
+        assert events[0] == (
+            "ensure",
+            "provider.claude_agent_sdk",
+            {"prompt": False},
+        )
+        assert events[1] == ("import", "claude_agent_sdk")

--- a/tests/agent/test_replay_cleanup.py
+++ b/tests/agent/test_replay_cleanup.py
@@ -93,6 +93,58 @@ def test_strip_dangling_tool_call_tail_preserves_answered_pair():
     assert out == history  # answered -> untouched
 
 
+def test_sanitize_partial_mixed_batch_recovers_only_missing_side_effect():
+    assistant = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": "read", "function": {"name": "read_file", "arguments": "{}"}},
+            {"id": "write", "function": {"name": "write_file", "arguments": "{}"}},
+        ],
+    }
+    answered_read = {
+        "role": "tool",
+        "tool_call_id": "read",
+        "content": "existing contents",
+    }
+    history = [_user("hi"), assistant, answered_read]
+
+    out = sanitize_replay_history(history)
+
+    assert out[:3] == history
+    results = [message for message in out if message.get("role") == "tool"]
+    assert [message["tool_call_id"] for message in results] == ["read", "write"]
+    assert results[0] == answered_read
+    assert "effect_disposition" not in results[0]
+    assert results[1]["effect_disposition"] == "unknown"
+    assert "unknown" in results[1]["content"].lower()
+
+
+def test_sanitize_partial_read_only_batch_keeps_answered_sibling_balanced():
+    assistant = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": "read-1", "function": {"name": "read_file", "arguments": "{}"}},
+            {"id": "read-2", "function": {"name": "search_files", "arguments": "{}"}},
+        ],
+    }
+    answered_read = {
+        "role": "tool",
+        "tool_call_id": "read-1",
+        "content": "existing contents",
+    }
+    history = [_user("hi"), assistant, answered_read]
+
+    out = sanitize_replay_history(history)
+
+    assert out[:3] == history
+    results = [message for message in out if message.get("role") == "tool"]
+    assert [message["tool_call_id"] for message in results] == ["read-1", "read-2"]
+    assert results[1]["effect_disposition"] == "none"
+    assert "no effect" in results[1]["content"].lower()
+
+
 def test_strip_interrupted_tool_tails_removes_interrupted_read_only_block():
     history = [_user("hi"), _assistant_tc("read_file"), _tool("[Command interrupted]")]
     out = strip_interrupted_tool_tails(history)

--- a/tests/agent/transports/test_hermes_tools_mcp_shims.py
+++ b/tests/agent/transports/test_hermes_tools_mcp_shims.py
@@ -1,0 +1,340 @@
+"""Tests for the stateless memory/session_search shims in the hermes-tools
+MCP server (#26567).
+
+Natively `memory` and `session_search` are `_AGENT_LOOP_TOOLS`: the generic
+dispatcher refuses them because they need live AIAgent state. The shims
+supply that state statelessly — `load_on_disk_store()` per call for memory,
+a read-only `SessionDB` + the calling session's id from env for
+session_search — so an agent whose loop is owned by an external runtime
+(claude-agent-sdk, codex app-server) regains both tools.
+
+No `mcp` package required: the dispatch functions are plain module-level
+callables; only `_build_server()` (not under test here) needs FastMCP.
+
+Plant-the-failure discipline: the DB-missing path must yield an EXPLICIT
+error (never a silently-empty result), and the refusal in
+`handle_function_call` must remain intact for non-shim callers.
+"""
+
+import json
+
+import pytest
+
+from agent.transports.hermes_tools_mcp_server import (
+    _stateless_shim_defs,
+    dispatch_memory,
+    dispatch_session_search,
+)
+
+
+@pytest.fixture()
+def tmp_hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # `set_current_session_id()` writes HERMES_SESSION_ID process-globally, so a
+    # developer's own live session id would otherwise leak into the suite and make
+    # the canonical-env tests below pass spuriously.
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.delenv("HERMES_MCP_STATE_DB", raising=False)
+    return home
+
+
+class TestMemoryShim:
+    def test_write_lands_in_canonical_memories_dir(self, tmp_hermes_home):
+        out = json.loads(
+            dispatch_memory(
+                {"action": "add", "target": "memory", "content": "auth refactor merged to main"}
+            )
+        )
+        assert out.get("success") is True
+        memory_file = tmp_hermes_home / "memories" / "MEMORY.md"
+        assert memory_file.exists()
+        assert "auth refactor merged to main" in memory_file.read_text()
+
+    def test_native_caps_enforced(self, tmp_hermes_home):
+        # The shim reuses the native store: an oversized add must be rejected
+        # with the native consolidation error, not silently truncated.
+        out = json.loads(
+            dispatch_memory({"action": "add", "target": "memory", "content": "x" * 5000})
+        )
+        assert out.get("success") is False
+        assert "exceed" in json.dumps(out).lower()
+
+    def test_batch_operations_supported(self, tmp_hermes_home):
+        out = json.loads(
+            dispatch_memory(
+                {
+                    "target": "memory",
+                    "operations": [
+                        {"action": "add", "content": "fact alpha"},
+                        {"action": "add", "content": "fact beta"},
+                    ],
+                }
+            )
+        )
+        assert out.get("success") is True
+        content = (tmp_hermes_home / "memories" / "MEMORY.md").read_text()
+        assert "fact alpha" in content and "fact beta" in content
+
+    def test_fails_closed_when_external_provider_configured(
+        self, tmp_hermes_home, monkeypatch
+    ):
+        # #26604 precondition: a shim write cannot mirror through
+        # MemoryProvider hooks (no MemoryManager in this subprocess), so a
+        # configured external backend must refuse the dispatch — silent
+        # store divergence is the failure this prevents.
+        import hermes_cli.config as cfg
+
+        monkeypatch.setattr(
+            cfg, "load_config", lambda *a, **k: {"memory": {"provider": "honcho"}}
+        )
+        out = json.loads(
+            dispatch_memory({"action": "add", "target": "memory", "content": "x"})
+        )
+        assert out.get("success") is False
+        assert "honcho" in out.get("error", "")
+        assert not (tmp_hermes_home / "memories" / "MEMORY.md").exists()
+
+        batch = json.loads(
+            dispatch_memory(
+                {"target": "memory", "operations": [{"action": "add", "content": "y"}]}
+            )
+        )
+        assert batch.get("success") is False
+
+    def test_builtin_provider_value_is_not_external(self, tmp_hermes_home, monkeypatch):
+        # Control (non-vacuous): 'builtin' means the on-disk store — the
+        # guard must not fire, and the write must land.
+        import hermes_cli.config as cfg
+
+        monkeypatch.setattr(
+            cfg, "load_config", lambda *a, **k: {"memory": {"provider": "builtin"}}
+        )
+        out = json.loads(
+            dispatch_memory({"action": "add", "target": "memory", "content": "kept"})
+        )
+        assert out.get("success") is True
+        assert "kept" in (tmp_hermes_home / "memories" / "MEMORY.md").read_text()
+
+    def test_shim_unregistered_when_external_provider_configured(
+        self, tmp_hermes_home, monkeypatch
+    ):
+        # Registration-level twin of the dispatch guard: the tool should not
+        # even be offered to the model when it can only refuse.
+        import hermes_cli.config as cfg
+
+        monkeypatch.setattr(
+            cfg,
+            "load_config",
+            lambda *a, **k: {"memory": {"memory_enabled": True, "provider": "mem0"}},
+        )
+        names = [name for name, _desc, _schema, _fn in _stateless_shim_defs()]
+        assert "memory" not in names
+        assert "session_search" in names
+
+
+class TestSessionSearchShim:
+    def _seed_db(self, path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=path)
+        db.create_session("sess-hist-1", source="telegram")
+        db.append_message("sess-hist-1", "user", "when did we merge the auth refactor?")
+        db.append_message("sess-hist-1", "assistant", "The auth refactor merged on Thursday.")
+        db.close()
+
+    def test_search_returns_seeded_rows(self, tmp_hermes_home, monkeypatch):
+        db_path = tmp_hermes_home / "state.db"
+        self._seed_db(db_path)
+        monkeypatch.setenv("HERMES_MCP_STATE_DB", str(db_path))
+        out = dispatch_session_search({"query": "auth refactor"})
+        assert "auth refactor" in out
+        assert "sess-hist-1" in out
+
+    def test_missing_db_yields_explicit_error(self, tmp_hermes_home, monkeypatch):
+        # A missing state DB must surface as an explicit error,
+        # never as a silently-empty result set.
+        monkeypatch.setenv(
+            "HERMES_MCP_STATE_DB", str(tmp_hermes_home / "nope" / "state.db")
+        )
+        out = json.loads(dispatch_session_search({"query": "anything"}))
+        assert out.get("success") is False
+        assert "state DB" in out.get("error", "")
+
+    def test_session_id_read_from_canonical_env(self, tmp_hermes_home, monkeypatch):
+        # The shim must read the CANONICAL `HERMES_SESSION_ID` — the name Hermes
+        # actually produces (`set_current_session_id` -> `_VAR_MAP` ->
+        # `_inject_session_context_env` -> the HOST process's spawn env; a codex
+        # MCP child additionally needs the entry to name it in `env_vars` — see
+        # the `_SESSION_ID_ENV` note in the server module). A bespoke name has a
+        # producer in NO launch path; the canonical name is delivered wherever
+        # the host forwards or sets it, and exclusion stays fail-open (inactive)
+        # where it doesn't.
+        db_path = tmp_hermes_home / "state.db"
+        self._seed_db(db_path)
+        monkeypatch.setenv("HERMES_MCP_STATE_DB", str(db_path))
+        monkeypatch.setenv("HERMES_SESSION_ID", "sess-current-9")
+
+        captured = {}
+        import tools.session_search_tool as sst
+
+        real = sst.session_search
+
+        def spy(**kwargs):
+            captured.update(kwargs)
+            return real(**kwargs)
+
+        monkeypatch.setattr(sst, "session_search", spy)
+        dispatch_session_search({"query": "auth"})
+        assert captured.get("current_session_id") == "sess-current-9"
+
+    def test_calling_session_excluded_via_production_producer(
+        self, tmp_hermes_home, monkeypatch
+    ):
+        # Producer/consumer NAME agreement, proven through the REAL producer:
+        # `set_current_session_id()` is what Hermes itself calls. Establishing the
+        # precondition that way — rather than a bare `setenv` of the very name
+        # under test — makes a name mismatch fail loudly. Producer and shim share
+        # this test process, so this pins the name contract, not delivery across a
+        # host's process boundary (see the `_SESSION_ID_ENV` note for who
+        # forwards it).
+        from gateway.session_context import set_current_session_id
+        from hermes_state import SessionDB
+
+        db_path = tmp_hermes_home / "state.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session("sess-other-1", source="telegram")
+        db.append_message(
+            "sess-other-1", "assistant", "the auth refactor merged on Thursday"
+        )
+        db.create_session("sess-mine-2", source="telegram")
+        db.append_message(
+            "sess-mine-2", "assistant", "the auth refactor notes are mine"
+        )
+        db.close()
+        monkeypatch.setenv("HERMES_MCP_STATE_DB", str(db_path))
+
+        # setenv first purely so monkeypatch restores the environment at teardown
+        # (the producer writes os.environ directly); the value under test is the
+        # one written by the real producer on the very next line.
+        monkeypatch.setenv("HERMES_SESSION_ID", "")
+        set_current_session_id("sess-mine-2")
+
+        out = dispatch_session_search({"query": "auth refactor", "limit": 10})
+        assert "sess-other-1" in out
+        assert "sess-mine-2" not in out
+
+    def test_zero_hit_multiterm_query_relaxes_to_or(self, tmp_hermes_home, monkeypatch):
+        # FTS5 ANDs terms, so multi-term prose queries can return no hits when
+        # content matches one distinctive term. The shim retries once with
+        # OR-joined terms, deterministically,
+        # and annotates the result honestly.
+        db_path = tmp_hermes_home / "state.db"
+        self._seed_db(db_path)
+        monkeypatch.setenv("HERMES_MCP_STATE_DB", str(db_path))
+        out = json.loads(
+            dispatch_session_search({"query": "auth refactor deployment window"})
+        )
+        assert out.get("count", 0) >= 1
+        assert out.get("relaxed_query") == "auth OR refactor OR deployment OR window"
+        assert "sess-hist-1" in json.dumps(out)
+
+    def test_explicit_fts_operators_are_never_relaxed(self, tmp_hermes_home, monkeypatch):
+        # A query that already uses FTS operators is the caller's intent —
+        # no second-guessing.
+        db_path = tmp_hermes_home / "state.db"
+        self._seed_db(db_path)
+        monkeypatch.setenv("HERMES_MCP_STATE_DB", str(db_path))
+        out = json.loads(
+            dispatch_session_search({"query": '"deployment window" OR rollout'})
+        )
+        assert out.get("count") == 0
+        assert "relaxed_query" not in out
+
+    def test_zero_hit_single_term_returns_honest_zero(self, tmp_hermes_home, monkeypatch):
+        # Nothing to relax on a single term: an honest empty result, never a
+        # fabricated one.
+        db_path = tmp_hermes_home / "state.db"
+        self._seed_db(db_path)
+        monkeypatch.setenv("HERMES_MCP_STATE_DB", str(db_path))
+        out = json.loads(dispatch_session_search({"query": "kubernetes"}))
+        assert out.get("count") == 0
+        assert "relaxed_query" not in out
+
+    def test_uninitialized_db_yields_explicit_error(self, tmp_hermes_home, monkeypatch):
+        # A 0-byte state.db from a crashed first initialization passes the
+        # exists() guard and used to return a SILENT success/count:0.
+        db_path = tmp_hermes_home / "state.db"
+        db_path.touch()  # present but uninitialized
+        monkeypatch.setenv("HERMES_MCP_STATE_DB", str(db_path))
+        out = json.loads(dispatch_session_search({"query": "anything"}))
+        assert out.get("success") is False
+        assert "not initialized" in out.get("error", "")
+
+    def test_db_opened_read_only(self, tmp_hermes_home, monkeypatch):
+        # The shim must never hand a writable DB handle to a model-facing
+        # subprocess. SessionDB(read_only=True) attaches with mode=ro.
+        db_path = tmp_hermes_home / "state.db"
+        self._seed_db(db_path)
+        monkeypatch.setenv("HERMES_MCP_STATE_DB", str(db_path))
+
+        captured = {}
+        import agent.transports.hermes_tools_mcp_server as srv
+        import hermes_state
+
+        real = hermes_state.SessionDB
+
+        class SpyDB(real):
+            def __init__(self, *args, **kwargs):
+                captured.update(kwargs)
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(hermes_state, "SessionDB", SpyDB)
+        dispatch_session_search({"query": "auth"})
+        assert captured.get("read_only") is True
+
+
+class TestShimRegistration:
+    def test_both_shims_defined_by_default(self, tmp_hermes_home):
+        names = [name for name, _desc, _schema, _fn in _stateless_shim_defs()]
+        assert names == ["memory", "session_search"]
+
+    def test_memory_shim_respects_config_disable(self, tmp_hermes_home, monkeypatch):
+        import hermes_cli.config as cfg
+
+        monkeypatch.setattr(
+            cfg, "load_config", lambda *a, **k: {"memory": {"memory_enabled": False}}
+        )
+        names = [name for name, _desc, _schema, _fn in _stateless_shim_defs()]
+        assert "memory" not in names
+        assert "session_search" in names
+
+    def test_shim_signatures_carry_the_registry_schema(self, tmp_hermes_home):
+        # Pin of the schema-inference regression: FastMCP derives the served
+        # schema from the handler's signature, so the signature synthesized
+        # from the registry schema must expose the real parameters — never a
+        # bare ``kwargs`` (pydantic renders that as a REQUIRED "kwargs"
+        # field, failing EVERY call at the validation layer).
+        from agent.transports.hermes_tools_mcp_server import (
+            _signature_from_schema,
+        )
+
+        for name, _desc, schema, _fn in _stateless_shim_defs():
+            sig, _annots = _signature_from_schema(schema)
+            params = list(sig.parameters)
+            assert "kwargs" not in params, f"{name} would serve an inferred schema"
+            assert params, f"{name} signature is empty"
+        shim_schemas = {n: s for n, _d, s, _f in _stateless_shim_defs()}
+        mem_sig, _ = _signature_from_schema(shim_schemas["memory"])
+        assert "target" in mem_sig.parameters
+        ss_sig, _ = _signature_from_schema(shim_schemas["session_search"])
+        assert "query" in ss_sig.parameters
+
+    def test_agent_loop_refusal_stays_intact_for_other_callers(self):
+        # The shims must NOT weaken the generic dispatcher: a stateless
+        # handle_function_call("memory", ...) still refuses.
+        from model_tools import handle_function_call
+
+        out = handle_function_call("memory", {"action": "add", "content": "x"})
+        assert "must be handled by the agent loop" in out

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -200,6 +200,37 @@ def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     assert shell.api_mode == "codex_responses"
 
 
+def test_claude_agent_sdk_runtime_accepts_empty_base_url(monkeypatch):
+    cli = _import_cli()
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "claude-agent-sdk",
+            "api_mode": "claude_agent_sdk",
+            "base_url": "",
+            "api_key": "claude-subscription-oauth",
+            "source": "claude-agent-sdk",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.format_runtime_provider_error",
+        lambda exc: str(exc),
+    )
+
+    shell = cli.HermesCLI(
+        model="claude-opus-5",
+        provider="claude-agent-sdk",
+        compact=True,
+        max_turns=1,
+    )
+
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.provider == "claude-agent-sdk"
+    assert shell.api_mode == "claude_agent_sdk"
+    assert shell.base_url == ""
+
+
 def test_cli_turn_routing_uses_primary_when_disabled(monkeypatch):
     cli = _import_cli()
     shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)

--- a/tests/gateway/test_model_command_flat_string_config.py
+++ b/tests/gateway/test_model_command_flat_string_config.py
@@ -11,8 +11,12 @@ before mutation, so ``--global`` succeeds and the config is rewritten in
 the proper ``model: {default: ..., provider: ...}`` form.
 """
 
-import yaml
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
 import pytest
+import yaml
 
 from gateway.config import Platform
 from gateway.platforms.base import MessageEvent, MessageType
@@ -204,3 +208,125 @@ async def test_model_session_flag_does_not_persist(tmp_path, monkeypatch):
     written = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     # Config untouched — the session override is in-memory only.
     assert written["model"]["default"] == "old-model"
+
+
+@pytest.mark.asyncio
+async def test_model_session_sdk_writes_clientless_override_without_credentials(
+    tmp_path, monkeypatch
+):
+    """The gateway slash path must carry the SDK's intentional empty URL to
+    persistence while the persistence sanitizer strips its runtime sentinel."""
+    from gateway.session import sanitize_model_override
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    _setup_isolated_home(
+        tmp_path,
+        monkeypatch,
+        {"default": "gpt-5.3-codex", "provider": "openai-codex"},
+    )
+    sdk_result = ModelSwitchResult(
+        success=True,
+        new_model="claude-opus-5",
+        target_provider="claude-agent-sdk",
+        provider_changed=True,
+        api_key="claude-subscription-oauth",
+        base_url="",
+        api_mode="claude_agent_sdk",
+        provider_label="Claude Agent SDK",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model", lambda **kw: sdk_result
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.resolve_display_context_length",
+        lambda *a, **k: 200_000,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_cost_guard.expensive_model_warning",
+        lambda *a, **k: None,
+    )
+    runner = _make_runner()
+    backing_store = object()
+    runner_any: Any = runner
+    runner_any.session_store = backing_store
+    async_store = AsyncMock()
+    async_store._store = backing_store
+    async_store.get_or_create_session.return_value = SimpleNamespace(
+        session_id="sess-gateway-sdk-in", was_auto_reset=False
+    )
+    runner_any._async_session_store = async_store
+    runner._session_db = AsyncMock()
+    monkeypatch.setattr(runner, "_evict_cached_agent", lambda _key: None)
+
+    result = await runner._handle_model_command(
+        _make_event(
+            "/model claude-opus-5 --provider claude-agent-sdk --session"
+        )
+    )
+
+    assert result is not None and "claude-opus-5" in result
+    async_store.set_model_override.assert_awaited_once()
+    persisted_input = async_store.set_model_override.await_args.args[1]
+    assert persisted_input == {
+        "model": "claude-opus-5",
+        "provider": "claude-agent-sdk",
+        "api_key": "claude-subscription-oauth",
+        "base_url": "",
+        "api_mode": "claude_agent_sdk",
+    }
+    assert sanitize_model_override(persisted_input) == {
+        "model": "claude-opus-5",
+        "provider": "claude-agent-sdk",
+        "base_url": "",
+    }
+    runner._session_db.update_claude_sdk_session_id.assert_awaited_once_with(
+        "sess-gateway-sdk-in", None
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_switch_rehydrates_restart_override_before_sdk_boundary_clear(
+    tmp_path, monkeypatch
+):
+    """A cache-miss after gateway restart still sees the persisted SDK route.
+
+    The live agent is gone and the global config points elsewhere, so the
+    persisted session override is the only evidence that crossing back to a
+    native provider must invalidate Claude SDK continuity.
+    """
+    _setup_isolated_home(
+        tmp_path,
+        monkeypatch,
+        {"default": "global-model", "provider": "openrouter"},
+    )
+    runner = _make_runner()
+    backing_store = object()
+    runner_any: Any = runner
+    runner_any.session_store = backing_store
+    async_store = AsyncMock()
+    async_store._store = backing_store
+    async_store.get_or_create_session.return_value = SimpleNamespace(
+        session_id="sess-gateway-sdk-out", was_auto_reset=False
+    )
+    runner_any._async_session_store = async_store
+    runner._session_db = AsyncMock()
+    monkeypatch.setattr(runner, "_evict_cached_agent", lambda _key: None)
+
+    def _rehydrate(session_key):
+        runner._session_model_overrides[session_key] = {
+            "model": "claude-opus-5",
+            "provider": "claude-agent-sdk",
+            "base_url": "",
+            "api_mode": "claude_agent_sdk",
+        }
+
+    monkeypatch.setattr(runner, "_rehydrate_session_model_override", _rehydrate)
+
+    result = await runner._handle_model_command(
+        _make_event("/model gpt-5.5 --provider openrouter --session")
+    )
+
+    assert result is not None and "gpt-5.5" in result
+    runner._session_db.update_claude_sdk_session_id.assert_awaited_once_with(
+        "sess-gateway-sdk-out", None
+    )

--- a/tests/gateway/test_model_picker_persist.py
+++ b/tests/gateway/test_model_picker_persist.py
@@ -20,6 +20,8 @@ closure the PR changed, against a real temp ``HERMES_HOME``.
 """
 
 import types
+from typing import Any
+from unittest.mock import AsyncMock
 
 import yaml
 import pytest
@@ -354,3 +356,34 @@ async def test_multiplex_picker_global_persists_only_named_profile(
     assert written["marker"] == "named"
     assert written["model"]["default"] == "gpt-5.5"
     assert written["model"]["provider"] == "openrouter"
+
+
+@pytest.mark.asyncio
+async def test_picker_cache_miss_clears_sdk_continuity_when_switching_away(
+    tmp_path, monkeypatch
+):
+    adapter = _FakePickerAdapter()
+    _setup_isolated_home(
+        tmp_path,
+        monkeypatch,
+        {"default": "claude-opus-5", "provider": "claude-agent-sdk"},
+    )
+    runner = _make_runner(adapter)
+    backing_store = object()
+    runner_any: Any = runner
+    runner_any.session_store = backing_store
+    async_store = AsyncMock()
+    async_store._store = backing_store
+    async_store.get_or_create_session.return_value = types.SimpleNamespace(
+        session_id="sess-picker-sdk-out"
+    )
+    runner_any._async_session_store = async_store
+    runner._session_db = AsyncMock()
+    runner_any._evict_cached_agent = lambda session_key: None
+
+    confirmation = await _drive_picker(runner, _make_event("/model --session"))
+
+    assert confirmation is not None and "gpt-5.5" in confirmation
+    runner._session_db.update_claude_sdk_session_id.assert_awaited_once_with(
+        "sess-picker-sdk-out", None
+    )

--- a/tests/gateway/test_session_model_override_persistence.py
+++ b/tests/gateway/test_session_model_override_persistence.py
@@ -232,3 +232,16 @@ def test_sanitize_model_override():
         "provider": "openai",
         "base_url": "https://api.openai.example/v1",
     }
+    assert sanitize_model_override(
+        {
+            "model": "claude-opus-5",
+            "provider": "claude-agent-sdk",
+            "base_url": "",
+            "api_key": "claude-subscription-oauth",
+            "api_mode": "claude_agent_sdk",
+        }
+    ) == {
+        "model": "claude-opus-5",
+        "provider": "claude-agent-sdk",
+        "base_url": "",
+    }

--- a/tests/hermes_cli/test_claude_agent_sdk_config.py
+++ b/tests/hermes_cli/test_claude_agent_sdk_config.py
@@ -1,0 +1,119 @@
+"""Tests for the agent.claude_agent_sdk config block.
+
+The claude-agent-sdk provider reads its behavioural flags exclusively from
+config.yaml, so the canonical defaults must be registered in DEFAULT_CONFIG.
+The example file alone does not make them real config options for
+default-driven config tooling.
+
+Adapted from upstream PR #65982 commit 10659717722effd9bb7738423a2399770f50a428.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hermes_cli.config import DEFAULT_CONFIG
+
+
+class TestClaudeAgentSdkDefaults:
+    def test_default_config_has_the_block(self):
+        agent = DEFAULT_CONFIG.get("agent")
+        assert isinstance(agent, dict)
+        assert "claude_agent_sdk" in agent
+
+    def test_canonical_defaults(self):
+        # Subscription-only is invariant runtime behavior, not a configurable
+        # escape hatch. Additional directory access is opt-in and empty by
+        # default.
+        assert DEFAULT_CONFIG["agent"]["claude_agent_sdk"] == {
+            "streaming": False,
+            "append_file": "",
+            "add_dirs": [],
+            "native_read_only": False,
+        }
+
+    def test_example_and_default_source_document_the_native_security_boundary(self):
+        root = Path(__file__).resolve().parents[2]
+        example_text = (root / "cli-config.yaml.example").read_text()
+        example_block = example_text.split("  # claude_agent_sdk:", 1)[1].split(
+            "  # Inactivity timeout", 1
+        )[0]
+        default_text = (root / "hermes_cli" / "config.py").read_text()
+        default_block = default_text.split('"claude_agent_sdk": {', 1)[1].split(
+            "        },", 1
+        )[0]
+
+        def normalize_comments(value):
+            return " ".join(value.replace("#", " ").split())
+
+        for documented_block in (
+            normalize_comments(example_block),
+            normalize_comments(default_block),
+        ):
+            assert "add_dirs" in documented_block
+            assert "not a read-only mount" in documented_block
+            assert "default auto/acceptEdits" in documented_block
+            assert "native edits and common filesystem mutations" in documented_block
+            assert (
+                "Removing Hermes MCP file/terminal tools does not remove Claude native tools"
+                in documented_block
+            )
+            assert (
+                "read-oriented headless profiles must use native_read_only: true"
+                in documented_block
+            )
+            assert "HERMES_TERMINAL_SECURITY_MODE=approval-required" in documented_block
+            assert "user/project/local Claude settings" in documented_block
+            assert "only Read, Glob, and Grep natively" in documented_block
+            assert (
+                "unavailable rather than interactively approvable" in documented_block
+            )
+        assert "native_read_only: false" in example_block
+
+
+class TestUserConfigMerge:
+    """Existing config gets defaults while explicit user values survive."""
+
+    def _load(self, tmp_path, monkeypatch, user_cfg):
+        import importlib
+
+        import yaml
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text(yaml.safe_dump(user_cfg))
+
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        import hermes_cli.config as cfg_mod
+
+        importlib.reload(cfg_mod)
+        return cfg_mod.load_config()
+
+    def test_config_without_block_gets_defaults(self, tmp_path, monkeypatch):
+        cfg = self._load(tmp_path, monkeypatch, {"agent": {"max_turns": 5}})
+        assert cfg["agent"]["claude_agent_sdk"] == {
+            "streaming": False,
+            "append_file": "",
+            "add_dirs": [],
+            "native_read_only": False,
+        }
+        assert cfg["agent"]["max_turns"] == 5
+
+    def test_explicit_user_values_survive_merge(self, tmp_path, monkeypatch):
+        cfg = self._load(
+            tmp_path,
+            monkeypatch,
+            {
+                "agent": {
+                    "claude_agent_sdk": {
+                        "streaming": True,
+                        "native_read_only": True,
+                    }
+                }
+            },
+        )
+        assert cfg["agent"]["claude_agent_sdk"]["streaming"] is True
+        assert "allow_metered_key" not in cfg["agent"]["claude_agent_sdk"]
+        assert cfg["agent"]["claude_agent_sdk"]["append_file"] == ""
+        assert cfg["agent"]["claude_agent_sdk"]["add_dirs"] == []
+        assert cfg["agent"]["claude_agent_sdk"]["native_read_only"] is True

--- a/tests/hermes_cli/test_claude_agent_sdk_model_switch.py
+++ b/tests/hermes_cli/test_claude_agent_sdk_model_switch.py
@@ -1,0 +1,42 @@
+"""Focused /model resolution tests for the clientless Claude Agent SDK runtime."""
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.model_switch import switch_model
+
+
+@pytest.mark.parametrize(
+    "provider_name",
+    (
+        "claude-agent-sdk",
+        "claude-sdk",
+        "claude-code-sdk",
+        "claude_agent_sdk",
+    ),
+)
+def test_explicit_provider_resolves_clientless_sdk_runtime(provider_name):
+    accepted = {
+        "accepted": True,
+        "persist": True,
+        "recognized": True,
+        "message": None,
+    }
+
+    with patch("hermes_cli.models.validate_requested_model", return_value=accepted):
+        result = switch_model(
+            raw_input="claude-opus-5",
+            current_provider="openai-codex",
+            current_model="gpt-5.3-codex",
+            current_base_url="",
+            current_api_key="",
+            explicit_provider=provider_name,
+        )
+
+    assert result.success is True
+    assert result.new_model == "claude-opus-5"
+    assert result.target_provider == "claude-agent-sdk"
+    assert result.base_url == ""
+    assert result.api_mode == "claude_agent_sdk"
+    assert result.api_key == "claude-subscription-oauth"

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -861,3 +861,23 @@ class TestHermesHomeLeakGuard:
             f"HERMES_HOME should not be set when env var is unset, got: "
             f"{env.get('HERMES_HOME')!r}"
         )
+
+    def test_session_id_is_never_burned_into_codex_config(self, monkeypatch):
+        """A session id must NEVER be serialized into the MCP entry.
+
+        This entry is written to ``~/.codex/config.toml`` at MIGRATE time, so any
+        per-session value baked in here is frozen for the life of that config and
+        would forever name the wrong session — the same burn-in failure the
+        HERMES_HOME guards above exist to prevent. The one legitimate delivery
+        under codex is the entry's ``env_vars`` name-passthrough (a spawn-time
+        snapshot of the codex process env — a NAME, never a value); this entry
+        does not wire it, so the shim's own-lineage exclusion stays INACTIVE
+        (fail-open) under codex rather than wrong. What this test pins is the
+        burn-in rule: no literal session id, under any key, may land in the
+        entry's ``env`` map."""
+        monkeypatch.setenv("HERMES_SESSION_ID", "sess-must-not-persist")
+        entry = _build_hermes_tools_mcp_entry()
+        env = entry.get("env", {})
+        assert not any("SESSION_ID" in key for key in env), (
+            f"no session id may be serialized into config.toml, got: {env!r}"
+        )

--- a/tests/hermes_state/test_claude_sdk_session_id.py
+++ b/tests/hermes_state/test_claude_sdk_session_id.py
@@ -1,0 +1,134 @@
+"""The sessions.claude_sdk_session_id continuity column (#25267).
+
+Declarative migration: the column lives in SCHEMA_SQL and
+_reconcile_columns adds it to older DBs on startup — so a fresh DB and an
+upgraded DB both expose it, nullable.
+"""
+
+from hermes_state import SessionDB
+
+
+def test_column_exists_null_by_default_and_round_trips(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("sess-cc-1", source="telegram")
+        row = db.get_session("sess-cc-1")
+        assert "claude_sdk_session_id" in row
+        assert row["claude_sdk_session_id"] is None
+
+        db.update_claude_sdk_session_id("sess-cc-1", "sdk-uuid-42")
+        assert db.get_session("sess-cc-1")["claude_sdk_session_id"] == "sdk-uuid-42"
+
+        # Clearing (error retire) round-trips to NULL.
+        db.update_claude_sdk_session_id("sess-cc-1", None)
+        assert db.get_session("sess-cc-1")["claude_sdk_session_id"] is None
+    finally:
+        db.close()
+
+
+def test_new_session_row_never_inherits_an_id(tmp_path):
+    # /new and expiry rotate to a NEW Hermes session row — fresh-by-keying:
+    # the new row must carry no resume id.
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("sess-old", source="telegram")
+        db.update_claude_sdk_session_id("sess-old", "sdk-uuid-1")
+        db.create_session("sess-new", source="telegram")
+        assert db.get_session("sess-new")["claude_sdk_session_id"] is None
+    finally:
+        db.close()
+
+
+def test_fts_probe_error_classifier():
+    # Only a missing FTS object may disable read-only search;
+    # a transient lock must never latch a silent false-empty.
+    import sqlite3
+
+    from hermes_state import _fts_object_missing
+
+    assert _fts_object_missing(sqlite3.OperationalError("no such table: messages_fts"))
+    assert _fts_object_missing(sqlite3.OperationalError("no such module: fts5"))
+    assert not _fts_object_missing(sqlite3.OperationalError("database is locked"))
+    assert not _fts_object_missing(sqlite3.OperationalError("disk I/O error"))
+
+
+def _read_only_db_with_trigram_probe_error(tmp_path, monkeypatch, message):
+    """Open a read-only SessionDB whose TRIGRAM probe raises `message`.
+
+    The seed DB is created first with a normal write handle (schema load),
+    THEN the tracked connection helper is wrapped so only the trigram probe
+    statement errors — tracking, the messages_fts probe, and everything else
+    run for real.
+    """
+    import sqlite3
+
+    import hermes_state
+
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+
+    real_connect_tracked_db = getattr(hermes_state, "_connect_tracked_db")
+
+    class _ProbeErrorConn:
+        def __init__(self, real):
+            self.__dict__["_real"] = real
+
+        def execute(self, sql, *args, **kwargs):
+            if "messages_fts_trigram" in sql:
+                raise sqlite3.OperationalError(message)
+            return self.__dict__["_real"].execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self.__dict__["_real"], name)
+
+        def __setattr__(self, name, value):
+            setattr(self.__dict__["_real"], name, value)
+
+    monkeypatch.setattr(
+        hermes_state,
+        "_connect_tracked_db",
+        lambda *args, **kwargs: _ProbeErrorConn(
+            real_connect_tracked_db(*args, **kwargs)
+        ),
+    )
+    return SessionDB(db_path=db_path, read_only=True)
+
+
+def test_trigram_probe_transient_error_keeps_trigram_available(tmp_path, monkeypatch):
+    # Same transient-vs-absent rule as the messages_fts probe directly above
+    # it: a lock during a checkpoint must not latch the LIKE fallback (which
+    # ORs tokens and drops NOT/rank) for the handle's lifetime. A wrongly-kept
+    # True costs nothing — search_messages catches the per-query error and
+    # falls through to LIKE.
+    db = _read_only_db_with_trigram_probe_error(
+        tmp_path, monkeypatch, "database is locked"
+    )
+    try:
+        assert db._trigram_available is True
+        assert db._fts_enabled is True
+    finally:
+        db.close()
+
+
+def test_trigram_probe_missing_table_disables_trigram(tmp_path, monkeypatch):
+    db = _read_only_db_with_trigram_probe_error(
+        tmp_path, monkeypatch, "no such table: messages_fts_trigram"
+    )
+    try:
+        assert db._trigram_available is False
+    finally:
+        db.close()
+
+
+def test_trigram_probe_missing_tokenizer_disables_trigram(tmp_path, monkeypatch):
+    # A build with FTS5 but without the trigram tokenizer (SQLite < 3.34)
+    # raises "no such tokenizer: trigram" — persistent absence, same latch as
+    # a missing table. _fts_object_missing alone does NOT classify this one;
+    # the probe must also consult _is_trigram_unavailable_error.
+    db = _read_only_db_with_trigram_probe_error(
+        tmp_path, monkeypatch, "no such tokenizer: trigram"
+    )
+    try:
+        assert db._trigram_available is False
+    finally:
+        db.close()

--- a/tests/run_agent/test_switch_model_claude_sdk.py
+++ b/tests/run_agent/test_switch_model_claude_sdk.py
@@ -1,0 +1,277 @@
+"""Live-agent /model swap coverage for the Claude Agent SDK runtime."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_agent(
+    *,
+    provider: str,
+    model: str,
+    base_url: str,
+    api_mode: str,
+    sdk_session=None,
+) -> Any:
+    agent: Any = AIAgent.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    agent.api_key = "old-key"
+    agent.api_mode = api_mode
+    agent.client = MagicMock(name="OldClient") if base_url else None
+    agent._client_kwargs = (
+        {"api_key": "old-key", "base_url": base_url} if base_url else {}
+    )
+    agent._anthropic_client = None
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = None
+    agent._is_anthropic_oauth = False
+    agent._claude_sdk_session = sdk_session
+    agent._credential_pool = None
+    agent._transport_cache = {}
+    agent._config_context_length = None
+    agent.context_compressor = None
+    agent.reasoning_config = None
+    agent._cached_system_prompt = "cached"
+    agent._primary_runtime = {}
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent._session_db = None
+    agent.session_id = None
+    agent.tool_progress_callback = None
+    agent._interrupt_requested = False
+    agent._persist_disabled = False
+    agent._iters_since_skill = 0
+    agent._skill_nudge_interval = 0
+    agent.valid_tool_names = set()
+    agent.session_api_calls = 0
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+    agent.session_input_tokens = 0
+    agent.session_output_tokens = 0
+    agent.session_cache_read_tokens = 0
+    agent.session_cache_write_tokens = 0
+    agent.session_reasoning_tokens = 0
+    return agent
+
+
+def _switch(agent: AIAgent, **kwargs) -> None:
+    with (
+        patch("agent.credential_pool.load_pool", return_value=None),
+        patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None),
+    ):
+        agent.switch_model(**kwargs)
+
+
+def test_codex_to_claude_sdk_is_clientless_with_empty_url():
+    agent = _make_agent(
+        provider="openai-codex",
+        model="gpt-5.3-codex",
+        base_url="https://chatgpt.com/backend-api/codex/responses",
+        api_mode="codex_responses",
+    )
+    agent._create_openai_client = MagicMock(
+        side_effect=AssertionError("OpenAI client must not be built")
+    )
+    agent._session_db = MagicMock()
+    agent.session_id = "sess-boundary-in"
+
+    with patch("agent.anthropic_adapter.build_anthropic_client") as build_anthropic:
+        _switch(
+            agent,
+            new_model="claude-opus-5",
+            new_provider="claude-agent-sdk",
+            api_key="claude-subscription-oauth",
+            base_url="",
+            api_mode="claude_agent_sdk",
+        )
+
+    agent._create_openai_client.assert_not_called()
+    build_anthropic.assert_not_called()
+    assert agent.provider == "claude-agent-sdk"
+    assert agent.model == "claude-opus-5"
+    assert agent.base_url == ""
+    assert agent.api_mode == "claude_agent_sdk"
+    assert agent.api_key == "claude-subscription-oauth"
+    assert agent.client is None
+    assert agent._client_kwargs == {}
+    agent._session_db.update_claude_sdk_session_id.assert_called_once_with(
+        "sess-boundary-in", None
+    )
+
+
+def test_switching_away_from_claude_sdk_retires_live_session():
+    sdk_session = MagicMock(name="ClaudeSdkSession")
+    agent = _make_agent(
+        provider="claude-agent-sdk",
+        model="claude-opus-5",
+        base_url="",
+        api_mode="claude_agent_sdk",
+        sdk_session=sdk_session,
+    )
+    new_client = MagicMock(name="OpenRouterClient")
+    agent._create_openai_client = MagicMock(return_value=new_client)
+    agent._session_db = MagicMock()
+    agent.session_id = "sess-boundary-out"
+
+    _switch(
+        agent,
+        new_model="openai/gpt-5",
+        new_provider="openrouter",
+        api_key="new-key",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="chat_completions",
+    )
+
+    sdk_session.close.assert_called_once_with()
+    assert agent._claude_sdk_session is None
+    assert agent.client is new_client
+    agent._session_db.update_claude_sdk_session_id.assert_called_once_with(
+        "sess-boundary-out", None
+    )
+
+
+def test_switch_away_and_back_clears_continuity_at_each_boundary():
+    agent = _make_agent(
+        provider="claude-agent-sdk",
+        model="claude-opus-5",
+        base_url="",
+        api_mode="claude_agent_sdk",
+        sdk_session=MagicMock(name="ClaudeSdkSession"),
+    )
+    agent._create_openai_client = MagicMock(return_value=MagicMock())
+    agent._session_db = MagicMock()
+    agent.session_id = "sess-round-trip"
+
+    _switch(
+        agent,
+        new_model="openai/gpt-5",
+        new_provider="openrouter",
+        api_key="new-key",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="chat_completions",
+    )
+    _switch(
+        agent,
+        new_model="claude-opus-5",
+        new_provider="claude-agent-sdk",
+        api_key="claude-subscription-oauth",
+        base_url="",
+        api_mode="claude_agent_sdk",
+    )
+
+    assert agent._session_db.update_claude_sdk_session_id.call_args_list == [
+        call("sess-round-trip", None),
+        call("sess-round-trip", None),
+    ]
+
+
+def test_claude_sdk_model_change_retires_session_for_lazy_resume(monkeypatch):
+    from agent.claude_sdk_runtime import run_claude_agent_sdk_turn
+
+    sdk_session = MagicMock(name="OldClaudeSdkSession")
+    agent = _make_agent(
+        provider="claude-agent-sdk",
+        model="claude-sonnet-5",
+        base_url="",
+        api_mode="claude_agent_sdk",
+        sdk_session=sdk_session,
+    )
+    agent._create_openai_client = MagicMock(
+        side_effect=AssertionError("OpenAI client must not be built")
+    )
+    agent._session_db = MagicMock()
+    agent.session_id = "sess-same-sdk"
+
+    _switch(
+        agent,
+        new_model="claude-opus-5",
+        new_provider="claude-agent-sdk",
+        api_key="claude-subscription-oauth",
+        base_url="",
+        api_mode="claude_agent_sdk",
+    )
+
+    sdk_session.close.assert_called_once_with()
+    assert agent._claude_sdk_session is None
+    assert agent.model == "claude-opus-5"
+    assert agent.api_mode == "claude_agent_sdk"
+    agent._session_db.update_claude_sdk_session_id.assert_not_called()
+
+    captured = {}
+
+    class SpySession:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def run_turn(self, user_input):
+            return SimpleNamespace(
+                interrupted=False,
+                error=None,
+                thread_id="new-sdk-session",
+                turn_id="new-turn",
+                projected_messages=[
+                    {"role": "assistant", "content": "new model response"}
+                ],
+                tool_iterations=0,
+                final_text="new model response",
+                should_retire=False,
+                token_usage_last={"input_tokens": 1, "output_tokens": 1},
+                token_usage_total=None,
+            )
+
+    monkeypatch.setattr(
+        "agent.transports.claude_agent_sdk_session.ClaudeAgentSdkSession",
+        SpySession,
+    )
+
+    result = run_claude_agent_sdk_turn(
+        agent,
+        user_message="continue",
+        original_user_message="continue",
+        messages=[{"role": "user", "content": "continue"}],
+        effective_task_id="task-1",
+    )
+
+    assert captured["model"] == "claude-opus-5"
+    assert result["final_response"] == "new model response"
+
+
+def test_failed_unrelated_http_switch_keeps_original_runtime():
+    agent = _make_agent(
+        provider="openrouter",
+        model="x-ai/grok-4",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="chat_completions",
+    )
+    old_client = agent.client
+    old_kwargs = dict(agent._client_kwargs)
+    agent._create_openai_client = MagicMock(
+        side_effect=RuntimeError("simulated HTTP client build failure")
+    )
+
+    with pytest.raises(RuntimeError, match="simulated HTTP client build failure"):
+        _switch(
+            agent,
+            new_model="MiniMax-M3",
+            new_provider="custom:minimax",
+            api_key="new-key",
+            base_url="https://api.minimax.io/v1",
+            api_mode="chat_completions",
+        )
+
+    assert agent.provider == "openrouter"
+    assert agent.model == "x-ai/grok-4"
+    assert agent.base_url == "https://openrouter.ai/api/v1"
+    assert agent.api_mode == "chat_completions"
+    assert agent.api_key == "old-key"
+    assert agent.client is old_client
+    assert agent._client_kwargs == old_kwargs

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -10,6 +10,7 @@ from tools.approval import (
     approve_session,
     check_all_command_guards,
     check_dangerous_command,
+    check_unconditional_command_guards,
     is_approved,
     set_current_session_key,
     reset_current_session_key,
@@ -73,6 +74,39 @@ class TestContainerSkip:
     def test_daytona_skips_both(self):
         result = check_all_command_guards("rm -rf /", "daytona")
         assert result["approved"] is True
+
+
+class TestUnconditionalCommandGuards:
+    def test_safe_command_passes(self):
+        result = check_unconditional_command_guards("printf ok")
+
+        assert result == {"approved": True, "message": None}
+
+    def test_hardline_command_is_blocked(self):
+        result = check_unconditional_command_guards("rm -rf /")
+
+        assert result["approved"] is False
+        assert result["hardline"] is True
+
+    def test_sudo_stdin_is_blocked_without_configured_password(self, monkeypatch):
+        monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+
+        result = check_unconditional_command_guards("echo guess | sudo -S id")
+
+        assert result["approved"] is False
+        assert "sudo -S" in result["message"]
+
+    def test_user_deny_rule_is_blocked(self, monkeypatch):
+        monkeypatch.setattr(
+            approval_module,
+            "_get_approval_config",
+            lambda: {"deny": ["echo forbidden"]},
+        )
+
+        result = check_unconditional_command_guards("echo forbidden")
+
+        assert result["approved"] is False
+        assert result["user_deny"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -103,6 +103,11 @@ class TestAllowlist:
     def test_feature_install_command_unknown(self):
         assert ld.feature_install_command("not.real") is None
 
+    def test_claude_agent_sdk_provider_uses_exact_runtime_pin(self):
+        assert ld.LAZY_DEPS["provider.claude_agent_sdk"] == (
+            "claude-agent-sdk==0.2.120",
+        )
+
 
 # ---------------------------------------------------------------------------
 # allow_lazy_installs gating
@@ -205,6 +210,38 @@ class TestEnsure:
         )
         with pytest.raises(ld.FeatureUnavailable, match="still not importable"):
             ld.ensure("test.cache", prompt=False)
+
+    def test_claude_agent_sdk_missing_package_installs_without_network(
+        self, monkeypatch
+    ):
+        states = iter([False, True])
+        installed = []
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: next(states))
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda specs, **kwargs: (
+                installed.append(specs) or ld._InstallResult(True, "ok", "")
+            ),
+        )
+
+        ld.ensure("provider.claude_agent_sdk", prompt=False)
+
+        assert installed == [("claude-agent-sdk==0.2.120",)]
+
+    def test_claude_agent_sdk_disabled_has_exact_manual_remediation(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: False)
+
+        with pytest.raises(ld.FeatureUnavailable) as exc:
+            ld.ensure("provider.claude_agent_sdk", prompt=False)
+
+        message = str(exc.value)
+        assert "lazy installs disabled" in message
+        assert "claude-agent-sdk==0.2.120" in message
 
 
 # ---------------------------------------------------------------------------
@@ -426,6 +463,27 @@ class TestRefreshActiveFeatures:
         )
         result = ld.refresh_active_features()
         assert result == {"test.feat": "refreshed"}
+
+    def test_active_claude_agent_sdk_pin_refreshes_without_network(self, monkeypatch):
+        monkeypatch.setattr(
+            ld, "active_features", lambda: ["provider.claude_agent_sdk"]
+        )
+        states = iter([False, False, True])
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: next(states))
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        installed = []
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda specs, **kwargs: (
+                installed.append(specs) or ld._InstallResult(True, "ok", "")
+            ),
+        )
+
+        result = ld.refresh_active_features()
+
+        assert result == {"provider.claude_agent_sdk": "refreshed"}
+        assert installed == [("claude-agent-sdk==0.2.120",)]
 
     def test_install_failure_recorded_not_raised(self, monkeypatch):
         # A failed refresh must NOT raise out of hermes update.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -599,6 +599,34 @@ def _sudo_stdin_block_result(description: str) -> dict:
     }
 
 
+def check_unconditional_command_guards(command: str) -> dict:
+    """Apply command blocks that no approval or bypass may override."""
+    is_hardline, hardline_desc = detect_hardline_command(command)
+    if is_hardline:
+        logger.warning(
+            "Hardline block: %s (command: %s)", hardline_desc, command[:200]
+        )
+        return _hardline_block_result(hardline_desc)
+
+    is_sudo_guess, sudo_guess_desc = _check_sudo_stdin_guard(command)
+    if is_sudo_guess:
+        logger.warning(
+            "Sudo stdin guard block: %s (command: %s)",
+            sudo_guess_desc,
+            command[:200],
+        )
+        return _sudo_stdin_block_result(sudo_guess_desc)
+
+    deny_pattern = _match_user_deny_rule(command)
+    if deny_pattern is not None:
+        logger.warning(
+            "User deny rule %r blocked command: %s", deny_pattern, command[:200]
+        )
+        return _user_deny_block_result(deny_pattern)
+
+    return {"approved": True, "message": None}
+
+
 # =========================================================================
 # Dangerous command patterns
 # =========================================================================
@@ -3351,34 +3379,9 @@ def check_all_command_guards(command: str, env_type: str,
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
         return {"approved": True, "message": None}
 
-    # Hardline floor: unconditional block for catastrophic commands
-    # (rm -rf /, mkfs, dd to raw device, shutdown/reboot, fork bomb,
-    # kill -1). Applies BEFORE yolo / mode=off / cron approve-mode so
-    # no session-level setting can bypass it.
-    is_hardline, hardline_desc = detect_hardline_command(command)
-    if is_hardline:
-        logger.warning("Hardline block: %s (command: %s)", hardline_desc, command[:200])
-        return _hardline_block_result(hardline_desc)
-
-    # == Sudo stdin guard ==
-    # Like the hardline floor above, this is unconditional: there is never a
-    # legitimate reason for the agent to pipe passwords to sudo -S when no
-    # SUDO_PASSWORD has been configured.  This must fire BEFORE the yolo
-    # check so even yolo/smart approval/mode=off cannot bypass it.
-    is_sudo_guess, sudo_guess_desc = _check_sudo_stdin_guard(command)
-    if is_sudo_guess:
-        logger.warning("Sudo stdin guard block: %s (command: %s)",
-                       sudo_guess_desc, command[:200])
-        return _sudo_stdin_block_result(sudo_guess_desc)
-
-    # User-defined deny rules (approvals.deny in config.yaml): like the
-    # hardline floor, these fire BEFORE the yolo / mode=off bypass — a deny
-    # rule is the user saying "never, even under yolo".
-    deny_pattern = _match_user_deny_rule(command)
-    if deny_pattern is not None:
-        logger.warning("User deny rule %r blocked command: %s",
-                       deny_pattern, command[:200])
-        return _user_deny_block_result(deny_pattern)
+    unconditional_guard = check_unconditional_command_guards(command)
+    if not unconditional_guard["approved"]:
+        return unconditional_guard
 
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -99,6 +99,9 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # Native Anthropic SDK — needed when provider=anthropic (not via
     # OpenRouter / aggregators which use the openai SDK).
     "provider.anthropic": ("anthropic==0.87.0",),  # CVE-2026-34450, CVE-2026-34452
+    # Official Claude Agent SDK subscription runtime. Keep this exact pin in
+    # lockstep with the claude-agent-sdk optional dependency in pyproject.toml.
+    "provider.claude_agent_sdk": ("claude-agent-sdk==0.2.120",),
     # AWS Bedrock provider
     "provider.bedrock": ("boto3==1.42.89",),
     # Google Vertex AI provider — OAuth2 token minting for the Gemini

--- a/uv.lock
+++ b/uv.lock
@@ -701,6 +701,24 @@ wheels = [
 ]
 
 [[package]]
+name = "claude-agent-sdk"
+version = "0.2.120"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "mcp" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/7f/7b69aed292a4edecae132e4dbe6b6decb4e88ec142fc91d117b19058c9e0/claude_agent_sdk-0.2.120.tar.gz", hash = "sha256:e428552f79a76e0d85789369eeb58249b33f350200124e5fc86b24168bd00805", size = 268639, upload-time = "2026-07-15T23:18:50.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/85/5e8958704db0f8195e63f8ec4a80c5fb14756edc785bb3535e0dc5d91104/claude_agent_sdk-0.2.120-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5ead9fb4bdaf70069978703ec6d74b30bd269e9632a4aea4dc8c4e999ac3a1b", size = 71110966, upload-time = "2026-07-15T23:18:54.743Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/53/c6cdad82ac100c8a45887999614e9fe206b77b43790dacc6de42b156ad4c/claude_agent_sdk-0.2.120-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:1248591c7bffeb6e10e8cd169e0766854951fba8816e3e7d81a003f8bfca6f08", size = 76067995, upload-time = "2026-07-15T23:18:58.398Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f8/248e3f58d0f0aa7d76bd34b11b18135cc124f5b9a9b55219cc1ca03d662a/claude_agent_sdk-0.2.120-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:abc73ccdf3decca566cd18084e74bc2f2d10b8b77cc1fd5ed4299d5c15e5078b", size = 81027434, upload-time = "2026-07-15T23:19:03.318Z" },
+    { url = "https://files.pythonhosted.org/packages/11/59/6adb0c53534646f1d5ddc41226ff37b2adc413a472e2f87a9011548a137f/claude_agent_sdk-0.2.120-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:888070c246c92e102c52001d26532cd3646a700656d7c368f2f91a1d3c16b534", size = 82084704, upload-time = "2026-07-15T23:19:08.729Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/06/036b8dce1e86ecd5e2e1ddc281736cdb33bad6d24e748b9553e235b028fe/claude_agent_sdk-0.2.120-py3-none-win_amd64.whl", hash = "sha256:bc1441c94f60c9e7b4b8c641742fedf68451f573062ef69dd43d86a61b1fb219", size = 81958518, upload-time = "2026-07-15T23:19:13.082Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1609,6 +1627,9 @@ azure-identity = [
 bedrock = [
     { name = "boto3" },
 ]
+claude-agent-sdk = [
+    { name = "claude-agent-sdk" },
+]
 cli = [
     { name = "simple-term-menu" },
 ]
@@ -1787,6 +1808,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'bedrock'", specifier = "==1.42.89" },
     { name = "brotlicffi", marker = "extra == 'messaging'", specifier = "==1.2.0.1" },
     { name = "certifi", specifier = "==2026.5.20" },
+    { name = "claude-agent-sdk", marker = "extra == 'claude-agent-sdk'", specifier = "==0.2.120" },
     { name = "concurrent-log-handler", marker = "sys_platform == 'win32'", specifier = "==0.9.29" },
     { name = "croniter", specifier = "==6.0.0" },
     { name = "cryptography", specifier = "==48.0.1" },
@@ -1900,7 +1922,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "claude-agent-sdk", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"


### PR DESCRIPTION
## Summary

Adds `claude-agent-sdk` as a first-class Hermes provider/runtime backed by Claude-managed subscription authentication.

- Runs the complete turn through the official Agent SDK and projects typed events into Hermes transcripts.
- Supports interruption, streaming, session resume, stale-resume recovery, model switching, and gateway rehydration.
- Preserves subscription-only accounting and fails closed instead of silently routing automatic auxiliary work to a metered provider.
- Adds curated Hermes MCP shims and an optional native read-only mode limited to `Read`, `Glob`, and `Grep` within configured roots.
- Keeps the SDK dependency optional and uses lazy imports when it is not installed.

## Safety boundaries

- No native Anthropic API-key, OpenRouter, Bedrock, Vertex, custom-base, or cloud fallback is reachable through the subscription runtime.
- Billing-route environment selectors are rejected before SDK startup.
- Native read-only mode forces the fail-closed permission mode, denies permission callbacks without consulting operator approval, exposes no mutating native tools, and preserves exact configured roots.
- Missing usage data records subscription-included zero-cost attribution without fabricating token counts.

## Verification

- Exact-head Claude SDK runtime suite: 193 passed (`scripts/run_tests.sh tests/agent/test_claude_sdk_runtime.py -q`).
- Exact-head command guard suite: 37 passed (`scripts/run_tests.sh tests/tools/test_command_guards.py -q`).
- Ruff on the four changed files and `git diff --check`: passed.
- GitHub-hosted CI has not started for this external-fork draft PR.

## Scope

This PR is limited to the Claude Agent SDK provider/runtime and its supporting tests, configuration, persistence, and optional dependency wiring. It does not change unrelated provider behavior or deploy any runtime configuration.
