### PR TITLE
fix(gateway): don't auto-replay the turn that requested the restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3268,6 +3268,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # Class-level defaults so partial construction in tests doesn't
     # blow up on attribute access.
     _running_agents_ts: Dict[str, float] = {}
+    # Sessions whose in-flight turn itself requested the gateway restart
+    # (see request_restart / _resume_reason_for_shutdown_mark).
+    _session_initiated_restart: Dict[str, bool] = {}
     _busy_input_mode: str = "interrupt"
     _busy_text_mode: str = "interrupt"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
@@ -3422,6 +3425,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
+        # session_key -> True when THAT session's turn asked for the restart.
+        self._session_initiated_restart: Dict[str, bool] = {}
         self._active_session_leases: Dict[str, Any] = {}
         # Per-SESSION_ID turn lease (#64934): serializes the
         # [load history → run → flush] region when two ROUTING KEYS resolve
@@ -7364,6 +7369,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def request_restart(self, *, detached: bool = False, via_service: bool = False) -> bool:
         if self._restart_task_started:
             return False
+        # Record WHICH session asked for this restart.  The drain-mark below
+        # runs much later, on the shutdown path, with no reference to the
+        # originating turn — without this breadcrumb it cannot tell the turn
+        # that CAUSED the restart apart from an innocent bystander that merely
+        # happened to be running, and marks both auto-resumable.
+        try:
+            from gateway.session_context import get_session_env
+
+            session_key = get_session_env("HERMES_SESSION_KEY", "")
+            if session_key:
+                self._session_initiated_restart[session_key] = True
+        except Exception:
+            pass
         self._restart_requested = True
         self._restart_detached = detached
         self._restart_via_service = via_service
@@ -7401,6 +7419,46 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _AUTO_RESUME_REASONS = frozenset(
         {"restart_timeout", "shutdown_timeout", "restart_interrupted"}
     )
