### PR TITLE
fix(gateway): reject a blank `prompt.submit` before it costs a full API call

### DIFF
--- a/tests/tui_gateway/test_prompt_submit_blank_text.py
+++ b/tests/tui_gateway/test_prompt_submit_blank_text.py
@@ -1,0 +1,175 @@
+"""``prompt.submit`` rejects a blank turn before it costs anything.
+
+A whitespace-only submit is never a real turn, but on the pre-fix path it ran
+one: the deferred build constructs a full agent and sends the entire
+conversation to the provider to answer nothing, then persists an empty user
+row. A reconnect-looping client that fires ``prompt.submit(text="")`` every
+cycle therefore burns one full-context API call per cycle.
+
+The one blank submit that IS legitimate is an image-only send — the turn's
+content is the attachment — so that path must keep working.
+"""
+
+import threading
+import time
+import types
+
+import pytest
+
+from tui_gateway import server
+
+
+@pytest.fixture(autouse=True)
+def _no_prewarm_timer(monkeypatch):
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+
+
+@pytest.fixture
+def submit_probe(monkeypatch):
+    """A live session plus counters for every side effect a real turn causes."""
+    sid = "blank-submit-sid"
+    ready = threading.Event()
+    ready.set()
+    session = {
+        "agent": types.SimpleNamespace(),
+        "agent_ready": ready,
+        "session_key": "session-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+    }
+    server._sessions[sid] = session
+
+    effects = {"agent_builds": 0, "db_rows": 0, "turns": []}
+    monkeypatch.setattr(
+        server,
+        "_start_agent_build",
+        lambda *_a, **_k: effects.__setitem__("agent_builds", effects["agent_builds"] + 1),
+    )
+    monkeypatch.setattr(
+        server,
+        "_ensure_session_db_row",
+        lambda *_a, **_k: effects.__setitem__("db_rows", effects["db_rows"] + 1),
+    )
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_wait_agent_for_prompt", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, _session, text, **_kw: effects["turns"].append(text),
+    )
+
+    def submit(text, **params):
+        response = server.handle_request(
+            {
+                "id": "req",
+                "method": "prompt.submit",
+                "params": {"session_id": sid, "text": text, **params},
+            }
+        )
+        # The accepted path runs the turn on a background thread.
+        deadline = time.time() + 2.0
+        while not effects["turns"] and time.time() < deadline:
+            time.sleep(0.01)
+        return response
+
+    try:
+        yield types.SimpleNamespace(sid=sid, session=session, submit=submit, effects=effects)
+    finally:
+        server._sessions.pop(sid, None)
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["", " ", "   \n\t  ", "\n", "\u00a0"],
+    ids=["empty", "one-space", "mixed-whitespace", "newline", "nbsp"],
+)
+def test_a_blank_submit_is_rejected(submit_probe, text):
+    response = submit_probe.submit(text)
+
+    assert "result" not in response
+    assert response["error"]["code"] == 4029
+
+
+def test_a_blank_submit_costs_no_agent_build_no_db_row_and_no_api_call(submit_probe):
+    """The whole point: rejection happens before anything expensive."""
+    submit_probe.submit("   \n  ")
+
+    assert submit_probe.effects == {"agent_builds": 0, "db_rows": 0, "turns": []}
+
+
+def test_a_blank_submit_leaves_the_session_idle(submit_probe):
+    """A rejected submit must not latch ``running`` and wedge the session."""
+    submit_probe.submit("")
+
+    assert submit_probe.session["running"] is False
+    assert submit_probe.session["history"] == []
+    assert submit_probe.session["history_version"] == 0
+
+
+def test_an_image_only_submit_still_runs(submit_probe):
+    """Blank text with an attachment is a real turn — the image is the content."""
+    submit_probe.session["attached_images"] = ["/tmp/screenshot.png"]
+
+    response = submit_probe.submit("")
+
+    assert response["result"] == {"status": "streaming"}
+    assert submit_probe.effects["turns"] == [""]
+    assert submit_probe.effects["agent_builds"] == 1
+
+
+def test_an_ordinary_submit_is_unaffected(submit_probe):
+    response = submit_probe.submit("what is the weather")
+
+    assert response["result"] == {"status": "streaming"}
+    assert submit_probe.effects["turns"] == ["what is the weather"]
+
+
+def test_text_that_only_looks_blank_after_sanitizing_is_still_rejected(submit_probe):
+    """The guard runs on the SANITIZED text, not the raw parameter.
+
+    ``sanitize_user_prompt_text`` strips leaked bracketed-paste wrappers. A
+    submit carrying nothing but a wrapper reduces to empty and must be rejected
+    on the same terms as a literal empty string — otherwise the whole class
+    reopens through a client that leaks escape sequences.
+    """
+    from hermes_cli.input_sanitize import sanitize_user_prompt_text
+
+    raw = "\x1b[200~\x1b[201~"
+    assert not sanitize_user_prompt_text(raw).strip(), "fixture no longer sanitizes to empty"
+
+    response = submit_probe.submit(raw)
+
+    assert response["error"]["code"] == 4029
+    assert submit_probe.effects["turns"] == []
+
+
+def test_the_rejection_code_is_not_reused_by_another_prompt_submit_error(submit_probe):
+    """4029 must be distinguishable from the other prompt.submit rejections.
+
+    A client needs to tell "you sent nothing" apart from "that truncation would
+    erase the transcript" (4028) and "target message is gone" (4018) to show
+    the right message.
+    """
+    blank = submit_probe.submit("")
+    bad_ordinal = server.handle_request(
+        {
+            "id": "req",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": submit_probe.sid,
+                "text": "real text",
+                "truncate_before_user_ordinal": -1,
+            },
+        }
+    )
+
+    assert blank["error"]["code"] == 4029
+    assert bad_ordinal["error"]["code"] != 4029

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10702,6 +10702,18 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    # A blank submit is never a real turn, and running it is expensive: the
+    # deferred path builds a full agent and sends the entire conversation to
+    # the provider to answer nothing, then writes an empty user row. A stale
+    # or reconnect-looping client that fires prompt.submit(text="") every
+    # cycle therefore burns one full-context API call per cycle. Reject before
+    # any agent build or DB write.
+    #
+    # Image-only submits are legitimate and must still run: the turn's content
+    # is the attached image, so this only rejects when there is no text AND
+    # nothing attached.
+    if isinstance(text, str) and not text.strip() and not session.get("attached_images"):
+        return _err(rid, 4029, "prompt text is empty")
     isolation_cfg = _load_dashboard_process_isolation_config()
     turn_isolation = _session_uses_compute_host(session, isolation_cfg)
     # Re-bind to the current client transport for this request. This keeps


