### PR TITLE
fix(computer_use): stop the cua-driver child on exit

### DIFF
--- a/tests/computer_use/test_cua_atexit_teardown.py
+++ b/tests/computer_use/test_cua_atexit_teardown.py
@@ -1,0 +1,75 @@
+"""Tests for cua-driver subprocess teardown on interpreter exit.
+
+``CuaDriverBackend`` spawns a long-lived ``cua-driver`` child process and
+caches it for the life of the Hermes process. Nothing ever tore it down, so
+the driver outlived the session that started it (#28152 item 3 — "Hermes does
+not keep the driver alive after tool completion"). #69903 fixed the *overlay*
+redraw loop that made the lingering process burn CPU, but not the lingering
+process itself.
+
+``tools/computer_use/tool.py`` registers an ``atexit`` hook that stops the
+cached backend, mirroring ``browser_tool``'s
+``atexit.register(_emergency_cleanup_all_sessions)``.
+
+These assert the behavior contract — the hook is registered, it stops a live
+backend, it is a no-op when nothing was ever started, and it never raises out
+of ``atexit`` — not a snapshot of the module's source.
+"""
+
+import atexit
+from unittest.mock import MagicMock, patch
+
+from tools.computer_use import tool as cu_tool
+
+
+class TestAtexitTeardown:
+    def test_shutdown_stops_a_live_backend(self):
+        """A cached backend is stopped when the interpreter exits."""
+        fake = MagicMock()
+        with patch.object(cu_tool, "_backend", fake):
+            cu_tool._shutdown_backend_atexit()
+            fake.stop.assert_called_once()
+
+    def test_shutdown_clears_the_cached_backend(self):
+        """After teardown the module cache is empty, so a later call re-spawns."""
+        fake = MagicMock()
+        with patch.object(cu_tool, "_backend", fake):
+            cu_tool._shutdown_backend_atexit()
+            assert cu_tool._backend is None
+
+    def test_shutdown_is_a_noop_when_never_started(self):
+        """No backend was ever created => nothing to stop, no error."""
+        with patch.object(cu_tool, "_backend", None):
+            cu_tool._shutdown_backend_atexit()  # must not raise
+            assert cu_tool._backend is None
+
+    def test_shutdown_swallows_backend_errors(self):
+        """A failing stop() must not raise out of an atexit hook.
+
+        Exceptions escaping atexit print a traceback on every exit and can
+        mask the real exit status.
+        """
+        fake = MagicMock()
+        fake.stop.side_effect = RuntimeError("driver already dead")
+        with patch.object(cu_tool, "_backend", fake):
+            cu_tool._shutdown_backend_atexit()  # must not raise
+            assert cu_tool._backend is None
+
+    def test_hook_is_registered_with_atexit(self):
+        """Importing the tool module registers the teardown hook.
+
+        Verified by unregistering and re-registering: atexit.unregister only
+        removes a function that was actually registered, so a successful
+        round-trip proves the import-time registration happened.
+        """
+        atexit.unregister(cu_tool._shutdown_backend_atexit)
+        try:
+            with patch.object(cu_tool, "_backend", MagicMock()) as fake:
+                # Re-register and fire the full atexit chain the way the
+                # interpreter would, then confirm our hook ran.
+                atexit.register(cu_tool._shutdown_backend_atexit)
+                atexit._run_exitfuncs()
+                fake.stop.assert_called_once()
+        finally:
+            atexit.unregister(cu_tool._shutdown_backend_atexit)
+            atexit.register(cu_tool._shutdown_backend_atexit)

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -38,6 +38,7 @@ For captures / actions with `capture_after=True`:
 
 from __future__ import annotations
 
+import atexit
 import base64
 import json
 import logging
@@ -177,16 +178,39 @@ def _get_backend() -> ComputerUseBackend:
         return _backend
 
 
