### PR TITLE
fix(matrix): add m.location (geo_uri) support for FluffyChat position sharing

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2723,15 +2723,97 @@ class MatrixAdapter(BasePlatformAdapter):
             return
 
         # Dispatch by msgtype.
-        media_msgtypes = ("m.image", "m.audio", "m.video", "m.file")
+        media_msgtypes = ("m.image", "m.audio", "m.video", "m.file", "m.location")
         if msgtype in media_msgtypes:
-            await self._handle_media_message(
-                room_id, sender, event_id, event_ts, source_content, relates_to, msgtype
-            )
+            if msgtype == "m.location":
+                await self._handle_location_message(
+                    room_id, sender, event_id, event_ts, source_content, relates_to
+                )
+            else:
+                await self._handle_media_message(
+                    room_id, sender, event_id, event_ts, source_content, relates_to, msgtype
+                )
         elif msgtype in ("m.text", "m.notice"):
             await self._handle_text_message(
                 room_id, sender, event_id, event_ts, source_content, relates_to
             )
+
+    async def _handle_location_message(
+        self,
+        room_id: str,
+        sender: str,
+        event_id: str,
+        event_ts: float,
+        source_content: dict,
+        relates_to: dict,
+    ) -> None:
+        """Process a location-sharing event (m.location).
+
+        Extracts geo_uri coordinates from the Matrix location event and
+        formats them as plain-text so the agent can use them for spatial
+        queries (maps, POI lookups, routing, etc.).
+        """
+        body = source_content.get("body", "") or ""
+
+        # Primary coordinate source: geo_uri (RFC 5870).
+        # Format: geo:<lat>,<lon>[;crs=wgs84][;u=<uncertainty>]
+        geo_uri = source_content.get("geo_uri", "")
+
+        # MSC3488 extended location (Matrix spec proposal).
+        # May carry a richer description and metadata.
+        msc3488 = source_content.get("org.matrix.msc3488.location", {})
+        if isinstance(msc3488, dict):
+            if not geo_uri:
+                geo_uri = msc3488.get("uri", "")
+            if not body:
+                body = msc3488.get("description", "") or body
+
+        # Parse coordinates from geo_uri.
+        lat, lon = None, None
+        if geo_uri and isinstance(geo_uri, str):
+            # Strip the "geo:" prefix.
+            coords_part = geo_uri[4:] if geo_uri.startswith("geo:") else geo_uri
+            # Split off parameters after ';'.
+            coords_part = coords_part.split(";")[0]
+            parts = coords_part.split(",")
+            if len(parts) >= 2:
+                try:
+                    lat = float(parts[0].strip())
+                    lon = float(parts[1].strip())
+                except ValueError:
+                    lat, lon = None, None
+
+        # Build a human-readable location text for the agent.
+        if lat is not None and lon is not None:
+            label = body.strip() if body and body.strip() else "Delt posisjon"
+            location_text = f"{label}\nKoordinater: {lat}, {lon}"
+        elif body and body.strip():
+            # No parseable coordinates — pass the body through as-is.
+            location_text = body.strip()
+        else:
+            return  # Nothing useful to pass on.
+
+        ctx = await self._resolve_message_context(
+            room_id,
+            sender,
+            event_id,
+            location_text,
+            source_content,
+            relates_to,
+        )
+        if ctx is None:
+            return
+        location_text, is_dm, chat_type, thread_id, display_name, source = ctx
+
+        msg_event = MessageEvent(
+            text=location_text,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=source_content,
+            message_id=event_id,
+        )
+
+        await self.handle_message(msg_event)
 
     async def _resolve_message_context(
         self,


### PR DESCRIPTION
## Problem

FluffyChat (and other Matrix clients) can share location via `m.location` events with RFC 5870 `geo_uri` coordinates. Hermes did not handle this message type - the location data was silently discarded.

Users would share their position but Hermes would respond "I didn't receive any coordinates".

## Fix

Adds `_handle_location_message()` to the Matrix adapter that:

1. Parses `geo_uri` (RFC 5870) from the `m.location` event
2. Supports MSC3488 extended location format (description + metadata fallback)
3. Formats coordinates as human-readable text: `Label` with `Koordinater: lat, lon`
4. Passes the formatted location as a regular text message to the agent

## Testing

Manually tested with FluffyChat position sharing against a local Hermes instance. Previously the event was silently discarded; now the agent receives the coordinates and can use them for spatial queries (maps, POI, routing via GIS-MCP).