### PR TITLE
fix: add CREATE_NO_WINDOW to subprocess calls in whatsapp, simplex, mem0 plugins

### DIFF
--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -11,6 +11,8 @@ import subprocess
 import sys
 import urllib.request
 from pathlib import Path
+
+from hermes_cli._subprocess_compat import windows_hide_flags
 from typing import Any
 
 from hermes_constants import get_hermes_home
@@ -538,12 +540,14 @@ def _ensure_pgvector(host: str = "localhost", port: int = 5432) -> dict | None:
             result = subprocess.run(
                 ["docker", "inspect", _PGVECTOR_CONTAINER, "--format", "{{.State.Status}}"],
                 capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=10, stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             if result.returncode == 0 and "exited" in result.stdout:
                 print(f"  Found stopped container '{_PGVECTOR_CONTAINER}', restarting...")
                 subprocess.run(["docker", "start", _PGVECTOR_CONTAINER],
                                capture_output=True, timeout=15,
-                               stdin=subprocess.DEVNULL)
+                               stdin=subprocess.DEVNULL,
+                               creationflags=windows_hide_flags())
                 _wait_for_port(host, port, timeout=15)
                 ok, _ = _check_pgvector(host, port)
                 if ok:
@@ -570,12 +574,14 @@ def _start_pgvector_docker(host: str, port: int) -> dict | None:
         print(f"  Pulling {_PGVECTOR_IMAGE}...")
         subprocess.run(["docker", "pull", _PGVECTOR_IMAGE],
                        capture_output=True, timeout=120,
-                       stdin=subprocess.DEVNULL)
+                       stdin=subprocess.DEVNULL,
+                       creationflags=windows_hide_flags())
 
         # Remove existing container if present
         subprocess.run(["docker", "rm", "-f", _PGVECTOR_CONTAINER],
                        capture_output=True, timeout=10,
-                       stdin=subprocess.DEVNULL)
+                       stdin=subprocess.DEVNULL,
+                       creationflags=windows_hide_flags())
 
         print(f"  Starting container '{_PGVECTOR_CONTAINER}' on port {port}...")
         subprocess.run([
@@ -584,7 +590,8 @@ def _start_pgvector_docker(host: str, port: int) -> dict | None:
             "-e", f"POSTGRES_PASSWORD={_PGVECTOR_PASSWORD}",
             "-p", f"{port}:5432",
             _PGVECTOR_IMAGE,
-        ], capture_output=True, timeout=30, check=True, stdin=subprocess.DEVNULL)
+        ], capture_output=True, timeout=30, check=True, stdin=subprocess.DEVNULL,
+           creationflags=windows_hide_flags())
 
         _wait_for_port(host, port, timeout=20)
         ok, _ = _check_pgvector(host, port)
@@ -866,6 +873,7 @@ def _install_provider_deps(llm_id: str, embedder_id: str, vector_id: str) -> Non
             subprocess.run(
                 ["uv", "pip", "install", "--python", sys.executable, dep],
                 capture_output=True, timeout=60,
+                creationflags=windows_hide_flags(),
             )
             print(f"  ✓ Installed {dep}")
         except Exception:

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -870,6 +870,8 @@ class SimplexAdapter(BasePlatformAdapter):
         import subprocess
         import tempfile
 
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
         p = Path(file_path)
         png_path = file_path
         thumb_uri = ""
@@ -900,6 +902,7 @@ class SimplexAdapter(BasePlatformAdapter):
                         check=True,
                         capture_output=True,
                         timeout=30,
+                        creationflags=windows_hide_flags(),
                     )
                 with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
                     tmp_path = tmp.name
@@ -916,6 +919,7 @@ class SimplexAdapter(BasePlatformAdapter):
                     check=True,
                     capture_output=True,
                     timeout=30,
