### PR TITLE
fix(agent): strip provider-unsupported content blocks before the API call

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1387,6 +1387,74 @@ def drop_thinking_only_and_merge_users(
 
 
 
+_TEXTONLY_ALLOWED_BLOCK_TYPES = {"text", "image_url"}
+
+
+def _model_requires_text_image_blocks_only(model: str, base_url: str = "") -> bool:
+    """True for endpoints that reject any content block other than text/image_url.
+
+    GitHub Copilot's Gemini models reject a request whose content list contains
+    an Anthropic-style ``{"type": "thinking", ...}`` block with HTTP 400
+    "type has to be either 'image_url' or 'text'". This bites when a session
+    that ran on a Claude model is switched mid-conversation to Copilot Gemini.
+    """
+    m = (model or "").strip().lower()
+    # Strip a provider namespace prefix (litellm routes these models as
+    # ``github_copilot/gemini-3.5-flash``).
+    bare = m.rsplit("/", 1)[-1]
+    if not bare.startswith("gemini"):
+        return False
+    url = (base_url or "").strip().lower()
+    return "githubcopilot.com" in url or "github_copilot/" in m or not url
+
+
+def strip_unsupported_content_blocks(
+    messages: List[Dict[str, Any]],
+    *,
+    allowed: Optional[set] = None,
+) -> List[Dict[str, Any]]:
+    """Drop content blocks whose ``type`` the target endpoint won't accept.
+
+    Operates on the per-call ``api_messages`` copy only — stored history keeps
+    the full reasoning trace for the UI transcript and session persistence.
+    """
+    allowed = allowed or _TEXTONLY_ALLOWED_BLOCK_TYPES
+    if not messages:
+        return messages
+
+    out: List[Dict[str, Any]] = []
+    stripped = 0
+    for msg in messages:
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if not isinstance(content, list):
+            out.append(msg)
+            continue
+        kept = []
+        for block in content:
+            if isinstance(block, dict):
+                btype = str(block.get("type") or "").strip().lower()
+                if btype and btype not in allowed:
+                    stripped += 1
+                    continue
+            kept.append(block)
+        if len(kept) == len(content):
+            out.append(msg)
+            continue
+        new_msg = dict(msg)
+        new_msg["content"] = kept if kept else ""
+        out.append(new_msg)
+
+    if stripped:
+        _ra().logger.debug(
+            "Pre-call sanitizer: stripped %d unsupported content block(s) "
+            "(allowed=%s)",
+            stripped,
+            sorted(allowed),
+        )
+        return out
+    return messages
+
+
 def restore_primary_runtime(agent) -> bool:
     """Restore the primary runtime at the start of a new turn.
 
@@ -3573,6 +3641,8 @@ __all__ = [
     "invoke_tool",
     "repair_tool_call",
     "sanitize_api_messages",
+    "strip_unsupported_content_blocks",
+    "_model_requires_text_image_blocks_only",
     "looks_like_codex_intermediate_ack",
     "copy_reasoning_content_for_api",
     "cleanup_dead_connections",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1397,6 +1397,13 @@ def _model_requires_text_image_blocks_only(model: str, base_url: str = "") -> bo
     an Anthropic-style ``{"type": "thinking", ...}`` block with HTTP 400
     "type has to be either 'image_url' or 'text'". This bites when a session
     that ran on a Claude model is switched mid-conversation to Copilot Gemini.
+
+    Requires **affirmative Copilot evidence**: either the request targets the
+    Copilot host, or the model carries the ``github_copilot/`` namespace that
+    litellm uses to route these same models. An unknown or empty base URL is
+    NOT treated as Copilot — the 400 was only ever observed on that endpoint,
+    so stripping blocks for an unverified endpoint would discard reasoning
+    content no provider asked us to drop.
     """
     m = (model or "").strip().lower()
     # Strip a provider namespace prefix (litellm routes these models as
@@ -1405,7 +1412,7 @@ def _model_requires_text_image_blocks_only(model: str, base_url: str = "") -> bo
     if not bare.startswith("gemini"):
         return False
     url = (base_url or "").strip().lower()
-    return "githubcopilot.com" in url or "github_copilot/" in m or not url
+    return "githubcopilot.com" in url or "github_copilot/" in m
 
 
 def strip_unsupported_content_blocks(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2028,6 +2028,19 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # turns so Anthropic-family providers don't 400 the summary call.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
 
+        # Copilot Gemini rejects any content block that isn't text/image_url
+        # (HTTP 400 "type has to be either 'image_url' or 'text'").
+        try:
+            from agent.agent_runtime_helpers import (
+                _model_requires_text_image_blocks_only as _needs_textonly,
+                strip_unsupported_content_blocks as _strip_blocks,
+            )
+            if _needs_textonly(getattr(agent, "model", ""), getattr(agent, "base_url", "")):
+                api_messages = _strip_blocks(api_messages)
+        except Exception:
+            pass
+
+
         summary_extra_body = {}
         try:
             from agent.auxiliary_client import _fixed_temperature_for_model, OMIT_TEMPERATURE as _OMIT_TEMP

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1468,6 +1468,18 @@ def run_conversation(
             drop_codex_reasoning_items=agent.api_mode != "codex_responses",
         )
 
+        # Copilot Gemini rejects any content block that isn't text/image_url
+        # (HTTP 400 "type has to be either 'image_url' or 'text'").
+        try:
+            from agent.agent_runtime_helpers import (
+                _model_requires_text_image_blocks_only as _needs_textonly,
+                strip_unsupported_content_blocks as _strip_blocks,
+            )
+            if _needs_textonly(getattr(agent, "model", ""), getattr(agent, "base_url", "")):
+                api_messages = _strip_blocks(api_messages)
+        except Exception:
+            pass
+
         # Normalize message whitespace and tool-call JSON for consistent
         # prefix matching.  Ensures bit-perfect prefixes across turns,
         # which enables KV cache reuse on local inference servers

--- a/tests/run_agent/test_unsupported_content_block_strip.py
+++ b/tests/run_agent/test_unsupported_content_block_strip.py
@@ -1,0 +1,179 @@
+"""Tests for stripping provider-unsupported content blocks before an API call.
+
+GitHub Copilot's Gemini models reject any content block whose ``type`` is not
+``text`` or ``image_url``::
+
+    HTTP 400 {"error": {"message": "type has to be either 'image_url' or
+              'text'", "code": "invalid_request_body"}}
+
+A session that ran on a Claude model persists extended-thinking blocks as
+``{"type": "thinking", ...}`` / ``{"type": "redacted_thinking", ...}``.
+Switching that session mid-conversation to a Copilot Gemini model replays those
+blocks onto the wire and every subsequent turn 400s.
+
+These tests cover the gate (which models need the strip) and the strip itself
+(what it removes, what it preserves, and that stored history is never mutated).
+"""
+
+from __future__ import annotations
+
+import copy
+
+from agent.agent_runtime_helpers import (
+    _model_requires_text_image_blocks_only,
+    strip_unsupported_content_blocks,
+)
+
+COPILOT = "https://api.githubcopilot.com"
+
+
+# --------------------------------------------------------------------------
+# Gate: only Copilot-served Gemini needs the strip.
+# --------------------------------------------------------------------------
+
+
+def test_gate_matches_copilot_gemini():
+    assert _model_requires_text_image_blocks_only("gemini-3.6-flash", COPILOT) is True
+
+
+def test_gate_matches_litellm_namespaced_copilot_gemini():
+    # litellm routes the same models as ``github_copilot/gemini-*``.
+    assert _model_requires_text_image_blocks_only(
+        "github_copilot/gemini-3.5-flash", "http://127.0.0.1:4000"
+    ) is True
+
+
+def test_gate_ignores_non_gemini_copilot_models():
+    # Claude on Copilot is exactly the model whose thinking blocks we preserve.
+    assert _model_requires_text_image_blocks_only("claude-opus-4.8", COPILOT) is False
+    assert _model_requires_text_image_blocks_only("gpt-5.5", COPILOT) is False
+
+
+def test_gate_ignores_gemini_on_native_google_endpoint():
+    # Google's native endpoint is a different wire format and is unaffected.
+    assert _model_requires_text_image_blocks_only(
+        "gemini-2.5-pro", "https://generativelanguage.googleapis.com"
+    ) is False
+
+
+def test_gate_ignores_non_gemini_namespaced_model():
+    assert _model_requires_text_image_blocks_only(
+        "openai/gpt-5.5", "http://127.0.0.1:4000"
+    ) is False
+
+
+# --------------------------------------------------------------------------
+# Strip behaviour.
+# --------------------------------------------------------------------------
+
+
+def test_thinking_block_is_stripped_and_text_survives():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "deliberating", "signature": "sig"},
+                {"type": "text", "text": "visible answer"},
+            ],
+        },
+    ]
+    out = strip_unsupported_content_blocks(messages)
+    assert out[1]["content"] == [{"type": "text", "text": "visible answer"}]
+
+
+def test_redacted_thinking_block_is_stripped():
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "redacted_thinking", "data": "opaque"},
+                {"type": "text", "text": "answer"},
+            ],
+        },
+    ]
+    out = strip_unsupported_content_blocks(messages)
+    assert out[0]["content"] == [{"type": "text", "text": "answer"}]
+
+
+def test_thinking_only_message_becomes_empty_string_not_empty_list():
+    # ``content: []`` is itself rejected by some providers; normalize to "".
+    messages = [{"role": "assistant", "content": [{"type": "thinking", "thinking": "x"}]}]
+    out = strip_unsupported_content_blocks(messages)
+    assert out[0]["content"] == ""
+
+
+def test_text_and_image_blocks_are_preserved():
+    blocks = [
+        {"type": "text", "text": "what is this?"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+    ]
+    messages = [{"role": "user", "content": list(blocks)}]
+    out = strip_unsupported_content_blocks(messages)
+    assert out[0]["content"] == blocks
+
+
+def test_string_content_is_untouched():
+    messages = [{"role": "user", "content": "plain string"}]
+    out = strip_unsupported_content_blocks(messages)
+    assert out[0]["content"] == "plain string"
+
+
+def test_stored_history_is_never_mutated():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "x", "signature": "s"},
+                {"type": "text", "text": "ok"},
+            ],
+        },
+    ]
+    original = copy.deepcopy(messages)
+    strip_unsupported_content_blocks(messages)
+    # The UI transcript and session persistence must keep the reasoning trace.
+    assert messages == original
+
+
+def test_nothing_to_strip_returns_input_unchanged():
+    messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+    out = strip_unsupported_content_blocks(messages)
+    assert out == messages
+
+
+def test_empty_messages_is_safe():
+    assert strip_unsupported_content_blocks([]) == []
+
+
+def test_custom_allowed_set_is_honoured():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hi"},
+                {"type": "image_url", "image_url": {"url": "u"}},
+            ],
+        }
+    ]
+    out = strip_unsupported_content_blocks(messages, allowed={"text"})
+    assert out[0]["content"] == [{"type": "text", "text": "hi"}]
+
+
+def test_tool_calls_and_other_keys_survive_the_copy():
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "x"},
+                {"type": "text", "text": "calling"},
+            ],
+            "tool_calls": [
+                {"id": "c1", "type": "function",
+                 "function": {"name": "f", "arguments": "{}"}}
+            ],
+        }
+    ]
+    out = strip_unsupported_content_blocks(messages)
+    assert out[0]["tool_calls"] == messages[0]["tool_calls"]
+    assert out[0]["role"] == "assistant"

