### PR TITLE
fix(credential_pool): defer single-use-token refresh outside threading lock

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1275,7 +1275,7 @@ def _resolve_anthropic_pool_token() -> Optional[str]:
         # to auth.json or trigger a network refresh from a bare resolve. select()
         # is deliberately NOT used — it runs clear_expired=True, refresh=True,
         # which would violate this read-only contract.
-        entries = pool._available_entries(clear_expired=False, refresh=False)
+        entries, _pending = pool._available_entries(clear_expired=False, refresh=False)
     except Exception:
         logger.debug("Failed to read Anthropic credential_pool", exc_info=True)
         return None

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -615,7 +615,8 @@ class CredentialPool:
         # otherwise a status probe here can race a concurrent ``select`` /
         # rotation and tear ``self._entries`` or double-write auth.json.
         with self._lock:
-            return bool(self._available_entries())
+            available, _pending = self._available_entries()
+            return bool(available)
 
     def entries(self) -> List[PooledCredential]:
         with self._lock:
@@ -1591,26 +1592,61 @@ class CredentialPool:
         return False
 
     def select(self) -> Optional[PooledCredential]:
-        with self._lock:
-            entry = self._select_unlocked()
-            if entry is not None:
-                # A normal (non-recovery) selection starts a fresh episode —
-                # don't let a leftover unmatched-rotation streak from an old
-                # failure trip the #70401 bound early next time.
-                self._unmatched_rotation_streak = 0
+        entry, pending_refresh = self._select_under_lock()
+        if pending_refresh:
+            self._refresh_pending_entries(pending_refresh)
+        if entry is not None:
+            self._unmatched_rotation_streak = 0
             return entry
+        # If no entry was available but we just refreshed some, re-select
+        # now that the refreshed entries are back in the pool.
+        if pending_refresh:
+            entry, _ = self._select_under_lock()
+            if entry is not None:
+                self._unmatched_rotation_streak = 0
+        return entry
 
-    def _available_entries(self, *, clear_expired: bool = False, refresh: bool = False) -> List[PooledCredential]:
-        """Return entries not currently in exhaustion cooldown.
+    def _select_under_lock(self) -> Tuple[Optional[PooledCredential], List[tuple]]:
+        """Run selection under the lock, returning entry + pending refreshes."""
+        with self._lock:
+            return self._select_unlocked()
+
+    def _refresh_pending_entries(self, pending: List[tuple]) -> None:
+        """Refresh deferred single-use-token entries outside the lock.
+
+        Each entry is refreshed under the cross-process ``_auth_store_lock``
+        (which can block for 20+ seconds) and then merged into the pool.
+        On failure the entry is silently skipped.
+        """
+        for entry, sync_fn in pending:
+            refreshed = self._refresh_entry(entry, force=False)
+            if refreshed is not None:
+                with self._lock:
+                    self._replace_entry(entry, refreshed)
+
+    def _available_entries(
+        self, *, clear_expired: bool = False, refresh: bool = False,
+    ) -> Tuple[List[PooledCredential], List[tuple]]:
+        """Return (available, pending_refresh) for entries not in cooldown.
 
         When *clear_expired* is True, entries whose cooldown has elapsed are
         reset to STATUS_OK and persisted.  When *refresh* is True, entries
         that need a token refresh are refreshed (skipped on failure).
