### PR TITLE
fix(sessions): reconstruct missing sessions instead of deleting salvaged messages

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -825,13 +825,76 @@ def _copy_state_meta_salvage(
     return result
 
 
+def _reconstruct_missing_sessions(
+    destination: sqlite3.Connection,
+) -> dict[str, Any]:
+    """Recreate placeholder session rows for salvaged orphaned messages.
+
+    When the ``sessions`` b-tree is damaged worse than ``messages``, salvage
+    can recover the conversation text while recovering few or none of the
+    session rows that own it. Deleting those messages as "orphans" throws away
+    the only readable copy of the user's data — the exact opposite of what
+    ``--allow-partial`` is for. A real report (July 2026) copied 20,817 of
+    20,824 messages and then removed every one of them, producing an output
+    with 0 sessions and 0 messages.
+
+    Instead, synthesize a minimal session row per orphaned ``session_id``
+    (only ``id``/``source``/``started_at`` are NOT NULL) so the messages stay
+    reachable and foreign keys hold. ``started_at`` is taken from the earliest
+    surviving message so ordering stays sane. Rows are marked with
+    ``source='recovered'`` and a ``title`` that says so, because a fabricated
+    session must never be mistaken for an original.
+    """
+    result: dict[str, Any] = {"sessions_reconstructed": 0, "messages_retained": 0}
+    if not _table_columns(destination, "sessions"):
+        return result
+    if not _table_columns(destination, "messages"):
+        return result
+
+    orphaned = destination.execute(
+        "SELECT m.session_id, MIN(m.timestamp), COUNT(*) "
+        "FROM messages AS m "
+        "WHERE m.session_id IS NOT NULL AND NOT EXISTS ("
+        "SELECT 1 FROM sessions WHERE sessions.id = m.session_id) "
+        "GROUP BY m.session_id"
+    ).fetchall()
+    if not orphaned:
+        return result
+
+    for session_id, first_timestamp, message_count in orphaned:
+        started_at = float(first_timestamp) if first_timestamp is not None else 0.0
+        destination.execute(
+            "INSERT OR IGNORE INTO sessions "
+            "(id, source, started_at, title, message_count) "
+            "VALUES (?, 'recovered', ?, ?, ?)",
+            (
+                session_id,
+                started_at,
+                "[recovered] session metadata was unreadable",
+                int(message_count),
+            ),
+        )
+        result["sessions_reconstructed"] += 1
+        result["messages_retained"] += int(message_count)
+    return result
+
+
 def _cleanup_partial_orphans(
     destination: sqlite3.Connection,
 ) -> dict[str, Any]:
-    """Remove references to sessions that could not be salvaged."""
+    """Reconcile references to sessions that could not be salvaged.
+
+    Messages are never discarded for lack of a session row: their owning
+    session is reconstructed as a placeholder first (see
+    :func:`_reconstruct_missing_sessions`). Only rows that remain orphaned
+    after that — and rows in tables carrying no recoverable user content —
+    are removed.
+    """
 
     result: dict[str, Any] = {
         "sessions_parent_cleared": 0,
+        "sessions_reconstructed": 0,
+        "messages_retained": 0,
         "messages_removed": 0,
         "session_model_usage_removed": 0,
         "compression_locks_removed": 0,
@@ -839,6 +902,12 @@ def _cleanup_partial_orphans(
     }
     destination.execute("BEGIN IMMEDIATE")
     try:
+        # Rebuild owners BEFORE any orphan deletion so salvaged conversation
+        # text is never dropped for want of a session row.
+        rebuilt = _reconstruct_missing_sessions(destination)
+        result["sessions_reconstructed"] = rebuilt["sessions_reconstructed"]
+        result["messages_retained"] = rebuilt["messages_retained"]
+
         parent_count = int(
             destination.execute(
                 "SELECT COUNT(*) FROM sessions AS child "
@@ -890,8 +959,15 @@ def _cleanup_partial_orphans(
     except BaseException:
         destination.execute("ROLLBACK")
         raise
-    result["total_removed_or_relinked"] = sum(
-        int(value) for value in result.values()
+    # Only destructive/relinking actions belong in this total. The
+    # reconstruction counters describe data RETAINED, so summing them here
+    # would report saving the user's messages as if it were losing them.
+    result["total_removed_or_relinked"] = (
+        int(result["sessions_parent_cleared"])
+        + int(result["messages_removed"])
+        + int(result["session_model_usage_removed"])
+        + int(result["compression_locks_removed"])
+        + int(result["telegram_dm_topic_bindings_removed"])
     )
     return result
 
@@ -1018,6 +1094,20 @@ def _verify_recovered_database(
             if orphan_count:
                 verification["warnings"].append(
                     f"{orphan_count} orphaned reference(s) were removed or relinked"
+                )
+                verification["loss_detected"] = True
+            rebuilt_sessions = int(
+                orphan_cleanup.get("sessions_reconstructed") or 0
+            )
+            if rebuilt_sessions:
+                retained = int(orphan_cleanup.get("messages_retained") or 0)
+                # Not a clean recovery: the conversation text survived but its
+                # session metadata did not, so these rows are placeholders.
+                verification["warnings"].append(
+                    f"{rebuilt_sessions} session(s) could not be salvaged and "
+                    f"were reconstructed as placeholders to retain "
+                    f"{retained} message(s); their metadata (title, model, "
+                    "timestamps, cost) is lost"
                 )
                 verification["loss_detected"] = True
 

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -375,6 +375,82 @@ def test_snapshot_blocks_connections_opened_during_the_copy(
     assert not errors, errors[0]
 
 
+def test_partial_recovery_keeps_messages_when_sessions_are_unsalvageable(
+    tmp_path: Path,
+) -> None:
+    """Salvaged messages must survive even when NO session row is recoverable.
+
+    Reported July 2026: a user's recovery copied 20,817 of 20,824 messages,
+    then orphan cleanup deleted every one of them because the sessions b-tree
+    was damaged worse than the messages b-tree. The output had 0 sessions and
+    0 messages — the salvage worked and then threw the result away, which is
+    the exact opposite of what --allow-partial is for.
+
+    Messages must be retained under reconstructed placeholder sessions, and
+    the placeholder-ness must be reported as loss rather than passed off as a
+    clean recovery.
+    """
+    source = tmp_path / "sessions-destroyed.db"
+    output = tmp_path / "sessions-destroyed-recovered.db"
+
+    db = SessionDB(db_path=source)
+    try:
+        db.create_session("doomed-session", "cli", cwd="/tmp/doomed")
+        for index in range(120):
+            db.append_message("doomed-session", "user", f"irreplaceable {index}")
+    finally:
+        db.close()
+
+    # sessions unrecoverable, messages intact — the reported shape.
+    conn = sqlite3.connect(str(source), isolation_level=None)
+    try:
+        conn.execute("DELETE FROM sessions")
+    finally:
+        conn.close()
+
+    report = recover_session_database(
+        source,
+        output,
+        work_dir=tmp_path,
+        chunk_size=16,
+        allow_partial=True,
+    )
+
+    cleanup = report["orphan_cleanup"]
+    assert cleanup["messages_removed"] == 0, (
+        "salvaged messages were deleted for lack of a session row"
+    )
+    assert cleanup["sessions_reconstructed"] >= 1
+    assert cleanup["messages_retained"] == 120
+
+    with sqlite3.connect(str(output)) as verify:
+        sessions = verify.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        messages = verify.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        placeholder_source = verify.execute(
+            "SELECT source FROM sessions LIMIT 1"
+        ).fetchone()[0]
+    assert messages == 120, f"expected all 120 messages retained, got {messages}"
+    assert sessions >= 1
+
+    # A fabricated session must be identifiable as such.
+    assert placeholder_source == "recovered"
+
+    # Retaining the data is still a lossy outcome and must say so.
+    assert report["verification"]["loss_detected"] is True
+    assert report["partial"] is True
+    assert report["complete"] is False
+    assert any(
+        "reconstructed as placeholders" in warning
+        for warning in report["verification"]["warnings"]
+    ), report["verification"]["warnings"]
+
+    # The output must remain structurally sound.
+    assert report["verification"]["integrity_check"] == ["ok"]
+    assert report["verification"]["foreign_key_check"] == []
+    assert report["verified"] is True
+    assert report["installed"] is False
+
+
 def test_partial_recovery_reports_damaged_state_meta_as_loss(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

`hermes sessions recover --allow-partial` could salvage a user's messages and then delete every one of them.

Reported by @spherohero: recovery copied **20,817 of 20,824** message rows, then orphan cleanup removed all of them because no `sessions` row was salvageable. Final output: **0 sessions, 0 messages.** The salvage worked and threw the result away — the opposite of what `--allow-partial` is for.

## Root cause

`_cleanup_partial_orphans()` deleted dependent rows whose `session_id` had no matching `sessions` row. That's right when a few sessions are lost. It's catastrophic when the `sessions` b-tree is damaged worse than `messages` — which is the *common* shape, since `sessions` is small and hot while `messages` is large.

Reproduced exactly: 500 readable messages + unreadable sessions → 500 copied, 500 removed, empty output.

## Fix

`_reconstruct_missing_sessions()` now runs first, in the same transaction, synthesizing a minimal row per orphaned `session_id` (only `id`/`source`/`started_at` are NOT NULL). `started_at` comes from the earliest surviving message so ordering holds.

Placeholders are marked `source='recovered'` with an explicit title — a fabricated session must never be mistaken for an original.

| | before | after |
|---|---|---|
| messages copied | 500 | 500 |
| messages removed | **500** | 0 |
| final output | 0 sessions, 0 messages | 1 session, **500 messages** |

## Reconstruction is reported as loss

Retaining the text is not a clean recovery — session metadata (title, model, timestamps, cost) is genuinely gone. So `loss_detected=True`, `partial=True`, `complete=False`, with a warning naming the counts. `verified=True` still holds because the output is structurally sound (integrity + FK clean).

Also fixes `total_removed_or_relinked`, which summed every dict value and would have counted *retained* messages as removed.

## Validation

- 942 targeted tests green; ruff clean.
- **Sabotage-verified:** removing the reconstruction call restores the wipe and fails the new test.
- Regression test reproduces the reported shape (sessions unsalvageable, messages intact) and asserts messages survive, placeholders are identifiable, FKs hold, and the loss is reported.

## For the affected user

@spherohero's preserved backup is untouched — recovery never modifies the source. Once this lands, re-running the same command against the same backup should retain the ~20.8k messages under reconstructed sessions.