--- a/tests/run_agent/test_unsupported_content_block_wiring.py
+++ b/tests/run_agent/test_unsupported_content_block_wiring.py
@@ -103,6 +103,34 @@ def _block_types(messages):
     return out
 
 
+def _sent_text(messages):
+    """All visible text in the payload, regardless of content representation.
+
+    Downstream normalization may flatten a content list into a plain string
+    before the transport, so assertions about surviving *text* must not depend
+    on the blocks still being a list. Reasoning text must never appear here.
+    """
+    parts = []
+    for m in messages or []:
+        c = m.get("content")
+        if isinstance(c, str):
+            parts.append(c)
+        elif isinstance(c, list):
+            for b in c:
+                if isinstance(b, dict) and isinstance(b.get("text"), str):
+                    parts.append(b["text"])
+    return "\n".join(parts)
+
+
+def _has_reasoning_leak(messages):
+    """True if any disallowed reasoning block survived, in either representation."""
+    if "thinking" in _block_types(messages):
+        return True
+    # If content was flattened to a string, the reasoning body would ride along
+    # as plain text — catch that too.
+    return "internal reasoning" in _sent_text(messages)
+
+
 # --------------------------------------------------------------------------
 # Main conversation loop wiring.
 # --------------------------------------------------------------------------
@@ -113,10 +141,9 @@ def test_main_loop_strips_thinking_block_for_copilot_gemini():
     sent = _run_turn(agent, _mixed_history())
 
     assert sent is not None, "provider was never called"
