### PR TITLE
fix(agent): restore shared OpenAI client retirement in stream watchdog/retry paths

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3492,9 +3492,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # already worker-owned-closed by _close_request_client_once
                         # above; the next attempt builds a fresh one. The shared
                         # _anthropic_client is never closed from inside a request.
-                        # #70773: same FD-recycle corruption vector for OpenAI.
-                        # The shared client will be replaced lazily by
-                        # _ensure_primary_openai_client on the next attempt.
+                        # #70773: retire (not close) the shared client —
+                        # _retire_shared_openai_client is FD-safe from any
+                        # thread. The next _ensure_primary_openai_client
+                        # will build a fresh shared client with clean sockets.
+                        try:
+                            agent._retire_shared_openai_client(
+                                agent.client,
+                                reason="stream_mid_tool_retry_pool_cleanup",
+                            )
+                        except Exception:
+                            pass
                         continue
 
                     # SSE error events from proxies (e.g. OpenRouter sends
@@ -3553,9 +3561,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             # above; next attempt builds fresh), so the shared
                             # _anthropic_client is never closed from inside a
                             # request — only the OpenAI-wire primary is refreshed.
-                            # #70773: same FD-recycle corruption vector for OpenAI.
-                            # The shared client will be replaced lazily by
-                            # _ensure_primary_openai_client on the next attempt.
+                            # #70773: retire (not close) the shared client —
+                            # _retire_shared_openai_client is FD-safe from any
+                            # thread.
+                            try:
+                                agent._retire_shared_openai_client(
+                                    agent.client,
+                                    reason="stream_retry_pool_cleanup",
+                                )
+                            except Exception:
+                                pass
                             continue
                         # Retries exhausted. Log the final failure with
                         # full diagnostic detail (chain, headers,
@@ -3798,15 +3813,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # FD-recycle corruption vector. Nothing further is needed.
                 pass
             else:
-                # #70773: same FD-recycle corruption vector as #67142.
-                # The shared OpenAI client's connection pool must NOT be
-                # closed from this watchdog/poll thread — worker threads
-                # from previous stale-killed attempts may still be
-                # unwinding their SSL BIOs.  The request-local client is
-                # already closed above via _close_request_client_once.
-                # The shared client will be replaced lazily by
-                # _ensure_primary_openai_client on the next request.
-                pass
+                # #70773: retire (not close) the shared client —
+                # _retire_shared_openai_client uses shutdown(SHUT_RDWR)
+                # which is FD-safe from any thread. The request-local
+                # client is already closed above.
+                try:
+                    agent._retire_shared_openai_client(
+                        agent.client,
+                        reason="stale_stream_pool_cleanup",
+                    )
+                except Exception:
+                    pass
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
             last_chunk_time["t"] = time.time()


### PR DESCRIPTION
## Summary

v0.19.0 commit e51abb2 removed `_replace_primary_openai_client()` from three streaming code paths to fix FD-recycle corruption (#70773), replacing them with `pass`. The follow-up commit 1608a4688 introduced the FD-safe `_retire_shared_openai_client()` but never wired it back into those three sites.

Without any shared client refresh, providers like DeepSeek experience persistent streaming timeouts in interactive CLI mode — every API call times out at 30s with `APITimeoutError`. Non-streaming (`-q`) and gateway modes are unaffected.

## Root Cause

The stale shared OpenAI client's connection pool is never refreshed after stream interruptions. Retries reuse the same dead connections, leading to deterministic timeouts.

## Fix

Replace the three `pass` sites with `agent._retire_shared_openai_client()` calls, which use `shutdown(SHUT_RDWR)` — FD-safe from any thread — instead of `close()`.

| Location | Reason |
|----------|--------|
| `stream_mid_tool_retry_cleanup` | Tool-call stream interruption retry |
| `stream_retry_pool_cleanup` | Stream retry cleanup |
| `stale_stream_pool_cleanup` | Stale stream watchdog trigger |

## Testing

- [x] Interactive CLI with DeepSeek v4 Pro + `display.streaming: true` — streaming works
- [x] Non-streaming (`-q`) — unaffected, still works
- [x] Gateway (Feishu) — unaffected, still works

## Related

- Fixes #71213
- Related to #71427 (alternative approach — this fix addresses the root cause rather than just skipping retries)
