### PR TITLE
fix(persist): suppress a /stop'd turn's zombie writes with an append-time generation gate

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -761,6 +761,12 @@ def init_agent(
     # Interrupt mechanism for breaking out of tool loops
     agent._interrupt_requested = False
     agent._interrupt_message = None  # Optional message that triggered interrupt
+    # Append-time generation gate: set True by the gateway when THIS turn's run
+    # generation is invalidated (/stop, /new). While set,
+    # _flush_messages_to_session_db suppresses the turn's continued CONTENT rows
+    # (the "zombie" writes after a /stop) but ALWAYS persists the interrupt-close
+    # tail. Fresh per agent, so the next turn's agent starts unset.
+    agent._persist_superseded = False
     agent._execution_thread_id: int | None = None  # Set at run_conversation() start
     agent._interrupt_thread_signal_pending = False
     agent._client_lock = threading.RLock()

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -279,6 +279,9 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     return "{}"
 
 
+_INTERRUPT_CLOSE_FINISH_REASON = "interrupt_close"
+
+
 def close_interrupted_tool_sequence(messages: list, final_response: Any = None) -> bool:
     """Append a synthetic assistant turn when an interrupted tail is a tool result.
 
@@ -297,6 +300,11 @@ def close_interrupted_tool_sequence(messages: list, final_response: Any = None) 
     placeholder is used rather than an empty-content assistant turn.
 
     Mutates ``messages`` in place. Returns True if a closing turn was appended.
+
+    The appended turn is stamped ``finish_reason =
+    _INTERRUPT_CLOSE_FINISH_REASON`` so downstream persistence can recognise it
+    as the load-bearing role-alternation repair and never suppress it, even
+    when the rest of the interrupted turn's writes are being dropped.
     """
     if not messages:
         return False
@@ -307,6 +315,7 @@ def close_interrupted_tool_sequence(messages: list, final_response: Any = None) 
     messages.append({
         "role": "assistant",
         "content": text.strip() or "Operation interrupted.",
+        "finish_reason": _INTERRUPT_CLOSE_FINISH_REASON,
     })
     return True
 
@@ -463,6 +472,7 @@ def _sanitize_structure_non_ascii(payload: Any) -> bool:
 
 __all__ = [
     "_SURROGATE_RE",
+    "_INTERRUPT_CLOSE_FINISH_REASON",
     "close_interrupted_tool_sequence",
     "_sanitize_surrogates",
     "_sanitize_structure_surrogates",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19057,6 +19057,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         running_agent = self._running_agents.get(session_key)
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             running_agent.interrupt(interrupt_reason)
+            # This turn's generation is about to be invalidated (below), so its
+            # continued CONTENT writes are unwanted. Flag the live agent so the
+            # persist layer suppresses the zombie's post-stop rows while still
+            # writing the interrupt-close tail. Every caller of this helper is a
+            # stop-family invalidation (/stop, /new), so it is unconditional.
+            # Best-effort: a set failure must never break /stop.
+            try:
+                running_agent._persist_superseded = True
+            except Exception:
+                logger.debug(
+                    "persist-superseded flag set skipped for %s",
+                    session_key, exc_info=True,
+                )
         self._invalidate_session_run_generation(session_key, reason=invalidation_reason)
         adapter = self._adapter_for_source(source)
         interrupt_session_activity = getattr(

--- a/run_agent.py
+++ b/run_agent.py
@@ -171,6 +171,7 @@ from agent.prompt_builder import (  # noqa: F401  # re-exported via _ra() / mock
 from agent.process_bootstrap import _get_proxy_from_env  # noqa: F401
 from agent.message_sanitization import (  # noqa: F401
     _SURROGATE_RE,
+    _INTERRUPT_CLOSE_FINISH_REASON,
     _sanitize_surrogates,
     _sanitize_structure_surrogates,
     _sanitize_messages_surrogates,
@@ -1959,6 +1960,36 @@ class AIAgent:
                 if isinstance(item, dict)
             }
 
+            # ── Superseded-turn write gate ──────────────────────────────────
+            # Resolve the flag ONCE and FAIL OPEN: any error reading it leaves
+            # suppression OFF, so a guard bug can never lose a real row. A stray
+            # late row is cosmetic; a dropped real row is data loss.
+            try:
+                _persist_superseded = bool(getattr(self, "_persist_superseded", False))
+            except Exception:
+                _persist_superseded = False
+            # Pairing safety: the tool_call ids whose owning assistant(tool_calls)
+            # row WE suppressed. A `tool` result may be suppressed ONLY if its
+            # owner was suppressed too — otherwise it orphans an already-durable
+            # tool call, which is the role-alternation corruption the
+            # interrupt-close repair exists to prevent.
+            #
+            # AGENT-scoped, not per-flush: within one iteration the
+            # assistant(tool_calls) row and its tool result flush SEPARATELY
+            # (conversation_loop appends the assistant row → flush → executes
+            # tools → flush). A per-flush set would be empty when the result's
+            # flush runs, letting it persist orphaned. Allocated lazily, so a
+            # normal turn never pays for it, and it dies with the agent object.
+            _suppressed_tool_call_ids = None
+            if _persist_superseded:
+                _suppressed_tool_call_ids = getattr(
+                    self, "_superseded_suppressed_tool_call_ids", None
+                )
+                if not isinstance(_suppressed_tool_call_ids, set):
+                    _suppressed_tool_call_ids = set()
+                    self._superseded_suppressed_tool_call_ids = _suppressed_tool_call_ids
+            _suppressed_superseded_rows = 0
+
             for _msg_idx, msg in enumerate(messages):
                 if not isinstance(msg, dict):
                     continue
@@ -1981,6 +2012,55 @@ class AIAgent:
                 if id(msg) in history_ids or id(msg) in seed_ids:
                     msg[_DB_PERSISTED_MARKER] = True
                     continue
+                # Superseded-turn gate. Runs AFTER every "already durable" skip
+                # above, so it only ever sees a genuinely NEW, about-to-be-
+                # written row. When the gateway invalidated this turn's run
+                # generation (/stop, /new), the turn is a zombie whose continued
+                # writes are unwanted: they land after the user stopped it and
+                # come back on the next /resume.
+                #
+                # LOAD-BEARING CARVE-OUT: the interrupt-close tail must ALWAYS
+                # persist — it is the role-alternation repair that stops the
+                # next user message landing as `... tool -> user`.
+                #
+                # PAIRING SAFETY: a `tool` result is suppressed only when its
+                # owning assistant(tool_calls) is also being suppressed. An
+                # already-durable owner was skipped above and its id never
+                # entered the set, so its result passes through and no dangling
+                # tool call is created.
+                if _persist_superseded and (
+                    msg.get("finish_reason") != _INTERRUPT_CLOSE_FINISH_REASON
+                ):
+                    if msg.get("role") == "tool":
+                        if msg.get("tool_call_id") in _suppressed_tool_call_ids:
+                            _suppressed_superseded_rows += 1
+                            continue
+                        # else: owner already durable → let the result through.
+                    elif msg.get("role") == "assistant":
+                        # The zombie's continued content. Record any tool_call
+                        # ids it carries so the matching results — in this or a
+                        # later flush — are suppressed too, keeping pairs atomic.
+                        _tcs = msg.get("tool_calls")
+                        if isinstance(_tcs, list):
+                            for _tc in _tcs:
+                                if isinstance(_tc, dict):
+                                    _tcid = _tc.get("id") or _tc.get("tool_call_id")
+                                else:
+                                    _tcid = getattr(_tc, "id", None)
+                                if _tcid:
+                                    _suppressed_tool_call_ids.add(_tcid)
+                        _suppressed_superseded_rows += 1
+                        continue
+                    else:
+                        # FAIL OPEN on any other role. A zombie turn only emits
+                        # assistant + tool rows, so a NEW user/system row here is
+                        # anomalous — and dropping a real user message would be
+                        # data loss. Persist it; log for diagnosability.
+                        logger.debug(
+                            "persist gate: superseded turn produced an unexpected "
+                            "new %r row for session %s — persisting (fail-open)",
+                            msg.get("role"), getattr(self, "session_id", "?"),
+                        )
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
                 # api_content sidecar: the exact bytes sent to the API when
@@ -2102,6 +2182,14 @@ class AIAgent:
                     ),
                 )
                 msg[_DB_PERSISTED_MARKER] = True
+            if _suppressed_superseded_rows:
+                logger.info(
+                    "persist: suppressed %d superseded-turn content row(s) for "
+                    "session %s (turn was /stop'd or /new'd; interrupt-close "
+                    "tail preserved)",
+                    _suppressed_superseded_rows,
+                    getattr(self, "session_id", "?"),
+                )
             # The intrinsic markers are now the sole source of truth. Reset the
             # one-shot seed so no id() outlives this flush to alias a message
             # allocated next turn at a recycled address.

--- a/tests/run_agent/test_persist_superseded_gate.py
+++ b/tests/run_agent/test_persist_superseded_gate.py
@@ -1,0 +1,235 @@
+"""A `/stop`'d turn's in-flight writes must not keep landing in the transcript.
+
+`/stop` interrupts the running agent and invalidates the turn's run generation,
+but interruption is cooperative: the turn is already inside a tool call or a
+streaming response and keeps going until it reaches a checkpoint. Every persist
+that fires in that window still writes — so a turn the user explicitly stopped
+continues appending assistant content to the durable transcript *after* the
+stop, and those rows come back on the next `/resume`.
+
+The persist layer must drop a superseded turn's NEW content rows, with two
+load-bearing carve-outs:
+
+* the interrupt-close tail must ALWAYS persist — it is the role-alternation
+  repair that stops the next user message landing as `... tool -> user`;
+* a `tool` result may only be dropped when its owning `assistant(tool_calls)`
+  row was dropped too, otherwise an already-durable tool call is orphaned —
+  the exact transcript corruption the repair above exists to prevent.
+"""
+
+import pytest
+
+from agent.message_sanitization import (
+    _INTERRUPT_CLOSE_FINISH_REASON,
+    close_interrupted_tool_sequence,
+)
+
+
+class _FakeDB:
+    """Records what actually reached the durable store."""
+
+    def __init__(self):
+        self.rows = []
+
+    def append_message(self, **kwargs):
+        self.rows.append(kwargs)
+        return True
+
+    def add_message(self, **kwargs):
+        self.rows.append(kwargs)
+        return True
+
+    @property
+    def roles(self):
+        return [row.get("role") for row in self.rows]
+
+    @property
+    def contents(self):
+        return [row.get("content") for row in self.rows]
+
+
+def _make_agent(*, superseded: bool):
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent._session_db = _FakeDB()
+    agent._session_db_created = True
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent.session_id = "sess-1"
+    agent._persist_disabled = False
+    agent._persist_superseded = superseded
+    return agent
+
+
+def _flush(agent, messages, history=None):
+    agent._flush_messages_to_session_db_unlocked(messages, history or [])
+    return agent._session_db
+
+
+# ── the core symptom ────────────────────────────────────────────────────────
+
+
+def test_stopped_turn_content_is_not_persisted():
+    """The zombie's continued assistant content must not reach the store."""
+    agent = _make_agent(superseded=True)
+
+    db = _flush(agent, [
+        {"role": "assistant", "content": "text written after the user pressed /stop"},
+    ])
+
+    assert db.rows == [], "a stopped turn's content still landed in the transcript"
+
+
+def test_normal_turn_still_persists_everything():
+    """Control: the gate is inert for a turn that was never stopped."""
+    agent = _make_agent(superseded=False)
+
+    db = _flush(agent, [
+        {"role": "user", "content": "do the thing"},
+        {"role": "assistant", "content": "done"},
+    ])
+
+    assert db.roles == ["user", "assistant"]
+
+
+# ── carve-out 1: the interrupt-close tail is load-bearing ───────────────────
+
+
+def test_interrupt_close_tail_still_persists_on_a_stopped_turn():
+    """The role-alternation repair must survive the gate.
+
+    Without it the durable transcript ends on a raw `tool` row and the next
+    user message lands as `... tool -> user`, which strict providers react to
+    by ignoring prior context.
+    """
+    agent = _make_agent(superseded=True)
+    messages = [{"role": "tool", "tool_call_id": "call-1", "content": "result"}]
+    # Reuse the real repair helper rather than hand-rolling its output, so this
+    # test tracks the helper's actual contract.
+    assert close_interrupted_tool_sequence(messages, "") is True
+
+    db = _flush(agent, messages)
+
+    # The `tool` row passes through because its owning tool_call was never
+    # suppressed by us (pairing safety), and the interrupt-close tail is
+    # carved out unconditionally — so the durable tail is assistant, not tool.
+    assert db.roles == ["tool", "assistant"], (
+        "the interrupt-close tail was suppressed"
+    )
+    assert db.rows[-1]["finish_reason"] == _INTERRUPT_CLOSE_FINISH_REASON
+
+
+# ── carve-out 2: tool-call pairing safety ───────────────────────────────────
+
+
+def test_orphan_is_not_created_when_the_owning_call_is_already_durable():
+    """A tool result whose owner already persisted must still be written.
+
+    Dropping it would strand a durable `assistant(tool_calls)` row with no
+    matching result — a dangling tool call, which is worse than a stray row.
+    """
+    agent = _make_agent(superseded=True)
+    owner = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"id": "call-1", "function": {"name": "terminal"}}],
+    }
+    # The owner was persisted in a PRIOR flush, before /stop.
+    _flush(_make_agent(superseded=False), [owner])
+    agent._flush_messages_to_session_db_unlocked([owner], [owner])
+    agent._session_db.rows.clear()
+
+    db = _flush(agent, [
+        owner,
+        {"role": "tool", "tool_call_id": "call-1", "content": "output"},
+    ], history=[owner])
+
+    assert db.roles == ["tool"], (
+        "suppressed a tool result whose owning tool_call is already durable "
+        "— that orphans the call"
+    )
+
+
+def test_new_call_and_its_result_are_dropped_together():
+    """When BOTH halves are new, the pair is dropped atomically."""
+    agent = _make_agent(superseded=True)
+
+    db = _flush(agent, [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call-9", "function": {"name": "terminal"}}],
+        },
+        {"role": "tool", "tool_call_id": "call-9", "content": "output"},
+    ])
+
+    assert db.rows == [], "a new tool_call/result pair was only half-suppressed"
+
+
+def test_pairing_holds_when_the_result_arrives_in_a_later_flush():
+    """The owner and its result flush separately within one turn.
+
+    `conversation_loop` appends the assistant(tool_calls) row and flushes,
+    THEN executes tools and flushes again. Suppression state must therefore
+    survive across flushes, or the result persists orphaned.
+    """
+    agent = _make_agent(superseded=True)
+    owner = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"id": "call-7", "function": {"name": "terminal"}}],
+    }
+
+    _flush(agent, [owner])
+    db = _flush(agent, [
+        owner,
+        {"role": "tool", "tool_call_id": "call-7", "content": "output"},
+    ])
+
+    assert db.rows == [], (
+        "the tool result persisted orphaned because suppression state did not "
+        "survive across flushes within the turn"
+    )
+
+
+# ── fail-open safety ────────────────────────────────────────────────────────
+
+
+def test_a_user_row_is_never_dropped():
+    """Fail-open on unexpected roles — losing a real user message is data loss.
+
+    A zombie turn only ever emits assistant/tool rows, so a NEW user row here
+    is anomalous and must be persisted rather than silently discarded.
+    """
+    agent = _make_agent(superseded=True)
+
+    db = _flush(agent, [{"role": "user", "content": "a real message"}])
+
+    assert db.contents == ["a real message"]
+
+
+def test_absent_flag_behaves_as_not_superseded():
+    """Back-compat: an agent without the attribute persists normally."""
+    agent = _make_agent(superseded=False)
+    del agent._persist_superseded
+
+    db = _flush(agent, [{"role": "assistant", "content": "hello"}])
+
+    assert db.contents == ["hello"]
+
+
+def test_unreadable_flag_fails_open():
+    """A guard bug must never cost a real row."""
+
+    class _Boom:
+        def __bool__(self):
+            raise RuntimeError("flag is broken")
+
+    agent = _make_agent(superseded=False)
+    agent._persist_superseded = _Boom()
+
+    db = _flush(agent, [{"role": "assistant", "content": "hello"}])
+
+    assert db.contents == ["hello"]


