### PR TITLE
fix(tui_gateway): stop TUI config toggles from wiping config.yaml on invalid YAML

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3145,6 +3145,32 @@ def _load_user_config_for_mutation(config_path: Path) -> Dict[str, Any]:
     return loaded
 
 
+def _load_user_config_for_cli_mutation(config_path: Path) -> Dict[str, Any]:
+    """CLI ``config set`` / ``unset`` entry: map parse refuses to SystemExit.
+
+    Library callers (``save_config``, ``atomic_config_write``, TUI gateway)
+    keep the raw :class:`RuntimeError` from
+    :func:`require_readable_config_before_write`. Interactive CLI mutations
+    instead exit with the established ``Cannot parse`` guidance (#75431)
+    so users get a clean error instead of a traceback. Unreadable-file
+    refuses (permission / I/O) still propagate as RuntimeError.
+    """
+    try:
+        return require_readable_config_before_write(config_path)
+    except RuntimeError as exc:
+        cause = exc.__cause__
+        if isinstance(cause, OSError):
+            raise
+        detail = cause if cause is not None else exc
+        print(
+            f"✗ Cannot parse {config_path}: {detail}\n"
+            f"  The file contains a YAML syntax error. Fix the error\n"
+            f"  in your config file first, then retry.\n"
+            f"  (hermes config edit will open it in your editor.)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
 
 def atomic_config_write(config_path: Path, data: Any, **kwargs: Any) -> None:
     """Fail-closed atomic write for ``config.yaml``.
@@ -4936,8 +4962,8 @@ def set_config_value(key: str, value: str, force: bool = False):
     # Read the raw user config (not merged with defaults) to avoid
     # dumping all default values back to the file
     config_path = get_config_path()
-    user_config = require_readable_config_before_write(config_path)
-    
+    user_config = _load_user_config_for_cli_mutation(config_path)
+
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to
     # _set_nested which preserves list-typed nodes; before #17876 the
@@ -5137,7 +5163,7 @@ def unset_config_value(key: str):
         return
 
     config_path = get_config_path()
-    user_config = require_readable_config_before_write(config_path)
+    user_config = _load_user_config_for_cli_mutation(config_path)
 
     removed = _unset_nested(user_config, key)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3062,14 +3062,33 @@ def read_raw_config_readonly() -> Dict[str, Any]:
         return cached_copy
 
 
-def require_readable_config_before_write(config_path: Optional[Path] = None) -> None:
-    """Refuse to replace an existing config.yaml that cannot be read."""
+def require_readable_config_before_write(
+    config_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Refuse to replace an existing config.yaml that cannot be read or parsed.
+
+    Guards two collapse-to-empty failure modes that would otherwise let a
+    read-then-write caller silently wipe user overrides:
+
+    1. **Unreadable** (permissions / broken mount) - byte open fails.
+    2. **Unparseable or non-mapping** - YAML load raises, or the root is a
+       list/scalar. ``read_raw_config()`` / bare ``except`` loaders treat both
+       as ``{}``, so a subsequent write would replace the recoverable file
+       with only the caller's partial dict.
+
+    Returns the loaded mapping (or ``{}`` for a missing / empty / null
+    document) so mutation callers can skip a second parse. A valid empty
+    mapping (``{}``) is allowed through so first-time installs and
+    intentional empty configs still work. On parse failure this also
+    snapshots a ``.corrupt.*.bak`` via :func:`_warn_config_parse_failure`
+    before raising.
+    """
     if config_path is None:
         config_path = get_config_path()
     try:
         config_path.stat()
     except FileNotFoundError:
-        return
+        return {}
     except OSError as exc:
         raise RuntimeError(
             f"Refusing to overwrite {config_path}: existing config.yaml cannot be accessed "
@@ -3084,6 +3103,47 @@ def require_readable_config_before_write(config_path: Optional[Path] = None) -> 
             f"Refusing to overwrite {config_path}: existing config.yaml cannot be read "
             f"({exc}). Fix the file permissions or move it aside first."
         ) from exc
+
+    return _load_user_config_for_mutation(config_path)
+
+
+def _load_user_config_for_mutation(config_path: Path) -> Dict[str, Any]:
+    """Load raw user config for a fail-closed mutation path.
+
+    Fail closed on parse / non-mapping (no bare-except -> ``{}`` collapse).
+    Used by :func:`require_readable_config_before_write` and any caller that
+    must re-validate after other work.
+    """
+    if not config_path.exists():
+        return {}
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            loaded = fast_safe_load(f)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Refusing to overwrite {config_path}: existing config.yaml cannot be read "
+            f"({exc}). Fix the file permissions or move it aside first."
+        ) from exc
+    except Exception as exc:
+        _warn_config_parse_failure(config_path, exc, fallback="refuse-write")
+        raise RuntimeError(
+            f"Refusing to overwrite {config_path}: existing config.yaml is not valid YAML "
+            f"({exc}). Fix the file or restore from a .corrupt.*.bak backup first."
+        ) from exc
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        exc = TypeError(
+            f"top-level YAML must be a mapping, got {type(loaded).__name__}"
+        )
+        _warn_config_parse_failure(config_path, exc, fallback="refuse-write")
+        raise RuntimeError(
+            f"Refusing to overwrite {config_path}: top-level YAML must be a mapping, "
+            f"got {type(loaded).__name__}. Fix the file or restore from a "
+            f".corrupt.*.bak backup first."
+        ) from exc
+    return loaded
+
 
 
 def atomic_config_write(config_path: Path, data: Any, **kwargs: Any) -> None:
