### PR TITLE
feat(pricing): fall back to a configurable external catalog, default models.dev

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1281,9 +1281,23 @@ def _add_model_aliases(cache: Dict[str, Dict[str, Any]], model_id: str, entry: D
         cache.setdefault(bare_model, entry)
 
 
-def fetch_model_metadata(force_refresh: bool = False) -> Dict[str, Dict[str, Any]]:
-    """Fetch model metadata from OpenRouter (cached for 1 hour)."""
+def fetch_model_metadata(
+    force_refresh: bool = False, *, allow_network: bool = True
+) -> Dict[str, Dict[str, Any]]:
+    """Fetch OpenRouter metadata, optionally restricting resolution to caches."""
     global _model_metadata_cache, _model_metadata_cache_time
+
+    if not allow_network:
+        if _model_metadata_cache:
+            return _model_metadata_cache
+        disk_cache = _load_model_metadata_disk_cache()
+        if disk_cache:
+            _model_metadata_cache = disk_cache
+            disk_age = _model_metadata_disk_cache_age_seconds()
+            _model_metadata_cache_time = (
+                time.time() - disk_age if disk_age is not None else 0
+            )
+        return _model_metadata_cache
 
     if not force_refresh and _model_metadata_cache and (time.time() - _model_metadata_cache_time) < _MODEL_CACHE_TTL:
         return _model_metadata_cache

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -969,6 +969,39 @@ def fetch_model_metadata(force_refresh: bool = False) -> Dict[str, Dict[str, Any
         return {}
 
 
+def cached_model_metadata() -> Dict[str, Dict[str, Any]]:
+    """Return OpenRouter model metadata WITHOUT ever touching the network.
+
+    Same cache hierarchy as :func:`fetch_model_metadata` minus the network
+    stage: fresh in-memory cache, else the on-disk cache (at any age), else an
+    empty dict. Callers that are pure predicates — notably
+    ``usage_pricing.has_known_pricing``, which runs inside display loops — use
+    this so rendering a session list can never block on an HTTP round trip.
+
+    An empty result means "not known from cache", not "not priced"; callers
+    must treat it as unknown rather than as an authoritative absence.
+    """
+    global _model_metadata_cache, _model_metadata_cache_time
+
+    if _model_metadata_cache and (time.time() - _model_metadata_cache_time) < _MODEL_CACHE_TTL:
+        return _model_metadata_cache
+
+    disk_cache = _load_model_metadata_disk_cache()
+    if disk_cache:
+        # Populate the in-memory cache but anchor its timestamp to the disk
+        # file's real age, so this never masquerades as a fresh fetch and the
+        # next non-cache-only caller still refreshes on schedule.
+        _model_metadata_cache = disk_cache
+        disk_age = _model_metadata_disk_cache_age_seconds()
+        if disk_age is not None:
+            _model_metadata_cache_time = time.time() - disk_age
+        else:
+            _model_metadata_cache_time = time.time() - _MODEL_CACHE_TTL
+        return disk_cache
+
+    return {}
+
+
 def fetch_endpoint_model_metadata(
     base_url: str,
     api_key: str = "",

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -839,6 +839,53 @@ def _extract_context(entry: Dict[str, Any]) -> Optional[int]:
     return None
 
 
+def _extract_cost(entry: Dict[str, Any]) -> Optional[Dict[str, float]]:
+    """Extract flat per-million USD rates from a models.dev model entry."""
+    if not isinstance(entry, dict):
+        return None
+    cost = entry.get("cost")
+    if not isinstance(cost, dict):
+        return None
+
+    def _rate(key: str) -> Optional[float]:
+        value = cost.get(key)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        return float(value) if value >= 0 else None
+
+    input_cost = _rate("input")
+    output_cost = _rate("output")
+    if input_cost is None and output_cost is None:
+        return None
+
+    result: Dict[str, float] = {}
+    for key, value in (
+        ("input", input_cost),
+        ("output", output_cost),
+        ("cache_read", _rate("cache_read")),
+        ("cache_write", _rate("cache_write")),
+    ):
+        if value is not None:
+            result[key] = value
+    return result
+
+
+def lookup_models_dev_pricing(
+    provider: str, model: str, *, allow_network: bool = True
+) -> Optional[Dict[str, float]]:
+    """Look up provider-scoped per-million pricing from models.dev.
+
+    Providers absent from :data:`PROVIDER_TO_MODELS_DEV` return ``None``;
+    model ids are never scanned across vendors. ``allow_network=False`` uses
+    only the existing memory/disk cache for display-path predicates.
+    """
+    models = _get_provider_models(provider, allow_network=allow_network)
+    if models is None:
+        return None
+    entry = _find_model_entry(models, model)
+    return _extract_cost(entry) if entry is not None else None
+
+
 # ---------------------------------------------------------------------------
 # Model capability metadata
 # ---------------------------------------------------------------------------

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -393,6 +393,75 @@ def _extract_context(entry: Dict[str, Any]) -> Optional[int]:
     return None
 
 
+def _extract_cost(entry: Dict[str, Any]) -> Optional[Dict[str, float]]:
+    """Extract the per-million-token USD cost block from a models.dev entry.
+
+    models.dev publishes cost already in per-million-token USD (unlike the
+    OpenRouter models API, which is per-token), shaped as::
+
+        {"input": 5, "output": 25, "cache_read": 0.5, "cache_write": 6.25}
+
+    Only the flat base-tier rates are read. Entries may also carry a ``tiers``
+    / ``context_over_200k`` block for long-context surcharges; those are
+    deliberately ignored so this returns the same flat shape the curated
+    snapshot uses.
+
+    Returns a dict holding only the keys actually present, or None when the
+    entry publishes neither an input nor an output rate (unpriced model).
+    """
+    if not isinstance(entry, dict):
+        return None
+    cost = entry.get("cost")
+    if not isinstance(cost, dict):
+        return None
+
+    def _num(key: str) -> Optional[float]:
+        value = cost.get(key)
+        # bool is an int subclass — reject it explicitly.
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, (int, float)) and value >= 0:
+            return float(value)
+        return None
+
+    input_cost = _num("input")
+    output_cost = _num("output")
+    if input_cost is None and output_cost is None:
+        return None
+
+    result: Dict[str, float] = {}
+    if input_cost is not None:
+        result["input"] = input_cost
+    if output_cost is not None:
+        result["output"] = output_cost
+    cache_read = _num("cache_read")
+    if cache_read is not None:
+        result["cache_read"] = cache_read
+    cache_write = _num("cache_write")
+    if cache_write is not None:
+        result["cache_write"] = cache_write
+    return result
+
+
+def lookup_models_dev_pricing(provider: str, model: str) -> Optional[Dict[str, float]]:
+    """Look up per-million USD pricing for a provider+model in models.dev.
+
+    Cost-dimension twin of :func:`lookup_models_dev_context`. Resolution is
+    provider-scoped on purpose: a provider absent from
+    ``PROVIDER_TO_MODELS_DEV`` (``custom``, ``local``, ``unknown``) yields
+    None rather than falling back to a cross-provider id scan, so a
+    self-hosted model that happens to share an id with a hosted one is never
+    billed at the hosted vendor's rate.
+    """
+    models = _get_provider_models(provider)
+    if models is None:
+        return None
+    entry = _find_model_entry(models, model)
+    if entry is None:
+        return None
+    return _extract_cost(entry)
+
+
 # ---------------------------------------------------------------------------
 # Model capability metadata
 # ---------------------------------------------------------------------------

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -318,6 +318,34 @@ def fetch_models_dev(force_refresh: bool = False) -> Dict[str, Any]:
     return _models_dev_cache
 
 
+def cached_models_dev() -> Dict[str, Any]:
+    """Return the models.dev registry WITHOUT ever touching the network.
+
+    Cache-only twin of :func:`fetch_models_dev`: fresh in-memory cache, else
+    the on-disk cache (at any age), else an empty dict. Used by pure
+    predicates that must not block — see
+    ``usage_pricing.has_known_pricing``.
+
+    An empty result means "not known from cache", not "not priced".
+    """
+    global _models_dev_cache, _models_dev_cache_time
+
+    if _models_dev_cache and (time.time() - _models_dev_cache_time) < _MODELS_DEV_CACHE_TTL:
+        return _models_dev_cache
+
+    disk_data = _load_disk_cache()
+    if disk_data:
+        _models_dev_cache = disk_data
+        disk_age = _disk_cache_age_seconds()
+        if disk_age is not None:
+            _models_dev_cache_time = time.time() - disk_age
+        else:
+            _models_dev_cache_time = time.time() - _MODELS_DEV_CACHE_TTL
+        return disk_data
+
+    return _models_dev_cache or {}
+
+
 def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:
     """Look up context_length for a provider+model combo in models.dev.
 
@@ -443,7 +471,9 @@ def _extract_cost(entry: Dict[str, Any]) -> Optional[Dict[str, float]]:
     return result
 
 
-def lookup_models_dev_pricing(provider: str, model: str) -> Optional[Dict[str, float]]:
+def lookup_models_dev_pricing(
+    provider: str, model: str, *, cache_only: bool = False
+) -> Optional[Dict[str, float]]:
     """Look up per-million USD pricing for a provider+model in models.dev.
 
     Cost-dimension twin of :func:`lookup_models_dev_context`. Resolution is
@@ -452,8 +482,10 @@ def lookup_models_dev_pricing(provider: str, model: str) -> Optional[Dict[str, f
     None rather than falling back to a cross-provider id scan, so a
     self-hosted model that happens to share an id with a hosted one is never
     billed at the hosted vendor's rate.
+
+    With ``cache_only=True`` the registry is never fetched over the network.
     """
-    models = _get_provider_models(provider)
+    models = _get_provider_models(provider, cache_only=cache_only)
     if models is None:
         return None
     entry = _find_model_entry(models, model)
@@ -479,16 +511,18 @@ class ModelCapabilities:
     model_family: str = ""
 
 
-def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
+def _get_provider_models(provider: str, *, cache_only: bool = False) -> Optional[Dict[str, Any]]:
     """Resolve a Hermes provider ID to its models dict from models.dev.
 
     Returns the models dict or None if the provider is unknown or has no data.
+    With ``cache_only=True`` the registry is read from cache only, never the
+    network (for pure predicates on display paths).
     """
     mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(provider)
     if not mdev_provider_id:
         return None
 
-    data = fetch_models_dev()
+    data = cached_models_dev() if cache_only else fetch_models_dev()
     provider_data = data.get(mdev_provider_id)
     if not isinstance(provider_data, dict):
         return None

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1207,13 +1207,91 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
     return None
 
 
-def _openrouter_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
+def _openrouter_pricing_entry(
+    route: BillingRoute, *, cache_only: bool = False
+) -> Optional[PricingEntry]:
+    # OpenRouter's catalog is a flat model-id namespace. It is authoritative
+    # only when OpenRouter is the billing vendor; consulting it for another
+    # provider can misprice a self-hosted model that shares a hosted model id.
+    if route.provider != "openrouter":
+        return None
     return _pricing_entry_from_metadata(
-        fetch_model_metadata(),
+        fetch_model_metadata(allow_network=not cache_only),
         route.model,
         source_url="https://openrouter.ai/docs/api/api-reference/models/get-models",
         pricing_version="openrouter-models-api",
     )
+
+
+_VALID_PRICING_SOURCES = ("models_dev", "openrouter")
+_DEFAULT_PRICING_SOURCE = "models_dev"
+
+
+def _pricing_source_order() -> tuple[str, ...]:
+    """Return the configured external pricing source followed by fallbacks."""
+    primary = _DEFAULT_PRICING_SOURCE
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        pricing = (load_config_readonly() or {}).get("pricing")
+        if isinstance(pricing, dict):
+            candidate = pricing.get("external_source")
+            if isinstance(candidate, str):
+                candidate = candidate.strip().lower()
+                if candidate in _VALID_PRICING_SOURCES:
+                    primary = candidate
+    except Exception:
+        pass
+    return (primary, *(source for source in _VALID_PRICING_SOURCES if source != primary))
+
+
+def _models_dev_pricing_entry(
+    route: BillingRoute, *, cache_only: bool = False
+) -> Optional[PricingEntry]:
+    from agent.models_dev import lookup_models_dev_pricing
+
+    cost = lookup_models_dev_pricing(
+        route.provider,
+        route.model,
+        allow_network=not cache_only,
+    )
+    if not cost:
+        return None
+    input_cost = _to_decimal(cost.get("input"))
+    output_cost = _to_decimal(cost.get("output"))
+    if input_cost is None and output_cost is None:
+        return None
+    return PricingEntry(
+        input_cost_per_million=input_cost,
+        output_cost_per_million=output_cost,
+        cache_read_cost_per_million=_to_decimal(cost.get("cache_read")),
+        cache_write_cost_per_million=_to_decimal(cost.get("cache_write")),
+        source="provider_models_api",
+        source_url="https://models.dev/api.json",
+        pricing_version="models-dev-api",
+        fetched_at=_UTC_NOW(),
+    )
+
+
+_PRICING_SOURCE_BUILDERS = {
+    "models_dev": _models_dev_pricing_entry,
+    "openrouter": _openrouter_pricing_entry,
+}
+
+
+def _external_pricing_entry(
+    route: BillingRoute, *, cache_only: bool = False
+) -> Optional[PricingEntry]:
+    """Resolve dynamic pricing without crossing provider namespaces."""
+    for source in _pricing_source_order():
+        builder = _PRICING_SOURCE_BUILDERS[source]
+        try:
+            entry = builder(route, cache_only=cache_only)
+        except Exception:
+            entry = None
+        if entry is not None:
+            return entry
+    return None
 
 
 def _pricing_entry_from_metadata(
@@ -1265,6 +1343,8 @@ def get_pricing_entry(
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
+    *,
+    cache_only: bool = False,
 ) -> Optional[PricingEntry]:
     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
     if route.billing_mode == "subscription_included":
@@ -1277,8 +1357,10 @@ def get_pricing_entry(
             pricing_version="included-route",
         )
     if route.provider == "openrouter":
-        return _openrouter_pricing_entry(route)
-    if route.base_url:
+        return _openrouter_pricing_entry(
+            route, cache_only=cache_only
+        ) or _models_dev_pricing_entry(route, cache_only=cache_only)
+    if route.base_url and not cache_only:
         entry = _pricing_entry_from_metadata(
             fetch_endpoint_model_metadata(route.base_url, api_key=api_key or ""),
             route.model,
@@ -1287,7 +1369,9 @@ def get_pricing_entry(
         )
         if entry:
             return entry
-    return _lookup_official_docs_pricing(route)
+    return _lookup_official_docs_pricing(route) or _external_pricing_entry(
+        route, cache_only=cache_only
+    )
 
 
 def normalize_usage(
@@ -1558,7 +1642,13 @@ def has_known_pricing(
     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
     if route.billing_mode == "subscription_included":
         return True
-    entry = get_pricing_entry(model_name, provider=provider, base_url=base_url, api_key=api_key)
+    entry = get_pricing_entry(
+        model_name,
+        provider=provider,
+        base_url=base_url,
+        api_key=api_key,
+        cache_only=True,
+    )
     return entry is not None
 
 

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1030,6 +1030,108 @@ def _openrouter_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
     )
 
 
+# --- External (dynamic-catalog) pricing sources ------------------------------
+#
+# The curated ``_OFFICIAL_DOCS_PRICING`` snapshot above is hand-maintained, so
+# every newly launched model records unpriced turns until someone edits the
+# table. An external catalog closes that window automatically. Which catalog
+# is used is configurable (``config.yaml`` -> ``pricing.external_source``),
+# defaulting to models.dev — the git-backed registry that already powers this
+# repo's context-window and capability resolution and publishes per-million
+# cost including cache tiers.
+#
+# The curated snapshot ALWAYS wins over any external source (see
+# ``get_pricing_entry``): it encodes deliberate corrections a live catalog
+# can't know, most importantly standing list price rather than a temporary
+# launch-intro rate.
+
+_VALID_PRICING_SOURCES = ("models_dev", "openrouter")
+_DEFAULT_PRICING_SOURCE = "models_dev"
+
+
+def _pricing_source_order() -> tuple[str, ...]:
+    """Resolve the external pricing-source preference order from config.yaml.
+
+    Reads ``pricing.external_source`` (default ``models_dev``). Returns the
+    configured primary first, then the remaining valid source(s) as automatic
+    fallback so a model missing from the primary catalog still resolves. An
+    unrecognized or missing value degrades to the default order — pricing
+    resolution must never raise into a turn.
+    """
+    primary = _DEFAULT_PRICING_SOURCE
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        pricing_cfg = (load_config_readonly() or {}).get("pricing")
+        if isinstance(pricing_cfg, dict):
+            candidate = pricing_cfg.get("external_source")
+            if isinstance(candidate, str):
+                candidate = candidate.strip().lower()
+                if candidate in _VALID_PRICING_SOURCES:
+                    primary = candidate
+    except Exception:
+        primary = _DEFAULT_PRICING_SOURCE
+    return (primary, *[s for s in _VALID_PRICING_SOURCES if s != primary])
+
+
+def _models_dev_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
+    """Build a :class:`PricingEntry` from the models.dev registry cost block.
+
+    models.dev stores cost already in per-million USD, so — unlike the
+    OpenRouter path — no per-token conversion is applied. Lookup is
+    provider-scoped (see ``agent.models_dev.lookup_models_dev_pricing``), so an
+    unmapped provider resolves to None instead of guessing a vendor rate.
+    """
+    from agent.models_dev import lookup_models_dev_pricing
+
+    cost = lookup_models_dev_pricing(route.provider, route.model)
+    if not cost:
+        return None
+    input_cost = _to_decimal(cost.get("input"))
+    output_cost = _to_decimal(cost.get("output"))
+    if input_cost is None and output_cost is None:
+        return None
+    return PricingEntry(
+        input_cost_per_million=input_cost,
+        output_cost_per_million=output_cost,
+        cache_read_cost_per_million=_to_decimal(cost.get("cache_read")),
+        cache_write_cost_per_million=_to_decimal(cost.get("cache_write")),
+        request_cost=None,
+        source="provider_models_api",
+        source_url="https://models.dev/api.json",
+        pricing_version="models-dev-api",
+        fetched_at=_UTC_NOW(),
+    )
+
+
+# Dispatch table: pricing-source name -> entry builder.
+_PRICING_SOURCE_BUILDERS = {
+    "models_dev": _models_dev_pricing_entry,
+    "openrouter": _openrouter_pricing_entry,
+}
+
+
+def _external_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
+    """Price a route from the configured external catalog(s).
+
+    Tries the config-selected primary source (default models.dev), then the
+    other valid source as fallback. Never raises: a catalog fetch failure
+    degrades to the next source and finally to None (unpriced), exactly as
+    before this indirection existed.
+    """
+    for source in _pricing_source_order():
+        builder = _PRICING_SOURCE_BUILDERS.get(source)
+        if builder is None:
+            continue
+        try:
+            entry = builder(route)
+        except Exception:
+            entry = None
+        if entry is not None:
+            return entry
+    return None
+
+
 def _pricing_entry_from_metadata(
     metadata: Dict[str, Dict[str, Any]],
     model_id: str,
@@ -1091,7 +1193,10 @@ def get_pricing_entry(
             pricing_version="included-route",
         )
     if route.provider == "openrouter":
-        return _openrouter_pricing_entry(route)
+        # OpenRouter's own models API is the billing vendor's rate card for
+        # this route, so it stays primary; the configured external catalog is
+        # consulted only when OpenRouter has no entry for the id.
+        return _openrouter_pricing_entry(route) or _external_pricing_entry(route)
     if route.base_url:
         entry = _pricing_entry_from_metadata(
             fetch_endpoint_model_metadata(route.base_url, api_key=api_key or ""),
@@ -1101,7 +1206,12 @@ def get_pricing_entry(
         )
         if entry:
             return entry
-    return _lookup_official_docs_pricing(route)
+    # The curated snapshot wins whenever it has the model: it encodes
+    # deliberate corrections a live catalog can't know. Only on a miss — a
+    # model launched since the snapshot was last hand-edited — do we consult
+    # the configured external catalog, so a new model records real cost
+    # instead of "n/a" until someone updates the table.
+    return _lookup_official_docs_pricing(route) or _external_pricing_entry(route)
 
 
 def normalize_usage(

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -6,7 +6,11 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Dict, Literal, Optional
 
-from agent.model_metadata import fetch_endpoint_model_metadata, fetch_model_metadata
+from agent.model_metadata import (
+    cached_model_metadata,
+    fetch_endpoint_model_metadata,
+    fetch_model_metadata,
+)
 from utils import base_url_host_matches
 
 DEFAULT_PRICING = {"input": 0.0, "output": 0.0}
@@ -1021,9 +1025,12 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
     return None
 
 
-def _openrouter_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
+def _openrouter_pricing_entry(
+    route: BillingRoute, *, cache_only: bool = False
+) -> Optional[PricingEntry]:
+    metadata = cached_model_metadata() if cache_only else fetch_model_metadata()
     return _pricing_entry_from_metadata(
-        fetch_model_metadata(),
+        metadata,
         route.model,
         source_url="https://openrouter.ai/docs/api/api-reference/models/get-models",
         pricing_version="openrouter-models-api",
@@ -1074,7 +1081,9 @@ def _pricing_source_order() -> tuple[str, ...]:
     return (primary, *[s for s in _VALID_PRICING_SOURCES if s != primary])
 
 
-def _models_dev_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
+def _models_dev_pricing_entry(
+    route: BillingRoute, *, cache_only: bool = False
+) -> Optional[PricingEntry]:
     """Build a :class:`PricingEntry` from the models.dev registry cost block.
 
     models.dev stores cost already in per-million USD, so — unlike the
@@ -1084,7 +1093,7 @@ def _models_dev_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
     """
     from agent.models_dev import lookup_models_dev_pricing
 
-    cost = lookup_models_dev_pricing(route.provider, route.model)
+    cost = lookup_models_dev_pricing(route.provider, route.model, cache_only=cache_only)
     if not cost:
         return None
     input_cost = _to_decimal(cost.get("input"))
@@ -1111,20 +1120,39 @@ _PRICING_SOURCE_BUILDERS = {
 }
 
 
-def _external_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
+def _external_pricing_entry(
+    route: BillingRoute, *, cache_only: bool = False
+) -> Optional[PricingEntry]:
     """Price a route from the configured external catalog(s).
 
     Tries the config-selected primary source (default models.dev), then the
     other valid source as fallback. Never raises: a catalog fetch failure
     degrades to the next source and finally to None (unpriced), exactly as
     before this indirection existed.
+
+    **Provider scoping is a hard precondition, not a per-source detail.**
+    ``_models_dev_pricing_entry`` is provider-scoped (an unmapped provider
+    yields None), but ``_openrouter_pricing_entry`` resolves by bare model id
+    with no provider scoping at all — OpenRouter's catalog is a flat id space.
+    Consulting it for a route whose billing vendor we could not identify would
+    bill a self-hosted or unrecognized model at OpenRouter's HOSTED rate,
+    which is exactly the failure ``lookup_models_dev_pricing`` documents that
+    it prevents. So when the route has no identified billing vendor
+    (``billing_mode == "unknown"``: ``custom``, ``local``, ``unknown``), every
+    external catalog is refused and the route stays honestly unpriced.
+
+    Unpriced is the correct answer here. A wrong price is strictly worse than
+    no price: it is silently attributed to the user's spend and, unlike "n/a",
+    gives no signal that anything needs checking.
     """
+    if route.billing_mode == "unknown":
+        return None
     for source in _pricing_source_order():
         builder = _PRICING_SOURCE_BUILDERS.get(source)
         if builder is None:
             continue
         try:
-            entry = builder(route)
+            entry = builder(route, cache_only=cache_only)
         except Exception:
             entry = None
         if entry is not None:
@@ -1181,7 +1209,16 @@ def get_pricing_entry(
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
+    *,
+    cache_only: bool = False,
 ) -> Optional[PricingEntry]:
+    """Resolve pricing for a model+route.
+
+    With ``cache_only=True`` no network call is made: dynamic catalogs are
+    read from their in-memory/on-disk caches only, and the per-endpoint
+    ``/models`` probe is skipped entirely. Used by pure predicates on display
+    paths — see :func:`has_known_pricing`.
+    """
     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
     if route.billing_mode == "subscription_included":
         return PricingEntry(
@@ -1195,9 +1232,13 @@ def get_pricing_entry(
     if route.provider == "openrouter":
         # OpenRouter's own models API is the billing vendor's rate card for
         # this route, so it stays primary; the configured external catalog is
-        # consulted only when OpenRouter has no entry for the id.
-        return _openrouter_pricing_entry(route) or _external_pricing_entry(route)
-    if route.base_url:
+        # consulted only when OpenRouter has no entry for the id. The bare-id
+        # lookup is correct HERE and only here: the route's billing vendor IS
+        # OpenRouter, so its flat id space is the right namespace.
+        return _openrouter_pricing_entry(
+            route, cache_only=cache_only
+        ) or _external_pricing_entry(route, cache_only=cache_only)
+    if route.base_url and not cache_only:
         entry = _pricing_entry_from_metadata(
             fetch_endpoint_model_metadata(route.base_url, api_key=api_key or ""),
             route.model,
@@ -1211,7 +1252,9 @@ def get_pricing_entry(
     # model launched since the snapshot was last hand-edited — do we consult
     # the configured external catalog, so a new model records real cost
     # instead of "n/a" until someone updates the table.
-    return _lookup_official_docs_pricing(route) or _external_pricing_entry(route)
+    return _lookup_official_docs_pricing(route) or _external_pricing_entry(
+        route, cache_only=cache_only
+    )
 
 
 def normalize_usage(
@@ -1398,11 +1441,24 @@ def has_known_pricing(
 
     Uses direct lookup instead of routing through the full estimation
     pipeline — avoids creating dummy usage objects just to check status.
+
+    **Never touches the network.** This is a pure predicate called inside
+    display loops (``agent/insights.py``), where one blocking HTTP round trip
+    per row would stall rendering. Dynamic catalogs are consulted cache-only,
+    so a cold cache reports "unknown pricing" rather than blocking — the
+    honest answer for a display column, and self-correcting once any normal
+    pricing path warms the cache.
     """
     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
     if route.billing_mode == "subscription_included":
         return True
-    entry = get_pricing_entry(model_name, provider=provider, base_url=base_url, api_key=api_key)
+    entry = get_pricing_entry(
+        model_name,
+        provider=provider,
+        base_url=base_url,
+        api_key=api_key,
+        cache_only=True,
+    )
     return entry is not None
 
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -5,6 +5,16 @@
 # variables in .env take precedence over their corresponding settings.
 
 # =============================================================================
+# Cost / pricing
+# =============================================================================
+# Preferred dynamic catalog for models absent from the curated pricing
+# snapshot. Sources remain provider-scoped: models.dev applies only to mapped
+# providers, while OpenRouter's flat model-id catalog applies only when the
+# route is billed by OpenRouter. Inapplicable sources are skipped safely.
+pricing:
+  external_source: models_dev  # models_dev | openrouter
+
+# =============================================================================
 # Database Configuration
 # =============================================================================
 # WAL is the normal default. Hermes automatically falls back to DELETE when

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1614,3 +1614,25 @@ updates:
 #     command: "cat /run/user/1000/hermes-secrets.env"
 #     helper_timeout_seconds: 3
 #     override_existing: false             # .env/shell win by default
+
+# =============================================================================
+# Cost / pricing
+# =============================================================================
+# How a turn's cost is estimated for models that are NOT in the curated
+# official-docs pricing snapshot baked into agent/usage_pricing.py. The
+# snapshot always takes precedence — it encodes deliberate corrections a live
+# catalog can't know (e.g. a model's standing LIST price rather than a
+# temporary launch-intro rate). `external_source` only picks the dynamic
+# catalog consulted when the snapshot has no entry, so a model released since
+# the snapshot was last hand-edited records real cost instead of "n/a":
+#
+#   models_dev  (default) — the git-backed models.dev registry, which already
+#                           supplies context windows and capabilities here and
+#                           publishes per-million cost including cache tiers.
+#   openrouter            — the OpenRouter models API.
+#
+# Whichever source is not selected is used automatically as the fallback when
+# the primary catalog is missing a model id.
+#
+# pricing:
+#   external_source: models_dev

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -10,6 +10,9 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    "pricing": {
+        "external_source": "models_dev",
+    },
     # SQLite journal mode used by every Hermes database opener. WAL is the
     # normal default; set DELETE for weak-fsync/shared filesystems where WAL is
     # not crash-safe (for example macOS virtiofs, NFS, or SMB).

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1399,6 +1399,9 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # models_dev field — fold it in with the other network/agent plumbing
     # rather than spawning a one-field orphan tab.
     "models_dev": "agent",
+    # `pricing.external_source` is the only schema-surfaced pricing field —
+    # keep catalog selection with the other model/agent settings.
+    "pricing": "agent",
     "checkpoints": "agent",
     "approvals": "security",
     "human_delay": "display",

--- a/scripts/tool_search_livetest2.py
+++ b/scripts/tool_search_livetest2.py
@@ -187,7 +187,7 @@ def run_one(scenario: Dict[str, Any], mode: str, rep: int, out_dir: Path) -> Dic
         "final_response": base._redact_secrets(final_response)[:500],
     }
     out_path = out_dir / f"{scenario['id']}__{'enabled' if enabled else 'disabled'}__rep{rep}.json"
-    out_path.write_text(json.dumps(rec, indent=1))
+    out_path.write_text(json.dumps(rec, indent=1), encoding="utf-8")
     shutil.rmtree(Path(os.environ["HERMES_HOME"]).parent, ignore_errors=True)
     return rec
 
@@ -210,7 +210,7 @@ def main():
     summary_name = os.environ.get("TS_BENCH_SUMMARY", "_bench_summary.json")
     (out_dir / summary_name).write_text(json.dumps(
         [{k: v for k, v in r.items() if k not in ("per_call_usage", "bridge_calls", "final_response")} for r in rows],
-        indent=1))
+        indent=1), encoding="utf-8")
     print("done ->", out_dir / summary_name)
 
 

--- a/tests/agent/test_usage_pricing_external_source.py
+++ b/tests/agent/test_usage_pricing_external_source.py
@@ -1,0 +1,299 @@
+"""External pricing fallback and display-path cache safety.
+
+The catalog fixtures are in-memory only: no test depends on live models.dev or
+OpenRouter data.
+"""
+
+from decimal import Decimal
+
+import pytest
+import yaml
+
+import agent.model_metadata as model_metadata
+import agent.models_dev as models_dev
+import agent.usage_pricing as usage_pricing
+from agent.usage_pricing import get_pricing_entry
+
+
+@pytest.fixture
+def seeded_models_dev(monkeypatch):
+    """Install a deterministic models.dev registry and return a seeder."""
+
+    def seed(registry):
+        monkeypatch.setattr(models_dev, "_models_dev_cache", registry)
+        monkeypatch.setattr(models_dev, "_models_dev_cache_time", float("inf"))
+
+    seed({})
+    return seed
+
+
+@pytest.fixture
+def default_source_order(monkeypatch):
+    monkeypatch.setattr(
+        usage_pricing,
+        "_pricing_source_order",
+        lambda: ("models_dev", "openrouter"),
+        raising=False,
+    )
+
+
+@pytest.fixture
+def openrouter_catalog_knows_glm5(monkeypatch):
+    catalog = {
+        "glm-5": {
+            "pricing": {
+                "prompt": "0.00000095",
+                "completion": "0.0000038",
+            }
+        }
+    }
+    monkeypatch.setattr(
+        usage_pricing,
+        "fetch_model_metadata",
+        lambda *args, **kwargs: catalog,
+    )
+    return catalog
+
+
+def test_models_dev_cost_reader_preserves_all_rate_classes():
+    assert models_dev._extract_cost(
+        {
+            "cost": {
+                "input": 5,
+                "output": 25,
+                "cache_read": 0.5,
+                "cache_write": 6.25,
+            }
+        }
+    ) == {
+        "input": 5.0,
+        "output": 25.0,
+        "cache_read": 0.5,
+        "cache_write": 6.25,
+    }
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        None,
+        {},
+        {"cost": {}},
+        {"cost": {"cache_read": 1}},
+        {"cost": {"input": True, "output": False}},
+        {"cost": {"input": "5", "output": "25"}},
+        {"cost": {"input": -1, "output": -2}},
+    ],
+)
+def test_models_dev_cost_reader_rejects_unpriced_or_malformed_entries(entry):
+    assert models_dev._extract_cost(entry) is None
+
+
+def test_models_dev_pricing_is_provider_scoped(seeded_models_dev):
+    seeded_models_dev(
+        {
+            "xiaomi": {
+                "models": {
+                    "mimo-new": {"cost": {"input": 1, "output": 3}},
+                }
+            }
+        }
+    )
+
+    assert models_dev.lookup_models_dev_pricing("xiaomi", "mimo-new") == {
+        "input": 1.0,
+        "output": 3.0,
+    }
+    assert models_dev.lookup_models_dev_pricing("custom", "mimo-new") is None
+    assert models_dev.lookup_models_dev_pricing("unknown", "mimo-new") is None
+
+
+def test_snapshot_miss_prices_from_models_dev(seeded_models_dev, default_source_order):
+    model = "claude-not-in-snapshot-1"
+    assert ("anthropic", model) not in usage_pricing._OFFICIAL_DOCS_PRICING
+    seeded_models_dev(
+        {
+            "anthropic": {
+                "models": {
+                    model: {
+                        "cost": {
+                            "input": 5,
+                            "output": 25,
+                            "cache_read": 0.5,
+                            "cache_write": 6.25,
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+    entry = get_pricing_entry(model, provider="anthropic")
+
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("5")
+    assert entry.output_cost_per_million == Decimal("25")
+    assert entry.cache_read_cost_per_million == Decimal("0.5")
+    assert entry.cache_write_cost_per_million == Decimal("6.25")
+    assert entry.pricing_version == "models-dev-api"
+
+
+def test_curated_snapshot_still_precedes_external_catalog(
+    seeded_models_dev, default_source_order
+):
+    seeded_models_dev(
+        {
+            "openai": {
+                "models": {
+                    "gpt-4o": {"cost": {"input": 999, "output": 999}},
+                }
+            }
+        }
+    )
+
+    entry = get_pricing_entry("gpt-4o", provider="openai")
+
+    assert entry is not None
+    assert entry.pricing_version != "models-dev-api"
+    assert entry.input_cost_per_million != Decimal("999")
+
+
+@pytest.mark.parametrize("provider", [None, "unknown", "custom", "local", "xiaomi"])
+def test_openrouter_bare_id_lookup_is_reserved_for_openrouter_routes(
+    provider, openrouter_catalog_knows_glm5
+):
+    route = usage_pricing.resolve_billing_route("glm-5", provider=provider)
+    assert route.provider != "openrouter"
+
+    assert usage_pricing._openrouter_pricing_entry(route) is None
+
+
+def test_openrouter_guard_is_not_vacuous(openrouter_catalog_knows_glm5):
+    entry = usage_pricing._pricing_entry_from_metadata(
+        openrouter_catalog_knows_glm5,
+        "glm-5",
+        source_url="test",
+        pricing_version="test",
+    )
+
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("0.95000000")
+
+
+@pytest.mark.parametrize("provider", [None, "unknown", "custom", "local"])
+def test_unknown_or_self_hosted_route_never_falls_through_to_openrouter(
+    provider,
+    seeded_models_dev,
+    default_source_order,
+    openrouter_catalog_knows_glm5,
+):
+    seeded_models_dev({"xiaomi": {"models": {}}})
+
+    assert get_pricing_entry("glm-5", provider=provider) is None
+    assert usage_pricing.has_known_pricing("glm-5", provider=provider) is False
+
+
+def test_mapped_named_provider_reaches_models_dev_despite_unknown_billing_mode(
+    seeded_models_dev, default_source_order
+):
+    seeded_models_dev(
+        {
+            "xiaomi": {
+                "models": {
+                    "mimo-new": {"cost": {"input": 1, "output": 3}},
+                }
+            }
+        }
+    )
+    route = usage_pricing.resolve_billing_route("mimo-new", provider="xiaomi")
+    assert route.billing_mode == "unknown"
+
+    entry = get_pricing_entry("mimo-new", provider="xiaomi")
+
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("1")
+    assert entry.pricing_version == "models-dev-api"
+
+
+def test_openrouter_route_keeps_its_bare_id_rate_card(openrouter_catalog_knows_glm5):
+    entry = get_pricing_entry("glm-5", provider="openrouter")
+
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("0.95000000")
+    assert entry.pricing_version == "openrouter-models-api"
+
+
+def test_external_source_order_is_configurable(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"pricing": {"external_source": "openrouter"}},
+    )
+
+    assert usage_pricing._pricing_source_order() == ("openrouter", "models_dev")
+    assert set(usage_pricing._pricing_source_order()) == set(
+        usage_pricing._VALID_PRICING_SOURCES
+    )
+
+
+def test_documented_pricing_config_path_is_registered_and_writable(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import config
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert config._validate_config_key("pricing.external_source") == (True, None)
+
+    config.set_config_value("pricing.external_source", "openrouter")
+
+    saved = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+    assert saved["pricing"]["external_source"] == "openrouter"
+
+
+def test_has_known_pricing_makes_no_outbound_connection(monkeypatch):
+    import socket
+
+    monkeypatch.setattr(model_metadata, "_model_metadata_cache", {})
+    monkeypatch.setattr(model_metadata, "_model_metadata_cache_time", 0)
+    monkeypatch.setattr(model_metadata, "_load_model_metadata_disk_cache", dict)
+    monkeypatch.setattr(
+        model_metadata,
+        "_model_metadata_disk_cache_age_seconds",
+        lambda: None,
+    )
+    monkeypatch.setattr(models_dev, "_models_dev_cache", {})
+    monkeypatch.setattr(models_dev, "_models_dev_cache_time", 0)
+    monkeypatch.setattr(models_dev, "_load_disk_cache", dict)
+
+    attempts = []
+
+    def refuse(self, address):
+        attempts.append(address)
+        raise AssertionError(f"has_known_pricing opened a connection to {address}")
+
+    monkeypatch.setattr(socket.socket, "connect", refuse)
+
+    for model, provider in [
+        ("glm-5", None),
+        ("gpt-4o", "openai"),
+        ("some-model", "openrouter"),
+        ("another", "anthropic"),
+    ]:
+        usage_pricing.has_known_pricing(model, provider)
+
+    assert attempts == []
+
+
+def test_has_known_pricing_uses_warm_models_dev_cache(
+    seeded_models_dev, default_source_order
+):
+    seeded_models_dev(
+        {
+            "anthropic": {
+                "models": {
+                    "claude-cached-1": {"cost": {"input": 3, "output": 15}},
+                }
+            }
+        }
+    )
+
+    assert usage_pricing.has_known_pricing("claude-cached-1", "anthropic") is True

--- a/tests/agent/test_usage_pricing_external_source.py
+++ b/tests/agent/test_usage_pricing_external_source.py
@@ -1,0 +1,444 @@
+"""External (dynamic-catalog) pricing source: models.dev by default.
+
+Every test seeds ``agent.models_dev``'s in-memory registry cache directly, so
+the whole suite is hermetic — no network, no disk cache, and no dependency on
+what models.dev happens to publish today.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+import agent.models_dev as models_dev
+import agent.usage_pricing as usage_pricing
+from agent.usage_pricing import (
+    CanonicalUsage,
+    estimate_usage_cost,
+    get_pricing_entry,
+)
+
+
+@pytest.fixture
+def seeded_models_dev(monkeypatch):
+    """Install a deterministic models.dev registry and return a seeder."""
+
+    def seed(registry):
+        monkeypatch.setattr(models_dev, "_models_dev_cache", registry)
+        monkeypatch.setattr(models_dev, "_models_dev_cache_time", float("inf"))
+
+    seed({})
+    return seed
+
+
+@pytest.fixture
+def default_source_order(monkeypatch):
+    """Pin the source order to the shipped default.
+
+    Keeps a test independent of whatever ``config.yaml`` the surrounding
+    HERMES_HOME happens to contain. Tests that exercise the config knob itself
+    deliberately do NOT use this.
+    """
+    monkeypatch.setattr(
+        usage_pricing, "_pricing_source_order", lambda: ("models_dev", "openrouter")
+    )
+
+
+def write_pricing_config(body: str) -> None:
+    """Write ``config.yaml`` into the test's HERMES_HOME and drop the cache."""
+    from hermes_cli.config import _LOAD_CONFIG_CACHE, get_config_path
+
+    path = get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    _LOAD_CONFIG_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# _extract_cost — the models.dev cost-block reader
+# ---------------------------------------------------------------------------
+
+
+def test_extract_cost_reads_all_four_rate_classes():
+    cost = models_dev._extract_cost(
+        {"cost": {"input": 5, "output": 25, "cache_read": 0.5, "cache_write": 6.25}}
+    )
+
+    assert cost == {
+        "input": 5.0,
+        "output": 25.0,
+        "cache_read": 0.5,
+        "cache_write": 6.25,
+    }
+
+
+def test_extract_cost_omits_absent_cache_rates_rather_than_zeroing_them():
+    """An absent cache rate must be absent, not 0.
+
+    A 0 would be read downstream as "this route bills cache tokens for free",
+    which silently under-bills. Absence is what makes ``estimate_usage_cost``
+    report ``unknown`` for a route whose cache rates aren't published.
+    """
+    cost = models_dev._extract_cost({"cost": {"input": 3, "output": 15}})
+
+    assert cost == {"input": 3.0, "output": 15.0}
+
+
+def test_extract_cost_ignores_long_context_tier_surcharges():
+    """Only the flat base rates are read; a tiers block must not leak in."""
+    cost = models_dev._extract_cost(
+        {
+            "cost": {
+                "input": 5,
+                "output": 30,
+                "tiers": [{"input": 10, "output": 45}],
+                "context_over_200k": {"input": 10, "output": 45},
+            }
+        }
+    )
+
+    assert cost == {"input": 5.0, "output": 30.0}
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        None,
+        {},
+        {"cost": None},
+        {"cost": {}},
+        {"cost": {"cache_read": 1.0}},
+        {"cost": {"input": True, "output": False}},
+        {"cost": {"input": "5", "output": "25"}},
+        {"cost": {"input": -1, "output": -2}},
+    ],
+    ids=[
+        "not-a-dict",
+        "no-cost-key",
+        "null-cost",
+        "empty-cost",
+        "cache-rate-only",
+        "bools-are-not-rates",
+        "strings-are-not-rates",
+        "negative-rates",
+    ],
+)
+def test_extract_cost_returns_none_for_unpriced_or_malformed_entries(entry):
+    assert models_dev._extract_cost(entry) is None
+
+
+# ---------------------------------------------------------------------------
+# lookup_models_dev_pricing — provider-scoped resolution
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_pricing_resolves_through_the_provider_id_mapping(seeded_models_dev):
+    """A Hermes provider slug resolves via PROVIDER_TO_MODELS_DEV, not verbatim.
+
+    ``gemini`` is the Hermes slug; models.dev files those models under
+    ``google``. Same mapping the context-window lookup already uses.
+    """
+    seeded_models_dev(
+        {"google": {"models": {"gemini-9-pro": {"cost": {"input": 2, "output": 12}}}}}
+    )
+
+    assert models_dev.lookup_models_dev_pricing("gemini", "gemini-9-pro") == {
+        "input": 2.0,
+        "output": 12.0,
+    }
+
+
+def test_lookup_pricing_matches_model_ids_case_insensitively(seeded_models_dev):
+    seeded_models_dev(
+        {"anthropic": {"models": {"claude-x-1": {"cost": {"input": 1, "output": 2}}}}}
+    )
+
+    assert models_dev.lookup_models_dev_pricing("anthropic", "CLAUDE-X-1") == {
+        "input": 1.0,
+        "output": 2.0,
+    }
+
+
+def test_lookup_pricing_is_provider_scoped_not_a_global_id_scan(seeded_models_dev):
+    """A model id must never be priced off some *other* provider's catalog.
+
+    ``custom``/``local``/``unknown`` are not in ``PROVIDER_TO_MODELS_DEV``. If
+    the lookup fell back to scanning every provider for the bare id, a
+    self-hosted model sharing a name with a hosted one would be billed at the
+    hosted vendor's rate. It must resolve to None instead.
+    """
+    seeded_models_dev(
+        {"anthropic": {"models": {"claude-x-1": {"cost": {"input": 1, "output": 2}}}}}
+    )
+
+    assert models_dev.lookup_models_dev_pricing("custom", "claude-x-1") is None
+    assert models_dev.lookup_models_dev_pricing("local", "claude-x-1") is None
+    assert models_dev.lookup_models_dev_pricing("unknown", "claude-x-1") is None
+
+
+def test_lookup_pricing_returns_none_for_a_model_absent_from_the_catalog(seeded_models_dev):
+    seeded_models_dev({"anthropic": {"models": {}}})
+
+    assert models_dev.lookup_models_dev_pricing("anthropic", "claude-x-1") is None
+
+
+# ---------------------------------------------------------------------------
+# get_pricing_entry — snapshot precedence and the external fallback
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_miss_now_prices_from_models_dev(seeded_models_dev, default_source_order):
+    """The regression this change fixes.
+
+    A model absent from the curated snapshot used to resolve to no pricing
+    entry at all, so every turn on it recorded cost "n/a" until a maintainer
+    hand-edited the table. It must now price from the external catalog.
+    """
+    model = "claude-not-in-the-snapshot-1"
+    assert ("anthropic", model) not in usage_pricing._OFFICIAL_DOCS_PRICING
+
+    seeded_models_dev(
+        {
+            "anthropic": {
+                "models": {
+                    model: {
+                        "cost": {
+                            "input": 5,
+                            "output": 25,
+                            "cache_read": 0.5,
+                            "cache_write": 6.25,
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+    entry = get_pricing_entry(model, provider="anthropic")
+
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("5")
+    assert entry.output_cost_per_million == Decimal("25")
+    assert entry.cache_read_cost_per_million == Decimal("0.5")
+    assert entry.cache_write_cost_per_million == Decimal("6.25")
+    assert entry.pricing_version == "models-dev-api"
+    assert entry.source_url == "https://models.dev/api.json"
+
+
+def test_models_dev_rates_are_per_million_not_per_token(
+    seeded_models_dev, default_source_order
+):
+    """models.dev publishes per-MILLION USD; OpenRouter publishes per-token.
+
+    Reusing the OpenRouter converter here would multiply by 1e6 and overcharge
+    by a factor of a million. This pins the unit contract end to end: 1M input
+    tokens at a published rate of 5 costs exactly $5.
+    """
+    model = "unit-contract-probe-1"
+    seeded_models_dev(
+        {"anthropic": {"models": {model: {"cost": {"input": 5, "output": 25}}}}}
+    )
+
+    result = estimate_usage_cost(
+        model,
+        CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000),
+        provider="anthropic",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd == Decimal("30")
+
+
+def test_curated_snapshot_always_beats_the_external_catalog(
+    seeded_models_dev, default_source_order
+):
+    """The snapshot encodes corrections a live catalog can't know.
+
+    The canonical case is list-price-not-intro-promo: a vendor's launch
+    discount shows up in models.dev, but billing must follow the standing list
+    price the snapshot records. A snapshot hit must never be overridden.
+    """
+    (provider, model), snapshot = next(iter(usage_pricing._OFFICIAL_DOCS_PRICING.items()))
+    decoy = (snapshot.input_cost_per_million or Decimal("0")) + Decimal("1234")
+
+    seeded_models_dev(
+        {
+            models_dev.PROVIDER_TO_MODELS_DEV.get(provider, provider): {
+                "models": {model: {"cost": {"input": float(decoy), "output": float(decoy)}}}
+            }
+        }
+    )
+
+    entry = get_pricing_entry(model, provider=provider)
+
+    assert entry is not None
+    assert entry.input_cost_per_million == snapshot.input_cost_per_million
+    assert entry.output_cost_per_million == snapshot.output_cost_per_million
+    assert entry.input_cost_per_million != decoy
+
+
+def test_unpriced_stays_unpriced_when_no_catalog_has_the_model(
+    seeded_models_dev, default_source_order, monkeypatch
+):
+    seeded_models_dev({"anthropic": {"models": {}}})
+    monkeypatch.setattr(usage_pricing, "fetch_model_metadata", dict)
+
+    assert get_pricing_entry("claude-nobody-has-heard-of-1", provider="anthropic") is None
+
+
+def test_a_catalog_failure_degrades_to_unpriced_instead_of_raising(
+    monkeypatch, default_source_order
+):
+    """Pricing must never raise into a turn."""
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("catalog unreachable")
+
+    monkeypatch.setattr(models_dev, "fetch_models_dev", _boom)
+    monkeypatch.setattr(usage_pricing, "fetch_model_metadata", _boom)
+
+    assert get_pricing_entry("claude-anything-1", provider="anthropic") is None
+
+
+def test_the_non_primary_source_is_used_when_the_primary_misses(
+    monkeypatch, seeded_models_dev, default_source_order
+):
+    """models.dev primary, OpenRouter fallback: a models.dev miss still prices.
+
+    The OpenRouter lane runs for real here (only its HTTP catalog is stubbed),
+    so this also pins the unit difference between the two sources: OpenRouter
+    publishes per-TOKEN rates, which the shared converter scales to
+    per-million.
+    """
+    model = "only-openrouter-knows-this-1"
+    seeded_models_dev({"anthropic": {"models": {}}})
+    monkeypatch.setattr(
+        usage_pricing,
+        "fetch_model_metadata",
+        lambda: {model: {"pricing": {"prompt": "0.000007", "completion": "0.000014"}}},
+    )
+
+    entry = get_pricing_entry(model, provider="anthropic")
+
+    assert entry is not None
+    assert entry.pricing_version == "openrouter-models-api"
+    assert entry.input_cost_per_million == Decimal("7.000000")
+    assert entry.output_cost_per_million == Decimal("14.000000")
+
+
+def test_openrouter_routes_still_price_from_openrouter_first(
+    monkeypatch, seeded_models_dev, default_source_order
+):
+    """A ``provider: openrouter`` route bills at OpenRouter's rate card.
+
+    OpenRouter is the actual billing vendor for that route, so its own models
+    API stays primary even though models.dev is the default *fallback* catalog
+    everywhere else.
+    """
+    model = "vendor/model-1"
+    seeded_models_dev(
+        {"openrouter": {"models": {model: {"cost": {"input": 99, "output": 99}}}}}
+    )
+    monkeypatch.setattr(
+        usage_pricing,
+        "fetch_model_metadata",
+        lambda: {model: {"pricing": {"prompt": "0.000003", "completion": "0.000015"}}},
+    )
+
+    entry = get_pricing_entry(model, provider="openrouter")
+
+    assert entry is not None
+    assert entry.pricing_version == "openrouter-models-api"
+    assert entry.input_cost_per_million == Decimal("3.000000")
+
+
+def test_subscription_included_routes_are_untouched_by_the_external_catalog(
+    seeded_models_dev, default_source_order
+):
+    """An included route reports $0/included, never a catalog rate."""
+    seeded_models_dev({"openai": {"models": {"gpt-9": {"cost": {"input": 100, "output": 200}}}}})
+
+    entry = get_pricing_entry("gpt-9", provider="openai-codex")
+
+    assert entry is not None
+    assert entry.pricing_version == "included-route"
+    assert entry.input_cost_per_million == Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# pricing.external_source — the config knob
+# ---------------------------------------------------------------------------
+
+
+def test_default_source_order_is_models_dev_then_openrouter():
+    write_pricing_config("model:\n  default: gpt-4o\n")
+
+    assert usage_pricing._pricing_source_order() == ("models_dev", "openrouter")
+
+
+def test_config_can_select_openrouter_as_the_primary_source():
+    write_pricing_config("pricing:\n  external_source: openrouter\n")
+
+    assert usage_pricing._pricing_source_order() == ("openrouter", "models_dev")
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "pricing:\n  external_source: not_a_real_source\n",
+        "pricing:\n  external_source: 17\n",
+        "pricing: not-a-mapping\n",
+        "pricing: {}\n",
+    ],
+    ids=["unknown-name", "wrong-type", "section-not-a-mapping", "empty-section"],
+)
+def test_an_unusable_config_value_degrades_to_the_default_order(body):
+    write_pricing_config(body)
+
+    assert usage_pricing._pricing_source_order() == ("models_dev", "openrouter")
+
+
+def test_source_order_always_covers_every_valid_source():
+    """Invariant: the order is a permutation of the valid sources.
+
+    Whichever source is selected, the other stays reachable as fallback —
+    selecting one must never make a model that only the other catalog knows
+    about unpriceable.
+    """
+    for source in usage_pricing._VALID_PRICING_SOURCES:
+        write_pricing_config(f"pricing:\n  external_source: {source}\n")
+        order = usage_pricing._pricing_source_order()
+
+        assert order[0] == source
+        assert sorted(order) == sorted(usage_pricing._VALID_PRICING_SOURCES)
+        assert len(set(order)) == len(order)
+
+
+def test_every_named_source_has_a_builder():
+    """Invariant: the config accepts exactly the sources that can be built."""
+    assert set(usage_pricing._PRICING_SOURCE_BUILDERS) == set(
+        usage_pricing._VALID_PRICING_SOURCES
+    )
+    assert usage_pricing._DEFAULT_PRICING_SOURCE in usage_pricing._VALID_PRICING_SOURCES
+
+
+def test_selecting_openrouter_makes_it_the_primary_for_a_snapshot_miss(
+    monkeypatch, seeded_models_dev
+):
+    """The knob has real effect: with openrouter selected, it is tried first."""
+    write_pricing_config("pricing:\n  external_source: openrouter\n")
+
+    model = "both-catalogs-know-this-1"
+    seeded_models_dev(
+        {"anthropic": {"models": {model: {"cost": {"input": 1, "output": 1}}}}}
+    )
+    monkeypatch.setattr(
+        usage_pricing,
+        "fetch_model_metadata",
+        lambda: {model: {"pricing": {"prompt": "0.000003", "completion": "0.000015"}}},
+    )
+
+    entry = get_pricing_entry(model, provider="anthropic")
+
+    assert entry is not None
+    assert entry.pricing_version == "openrouter-models-api"
+    assert entry.input_cost_per_million == Decimal("3.000000")

--- a/tests/agent/test_usage_pricing_external_source.py
+++ b/tests/agent/test_usage_pricing_external_source.py
@@ -442,3 +442,141 @@ def test_selecting_openrouter_makes_it_the_primary_for_a_snapshot_miss(
     assert entry is not None
     assert entry.pricing_version == "openrouter-models-api"
     assert entry.input_cost_per_million == Decimal("3.000000")
+
+
+# ---------------------------------------------------------------------------
+# Provider scoping of the external catalogs (the billing-vendor guarantee)
+# ---------------------------------------------------------------------------
+#
+# ``lookup_models_dev_pricing`` documents that a self-hosted model sharing an
+# id with a hosted one is never billed at the hosted vendor's rate. The
+# OpenRouter catalog resolves by BARE MODEL ID with no provider scoping, so
+# that guarantee only holds if unidentified-vendor routes refuse every
+# external catalog. These tests pin exactly that.
+
+
+@pytest.fixture
+def openrouter_catalog_knows_glm5(monkeypatch):
+    """OpenRouter publishes a hosted 'glm-5' at $0.95/M input."""
+    monkeypatch.setattr(
+        usage_pricing,
+        "fetch_model_metadata",
+        lambda: {
+            "glm-5": {"pricing": {"prompt": "0.00000095", "completion": "0.0000038"}}
+        },
+    )
+    # raising=False so this fixture also applies against a tree where the
+    # cache-only accessor does not exist yet — that keeps the RED proof
+    # behavioural (a wrong PRICE) instead of a fixture-setup error.
+    monkeypatch.setattr(
+        usage_pricing,
+        "cached_model_metadata",
+        lambda: {
+            "glm-5": {"pricing": {"prompt": "0.00000095", "completion": "0.0000038"}}
+        },
+        raising=False,
+    )
+
+
+@pytest.mark.parametrize("provider", [None, "unknown", "custom", "local"])
+def test_an_unidentified_billing_vendor_is_never_priced_from_a_hosted_catalog(
+    provider, seeded_models_dev, default_source_order, openrouter_catalog_knows_glm5
+):
+    """The core guarantee: no identified vendor => no external catalog at all.
+
+    A self-hosted 'glm-5' must not be billed at OpenRouter's hosted rate just
+    because the id collides. Unpriced is the correct answer — a wrong price is
+    silently attributed to the user's spend, while 'n/a' is visible.
+    """
+    route = usage_pricing.resolve_billing_route("glm-5", provider=provider)
+    assert route.billing_mode == "unknown", "precondition: vendor unidentified"
+
+    assert usage_pricing._external_pricing_entry(route) is None
+    assert get_pricing_entry("glm-5", provider=provider) is None
+    assert usage_pricing.has_known_pricing("glm-5", provider) is False
+
+
+def test_the_bare_id_scan_still_finds_the_model_it_is_refused_for(
+    openrouter_catalog_knows_glm5,
+):
+    """Control: the refusal is the guard, not an empty catalog.
+
+    Without this, the test above would pass vacuously if the OpenRouter stub
+    simply had no 'glm-5'.
+    """
+    route = usage_pricing.resolve_billing_route("glm-5", provider="unknown")
+    entry = usage_pricing._openrouter_pricing_entry(route)
+
+    assert entry is not None, "the bare-id scan does match; the guard is what refuses"
+    assert entry.input_cost_per_million == Decimal("0.950000")
+
+
+def test_an_identified_vendor_still_reaches_the_external_catalog(
+    seeded_models_dev, default_source_order
+):
+    """The guard must not disable the feature for legitimate routes."""
+    seeded_models_dev(
+        {"anthropic": {"models": {"claude-brand-new-1": {"cost": {"input": 3, "output": 15}}}}}
+    )
+    entry = get_pricing_entry("claude-brand-new-1", provider="anthropic")
+
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("3")
+
+
+def test_openrouter_routes_keep_their_own_bare_id_lookup(openrouter_catalog_knows_glm5):
+    """On an OpenRouter route the flat id space IS the correct namespace."""
+    entry = get_pricing_entry("glm-5", provider="openrouter")
+
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("0.950000")
+
+
+# ---------------------------------------------------------------------------
+# has_known_pricing is a pure predicate — no network from a display loop
+# ---------------------------------------------------------------------------
+
+
+def test_has_known_pricing_makes_no_outbound_connection(monkeypatch):
+    """It runs per-row in display loops; a blocking fetch there is a defect."""
+    import socket
+
+    import agent.model_metadata as model_metadata
+    import agent.models_dev as models_dev
+
+    # Cold caches, so only a network call could produce an answer.
+    monkeypatch.setattr(model_metadata, "_model_metadata_cache", {})
+    monkeypatch.setattr(model_metadata, "_model_metadata_cache_time", 0)
+    monkeypatch.setattr(model_metadata, "_load_model_metadata_disk_cache", dict)
+    monkeypatch.setattr(model_metadata, "_model_metadata_disk_cache_age_seconds", lambda: None)
+    monkeypatch.setattr(models_dev, "_models_dev_cache", {})
+    monkeypatch.setattr(models_dev, "_models_dev_cache_time", 0)
+    monkeypatch.setattr(models_dev, "_load_disk_cache", dict)
+
+    attempts = []
+
+    def _refuse(self, address):
+        attempts.append(address)
+        raise AssertionError(f"has_known_pricing opened a connection to {address}")
+
+    monkeypatch.setattr(socket.socket, "connect", _refuse)
+
+    for model, provider in [
+        ("glm-5", None),
+        ("gpt-4o", "openai"),
+        ("some-model", "openrouter"),
+        ("another", "anthropic"),
+    ]:
+        usage_pricing.has_known_pricing(model, provider)
+
+    assert attempts == []
+
+
+def test_has_known_pricing_still_answers_true_from_a_warm_cache(
+    seeded_models_dev, default_source_order
+):
+    """Cache-only must not mean always-False for catalog-priced models."""
+    seeded_models_dev(
+        {"anthropic": {"models": {"claude-cached-1": {"cost": {"input": 3, "output": 15}}}}}
+    )
+    assert usage_pricing.has_known_pricing("claude-cached-1", "anthropic") is True


### PR DESCRIPTION
## Summary

Adds a configurable dynamic pricing fallback for models absent from the curated `_OFFICIAL_DOCS_PRICING` snapshot. The default source is [models.dev](https://models.dev); the existing OpenRouter catalog remains available only for routes actually billed by OpenRouter.

```yaml
pricing:
  external_source: models_dev  # or: openrouter
```

The curated snapshot still wins whenever it has an entry, preserving deliberate corrections and standing-price overrides.

## Provider boundaries

The fallback no longer treats a model ID as a billing-vendor identity.

- models.dev lookup is admitted only through `PROVIDER_TO_MODELS_DEV` and searches that provider's model table. A mapped provider such as Xiaomi remains eligible even though its generic billing mode is `unknown`.
- OpenRouter's flat bare-ID lookup is admitted only when `route.provider == "openrouter"`.
- Unidentified, custom, local, and self-hosted routes therefore remain unpriced instead of inheriting a hosted rate from an unrelated vendor with a colliding model ID.

The regression fixture makes OpenRouter publish bare ID `glm-5` at `$0.95/M` input and `$3.80/M` output, then proves that `None`, `unknown`, `custom`, `local`, and Xiaomi routes cannot consume it. A genuine OpenRouter route still resolves the same fixture from OpenRouter's rate card.

This preserves the useful part of the earlier provider-scoping policy while avoiding the coarse `billing_mode == "unknown"` guard: named providers mapped by `PROVIDER_TO_MODELS_DEV` can still use their own catalog namespace.

## Display-path network safety

`has_known_pricing()` runs in display loops, so it now calls `get_pricing_entry(..., cache_only=True)`.

- OpenRouter metadata resolution uses memory/disk cache only (`allow_network=False`).
- models.dev resolution uses its existing memory/disk cache-only path.
- custom endpoint `/models` probing is skipped on this predicate path.
- Warm dynamic-catalog caches can still return `True`; a cold cache returns an honest unknown without blocking rendering.

## Configuration

`pricing.external_source` is registered in `DEFAULT_CONFIG`, so `hermes config set pricing.external_source ...` is recognized and typed as a string. `cli-config.yaml.example` documents the provider-scoped applicability of both source names.

## Validation

RED on current `origin/main`:

- `scripts/run_tests.sh tests/agent/test_usage_pricing_external_source.py -q`
- **7 passed, 20 failed** before the implementation.
- The original OpenRouter builder returned the hosted `glm-5` entry for every non-OpenRouter route.
- The display predicate opened a real TCP connection on a cold cache.

GREEN:

- Seven affected files through the repository's hermetic test runner: **553 passed, 0 failed**.
- New regression file: **27 passed, 0 failed**.
- `uv run ruff check .`: passed.
- `git diff --check`: passed.

Mutation proof:

- Removing only the `route.provider == "openrouter"` guard makes all five provider-scope cases fail with the armed `$0.95/M` entry.
- Changing only `has_known_pricing()` back to `cache_only=False` makes the connection sentinel fail with two outbound attempts.

`tests/agent/test_insights.py::TestHasKnownPricing::test_unknown_custom_model` remains unchanged and green; `glm-5` without an identified provider still returns `False`.

## Related work

This overlaps the models.dev fallback discussed in #56625 and the cache-rate work in #54268. This revision keeps source ordering in one pricing lane, uses the repository's existing provider mapping as the models.dev allowlist, and does not infer upstream vendors for arbitrary custom endpoints.
