### PR TITLE
fix(desktop): preserve active stream across hydration

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -24,7 +24,7 @@ import { FloatingPet } from '@/components/pet/floating-pet'
 import { RemoteDisplayBanner } from '@/components/remote-display-banner'
 import { emitGatewayEvent } from '@/contrib/events'
 import { getSessionMessages, triggerCronJob } from '@/hermes'
-import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { type ChatMessage, chatMessageText, toChatMessages } from '@/lib/chat-messages'
 import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { isMessagingSource } from '@/lib/session-source'
 import { latestSessionTodos } from '@/lib/todos'
@@ -87,6 +87,7 @@ import { usePreviewRouting } from '../session/hooks/use-preview-routing'
 import { usePromptActions } from '../session/hooks/use-prompt-actions'
 import { useRouteResume } from '../session/hooks/use-route-resume'
 import { useSessionActions } from '../session/hooks/use-session-actions'
+import { reconcileStoredSessionMessages } from '../session/hooks/use-session-actions/utils'
 import { useSessionListActions } from '../session/hooks/use-session-list-actions'
 import { useSessionStateCache } from '../session/hooks/use-session-state-cache'
 import { startWorkspaceSession } from '../session/workspace-session-target'
@@ -311,7 +312,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
           const messages = toChatMessages(latest.messages)
           updateSessionState(
             runtimeSessionId,
-            state => ({ ...state, messages: preserveLocalAssistantErrors(messages, state.messages) }),
+            state => ({ ...state, messages: reconcileStoredSessionMessages(messages, state.messages) }),
             storedSessionId
           )
 
