### PR TITLE
fix(telegram): preserve pending-update queue on cold boot by default

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -698,6 +698,19 @@ class TelegramAdapter(BasePlatformAdapter):
         # can leave Bot API 10.1 rich draft frames visually overlaid until the
         # chat is redrawn, while final rich messages remain useful.
         self._rich_drafts_enabled: bool = self._coerce_bool_extra("rich_drafts", False)
+        # platforms.telegram.catchup_on_startup (default True): whether a
+        # COLD boot (is_reconnect=False) preserves Telegram's server-side
+        # pending-update queue instead of dropping it. Telegram retains
+        # undelivered updates for ~24h regardless, so this only controls
+        # whether Hermes asks for them back after a fresh process start --
+        # the dominant real-world cold-boot case on a laptop/desktop is the
+        # machine having been off/asleep, which is exactly the outage #46621
+        # already preserves the queue for on the *reconnect* path. Without
+        # this, every reboot silently discarded commands sent while the
+        # machine was off, with no log line (issue #71811).
+        self._catchup_on_startup: bool = self._coerce_bool_extra(
+            "catchup_on_startup", True
+        )
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
         # endpoint) so later sends skip the doomed rich attempt entirely.
@@ -3889,6 +3902,25 @@ class TelegramAdapter(BasePlatformAdapter):
             # Decide between webhook and polling mode
             webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL", "").strip()
 
+            # Reconnect (watcher-recovered outage) always preserves the
+            # queue (#46621). Cold boot (fresh process) preserves it too
+            # unless the operator opted out via catchup_on_startup: false --
+            # see the field comment on self._catchup_on_startup above.
+            drop_pending = (not is_reconnect) and not self._catchup_on_startup
+            if not is_reconnect:
+                if drop_pending:
+                    logger.info(
+                        "[%s] Cold boot: dropping any Telegram updates queued "
+                        "while offline (platforms.telegram.catchup_on_startup: false)",
+                        self.name,
+                    )
+                else:
+                    logger.info(
+                        "[%s] Cold boot: preserving Telegram's pending-update "
+                        "queue (delivered within its ~24h retention window)",
+                        self.name,
+                    )
+
             if webhook_url:
                 # ── Webhook mode ─────────────────────────────────────
                 # Telegram pushes updates to our HTTP endpoint.  This
@@ -3928,9 +3960,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     allowed_updates=Update.ALL_TYPES,
                     # Webhooks are push-based — Telegram does not hold a
                     # server-side getUpdates queue, so this flag is a no-op
-                    # in practice. Mirror the polling path's reconnect
-                    # semantics for consistency.
-                    drop_pending_updates=not is_reconnect,
+                    # in practice. Mirror the polling path's cold-boot/
+                    # reconnect/catchup_on_startup semantics for consistency.
+                    drop_pending_updates=drop_pending,
                 )
                 self._webhook_mode = True
                 self._polling_progress_accepting = False
@@ -3981,10 +4013,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._polling_error_callback_ref = _polling_error_callback
 
                 polling_started = await self._start_polling_resilient(
-                    # On a cold first boot drop the stale Bot API queue; on a
-                    # watcher reconnect after an outage preserve it so messages
-                    # sent while the bot was offline are delivered (#46621).
-                    drop_pending_updates=not is_reconnect,
+                    # Preserve the pending-update queue on both cold boot
+                    # and watcher reconnect by default (#46621, #71811) --
+                    # Telegram's own ~24h retention bounds the replay.
+                    # Opt out via platforms.telegram.catchup_on_startup: false.
+                    drop_pending_updates=drop_pending,
                     error_callback=_polling_error_callback,
                     require_progress=not is_reconnect,
                 )

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -645,9 +645,32 @@ def _build_polling_app(monkeypatch, adapter):
 
 
 @pytest.mark.asyncio
-async def test_cold_connect_drops_pending_updates(monkeypatch):
-    """A cold first boot (is_reconnect=False) drops the stale Bot API queue."""
+async def test_cold_connect_preserves_pending_updates_by_default(monkeypatch):
+    """Regression (issue #71811): a cold first boot (is_reconnect=False) now
+    preserves the queue by default, the same as a reconnect -- Telegram's
+    own ~24h retention bounds the replay. Every real-machine reboot runs
+    this cold-boot path, so dropping by default silently discarded commands
+    sent while the machine was off/asleep."""
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    captured = _build_polling_app(monkeypatch, adapter)
+
+    ok = await adapter.connect()  # default is_reconnect=False
+
+    assert ok is True
+    assert captured["drop_pending_updates"] is False
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
+async def test_cold_connect_drops_pending_updates_when_catchup_disabled(monkeypatch):
+    """platforms.telegram.catchup_on_startup: false opts back into the old
+    drop-on-cold-boot behavior, for operators who explicitly want it."""
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True, token="***",
+            extra={"catchup_on_startup": False},
+        )
+    )
     captured = _build_polling_app(monkeypatch, adapter)
 
     ok = await adapter.connect()  # default is_reconnect=False
