### PR TITLE
fix(gateway): synthetic internal events must never impersonate the user

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -310,6 +310,21 @@ def _gateway_platform_value(platform: Any) -> str:
     return str(getattr(platform, "value", platform) or "").strip().lower()
 
 
+def describe_inbound_event_author(event: Any, source: Any) -> str:
+    """Return the identity to log for an inbound event.
+
+    Synthetic/internal events (boot auto-resume re-prompts, queued
+    continuations, background-process completion notices) are produced by the
+    gateway, not typed by a human.  Logging them under the human's display name
+    sends incident forensics chasing a phantom "user sent an empty message", so
+    they are attributed to ``<system:internal>`` instead.  Genuine inbound
+    messages keep the existing display-name → user-id → ``"unknown"`` ladder.
+    """
+    if getattr(event, "internal", False):
+        return "<system:internal>"
+    return getattr(source, "user_name", None) or getattr(source, "user_id", None) or "unknown"
+
+
 def _non_conversational_metadata(
     metadata: Optional[Dict[str, Any]] = None,
     *,
@@ -12394,7 +12409,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             group_sessions_per_user=_group_sessions_per_user,
             thread_sessions_per_user=_thread_sessions_per_user,
         )
-        if _is_shared_multi_user and source.user_name:
+        # A synthetic event is not authored by any human, so it must never be
+        # stamped with a participant's display name (see
+        # ``describe_inbound_event_author`` for the same invariant on the log
+        # line).  Two concrete harms: a shared group session shows a ghost
+        # message apparently sent by someone who never spoke, and prefixing an
+        # EMPTY internal event makes it non-empty — which silently skips the
+        # downstream blank-text recovery-note substitution that only fires on
+        # empty text.
+        if (
+            _is_shared_multi_user
+            and source.user_name
+            and not getattr(event, "internal", False)
+        ):
             # source.user_name is the platform display name — attacker-
             # influenceable on any platform that lets participants set their
             # own name. Neutralize embedded newlines/control chars before
@@ -12844,7 +12871,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _reply_txt = (getattr(event, "reply_to_text", None) or "")[:80].replace("\n", " ")
         logger.info(
             "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r",
-            _platform_name, source.user_name or source.user_id or "unknown",
+            _platform_name, describe_inbound_event_author(event, source),
             source.chat_id or "unknown", _msg_preview, _reply_id, _reply_txt,
         )
 
@@ -15256,6 +15283,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     source=source,
                     message_id=None,
                     channel_prompt=None,
+                    # Synthetic continuation authored by the goal judge, not by
+                    # the human. Without this flag the shared-multi-user sender
+                    # prefix stamps "[<display name>] " onto it (impersonation)
+                    # and the inbound log attributes it to a user who never
+                    # sent it.
+                    internal=True,
                 )
                 self._enqueue_fifo(_quick_key, cont_event, adapter)
         except Exception as exc:

--- a/tests/gateway/test_internal_event_no_impersonation.py
+++ b/tests/gateway/test_internal_event_no_impersonation.py
@@ -1,0 +1,164 @@
+"""Synthetic internal events must never be attributed to the human user.
+
+Regression guard for the whole bug class: the gateway synthesises inbound
+``MessageEvent``s that no human typed (boot auto-resume re-prompts, queued
+continuations, background-process completion notices).  These already carry
+``MessageEvent.internal=True`` so they bypass authorization.  Two user-visible
+surfaces still treated them as human-authored:
+
+1. The shared-multi-user sender prefix stamped ``"[<display name>] "`` onto
+   them, so a group session saw a ghost message apparently sent by a
+   participant who never spoke.  Worse, prefixing an EMPTY synthetic event
+   makes it non-empty, which suppresses the blank-text recovery-note
+   substitution downstream.
+2. The inbound log line recorded ``user=<display name>``, sending incident
+   forensics chasing a phantom "user sent an empty message".
+"""
+
+import logging
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner(config: GatewayConfig) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    runner.adapters = {}
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    return runner
+
+
+def _shared_group_source(**overrides) -> SessionSource:
+    kwargs = dict(
+        platform=Platform.TELEGRAM,
+        chat_id="-1002285219667",
+        chat_name="Test Group",
+        chat_type="group",
+        user_name="Alice",
+    )
+    kwargs.update(overrides)
+    return SessionSource(**kwargs)
+
+
+def _shared_group_config() -> GatewayConfig:
+    return GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+        group_sessions_per_user=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_internal_event_is_not_prefixed_with_a_user_name():
+    """A synthetic continuation must not be stamped with a participant's name."""
+    runner = _make_runner(_shared_group_config())
+    source = _shared_group_source()
+    event = MessageEvent(text="continue", source=source, internal=True)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == "continue"
+    assert "[Alice]" not in result
+
+
+@pytest.mark.asyncio
+async def test_empty_internal_event_stays_empty():
+    """An EMPTY synthetic event must stay empty.
+
+    Prefixing turns "" into "[Alice] ", which is both an impersonation and a
+    silent behavior change: downstream blank-text handling (the reason-aware
+    recovery system-note substitution) only fires on empty text.
+    """
+    runner = _make_runner(_shared_group_config())
+    source = _shared_group_source()
+    event = MessageEvent(text="", source=source, internal=True)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_slack_internal_event_gets_no_author_mention():
+    """Sibling call path: the Slack author-mention variant of the same prefix."""
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.SLACK: PlatformConfig(enabled=True, token="fake")},
+        )
+    )
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_name="team-channel",
+        chat_type="group",
+        user_id="U123",
+        user_name="Alice",
+        thread_id="171.000",
+    )
+    event = MessageEvent(text="continue", source=source, internal=True)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == "continue"
+    assert "U123" not in result
+
+
+@pytest.mark.asyncio
+async def test_human_event_still_gets_the_sender_prefix():
+    """Control: the feature itself is preserved for genuine human messages."""
+    runner = _make_runner(_shared_group_config())
+    source = _shared_group_source()
+    event = MessageEvent(text="hello", source=source)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == "[Alice] hello"
+
+
+def test_internal_event_log_identity_is_system_not_the_user():
+    """The inbound log line must not name a human for a synthetic event."""
+    from gateway.run import describe_inbound_event_author
+
+    source = _shared_group_source(user_id="7788")
+    internal_event = MessageEvent(text="", source=source, internal=True)
+    human_event = MessageEvent(text="hello", source=source)
+
+    assert describe_inbound_event_author(internal_event, source) == "<system:internal>"
+    # Control: a real human message still logs the human's identity.
+    assert describe_inbound_event_author(human_event, source) == "Alice"
+
+
+def test_log_identity_falls_back_to_user_id_then_unknown():
+    """Behavior contract for the non-internal fallback ladder."""
+    from gateway.run import describe_inbound_event_author
+
+    id_only = _shared_group_source(user_name=None, user_id="7788")
+    assert describe_inbound_event_author(
+        MessageEvent(text="hi", source=id_only), id_only
+    ) == "7788"
+
+    anonymous = _shared_group_source(user_name=None, user_id=None)
+    assert describe_inbound_event_author(
+        MessageEvent(text="hi", source=anonymous), anonymous
+    ) == "unknown"


