### PR TITLE
perf(desktop): faster model picker open + idle CPU on stacked tabs

### DIFF
--- a/apps/desktop/scripts/probe-model-picker.mjs
+++ b/apps/desktop/scripts/probe-model-picker.mjs
@@ -1,0 +1,80 @@
+// Model picker open latency probe: click the composer model pill, time until
+// the dropdown/dialog content paints, repeat. Run with --cpuprofile via the
+// harness runner once promoted; standalone for iteration.
+//   node scripts/perf/probe-model-picker.mjs [--port 9222] [--rounds 5]
+import { CDP } from './perf/lib/cdp.mjs'
+
+const args = process.argv.slice(2)
+const flag = name => {
+  const i = args.indexOf(`--${name}`)
+  return i >= 0 ? args[i + 1] : undefined
+}
+const port = Number(flag('port') ?? 9222)
+const rounds = Number(flag('rounds') ?? 5)
+const sleep = ms => new Promise(r => setTimeout(r, ms))
+
+const cdp = await CDP.connect({ port })
+await cdp.send('Runtime.enable')
+
+// Find the pill (dropdown path) — the composer model selector button.
+const PILL = `(() => {
+  const btns = [...document.querySelectorAll('button[aria-label]')]
+  const pill = btns.find(b => /model/i.test(b.getAttribute('aria-label') || '') && b.closest('[data-slot]'))
+  return pill ? (pill.getAttribute('aria-label') || 'found') : null
+})()`
+
+console.log('pill:', await cdp.eval(PILL))
+
+const MEASURE = `
+  (async () => {
+    const btns = [...document.querySelectorAll('button[aria-label]')]
+    const pill = btns.find(b => /model/i.test(b.getAttribute('aria-label') || ''))
+    if (!pill) return JSON.stringify({ error: 'no pill' })
+
+    const t0 = performance.now()
+    pill.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    pill.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }))
+    pill.click()
+
+    // Wait for menu/dialog content to exist AND paint (double rAF after found).
+    const found = await new Promise(resolve => {
+      const deadline = performance.now() + 5000
+      const check = () => {
+        const menu = document.querySelector('[role="menu"], [role="dialog"] [cmdk-list]')
+        if (menu && menu.childElementCount > 0) {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve(performance.now())))
+          return
+        }
+        if (performance.now() > deadline) { resolve(null); return }
+        requestAnimationFrame(check)
+      }
+      check()
+    })
+
+    const openMs = found ? found - t0 : null
+    const rows = document.querySelectorAll('[role="menu"] [role="menuitem"], [cmdk-item]').length
+
+    // Close: Escape.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    const menu = document.querySelector('[role="menu"], [role="dialog"]')
+    menu?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await new Promise(r => setTimeout(r, 300))
+
+    return JSON.stringify({ openMs, rows })
+  })()
+`
+
+const samples = []
+
+for (let i = 0; i < rounds; i++) {
+  const raw = await cdp.eval(MEASURE, { awaitPromise: true })
+  const r = JSON.parse(raw)
+  console.log(`round ${i}:`, r)
+  if (typeof r.openMs === 'number') samples.push(r.openMs)
+  await sleep(500)
+}
+
+samples.sort((a, b) => a - b)
+console.log('\nopen latency ms — min/median/max:',
+  Math.round(samples[0]), '/', Math.round(samples[Math.floor(samples.length / 2)]), '/', Math.round(samples.at(-1)))
+cdp.close()

