### PR TITLE
fix(openrouter): give auxiliary calls the sticky routing key

### DIFF
--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Any
 
+from agent.portal_tags import get_conversation_context
 from providers import register_provider
 from providers.base import ProviderProfile
 
@@ -77,8 +78,26 @@ class OpenRouterProfile(ProviderProfile):
         self, *, session_id: str | None = None, **context: Any
     ) -> dict[str, Any]:
         body: dict[str, Any] = {}
-        if session_id:
-            body["session_id"] = session_id
+        # Top-level session_id → OpenRouter's sticky routing key. Per their
+        # prompt-caching docs it is used directly as the routing key instead of
+        # hashing the opening messages, and it activates stickiness on the
+        # first successful request rather than only after a cache hit.
+        #
+        # Resolve it from the ambient conversation contextvar first, explicit
+        # argument as fallback. The gap this closes is the auxiliary call sites
+        # — compression, title generation, vision, web_extract, session_search,
+        # MoA slots — which funnel through ``agent.auxiliary_client``. That
+        # module has no session handle and passes no ``session_id``, so those
+        # calls sent NO sticky key at all and each routed independently of the
+        # conversation it belonged to (#70820).
+        #
+        # Mirrors the Nous Portal profile, which resolves the same way
+        # (f2f4df064d). The ambient value is the session-lineage ROOT, so it
+        # also stays stable for installs that opt out of the default
+        # ``compression.in_place: true`` and across delegate-subagent trees.
+        sticky_key = get_conversation_context() or session_id
+        if sticky_key:
+            body["session_id"] = sticky_key
         prefs = context.get("provider_preferences")
         if prefs:
             body["provider"] = prefs
@@ -159,8 +178,13 @@ class OpenRouterProfile(ProviderProfile):
             else:
                 extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
 
-        if session_id and model and model.startswith(("x-ai/grok-", "xai/grok-")):
-            extra_headers["x-grok-conv-id"] = session_id
+        # Same resolution as build_extra_body: xAI's prompt cache is pinned per
+        # backend server via this header, and aux calls pass no session_id, so
+        # reading the ambient conversation keeps compression/vision/MoA traffic
+        # on the same Grok backend as the conversation it belongs to.
+        grok_conv_id = get_conversation_context() or session_id
+        if grok_conv_id and model and model.startswith(("x-ai/grok-", "xai/grok-")):
+            extra_headers["x-grok-conv-id"] = grok_conv_id
         if extra_headers:
             top_level["extra_headers"] = extra_headers
 

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -112,6 +112,53 @@ class TestOpenRouterProfile:
         body = p.build_extra_body()
         assert body == {}
 
+    def test_aux_call_inherits_ambient_conversation_as_sticky_key(self):
+        """Auxiliary calls pass no session_id but must still route stickily.
+
+        Compression, titles, vision, web_extract, session_search and MoA slots
+        funnel through ``agent.auxiliary_client``, which has no session handle.
+        Before the ambient resolution they sent NO sticky key at all and each
+        routed independently of its conversation (#70820).
+        """
+        from agent.portal_tags import (
+            reset_conversation_context,
+            set_conversation_context,
+        )
+
+        p = get_provider_profile("openrouter")
+        token = set_conversation_context("root-conversation")
+        try:
+            assert p.build_extra_body()["session_id"] == "root-conversation"
+            # An explicitly-passed segment id never beats the lineage root.
+            body = p.build_extra_body(session_id="segment-after-rotation")
+            assert body["session_id"] == "root-conversation"
+        finally:
+            reset_conversation_context(token)
+
+    def test_grok_cache_header_inherits_ambient_conversation(self):
+        """The xAI cache-affinity header resolves the same way as the body key."""
+        from agent.portal_tags import (
+            reset_conversation_context,
+            set_conversation_context,
+        )
+
+        p = get_provider_profile("openrouter")
+        token = set_conversation_context("root-conversation")
+        try:
+            _, top_level = p.build_api_kwargs_extras(
+                supports_reasoning=False, model="x-ai/grok-4"
+            )
+            headers = top_level.get("extra_headers", {})
+            assert headers["x-grok-conv-id"] == "root-conversation"
+
+            # Still model-gated: non-Grok models get no affinity header.
+            _, other = p.build_api_kwargs_extras(
+                supports_reasoning=False, model="anthropic/claude-sonnet-4.6"
+            )
+            assert "x-grok-conv-id" not in other.get("extra_headers", {})
+        finally:
+            reset_conversation_context(token)
+
     def test_pareto_min_coding_score_emitted_for_pareto_model(self):
         """min_coding_score → plugins block when model is openrouter/pareto-code."""
         p = get_provider_profile("openrouter")


### PR DESCRIPTION
## Summary

Auxiliary LLM calls routed through OpenRouter now carry the `session_id` sticky routing key, so they pin to the same provider endpoint as the conversation they belong to instead of routing independently.

Fixes #70820. Completes the sibling half of `f2f4df064d`, which fixed the same bug class in the Nous Portal profile.

## Root cause

`OpenRouterProfile.build_extra_body` sourced the key only from its explicit argument. Auxiliary call sites (compression, title generation, vision, `web_extract`, `session_search`, MoA slots) funnel through `agent/auxiliary_client.py`, which has no session handle and never passes one — so those requests sent **no sticky key at all** and OpenRouter fell back to hashing the opening messages.

Per [OpenRouter's prompt-caching docs](https://openrouter.ai/docs/features/prompt-caching#using-session_id-for-sticky-sessions), a present `session_id` is used *directly* as the routing key and activates stickiness on the first successful request rather than only after a cache hit — so the missing key also delayed pinning for the main loop.

Probed against the live profile:

| call site | before | after |
| --- | --- | --- |
| aux call (no `session_id`) | `None` | `root-abc` |
| explicit id + ambient root | `segment-9` | `root-abc` |
| `x-grok-conv-id` on aux call | *(absent)* | `root-abc` |

## Changes

- `plugins/model-providers/openrouter/__init__.py`: resolve the sticky key from the ambient conversation contextvar first, explicit argument as fallback — the same resolution the Nous profile uses and the same one `nous_portal_tags` already used for the `conversation=` tag.
- Same fix for the xAI `x-grok-conv-id` cache-affinity header in `build_api_kwargs_extras`, which had the identical gap. Still model-gated to `x-ai/grok-*` / `xai/grok-*`.
- `tests/providers/test_provider_profiles.py`: 2 cases.

Because the ambient value is the session-lineage ROOT, the key also stays stable for installs that opt out of the default `compression.in_place: true`, and across delegate-subagent trees.

## Validation

```
=== Summary: 4 files, 459 tests passed, 0 failed ===
tests/providers/test_provider_profiles.py  tests/agent/test_portal_tags.py
tests/agent/test_auxiliary_client.py  tests/agent/test_auxiliary_runtime_cache_key.py
```

Sabotage run — both resolutions reverted to pre-fix behavior, confirming the new tests actually bite: 60 passed / **2 failed**.

E2E on a real `AIAgent` (no mocks) driving the out-of-turn compaction path:

```
aux sticky key : or-root-1
grok conv hdr  : or-root-1
no leak after  : None
```

Back-compat verified: explicit `session_id` still wins outside any turn, non-Grok models still get no affinity header, and the Pareto `plugins` block is untouched.

## Credit

@webtecnica reported #70820 and submitted #70883 first, threading `session_id` through `call_llm` toward the same goal. This takes the ambient-contextvar route instead: none of the 34 `call_llm` call sites currently pass a `session_id`, so the parameter alone would not have changed any live request. Their diagnosis of the gap was correct and is what this builds on.
