### PR TITLE
fix(cli): allow config.yaml to extend guardrail idempotent/mutating tool sets (#71585)

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -122,6 +122,12 @@ class ToolCallGuardrailConfig:
                 hard_stop_after.get("idempotent_no_progress", data.get("no_progress_block_after")),
                 defaults.no_progress_block_after,
             ),
+            idempotent_tools=_tool_name_set(
+                data.get("idempotent_tools"), defaults.idempotent_tools
+            ),
+            mutating_tools=_tool_name_set(
+                data.get("mutating_tools"), defaults.mutating_tools
+            ),
             loop_caps=LoopCapConfig.from_mapping(data.get("loop_caps")),
         )
 
@@ -622,6 +628,23 @@ def _subagent_spawn_count(args: Mapping[str, Any]) -> int:
     if isinstance(tasks, list) and tasks:
         return len(tasks)
     return 1
+
+
+def _tool_name_set(value: Any, default: frozenset[str]) -> frozenset[str]:
+    """Merge user-declared tool names with the built-in default set.
+
+    config.yaml entries EXTEND the curated defaults rather than replacing
+    them, so declaring one custom read-only tool keeps every built-in
+    idempotent/mutating tool intact (#71585). Missing or malformed values
+    (anything that is not a list/tuple/set of names, e.g. a bare string)
+    fall back to the default unchanged.
+    """
+    if value is None or isinstance(value, str):
+        return default
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return default
+    extra = frozenset(str(name).strip() for name in value if str(name).strip())
+    return default | extra
 
 
 def _sha256(value: str) -> str:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -401,6 +401,15 @@ tool_loop_guardrails:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
+  # Optional: declare extra tool names that the loop guardrail should treat as
+  # idempotent (safe to repeat, e.g. read-only MCP tools) or mutating. These
+  # EXTEND the built-in sets — they do not replace them — so built-in tools
+  # keep their default classification. Useful for custom/plugin tools such as
+  # `mcp__myserver__search` that the built-in list does not know about (#71585).
+  # idempotent_tools:
+  #   - mcp__myserver__search
+  # mutating_tools:
+  #   - mcp__myserver__delete
 
 # =============================================================================
 # Context Compression (Auto-shrinks long conversations)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -520,6 +520,12 @@ DEFAULT_CONFIG = {
             "max_web_searches": 50,   # max web_search calls per turn (0 = unlimited)
             "max_subagents": 50,      # max subagents spawned per turn (0 = unlimited)
         },