+
+    # Drain-mark reason for a session whose interrupted turn was ITSELF
+    # initiating the restart.  Deliberately NOT in _AUTO_RESUME_REASONS: the
+    # turn already did what it was asked to do (restart the gateway), so
+    # replaying it just re-fires the restart.  The session keeps its
+    # transcript and resume_pending flag, so a real user message still
+    # continues it — only the *automatic* replay is suppressed.
+    _RESTART_CONSUMED_REASON = "restart_consumed"
+
+    def _resume_reason_for_shutdown_mark(self, session_key: str) -> str:
+        """Pick the drain-mark reason for ``session_key``.
+
+        A turn that asked for the restart must not be auto-replayed after it:
+        the replay re-runs the same work, re-fires the restart, and the
+        gateway cascades (each iteration also emitting a shutdown banner).
+        Innocent bystander turns — merely running when someone else's restart
+        landed — keep their normal auto-resume reason.
+
+        The initiator is identified two ways, because the in-memory flag does
+        not survive the restart it caused:
+
+        1. ``_session_initiated_restart`` — set by ``request_restart`` in THIS
+           process.
+        2. the durable session entry's existing ``restart_consumed`` reason —
+           so a relapse on a later boot cannot overwrite the mark back to an
+           auto-resume reason and simply resume the cascade one boot later.
+        """
+        if getattr(self, "_session_initiated_restart", {}).get(session_key):
+            return self._RESTART_CONSUMED_REASON
+        try:
+            entry = self.session_store._entries.get(session_key)
+            if (
+                entry is not None
+                and getattr(entry, "resume_reason", None)
+                == self._RESTART_CONSUMED_REASON
+            ):
+                return self._RESTART_CONSUMED_REASON
+        except Exception:
+            pass
+        return "restart_timeout" if self._restart_requested else "shutdown_timeout"
 
     async def _run_startup_resume_event(
         self,
@@ -9610,7 +9668,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     await self.async_session_store.mark_resume_pending(
                         _sk,
-                        "restart_timeout" if self._restart_requested else "shutdown_timeout",
+                        self._resume_reason_for_shutdown_mark(_sk),
                     )
                     _pre_drain_keys.append(_sk)
                 except Exception as _e:
@@ -9681,14 +9739,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # _interrupt_running_agents() does: their agent hasn't
                 # started yet, there's nothing to interrupt, and the
                 # session shouldn't carry a misleading resume flag.
-                _resume_reason = (
-                    "restart_timeout" if self._restart_requested else "shutdown_timeout"
-                )
                 for _sk, _agent in list(self._running_agents.items()):
                     if _agent is _AGENT_PENDING_SENTINEL:
                         continue
                     try:
-                        await self.async_session_store.mark_resume_pending(_sk, _resume_reason)
+                        await self.async_session_store.mark_resume_pending(
+                            _sk, self._resume_reason_for_shutdown_mark(_sk)
+                        )
                     except Exception as _e:
                         logger.debug(
                             "mark_resume_pending failed for %s: %s",
@@ -14057,6 +14114,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # the restart-interruption system note.
             if session_key and _should_clear_resume_pending_after_turn(agent_result):
                 self._clear_restart_failure_count(session_key)
+                # A turn that completed cleanly is forward progress: drop the
+                # restart-initiator breadcrumb so a LATER, unrelated restart
+                # while this session happens to be running is marked normally
+                # and still auto-resumes.  Without this the session would lose
+                # its replay permanently after one /restart.
+                try:
+                    self._session_initiated_restart.pop(session_key, None)
+                except Exception:
+                    pass
                 try:
                     await self.async_session_store.clear_resume_pending(session_key)
                 except Exception as _e:

--- a/tests/gateway/test_restart_initiator_not_replayed.py
+++ b/tests/gateway/test_restart_initiator_not_replayed.py
@@ -1,0 +1,264 @@
+"""A turn that ASKED for the restart must not be auto-replayed after it.
+
+The restart-cascade loop
+------------------------
+1. A user turn runs ``/restart`` (or otherwise reaches ``request_restart``).
+2. ``stop()`` drains.  That turn is still running — it IS the turn that asked
+   for the restart — so the drain-timeout path marks it ``resume_pending`` with
+   reason ``restart_timeout``.
+3. ``restart_timeout`` is in ``_AUTO_RESUME_REASONS``, so on the next boot
+   ``_schedule_resume_pending_sessions`` synthesizes a continuation turn for it.
+4. The replayed turn re-runs the same work — including the restart request.
+5. Go to 1.
+
+Each iteration also emits a shutdown notification, so the user sees a stream of
+"Gateway restarting" banners.
+
+The distinguishing signal already exists in the runner: ``request_restart``
+knows a restart was requested, and ``_restart_command_source`` records WHICH
+session's command asked for it.  Nothing consults it at the drain-mark, so a
+restart-initiating turn is marked with the same reason as an innocent
+bystander turn that merely happened to be running.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry
+from tests.gateway.restart_test_helpers import (
+    make_restart_runner,
+    make_restart_source,
+)
+
+
+def _entry(session_key: str, source) -> SessionEntry:
+    return SessionEntry(
+        session_key=session_key,
+        session_id="sid-" + session_key,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+
+
+class _RecordingStore:
+    """Minimal session store that records mark_resume_pending reasons."""
+
+    def __init__(self):
+        self._entries = {}
+        self.marks = []
+
+    def mark_resume_pending(self, session_key, reason="restart_timeout"):
+        self.marks.append((session_key, reason))
+        entry = self._entries.get(session_key)
+        if entry is None:
+            return False
+        entry.resume_pending = True
+        entry.resume_reason = reason
+        entry.last_resume_marked_at = datetime.now()
+        return True
+
+    def clear_resume_pending(self, session_key):
+        entry = self._entries.get(session_key)
+        if entry is not None:
+            entry.resume_pending = False
+        return True
+
+    def _save(self):
+        return None
+
+
+def _prepare(runner, initiator_key, bystander_key):
+    source = make_restart_source(chat_id="initiator")
+    other = make_restart_source(chat_id="bystander")
+    store = _RecordingStore()
+    store._entries = {
+        initiator_key: _entry(initiator_key, source),
+        bystander_key: _entry(bystander_key, other),
+    }
+    runner.session_store = store
+    return store
+
+
+@pytest.mark.asyncio
+async def test_restart_initiating_turn_is_not_marked_auto_resumable():
+    """The turn that requested the restart must get a NON-auto-resume reason.
+
+    Without this the same turn is replayed on the next boot, re-runs the
+    restart request, and the gateway restarts forever.
+    """
+    runner, _adapter = make_restart_runner()
+    initiator = "agent:main:telegram:dm:initiator"
+    bystander = "agent:main:telegram:dm:bystander"
+    store = _prepare(runner, initiator, bystander)
+
+    runner._restart_requested = True
+    runner._session_initiated_restart = {initiator: True}
+
+    reason = runner._resume_reason_for_shutdown_mark(initiator)
+
+    assert reason not in GatewayRunner._AUTO_RESUME_REASONS, (
+        f"the restart-initiating turn was marked {reason!r}, which IS an "
+        "auto-resume reason — the next boot replays it, it re-fires the "
+        "restart, and the gateway cascades"
+    )
+
+
+@pytest.mark.asyncio
+async def test_bystander_turn_still_auto_resumes():
+    """Feature preserved: an innocent interrupted turn still auto-resumes.
+
+    The fix must be surgical — only the turn that CAUSED the restart loses
+    its replay, not every session that happened to be running.
+    """
+    runner, _adapter = make_restart_runner()
+    initiator = "agent:main:telegram:dm:initiator"
+    bystander = "agent:main:telegram:dm:bystander"
+    _prepare(runner, initiator, bystander)
+
+    runner._restart_requested = True
+    runner._session_initiated_restart = {initiator: True}
+
+    reason = runner._resume_reason_for_shutdown_mark(bystander)
+
+    assert reason in GatewayRunner._AUTO_RESUME_REASONS, (
+        "a bystander turn lost its auto-resume — the fix over-reached"
+    )
+
+
+@pytest.mark.asyncio
+async def test_restart_consumed_reason_survives_across_boots():
+    """A relapse must not overwrite the mark back to an auto-resume reason.
+
+    If boot N marks the initiator ``restart_consumed`` but boot N+1 (where the
+    in-memory ``_session_initiated_restart`` flag is gone, the process being
+    new) re-marks it ``restart_timeout``, the loop simply resumes one boot
+    later. The durable session entry has to be consulted too.
+    """
+    runner, _adapter = make_restart_runner()
+    initiator = "agent:main:telegram:dm:initiator"
+    bystander = "agent:main:telegram:dm:bystander"
+    store = _prepare(runner, initiator, bystander)
+
+    # Boot N: in-memory flag present.
+    runner._restart_requested = True
+    runner._session_initiated_restart = {initiator: True}
+    first = runner._resume_reason_for_shutdown_mark(initiator)
+    store.mark_resume_pending(initiator, first)
+
+    # Boot N+1: fresh process — no in-memory flag, only the durable entry.
+    runner._session_initiated_restart = {}
+    second = runner._resume_reason_for_shutdown_mark(initiator)
+
+    assert second not in GatewayRunner._AUTO_RESUME_REASONS, (
+        f"the cross-boot mark decayed to {second!r} — the cascade resumes one "
+        "boot later instead of being broken"
+    )
+
+
+@pytest.mark.asyncio
+async def test_scheduler_skips_a_restart_consumed_session():
+    """E2E: the non-auto-resume reason actually suppresses the replay."""
+    runner, _adapter = make_restart_runner()
+    initiator = "agent:main:telegram:dm:initiator"
+    bystander = "agent:main:telegram:dm:bystander"
+    store = _prepare(runner, initiator, bystander)
+
+    runner._restart_requested = True
+    runner._session_initiated_restart = {initiator: True}
+
+    # Mark BOTH as the drain path would.
+    store.mark_resume_pending(
+        initiator, runner._resume_reason_for_shutdown_mark(initiator)
+    )
+    store.mark_resume_pending(
+        bystander, runner._resume_reason_for_shutdown_mark(bystander)
+    )
+
+    replayed = [
+        key
+        for key, entry in store._entries.items()
+        if entry.resume_pending
+        and entry.resume_reason in GatewayRunner._AUTO_RESUME_REASONS
+    ]
+
+    assert initiator not in replayed, (
+        "the restart-initiating session is still scheduled for replay — the "
+        "cascade is intact"
+    )
+    assert bystander in replayed, "the bystander lost its legitimate resume"
+
+
+def test_request_restart_records_the_initiating_session():
+    """``request_restart`` must record WHICH session asked.
+
+    Without this breadcrumb the drain-mark (which runs later, on the shutdown
+    path, with no reference to the originating turn) has no way to tell the
+    initiator apart from a bystander.
+    """
+    runner, _adapter = make_restart_runner()
+    initiator = "agent:main:telegram:dm:initiator"
+
+    from gateway.session_context import set_session_vars
+
+    async def _drive():
+        set_session_vars(session_key=initiator)
+        runner.request_restart(detached=False, via_service=True)
+
+    asyncio.run(_drive())
+
+    assert getattr(runner, "_session_initiated_restart", {}).get(initiator), (
+        "request_restart did not record the initiating session, so the "
+        "drain-mark cannot distinguish it from an interrupted bystander"
+    )
+
+
+def test_clean_turn_clears_the_initiator_breadcrumb():
+    """Forward progress must release the suppression.
+
+    A session that ran ``/restart`` once must not lose auto-resume forever.
+    Once it completes a clean turn, a LATER unrelated restart that happens to
+    interrupt it should be marked normally and still auto-resume.
+    """
+    runner, _adapter = make_restart_runner()
+    initiator = "agent:main:telegram:dm:initiator"
+    bystander = "agent:main:telegram:dm:bystander"
+    _prepare(runner, initiator, bystander)
+
+    runner._restart_requested = True
+    runner._session_initiated_restart = {initiator: True}
+    assert (
+        runner._resume_reason_for_shutdown_mark(initiator)
+        not in GatewayRunner._AUTO_RESUME_REASONS
+    )
+
+    # A clean turn completes for that session (what the post-turn hook does).
+    runner._session_initiated_restart.pop(initiator, None)
+    # Its durable entry no longer carries the consumed reason either.
+    runner.session_store._entries[initiator].resume_reason = None
+
+    assert (
+        runner._resume_reason_for_shutdown_mark(initiator)
+        in GatewayRunner._AUTO_RESUME_REASONS
+    ), "the session lost auto-resume permanently after one /restart"
+
+
+def test_restart_consumed_is_not_an_auto_resume_reason():
+    """Invariant: the two sets must stay disjoint.
+
+    If a future edit adds ``restart_consumed`` to ``_AUTO_RESUME_REASONS`` the
+    whole fix silently becomes a no-op, so pin the relationship rather than
+    the literal.
+    """
+    assert (
+        GatewayRunner._RESTART_CONSUMED_REASON
+        not in GatewayRunner._AUTO_RESUME_REASONS
+    )


### PR DESCRIPTION
# fix(gateway): don't auto-replay the turn that requested the restart

## Symptom

One deliberate restart turns into a **restart cascade**: the gateway restarts,
comes up, immediately restarts again, and repeats. Each iteration also fires a
shutdown notification, so the user sees a stream of "⚠️ Gateway restarting"
banners.

## Root cause

The loop closes in four steps, all on current `main`:

1. A user turn reaches `request_restart` (via `/restart`, `/update`, SIGUSR1, or
   an agent-driven restart).
2. `_stop_impl` drains. That turn is still running — it *is* the turn that asked
   for the restart — so the drain path marks it `resume_pending`.
3. The reason it is marked with is `restart_timeout`, which is a member of
   `_AUTO_RESUME_REASONS`.
4. On the next boot `_schedule_resume_pending_sessions` therefore synthesizes a
   continuation turn for it. The replayed turn re-runs the same work — including
   the restart request. → back to step 1.

The mark is computed from `self._restart_requested` **alone**:

```python
# both drain-mark sites, gateway/run.py
"restart_timeout" if self._restart_requested else "shutdown_timeout"
```

That expression cannot distinguish the turn that **caused** the restart from an
innocent bystander turn that merely happened to be running when someone else's
restart landed. Both get the same auto-resumable reason, so the initiator gets
replayed.

Note the runner already half-knows the answer: `_restart_command_source` records
*which* session's command asked for the restart — but it is only consulted for
the shutdown banner and the planned-restart marker, never at the drain-mark.

## Fix

Record the initiating session where it is known (`request_restart`, the single
funnel every restart path goes through), and consult it at the convergent
drain-mark via a new `_resume_reason_for_shutdown_mark(session_key)`.

The initiator is marked **`restart_consumed`**, deliberately *not* a member of
`_AUTO_RESUME_REASONS`. The turn already did what it was asked to do, so there is
nothing to replay. Crucially it still keeps its transcript **and** its
`resume_pending` flag — a real user message continues it exactly as before. Only
the *automatic* replay is suppressed. Bystander turns are untouched and still
auto-resume.

Both drain-mark sites (pre-drain and post-drain-timeout) route through the same
resolver, so this fixes the bug class rather than the one site.

### Two details the naive version gets wrong

- **The breadcrumb cannot survive the restart it caused.** An in-memory-only flag
  means boot N+1 re-marks the session `restart_timeout` and the cascade simply
  resumes one boot later. The resolver therefore *also* consults the durable
  session entry's existing `restart_consumed` reason, so the mark persists across
  boots.
- **Suppression must not be permanent.** A session that ran `/restart` once must
  not lose auto-resume forever. A clean turn is forward progress and drops the
  breadcrumb, so a later, unrelated restart that interrupts that session is
  marked normally and still auto-resumes.

## Scope — what this deliberately does NOT add

The fork lineage for this symptom also carried an **F2 replay-outcome circuit
breaker**. That is not included, because `main` already has a parallel invention:
`gateway/restart_loop_guard.py` (`check_and_record`, a persisted boot-window
breaker) is already wired into `_schedule_resume_pending_sessions`:

```python
if candidates:
    from gateway import restart_loop_guard as _rlg
    _max_restarts, _window = self._restart_loop_guard_config()
    if _rlg.check_and_record(_max_restarts, _window):
        return 0
```

Adding a second breaker would duplicate existing infrastructure rather than
extend it. The two are complementary as they stand: `restart_loop_guard` is the
last-resort *boot-frequency* backstop that skips auto-resume wholesale; this PR
removes the specific replay that manufactures the loop in the first place, and
leaves every other session resumable.

Likewise, no new state file or schema: this reuses the existing `resume_reason`
field and adds one in-memory dict.

## Tests

7 new tests in `tests/gateway/test_restart_initiator_not_replayed.py`, **all
RED-proven on `main`**:

| test | proves |
|---|---|
| `test_restart_initiating_turn_is_not_marked_auto_resumable` | the core defect — the initiator's reason is in `_AUTO_RESUME_REASONS` on `main` |
| `test_bystander_turn_still_auto_resumes` | the fix does not over-reach |
| `test_restart_consumed_reason_survives_across_boots` | the cross-boot relapse gap |
| `test_scheduler_skips_a_restart_consumed_session` | E2E — initiator excluded from the replay set, bystander still in it |
| `test_request_restart_records_the_initiating_session` | the breadcrumb is recorded |
| `test_clean_turn_clears_the_initiator_breadcrumb` | forward progress releases suppression |
| `test_restart_consumed_is_not_an_auto_resume_reason` | disjointness invariant, so a future edit can't silently no-op the fix |

The last one is written as a *relationship* between two shipped sets rather than
a literal, so it stays meaningful as the reason vocabulary evolves.

**Results:** 226 passed / 1 failed across the 8 restart/resume suites
(`test_restart_initiator_not_replayed` 7, `test_restart_resume_pending` 84,
`test_resume_command` 52, `test_restart_notification` 33, `test_restart_drain` 24,
`test_restart_redelivery_dedup` 13, `test_stuck_loop` 9,
`test_startup_restart_race` 4).

**Ambient failure disclosure (A/B'd):** the single failure,
`tests/gateway/test_startup_restart_race.py::test_startup_aborts_when_restart_begins_during_platform_connect`,
fails **identically on clean `origin/main`** (verified by stashing the diff and
re-running: 4 passed / 1 failed both ways). This diff adds zero failures.
