### PR TITLE
Fix session search topic isolation

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5673,16 +5673,25 @@ class SessionDB:
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
-    def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
+    def get_session_by_title(
+        self, title: str, session_key: str = None
+    ) -> Optional[Dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""
+        where = "title = ?"
+        params = [title]
+        if session_key:
+            where += " AND session_key = ?"
+            params.append(session_key)
         with self._lock:
             cursor = self._conn.execute(
-                "SELECT * FROM sessions WHERE title = ?", (title,)
+                f"SELECT * FROM sessions WHERE {where}", params
             )
             row = cursor.fetchone()
         return dict(row) if row else None
 
-    def resolve_session_by_title(self, title: str) -> Optional[str]:
+    def resolve_session_by_title(
+        self, title: str, session_key: str = None
+    ) -> Optional[str]:
         """Resolve a title to a session ID, preferring the latest in a lineage.
 
         If the exact title exists, returns that session's ID.
@@ -5691,16 +5700,21 @@ class SessionDB:
         latest numbered variant (the most recent continuation).
         """
         # First try exact match
-        exact = self.get_session_by_title(title)
+        exact = self.get_session_by_title(title, session_key=session_key)
 
         # Also search for numbered variants: "title #2", "title #3", etc.
         # Escape SQL LIKE wildcards (%, _) in the title to prevent false matches
         escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        key_clause = " AND session_key = ?" if session_key else ""
+        params = [f"{escaped} #%"]
+        if session_key:
+            params.append(session_key)
         with self._lock:
             cursor = self._conn.execute(
                 "SELECT id, title, started_at FROM sessions "
-                "WHERE title LIKE ? ESCAPE '\\' ORDER BY started_at DESC",
-                (f"{escaped} #%",),
+                f"WHERE title LIKE ? ESCAPE '\\'{key_clause} "
+                "ORDER BY started_at DESC",
+                params,
             )
             numbered = cursor.fetchall()
 
@@ -5873,6 +5887,7 @@ class SessionDB:
         id_query: str = None,
         search_query: str = None,
         compact_rows: bool = False,
+        session_key: str = None,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -5912,6 +5927,9 @@ class SessionDB:
         the SELECT so SQLite never copies it out of the B-tree page — a
         significant I/O saving on large databases where the blob routinely
         runs to tens of kilobytes per row.
+
+        Pass ``session_key`` to restrict rows to one exact persisted gateway
+        conversation before ordering and pagination are applied.
         """
         where_clauses = []
         params = []
@@ -5941,6 +5959,9 @@ class SessionDB:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")
             params.extend(exclude_sources)
+        if session_key:
+            where_clauses.append("s.session_key = ?")
+            params.append(session_key)
         if cwd_prefix:
             clause, clause_params = _cwd_prefix_clause(cwd_prefix)
             where_clauses.append(clause)
@@ -7839,6 +7860,7 @@ class SessionDB:
         role_filter: List[str] = None,
         limit: int = 20,
         offset: int = 0,
+        session_key: str = None,
     ) -> Optional[List[Dict[str, Any]]]:
         """Run a search against a substring-capable FTS index.
 
@@ -7878,6 +7900,9 @@ class SessionDB:
         if role_filter:
             tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
             tri_params.extend(role_filter)
+        if session_key:
+            tri_where.append("s.session_key = ?")
+            tri_params.append(session_key)
         tri_sql = f"""
             SELECT
                 m.id,
@@ -7916,6 +7941,7 @@ class SessionDB:
         offset: int = 0,
         sort: str = None,
         include_inactive: bool = False,
+        session_key: str = None,
     ) -> List[Dict[str, Any]]:
         """Instrumented wrapper around :meth:`_search_messages_impl`.
 
@@ -7937,6 +7963,7 @@ class SessionDB:
                 offset=offset,
                 sort=sort,
                 include_inactive=include_inactive,
+                session_key=session_key,
             )
             return rows
         finally:
@@ -7986,6 +8013,7 @@ class SessionDB:
         offset: int = 0,
         sort: str = None,
         include_inactive: bool = False,
+        session_key: str = None,
     ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
@@ -8007,6 +8035,9 @@ class SessionDB:
         The short-CJK LIKE fallback already orders by timestamp DESC and
         ignores ``sort``. The trigram CJK path honours ``sort`` like the main
         FTS5 path.
