### PR TITLE
fix(state): match the gateway channel/thread name in session search

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6002,9 +6002,18 @@ class SessionDB:
                 )
                 id_params.append(_like_pattern(id_needle))
             if search_needle:
-                # Same chain-membership trick as id_query, but matching either
-                # the title or the id of any session in the chain. The compact
-                # (punctuation-stripped) variant lets `an94` match `AN-94`.
+                # Same chain-membership trick as id_query, but matching the
+                # title, the id, or the gateway display name of any session in
+                # the chain. The compact (punctuation-stripped) variant lets
+                # `an94` match `AN-94`.
+                #
+                # display_name is the gateway's presentation string for a
+                # messaging origin — "Server / #channel / thread". Without it,
+                # a conversation that lives in a named channel is unfindable by
+                # that channel's name unless the words also happen to appear in
+                # its title, which is how users actually remember gateway
+                # sessions. It is a plain column on the same row the clause
+                # already joins, so matching it costs no extra join.
                 compact_needle = re.sub(r"[\W_]+", "", search_needle)
                 compact_sql = (
                     "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(COALESCE({0}, '')),"
@@ -6015,14 +6024,16 @@ class SessionDB:
                     " JOIN sessions cs ON cs.id = cq.cur_id"
                     " WHERE cq.root_id = s.id"
                     " AND (LOWER(COALESCE(cs.title, '')) LIKE ? ESCAPE '\\'"
+                    " OR LOWER(COALESCE(cs.display_name, '')) LIKE ? ESCAPE '\\'"
                     " OR LOWER(cq.cur_id) LIKE ? ESCAPE '\\'"
                 )
-                id_params.extend([_like_pattern(search_needle)] * 2)
+                id_params.extend([_like_pattern(search_needle)] * 3)
                 if compact_needle:
                     search_clause += (
                         f" OR {compact_sql.format('cs.title')} LIKE ? ESCAPE '\\'"
+                        f" OR {compact_sql.format('cs.display_name')} LIKE ? ESCAPE '\\'"
                     )
-                    id_params.append(_like_pattern(compact_needle))
+                    id_params.extend([_like_pattern(compact_needle)] * 2)
                 filter_clauses.append(search_clause + "))")
             if filter_clauses:
                 combined = " AND ".join(filter_clauses)

