### PR TITLE
fix(logging): redact configured secrets in persistent logs

### DIFF
--- a/agent/configured_secret_redaction.py
+++ b/agent/configured_secret_redaction.py
@@ -1,0 +1,94 @@
+"""Exact-value redaction for credentials loaded into Hermes.
+
+Kept independent of :mod:`agent.redact` so env/config/profile loaders can
+register values without changing the pattern redactor's import-time settings.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import threading
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+CONFIGURED_SECRET_MARKER = "[REDACTED_CONFIGURED_SECRET]"
+_MIN_SECRET_LENGTH = 8
+_SECRET_NAME_RE = re.compile(
+    r"(?:^|_)(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|KEY)(?:_|$)",
+    re.IGNORECASE,
+)
+
+_lock = threading.Lock()
+_values: tuple[str, ...] = ()
+
+
+def _is_secret_name(name: object) -> bool:
+    return _SECRET_NAME_RE.search(str(name)) is not None
+
+
+def _collect_env_values(environ: Mapping[str, Any]) -> set[str]:
+    return {
+        value
+        for name, value in environ.items()
+        if _is_secret_name(name)
+        and isinstance(value, str)
+        and len(value) >= _MIN_SECRET_LENGTH
+    }
+
+
+def _collect_config_values(value: Any) -> set[str]:
+    found: set[str] = set()
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if (
+                _is_secret_name(key)
+                and isinstance(child, str)
+                and len(child) >= _MIN_SECRET_LENGTH
+            ):
+                found.add(child)
+            else:
+                found.update(_collect_config_values(child))
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            found.update(_collect_config_values(child))
+    return found
+
+
+def refresh_configured_secret_values(
+    environ: Mapping[str, Any] | None = None,
+    config: Mapping[str, Any] | None = None,
+) -> None:
+    """Register configured values without exposing the registry to callers."""
+    discovered = _collect_env_values(os.environ if environ is None else environ)
+    if config is not None:
+        discovered.update(_collect_config_values(config))
+    register_secret_values(discovered)
+
+
+def register_secret_values(values: Iterable[object]) -> None:
+    """Register values from an already trusted secret-only source."""
+    global _values
+    discovered = {
+        value
+        for value in values
+        if isinstance(value, str) and len(value) >= _MIN_SECRET_LENGTH
+    }
+    if not discovered:
+        return
+    with _lock:
+        merged = set(_values).union(discovered)
+        if len(merged) != len(_values):
+            _values = tuple(sorted(merged, key=len, reverse=True))
+
+
+def redact_configured_secret_values(text: str) -> str:
+    """Replace registered opaque credential values in *text*."""
+    values = _values
+    for secret in values:
+        text = text.replace(secret, CONFIGURED_SECRET_MARKER)
+    return text
+
+
+# Support direct RedactingFormatter use outside normal startup.
+refresh_configured_secret_values()

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -1,7 +1,8 @@
-"""Regex-based secret redaction for logs and tool output.
+"""Secret redaction for logs and tool output.
 
-Applies pattern matching to mask API keys, tokens, and credentials
-before they reach log files, verbose output, or gateway logs.
+Applies pattern matching plus exact-value masking for configured credentials
+before they reach persistent logs. Tool and chat output use pattern matching
+and continue to honor the user-facing redaction setting.
 
 Short tokens (< 18 chars) are fully masked. Longer tokens preserve
 the first 6 and last 4 characters for debuggability.
@@ -12,6 +13,11 @@ import os
 import re
 import shlex
 from urllib.parse import unquote_plus
+
+from agent.configured_secret_redaction import (
+    redact_configured_secret_values,
+    refresh_configured_secret_values,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -60,12 +66,13 @@ _SENSITIVE_BODY_KEYS = frozenset({
 # Snapshot at import time so runtime env mutations (e.g. LLM-generated
 # `export HERMES_REDACT_SECRETS=false`) cannot disable redaction
 # mid-session.  ON by default — secure default per issue #17691. Users who
-# need raw credential values in tool output (e.g. working on the redactor
+# need raw credential values in tool or chat output (e.g. working on the redactor
 # itself) can opt out via `security.redact_secrets: false` in config.yaml
 # (bridged to this env var in hermes_cli/main.py, gateway/run.py, and
 # cli.py) or `HERMES_REDACT_SECRETS=false` in ~/.hermes/.env. An opt-out
 # warning is logged at gateway and CLI startup so operators see the
 # downgrade — see `_log_redaction_status()` in gateway/run.py and cli.py.
+# Persistent logs remain force-redacted by RedactingFormatter.
 _REDACT_ENABLED = os.getenv("HERMES_REDACT_SECRETS", "true").lower() in {"1", "true", "yes", "on"}
 
 # Known API key prefixes -- match the prefix + contiguous token chars
@@ -862,11 +869,20 @@ def _has_http_method_substring(text: str) -> bool:
 
 
 class RedactingFormatter(logging.Formatter):
-    """Log formatter that redacts secrets from all log messages."""
+    """Redact logs, with an explicit hard-boundary mode for persistent files."""
 
-    def __init__(self, fmt=None, datefmt=None, style='%', **kwargs):
+    def __init__(
+        self, fmt=None, datefmt=None, style='%', *, force_redaction=False, **kwargs
+    ):
         super().__init__(fmt, datefmt, style, **kwargs)
+        self.force_redaction = force_redaction
+        refresh_configured_secret_values()
 
     def format(self, record: logging.LogRecord) -> str:
-        original = super().format(record)
-        return redact_sensitive_text(original)
+        text = super().format(record)
+        if self.force_redaction:
+            # Log files are a hard egress boundary. The user-facing opt-out is
+            # for tool/console output, not files that may enter debug bundles.
+            text = redact_configured_secret_values(text)
+            return redact_sensitive_text(text, force=True)
+        return redact_sensitive_text(text)

--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -27,6 +27,8 @@ from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import Dict, Mapping, Optional
 
+from agent.configured_secret_redaction import register_secret_values
+
 
 # ── multiplex-active flag ────────────────────────────────────────────────
 # Process-global: set once at gateway startup when gateway.multiplex_profiles
@@ -72,7 +74,11 @@ def set_secret_scope(secrets: Optional[Mapping[str, str]]) -> Token:
     """Install the active profile's secret mapping for the current context.
 
     Returns a token for ``reset_secret_scope``. Pass ``None`` to clear.
