### PR TITLE
fix(telegram): normalize provider slug case in /model picker keyboard (#35932)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5659,7 +5659,11 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception:
             group_providers = None
 
-        by_slug = {p.get("slug"): p for p in providers}
+        # group_providers() normalises slugs to lowercase for canonical
+        # matching; the lookup dict must use the same casing so providers
+        # whose configured slug is mixed-case (e.g. "BitFun") still resolve
+        # instead of being silently dropped from the keyboard. See #35932.
+        by_slug = {p.get("slug", "").lower(): p for p in providers}
 
         def _provider_button(p):
             count = p.get("total_models", len(p.get("models", [])))
@@ -6017,7 +6021,10 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception:
                 _label, member_slugs = "", []
 
-            by_slug = {p["slug"]: p for p in state["providers"]}
+            # Member slugs from PROVIDER_GROUPS are lowercase; the lookup
+            # must be case-insensitive so mixed-case configured slugs
+            # (e.g. "Minimax") resolve here too. See #35932.
+            by_slug = {p.get("slug", "").lower(): p for p in state["providers"]}
             members = [by_slug[m] for m in member_slugs if m in by_slug]
             if not members:
                 await query.answer(text="Group not found.")

--- a/tests/gateway/test_telegram_model_picker.py
+++ b/tests/gateway/test_telegram_model_picker.py
@@ -354,3 +354,98 @@ class TestTelegramModelPicker:
         assert len(call_log) == 2
         assert call_log[0]["message_thread_id"] == 99999
         assert "message_thread_id" not in call_log[1] or call_log[1]["message_thread_id"] is None
+
+    def test_provider_keyboard_shows_mixed_case_slug_provider(self, monkeypatch):
+        """Regression for #35932: providers with mixed-case slugs (e.g.
+        'BitFun') must still appear in the /model picker keyboard.
+
+        group_providers() lowercases slugs when emitting its rows, so the
+        by_slug lookup in _build_provider_keyboard must key on the lowercased
+        slug too — otherwise the lookup fails and the provider is silently
+        dropped from the keyboard."""
+        import plugins.platforms.telegram.adapter as tg
+
+        built: list = []
+
+        class _RecordingButton:
+            def __init__(self, text, callback_data=None, **kw):
+                self.text = text
+                self.callback_data = callback_data
+                built.append(callback_data)
+
+        class _RecordingMarkup:
+            def __init__(self, rows):
+                self.inline_keyboard = rows
+
+        monkeypatch.setattr(tg, "InlineKeyboardButton", _RecordingButton)
+        monkeypatch.setattr(tg, "InlineKeyboardMarkup", _RecordingMarkup)
+
+        adapter = _make_adapter()
+
+        # Mixed-case slug that would be silently dropped without the fix.
+        # group_providers() emits this as {"slug": "bitfun", "kind": ...}
+        # (lowercased), so by_slug must use the lowercased key to resolve it.
+        providers = [
+            {"slug": "BitFun", "name": "BitFun", "total_models": 2, "is_current": False},
+        ]
+
+        adapter._build_provider_keyboard(providers)
+
+        # The provider must surface as a direct mp: button with its ORIGINAL
+        # slug preserved in callback_data (so the configured slug still
+        # works when the user taps it).
+        assert "mp:BitFun" in built, "Mixed-case slug provider was dropped from the picker"
+        assert "mx" in built  # Cancel button is always present
+
+    @pytest.mark.asyncio
+    async def test_provider_group_callback_resolves_mixed_case_member_slugs(self, monkeypatch):
+        """Regression for #35932: the mpg: callback path must resolve group
+        members case-insensitively. PROVIDER_GROUPS emits lowercase member
+        slugs, but the provider's configured slug may be mixed-case (e.g.
+        'Minimax'); the by_slug lookup in the callback must lowercase its
+        keys or the group expansion shows no members for the mixed-case one."""
+        import plugins.platforms.telegram.adapter as tg
+
+        built: list = []
+
+        class _RecordingButton:
+            def __init__(self, text, callback_data=None, **kw):
+                self.text = text
+                self.callback_data = callback_data
+                built.append(callback_data)
+
+        class _RecordingMarkup:
+            def __init__(self, rows):
+                self.inline_keyboard = rows
+
+        monkeypatch.setattr(tg, "InlineKeyboardButton", _RecordingButton)
+        monkeypatch.setattr(tg, "InlineKeyboardMarkup", _RecordingMarkup)
+
+        adapter = _make_adapter()
+        adapter._model_picker_state["12345"] = {
+            "providers": [
+                {"slug": "Minimax", "name": "Minimax", "total_models": 2},
+                {"slug": "minimax-cn", "name": "Minimax CN", "total_models": 3},
+            ],
+            "current_model": "m",
+            "current_provider": "Minimax",
+            "session_key": "s",
+            "on_model_selected": AsyncMock(),
+            "msg_id": 42,
+        }
+
+        query = AsyncMock()
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        await adapter._handle_model_picker_callback(query, "mpg:minimax", "12345")
+
+        # Both members must surface as mp: buttons. Before the fix, the
+        # mixed-case "Minimax" slug would not match the lowercase "minimax"
+        # member slug from PROVIDER_GROUPS, so only minimax-cn appeared.
+        assert "mp:Minimax" in built, "Mixed-case group member 'Minimax' was dropped"
+        assert "mp:minimax-cn" in built
+        assert "mb" in built  # Back button


### PR DESCRIPTION
## What

Fixes #35932.

`group_providers()` lowercases provider slugs in its output, but the `by_slug` lookup dicts in `_build_provider_keyboard()` and the `mpg:` group callback handler used original-case keys. This meant providers whose configured slug was mixed-case (e.g. `BitFun`, `Minimax`) were silently dropped from the `/model` picker keyboard - the lookup failed and the button just wasn't rendered.

## Why

Existing PRs targeting this issue (#35933, #35953, #37282) patch `gateway/platforms/telegram.py`, which no longer exists on `main` - the Telegram adapter was moved into the plugins tree as `plugins/platforms/telegram/adapter.py`. Those PRs therefore cannot merge cleanly and the bug has remained live.

This PR targets the correct file.

## Changes

`plugins/platforms/telegram/adapter.py`:
- `_build_provider_keyboard()`: build `by_slug` with lowercased slug keys so the lookup matches the lowercased slugs emitted by `group_providers()`.
- `_handle_model_picker_callback()` (`mpg:` branch): same case-normalization on the `by_slug` lookup that resolves group members.
- The provider's original (configured-case) slug is preserved in `callback_data` (`mp:<original-slug>`), so identity elsewhere is unaffected.

`tests/gateway/test_telegram_model_picker.py`:
- `test_provider_keyboard_shows_mixed_case_slug_provider` - adds a provider with a mixed-case slug (`BitFun`) and asserts it still appears as `mp:BitFun` in the picker keyboard.
- `test_provider_group_callback_resolves_mixed_case_member_slugs` - asserts the `mpg:` callback path expands group members case-insensitively (`Minimax` still renders as `mp:Minimax`).

## How to verify

```
scripts/run_tests.sh tests/gateway/test_telegram_model_picker.py
```

Both new regression tests fail on the pre-fix code and pass after this change; all existing picker tests still pass.

## Notes for reviewers

- The fix is intentionally minimal: only the lookup-dict key casing changes. No touch to `group_providers()`, `PROVIDER_GROUPS`, or callback_data format.
- Built on a fresh worktree off `upstream/main`, so this branch contains only the fix + tests (no merge noise).