### PR TITLE
fix: close stale TUI sessions when resuming another chat

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4331,6 +4331,23 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def close_other_source_sessions(
+        self, session_id: str, source: str = "tui", end_reason: str = "session_switch"
+    ) -> None:
+        """Close all sessions from a given source except the specified one.
+
+        Used by session.resume to clean up stale open sessions when switching
+        between chats in the TUI sidebar. No-op when there are no other open
+        sessions from this source.
+        """
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET ended_at = ?, end_reason = ? "
+                "WHERE source = ? AND ended_at IS NULL AND id != ?",
+                (time.time(), end_reason, source, session_id),
+            )
+        self._execute_write(_do)
+
     def reopen_session(self, session_id: str) -> None:
         """Clear ended_at/end_reason so a session can be resumed."""
         def _do(conn):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7249,6 +7249,13 @@ def _(rid, params: dict) -> dict:
             target = tip
             found = db.get_session(target) or found
 
+    # Close stale open sessions when switching — the TUI sidebar does not
+    # end the previous session, leaving ghost rows with ended_at=NULL.
+    try:
+        db.close_other_source_sessions(target, source="tui")
+    except Exception:
+        pass
+
     profile_resume_cwd = str(found.get("cwd") or "").strip() or _profile_configured_cwd(
         profile_home
     )


### PR DESCRIPTION
## Summary

When switching between chats in the TUI sidebar, `session.resume` reopens the target session but never closes the previous one. Over time this accumulates multiple open TUI sessions with `ended_at=NULL`, causing `/endsession` and other session-picking heuristics that query `WHERE ended_at IS NULL` to target the wrong session.

## Changes

**`hermes_state.py`** — Add `SessionDB.close_other_source_sessions(session_id, source, end_reason)`:
- Closes all sessions from a given `source` that have `ended_at IS NULL`, except the one specified by `session_id`
- No-op when there are no other open sessions

**`tui_gateway/server.py`** — Call `db.close_other_source_sessions(target, source="tui")` in `session.resume` after target resolution and before any `reopen_session` call:
- Covers lazy/watch, cold deferred, and eager build paths
- Wrapped in try/except so a failure doesn't block the resume

## Testing

- Existing behavior unchanged: the method is a no-op when there's only one open TUI session
- When switching sessions with multiple open TUI sessions, the old ones are now properly closed