### PR TITLE
fix(hermes-achievements): allow filter pills to toggle off when clicked again

### DIFF
--- a/plugins/hermes-achievements/dashboard/dist/index.js
+++ b/plugins/hermes-achievements/dashboard/dist/index.js
@@ -695,10 +695,10 @@
           // Render the localized "All" pill but keep the underlying value
           // unchanged so the filter logic still compares against "All".
           const pillLabel = cat === "All" ? allCategoryLabel : cat;
-          return React.createElement("button", { key: cat, onClick: function () { setCategory(cat); }, className: cat === category ? "active" : "" }, pillLabel);
+          return React.createElement("button", { key: cat, onClick: function () { setCategory(cat === category ? "All" : cat); }, className: cat === category ? "active" : "" }, pillLabel);
         })),
         React.createElement("div", { className: "ha-pills" }, ["all", "unlocked", "discovered", "secret"].map(function (v) {
-          return React.createElement("button", { key: v, onClick: function () { setVisibility(v); }, className: v === visibility ? "active" : "" }, visibilityLabels[v] || v);
+          return React.createElement("button", { key: v, onClick: function () { setVisibility(v === visibility ? "all" : v); }, className: v === visibility ? "active" : "" }, visibilityLabels[v] || v);
         }))
       ),
       latest.length > 0 && React.createElement("section", { className: "ha-latest" },


### PR DESCRIPTION
## Problem

Clicking an already-active filter pill (category or visibility) in the
hermes-achievements dashboard tab was a no-op — the pill stayed selected
and the user couldn't clear the filter without picking another one or
refreshing the tab.

## Fix

When the clicked pill already matches the active state, reset to the
neutral default:
- category pill active -> set back to "All"
- visibility pill active -> set back to "all"

Two-line change in the filter toolbar render. Filter logic itself is
unchanged (the visible-results predicate still treats "All" / "all" as 'show everything').

## Tested

```bash
node --check plugins/hermes-achievements/dashboard/dist/index.js  # OK
python3 -m py_compile plugins/hermes-achievements/dashboard/plugin_api.py  # OK
```

Files touched: `plugins/hermes-achievements/dashboard/dist/index.js` (+2 / -2). The plugin ships without a build step — `dist/index.js` is the source of record.