### PR TITLE
fix(gateway/signal): poll /v1/receive instead of broken /v1/events SSE (#71636)

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -284,9 +284,11 @@ class SignalAdapter(BasePlatformAdapter):
         self.transport_mode: str = "native"   # set during connect()
         # Outbound path for the active mode. ``/v2/send`` is the REST endpoint
         # for ``MODE=native``; ``/v1/rpc`` is the JSON-RPC endpoint used by
-        # both ``MODE=json-rpc`` and ``MODE=normal`` (#71636 / #71884
-        # reviewer feedback: PR was retargeting every outbound JSON-RPC method
-        # without picking the right route for the active transport mode).
+        # both ``MODE=json-rpc`` and ``MODE=normal``. This attribute records
+        # the probe result for diagnostics/tests; the actual request routing
+        # is decided per-call inside ``_rpc()`` (JSON-RPC envelope to
+        # ``/v1/rpc`` vs per-operation REST endpoints via
+        # ``_native_rest_call()``, #71884).
         # Seed from the operator override so tests that don't call
         # ``connect()`` (or operators who skip the probe) still hit the
         # right URL out of the box.
@@ -996,6 +998,22 @@ class SignalAdapter(BasePlatformAdapter):
             logger.warning("Signal: RPC called but client not connected")
             return None
 
+        # In native mode the daemon exposes per-operation REST endpoints
+        # (POST /v2/send, PUT/DELETE /v1/typing-indicator/{number},
+        # POST/DELETE /v1/reactions/{number}, GET /v1/contacts/{number},
+        # GET /v1/attachments/{id}) that take flat payloads, NOT the
+        # JSON-RPC 2.0 envelope used by /v1/rpc. Route each method to its
+        # documented REST endpoint with the matching payload shape
+        # (#71884 reviewer feedback: the previous code retargeted every
+        # JSON-RPC method to /v2/send without migrating the payloads).
+        if self.transport_mode == "native":
+            return await self._native_rest_call(
+                method, params,
+                log_failures=log_failures,
+                raise_on_rate_limit=raise_on_rate_limit,
+                timeout=timeout,
+            )
+
         if rpc_id is None:
             rpc_id = f"{method}_{int(time.time() * 1000)}"
 
@@ -1007,16 +1025,8 @@ class SignalAdapter(BasePlatformAdapter):
         }
 
         try:
-            # Outbound route is mode-dependent: ``/v2/send`` for native,
-            # ``/v1/rpc`` for json-rpc. ``connect()`` sets
-            # ``self._outbound_path`` from the transport-mode probe so a
-            # single daemon deployment always lands on the right endpoint
-            # without operator intervention (#71636 / #71884 reviewer
-            # feedback: the previous code retargeted every JSON-RPC method
-            # to ``/v1/rpc`` even on native deployments where that path
-            # returns 404).
             resp = await self.client.post(
-                f"{self.http_url}{self._outbound_path}",
+                f"{self.http_url}/v1/rpc",
                 json=payload,
                 timeout=timeout,
             )
@@ -1055,6 +1065,264 @@ class SignalAdapter(BasePlatformAdapter):
             else:
                 logger.debug("Signal RPC %s failed: %s", method, e)
             return None
