### PR TITLE
docs: point skill users at doctor

### DIFF
--- a/website/docs/guides/work-with-skills.md
+++ b/website/docs/guides/work-with-skills.md
@@ -109,6 +109,8 @@ What happens:
 Installed skills take effect in new sessions. If you want it available in the current session, use `/reset` to start fresh, or add `--now` to invalidate the prompt cache immediately (costs more tokens on the next turn).
 :::
 
+If you rely on custom providers or a local OpenAI-compatible endpoint, run `hermes doctor` before you start a long session. The doctor now checks custom provider reachability too, so a broken base URL or invalid API key shows up before the first skill load.
+
 ### Verifying Installation
 
 ```bash


### PR DESCRIPTION
Tell skill users to run 
┌─────────────────────────────────────────────────────────┐
│                 🩺 Hermes Doctor                        │
└─────────────────────────────────────────────────────────┘

◆ Security Advisories
  ✓ No active security advisories

◆ MCP Server Security
  ✓ No suspicious MCP stdio commands

◆ Python Environment
  ✓ Python 3.11.15
  ✓ SQLite 3.53.1
    → SQLite source id: 2026-05-05 10:34:17 c88b22011a54b4f6fbd149e9f8e4…
  ✓ Virtual environment active
  ✓ Version files consistent (0.19.0)

◆ SSL / CA Certificates
  ✓ SSL CA certificate bundle is valid

◆ Required Packages
  ✓ OpenAI SDK
  ✓ Rich (terminal UI)
  ✓ python-dotenv
  ✓ PyYAML
  ✓ HTTPX
  ✓ Croniter (cron expressions) (optional)
  ⚠ python-telegram-bot (optional, not installed)
  ✓ discord.py (optional)

◆ Configuration Files
  ✓ ~/.hermes/.env file exists
  ✓ API key or custom endpoint configured
  ✓ ~/.hermes/config.yaml exists
  ✓ Config version up to date (v33)
  ✓ No deprecated config keys or env vars

◆ xAI Model Retirement (May 15, 2026)
  ✓ No retired xAI models in config

◆ Auth Providers
  ⚠ Nous Portal auth (not logged in)
  ✓ OpenAI Codex auth (logged in)
  ⚠ MiniMax OAuth (not logged in)
  ⚠ xAI OAuth (not logged in)
    → No xAI OAuth credentials stored. Select xAI Grok OAuth (SuperGrok / Premium+) in `hermes model`.

◆ Directory Structure
  ✓ ~/.hermes directory exists
  ✓ ~/.hermes/cron/ exists
  ✓ ~/.hermes/sessions/ exists
  ✓ ~/.hermes/logs/ exists
  ✓ ~/.hermes/skills/ exists
  ✓ ~/.hermes/memories/ exists
  ✓ ~/.hermes/SOUL.md exists (persona configured)
  ✓ ~/.hermes/memories/ directory exists
  ✓ MEMORY.md exists (1704 chars)
  ✓ USER.md exists (1359 chars)
  ✓ ~/.hermes/state.db exists (1220 sessions)

◆ Gateway Service
  ✓ Systemd linger enabled (gateway service survives logout)

◆ Command Installation
  ✓ Venv entry point exists (venv/bin/hermes)
  ✓ ~/.local/bin/hermes → correct target

◆ External Tools
  ✓ git
  ✓ ripgrep (rg) (faster file search)
  ✓ docker (optional)
  ✓ Node.js
  ✓ agent-browser (browser automation)
  ✓ Playwright Chromium (browser engine)
  ✓ Browser tools (agent-browser) deps (no known vulnerabilities)
  ⚠ web workspace deps (0 critical, 8 high, 0 moderate — build-tool advisory; clears via lockfile bump)
    →   ^ build-time tooling (not runtime); if manual npm remediation errors with an arborist crash it's a known npm bug — clears via a lockfile bump
  ⚠ ui-tui workspace deps (0 critical, 7 high, 0 moderate — build-tool advisory; clears via lockfile bump)
    →   ^ build-time tooling (not runtime); if manual npm remediation errors with an arborist crash it's a known npm bug — clears via a lockfile bump
  ✓ WhatsApp bridge deps (no known vulnerabilities)

◆ API Connectivity
  Running 29 connectivity checks in parallel…                                                                        ⚠ OpenRouter API (not configured)

◆ Tool Availability
  ✓ browser
  ✓ clarify
  ✓ code_execution
  ✓ cronjob
  ✓ delegation
  ✓ file
  ✓ image_gen
  ✓ memory
  ✓ project
  ✓ session_search
  ✓ skills
  ✓ terminal
  ✓ todo
  ✓ tts
  ✓ video
  ✓ vision
  ✓ web
  ✓ kanban (runtime-gated; loaded only for dispatcher-spawned workers)
  ⚠ browser-cdp (system dependency not met)
  ⚠ computer_use (system dependency not met)
  ⚠ discord (missing DISCORD_BOT_TOKEN)
  ⚠ discord_admin (missing DISCORD_BOT_TOKEN)
  ⚠ feishu_doc (system dependency not met)
  ⚠ feishu_drive (system dependency not met)
  ⚠ hermes-yuanbao (system dependency not met)
  ⚠ homeassistant (system dependency not met)
  ⚠ spotify (system dependency not met)
  ⚠ video_gen (system dependency not met)
  ⚠ x_search (missing XAI_API_KEY)

◆ Skills Hub
  ✓ Skills Hub directory exists
  ✓ Lock file OK (5 hub-installed skill(s))
  ⚠ No GITHUB_TOKEN (60 req/hr rate limit — set in ~/.hermes/.env for better rates)

◆ Memory Provider
  ✓ Built-in memory active (no external provider configured — this is fine)

◆ Profiles
  ✓ 1 profile(s) found
  ✓   camanji: no alias

────────────────────────────────────────────────────────────
  Found 2 issue(s) to address:

  1. web workspace has 8 npm vulnerabilities
  2. ui-tui workspace has 7 npm vulnerabilities

  Tip: run 'hermes doctor --fix' to auto-fix what's possible. before long sessions when they rely on custom providers or local OpenAI-compatible endpoints. This gives them an early failure signal for bad base URLs or API keys.