-    types = _block_types(sent)
-    assert "thinking" not in types, f"thinking block reached the wire: {types}"
-    # The visible half of the same message must survive.
-    assert "text" in types
+    assert not _has_reasoning_leak(sent), f"reasoning reached the wire: {sent}"
+    # The visible half of the same message must survive the strip.
+    assert "visible answer" in _sent_text(sent)
 
 
 def test_main_loop_preserves_thinking_block_for_claude():
@@ -125,7 +152,7 @@ def test_main_loop_preserves_thinking_block_for_claude():
     sent = _run_turn(agent, _mixed_history())
 
     assert sent is not None, "provider was never called"
-    assert "thinking" in _block_types(sent)
+    assert _has_reasoning_leak(sent), "reasoning was stripped for a non-Gemini model"
 
 
 def test_gate_does_not_fire_on_empty_base_url():
@@ -182,10 +209,12 @@ def test_main_loop_keeps_allowed_block_types_intact():
     sent = _run_turn(agent, history)
 
     assert sent is not None, "provider was never called"
-    types = _block_types(sent)
-    assert "redacted_thinking" not in types, f"disallowed block reached wire: {types}"
+    assert "redacted_thinking" not in _block_types(sent)
+    assert "opaque" not in _sent_text(sent), "redacted reasoning reached the wire"
     # Every allowed block survives — both user text parts and the answer.
