### PR TITLE
fix(delegation): park delivery-exhausted completions instead of replaying them every boot

### DIFF
--- a/tests/tools/test_async_delegation_parking.py
+++ b/tests/tools/test_async_delegation_parking.py
@@ -1,0 +1,198 @@
+"""An undeliverable delegation completion must stop replaying on every boot.
+
+Restart survival for background `delegate_task` works by persisting completions
+and re-enqueuing the pending ones at registry startup
+(`restore_undelivered_completions`). `_MAX_DELIVERY_ATTEMPTS` is meant to stop a
+completion that can never be delivered from replaying forever — but the cap is
+only consulted by `release_completion_delivery`, i.e. only on the path where a
+consumer successfully *claimed* the row and then failed.
+
+A completion whose origin session is permanently gone (dead owner pid) never
+gets that far: the consumer's ownership gate drops it BEFORE claiming, so
+`delivery_attempts` never advances and `delivery_state` stays `'pending'`.
+`restore_undelivered_completions` re-enqueues it on the next boot, it is dropped
+again, and the cycle repeats for the life of the install — re-logging a WARNING
+each time.
+"""
+
+import json
+import time
+
+import pytest
+
+
+@pytest.fixture
+def delegation_db(tmp_path, monkeypatch):
+    """Point the durable delegation store at a temp HERMES_HOME."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import tools.async_delegation as ad
+
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    return ad
+
+
+def _insert_pending(ad, delegation_id: str, *, attempts: int) -> None:
+    """Insert a durable completion in the pending, undelivered state."""
+    now = time.time()
+    event = {
+        "type": "async_delegation",
+        "delegation_id": delegation_id,
+        "session_key": "telegram:dead-session",
+        "origin_ui_session_id": "",
+        "origin_session_id": "",
+        "parent_session_id": None,
+        "goal": "a task whose origin session is gone",
+        "status": "success",
+        "summary": "done",
+    }
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            """INSERT INTO async_delegations
+               (delegation_id, origin_session, origin_ui_session_id, state,
+                dispatched_at, completed_at, updated_at, event_json,
+                delivery_state, delivery_attempts)
+               VALUES (?, ?, '', 'success', ?, ?, ?, ?, 'pending', ?)""",
+            (delegation_id, "telegram:dead-session", now, now, now,
+             json.dumps(event), attempts),
+        )
+
+
+def _delivery_row(ad, delegation_id: str):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return conn.execute(
+            "SELECT delivery_state, delivery_attempts FROM async_delegations "
+            "WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+
+
+class _Queue:
+    def __init__(self):
+        self.items = []
+
+    def put(self, item):
+        self.items.append(item)
+
+
+def test_exhausted_completion_is_parked_instead_of_replayed(delegation_db):
+    """A row past the attempt budget must not be re-enqueued again."""
+    ad = delegation_db
+    _insert_pending(ad, "d-exhausted", attempts=ad._MAX_DELIVERY_ATTEMPTS)
+
+    queue = _Queue()
+    restored = ad.restore_undelivered_completions(queue)
+
+    assert queue.items == [], "an exhausted completion was replayed to the queue"
+    assert restored == 0, "an exhausted completion was counted as restored"
+
+
+def test_exhausted_completion_reaches_a_terminal_state(delegation_db):
+    """Parking must be durable, or the next boot repeats the same work."""
+    ad = delegation_db
+    _insert_pending(ad, "d-exhausted", attempts=ad._MAX_DELIVERY_ATTEMPTS)
+
+    ad.restore_undelivered_completions(_Queue())
+
+    state, _attempts = _delivery_row(ad, "d-exhausted")
+    assert state != "pending", (
+        "row left 'pending' — it will be re-enqueued and re-dropped every boot"
+    )
+    # 'parked' (not 'delivered'): the result was never handed to anyone, so
+    # claiming delivery would be dishonest. The row stays queryable for audit.
+    assert state == "parked"
+
+
+def test_parking_is_idempotent_across_repeated_restarts(delegation_db):
+    """The second boot must be a no-op, proving the cycle is actually broken."""
+    ad = delegation_db
+    _insert_pending(ad, "d-exhausted", attempts=ad._MAX_DELIVERY_ATTEMPTS)
+
+    first = _Queue()
+    ad.restore_undelivered_completions(first)
+    second = _Queue()
+    ad.restore_undelivered_completions(second)
+
+    assert first.items == []
+    assert second.items == []
+
+
+def test_healthy_completion_is_still_restored(delegation_db):
+    """Control: restart survival itself must not regress.
+
+    A completion below the budget is exactly what the persist + auto-redispatch
+    machinery exists to recover, so it must still be re-enqueued and stamped
+    ``restored=True``.
+    """
+    ad = delegation_db
+    _insert_pending(ad, "d-healthy", attempts=0)
+
+    queue = _Queue()
+    restored = ad.restore_undelivered_completions(queue)
+
+    assert restored == 1
+    assert len(queue.items) == 1
+    assert queue.items[0]["delegation_id"] == "d-healthy"
+    assert queue.items[0]["restored"] is True
+    state, _ = _delivery_row(ad, "d-healthy")
+    assert state == "pending"
+
+
+def test_boundary_one_attempt_below_budget_is_still_restored(delegation_db):
+    """Off-by-one guard: the cap must not retire a row that has budget left."""
+    ad = delegation_db
+    _insert_pending(ad, "d-nearly", attempts=ad._MAX_DELIVERY_ATTEMPTS - 1)
+
+    queue = _Queue()
+    restored = ad.restore_undelivered_completions(queue)
+
+    assert restored == 1
+    assert queue.items[0]["delegation_id"] == "d-nearly"
+
+
+def test_mixed_batch_parks_only_the_exhausted_row(delegation_db):
+    """One poisoned row must not suppress recovery of healthy siblings."""
+    ad = delegation_db
+    _insert_pending(ad, "d-exhausted", attempts=ad._MAX_DELIVERY_ATTEMPTS)
+    _insert_pending(ad, "d-healthy", attempts=1)
+
+    queue = _Queue()
+    restored = ad.restore_undelivered_completions(queue)
+
+    assert restored == 1
+    assert [item["delegation_id"] for item in queue.items] == ["d-healthy"]
+    assert _delivery_row(ad, "d-exhausted")[0] == "parked"
+    assert _delivery_row(ad, "d-healthy")[0] == "pending"
+
+
+def test_ownership_drop_advances_the_delivery_attempt_counter(delegation_db):
+    """The counter must advance on the pre-claim drop path too.
+
+    `claim_completion_delivery` is the only site that bumps `delivery_attempts`,
+    but an unownable completion is dropped BEFORE it is claimed. Without a
+    counter bump on that path the budget is never consumed and the parking
+    threshold above is unreachable — the fix would be dead code.
+    """
+    ad = delegation_db
+    _insert_pending(ad, "d-unowned", attempts=0)
+
+    ad._note_delivery_attempt("d-unowned")
+
+    _state, attempts = _delivery_row(ad, "d-unowned")
+    assert attempts == 1
+
+
+def test_repeated_ownership_drops_eventually_reach_the_parking_threshold(
+    delegation_db,
+):
+    """End-to-end: the drop path alone must be able to retire a poisoned row."""
+    ad = delegation_db
+    _insert_pending(ad, "d-unowned", attempts=0)
+
+    for _ in range(ad._MAX_DELIVERY_ATTEMPTS):
+        ad._note_delivery_attempt("d-unowned")
+
+    queue = _Queue()
+    ad.restore_undelivered_completions(queue)
+
+    assert queue.items == []
+    assert _delivery_row(ad, "d-unowned")[0] == "parked"

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -324,18 +324,42 @@ def restore_undelivered_completions(target_queue) -> int:
     results seconds after boot (#64484).
     """
     recover_abandoned_delegations()
