### PR TITLE
docs(sessions): note that session storage is per profile

### DIFF
--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -650,6 +650,24 @@ Sessions with **active background processes** are never auto-reset, regardless o
 
 The SQLite database uses WAL mode for concurrent readers and a single writer, which suits the gateway's multi-platform architecture well.
 
+:::warning Sessions are per profile
+The paths above are relative to the **active profile's** `HERMES_HOME`, not to a single
+shared database. `~/.hermes/state.db` holds the default profile's sessions; a session
+started under profile `work` lives in `~/.hermes/profiles/work/state.db` and is invisible
+from any other profile. `hermes sessions list`, `/sessions`, `session_search`, and the
+dashboard all read the active profile's database only.
+
+So if a session has vanished, check the other profiles before concluding it was lost:
+
+```bash
+hermes profile list
+hermes --profile work sessions list
+```
+
+Profile-scoped storage is also why `hermes profile create --clone-all` excludes
+`state.db` — history belongs to the source profile. See [Profiles](/user-guide/profiles).
+:::
+
 :::warning `sessions.json` is not the session list
 `~/.hermes/sessions/sessions.json` is the **gateway routing index** — it maps
 messaging session keys (`agent:main:<platform>:...`) to active session IDs.

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -653,16 +653,22 @@ The SQLite database uses WAL mode for concurrent readers and a single writer, wh
 :::warning Sessions are per profile
 The paths above are relative to the **active profile's** `HERMES_HOME`, not to a single
 shared database. `~/.hermes/state.db` holds the default profile's sessions; a session
-started under profile `work` lives in `~/.hermes/profiles/work/state.db` and is invisible
-from any other profile. `hermes sessions list`, `/sessions`, `session_search`, and the
-dashboard all read the active profile's database only.
+started under profile `work` lives in its own `~/.hermes/profiles/work/state.db`.
 
-So if a session has vanished, check the other profiles before concluding it was lost:
+Nothing crosses profiles unless you ask it to. `hermes sessions list` and `/sessions` read
+the active profile's database and no other, so if a session has vanished, check the other
+profiles before concluding it was lost:
 
 ```bash
 hermes profile list
 hermes --profile work sessions list
 ```
+
+Where a cross-profile read is asked for, it works. `session_search` takes a `profile`
+argument and opens that profile's database read-only — this is how `@session:<profile>/<id>`
+links resolve — and given a session id with no profile attached, it falls back to scanning
+every profile's database to find the owner. The dashboard scopes its listings to whichever
+profile it has focused.
 
 Profile-scoped storage is also why `hermes profile create --clone-all` excludes
 `state.db` — history belongs to the source profile. See [Profiles](/user-guide/profiles).


### PR DESCRIPTION
## What does this PR do?

adds a per-profile note to the sessions page's Storage Locations section.

the page currently states `~/.hermes/state.db` as though there were one session database, and the word "profile" does not appear anywhere in it. sessions are stored per profile under each profile's `HERMES_HOME`, which is why `hermes profile create --clone-all` excludes `state.db` (`hermes_cli/profiles.py`) and why cron scopes its own store the same way (`cron/jobs.py`, #4707).

the support shape this fixes: someone switches profile, their history is not in `hermes sessions list`, and they conclude the session was destroyed. one recent report described losing their most productive session and blamed a project directory outside the Hermes tree. I could not reproduce that — a session with cwd well outside `~/.hermes` persisted fine and cwd is not part of session identity in the source — which leaves a profile switch as the likeliest explanation, and nothing in the docs would have pointed them there.

the note goes directly above the existing "`sessions.json` is not the session list" warning so the two "your sessions are not actually missing" answers sit together. related: #70877 on the same theme from the backup side.

## Type of Change

- [x] Documentation update
