### PR TITLE
fix: pin audited frontend build dependencies

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -116,7 +116,7 @@
     "react-arborist": "^3.5.0",
     "react-dnd-html5-backend": "^14.0.3",
     "react-dom": "^19.2.5",
-    "react-router-dom": "^7.17.0",
+    "react-router-dom": "7.11.0",
     "react-shiki": "^0.9.3",
     "remark-math": "^6.0.0",
     "remend": "^1.3.0",

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -35,16 +35,14 @@ if (new URLSearchParams(window.location.search).get('win') === 'overlay') {
           <I18nProvider>
             <ThemeProvider>
               <HapticsProvider>
-                {/* useTransitions={false}: react-router v7's HashRouter wraps every
-                    route state update in React.startTransition() by default. In
-                    React 19's concurrent renderer, transitions are non-urgent — React
-                    can yield mid-render and resume later. When the app is under load
-                    (streaming token deltas, gateway events, store updates), those
-                    higher-priority updates keep interrupting the transition, starving
-                    the route change commit. The session sidebar highlight + main pane
-                    both freeze for seconds despite the main thread being free.
-                    Disabling transitions makes navigate() commit at default priority. */}
-                <HashRouter useTransitions={false}>
+                {/* react-router-dom is intentionally pinned to 7.11.0. Later v7
+                    releases enabled transition-backed HashRouter updates and exposed
+                    useTransitions={false}; under React 19 those non-urgent route commits
+                    can be starved by streaming token and gateway updates. Version 7.11
+                    predates that behavior, so its plain HashRouter keeps navigation at
+                    default priority without the later-only prop. Keep the pin and this
+                    invariant together when upgrading after the advisory is fixed. */}
+                <HashRouter>
                   <App />
                 </HashRouter>
               </HapticsProvider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,7 +135,7 @@
         "react-arborist": "^3.5.0",
         "react-dnd-html5-backend": "^14.0.3",
         "react-dom": "^19.2.5",
-        "react-router-dom": "^7.17.0",
+        "react-router-dom": "7.11.0",
         "react-shiki": "^0.9.3",
         "remark-math": "^6.0.0",
         "remend": "^1.3.0",
@@ -448,6 +448,44 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "apps/desktop/node_modules/react-router": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.11.0.tgz",
+      "integrity": "sha512-uI4JkMmjbWCZc01WVP2cH7ZfSzH91JAZUDd7/nIprDgWxBV1TkkmLToFh7EbMTcMak8URFRa2YoBL/W8GWnCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/desktop/node_modules/react-router-dom": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.11.0.tgz",
+      "integrity": "sha512-e49Ir/kMGRzFOOrYQBdoitq3ULigw4lKbAyKusnvtDu2t4dBX4AGYPrzNvorXmVuOyeakai6FUPW5MmibvVG8g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.11.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "apps/desktop/node_modules/undici-types": {
@@ -9549,9 +9587,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -15544,9 +15582,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -15563,7 +15601,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -15585,9 +15623,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -16266,44 +16304,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
-      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
-      "integrity": "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-shiki": {
@@ -19652,7 +19652,7 @@
         "qrcode": "^1.5.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router-dom": "^7.17.0",
+        "react-router-dom": "7.11.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.1",
         "unicode-animations": "^1.0.3"
@@ -19740,6 +19740,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "web/node_modules/react-router": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.11.0.tgz",
+      "integrity": "sha512-uI4JkMmjbWCZc01WVP2cH7ZfSzH91JAZUDd7/nIprDgWxBV1TkkmLToFh7EbMTcMak8URFRa2YoBL/W8GWnCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "web/node_modules/react-router-dom": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.11.0.tgz",
+      "integrity": "sha512-e49Ir/kMGRzFOOrYQBdoitq3ULigw4lKbAyKusnvtDu2t4dBX4AGYPrzNvorXmVuOyeakai6FUPW5MmibvVG8g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.11.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "web/node_modules/undici-types": {

--- a/web/package.json
+++ b/web/package.json
@@ -34,7 +34,7 @@
     "qrcode": "^1.5.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router-dom": "^7.17.0",
+    "react-router-dom": "7.11.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.1",
     "unicode-animations": "^1.0.3"


### PR DESCRIPTION
## Summary

- refresh the lockfile so `dompurify` resolves to 3.4.12 and `postcss` to 8.5.23
- pin `react-router-dom` to 7.11.0 in the web and desktop workspaces because GHSA-qwww-vcr4-c8h2 affects the currently published 7.12.0–8.2.0 range
- keep Desktop navigation at default priority on 7.11.0 without the later-only `useTransitions` prop

## Security evidence

Initial `npm audit` reported:

- GHSA-qwww-vcr4-c8h2 (`react-router` / `react-router-dom`), high
- GHSA-r28c-9q8g-f849 (`postcss`), high
- GHSA-c2j3-45gr-mqc4 (`dompurify`), low

Resolved versions in the lock/install tree:

- `react-router-dom` / `react-router`: 7.11.0
- `postcss`: 8.5.23
- `dompurify`: 3.4.12

A final live `npm audit` request is currently blocked by a registry response-encoding failure (`invalid json response body`, gzip bytes returned to npm's bulk advisory endpoint). This PR is intentionally draft until that endpoint can be rechecked.

## Verification

- Web: typecheck, 97 tests, lint (existing warnings only), production build
- Desktop: typecheck, 3,032 tests passed / 3 skipped, production build
- TUI: typecheck, 1,389 tests passed / 1 skipped, production build, lint
- `git diff --check`

## Risk

The React Router pin is a deliberate downgrade to the most recent published version outside the advisory range. Desktop's later-only `useTransitions={false}` prop is removed because 7.11.0 predates transition-backed HashRouter updates; the surrounding comment records the navigation-priority invariant for a future safe upgrade.
