### PR TITLE
Remove the fade mask on the live thinking preview

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -74,9 +74,7 @@ const ThinkingDisclosure: FC<{
   const isPreview = pending && userOpen === null
 
   // While the preview is live, pin the scroll container to the bottom on
-  // every content growth so the latest tokens are always visible. Combined
-  // with the top mask in styles.css, this reads as text settling in from
-  // below while older lines fade out at the top.
+  // every content growth so the latest tokens are always visible.
   useEffect(() => {
     if (!isPreview) {
       return
@@ -134,7 +132,7 @@ const ThinkingDisclosure: FC<{
             // and inherits the disclosure-level opacity fade defined in
             // styles.css (~0.67 at rest, 1 on hover/focus).
             'mt-0.5 w-full min-w-0 max-w-full overflow-hidden wrap-anywhere pb-1',
-            isPreview && 'thinking-preview max-h-40'
+            isPreview && 'max-h-40'
           )}
           ref={scrollRef}
         >

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1467,14 +1467,6 @@ text-* variant utilities. */ .btn-arc {
   height: 0.875rem;
 }
 
-/* Live thinking preview window. Pairs with the ResizeObserver in
-   ThinkingDisclosure that pins scrollTop to the bottom — older lines fade
-   into the top mask while the latest tokens settle in below. */
-.thinking-preview {
-  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 28%, black 100%);
-  mask-image: linear-gradient(to bottom, transparent 0%, black 28%, black 100%);
-}
-
 /* Long adjacent tool-call run collapsed into a fixed, auto-scrolling window.
    ToolGroupSlot pins the newest call to the bottom (unless the user scrolls
    up), so a back-to-back run stays compact instead of pushing the reply off


### PR DESCRIPTION
The thinking disclosure masked the top 28% of its preview window to transparent while reasoning streamed, so a gradient sat over the text and disappeared as soon as the block finished. It's gone now — the top edge is a clean cut.

The `max-h-40` window and the bottom-pinned ResizeObserver are untouched, so the preview still stays compact and follows the newest tokens.