### PR TITLE
Redact Feishu websocket credentials from SDK logs

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -177,6 +177,25 @@ _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_FEISHU_SDK_SECRET_QUERY_RE = re.compile(
+    r"(?i)([?&](?:access_key|ticket|token|app_secret)=)[^&\s\]\"']+"
+)
+
+
+def _redact_feishu_sdk_log(message: str) -> str:
+    """Remove credentials embedded in URLs emitted by the Lark SDK."""
+    return _FEISHU_SDK_SECRET_QUERY_RE.sub(r"\1[REDACTED]", message)
+
+
+class _FeishuSDKLogRedactionFilter(logging.Filter):
+    """Redact SDK credentials before any attached handler formats a record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.msg = _redact_feishu_sdk_log(record.getMessage())
+        record.args = ()
+        return True
+
+
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -1319,6 +1338,24 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
 
     original_connect = ws_client_module.websockets.connect
     original_configure = getattr(ws_client, "_configure", None)
+    lark_sdk_logger = getattr(ws_client_module, "logger", logging.getLogger("Lark"))
+    log_redaction_filter = _FeishuSDKLogRedactionFilter()
+    original_sdk_log = lark_sdk_logger._log
+
+    def _redacted_sdk_log(level: int, message: object, args: Any, *rest: Any, **kwargs: Any) -> Any:
+        return original_sdk_log(
+            level,
+            _redact_feishu_sdk_log(str(message)),
+            args,
+            *rest,
+            **kwargs,
+        )
+
+    lark_sdk_logger._log = _redacted_sdk_log
+    lark_sdk_logger.addFilter(log_redaction_filter)
+    filtered_handlers = list(lark_sdk_logger.handlers)
+    for handler in filtered_handlers:
+        handler.addFilter(log_redaction_filter)
 
     def _apply_runtime_ws_overrides() -> None:
         try:
@@ -1352,6 +1389,10 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     except Exception:
         pass
     finally:
+        lark_sdk_logger._log = original_sdk_log
+        lark_sdk_logger.removeFilter(log_redaction_filter)
+        for handler in filtered_handlers:
+            handler.removeFilter(log_redaction_filter)
         ws_client_module.websockets.connect = original_connect
         if original_configure is not None:
             setattr(ws_client, "_configure", original_configure)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -712,6 +712,42 @@ class TestAdapterModule(unittest.TestCase):
         self.assertEqual(fake_client._reconnect_interval, 3)
         self.assertEqual(fake_client._ping_interval, 4)
 
+    def test_feishu_sdk_log_redaction_removes_credentials(self):
+        from plugins.platforms.feishu.adapter import _redact_feishu_sdk_log
+
+        message = (
+            "connected to wss://example.test/ws?device_id=device-1"
+            "&access_key=secret-key&ticket=secret-ticket&service_id=service-1"
+        )
+        redacted = _redact_feishu_sdk_log(message)
+
+        self.assertNotIn("secret-key", redacted)
+        self.assertNotIn("secret-ticket", redacted)
+        self.assertIn("access_key=[REDACTED]", redacted)
+        self.assertIn("ticket=[REDACTED]", redacted)
+        self.assertIn("device_id=device-1", redacted)
+        self.assertIn("service_id=service-1", redacted)
+
+    def test_feishu_sdk_log_filter_formats_args_before_redaction(self):
+        import logging
+
+        from plugins.platforms.feishu.adapter import _FeishuSDKLogRedactionFilter
+
+        record = logging.LogRecord(
+            "Lark",
+            logging.INFO,
+            __file__,
+            1,
+            "connected to %s",
+            ("wss://example.test/ws?access_key=secret&ticket=ticket-secret",),
+            None,
+        )
+
+        self.assertTrue(_FeishuSDKLogRedactionFilter().filter(record))
+        self.assertNotIn("secret", record.getMessage())
+        self.assertIn("access_key=[REDACTED]", record.getMessage())
+        self.assertIn("ticket=[REDACTED]", record.getMessage())
+
 
 def _admits_group(adapter, message, sender_id, chat_id=""):
     """Group-path shim: run a message through ``_admit`` and return a bool."""


### PR DESCRIPTION
## What changed

- redacts `access_key`, `ticket`, token, and app-secret query parameters from Lark SDK log records
- applies the protection to the exact SDK logger and its handlers for defense in depth
- restores all temporary logger hooks when the websocket client exits
- adds regression tests for URL redaction and deferred `%s` log formatting

## Why

The official Lark websocket SDK logs its complete connection URL at INFO level. That URL contains short-lived connection credentials, so journald could retain them in plaintext.

## Impact

Normal connection diagnostics remain visible, including non-sensitive connection metadata, while credential values are replaced with `[REDACTED]` before formatting.

## Validation

- 207 Feishu tests passed against the deployed Hermes revision
- both added tests pass after rebasing onto current upstream `main`
- live process validation observed one connection record, two redacted credential fields, and zero plaintext credential values
- `git diff --check` passed

The full latest-upstream test file has one environment-only failure with the deployment virtualenv's older `lark-oapi`, which lacks the new `extra_ua_tags` parameter; it is unrelated to this patch.