+                    creationflags=windows_hide_flags(),
                 )
                 with open(tmp_path, "rb") as f:
                     thumb_uri = (

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -27,7 +27,7 @@ _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
 from typing import Dict, Optional, Any
 
-from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
+from hermes_cli._subprocess_compat import windows_detach_popen_kwargs, windows_hide_flags
 from hermes_constants import (
     find_node_executable,
     get_hermes_dir,
@@ -83,8 +83,6 @@ def _kill_port_process(port: int) -> None:
     """Kill any process *listening* on the given TCP port (a stale bridge)."""
     try:
         if _IS_WINDOWS:
-            from hermes_cli._subprocess_compat import windows_hide_flags
-
             # Use netstat to find the PID bound to this port, then taskkill
             result = subprocess.run(
                 ["netstat", "-ano", "-p", "TCP"],
@@ -225,6 +223,7 @@ def _terminate_bridge_process(proc, *, force: bool = False) -> None:
                 capture_output=True,
                 text=True, encoding='utf-8', errors='replace',
                 timeout=10,
+                creationflags=windows_hide_flags(),
             )
         except FileNotFoundError:
             if force:
@@ -350,7 +349,8 @@ def check_whatsapp_requirements() -> bool:
             [_node, "--version"],
             capture_output=True,
             text=True, encoding='utf-8', errors='replace',
-            timeout=5
+            timeout=5,
+            creationflags=windows_hide_flags(),
         )
         return result.returncode == 0
     except Exception:
@@ -552,6 +552,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         text=True, encoding='utf-8', errors='replace',
                         timeout=npm_install_timeout,
                         env=with_hermes_node_path(),
+                        creationflags=windows_hide_flags(),
                     )
                     if install_result.returncode != 0:
                         print(f"[{self.name}] npm install failed: {install_result.stderr}")

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -594,6 +594,7 @@ class TestHttpSessionLifecycle:
             encoding="utf-8",
             errors="replace",
             timeout=10,
+            creationflags=0,
         )
         mock_proc.terminate.assert_not_called()
         mock_proc.kill.assert_not_called()


### PR DESCRIPTION
## Summary

On Windows, `subprocess.run()` and `subprocess.Popen()` without `creationflags=CREATE_NO_WINDOW` spawn a visible console window (conhost.exe / cmd.exe) that flashes on every invocation. This PR adds `windows_hide_flags()` to all unprotected subprocess calls in three plugin files.

## Changes

### `plugins/platforms/whatsapp/adapter.py` (3 calls)
- `_terminate_bridge_process()`: `taskkill` subprocess.run — added `creationflags=windows_hide_flags()`
- Node.js `--version` probe: subprocess.run — added `creationflags=windows_hide_flags()`
- `npm install` for bridge dependencies: subprocess.run — added `creationflags=windows_hide_flags()`
- Promoted `windows_hide_flags` to module-level import alongside existing `windows_detach_popen_kwargs`
- Removed redundant local imports inside `_kill_port_process()`

### `plugins/platforms/simplex/adapter.py` (2 calls)
- ImageMagick `convert` for PNG conversion: subprocess.run — added `creationflags=windows_hide_flags()`
- ImageMagick `convert` for thumbnail generation: subprocess.run — added `creationflags=windows_hide_flags()`

### `plugins/memory/mem0/_setup.py` (6 calls)
- `docker inspect`: subprocess.run — added `creationflags=windows_hide_flags()`
- `docker start`: subprocess.run — added `creationflags=windows_hide_flags()`
- `docker pull`: subprocess.run — added `creationflags=windows_hide_flags()`
- `docker rm -f`: subprocess.run — added `creationflags=windows_hide_flags()`
- `docker run -d`: subprocess.run — added `creationflags=windows_hide_flags()`
- `uv pip install`: subprocess.run — added `creationflags=windows_hide_flags()`

## Notes

- `windows_hide_flags()` returns `0` on non-Windows, so all additions are no-ops on Linux/macOS
- The `Popen` call in whatsapp/adapter.py already uses `windows_detach_popen_kwargs()` (correct for long-running bridge processes)
- The `lsof` and `ss` calls in whatsapp/adapter.py are Unix-only commands and don't need the fix
- Related to the existing subprocess console flash fix PRs (#64081, #65635, #65660, #66785)