@@ -367,7 +368,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
       updateSessionState(
         runtimeSessionId,
-        state => ({ ...state, messages: preserveLocalAssistantErrors(messages, state.messages) }),
+        state => ({ ...state, messages: reconcileStoredSessionMessages(messages, state.messages) }),
         storedSessionId
       )
     } catch {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/hydration-stream-race.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/hydration-stream-race.test.tsx
@@ -1,0 +1,92 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { assistantTextPart, chatMessageText, textPart } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-1'
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let latestState: ClientSessionState
+
+function postHydrationState(): ClientSessionState {
+  return {
+    ...createClientSessionState(),
+    awaitingResponse: true,
+    busy: true,
+    messages: [
+      { id: 'user-live', role: 'user', parts: [textPart('follow-up')] },
+      {
+        id: 'assistant-hydrated-pending',
+        role: 'assistant',
+        parts: [assistantTextPart('partial')],
+        pending: true
+      }
+    ],
+    // A lagging hydrate replaced the messages array but left the live stream id.
+    streamId: 'assistant-stream-orphaned'
+  }
+}
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>([[SID, postHydrationState()]]))
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+      latestState = next
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    latestState = sessionStateByRuntimeIdRef.current.get(SID)!
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent, sessionStateByRuntimeIdRef])
+
+  return null
+}
+
+describe('useMessageStream hydration race recovery', () => {
+  beforeEach(() => {
+    handleEvent = null
+    latestState = postHydrationState()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('reuses the pending assistant when hydration orphaned streamId', async () => {
+    render(<Harness />)
+    await waitFor(() => expect(handleEvent).not.toBeNull())
+
+    act(() => {
+      handleEvent!({ payload: { text: ' continued' }, session_id: SID, type: 'message.delta' })
+    })
+
+    await waitFor(() => {
+      const assistants = latestState.messages.filter(message => message.role === 'assistant' && !message.hidden)
+      expect(assistants).toHaveLength(1)
+      expect(chatMessageText(assistants[0])).toBe('partial continued')
+      expect(assistants[0].id).toBe('assistant-stream-orphaned')
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -98,22 +98,47 @@ export function useMessageStream({
             return state
           }
 
-          const streamId = state.streamId ?? nextStreamMessageId('assistant-stream')
+          const priorStreamId = state.streamId
+          const streamId = priorStreamId ?? nextStreamMessageId('assistant-stream')
           const groupId = state.pendingBranchGroup ?? undefined
           const prev = state.messages
           let nextMessages: ChatMessage[]
 
           if (!prev.some(m => m.id === streamId)) {
-            nextMessages = [
-              ...prev,
-              {
-                id: streamId,
-                role: 'assistant',
-                parts: seed(),
-                pending: true,
-                branchGroupId: groupId
-              }
-            ]
+            // A lagging transcript hydrate can replace the messages array while
+            // leaving the active stream id intact. Rebind the newest pending
+            // assistant instead of seeding a second bubble for the same turn
+            // (#38319, #71857). Only recover an already-established stream id;
+            // a genuinely new stream still creates its own message below.
+            const pendingFromEnd = priorStreamId
+              ? [...prev].reverse().findIndex(m => m.role === 'assistant' && m.pending && !m.hidden)
+              : -1
+
+            if (pendingFromEnd >= 0) {
+              const pendingIndex = prev.length - 1 - pendingFromEnd
+              nextMessages = prev.map((message, index) =>
+                index === pendingIndex
+                  ? {
+                      ...message,
+                      id: streamId,
+                      parts: transform(message.parts, message),
+                      pending: opts.pending ? opts.pending(message) : true,
+                      branchGroupId: message.branchGroupId ?? groupId
+                    }
+                  : message
+              )
+            } else {
+              nextMessages = [
+                ...prev,
+                {
+                  id: streamId,
+                  role: 'assistant',
+                  parts: seed(),
+                  pending: true,
+                  branchGroupId: groupId
+                }
+              ]
+            }
           } else {
             nextMessages = prev.map(m =>
               m.id === streamId

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -15,6 +15,7 @@ import {
   isSessionGoneError,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
+  reconcileStoredSessionMessages,
   sessionMatchesStoredId,
   sessionShouldHaveTranscript,
   toBranchMessages
@@ -362,6 +363,28 @@ describe('reconcileResumeMessages', () => {
     const [out] = reconcileResumeMessages(next, previous)
 
     expect(out.attachmentRefs).toBeUndefined()
+  })
+})
+
+describe('reconcileStoredSessionMessages', () => {
+  it('keeps the live turn when a lagging post-turn hydrate lands mid-stream', () => {
+    const stored = [msg('1-user', 'user', 'first'), msg('2-assistant', 'assistant', 'first answer')]
+
+    const current = [
+      ...stored,
+      msg('user-live', 'user', 'follow-up'),
+      msg('assistant-stream-live', 'assistant', 'partial', { pending: true })
+    ]
+
+    const reconciled = reconcileStoredSessionMessages(stored, current)
+
+    expect(reconciled.map(message => message.id)).toEqual([
+      '1-user',
+      '2-assistant',
+      'user-live',
+      'assistant-stream-live'
+    ])
+    expect(reconciled.at(-1)?.pending).toBe(true)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1,5 +1,11 @@
 import { getSession } from '@/hermes'
-import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
+import {
+  assistantTextPart,
+  type ChatMessage,
+  chatMessageText,
+  preserveLocalAssistantErrors,
+  textPart
+} from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages, textWithoutImageRefs } from '@/lib/embedded-images'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
@@ -331,6 +337,23 @@ export function preserveLocalPendingTurnMessages(
   }
 
   return preserved.length ? [...nextMessages, ...preserved] : nextMessages
+}
+
+/**
+ * Reconcile a stored transcript without discarding a newer live renderer tail.
+ *
+ * Post-turn hydration can resolve after the next turn has already started. The
+ * stored snapshot is then legitimately behind: keep its authoritative history,
+ * but retain the newest optimistic user row and pending assistant stream before
+ * merging renderer-only assistant errors.
+ */
+export function reconcileStoredSessionMessages(
+  storedMessages: ChatMessage[],
+  currentMessages: ChatMessage[]
+): ChatMessage[] {
+  const withLiveTail = preserveLocalPendingTurnMessages(storedMessages, currentMessages)
+
+  return preserveLocalAssistantErrors(withLiveTail, currentMessages)
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Prevents a lagging Desktop transcript hydration from splitting one live assistant turn into two bubbles.

The post-turn hydrator can finish after the user has already started the next turn. It replaced the renderer's message array with the older stored snapshot while leaving the active `streamId` unchanged. The next `message.delta` could no longer find that id and created a second assistant row, producing the intermittent byte-for-byte duplicate described in #38319 and #71857.

This PR closes the race at both seams:

1. Stored-session hydration now reconciles through the existing live-tail contract, preserving the newest optimistic user row and pending assistant before merging renderer-only assistant errors.
2. If another hydration/reconnect source still leaves an established `streamId` orphaned, the next delta rebinds the newest pending assistant to that id instead of appending a second bubble.

The fallback is deliberately narrow. It runs only when a prior stream id exists and a non-hidden pending assistant is present. A genuinely new stream still creates a new assistant message, and completed historical assistants are never reused by text equality.

## Related Issue

Fixes #38319
Fixes #71857

Related but not duplicated by #68478: that broader session-reliability PR explicitly leaves the streaming-versus-hydration duplicate-response race out of scope.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add `reconcileStoredSessionMessages()` as the shared stored-history reconciliation seam;
- preserve the current live turn in both post-turn hydration and active messaging transcript refresh;
- recover an orphaned `streamId` by rebinding the newest pending assistant;
- add an exact stream regression for the hydrated-pending-row → next-delta sequence;
- add a utility regression proving a lagging stored projection keeps the optimistic user and pending assistant tail.

## How to Test

```bash
cd apps/desktop

../../node_modules/.bin/vitest run --project ui \
  src/app/session/hooks/use-message-stream/hydration-stream-race.test.tsx \
  src/app/session/hooks/use-session-actions/utils.test.ts

npm run typecheck
```

Then run ESLint on the five changed TypeScript files and `git diff --check`.

Expected focused result: **40 passed**.

The stream regression was run against the pre-fix behavior first and failed with two assistant rows instead of one. The utility regression likewise failed because the shared reconciliation seam did not exist.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched open and merged issues/PRs and compared #38319, #71857, and #68478
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for this Desktop-only TypeScript change; the focused UI tests and complete Desktop typecheck pass
- [x] I've added tests for the bug
- [x] I've tested on macOS Apple Silicon

### Documentation & Housekeeping

- [x] Relevant documentation — N/A; no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example` — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no contributor workflow or architecture changed
- [x] Cross-platform impact considered; the state reconciliation is renderer-platform-neutral
- [x] Tool descriptions/schemas — N/A; no model-facing tool behavior changed

## Verification

```text
Focused Desktop tests: 40 passed
Desktop typecheck:      passed (renderer, Electron, E2E tsconfigs)
ESLint:                 passed
Diff hygiene:           passed
```
