### PR TITLE
fix(doctor): health-check custom providers safely

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -5,9 +5,11 @@ Diagnoses issues with Hermes Agent setup.
 """
 
 import os
+import ssl
 import sys
 import subprocess
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
@@ -554,6 +556,182 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
 
 
 _APIKEY_PROVIDERS_CACHE: list | None = None
+
+
+@dataclass(frozen=True)
+class _CustomProviderProbeSpec:
+    """Resolved, secret-bearing inputs for one custom-provider health check."""
+
+    label: str
+    base_url: str
+    api_key: str | None
+    api_mode: str
+    extra_headers: dict[str, str]
+    ssl_ca_cert: str | None = None
+    ssl_verify: bool | str | None = None
+    resolution_error: bool = False
+
+
+@dataclass(frozen=True)
+class _CustomProviderProbeResult:
+    """Sanitized custom-provider probe result safe for doctor output."""
+
+    kind: str
+    status_code: int | None = None
+
+
+def _build_custom_provider_probe_specs() -> list[_CustomProviderProbeSpec]:
+    """Resolve all enabled custom providers exactly as the agent runtime does."""
+    try:
+        from hermes_cli.config import (
+            get_compatible_custom_providers,
+            load_config_readonly,
+        )
+        from hermes_cli.providers import custom_provider_slug
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        config = load_config_readonly()
+        custom_providers = get_compatible_custom_providers(config)
+    except Exception:
+        return []
+
+    specs: list[_CustomProviderProbeSpec] = []
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        label = str(entry.get("name") or entry.get("provider_key") or "").strip()
+        identity = str(entry.get("provider_key") or label).strip()
+        if not label or not identity:
+            continue
+
+        try:
+            runtime = resolve_runtime_provider(
+                requested=custom_provider_slug(identity),
+            )
+            api_key = str(runtime.get("api_key") or "").strip()
+            if api_key == "no-key-required":
+                api_key = ""
+            specs.append(
+                _CustomProviderProbeSpec(
+                    label=label,
+                    base_url=str(runtime.get("base_url") or entry.get("base_url") or "").strip(),
+                    api_key=api_key or None,
+                    api_mode=str(runtime.get("api_mode") or "chat_completions"),
+                    extra_headers=dict(runtime.get("extra_headers") or {}),
+                    ssl_ca_cert=(str(entry.get("ssl_ca_cert") or "").strip() or None),
+                    ssl_verify=entry.get("ssl_verify"),
+                )
+            )
+        except Exception:
+            # Resolution errors are surfaced without echoing exception text:
+            # it may contain a credential-bearing URL or provider header.
+            specs.append(
+                _CustomProviderProbeSpec(
+                    label=label,
+                    base_url="",
+                    api_key=None,
+                    api_mode="chat_completions",
+                    extra_headers={},
+                    resolution_error=True,
+                )
+            )
+    return specs
+
+
+def _exception_contains_ssl_error(exc: BaseException) -> bool:
+    """Identify wrapped TLS failures without exposing exception text."""
+    pending: list[BaseException] = [exc]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        if isinstance(current, ssl.SSLError):
+            return True
+        message = str(current).lower()
+        if "certificate verify failed" in message or "ssl certificate" in message:
+            return True
+        for nested in (current.__cause__, current.__context__):
+            if isinstance(nested, BaseException):
+                pending.append(nested)
+    return False
+
+
+def _probe_custom_provider_health(
+    spec: _CustomProviderProbeSpec,
+    *,
+    timeout: float = 5.0,
+) -> _CustomProviderProbeResult:
+    """Probe a custom provider's free model catalog and classify the result."""
+    if spec.resolution_error or not spec.base_url:
+        return _CustomProviderProbeResult("configuration_error")
+
+    import httpx
+    from agent.ssl_verify import resolve_httpx_verify
+    from hermes_cli.models import (
+        _api_models_probe_candidates,
+        _api_models_probe_headers,
+    )
+
+    normalized = spec.base_url.strip().rstrip("/")
+    candidates, _alternate = _api_models_probe_candidates(normalized)
+    headers = _api_models_probe_headers(
+        spec.api_key,
+        normalized,
+        api_mode=spec.api_mode,
+        request_headers=spec.extra_headers,
+    )
+    verify = resolve_httpx_verify(
+        ca_bundle=spec.ssl_ca_cert,
+        ssl_verify=spec.ssl_verify,
+        base_url=normalized,
+    )
+
+    statuses: list[int] = []
+    try:
+        with httpx.Client(
+            verify=verify,
+            timeout=timeout,
+            follow_redirects=False,
+        ) as client:
+            for candidate_base, _is_fallback in candidates:
+                try:
+                    response = client.get(
+                        candidate_base.rstrip("/") + "/models",
+                        headers=headers,
+                    )
+                except httpx.TimeoutException:
+                    return _CustomProviderProbeResult("timeout")
+                except httpx.RequestError as exc:
+                    return _CustomProviderProbeResult(
+                        "ssl_error" if _exception_contains_ssl_error(exc) else "unreachable"
+                    )
+
+                status = response.status_code
+                if 200 <= status < 300:
+                    return _CustomProviderProbeResult("reachable", status)
+                statuses.append(status)
+    except Exception as exc:
+        return _CustomProviderProbeResult(
+            "ssl_error" if _exception_contains_ssl_error(exc) else "configuration_error"
+        )
+
+    for status in statuses:
+        if status in {401, 403}:
+            return _CustomProviderProbeResult("authentication_rejected", status)
+    for status in statuses:
+        if 500 <= status < 600:
+            return _CustomProviderProbeResult("provider_failure", status)
+    for status in statuses:
+        if 400 <= status < 500 and status not in {404, 405}:
+            return _CustomProviderProbeResult("http_warning", status)
+    for status in statuses:
+        if status in {404, 405}:
+            return _CustomProviderProbeResult("models_unsupported", status)
+    if statuses:
+        return _CustomProviderProbeResult("http_warning", statuses[0])
+    return _CustomProviderProbeResult("unreachable")
 
 
 def _build_apikey_providers_list() -> list:
