### PR TITLE
fix(cli): make hermes model wizard check auth.json credential pool (#65977)

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -129,6 +129,49 @@ def _prune_replaced_custom_model_config_credentials(
         return
 
 
+def _resolve_existing_api_key_for_wizard(provider_id: str, pconfig) -> str:
+    """Resolve an existing API key for the wizard's pre-prompt detection.
+
+    Issue #65977: the wizard used to only look at ``~/.hermes/.env`` / process
+    env, which silently mis-reported providers whose key lives in the
+    ``auth.json`` credential pool (added by ``hermes auth login``). This
+    fallback mirrors ``hermes_cli.auth._resolve_api_key_provider_secret`` so
+    flows like ``openrouter`` / ``kimi`` / ``stepfun`` / the generic
+    ``_model_flow_api_key_provider`` path also detect credentials stored via
+    ``hermes auth``.
+
+    Order: env vars (``get_env_value`` + ``os.getenv``) → credential pool.
+    """
+    try:
+        from hermes_cli.config import get_env_value
+    except Exception:
+        get_env_value = None  # type: ignore[assignment]
+
+    env_vars = list(getattr(pconfig, "api_key_env_vars", None) or ())
+    for ev in env_vars:
+        try:
+            if get_env_value is not None:
+                val = get_env_value(ev) or ""
+                if val:
+                    return val
+        except Exception:
+            pass
+        val = os.getenv(ev, "") or ""
+        if val:
+            return val
+
+    try:
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+    except Exception:
+        return ""
+
+    try:
+        api_key, _key_source = _resolve_api_key_provider_secret(provider_id, pconfig)
+    except Exception:
+        return ""
+    return api_key or ""
+
+
 def _prompt_auth_credentials_choice(title: str) -> str:
     """Prompt for reuse / reauthenticate / cancel with the standard radio UI.
 
@@ -190,7 +233,8 @@ def _model_flow_openrouter(config, current_model=""):
         auth_type="api_key",
         api_key_env_vars=("OPENROUTER_API_KEY",),
     )
-    existing_key = get_env_value("OPENROUTER_API_KEY") or ""
+    # #65977: also check auth.json credential pool, not just .env / process env.
+    existing_key = _resolve_existing_api_key_for_wizard("openrouter", pconfig)
     if not existing_key:
         print("Get one at: https://openrouter.ai/keys")
         print()
@@ -1975,11 +2019,8 @@ def _model_flow_kimi(config, current_model=""):
     base_url_env = pconfig.base_url_env_var or ""
 
     # Step 1: Check / prompt for API key
-    existing_key = ""
-    for ev in pconfig.api_key_env_vars:
-        existing_key = get_env_value(ev) or os.getenv(ev, "")
-        if existing_key:
-            break
+    # #65977: env vars + auth.json credential pool (hermes auth login)
+    existing_key = _resolve_existing_api_key_for_wizard(provider_id, pconfig)
 
     existing_key, abort = _prompt_api_key(
         pconfig, existing_key, provider_id=provider_id
@@ -2060,11 +2101,8 @@ def _model_flow_stepfun(config, current_model=""):
     key_env = pconfig.api_key_env_vars[0] if pconfig.api_key_env_vars else ""
     base_url_env = pconfig.base_url_env_var or ""
 
-    existing_key = ""
-    for ev in pconfig.api_key_env_vars:
-        existing_key = get_env_value(ev) or os.getenv(ev, "")
-        if existing_key:
-            break
+    # #65977: env vars + auth.json credential pool (hermes auth login)
+    existing_key = _resolve_existing_api_key_for_wizard(provider_id, pconfig)
 
     existing_key, abort = _prompt_api_key(
         pconfig, existing_key, provider_id=provider_id
@@ -2642,11 +2680,8 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
     base_url_env = pconfig.base_url_env_var or ""
 
     # Check / prompt for API key
-    existing_key = ""
-    for ev in pconfig.api_key_env_vars:
-        existing_key = get_env_value(ev) or os.getenv(ev, "")
-        if existing_key:
-            break
+    # #65977: env vars + auth.json credential pool (hermes auth login)
+    existing_key = _resolve_existing_api_key_for_wizard(provider_id, pconfig)
 
     existing_key, abort = _prompt_api_key(
         pconfig, existing_key, provider_id=provider_id

--- a/tests/hermes_cli/test_prompt_api_key.py
+++ b/tests/hermes_cli/test_prompt_api_key.py
@@ -155,3 +155,73 @@ def test_lmstudio_replace_empty_does_not_overwrite_with_placeholder(profile_env)
     assert key == "my-real-lmstudio-key"
     assert abort is False
     assert get_env_value("LM_API_KEY") == "my-real-lmstudio-key"
+
+
+# #65977: wizard helper must also check auth.json credential pool ─────────────
+
+def test_wizard_helper_env_only(profile_env, monkeypatch):
+    """When no credential pool entry exists, env var resolves the key."""
+    from hermes_cli.config import save_env_value
+    from hermes_cli.model_setup_flows import _resolve_existing_api_key_for_wizard
+
+    pconfig = _pconfig("deepseek")
+    save_env_value("DEEPSEEK_API_KEY", "sk-from-env")
+
+    # No credential pool → still resolves via env path
+    from hermes_cli.auth import _resolve_api_key_provider_secret
+    monkeypatch.setattr(
+        "hermes_cli.auth._resolve_api_key_provider_secret",
+        lambda provider_id, p: ("", ""),  # pool empty
+    )
+    assert _resolve_existing_api_key_for_wizard("deepseek", pconfig) == "sk-from-env"
+
+
+def test_wizard_helper_credential_pool(profile_env, monkeypatch):
+    """#65977: credential pool entry should be detected when .env has no key."""
+    from hermes_cli.model_setup_flows import _resolve_existing_api_key_for_wizard
+
+    pconfig = _pconfig("deepseek")
+    # .env is empty (profile_env fixture writes "")
+    # Stub the auth helper to simulate a pool entry
+    from hermes_cli.auth import _resolve_api_key_provider_secret
+    monkeypatch.setattr(
+        "hermes_cli.auth._resolve_api_key_provider_secret",
+        lambda provider_id, p: ("sk-from-pool", "credential_pool:deepseek"),
+    )
+    assert _resolve_existing_api_key_for_wizard("deepseek", pconfig) == "sk-from-pool"
+
+
+def test_wizard_helper_neither_configured(profile_env, monkeypatch):
+    """When neither .env nor credential pool has the key, helper returns ""."""
+    from hermes_cli.model_setup_flows import _resolve_existing_api_key_for_wizard
+
+    pconfig = _pconfig("deepseek")
+    # .env empty; pool empty
+    from hermes_cli.auth import _resolve_api_key_provider_secret
+    monkeypatch.setattr(
+        "hermes_cli.auth._resolve_api_key_provider_secret",
+        lambda provider_id, p: ("", ""),
+    )
+    assert _resolve_existing_api_key_for_wizard("deepseek", pconfig) == ""
+
+
+def test_wizard_helper_openrouter_via_pool(profile_env, monkeypatch):
+    """#65977 specifically: openrouter flow synthesizes a ProviderConfig and
+    should still detect a credential pool entry, not just env vars."""
+    from hermes_cli.model_setup_flows import _resolve_existing_api_key_for_wizard
+    from hermes_cli.auth import ProviderConfig
+
+    pconfig = ProviderConfig(
+        id="openrouter",
+        name="OpenRouter",
+        auth_type="api_key",
+        api_key_env_vars=("OPENROUTER_API_KEY",),
+    )
+    # No OPENROUTER_API_KEY in env; pool returns the key
+    from hermes_cli.auth import _resolve_api_key_provider_secret
+    monkeypatch.setattr(
+        "hermes_cli.auth._resolve_api_key_provider_secret",
+        lambda provider_id, p: ("sk-or-pool-key", "credential_pool:openrouter"),
+    )
+    assert _resolve_existing_api_key_for_wizard("openrouter", pconfig) == "sk-or-pool-key"
+


### PR DESCRIPTION
## Summary

Fixes the `hermes setup` / `hermes model` wizard for users who added their API key via `hermes auth login` (which stores the credential in the `auth.json` credential pool).

The four wizard flows that pre-check whether an API key already exists only inspected `~/.hermes/.env` and process env vars. Providers whose key lived in the credential pool were silently reported as unconfigured, forcing the user to re-paste their key on every wizard run.

## Changes

Single-file behavior change + tests.

**`hermes_cli/model_setup_flows.py`** — add one helper and call it from four existing sites:

- New helper `_resolve_existing_api_key_for_wizard(provider_id, pconfig)` mirrors the env-then-pool lookup already implemented by `hermes_cli.auth._resolve_api_key_provider_secret` (no refactor of `auth.py`).
- Replace the env-only `existing_key = ...` blocks in:
  - `_model_flow_openrouter`
  - `_model_flow_kimi`
  - `_model_flow_stepfun`
  - `_model_flow_api_key_provider` (generic path used by z.ai, MiniMax, OpenCode, etc.)

The lookup order is unchanged when env vars are set: env wins, pool only consulted as fallback. No public API change.

**`tests/hermes_cli/test_prompt_api_key.py`** — 4 new tests covering:

- env-only → helper returns env value (compatibility)
- credential-pool-only → helper returns pool value (the #65977 fix)
- neither configured → helper returns `""` (no false-positive "configured")
- openrouter synthesized `ProviderConfig` → pool value still detected

## Test plan

```bash
.venv/Scripts/python.exe -m pytest tests/hermes_cli/test_prompt_api_key.py -q
# 15 passed
```

## NOT doing X

- **No refactor of `hermes_cli/auth.py`** — the existing `_resolve_api_key_provider_secret` helper already implements env-then-pool. We call it; we don't rewrite it.
- **No public API change** — only the wizard's pre-prompt key detection uses the new helper.
- **No change to credential storage** — `hermes auth login` already writes to the pool correctly; this PR only fixes the wizard's reading.
- **No scope creep beyond the four flows** in the issue.