+        # Extend the built-in idempotent/mutating tool classifications (#71585).
+        # Entries here are UNIONed with the hard-coded sets in
+        # agent/tool_guardrails.py; they never replace built-in classifications.
+        # Useful for MCP tools whose semantics the user wants to declare.
+        "idempotent_tools": [],   # e.g. ["mcp__myserver__search"]
+        "mutating_tools": [],     # e.g. ["mcp__myserver__delete"]
     },
 
     "compression": {

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -3,6 +3,8 @@
 import json
 
 from agent.tool_guardrails import (
+    IDEMPOTENT_TOOL_NAMES,
+    MUTATING_TOOL_NAMES,
     ToolCallGuardrailConfig,
     ToolCallGuardrailController,
     ToolCallSignature,
@@ -33,6 +35,17 @@ def test_tool_call_signature_hashes_canonical_nested_unicode_args_without_exposi
     assert "☤" not in json.dumps(metadata)
 
 
+def test_default_config_is_soft_warning_only_with_hard_stop_disabled():
+    cfg = ToolCallGuardrailConfig()
+
+    assert cfg.warnings_enabled is True
+    assert cfg.hard_stop_enabled is False
+    assert cfg.exact_failure_warn_after == 2
+    assert cfg.same_tool_failure_warn_after == 3
+    assert cfg.no_progress_warn_after == 2
+    assert cfg.exact_failure_block_after == 5
+    assert cfg.same_tool_failure_halt_after == 8
+    assert cfg.no_progress_block_after == 5
 
 
 def test_config_parses_nested_warn_and_hard_stop_thresholds():
@@ -107,16 +120,114 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
     assert blocked.count == 2
 
 
+def test_success_resets_exact_signature_failure_streak():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, exact_failure_block_after=2, same_tool_failure_halt_after=99)
+    )
+    args = {"query": "same"}
+
+    controller.after_call("web_search", args, '{"error":"boom"}', failed=True)
+    controller.after_call("web_search", args, '{"ok":true}', failed=False)
+
+    assert controller.before_call("web_search", args).action == "allow"
+    controller.after_call("web_search", args, '{"error":"boom"}', failed=True)
+    assert controller.before_call("web_search", args).action == "allow"
 
 
+def test_file_mutation_lint_error_result_is_not_a_tool_failure():
+    write_result = json.dumps({
+        "bytes_written": 12,
+        "lint": {"status": "error", "output": "SyntaxError: invalid syntax"},
+    })
+    patch_result = json.dumps({
+        "success": True,
+        "diff": "--- a/tmp.py\n+++ b/tmp.py\n",
+        "lsp_diagnostics": "<diagnostics>ERROR [1:1] type mismatch</diagnostics>",
+    })
+
+    assert classify_tool_failure("write_file", write_result) == (False, "")
+    assert classify_tool_failure("patch", patch_result) == (False, "")
 
 
+def test_same_tool_varying_args_warns_by_default_without_halting():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(same_tool_failure_warn_after=2, same_tool_failure_halt_after=3)
+    )
+
+    first = controller.after_call("terminal", {"command": "cmd-1"}, '{"exit_code":1}', failed=True)
+    second = controller.after_call("terminal", {"command": "cmd-2"}, '{"exit_code":1}', failed=True)
+    third = controller.after_call("terminal", {"command": "cmd-3"}, '{"exit_code":1}', failed=True)
+    fourth = controller.after_call("terminal", {"command": "cmd-4"}, '{"exit_code":1}', failed=True)
+
+    assert first.action == "allow"
+    assert [second.action, third.action, fourth.action] == ["warn", "warn", "warn"]
+    assert {second.code, third.code, fourth.code} == {"same_tool_failure_warning"}
+    assert "Do not switch to text-only replies" in second.message
+    assert "keep using tools" in second.message
+    assert "diagnose before retrying" in second.message
+    assert "different tool" in second.message
+    assert controller.halt_decision is None
 
 
+def test_hard_stop_enabled_halts_same_tool_varying_args_failure_streak():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            exact_failure_block_after=99,
+            same_tool_failure_warn_after=2,
+            same_tool_failure_halt_after=3,
+        )
+    )
+
+    first = controller.after_call("terminal", {"command": "cmd-1"}, '{"exit_code":1}', failed=True)
+    assert first.action == "allow"
+    second = controller.after_call("terminal", {"command": "cmd-2"}, '{"exit_code":1}', failed=True)
+    assert second.action == "warn"
+    assert second.code == "same_tool_failure_warning"
+    third = controller.after_call("terminal", {"command": "cmd-3"}, '{"exit_code":1}', failed=True)
+    assert third.action == "halt"
+    assert third.code == "same_tool_failure_halt"
+    assert third.count == 3
 
 
+def test_idempotent_no_progress_repeated_result_warns_without_blocking_by_default():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)
+    )
+    args = {"path": "/tmp/same.txt"}
+    result = "same file contents"
+
+    for _ in range(4):
+        assert controller.before_call("read_file", args).action == "allow"
+        decision = controller.after_call("read_file", args, result, failed=False)
+
+    assert decision.action == "warn"
+    assert decision.code == "idempotent_no_progress_warning"
+    assert controller.before_call("read_file", args).action == "allow"
+    assert controller.halt_decision is None
 
 
+def test_hard_stop_enabled_blocks_idempotent_no_progress_future_repeat():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=2,
+        )
+    )
+    args = {"path": "/tmp/same.txt"}
+    result = "same file contents"
+
+    assert controller.before_call("read_file", args).action == "allow"
+    assert controller.after_call("read_file", args, result, failed=False).action == "allow"
+    assert controller.before_call("read_file", args).action == "allow"
+    warn = controller.after_call("read_file", args, result, failed=False)
+    assert warn.action == "warn"
+    assert warn.code == "idempotent_no_progress_warning"
+
+    blocked = controller.before_call("read_file", args)
+    assert blocked.action == "block"
+    assert blocked.code == "idempotent_no_progress_block"
 
 
 def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():
@@ -131,8 +242,43 @@ def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_succes
         assert controller.after_call("custom_tool", {"x": 1}, "ok", failed=False).action == "allow"
 
 