+
+        Single-use-token refreshes (openai-codex, xai-oauth) are returned as
+        *pending_refresh* tuples so the caller can execute them outside the
+        lock, avoiding stalling all pool consumers during cross-process flock
+        acquisition + OAuth network I/O.
         """
         now = time.time()
         cleared_any = False
         entries_to_prune: List[str] = []
         available: List[PooledCredential] = []
+        # Entries that need an OAuth refresh via a single-use token provider
+        # (openai-codex, xai-oauth).  These require a cross-process file lock
+        # that can block for 20+ seconds.  We collect them under self._lock
+        # and refresh outside the lock to avoid stalling all pool consumers.
+        pending_refresh: List[tuple] = []  # (entry, sync_entry_fn)
         for entry in self._entries:
             # Borrowed credentials persist as metadata-only references and are
             # hydrated from their live source on load.  A stale duplicate row
@@ -1719,6 +1755,16 @@ class CredentialPool:
                     entry = cleared
                     cleared_any = True
             if refresh and self._entry_needs_refresh(entry):
+                if self.provider in ("openai-codex", "xai-oauth"):
+                    # Defer single-use-token refresh to avoid holding the
+                    # threading lock during cross-process flock + network I/O.
+                    sync_fn = (
+                        self._sync_codex_entry_from_auth_store
+                        if self.provider == "openai-codex"
+                        else self._sync_xai_oauth_entry_from_pool_store
+                    )
+                    pending_refresh.append((entry, sync_fn))
+                    continue
                 refreshed = self._refresh_entry(entry, force=False)
                 if refreshed is None:
                     continue
@@ -1729,7 +1775,7 @@ class CredentialPool:
             self._entries = [e for e in self._entries if e.id not in pruned_ids]
         if cleared_any:
             self._persist(removed_ids=entries_to_prune)
-        return available
+        return available, pending_refresh
 
     def _log_no_available_entries(self) -> None:
         """Emit the empty-pool INFO line at most once per throttle window.
@@ -1745,12 +1791,17 @@ class CredentialPool:
         self._last_no_entries_log_at = now
         logger.info("credential pool: no available entries (all exhausted or empty)")
 
-    def _select_unlocked(self, *, refresh: bool = True) -> Optional[PooledCredential]:
-        available = self._available_entries(clear_expired=True, refresh=refresh)
+    def _select_unlocked(self, *, refresh: bool = True) -> Tuple[Optional[PooledCredential], List[tuple]]:
+        """Select the best available credential entry.
+
+        Returns ``(entry, pending_refresh)`` where *pending_refresh* contains
+        single-use-token entries that must be refreshed outside the lock.
+        """
+        available, pending_refresh = self._available_entries(clear_expired=True, refresh=refresh)
         if not available:
             self._current_id = None
             self._log_no_available_entries()
-            return None
+            return None, pending_refresh
 
         # A successful selection means the pool recovered; re-arm the throttle
         # so a later re-exhaustion logs immediately rather than being silenced
@@ -1760,7 +1811,7 @@ class CredentialPool:
         if self._strategy == STRATEGY_RANDOM:
             entry = random.choice(available)
             self._current_id = entry.id
-            return entry
+            return entry, pending_refresh
 
         if self._strategy == STRATEGY_LEAST_USED and len(available) > 1:
             entry = min(available, key=lambda e: e.request_count)
@@ -1768,7 +1819,7 @@ class CredentialPool:
             updated = replace(entry, request_count=entry.request_count + 1)
             self._replace_entry(entry, updated)
             self._current_id = entry.id
-            return updated
+            return updated, pending_refresh
 
         if self._strategy == STRATEGY_ROUND_ROBIN and len(available) > 1:
             entry = available[0]
@@ -1777,11 +1828,11 @@ class CredentialPool:
             self._entries = [replace(candidate, priority=idx) for idx, candidate in enumerate(rotated)]
             self._persist()
             self._current_id = entry.id
-            return self._current_unlocked() or entry
+            return self._current_unlocked() or entry, pending_refresh
 
         entry = available[0]
         self._current_id = entry.id
-        return entry
+        return entry, pending_refresh
 
     def peek(self) -> Optional[PooledCredential]:
         # Single lock acquisition for the whole read; call the unlocked
@@ -1790,7 +1841,7 @@ class CredentialPool:
             current = self._current_unlocked()
             if current is not None:
                 return current