@@ -2210,6 +2388,77 @@ def run_doctor(args):
                 [],
             )
 
+    def _probe_custom_provider(
+        spec: _CustomProviderProbeSpec,
+    ) -> _ConnectivityResult:
+        result = _probe_custom_provider_health(spec)
+        label = spec.label.ljust(20)
+        if result.kind == "reachable":
+            return _ConnectivityResult(
+                spec.label,
+                [(color("✓", Colors.GREEN), label,
+                  color("(reachable)", Colors.DIM))],
+                [],
+            )
+        if result.kind == "authentication_rejected":
+            return _ConnectivityResult(
+                spec.label,
+                [(color("✗", Colors.RED), label,
+                  color(f"(authentication rejected: HTTP {result.status_code})", Colors.DIM))],
+                [
+                    f"Custom provider '{spec.label}' rejected authentication — "
+                    "check its configured API key and custom auth headers"
+                ],
+            )
+        if result.kind == "models_unsupported":
+            return _ConnectivityResult(
+                spec.label,
+                [(color("⚠", Colors.YELLOW), label,
+                  color(
+                      f"(reachable; /models unsupported: HTTP {result.status_code})",
+                      Colors.DIM,
+                  ))],
+                [],
+            )
+        if result.kind == "http_warning":
+            return _ConnectivityResult(
+                spec.label,
+                [(color("⚠", Colors.YELLOW), label,
+                  color(f"(reachable; HTTP {result.status_code})", Colors.DIM))],
+                [],
+            )
+        if result.kind == "provider_failure":
+            return _ConnectivityResult(
+                spec.label,
+                [(color("✗", Colors.RED), label,
+                  color(f"(provider failure: HTTP {result.status_code})", Colors.DIM))],
+                [
+                    f"Custom provider '{spec.label}' returned HTTP {result.status_code} "
+                    "from its model-health endpoint"
+                ],
+            )
+        if result.kind == "ssl_error":
+            return _ConnectivityResult(
+                spec.label,
+                [(color("⚠", Colors.YELLOW), label,
+                  color("(SSL certificate error)", Colors.DIM))],
+                [
+                    f"Custom provider '{spec.label}' failed TLS certificate verification — "
+                    "configure its ssl_ca_cert with the trusted CA when required"
+                ],
+            )
+        if result.kind == "timeout":
+            detail = "(unreachable: connection timeout)"
+        elif result.kind == "configuration_error":
+            detail = "(health-check configuration could not be resolved)"
+        else:
+            detail = "(unreachable: connection failed)"
+        return _ConnectivityResult(
+            spec.label,
+            [(color("✗", Colors.RED), label, color(detail, Colors.DIM))],
+            [f"Custom provider '{spec.label}' is unreachable — check its configuration and network path"],
+        )
+
     def _probe_bedrock() -> _ConnectivityResult:
         try:
             from agent.bedrock_adapter import (
@@ -2357,6 +2606,14 @@ def run_doctor(args):
         _probes.append((_pname, lambda p=_pname, e=_env_vars, u=_default_url,
                                        b=_base_env, s=_supports:
                                 _probe_apikey_provider(p, e, u, b, s)))
+
+    for _custom_spec in _build_custom_provider_probe_specs():
+        _probes.append(
+            (
+                _custom_spec.label,
+                lambda spec=_custom_spec: _probe_custom_provider(spec),
+            )
+        )
 
     _probes.append(("AWS Bedrock", _probe_bedrock))
     _probes.append(("Azure Foundry (Entra ID)", _probe_azure_entra))

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3899,32 +3899,15 @@ def probe_api_models(
             "used_fallback": False,
         }
 
-    if normalized.endswith("/v1"):
-        alternate_base = normalized[:-3].rstrip("/")
-    else:
-        alternate_base = normalized + "/v1"
-
-    candidates: list[tuple[str, bool]] = [(normalized, False)]
-    if alternate_base and alternate_base != normalized:
-        candidates.append((alternate_base, True))
+    candidates, alternate_base = _api_models_probe_candidates(normalized)
 
     tried: list[str] = []
-    headers: dict[str, str] = {"User-Agent": _HERMES_USER_AGENT}
-    if urllib.parse.urlparse(normalized).hostname == "generativelanguage.googleapis.com":
-        headers["X-Goog-Api-Client"] = f"hermes-agent/{_HERMES_VERSION}"
-    if api_key and api_mode == "anthropic_messages":
-        headers["x-api-key"] = api_key
-        headers["anthropic-version"] = "2023-06-01"
-    elif api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
-    if normalized.startswith(COPILOT_BASE_URL):
-        headers.update(copilot_default_headers())
-    if isinstance(request_headers, dict):
-        # Per-provider custom headers can contain auth/proxy secrets. Merge
-        # last so endpoint-specific config wins, and never log the values.
-        from hermes_cli.config import normalize_extra_headers
-
-        headers.update(normalize_extra_headers(request_headers))
+    headers = _api_models_probe_headers(
+        api_key,
+        normalized,
+        api_mode=api_mode,
+        request_headers=request_headers,
+    )
 
     for candidate_base, is_fallback in candidates:
         url = candidate_base.rstrip("/") + "/models"
@@ -3950,6 +3933,52 @@ def probe_api_models(
         "suggested_base_url": alternate_base if alternate_base != normalized else None,
         "used_fallback": False,
     }
+
+
+def _api_models_probe_candidates(
+    normalized_base_url: str,
+) -> tuple[list[tuple[str, bool]], str]:
+    """Return the normal and ``/v1`` fallback bases for a models probe."""
+    if normalized_base_url.endswith("/v1"):
+        alternate_base = normalized_base_url[:-3].rstrip("/")
+    else:
+        alternate_base = normalized_base_url + "/v1"
+
+    candidates: list[tuple[str, bool]] = [(normalized_base_url, False)]
+    if alternate_base and alternate_base != normalized_base_url:
+        candidates.append((alternate_base, True))
+    return candidates, alternate_base
+
+
+def _api_models_probe_headers(
+    api_key: Optional[str],
+    normalized_base_url: str,
+    *,
+    api_mode: Optional[str] = None,
+    request_headers: Optional[dict[str, str]] = None,
+) -> dict[str, str]:
+    """Build auth and custom headers shared by model-health probes.
+
+    Custom header values may contain credentials. Callers must never log the
+    returned mapping or include it in error output.
+    """
+    headers: dict[str, str] = {"User-Agent": _HERMES_USER_AGENT}
+    if urllib.parse.urlparse(normalized_base_url).hostname == "generativelanguage.googleapis.com":
+        headers["X-Goog-Api-Client"] = f"hermes-agent/{_HERMES_VERSION}"
+    if api_key and api_mode == "anthropic_messages":
+        headers["x-api-key"] = api_key
+        headers["anthropic-version"] = "2023-06-01"
+    elif api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    if normalized_base_url.startswith(COPILOT_BASE_URL):
+        headers.update(copilot_default_headers())
+    if isinstance(request_headers, dict):
+        # Per-provider custom headers can contain auth/proxy secrets. Merge
+        # last so endpoint-specific config wins, and never log the values.
+        from hermes_cli.config import normalize_extra_headers
+
+        headers.update(normalize_extra_headers(request_headers))
+    return headers
 
 
 # Legacy filter — used when an item has no surface tag (rolling out

--- a/tests/hermes_cli/test_doctor_custom_provider_health.py
+++ b/tests/hermes_cli/test_doctor_custom_provider_health.py
@@ -1,0 +1,296 @@
+"""Custom-provider connectivity checks for ``hermes doctor``."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import ssl
+import sys
+import threading
+import types
+from argparse import Namespace
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from hermes_cli import config as config_mod
+from hermes_cli import doctor
+
+
+class _ModelsHandler(BaseHTTPRequestHandler):
+    requests: list[tuple[str, dict[str, str]]] = []
+    status_code = 200
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+        type(self).requests.append((self.path, dict(self.headers.items())))
+        body = b'{"data": [{"id": "local-model"}]}'
+        self.send_response(type(self).status_code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        pass
+
+
+@contextlib.contextmanager
+def _models_server():
+    _ModelsHandler.requests = []
+    _ModelsHandler.status_code = 200
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _ModelsHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _run_isolated_doctor(monkeypatch, tmp_path, config_yaml: str) -> str:
+    home = tmp_path / ".hermes"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    (home / "config.yaml").write_text(config_yaml, encoding="utf-8")
+    (home / ".env").write_text("PENG_API_KEY=resolved-provider-secret\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("PENG_API_KEY", "resolved-provider-secret")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.setattr(doctor, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor, "_DHH", str(home))
+    monkeypatch.setattr(doctor, "_APIKEY_PROVIDERS_CACHE", [])
+
+    config_mod._LOAD_CONFIG_CACHE.clear()
+    config_mod._RAW_CONFIG_CACHE.clear()
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *args, **kwargs: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    from hermes_cli import auth
+
+    monkeypatch.setattr(auth, "get_anthropic_key", lambda: "")
+    monkeypatch.setattr(auth, "get_nous_auth_status", lambda: {})
+    monkeypatch.setattr(auth, "get_codex_auth_status", lambda: {})
+    monkeypatch.setattr(auth, "get_xai_oauth_auth_status", lambda: {})
+
+    from agent import bedrock_adapter
+
+    monkeypatch.setattr(bedrock_adapter, "has_aws_credentials", lambda: False)
+
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        doctor.run_doctor(Namespace(fix=False, ack=None))
+    return output.getvalue()
+
+
+def test_doctor_probes_custom_provider_with_resolved_runtime_config(
+    monkeypatch,
+    tmp_path,
+):
+    with _models_server() as server:
+        output = _run_isolated_doctor(
+            monkeypatch,
+            tmp_path,
+            f"""\
+model:
+  provider: custom:pengcc8
+  default: local-model
+custom_providers:
+  - name: pengcc8
+    base_url: http://127.0.0.1:{server.server_port}/v1
+    api_key: ${{PENG_API_KEY}}
+    extra_headers:
+      X-Tenant-Secret: tenant-header-secret
+""",
+        )
+
+    assert "pengcc8" in output
+    assert "reachable" in output
+    assert _ModelsHandler.requests
+    path, headers = _ModelsHandler.requests[0]
+    assert path == "/v1/models"
+    assert headers["Authorization"] == "Bearer resolved-provider-secret"
+    assert headers["X-Tenant-Secret"] == "tenant-header-secret"
+    assert "resolved-provider-secret" not in output
+    assert "tenant-header-secret" not in output
+
+
+def _probe_spec(base_url: str) -> doctor._CustomProviderProbeSpec:
+    return doctor._CustomProviderProbeSpec(
+        label="test-provider",
+        base_url=base_url,
+        api_key="provider-secret",
+        api_mode="chat_completions",
+        extra_headers={"X-Secret": "header-secret"},
+    )
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_custom_provider_probe_classifies_authentication_rejection(status_code):
+    with _models_server() as server:
+        _ModelsHandler.status_code = status_code
+        result = doctor._probe_custom_provider_health(
+            _probe_spec(f"http://127.0.0.1:{server.server_port}/v1")
+        )
+
+    assert result.kind == "authentication_rejected"
+    assert result.status_code == status_code
+
+
+@pytest.mark.parametrize("status_code", [404, 405])
+def test_custom_provider_probe_treats_missing_models_endpoint_as_reachable(status_code):
+    with _models_server() as server:
+        _ModelsHandler.status_code = status_code
+        result = doctor._probe_custom_provider_health(
+            _probe_spec(f"http://127.0.0.1:{server.server_port}/v1")
+        )
+
+    assert result.kind == "models_unsupported"
+    assert result.status_code == status_code
+
+
+def test_custom_provider_probe_classifies_other_4xx_as_warning():
+    with _models_server() as server:
+        _ModelsHandler.status_code = 429
+        result = doctor._probe_custom_provider_health(
+            _probe_spec(f"http://127.0.0.1:{server.server_port}/v1")
+        )
+
+    assert result.kind == "http_warning"
+    assert result.status_code == 429
+
+
+def test_custom_provider_probe_classifies_5xx_as_provider_failure():
+    with _models_server() as server:
+        _ModelsHandler.status_code = 503
+        result = doctor._probe_custom_provider_health(
+            _probe_spec(f"http://127.0.0.1:{server.server_port}/v1")
+        )
+
+    assert result.kind == "provider_failure"
+    assert result.status_code == 503
+
+
+def test_custom_provider_probe_uses_anthropic_auth_headers():
+    with _models_server() as server:
+        spec = doctor._CustomProviderProbeSpec(
+            label="anthropic-proxy",
+            base_url=f"http://127.0.0.1:{server.server_port}/v1",
+            api_key="anthropic-provider-secret",
+            api_mode="anthropic_messages",
+            extra_headers={},
+        )
+        result = doctor._probe_custom_provider_health(spec)
+
+    assert result.kind == "reachable"
+    _, raw_headers = _ModelsHandler.requests[0]
+    headers = {name.lower(): value for name, value in raw_headers.items()}
+    assert headers["x-api-key"] == "anthropic-provider-secret"
+    assert headers["anthropic-version"] == "2023-06-01"
+    assert "authorization" not in headers
+
+
+def test_custom_provider_probe_applies_provider_tls_settings(monkeypatch):
+    from agent import ssl_verify
+
+    captured: dict[str, object] = {}
+
+    def fake_resolve_httpx_verify(**kwargs):
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setattr(ssl_verify, "resolve_httpx_verify", fake_resolve_httpx_verify)
+    with _models_server() as server:
+        spec = doctor._CustomProviderProbeSpec(
+            label="tls-provider",
+            base_url=f"http://127.0.0.1:{server.server_port}/v1",
+            api_key=None,
+            api_mode="chat_completions",
+            extra_headers={},
+            ssl_ca_cert="/tmp/provider-ca.pem",
+            ssl_verify=False,
+        )
+        result = doctor._probe_custom_provider_health(spec)
+
+    assert result.kind == "reachable"
+    assert captured["ca_bundle"] == "/tmp/provider-ca.pem"
+    assert captured["ssl_verify"] is False
+
+
+def test_custom_provider_probe_classifies_timeout(monkeypatch):
+    import httpx
+
+    def raise_timeout(_client, url, **_kwargs):
+        raise httpx.ReadTimeout(
+            "provider-secret",
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(httpx.Client, "get", raise_timeout)
+    result = doctor._probe_custom_provider_health(
+        _probe_spec("https://provider.example/v1")
+    )
+
+    assert result.kind == "timeout"
+
+
+def test_custom_provider_probe_classifies_wrapped_ssl_error(monkeypatch):
+    import httpx
+
+    def raise_ssl_error(_client, url, **_kwargs):
+        try:
+            raise ssl.SSLCertVerificationError(1, "certificate verify failed")
+        except ssl.SSLCertVerificationError as cause:
+            raise httpx.ConnectError(
+                "provider-secret",
+                request=httpx.Request("GET", url),
+            ) from cause
+
+    monkeypatch.setattr(httpx.Client, "get", raise_ssl_error)
+    result = doctor._probe_custom_provider_health(
+        _probe_spec("https://provider.example/v1")
+    )
+
+    assert result.kind == "ssl_error"
+
+
+def test_custom_provider_specs_omit_disabled_entries_and_preserve_tls(
+    monkeypatch,
+    tmp_path,
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """\
+providers:
+  enabled-provider:
+    name: Enabled Provider
+    api: https://enabled.example/v1
+    ssl_ca_cert: /tmp/provider-ca.pem
+    ssl_verify: false
+  disabled-provider:
+    name: Disabled Provider
+    api: https://disabled.example/v1
+    enabled: false
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    config_mod._LOAD_CONFIG_CACHE.clear()
+    config_mod._RAW_CONFIG_CACHE.clear()
+
+    specs = doctor._build_custom_provider_probe_specs()
+
+    assert [spec.label for spec in specs] == ["Enabled Provider"]
+    assert specs[0].ssl_ca_cert == "/tmp/provider-ca.pem"
+    assert specs[0].ssl_verify is False


### PR DESCRIPTION
## What does this PR do?

Teach `hermes doctor` to health-check every enabled custom provider instead of only using custom-provider names during config validation.

The probe inputs come from `resolve_runtime_provider()`, so doctor exercises the same resolved base URL, environment-expanded or pooled credential, API mode, and custom headers as the agent runtime. Each provider stays inside the existing connectivity executor and receives a bounded, non-billable `GET /models` check with the existing `/v1` fallback rules.

Results distinguish reachable 2xx responses, rejected authentication, unsupported model-list endpoints, other 4xx responses, provider-side 5xx failures, timeouts, connection failures, and TLS certificate failures. A 404/405 means the provider is reachable but does not expose the optional health endpoint; it is not reported as provider downtime.

Credential-bearing redirects are not followed, and exception text, API keys, and custom header values are never rendered in doctor output.

This is a concurrent alternative to #71879. In addition to the basic custom-provider row, this version keeps the HTTP work parallel, uses runtime credential resolution, supports native Anthropic auth and per-provider TLS settings, preserves `/v1` fallback behavior, and validates the real config-to-request path with a local HTTP server.

## Related Issue

Fixes #71854

Related: #71879

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/doctor.py`: resolve enabled custom providers, probe them in the existing executor, and render sanitized status-specific diagnostics.
- `hermes_cli/models.py`: share the existing model-probe URL fallback and request-header construction with doctor.
- `tests/hermes_cli/test_doctor_custom_provider_health.py`: add temp-`HERMES_HOME` E2E coverage plus HTTP, timeout, TLS, API-mode, disabled-provider, and secret-redaction cases.

## How to Test

1. Configure a custom provider with `base_url`, `${KEY_ENV}`, and optional `extra_headers`.
2. Run `hermes doctor` and inspect the `API Connectivity` section for the custom-provider row.
3. Verify a working `/models` endpoint reports `reachable`; 401/403 reports authentication rejection; 404/405 reports reachable but unsupported; and transport/TLS failures are classified without exposing secrets.
4. Run the focused automated checks below.

```bash
pytest tests/hermes_cli/test_doctor_custom_provider_health.py -q
pytest tests/hermes_cli/test_doctor.py tests/hermes_cli/test_doctor_dedicated_provider_skip.py -q
pytest tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_urllib_security.py -q
ruff check hermes_cli/doctor.py hermes_cli/models.py tests/hermes_cli/test_doctor_custom_provider_health.py
```

Post-fix results:

- custom-provider health tests: 12 passed
- doctor regressions: 78 passed
- model probe and credential-redirect regressions: 106 passed
- focused Ruff and Python compilation checks: passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused suites above pass; full suite left to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing config or command syntax changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The E2E test starts a local `/v1/models` server, loads a real temporary `config.yaml` containing `${PENG_API_KEY}`, and verifies that doctor:

- prints the configured provider as reachable;
- sends the resolved Bearer credential and configured custom header;
- never prints either secret value.
