### PR TITLE
fix(desktop): reconcile backend main-lane ids with the frontend overlay convention (#71837)

### DIFF
--- a/tests/tui_gateway/test_git_probe.py
+++ b/tests/tui_gateway/test_git_probe.py
@@ -1,0 +1,52 @@
+"""Unit tests for ``tui_gateway.git_probe.resolve`` root normalization.
+
+The desktop "duplicate branch lanes" bug (a repo's main checkout showing both a
+``main`` lane and a folder-named lane holding the same sessions) traces back to
+``resolve`` returning a ``worktree_root`` and ``repo_root`` that are the same
+location spelled differently, so ``project_tree`` cannot recognize the main
+checkout. In production the mismatch is Windows separator style —
+``git rev-parse --show-toplevel`` prints ``C:/Users/x/repo`` while
+``common_repo_root`` runs the result through ``os.path.realpath`` and gets
+``C:\\Users\\x\\repo``. ``resolve`` now normalizes both with
+``os.path.normpath`` so the main-checkout comparison holds.
+
+These tests exercise the normalization portably (``os.path.normpath`` is
+``ntpath`` on Windows but ``posixpath`` on the Linux CI host, so backslash
+conversion can't be asserted cross-platform); they use redundant path segments
+that ``posixpath.normpath`` collapses to prove both roots are normalized and end
+up equal for a main checkout.
+"""
+from __future__ import annotations
+
+from tui_gateway import git_probe
+
+
+def test_resolve_normalizes_both_roots(monkeypatch):
+    # Same location, spelled with a redundant "." segment / trailing slash — the
+    # kind of textual difference that left main checkouts misclassified.
+    monkeypatch.setattr(git_probe, "repo_root", lambda _cwd: "/home/u/repo/./")
+    monkeypatch.setattr(git_probe, "common_repo_root", lambda _cwd: "/home/u/repo")
+
+    info = git_probe.resolve("/home/u/repo")
+
+    assert info == {"repo_root": "/home/u/repo", "worktree_root": "/home/u/repo"}
+    # The whole point: a main checkout now compares equal.
+    assert info["worktree_root"] == info["repo_root"]
+
+
+def test_resolve_preserves_distinct_worktree_root(monkeypatch):
+    # A genuine linked worktree (distinct location) must stay distinct after
+    # normalization, so it is still folded under its common root as non-main.
+    monkeypatch.setattr(git_probe, "repo_root", lambda _cwd: "/home/u/repo/../repo-wt")
+    monkeypatch.setattr(git_probe, "common_repo_root", lambda _cwd: "/home/u/repo")
+
+    info = git_probe.resolve("/home/u/repo-wt")
+
+    assert info == {"repo_root": "/home/u/repo", "worktree_root": "/home/u/repo-wt"}
+    assert info["worktree_root"] != info["repo_root"]
+
+
+def test_resolve_returns_none_when_not_a_repo(monkeypatch):
+    monkeypatch.setattr(git_probe, "repo_root", lambda _cwd: "")
+
+    assert git_probe.resolve("/tmp/not-a-repo") is None

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -193,8 +193,28 @@ def test_non_git_cwd_preserves_legacy_workspace_grouping():
     assert project["isAuto"] is True
     assert project["label"] == "notes"
     assert project["sessionCount"] == 1
-    assert _lane_ids(project) == ["/work/notes"]
+    # A non-git folder's main lane uses the canonical ``<root>::branch::main``
+    # lane id (not the raw path) so the desktop live overlay matches it instead
+    # of injecting a duplicate synthetic "main" lane.
+    assert _lane_ids(project) == ["/work/notes::branch::main"]
+    lane = project["repos"][0]["groups"][0]
+    assert lane["label"] == "main"
+    assert lane["isMain"] is True
     assert tree["scoped_session_ids"] == [legacy["id"]]
+
+
+def test_non_git_folder_main_lane_matches_frontend_overlay_convention():
+    # Regression for the desktop duplicate-branch-lane bug: the backend heuristic
+    # lane for a plain folder must equal what the frontend live overlay computes
+    # (``branchLaneId(repoRoot, 'main')``); otherwise the overlay can't match it
+    # and pushes a second "main" lane holding the same sessions.
+    path = "/work/scratch"
+    legacy = _session(path)
+
+    tree = pt.build_tree([], [legacy], [], resolve=lambda _cwd: None, hydrate=True)
+    project = tree["projects"][0]
+
+    assert _lane_ids(project) == [pt._branch_lane_id(path, "main")]
 
 
 def test_non_git_windows_cwd_preserves_legacy_workspace_grouping():

--- a/tui_gateway/git_probe.py
+++ b/tui_gateway/git_probe.py
@@ -162,11 +162,21 @@ def resolve(cwd: str) -> dict | None:
     Returns ``{"repo_root": <common root>, "worktree_root": <this checkout>}``
     or ``None`` when ``cwd`` is not in a git repo. ``build_tree`` treats
     ``worktree_root == repo_root`` as the main checkout.
+
+    Both roots are ``os.path.normpath``-normalized so the main-checkout test
+    holds on Windows: ``repo_root`` comes from ``git rev-parse --show-toplevel``
+    (forward slashes, e.g. ``C:/Users/x/repo``) while ``common_repo_root`` runs
+    the result through ``os.path.realpath`` (backslashes, ``C:\\Users\\x\\repo``).
+    Without normalization the two never compare equal there, so a repo's own
+    main checkout is misclassified as a linked worktree and gets a path-keyed
+    lane instead of the canonical ``<root>::branch::main`` lane.
     """
     worktree_root = repo_root(cwd)
     if not worktree_root:
         return None
-    return {"repo_root": common_repo_root(cwd) or worktree_root, "worktree_root": worktree_root}
+    worktree_root = os.path.normpath(worktree_root)
+    repo = os.path.normpath(common_repo_root(cwd) or worktree_root)
+    return {"repo_root": repo, "worktree_root": worktree_root}
 
 
 def warm_roots(cwds: Iterable[str], max_workers: int = _WARM_WORKERS) -> None:

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -212,7 +212,14 @@ def _place_by_heuristic(path: str) -> Optional[dict]:
         repo_path = _with_base_name(path, m.group(1))
         return _placement(repo_path, path, m.group(2), path, False, False)
 
-    return _placement(path, path, base, path, True, False)
+    # A plain (non-git) folder is still a "main" lane. Use the canonical
+    # ``<root>::branch::main`` lane id and ``main`` label so the desktop live
+    # overlay (``overlayRepoLanes`` -> ``branchLaneId(repoRoot, 'main')``)
+    # matches this lane instead of injecting a second synthetic ``main`` lane
+    # for the same sessions.
+    return _placement(
+        path, _branch_lane_id(path, DEFAULT_BRANCH_LABEL), DEFAULT_BRANCH_LABEL, path, True, False
+    )
 
 
 def _place(cwd: str, branch: str, resolve: Optional[Resolve], persisted_root: str) -> Optional[dict]:


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop sidebar showing **two branch lanes for the same sessions** in a single project on Windows (a `main` lane plus a folder-named lane; the same session can even show a different title per lane because one comes from the backend snapshot and the other from the frontend live overlay).

The desktop live overlay (`overlayRepoLanes` in `apps/desktop/.../workspace-groups.ts`) places every live session at `branchLaneId(repoRoot, "main")` = `<root>::branch::main` (label `main`), and matches an existing lane by exact id, then by `isMain` + case-insensitive label. Two backend defects emit a **non-canonical** main-lane id, so both match attempts fail and the overlay injects a second synthetic `main` lane holding the same sessions:

1. **`tui_gateway/git_probe.py` — `resolve()`**: `worktree_root` comes from `git rev-parse --show-toplevel` (forward slashes on Windows, `C:/Users/x/repo`) while `repo_root` runs through `os.path.realpath` (backslashes, `C:\Users\x\repo`). `project_tree._place()` compares them with `==` to detect the main checkout, which never holds on Windows, so the repo's own main checkout is misclassified as a *linked worktree* and gets a path-keyed lane. Fix: normalize both roots with `os.path.normpath`.
2. **`tui_gateway/project_tree.py` — `_place_by_heuristic()`**: a non-git folder's main lane was keyed by its raw path with the folder basename as label. Fix: emit the canonical `<root>::branch::main` lane id and `main` label so it matches the overlay.

## Why

Both lanes come from two data sources (backend snapshot vs frontend live overlay) keyed by different lane ids, so the UI double-lists the same sessions. Backend-only change — no Electron rebuild required.

## Testing

- `tests/tui_gateway/test_git_probe.py` (new): `resolve()` normalizes both roots so a main checkout compares equal, keeps a genuinely-distinct linked worktree distinct, and returns `None` for non-repos. (Written POSIX-portably — `os.path.normpath` is `ntpath` on Windows but `posixpath` on CI, so backslash conversion isn't assertable cross-platform; the tests use redundant path segments `posixpath` collapses.)
- `tests/tui_gateway/test_project_tree.py`: updated the legacy non-git grouping test to the canonical `<root>::branch::main` lane id + `main` label, and added `test_non_git_folder_main_lane_matches_frontend_overlay_convention` asserting the backend lane id equals what the overlay computes.
- All gates pass (`ruff`, windows-footguns, affected tests). Also ran `tests/tui_gateway/test_projects_rpc.py` (22 passed).

### Known cosmetic side effect

Non-git folder lanes now label `main` instead of the folder basename, consistent with git-repo behavior — noted in #71837.

Fixes #71837