### PR DESCRIPTION
fix(gateway): synthetic internal events must never impersonate the user

## Symptom

In a shared multi-user session (a Telegram group / Slack channel with
`group_sessions_per_user: false`), a message appears in the transcript
attributed to a participant who never sent it:

```
[Alice] continue
```

Alice typed nothing. The gateway synthesised that turn — a boot auto-resume
re-prompt, a queued continuation, or a goal-judge continuation — and then
stamped a human's display name onto it on the way in.

The same event is written to `gateway.log` as if a human sent it:

```
inbound message: platform=telegram user=Alice chat=-100... msg='' ...
```

`user=Alice msg=''` sends anyone reading the log after an incident hunting a
"user sent an empty message" bug that does not exist.

## Root cause

`MessageEvent` already carries an `internal: bool` flag for exactly this class
of event ("synthetic events ... that must bypass user authorization checks",
`gateway/platforms/base.py`). Two user-visible surfaces did not consult it:

1. `GatewayRunner._prepare_inbound_message_text` (`gateway/run.py`) —
   the shared-multi-user sender prefix gated only on
   `_is_shared_multi_user and source.user_name`, so a synthetic event got the
   `"[<display name>] "` prefix (and, on Slack, the `<@U...>` author mention).
2. `GatewayRunner._handle_message_with_agent` — the inbound log line rendered
   `source.user_name or source.user_id or "unknown"` unconditionally.

There is a second-order effect on surface 1 that is worse than the cosmetic
impersonation: prefixing an **empty** internal event turns `""` into
`"[Alice] "`. Downstream blank-text handling — the reason-aware recovery
system-note substitution — only fires on empty text, so the prefix silently
suppresses it and the session shows a ghost `[Alice]` message where the
recovery note should have been.

This also violates the project's own stated invariant: *"never a synthetic
user message injected mid-loop"* (AGENTS.md, "Cache-, alternation-, and
invariant-safe").

## Fix

Fixes the whole bug class rather than the one reported site — all three places
the flag should have been consulted or set:

- **Prefix site:** gate the sender prefix on `not event.internal`. Covers both
  the plain-name and the Slack author-mention variants, since both live behind
  the same condition.
- **Log site:** extract `describe_inbound_event_author(event, source)`, a
  module-level pure helper that returns `"<system:internal>"` for a synthetic
  event and otherwise preserves the existing
  display-name → user-id → `"unknown"` ladder exactly.
- **Producer site (sibling call path):** the goal-judge continuation in
  `_maybe_continue_after_goal_check` constructed its `MessageEvent` *without*
  `internal=True`, so it was mislabelled at the source. Setting the flag there
  fixes the producer as well as the consumers — otherwise the same ghost
  message reappears from a different path.

No behavior change for genuine human messages on any path.

## Tests

`tests/gateway/test_internal_event_no_impersonation.py` (6 new tests):

- an internal event is not prefixed with a participant's name;
- an **empty** internal event stays empty (guards the blank-text
  recovery-note substitution described above);
- the Slack author-mention sibling path is covered too;
- **control:** a genuine human message still gets `"[Alice] hello"` — the
  feature this fix constrains is not destroyed;
- the log identity is `"<system:internal>"` for a synthetic event and the
  human's name for a real one;
- the non-internal fallback ladder (name → id → `"unknown"`) is asserted as a
  behavior contract.

The 4 pre-existing tests in `tests/gateway/test_shared_group_sender_prefix.py`
continue to pass unchanged, which is the regression guard that the prefix
feature itself still works.

**Red proof** — on `main` before the fix:

```
FAILED tests/gateway/test_internal_event_no_impersonation.py::test_internal_event_is_not_prefixed_with_a_user_name
E       AssertionError: assert '[Alice] continue' == 'continue'
E         - continue
E         + [Alice] continue
```

After: `10 passed` (6 new + 4 existing).
