### PR TITLE
fix(browser): don't resolve CDP endpoint during startup tool-schema assembly (#71817)

### DIFF
--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -187,6 +187,56 @@ class TestGetCdpOverride:
         with patch("hermes_cli.config.read_raw_config", return_value={}):
             assert bc.is_camofox_mode() is False
 
+
+class TestHasCdpOverride:
+    """``_has_cdp_override`` / ``_raw_cdp_override`` must report presence without
+    ever resolving the endpoint (no network I/O). See #71817."""
+
+    def test_reports_configured_override_without_network(self, monkeypatch):
+        import tools.browser_tool as browser_tool
+
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+
+        with patch("hermes_cli.config.read_raw_config",
+                   return_value={"browser": {"cdp_url": HTTP_URL}}), \
+             patch("tools.browser_tool.requests.get") as mock_get:
+            assert browser_tool._raw_cdp_override() == HTTP_URL
+            assert browser_tool._has_cdp_override() is True
+
+        mock_get.assert_not_called()
+
+    def test_false_when_no_override_configured(self, monkeypatch):
+        import tools.browser_tool as browser_tool
+
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+
+        with patch("hermes_cli.config.read_raw_config", return_value={}), \
+             patch("tools.browser_tool.requests.get") as mock_get:
+            assert browser_tool._raw_cdp_override() == ""
+            assert browser_tool._has_cdp_override() is False
+
+        mock_get.assert_not_called()
+
+    def test_check_browser_requirements_does_not_resolve_cdp(self, monkeypatch):
+        """Startup tool-schema assembly must not block resolving an unreachable
+        CDP endpoint: ``check_browser_requirements`` should short-circuit on a
+        configured override without issuing the ``/json/version`` request
+        (regression for the 10s+ startup stall in #71817)."""
+        import tools.browser_tool as browser_tool
+
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+
+        def _boom(*args, **kwargs):  # pragma: no cover - must never run
+            raise AssertionError("check_browser_requirements resolved CDP at startup")
+
+        with patch("hermes_cli.config.read_raw_config",
+                   return_value={"browser": {"cdp_url": HTTP_URL}}), \
+             patch("tools.browser_tool.requests.get", side_effect=_boom) as mock_get:
+            assert browser_tool.check_browser_requirements() is True
+
+        mock_get.assert_not_called()
+
+
 class TestCreateCdpSession:
     """_create_cdp_session() must sanitize the CDP URL before logging.
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -457,20 +457,21 @@ def _resolve_cdp_override(cdp_url: str) -> str:
     return raw
 
 
-def _get_cdp_override() -> str:
-    """Return a normalized CDP URL override, or empty string.
+def _raw_cdp_override() -> str:
+    """Return the *unresolved* configured CDP override, or empty string.
 
     Precedence is:
     1. ``BROWSER_CDP_URL`` env var (live override from ``/browser connect``)
     2. ``browser.cdp_url`` in config.yaml (persistent config)
 
-    When either is set, we skip both Browserbase and the local headless
-    launcher and connect directly to the supplied Chrome DevTools Protocol
-    endpoint.
+    This performs **no network I/O** — it only reports what the user configured.
+    Use it (or ``_has_cdp_override``) whenever only the presence/value of the
+    override matters; call ``_get_cdp_override`` when a concrete connectable
+    websocket URL is actually needed.
     """
     env_override = os.environ.get("BROWSER_CDP_URL", "").strip()
     if env_override:
-        return _resolve_cdp_override(env_override)
+        return env_override
 
     try:
         from hermes_cli.config import read_raw_config
@@ -478,11 +479,34 @@ def _get_cdp_override() -> str:
         cfg = read_raw_config()
         browser_cfg = cfg.get("browser", {})
         if isinstance(browser_cfg, dict):
-            return _resolve_cdp_override(str(browser_cfg.get("cdp_url", "") or ""))
+            return str(browser_cfg.get("cdp_url", "") or "").strip()
     except Exception as e:
         logger.debug("Could not read browser.cdp_url from config: %s", e)
 
     return ""