+    Registered values only enter the process-local log-redaction registry;
+    ``os.environ`` remains untouched, preserving profile isolation.
     """
+    if secrets is not None:
+        register_secret_values(secrets.values())
     return _SECRET_SCOPE.set(secrets)
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20739,7 +20739,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 backupCount=3,
                 encoding="utf-8",
             )
-            file_handler.setFormatter(RedactingFormatter("%(message)s"))
+            file_handler.setFormatter(
+                RedactingFormatter("%(message)s", force_redaction=True)
+            )
             tool_logger = logging.getLogger(f"hermes.tool_calls.{id(log_queue)}")
             tool_logger.setLevel(logging.INFO)
             tool_logger.propagate = False

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -342,6 +342,13 @@ def load_hermes_dotenv(
     _apply_external_secret_sources(home_path)
     _apply_managed_env()
 
+    # Long-running processes reload this function to pick up rotated
+    # credentials. Refresh after every source has applied; the registry retains
+    # both new and previously used values for delayed diagnostics.
+    from agent.configured_secret_redaction import refresh_configured_secret_values
+
+    refresh_configured_secret_values()
+
     return loaded
 
 

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -324,7 +324,7 @@ def setup_logging(
         level=level,
         max_bytes=max_bytes,
         backup_count=backups,
-        formatter=RedactingFormatter(_LOG_FORMAT),
+        formatter=RedactingFormatter(_LOG_FORMAT, force_redaction=True),
     )
 
     # --- errors.log (WARNING+) — quick triage log --------------------------
@@ -334,7 +334,7 @@ def setup_logging(
         level=logging.WARNING,
         max_bytes=2 * 1024 * 1024,
         backup_count=2,
-        formatter=RedactingFormatter(_LOG_FORMAT),
+        formatter=RedactingFormatter(_LOG_FORMAT, force_redaction=True),
     )
 
     # --- gateway.log (INFO+, gateway component only) ------------------------
@@ -345,7 +345,7 @@ def setup_logging(
             level=logging.INFO,
             max_bytes=5 * 1024 * 1024,
             backup_count=3,
-            formatter=RedactingFormatter(_LOG_FORMAT),
+            formatter=RedactingFormatter(_LOG_FORMAT, force_redaction=True),
             log_filter=_ComponentFilter(COMPONENT_PREFIXES["gateway"]),
         )
 
@@ -357,7 +357,7 @@ def setup_logging(
             level=logging.INFO,
             max_bytes=10 * 1024 * 1024,
             backup_count=5,
-            formatter=RedactingFormatter(_LOG_FORMAT),
+            formatter=RedactingFormatter(_LOG_FORMAT, force_redaction=True),
             log_filter=_ComponentFilter(COMPONENT_PREFIXES["gui"]),
         )
 
@@ -777,6 +777,9 @@ def _read_logging_config():
                 cfg = managed_scope.apply_managed_overlay(cfg)
             except Exception:
                 pass
+            from agent.configured_secret_redaction import refresh_configured_secret_values
+
+            refresh_configured_secret_values(config=cfg)
             log_cfg = cfg.get("logging", {})
             if isinstance(log_cfg, dict):
                 return (

--- a/skills/autonomous-ai-agents/hermes-agent/references/security-privacy.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/security-privacy.md
@@ -4,7 +4,7 @@ Common "why is Hermes doing X to my output / tool calls / commands?" toggles —
 
 ### Secret redaction in tool output
 
-Secret redaction is **on by default** — tool output (terminal stdout, `read_file`, web content, subagent summaries, etc.) is scanned for strings that look like API keys, tokens, and secrets before it enters the conversation context and logs. Leave it enabled for normal use:
+Secret redaction is **on by default** — tool output (terminal stdout, `read_file`, web content, subagent summaries, etc.) is scanned for strings that look like API keys, tokens, and secrets before it enters the conversation context. Persistent logs are always force-redacted and also mask exact values loaded from secret-like environment variables and configuration keys. Leave user-facing redaction enabled for normal use:
 
 ```bash
 hermes config set security.redact_secrets true       # keep enabled globally
@@ -12,7 +12,7 @@ hermes config set security.redact_secrets true       # keep enabled globally
 
 **Restart required.** `security.redact_secrets` is snapshotted at import time — toggling it mid-session (e.g. via `export HERMES_REDACT_SECRETS=false` from a tool call) will NOT take effect for the running process. Tell the user to change it in config from a terminal, then start a new session. This is deliberate — it prevents an LLM from flipping the toggle on itself mid-task.
 
-Disable only when you deliberately need raw credential-like strings for debugging or redactor development:
+Disable only when you deliberately need raw credential-like strings in tool or chat output for debugging or redactor development. This does not disable persistent-log redaction:
 ```bash
 hermes config set security.redact_secrets false
 ```

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -361,6 +361,114 @@ class TestRedactingFormatter:
         assert "abc123def456" not in result
         assert "sk-pro" in result
 
+    def test_redacts_exact_configured_opaque_secret_even_when_pattern_redaction_disabled(
+        self, monkeypatch
+    ):
+        secret = "opaque-configured-value-abc123"
+        monkeypatch.setenv("FEISHU_APP_SECRET", secret)
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        formatter = RedactingFormatter("%(message)s", force_redaction=True)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="normal diagnostic body contains %s",
+            args=(secret,),
+            exc_info=None,
+        )
+
+        result = formatter.format(record)
+
+        assert secret not in result
+        assert "normal diagnostic body contains" in result
+        assert "[REDACTED_CONFIGURED_SECRET]" in result
+
+    def test_default_formatter_preserves_opt_out_for_console_diagnostics(
+        self, monkeypatch
+    ):
+        secret = "opaque-console-diagnostic-value"
+        monkeypatch.setenv("CONSOLE_SECRET", secret)
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        formatter = RedactingFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="console=%s",
+            args=(secret,),
+            exc_info=None,
+        )
+
+        assert formatter.format(record) == f"console={secret}"
+
+    def test_does_not_redact_non_secret_environment_values(self, monkeypatch):
+        value = "ordinary-configured-value"
+        monkeypatch.setenv("HERMES_TEST_LABEL", value)
+        formatter = RedactingFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="label=%s",
+            args=(value,),
+            exc_info=None,
+        )
+
+        assert formatter.format(record) == f"label={value}"
+
+    def test_refresh_api_does_not_return_registered_values(self):
+        from agent.redact import refresh_configured_secret_values
+
+        result = refresh_configured_secret_values(
+            environ={"PROFILE_SECRET": "opaque-private-profile-value"}
+        )
+
+        assert result is None
+
+    def test_refresh_redacts_rotated_secret_and_retains_old_value(self, monkeypatch):
+        from agent.redact import refresh_configured_secret_values
+
+        old_secret = "opaque-old-secret-ghi789"
+        new_secret = "opaque-new-secret-jkl012"
+        monkeypatch.setenv("FEISHU_APP_SECRET", old_secret)
+        formatter = RedactingFormatter("%(message)s", force_redaction=True)
+        monkeypatch.setenv("FEISHU_APP_SECRET", new_secret)
+
+        refresh_configured_secret_values()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="old=%s new=%s",
+            args=(old_secret, new_secret),
+            exc_info=None,
+        )
+
+        result = formatter.format(record)
+
+        assert old_secret not in result
+        assert new_secret not in result
+        assert result.count("[REDACTED_CONFIGURED_SECRET]") == 2
+
+    def test_ignores_short_values_to_avoid_common_word_corruption(self, monkeypatch):
+        monkeypatch.setenv("TEST_API_TOKEN", "token")
+        formatter = RedactingFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="token counting remains diagnostic",
+            args=(),
+            exc_info=None,
+        )
+
+        assert formatter.format(record) == "token counting remains diagnostic"
+
 
 class TestPrintenvSimulation:
     """Simulate what happens when the agent runs `env` or `printenv`."""

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -1,7 +1,10 @@
 """Tests for the profile-scoped credential primitive (Workstream A / Phase 2)."""
+import logging
+
 import pytest
 
 from agent import secret_scope as ss
+from agent.redact import RedactingFormatter
 
 
 @pytest.fixture(autouse=True)
@@ -32,6 +35,31 @@ class TestMultiplexInactiveBackwardCompat:
 
 class TestMultiplexActiveFailClosed:
     """Multiplex on: an unscoped secret read raises instead of leaking."""
+
+    def test_scope_registers_opaque_secret_for_persistent_log_redaction(
+        self, monkeypatch
+    ):
+        secret = "opaque-multiplex-profile-value"
+        monkeypatch.delenv("CUSTOM_AUTH", raising=False)
+        formatter = RedactingFormatter("%(message)s", force_redaction=True)
+
+        token = ss.set_secret_scope({"CUSTOM_AUTH": secret})
+        try:
+            record = logging.LogRecord(
+                name="gateway.run",
+                level=logging.INFO,
+                pathname="",
+                lineno=0,
+                msg="profile credential=%s",
+                args=(secret,),
+                exc_info=None,
+            )
+            result = formatter.format(record)
+        finally:
+            ss.reset_secret_scope(token)
+
+        assert secret not in result
+        assert "[REDACTED_CONFIGURED_SECRET]" in result
 
     def test_unscoped_read_raises(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-leaky")

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -169,6 +169,47 @@ class TestSetupLogging:
         content = agent_log.read_text()
         assert "test message for agent.log" in content
 
+    def test_loaded_opaque_secret_is_redacted_while_message_body_is_preserved(
+        self, hermes_home, monkeypatch
+    ):
+        from hermes_cli.env_loader import load_hermes_dotenv
+
+        env_secret = "opaque-runtime-secret-def456"
+        config_secret = "opaque-config-secret-mno345"
+        config_label = "ordinary-config-label"
+        monkeypatch.delenv("FEISHU_APP_SECRET", raising=False)
+        (hermes_home / ".env").write_text(
+            f"FEISHU_APP_SECRET={env_secret}\n",
+            encoding="utf-8",
+        )
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n  custom:\n    app_secret: "
+            + config_secret
+            + "\n    label: "
+            + config_label
+            + "\n",
+            encoding="utf-8",
+        )
+        load_hermes_dotenv(hermes_home=hermes_home)
+        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+        logging.getLogger("gateway.run").info(
+            "inbound message body preserved; env=%s config=%s label=%s",
+            env_secret,
+            config_secret,
+            config_label,
+        )
+        hermes_logging.flush_log_queue()
+
+        for log_name in ("agent.log", "gateway.log"):
+            content = (hermes_home / "logs" / log_name).read_text()
+            assert env_secret not in content
+            assert config_secret not in content
+            assert "inbound message body preserved; env=" in content
+            assert config_label in content
+            assert content.count("[REDACTED_CONFIGURED_SECRET]") == 2
+
     def test_warnings_appear_in_both_logs(self, hermes_home):
         hermes_logging.setup_logging(hermes_home=hermes_home)
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -769,7 +769,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_EPHEMERAL_SYSTEM_PROMPT` | Ephemeral system prompt injected at API-call time (never persisted to sessions) |
 | `HERMES_PREFILL_MESSAGES_FILE` | Path to a JSON file of ephemeral prefill messages injected at API-call time. |
 | `HERMES_ALLOW_PRIVATE_URLS` | `true`/`false` — allow tools to fetch localhost/private-network URLs. Off by default in gateway mode. |
-| `HERMES_REDACT_SECRETS` | `true`/`false` — control secret redaction in tool output, logs, and chat responses (default: `true`). |
+| `HERMES_REDACT_SECRETS` | `true`/`false` — control secret redaction in tool output and chat responses (default: `true`). Persistent logs are always redacted. |
 | `HERMES_WRITE_SAFE_ROOT` | Optional directory prefix that **hard-blocks** `write_file`/`patch` writes outside the listed roots (no approval prompt). Supports multiple directories separated by `os.pathsep` (`:` on Unix, `;` on Windows). See [HERMES_WRITE_SAFE_ROOT](#hermes_write_safe_root) below. |
 | `HERMES_DISABLE_LAZY_INSTALLS` | Internal bridge var set automatically in the official Docker image to prevent runtime dependency installs into the immutable `/opt/hermes` tree. The user-facing equivalent is `security.allow_lazy_installs: false` in `config.yaml`; do not set this in `.env`. |
 | `HERMES_DISABLE_FILE_STATE_GUARD` | Set to `1` to turn off the "file changed since you read it" guard on `patch`/`write_file`. |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1946,7 +1946,7 @@ Pre-execution security scanning and secret redaction:
 
 ```yaml
 security:
-  redact_secrets: true           # Redact API key patterns in tool output and logs (on by default)
+  redact_secrets: true           # Redact API key patterns in tool/chat output (on by default)
   tirith_enabled: true           # Enable Tirith security scanning for terminal commands
   tirith_path: "tirith"          # Path to tirith binary (default: "tirith" in $PATH)
   tirith_timeout: 5              # Seconds to wait for tirith scan before timing out
@@ -1957,7 +1957,7 @@ security:
     shared_files: []
 ```
 
-- `redact_secrets` — when `true`, automatically detects and redacts patterns that look like API keys, tokens, and passwords in tool output before it enters the conversation context and logs. **On by default**. Set to `false` explicitly only when you need raw credential-like strings for debugging or redactor development.
+- `redact_secrets` — when `true`, automatically detects and redacts patterns that look like API keys, tokens, and passwords in tool and chat output. **On by default**. Set to `false` explicitly only when you need raw credential-like strings for debugging or redactor development. Persistent logs remain force-redacted, including exact values loaded from secret-like environment variables and configuration keys.
 - `tirith_enabled` — when `true`, terminal commands are scanned by [Tirith](https://github.com/sheeki03/tirith) before execution to detect potentially dangerous operations.
 - `tirith_path` — path to the tirith binary. Set this if tirith is installed in a non-standard location.
 - `tirith_timeout` — maximum seconds to wait for a tirith scan. Commands proceed if the scan times out.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
@@ -558,7 +558,7 @@ Graph 事件（Teams 会议、日历、聊天等）的入站变更通知监听�
 | `HERMES_EPHEMERAL_SYSTEM_PROMPT` | 在 API 调用时注入的临时系统 prompt（永不持久化到会话） |
 | `HERMES_PREFILL_MESSAGES_FILE` | 包含在 API 调用时注入的临时预填消息的 JSON 文件路径。 |
 | `HERMES_ALLOW_PRIVATE_URLS` | `true`/`false`——允许工具获取 localhost/私有网络 URL。gateway 模式下默认关闭。 |
-| `HERMES_REDACT_SECRETS` | `true`/`false`——控制工具输出、日志和聊天响应中的密钥脱敏（默认：`true`）。 |
+| `HERMES_REDACT_SECRETS` | `true`/`false`——控制工具输出和聊天响应中的密钥脱敏（默认：`true`）。持久化日志始终执行密钥脱敏。 |
 | `HERMES_WRITE_SAFE_ROOT` | 可选目录前缀，**硬阻止** `write_file`/`patch` 写入列出的根目录之外的路径（无审批提示）。支持多个目录，使用 `os.pathsep` 分隔（Unix 为 `:`，Windows 为 `;`）。详见下方 [HERMES_WRITE_SAFE_ROOT](#hermes_write_safe_root)。 |
 | `HERMES_DISABLE_LAZY_INSTALLS` | 官方 Docker 镜像中自动设置的内部桥接变量，用于阻止运行时将依赖安装到不可变的 `/opt/hermes` 树。面向用户的等价配置是 `config.yaml` 中的 `security.allow_lazy_installs: false`；不要在 `.env` 中手动设置此变量。 |
 | `HERMES_DISABLE_FILE_STATE_GUARD` | 设为 `1` 可关闭 `patch`/`write_file` 上的"文件自上次读取后已更改"保护。 |


### PR DESCRIPTION
## Summary

Persistent Hermes logs can retain opaque configured credentials that do not match the existing vendor/prefix regexes. This change keeps ordinary diagnostic and inbound-message text available while making persistent file handlers a hard redaction boundary.

- register opaque credential values loaded from credential-shaped environment/config fields
- register all qualifying values from trusted multiplex profile secret scopes without mutating `os.environ`
- force both exact-value and existing pattern redaction only on persistent rotating file handlers (`agent.log`, `errors.log`, `gateway.log`, `gui.log`, and `tool_calls.log`)
- preserve the existing `security.redact_secrets=false` behavior for console/user-facing diagnostics
- retain previously registered values so rotated credentials remain protected in delayed diagnostics
- document that the opt-out does not disable persistent-log redaction

Configured values shorter than 8 characters are intentionally not globally replaced to avoid corrupting ordinary log text containing common short words.

## Relationship to #64376

This is complementary to #64376, not a replacement:

- #64376 force-redacts recognized credential patterns at the inbound gateway log call site.
- this PR protects every persistent file-handler boundary and additionally catches opaque configured values.

There is no message-routing change and ordinary message bodies remain logged around redacted values.

## Verification

- `487 passed` across the redactor, secret-scope, central logging, gateway tool-log, env-loader, managed-scope, and external secret-source suites
- Ruff: PASS
- `git diff --check`: PASS
- independent read-only review of exact staged tree `e44df15b8ef99fd3bcb71c25caec96b5b6cc5143`: READY, no Critical/High/Medium/Low findings
