### PR TITLE
fix(tools): inject items into array tool schemas so Gemini accepts declarations (#71804)

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -91,6 +91,41 @@ def test_multitype_array_becomes_anyof_no_branch_dropped():
     assert prop["description"] == "status filter"
 
 
+def test_multitype_array_branch_gets_items_and_properties():
+    # A multi-type ``type`` that includes "array"/"object" synthesizes an
+    # anyOf whose branches must ALSO be repaired: a bare {"type": "array"}
+    # branch would otherwise skip the array-items injection and Gemini would
+    # still 400 the whole declaration with ``...items: missing field`` (#71804).
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "flex": {"type": ["array", "object", "string"]},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["flex"]
+    assert "type" not in prop
+    assert prop["anyOf"] == [
+        {"type": "array", "items": {}},
+        {"type": "object", "properties": {}},
+        {"type": "string"},
+    ]
+
+
+def test_nullable_multitype_array_branch_gets_items():
+    # Same repair with a "null" member lifted to ``nullable: true``.
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "flex": {"type": ["array", "string", "null"]},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["flex"]
+    assert prop["anyOf"] == [{"type": "array", "items": {}}, {"type": "string"}]
+    assert prop["nullable"] is True
+
+
 def test_all_null_type_array_becomes_null_type():
     tools = [_tool("t", {
         "type": "object",

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -200,6 +200,63 @@ def test_items_sanitized_in_array_schema():
     assert items == {"type": "object", "properties": {}}
 
 
+def test_array_without_items_gets_empty_items():
+    """#71804: Gemini 400s a bare ``{"type": "array"}`` with
+    ``...items: missing field``. Inject a permissive ``items: {}``."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "command": {"type": "array"},  # no ``items``
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    command = out[0]["function"]["parameters"]["properties"]["command"]
+    assert command == {"type": "array", "items": {}}
+
+
+def test_nested_array_without_items_gets_empty_items():
+    """An inner array element type missing ``items`` is also filled."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "matrix": {
+                "type": "array",
+                "items": {"type": "array"},  # inner array missing ``items``
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    matrix = out[0]["function"]["parameters"]["properties"]["matrix"]
+    assert matrix["items"] == {"type": "array", "items": {}}
+
+
+def test_array_with_items_is_unchanged():
+    """A well-formed array (``items`` present) keeps its declared item type."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "tags": {"type": "array", "items": {"type": "string"}},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    tags = out[0]["function"]["parameters"]["properties"]["tags"]
+    assert tags == {"type": "array", "items": {"type": "string"}}
+
+
+def test_bare_string_array_value_gets_items():
+    """A malformed bare-string ``"array"`` schema node normalizes to a
+    dict *with* ``items`` (#71804)."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "items_list": "array",  # bare string where a schema dict belongs
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    node = out[0]["function"]["parameters"]["properties"]["items_list"]
+    assert node == {"type": "array", "items": {}}
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # strip_pattern_and_format — reactive recovery when llama.cpp rejects a
 # schema with an HTTP 400 grammar-parse error. Must be opt-in (only

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -380,7 +380,17 @@ def _sanitize_node(node: Any, path: str) -> Any:
                 continue
             if len(non_null) >= 2:
                 # Preserve all branches as a union instead of dropping them.
-                out["anyOf"] = [{"type": t} for t in non_null]
+                # Route each synthesized branch back through _sanitize_node so
+                # a branch that is itself hostile gets repaired — notably an
+                # ``"array"`` branch gains ``items: {}`` and an ``"object"``
+                # branch gains ``properties: {}``. A bare ``{"type": "array"}``
+                # here would otherwise skip the array-``items`` injection below
+                # (that runs on ``out.type``, not on anyOf members) and Gemini
+                # would still 400 the declaration (#71804).
+                out["anyOf"] = [
+                    _sanitize_node({"type": t}, f"{path}.anyOf[{i}]")
+                    for i, t in enumerate(non_null)
+                ]
                 if has_null:
                     out.setdefault("nullable", True)
                 continue

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -323,10 +323,13 @@ def _sanitize_node(node: Any, path: str) -> Any:
                 "with {'type': %r}",
                 path, node, node,
             )
-            return {"type": node} if node != "object" else {
-                "type": "object",
-                "properties": {},
-            }
+            if node == "object":
+                return {"type": "object", "properties": {}}
+            # A bare-string ``"array"`` must gain ``items`` too, or Gemini
+            # rejects the resulting ``{"type": "array"}`` node (#71804).
+            if node == "array":
+                return {"type": "array", "items": {}}
+            return {"type": node}
         # Any other stray string is not a schema — drop it by replacing with
         # a permissive object schema rather than propagate something the
         # backend will reject.
@@ -429,6 +432,14 @@ def _sanitize_node(node: Any, path: str) -> Any:
     # llama.cpp's grammar generator can't constrain a free-form object.
     if out.get("type") == "object" and not isinstance(out.get("properties"), dict):
         out["properties"] = {}
+
+    # Array nodes without ``items``: inject a permissive ``items: {}``.
+    # OpenAI-compatible backends tolerate a bare ``{"type": "array"}``, but
+    # Gemini strictly validates function declarations and 400s the whole
+    # request with ``...items: missing field`` (#71804). An empty ``items``
+    # schema is the minimal, universally-accepted form (any element type).
+    if out.get("type") == "array" and "items" not in out:
+        out["items"] = {}
 
     # Prune ``required`` entries that don't exist in properties (defense
     # against malformed MCP schemas; also caught upstream for MCP tools, but


### PR DESCRIPTION
## Problem

When Hermes sends tool declarations to a Gemini model through an OpenAI-compatible provider, the request fails before generation with:

```
HTTP 400: ...tools[0].function_declarations[N].*.properties[command].items: missing field
```

Gemini strictly validates function declarations and rejects the entire request when a tool parameter schema contains a bare `{"type": "array"}` with no `items`. OpenAI-compatible backends tolerate the underspecified schema, but the OpenAI-compatible transport forwards it verbatim, so `tools/schema_sanitizer.py` must fill it before the payload is sent.

This is the generic OpenAI-compatible sanitizer path (`tools/schema_sanitizer.py`), distinct from the native Gemini adapter path (`agent/gemini_schema.py`) addressed by #69928 — the two touch different files and cover different transports.

## Fix

In `_sanitize_node`:

- Inject a permissive `items: {}` into any array node missing `items`, mirroring the existing object-without-`properties` injection.
- Normalize a malformed bare-string `"array"` schema node to `{"type": "array", "items": {}}` (the early-return path previously produced a bare `{"type": "array"}`).

An empty `items` schema is the minimal, universally-accepted form (any element type), matching the issue's controlled verification (array with `items` → HTTP 200).

## Tests

Added to `tests/tools/test_schema_sanitizer.py`:
- array without `items` → `{"type": "array", "items": {}}`
- nested inner array without `items` → filled
- array with `items` → unchanged (no clobber)
- bare-string `"array"` node → `{"type": "array", "items": {}}`

`tests/tools/test_schema_sanitizer.py` — 51 passed. Ruff clean.

Fixes #71804