### PR DESCRIPTION
fix(persist): suppress a /stop'd turn's zombie writes with an append-time generation gate

## Symptom

The user presses `/stop`. The gateway acknowledges it. Seconds later, more
assistant output from the *stopped* turn appears in the transcript — and it is
still there on the next `/resume`, because it was written to the durable session
store after the stop.

## Root cause

Interruption is **cooperative**. `/stop` sets the interrupt flag and invalidates
the turn's run generation, but the turn is typically parked inside a tool call
or a streaming response and continues until it reaches a checkpoint. Every
persist that fires in that window — and `conversation_loop` flushes several
times per iteration — writes normally, because
`_flush_messages_to_session_db_unlocked` has no notion of "this turn has been
superseded." The generation counter is consulted when deciding whether to
*deliver* a response, but never at the point where rows are *appended*.

Verified against `main`: with the turn's generation invalidated, a flush of a
post-stop assistant row still lands the row in the store.

## Fix

An **append-time generation gate**: the persist layer drops a superseded turn's
NEW content rows. Placement matters — the gate sits *after* every "already
durable" skip, so it only ever inspects a genuinely new, about-to-be-written
row and can never retroactively affect something already persisted.

Two load-bearing carve-outs, both of which are why this is subtler than a
one-line guard:

1. **The interrupt-close tail always persists.** `close_interrupted_tool_sequence`
   appends the synthetic assistant turn that stops the transcript ending on a
   raw `tool` row. Without it the next user message lands as `... tool -> user`,
   a role-alternation violation that strict providers (Gemini, Claude) react to
   by hallucinating a continuation and ignoring prior context — the "lost
   context" symptom. To make that row recognisable at the persist layer, the
   helper now stamps it `finish_reason = _INTERRUPT_CLOSE_FINISH_REASON`
   (a new module constant, exported). The gate never touches a row carrying it.

