### PR TITLE
fix(inventory): keep exhausted-pool providers in Desktop model.options pickers

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -286,6 +286,11 @@ def build_model_options_payload(
       endpoints do not block the picker
     - explicit refresh: probe every custom provider while busting the model
       cache so live catalogs repopulate fully
+    - ``for_picker=True``: keep providers whose credential pool is entirely
+      rate-limited visible. Desktop/TUI/API pickers are human-facing surfaces;
+      hiding a temporarily exhausted pool makes providers vanish mid-session
+      even though another model under the same provider may still work
+      (same contract as ``/model`` and aux pickers — #66584 / #66624).
     """
     refresh = bool(refresh)
     return build_models_payload(
@@ -299,6 +304,7 @@ def build_model_options_payload(
         refresh=refresh,
         probe_custom_providers=refresh,
         probe_current_custom_provider=not refresh,
+        for_picker=True,
     )
 
 

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 
 from hermes_cli.inventory import (
     ConfigContext,
+    build_model_options_payload,
     build_models_payload,
     load_picker_context,
 )
@@ -1031,3 +1032,31 @@ def test_list_authenticated_providers_refresh_busts_cache():
         assert clear.call_count == 0
         model_switch.list_authenticated_providers(refresh=True)
         assert clear.call_count == 1
+
+
+# ─── model.options picker visibility ───────────────────────────────────
+
+
+def test_build_model_options_payload_requests_for_picker():
+    """GUI/TUI/API model.options must keep exhausted credential pools visible.
+
+    Aux pickers already forward for_picker=True (#66624). build_model_options_payload
+    is the shared path for Desktop/TUI/dashboard pickers — omitting the flag
+    hid rate-limited providers from the chat model dropdown mid-session.
+    """
+    captured: dict = {}
+
+    def _capture(*_args, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    with patch(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        side_effect=_capture,
+    ):
+        build_model_options_payload(_empty_ctx())
+
+    assert captured.get("for_picker") is True, (
+        "build_model_options_payload must pass for_picker=True so exhausted-pool "
+        "providers stay visible in Desktop/TUI model pickers"
+    )


### PR DESCRIPTION
## Summary
- Desktop/TUI/API chat model pickers call `build_model_options_payload`, which never forwarded `for_picker=True`.
- When a credential pool was fully rate-limited, those providers were hidden mid-session, so they disappeared from the model dropdown even though another model under the same provider may still work.
- Match the `/model` and aux-picker contract (`for_picker=True`) so exhausted pools stay visible.

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_inventory.py::test_build_model_options_payload_requests_for_picker -q`
- [ ] Open Desktop chat model dropdown with a provider whose credential pool is rate-limited — provider row still listed
- [ ] Confirm providers with valid credentials still appear as before