--- a/tests/hermes_state/test_session_search_display_name.py
+++ b/tests/hermes_state/test_session_search_display_name.py
@@ -1,0 +1,185 @@
+"""Session search matches the gateway channel/thread name, not just the title.
+
+``display_name`` is the gateway's presentation string for a messaging origin
+("Server / #channel / thread"). Users remember a gateway conversation by the
+channel it lives in far more reliably than by whatever title it ended up with,
+so ``list_sessions_rich(search_query=...)`` has to match it.
+"""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "search_state.db")
+    yield session_db
+    session_db.close()
+
+
+def make_gateway_session(
+    db,
+    session_id,
+    *,
+    source="discord",
+    title=None,
+    display_name=None,
+    text="some ordinary conversation text",
+):
+    """Create a session the way the gateway does: row, message, origin, title."""
+    db.create_session(session_id, source)
+    db.append_message(session_id, "user", text)
+    if display_name is not None:
+        db.record_gateway_session_peer(
+            session_id,
+            source=source,
+            session_key=f"key:{session_id}",
+            display_name=display_name,
+        )
+    if title is not None:
+        db.set_session_title(session_id, title)
+    return session_id
+
+
+def search(db, needle, **kwargs):
+    rows = db.list_sessions_rich(order_by_last_active=True, search_query=needle, **kwargs)
+    return [row["id"] for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# The gap: channel/thread names were unsearchable
+# ---------------------------------------------------------------------------
+
+
+def test_a_session_is_findable_by_its_channel_name(db):
+    """The regression this fixes.
+
+    A conversation in "Acme Guild / #finance" whose title says nothing about
+    finance was previously unreachable from search: the title lane missed it,
+    and message FTS only covers message text.
+    """
+    make_gateway_session(
+        db,
+        "s_channel",
+        title="Quarterly Budget Review",
+        display_name="Acme Guild / #finance",
+        text="numbers and projections",
+    )
+
+    assert search(db, "finance") == ["s_channel"]
+    assert search(db, "Acme Guild") == ["s_channel"]
+
+
+def test_channel_matching_is_case_insensitive(db):
+    make_gateway_session(db, "s_case", display_name="Acme Guild / #Voice-Assistant")
+
+    assert search(db, "VOICE") == ["s_case"]
+    assert search(db, "acme guild") == ["s_case"]
+
+
+def test_a_thread_name_is_searchable_the_same_way(db):
+    """display_name carries server / channel / thread; all three must match."""
+    make_gateway_session(
+        db, "s_thread", display_name="Acme Guild / #general / deploy-postmortem"
+    )
+
+    assert search(db, "postmortem") == ["s_thread"]
+
+
+def test_the_punctuation_stripped_variant_applies_to_channel_names_too(db):
+    """`an94` already finds `AN-94` in a title; the same must hold for a channel.
+
+    The compact variant is what makes hyphenated channel names findable the way
+    users type them.
+    """
+    make_gateway_session(db, "s_compact", display_name="Acme Guild / #an-94-ops")
+
+    assert search(db, "an94") == ["s_compact"]
+
+
+# ---------------------------------------------------------------------------
+# The existing lanes must not regress
+# ---------------------------------------------------------------------------
+
+
+def test_title_matching_still_works(db):
+    make_gateway_session(db, "s_title", title="Quarterly Budget Review")
+
+    assert search(db, "Quarterly") == ["s_title"]
+    assert search(db, "budget") == ["s_title"]
+
+
+def test_id_matching_still_works(db):
+    make_gateway_session(db, "s_distinctive_id", title="Untitled")
+
+    assert search(db, "distinctive") == ["s_distinctive_id"]
+
+
+def test_a_session_with_no_display_name_is_unaffected(db):
+    """A CLI session has display_name NULL; COALESCE must not make it match all."""
+    make_gateway_session(db, "s_cli", source="cli", title="Local Work")
+
+    assert search(db, "Local") == ["s_cli"]
+    assert search(db, "anything-else-entirely") == []
+
+
+def test_search_still_narrows_rather_than_returning_everything(db):
+    """A widened clause must not degenerate into matching every row."""
+    make_gateway_session(db, "s_a", title="Alpha", display_name="Server / #alpha-room")
+    make_gateway_session(db, "s_b", title="Beta", display_name="Server / #beta-room")
+    make_gateway_session(db, "s_c", title="Gamma", display_name="Server / #gamma-room")
+
+    assert search(db, "beta") == ["s_b"]
+    assert search(db, "zzz-matches-nothing") == []
+    assert sorted(search(db, "room")) == ["s_a", "s_b", "s_c"]
+
+
+def test_like_wildcards_in_the_needle_are_escaped_not_interpreted(db):
+    """A user typing `%` must match a literal percent sign, not every session.
+
+    An unescaped `%` in the widened display_name clause would turn the whole
+    predicate into a tautology and return the entire session table.
+    """
+    make_gateway_session(db, "alpha", title="Plain Title", display_name="Server / #room")
+    make_gateway_session(db, "beta", display_name="Server / #100%-uptime")
+
+    assert search(db, "%") == ["beta"]
+    assert search(db, "_") == []
+
+
+def test_the_needle_matches_display_name_across_a_compression_chain(db):
+    """Search admits a root whose forward chain matches — channel lane included.
+
+    The clause walks the same ``chain`` CTE the title and id lanes use, so a
+    conversation that compressed onto a continuation still surfaces under its
+    channel name from the root row.
+    """
+    root = make_gateway_session(db, "s_root", title="Old Root")
+    db.end_session(root, end_reason="compression")
+    db.create_session("s_tip", "discord", parent_session_id=root)
+    db.append_message("s_tip", "user", "continued")
+    db.record_gateway_session_peer(
+        "s_tip",
+        source="discord",
+        session_key="key:s_tip",
+        display_name="Acme Guild / #late-named-channel",
+    )
+
+    # The root is what the query admits; the default tip projection then
+    # surfaces it as the live continuation, exactly as the title lane does.
+    (row,) = db.list_sessions_rich(
+        order_by_last_active=True, search_query="late-named-channel"
+    )
+
+    assert row["id"] == "s_tip"
+    assert row["_lineage_root_id"] == "s_root"
+
+
+def test_display_name_survives_to_the_returned_row(db):
+    """Callers ranking a channel hit need the value that matched."""
+    make_gateway_session(db, "s_payload", display_name="Acme Guild / #finance")
+
+    (row,) = db.list_sessions_rich(order_by_last_active=True, search_query="finance")
+
+    assert row["display_name"] == "Acme Guild / #finance"


### PR DESCRIPTION
# fix(state): match the gateway channel/thread name in session search

## The problem

Session search — the `search_query` lane of
`SessionDB.list_sessions_rich`, behind `/sessions search` and the CLI/gateway
session picker — matches a session's **title** and its **id**. It does not
match `display_name`, the gateway's presentation string for a messaging
origin (`"Server / #channel / thread"`, added in #9006).

Users remember a gateway conversation by the channel it lives in far more
reliably than by whatever title it ended up with. And message FTS can't cover
the gap: `messages_fts` indexes `content` / `tool_name` / `tool_calls` from
`messages`, so the channel name appears in no index at all.

Result: a conversation in a named channel whose title says nothing about that
channel is findable by **no** surface.

Reproduced on `main` (`dacd8d541`):

```python
sid = db.create_session("s1", "discord")
db.append_message(sid, "user", "hello weather")
db.set_session_title(sid, "Quarterly Budget Review")
db.record_gateway_session_peer(sid, source="discord", session_key="k",
                               display_name="Acme Guild / #finance")

search_query='Quarterly'    -> ['s1']    # title lane
search_query='budget'       -> ['s1']    # title lane
search_query='finance'      -> []        # <- the channel it lives in
search_query='Acme Guild'   -> []        # <- the server it lives in

db.search_messages("finance*") -> []     # FTS can't help: message text only
db.search_messages("weather*") -> ['s1'] # control
```

## The change

One column added to the existing search predicate. The clause already
`JOIN sessions cs ON cs.id = cq.cur_id` in order to read `cs.title`;
`display_name` is a plain column on that same row, so this is one more `LIKE`
against a row already being examined — **no new method, no new join, no new
index, no schema change.**

Both variants stay in step with the title lane:

- the raw needle, and
- the punctuation-stripped compact form — so `an94` finds the channel
  `#an-94-ops` the same way it already finds the title `AN-94`.

`LIKE` wildcards in the needle keep the existing `ESCAPE` treatment, which
matters *more* after widening: an unescaped `%` would turn the predicate into
a tautology and return the entire session table. Pinned by
`test_like_wildcards_in_the_needle_are_escaped_not_interpreted`.

The clause walks the same `chain` CTE the title and id lanes use, so a
conversation that compressed onto a continuation still surfaces under a
channel name attached to the tip — pinned by
`test_the_needle_matches_display_name_across_a_compression_chain`.

## Why extend `search_query` rather than add a title/channel search method

`list_sessions_rich(search_query=...)` is already the single SQL-level search
lane behind every session-picking surface (`hermes_cli/session_listing.py`
→ `query_session_listing`, used by the CLI picker and `gateway/slash_commands.py`
`/sessions search`). Adding a sibling `search_sessions_by_channel()` would
duplicate the chain CTE, the compact-needle normalization, the escaping, and
the visibility contract, and would leave the two to drift. Extending the
existing predicate keeps one lane with one contract.

## Tests

`tests/hermes_state/test_session_search_display_name.py` — **11 tests.** All
run against a real `SessionDB` on a temp file in the per-test `HERMES_HOME`,
building rows the way the gateway does (`create_session` → `append_message` →
`record_gateway_session_peer` → `set_session_title`). No mocks.

Three of the eleven are deliberate no-regression guards that pass on `main`
too — title matching, id matching, and "a CLI session with `display_name`
NULL is unaffected" (a `COALESCE` mistake here would make every NULL-channel
row match everything).

**RED-proved:** 8 failed / 3 passed on this commit's parent; 11 passed with
the change.

**Regression scope:** 560 passed across `tests/test_hermes_state.py`,
`tests/hermes_state/`, and `tests/hermes_cli/test_session_listing.py`
(the last is the existing behavioural contract for this exact lane — green
unchanged, no existing expectation edited). 16 passed across
`tests/hermes_cli/test_web_server_session_search.py` and
`tests/test_fts_cjk_bigram.py`. `ruff check` clean.

See `TEST-EVIDENCE.md` for the full transcripts.

## Not included, and why

The shortlist this came from also carried a **session-list recency
denormalization** (a `sessions.effective_last_active` column + indexes +
backfill marker, replacing the recursive CTE in
`list_sessions_rich(order_by_last_active=True)`).

That is deliberately **not** in this PR. The underlying latency is real —
measured on a 20,000-session / 160,000-message DB, the CTE-ordered page costs
249.7 ms against 0.4 ms for the same page unordered — but landing it means a
schema migration plus a backfill marker in the repo's most-churned file,
right after `main` moved to `SCHEMA_VERSION = 23`. It deserves its own PR with
its own migration-path proof, not a rider on a search fix.

For the record, since `sessions optimize-storage` shipped recently and the
question naturally arises: the two are **orthogonal**. v23 changed the FTS5
tables over `messages` from inline to external content (disk footprint and
write amplification); the denorm would touch `sessions` and the `ORDER BY`
path. They share no table, column, trigger, or `state_meta` marker keyspace,
and `optimize-storage` does not move any of the numbers above.

## Relationship to open PR #62399 (complementary, not overlapping)

Both touch `hermes_state.py`, so to be explicit about the seam:

- **#62399** adds a *new* method, `search_sessions_by_title()`, consumed by the
  desktop sidebar via `hermes_cli/web_server.py`. It has its own
  title+`display_name` candidate scan.
- **This PR** widens the existing `search_query` predicate inside
  `list_sessions_rich()`, which is the lane used by the **gateway `/sessions`
  search and the CLI** (`hermes_cli/session_listing.py:72` →
  `gateway/slash_commands.py:4122`, `cli.py:7354`).

They are different methods serving different surfaces, so #62399 does not fix
this bug on the gateway/CLI lane. Verified empirically — with only #62399's
Python half applied on `origin/main`, a Discord session in
`"Acme Guild / #finance"` titled `"Quarterly Budget Review"`:

```
'finance'      list_sessions_rich -> []            search_sessions_by_title -> 1 hit
'Acme Guild'   list_sessions_rich -> []            search_sessions_by_title -> 1 hit
'Quarterly'    list_sessions_rich -> ['s_channel'] search_sessions_by_title -> 1 hit
```

The gateway/CLI lane is still blind to the channel name. This patch also
applies cleanly on top of #62399 and the combined tree is green
(`486 passed` across `tests/hermes_state/`, `tests/test_hermes_state.py`, and
`tests/hermes_cli/test_web_server_session_search.py`), so the two can merge in
either order.