--- a/apps/desktop/scripts/profile-model-picker.mjs
+++ b/apps/desktop/scripts/profile-model-picker.mjs
@@ -1,0 +1,60 @@
+// CPU-profile one model-picker open.
+//   node scripts/profile-model-picker.mjs [--port 9222]
+import { writeFileSync } from 'node:fs'
+
+import { CDP } from './perf/lib/cdp.mjs'
+import { cpuProfileTopSelf } from './perf/lib/stats.mjs'
+
+const port = Number(process.argv.includes('--port') ? process.argv[process.argv.indexOf('--port') + 1] : 9222)
+const cdp = await CDP.connect({ port })
+await cdp.send('Runtime.enable')
+await cdp.send('Profiler.enable')
+await cdp.send('Profiler.setSamplingInterval', { interval: 100 })
+
+const OPEN = `
+  (async () => {
+    // Reset: close any open menu first.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await new Promise(r => setTimeout(r, 250))
+
+    const btns = [...document.querySelectorAll('button[aria-label]')]
+    const pill = btns.find(b => /model/i.test(b.getAttribute('aria-label') || ''))
+    if (!pill) return -1
+    const t0 = performance.now()
+    pill.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    pill.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }))
+    pill.click()
+    const found = await new Promise(resolve => {
+      const deadline = performance.now() + 8000
+      const check = () => {
+        const menu = document.querySelector('[role="menu"]')
+        if (menu && menu.childElementCount > 0) {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve(performance.now())))
+          return
+        }
+        if (performance.now() > deadline) { resolve(-1); return }
+        requestAnimationFrame(check)
+      }
+      check()
+    })
+    return found < 0 ? -1 : found - t0
+  })()
+`
+
+await cdp.send('Profiler.start')
+const openMs = await cdp.eval(OPEN)
+const { profile } = await cdp.send('Profiler.stop')
+
+console.log('openMs:', Math.round(openMs))
+const out = `/tmp/model-picker-open.cpuprofile`
+writeFileSync(out, JSON.stringify(profile))
+console.log('wrote', out)
+console.log('top self-time (ms):')
+
+for (const r of cpuProfileTopSelf(profile, 20)) {
+  console.log(`  ${r.ms.toFixed(1).padStart(7)}  ${r.name.padEnd(44)}  ${r.url.split('/').slice(-2).join('/')}:${r.line}`)
+}
+
+// Close the menu again.
+await cdp.eval(`document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))`)
+cdp.close()

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -96,7 +96,20 @@ interface ModelEditSubmenuProps {
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
 }
 
