### PR TITLE
Keep initially blocked Kanban tasks sticky

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3172,6 +3172,21 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                if task_status == "blocked":
+                    # ``recompute_ready`` treats explicit blocked events as
+                    # sticky operator gates. Creation-time blocks need the
+                    # same durable marker or the next dispatcher tick can
+                    # silently promote them.
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": "initial_status=blocked",
+                            "kind": None,
+                            "recurrences": 1,
+                        },
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -272,6 +272,30 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Create-time blocked rows are also sticky
+# ---------------------------------------------------------------------------
+
+
+def test_create_time_blocked_task_survives_recompute_ready(kanban_home: Path) -> None:
+    """A task deliberately created as blocked must remain an inert human gate."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="parked owner decision",
+            initial_status="blocked",
+        )
+
+        events = conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id",
+            (tid,),
+        ).fetchall()
+        assert [row["kind"] for row in events] == ["created", "blocked"]
+        assert kb._has_sticky_block(conn, tid) is True
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+# ---------------------------------------------------------------------------
 # Schema-init recovery on legacy DBs is covered by
 # tests/hermes_cli/test_kanban_db.py::test_connect_migrates_legacy_db_before_optional_column_indexes
 # (landed via #28754 / #28781).  The original PR shipped a duplicate test


### PR DESCRIPTION
## What changed

- Records an explicit `blocked` event when a Kanban task is created with `initial_status="blocked"`.
- Adds a regression test proving the initial block is sticky and that `recompute_ready()` does not promote the task.

## Root cause

The task row could be created in the blocked state without the event history used by `_has_sticky_block()`. A later readiness recomputation therefore treated the initial block as non-sticky and could promote the task.

## User impact

Tasks intentionally created as blocked remain blocked until an explicit operator action changes that state.

## Validation

- Replayed as a two-file commit on current upstream `main` in an isolated worktree.
- `468 passed, 1 skipped` across the sticky-block regression and adjacent Kanban core, DB, init, repair, decompose, and specify suites.
- `git diff --check` passed.
- No live Kanban task data was accessed or mutated by the publication work.