2. **Tool-call pairing is atomic.** A `tool` result is suppressed *only* when
   its owning `assistant(tool_calls)` row was suppressed too. If the owner was
   already durable (persisted before the stop), dropping its result would strand
   a dangling tool call — the same transcript corruption carve-out 1 exists to
   prevent. The suppressed-id set is **agent-scoped, not per-flush**, because
   within a single iteration the assistant row and its tool result flush
   *separately* (`conversation_loop` appends the assistant row → flush →
   executes tools → flush). A per-flush set would be empty when the result's
   flush runs, letting it persist orphaned. The set is allocated lazily, so a
   normal turn never pays for it.

**Fail-open throughout**, deliberately: the flag is read once inside a
`try/except` defaulting to False, and any role other than `assistant`/`tool`
is persisted with a debug log rather than dropped. A stray late row is
cosmetic; a dropped real row is data loss.

Wiring: `agent._persist_superseded` is initialised False per agent
(`agent/agent_init.py`) and set by `_interrupt_and_clear_session`
(`gateway/run.py`) — grep-confirmed that every caller of that helper is a
stop-family invalidation (`/stop`, `/new`), so the set is unconditional and
best-effort (a failure there must never break `/stop`). A suppression count is
logged once per flush so "why did my stopped turn's rows vanish" is diagnosable.

