### PR TITLE
fix(desktop): bind a tab's slash command to its own session

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getSession } from '@/hermes'
 import { textPart } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
 import { $queuedPromptsBySession, getQueuedPrompts } from '@/store/composer-queue'
 import { $notifications, clearNotifications } from '@/store/notifications'
@@ -19,6 +20,7 @@ import {
   setMessages,
   setSessions
 } from '@/store/session'
+import { dropSessionState, publishSessionState } from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
 
 import type { SubmitTextOptions } from './utils'
@@ -1040,6 +1042,83 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
     expect(renderedText).toContain('⊙ Goal set (20-turn budget): ship the release notes')
     expect(renderedText).toContain('queued')
 
+    $queuedPromptsBySession.set({})
+  })
+
+  it('gates the busy queue on the TARGET session, not the foreground busy flag', async () => {
+    // `busyRef` is the FOREGROUND view's busy flag; a slash command runs against
+    // the session `resolveTargetSessionId` picked, which is frequently not the
+    // foreground one (tile, route rebind, freshly created session). A stale
+    // foreground `true` — e.g. left behind by a warm resume of a *different*,
+    // still-running session — parked the kickoff of an idle session's command
+    // on the queue and told the user "session busy" about a session that was
+    // doing nothing.
+    $queuedPromptsBySession.set({})
+    publishSessionState(RUNTIME_SESSION_ID, createClientSessionState(RUNTIME_SESSION_ID))
+
+    const calls: string[] = []
+    const busyRef = { current: true }
+
+    const requestGateway = vi.fn(async (method: string) => {
+      calls.push(method)
+
+      return (method === 'slash.exec' ? { type: 'send', message: 'audit the session states' } : {}) as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        busyRef={busyRef}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/audit-only audit the session states')
+
+    // The target session is idle, so the command sends now — nothing queues.
+    expect(calls).toContain('prompt.submit')
+    expect(getQueuedPrompts(RUNTIME_SESSION_ID)).toEqual([])
+
+    dropSessionState(RUNTIME_SESSION_ID)
+    $queuedPromptsBySession.set({})
+  })
+
+  it('still queues when the TARGET session is busy and the foreground flag is not', async () => {
+    // The converse leak: a background/tile command must not submit mid-turn
+    // just because the foreground view happens to be idle.
+    $queuedPromptsBySession.set({})
+    publishSessionState(RUNTIME_SESSION_ID, {
+      ...createClientSessionState(RUNTIME_SESSION_ID),
+      busy: true
+    })
+
+    const calls: string[] = []
+    const busyRef = { current: false }
+
+    const requestGateway = vi.fn(async (method: string) => {
+      calls.push(method)
+
+      return (method === 'slash.exec' ? { type: 'send', message: 'audit the session states' } : {}) as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        busyRef={busyRef}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/audit-only audit the session states')
+
+    expect(calls).toEqual(['slash.exec'])
+    expect(getQueuedPrompts(RUNTIME_SESSION_ID).map(entry => entry.text)).toEqual(['audit the session states'])
+
+    dropSessionState(RUNTIME_SESSION_ID)
     $queuedPromptsBySession.set({})
   })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1122,6 +1122,51 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
     $queuedPromptsBySession.set({})
   })
 
+  it('binds slash output and the busy queue to the TARGET session, not the foreground selection', async () => {
+    // A tile (⌘T tab, split pane) routes its slash commands through this hook
+    // with an explicit runtime id while the foreground selection names a
+    // different conversation. Binding the output writer to the foreground
+    // selection re-keyed the tile's cache entry onto the primary's stored
+    // session and parked its queued payload on the primary's queue.
+    const tileRuntimeId = 'tile-runtime'
+    const tileStoredId = 'tile-stored'
+
+    $queuedPromptsBySession.set({})
+    publishSessionState(tileRuntimeId, {
+      ...createClientSessionState(tileStoredId),
+      busy: true
+    })
+
+    const boundStoredIds: (null | string | undefined)[] = []
+
+    const requestGateway = vi.fn(
+      async (method: string) => (method === 'slash.exec' ? { type: 'send', message: 'run it in the tab' } : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onUpdateState={(_sessionId, storedSessionId) => boundStoredIds.push(storedSessionId)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId="primary-stored"
+      />
+    )
+
+    await handle!.submitText('/audit-only run it in the tab', { sessionId: tileRuntimeId })
+
+    // Every transcript write lands on the tile's own stored session.
+    expect(boundStoredIds).not.toHaveLength(0)
+    expect(new Set(boundStoredIds)).toEqual(new Set([tileStoredId]))
+    // …and the kickoff queues against the tile, never the foreground chat.
+    expect(getQueuedPrompts(tileStoredId).map(entry => entry.text)).toEqual(['run it in the tab'])
+    expect(getQueuedPrompts('primary-stored')).toEqual([])
+
+    dropSessionState(tileRuntimeId)
+    $queuedPromptsBySession.set({})
+  })
+
   it('slash status header carries the command token, not the full invocation', async () => {
     // `/goal <long prose>` used to echo the entire invocation in the mono
     // header AND the goal text again in the backend notice right under it.

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -519,7 +519,9 @@ export function usePromptActions({
 
       if (!attachments.length && SLASH_COMMAND_RE.test(visibleText)) {
         triggerHaptic('selection')
-        await executeSlashCommand(visibleText)
+        // Forward the explicit target (background queue drain, tile) — dropping
+        // it ran the command against whatever chat happened to be in front.
+        await executeSlashCommand(visibleText, options?.sessionId ? { sessionId: options.sessionId } : undefined)
 
         return true
       }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -48,6 +48,7 @@ import { resolveTargetSessionId } from './resolve-target-session'
 import {
   type GatewayRequest,
   isSessionIdCandidate,
+  isTargetSessionBusy,
   renderCommandsCatalog,
   renderRpcResult,
   slashStatusText,
@@ -252,7 +253,14 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             renderSlashOutput(`⚡ loading skill: ${dispatch.name}`)
           }
 
-          if (busyRef.current) {
+          // Gate on the TARGET session's own busy state, not the foreground
+          // view's — see isTargetSessionBusy. `busyRef` mirrors whatever chat
+          // is on screen, while this command runs against the session
+          // resolveTargetSessionId picked, routinely a different one.
+          const sessionStates = $sessionStates.get()
+          const targetState = sessionStates[sessionId]
+
+          if (isTargetSessionBusy(sessionStates, sessionId, busyRef.current)) {
             // The backend already executed the command — for `/goal <text>`
             // the goal is set and `message` is its kickoff prompt. Dropping
             // it here loses the kickoff silently (the goal exists but the
@@ -266,8 +274,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             // would otherwise park the kickoff on whichever chat is now in
             // front. Fall back through the live selection for a session whose
             // cache entry hasn't landed yet.
-            const storedId =
-              storedSessionId || $sessionStates.get()[sessionId]?.storedSessionId || $selectedStoredSessionId.get()
+            const storedId = storedSessionId || targetState?.storedSessionId || $selectedStoredSessionId.get()
 
             const queueKey = resolveComposerSessionKey(storedId, $sessions.get()) || storedId || sessionId
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -24,7 +24,6 @@ import { $petGenInput, openPetGenerate } from '@/store/pet-generate'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import {
   $connection,
-  $selectedStoredSessionId,
   $sessions,
   $yoloActive,
   resolveComposerSessionKey,
@@ -167,9 +166,15 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           return null
         }
 
-        // A long-running command can finish after a session switch. Keep its
-        // output bound to the stored session selected at invocation time.
-        const storedSessionId = selectedStoredSessionIdRef.current
+        // Bind output to the TARGET session's own stored id, snapshotted now so
+        // a command that outlives a session switch still lands on the right
+        // chat. NOT the foreground selection: a tile (⌘T tab, split) runs its
+        // slash commands through this hook with an explicit runtime id while
+        // the selection names a different conversation, and passing that down
+        // to updateSessionState re-keyed the tile's cache entry onto the
+        // primary's stored session. Fall back to the selection only for a
+        // session with no published state yet (a draft this call just created).
+        const storedSessionId = $sessionStates.get()[sessionId]?.storedSessionId ?? selectedStoredSessionIdRef.current
 
         // Header carries the command token only. The full invocation would
         // duplicate long args — `/goal <prose>` echoed the whole goal in the
@@ -257,10 +262,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           // view's — see isTargetSessionBusy. `busyRef` mirrors whatever chat
           // is on screen, while this command runs against the session
           // resolveTargetSessionId picked, routinely a different one.
-          const sessionStates = $sessionStates.get()
-          const targetState = sessionStates[sessionId]
-
-          if (isTargetSessionBusy(sessionStates, sessionId, busyRef.current)) {
+          if (isTargetSessionBusy($sessionStates.get(), sessionId, busyRef.current)) {
             // The backend already executed the command — for `/goal <text>`
             // the goal is set and `message` is its kickoff prompt. Dropping
             // it here loses the kickoff silently (the goal exists but the
@@ -268,15 +270,11 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             // queue instead: it fires when the running turn settles, and the
             // queue panel above the composer shows it in the meantime.
             //
-            // Key off the storedSessionId resolved at invocation time (same
-            // value the output writer is bound to) rather than re-reading the
-            // globals here — a session switch between dispatch and this branch
-            // would otherwise park the kickoff on whichever chat is now in
-            // front. Fall back through the live selection for a session whose
-            // cache entry hasn't landed yet.
-            const storedId = storedSessionId || targetState?.storedSessionId || $selectedStoredSessionId.get()
-
-            const queueKey = resolveComposerSessionKey(storedId, $sessions.get()) || storedId || sessionId
+            // Park it on the same stored session the output writer is bound to
+            // rather than re-reading the globals here — a session switch between
+            // dispatch and this branch would otherwise queue the kickoff on
+            // whichever chat is now in front.
+            const queueKey = resolveComposerSessionKey(storedSessionId, $sessions.get()) || storedSessionId || sessionId
 
             if (enqueueQueuedPrompt(queueKey, { attachments: [], text: message })) {
               renderSlashOutput('session busy — message queued to send when the current turn finishes')

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -21,6 +21,7 @@ import {
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
 import { $sessions, resolveComposerSessionKey, setAwaitingResponse, setBusy, setMessages } from '@/store/session'
+import { $sessionStates } from '@/store/session-states'
 
 import type { ClientSessionState } from '../../../types'
 import { sessionContextDrift } from '../session-context-drift'
@@ -34,6 +35,7 @@ import {
   isProviderSetupError,
   isSessionBusyError,
   isSessionNotFoundError,
+  isTargetSessionBusy,
   type SubmitTextOptions,
   withSessionBusyRetry
 } from './utils'
@@ -143,9 +145,19 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // from $busy by a separate effect) may still read true — honoring it would
       // bounce the drained send. The drain lock serializes them; the user path
       // keeps the guard so a stray Enter mid-turn can't double-submit.
+      //
+      // The guard reads the TARGET session's busy state (isTargetSessionBusy),
+      // not the foreground flag: an explicit target (tile, queue drain) is
+      // frequently not the session on screen, so the foreground flag would gate
+      // one session's send on another session's turn.
       const hasSendable = Boolean(visibleText || terminalContextBlocks || attachments.length || hasImage)
 
-      if (!hasSendable || (!options?.fromQueue && busyRef.current)) {
+      const guardSessionId = options?.sessionId ?? activeSessionIdRef.current
+
+      if (
+        !hasSendable ||
+        (!options?.fromQueue && isTargetSessionBusy($sessionStates.get(), guardSessionId, busyRef.current))
+      ) {
         return false
       }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -52,6 +52,32 @@ export function isSessionNotFoundError(error: unknown): boolean {
   return /session not found/i.test(message)
 }
 
+/**
+ * Is the session a prompt is about to run against currently mid-turn?
+ *
+ * The foreground `busyRef` is NOT the answer. It mirrors whatever chat is on
+ * screen, while submit and slash both resolve their target through
+ * `resolveTargetSessionId` — routinely a different session (a tile, a route
+ * rebind, a session created by this very call). Reading the foreground flag
+ * therefore gates one session's send on another session's turn: a stale
+ * foreground `true` (a warm resume of a still-running chat leaves one behind)
+ * blocks an IDLE target and reports "session busy" about a session doing
+ * nothing, and the converse lets a background send fire mid-turn.
+ *
+ * The published per-session state is authoritative. Fall back to the
+ * foreground flag only when the target has no state yet — a just-minted
+ * session whose first publish hasn't landed.
+ */
+export function isTargetSessionBusy(
+  sessionStates: Record<string, { busy: boolean }>,
+  sessionId: null | string,
+  foregroundBusy: boolean
+): boolean {
+  const state = sessionId ? sessionStates[sessionId] : undefined
+
+  return state ? state.busy : foregroundBusy
+}
+
 // Gateway JSON-RPC calls reject with "request timed out: <method>" when the
 // backend event loop is starved (e.g. a poller spin or a heavy async-injected
 // turn). For prompt.submit this is indistinguishable from a dead runtime


### PR DESCRIPTION
A slash command typed in a ⌘T tab or a split pane runs through the primary chat's dispatcher, which read the **foreground view's** identity for two decisions it had no business asking the foreground about. Both are fixed here by reading the target session's own published state.

## Busy

The gate at `slash.ts` read `busyRef` — a mirror of `$busy`, which tracks whatever chat is on screen. A brand-new tab (`openNewSessionTile('center', { listed: false })`: fresh backend session, zero turns) reported

```
/work · ⚡ loading skill: work
/work · session busy — message queued to send when the current turn finishes
```

because an unrelated chat happened to be mid-stream. The converse leaked too: a background or tile send could fire into a live turn whenever the foreground was idle.

`submit.ts` had the same guard against the same flag.

## Identity

`withSlashOutput` bound its output writer to `selectedStoredSessionIdRef` — again the foreground. Passing that stored id into `updateSessionState` makes `ensureSessionState` treat it as a stored-id rotation, so a tab's transcript writes **re-key its cache entry onto the primary's stored session** and remap `runtimeIdByStoredSessionId` with it. The queue key derived from the same value, so a queued kickoff parked on the primary's queue and `useBackgroundQueueDrain` would later fire it into the wrong conversation.

`submitText` also dropped `options.sessionId` when it routed to a slash command, so a background queue drain's explicit target was silently swapped for the foreground session.

## Shape

`isTargetSessionBusy` in `utils.ts` reads the target's published `$sessionStates` entry and falls back to the foreground flag only when the target has no state yet — a just-minted session whose first publish hasn't landed. Submit and slash both call it, so they can't drift apart again.

## Verification

`apps/desktop`: 132 tests in `use-prompt-actions` pass, 567 across `src/app/session/hooks`, `src/app/chat`, and the composer queue. `tsc --noEmit` clean. Three new tests cover the idle-target, busy-target, and tile-binding cases; the tile-binding one fails on the parent commit and passes here.

## Prior art

Distinct from [#44978](https://github.com/NousResearch/hermes-agent/issues/44978) / [#45030](https://github.com/NousResearch/hermes-agent/pull/45030), which are about a genuinely busy session having no escape hatch — this is a session that isn't busy at all being told it is. No open PR touches these files.