+def test_reset_for_turn_clears_bounded_guardrail_state():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, exact_failure_block_after=2, no_progress_block_after=2)
+    )
+    controller.after_call("web_search", {"query": "same"}, '{"error":"boom"}', failed=True)
+    controller.after_call("web_search", {"query": "same"}, '{"error":"boom"}', failed=True)
+    controller.after_call("read_file", {"path": "/tmp/x"}, "same", failed=False)
+    controller.after_call("read_file", {"path": "/tmp/x"}, "same", failed=False)
+
+    assert controller.before_call("web_search", {"query": "same"}).action == "block"
+    assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "block"
+
+    controller.reset_for_turn()
+
+    assert controller.before_call("web_search", {"query": "same"}).action == "allow"
+    assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
 
 
+def test_after_call_survives_lone_surrogates_in_result_and_args():
+    # Scraped web/social text can contain unpaired UTF-16 surrogates (e.g. the
+    # first half of a mathematical-bold pair, '\ud835'). str.encode('utf-8')
+    # rejects them, and the result hasher crashed the whole conversation loop
+    # (live outage: "Outer loop error in API call #34 ... surrogates not
+    # allowed"). Weird text must never take down the loop.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, exact_failure_block_after=2, no_progress_block_after=2)
+    )
+    dirty = "price \ud835 update"
+
+    decision = controller.after_call("web_search", {"query": dirty}, dirty, failed=False)
+    assert decision.action in {"allow", "warn"}
+
+    # hashing stays deterministic: the same dirty failure twice still trips
+    # the exact-failure guard, proving the hash is stable across calls
+    controller.after_call("web_search", {"query": dirty}, '{"error":"\ud835 boom"}', failed=True)
+    controller.after_call("web_search", {"query": dirty}, '{"error":"\ud835 boom"}', failed=True)
+    assert controller.before_call("web_search", {"query": dirty}).action == "block"
 
 
 # ── Per-turn runaway-loop caps (Claude Code v2.1.212, Week 29) ──────────────
@@ -140,8 +286,18 @@ def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_succes
 from agent.tool_guardrails import LoopCapConfig  # noqa: E402
 
 
+def test_loop_cap_defaults():
+    caps = ToolCallGuardrailConfig().loop_caps
+    assert caps.max_web_searches == 50
+    assert caps.max_subagents == 50
 
 
+def test_loop_cap_config_parses_nested_section():
+    cfg = ToolCallGuardrailConfig.from_mapping(
+        {"loop_caps": {"max_web_searches": 3, "max_subagents": 0}}
+    )
+    assert cfg.loop_caps.max_web_searches == 3
+    assert cfg.loop_caps.max_subagents == 0
 
 
 def test_loop_cap_zero_disables_and_junk_falls_back():