## Tests

`tests/run_agent/test_persist_superseded_gate.py` (9 new tests) exercising the
real `_flush_messages_to_session_db_unlocked` against a recording store:

- a stopped turn's continued content is not persisted;
- **control:** a normal turn still persists everything (the gate is inert);
- the interrupt-close tail still persists on a stopped turn, and carries the
  marker — driven through the real `close_interrupted_tool_sequence` helper
  rather than a hand-rolled row, so the test tracks its actual contract;
- a tool result whose owner is already durable is still written (no orphan);
- a new tool_call/result pair is dropped atomically;
- **pairing across flushes** — the owner and result flushing separately within
  one turn, which is the case a per-flush set would get wrong;
- a `user` row is never dropped (fail-open on unexpected roles);
- an agent without the attribute behaves as not-superseded (back-compat);
- an attribute that raises on truth-test fails open.

**Red proof** — on `main` with only the marker constant added (so the module
imports), 3 of the 9 fail:

```
FAILED ...::test_stopped_turn_content_is_not_persisted
FAILED ...::test_new_call_and_its_result_are_dropped_together
FAILED ...::test_pairing_holds_when_the_result_arrives_in_a_later_flush
3 failed, 6 passed
```

After the fix: `9 passed`.

**Regression:** `test_close_interrupted_tool_sequence.py` (the direct guard for
the helper this patch modifies), `test_turn_finalizer_interrupt_alternation.py`,
`test_turn_finalizer_final_response_persistence.py`,
`test_rotation_flush_persisted_boundary_68196.py`, `test_860_dedup.py` (the
duplicate-write guard around this exact flush), `test_stop_thread_sibling.py`,
`test_undo_rewind_session.py` — **50 passed**, unchanged.

No new config keys, no new env vars.