+
+        ``session_key`` applies an exact gateway-conversation predicate in
+        every search route before ranking and limits.
 
         Rewound (``active=0``, ``compacted=0``) rows are excluded by default —
         the user took those back. Compaction-archived rows (``active=0``,
@@ -8067,6 +8098,9 @@ class SessionDB:
             role_placeholders = ",".join("?" for _ in role_filter)
             where_clauses.append(f"m.role IN ({role_placeholders})")
             params.extend(role_filter)
+        if session_key:
+            where_clauses.append("s.session_key = ?")
+            params.append(session_key)
 
         where_sql = " AND ".join(where_clauses)
         params.extend([limit, offset])
@@ -8160,6 +8194,9 @@ class SessionDB:
                 if role_filter:
                     cjk_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     cjk_params.extend(role_filter)
+                if session_key:
+                    cjk_where.append("s.session_key = ?")
+                    cjk_params.append(session_key)
                 cjk_sql = f"""
                     SELECT
                         m.id,
@@ -8249,6 +8286,9 @@ class SessionDB:
                 if role_filter:
                     tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     tri_params.extend(role_filter)
+                if session_key:
+                    tri_where.append("s.session_key = ?")
+                    tri_params.append(session_key)
                 tri_sql = f"""
                     SELECT
                         m.id,
@@ -8343,6 +8383,9 @@ class SessionDB:
                 if role_filter:
                     like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     like_params.extend(role_filter)
+                if session_key:
+                    like_where.append("s.session_key = ?")
+                    like_params.append(session_key)
                 like_sql = f"""
                     SELECT m.id, m.session_id, m.role,
                            substr(m.content,
@@ -8402,6 +8445,7 @@ class SessionDB:
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
                     role_filter=role_filter,
+                    session_key=session_key,
                 )
                 seen_ids = {m["id"] for m in matches}
                 matches.extend(m for m in gap_matches if m["id"] not in seen_ids)
@@ -8440,6 +8484,7 @@ class SessionDB:
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
                     role_filter=role_filter,
+                    session_key=session_key,
                     limit=limit,
                     offset=offset,
                 )
@@ -8457,6 +8502,7 @@ class SessionDB:
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
                     role_filter=role_filter,
+                    session_key=session_key,
                     limit=limit,
                     offset=offset,
                 )
@@ -8540,6 +8586,7 @@ class SessionDB:
         source_filter: Optional[List[str]] = None,
         exclude_sources: Optional[List[str]] = None,
         role_filter: Optional[List[str]] = None,
+        session_key: str = None,
     ) -> List[Dict[str, Any]]:
         """LIKE-scan the rows the deferred rebuild hasn't indexed yet.
 
@@ -8585,6 +8632,9 @@ class SessionDB:
         if role_filter:
             where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
             params.extend(role_filter)
+        if session_key:
+            where.append("s.session_key = ?")
+            params.append(session_key)
 
         sql = f"""
             SELECT m.id, m.session_id, m.role,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2419,6 +2419,30 @@ class TestCJKSearchFallback:
     the query contains CJK characters.
     """
 
+    @pytest.mark.parametrize("query", ["sharedtoken", "记忆断裂", "通信"])
+    def test_session_key_filter_applies_before_limit_on_every_search_path(
+        self, db, query
+    ):
+        current_key = "agent:main:telegram:group:-1003966911334:40507"
+        other_key = "agent:main:telegram:group:-1003966911334:799"
+        db.create_session("current-topic", source="telegram", session_key=current_key)
+        db.append_message(
+            "current-topic", role="user",
+            content=f"sharedtoken 记忆断裂 通信 {query}",
+        )
+        for index in range(25):
+            sid = f"other-topic-{index}"
+            db.create_session(sid, source="telegram", session_key=other_key)
+            db.append_message(
+                sid, role="user",
+                content=f"sharedtoken 记忆断裂 通信 {query}",
+            )
+
+        results = db.search_messages(
+            query, session_key=current_key, limit=1, sort="newest",
+        )
+        assert [row["session_id"] for row in results] == ["current-topic"]
+
     def test_cjk_detection_covers_all_ranges(self):
         from hermes_state import SessionDB
         f = SessionDB._contains_cjk
@@ -7703,4 +7727,3 @@ class TestDisplayMetadataReadPaths:
             }],
         )
         assert db.get_messages_as_conversation("s1")[0]["display_metadata"] == self.META