-    assert types.count("text") == 3, types
+    text = _sent_text(sent)
+    for expected in ("part one", "part two", "answer"):
+        assert expected in text, f"{expected!r} missing from payload: {text!r}"
 
 
 # --------------------------------------------------------------------------
@@ -215,8 +244,7 @@ def test_summary_path_strips_thinking_block_for_copilot_gemini():
     sent = _run_summary(agent, _mixed_history())
 
     assert sent is not None, "summary path never reached the provider"
-    types = _block_types(sent)
-    assert "thinking" not in types, f"thinking block reached the wire: {types}"
+    assert not _has_reasoning_leak(sent), f"reasoning reached the wire: {sent}"
 
 
 def test_summary_path_preserves_thinking_block_for_claude():
@@ -224,4 +252,4 @@ def test_summary_path_preserves_thinking_block_for_claude():
     sent = _run_summary(agent, _mixed_history())
 
     assert sent is not None, "summary path never reached the provider"
-    assert "thinking" in _block_types(sent)
+    assert _has_reasoning_leak(sent), "reasoning was stripped for a non-Gemini model"

--- a/tests/run_agent/test_unsupported_content_block_wiring.py
+++ b/tests/run_agent/test_unsupported_content_block_wiring.py
@@ -1,0 +1,227 @@
+"""Outbound-payload tests for the unsupported-content-block strip.
+
+Companion to ``test_unsupported_content_block_strip.py``, which covers the
+helper in isolation. These tests exercise the two WIRING sites by driving a
+real ``run_conversation`` / summary call and inspecting the payload the
+provider actually receives:
+
+- the main conversation loop (``agent/conversation_loop.py``)
+- the bounded-response summary path (``agent/chat_completion_helpers.py``)
+
+They assert on the intercepted ``chat.completions.create(**kwargs)`` messages
+rather than on the helper's return value, so a regression that removes either
+call site fails here even though the helper still works.
+"""
+
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+
+from run_agent import AIAgent
+
+COPILOT = "https://api.githubcopilot.com"
+
+
+def _mock_response(content="done", finish_reason="stop"):
+    msg = SimpleNamespace(
+        content=content, tool_calls=None, reasoning_content=None, reasoning=None
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=msg, finish_reason=finish_reason)],
+        model="test/model",
+        usage=None,
+    )
+
+
+def _make_agent(model: str, base_url: str) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url=base_url,
+            model=model,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    a.client = MagicMock()
+    a._cached_system_prompt = "You are helpful."
+    a._use_prompt_caching = False
+    a.tool_delay = 0
+    a.compression_enabled = False
+    a.save_trajectories = False
+    return a
+
+
+def _mixed_history():
+    """A Claude-style turn: signed thinking block next to visible text."""
+    return [
+        {"role": "user", "content": "first question"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "internal reasoning", "signature": "sig"},
+                {"type": "text", "text": "visible answer"},
+            ],
+        },
+    ]
+
+
+def _run_turn(agent, history):
+    """Drive one turn and return the messages sent to the provider."""
+    captured = {}
+
+    def _capture(*_args, **kwargs):
+        captured.setdefault("messages", copy.deepcopy(kwargs.get("messages")))
+        return _mock_response()
+
+    agent.client.chat.completions.create.side_effect = _capture
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        agent.run_conversation("second question", conversation_history=history)
+    return captured.get("messages")
+
+
+def _block_types(messages):
+    out = []
+    for m in messages or []:
+        c = m.get("content")
+        if isinstance(c, list):
+            out.extend(
+                str(b.get("type")) for b in c if isinstance(b, dict) and b.get("type")
+            )
+    return out
+
+
+# --------------------------------------------------------------------------
+# Main conversation loop wiring.
+# --------------------------------------------------------------------------
+
+
+def test_main_loop_strips_thinking_block_for_copilot_gemini():
+    agent = _make_agent("gemini-3.6-flash", COPILOT)
+    sent = _run_turn(agent, _mixed_history())
+
+    assert sent is not None, "provider was never called"
+    types = _block_types(sent)
+    assert "thinking" not in types, f"thinking block reached the wire: {types}"
+    # The visible half of the same message must survive.
+    assert "text" in types
+
+
+def test_main_loop_preserves_thinking_block_for_claude():
+    """The same history on Claude must go out untouched."""
+    agent = _make_agent("claude-opus-4.8", COPILOT)
+    sent = _run_turn(agent, _mixed_history())
+
+    assert sent is not None, "provider was never called"
+    assert "thinking" in _block_types(sent)
+
+
+def test_gate_does_not_fire_on_empty_base_url():
+    """An unknown/empty endpoint is NOT Copilot — do not strip on a guess.
+
+    Regression guard: the gate previously matched any bare ``gemini*`` model
+    when no base URL was known, which would strip reasoning blocks for an
+    unverified endpoint. Asserted at the gate rather than through a live turn
+    because ``AIAgent`` refuses to construct without a resolvable provider.
+    """
+    from agent.agent_runtime_helpers import _model_requires_text_image_blocks_only
+
+    assert _model_requires_text_image_blocks_only("gemini-3.6-flash", "") is False
+    assert _model_requires_text_image_blocks_only("gemini-3.6-flash", None) is False
+    # ...while affirmative Copilot evidence still matches.
+    assert _model_requires_text_image_blocks_only("gemini-3.6-flash", COPILOT) is True
+
+
+def test_main_loop_does_not_mutate_stored_history():
+    """Stored history keeps the reasoning trace for the UI and persistence."""
+    agent = _make_agent("gemini-3.6-flash", COPILOT)
+    history = _mixed_history()
+    snapshot = copy.deepcopy(history)
+
+    _run_turn(agent, history)
+
+    assert history == snapshot
+
+
+def test_main_loop_keeps_allowed_block_types_intact():
+    """Only disallowed types are dropped; allowed ones pass through untouched.
+
+    Uses two text blocks plus a disallowed one rather than a real image, since
+    an image payload is rewritten by vision preprocessing before it reaches the
+    transport, which would test that pipeline instead of this strip.
+    """
+    agent = _make_agent("gemini-3.6-flash", COPILOT)
+    history = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "part one"},
+                {"type": "text", "text": "part two"},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "redacted_thinking", "data": "opaque"},
+                {"type": "text", "text": "answer"},
+            ],
+        },
+    ]
+    sent = _run_turn(agent, history)
+
+    assert sent is not None, "provider was never called"
+    types = _block_types(sent)
+    assert "redacted_thinking" not in types, f"disallowed block reached wire: {types}"
+    # Every allowed block survives — both user text parts and the answer.
+    assert types.count("text") == 3, types
+
+
+# --------------------------------------------------------------------------
+# Summary path wiring (chat_completion_helpers).
+# --------------------------------------------------------------------------
+
+
+def _run_summary(agent, history):
+    """Drive the bounded-response summary path; return the sent messages."""
+    from agent.chat_completion_helpers import handle_max_iterations
+
+    captured = {}
+
+    def _capture(*_args, **kwargs):
+        captured.setdefault("messages", copy.deepcopy(kwargs.get("messages")))
+        return _mock_response("summary text")
+
+    agent.client.chat.completions.create.side_effect = _capture
+    messages = list(history)
+    agent.messages = messages
+    handle_max_iterations(agent, messages, api_call_count=90)
+    return captured.get("messages")
+
+
+def test_summary_path_strips_thinking_block_for_copilot_gemini():
+    agent = _make_agent("gemini-3.6-flash", COPILOT)
+    sent = _run_summary(agent, _mixed_history())
+
+    assert sent is not None, "summary path never reached the provider"
+    types = _block_types(sent)
+    assert "thinking" not in types, f"thinking block reached the wire: {types}"
+
+
+def test_summary_path_preserves_thinking_block_for_claude():
+    agent = _make_agent("claude-opus-4.8", COPILOT)
+    sent = _run_summary(agent, _mixed_history())
+
+    assert sent is not None, "summary path never reached the provider"
+    assert "thinking" in _block_types(sent)