### PR DESCRIPTION
# fix(gateway): reject a blank `prompt.submit` before it costs a full API call

## The problem

A whitespace-only `prompt.submit` is accepted as a real turn. The deferred
path builds a full agent, sends the entire conversation to the provider to
answer nothing, and persists an empty user row. A stale or reconnect-looping
client that fires `prompt.submit(text="")` every cycle therefore burns **one
full-context API call per cycle** — the symptom that surfaced this was a
desktop app stuck in a reconnect loop doing exactly that.

Reproduced on `main` (`dacd8d541`) against the real handler, with the agent
build and turn delivery replaced by counters so the side effects are visible:

```
prompt.submit(text="")           -> {'status': 'streaming'}
prompt.submit(text="   \n\t  ")  -> {'status': 'streaming'}

agent builds triggered:          2
session DB rows written:         2
turns delivered to the agent:    ['', '   \n\t  ']
```

Both blank submits ran a complete turn.

## The change

Reject with a distinct code (`4029`) immediately after session resolution —
**before** `_ensure_session_db_row`, **before** `_start_agent_build`, before
the `running` latch, and before any compute-host dispatch. A rejected submit
then costs nothing and cannot leave the session wedged in `running`.

```python
if isinstance(text, str) and not text.strip() and not session.get("attached_images"):
    return _err(rid, 4029, "prompt text is empty")
```

## Two boundaries the guard has to respect

**1. An image-only submit is a legitimate turn.** Blank text with
`attached_images` set still runs, because the attachment *is* the content
(`image.attach` / clipboard paste followed by a bare Enter is a real user
flow in both the TUI and the desktop composer). Pinned by
`test_an_image_only_submit_still_runs`.

**2. The check runs on the sanitized text, not the raw parameter.** The
handler already passes `text` through `sanitize_user_prompt_text`, which
strips leaked bracketed-paste wrappers. A submit carrying nothing but a
wrapper reduces to empty and is rejected on the same terms — otherwise the
whole bug class reopens through any client that leaks escape sequences.
Pinned by `test_text_that_only_looks_blank_after_sanitizing_is_still_rejected`,
which asserts the fixture genuinely sanitizes to empty before relying on it.

## Why a new error code

`4029` was previously unused. It is deliberately distinct from the other
`prompt.submit` rejections so a client can tell them apart and show the right
message:

| code | meaning |
|---|---|
| `4009` | subagent still running |
| `4018` | target user message is no longer in history |
| `4028` | truncation would erase the entire transcript |
| **`4029`** | **prompt text is empty** |

`test_the_rejection_code_is_not_reused_by_another_prompt_submit_error` pins
that it is distinguishable rather than freezing the literal.

## Tests

`tests/tui_gateway/test_prompt_submit_blank_text.py` — **11 tests**, driving
the real `server.handle_request` dispatch (not the inner function) against a
live in-`_sessions` entry, with every expensive side effect instrumented as a
counter. Blank inputs are parameterized across empty / space / mixed
whitespace / newline / non-breaking space.

Two of the eleven pass on `main` too — the ordinary-submit and image-only
guards. That is the point: a patch that broke either would be the wrong fix.

**RED-proved:** 9 failed / 2 passed on this commit's parent; 11 passed with
the change.

**Regression scope:** 569 passed across `tests/test_tui_gateway_server.py`,
`tests/tui_gateway/test_protocol.py`, and the new file. `ruff check` clean.

See `TEST-EVIDENCE.md`.

## Scope note

This is one slice of a larger fork-side cluster around `/fast`, model-switch
side effects, and session-banner honesty. The rest of that cluster is built on
a route-aware fast-mode capability model that does not exist in this repo
(`resolve_fast_mode_capability` / `FAST_MODE_CAPABILITY_CATALOG`: zero matches
on `main` — only the model-only `model_supports_fast_mode` wrapper exists), so
porting it would mean importing a whole subsystem rather than fixing a
reported bug. This slice is the part that reproduces here, on this repo's own
code, with a cost the user actually pays.
