### PR TITLE
fix(desktop): send a skill's kickoff into the tab that invoked it

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1167,6 +1167,56 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
     $queuedPromptsBySession.set({})
   })
 
+  it("sends a skill's kickoff into the TAB that invoked it, not the foreground chat", async () => {
+    // `/work` in a fresh ⌘T tab: slash.exec returns a skill dispatch whose
+    // `message` is the kickoff prompt. The dispatcher resolved the tab as its
+    // target, printed "⚡ loading skill" there — then submitted the kickoff
+    // with no target at all, so submit re-resolved from activeSessionIdRef and
+    // fired it as a user message into whatever conversation was on screen.
+    const tabRuntimeId = 'tab-runtime'
+    const tabStoredId = 'tab-stored'
+
+    $queuedPromptsBySession.set({})
+    publishSessionState(tabRuntimeId, createClientSessionState(tabStoredId))
+
+    const submitted: (Record<string, unknown> | undefined)[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'prompt.submit') {
+        submitted.push(params)
+      }
+
+      return (
+        method === 'slash.exec'
+          ? { type: 'skill', name: 'work', message: 'Load the work skill, then: fix the tab bug' }
+          : {}
+      ) as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionId="foreground-runtime"
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId="foreground-stored"
+      />
+    )
+
+    await handle!.submitText('/work fix the tab bug', { sessionId: tabRuntimeId })
+
+    expect(submitted).toEqual([
+      expect.objectContaining({
+        session_id: tabRuntimeId,
+        text: 'Load the work skill, then: fix the tab bug'
+      })
+    ])
+
+    dropSessionState(tabRuntimeId)
+    $queuedPromptsBySession.set({})
+  })
+
   it('slash status header carries the command token, not the full invocation', async () => {
     // `/goal <long prose>` used to echo the entire invocation in the mono
     // header AND the goal text again in the backend notice right under it.

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -285,7 +285,16 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             return
           }
 
-          await submitPromptText(message)
+          // Submit into the session this command was resolved against — the
+          // same pair the output writer and the busy gate above already use.
+          // Bare `submitPromptText(message)` let submit re-resolve from
+          // `activeSessionIdRef`, which names the FOREGROUND chat: a `/work`
+          // typed into a fresh ⌘T tab loaded the skill in that tab, printed
+          // "⚡ loading skill" there, then fired its kickoff as a user message
+          // into whatever conversation was on screen. Every other target the
+          // dispatcher serves (tile, background queue drain, a session created
+          // by this very call) had the same leak.
+          await submitPromptText(message, { sessionId, storedSessionId })
         }
 
         try {


### PR DESCRIPTION
Typing `/work` into a fresh ⌘T tab loaded the skill in that tab and printed `⚡ loading skill: work` there — then fired the skill's kickoff prompt as a user message into whatever conversation was on screen. The tab sat empty while the primary chat got hijacked mid-conversation.

The dispatcher resolves its target once, through `resolveTargetSessionId`, and every other consumer of that answer already honors it: the output writer binds to the target's stored id, and the busy gate reads the target's own published state. The send did not. `submitPromptText(message)` passed no target at all, so submit fell back to `activeSessionIdRef` — which names the foreground chat, not the session the command was resolved against.

[#71805](https://github.com/NousResearch/hermes-agent/pull/71805) fixed the two sibling leaks in this same function (the busy gate and the output binding). This is the third, and the one that actually moved the user's prompt: the tab correctly showed the skill loading, so the surface looked right while the payload went elsewhere.

Forwarding the resolved `{ sessionId, storedSessionId }` pair fixes the whole class, not just the tab case that surfaced it — a tile, a background queue drain, and a session created by the slash call itself were all landing on the same fallback.

### Verification

The new test reverses on the parent commit with `session_id: "foreground-runtime"` where `"tab-runtime"` is expected — the exact symptom, not a restatement of the implementation. 941 tests pass across `src/app`; `tsc --noEmit`, eslint, and prettier clean.
