### PR TITLE
fix(tests): stop unit tests from lazy-installing backends over the network

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -398,6 +398,23 @@ def _hermetic_environment(tmp_path, monkeypatch):
     # tests opt back in by patching the security config directly.
     monkeypatch.setenv("TIRITH_ENABLED", "false")
 
+    # 4c. Seal the venv against lazy installs. Importing an opt-in backend
+    #     (plugins.memory.mem0, a TTS/STT provider, a messaging adapter, …)
+    #     calls tools.lazy_deps.ensure(), which shells out to `uv pip install`
+    #     against PyPI. That is a live network dependency inside a unit test:
+    #     it passes in ~17s on a good day and hangs to the 300s per-file
+    #     SIGKILL when PyPI is slow, turning any shard that happens to touch a
+    #     lazy backend red for reasons unrelated to the diff under test.
+    #
+    #     The specs are pinned in LAZY_DEPS and CI installs `--extra all`, so
+    #     anything a test legitimately needs is already present; a lazy
+    #     backend that ISN'T installed should surface as FeatureUnavailable,
+    #     not as a network call. Tests that exercise the install path itself
+    #     stub `_venv_pip_install` / `_allow_lazy_installs` and are unaffected
+    #     by this env var.
+    monkeypatch.setenv("HERMES_DISABLE_LAZY_INSTALLS", "1")
+    monkeypatch.delenv("HERMES_LAZY_INSTALL_TARGET", raising=False)
+
     # 5. Reset plugin singleton so tests don't leak plugins from
     #    ~/.hermes/plugins/ (which, per step 3, is now empty — but the
     #    singleton might still be cached from a previous test).

--- a/tests/test_no_lazy_installs_in_tests.py
+++ b/tests/test_no_lazy_installs_in_tests.py
@@ -1,0 +1,70 @@
+"""Unit tests must never shell out to PyPI.
+
+Importing an opt-in backend (``plugins.memory.mem0`` and friends) calls
+``tools.lazy_deps.ensure()``, which runs ``uv pip install`` against the
+network. Inside a test that is a live dependency on PyPI reachability: on a
+good day it costs ~17s, and when PyPI is slow it hangs until the 300s per-file
+SIGKILL and fails a shard for reasons that have nothing to do with the diff
+under test.
+
+``tests/conftest.py`` seals the venv (``HERMES_DISABLE_LAZY_INSTALLS=1`` with
+no durable target) so ``ensure()`` raises ``FeatureUnavailable`` instead of
+installing. These tests hold that seal in place.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import tools.lazy_deps as ld
+
+
+def test_lazy_installs_are_sealed_for_every_test():
+    """The autouse hermetic fixture must leave installs disabled."""
+    assert os.environ.get("HERMES_DISABLE_LAZY_INSTALLS") == "1"
+    # A durable target would UN-seal the venv (installs get redirected there
+    # rather than blocked), so the seal depends on it staying unset.
+    assert not os.environ.get("HERMES_LAZY_INSTALL_TARGET")
+    assert ld._allow_lazy_installs() is False
+
+
+def test_ensure_refuses_to_install_a_missing_backend(monkeypatch):
+    """A missing lazy backend surfaces as an error, never as a pip subprocess."""
+    monkeypatch.setitem(ld.LAZY_DEPS, "test.sealed", ("packageX==1.0",))
+    monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+
+    def explode(*_a, **_k):  # pragma: no cover — must never run
+        raise AssertionError("ensure() shelled out to pip inside a test")
+
+    monkeypatch.setattr(ld, "_venv_pip_install", explode)
+
+    with pytest.raises(ld.FeatureUnavailable, match="lazy installs disabled"):
+        ld.ensure("test.sealed", prompt=False)
+
+
+def test_importing_a_lazy_memory_backend_does_not_install(monkeypatch):
+    """The exact path that hung CI: constructing the mem0 provider.
+
+    ``_create_backend`` calls ``ensure("memory.mem0")`` before importing the
+    SDK, and swallows whatever it raises — so a raising stub would be hidden.
+    Count the calls instead: under the seal the installer must not be reached
+    at all.
+    """
+    from plugins.memory.mem0 import Mem0MemoryProvider
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+    monkeypatch.setattr(
+        ld, "_venv_pip_install",
+        lambda specs, **kw: calls.append(specs) or ld._InstallResult(True, "", ""),
+    )
+    monkeypatch.setattr(
+        "plugins.memory.mem0._load_config",
+        lambda: {"api_key": "test-key", "agent_id": "hermes"},
+    )
+
+    Mem0MemoryProvider().initialize(session_id="sealed-sess")
+
+    assert calls == [], f"mem0 provider shelled out to pip inside a test: {calls}"


### PR DESCRIPTION
Unit tests reach PyPI. Importing an opt-in backend calls `tools.lazy_deps.ensure()`, which shells out to `uv pip install` — so a test that touches a lazy backend depends on PyPI being reachable and fast.

`tests/agent/test_memory_user_id.py` imports `plugins.memory.mem0`, which lazy-installs `mem0ai`. That spec isn't in `[all]`, so CI never has it preinstalled and the install runs on every job: ~17s when PyPI is healthy, and a hang to the 300s per-file SIGKILL when it isn't. That's what turned slice 3/8 red on [#71864](https://github.com/NousResearch/hermes-agent/pull/71864) — a gateway-only diff that never touches memory:

```
600.06s  tests/agent/test_memory_user_id.py
(300s exceeded; process tree SIGKILL'd)
```

The file passes in 2.2s locally with `mem0ai` already present, which is why this reads as a random flake rather than a reproducible failure — it's latent on `main` and fires on whichever shard owns the file when PyPI is slow.

The fix seals the venv in the existing hermetic fixture (`HERMES_DISABLE_LAZY_INSTALLS=1`, no durable target), so `ensure()` fails closed with `FeatureUnavailable` instead of reaching the network. Anything a test legitimately needs is already installed via `--extra all`; a backend that genuinely isn't installed should surface as unavailable, not as a pip subprocess. Tests that exercise the install path itself stub `_venv_pip_install` / `_allow_lazy_installs` and are unaffected.

Verified by reverting the conftest change and re-running the new tests: all three fail on `origin/main` (`AssertionError: ensure() shelled out to pip inside a test`) and pass with it. Full sweep of every lazy-install-touching suite: 935 passed. The one failure, `test_linux_default_capture_skips_gnome_shell_helper`, reproduces identically on unmodified `main` — a Linux-only assertion failing on macOS, unrelated to this change.