### PR TITLE
fix(desktop): pass active profile to WebSocket connection URL (#71527)

### DIFF
--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -72,20 +72,22 @@ function normalizeRemoteBaseUrl(rawUrl) {
   return parsed.toString().replace(/\/+$/, '')
 }
 
-function buildGatewayWsUrl(baseUrl, token) {
+function buildGatewayWsUrl(baseUrl, token, profile?) {
   const parsed = new URL(baseUrl)
   const wsScheme = parsed.protocol === 'https:' ? 'wss' : 'ws'
   const prefix = parsed.pathname.replace(/\/+$/, '')
+  const profileParam = profile ? `&profile=${encodeURIComponent(profile)}` : ''
 
-  return `${wsScheme}://${parsed.host}${prefix}/api/ws?token=${encodeURIComponent(token)}`
+  return `${wsScheme}://${parsed.host}${prefix}/api/ws?token=${encodeURIComponent(token)}${profileParam}`
 }
 
-function buildGatewayWsUrlWithTicket(baseUrl, ticket) {
+function buildGatewayWsUrlWithTicket(baseUrl, ticket, profile?) {
   const parsed = new URL(baseUrl)
   const wsScheme = parsed.protocol === 'https:' ? 'wss' : 'ws'
   const prefix = parsed.pathname.replace(/\/+$/, '')
+  const profileParam = profile ? `&profile=${encodeURIComponent(profile)}` : ''
 
-  return `${wsScheme}://${parsed.host}${prefix}/api/ws?ticket=${encodeURIComponent(ticket)}`
+  return `${wsScheme}://${parsed.host}${prefix}/api/ws?ticket=${encodeURIComponent(ticket)}${profileParam}`
 }
 
 /** True only when a gateway explicitly rejected the current OAuth session. */

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6168,7 +6168,7 @@ async function freshGatewayWsUrl(profile) {
   if (connection.authMode === 'oauth') {
     const ticket = await mintGatewayWsTicket(connection.baseUrl)
 
-    return buildGatewayWsUrlWithTicket(connection.baseUrl, ticket)
+    return buildGatewayWsUrlWithTicket(connection.baseUrl, ticket, profile)
   }
 
   // Local/token: the cached wsUrl already carries the (long-lived) token.
@@ -6886,7 +6886,8 @@ async function buildRemoteConnection(
   source,
   remoteHost?,
   remoteKind = 'url',
-  remoteIdentity?
+  remoteIdentity?,
+  profile?
 ) {
   const baseUrl = normalizeRemoteBaseUrl(rawUrl)
   // For token/oauth remotes the meaningful host is the real backend URL; for
@@ -6945,7 +6946,7 @@ async function buildRemoteConnection(
       remoteKind,
       // No static token in OAuth mode; REST is cookie-authed via the partition.
       token: null,
-      wsUrl: buildGatewayWsUrlWithTicket(baseUrl, ticket)
+      wsUrl: buildGatewayWsUrlWithTicket(baseUrl, ticket, profile)
     }
   }
 
@@ -6965,7 +6966,7 @@ async function buildRemoteConnection(
     remoteIdentity,
     remoteKind,
     token,
-    wsUrl: buildGatewayWsUrl(baseUrl, token)
+    wsUrl: buildGatewayWsUrl(baseUrl, token, profile)
   }
 }
 
@@ -7275,7 +7276,9 @@ async function resolveRemoteBackend(profile) {
       token,
       'profile',
       undefined,
-      config.profiles?.[connectionScopeKey(profile)]?.mode === 'cloud' ? 'cloud' : 'url'
+      config.profiles?.[connectionScopeKey(profile)]?.mode === 'cloud' ? 'cloud' : 'url',
+      undefined,
+      profile
     )
   }
 


### PR DESCRIPTION
## Summary

Fixes #71527 — Desktop does not pass active profile as `?profile=` query param to `/api/ws` WebSocket.

## Root Cause

When Hermes Desktop connects to a remote dashboard with multiple profiles, it stores the active profile in localStorage but does not inject it as the `?profile=` query parameter in the WebSocket connection URL. The dashboard backend reads the profile from `ws.query_params.get("profile")`, so sessions always default to the dashboard's boot profile.

## Fix

Pass the profile parameter through `buildRemoteConnection` -> `buildGatewayWsUrlWithTicket`/`buildGatewayWsUrl` so the backend routes sessions to the correct profile's `state.db`. All parameters are optional (`?`) for backward compatibility.

## Changes

- `apps/desktop/electron/connection-config.ts`: Add optional `profile` param to `buildGatewayWsUrl` and `buildGatewayWsUrlWithTicket`, append `&profile=<name>` when set
- `apps/desktop/electron/main.ts`: Add optional `profile` param to `buildRemoteConnection`, pass through to WS URL builders, update callers

Replaces #71732 (which had lint failures from non-optional parameters).