### PR TITLE
fix(slack): include reactions:write in generated manifest

### DIFF
--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -92,6 +92,7 @@ def _build_full_manifest(
         "mpim:history",
         "mpim:read",
         "reactions:read",
+        "reactions:write",
         "users:read",
     ]
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -999,6 +999,10 @@ class SlackAdapter(BasePlatformAdapter):
         # exception between add and finalize would leak them — keep it bounded.
         self._reacting_message_ids: set = set()
         self._REACTING_MESSAGE_IDS_MAX = 5000
+        # Existing Slack installs do not gain new OAuth scopes until the app
+        # is reinstalled. Warn once per workspace when reaction writes expose
+        # a stale manifest, without flooding every lifecycle transition.
+        self._reaction_scope_warned: set[str] = set()
         # Track active Assistant statuses by (team_id, channel_id, thread_ts)
         # so cleanup cannot clear an overlapping Slack Connect workspace.
         # Entries are popped when the status clears, but statuses abandoned
@@ -3708,6 +3712,38 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ----- Reactions -----
 
+    def _log_reaction_failure(
+        self, operation: str, emoji: str, error: Exception, team_id: str
+    ) -> None:
+        """Surface a stale reaction scope once; keep routine failures quiet."""
+        error_code = ""
+        response = getattr(error, "response", None)
+        response_get = getattr(response, "get", None)
+        if callable(response_get):
+            try:
+                error_code = str(response_get("error") or "")
+            except Exception:
+                pass
+
+        if error_code == "missing_scope" or "missing_scope" in str(error):
+            warned = getattr(self, "_reaction_scope_warned", None)
+            if warned is None:
+                warned = set()
+                self._reaction_scope_warned = warned
+            team_key = team_id or ""
+            if team_key not in warned:
+                warned.add(team_key)
+                logger.warning(
+                    "[Slack] Processing reactions are unavailable in workspace %s: "
+                    "the app is missing the 'reactions:write' bot scope. Run "
+                    "`hermes slack manifest --write`, apply the updated manifest, "
+                    "then reinstall the app to the workspace.",
+                    team_key or "this workspace",
+                )
+            return
+
+        logger.debug("[Slack] reactions.%s failed (%s): %s", operation, emoji, error)
+
     async def _add_reaction(
         self, channel: str, timestamp: str, emoji: str, team_id: str = ""
     ) -> bool:
@@ -3720,8 +3756,7 @@ class SlackAdapter(BasePlatformAdapter):
             )
             return True
         except Exception as e:
-            # Don't log as error — may fail if already reacted or missing scope
-            logger.debug("[Slack] reactions.add failed (%s): %s", emoji, e)
+            self._log_reaction_failure("add", emoji, e, team_id)
             return False
 
     async def _remove_reaction(
@@ -3736,7 +3771,7 @@ class SlackAdapter(BasePlatformAdapter):
             )
             return True
         except Exception as e:
-            logger.debug("[Slack] reactions.remove failed (%s): %s", emoji, e)
+            self._log_reaction_failure("remove", emoji, e, team_id)
             return False
 
     def _reactions_enabled(self) -> bool:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -12,6 +12,7 @@ import asyncio
 import contextlib
 import importlib
 from importlib.machinery import PathFinder
+import logging
 import os
 import socket
 import sys
@@ -2558,6 +2559,32 @@ class TestReactions:
             channel="C123", timestamp="ts1", name="eyes"
         )
 
+
+    @pytest.mark.asyncio
+    async def test_missing_reaction_scope_warns_once(self, adapter, caplog):
+        class MissingScopeError(Exception):
+            response = {
+                "error": "missing_scope",
+                "needed": "reactions:write",
+            }
+
+        adapter._app.client.reactions_add = AsyncMock(
+            side_effect=MissingScopeError("missing_scope")
+        )
+        caplog.set_level(logging.WARNING, logger="plugins.platforms.slack.adapter")
+
+        await adapter._add_reaction("C123", "ts1", "eyes", "T123")
+        await adapter._add_reaction("C123", "ts2", "white_check_mark", "T123")
+
+        warnings = [
+            record.getMessage()
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+        ]
+        assert len(warnings) == 1
+        assert "reactions:write" in warnings[0]
+        assert "hermes slack manifest --write" in warnings[0]
+        assert "reinstall" in warnings[0].lower()
 
     @pytest.mark.asyncio
     async def test_remove_reaction_calls_api(self, adapter):

--- a/tests/gateway/test_slack_plugin_setup.py
+++ b/tests/gateway/test_slack_plugin_setup.py
@@ -7,12 +7,16 @@ from ``hermes_cli.config`` (get_env_value / save_env_value / remove_env_value)
 and ``hermes_cli.cli_output`` (prompt / prompt_yes_no / print_*), so we patch
 those source modules.
 """
+import json
+
 import hermes_cli.config as config_mod
 import hermes_cli.cli_output as cli_output_mod
 from plugins.platforms.slack.adapter import interactive_setup
 
 
-def _patch_setup_io(monkeypatch, prompts, saved, removed, existing):
+def _patch_setup_io(
+    monkeypatch, prompts, saved, removed, existing, *, stub_manifest=True
+):
     """Wire interactive_setup's lazy-imported CLI helpers to test doubles."""
     prompt_iter = iter(prompts)
     monkeypatch.setattr(config_mod, "get_env_value", lambda key: existing.get(key, ""))