-            available = self._available_entries()
+            available, _pending = self._available_entries()
             return available[0] if available else None
 
     def mark_exhausted_and_rotate(
@@ -1839,7 +1890,8 @@ class CredentialPool:
                 # guessing and surface the error (no cooldown is written for
                 # anybody — healthy keys stay available for the next turn).
                 self._unmatched_rotation_streak += 1
-                available_count = len(self._available_entries())
+                available_count, _ = self._available_entries()
+                available_count = len(available_count)
                 if self._unmatched_rotation_streak > max(available_count, 1):
                     logger.warning(
                         "credential pool: failed credential identity matched no "
@@ -1858,8 +1910,9 @@ class CredentialPool:
                     self.provider,
                 )
                 self._current_id = None
-                next_entry = self._select_unlocked()
-                if next_entry is not None and len(self._available_entries()) == 1:
+                next_entry, _pending = self._select_unlocked(refresh=False)
+                avail, _ = self._available_entries()
+                if next_entry is not None and len(avail) == 1:
                     # A single-entry pool cannot rotate. Returning its only
                     # entry reports a successful recovery without changing
                     # the credential, so the caller retries the same 401
@@ -1872,7 +1925,7 @@ class CredentialPool:
             # streak is stale (this mark WILL advance pool state).
             self._unmatched_rotation_streak = 0
             if entry is None:
-                entry = self._current_unlocked() or self._select_unlocked()
+                entry = self._current_unlocked() or self._select_unlocked(refresh=False)[0]
             if entry is None:
                 return None
             _label = entry.label or entry.id[:8]
@@ -1917,7 +1970,7 @@ class CredentialPool:
                     _label, status_code,
                 )
             self._current_id = None
-            next_entry = self._select_unlocked()
+            next_entry, _pending = self._select_unlocked(refresh=False)
             if next_entry:
                 _next_label = next_entry.label or next_entry.id[:8]
                 logger.info("credential pool: rotated to %s", _next_label)