+
+
+def _has_cdp_override() -> bool:
+    """Whether a CDP override endpoint is *configured*, without resolving it.
+
+    Unlike ``_get_cdp_override`` this does no network request, so it is safe to
+    call on hot/startup paths (e.g. tool-schema assembly) that only need to know
+    whether an override is present.
+    """
+    return bool(_raw_cdp_override())
+
+
+def _get_cdp_override() -> str:
+    """Return a normalized, connectable CDP URL override, or empty string.
+
+    When an override is configured (see ``_raw_cdp_override``) we skip both
+    Browserbase and the local headless launcher and connect directly to the
+    supplied Chrome DevTools Protocol endpoint. Discovery-style endpoints are
+    resolved to a concrete ``webSocketDebuggerUrl`` via a blocking HTTP request,
+    so avoid calling this on startup paths — use ``_has_cdp_override`` there.
+    """
+    raw = _raw_cdp_override()
+    return _resolve_cdp_override(raw) if raw else ""
 
 
 def _get_dialog_policy_config() -> Tuple[str, float]:
@@ -4739,8 +4763,13 @@ def check_browser_requirements() -> bool:
         return True
 
     # CDP override mode can connect to an existing remote/local browser endpoint
-    # without requiring the local agent-browser binary on PATH.
-    if _get_cdp_override():
+    # without requiring the local agent-browser binary on PATH. Only check that
+    # an override is *configured* here — resolving it issues a blocking
+    # ``/json/version`` request, and this runs during startup tool-schema
+    # assembly for every browser tool, so an unreachable endpoint would stall
+    # startup for the full request timeout (#71817). Resolution stays deferred
+    # to the browser-command paths that actually need the websocket URL.
+    if _has_cdp_override():
         return True
 
     # The agent-browser CLI is required for local launch and cloud-provider flows.


### PR DESCRIPTION
## Summary

Fixes #71817 — a configured `browser.cdp_url` that points at an unreachable endpoint stalls Hermes startup by 10s+.

`check_browser_requirements()` is registered as the `check_fn` for every browser tool and runs during startup **tool-schema assembly**. It called `_get_cdp_override()`, which resolves a discovery-style `browser.cdp_url` into a concrete `webSocketDebuggerUrl` via a blocking `requests.get(<url>/json/version, timeout=10)`. When the endpoint is down (classic case: a stale `cdp_url` persisted from an earlier `/browser connect` the user no longer runs), every one of those startup checks blocks for the full timeout, pushing startup from ~2s to 12–20s.

## Fix

The CDP branch in `check_browser_requirements()` only needs to know whether an override is **configured**, not its resolved websocket URL — resolution belongs on the actual browser-command paths that connect. So:

- Factor the network-free read into `_raw_cdp_override()` (returns the unresolved env/config value) and `_has_cdp_override()` (bool presence).
- `check_browser_requirements()` now uses `_has_cdp_override()` — no network I/O at startup.
- `_get_cdp_override()` is unchanged in behavior: it reuses `_raw_cdp_override()` and resolves only when a raw value is present. Precedence (`BROWSER_CDP_URL` env → `browser.cdp_url` config) and the resolve-on-failure fallback are preserved.

This implements suggestion #1 from the issue (lazy resolution). With no network call in the check, the "12 tools each re-check" concern is moot — each check is now a cheap config read.

Scope is intentionally limited to the startup `check_fn`. Other `_get_cdp_override()` callsites that consume the resolved URL (session creation, navigation) are unchanged.

## Tests

`tests/tools/test_browser_cdp_override.py::TestHasCdpOverride` (new):
- presence reported without any `requests.get` call;
- `False` when nothing is configured;
- **regression**: `check_browser_requirements()` returns `True` for a configured override while `requests.get` is patched to raise — proving startup no longer resolves the endpoint.

`108 passed` across the browser tool + camofox + chromium-check + cli-browser-connect suites; preflight gates (ruff, windows-footguns, affected tests) green.

The arm64-fork-Docker build failure is the known fork-CI limitation, not related to this change.
