### PR TITLE
fix(web-tools): lazy plugin discovery in registry access functions

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -173,6 +173,30 @@ _LEGACY_WEB_BACKENDS = frozenset(
 )
 
 
+def _ensure_web_plugins_loaded_once() -> None:
+    """Lazily trigger plugin discovery so the web registry is populated.
+
+    Idempotent and cheap on subsequent calls (plugin discovery itself is
+    cached). This makes every registry access in this module order-
+    independent: ``_registered_web_provider()``, ``_list_registered_web_
+    providers()``, and every caller that chains through them
+    (``_is_backend_available``, ``_get_backend``, ``_get_capability_backend``)
+    no longer depend on the caller having called ``_ensure_web_plugins_loaded``
+    first.
+
+    This fixes the class of bug where ``web_extract_tool`` selected a
+    backend (e.g. ``crawl4ai``) before plugin discovery ran, causing
+    ``_is_backend_available`` to miss the provider and silently fall back
+    to the wrong backend (issue: extract_backend=crawl4ai not resolving).
+    """
+    try:
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+    except Exception as exc:  # noqa: BLE001 — discovery must never be fatal
+        logger.debug("web plugin discovery failed (non-fatal): %s", exc)
+
+
 def _registered_web_provider(backend: str):
     """Return a plugin-registered web provider by name, or ``None``.
 
@@ -180,9 +204,14 @@ def _registered_web_provider(backend: str):
     plugin system (which are absent from :data:`_LEGACY_WEB_BACKENDS`) are
     discoverable during availability/selection resolution. Returns ``None``
     on any lookup failure so callers can fall through to legacy checks.
+
+    Lazily triggers plugin discovery first so the registry is populated
+    even when this is called before any tool has run
+    ``_ensure_web_plugins_loaded()``.
     """
     if not backend:
         return None
+    _ensure_web_plugins_loaded_once()
     try:
         from agent.web_search_registry import get_provider
 
@@ -210,7 +239,13 @@ def _registered_web_provider_available(backend: str):
 
 
 def _list_registered_web_providers():
-    """Return all plugin-registered web providers (empty list on failure)."""
+    """Return all plugin-registered web providers (empty list on failure).
+
+    Lazily triggers plugin discovery first so the registry is populated
+    even when this is called before any tool has run
+    ``_ensure_web_plugins_loaded()``.
+    """
+    _ensure_web_plugins_loaded_once()
     try:
         from agent.web_search_registry import list_providers
 


### PR DESCRIPTION
## Problem

`web_extract_tool()` called `_get_extract_backend()` **before** `_ensure_web_plugins_loaded()`, so plugin-registered backends (e.g. a custom `crawl4ai` extract provider) were not yet in the `web_search_registry` when availability was checked. `_is_backend_available()` returned `None` for the configured backend, silently falling back to the wrong provider (e.g. `ddgs` or `firecrawl` instead of `crawl4ai`).

The symptom: `web.extract_backend: crawl4ai` set in config, `web-crawl4ai` plugin enabled, container running — but `web_extract` returned `"ddgs is a search-only backend and cannot extract URL content"`.

## Root Cause

The registry access functions (`_registered_web_provider`, `_list_registered_web_providers`) assumed plugin discovery had already been triggered by the caller. This made the entire backend selection chain fragile and order-dependent:

```
_get_extract_backend()
  → _get_capability_backend("extract")
    → _is_backend_available("crawl4ai")
      → _registered_web_provider_available("crawl4ai")
        → _registered_web_provider("crawl4ai")
          → registry lookup → None (discovery hasn't run yet!)
      → returns None → falls through to _get_backend() → wrong backend
```

`web_search_tool()` happened to have the correct call order (`_ensure_web_plugins_loaded()` before `_get_search_backend()`), but `web_extract_tool()` had them reversed — a copy-paste regression.

## Fix

Added `_ensure_web_plugins_loaded_once()` — a lazy discovery helper that calls the idempotent `_ensure_plugins_discovered()`. Injected it into the two registry access functions that all backend selection chains through:

- `_registered_web_provider(backend)` — calls `_ensure_web_plugins_loaded_once()` before registry lookup
- `_list_registered_web_providers()` — calls `_ensure_web_plugins_loaded_once()` before listing

This makes `_is_backend_available` → `_get_capability_backend` → `_get_extract_backend` fully order-independent. Any caller that queries the registry gets discovery for free, regardless of call order.

The existing explicit `_ensure_web_plugins_loaded()` calls in `web_search_tool()` and `web_extract_tool()` are left in place as belt-and-suspenders (0ms overhead after first call due to the `_discovered` re-entrancy guard in `PluginManager.discover_and_load()`).

## Verification

```python
# Without any prior plugin discovery call:
>>> _is_backend_available("crawl4ai")
True
>>> _get_extract_backend()
'crawl4ai'

# Idempotency: 100 calls take 0.000s (cached via _discovered flag)
# No circular import (try/except guards; hermes_cli.plugins does not import web_tools)
```

End-to-end test:
```
web_search("e-waste recycling Victoria")  → 3 results via ddgs ✅
web_extract("https://www.sustainability.vic.gov.au/...")  → 3488 chars via crawl4ai ✅
```

## Checklist

- [x] Root cause identified (order-dependent registry access)
- [x] Fix targets the registry access layer, not a single call site
- [x] Idempotent (relies on existing `_discovered` re-entrancy guard)
- [x] No circular import risk (verified at runtime)
- [x] No performance impact (0ms per call after first)
- [x] Existing explicit `_ensure_web_plugins_loaded()` calls preserved as belt-and-suspenders
- [x] `web_extract_tool()` code unchanged from upstream (no ordering hack)