-

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -23,6 +23,7 @@ from tools.session_search_tool import (
     _session_link,
     session_search,
 )
+from tools.registry import registry
 
 
 @pytest.fixture
@@ -89,6 +90,11 @@ class TestSchema:
         params = SESSION_SEARCH_SCHEMA["parameters"]["properties"]
         assert params["sort"]["enum"] == ["newest", "oldest"]
 
+    def test_scope_enum_defaults_safe(self):
+        scope = SESSION_SEARCH_SCHEMA["parameters"]["properties"]["scope"]
+        assert scope["enum"] == ["current", "all"]
+        assert scope["default"] == "current"
+
     def test_schema_description_teaches_scroll(self):
         desc = SESSION_SEARCH_SCHEMA["description"]
         assert "SCROLL" in desc
@@ -153,6 +159,71 @@ class TestBrowseShape:
         titles = [r.get("title") for r in result["results"]]
         assert any("Modpack" in (t or "") for t in titles)
 
+    def test_gateway_browse_defaults_to_current_session_key_before_limit(self, db):
+        current_key = "agent:main:telegram:group:-1003966911334:40507"
+        other_key = "agent:main:telegram:group:-1003966911334:799"
+        db.create_session(
+            "topic-40507-current", source="telegram", session_key=current_key,
+            chat_id="-1003966911334", thread_id="40507",
+        )
+        db.create_session(
+            "topic-40507-prior", source="telegram", session_key=current_key,
+            chat_id="-1003966911334", thread_id="40507",
+        )
+        for index in range(12):
+            db.create_session(
+                f"topic-799-newer-{index}", source="telegram",
+                session_key=other_key, chat_id="-1003966911334", thread_id="799",
+            )
+        result = json.loads(session_search(
+            db=db, current_session_id="topic-40507-current", limit=1,
+        ))
+        assert [row["session_id"] for row in result["results"]] == ["topic-40507-prior"]
+        assert result["results"][0]["chat_id"] == "-1003966911334"
+        assert result["results"][0]["thread_id"] == "40507"
+        assert result["results"][0]["session_key"] == current_key
+
+    def test_gateway_browse_scope_all_is_explicit_global_opt_in(self, db):
+        current_key = "agent:main:telegram:group:-1003966911334:40507"
+        other_key = "agent:main:telegram:group:-1003966911334:799"
+        db.create_session("current", source="telegram", session_key=current_key)
+        db.create_session("same-topic", source="telegram", session_key=current_key)
+        db.create_session("other-topic", source="telegram", session_key=other_key)
+        result = json.loads(session_search(
+            db=db, current_session_id="current", scope="all", limit=10,
+        ))
+        assert {"same-topic", "other-topic"} <= {
+            row["session_id"] for row in result["results"]
+        }
+
+    @pytest.mark.parametrize(
+        ("args", "expected_ids"),
+        [
+            ({}, {"topic-40507-prior"}),
+            ({"scope": "all"}, {"topic-40507-prior", "topic-799-prior"}),
+        ],
+    )
+    def test_registered_handler_receives_production_session_id_scope(
+        self, db, args, expected_ids
+    ):
+        current_key = "agent:main:telegram:group:-1003966911334:40507"
+        other_key = "agent:main:telegram:group:-1003966911334:799"
+        db.create_session(
+            "topic-40507-current", source="telegram", session_key=current_key,
+        )
+        db.create_session(
+            "topic-40507-prior", source="telegram", session_key=current_key,
+        )
+        db.create_session(
+            "topic-799-prior", source="telegram", session_key=other_key,
+        )
+
+        result = json.loads(registry.dispatch(
+            "session_search", args, db=db, session_id="topic-40507-current",
+        ))
+
+        assert {row["session_id"] for row in result["results"]} == expected_ids
+
 
 # =========================================================================
 # Discovery shape (with query)
@@ -165,6 +236,52 @@ class TestDiscoveryShape:
         assert result["success"] is True
         assert result["mode"] == "discover"
         assert result["count"] >= 1