### PR DESCRIPTION
## Problem

GitHub Copilot's Gemini models reject any content block whose `type` is not `text` or `image_url`:

```text
HTTP 400 {"error": {"message": "type has to be either 'image_url' or 'text'", "code": "invalid_request_body"}}
```

A session that ran on a Claude model persists extended thinking as `{"type": "thinking", ...}` / `{"type": "redacted_thinking", ...}` content blocks. Switching that session mid-conversation to a Copilot Gemini model replays those blocks onto the wire, so **every turn from that point on 400s** and the conversation is unusable until a brand-new session is started.

I hit this after switching a live session to an affected Copilot Gemini model.

## Root cause

Nothing in the pre-call sanitizer chain filters content blocks by `type`. The existing `_drop_thinking_only_and_merge_users` only drops assistant turns that are *entirely* reasoning — a mixed `[thinking, text]` message (the common shape) survives intact and its `thinking` block goes out on the wire.

## Isolating the trigger

Against a Copilot Gemini model, with the same credentials and model:

| Request | Result |
|---|---|
| plain / streaming / system prompt / tools / temperature | 200 |
| tool schemas with `anyOf`, `nullable`, `enum`, `minItems`… | 200 |
| 32k → 1000k token payloads | 200 |
| `reasoning_text` / `reasoning_opaque` on an assistant message | 200 |
| **assistant content containing `{"type": "thinking", ...}`** | **400 `invalid_request_body`** |

