### PR TITLE
feat(agent): support terminal MCP tool results

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5802,12 +5802,6 @@ def run_conversation(
                     final_response = agent._terminal_tool_result_error
                     messages.append({"role": "assistant", "content": final_response})
                     agent._emit_status(f"⚠️ {final_response}")
-                    if agent.stream_delta_callback:
-                        try:
-                            agent.stream_delta_callback(final_response)
-                            agent.stream_delta_callback(None)
-                        except Exception:
-                            pass
                     break
 
                 if agent._terminal_tool_result is not None:
@@ -5819,7 +5813,6 @@ def run_conversation(
                         if agent.stream_delta_callback:
                             try:
                                 agent.stream_delta_callback(final_response)
-                                agent.stream_delta_callback(None)
                             except Exception:
                                 pass
                     break

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1057,6 +1057,10 @@ def run_conversation(
     # reused as the final response — not merely because any interim was
     # streamed. (#65919 review: response-loss blocker)
     _pending_verification_response_previewed = False
+    # A terminal-capable tool may supply the participant-facing answer itself.
+    # Reset this per turn so no result can leak across conversations.
+    agent._terminal_tool_result = None
+    agent._terminal_tool_result_error = None
     # If pre-API compression fires after MoA advisors have produced guidance,
     # retain that ephemeral output and rebase it onto the compacted transcript
     # on the next loop iteration. This prevents a second advisor fan-out.
@@ -5791,6 +5795,34 @@ def run_conversation(
                         pass
 
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+
+                if agent._terminal_tool_result_error is not None:
+                    failed = True
+                    _turn_exit_reason = "invalid_terminal_tool_result"
+                    final_response = agent._terminal_tool_result_error
+                    messages.append({"role": "assistant", "content": final_response})
+                    agent._emit_status(f"⚠️ {final_response}")
+                    if agent.stream_delta_callback:
+                        try:
+                            agent.stream_delta_callback(final_response)
+                            agent.stream_delta_callback(None)
+                        except Exception:
+                            pass
+                    break
+
+                if agent._terminal_tool_result is not None:
+                    _turn_exit_reason = "terminal_tool_result"
+                    final_response = agent._terminal_tool_result.answer
+                    messages.append({"role": "assistant", "content": final_response})
+                    if final_response:
+                        agent._safe_print(f"\n{final_response}\n")
+                        if agent.stream_delta_callback:
+                            try:
+                                agent.stream_delta_callback(final_response)
+                                agent.stream_delta_callback(None)
+                            except Exception:
+                                pass
+                    break
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision

--- a/agent/terminal_tool_result.py
+++ b/agent/terminal_tool_result.py
@@ -1,0 +1,144 @@
+"""Validated terminal tool-result contracts.
+
+A terminal tool returns the participant-facing answer itself, so the agent
+loop must deliver that answer without asking the model to synthesize it again.
+Only tools whose declared output schema opts into this behavior are eligible.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import re
+from typing import Any
+
+
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+
+
+@dataclass(frozen=True)
+class TerminalToolResult:
+    answer: str
+    answer_sha256: str
+    tool_name: str
+    tool_call_id: str
+
+
+class TerminalToolResultError(ValueError):
+    """A terminal-capable tool returned an invalid terminal envelope."""
+
+
+def output_schema_declares_terminal_verbatim(output_schema: Any) -> bool:
+    """Return whether an MCP output schema explicitly opts into termination."""
+    if not isinstance(output_schema, dict) or output_schema.get("type") != "object":
+        return False
+    properties = output_schema.get("properties")
+    required = output_schema.get("required")
+    if not isinstance(properties, dict) or not isinstance(required, list):
+        return False
+    if not {"delivery_semantics", "answer", "answer_sha256"}.issubset(required):
+        return False
+
+    delivery = properties.get("delivery_semantics")
+    answer = properties.get("answer")
+    digest = properties.get("answer_sha256")
+    return (
+        isinstance(delivery, dict)
+        and delivery.get("const") == "terminal_verbatim"
+        and isinstance(answer, dict)
+        and answer.get("type") == "string"
+        and isinstance(digest, dict)
+        and digest.get("type") == "string"
+    )
+
+
+def _structured_payload(raw_result: Any) -> dict[str, Any]:
+    if not isinstance(raw_result, str):
+        raise TerminalToolResultError("result must be a JSON string")
+    try:
+        outer = json.loads(raw_result)
+    except json.JSONDecodeError as exc:
+        raise TerminalToolResultError("result is not valid JSON") from exc
+    if not isinstance(outer, dict):
+        raise TerminalToolResultError("result must decode to an object")
+
+    structured = outer.get("structuredContent")
+    if isinstance(structured, dict):
+        return structured
+    result = outer.get("result")
+    if isinstance(result, dict):
+        return result
+    raise TerminalToolResultError(
+        "result does not contain structuredContent or an object result"
+    )
+
+
+def parse_terminal_tool_result(
+    raw_result: Any,
+    *,
+    tool_name: str,
+    tool_call_id: str,
+) -> TerminalToolResult:
+    """Parse and verify the generic ``terminal_verbatim`` envelope."""
+    payload = _structured_payload(raw_result)
+    if payload.get("delivery_semantics") != "terminal_verbatim":
+        raise TerminalToolResultError(
+            "delivery_semantics must be terminal_verbatim"
+        )
+
+    answer = payload.get("answer")
+    if not isinstance(answer, str) or not answer:
+        raise TerminalToolResultError("answer must be a non-empty string")
+
+    answer_sha256 = payload.get("answer_sha256")
+    if not isinstance(answer_sha256, str) or not _SHA256_RE.fullmatch(
+        answer_sha256
+    ):
+        raise TerminalToolResultError(
+            "answer_sha256 must be a lowercase SHA-256 digest"
+        )
+    actual_digest = hashlib.sha256(answer.encode("utf-8")).hexdigest()
+    if actual_digest != answer_sha256:
+        raise TerminalToolResultError("answer_sha256 does not match answer")
+
+    return TerminalToolResult(
+        answer=answer,
+        answer_sha256=answer_sha256,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+    )
+
+
+def capture_terminal_tool_result(
+    agent: Any,
+    *,
+    tool_name: str,
+    tool_call_id: str,
+    raw_result: Any,
+) -> None:
+    """Capture one validated terminal result on the current agent turn."""
+    from tools.registry import registry
+
+    if not registry.is_terminal_result_tool(tool_name):
+        return
+
+    try:
+        parsed = parse_terminal_tool_result(
+            raw_result,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+        )
+    except TerminalToolResultError as exc:
+        agent._terminal_tool_result_error = (
+            f"Terminal tool {tool_name!r} returned an invalid terminal result: {exc}"
+        )
+        return
+
+    existing = getattr(agent, "_terminal_tool_result", None)
+    if existing is not None:
+        agent._terminal_tool_result_error = (
+            "A single assistant turn returned more than one terminal tool result"
+        )
+        return
+    agent._terminal_tool_result = parsed

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -32,6 +32,7 @@ from agent.display import (
     _detect_tool_failure,
 )
 from agent.tool_guardrails import ToolGuardrailDecision
+from agent.terminal_tool_result import capture_terminal_tool_result
 from agent.tool_dispatch_helpers import (
     _is_destructive_command,
     _is_multimodal_tool_result,
@@ -913,6 +914,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 effect_disposition = "none"
 
             if not blocked:
+                capture_terminal_tool_result(
+                    agent,
+                    tool_name=function_name,
+                    tool_call_id=getattr(tc, "id", "") or "",
+                    raw_result=function_result,
+                )
                 function_result = agent._append_guardrail_observation(
                     function_name,
                     function_args,
@@ -1596,6 +1603,13 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Log tool errors to the persistent error log so [error] tags
         # in the UI always have a corresponding detailed entry on disk.
         _is_error_result, _ = _detect_tool_failure(function_name, function_result)
+        if not _execution_blocked:
+            capture_terminal_tool_result(
+                agent,
+                tool_name=function_name,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                raw_result=function_result,
+            )
         # The agent-runtime tools above (todo, session_search, memory,
         # context-engine, memory-manager, clarify, delegate_task) are
         # dispatched inline — they never reach handle_function_call, so the

--- a/tests/agent/test_terminal_tool_result.py
+++ b/tests/agent/test_terminal_tool_result.py
@@ -1,0 +1,105 @@
+import hashlib
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.terminal_tool_result import (
+    TerminalToolResultError,
+    output_schema_declares_terminal_verbatim,
+    parse_terminal_tool_result,
+)
+from tools.mcp_tool import _mcp_tool_returns_terminal_result
+from tools.registry import registry
+
+
+def _payload(answer: str) -> dict:
+    return {
+        "delivery_semantics": "terminal_verbatim",
+        "answer": answer,
+        "answer_sha256": hashlib.sha256(answer.encode("utf-8")).hexdigest(),
+    }
+
+
+def test_output_schema_requires_explicit_terminal_contract():
+    schema = {
+        "type": "object",
+        "properties": {
+            "delivery_semantics": {
+                "type": "string",
+                "const": "terminal_verbatim",
+            },
+            "answer": {"type": "string"},
+            "answer_sha256": {"type": "string"},
+        },
+        "required": ["delivery_semantics", "answer", "answer_sha256"],
+    }
+
+    assert output_schema_declares_terminal_verbatim(schema) is True
+    assert _mcp_tool_returns_terminal_result(
+        SimpleNamespace(outputSchema=schema)
+    ) is True
+    assert output_schema_declares_terminal_verbatim(
+        {
+            **schema,
+            "properties": {
+                **schema["properties"],
+                "delivery_semantics": {"type": "string"},
+            },
+        }
+    ) is False
+
+
+def test_parse_terminal_result_prefers_structured_content():
+    expected = _payload("Exact participant answer.")
+    raw = json.dumps(
+        {
+            "result": "model-oriented duplicate",
+            "structuredContent": expected,
+        }
+    )
+
+    parsed = parse_terminal_tool_result(
+        raw,
+        tool_name="mcp__knowledge__search",
+        tool_call_id="call-1",
+    )
+
+    assert parsed.answer == expected["answer"]
+    assert parsed.answer_sha256 == expected["answer_sha256"]
+
+
+def test_parse_terminal_result_rejects_digest_mismatch():
+    invalid = {
+        **_payload("Exact participant answer."),
+        "answer_sha256": "0" * 64,
+    }
+
+    with pytest.raises(
+        TerminalToolResultError,
+        match="does not match",
+    ):
+        parse_terminal_tool_result(
+            json.dumps({"result": invalid}),
+            tool_name="mcp__knowledge__search",
+            tool_call_id="call-1",
+        )
+
+
+def test_registry_retains_terminal_result_capability():
+    name = "test_terminal_result_capability"
+    registry.register(
+        name=name,
+        toolset="test-terminal-result",
+        schema={
+            "name": name,
+            "description": "test",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=lambda _args: "{}",
+        terminal_result=True,
+    )
+    try:
+        assert registry.is_terminal_result_tool(name) is True
+    finally:
+        registry.deregister(name)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6,6 +6,7 @@ are made.
 """
 
 import ast
+import hashlib
 import inspect
 import io
 import json
@@ -4342,6 +4343,95 @@ class TestRunConversation:
         assert result["api_calls"] == 2
         assert mock_handle_function_call.call_args.kwargs["tool_call_id"] == "c1"
         assert mock_handle_function_call.call_args.kwargs["session_id"] == agent.session_id
+
+    def test_terminal_tool_result_ends_turn_without_second_model_call(
+        self,
+        agent,
+        monkeypatch,
+    ):
+        self._setup_agent(agent)
+        answer = "Exact participant-facing answer."
+        terminal_result = json.dumps(
+            {
+                "result": {
+                    "delivery_semantics": "terminal_verbatim",
+                    "answer": answer,
+                    "answer_sha256": hashlib.sha256(answer.encode("utf-8")).hexdigest(),
+                }
+            }
+        )
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[tc],
+        )
+
+        from tools.registry import registry
+
+        monkeypatch.setattr(
+            registry,
+            "is_terminal_result_tool",
+            lambda name: name == "web_search",
+        )
+        with (
+            patch("run_agent.handle_function_call", return_value=terminal_result),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something")
+
+        assert result["final_response"] == answer
+        assert result["completed"] is True
+        assert result["turn_exit_reason"] == "terminal_tool_result"
+        assert result["api_calls"] == 1
+        assert agent.client.chat.completions.create.call_count == 1
+
+    def test_invalid_terminal_tool_result_fails_without_model_rewrite(
+        self,
+        agent,
+        monkeypatch,
+    ):
+        self._setup_agent(agent)
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[tc],
+        )
+
+        from tools.registry import registry
+
+        monkeypatch.setattr(
+            registry,
+            "is_terminal_result_tool",
+            lambda name: name == "web_search",
+        )
+        with (
+            patch(
+                "run_agent.handle_function_call",
+                return_value=json.dumps(
+                    {
+                        "result": {
+                            "delivery_semantics": "terminal_verbatim",
+                            "answer": "Do not deliver this.",
+                            "answer_sha256": "0" * 64,
+                        }
+                    }
+                ),
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something")
+
+        assert result["completed"] is False
+        assert result["failed"] is True
+        assert result["turn_exit_reason"] == "invalid_terminal_tool_result"
+        assert "does not match answer" in result["final_response"]
+        assert agent.client.chat.completions.create.call_count == 1
 
     def test_tool_call_none_args_verbose_logging_does_not_crash(self, agent):
         self._setup_agent(agent)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4374,6 +4374,8 @@ class TestRunConversation:
             "is_terminal_result_tool",
             lambda name: name == "web_search",
         )
+        streamed: list[str | None] = []
+        agent.stream_delta_callback = streamed.append
         with (
             patch("run_agent.handle_function_call", return_value=terminal_result),
             patch.object(agent, "_persist_session"),
@@ -4387,6 +4389,9 @@ class TestRunConversation:
         assert result["turn_exit_reason"] == "terminal_tool_result"
         assert result["api_calls"] == 1
         assert agent.client.chat.completions.create.call_count == 1
+        # Existing tool-boundary break first; the terminal answer must not add
+        # a trailing break because the gateway's normal finish finalizes it.
+        assert streamed == [None, answer]
 
     def test_invalid_terminal_tool_result_fails_without_model_rewrite(
         self,
@@ -4408,6 +4413,8 @@ class TestRunConversation:
             "is_terminal_result_tool",
             lambda name: name == "web_search",
         )
+        streamed: list[str | None] = []
+        agent.stream_delta_callback = streamed.append
         with (
             patch(
                 "run_agent.handle_function_call",
@@ -4432,6 +4439,9 @@ class TestRunConversation:
         assert result["turn_exit_reason"] == "invalid_terminal_tool_result"
         assert "does not match answer" in result["final_response"]
         assert agent.client.chat.completions.create.call_count == 1
+        # The ordinary pre-tool segment break remains, but invalid terminal
+        # content is never streamed to the participant.
+        assert streamed == [None]
 
     def test_tool_call_none_args_verbose_logging_does_not_crash(self, agent):
         self._setup_agent(agent)

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1084,6 +1084,48 @@ class TestDiscoverAndRegister:
 
         _servers.pop("srv", None)
 
+    def test_terminal_output_schema_marks_registered_tool(self):
+        """An explicit terminal output contract survives MCP registration."""
+        from tools.registry import ToolRegistry
+        from tools.mcp_tool import _discover_and_register_server, _servers, MCPServerTask
+
+        mock_registry = ToolRegistry()
+        terminal_tool = _make_mcp_tool("final_answer", "Return a final answer")
+        terminal_tool.outputSchema = {
+            "type": "object",
+            "properties": {
+                "delivery_semantics": {
+                    "type": "string",
+                    "const": "terminal_verbatim",
+                },
+                "answer": {"type": "string"},
+                "answer_sha256": {"type": "string"},
+            },
+            "required": [
+                "delivery_semantics",
+                "answer",
+                "answer_sha256",
+            ],
+        }
+
+        async def fake_connect(name, config):
+            server = MCPServerTask(name)
+            server.session = MagicMock()
+            server._tools = [terminal_tool]
+            return server
+
+        with patch("tools.mcp_tool._connect_server", side_effect=fake_connect), \
+             patch("tools.registry.registry", mock_registry):
+            asyncio.run(
+                _discover_and_register_server("answers", {"command": "test"})
+            )
+
+        assert mock_registry.is_terminal_result_tool(
+            "mcp__answers__final_answer"
+        ) is True
+
+        _servers.pop("answers", None)
+
 
 # ---------------------------------------------------------------------------
 # MCPServerTask (run / start / shutdown)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5234,6 +5234,17 @@ def _convert_mcp_schema(server_name: str, mcp_tool) -> dict:
     }
 
 
+def _mcp_tool_returns_terminal_result(mcp_tool) -> bool:
+    """Detect the generic terminal-result opt-in from the advertised schema."""
+    from agent.terminal_tool_result import (
+        output_schema_declares_terminal_verbatim,
+    )
+
+    return output_schema_declares_terminal_verbatim(
+        getattr(mcp_tool, "outputSchema", None)
+    )
+
+
 def _build_utility_schemas(server_name: str) -> List[dict]:
     """Build schemas for the MCP utility tools (resources & prompts).
 
@@ -5526,6 +5537,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             check_fn=_make_check_fn(name),
             is_async=False,
             description=schema["description"],
+            terminal_result=_mcp_tool_returns_terminal_result(mcp_tool),
         )
         _track_mcp_tool_server(tool_name_prefixed, name)
         registered_names.append(tool_name_prefixed)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -91,11 +91,13 @@ class ToolEntry:
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
         "max_result_size_chars", "dynamic_schema_overrides",
+        "terminal_result",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 terminal_result=False):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -114,6 +116,7 @@ class ToolEntry:
         # on every get_definitions() call; results are merged shallow on top
         # of the base schema before the {"type": "function", ...} wrap.
         self.dynamic_schema_overrides = dynamic_schema_overrides
+        self.terminal_result = bool(terminal_result)
 
 
 # ---------------------------------------------------------------------------
@@ -276,6 +279,12 @@ class ToolRegistry:
         with self._lock:
             return self._tools.get(name)
 
+    def is_terminal_result_tool(self, name: str) -> bool:
+        """Return whether *name* may terminate a turn with its own answer."""
+        with self._lock:
+            entry = self._tools.get(name)
+            return bool(entry and entry.terminal_result)
+
     def get_registered_toolset_names(self) -> List[str]:
         """Return sorted unique toolset names present in the registry."""
         return sorted({entry.toolset for entry in self._snapshot_entries()})
@@ -375,6 +384,7 @@ class ToolRegistry:
         emoji: str = "",
         max_result_size_chars: int | float | None = None,
         dynamic_schema_overrides: Callable = None,
+        terminal_result: bool = False,
         override: bool = False,
     ):
         """Register a tool.  Called at module-import time by each tool file.
@@ -445,6 +455,7 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                terminal_result=terminal_result,
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by

--- a/website/docs/developer-guide/tools-runtime.md
+++ b/website/docs/developer-guide/tools-runtime.md
@@ -160,6 +160,37 @@ All tool execution is wrapped in error handling at two levels:
 
 This ensures the model always receives a well-formed JSON string, never an unhandled exception.
 
+### Terminal MCP results
+
+An MCP tool may explicitly declare that its result is already the
+participant-facing answer. Hermes detects this capability from the tool's
+advertised `outputSchema`; it is not inferred from the runtime payload alone.
+
+The output schema must require these fields:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "delivery_semantics": {
+      "type": "string",
+      "const": "terminal_verbatim"
+    },
+    "answer": {"type": "string"},
+    "answer_sha256": {"type": "string"}
+  },
+  "required": ["delivery_semantics", "answer", "answer_sha256"]
+}
+```
+
+When such a tool returns a valid result, Hermes verifies the lowercase SHA-256
+digest of the UTF-8 answer and ends the turn with the answer unchanged. It does
+not make another model call to rewrite or summarize the result. A missing,
+malformed, or mismatched terminal envelope fails the turn visibly instead of
+falling back to model synthesis.
+
+Ordinary MCP tools retain the normal tool-result-to-model continuation flow.
+
 ### Agent-loop tools
 
 Four tools are intercepted before registry dispatch because they need agent-level state (TodoStore, MemoryStore, etc.):


### PR DESCRIPTION
## Summary

- let MCP tools explicitly opt into terminal, participant-facing results through their advertised `outputSchema`
- validate the terminal envelope and SHA-256 digest before delivery
- end the turn with the exact answer without a second model rewrite
- fail visibly on malformed terminal results while leaving ordinary tools unchanged

## Contract

A terminal MCP tool must require `delivery_semantics`, `answer`, and `answer_sha256`, with `delivery_semantics` constrained to `terminal_verbatim`. Runtime payloads alone cannot opt a tool into terminal behavior.

## Verification

```text
HERMES_PYTHON=/home/brian/projects/.venv/bin/python scripts/run_tests.sh -j 2 \
  tests/agent/test_terminal_tool_result.py \
  tests/run_agent/test_run_agent.py \
  tests/tools/test_mcp_tool.py \
  -q -k 'terminal_tool_result or tool_calls_then_stop or terminal_output_schema_marks_registered_tool'

8 passed, 0 failed
```

`ruff check` and `git diff --check` also pass for the changed files.