+def _shutdown_backend_atexit() -> None:
+    """Stop the cached backend so the cua-driver child doesn't outlive us.
+
+    The backend is cached per-process and holds a long-lived ``cua-driver``
+    subprocess, so without this the driver survives the Hermes process that
+    spawned it (#28152 item 3). #69903 kept the orphan from burning a core by
+    disabling the cursor overlay; the process itself still lingered.
+
+    Mirrors ``browser_tool``'s ``atexit.register(_emergency_cleanup_all_sessions)``
+    — same spawn-and-drive-a-subprocess shape. atexit only, no signal handlers:
+    a ``SystemExit`` raised from a prompt_toolkit key binding corrupts its
+    coroutine state and makes the process unkillable. Never raises, since an
+    exception escaping atexit prints a traceback on every exit.
+    """
+    global _backend
+    # Drop the lock before stop() — teardown budgets 5s and shouldn't block
+    # an unrelated caller waiting to spawn.
+    with _backend_lock:
+        backend, _backend = _backend, None
+    if backend is None:
+        return
+    try:
+        backend.stop()
+    except Exception as e:
+        logger.debug("cua-driver atexit teardown failed: %s", e)
+
+
+atexit.register(_shutdown_backend_atexit)
+
+
 def reset_backend_for_tests() -> None:  # pragma: no cover
     """Test helper — tear down the cached backend and per-session state."""
-    global _backend
-    with _backend_lock:
-        if _backend is not None:
-            try:
-                _backend.stop()
-            except Exception:
-                pass
-        _backend = None
+    _shutdown_backend_atexit()
     _AUX_VISION_ROUTE_CACHE.clear()
     with _approval_lock:
         _session_auto_approve.clear()


### PR DESCRIPTION
`CuaDriverBackend` spawns a `cua-driver` subprocess and caches it in a module global for the life of the Hermes process. `stop()` exists at `cua_backend.py:1078` and works — nothing ever calls it. There is no atexit hook and no reaper, so the driver outlives the session that spawned it.

`computer_use` is the only subprocess-owning tool without exit cleanup. `browser_tool` (same spawn-and-drive shape), `terminal_tool`, and `credential_files` all register one. This copies that pattern rather than inventing a new one.

## Relationship to the closed idle-CPU work

[#28152](https://github.com/NousResearch/hermes-agent/issues/28152) and [#47032](https://github.com/NousResearch/hermes-agent/issues/47032) are both closed and stay closed — this does not reopen or supersede them. [#69903](https://github.com/NousResearch/hermes-agent/pull/69903) fixed what those issues were loudest about: the cursor-overlay vImage redraw loop that had an orphaned driver at 105% CPU for ~64 hours. That fix is correct and this does not touch it.

What it did not cover is the lingering process itself. #28152 asked for four things; item 3 was "Hermes does not keep the driver or related screen-observation loop alive after tool completion." Disabling the overlay stopped the orphan from burning a core, but the orphan is still there. This PR covers that remaining item, in the same spirit as [#71629](https://github.com/NousResearch/hermes-agent/pull/71629) complementing #43149/#68653 rather than superseding them.

Refs #28152 (item 3), #47032. No closing keyword — both are already closed as completed.

## Implementation

atexit only, no signal handlers — for the reason documented above `browser_tool`'s registration: a `SystemExit` raised from a prompt_toolkit key-binding callback corrupts the coroutine state and makes the process unkillable. The hook never raises, since an exception escaping atexit prints a traceback on every exit and can mask the real exit status. It takes the lock only to swap the global out, then calls `stop()` unlocked so the 5s teardown budget can't block a caller waiting to spawn. `reset_backend_for_tests` now reuses the same teardown instead of duplicating it.

No idle reaper here. That needs a timeout value worth picking deliberately, and it can tear the driver down mid-task; worth doing separately if wanted.

## Test plan

`tests/computer_use/test_cua_atexit_teardown.py` — 5 tests: stops a live backend, clears the cache so a later call re-spawns, no-ops when nothing was started, swallows a failing `stop()`, and confirms the hook is registered by firing the real atexit chain.

- [x] 5/5 fail on `main` (`AttributeError: no attribute '_shutdown_backend_atexit'`), pass with the fix
- [x] Reverting just `tool.py` puts all 5 back to failing — the mechanism is load-bearing, not decorative
- [x] `pytest tests/computer_use/` → 64 passed
- [x] `pytest tests/tools/test_computer_use*.py tests/tools/test_registry.py` → 327 passed
- [x] E2E: cached a backend in a real subprocess, let the interpreter exit naturally, observed `stop()` fire during shutdown with exit code 0

One pre-existing failure, `TestCaptureAppFilterNoMatch::test_linux_default_capture_skips_gnome_shell_helper`, reproduces on clean `main` on macOS and is untouched by this change.
