### PR TITLE
docs: clarify response-only reasoning mode

### DIFF
--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1519,7 +1519,7 @@ display:
   compact: false          # Compact output mode (less whitespace)
   resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
-  show_reasoning: false   # Show model reasoning/thinking above each response (toggle with /reasoning show|hide)
+  show_reasoning: false   # Hide model reasoning/thinking above each response; OFF = response-only mode (toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   show_cost: false        # Show estimated $ cost in the CLI status bar
   timestamps: false       # When true, prefixes user and assistant labels with [HH:MM] timestamps in the CLI / TUI transcript
@@ -1531,6 +1531,11 @@ display:
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
   language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
 ```
+
+`display.show_reasoning: false` hides the streaming thinking UI and leaves only
+user messages, assistant final text, and tool output in the transcript. Turn it
+on when you want to inspect chain-of-thought locally; leave it off for a clean
+response-only view.
 
 ### File-mutation verifier
 


### PR DESCRIPTION
Clarify that  is the durable response-only view and document what the transcript shows when reasoning is hidden.