### PR TITLE
fix: ignore leaked Windows HERMES_HOME in WSL sessions (#71826)

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -62,6 +62,14 @@ def _hermes_home_from_env() -> Path:
     """
     val = os.environ.get("HERMES_HOME", "").strip()
     if val:
+        # Guard: WSL auto-forwards Windows user env vars via /init interop.
+        # The Desktop installer writes HERMES_HOME as a Windows user env var
+        # (e.g. ``D:\\hermes-desktop\\hermes``) which leaks into every WSL
+        # shell — silently routing CLI sessions into the Desktop's state.db.
+        # Detect a Windows drive-letter path inside WSL and fall back to the
+        # platform default instead.  See issue #71826.
+        if is_wsl() and len(val) >= 2 and val[1] == ":":
+            return _get_platform_default_hermes_home()
         return Path(val)
     return _get_platform_default_hermes_home()
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -150,6 +150,23 @@ class TestGetProcessHermesHome:
         finally:
             reset_hermes_home_override(token)
 
+    def test_wsl_ignores_windows_drive_letter_hermes_home(
+        self, tmp_path, monkeypatch
+    ):
+        """WSL inheriting a Windows HERMES_HOME (issue #71826) should fall
+        back to the platform default instead of using the leaked value."""
+        monkeypatch.setenv("HERMES_HOME", "D:\\hermes-desktop\\hermes")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # Simulate WSL environment
+        monkeypatch.setattr(hermes_constants, "_wsl_detected", True)
+        assert get_process_hermes_home() == tmp_path / ".hermes"
+
+    def test_non_wsl_keeps_windows_path(self, tmp_path, monkeypatch):
+        """Outside WSL, a Windows HERMES_HOME should be honoured."""
+        monkeypatch.setenv("HERMES_HOME", "D:\\hermes-desktop\\hermes")
+        monkeypatch.setattr(hermes_constants, "_wsl_detected", False)
+        assert get_process_hermes_home() == Path("D:\\hermes-desktop\\hermes")
+
 
 class TestHermesManagedNode:
     def test_windows_node_dir_prefers_portable_root(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

The Desktop installer writes `HERMES_HOME` as a Windows user-level env var (`HKCU\Environment`). WSL2 auto-forwards all Windows user env vars via `/init` interop, causing every WSL CLI session to silently write into the Desktop's `state.db` instead of `~/.hermes/state.db`.

## Root Cause

`_hermes_home_from_env()` in `hermes_constants.py` reads `HERMES_HOME` from the environment unconditionally. When the Desktop installer sets it to `D:\hermes-desktop\hermes`, WSL CLI sessions inherit that path and pollute the Desktop's data directory.

## Fix

In `_hermes_home_from_env()`, detect when running inside WSL and `HERMES_HOME` contains a Windows drive-letter path (e.g. `D:\...`). In that case, fall back to the platform default (`~/.hermes`) instead of using the leaked value.

## Changes

- `hermes_constants.py`: Add WSL + Windows-path guard in `_hermes_home_from_env()` (8 lines including comments)
- `tests/test_hermes_constants.py`: 2 new tests — WSL ignores Windows path, non-WSL keeps it

## Tests

```
tests/test_hermes_constants.py::TestGetProcessHermesHome::test_wsl_ignores_windows_drive_letter_hermes_home PASSED
tests/test_hermes_constants.py::TestGetProcessHermesHome::test_non_wsl_keeps_windows_path PASSED
5 passed in 0.14s
```

Fixes #71826