+
+    def test_gateway_discovery_defaults_to_current_session_key_before_limit(self, db):
+        current_key = "agent:main:telegram:group:-1003966911334:40507"
+        other_key = "agent:main:telegram:group:-1003966911334:799"
+        db.create_session(
+            "topic-40507-current", source="telegram", session_key=current_key,
+            chat_id="-1003966911334", thread_id="40507",
+        )
+        db.append_message("topic-40507-current", role="user", content="Sauna steam schedule")
+        db.create_session(
+            "topic-40507-prior", source="telegram", session_key=current_key,
+            chat_id="-1003966911334", thread_id="40507",
+        )
+        db.append_message("topic-40507-prior", role="user", content="Sauna steam schedule history")
+        for index in range(25):
+            sid = f"topic-799-newer-{index}"
+            db.create_session(
+                sid, source="telegram", session_key=other_key,
+                chat_id="-1003966911334", thread_id="799",
+            )
+            db.append_message(sid, role="user", content="Sauna steam schedule form")
+
+        scoped = json.loads(session_search(
+            query="Sauna steam schedule", db=db,
+            current_session_id="topic-40507-current", limit=1, sort="newest",
+        ))
+        assert [row["session_id"] for row in scoped["results"]] == ["topic-40507-prior"]
+        assert scoped["results"][0]["thread_id"] == "40507"
+        assert scoped["results"][0]["session_key"] == current_key
+
+        global_result = json.loads(session_search(
+            query="Sauna steam schedule", db=db,
+            current_session_id="topic-40507-current", scope="all", limit=10,
+            sort="newest",
+        ))
+        assert any(row["thread_id"] == "799" for row in global_result["results"])
+
+    def test_missing_current_routing_metadata_falls_back_to_global(self, db):
+        db.create_session("current-without-route", source="cli")
+        db.create_session("global-history", source="telegram")
+        db.append_message("global-history", role="user", content="route fallback token")
+        result = json.loads(session_search(
+            query="route fallback token", db=db,
+            current_session_id="current-without-route",
+        ))
+        assert [row["session_id"] for row in result["results"]] == ["global-history"]
 
     def test_discovery_result_has_bookends_and_window(self, db):
         _seed_modpack_sessions(db)
@@ -459,6 +576,23 @@ class TestShapePrecedence:
         # session_id alone (no anchor, no query) → read shape, not browse.
         result = json.loads(session_search(session_id="s_oldest", db=db))
         assert result["mode"] == "read"
+
+    def test_explicit_read_ignores_current_topic_scope_and_reports_route(self, db):
+        current_key = "agent:main:telegram:group:-1003966911334:40507"
+        other_key = "agent:main:telegram:group:-1003966911334:799"
+        db.create_session("current", source="telegram", session_key=current_key)
+        db.create_session(
+            "explicit-other", source="telegram", session_key=other_key,
+            chat_id="-1003966911334", thread_id="799",
+        )
+        db.append_message("explicit-other", role="user", content="exact linked read")
+        result = json.loads(session_search(
+            session_id="explicit-other", db=db, current_session_id="current",
+        ))
+        assert result["mode"] == "read"
+        assert result["session_meta"]["session_key"] == other_key
+        assert result["session_meta"]["chat_id"] == "-1003966911334"
+        assert result["session_meta"]["thread_id"] == "799"
 
 
 # =========================================================================

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -394,6 +394,9 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
             "source": meta.get("source"),
             "model": meta.get("model"),
             "title": meta.get("title"),
+            "session_key": meta.get("session_key"),
+            "chat_id": meta.get("chat_id"),
+            "thread_id": meta.get("thread_id"),
         },
         "message_count": total,
         "truncated": truncated,
@@ -407,13 +410,20 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
     return json.dumps(response, ensure_ascii=False)
 
 
-def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_profile: str = None) -> str:
+def _list_recent_sessions(
+    db,
+    limit: int,
+    current_session_id: str = None,
+    link_profile: str = None,
+    session_key: str = None,
+) -> str:
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
         sessions = db.list_sessions_rich(
             limit=limit + 5,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             order_by_last_active=True,
+            session_key=session_key,
         )  # fetch extra so we can skip current
 
         current_root = _resolve_lineage(db, current_session_id) if current_session_id else None
@@ -435,6 +445,9 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_p
                 "last_active": s.get("last_active", ""),
                 "message_count": s.get("message_count", 0),
                 "preview": s.get("preview", ""),
+                "session_key": s.get("session_key"),
+                "chat_id": s.get("chat_id"),
+                "thread_id": s.get("thread_id"),
             })
             if len(results) >= limit:
                 break