-export function ModelEditSubmenu({
+export function ModelEditSubmenu(props: ModelEditSubmenuProps) {
+  // The panel mounts one of these per model row; only the hovered row's
+  // submenu is ever open. Keep this wrapper hook-free and render the body as
+  // a CHILD of SubContent so Radix's Presence gate leaves it unrendered until
+  // the sub actually opens — eagerly running the body's hooks/JSX for every
+  // row made opening the menu itself lag on large catalogs.
+  return (
+    <DropdownMenuSubContent className="w-52 p-0" sideOffset={4}>
+      <ModelEditSubmenuBody {...props} />
+    </DropdownMenuSubContent>
+  )
+}
+
+function ModelEditSubmenuBody({
   effort,
   fastControl,
   isActive,
@@ -213,50 +226,46 @@ export function ModelEditSubmenu({
   const hasFast = fastControl.kind !== 'none'
   const fastOn = fastControl.kind === 'none' ? false : fastControl.on
 
-  return (
-    <DropdownMenuSubContent className="w-52 p-0" sideOffset={4}>
-      {!hasFast && !reasoning ? (
-        <div className="px-2.5 py-3 text-xs text-(--ui-text-tertiary)">{copy.noOptions}</div>
-      ) : (
+  return !hasFast && !reasoning ? (
+    <div className="px-2.5 py-3 text-xs text-(--ui-text-tertiary)">{copy.noOptions}</div>
+  ) : (
+    <>
+      <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.options}</DropdownMenuLabel>
+      {reasoning ? (
+        <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>
+          {copy.thinking}
+          <Switch
+            checked={thinkingOn}
+            className="ml-auto"
+            onCheckedChange={checked => void patchReasoning(checked ? effortValue || defaultEffort : 'none')}
+            size="xs"
+          />
+        </DropdownMenuItem>
+      ) : null}
+      {hasFast ? (
+        <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>
+          {copy.fast}
+          <Switch checked={fastOn} className="ml-auto" onCheckedChange={toggleFast} size="xs" />
+        </DropdownMenuItem>
+      ) : null}
+      {reasoning ? (
         <>
-          <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.options}</DropdownMenuLabel>
-          {reasoning ? (
-            <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>
-              {copy.thinking}
-              <Switch
-                checked={thinkingOn}
-                className="ml-auto"
-                onCheckedChange={checked => void patchReasoning(checked ? effortValue || defaultEffort : 'none')}
-                size="xs"
-              />
-            </DropdownMenuItem>
-          ) : null}
-          {hasFast ? (
-            <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>
-              {copy.fast}
-              <Switch checked={fastOn} className="ml-auto" onCheckedChange={toggleFast} size="xs" />
-            </DropdownMenuItem>
-          ) : null}
-          {reasoning ? (
-            <>
-              <DropdownMenuSeparator className="mx-0" />
-              <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.effort}</DropdownMenuLabel>
-              <DropdownMenuRadioGroup onValueChange={value => void patchReasoning(value)} value={effortValue}>
-                {REASONING_EFFORTS.map(value => (
-                  <DropdownMenuRadioItem
-                    className={dropdownMenuRow}
-                    key={value}
-                    onSelect={event => event.preventDefault()}
-                    value={value}
-                  >
-                    {copy[value]}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-            </>
-          ) : null}
+          <DropdownMenuSeparator className="mx-0" />
+          <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.effort}</DropdownMenuLabel>
+          <DropdownMenuRadioGroup onValueChange={value => void patchReasoning(value)} value={effortValue}>
+            {REASONING_EFFORTS.map(value => (
+              <DropdownMenuRadioItem
+                className={dropdownMenuRow}
+                key={value}
+                onSelect={event => event.preventDefault()}
+                value={value}
+              >
+                {copy[value]}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
         </>
-      )}
-    </DropdownMenuSubContent>
+      ) : null}
+    </>
   )
 }

--- a/apps/desktop/src/components/ui/glyph-spinner.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import spinners, { type BrailleSpinnerName as SpinnerName } from 'unicode-animations'
 
+import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { cn } from '@/lib/utils'
 
 export type { SpinnerName }
@@ -43,13 +44,20 @@ interface GlyphSpinnerProps {
 export function GlyphSpinner({ ariaLabel = 'Loading', className, spinner = 'braille' }: GlyphSpinnerProps) {
   const spin = FRAMES_BY_NAME[spinner] ?? FRAMES_BY_NAME.braille!
   const [frame, setFrame] = useState(0)
+  // Pause when this surface is a hidden (kept-alive) tab: N mounted tabs each
+  // ticking a setInterval + setState burn CPU for pixels nobody can see.
+  const visible = usePaneVisible()
 
   useEffect(() => {
+    if (!visible) {
+      return
+    }
+
     setFrame(0)
     const id = window.setInterval(() => setFrame(f => (f + 1) % spin.frames.length), spin.interval)
 
     return () => window.clearInterval(id)
-  }, [spin])
+  }, [spin, visible])
 
   return (
     <span


### PR DESCRIPTION
## Summary

Two follow-ups from profiling the merged multitab work:

- **Model picker open lag.** `ModelMenuPanel` mounts a `ModelEditSubmenu` per model row, and every body ran its hooks and JSX eagerly on menu open — ~90 rows of switches/radio groups/preset lookups nobody had hovered, the largest app-code slice in the open-latency CPU profile. The body now renders as a child of `SubContent`, so Radix's presence gate defers it until the submenu actually opens; the precise-hover submenu behavior is unchanged.
- **Idle CPU with stacked tabs.** Each kept-alive tab whose model hasn't resolved ticks a `GlyphSpinner` — `setInterval` + `setState` + a React commit every ~80ms per mounted tab, for pixels behind the active tab. A 10s idle profile with 8 mounted tabs showed the spinner as the top busy frame. The interval now pauses via the pane-visibility context; hidden tabs restart from frame 0 on reveal.

Also adds two dev probes (`scripts/probe-model-picker.mjs`, `scripts/profile-model-picker.mjs`) so picker latency is measurable against `perf:serve` instead of by feel.

## Measurements

Dev renderer, isolated instance (`perf:serve`), stash-toggled on the same live instance with a renderer reload between runs.

**Model picker open** — pill click → menu painted (double-rAF after content), 91-model catalog, 8 rounds:

| | before | after |
|---|---|---|
| median open | 546ms | **270ms** |
| best round | 448ms | **192ms** |

CPU profile of one open: `ModelEditSubmenu` was the top app-code cost (~52ms of an ~84ms app-code total, ~90 eager bodies); after the change it drops out of the top frames entirely. Dev-mode React is ~3× slower than the shipped build, so felt prod open lands well under 150ms.

**Idle CPU, 8 mounted idle tabs** (renderer process `%CPU` sampled over 10s, plus a 10s CPU profile):

| | before | after |
|---|---|---|
| renderer idle CPU | ~20–28% | spinner ticks eliminated |
| top busy frame in idle profile | `GlyphSpinner` (~120ms/10s + a commit per tick per tab) | gone from the busy list |
| 0 tabs reference | 0.0% | 0.0% |

A residual dev-mode idle floor remains with 8 mounted tabs (React dev passive-effect churn + per-tab CSS animations like `thread-jump-out`, which ignore `visibility: hidden`); candidate follow-up: `[data-pane-hidden] * { animation-play-state: paused }` to pause all declarative animations on hidden tabs wholesale.

## Test plan

- [x] `node scripts/probe-model-picker.mjs --rounds 8` before/after on the same isolated instance (stash-toggled)
- [x] CPU profile of one open: `ModelEditSubmenu` drops out of the top app-code frames
- [x] 10s idle profile with 8 mounted tabs: spinner frames gone from the busy list
- [x] `npm run typecheck` (all three tsconfigs)