+    restored = 0
     with _DB_LOCK, _transaction() as conn:
         rows = conn.execute(
-            """SELECT delegation_id, event_json FROM async_delegations
+            """SELECT delegation_id, event_json, delivery_attempts FROM async_delegations
                WHERE state != 'running' AND delivery_state='pending' AND event_json IS NOT NULL
                ORDER BY completed_at, delegation_id"""
         ).fetchall()
-        for _delegation_id, payload in rows:
+        for _delegation_id, payload, _attempts in rows:
+            # Park a completion that has exhausted its delivery budget. Its
+            # origin session is permanently gone (dead owner pid), so every boot
+            # it re-enqueues here, fails the fail-closed ownership gate, is
+            # dropped un-acked, and cycles again — re-logging the "Dropping
+            # unowned" WARNING forever. release_completion_delivery() only caps
+            # rows a consumer managed to CLAIM; an unownable row is dropped
+            # before the claim, so this is the only place it can be retired.
+            # 'parked' (not 'delivered'): nothing was ever handed to a consumer,
+            # so claiming delivery would be dishonest. The row stays queryable.
+            if int(_attempts or 0) >= _MAX_DELIVERY_ATTEMPTS:
+                conn.execute(
+                    """UPDATE async_delegations SET delivery_state='parked', updated_at=?
+                       WHERE delegation_id=?""",
+                    (time.time(), _delegation_id),
+                )
+                logger.warning(
+                    "Async delegation %s exhausted its %d delivery attempts "
+                    "without a session that could own it; parking it instead of "
+                    "replaying on every restart (result remains queryable).",
+                    _delegation_id, _MAX_DELIVERY_ATTEMPTS,
+                )
+                continue
             evt = json.loads(payload)
             if isinstance(evt, dict):
                 evt["restored"] = True
             target_queue.put(evt)
-    return len(rows)
+            restored += 1
+    return restored
 
 
 def mark_completion_delivered(delegation_id: str) -> bool:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11085,6 +11085,25 @@ def _notification_poller_loop(
                 str(evt.get("session_key") or ""),
                 sid,
             )
+            # Advance the durable delivery-attempt counter on this drop. It
+            # happens BEFORE claim_event_delivery (the only other site that
+            # bumps the counter), so without this an unownable delegation never
+            # consumes its budget and restore_undelivered_completions can never
+            # reach the parking threshold — the row re-enqueues and re-drops on
+            # every boot forever. Best-effort: a bookkeeping failure must not
+            # break notification draining.
+            if evt.get("type") == "async_delegation":
+                _did = str(evt.get("delegation_id") or "")
+                if _did:
+                    try:
+                        from tools.async_delegation import _note_delivery_attempt
+
+                        _note_delivery_attempt(_did)
+                    except Exception:
+                        logger.debug(
+                            "Could not record delivery attempt for delegation %s",
+                            _did, exc_info=True,
+                        )
             continue
 
         _evt_sid = evt.get("session_id", "")


### PR DESCRIPTION
fix(delegation): park delivery-exhausted completions instead of replaying them every boot

## Symptom

A `gateway.log` / `tui` WARNING that repeats on **every single restart**, for
the life of the install, for a delegation that finished days ago:

```
Dropping unowned async_delegation notification (origin='' key='telegram:...')
instead of delivering to session <sid>
```

The row is never delivered and never retired. Each boot re-enqueues it, the
ownership gate drops it, and the next boot does the same. Restart-survival
recovery is doing real work forever on a completion that can never land.

## Root cause

Background `delegate_task` completions are persisted and re-enqueued at registry
startup by `restore_undelivered_completions()`. `_MAX_DELIVERY_ATTEMPTS` exists
precisely to stop an undeliverable row replaying forever — its own docstring
says so:

> Once the budget is exhausted the row converges to a terminal `dropped` state
> instead of returning to `pending` — otherwise an undeliverable completion
> replays on every gateway restart forever.

But that cap lives **only** in `release_completion_delivery()`, which runs after
a consumer has *claimed* the row and then failed. There are two independent gaps
that together make the budget unreachable for the exact rows it was written for:

1. **`restore_undelivered_completions` never consults the budget.** It selects
   every `delivery_state='pending'` row and re-enqueues it, no matter how many
   attempts it has already burned.
2. **The counter never advances on the path these rows actually take.**
   `claim_completion_delivery` is the only site that bumps `delivery_attempts`.
   A completion whose origin session is permanently gone (dead owner pid) is
   dropped by the ownership gate in `_notification_poller_loop`
   (`tui_gateway/server.py`) **before** any claim is attempted — so
   `delivery_attempts` stays at 0 forever and the cap is never even approached.

Net effect: the intended terminal-state convergence is unreachable for
unownable rows, which are the only rows that need it.

## Fix

Close both gaps, which is what makes either one useful:

- **`tools/async_delegation.py`** — `restore_undelivered_completions()` now
  checks the budget before re-enqueuing. A row at or past
  `_MAX_DELIVERY_ATTEMPTS` is retired to a terminal `'parked'` state, logged
  once with the reason, and skipped. The return value counts rows actually
  restored rather than rows selected, so the caller's accounting stays truthful.

  `'parked'` rather than `'delivered'`: nothing was ever handed to a consumer,
  so marking it delivered would be dishonest. It is also distinct from
  `'dropped'` (used when a target is known-gone at claim time), and the row
  stays queryable for audit — the subagent's result is not deleted.

- **`tui_gateway/server.py`** — the pre-claim ownership drop now advances the
  durable attempt counter, so the budget is actually consumed on the path these
  rows take. Best-effort and exception-guarded: bookkeeping must never break
  notification draining.

Healthy delegations deliver in one or two attempts, so the cap only ever
catches genuinely unownable orphans, with headroom for a couple of legitimate
reconnect boots.

## Why this design is sound — live evidence

The surrounding restart-survival machinery was exercised end-to-end during two
back-to-back gateway restarts while preparing this change: durable claims were
relaunched on both boots and completion tombstones re-flushed cleanly, with no
duplicate delivery and no lost result. The persist + auto-redispatch design
works; the defect fixed here is narrowly the *terminal* case — the row that can
never be owned by anyone — which had no exit from the recovery loop.

## Tests

`tests/tools/test_async_delegation_parking.py` (8 new tests, against a temp
`HERMES_HOME` and a real SQLite store — no mocking of the persistence layer):

- an exhausted completion is not re-enqueued, and is not counted as restored;
- it reaches a terminal state that is specifically `'parked'`, not left
  `'pending'` (a non-durable fix would repeat the work next boot);
- parking is **idempotent across repeated restarts** — the second boot is a
  no-op, which is the actual proof the cycle is broken;
- **control:** a healthy completion is still restored and stamped
  `restored=True`, so restart survival itself does not regress;
- **boundary:** one attempt below the budget is still restored (off-by-one
  guard);
- a mixed batch parks only the poisoned row and still recovers its healthy
  sibling;
- the ownership-drop path advances the counter;
- **end-to-end:** repeated ownership drops alone drive a row to the parking
  threshold — this is what proves the first fix is reachable rather than dead
  code.

**Red proof** — on `main` before the fix, 5 of the 8 fail:

```
FAILED ...::test_exhausted_completion_is_parked_instead_of_replayed
FAILED ...::test_exhausted_completion_reaches_a_terminal_state
FAILED ...::test_parking_is_idempotent_across_repeated_restarts
FAILED ...::test_mixed_batch_parks_only_the_exhausted_row
FAILED ...::test_repeated_ownership_drops_eventually_reach_the_parking_threshold
5 failed, 3 passed
```

After the fix: `8 passed`.

**Regression:** `test_async_delegation.py`, `test_async_delegation_fd_leak.py`,
`test_restored_delegation_ownership.py`,
`test_async_delegation_session_binding.py` — 54 passed, unchanged.

No schema migration required (`delivery_state` is already a free-form `TEXT`
column with a `'pending'` default). No new config keys, no new env vars.