@@ -658,9 +681,29 @@ async def test_cold_connect_drops_pending_updates(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_cold_connect_catchup_disabled_string_form(monkeypatch):
+    """YAML-string 'false' must also disable catchup (config values coming
+    from config.yaml are often strings, not native bools)."""
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True, token="***",
+            extra={"catchup_on_startup": "false"},
+        )
+    )
+    captured = _build_polling_app(monkeypatch, adapter)
+
+    ok = await adapter.connect()
+
+    assert ok is True
+    assert captured["drop_pending_updates"] is True
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
 async def test_reconnect_preserves_pending_updates(monkeypatch):
     """A watcher reconnect (is_reconnect=True) preserves the queue Telegram
-    accumulated during the outage — the core of #46621."""
+    accumulated during the outage — the core of #46621. Unaffected by
+    catchup_on_startup, which only governs the cold-boot path."""
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
     captured = _build_polling_app(monkeypatch, adapter)
 
@@ -668,6 +711,47 @@ async def test_reconnect_preserves_pending_updates(monkeypatch):
 
     assert ok is True
     assert captured["drop_pending_updates"] is False
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
+async def test_reconnect_ignores_catchup_on_startup_false(monkeypatch):
+    """catchup_on_startup: false must only affect the cold-boot path --
+    a reconnect must still preserve the queue regardless (#46621's
+    guarantee must not regress for operators who opt out of cold-boot
+    catchup)."""
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True, token="***",
+            extra={"catchup_on_startup": False},
+        )
+    )
+    captured = _build_polling_app(monkeypatch, adapter)
+
+    ok = await adapter.connect(is_reconnect=True)
+
+    assert ok is True
+    assert captured["drop_pending_updates"] is False
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
+async def test_cold_connect_logs_the_catchup_decision(monkeypatch, caplog):
+    """Regression (#71811): 'nothing is logged when the queue is dropped'
+    was part of the reported bug -- the decision must now be visible in
+    logs either way, so an operator debugging a missing command can see
+    what happened."""
+    import logging
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    _build_polling_app(monkeypatch, adapter)
+
+    with caplog.at_level(logging.INFO, logger="plugins.platforms.telegram.adapter"):
+        await adapter.connect()
+
+    assert any(
+        "preserving" in r.message.lower() and "pending-update" in r.message.lower()
+        for r in caplog.records
+    ), [r.message for r in caplog.records]
     await _cancel_heartbeat(adapter)
 
 

--- a/tests/gateway/test_telegram_polling_progress.py
+++ b/tests/gateway/test_telegram_polling_progress.py
@@ -166,6 +166,77 @@ async def test_polling_disconnect_webhook_reconnect_heals_webhook_send_path(monk
         await adapter.disconnect()
 
 
+# ── drop_pending_updates on the webhook start path (review of #71862) ──────
+#
+# The existing webhook test above only asserts that start_webhook() was
+# awaited, not what value it was called with -- so a cold-start or reconnect
+# queue-policy regression on the webhook path went undetected. Webhooks are
+# push-based (Telegram holds no server-side getUpdates queue for this
+# call), so drop_pending_updates is a no-op in practice here, but the
+# adapter still computes and passes the SAME drop_pending value as the
+# polling path for consistency, and that computation itself is exactly
+# what's being regression-tested.
+
+def _webhook_connect_adapter(monkeypatch, *, extra=None):
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="test-token", extra=extra or {})
+    )
+    webhook_app = _lifecycle_app()
+    _configure_lifecycle_connect(monkeypatch, adapter, [webhook_app])
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.test/telegram")
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "test-secret")
+    return adapter, webhook_app
+
+
+@pytest.mark.asyncio
+async def test_webhook_cold_start_default_preserves_pending_updates(monkeypatch):
+    """Cold boot (is_reconnect=False), catchup_on_startup left at its
+    default (true): drop_pending_updates must be False."""
+    adapter, webhook_app = _webhook_connect_adapter(monkeypatch)
+    try:
+        assert await adapter.connect(is_reconnect=False) is True
+        webhook_app.updater.start_webhook.assert_awaited_once()
+        kwargs = webhook_app.updater.start_webhook.call_args.kwargs
+        assert kwargs["drop_pending_updates"] is False
+    finally:
+        await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_webhook_cold_start_configured_opt_out_drops_pending_updates(monkeypatch):
+    """Cold boot with catchup_on_startup explicitly disabled:
+    drop_pending_updates must be True, matching the polling path's
+    opt-out semantics."""
+    adapter, webhook_app = _webhook_connect_adapter(
+        monkeypatch, extra={"catchup_on_startup": False}
+    )
+    try:
+        assert await adapter.connect(is_reconnect=False) is True
+        webhook_app.updater.start_webhook.assert_awaited_once()
+        kwargs = webhook_app.updater.start_webhook.call_args.kwargs
+        assert kwargs["drop_pending_updates"] is True
+    finally:
+        await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_webhook_reconnect_always_preserves_pending_updates(monkeypatch):
+    """A reconnect (is_reconnect=True) must preserve the queue regardless
+    of catchup_on_startup -- that setting only governs the FIRST
+    (cold-boot) connection, matching the polling path's reconnect
+    semantics from #46621."""
+    adapter, webhook_app = _webhook_connect_adapter(
+        monkeypatch, extra={"catchup_on_startup": False}
+    )
+    try:
+        assert await adapter.connect(is_reconnect=True) is True
+        webhook_app.updater.start_webhook.assert_awaited_once()
+        kwargs = webhook_app.updater.start_webhook.call_args.kwargs
+        assert kwargs["drop_pending_updates"] is False
+    finally:
+        await adapter.disconnect()
+
+
 @pytest.mark.asyncio
 async def test_webhook_disconnect_polling_reconnect_resets_mode_and_waits_for_progress(
     monkeypatch,

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -104,6 +104,22 @@ platforms:
 
 Telegram allows up to 100 BotCommands, but large command payloads can fail. Hermes defaults to 60 for reliability and clamps configured values to `1..100`; use `/commands` for the full command list.
 
+### Cold-boot update catchup (Optional)
+
+By default, when the gateway starts fresh (not a watcher-recovered reconnect), Hermes preserves any Telegram updates that queued while it was offline — bounded by Telegram's own ~24h retention window. This matters most on a laptop or desktop: the machine being shut down or asleep is a cold boot from the gateway's point of view, so without this a reboot silently discarded any command sent while the machine was off.
+
+To opt back into the old behavior — dropping the queue on every fresh start — set:
+
+```yaml
+gateway:
+  platforms:
+    telegram:
+      extra:
+        catchup_on_startup: false
+```
+
+The gateway logs which choice it made on every cold boot (`Cold boot: preserving...` / `Cold boot: dropping...`), so you can confirm the setting took effect.
+
 ## Step 3: Privacy Mode (Critical for Groups)
 
 Telegram bots have a **privacy mode** that is **enabled by default**. This is the single most common source of confusion when using bots in groups.


### PR DESCRIPTION
## Context

Fixes #71811.

## Problem

A cold gateway boot discarded every Telegram update queued while the bot was offline. `connect()` passed `drop_pending_updates=not is_reconnect`, so the cold-start path told Telegram to throw the queue away. #46621 fixed this for the watcher-reconnect path, but on a laptop/desktop the dominant outage is the machine being shut down or asleep -- every power-on runs the cold-boot path, so commands sent while offline were silently deleted with no log line.

## Fix

Added `platforms.telegram.catchup_on_startup` config key (default: `true`) controlling whether a cold boot preserves the pending-update queue -- exposed as config.yaml (not an env var, per the standing policy noted when #41193 was closed) rather than silently flipping the default with no opt-out. Reconnect (#46621) is unaffected regardless of this setting. Applied to both the polling and webhook startup paths. Logs the decision on every cold boot, addressing the "nothing is logged" complaint. Documented in the Telegram guide.

## Verification

Updated the two existing tests that encoded the old (buggy) default, added tests for the explicit opt-out (bool and YAML-string forms), reconnect-unaffected-by-opt-out, and the log-line regression. 6/6 new/updated tests pass; 19/19 in the full `test_telegram_conflict.py` file; 68/68 in related polling-progress/network-reconnect test files (no regression).