### PR TITLE
fix(update): remove Windows reserved-device-name files before stashing

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7515,6 +7515,44 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
 
     from datetime import datetime, timezone
 
+    # On Windows, untracked files whose names match reserved device names
+    # (CON, PRN, AUX, NUL, COM1-9, LPT1-9) break ``git stash --include-untracked``
+    # because Windows treats those names as system devices.  Remove them before
+    # stashing — they are usually 0-byte artefacts created by accidental
+    # redirections (e.g. ``echo x > nul`` run in a context that creates a real
+    # file instead of discarding to the NUL device).
+    if sys.platform == "win32":
+        import re
+        _WIN_RESERVED = re.compile(
+            r"^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..*)?$", re.IGNORECASE
+        )
+        untracked = subprocess.run(
+            git_cmd + ["ls-files", "--others", "--exclude-standard"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=True,
+        )
+        removed_any = False
+        for line in untracked.stdout.splitlines():
+            name = Path(line).name
+            if _WIN_RESERVED.match(name):
+                # Use the \\?\ prefix to bypass Windows' reserved-name check
+                # so we can actually delete the file.
+                abs_path = cwd / line
+                try:
+                    os.remove(r"\\?\" + str(abs_path))
+                    removed_any = True
+                except OSError:
+                    pass
+        if removed_any:
+            print(
+                "  ⚠ Removed Windows reserved-device-name file(s) from the "
+                "working tree before stashing."
+            )
+
     stash_name = datetime.now(timezone.utc).strftime(
         "hermes-update-autostash-%Y%m%d-%H%M%S"
     )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7543,7 +7543,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
                 # so we can actually delete the file.
                 abs_path = cwd / line
                 try:
-                    os.remove(r"\\?\" + str(abs_path))
+                    os.remove(r"\\?" + "\\" + str(abs_path))
                     removed_any = True
                 except OSError:
                     pass

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+import sys
 
 from hermes_cli import config as hermes_config
 from hermes_cli import main as hermes_main
@@ -65,6 +66,8 @@ def test_stash_local_changes_if_needed_returns_specific_stash_commit(monkeypatch
             return SimpleNamespace(stdout=" M hermes_cli/main.py\n?? notes.txt\n", returncode=0)
         if cmd[-2:] == ["ls-files", "--unmerged"]:
             return SimpleNamespace(stdout="", returncode=0)
+        if cmd[-3:] == ["ls-files", "--others", "--exclude-standard"]:
+            return SimpleNamespace(stdout="", returncode=0)
         if cmd[1:4] == ["stash", "push", "--include-untracked"]:
             return SimpleNamespace(stdout="Saved working directory\n", returncode=0)
         if cmd[-3:] == ["rev-parse", "--verify", "refs/stash"]:
@@ -77,11 +80,14 @@ def test_stash_local_changes_if_needed_returns_specific_stash_commit(monkeypatch
 
     assert stash_ref == "abc123"
     assert calls[1][0][-2:] == ["ls-files", "--unmerged"]
+    # On Windows there's an extra ls-files --others --exclude-standard call
+    # before the pre-push probe.
+    offset = 1 if sys.platform == "win32" else 0
     # Pre-push probe of refs/stash (baseline for detecting a fresh entry),
     # then the push, then the post-push probe.
-    assert calls[2][0][-3:] == ["rev-parse", "--verify", "refs/stash"]
-    assert calls[3][0][1:4] == ["stash", "push", "--include-untracked"]
-    assert calls[4][0][-3:] == ["rev-parse", "--verify", "refs/stash"]
+    assert calls[2 + offset][0][-3:] == ["rev-parse", "--verify", "refs/stash"]
+    assert calls[3 + offset][0][1:4] == ["stash", "push", "--include-untracked"]
+    assert calls[4 + offset][0][-3:] == ["rev-parse", "--verify", "refs/stash"]
 
 
 def test_resolve_stash_selector_returns_matching_entry(monkeypatch, tmp_path):
@@ -313,6 +319,8 @@ def test_stash_local_changes_if_needed_raises_when_stash_ref_missing(monkeypatch
         if cmd[-2:] == ["status", "--porcelain"]:
             return SimpleNamespace(stdout=" M hermes_cli/main.py\n", returncode=0)
         if cmd[-2:] == ["ls-files", "--unmerged"]:
+            return SimpleNamespace(stdout="", returncode=0)
+        if cmd[-3:] == ["ls-files", "--others", "--exclude-standard"]:
             return SimpleNamespace(stdout="", returncode=0)
         if cmd[1:4] == ["stash", "push", "--include-untracked"]:
             return SimpleNamespace(stdout="Saved working directory\n", returncode=0)
@@ -1017,6 +1025,8 @@ def test_stash_push_failure_without_stash_entry_still_raises(monkeypatch, tmp_pa
             return SimpleNamespace(stdout=" M x.py\n", returncode=0)
         if cmd[-2:] == ["ls-files", "--unmerged"]:
             return SimpleNamespace(stdout="", returncode=0)
+        if cmd[-3:] == ["ls-files", "--others", "--exclude-standard"]:
+            return SimpleNamespace(stdout="", returncode=0)
         if cmd[-3:] == ["rev-parse", "--verify", "refs/stash"]:
             return SimpleNamespace(stdout="", returncode=1)
         if cmd[1:4] == ["stash", "push", "--include-untracked"]:
@@ -1043,6 +1053,8 @@ def test_stash_push_failure_with_preexisting_stash_unchanged_still_raises(
         if cmd[-2:] == ["status", "--porcelain"]:
             return SimpleNamespace(stdout=" M x.py\n", returncode=0)
         if cmd[-2:] == ["ls-files", "--unmerged"]:
+            return SimpleNamespace(stdout="", returncode=0)
+        if cmd[-3:] == ["ls-files", "--others", "--exclude-standard"]:
             return SimpleNamespace(stdout="", returncode=0)
         if cmd[-3:] == ["rev-parse", "--verify", "refs/stash"]:
             return SimpleNamespace(stdout="oldref456\n", returncode=0)


### PR DESCRIPTION
## Problem

On Windows, `hermes update` hangs indefinitely at:

```
→ Local changes detected — stashing before update...
```

when the working tree contains a file named `nul` (or any other Windows reserved device name: `CON`, `PRN`, `AUX`, `COM1-9`, `LPT1-9`). Git cannot stash these files because Windows intercepts the name as a system device, so `git stash push --include-untracked` blocks forever.

These files are typically 0-byte artefacts created accidentally by shell redirections (e.g. `echo x > nul` run in a context that creates a real file instead of writing to the NUL device).

Closes #57081

## Root Cause

`_stash_local_changes_if_needed()` unconditionally runs:

```python
git stash push --include-untracked
```

which attempts to read every untracked file. On Windows, accessing a path named `nul` is equivalent to opening the null device, causing git to hang.

## Fix

On Windows only, before stashing, enumerate untracked files with `git ls-files --others --exclude-standard` and delete any whose basename matches the reserved-device regex. The deletion uses the `\\?\` extended path prefix to bypass Windows' reserved-name check so the file can actually be removed from disk.

If any files are removed, a warning is printed so the user knows what happened.

## Testing

- Reproduced on Windows 11 Pro (Chinese locale, GBK default encoding) with a 0-byte `nul` file in the repo root. Before the fix, `hermes update` hung for >30 min at the stash step. After the fix, the update completes in ~45 seconds and prints:
  ```
  ⚠ Removed Windows reserved-device-name file(s) from the working tree before stashing.
  ```
- Verified that normal untracked files are still stashed correctly.
- Verified that the fix is a no-op on non-Windows platforms.
