### PR TITLE
fix(tools): inject items schema into array types missing it (#71804)

### DIFF
--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -249,10 +249,12 @@ def _sanitize_node(node: Any, path: str) -> Any:
                 "with {'type': %r}",
                 path, node, node,
             )
-            return {"type": node} if node != "object" else {
-                "type": "object",
-                "properties": {},
-            }
+            if node == "object":
+                return {"type": "object", "properties": {}}
+            if node == "array":
+                # Gemini rejects array schemas without `items` (#71804)
+                return {"type": "array", "items": {}}
+            return {"type": node}
         # Any other stray string is not a schema — drop it by replacing with
         # a permissive object schema rather than propagate something the
         # backend will reject.
@@ -339,6 +341,13 @@ def _sanitize_node(node: Any, path: str) -> Any:
     # llama.cpp's grammar generator can't constrain a free-form object.
     if out.get("type") == "object" and not isinstance(out.get("properties"), dict):
         out["properties"] = {}
+
+    # Array nodes without items: inject permissive items schema.
+    # Gemini strictly validates function declarations and rejects array
+    # schemas missing the `items` keyword (#71804).  An empty `items: {}`
+    # is accepted by all backends as "any element type".
+    if out.get("type") == "array" and "items" not in out:
+        out["items"] = {}
 
     # Prune ``required`` entries that don't exist in properties (defense
     # against malformed MCP schemas; also caught upstream for MCP tools, but


### PR DESCRIPTION
## Summary

Fixes #71804 — Gemini rejects tool schemas when array parameters omit `items`.

## Root Cause

Hermes' schema sanitizer allows array schemas like `{"type": "array"}` to pass through without an `items` keyword. OpenAI-compatible models accept this, but Gemini strictly validates function declarations and rejects the entire request with HTTP 400.

## Fix

1. In `_sanitize_node`, inject `items: {}` into array-typed nodes missing `items`
2. Handle bare-string `"array"` schema to also include `items: {}`

An empty `items: {}` is accepted by all backends as "any element type".

## Changes

- `tools/schema_sanitizer.py`: Add array items injection in `_sanitize_node` (~10 lines)

## Test Results

```
tests/tools/test_schema_sanitizer.py ............................................... [100%]
47 passed in 0.36s
```