### PR TITLE
fix(tui_gateway): normalize lane roots so Windows main checkout isn't duplicated (#71837)

### DIFF
--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -193,7 +193,10 @@ def test_non_git_cwd_preserves_legacy_workspace_grouping():
     assert project["isAuto"] is True
     assert project["label"] == "notes"
     assert project["sessionCount"] == 1
-    assert _lane_ids(project) == ["/work/notes"]
+    # Canonical branch-lane id, NOT the raw path: the desktop live overlay
+    # matches lanes by `<root>::branch::main` (or isMain + "main" label) and
+    # injects a duplicate lane when neither matches (issue #71837).
+    assert _lane_ids(project) == ["/work/notes::branch::main"]
     assert tree["scoped_session_ids"] == [legacy["id"]]
 
 
@@ -579,3 +582,47 @@ def test_colliding_repo_basenames_disambiguate_labels():
     labels = sorted(p["label"] for p in tree["projects"])
 
     assert labels == ["x/proj", "y/proj"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #71837 — Windows duplicate branch lanes (backend/frontend lane-id
+# mismatch): mixed-separator roots and heuristic (non-git) lane ids.
+# ---------------------------------------------------------------------------
+
+
+def test_windows_mixed_separator_roots_still_classify_as_main_checkout():
+    # On Windows `git rev-parse --show-toplevel` prints forward slashes while
+    # the common-root probe goes through realpath and returns backslashes.
+    # Placement must not depend on byte equality of the two spellings, or the
+    # main checkout degrades to a path-keyed worktree lane the desktop live
+    # overlay cannot match — which then injects a duplicate "main" lane.
+    repo_bs = r"C:\Users\alice\repo"
+    resolve = _resolver({repo_bs: (repo_bs, "C:/Users/alice/repo")})
+    sessions = [_session(repo_bs, branch="main")]
+
+    tree = pt.build_tree([], sessions, [], resolve, hydrate=True)
+    project = tree["projects"][0]
+    lanes = [g for repo in project["repos"] for g in repo["groups"]]
+
+    assert len(lanes) == 1
+    assert lanes[0]["id"] == repo_bs + "::branch::main"
+    assert lanes[0]["isMain"] is True
+    assert lanes[0]["label"] == "main"
+
+
+def test_non_git_folder_lane_uses_canonical_branch_lane_id():
+    # Heuristic (non-git) folders must emit `<root>::branch::main` with an
+    # isMain "main" label — the same convention the desktop live overlay
+    # computes via branchLaneId(root, 'main') — instead of a raw path lane id
+    # labeled by the folder basename, which matches neither of the overlay's
+    # lookups and produces a second synthetic lane with the same sessions.
+    cwd = r"C:\Users\alice\workspace\notes"
+    sessions = [_session(cwd)]
+
+    tree = pt.build_tree([], sessions, [], resolve=lambda _cwd: None, hydrate=True)
+    project = tree["projects"][0]
+    lane = project["repos"][0]["groups"][0]
+
+    assert lane["id"] == cwd + "::branch::main"
+    assert lane["label"] == "main"
+    assert lane["isMain"] is True

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -163,7 +163,10 @@ def test_resolve_normalizes_both_roots(monkeypatch):
     monkeypatch.setattr(git_probe, "repo_root", lambda cwd: "/repo/sub/..")
     monkeypatch.setattr(git_probe, "common_repo_root", lambda cwd: "/repo/./")
 
-    assert git_probe.resolve("/repo/x") == {"repo_root": "/repo", "worktree_root": "/repo"}
+    # Build the expected spelling through normpath so this holds on Windows too,
+    # where os.path.normpath renders "/repo" as "\\repo" (issue #71837 target).
+    expected = os.path.normpath("/repo")
+    assert git_probe.resolve("/repo/x") == {"repo_root": expected, "worktree_root": expected}
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific regression (issue #71837)")
@@ -192,9 +195,13 @@ def test_resolve_preserves_distinct_worktree_root(monkeypatch):
     monkeypatch.setattr(git_probe, "repo_root", lambda cwd: "/home/u/repo/../repo-wt")
     monkeypatch.setattr(git_probe, "common_repo_root", lambda cwd: "/home/u/repo")
 
+    # Construct expected paths via normpath so they match on Windows too, where
+    # the separator flips and "/home/u/..." becomes "\\home\\u\\...".
+    expected_repo = os.path.normpath("/home/u/repo")
+    expected_wt = os.path.normpath("/home/u/repo-wt")
     info = git_probe.resolve("/home/u/repo-wt")
 
-    assert info == {"repo_root": "/home/u/repo", "worktree_root": "/home/u/repo-wt"}
+    assert info == {"repo_root": expected_repo, "worktree_root": expected_wt}
     assert info["worktree_root"] != info["repo_root"]
 
 

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 
 import pytest
 
@@ -148,6 +149,37 @@ def test_warm_roots_probes_in_parallel_and_fills_the_cache(monkeypatch):
     before = live["calls"]
     assert git_probe.repo_root("/repo0") == "/repo0"
     assert live["calls"] == before
+
+
+def test_resolve_normalizes_both_roots(monkeypatch):
+    # `resolve()` must normpath both roots so the two probe sources agree on
+    # one spelling. On Windows `--show-toplevel` prints forward slashes while
+    # common_repo_root() (via realpath) returns backslashes; unnormalized, the
+    # downstream main-checkout comparison always fails and every main checkout
+    # is misclassified as a linked worktree (issue #71837).
+    from tui_gateway import git_probe
+
+    git_probe.invalidate()
+    monkeypatch.setattr(git_probe, "repo_root", lambda cwd: "/repo/sub/..")
+    monkeypatch.setattr(git_probe, "common_repo_root", lambda cwd: "/repo/./")
+
+    assert git_probe.resolve("/repo/x") == {"repo_root": "/repo", "worktree_root": "/repo"}
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific regression (issue #71837)")
+def test_resolve_folds_forward_slash_toplevel_into_backslash_common_root(monkeypatch):
+    # The exact defect from issue #71837: git prints `C:/Users/x/repo`,
+    # realpath spells the common root `C:\Users\x\repo`. After normalization
+    # both fields must agree so the main checkout classifies as main.
+    from tui_gateway import git_probe
+
+    git_probe.invalidate()
+    monkeypatch.setattr(git_probe, "repo_root", lambda cwd: "C:/Users/x/repo")
+    monkeypatch.setattr(git_probe, "common_repo_root", lambda cwd: "C:\\Users\\x\\repo")
+
+    info = git_probe.resolve("C:\\Users\\x\\repo")
+
+    assert info["repo_root"] == info["worktree_root"] == "C:\\Users\\x\\repo"
 
 
 def test_create_list_roundtrip(tmp_path):

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -182,6 +182,33 @@ def test_resolve_folds_forward_slash_toplevel_into_backslash_common_root(monkeyp
     assert info["repo_root"] == info["worktree_root"] == "C:\\Users\\x\\repo"
 
 
+def test_resolve_preserves_distinct_worktree_root(monkeypatch):
+    # A genuine linked worktree is a *distinct* location; normalization must
+    # collapse only redundant segments, never fold a real worktree into the
+    # main checkout — otherwise it would wrongly classify as main (issue #71837).
+    from tui_gateway import git_probe
+
+    git_probe.invalidate()
+    monkeypatch.setattr(git_probe, "repo_root", lambda cwd: "/home/u/repo/../repo-wt")
+    monkeypatch.setattr(git_probe, "common_repo_root", lambda cwd: "/home/u/repo")
+
+    info = git_probe.resolve("/home/u/repo-wt")
+
+    assert info == {"repo_root": "/home/u/repo", "worktree_root": "/home/u/repo-wt"}
+    assert info["worktree_root"] != info["repo_root"]
+
+
+def test_resolve_returns_none_when_not_a_repo(monkeypatch):
+    # When git cannot resolve a repo root the resolver must short-circuit to
+    # None rather than building a bogus lane for a non-repo cwd (issue #71837).
+    from tui_gateway import git_probe
+
+    git_probe.invalidate()
+    monkeypatch.setattr(git_probe, "repo_root", lambda cwd: "")
+
+    assert git_probe.resolve("/tmp/not-a-repo") is None
+
+
 def test_create_list_roundtrip(tmp_path):
     created = _call("projects.create", {"name": "Demo", "folders": [str(tmp_path)], "use": True})
     assert created["project"]["slug"] == "demo"

--- a/tui_gateway/git_probe.py
+++ b/tui_gateway/git_probe.py
@@ -162,11 +162,21 @@ def resolve(cwd: str) -> dict | None:
     Returns ``{"repo_root": <common root>, "worktree_root": <this checkout>}``
     or ``None`` when ``cwd`` is not in a git repo. ``build_tree`` treats
     ``worktree_root == repo_root`` as the main checkout.
+
+    Both roots are separator-normalized (``os.path.normpath``): on Windows,
+    ``git rev-parse --show-toplevel`` prints forward slashes (``C:/Users/x/repo``)
+    while :func:`common_repo_root` goes through ``os.path.realpath`` and returns
+    backslashes (``C:\\Users\\x\\repo``). Left unnormalized, the main-checkout
+    equality check downstream always fails, so every repo's main checkout is
+    misclassified as a linked worktree and gets a path-keyed lane the desktop's
+    live overlay can't match (issue #71837).
     """
     worktree_root = repo_root(cwd)
     if not worktree_root:
         return None
-    return {"repo_root": common_repo_root(cwd) or worktree_root, "worktree_root": worktree_root}
+    worktree_root = os.path.normpath(worktree_root)
+    repo = os.path.normpath(common_repo_root(cwd) or worktree_root)
+    return {"repo_root": repo, "worktree_root": worktree_root}
 
 
 def warm_roots(cwds: Iterable[str], max_workers: int = _WARM_WORKERS) -> None:

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -212,7 +212,14 @@ def _place_by_heuristic(path: str) -> Optional[dict]:
         repo_path = _with_base_name(path, m.group(1))
         return _placement(repo_path, path, m.group(2), path, False, False)
 
-    return _placement(path, path, base, path, True, False)
+    # Emit the canonical `<root>::branch::main` lane id, NOT the raw path: the
+    # desktop's live overlay computes `branchLaneId(root, 'main')` for every
+    # live session and only falls back to isMain+label matching — a path-keyed
+    # lane matches neither, so it would inject a duplicate synthetic "main"
+    # lane next to this one (issue #71837).
+    return _placement(
+        path, _branch_lane_id(path, DEFAULT_BRANCH_LABEL), DEFAULT_BRANCH_LABEL, path, True, False
+    )
 
 
 def _place(cwd: str, branch: str, resolve: Optional[Resolve], persisted_root: str) -> Optional[dict]:
@@ -221,7 +228,11 @@ def _place(cwd: str, branch: str, resolve: Optional[Resolve], persisted_root: st
     if info and info.get("repo_root") and info.get("worktree_root"):
         repo_root = info["repo_root"]
         worktree_root = info["worktree_root"]
-        is_main = worktree_root == repo_root or bool(info.get("is_main"))
+        # Separator/case-agnostic comparison: a resolver may spell the two
+        # roots differently on Windows (git prints `C:/x/repo`, realpath
+        # returns `C:\x\repo`). A raw `==` would misclassify every main
+        # checkout as a linked worktree (issue #71837).
+        is_main = _path_key(worktree_root) == _path_key(repo_root) or bool(info.get("is_main"))
 
         if is_main:
             # Unrecorded branch folds into the one trunk lane, so a repo never


### PR DESCRIPTION
## Summary

Fixes #71837 — duplicate branch lanes in the Desktop sidebar on Windows.

On Windows, `git rev-parse --show-toplevel` prints forward slashes
(`C:/Users/x/repo`) while `common_repo_root()` goes through
`os.path.realpath` and returns backslashes (`C:\Users\x\repo`). The two
spellings never compared equal, so `build_tree` misclassified every main
checkout as a linked worktree and emitted a **path-keyed lane**. The
desktop live overlay matches lanes by `<root>::branch::main` (or
`isMain` + `"main"` label) and, finding no match, injected a **second
synthetic `main` lane** for the same sessions — the duplicate lanes
reported in the issue.

### Consolidation of #71858 and #71860

This PR is the single consolidation of the three sub-fixes that were
split across two other open PRs for the same bug; those should be closed
in favor of this one:

| Sub-fix | Origin PR |
| --- | --- |
| `git_probe.resolve()` normalizes both roots (`os.path.normpath`) | #71860 |
| `project_tree._place()` compares roots via `_path_key()` (separator/case-agnostic) instead of raw `==` | #71858 |
| `project_tree._place_by_heuristic()` emits the canonical `<root>::branch::main` lane id (isMain, `"main"`) | #71860 |

The source changes are a strict superset of #71858 + #71860, and the test
coverage is likewise consolidated (including the distinct-worktree and
non-repo `resolve()` regression tests from #71860) so nothing is lost when
those PRs are closed.

### Changes
- `tui_gateway/git_probe.py` — `resolve()` now `os.path.normpath`s both
  `repo_root` and `worktree_root`.
- `tui_gateway/project_tree.py`:
  - `_place()` compares the two roots via `_path_key()` (separator/case
    agnostic) instead of raw `==`.
  - `_place_by_heuristic()` emits the canonical `<root>::branch::main` lane
    id (isMain, `"main"` label) instead of the raw path, so the overlay's
    lookup matches instead of duplicating.
- Tests: regression coverage for mixed-separator roots, the heuristic
  branch-lane id, `resolve()` normalization (incl. a Windows-specific skip,
  a distinct linked-worktree case, and a non-repo `None` case).

## Test plan
- `scripts/run_tests.sh tests/tui_gateway/test_project_tree.py tests/tui_gateway/test_projects_rpc.py`
  → 60 tests pass (incl. the new regression tests) under the hermetic
  `TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0` env.
- `scripts/check-windows-footguns.py` on the 4 changed files →
  ✓ No Windows footguns found.

## Platforms
- macOS: full test run passes.
- Windows: path behavior verified via the new regression tests (no Windows
  builder available in this environment).

## Notes
- Backend-only fix; no desktop/Electron rebuild required.
- `js` lints (`npm run fix` / prettier) not applicable — no frontend files
  changed.