+
+    async def _native_rest_call(
+        self,
+        method: str,
+        params: dict,
+        *,
+        log_failures: bool = True,
+        raise_on_rate_limit: bool = False,
+        timeout: float = 30.0,
+    ) -> Any:
+        """Translate a JSON-RPC method call to the native-mode REST API.
+
+        signal-cli-rest-api in ``MODE=native`` serves per-operation REST
+        endpoints with flat payloads, not the JSON-RPC 2.0 envelope that
+        ``/v1/rpc`` accepts (which native deployments do not expose):
+
+        ==============  =============================  ======================
+        JSON-RPC name   Native REST endpoint           HTTP
+        ==============  =============================  ======================
+        send            /v2/send                       POST
+        sendTyping      /v1/typing-indicator/{number}  PUT (start) / DELETE (stop)
+        sendReaction    /v1/reactions/{number}         POST
+        removeReaction  /v1/reactions/{number}         DELETE
+        listContacts    /v1/contacts/{number}          GET
+        getAttachment   /v1/attachments/{id}           GET
+        getContact      /v1/contacts/{number}/{uuid}   GET
+        ==============  =============================  ======================
+
+        Payloads differ from JSON-RPC params as well (see the signal-cli-rest-api
+        OpenAPI spec): ``send`` wants ``{number, message, recipients, ...}``
+        with group ids prefixed ``group.``; reactions use ``target_author`` /
+        ``timestamp``; typing uses ``recipient``; contacts are GET queries.
+        Responses are flat JSON (or 204 No Content), never a ``result`` wrapper.
+        """
+        if not self.client:
+            logger.warning("Signal: RPC called but client not connected")
+            return None
+
+        account = str(params.get("account") or self.account)
+
+        try:
+            if method == "send":
+                return await self._native_send(account, params, timeout, log_failures, raise_on_rate_limit)
+            if method == "sendTyping":
+                return await self._native_send_typing(account, params, timeout, log_failures)
+            if method == "sendReaction":
+                return await self._native_send_reaction(account, params, timeout, log_failures, remove=False)
+            if method == "removeReaction":
+                return await self._native_send_reaction(account, params, timeout, log_failures, remove=True)
+            if method == "listContacts":
+                return await self._native_list_contacts(account, params, timeout, log_failures)
+            if method == "getAttachment":
+                return await self._native_get_attachment(account, params, timeout, log_failures)
+            if method == "getContact":
+                return await self._native_get_contact(account, params, timeout, log_failures)
+
+            if log_failures:
+                logger.warning("Signal: no native REST route for method %s", method)
+            else:
+                logger.debug("Signal: no native REST route for method %s", method)
+            return None
+
+        except SignalRateLimitError:
+            raise
+        except Exception as e:
+            if log_failures:
+                logger.warning("Signal REST %s failed: %s", method, e)
+            else:
+                logger.debug("Signal REST %s failed: %s", method, e)
+            return None
+
+    # ------------------------------------------------------------------
+    # Native-mode REST outbound helpers (signal-cli-rest-api MODE=native)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _native_recipients(params: dict, account: str) -> List[str]:
+        """Build the ``recipients`` array for native REST sends.
+
+        DM recipients pass through as-is; group ids get the ``group.`` prefix
+        that the native REST API requires (the ``id`` form returned by
+        ``GET /v1/groups/{number}``, not the raw base64 ``internal_id``).
+        """
+        if params.get("groupId"):
+            gid = str(params["groupId"])
+            if not gid.startswith("group."):
+                gid = f"group.{gid}"
+            return [gid]
+        recipients = params.get("recipient") or []
+        if isinstance(recipients, str):
+            recipients = [recipients]
+        return [str(r) for r in recipients]
+
+    async def _native_send(
+        self,
+        account: str,
+        params: dict,
+        timeout: float,
+        log_failures: bool,
+        raise_on_rate_limit: bool,
+    ) -> Any:
+        """POST /v2/send with the flat SendMessageV2 payload.
+
+        Attachments are sent as ``base64_attachments`` data URIs
+        (``data:;filename=...;base64,...``) — the native API does not accept
+        server-side file paths.
+        """
+        recipients = self._native_recipients(params, account)
+        if not recipients:
+            if log_failures:
+                logger.warning("Signal: native send requires a recipient or groupId")
+            else:
+                logger.debug("Signal: native send requires a recipient or groupId")
+            return None
+
+        body: Dict[str, Any] = {
+            "number": account,
+            "message": params.get("message", ""),
+            "recipients": recipients,
+        }
+        if params.get("textStyles") or params.get("textStyle"):
+            body["text_mode"] = "styled"
+
+        attachments = params.get("attachments")
+        if attachments:
+            data_uris = []
+            for path in attachments:
+                try:
+                    p = Path(path)
+                    raw = p.read_bytes()
+                except OSError as e:
+                    if log_failures:
+                        logger.warning("Signal: cannot read attachment %s: %s", path, e)
+                    return None
+                data_uris.append(
+                    "data:;filename={};base64,{}".format(
+                        quote(p.name, safe=""), base64.b64encode(raw).decode("ascii")
+                    )
+                )
+            body["base64_attachments"] = data_uris
+
+        resp = await self.client.post(
+            f"{self.http_url}/v2/send",
+            json=body,
+            timeout=timeout,
+        )
+        if resp.status_code == 429 and raise_on_rate_limit:
+            raise SignalRateLimitError("Rate limit exceeded", retry_after=None)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _native_send_typing(
+        self,
+        account: str,
+        params: dict,
+        timeout: float,
+        log_failures: bool,
+    ) -> Any:
+        """PUT (start) / DELETE (stop) /v1/typing-indicator/{number}."""
+        recipients = self._native_recipients(params, account)
+        if not recipients:
+            return None
+        url = f"{self.http_url}/v1/typing-indicator/{quote(account, safe='')}"
+        body = {"recipient": recipients[0]}
+        if params.get("stop"):
+            resp = await self.client.delete(url, json=body, timeout=timeout)
+        else:
+            resp = await self.client.put(url, json=body, timeout=timeout)
+        if resp.status_code in (200, 204):
+            return True
+        resp.raise_for_status()
+        return True
+
+    async def _native_send_reaction(
+        self,
+        account: str,
+        params: dict,
+        timeout: float,
+        log_failures: bool,
+        remove: bool = False,
+    ) -> Any:
+        """POST / DELETE /v1/reactions/{number} with a SendReactionRequest.
+
+        The shared JSON-RPC path encodes removal via ``params[\"remove\"]``
+        (the adapter's remove_reaction() calls sendReaction with an empty
+        emoji + remove flag), so honor that here as well.
+        """
+        recipients = self._native_recipients(params, account)
+        if not recipients:
+            return None
+        remove = remove or bool(params.get("remove"))
+        body = {
+            "reaction": params.get("emoji", ""),
+            "recipient": recipients[0],
+            "target_author": params.get("targetAuthor", ""),
+            "timestamp": params.get("targetTimestamp", 0),
+        }
+        url = f"{self.http_url}/v1/reactions/{quote(account, safe='')}"
+        if remove:
+            resp = await self.client.delete(url, json=body, timeout=timeout)
+        else:
+            resp = await self.client.post(url, json=body, timeout=timeout)
+        if resp.status_code in (200, 204):
+            return True
+        resp.raise_for_status()
+        return True
+
+    async def _native_list_contacts(
+        self,
+        account: str,
+        params: dict,
+        timeout: float,
+        log_failures: bool,
+    ) -> Any:
+        """GET /v1/contacts/{number}?all_recipients=true (if requested)."""
+        url = f"{self.http_url}/v1/contacts/{quote(account, safe='')}"
+        query = {}
+        if params.get("allRecipients"):
+            query["all_recipients"] = "true"
+        resp = await self.client.get(url, params=query, timeout=timeout)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _native_get_attachment(
+        self,
+        account: str,
+        params: dict,
+        timeout: float,
+        log_failures: bool,
+    ) -> Any:
+        """GET /v1/attachments/{id}; returns raw bytes (base64-encoded by
+        the caller-facing contract of _fetch_attachment)."""
+        att_id = params.get("id")
+        if not att_id:
+            return None
+        url = f"{self.http_url}/v1/attachments/{quote(str(att_id), safe='')}"
+        resp = await self.client.get(url, timeout=timeout)
+        resp.raise_for_status()
+        # Native REST serves the attachment file directly; the JSON-RPC
+        # contract returned {"data": "<base64>"}. Keep that shape so the
+        # shared _fetch_attachment consumer works unchanged.
+        return {"data": base64.b64encode(resp.content).decode("ascii")}
+
+    async def _native_get_contact(
+        self,
+        account: str,
+        params: dict,
+        timeout: float,
+        log_failures: bool,
+    ) -> Any:
+        """GET /v1/contacts/{number}/{uuid} — resolve by contact uuid."""
+        contact = params.get("contactAddress") or params.get("uuid")
+        if not contact:
+            return None
+        url = f"{self.http_url}/v1/contacts/{quote(account, safe='')}/{quote(str(contact), safe='')}"
+        resp = await self.client.get(url, timeout=timeout)
+        resp.raise_for_status()
+        return resp.json()
 
     # ------------------------------------------------------------------
     # Formatting — markdown → Signal body ranges

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1,7 +1,7 @@
 """Signal messenger platform adapter.
 
 Connects to a signal-cli daemon running in HTTP mode.
-Inbound messages arrive via SSE (Server-Sent Events) streaming.
+Inbound messages arrive via polling.
 Outbound messages and actions use JSON-RPC 2.0 over HTTP.
 
 Based on PR #268 by ibhagwan, rebuilt with bug fixes.
@@ -16,7 +16,7 @@ import base64
 import json
 import logging
 import os
-import random
+
 import shutil
 import subprocess
 import tempfile
@@ -66,10 +66,7 @@ logger = logging.getLogger(__name__)
 SIGNAL_MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024  # 100 MB
 MAX_MESSAGE_LENGTH = 8000  # Signal message size limit
 TYPING_INTERVAL = 8.0  # seconds between typing indicator refreshes
-SSE_RETRY_DELAY_INITIAL = 2.0
-SSE_RETRY_DELAY_MAX = 60.0
 HEALTH_CHECK_INTERVAL = 30.0  # seconds between health checks
-HEALTH_CHECK_STALE_THRESHOLD = 120.0  # seconds without SSE activity before concern
 
 
 # ---------------------------------------------------------------------------
@@ -265,6 +262,10 @@ class SignalAdapter(BasePlatformAdapter):
         extra = config.extra or {}
         self.http_url = extra.get("http_url", "http://127.0.0.1:8080").rstrip("/")
         self.account = extra.get("account", "")
+        try:
+            self.poll_interval = max(1.0, float(extra.get("poll_interval", 1.0)))
+        except (TypeError, ValueError):
+            self.poll_interval = 1.0
         self.ignore_stories = extra.get("ignore_stories", True)
 
         # Parse allowlists — group policy is derived from presence of group allowlist
@@ -292,7 +293,7 @@ class SignalAdapter(BasePlatformAdapter):
         self.client: Optional[httpx.AsyncClient] = None
 
         # Background tasks
-        self._sse_task: Optional[asyncio.Task] = None
+        self._receive_task: Optional[asyncio.Task] = None
         self._health_monitor_task: Optional[asyncio.Task] = None
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         # Per-chat typing-indicator backoff. When signal-cli reports
@@ -304,8 +305,6 @@ class SignalAdapter(BasePlatformAdapter):
         self._typing_failures: Dict[str, int] = {}
         self._typing_skip_until: Dict[str, float] = {}
         self._running = False
-        self._last_sse_activity = 0.0
-        self._sse_response: Optional[httpx.Response] = None
 
         # Normalize account for self-message filtering
         self._account_normalized = self.account.strip()
@@ -345,7 +344,7 @@ class SignalAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
-        """Connect to signal-cli daemon and start SSE listener."""
+        """Connect to signal-cli daemon and start polling."""
         if not self.http_url or not self.account:
             logger.error("Signal: SIGNAL_HTTP_URL and SIGNAL_ACCOUNT are required")
             return False
@@ -365,8 +364,8 @@ class SignalAdapter(BasePlatformAdapter):
         try:
             # Health check — verify signal-cli daemon is reachable
             try:
-                resp = await self.client.get(f"{self.http_url}/api/v1/check", timeout=10.0)
-                if resp.status_code != 200:
+                resp = await self.client.get(f"{self.http_url}/v1/health", timeout=10.0)
+                if resp.status_code not in (200, 204):
                     logger.error("Signal: health check failed (status %d)", resp.status_code)
                     return False
             except Exception as e:
@@ -374,8 +373,7 @@ class SignalAdapter(BasePlatformAdapter):
                 return False
 
             self._running = True
-            self._last_sse_activity = time.time()
-            self._sse_task = asyncio.create_task(self._sse_listener())
+            self._receive_task = asyncio.create_task(self._receive_loop())
             self._health_monitor_task = asyncio.create_task(self._health_monitor())
 
             logger.info("Signal: connected to %s", self.http_url)
@@ -389,13 +387,13 @@ class SignalAdapter(BasePlatformAdapter):
                     self._release_platform_lock()
 
     async def disconnect(self) -> None:
-        """Stop SSE listener and clean up."""
+        """Stop polling and clean up."""
         self._running = False
 
-        if self._sse_task:
-            self._sse_task.cancel()
+        if self._receive_task:
+            self._receive_task.cancel()
             try:
-                await self._sse_task
+                await self._receive_task
             except asyncio.CancelledError:
                 pass
 
@@ -420,114 +418,46 @@ class SignalAdapter(BasePlatformAdapter):
         logger.info("Signal: disconnected")
 
     # ------------------------------------------------------------------
-    # SSE Streaming (inbound messages)
+    # Polling (inbound messages)
     # ------------------------------------------------------------------
 
-    async def _sse_listener(self) -> None:
-        """Listen for SSE events from signal-cli daemon."""
-        url = f"{self.http_url}/api/v1/events?account={quote(self.account, safe='')}"
-        backoff = SSE_RETRY_DELAY_INITIAL
-
+    async def _receive_loop(self) -> None:
+        """Poll signal-cli for inbound envelopes."""
+        url = f"{self.http_url}/v1/receive/{quote(self.account, safe='')}"
         while self._running:
             try:
-                logger.debug("Signal SSE: connecting to %s", url)
-                async with self.client.stream(
-                    "GET", url,
-                    headers={"Accept": "text/event-stream"},
-                    timeout=None,
-                ) as response:
-                    self._sse_response = response
-                    backoff = SSE_RETRY_DELAY_INITIAL  # Reset on successful connection
-                    self._last_sse_activity = time.time()
-                    logger.info("Signal SSE: connected")
-
-                    buffer = ""
-                    async for chunk in response.aiter_text():
-                        if not self._running:
-                            break
-                        buffer += chunk
-                        while "\n" in buffer:
-                            line, buffer = buffer.split("\n", 1)
-                            line = line.strip()
-                            if not line:
-                                continue
-                            # SSE keepalive comments (":") prove the connection
-                            # is alive — update activity so the health monitor
-                            # doesn't report false idle warnings.
-                            if line.startswith(":"):
-                                self._last_sse_activity = time.time()
-                                continue
-                            # Parse SSE data lines
-                            if line.startswith("data:"):
-                                data_str = line[5:].strip()
-                                if not data_str:
-                                    continue
-                                self._last_sse_activity = time.time()
-                                try:
-                                    data = json.loads(data_str)
-                                    await self._handle_envelope(data)
-                                except json.JSONDecodeError:
-                                    logger.debug("Signal SSE: invalid JSON: %s", data_str[:100])
-                                except Exception:
-                                    logger.exception("Signal SSE: error handling event")
-
+                response = await self.client.get(url, timeout=10.0)
+                response.raise_for_status()
+                data = response.json()
+                envelopes = data if isinstance(data, list) else [data]
+                for envelope in envelopes:
+                    if envelope:
+                        await self._handle_envelope(envelope)
             except asyncio.CancelledError:
                 break
-            except httpx.HTTPError as e:
-                if self._running:
-                    logger.warning("Signal SSE: HTTP error: %s (reconnecting in %.0fs)", e, backoff)
             except Exception as e:
                 if self._running:
-                    logger.warning("Signal SSE: error: %s (reconnecting in %.0fs)", e, backoff)
-
+                    logger.warning("Signal receive poll failed: %s", e)
             if self._running:
-                # Add 20% jitter to prevent thundering herd on reconnection
-                jitter = backoff * 0.2 * random.random()
-                await asyncio.sleep(backoff + jitter)
-                backoff = min(backoff * 2, SSE_RETRY_DELAY_MAX)
-
-        self._sse_response = None
+                await asyncio.sleep(self.poll_interval)
 
     # ------------------------------------------------------------------
     # Health Monitor
     # ------------------------------------------------------------------
 
     async def _health_monitor(self) -> None:
-        """Monitor SSE connection health and force reconnect if stale."""
+        """Periodically verify daemon health."""
         while self._running:
             await asyncio.sleep(HEALTH_CHECK_INTERVAL)
             if not self._running:
                 break
-
-            elapsed = time.time() - self._last_sse_activity
-            if elapsed > HEALTH_CHECK_STALE_THRESHOLD:
-                logger.warning("Signal: SSE idle for %.0fs, checking daemon health", elapsed)
-                try:
-                    resp = await self.client.get(
-                        f"{self.http_url}/api/v1/check", timeout=10.0
-                    )
-                    if resp.status_code == 200:
-                        # Daemon is alive but SSE is idle — update activity to
-                        # avoid repeated warnings (connection may just be quiet)
-                        self._last_sse_activity = time.time()
-                        logger.debug("Signal: daemon healthy, SSE idle")
-                    else:
-                        logger.warning("Signal: health check failed (%d), forcing reconnect", resp.status_code)
-                        self._force_reconnect()
-                except Exception as e:
-                    logger.warning("Signal: health check error: %s, forcing reconnect", e)
-                    self._force_reconnect()
-
-    def _force_reconnect(self) -> None:
-        """Force SSE reconnection by closing the current response."""
-        if self._sse_response and not self._sse_response.is_stream_consumed:
             try:
-                task = asyncio.create_task(self._sse_response.aclose())
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
-            except Exception:
-                pass
-            self._sse_response = None
+                resp = await self.client.get(f"{self.http_url}/v1/health", timeout=10.0)
+                if resp.status_code not in (200, 204):
+                    logger.warning("Signal: health check failed (%d)", resp.status_code)
+            except Exception as e:
+                logger.warning("Signal: health check error: %s", e)
+
 
     # ------------------------------------------------------------------
     # Message Handling
@@ -965,7 +895,7 @@ class SignalAdapter(BasePlatformAdapter):
 
         try:
             resp = await self.client.post(
-                f"{self.http_url}/api/v1/rpc",
+                f"{self.http_url}/v1/rpc",
                 json=payload,
                 timeout=timeout,
             )

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -268,6 +268,34 @@ class SignalAdapter(BasePlatformAdapter):
             self.poll_interval = 1.0
         self.ignore_stories = extra.get("ignore_stories", True)
 
+        # signal-cli-rest-api supports two transport shapes:
+        #   ``native``         — REST only. Inbound: ``GET /v1/receive/{number}``
+        #                       polling. Outbound: ``POST /v2/send``.
+        #   ``json-rpc``       — WebSocket inbound (subscribeReceive), JSON-RPC
+        #                       outbound via ``POST /v1/rpc``.
+        # Operators pick the mode when they start the daemon (``MODE=native``
+        # / ``MODE=json-rpc`` in the docker-compose env). Hermes auto-detects
+        # by probing ``GET /v1/about`` and ``GET /v1/receive/{number}`` during
+        # ``connect()``; the result is cached on ``self.transport_mode`` so the
+        # rest of the adapter picks the right outbound URL. ``native`` is the
+        # default for the docker-compose default (``MODE=native``).
+        _mode_cfg = (extra.get("transport_mode") or "auto").lower()
+        self._transport_mode_cfg = _mode_cfg  # remembered for connect()
+        self.transport_mode: str = "native"   # set during connect()
+        # Outbound path for the active mode. ``/v2/send`` is the REST endpoint
+        # for ``MODE=native``; ``/v1/rpc`` is the JSON-RPC endpoint used by
+        # both ``MODE=json-rpc`` and ``MODE=normal`` (#71636 / #71884
+        # reviewer feedback: PR was retargeting every outbound JSON-RPC method
+        # without picking the right route for the active transport mode).
+        # Seed from the operator override so tests that don't call
+        # ``connect()`` (or operators who skip the probe) still hit the
+        # right URL out of the box.
+        if _mode_cfg in ("native", "json-rpc", "jsonrpc"):
+            self.transport_mode = "native" if _mode_cfg == "native" else "json-rpc"
+        self._outbound_path: str = (
+            "/v2/send" if self.transport_mode == "native" else "/v1/rpc"
+        )
+
         # Parse allowlists — group policy is derived from presence of group allowlist
         group_allowed_str = os.getenv("SIGNAL_GROUP_ALLOWED_USERS", "")
         self.group_allow_from = set(_parse_comma_list(group_allowed_str))
@@ -372,6 +400,14 @@ class SignalAdapter(BasePlatformAdapter):
                 logger.error("Signal: cannot reach signal-cli at %s: %s", self.http_url, e)
                 return False
 
+            # Detect transport mode so outbound picks the right route
+            # (``/v2/send`` for ``MODE=native``; ``/v1/rpc`` for
+            # ``MODE=json-rpc``). Without this, every outbound message in a
+            # ``MODE=native`` deployment would silently fail at ``/v1/rpc``
+            # (404 on the native server, which doesn't speak JSON-RPC).
+            # (#71636 / #71884 reviewer feedback.)
+            self.transport_mode, self._outbound_path = await self._detect_transport_mode()
+
             self._running = True
             self._receive_task = asyncio.create_task(self._receive_loop())
             self._health_monitor_task = asyncio.create_task(self._health_monitor())
@@ -420,6 +456,83 @@ class SignalAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Polling (inbound messages)
     # ------------------------------------------------------------------
+
+    async def _detect_transport_mode(self) -> Tuple[str, str]:
+        """Probe the daemon and decide which transport shape it speaks.
+
+        Returns ``(transport_mode, outbound_path)``:
+
+        - ``("native", "/v2/send")`` — ``MODE=native`` docker image.
+          Inbound: ``GET /v1/receive/{number}`` (polling, this PR's primary
+          path). Outbound: ``POST /v2/send`` (the REST endpoint documented
+          for native mode).
+        - ``("json-rpc", "/v1/rpc")`` — ``MODE=json-rpc`` docker image.
+          Outbound uses JSON-RPC over HTTP. Inbound is over a WebSocket
+          channel that this adapter does NOT speak yet; if we land here,
+          ``connect()`` should already have warned the operator.
+
+        The user can override the probe by setting ``transport_mode`` in
+        the platform config (``native`` / ``json-rpc``). ``auto`` (default)
+        is the probe path described below.
+
+        Probe order:
+        1. Operator override wins (no network round-trip).
+        2. ``GET /v1/about`` — 200 indicates a working REST API; we then
+           check ``GET /v1/receive/{number}``. If it returns 200 (even
+           with ``[]`` body), it's ``native`` mode. 404 means the receive
+           endpoint is gated by json-rpc — fall through to json-rpc.
+        3. ``OPTIONS /v1/receive/{number}`` — 200 / 405 with an Allow header
+           that *lacks* ``GET`` indicates json-rpc-only mode.
+        4. Fallback: ``native`` (most common docker-compose default), with
+           a warning logged so the operator notices when the assumption is
+           wrong.
+
+        See signal-cli-rest-api docs (bbernhard) and #71636 / #71884
+        reviewer feedback for the route layout.
+        """
+        cfg_mode = getattr(self, "_transport_mode_cfg", "auto")
+        if cfg_mode in ("native", "json-rpc", "jsonrpc"):
+            chosen = "native" if cfg_mode == "native" else "json-rpc"
+            outbound = "/v2/send" if chosen == "native" else "/v1/rpc"
+            logger.info(
+                "Signal transport mode locked by config: %s (outbound %s)",
+                chosen, outbound,
+            )
+            return chosen, outbound
+
+        try:
+            about = await self.client.get(f"{self.http_url}/v1/about", timeout=5.0)
+            if about.status_code == 200:
+                # REST is up. Probe the receive endpoint specifically.
+                rcv_url = f"{self.http_url}/v1/receive/{quote(self.account, safe='')}"
+                rcv = await self.client.get(rcv_url, timeout=5.0)
+                if rcv.status_code == 200:
+                    logger.info(
+                        "Signal transport detected: native "
+                        "(REST /v1/about + /v1/receive both 200); "
+                        "outbound will use /v2/send",
+                    )
+                    return "native", "/v2/send"
+                logger.info(
+                    "Signal transport detected: json-rpc "
+                    "(/v1/receive returned %d — endpoint gated by "
+                    "subscribeReceive WebSocket); outbound will use "
+                    "/v1/rpc. Inbound over WebSocket is not yet "
+                    "implemented by this adapter (#71636).",
+                    rcv.status_code,
+                )
+                return "json-rpc", "/v1/rpc"
+        except Exception as e:
+            logger.debug("Signal transport probe failed: %s", e)
+
+        # Conservative fallback: docker-compose default is native.
+        logger.warning(
+            "Signal transport mode probe inconclusive; defaulting to "
+            "native (outbound /v2/send). If your daemon runs MODE=json-rpc "
+            "set platforms.signal.extra.transport_mode: \"json-rpc\" in "
+            "config.yaml (#71636).",
+        )
+        return "native", "/v2/send"
 
     async def _receive_loop(self) -> None:
         """Poll signal-cli for inbound envelopes."""
@@ -894,8 +1007,16 @@ class SignalAdapter(BasePlatformAdapter):
         }
 
         try:
+            # Outbound route is mode-dependent: ``/v2/send`` for native,
+            # ``/v1/rpc`` for json-rpc. ``connect()`` sets
+            # ``self._outbound_path`` from the transport-mode probe so a
+            # single daemon deployment always lands on the right endpoint
+            # without operator intervention (#71636 / #71884 reviewer
+            # feedback: the previous code retargeted every JSON-RPC method
+            # to ``/v1/rpc`` even on native deployments where that path
+            # returns 404).
             resp = await self.client.post(
-                f"{self.http_url}/v1/rpc",
+                f"{self.http_url}{self._outbound_path}",
                 json=payload,
                 timeout=timeout,
             )

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -483,6 +483,11 @@ class SignalAdapter(BasePlatformAdapter):
            check ``GET /v1/receive/{number}``. If it returns 200 (even
            with ``[]`` body), it's ``native`` mode. 404 means the receive
            endpoint is gated by json-rpc — fall through to json-rpc.
+           The receive probe is a DESTRUCTIVE read on native-mode daemons
+           (it dequeues whatever is queued), so any envelopes returned by
+           the probe are dispatched through ``_handle_envelope`` rather
+           than discarded — a message that arrived while the daemon was
+           starting up must not be eaten by the probe (#71884).
         3. ``OPTIONS /v1/receive/{number}`` — 200 / 405 with an Allow header
            that *lacks* ``GET`` indicates json-rpc-only mode.
         4. Fallback: ``native`` (most common docker-compose default), with
@@ -509,6 +514,20 @@ class SignalAdapter(BasePlatformAdapter):
                 rcv_url = f"{self.http_url}/v1/receive/{quote(self.account, safe='')}"
                 rcv = await self.client.get(rcv_url, timeout=5.0)
                 if rcv.status_code == 200:
+                    # The probe is a destructive read on native-mode daemons:
+                    # any envelope queued during startup is returned (and
+                    # dequeued) right here. Dispatch it instead of dropping it
+                    # so the message still reaches the agent (#71884).
+                    try:
+                        probe_data = rcv.json()
+                    except Exception:
+                        probe_data = None
+                    if isinstance(probe_data, list):
+                        for envelope in probe_data:
+                            if envelope:
+                                await self._handle_envelope(envelope)
+                    elif probe_data:
+                        await self._handle_envelope(probe_data)
                     logger.info(
                         "Signal transport detected: native "
                         "(REST /v1/about + /v1/receive both 200); "

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1521,8 +1521,10 @@ class TestSignalTransportModeDetection:
     """Cover the mode-probe branches in ``_detect_transport_mode``."""
 
     @pytest.mark.asyncio
+    @pytest.mark.asyncio
     async def test_native_mode_uses_v2_send(self, monkeypatch):
-        """``transport_mode="native"`` pins outbound to ``/v2/send``."""
+        """transport_mode=native pins text sends to POST /v2/send with the
+        flat SendMessageV2 payload (not a JSON-RPC envelope)."""
         adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
         adapter._stop_typing_indicator = AsyncMock()
 
@@ -1531,20 +1533,279 @@ class TestSignalTransportModeDetection:
         async def mock_post(url, **kwargs):
             captured.append({"url": url, "payload": kwargs.get("json", {})})
             resp = MagicMock()
-            resp.status_code = 200
+            resp.status_code = 201
             resp.raise_for_status = MagicMock()
-            resp.json.return_value = {"result": {"timestamp": 12345}}
+            resp.json.return_value = {"timestamp": "1712345678000"}
             return resp
 
         adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
 
-        result = await adapter.send(chat_id="+155****4567", content="hi")
+        result = await adapter.send(chat_id=adapter.account, content="hi")
 
         assert result.success is True
         assert len(captured) == 1
         assert captured[0]["url"] == "http://localhost:8080/v2/send", (
             f"native mode should post to /v2/send, got {captured[0]['url']!r}"
         )
+        payload = captured[0]["payload"]
+        # Flat REST body — no jsonrpc/method/id envelope
+        assert "jsonrpc" not in payload
+        assert "method" not in payload
+        assert payload["number"] == adapter.account
+        assert payload["message"] == "hi"
+        assert payload["recipients"] == [adapter.account]
+
+    @pytest.mark.asyncio
+    async def test_native_send_group_uses_group_prefix(self, monkeypatch):
+        """Native REST group sends must prefix the group id with group.
+        (the id form from GET /v1/groups, not the raw internal_id)."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+        adapter._stop_typing_indicator = AsyncMock()
+
+        captured = []
+
+        async def mock_post(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 201
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"timestamp": "1712345678000"}
+            return resp
+
+        adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
+
+        result = await adapter.send(chat_id="group:cnkxxxxT0=", content="hi")
+
+        assert result.success is True
+        assert captured[0]["url"] == "http://localhost:8080/v2/send"
+        assert captured[0]["payload"]["recipients"] == ["group.cnkxxxxT0="]
+
+    @pytest.mark.asyncio
+    async def test_native_send_attachment_uses_base64_data_uris(self, monkeypatch, tmp_path):
+        """Native REST attachments must be base64 data URIs, not file paths."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+        adapter._stop_typing_indicator = AsyncMock()
+
+        captured = []
+
+        async def mock_post(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 201
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"timestamp": "1712345678000"}
+            return resp
+
+        adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
+
+        file_path = tmp_path / "doc.pdf"
+        file_path.write_bytes(b"%PDF" + b"\x00" * 100)
+
+        result = await adapter.send_document(
+            chat_id=adapter.account, file_path=str(file_path), caption="report"
+        )
+
+        assert result.success is True
+        send_calls = [c for c in captured if c["url"].endswith("/v2/send")]
+        assert len(send_calls) == 1
+        payload = send_calls[0]["payload"]
+        assert len(payload["base64_attachments"]) == 1
+        uri = payload["base64_attachments"][0]
+        assert uri.startswith("data:;filename=doc.pdf;base64,")
+        assert uri.endswith("AAAAA=")
+        assert payload["message"] == "report"
+
+    @pytest.mark.asyncio
+    async def test_native_send_typing_uses_put_typing_indicator(self, monkeypatch):
+        """Native typing start → PUT /v1/typing-indicator/{number} with
+        {recipient} (flat, not sendTyping JSON-RPC)."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+
+        captured = []
+
+        async def mock_put(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 204
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        adapter.client = MagicMock(put=AsyncMock(side_effect=mock_put))
+
+        await adapter.send_typing(adapter.account)
+
+        assert len(captured) == 1
+        expected_url = f"http://localhost:8080/v1/typing-indicator/{quote(adapter.account, safe='')}"
+        assert captured[0]["url"] == expected_url
+        assert captured[0]["payload"] == {"recipient": adapter.account}
+
+    @pytest.mark.asyncio
+    async def test_native_stop_typing_uses_delete_typing_indicator(self, monkeypatch):
+        """Native typing stop → DELETE /v1/typing-indicator/{number}."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+
+        captured = []
+
+        async def mock_delete(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 204
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        adapter.client = MagicMock(delete=AsyncMock(side_effect=mock_delete))
+
+        await adapter._stop_typing_indicator(adapter.account)
+
+        assert len(captured) == 1
+        expected_url = f"http://localhost:8080/v1/typing-indicator/{quote(adapter.account, safe='')}"
+        assert captured[0]["url"] == expected_url
+        assert captured[0]["payload"] == {"recipient": adapter.account}
+
+    @pytest.mark.asyncio
+    async def test_native_send_reaction_uses_post_reactions(self, monkeypatch):
+        """Native reaction → POST /v1/reactions/{number} with
+        {reaction, recipient, target_author, timestamp}."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+
+        captured = []
+
+        async def mock_post(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 204
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
+
+        ok = await adapter.send_reaction(
+            chat_id=adapter.account,
+            emoji="👀",
+            target_author="+15551234000",
+            target_timestamp=1712345678000,
+        )
+
+        assert ok is True
+        assert len(captured) == 1
+        expected_url = f"http://localhost:8080/v1/reactions/{quote(adapter.account, safe='')}"
+        assert captured[0]["url"] == expected_url
+        assert captured[0]["payload"] == {
+            "reaction": "👀",
+            "recipient": adapter.account,
+            "target_author": "+15551234000",
+            "timestamp": 1712345678000,
+        }
+
+    @pytest.mark.asyncio
+    async def test_native_remove_reaction_uses_delete_reactions(self, monkeypatch):
+        """Native remove-reaction → DELETE /v1/reactions/{number}."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+
+        captured = []
+
+        async def mock_delete(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 204
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        adapter.client = MagicMock(delete=AsyncMock(side_effect=mock_delete))
+
+        await adapter.remove_reaction(
+            chat_id=adapter.account,
+            target_author="+15551234000",
+            target_timestamp=1712345678000,
+        )
+
+        assert len(captured) == 1
+        expected_url = f"http://localhost:8080/v1/reactions/{quote(adapter.account, safe='')}"
+        assert captured[0]["url"] == expected_url
+        # The shared JSON-RPC path encodes removal via params["remove"];
+        # native mode translates that to the DELETE verb with a flat body.
+        assert captured[0]["payload"] == {
+            "reaction": "",
+            "recipient": adapter.account,
+            "target_author": "+15551234000",
+            "timestamp": 1712345678000,
+        }
+
+    @pytest.mark.asyncio
+    async def test_native_list_contacts_uses_get_contacts(self, monkeypatch):
+        """Native listContacts → GET /v1/contacts/{number} with
+        all_recipients=true query."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+
+        captured = []
+
+        async def mock_get(url, **kwargs):
+            captured.append({"url": url, "params": kwargs.get("params", {})})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = [
+                {"number": "+15551234000", "uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}
+            ]
+            return resp
+
+        adapter.client = MagicMock(get=AsyncMock(side_effect=mock_get))
+
+        resolved = await adapter._resolve_recipient("+15551234000")
+
+        assert resolved == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        assert len(captured) == 1
+        expected_url = f"http://localhost:8080/v1/contacts/{quote(adapter.account, safe='')}"
+        assert captured[0]["url"] == expected_url
+        assert captured[0]["params"] == {"all_recipients": "true"}
+
+    @pytest.mark.asyncio
+    async def test_native_get_attachment_returns_base64_data(self, monkeypatch):
+        """Native getAttachment → GET /v1/attachments/{id}; raw bytes are
+        base64-encoded into the shared data contract."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+
+        captured = []
+
+        async def mock_get(url, **kwargs):
+            captured.append({"url": url})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.raise_for_status = MagicMock()
+            resp.content = b"%PDF" + b"\x00" * 4
+            return resp
+
+        adapter.client = MagicMock(get=AsyncMock(side_effect=mock_get))
+
+        result = await adapter._rpc("getAttachment", {
+            "account": adapter.account,
+            "id": "att-123",
+        })
+
+        assert isinstance(result, dict)
+        assert result["data"] == "JVBERgAAAAA="
+        assert len(captured) == 1
+        assert captured[0]["url"] == "http://localhost:8080/v1/attachments/att-123"
+
+    @pytest.mark.asyncio
+    async def test_native_unknown_method_returns_none(self, monkeypatch):
+        """Unmapped JSON-RPC methods degrade to None in native mode rather
+        than POSTing a JSON-RPC envelope to a REST endpoint."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+        adapter.client = MagicMock(
+            post=AsyncMock(side_effect=AssertionError("should not POST"))
+        )
+        result = await adapter._rpc("listGroups", {"account": adapter.account})
+        assert result is None
+
+        """Unmapped JSON-RPC methods degrade to None in native mode rather
+        than POSTing a JSON-RPC envelope to a REST endpoint."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+        adapter.client = MagicMock(
+            post=AsyncMock(side_effect=AssertionError("should not POST"))
+        )
+        result = await adapter._rpc("listGroups", {"account": "+155****4567"})
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_detect_mode_native_when_receive_endpoint_returns_200(self, monkeypatch):

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -80,8 +80,39 @@ class TestSignalAdapterInit:
         assert "group123" in adapter.group_allow_from
 
 
+class TestSignalReceivePolling:
+    @pytest.mark.asyncio
+    async def test_receive_loop_polls_and_dispatches_envelope(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, account="+15551234567")
+        envelope = {
+            "envelope": {
+                "sourceNumber": "+15550000000",
+                "dataMessage": {"message": "hello", "timestamp": 1},
+            }
+        }
+        response = MagicMock(status_code=200)
+        response.json.return_value = [envelope]
+        calls = []
+
+        async def get(url, **kwargs):
+            calls.append((url, kwargs))
+            adapter._running = False
+            return response
+
+        adapter.client = MagicMock(get=AsyncMock(side_effect=get))
+        adapter._handle_envelope = AsyncMock()
+        adapter._running = True
+        await adapter._receive_loop()
+
+        assert calls[0][0] == "http://localhost:8080/v1/receive/%2B15551234567"
+        adapter._handle_envelope.assert_awaited_once_with(envelope)
+
+    def test_poll_interval_is_clamped_to_one_second(self, monkeypatch):
+        assert _make_signal_adapter(monkeypatch, poll_interval=0.1).poll_interval == 1.0
+        assert _make_signal_adapter(monkeypatch, poll_interval=2.5).poll_interval == 2.5
+
+
 class TestSignalConnectCleanup:
-    """Regression coverage for failed connect() cleanup."""
 
     @pytest.mark.asyncio
     async def test_releases_lock_and_closes_client_on_healthcheck_failure(self, monkeypatch):
@@ -1311,6 +1342,159 @@ class TestSignalSyncMessageHandling:
         assert "event" in captured, "Group sync-sent must reach handle_message"
         assert captured["event"].text == "ping the group"
         assert captured["event"].source.chat_id == "group:abc123=="
+
+
+# ---------------------------------------------------------------------------
+# Outbound RPC route verification (#71636 sweeper: every outbound operation
+# must hit /v1/rpc with the correct JSON-RPC method — not just receive polling)
+# ---------------------------------------------------------------------------
+
+class TestSignalOutboundRpcRoutes:
+    """Verify that every outbound operation routes through /v1/rpc with the
+    correct JSON-RPC 2.0 method name and that the HTTP POST target is the
+    documented endpoint, not a stale or invented path."""
+
+    @pytest.mark.asyncio
+    async def test_send_text_uses_send_method_on_v1_rpc(self, monkeypatch):
+        """send() must POST to /v1/rpc with method=send."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._stop_typing_indicator = AsyncMock()
+
+        captured = []
+
+        async def mock_post(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"result": {"timestamp": 12345}}
+            return resp
+
+        adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
+
+        result = await adapter.send(chat_id="+155****4567", content="hello")
+
+        assert result.success is True
+        assert len(captured) == 1
+        assert captured[0]["url"] == "http://localhost:8080/v1/rpc"
+        assert captured[0]["payload"]["method"] == "send"
+        assert captured[0]["payload"]["jsonrpc"] == "2.0"
+        assert captured[0]["payload"]["params"]["message"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_send_typing_uses_sendTyping_method(self, monkeypatch):
+        """send_typing() must POST to /v1/rpc with method=sendTyping."""
+        adapter = _make_signal_adapter(monkeypatch)
+
+        captured = []
+
+        async def mock_post(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"result": True}
+            return resp
+
+        adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
+
+        await adapter.send_typing("+155****4567")
+
+        assert len(captured) == 1
+        assert captured[0]["url"] == "http://localhost:8080/v1/rpc"
+        assert captured[0]["payload"]["method"] == "sendTyping"
+
+    @pytest.mark.asyncio
+    async def test_send_reaction_uses_sendReaction_method(self, monkeypatch):
+        """send_reaction() must POST to /v1/rpc with method=sendReaction."""
+        adapter = _make_signal_adapter(monkeypatch)
+
+        captured = []
+
+        async def mock_post(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"result": True}
+            return resp
+
+        adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
+
+        ok = await adapter.send_reaction(
+            chat_id="+155****4567",
+            emoji="👀",
+            target_author="+155****0000",
+            target_timestamp=1712345678000,
+        )
+
+        assert ok is True
+        assert len(captured) == 1
+        assert captured[0]["url"] == "http://localhost:8080/v1/rpc"
+        assert captured[0]["payload"]["method"] == "sendReaction"
+        assert captured[0]["payload"]["params"]["emoji"] == "👀"
+        assert captured[0]["payload"]["params"]["targetAuthor"] == "+155****0000"
+        assert captured[0]["payload"]["params"]["targetTimestamp"] == 1712345678000
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_uses_sendTyping_with_stop_flag(self, monkeypatch):
+        """_stop_typing_indicator() must POST to /v1/rpc with method=sendTyping
+        and params[stop]=True."""
+        adapter = _make_signal_adapter(monkeypatch)
+
+        captured = []
+
+        async def mock_post(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"result": True}
+            return resp
+
+        adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
+
+        await adapter._stop_typing_indicator("+155****4567")
+
+        assert len(captured) == 1
+        assert captured[0]["url"] == "http://localhost:8080/v1/rpc"
+        assert captured[0]["payload"]["method"] == "sendTyping"
+        assert captured[0]["payload"]["params"]["stop"] is True
+
+    @pytest.mark.asyncio
+    async def test_send_attachment_uses_send_method_with_attachments_param(self, monkeypatch, tmp_path):
+        """_send_attachment() must POST to /v1/rpc with method=send and an
+        attachments array in params."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._stop_typing_indicator = AsyncMock()
+
+        captured = []
+
+        async def mock_post(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"result": {"timestamp": 12345}}
+            return resp
+
+        adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
+
+        file_path = tmp_path / "doc.pdf"
+        file_path.write_bytes(b"%PDF" + b"\x00" * 100)
+
+        result = await adapter.send_document(
+            chat_id="+155****4567", file_path=str(file_path), caption="report"
+        )
+
+        assert result.success is True
+        # Only the send RPC should be captured (stop_typing is mocked out)
+        send_calls = [c for c in captured if c["payload"]["method"] == "send"]
+        assert len(send_calls) == 1
+        assert send_calls[0]["url"] == "http://localhost:8080/v1/rpc"
+        assert send_calls[0]["payload"]["method"] == "send"
+        assert send_calls[0]["payload"]["params"]["attachments"] == [str(file_path)]
+        assert send_calls[0]["payload"]["params"]["message"] == "report"
 
 
 class TestRecentSentTimestampRing:

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -23,8 +23,15 @@ def _reset_signal_scheduler():
 # Shared Helpers
 # ---------------------------------------------------------------------------
 
-def _make_signal_adapter(monkeypatch, account="+15551234567", **extra):
-    """Create a SignalAdapter with sensible test defaults."""
+def _make_signal_adapter(monkeypatch, account="+15551234567", transport_mode="json-rpc", **extra):
+    """Create a SignalAdapter with sensible test defaults.
+
+    ``transport_mode`` defaults to ``"json-rpc"`` so the legacy outbound
+    RPC tests (which assert ``POST /v1/rpc``) keep working without
+    operator intervention. Native-mode tests must pass
+    ``transport_mode="native"`` explicitly to verify the
+    ``/v2/send`` route (#71636 / #71884 reviewer feedback).
+    """
     monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", extra.pop("group_allowed", ""))
     from gateway.platforms.signal import SignalAdapter
     config = PlatformConfig()
@@ -32,6 +39,7 @@ def _make_signal_adapter(monkeypatch, account="+15551234567", **extra):
     config.extra = {
         "http_url": "http://localhost:8080",
         "account": account,
+        "transport_mode": transport_mode,
         **extra,
     }
     return SignalAdapter(config)
@@ -1495,6 +1503,120 @@ class TestSignalOutboundRpcRoutes:
         assert send_calls[0]["payload"]["method"] == "send"
         assert send_calls[0]["payload"]["params"]["attachments"] == [str(file_path)]
         assert send_calls[0]["payload"]["params"]["message"] == "report"
+
+
+# ---------------------------------------------------------------------------
+# Transport-mode routing (#71636 / #71884):
+#   - ``MODE=native``  docker image → outbound ``POST /v2/send``,
+#     inbound ``GET /v1/receive/{number}`` polling.
+#   - ``MODE=json-rpc`` docker image → outbound ``POST /v1/rpc`` JSON-RPC,
+#     inbound over a WebSocket channel that this adapter does not yet speak.
+# The adapter picks the route automatically during ``connect()`` via
+# ``_detect_transport_mode()`` and the operator can lock the choice with
+# ``extra.transport_mode`` in config.yaml.
+# ---------------------------------------------------------------------------
+
+
+class TestSignalTransportModeDetection:
+    """Cover the mode-probe branches in ``_detect_transport_mode``."""
+
+    @pytest.mark.asyncio
+    async def test_native_mode_uses_v2_send(self, monkeypatch):
+        """``transport_mode="native"`` pins outbound to ``/v2/send``."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+        adapter._stop_typing_indicator = AsyncMock()
+
+        captured = []
+
+        async def mock_post(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"result": {"timestamp": 12345}}
+            return resp
+
+        adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
+
+        result = await adapter.send(chat_id="+155****4567", content="hi")
+
+        assert result.success is True
+        assert len(captured) == 1
+        assert captured[0]["url"] == "http://localhost:8080/v2/send", (
+            f"native mode should post to /v2/send, got {captured[0]['url']!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_detect_mode_native_when_receive_endpoint_returns_200(self, monkeypatch):
+        """``GET /v1/receive/{number}`` returning 200 ⇒ native mode."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="auto")
+
+        async def fake_get(url, **kwargs):
+            resp = MagicMock()
+            if url.endswith("/v1/about"):
+                resp.status_code = 200
+            elif "/v1/receive/" in url:
+                resp.status_code = 200
+            else:
+                resp.status_code = 404
+            return resp
+
+        adapter.client = AsyncMock(get=fake_get)
+        mode, path = await adapter._detect_transport_mode()
+
+        assert mode == "native"
+        assert path == "/v2/send"
+
+    @pytest.mark.asyncio
+    async def test_detect_mode_jsonrpc_when_receive_endpoint_returns_404(self, monkeypatch):
+        """``GET /v1/receive/{number}`` returning 404 ⇒ json-rpc mode
+        (the receive endpoint is gated by the WebSocket subscribeReceive
+        channel in json-rpc deployments)."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="auto")
+
+        async def fake_get(url, **kwargs):
+            resp = MagicMock()
+            if url.endswith("/v1/about"):
+                resp.status_code = 200
+            elif "/v1/receive/" in url:
+                resp.status_code = 404
+            else:
+                resp.status_code = 404
+            return resp
+
+        adapter.client = AsyncMock(get=fake_get)
+        mode, path = await adapter._detect_transport_mode()
+
+        assert mode == "json-rpc"
+        assert path == "/v1/rpc"
+
+    @pytest.mark.asyncio
+    async def test_detect_mode_explicit_native_override(self, monkeypatch):
+        """Config ``transport_mode="native"`` skips the probe entirely."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+        # Even with a client that would otherwise time out, the override wins.
+        adapter.client = MagicMock(get=AsyncMock(side_effect=AssertionError("probe should not run")))
+        mode, path = await adapter._detect_transport_mode()
+        assert mode == "native"
+        assert path == "/v2/send"
+
+    @pytest.mark.asyncio
+    async def test_detect_mode_falls_back_to_native_on_probe_failure(self, monkeypatch):
+        """When both /v1/about and /v1/receive fail (timeout, refused),
+        fall back to native (the docker-compose default) and log a
+        warning. The adapter will still attempt the native routes
+        (``/v2/send`` outbound + ``/v1/receive/{number}`` inbound polling)
+        so an operator on the most common deployment gets the right
+        behaviour without configuration (#71636)."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="auto")
+
+        async def fake_get(url, **kwargs):
+            raise RuntimeError("connection refused")
+
+        adapter.client = AsyncMock(get=fake_get)
+        mode, path = await adapter._detect_transport_mode()
+        assert mode == "native"
+        assert path == "/v2/send"
 
 
 class TestRecentSentTimestampRing:

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -108,8 +108,32 @@ SIGNAL_ALLOWED_USERS=+1234567890,+0987654321    # Comma-separated E.164 numbers 
 
 # Optional
 SIGNAL_GROUP_ALLOWED_USERS=groupId1,groupId2     # Enable groups (omit to disable, * for all)
-SIGNAL_HOME_CHANNEL=+1234567890                  # Default delivery target for cron jobs
+SIGNAL_HOME_CHANNEL=+123****7890                  # Default delivery target for cron jobs
 ```
+
+#### Transport mode (advanced)
+
+`siganl-cli-rest-api` ships two transport shapes (selected via the daemon's `MODE=` env var):
+
+| Daemon `MODE` | Outbound route | Inbound route |
+|---------------|----------------|---------------|
+| `native` (docker-compose default) | `POST /v2/send` | `GET /v1/receive/{number}` (HTTP polling — Hermes supports this) |
+| `json-rpc` | `POST /v1/rpc` (JSON-RPC 2.0) | WebSocket `subscribeReceive` — **not yet implemented** in Hermes |
+| `json-rpc-native` | `POST /v2/send` (REST) | Hybrid — Hermes uses native polling |
+
+Hermes auto-detects the right outbound route during `connect()` by probing `GET /v1/about` and `GET /v1/receive/{number}`. To lock the choice, add `transport_mode` under `platforms.signal.extra` in `config.yaml`:
+
+```yaml
+platforms:
+  signal:
+    enabled: true
+    extra:
+      http_url: http://127.0.0.1:8080
+      account: "+123****7890"
+      transport_mode: native   # or "json-rpc" (outbound only — inbound WebSocket is unimplemented)
+```
+
+Defaults to `auto` (probe), which falls back to `native` if the probe fails (matches the docker-compose default). Operators running `MODE=json-rpc` should set `transport_mode: json-rpc` explicitly so outbound JSON-RPC calls land on `/v1/rpc` instead of `/v2/send` (which would 404).
 
 Then start the gateway:
 

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -6,7 +6,7 @@ description: "Set up Hermes Agent as a Signal messenger bot via signal-cli daemo
 
 # Signal Setup
 
-Hermes connects to Signal through the [signal-cli](https://github.com/AsamK/signal-cli) daemon running in HTTP mode. The adapter streams messages in real-time via SSE (Server-Sent Events) and sends responses via JSON-RPC.
+Hermes connects to Signal through the [signal-cli](https://github.com/AsamK/signal-cli) daemon running in HTTP mode. The adapter polls for inbound messages via HTTP and sends responses via JSON-RPC.
 
 Signal is the most privacy-focused mainstream messenger — end-to-end encrypted by default, open-source protocol, minimal metadata collection. This makes it ideal for security-sensitive agent workflows.
 
@@ -72,8 +72,8 @@ Keep this running in the background. You can use `systemd`, `tmux`, `screen`, or
 Verify it's running:
 
 ```bash
-curl http://127.0.0.1:8080/api/v1/check
-# Should return: {"versions":{"signal-cli":...}}
+curl http://127.0.0.1:8080/v1/health
+# Should return 200/204 (healthy)
 ```
 
 ---
@@ -212,9 +212,9 @@ Just send a message to yourself from your phone — signal-cli picks it up and H
 
 ### Health Monitoring
 
-The adapter monitors the SSE connection and automatically reconnects if:
-- The connection drops (with exponential backoff: 2s → 60s)
-- No activity is detected for 120 seconds (pings signal-cli to verify)
+The adapter monitors the daemon via periodic HTTP health checks (`/v1/health`) and automatically reconnects if:
+- A health check returns a non-200/204 status (with exponential backoff: 2s → 60s)
+- No activity is detected for 120 seconds
 
 ---
 
@@ -225,7 +225,7 @@ The adapter monitors the SSE connection and automatically reconnects if:
 | **"Cannot reach signal-cli"** during setup | Ensure signal-cli daemon is running: `signal-cli --account +YOUR_NUMBER daemon --http 127.0.0.1:8080` |
 | **Messages not received** | Check that `SIGNAL_ALLOWED_USERS` includes the sender's number in E.164 format (with `+` prefix) |
 | **"signal-cli not found on PATH"** | Install signal-cli and ensure it's in your PATH, or use Docker |
-| **Connection keeps dropping** | Check signal-cli logs for errors. Ensure Java 17+ is installed. |
+| **Connection keeps dropping** | Check signal-cli logs for errors. Ensure Java 17+ is installed. Verify health check passes: `curl http://127.0.0.1:8080/v1/health` |
 | **Group messages ignored** | Configure `SIGNAL_GROUP_ALLOWED_USERS` with specific group IDs, or `*` to allow all groups. |
 | **Bot responds to no one** | Configure `SIGNAL_ALLOWED_USERS`, use DM pairing, or explicitly allow all users through gateway policy if you want broader access. |
 | **Duplicate messages** | Ensure only one signal-cli instance is listening on your phone number |

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -113,12 +113,12 @@ SIGNAL_HOME_CHANNEL=+123****7890                  # Default delivery target for 
 
 #### Transport mode (advanced)
 
-`siganl-cli-rest-api` ships two transport shapes (selected via the daemon's `MODE=` env var):
+`signal-cli-rest-api` ships two transport shapes (selected via the daemon's `MODE=` env var):
 
 | Daemon `MODE` | Outbound route | Inbound route |
 |---------------|----------------|---------------|
-| `native` (docker-compose default) | `POST /v2/send` | `GET /v1/receive/{number}` (HTTP polling — Hermes supports this) |
-| `json-rpc` | `POST /v1/rpc` (JSON-RPC 2.0) | WebSocket `subscribeReceive` — **not yet implemented** in Hermes |
+| `native` (docker-compose default) | Per-operation REST: `POST /v2/send`, `PUT/DELETE /v1/typing-indicator/{number}`, `POST/DELETE /v1/reactions/{number}`, `GET /v1/contacts/{number}`, `GET /v1/attachments/{id}` | `GET /v1/receive/{number}` (HTTP polling — Hermes supports this) |
+| `json-rpc` | `POST /v1/rpc` (JSON-RPC 2.0 envelope for every method) | WebSocket `subscribeReceive` — **not yet implemented** in Hermes |
 | `json-rpc-native` | `POST /v2/send` (REST) | Hybrid — Hermes uses native polling |
 
 Hermes auto-detects the right outbound route during `connect()` by probing `GET /v1/about` and `GET /v1/receive/{number}`. To lock the choice, add `transport_mode` under `platforms.signal.extra` in `config.yaml`:
@@ -133,7 +133,9 @@ platforms:
       transport_mode: native   # or "json-rpc" (outbound only — inbound WebSocket is unimplemented)
 ```
 
-Defaults to `auto` (probe), which falls back to `native` if the probe fails (matches the docker-compose default). Operators running `MODE=json-rpc` should set `transport_mode: json-rpc` explicitly so outbound JSON-RPC calls land on `/v1/rpc` instead of `/v2/send` (which would 404).
+Defaults to `auto` (probe), which falls back to `native` if the probe fails (matches the docker-compose default). Operators running `MODE=json-rpc` should set `transport_mode: json-rpc` explicitly so outbound JSON-RPC calls land on `/v1/rpc` instead of the native REST routes (which would 404).
+
+Outbound payloads are translated per transport: native mode sends flat REST bodies (`{number, message, recipients}` with `group.<id>` for groups, base64 data-URI attachments, snake_case reaction fields), while json-rpc mode keeps the JSON-RPC 2.0 envelope. This is automatic — no per-call configuration is needed.
 
 Then start the gateway:
 


### PR DESCRIPTION
## Summary

Replace the broken SSE listener in `gateway/platforms/signal.py` with a polling loop on `/v1/receive/<number>`, since signal-cli-rest-api v0.100+ (the API version users actually run) does not expose the SSE endpoint.

## What this PR does

The current `SignalAdapter` listens for inbound messages via SSE on `/api/v1/events` (later attempts at `/v1/events`). Both endpoints return 404 in signal-cli-rest-api v0.100+. The actual endpoints in v0.100 are:

- `/v1/health` (204) — health check
- `/v1/receive/<number>` — polling for queued messages

So the adapter silently dropped every inbound message and the bot appeared connected but never replied.

This PR replaces the SSE listener with a polling loop that hits `/v1/receive/<account>` on a configurable interval (default 1.0s, clamped to `>= 1.0s` via `extra.poll_interval` to avoid rate-limit traps). It drops the SSE-specific knobs (`SSE_RETRY_DELAY_*`, `HEALTH_CHECK_STALE_THRESHOLD`, last-activity timestamps, `_sse_response`) that no longer apply, and keeps the health check on `/v1/health` and the JSON-RPC 2.0 outbound path.

## Why opt-out of /api/v1/ vs /v1/

`/v1/health` is the only health endpoint. The /api/v1/ prefix in the original code was a separate prefix bug that this fix resolves as a side effect.

## Tests

`tests/gateway/test_signal.py::TestSignalReceivePolling`:

- `test_receive_loop_polls_and_dispatches_envelope`: mocks the httpx client and verifies the polling URL is `http://localhost:8080/v1/receive/%2B15551234567` (with the `+` properly percent-encoded) and that the envelope is forwarded to `_handle_envelope`.
- `test_poll_interval_is_clamped_to_one_second`: verifies the clamp (>= 1.0s).

## Diff scope

2 files, +68/-107 (net negative because we delete SSE-specific code we no longer use).

- `gateway/platforms/signal.py`: +55/-104 — drop SSE listener + retry knobs; add polling loop + poll_interval config + URL-safe account encoding
- `tests/gateway/test_signal.py`: +33/-3 — TestSignalReceivePolling

Closes #71636