### PR TITLE
fix(tui_gateway): stop multi-profile slash sessions from leaking tool config into the launch HOME

### DIFF
--- a/tests/tui_gateway/test_slash_worker_profile_home.py
+++ b/tests/tui_gateway/test_slash_worker_profile_home.py
@@ -35,3 +35,56 @@ def test_slash_worker_accepts_profile_home():
             assert call_kwargs["env"]["HERMES_HOME"] == "/home/luke/.hermes/profiles/work"
 
 
+def _mock_slash_worker_proc(mock_popen: MagicMock) -> None:
+    mock_popen.return_value.stdout = MagicMock()
+    mock_popen.return_value.stderr = MagicMock()
+    mock_popen.return_value.poll = MagicMock(return_value=None)
+    mock_popen.return_value.stdin = MagicMock()
+
+
+def test_slash_worker_reapplies_home_for_session_profile(tmp_path, monkeypatch):
+    """Under home_mode=profile, HOME must follow session HERMES_HOME, not launch."""
+    launch = tmp_path / "launch"
+    session = tmp_path / "session"
+    (launch / "home").mkdir(parents=True)
+    (session / "home").mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(launch))
+    monkeypatch.setenv("TERMINAL_HOME_MODE", "profile")
+
+    with patch("subprocess.Popen") as mock_popen:
+        _mock_slash_worker_proc(mock_popen)
+        from tui_gateway.server import _SlashWorker
+
+        _SlashWorker("test_key", "test-model", profile_home=str(session))
+
+        env = mock_popen.call_args.kwargs["env"]
+        assert env["HERMES_HOME"] == str(session)
+        assert env["HOME"] == str(session / "home")
+
+
+def test_slash_worker_home_follows_profile_despite_stale_override(tmp_path, monkeypatch):
+    """In-process HERMES_HOME override must not leave HOME on the launch profile."""
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    launch = tmp_path / "launch"
+    session = tmp_path / "session"
+    (launch / "home").mkdir(parents=True)
+    (session / "home").mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(launch))
+    monkeypatch.setenv("TERMINAL_HOME_MODE", "profile")
+
+    token = set_hermes_home_override(str(launch))
+    try:
+        with patch("subprocess.Popen") as mock_popen:
+            _mock_slash_worker_proc(mock_popen)
+            from tui_gateway.server import _SlashWorker
+
+            _SlashWorker("test_key", "test-model", profile_home=str(session))
+
+            env = mock_popen.call_args.kwargs["env"]
+            assert env["HERMES_HOME"] == str(session)
+            assert env["HOME"] == str(session / "home")
+    finally:
+        reset_hermes_home_override(token)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -26,6 +26,7 @@ from agent.secret_scope import (
 from hermes_constants import (
     DEFAULT_INDICATOR_STYLE,
     INDICATOR_STYLES,
+    apply_subprocess_home_env,
     get_hermes_home,
     get_hermes_home_override,
     reset_hermes_home_override,
@@ -356,6 +357,18 @@ class _SlashWorker:
             inherit_profile_home=False,  # base already carries the HOME contract
             extra={"HERMES_HOME": str(profile_home)} if profile_home else None,
         )
+        if profile_home:
+            # hermes_subprocess_env already applied HOME against the launch
+            # HERMES_HOME, and with scrub_secrets=False the factory applies
+            # `extra` after that HOME pass. Re-apply so home_mode=profile
+            # (and container auto) bind HOME to {session profile}/home rather
+            # than the stale launch profile home. Bind the ContextVar for the
+            # apply so an in-process override cannot shadow env["HERMES_HOME"].
+            home_token = set_hermes_home_override(str(profile_home))
+            try:
+                apply_subprocess_home_env(env)
+            finally:
+                reset_hermes_home_override(home_token)
 
         # start_new_session=True detaches the slash worker into its own
         # process group / session. Without this, the worker inherits the


### PR DESCRIPTION
## What does this PR do?

Under `terminal.home_mode: profile`, TUI/Desktop slash-command workers for a non-launch profile kept `HOME` pointed at the gateway launch profile's `{HERMES_HOME}/home` even after `#40677` set session `HERMES_HOME`. That broke per-profile HOME isolation for CLI tool config and `~`-resolved paths. This PR re-applies the subprocess HOME contract after the session override.

### Bug Cause

`_SlashWorker` called `hermes_subprocess_env()` (which already runs `apply_subprocess_home_env` against the launch `HERMES_HOME`), then overwrote only `env["HERMES_HOME"]` with the session profile. `HOME` stayed on the launch profile home.

### Reproduction Steps

1. Set `terminal.home_mode: profile` and ensure `{HERMES_HOME}/home` exists for the launch profile and a second profile.
2. Start TUI/Desktop under the launch profile, open a session bound to the second profile.
3. Run a slash command that spawns `_SlashWorker` and inspect the worker environ.

Expected: `HOME` is `{session_profile}/home` when `HERMES_HOME` is the session profile.
Before fix: `HERMES_HOME` is the session profile, but `HOME` remains `{launch_profile}/home`.

### Fix

After setting `env["HERMES_HOME"]` to the session profile, bind `set_hermes_home_override` to that path and call `apply_subprocess_home_env(env)` so `HOME` tracks the session under `home_mode=profile` (and container auto). The ContextVar bind is required because `_profile_home_path` prefers an in-process override over `env["HERMES_HOME"]`.

Regression tests cover the launch/session mismatch and a stale ContextVar override.

## Related Issue

No issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` - re-apply subprocess HOME after slash-worker `profile_home` override
- `tests/tui_gateway/test_slash_worker_profile_home.py` - regression coverage for HOME/HERMES_HOME alignment

## How to Test

1. Manual: follow Reproduction Steps and confirm worker `HOME` equals `{session_profile}/home`.
2. Automated (already run locally, 11 passed):

```bash
scripts/run_tests.sh \
  tests/tui_gateway/test_slash_worker_profile_home.py \
  tests/tui_gateway/test_subprocess_encoding.py \
  tests/tui_gateway/test_slash_worker_mcp_discovery.py \
  -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` on relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A