### PR TITLE
docs(memory-providers): drop the stale provider count from the intro

### DIFF
--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -85,7 +85,7 @@ Speech-to-text supports six providers: local faster-whisper (free, runs on-devic
 ## Memory & Personalization
 
 - **[Built-in Memory](/user-guide/features/memory)** — Persistent, curated memory via `MEMORY.md` and `USER.md` files. The agent maintains bounded stores of personal notes and user profile data that survive across sessions.
-- **[Memory Providers](/user-guide/features/memory-providers)** — Plug in external memory backends for deeper personalization. Eight providers are supported: Honcho (dialectic reasoning), OpenViking (tiered retrieval), Mem0 (cloud extraction), Hindsight (knowledge graphs), Holographic (local SQLite), RetainDB (hybrid search), ByteRover (CLI-based), and Supermemory.
+- **[Memory Providers](/user-guide/features/memory-providers)** — Plug in external memory backends for deeper personalization: Honcho (dialectic reasoning), OpenViking (tiered retrieval), Mem0 (cloud extraction), Hindsight (knowledge graphs), Holographic (local SQLite), RetainDB (hybrid search), ByteRover (CLI-based), Supermemory, and Memori (structured cloud recall). The linked page is the current list.
 
 ## Messaging Platforms
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory, Memori"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent supports a set of external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. The full list is under [Available Providers](#available-providers) below. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 


### PR DESCRIPTION
## What does this PR do?

the memory providers page opens with "ships with 8 external memory provider plugins" and then documents nine of them. the frontmatter description lists eight as well, missing Memori.

`plugins/memory/` holds eight in-tree providers (byterover, hindsight, holographic, honcho, mem0, openviking, retaindb, supermemory). Memori is the ninth on the page and installs separately via `pip install hermes-memori`, so the two sets genuinely differ and "8" was accurate for the bundled set when it was written.

I have dropped the number rather than bumping it to 9, because the count is the half of that sentence that dates fastest and the list right below it is the half readers actually use. #31316 and #34356 both add a provider without touching the intro, so the drift is ongoing.

this came off a support thread where someone was choosing a provider and counting the options.

## Type of Change

- [x] Documentation update