@@ -4876,21 +4936,7 @@ def set_config_value(key: str, value: str, force: bool = False):
     # Read the raw user config (not merged with defaults) to avoid
     # dumping all default values back to the file
     config_path = get_config_path()
-    require_readable_config_before_write(config_path)
-    user_config = {}
-    if config_path.exists():
-        try:
-            with open(config_path, encoding="utf-8") as f:
-                user_config = fast_safe_load(f) or {}
-        except Exception as exc:
-            print(
-                f"✗ Cannot parse {config_path}: {exc}\n"
-                f"  The file contains a YAML syntax error. Fix the error\n"
-                f"  in your config file first, then retry.\n"
-                f"  (hermes config edit will open it in your editor.)",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+    user_config = require_readable_config_before_write(config_path)
     
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to
@@ -5091,21 +5137,7 @@ def unset_config_value(key: str):
         return
 
     config_path = get_config_path()
-    require_readable_config_before_write(config_path)
-    user_config = {}
-    if config_path.exists():
-        try:
-            with open(config_path, encoding="utf-8") as f:
-                user_config = fast_safe_load(f) or {}
-        except Exception as exc:
-            print(
-                f"✗ Cannot parse {config_path}: {exc}\n"
-                f"  The file contains a YAML syntax error. Fix the error\n"
-                f"  in your config file first, then retry.\n"
-                f"  (hermes config edit will open it in your editor.)",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+    user_config = require_readable_config_before_write(config_path)
 
     removed = _unset_nested(user_config, key)
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -240,10 +240,191 @@ class TestSaveAndLoadRoundtrip:
 
         assert config_path.read_text(encoding="utf-8") == original
 
+    def test_config_set_refuses_to_overwrite_unreadable_existing_config(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        original = "model:\n  provider: openrouter\n"
+        config_path.write_text(original, encoding="utf-8")
 
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with patch("builtins.open", side_effect=self._deny_config_reads(config_path)):
+                with pytest.raises(RuntimeError, match="Refusing to overwrite"):
+                    set_config_value("model.provider", "openai")
 
+        assert config_path.read_text(encoding="utf-8") == original
 
+    def test_atomic_config_write_refuses_unreadable_existing_config(self, tmp_path):
+        """The shared chokepoint every sibling write site routes through must
+        fail closed on an unreadable existing config.yaml — this locks in the
+        whole bug class (gateway slash commands, doctor --fix, yuanbao/telegram
+        auto-sethome, tui_gateway _save_cfg), not just the three named paths."""
+        from hermes_cli.config import atomic_config_write
 
+        config_path = tmp_path / "config.yaml"
+        original = "model:\n  provider: openrouter\n"
+        config_path.write_text(original, encoding="utf-8")
+
+        with patch("builtins.open", side_effect=self._deny_config_reads(config_path)):
+            with pytest.raises(RuntimeError, match="Refusing to overwrite"):
+                atomic_config_write(config_path, {"model": {"provider": "openai"}})
+
+        assert config_path.read_text(encoding="utf-8") == original
+
+    def test_config_set_refuses_to_overwrite_unparseable_existing_config(self, tmp_path):
+        """Unparseable YAML must not be replaced with a single-key document."""
+        config_path = tmp_path / "config.yaml"
+        original = (
+            "model:\n"
+            "  default: claude-opus\n"
+            "  provider: anthropic\n"
+            "gateway:\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      enabled: true\n"
+            "broken: [unterminated\n"
+        )
+        config_path.write_text(original, encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(RuntimeError, match="not valid YAML"):
+                set_config_value("model.default", "gpt-4o")
+
+        assert config_path.read_text(encoding="utf-8") == original
+        assert list(tmp_path.glob("config.yaml.corrupt.*.bak")), (
+            "parse-failure path should snapshot a corrupt backup before refusing"
+        )
+
+    def test_config_unset_refuses_to_overwrite_unparseable_existing_config(self, tmp_path):
+        """Unset must refuse the same way - env-sync paths used to write {}."""
+        config_path = tmp_path / "config.yaml"
+        original = "model:\n  default: keep-me\nbroken: [unterminated\n"
+        config_path.write_text(original, encoding="utf-8")
+        (tmp_path / ".env").write_text("TERMINAL_TIMEOUT=30\n", encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(RuntimeError, match="not valid YAML"):
+                unset_config_value("terminal.timeout")
+
+        assert config_path.read_text(encoding="utf-8") == original
+        assert (tmp_path / ".env").read_text(encoding="utf-8") == "TERMINAL_TIMEOUT=30\n"
+        assert list(tmp_path.glob("config.yaml.corrupt.*.bak")), (
+            "unset parse-failure path should snapshot a corrupt backup before refusing"
+        )
+
+    def test_config_set_refuses_non_mapping_root(self, tmp_path):
+        """A list/scalar root parses without raising but would still wipe."""
+        config_path = tmp_path / "config.yaml"
+        original = "- just\n- a\n- list\n"
+        config_path.write_text(original, encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(RuntimeError, match="must be a mapping"):
+                set_config_value("model.default", "gpt-4o")
+
+        assert config_path.read_text(encoding="utf-8") == original
+        assert list(tmp_path.glob("config.yaml.corrupt.*.bak")), (
+            "non-mapping root should snapshot a corrupt backup before refusing"
+        )
+
+    def test_config_unset_refuses_non_mapping_root(self, tmp_path):
+        """Unset shares the same non-mapping refuse path as set."""
+        config_path = tmp_path / "config.yaml"
+        original = "- just\n- a\n- list\n"
+        config_path.write_text(original, encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(RuntimeError, match="must be a mapping"):
+                unset_config_value("model.default")
+
+        assert config_path.read_text(encoding="utf-8") == original
+        assert list(tmp_path.glob("config.yaml.corrupt.*.bak"))
+
+    def test_config_set_allows_valid_empty_mapping(self, tmp_path):
+        """A genuine empty {} config must still be writable (not a false refuse)."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("{}\n", encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            set_config_value("model.default", "gpt-4o")
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved == {"model": {"default": "gpt-4o"}}
+
+    def test_atomic_config_write_refuses_unparseable_existing_config(self, tmp_path):
+        """Shared chokepoint must refuse unparseable YAML, not only unreadable."""
+        from hermes_cli.config import atomic_config_write
+
+        config_path = tmp_path / "config.yaml"
+        original = "broken: [unterminated\n"
+        config_path.write_text(original, encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="not valid YAML"):
+            atomic_config_write(config_path, {"model": {"provider": "openai"}})
+
+        assert config_path.read_text(encoding="utf-8") == original
+        assert list(tmp_path.glob("config.yaml.corrupt.*.bak"))
+
+    def test_save_config_refuses_to_overwrite_unparseable_existing_config(self, tmp_path):
+        """save_config (tools.configure path) must share the refuse gate."""
+        config_path = tmp_path / "config.yaml"
+        original = (
+            "model:\n"
+            "  default: precious/model\n"
+            "broken: [unterminated\n"
+        )
+        config_path.write_text(original, encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(RuntimeError, match="not valid YAML"):
+                save_config({"model": {"default": "wiped"}})
+
+        assert config_path.read_text(encoding="utf-8") == original
+        assert list(tmp_path.glob("config.yaml.corrupt.*.bak"))
+
+    def test_atomic_config_write_creates_new_file(self, tmp_path):
+        """A genuinely absent config.yaml must still be created — the guard
+        only refuses to clobber an existing-but-unreadable file."""
+        from hermes_cli.config import atomic_config_write
+
+        config_path = tmp_path / "config.yaml"
+        assert not config_path.exists()
+        atomic_config_write(config_path, {"model": {"provider": "openrouter"}})
+        assert config_path.exists()
+        assert "openrouter" in config_path.read_text(encoding="utf-8")
+
+    def test_save_config_normalizes_legacy_root_level_max_turns(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_config({"model": "test/custom-model", "max_turns": 37})
+
+            saved = yaml.safe_load((tmp_path / "config.yaml").read_text())
+            assert saved["agent"]["max_turns"] == 37
+            assert "max_turns" not in saved
+
+    def test_nested_values_preserved(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+            config["terminal"]["timeout"] = 999
+            save_config(config)
+
+            reloaded = load_config()
+            assert reloaded["terminal"]["timeout"] == 999
+
+    def test_write_platform_config_field_coerces_nested_platform_maps(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            (tmp_path / "config.yaml").write_text(
+                "model: test/custom-model\nplatforms: not-a-map\n",
+                encoding="utf-8",
+            )
+
+            write_platform_config_field(
+                "email",
+                "unauthorized_dm_behavior",
+                "pair",
+                raw=True,
+            )
+
+            saved = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+            assert saved["model"] == "test/custom-model"
+            assert saved["platforms"]["email"]["unauthorized_dm_behavior"] == "pair"
 
 
 class TestSaveEnvValueSecure:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -286,7 +286,7 @@ class TestSaveAndLoadRoundtrip:
         config_path.write_text(original, encoding="utf-8")
 
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
-            with pytest.raises(RuntimeError, match="not valid YAML"):
+            with pytest.raises(SystemExit):
                 set_config_value("model.default", "gpt-4o")
 
         assert config_path.read_text(encoding="utf-8") == original
@@ -302,7 +302,7 @@ class TestSaveAndLoadRoundtrip:
         (tmp_path / ".env").write_text("TERMINAL_TIMEOUT=30\n", encoding="utf-8")
 
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
-            with pytest.raises(RuntimeError, match="not valid YAML"):
+            with pytest.raises(SystemExit):
                 unset_config_value("terminal.timeout")
 
         assert config_path.read_text(encoding="utf-8") == original
@@ -318,7 +318,7 @@ class TestSaveAndLoadRoundtrip:
         config_path.write_text(original, encoding="utf-8")
 
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
-            with pytest.raises(RuntimeError, match="must be a mapping"):
+            with pytest.raises(SystemExit):
                 set_config_value("model.default", "gpt-4o")
 
         assert config_path.read_text(encoding="utf-8") == original
@@ -333,7 +333,7 @@ class TestSaveAndLoadRoundtrip:
         config_path.write_text(original, encoding="utf-8")
 
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
-            with pytest.raises(RuntimeError, match="must be a mapping"):
+            with pytest.raises(SystemExit):
                 unset_config_value("model.default")
 
         assert config_path.read_text(encoding="utf-8") == original

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -26,6 +26,7 @@ from hermes_cli.config import (
     save_env_value_secure,
     sanitize_env_file,
     set_config_value,
+    unset_config_value,
     write_platform_config_field,
     _sanitize_env_lines,
 )

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -425,6 +425,53 @@ def test_config_roundtrip(server, tmp_path):
     assert server._load_cfg()["model"] == "test/model"
 
 
+def _reset_cfg_cache(server):
+    server._cfg_cache = None
+    server._cfg_mtime = None
+    server._cfg_path = None
+
+
+def test_write_config_key_refuses_unparseable_yaml(server, tmp_path):
+    """Corrupt-but-readable YAML must not be replaced by a one-key document."""
+    server._hermes_home = tmp_path
+    _reset_cfg_cache(server)
+    original = "model:\n  default: precious/model\nbroken: [unterminated\n"
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="invalid YAML"):
+        server._write_config_key("display.busy_input_mode", "steer")
+
+    assert cfg_path.read_text(encoding="utf-8") == original
+    assert list(tmp_path.glob("config.yaml.corrupt.*.bak")), "expected corrupt backup"
+
+
+def test_save_cfg_refuses_non_mapping_root(server, tmp_path):
+    server._hermes_home = tmp_path
+    _reset_cfg_cache(server)
+    original = "- just\n- a\n- list\n"
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="mapping"):
+        server._save_cfg({"display": {"busy_input_mode": "steer"}})
+
+    assert cfg_path.read_text(encoding="utf-8") == original
+
+
+def test_write_config_key_allows_valid_empty_mapping(server, tmp_path):
+    server._hermes_home = tmp_path
+    _reset_cfg_cache(server)
+    (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+    server._write_config_key("display.busy_input_mode", "steer")
+
+    import yaml
+
+    disk = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+    assert disk == {"display": {"busy_input_mode": "steer"}}
+
+
 # ── _cli_exec_blocked ────────────────────────────────────────────────
 
 

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -457,6 +457,30 @@ def test_save_cfg_refuses_non_mapping_root(server, tmp_path):
         server._save_cfg({"display": {"busy_input_mode": "steer"}})
 
     assert cfg_path.read_text(encoding="utf-8") == original
+    assert list(tmp_path.glob("config.yaml.corrupt.*.bak")), "expected corrupt backup"
+
+
+def test_config_set_rpc_refuses_unparseable_yaml(server, tmp_path):
+    """Inline config.set must error out, not raise through dispatch (stdio crash)."""
+    server._hermes_home = tmp_path
+    _reset_cfg_cache(server)
+    original = "model:\n  default: precious/model\nbroken: [unterminated\n"
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(original, encoding="utf-8")
+
+    resp = server.dispatch(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "busy", "value": "steer"},
+        }
+    )
+
+    assert resp is not None
+    assert "error" in resp
+    assert "invalid YAML" in resp["error"]["message"]
+    assert cfg_path.read_text(encoding="utf-8") == original
+    assert list(tmp_path.glob("config.yaml.corrupt.*.bak"))
 
 
 def test_write_config_key_allows_valid_empty_mapping(server, tmp_path):

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -439,7 +439,7 @@ def test_write_config_key_refuses_unparseable_yaml(server, tmp_path):
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text(original, encoding="utf-8")
 
-    with pytest.raises(RuntimeError, match="invalid YAML"):
+    with pytest.raises(RuntimeError, match="not valid YAML"):
         server._write_config_key("display.busy_input_mode", "steer")
 
     assert cfg_path.read_text(encoding="utf-8") == original
@@ -453,7 +453,7 @@ def test_save_cfg_refuses_non_mapping_root(server, tmp_path):
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text(original, encoding="utf-8")
 
-    with pytest.raises(RuntimeError, match="mapping"):
+    with pytest.raises(RuntimeError, match="must be a mapping"):
         server._save_cfg({"display": {"busy_input_mode": "steer"}})
 
     assert cfg_path.read_text(encoding="utf-8") == original
@@ -478,9 +478,41 @@ def test_config_set_rpc_refuses_unparseable_yaml(server, tmp_path):
 
     assert resp is not None
     assert "error" in resp
-    assert "invalid YAML" in resp["error"]["message"]
+    assert "not valid YAML" in resp["error"]["message"]
     assert cfg_path.read_text(encoding="utf-8") == original
     assert list(tmp_path.glob("config.yaml.corrupt.*.bak"))
+
+
+def test_tools_configure_rpc_refuses_unparseable_yaml(server, tmp_path, monkeypatch):
+    """tools.configure uses save_config(), which must share the refuse gate."""
+    server._hermes_home = tmp_path
+    _reset_cfg_cache(server)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    original = (
+        "model:\n"
+        "  default: precious/model\n"
+        "platform_toolsets:\n"
+        "  cli: [web, terminal]\n"
+        "broken: [unterminated\n"
+    )
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(original, encoding="utf-8")
+
+    resp = server.dispatch(
+        {
+            "id": "1",
+            "method": "tools.configure",
+            "params": {"action": "disable", "names": ["web"]},
+        }
+    )
+
+    assert resp is not None
+    assert "error" in resp
+    assert "not valid YAML" in resp["error"]["message"]
+    assert cfg_path.read_text(encoding="utf-8") == original
+    assert list(tmp_path.glob("config.yaml.corrupt.*.bak")), (
+        "tools.configure bypass must still snapshot a corrupt backup"
+    )
 
 
 def test_write_config_key_allows_valid_empty_mapping(server, tmp_path):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2858,12 +2858,61 @@ def _apply_managed(cfg: dict) -> dict:
         return cfg
 
 
+def _require_parseable_config_for_write(path: Path) -> None:
+    """Refuse to replace an existing config.yaml that cannot be parsed as a mapping.
+
+    ``_load_cfg`` fail-opens to ``{}`` on YAML errors so the TUI can still start.
+    Writers that mutate that empty dict and call ``_save_cfg`` would otherwise
+    wipe model/provider/gateway/plugin overrides with a near-empty document.
+    ``atomic_config_write`` only checks byte readability, so corrupt-but-readable
+    YAML must be rejected here before any full-file replacement.
+    """
+    try:
+        path.stat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise RuntimeError(
+            f"Refusing to overwrite {path}: existing config.yaml cannot be accessed "
+            f"({exc}). Fix the file permissions or move it aside first."
+        ) from exc
+
+    import yaml
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        from hermes_cli.config import _backup_corrupt_config
+
+        _backup_corrupt_config(path)
+        raise RuntimeError(
+            f"Refusing to overwrite {path}: existing config.yaml contains invalid YAML "
+            f"({exc}). Fix the syntax error first, then retry."
+        ) from exc
+    except OSError as exc:
+        raise RuntimeError(
+            f"Refusing to overwrite {path}: existing config.yaml cannot be read "
+            f"({exc}). Fix the file permissions or move it aside first."
+        ) from exc
+
+    if raw is not None and not isinstance(raw, dict):
+        from hermes_cli.config import _backup_corrupt_config
+
+        _backup_corrupt_config(path)
+        raise RuntimeError(
+            f"Refusing to overwrite {path}: existing config.yaml root must be a mapping "
+            f"(got {type(raw).__name__}). Fix the file, then retry."
+        )
+
+
 def _save_cfg(cfg: dict):
     global _cfg_cache, _cfg_mtime, _cfg_path
 
     from hermes_cli.config import atomic_config_write
 
     path = _hermes_home / "config.yaml"
+    _require_parseable_config_for_write(path)
     atomic_config_write(path, cfg)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1784,7 +1784,14 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
 
         _rid, method, _params = normalized
         if method not in _LONG_HANDLERS:
-            return handle_request(req)
+            # Mirror the pool path: uncaught handler errors must become JSON-RPC
+            # errors. config.set (and other inline methods) can raise when
+            # _save_cfg refuses a corrupt config.yaml — without this, stdio
+            # entry crashes the whole TUI gateway process.
+            try:
+                return handle_request(req)
+            except Exception as exc:
+                return _err(_rid, -32000, f"handler error: {exc}")
 
         # Snapshot the context so the pool worker sees the bound transport.
         ctx = contextvars.copy_context()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2865,61 +2865,15 @@ def _apply_managed(cfg: dict) -> dict:
         return cfg
 
 
-def _require_parseable_config_for_write(path: Path) -> None:
-    """Refuse to replace an existing config.yaml that cannot be parsed as a mapping.
-
-    ``_load_cfg`` fail-opens to ``{}`` on YAML errors so the TUI can still start.
-    Writers that mutate that empty dict and call ``_save_cfg`` would otherwise
-    wipe model/provider/gateway/plugin overrides with a near-empty document.
-    ``atomic_config_write`` only checks byte readability, so corrupt-but-readable
-    YAML must be rejected here before any full-file replacement.
-    """
-    try:
-        path.stat()
-    except FileNotFoundError:
-        return
-    except OSError as exc:
-        raise RuntimeError(
-            f"Refusing to overwrite {path}: existing config.yaml cannot be accessed "
-            f"({exc}). Fix the file permissions or move it aside first."
-        ) from exc
-
-    import yaml
-
-    try:
-        with open(path, encoding="utf-8") as f:
-            raw = yaml.safe_load(f)
-    except yaml.YAMLError as exc:
-        from hermes_cli.config import _backup_corrupt_config
-
-        _backup_corrupt_config(path)
-        raise RuntimeError(
-            f"Refusing to overwrite {path}: existing config.yaml contains invalid YAML "
-            f"({exc}). Fix the syntax error first, then retry."
-        ) from exc
-    except OSError as exc:
-        raise RuntimeError(
-            f"Refusing to overwrite {path}: existing config.yaml cannot be read "
-            f"({exc}). Fix the file permissions or move it aside first."
-        ) from exc
-
-    if raw is not None and not isinstance(raw, dict):
-        from hermes_cli.config import _backup_corrupt_config
-
-        _backup_corrupt_config(path)
-        raise RuntimeError(
-            f"Refusing to overwrite {path}: existing config.yaml root must be a mapping "
-            f"(got {type(raw).__name__}). Fix the file, then retry."
-        )
-
-
 def _save_cfg(cfg: dict):
     global _cfg_cache, _cfg_mtime, _cfg_path
 
+    # Shared fail-closed chokepoint: atomic_config_write ->
+    # require_readable_config_before_write refuses unreadable, unparseable,
+    # and non-mapping roots (same guard as save_config / tools.configure).
     from hermes_cli.config import atomic_config_write
 
     path = _hermes_home / "config.yaml"
-    _require_parseable_config_for_write(path)
     atomic_config_write(path, cfg)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)


### PR DESCRIPTION
## What does this PR do?

When `config.yaml` is present but unparseable, TUI/desktop settings that persist through `_save_cfg` (busy mode, theme, approvals, etc.) could replace the entire file with a near-empty document containing only the edited key. This PR fail-closes those writes, snapshots a `.corrupt.*.bak`, and returns a JSON-RPC error on the inline `config.set` path instead of crashing the stdio gateway.

### Bug Cause

`_load_cfg()` fail-opens to `{}` on YAML parse errors. Callers mutate that empty dict and call `_save_cfg` -> `atomic_config_write`, which only checks byte readability. Corrupt-but-readable YAML therefore passes the guard and is overwritten with a one-key document. No `.corrupt.*.bak` was created on this path.

### Reproduction Steps

1. Under a temp `HERMES_HOME`, write a `config.yaml` with real overrides plus invalid YAML (e.g. `broken: [unterminated`).
2. Call `_write_config_key("display.busy_input_mode", "steer")`, or dispatch `config.set` with `key=busy`, `value=steer`.
3. Inspect the on-disk file.

Expected: refuse the write; leave original bytes unchanged; snapshot `config.yaml.corrupt.*.bak`; RPC returns an error (no process crash).
Before fix: disk became only `display.busy_input_mode: steer`; prior `model`/other sections gone; inline dispatch could crash stdio.

### Fix

- Guard `_save_cfg` with `_require_parseable_config_for_write` so every `_load_cfg` -> mutate -> `_save_cfg` path refuses unparseable YAML and non-mapping roots.
- Snapshot via `_backup_corrupt_config` before refusing.
- Catch inline `dispatch` handler exceptions like the pool path so refuse raises become JSON-RPC errors.
- Regressions in `tests/tui_gateway/test_protocol.py`.

Related incomplete/stale open PRs: #66844, #14276. Sibling CLI write-guard work: #71385. Fixes #66752.

## Related Issue

Fixes #66752

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` - parse/mapping refuse gate on `_save_cfg`; inline `dispatch` exception -> JSON-RPC error
- `tests/tui_gateway/test_protocol.py` - refuse / bak / RPC / valid-empty regressions

## How to Test

1. Manual: reproduce with invalid YAML under temp `HERMES_HOME`; confirm write refused, file unchanged, `.corrupt.*.bak` present; confirm `config.set busy=steer` returns an error without crashing.
2. Automated (already run locally, 99 passed):

```bash
scripts/run_tests.sh tests/tui_gateway/test_protocol.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A - no doc updates required for this bug fix
- [x] N/A - no config key changes
- [x] N/A - no architecture doc changes
- [x] I've considered cross-platform impact - pure Python YAML I/O
- [x] N/A - no tool schema changes
