### PR TITLE
fix(approval): preserve Windows path command boundaries

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -174,6 +174,32 @@ class TestWindowsShellDestructiveCommands:
         assert key is not None
         assert desc == "Windows cmd destructive delete"
 
+    def test_extended_absolute_cmd_path_requires_approval(self):
+        command = r"\\?\C:\Windows\System32\cmd.exe /c del /q C:\data"
+        normalized = approval_module._normalize_command_for_detection(command)
+        assert normalized == "//?/C:/Windows/System32/cmd.exe /c del /q C:/data"
+
+        dangerous, key, desc = detect_dangerous_command(command)
+        assert dangerous is True
+        assert key is not None
+        assert desc == "Windows cmd destructive delete"
+
+    def test_quoted_device_absolute_pwsh_path_requires_approval(self):
+        command = (
+            r'"\\.\C:\Program Files\PowerShell\7\pwsh.exe" '
+            r"-Command Remove-Item -Recurse C:\data"
+        )
+        normalized = approval_module._normalize_command_for_detection(command)
+        assert normalized == (
+            '"//./C:/Program Files/PowerShell/7/pwsh.exe" '
+            "-Command Remove-Item -Recurse C:/data"
+        )
+
+        dangerous, key, desc = detect_dangerous_command(command)
+        assert dangerous is True
+        assert key is not None
+        assert desc == "Windows PowerShell destructive delete"
+
     def test_windows_destructive_requires_approval(self):
         cases = [
             (r"cmd /c del /f /q C:\tmp\hermes-victim\file.txt", "Windows cmd destructive delete"),

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -144,6 +144,36 @@ class TestDetectDangerousRm:
 
 
 class TestWindowsShellDestructiveCommands:
+    def test_absolute_taskkill_path_keeps_executable_boundary(self):
+        normalized = approval_module._normalize_command_for_detection(
+            r"C:\Windows\System32\taskkill.exe /f /im hermes.exe"
+        )
+        assert normalized == "C:/Windows/System32/taskkill.exe /f /im hermes.exe"
+
+    def test_absolute_cmd_path_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command(
+            r"C:\Windows\System32\cmd.exe /c del /s /q C:\data"
+        )
+        assert dangerous is True
+        assert key is not None
+        assert desc == "Windows cmd destructive delete"
+
+    def test_quoted_absolute_pwsh_path_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command(
+            r'"C:\Program Files\PowerShell\7\pwsh.exe" -Command Remove-Item -Recurse C:\data'
+        )
+        assert dangerous is True
+        assert key is not None
+        assert desc == "Windows PowerShell destructive delete"
+
+    def test_unc_cmd_path_requires_approval(self):
+        dangerous, key, desc = detect_dangerous_command(
+            r"\\server\share\cmd.exe /c del /q C:\data"
+        )
+        assert dangerous is True
+        assert key is not None
+        assert desc == "Windows cmd destructive delete"
+
     def test_windows_destructive_requires_approval(self):
         cases = [
             (r"cmd /c del /f /q C:\tmp\hermes-victim\file.txt", "Windows cmd destructive delete"),

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -913,6 +913,40 @@ def _approval_key_aliases(pattern_key: str) -> set[str]:
 # Detection
 # =========================================================================
 
+# Windows absolute paths are unambiguous command-line path syntax. Preserve
+# their separators before the generic POSIX shell escape fold below; otherwise
+# ``C:\Windows\System32\cmd.exe`` becomes ``C:WindowsSystem32cmd.exe`` and
+# destroys the word boundary every ``\bcmd\b``-style safety rule relies on.
+# Quoted paths get a separate expression so spaces remain part of the path.
+_WINDOWS_QUOTED_ABSOLUTE_PATH_RE = re.compile(
+    r"(?P<quote>[\"'])(?P<path>(?:[A-Za-z]:[\\/]|(?:\\\\|//)(?:[?.][\\/])?)[^\"'\r\n]+)(?P=quote)"
+)
+_WINDOWS_UNQUOTED_ABSOLUTE_PATH_RE = re.compile(
+    r"(?P<path>(?:[A-Za-z]:[\\/]|(?:\\\\|//)(?:[?.][\\/])?)[^\s\"'`;|&<>()]+)"
+)
+
+
+def _normalize_windows_absolute_path_separators(command: str) -> str:
+    r"""Rewrite separators inside unambiguous Windows absolute path tokens.
+
+    Drive-rooted, UNC, and extended/device paths are normalized to forward
+    slashes. This preserves executable-name word boundaries while leaving shell
+    escape obfuscation outside those path tokens available to the existing
+    ``r\m -> rm`` fold.
+    """
+
+    def _quoted_replacement(match: re.Match) -> str:
+        quote = match.group("quote")
+        path = match.group("path").replace("\\", "/")
+        return f"{quote}{path}{quote}"
+
+    command = _WINDOWS_QUOTED_ABSOLUTE_PATH_RE.sub(_quoted_replacement, command)
+    return _WINDOWS_UNQUOTED_ABSOLUTE_PATH_RE.sub(
+        lambda match: match.group("path").replace("\\", "/"),
+        command,
+    )
+
+
 def _normalize_command_for_detection(command: str) -> str:
     """Normalize a command string before dangerous-pattern matching.
 
@@ -955,6 +989,9 @@ def _normalize_command_for_detection(command: str) -> str:
     # first would eat the prefix the Hermes-home fold needs.
     command = _rewrite_resolved_hermes_home(command)
     command = _rewrite_resolved_user_home(command)
+    # Preserve unambiguous Windows path separators as token boundaries before
+    # the generic POSIX shell backslash-escape fold below (#71890).
+    command = _normalize_windows_absolute_path_separators(command)
     # Strip shell backslash-escapes: r\m → rm. Prevents \-injection bypass.
     command = re.sub(r'\\([^\n])', r'\1', command)
     # Strip empty-string literals that split tokens: r''m → rm, r"\"m → rm.


### PR DESCRIPTION
## What does this PR do?

Preserves executable-name token boundaries when dangerous-command detection receives an absolute Windows path.

`_normalize_command_for_detection()` intentionally strips POSIX shell backslash escapes so obfuscations such as `r\m -r\f /` become `rm -rf /`. The same global fold also transformed a native path such as:

```text
C:\Windows\System32\cmd.exe
```

into:

```text
C:WindowsSystem32cmd.exe
```

That fuses the path prefix to the executable name, so `\bcmd(?:\.exe)?\b`, `\bpwsh\b`, and similar safety rules cannot match.

Before the generic escape fold, this change identifies unambiguous drive-rooted, UNC, extended (`\\?\`), and device (`\\.\`) absolute path tokens and normalizes only their separators to `/`. Quoted paths retain embedded spaces. Backslashes outside those path tokens still take the existing shell de-obfuscation path.

## Related issue

Fixes #71890.

Related to #35971, which adds Windows self-termination patterns. This PR fixes the shared normalization layer those and existing Windows patterns depend on; it does not add or change taskkill policy.

## Changes made

- `tools/approval.py`
  - recognize quoted and unquoted Windows absolute path tokens
  - normalize separators inside drive-rooted, UNC, extended, and device paths before shell escape stripping
  - retain the existing `r\m -> rm` command-word de-obfuscation contract
- `tests/tools/test_approval.py`
  - cover drive-rooted `cmd.exe /c del`
  - cover a quoted `pwsh.exe` path containing spaces
  - cover UNC `cmd.exe /c del`
  - cover extended `\\?\...\cmd.exe` and quoted device `\\.\...\pwsh.exe` forms
  - pin the reporter's absolute `taskkill.exe` normalization shape without adding a new policy rule

## Validation

Fresh verification on the current head:

```text
Focused canonical security slice: 15 passed
Ruff:                             passed
py_compile -Werror:               passed
Windows-footgun scan:             passed
Diff hygiene:                     passed
GitHub CI:                        passed
```

The destructive-command regressions fail on the pre-fix behavior because detection returns `(False, None, None)`. The POSIX shell-escape bypass controls remain green.