So it is specifically the content-block type, not payload size, tool schemas, or reasoning metadata.

## Fix

Add `strip_unsupported_content_blocks()`, which drops blocks the target endpoint won't accept, gated behind `_model_requires_text_image_blocks_only()` so it runs **only** for Gemini served by Copilot — direct `api.githubcopilot.com`, or the same models proxied via litellm as `github_copilot/gemini-*`. Claude, GPT, and Gemini on Google's native endpoint are untouched.

Design notes:

- Runs on the **per-call `api_messages` copy only**, right after the existing `_drop_thinking_only_and_merge_users`. Stored history keeps the full reasoning trace for the UI transcript and session persistence — the function is pure and shallow-copies before mutating.
- A message whose content list becomes empty is normalized to `""` rather than `[]`, since some providers reject an empty content array. The surrounding sanitizers already handle empty-assistant turns.
- Wired into **both** call sites that build a chat payload — the main conversation loop and the bounded-response summary path in `chat_completion_helpers` — rather than just the one that reproduced the bug.

## Verification

End-to-end against the real endpoint: the identical message list returns **400** with the `thinking` block present and **200** once stripped.

15 regression tests in `tests/run_agent/test_unsupported_content_block_strip.py` cover:
- the gate — Copilot Gemini and the litellm `github_copilot/` namespace match; Claude, GPT, and native-endpoint Gemini do not
- the strip — `thinking` and `redacted_thinking` removed, `text` and `image_url` preserved, thinking-only content normalized to `""`, `tool_calls` and other keys preserved
- the purity guarantee — stored history is never mutated

They fail before the fix (`ImportError`) and pass after. Also ran the neighbouring sanitizer suites — `tests/run_agent/test_thinking_only_sanitizer.py`, `test_tool_call_args_sanitizer.py`, `tests/tools/test_schema_sanitizer.py` plus the new file: **98 passed**.

## What I could not verify

I ran the targeted and neighbouring suites locally, not the full `tests/run_agent/ tests/tools/` sweep (~11k cases) — leaving that to CI.

The gate is deliberately narrow because I could only test the Copilot endpoint. If other providers reject the same blocks, the allowlist is a parameter and the gate is one predicate, so widening it is a one-line change.

## Related

This is distinct from the `array`-missing-`items` Gemini 400 tracked in #71804 — different symptom (`invalid request body` from a tool schema vs. `type has to be either 'image_url' or 'text'` from message content), different code path, different fix. I hit both while debugging the same session and am deliberately not touching the `items` one here, since #71804 already has PRs.