@@ -28,9 +32,34 @@ def _patch_setup_io(monkeypatch, prompts, saved, removed, existing):
     monkeypatch.setattr(cli_output_mod, "prompt_yes_no", lambda *_a, **_kw: False)
     for name in ("print_header", "print_info", "print_success", "print_warning"):
         monkeypatch.setattr(cli_output_mod, name, lambda *_a, **_kw: None)
-    # Manifest writing reaches out to hermes_cli.slack_cli + filesystem; stub it.
-    import hermes_cli.slack_cli as slack_cli_mod
-    monkeypatch.setattr(slack_cli_mod, "_build_full_manifest", lambda **_kw: {"display_information": {}})
+    if stub_manifest:
+        # Most setup tests only exercise prompts; keep their manifest I/O inert.
+        import hermes_cli.slack_cli as slack_cli_mod
+
+        monkeypatch.setattr(
+            slack_cli_mod,
+            "_build_full_manifest",
+            lambda **_kw: {"display_information": {}},
+        )
+
+
+def test_interactive_setup_writes_reaction_capable_manifest(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    saved, removed = {}, []
+    _patch_setup_io(
+        monkeypatch,
+        ["xoxb-test-token", "xapp-test-token", "", ""],
+        saved,
+        removed,
+        existing={},
+        stub_manifest=False,
+    )
+
+    interactive_setup()
+
+    manifest = json.loads((tmp_path / "slack-manifest.json").read_text(encoding="utf-8"))
+    bot_scopes = manifest["oauth_config"]["scopes"]["bot"]
+    assert {"reactions:read", "reactions:write"} <= set(bot_scopes)
 
 
 def test_interactive_setup_saves_home_channel(monkeypatch, tmp_path):
@@ -68,5 +97,3 @@ class TestSlackHomeChannelClear:
         interactive_setup()
         assert "SLACK_HOME_CHANNEL" in removed
         assert "SLACK_HOME_CHANNEL" not in saved
-
-

--- a/tests/hermes_cli/test_slack_cli.py
+++ b/tests/hermes_cli/test_slack_cli.py
@@ -126,7 +126,9 @@ class TestSlackFullManifest:
 
         assert "assistant_view" in manifest["features"]
         assert "agent_view" not in manifest["features"]
-        assert "assistant:write" in manifest["oauth_config"]["scopes"]["bot"]
+        bot_scopes = manifest["oauth_config"]["scopes"]["bot"]
+        assert "assistant:write" in bot_scopes
+        assert "reactions:write" in bot_scopes
         bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
         assert "assistant_thread_started" in bot_events
 
@@ -146,10 +148,14 @@ class TestSlackFullManifest:
         assert manifest["settings"]["socket_mode_enabled"] is True
         # Channel + DM scopes/events survive so the bot still works everywhere.
         bot_scopes = manifest["oauth_config"]["scopes"]["bot"]
-        for scope in ("commands", "channels:history", "groups:read", "im:history"):
+        for scope in (
+            "commands",
+            "channels:history",
+            "groups:read",
+            "im:history",
+            "reactions:write",
+        ):
             assert scope in bot_scopes
         bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
         for event in ("message.im", "message.channels", "message.groups", "app_mention"):
             assert event in bot_events
-
-


### PR DESCRIPTION
## What does this PR do?

Adds the missing `reactions:write` bot scope to Slack manifests generated by both `hermes slack manifest` and the interactive setup flow. Without that scope, the processing reaction lifecycle is enabled by default but every `reactions.add` and `reactions.remove` request fails with `missing_scope`.

The adapter now logs one actionable warning per affected workspace for `missing_scope`, while keeping routine reaction failures such as `already_reacted` at DEBUG level.

Existing Slack apps must apply the updated manifest and be reinstalled to the workspace before the new OAuth scope takes effect.

## Related Issue

Fixes #71827

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Add `reactions:write` to the shared Slack manifest builder.
- Surface `missing_scope` as a once-per-workspace warning with remediation steps.
- Cover default and non-Assistant manifests, the real setup-generated manifest, and warning deduplication.

## How to Test

1. Generate a manifest with `hermes slack manifest --write` and verify `oauth_config.scopes.bot` contains both `reactions:read` and `reactions:write`.
2. Install or reinstall the Slack app using that manifest.
3. Send the bot a DM or mention and verify the processing and completion reactions appear.

Regression evidence:

```text
Before the production fix:
3 files, 0 tests passed, 4 failed

Focused post-fix checks:
5 passed in 0.80s

Ruff:
All checks passed!

git diff --check:
passed

Windows footgun check:
passed
```

The broader three-file Slack test run reached 468 passed with one environment-dependent existing failure: the sandbox could not resolve `files.slack.com` in `TestDownloadTokenWorkspaceRouting::test_download_uses_owning_workspace_token`. The failing download path is unchanged by this PR.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation update is N/A; the generated manifest and runtime warning carry the migration guidance
- [x] `cli-config.yaml.example` update is N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] Cross-platform impact considered; the diff passes the Windows footgun check
- [x] Tool descriptions/schemas update is N/A