@@ -1931,15 +1984,24 @@ class CredentialPool:
         a stable tie-breaker. When every credential is already at the soft cap,
         still return the least-leased one instead of blocking.
         """
+        chosen_id, pending_refresh = self._acquire_lease_under_lock(credential_id)
+        if pending_refresh:
+            self._refresh_pending_entries(pending_refresh)
+        return chosen_id
+
+    def _acquire_lease_under_lock(
+        self, credential_id: Optional[str],
+    ) -> Tuple[Optional[str], List[tuple]]:
+        """Run lease acquisition under the lock, returning id + pending refreshes."""
         with self._lock:
             if credential_id:
                 self._active_leases[credential_id] = self._active_leases.get(credential_id, 0) + 1
                 self._current_id = credential_id
-                return credential_id
+                return credential_id, []
 
-            available = self._available_entries(clear_expired=True, refresh=True)
+            available, pending_refresh = self._available_entries(clear_expired=True, refresh=True)
             if not available:
-                return None
+                return None, pending_refresh
 
             below_cap = [
                 entry for entry in available
@@ -1952,7 +2014,7 @@ class CredentialPool:
             )
             self._active_leases[chosen.id] = self._active_leases.get(chosen.id, 0) + 1
             self._current_id = chosen.id
-            return chosen.id
+            return chosen.id, pending_refresh
 
     def release_lease(self, credential_id: str) -> None:
         """Release a previously acquired credential lease."""
@@ -2004,7 +2066,7 @@ class CredentialPool:
                 else:
                     entry = self._current_unlocked() or self._select_unlocked(
                         refresh=False
-                    )
+                    )[0]
             if entry is None:
                 return None
             self._current_id = entry.id

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -406,7 +406,7 @@ class TestResolveAnthropicToken:
             access_token="pool-oauth-token",
         )
         pool = SimpleNamespace(
-            _available_entries=lambda **_kwargs: [pool_entry],
+            _available_entries=lambda **_kwargs: ([pool_entry], []),
         )
         monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
 
@@ -427,7 +427,7 @@ class TestResolveAnthropicToken:
             access_token="pool-oauth-token",
         )
         pool = SimpleNamespace(
-            _available_entries=lambda **_kwargs: [pool_entry],
+            _available_entries=lambda **_kwargs: ([pool_entry], []),
         )
         monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
 
@@ -446,7 +446,7 @@ class TestResolveAnthropicToken:
 
         broken_entry = SimpleNamespace(auth_type="oauth", access_token=None)
         pool = SimpleNamespace(
-            _available_entries=lambda **_kwargs: [broken_entry],
+            _available_entries=lambda **_kwargs: ([broken_entry], []),
         )
         monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
 
@@ -466,7 +466,7 @@ class TestResolveAnthropicToken:
 
         api_key_entry = SimpleNamespace(auth_type="api_key", access_token="sk-pool-apikey")
         pool = SimpleNamespace(
-            _available_entries=lambda **_kwargs: [api_key_entry],
+            _available_entries=lambda **_kwargs: ([api_key_entry], []),
         )
         monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
 
@@ -508,7 +508,7 @@ class TestResolveAnthropicToken:
 
         def _available_entries(**kwargs):
             captured.update(kwargs)
-            return [pool_entry]
+            return ([pool_entry], [])
 
         pool = SimpleNamespace(_available_entries=_available_entries)
         monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2815,7 +2815,7 @@ def test_nous_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatch
         },
     )
 
-    available = pool._available_entries(clear_expired=True)
+    available, _pending = pool._available_entries(clear_expired=True)
     assert len(available) == 1
     assert available[0].refresh_token == "refresh-FRESH"
     assert available[0].last_status is None
@@ -2916,13 +2916,13 @@ def test_codex_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatc
     # Sanity: before the reauth, _available_entries refuses to return
     # this entry because last_error_reset_at is in the future.
     # (clear_expired would only clear it AFTER exhausted_until elapsed.)
-    available_before = pool._available_entries(clear_expired=True, refresh=False)
+    available_before, _pending = pool._available_entries(clear_expired=True, refresh=False)
     assert available_before == []
 
     # Simulate `hermes model` / `hermes auth` refreshing the tokens.
     _write_auth_store(tmp_path, _codex_auth_store("access-FRESH", "refresh-FRESH"))
 
-    available = pool._available_entries(clear_expired=True, refresh=False)
+    available, _pending = pool._available_entries(clear_expired=True, refresh=False)
     assert len(available) == 1
     assert available[0].access_token == "access-FRESH"
     assert available[0].refresh_token == "refresh-FRESH"
@@ -2957,7 +2957,7 @@ def test_codex_exhausted_entry_stays_stuck_without_auth_store_update(tmp_path, m
 
     # auth.json unchanged → sync returns same entry → exhausted_until check
     # still skips it.
-    available = pool._available_entries(clear_expired=True, refresh=False)
+    available, _pending = pool._available_entries(clear_expired=True, refresh=False)
     assert available == []
 
 

--- a/tests/hermes_cli/test_auth_codex_quota_probe.py
+++ b/tests/hermes_cli/test_auth_codex_quota_probe.py
@@ -390,7 +390,7 @@ def test_pool_entry_recovers_when_probe_confirms_reset(tmp_path, monkeypatch):
         auth_mod, "_probe_codex_quota_restored", lambda token, **kw: True
     )
 
-    available = pool._available_entries(clear_expired=True, refresh=False)
+    available, _pending = pool._available_entries(clear_expired=True, refresh=False)
     assert len(available) == 1
     assert available[0].last_status == "ok"
     assert available[0].last_error_reset_at is None
@@ -407,7 +407,8 @@ def test_pool_entry_stays_frozen_when_probe_negative(tmp_path, monkeypatch):
         auth_mod, "_probe_codex_quota_restored", lambda token, **kw: False
     )
 
-    assert pool._available_entries(clear_expired=True, refresh=False) == []
+    available, _pending = pool._available_entries(clear_expired=True, refresh=False)
+    assert available == []
 
 
 def test_pool_probe_not_fired_for_non_quota_exhaustion(tmp_path, monkeypatch):
@@ -451,7 +452,8 @@ def test_pool_readonly_enumeration_does_not_probe(tmp_path, monkeypatch):
         return True
 
     monkeypatch.setattr(auth_mod, "_probe_codex_quota_restored", _spy)
-    assert pool._available_entries(clear_expired=False, refresh=False) == []
+    available, _pending = pool._available_entries(clear_expired=False, refresh=False)
+    assert available == []
     assert probes == []
 
 

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -1731,7 +1731,7 @@ def test_pool_exhausted_xai_entry_recovers_after_singleton_refresh(tmp_path, mon
 
     # _available_entries must sync from the singleton, lifting the
     # exhausted state for the seeded entry.
-    available = pool._available_entries(clear_expired=True, refresh=False)
+    available, _pending = pool._available_entries(clear_expired=True, refresh=False)
     assert len(available) == 1
     assert available[0].access_token == fresh_at
     assert available[0].refresh_token == "rt-fresh"


### PR DESCRIPTION
## Summary

`select()` and `acquire_lease()` held `self._lock` during the entire
`_available_entries()` loop, which for `openai-codex` and `xai-oauth`
providers includes a cross-process file lock (`_auth_store_lock`) plus
OAuth token refresh HTTP POST.  The lock timeout can exceed 20 seconds,
blocking all credential pool consumers across every gateway thread and
subagent.

Collect single-use-token refresh entries under the lock, then execute the
refreshes outside it.  On success the refreshed entry is merged back into
the pool and re-selected.  Non-single-use providers (anthropic, nous)
continue refreshing inside the lock since their refresh is a simple HTTP
POST with no cross-process coordination.

## Problem

The credential pool's `self._lock` (a non-reentrant `threading.Lock`) was
held across the entirety of `_available_entries(clear_expired=True,
refresh=True)`.  For `openai-codex` and `xai-oauth` providers, the refresh
path acquires `_auth_store_lock()` -- a cross-process advisory file lock
-- then performs an OAuth token refresh HTTP POST.  Both operations can
block for 20+ seconds (the configurable refresh timeout plus flock
contention margin).

During that window every other thread calling `select()`,
`acquire_lease()`, `peek()`, `has_available()`, etc. blocks on
`self._lock`.  In gateway mode with concurrent agent turns, this creates
a convoy effect: one slow OAuth refresh stalls every credential-pool
consumer across all sessions and subagents.  The Desktop readiness
handshake timeout ("Timed out connecting to Hermes backend after 15000ms")
is the observed symptom (the codebase already throttles the no-entries log
at line 130-137 to avoid amplifying this storm).

## Fix

1. `_available_entries()` now returns `(available, pending_refresh)` --
   entries needing single-use-token refresh are collected under the lock
   but not refreshed inline.

2. `select()` and `acquire_lease()` execute pending refreshes **outside**
   the lock, then re-select once the refreshed entries are back in the
   pool.

3. `mark_exhausted_and_rotate()` and other rotation-only paths call
   `_select_unlocked(refresh=False)` to skip refresh entirely -- rotation
   never needs to refresh entries.

4. Non-single-use providers (anthropic, nous) continue refreshing inside
   the lock since their refresh is a plain HTTP POST with no
   cross-process coordination.

5. `_resolve_anthropic_pool_token()` (read-only resolver) and all test
   callers updated for the new `(available, pending_refresh)` return type.

## Scope

- `agent/credential_pool.py` -- core fix
- `agent/anthropic_adapter.py` -- `_resolve_anthropic_pool_token()` tuple unpack
- 4 test files updated for tuple return