### PR TITLE
fix: add missing creationflags to subprocess calls (Windows console flash)

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -27,7 +27,7 @@ _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
 from typing import Dict, Optional, Any
 
-from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
+from hermes_cli._subprocess_compat import windows_detach_popen_kwargs, windows_hide_flags
 from hermes_constants import (
     find_node_executable,
     get_hermes_dir,
@@ -225,6 +225,7 @@ def _terminate_bridge_process(proc, *, force: bool = False) -> None:
                 capture_output=True,
                 text=True, encoding='utf-8', errors='replace',
                 timeout=10,
+                creationflags=windows_hide_flags(),
             )
         except FileNotFoundError:
             if force:
@@ -350,7 +351,8 @@ def check_whatsapp_requirements() -> bool:
             [_node, "--version"],
             capture_output=True,
             text=True, encoding='utf-8', errors='replace',
-            timeout=5
+            timeout=5,
+            creationflags=windows_hide_flags(),
         )
         return result.returncode == 0
     except Exception:
@@ -552,6 +554,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         text=True, encoding='utf-8', errors='replace',
                         timeout=npm_install_timeout,
                         env=with_hermes_node_path(),
+                        creationflags=windows_hide_flags(),
                     )
                     if install_result.returncode != 0:
                         print(f"[{self.name}] npm install failed: {install_result.stderr}")

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4690,6 +4690,7 @@ def _maybe_autoinstall_chromium() -> bool:
             text=True, encoding='utf-8', errors='replace',
             timeout=600,
             env=_build_browser_env(),
+            creationflags=windows_hide_flags(),
         )
     except (OSError, subprocess.SubprocessError) as e:
         logger.warning("browser: Chromium auto-install failed to start: %s", e)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2103,6 +2103,7 @@ def _resolve_piper_voice_path(voice: str, download_dir: Path) -> str:
              "--download-dir", str(download_dir)],
             capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=300,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(


### PR DESCRIPTION
## Summary

Adds missing `creationflags=windows_hide_flags()` to three files where `subprocess.run` calls on Windows spawn visible console windows (cmd.exe / conhost.exe flash).

## Changes

**`tools/browser_tool.py`** — Chromium auto-install (`npx agent-browser install`):
- The one-time ~170MB browser binary download subprocess was missing creationflags, causing a visible console window flash on every fresh install.

**`tools/tts_tool.py`** — Piper voice download:
- First-use voice model download via `python -m piper.download_voices` was missing creationflags.

**`plugins/platforms/whatsapp/adapter.py`** — Three call sites:
1. `_terminate_bridge_process` taskkill (line ~223) — Windows-only path to kill the bridge process tree
2. Node.js version probe (line ~349) — checks `node --version` during bridge setup
3. npm install (line ~548) — installs bridge dependencies during first connect

The file already imported `windows_detach_popen_kwargs` but not `windows_hide_flags`; added the import alongside it.

## Why these are real bugs

On Windows, every `subprocess.run`/`subprocess.Popen` without `CREATE_NO_WINDOW` (0x08000000) spawns a visible console window that flashes briefly. The `windows_hide_flags()` helper returns this flag on Windows and 0 on other platforms, so it's safe to pass unconditionally.

## Pattern coverage

Existing PRs cover most other subprocess sites:
- #64081: env_probe, lazy_deps, tts_tool (lines 2002/2087)
- #65635: tirith_security
- #65660: telegram ffprobe, discord ffmpeg, raft bridge
- #66785: tts_tool taskkill, vision_tools

These three files were gaps in the coverage. No existing PR touches them.

## Test plan
- [ ] Verify syntax: `python3 -c "import ast; ast.parse(open(f).read())"` for all 3 files
- [ ] `windows_hide_flags()` returns 0 on non-Windows — no behavioral change on Linux/macOS