@@ -564,6 +577,9 @@ def _scroll(
             "source": session_meta.get("source"),
             "model": session_meta.get("model"),
             "title": session_meta.get("title"),
+            "session_key": session_meta.get("session_key"),
+            "chat_id": session_meta.get("chat_id"),
+            "thread_id": session_meta.get("thread_id"),
         },
         "window": window,
         "messages": [_shape_message(m, anchor_id=around_message_id) for m in messages],
@@ -584,6 +600,7 @@ def _title_match_result(
     db,
     query: str,
     current_lineage_root: Optional[str],
+    session_key: str = None,
 ) -> Optional[Dict[str, Any]]:
     """Return a discovery-shaped result when the query matches a session title."""
     title_query = _normalize_title_query(query)
@@ -591,7 +608,12 @@ def _title_match_result(
         return None
 
     try:
-        session_id = db.resolve_session_by_title(title_query)
+        if session_key:
+            session_id = db.resolve_session_by_title(
+                title_query, session_key=session_key,
+            )
+        else:
+            session_id = db.resolve_session_by_title(title_query)
     except Exception:
         logging.debug("resolve_session_by_title failed for %r", title_query, exc_info=True)
         return None
@@ -608,6 +630,8 @@ def _title_match_result(
         logging.debug("get_session failed for title match %s", session_id, exc_info=True)
         session_meta = {}
     if session_meta.get("source") in _HIDDEN_SESSION_SOURCES:
+        return None
+    if session_key and session_meta.get("session_key") != session_key:
         return None
 
     try:
@@ -632,6 +656,9 @@ def _title_match_result(
         "source": session_meta.get("source", "unknown"),
         "model": session_meta.get("model") or "unknown",
         "title": session_meta.get("title") or title_query,
+        "session_key": session_meta.get("session_key"),
+        "chat_id": session_meta.get("chat_id"),
+        "thread_id": session_meta.get("thread_id"),
         "matched_role": "session_title",
         "match_message_id": anchor_id,
         "snippet": f"Session title matched: {session_meta.get('title') or title_query}",
@@ -655,11 +682,14 @@ def _discover(
     sort: Optional[str],
     current_session_id: str = None,
     link_profile: str = None,
+    session_key: str = None,
 ) -> str:
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
-    title_result = _title_match_result(db, query, current_lineage_root)
+    title_result = _title_match_result(
+        db, query, current_lineage_root, session_key=session_key,
+    )
 
     try:
         raw_results = db.search_messages(
@@ -671,6 +701,7 @@ def _discover(
             # of cron rows are still in hand for the demotion pass below.
             offset=0,
             sort=sort,
+            session_key=session_key,
         )
     except Exception as e:
         logging.error("FTS5 search failed: %s", e, exc_info=True)
@@ -768,6 +799,9 @@ def _discover(
             "source": session_meta.get("source") or match_info.get("source", "unknown"),
             "model": session_meta.get("model") or match_info.get("model") or "unknown",
             "title": session_meta.get("title") or None,
+            "session_key": session_meta.get("session_key"),
+            "chat_id": session_meta.get("chat_id"),
+            "thread_id": session_meta.get("thread_id"),
             "matched_role": match_info.get("role"),
             "match_message_id": msg_id,
             "snippet": match_info.get("snippet") or "",
@@ -818,6 +852,8 @@ def session_search(
     sort: str = None,
     # Cross-profile (any shape)
     profile: str = None,
+    # Browse/discovery visibility
+    scope: str = "current",
 ) -> str:
     """Single-shape tool. Mode inferred from which args are set.
 
@@ -826,7 +862,9 @@ def session_search(
     Read:      pass ``session_id`` (no anchor) — dumps the whole session.
     Browse:    pass nothing.
 
-    Pass ``profile`` to read another profile's sessions (e.g. resolving an
+    Browse and discovery default to the current routed gateway conversation
+    when its persisted session_key is available. Pass ``scope="all"`` for
+    global history. Pass ``profile`` to read another profile's sessions (e.g. resolving an
     ``@session:<profile>/<id>`` link). Scroll wins over read/discovery when an
     anchor is set — the agent has asked for a specific slice.
     """
@@ -894,6 +932,27 @@ def session_search(
                 return json.dumps(found, ensure_ascii=False)
         return result
 
+    scope_norm = str(scope or "current").strip().lower()
+    if scope_norm not in ("current", "all"):
+        return tool_error("scope must be 'current' or 'all'", success=False)
+
+    # Cross-profile browse/discovery is intentionally global within the named
+    # profile. A session_key from the caller's profile/conversation must never
+    # silently constrain another profile.
+    scoped_session_key = None
+    if scope_norm == "current" and current_session_id:
+        try:
+            current_meta = db.get_session(current_session_id) or {}
+        except Exception:
+            logging.debug(
+                "get_session failed while resolving session_search scope",
+                exc_info=True,
+            )
+            current_meta = {}
+        key = current_meta.get("session_key")
+        if isinstance(key, str) and key.strip():
+            scoped_session_key = key.strip()
+
     # Limit clamp [1, 10]
     if not isinstance(limit, int):
         try:
@@ -904,7 +963,13 @@ def session_search(
 
     # Browse shape: no query → recent sessions.
     if not query or not isinstance(query, str) or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id, link_profile=profile)
+        return _list_recent_sessions(
+            db,
+            limit,
+            current_session_id,
+            link_profile=profile,
+            session_key=scoped_session_key,
+        )
 
     # Parse role_filter
     role_list: Optional[List[str]] = None
@@ -926,6 +991,7 @@ def session_search(
         sort=sort_norm,
         current_session_id=current_session_id,
         link_profile=profile,
+        session_key=scoped_session_key,
     )
 
 
@@ -971,6 +1037,10 @@ SESSION_SEARCH_SCHEMA = {
         "       - match_message_id, messages_before, messages_after\n"
         "     Bookends + window together let you reconstruct goal → match → resolution "
         "without paying for the whole transcript.\n\n"
+        "     In routed gateway conversations, discovery and browse default to the "
+        "same authenticated conversation/session_key (including its older reset or "
+        "compression history). Pass scope=\"all\" explicitly to search other chats "
+        "or topics. Direct READ and SCROLL by session_id remain exact and unscoped.\n\n"
         "  2) SCROLL — pass `session_id` + `around_message_id`:\n"
         "     session_search(session_id=\"...\", around_message_id=12345, window=10)\n"
         "     Returns a window of ±`window` messages centered on the anchor. No FTS5, "
@@ -1090,6 +1160,19 @@ SESSION_SEARCH_SCHEMA = {
                     "Omit to use the current profile."
                 ),
             },
+            "scope": {
+                "type": "string",
+                "enum": ["current", "all"],
+                "default": "current",
+                "description": (
+                    "Browse/discovery scope. 'current' (default) restricts routed "
+                    "gateway calls to the current authenticated conversation's exact "
+                    "session_key when available; CLI and sessions without routing "
+                    "metadata fall back to global history. Use 'all' only as an "
+                    "explicit opt-in to cross-chat/topic history. READ and SCROLL by "
+                    "session_id are always exact and ignore this scope."
+                ),
+            },
         },
         "required": [],
     },
@@ -1112,8 +1195,9 @@ registry.register(
         window=args.get("window", 5),
         sort=args.get("sort"),
         profile=args.get("profile"),
+        scope=args.get("scope", "current"),
         db=kw.get("db"),
-        current_session_id=kw.get("current_session_id"),
+        current_session_id=kw.get("session_id"),
     ),
     check_fn=check_session_search_requirements,
     emoji="🔍",


### PR DESCRIPTION
## Summary

- scope `session_search` browse/discovery to the active persisted gateway `session_key` by default
- add explicit `scope="all"` opt-in for cross-topic/global history
- expose `session_key`, `chat_id`, and `thread_id` provenance in search/read results
- apply the session-key predicate before ranking and limits across FTS, CJK, trigram, LIKE, deferred-index, title, and browse paths
- preserve global CLI/no-route behavior, cross-profile lookup, and explicit cross-topic read/scroll
- wire the production registry `session_id` into current-conversation scoping

## Incident

A Telegram conversation in topic `40507` recovered unrelated context from topic `799` after a session reset because discovery searched all stored sessions globally. Telegram ingress had preserved the correct topic; the contamination happened during unrestricted history recovery.

## Validation

- Exact-source Docker validation: `565 passed, 1 skipped`
- Ruff: `All checks passed!`
- `git diff --check`: clean
- Fresh independent Threadwire review of staged patch `9c989d2a45f46800424e05339902db780a316e6286bd42648746d7fb68ffbfa2`: PASS, no blocking findings

## Safety

- No live database changes
- No Hermes restart or deployment
- Cross-topic history remains available only through explicit `scope="all"` or explicit session reads