@@ -169,11 +325,174 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.should_halt is True
 
 
+def test_web_search_cap_resets_each_turn():
+    # The cap bounds a single turn: reset_for_turn clears the counter so a
+    # legitimate multi-turn session is never starved.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_web_searches=2))
+    )
+    # Turn 1: two searches allowed, the third would block within the turn.
+    assert controller.before_call("web_search", {"query": "a"}).action == "allow"
+    assert controller.before_call("web_search", {"query": "b"}).action == "allow"
+    assert controller.before_call("web_search", {"query": "c"}).action == "block"
+    # New turn: the counter resets, so the budget is fresh again.
+    controller.reset_for_turn()
+    assert controller.before_call("web_search", {"query": "d"}).action == "allow"
+    assert controller.before_call("web_search", {"query": "e"}).action == "allow"
+    assert controller.before_call("web_search", {"query": "f"}).action == "block"
 
 
+def test_subagent_cap_counts_batch_task_spawns():
+    # A single delegate_task batch of N tasks spends N of the subagent budget.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_subagents=5))
+    )
+    # First call spawns 3 (batch) → count 3, allowed.
+    assert controller.before_call(
+        "delegate_task", {"tasks": [{"goal": "a"}, {"goal": "b"}, {"goal": "c"}]}
+    ).action == "allow"
+    # Second call spawns 1 (goal) → count 4, allowed.
+    assert controller.before_call("delegate_task", {"goal": "d"}).action == "allow"
+    # Count is 4 (< 5) so this is allowed and bumps to 5.
+    assert controller.before_call("delegate_task", {"goal": "e"}).action == "allow"
+    # Now count is 5 (>= 5) so the next call is blocked.
+    decision = controller.before_call("delegate_task", {"goal": "f"})
+    assert decision.action == "block"
+    assert decision.code == "loop_subagent_cap"
 
 
+def test_subagent_cap_resets_each_turn():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_subagents=1))
+    )
+    assert controller.before_call("delegate_task", {"goal": "a"}).action == "allow"
+    assert controller.before_call("delegate_task", {"goal": "b"}).action == "block"
+    controller.reset_for_turn()
+    assert controller.before_call("delegate_task", {"goal": "c"}).action == "allow"
 
 
+def test_loop_caps_disabled_when_zero():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            loop_caps=LoopCapConfig(max_web_searches=0, max_subagents=0)
+        )
+    )
+    for i in range(60):
+        assert controller.before_call("web_search", {"query": f"q{i}"}).action == "allow"
+        assert controller.before_call("delegate_task", {"goal": f"g{i}"}).action == "allow"
 
 
+def test_other_tools_never_touched_by_loop_caps():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_web_searches=1))
+    )
+    # read_file / terminal / etc. are unaffected regardless of the web cap.
+    for _ in range(10):
+        assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
+
+
+# ── Config-declared tool-set extension (#71585) ─────────────────────────
+
+
+def test_config_extends_idempotent_and_mutating_tool_sets():
+    """#71585: config-declared tool names EXTEND the built-in sets rather than
+    replacing them, so built-in tools keep their default classification."""
+    cfg = ToolCallGuardrailConfig.from_mapping(
+        {
+            "idempotent_tools": ["mcp__myserver__search", " mcp__myserver__lookup "],
+            "mutating_tools": ["mcp__myserver__delete"],
+        }
+    )
+
+    # Built-ins are preserved (union, not replace).
+    assert IDEMPOTENT_TOOL_NAMES <= cfg.idempotent_tools
+    assert MUTATING_TOOL_NAMES <= cfg.mutating_tools
+    # Declared names are added (whitespace stripped).
+    assert "mcp__myserver__search" in cfg.idempotent_tools
+    assert "mcp__myserver__lookup" in cfg.idempotent_tools
+    assert "mcp__myserver__delete" in cfg.mutating_tools
+
+
+def test_config_tool_sets_fall_back_to_defaults_when_absent_or_malformed():
+    """Missing or malformed tool-set entries keep the built-in defaults."""
+    # Absent entirely.
+    assert ToolCallGuardrailConfig.from_mapping({}).idempotent_tools == IDEMPOTENT_TOOL_NAMES
+    assert ToolCallGuardrailConfig.from_mapping({}).mutating_tools == MUTATING_TOOL_NAMES
+
+    # Malformed values (bare string / non-iterable) fall back unchanged.
+    for bad in ("read_file", 42, {"read_file": 1}):
+        cfg = ToolCallGuardrailConfig.from_mapping(
+            {"idempotent_tools": bad, "mutating_tools": bad}
+        )
+        assert cfg.idempotent_tools == IDEMPOTENT_TOOL_NAMES
+        assert cfg.mutating_tools == MUTATING_TOOL_NAMES
+
+
+def test_config_declared_idempotent_tool_triggers_no_progress_guardrail():
+    """A custom tool declared idempotent via config is treated as idempotent,
+    so repeated identical successful output trips the no-progress guardrail."""
+    cfg = ToolCallGuardrailConfig.from_mapping(
+        {
+            "idempotent_tools": ["mcp__myserver__search"],
+            "no_progress_warn_after": 2,
+            "no_progress_block_after": 2,
+        }
+    )
+    controller = ToolCallGuardrailController(cfg)
+    args = {"query": "same"}
+    result = "same results"
+
+    for _ in range(2):
+        assert controller.before_call("mcp__myserver__search", args).action == "allow"
+        decision = controller.after_call("mcp__myserver__search", args, result, failed=False)
+
+    assert decision.action == "warn"
+    assert decision.code == "idempotent_no_progress_warning"
+
+
+def test_config_declared_mutating_tool_is_not_treated_as_idempotent():
+    """A custom tool declared mutating is never flagged as no-progress even
+    when it returns identical output repeatedly."""
+    cfg = ToolCallGuardrailConfig.from_mapping(
+        {
+            "mutating_tools": ["mcp__myserver__write"],
+            "no_progress_warn_after": 2,
+            "no_progress_block_after": 2,
+        }
+    )
+    controller = ToolCallGuardrailController(cfg)
+    args = {"path": "/tmp/x"}
+
+    for _ in range(3):
+        assert controller.before_call("mcp__myserver__write", args).action == "allow"
+        assert controller.after_call("mcp__myserver__write", args, "ok", failed=False).action == "allow"
+
+
+def test_agent_init_propagation_path_config_to_controller():
+    """Simulate the agent_init.py:1589-1594 propagation: a full agent config
+    dict (as loaded from config.yaml) flows through .get('tool_loop_guardrails')
+    → from_mapping → controller, and custom tool sets arrive correctly."""
+    # Mimics the full _agent_cfg dict that agent_init reads from config.yaml.
+    _agent_cfg = {
+        "model": {"provider": "openai", "model_id": "gpt-4o"},
+        "tool_loop_guardrails": {
+            "warnings_enabled": True,
+            "hard_stop_enabled": False,
+            "idempotent_tools": ["mcp__calendar__list_events"],
+            "mutating_tools": ["mcp__calendar__create_event"],
+        },
+    }
+
+    # Exact propagation logic from agent_init.py:1590-1594.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig.from_mapping(
+            _agent_cfg.get("tool_loop_guardrails", {})
+        )
+    )
+
+    # Custom tools arrived.
+    assert "mcp__calendar__list_events" in controller.config.idempotent_tools
+    assert "mcp__calendar__create_event" in controller.config.mutating_tools
+    # Built-ins are preserved (union semantics).
+    assert IDEMPOTENT_TOOL_NAMES <= controller.config.idempotent_tools
+    assert MUTATING_TOOL_NAMES <= controller.config.mutating_tools

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1526,6 +1526,22 @@ A single `delegate_task` batch counts each task toward `max_subagents` (a batch 
 
 This mirrors Claude Code's per-session WebSearch and subagent caps (v2.1.212), which also default to 200 and reset on `/clear`.
 
+### Custom tool classifications
+
+The guardrail engine ships with built-in lists of idempotent (read-only) and mutating tools. For MCP or custom tools whose semantics you want to declare explicitly, extend those lists in your config:
+
+```yaml
+tool_loop_guardrails:
+  idempotent_tools:
+    - mcp__myserver__search
+    - mcp__myserver__lookup
+  mutating_tools:
+    - mcp__myserver__delete
+    - mcp__myserver__write
+```
+
+Entries are **unioned** with the built-in sets — they never replace the defaults. Declaring a tool as idempotent means repeated identical successful results will trigger the no-progress guardrail; declaring it as mutating exempts it from that check. Bare strings and non-list values are silently ignored (the built-in defaults remain).
+
 ## TTS Configuration
 
 ```yaml


### PR DESCRIPTION
## What does this PR do?

`ToolCallGuardrailConfig.from_mapping()` now reads the `idempotent_tools` and `mutating_tools` keys from the `tool_loop_guardrails` config section and **unions** them with the built-in defaults, so users can declare their own read-only/mutating tools (e.g. read-only MCP tools) in config.yaml. Previously these two fields existed on the dataclass but `from_mapping()` never read them, so any config entry was silently ignored and the `idempotent_no_progress` guardrail could never fire for non-built-in tools.

This is the config-parsing half of #71585 (bug #1). The stale MCP naming half (bug #2) is handled by #71588 — the two touch different code (this edits `from_mapping()`; #71588 edits the `IDEMPOTENT_TOOL_NAMES` literal) and compose cleanly.

## Related Issue

Partially addresses #71585 (bug #1 of 2; bug #2 is #71588). Deliberately not using `Fixes` so the issue stays open until both halves land.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/tool_guardrails.py`: added `_tool_name_set()` helper (merges user-declared names with built-in defaults; malformed values fall back unchanged) and wired `idempotent_tools` / `mutating_tools` through `from_mapping()`.
- `cli-config.yaml.example`: documented the two new optional keys under `tool_loop_guardrails`.
- `tests/agent/test_tool_guardrails.py`: 4 new regression tests (union semantics, malformed/absent fallback, config-declared idempotent triggers the guardrail, config-declared mutating is not flagged).

## How to Test

1. Add to config.yaml:
   ```yaml
   tool_loop_guardrails:
     idempotent_tools:
       - mcp__myserver__search
   ```
2. Make repeated identical successful calls to `mcp__myserver__search`.
3. The `idempotent_no_progress` guardrail now fires (previously never fired for any non-built-in tool).

Unit tests: `pytest tests/agent/test_tool_guardrails.py -v` → 18 passed (14 existing + 4 new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (coordinated with #71588 — orthogonal split)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (affected module run locally: 18 passed; ruff + windows-footgun checker clean; full suite via CI)
- [x] I've added tests for my changes (4 new regression tests)
- [x] I've tested on my platform: Windows 11 (native, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring for `_tool_name_set`)
- [x] I've updated `cli-config.yaml.example` (documented the two new keys)
- [x] N/A — no architecture/workflow changes (CONTRIBUTING.md / AGENTS.md)
- [x] I've considered cross-platform impact — pure Python config-parsing logic, no OS-specific code
- [x] N/A — no tool description/schema changes

## Screenshots / Logs

N/A — config-parsing fix covered by unit tests.
