### PR TITLE
fix(desktop): route /yolo, /handoff and /skin through the shared session resolver

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash-target-session.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash-target-session.test.tsx
@@ -1,0 +1,256 @@
+import { act, cleanup, render } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { useEffect } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $notifications, clearNotifications } from '@/store/notifications'
+import { $yoloActive, setSessions, setYoloActive } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+import type { SubmitTextOptions } from './utils'
+
+import { usePromptActions } from '.'
+
+vi.mock('@/hermes', () => ({
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  getSession: vi.fn(),
+  PROMPT_SUBMIT_REQUEST_TIMEOUT_MS: 1_800_000,
+  setApiRequestProfile: vi.fn(),
+  transcribeAudio: vi.fn()
+}))
+
+// The scenario every assertion below is built on: the user streamed in chat A,
+// then clicked chat B in the sidebar (or swapped profile / the gateway
+// reconnected). The durable route names B, but the runtime ref still points at
+// A's runtime session and the cache cannot confirm a runtime for B — exactly
+// `resolveTargetSessionId`'s "routed needs resume" rung.
+const RUNTIME_A = 'rt-chat-a'
+const RUNTIME_B = 'rt-chat-b'
+const STORED_B = 'stored-chat-b'
+
+interface GatewayCall {
+  method: string
+  params?: Record<string, unknown>
+}
+
+function storedSessionRow(): SessionInfo {
+  return {
+    ended_at: null,
+    id: STORED_B,
+    input_tokens: 0,
+    is_active: true,
+    last_active: 0,
+    message_count: 3,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: null,
+    started_at: 0,
+    title: 'Chat B',
+    tool_call_count: 0
+  }
+}
+
+interface HarnessHandle {
+  submitText: (text: string, options?: SubmitTextOptions) => Promise<boolean>
+}
+
+interface HarnessProps {
+  activeSessionId?: null | string
+  createBackendSessionForSend?: (preview?: null | string) => Promise<null | string>
+  onReady: (handle: HarnessHandle) => void
+  onUpdateState?: (sessionId: string) => void
+  requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
+  routedStoredSessionId?: null | string
+  runtimeIdForStoredSession?: null | string
+  selectedStoredSessionId?: null | string
+}
+
+function Harness({
+  activeSessionId = RUNTIME_A,
+  createBackendSessionForSend,
+  onReady,
+  onUpdateState,
+  requestGateway,
+  routedStoredSessionId = STORED_B,
+  runtimeIdForStoredSession = null,
+  selectedStoredSessionId = STORED_B
+}: HarnessProps) {
+  const activeSessionIdRef: MutableRefObject<null | string> = { current: activeSessionId }
+  const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: selectedStoredSessionId }
+  const busyRef: MutableRefObject<boolean> = { current: false }
+
+  const actions = usePromptActions({
+    activeSessionId,
+    activeSessionIdRef,
+    branchCurrentSession: async () => true,
+    busyRef,
+    createBackendSessionForSend: createBackendSessionForSend ?? (async () => RUNTIME_A),
+    getRoutedStoredSessionId: () => routedStoredSessionId,
+    getRouteToken: () => 'token',
+    getRuntimeIdForStoredSession: () => runtimeIdForStoredSession,
+    handleSkinCommand: () => 'Skin set to midnight.',
+    openMemoryGraph: () => undefined,
+    refreshSessions: async () => undefined,
+    requestGateway,
+    resumeStoredSession: () => undefined,
+    selectedStoredSessionIdRef,
+    startFreshSessionDraft: () => undefined,
+    sttEnabled: false,
+    updateSessionState: (sessionId, updater) => {
+      onUpdateState?.(sessionId)
+
+      return updater({ messages: [], busy: false, awaitingResponse: false, interrupted: false } as never)
+    }
+  })
+
+  useEffect(() => {
+    onReady({
+      submitText: (...args: Parameters<typeof actions.submitText>) =>
+        act(async () => actions.submitText(...args)) as Promise<boolean>
+    })
+  }, [actions.submitText, onReady])
+
+  return null
+}
+
+async function actRender(ui: React.ReactElement) {
+  let result: ReturnType<typeof render>
+  await act(async () => {
+    result = render(ui)
+  })
+
+  return result!
+}
+
+describe('slash commands that act on an existing session resolve it through the shared ladder', () => {
+  beforeEach(() => {
+    // Seed the sidebar row so the resolver's profile lookup resolves from cache
+    // instead of probing the backend.
+    setSessions(() => [storedSessionRow()])
+    setYoloActive(false)
+    clearNotifications()
+  })
+
+  afterEach(() => {
+    cleanup()
+    setSessions(() => [])
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('writes /yolo to the routed chat, not the stale runtime ref', async () => {
+    const calls: GatewayCall[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'session.resume') {
+        return { session_id: RUNTIME_B } as never
+      }
+
+      return { value: '1' } as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(<Harness onReady={h => (handle = h)} requestGateway={requestGateway} />)
+
+    await handle!.submitText('/yolo')
+
+    // The approval bypass is a per-session safety flag. Landing it on the chat
+    // the user left leaves that conversation auto-approving tool calls while
+    // the visible one keeps prompting.
+    expect(calls).toContainEqual({
+      method: 'config.set',
+      params: { key: 'yolo', session_id: RUNTIME_B, value: '1' }
+    })
+    expect(calls.some(call => call.params?.session_id === RUNTIME_A)).toBe(false)
+    expect(calls.some(call => call.method === 'session.resume')).toBe(true)
+  })
+
+  it('hands off the routed chat, not the stale runtime ref', async () => {
+    vi.useFakeTimers()
+    const calls: GatewayCall[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'session.resume') {
+        return { session_id: RUNTIME_B } as never
+      }
+
+      if (method === 'handoff.state') {
+        return { state: 'completed' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(<Harness onReady={h => (handle = h)} requestGateway={requestGateway} />)
+
+    const pending = handle!.submitText('/handoff telegram')
+    await vi.advanceTimersByTimeAsync(2_000)
+    await pending
+
+    // A handoff leaves the app — the wrong target ships another conversation's
+    // transcript to Telegram/Discord.
+    expect(calls).toContainEqual({
+      method: 'handoff.request',
+      params: { platform: 'telegram', session_id: RUNTIME_B }
+    })
+    expect(calls.some(call => call.method === 'handoff.request' && call.params?.session_id === RUNTIME_A)).toBe(false)
+  })
+
+  it('prints /skin confirmation into the routed chat, not the stale runtime ref', async () => {
+    const updated: string[] = []
+
+    const requestGateway = vi.fn(
+      async (method: string) => (method === 'session.resume' ? { session_id: RUNTIME_B } : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} onUpdateState={id => updated.push(id)} requestGateway={requestGateway} />
+    )
+
+    await handle!.submitText('/skin midnight')
+
+    expect(updated).toContain(RUNTIME_B)
+    expect(updated).not.toContain(RUNTIME_A)
+  })
+
+  it('still arms /yolo locally on a new-chat draft instead of minting a session', async () => {
+    const createBackendSessionForSend = vi.fn(async () => 'rt-should-not-exist')
+    const calls: GatewayCall[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionId={null}
+        createBackendSessionForSend={createBackendSessionForSend}
+        onReady={h => (handle = h)}
+        requestGateway={requestGateway}
+        routedStoredSessionId={null}
+        selectedStoredSessionId={null}
+      />
+    )
+
+    await handle!.submitText('/yolo')
+
+    // No durable conversation is in play, so `/yolo` keeps its deliberate
+    // local-arm behaviour; the session-create path applies it on the first
+    // message. Spinning up a backend session just to hold the flag would leave
+    // an empty chat in the sidebar.
+    expect(createBackendSessionForSend).not.toHaveBeenCalled()
+    expect(calls).toEqual([])
+    expect($yoloActive.get()).toBe(true)
+    expect($notifications.get().length).toBe(1)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -148,6 +148,24 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           selectedStoredSessionId: selectedStoredSessionIdRef.current
         })
 
+      // Same ladder, minus the create rung: `/yolo`, `/handoff` and `/skin`
+      // act on a conversation that already exists and deliberately do
+      // something else when there is none (arm YOLO locally, toast the skin,
+      // report the handoff can't run). They must NOT mint a session — but they
+      // must still honour rung 2's route check, or a durable route the runtime
+      // ref disagrees with (profile swap, reconnect, in-flight resume) sends a
+      // per-session write to the chat the user just left.
+      const resolveExistingSessionId = async (sessionHint?: string) =>
+        resolveTargetSessionId({
+          activeRuntimeId: activeSessionIdRef.current,
+          createSession: async () => null,
+          explicitRuntimeId: sessionHint,
+          getRuntimeIdForStoredSession,
+          requestGateway,
+          routedStoredSessionId: getRoutedStoredSessionId(),
+          selectedStoredSessionId: selectedStoredSessionIdRef.current
+        })
+
       // Resolve the target session plus a writer for inline slash output, or
       // notify + return null when none can be created. Folds the ensure / bail /
       // build-renderSlashOutput boilerplate every exec-style handler repeats.
@@ -544,8 +562,11 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         // bypass, same scope as the TUI's Shift+Tab. With no session yet we arm
         // it locally; the session-create path applies it on the first message.
         yolo: async ({ sessionHint }) => {
-          const sid = sessionHint || activeSessionIdRef.current
+          // Snapshot the toggle before resolving: the resolve can await a
+          // session.resume, and the flag must invert what the user saw when
+          // they typed the command.
           const next = !$yoloActive.get()
+          const sid = await resolveExistingSessionId(sessionHint)
 
           if (!sid) {
             setYoloActive(next)
@@ -574,7 +595,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             return
           }
 
-          const sid = sessionHint || activeSessionIdRef.current
+          const sid = await resolveExistingSessionId(sessionHint)
 
           if (!sid) {
             notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.createSessionFailed })
@@ -626,8 +647,10 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           }
         },
         skin: async ({ arg, command, recordInput, sessionHint }) => {
-          const sid = sessionHint || activeSessionIdRef.current
+          // Apply the theme first — it is local and instant, and must not wait
+          // on the resolve's session.resume round-trip.
           const message = handleSkinCommand(arg)
+          const sid = await resolveExistingSessionId(sessionHint)
 
           // No session to print into yet — surface it as a toast instead of
           // spinning up a backend session just to change the theme.


### PR DESCRIPTION
## What does this PR do?

`584b27449` ("slash commands target the user's chat, not a new session") introduced
`resolveTargetSessionId` and moved the slash pipeline onto it, so a command runs against the
conversation the user is actually looking at. **Three action handlers were left behind on the old
idiom** the new resolver's docblock names as the bug it exists to prevent:

| line | handler | current |
|------|---------|---------|
| `slash.ts:547` | `/yolo` | `const sid = sessionHint \|\| activeSessionIdRef.current` |
| `slash.ts:577` | `/handoff` | `const sid = sessionHint \|\| activeSessionIdRef.current` |
| `slash.ts:629` | `/skin` | `const sid = sessionHint \|\| activeSessionIdRef.current` |

From the chat composer, `submitText` forwards an explicit target only for a queue drain or a tile
(`use-prompt-actions/index.ts:524`), so `sessionHint` is `undefined` in the ordinary case and the
bare ref **is** the value used.

That skips the resolver's rung 2 route check (`routedNeedsResume`). When the durable route names
conversation **B** while the runtime ref still points at **A** — profile swap, gateway reconnect,
an in-flight resume — the resolver resumes B, but the bare read returns A.

**User-visible symptom.** You stream in chat A, click chat B in the sidebar, type `/yolo` in B.
The per-session approval bypass is written to **A** (`config.set { key: 'yolo', session_id }`,
`lib/yolo-session.ts:15`). B keeps prompting for every tool approval, so you press `/yolo` again —
toggling A back off — while A (possibly a background agent) spent that window auto-approving tool
calls. The confirmation line is appended to A's transcript, so B shows nothing at all.
`/handoff <platform>` has the same shape and is worse in one respect: the wrong conversation's
transcript **leaves the app** for Telegram/Discord.

All three now resolve through a `resolveExistingSessionId` helper defined next to `ensureSessionId`
— the same ladder with `createSession: async () => null`, so these verbs can never mint a backend
session and the deliberate no-session behaviour survives byte-for-byte (`/yolo` arms locally,
`/skin` toasts instead of spinning up a session just to change a theme, `/handoff` reports it
cannot run). All three already branch on `!sid`, so the `null` return needs no new handling.

### Sibling-site sweep

`grep -rn "|| activeSessionIdRef.current" apps/desktop/src` returns 8 non-test sites. This PR is
the complete set of the ones sharing this root cause; the other five are deliberately excluded:

- `use-prompt-actions/index.ts:421` — the shared `handoffSession` helper. Its only in-repo caller is
  `slash.ts:585`, which passes an explicit id once this lands, so the fallback becomes a defensive
  default rather than a live path.
- `workspace-session-target.ts:44`, `use-cwd-actions.ts:28`, `use-cwd-actions.ts:72` — presence
  tests (`if (… || activeSessionIdRef.current)`), not target resolution.
- `use-preview-routing.ts:41` — already a ladder with the route ahead of the ref; different concern.

The other `activeSessionIdRef.current` reads in `index.ts` (`cancelRun`, `redirectPrompt`,
`reloadFromMessage`, `restoreToMessage`, `editMessage`) are `771f1b7f2`'s deliberate design: they
act on the *foreground* thread and must not resume a different conversation.

## Related Issue

No filed issue — found by auditing the call sites `584b27449` did not convert.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts`
  - Add `resolveExistingSessionId` beside `ensureSessionId`: `resolveTargetSessionId` with the
    create rung disabled.
  - `/yolo` (`:547`), `/handoff` (`:577`), `/skin` (`:629`) now resolve through it.
  - `/yolo` snapshots `!$yoloActive.get()` *before* the resolve so the toggle still inverts what the
    user saw; `/skin` applies the theme *before* the resolve so it stays instant.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/slash-target-session.test.tsx` — new
  regression file (kept out of `index.test.tsx`, which several open PRs are editing).

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/app/session/hooks/use-prompt-actions/`
   → **136 passing** (5 files).
2. Regression guard — with `slash.ts` reverted to `main` and the new test file kept:

   ```
   × writes /yolo to the routed chat, not the stale runtime ref
   × hands off the routed chat, not the stale runtime ref
   × prints /skin confirmation into the routed chat, not the stale runtime ref
   Tests  3 failed | 1 passed (4)
   ```

   `/yolo` on `main` produces `config.set { session_id: 'rt-chat-a' }` and issues **no**
   `session.resume`; `/handoff` produces `handoff.request { session_id: 'rt-chat-a' }`. With the fix
   applied, all 4 pass. The 4th case ("still arms `/yolo` locally on a new-chat draft instead of
   minting a session") is green both before and after by design — it pins the behaviour the
   `createSession: async () => null` rung preserves.
3. Manually: open chat A and let it stream, click chat B in the sidebar, type `/yolo`. Before, the
   zap and the `config.set` land on A. After, they land on B.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no open PR touches `use-prompt-actions/slash.ts`
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] N/A — JS-only change, no Python touched. Ran `npx vitest run --project ui src/app/session/` instead: **342 passing** (29 files). Also `npx eslint` (clean) and `npx tsc -p . --noEmit` (clean).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Node 22

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure renderer logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
