### PR TITLE
feat(browser): add configurable humanize parameter to Camofox interactions

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -457,3 +457,85 @@ class TestBrowserToolRouting:
         assert check_browser_requirements() is True
 
 
+class TestGetHumanize:
+    """Test suite for _get_humanize() config resolution."""
+
+    def test_default_when_no_config(self):
+        """Returns 1.0 when browser.camofox block is missing or empty."""
+        from tools.browser_camofox import _get_humanize
+
+        with patch("tools.browser_camofox._get_camofox_config", return_value={}):
+            assert _get_humanize() == 1.0
+
+    def test_default_when_humanize_not_set(self):
+        """Returns 1.0 when humanize key is absent from config block."""
+        from tools.browser_camofox import _get_humanize
+
+        with patch("tools.browser_camofox._get_camofox_config",
+                   return_value={"managed_persistence": True}):
+            assert _get_humanize() == 1.0
+
+    def test_reads_configured_value(self):
+        """Returns the configured float value when present."""
+        from tools.browser_camofox import _get_humanize
+
+        with patch("tools.browser_camofox._get_camofox_config",
+                   return_value={"humanize": 0.5}):
+            assert _get_humanize() == 0.5
+
+    def test_reads_zero(self):
+        """Returns 0.0 when configured (disables humanization)."""
+        from tools.browser_camofox import _get_humanize
+
+        with patch("tools.browser_camofox._get_camofox_config",
+                   return_value={"humanize": 0.0}):
+            assert _get_humanize() == 0.0
+
+    def test_reads_one(self):
+        """Returns 1.0 when explicitly configured."""
+        from tools.browser_camofox import _get_humanize
+
+        with patch("tools.browser_camofox._get_camofox_config",
+                   return_value={"humanize": 1.0}):
+            assert _get_humanize() == 1.0
+
+    def test_clamps_above_one(self):
+        """Values above 1.0 are clamped to 1.0."""
+        from tools.browser_camofox import _get_humanize
+
+        with patch("tools.browser_camofox._get_camofox_config",
+                   return_value={"humanize": 2.5}):
+            assert _get_humanize() == 1.0
+
+    def test_clamps_below_zero(self):
+        """Values below 0.0 are clamped to 0.0."""
+        from tools.browser_camofox import _get_humanize
+
+        with patch("tools.browser_camofox._get_camofox_config",
+                   return_value={"humanize": -0.3}):
+            assert _get_humanize() == 0.0
+
+    def test_handles_non_numeric_value(self):
+        """Non-numeric config values fall back to default 1.0."""
+        from tools.browser_camofox import _get_humanize
+
+        with patch("tools.browser_camofox._get_camofox_config",
+                   return_value={"humanize": "fast"}):
+            assert _get_humanize() == 1.0
+
+    def test_handles_none_value(self):
+        """None config value falls back to default 1.0."""
+        from tools.browser_camofox import _get_humanize
+
+        with patch("tools.browser_camofox._get_camofox_config",
+                   return_value={"humanize": None}):
+            assert _get_humanize() == 1.0
+
+    def test_integer_value_converted_to_float(self):
+        """Integer config values are converted to float."""
+        from tools.browser_camofox import _get_humanize
+
+        with patch("tools.browser_camofox._get_camofox_config",
+                   return_value={"humanize": 1}):
+            assert _get_humanize() == 1.0
+            assert isinstance(_get_humanize(), float)

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -172,6 +172,22 @@ def _get_camofox_config() -> Dict[str, Any]:
     return camofox_cfg if isinstance(camofox_cfg, dict) else {}
 
 
+def _get_humanize() -> float:
+    """Return the ``humanize`` value from config, defaulting to 1.0.
+
+    Controls Camofox behavioral humanization (mouse curves, click delays,
+    smooth scrolling, character-by-character typing).  0.0 = off (fastest,
+    most detectable), 1.0 = maximum (slowest, least detectable).
+    """
+    try:
+        val = _get_camofox_config().get("humanize")
+        if val is not None:
+            return max(0.0, min(1.0, float(val)))
+    except (ValueError, TypeError):
+        pass
+    return 1.0
+
+
 def _managed_persistence_enabled() -> bool:
     """Return whether Hermes-managed persistence is enabled for Camofox.
 
@@ -662,7 +678,7 @@ def camofox_click(ref: str, task_id: Optional[str] = None) -> str:
 
         data = _post(
             f"/tabs/{session['tab_id']}/click",
-            {"userId": session["user_id"], "ref": clean_ref},
+            {"userId": session["user_id"], "ref": clean_ref, "humanize": _get_humanize()},
         )
         return json.dumps({
             "success": True,
@@ -688,7 +704,7 @@ def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
 
         _post(
             f"/tabs/{session['tab_id']}/type",
-            {"userId": session["user_id"], "ref": clean_ref, "text": text},
+            {"userId": session["user_id"], "ref": clean_ref, "text": text, "humanize": _get_humanize()},
         )
         from agent.display import (
             redact_browser_typed_text_for_display,
@@ -723,7 +739,7 @@ def camofox_scroll(direction: str, task_id: Optional[str] = None) -> str:
 
         _post(
             f"/tabs/{session['tab_id']}/scroll",
-            {"userId": session["user_id"], "direction": direction},
+            {"userId": session["user_id"], "direction": direction, "humanize": _get_humanize()},
         )
         return json.dumps({"success": True, "scrolled": direction})
     except Exception as e:
@@ -759,7 +775,7 @@ def camofox_press(key: str, task_id: Optional[str] = None) -> str:
 
         _post(
             f"/tabs/{session['tab_id']}/press",
-            {"userId": session["user_id"], "key": key},
+            {"userId": session["user_id"], "key": key, "humanize": _get_humanize()},
         )
         return json.dumps({"success": True, "pressed": key})
     except Exception as e:


### PR DESCRIPTION
## What

Adds a `_get_humanize()` helper that reads `browser.camofox.humanize` from config (defaults to 1.0), and passes it to Camofox click, type, and scroll REST API calls.

## Why

Sites with behavioral detection — LinkedIn is the primary case — silently ignore interactions that don't include humanized mouse curves, randomized click delays, and character-by-character typing. The Camofox API supports a `humanize` parameter (float 0.0–1.0) but Hermes was not passing it on click, type, or scroll requests.

Without this, `browser_click` on LinkedIn returns `success: true` but the click never lands — comment boxes don't open, reaction menus don't appear, and there's no indication of failure to the user or agent.

## Change

- Add `_get_humanize()` function (clamped to 0.0–1.0, default 1.0)
- Pass `humanize` in `camofox_click` (line 681)
- Pass `humanize` in `camofox_type` (line 707)
- Pass `humanize` in `camofox_scroll` (line 742)

Config path: `browser.camofox.humanize` (float, default 1.0)

## Tests

10 new tests in `tests/tools/test_browser_camofox.py` (appended to existing test file):

- Default value when config is missing or key is absent
- Reads configured value (0.0, 0.5, 1.0, integer)
- Clamping (above 1.0 → 1.0, below 0.0 → 0.0)
- Error handling (non-numeric string → 1.0, None → 1.0)

Existing 30 tests preserved and pass.

## Testing

Manually verified against LinkedIn feed:
- Comment button clicks now open the textbox (previously silent no-op)
- Typed text appears in the comment editor
- Post button submits the comment
- Comment appears in thread with correct author

## Config

No new env vars. Reads from existing config structure:

```yaml
browser:
  camofox:
    humanize: 1.0  # default
```