### PR TITLE
fix(projects): keep Windows main checkout in branch lane

### DIFF
--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -7,6 +7,7 @@ break them.
 
 from __future__ import annotations
 
+from tui_gateway import git_probe
 from tui_gateway import project_tree as pt
 
 _SID = 0
@@ -76,6 +77,22 @@ def test_main_checkout_groups_by_recorded_branch_with_stable_lane_ids():
     # Trunk sorts ahead of the feature branch; both live in the main checkout.
     assert [g["label"] for repo in project["repos"] for g in repo["groups"]] == ["main", "feature"]
     assert all(g["isMain"] for repo in project["repos"] for g in repo["groups"])
+
+
+def test_windows_main_checkout_matches_mixed_separator_roots(monkeypatch):
+    cwd = r"C:\Users\alice\repo"
+    monkeypatch.setattr(git_probe, "repo_root", lambda _cwd: "C:/Users/alice/repo")
+    monkeypatch.setattr(git_probe, "common_repo_root", lambda _cwd: cwd)
+    session = _session(cwd, branch="main")
+
+    tree = pt.build_tree([], [session], [], git_probe.resolve, hydrate=True)
+    project = tree["projects"][0]
+    lane = project["repos"][0]["groups"][0]
+
+    assert lane["id"] == rf"{cwd}::branch::main"
+    assert lane["label"] == "main"
+    assert lane["isMain"] is True
+    assert lane["sessions"] == [session]
 
 
 def test_linked_worktrees_fold_under_their_common_repo_root():

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -221,7 +221,9 @@ def _place(cwd: str, branch: str, resolve: Optional[Resolve], persisted_root: st
     if info and info.get("repo_root") and info.get("worktree_root"):
         repo_root = info["repo_root"]
         worktree_root = info["worktree_root"]
-        is_main = worktree_root == repo_root or bool(info.get("is_main"))
+        is_main = _path_key(worktree_root) == _path_key(repo_root) or bool(
+            info.get("is_main")
+        )
 
         if is_main:
             # Unrecorded branch folds into the one trunk lane, so a repo never


### PR DESCRIPTION
## What does this PR do?

Fixes Windows main checkouts being classified as linked worktrees in the authoritative project tree.

Git for Windows can return `worktree_root` with forward slashes while `common_repo_root()` passes the same path through `os.path.realpath()` and returns backslashes. `_place()` compared those values as raw strings, so the main checkout became a path-keyed, folder-labeled worktree lane. The Desktop live overlay then inferred the canonical branch lane and displayed the same session in both lanes.

The fix compares the roots with the existing separator-, trailing-slash-, and Windows-case-aware `_path_key()` helper. It deliberately preserves the original path spelling in emitted IDs and does not change the legacy lane identity for non-Git folders.

## Related Issue

Related to #71837.

This PR addresses only the mixed-separator main-checkout classification defect. It does not address the non-Git heuristic lane identity described in the issue and therefore does not claim to close #71837. #71889 is the complete consolidation covering root normalization, this `_path_key()` comparison, and canonical heuristic-lane identity.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Compare resolved repo/worktree roots using `_path_key()` when deciding whether a checkout is the main checkout.
- Add a regression test that exercises the real `git_probe.resolve()` to `project_tree.build_tree()` chain with mixed Windows separators.
- Preserve raw-path non-Git lanes and all emitted path spellings.

## Consolidation

- #71889 is a strict superset of this PR and is the complete fix for #71837.
- #71860 supplied the companion root-normalization and canonical non-Git heuristic-lane changes and was closed in favor of #71889.
- This PR remains narrowly scoped to the mixed-separator classification defect and preserves its focused regression evidence.

## How to Test

```bash
.venv/bin/python -m pytest -q \
  tests/tui_gateway/test_project_tree.py \
  tests/tui_gateway/test_projects_rpc.py

npm --workspace apps/desktop run test:ui -- \
  workspace-groups.test.ts --reporter=verbose

.venv/bin/ruff check \
  tui_gateway/project_tree.py \
  tests/tui_gateway/test_project_tree.py
```

Regression evidence:

```text
Before the production fix:
test_windows_main_checkout_matches_mixed_separator_roots FAILED
actual lane id: C:/Users/alice/repo
expected lane id: C:\Users\alice\repo::branch::main

After the fix:
targeted regression: 1 passed
project-tree + projects RPC: 56 passed
Desktop workspace-groups: 48 passed
Ruff: passed
git diff --check: passed
Windows footgun check: passed
```

The broader `tests/tui_gateway` run reached 477 passed with one unrelated order-dependent failure in `test_prompt_submit_rejected_while_child_run_active`; that test passed when rerun alone.

## Compatibility Notes

This was validated on macOS by injecting the two path spellings produced by the Windows Git/realpath boundary. It was not run on a Windows host. Because `_path_key()` is used only for identity comparison, existing displayed paths and persisted lane IDs keep their original spelling.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS with simulated Windows Git path outputs

### Documentation & Housekeeping

- [x] Documentation update is N/A
- [x] `cli-config.yaml.example` update is N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] Cross-platform impact considered; existing path spelling and lane IDs are preserved
- [x] Tool descriptions/schemas update is N/A
