### PR TITLE
fix(tui_gateway): stop dead compute-host Stop from leaving the session forever queued

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -359,6 +359,9 @@ def test_compute_host_interrupt_failure_clears_stuck_running(monkeypatch):
         def interrupt(self, sid, *, request_id=None):
             raise RuntimeError("compute host is not running")
 
+        def has_pending_turn(self, sid: str) -> bool:
+            return False
+
     session = _session(
         agent=None,
         agent_ready=threading.Event(),
@@ -386,6 +389,49 @@ def test_compute_host_interrupt_failure_clears_stuck_running(monkeypatch):
         assert session.get("inflight_turn") is None
     finally:
         server._sessions.pop("iso-int-dead", None)
+
+
+def test_compute_host_interrupt_failure_leaves_running_when_turn_pending(monkeypatch):
+    """If a host completion is still registered, leave running for the waiter."""
+
+    class _DeadHostWithPending:
+        def __init__(self):
+            self._lock = threading.Lock()
+            self._pending_turns = {"req-1": ("iso-int-pending", lambda _f: None)}
+
+        def interrupt(self, sid, *, request_id=None):
+            raise RuntimeError("compute host is not running")
+
+        def has_pending_turn(self, sid: str) -> bool:
+            with self._lock:
+                return any(s == sid for s, _ in self._pending_turns.values())
+
+    session = _session(
+        agent=None,
+        agent_ready=threading.Event(),
+        running=True,
+        _compute_host_active=True,
+        inflight_turn={"user": "hi", "assistant": "", "streaming": True},
+    )
+    server._sessions["iso-int-pending"] = session
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(
+        server, "_get_compute_host_supervisor", lambda _cfg=None: _DeadHostWithPending()
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "int-pending",
+                "method": "session.interrupt",
+                "params": {"session_id": "iso-int-pending"},
+            }
+        )
+        assert resp.get("result") == {"status": "interrupted", "turn_isolation": True}
+        assert session["running"] is True
+        assert session.get("_turn_cancel_requested") is True
+        assert session.get("inflight_turn") is not None
+    finally:
+        server._sessions.pop("iso-int-pending", None)
 
 
 def test_compute_host_turn_end_updates_metadata_mirror(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -434,6 +434,44 @@ def test_compute_host_interrupt_failure_leaves_running_when_turn_pending(monkeyp
         server._sessions.pop("iso-int-pending", None)
 
 
+def test_compute_host_interrupt_failure_leaves_running_after_teardown(monkeypatch):
+    """After pending pop + turn teardown, do not clobber drain-owned busy."""
+
+    class _DeadHostNoPending:
+        def interrupt(self, sid, *, request_id=None):
+            raise RuntimeError("compute host is not running")
+
+        def has_pending_turn(self, sid: str) -> bool:
+            return False
+
+    session = _session(
+        agent=None,
+        agent_ready=threading.Event(),
+        running=True,
+        _compute_host_active=True,
+        # Crash waiter already cleared inflight; a successor drain may own running.
+        inflight_turn=None,
+    )
+    server._sessions["iso-int-post"] = session
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(
+        server, "_get_compute_host_supervisor", lambda _cfg=None: _DeadHostNoPending()
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "int-post",
+                "method": "session.interrupt",
+                "params": {"session_id": "iso-int-post"},
+            }
+        )
+        assert resp.get("result") == {"status": "interrupted", "turn_isolation": True}
+        assert session["running"] is True
+        assert session.get("_turn_cancel_requested") is True
+    finally:
+        server._sessions.pop("iso-int-post", None)
+
+
 def test_compute_host_turn_end_updates_metadata_mirror(monkeypatch):
     session = _session(
         agent=None,

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -347,6 +347,47 @@ def test_prompt_submit_fails_open_inline_when_compute_host_dispatch_breaks(monke
     assert session.get("_compute_host_active") is not True
 
 
+def test_compute_host_interrupt_failure_clears_stuck_running(monkeypatch):
+    """Dead compute host must not leave session.running stuck after Stop.
+
+    When HostSupervisor.interrupt raises (host gone / respawn disabled), no
+    turn.end will arrive to clear busy. Force-clear running + latch cancel so
+    the next prompt.submit is not forever queued.
+    """
+
+    class _DeadHost:
+        def interrupt(self, sid, *, request_id=None):
+            raise RuntimeError("compute host is not running")
+
+    session = _session(
+        agent=None,
+        agent_ready=threading.Event(),
+        running=True,
+        _compute_host_active=True,
+        queued_prompt={"text": "stale next", "transport": None},
+        inflight_turn={"user": "hi", "assistant": "", "streaming": True},
+    )
+    server._sessions["iso-int-dead"] = session
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _DeadHost())
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "int-dead",
+                "method": "session.interrupt",
+                "params": {"session_id": "iso-int-dead"},
+            }
+        )
+        assert resp.get("result") == {"status": "interrupted", "turn_isolation": True}
+        assert session["running"] is False
+        assert session.get("_turn_cancel_requested") is True
+        assert session.get("queued_prompt") is None
+        assert session.get("inflight_turn") is None
+    finally:
+        server._sessions.pop("iso-int-dead", None)
+
+
 def test_compute_host_turn_end_updates_metadata_mirror(monkeypatch):
     session = _session(
         agent=None,

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -472,6 +472,58 @@ def test_compute_host_interrupt_failure_leaves_running_after_teardown(monkeypatc
         server._sessions.pop("iso-int-post", None)
 
 
+def test_compute_host_interrupt_failure_does_not_clobber_replaced_inflight(monkeypatch):
+    """Successor submit may replace inflight before pending is registered."""
+
+    class _DeadHostNoPending:
+        def interrupt(self, sid, *, request_id=None):
+            raise RuntimeError("compute host is not running")
+
+        def has_pending_turn(self, sid: str) -> bool:
+            return False
+
+    old_inflight = {"user": "old", "assistant": "", "streaming": True}
+    new_inflight = {"user": "new", "assistant": "", "streaming": True}
+    session = _session(
+        agent=None,
+        agent_ready=threading.Event(),
+        running=True,
+        _compute_host_active=True,
+        inflight_turn=old_inflight,
+    )
+    server._sessions["iso-int-race"] = session
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+
+    host = _DeadHostNoPending()
+    real_interrupt = host.interrupt
+
+    def _interrupt_and_swap(sid, *, request_id=None):
+        # Simulate prompt.submit replacing inflight after lock release,
+        # before submit_turn registers pending.
+        with session["history_lock"]:
+            session["inflight_turn"] = new_inflight
+            session["_turn_cancel_requested"] = False
+        return real_interrupt(sid, request_id=request_id)
+
+    host.interrupt = _interrupt_and_swap
+    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: host)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "int-race",
+                "method": "session.interrupt",
+                "params": {"session_id": "iso-int-race"},
+            }
+        )
+        assert resp.get("result") == {"status": "interrupted", "turn_isolation": True}
+        assert session["running"] is True
+        assert session.get("inflight_turn") is new_inflight
+        assert session.get("_turn_cancel_requested") is True
+    finally:
+        server._sessions.pop("iso-int-race", None)
+
+
 def test_compute_host_turn_end_updates_metadata_mirror(monkeypatch):
     session = _session(
         agent=None,

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -270,6 +270,11 @@ class HostSupervisor:
         self.start()
         self._send_frame({"type": "interrupt", "sid": sid, "request_id": request_id or uuid.uuid4().hex})
 
+    def has_pending_turn(self, sid: str) -> bool:
+        """True when a host completion callback is still registered for ``sid``."""
+        with self._lock:
+            return any(s == sid for s, _cb in self._pending_turns.values())
+
     def reload_mcp(self, sid: str, *, request_id: str | None = None) -> dict:
         return self.control(
             sid,

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2713,16 +2713,58 @@ def _(rid, params: dict) -> dict:
         return err
     if _session_uses_compute_host(session):
         sid = str(params.get("session_id") or "")
+        # A host that is gone (broken pipe, respawn exhausted) can never deliver
+        # the turn.end that clears `running`, so returning an error here left the
+        # session permanently busy: every later prompt.submit fell into
+        # _handle_busy_submit and queued forever, with no way back short of a
+        # backend restart. Recover instead - the same safety net the in-process
+        # branch below applies when the run thread is already gone.
+        host_unreachable = False
+        inflight_at_interrupt = None
         if session.get("running"):
+            with session["history_lock"]:
+                inflight_at_interrupt = session.get("inflight_turn")
             try:
                 _get_compute_host_supervisor().interrupt(sid, request_id=f"interrupt-{rid}")
             except Exception as exc:
-                return _err(rid, 5019, f"compute-host interrupt failed: {exc}")
+                host_unreachable = True
+                logger.warning("session.interrupt: compute-host interrupt failed for %s: %s", sid, exc)
+        # Probe BEFORE taking history_lock: the surrounding code holds the
+        # invariant that a compute-host call is never made under that lock, since
+        # an interrupt can wait behind the very operation it is cancelling.
+        # has_pending_turn is a local dict lookup (not host IPC), but keep the
+        # sample outside the session lock for consistency with that invariant.
+        pending_for_sid = True
+        if host_unreachable:
+            try:
+                pending_for_sid = _get_compute_host_supervisor().has_pending_turn(sid)
+            except Exception as exc:
+                # Fail closed. An unreadable supervisor is not evidence the turn
+                # is over, and force-clearing on a guess would drop a live turn's
+                # own teardown on the floor.
+                logger.warning(
+                    "session.interrupt: compute-host pending-turn probe failed for %s: %s", sid, exc
+                )
+                pending_for_sid = True
         with session["history_lock"]:
             session["_turn_cancel_requested"] = True
             session["queued_prompt"] = None
             session.pop("queued_prompts", None)
             session["_queued_prompt_generation"] = int(session.get("_queued_prompt_generation", 0)) + 1
+            # Re-checked under the lock: a completion callback may have landed
+            # since the probe, and a successor submit/drain may already own
+            # `running` with a fresh inflight dict. Only clear the turn this Stop
+            # actually observed.
+            inflight_now = session.get("inflight_turn")
+            if (
+                host_unreachable
+                and not pending_for_sid
+                and session.get("running")
+                and inflight_now is not None
+                and inflight_now is inflight_at_interrupt
+            ):
+                session["running"] = False
+                _clear_inflight_turn(session)
         _clear_pending(sid)
         try:
             from tools.approval import resolve_gateway_approval


### PR DESCRIPTION
## What does this PR do?

When turn isolation routes a session through the compute-host child and that host is already gone, `session.interrupt` used to return 5019 without clearing `running` or latching cancel. Later `prompt.submit` calls only queued forever until a backend restart. This mirrors the in-process dead-thread busy recovery for that failure path, with guards so a still-pending or successor turn is not clobbered.

### Bug Cause

The compute-host branch of `session.interrupt` early-returned on `HostSupervisor.interrupt` failure before latching `_turn_cancel_requested` or clearing `session["running"]`. With no live host, `turn.end` never arrives to clear busy, so `_handle_busy_submit` kept queueing new prompts.

### Reproduction Steps

1. Enable `dashboard.turn_isolation` and leave a session with `_compute_host_active=True` and `running=True`.
2. Make `HostSupervisor.interrupt` raise (host not running / respawn disabled).
3. Call `session.interrupt`, then `prompt.submit`.

Expected: Stop recovers local busy state so a later prompt can start a new turn.
Before fix: interrupt returned 5019 with `running` still true and cancel unset; subsequent submits only queued.

### Fix

On compute-host interrupt failure, latch cancel, clear `queued_prompt`, and force-clear busy only when safe:
- no pending host completion for that sid (`HostSupervisor.has_pending_turn`)
- `inflight_turn` is still the same object observed before `interrupt()`

Otherwise leave `running` for the crash waiter / successor. Added regression tests for clear, pending, post-teardown, and replaced-inflight cases.

## Related Issue

No issue 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` - recover stuck busy on compute-host interrupt failure with pending/inflight guards
- `tui_gateway/host_supervisor.py` - add `has_pending_turn(sid)`
- `tests/test_tui_gateway_server.py` - regression coverage for the four interrupt-failure cases

## How to Test

1. Manual: with turn isolation on, kill/desync the compute host mid-turn, press Stop, then send another message - it should start a new turn instead of queueing forever.
2. Automated (already run locally):

```bash
scripts/run_tests.sh tests/test_tui_gateway_server.py -k "compute_host_interrupt or compute_host_turn or prompt_submit_dispatches_to_compute or prompt_submit_fails_open" -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact - N/A (Python session state only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
