### PR TITLE
fix(usage): show custom provider quotas across clients

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import httpx
 
-from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
+from agent.anthropic_adapter import _is_oauth_token, _requires_bearer_auth, resolve_anthropic_token
 from hermes_cli.auth import AuthError, _read_codex_tokens, resolve_codex_runtime_credentials
 from hermes_cli.runtime_provider import resolve_runtime_provider
 
@@ -881,14 +881,257 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+def _custom_usage_base_identity(
+    value: Optional[str],
+) -> Optional[tuple[str, str, int, str, str]]:
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(str(value or "").strip())
+        scheme = parsed.scheme.lower()
+        if scheme not in {"http", "https"} or not parsed.hostname:
+            return None
+        if parsed.username is not None or parsed.password is not None:
+            return None
+        port = parsed.port or (443 if scheme == "https" else 80)
+        return (
+            scheme,
+            parsed.hostname.lower(),
+            port,
+            parsed.path.rstrip("/"),
+            parsed.query,
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _custom_usage_config_entry(
+    provider: Optional[str],
+    base_url: Optional[str],
+) -> Optional[dict[str, Any]]:
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+        from hermes_cli.providers import custom_provider_aliases
+
+        entries = get_compatible_custom_providers()
+        requested = str(provider or "custom").strip().lower()
+        if requested != "custom":
+            return next(
+                (
+                    entry
+                    for entry in entries
+                    if requested
+                    in custom_provider_aliases(
+                        str(entry.get("name") or ""),
+                        str(entry.get("provider_key") or ""),
+                    )
+                ),
+                None,
+            )
+
+        target = _custom_usage_base_identity(base_url)
+        if target is None:
+            return None
+        matches = [
+            entry
+            for entry in entries
+            if _custom_usage_base_identity(str(entry.get("base_url") or "")) == target
+        ]
+        return matches[0] if len(matches) == 1 else None
+    except Exception:
+        return None
+
+
+def _peek_custom_usage_api_key(entry: dict[str, Any], base_url: str) -> Optional[str]:
+    try:
+        from agent.credential_pool import get_custom_provider_pool_key, load_pool
+
+        pool_key = get_custom_provider_pool_key(
+            base_url,
+            provider_name=str(entry.get("name") or ""),
+        )
+        if pool_key:
+            pooled = load_pool(pool_key).peek()
+            pooled_key = getattr(pooled, "runtime_api_key", None) if pooled else None
+            if pooled_key:
+                return str(pooled_key)
+    except Exception:
+        pass
+
+    try:
+        from agent.secret_scope import get_secret
+        from hermes_cli.auth import has_usable_secret
+
+        candidates = [entry.get("api_key")]
+        key_env = str(entry.get("key_env") or "").strip()
+        if key_env:
+            candidates.append(get_secret(key_env, ""))
+        return next(
+            (
+                str(candidate).strip()
+                for candidate in candidates
+                if has_usable_secret(candidate)
+            ),
+            None,
+        )
+    except Exception:
+        return None
+
+
+def _fetch_custom_account_usage(
+    provider: Optional[str],
+    base_url: Optional[str],
+    api_key: Optional[str],
+    api_mode: Optional[str],
+) -> Optional[AccountUsageSnapshot]:
+    resolved_base_url = str(base_url or "").strip()
+    resolved_api_key = api_key
+    resolved_api_mode = str(api_mode or "").strip().lower()
+    extra_headers: dict[str, str] = {}
+    live_pair_complete = bool(resolved_base_url) and resolved_api_key is not None
+    config_entry = _custom_usage_config_entry(provider, resolved_base_url)
+    config_base_url = str((config_entry or {}).get("base_url") or "").strip()
+    config_matches_live = (
+        live_pair_complete
+        and _custom_usage_base_identity(config_base_url) is not None
+        and _custom_usage_base_identity(config_base_url)
+        == _custom_usage_base_identity(resolved_base_url)
+    )
+
+    if config_entry and (not live_pair_complete or config_matches_live):
+        raw_headers = config_entry.get("extra_headers")
+        if isinstance(raw_headers, dict):
+            extra_headers = {
+                str(key): str(value)
+                for key, value in raw_headers.items()
+                if value is not None
+            }
+
+    if not live_pair_complete:
+        # A partial caller pair is never combined with unrelated config. Only a
+        # uniquely identified entry can supply the complete endpoint/key pair.
+        if config_entry and config_base_url:
+            resolved_base_url = config_base_url
+            resolved_api_key = _peek_custom_usage_api_key(config_entry, config_base_url)
+            resolved_api_mode = str(config_entry.get("api_mode") or "").strip().lower()
+        else:
+            resolved_api_key = None
+    elif config_matches_live and not resolved_api_mode:
+        resolved_api_mode = str((config_entry or {}).get("api_mode") or "").strip().lower()
+
+    if not resolved_base_url:
+        return None
+    try:
+        from urllib.parse import urlparse, urlunparse
+
+        parsed = urlparse(resolved_base_url)
+        if _custom_usage_base_identity(resolved_base_url) is None:
+            return None
+        base_path = parsed.path.rstrip("/")
+        usage_path = f"{base_path}/usage" if base_path.endswith("/v1") else f"{base_path}/v1/usage"
+        usage_url = urlunparse(
+            (parsed.scheme, parsed.netloc, usage_path, "", parsed.query, "")
+        )
+        headers = dict(extra_headers)
+        key = str(resolved_api_key or "").strip()
+        if key and key != "no-key-required":
+            lowered_header_names = {name.lower() for name in headers}
+            if not resolved_api_mode:
+                resolved_api_mode = (
+                    "anthropic_messages"
+                    if "/anthropic" in parsed.path.lower()
+                    else "chat_completions"
+                )
+            if resolved_api_mode == "anthropic_messages":
+                if _requires_bearer_auth(resolved_base_url):
+                    if "authorization" not in lowered_header_names:
+                        headers["Authorization"] = f"Bearer {key}"
+                elif "x-api-key" not in lowered_header_names:
+                    headers["x-api-key"] = key
+            elif "authorization" not in lowered_header_names:
+                headers["Authorization"] = f"Bearer {key}"
+        from agent.ssl_verify import resolve_httpx_verify
+
+        verify = resolve_httpx_verify(
+            ca_bundle=str((config_entry or {}).get("ssl_ca_cert") or "")
+            if config_matches_live or not live_pair_complete
+            else None,
+            ssl_verify=(config_entry or {}).get("ssl_verify")
+            if config_matches_live or not live_pair_complete
+            else None,
+            base_url=resolved_base_url,
+        )
+        with httpx.Client(timeout=5.0, verify=verify) as client:
+            resp = client.get(usage_url, headers=headers)
+            if resp.status_code != 200:
+                return None
+            data = resp.json()
+            if not isinstance(data, dict):
+                return None
+
+            provider_name = str(data.get("provider") or "custom-proxy")
+            windows_raw = data.get("windows", [])
+            windows: list[AccountUsageWindow] = []
+            if isinstance(windows_raw, list):
+                for w in windows_raw:
+                    if isinstance(w, dict):
+                        label = str(w.get("label") or "Quota")
+                        used_pct = w.get("used_percent")
+                        rem_frac = w.get("remaining_fraction")
+                        if used_pct is None and _is_finite_num(rem_frac):
+                            used_pct = (1.0 - float(rem_frac)) * 100.0
+                        normalized_used_pct = (
+                            min(100.0, max(0.0, float(used_pct)))
+                            if _is_finite_num(used_pct)
+                            else None
+                        )
+                        reset_at = _parse_dt(w.get("reset_at"))
+                        windows.append(
+                            AccountUsageWindow(
+                                label=label,
+                                used_percent=normalized_used_pct,
+                                reset_at=reset_at,
+                            )
+                        )
+
+            details: list[str] = []
+            models_raw = data.get("models", [])
+            if isinstance(models_raw, list) and not windows:
+                for m in models_raw:
+                    if isinstance(m, dict):
+                        name = str(m.get("display_name") or m.get("id") or "Model")
+                        used = m.get("used_percent")
+                        if _is_finite_num(used):
+                            used_pct = min(100.0, max(0.0, float(used)))
+                            details.append(
+                                f"{name}: {100.0 - used_pct:.0f}% remaining "
+                                f"({used_pct:.0f}% used)"
+                            )
+
+            if not windows and not details:
+                return None
+
+            return AccountUsageSnapshot(
+                provider=provider_name,
+                source=str(data.get("source") or "custom-api"),
+                fetched_at=_utc_now(),
+                title="Account limits",
+                windows=tuple(windows),
+                details=tuple(details),
+            )
+    except Exception:
+        return None
+
+
 def fetch_account_usage(
     provider: Optional[str],
     *,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
+    api_mode: Optional[str] = None,
 ) -> Optional[AccountUsageSnapshot]:
     normalized = str(provider or "").strip().lower()
-    if normalized in {"", "auto", "custom"}:
+    if normalized in {"", "auto"}:
         return None
     try:
         if normalized == "openai-codex":
@@ -897,6 +1140,13 @@ def fetch_account_usage(
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+        if normalized == "custom" or normalized.startswith("custom:"):
+            return _fetch_custom_account_usage(
+                provider=provider,
+                base_url=base_url,
+                api_key=api_key,
+                api_mode=api_mode,
+            )
     except Exception:
         return None
     return None

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -252,6 +252,27 @@ describe('renderRpcResult', () => {
         'Resets: 2026-08-01'
       ])
     })
+
+    it('appends provider account_lines before Nous credits', () => {
+      const body = renderRpcResult(
+        {
+          calls: 1,
+          input: 10,
+          output: 20,
+          total: 30,
+          account_lines: ['Account limits', 'Gemini quota: 5% used'],
+          credits_lines: ['Nous credits: 8,420 remaining']
+        },
+        'usage'
+      )
+
+      expect(body.split('\n')).toEqual([
+        'Usage: 1 calls · 10 in / 20 out · 30 total',
+        'Account limits',
+        'Gemini quota: 5% used',
+        'Nous credits: 8,420 remaining'
+      ])
+    })
   })
 
   describe('agents.list', () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -290,7 +290,7 @@ export function renderRpcResult(response: unknown, name: string): string {
     return r.output
   }
 
-  // session.usage — { calls, input, output, total, credits_lines? }
+  // session.usage — { calls, input, output, total, account_lines?, credits_lines? }
   if ('total' in r || 'input' in r || 'output' in r || 'calls' in r) {
     const calls = Number(r.calls ?? 0)
     const input = Number(r.input ?? 0)
@@ -300,6 +300,14 @@ export function renderRpcResult(response: unknown, name: string): string {
     const lines: string[] = [
       `Usage: ${calls.toLocaleString()} calls · ${input.toLocaleString()} in / ${output.toLocaleString()} out · ${total.toLocaleString()} total`
     ]
+
+    if (Array.isArray(r.account_lines)) {
+      for (const accountLine of r.account_lines) {
+        if (typeof accountLine === 'string' && accountLine.trim()) {
+          lines.push(accountLine.trim())
+        }
+      }
+    }
 
     if (Array.isArray(r.credits_lines)) {
       for (const credit of r.credits_lines) {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -630,11 +630,13 @@ export interface SessionRuntimeInfo {
 }
 
 export interface UsageStats {
+  account_lines?: string[]
   calls: number
   context_max?: number
   context_percent?: number
   context_used?: number
   cost_usd?: number
+  credits_lines?: string[]
   input: number
   output: number
   total: number

--- a/cli.py
+++ b/cli.py
@@ -11060,8 +11060,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
                 try:
                     account_snapshot = _pool.submit(
-                        fetch_account_usage, provider,
-                        base_url=base_url, api_key=api_key,
+                        fetch_account_usage,
+                        provider,
+                        base_url=base_url,
+                        api_key=api_key,
+                        api_mode=getattr(agent, "api_mode", None),
                     ).result(timeout=10.0)
                 except (concurrent.futures.TimeoutError, Exception):
                     account_snapshot = None

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4815,6 +4815,7 @@ class GatewaySlashCommandsMixin:
                     provider,
                     base_url=base_url,
                     api_key=api_key,
+                    api_mode=getattr(agent, "api_mode", None) if agent else None,
                 )
             except Exception:
                 account_snapshot = None

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -3,11 +3,13 @@ from types import SimpleNamespace
 import pytest
 
 from agent import account_usage
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
 
 class _FakeResponse:
-    def __init__(self, payload):
+    def __init__(self, payload, status_code=200):
         self._payload = payload
+        self.status_code = status_code
 
     def raise_for_status(self):
         return None
@@ -227,3 +229,302 @@ def test_redeem_missing_credentials_reports_unavailable(monkeypatch):
 
     assert result.status == "unavailable"
     assert "hermes auth" in result.message
+
+
+def test_fetch_account_usage_custom_provider(monkeypatch):
+    custom_payload = {
+        "provider": "antigravity-proxy",
+        "source": "cloudcode.fetchAvailableModels",
+        "windows": [
+            {
+                "label": "Gemini quota",
+                "remaining_fraction": 0.95,
+                "used_percent": 5.0,
+                "reset_at": "2026-07-26T15:26:20Z",
+            }
+        ],
+    }
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda *a, **kw: _FakeClient(calls, custom_payload),
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "_custom_usage_config_entry",
+        lambda *args, **kwargs: {
+            "base_url": "https://wrong.example/anthropic",
+            "api_mode": "anthropic_messages",
+            "extra_headers": {"X-Wrong-Tenant": "wrong"},
+        },
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "custom:antigravity-proxy",
+        base_url="http://127.0.0.1:8091/anthropic",
+        api_key="agy-key",
+        api_mode="anthropic_messages",
+    )
+
+    assert snapshot is not None
+    assert snapshot.provider == "antigravity-proxy"
+    assert snapshot.windows[0].label == "Gemini quota"
+    assert snapshot.windows[0].used_percent == 5.0
+    assert calls[0]["url"] == "http://127.0.0.1:8091/anthropic/v1/usage"
+    assert calls[0]["headers"]["x-api-key"] == "agy-key"
+    assert "Authorization" not in calls[0]["headers"]
+    assert "X-Wrong-Tenant" not in calls[0]["headers"]
+
+
+def test_fetch_account_usage_custom_provider_uses_resolved_endpoint_with_resolved_key(monkeypatch):
+    """Never combine a caller URL with credentials resolved for another endpoint."""
+    calls = []
+
+    class _MultiPortClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def get(self, url, headers):
+            calls.append({"url": url, "headers": headers})
+            return _FakeResponse(
+                {
+                    "provider": "proxy-b",
+                    "windows": [{"label": "Quota B", "used_percent": 10.0}],
+                }
+            )
+
+    monkeypatch.setattr(account_usage.httpx, "Client", _MultiPortClient)
+    monkeypatch.setattr(
+        account_usage,
+        "_custom_usage_config_entry",
+        lambda *args, **kwargs: {
+            "base_url": "https://trusted.example/anthropic",
+            "api_mode": "anthropic_messages",
+            "extra_headers": {"X-Proxy-Tenant": "tenant-a"},
+        },
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "_peek_custom_usage_api_key",
+        lambda *args, **kwargs: "trusted-key",
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "custom:proxy-b",
+        base_url="https://attacker.example/anthropic",
+        api_key=None,
+    )
+
+    assert snapshot is not None
+    assert snapshot.provider == "proxy-b"
+    assert len(calls) == 1
+    assert calls[0]["url"] == "https://trusted.example/anthropic/v1/usage"
+    assert calls[0]["headers"] == {
+        "X-Proxy-Tenant": "tenant-a",
+        "x-api-key": "trusted-key",
+    }
+
+
+def test_fetch_account_usage_custom_openai_mode_uses_bearer_auth(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda *a, **kw: _FakeClient(
+            calls,
+            {"provider": "proxy", "windows": [{"label": "Quota", "used_percent": 1}]},
+        ),
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "_custom_usage_config_entry",
+        lambda *args, **kwargs: {
+            "base_url": "https://proxy.example/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "_peek_custom_usage_api_key",
+        lambda *args, **kwargs: "proxy-key",
+    )
+
+    snapshot = account_usage.fetch_account_usage("custom:proxy")
+
+    assert snapshot is not None
+    assert calls[0]["headers"] == {"Authorization": "Bearer proxy-key"}
+
+
+def test_fetch_account_usage_live_pair_keeps_matching_runtime_extra_headers(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda *a, **kw: _FakeClient(
+            calls,
+            {"provider": "proxy", "windows": [{"label": "Quota", "used_percent": 1}]},
+        ),
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "_custom_usage_config_entry",
+        lambda *args, **kwargs: {
+            "base_url": "https://proxy.example/v1/",
+            "api_mode": "chat_completions",
+            "extra_headers": {"CF-Access-Client-Secret": "cf-secret"},
+        },
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "custom:proxy",
+        base_url="https://proxy.example/v1",
+        api_key="live-pool-key",
+        api_mode="chat_completions",
+    )
+
+    assert snapshot is not None
+    assert calls[0]["headers"] == {
+        "CF-Access-Client-Secret": "cf-secret",
+        "Authorization": "Bearer live-pool-key",
+    }
+
+
+def test_fetch_account_usage_anthropic_bearer_endpoint_uses_main_client_auth_contract(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda *a, **kw: _FakeClient(
+            calls,
+            {"provider": "minimax", "windows": [{"label": "Quota", "used_percent": 1}]},
+        ),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "custom:minimax",
+        base_url="https://api.minimax.io/anthropic",
+        api_key="minimax-key",
+        api_mode="anthropic_messages",
+    )
+
+    assert snapshot is not None
+    assert calls[0]["headers"] == {"Authorization": "Bearer minimax-key"}
+
+
+def test_fetch_account_usage_custom_rejects_non_finite_percentages(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda *a, **kw: _FakeClient(
+            calls,
+            {
+                "provider": "malformed-proxy",
+                "windows": [
+                    {"label": "NaN quota", "used_percent": float("nan")},
+                    {"label": "Infinite quota", "remaining_fraction": float("inf")},
+                ],
+            },
+        ),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "custom:malformed",
+        base_url="https://malformed.example/v1",
+        api_key="live-key",
+    )
+
+    assert snapshot is not None
+    assert [window.used_percent for window in snapshot.windows] == [None, None]
+    assert account_usage.render_account_usage_lines(snapshot)[2:] == [
+        "NaN quota: unavailable",
+        "Infinite quota: unavailable",
+    ]
+
+
+def test_fetch_account_usage_resolves_keyed_provider_key_env(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+providers:
+  proxy-v12:
+    base_url: https://trusted.example/proxy-v12?tenant=one
+    api_mode: anthropic_messages
+    key_env: TEST_CUSTOM_USAGE_KEY
+    extra_headers:
+      X-Proxy-Tenant: tenant-one
+    ssl_verify: false
+""".lstrip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TEST_CUSTOM_USAGE_KEY", "v12-provider-key")
+    calls = []
+    client_options = []
+
+    def fake_client(*args, **kwargs):
+        client_options.append(kwargs)
+        return _FakeClient(
+            calls,
+            {"provider": "proxy-v12", "windows": [{"label": "Quota", "used_percent": 2}]},
+        )
+
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        fake_client,
+    )
+    token = set_hermes_home_override(home)
+    try:
+        snapshot = account_usage.fetch_account_usage(
+            "custom",
+            base_url="https://trusted.example/proxy-v12?tenant=one",
+            api_key=None,
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    assert snapshot is not None
+    assert calls == [
+        {
+            "url": "https://trusted.example/proxy-v12/v1/usage?tenant=one",
+            "headers": {
+                "X-Proxy-Tenant": "tenant-one",
+                "x-api-key": "v12-provider-key",
+            },
+        }
+    ]
+    assert client_options[0]["verify"] is False
+
+
+def test_custom_usage_pool_lookup_peeks_without_selecting(monkeypatch):
+    events = []
+
+    class _Pool:
+        def peek(self):
+            events.append("peek")
+            return type("Entry", (), {"runtime_api_key": "pooled-key"})()
+
+        def select(self):
+            raise AssertionError("read-only usage must not rotate the pool")
+
+    monkeypatch.setattr(
+        "agent.credential_pool.get_custom_provider_pool_key",
+        lambda *args, **kwargs: "custom:proxy",
+    )
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda key: _Pool())
+
+    key = account_usage._peek_custom_usage_api_key(
+        {"name": "proxy"},
+        "https://proxy.example/v1",
+    )
+
+    assert key == "pooled-key"
+    assert events == ["peek"]

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -141,7 +141,7 @@ class TestUsageAccountSection:
         monkeypatch.setattr("gateway.run.asyncio.to_thread", _fake_to_thread)
         monkeypatch.setattr(
             "gateway.slash_commands.fetch_account_usage",
-            lambda provider, base_url=None, api_key=None: object(),
+            lambda provider, base_url=None, api_key=None, api_mode=None: object(),
         )
         monkeypatch.setattr(
             "gateway.slash_commands.render_account_usage_lines",

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17,6 +17,98 @@ from hermes_cli.browser_connect import ChromeDebugLaunch
 from tui_gateway import server
 
 
+def test_session_usage_includes_live_provider_account_lines(monkeypatch):
+    agent = types.SimpleNamespace(
+        provider="custom:antigravity-proxy",
+        base_url="http://127.0.0.1:8091/anthropic",
+        api_key="live-key",
+    )
+    session = {"agent": agent}
+    monkeypatch.setattr(server, "_sess_nowait", lambda params, rid: (session, None))
+    monkeypatch.setattr(
+        server,
+        "_session_usage_snapshot",
+        lambda current: {"calls": 1, "input": 10, "output": 20, "total": 30},
+    )
+
+    with (
+        patch("agent.account_usage.fetch_account_usage", return_value=object()) as fetch,
+        patch("agent.account_usage.render_account_usage_lines", return_value=["Account limits", "Gemini quota: 5% used"]),
+        patch("agent.account_usage.nous_credits_lines", return_value=[]),
+    ):
+        response = server._methods["session.usage"]("usage-1", {"session_id": "s-1"})
+
+    assert response["result"]["account_lines"] == ["Account limits", "Gemini quota: 5% used"]
+    fetch.assert_called_once_with(
+        "custom:antigravity-proxy",
+        base_url="http://127.0.0.1:8091/anthropic",
+        api_key="live-key",
+        api_mode=None,
+    )
+
+
+def test_session_usage_keeps_nous_credits_when_provider_usage_fails(monkeypatch):
+    session = {"agent": types.SimpleNamespace(provider="custom:broken")}
+    monkeypatch.setattr(server, "_sess_nowait", lambda params, rid: (session, None))
+    monkeypatch.setattr(
+        server,
+        "_session_usage_snapshot",
+        lambda current: {"calls": 0, "input": 0, "output": 0, "total": 0},
+    )
+
+    with (
+        patch("agent.account_usage.fetch_account_usage", side_effect=RuntimeError("broken")),
+        patch("agent.account_usage.nous_credits_lines", return_value=["Nous credits: 42"]),
+    ):
+        response = server._methods["session.usage"]("usage-2", {"session_id": "s-2"})
+
+    assert response["result"]["credits_lines"] == ["Nous credits: 42"]
+
+
+def test_session_usage_resolves_persisted_provider_without_live_agent(monkeypatch):
+    session = {"agent": None}
+    seen = {}
+    monkeypatch.setattr(server, "_sess_nowait", lambda params, rid: (session, None))
+    monkeypatch.setattr(
+        server,
+        "_metadata_mirror",
+        lambda current: {
+            "provider": "custom",
+            "base_url": "https://proxy.example/anthropic",
+            "api_mode": "anthropic_messages",
+        },
+    )
+    monkeypatch.setattr(
+        server,
+        "_session_usage_snapshot",
+        lambda current: {"calls": 0, "input": 0, "output": 0, "total": 0},
+    )
+
+    def fake_fetch(provider, *, base_url=None, api_key=None, api_mode=None):
+        seen.update(
+            provider=provider,
+            base_url=base_url,
+            api_key=api_key,
+            api_mode=api_mode,
+        )
+        return object()
+
+    with (
+        patch("agent.account_usage.fetch_account_usage", side_effect=fake_fetch),
+        patch("agent.account_usage.render_account_usage_lines", return_value=["Quota"]),
+        patch("agent.account_usage.nous_credits_lines", return_value=[]),
+    ):
+        response = server._methods["session.usage"]("usage-3", {"session_id": "s-3"})
+
+    assert response["result"]["account_lines"] == ["Quota"]
+    assert seen == {
+        "provider": "custom",
+        "base_url": "https://proxy.example/anthropic",
+        "api_key": None,
+        "api_mode": "anthropic_messages",
+    }
+
+
 @pytest.fixture(autouse=True)
 def _neuter_agent_prewarm_timer(request, monkeypatch):
     """Stub the deferred agent pre-warm timer for every test in this module.

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1176,13 +1176,43 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
     agent = session.get("agent")
+    mirror = _metadata_mirror(session)
     usage: dict = _session_usage_snapshot(session)
     if agent is None and not usage:
         usage = {"calls": 0, "input": 0, "output": 0, "total": 0}
-    # Nous credits block — agent-independent (a portal fetch), so it shows even
-    # with zero API calls or on a resumed session. The TUI /usage panel renders
-    # these lines regardless of `calls`. Fail-open: [] when not logged into Nous
-    # or on any portal hiccup.
+    provider = (
+        getattr(agent, "provider", None) if agent is not None else None
+    ) or mirror.get("provider")
+    if provider:
+        try:
+            from agent.account_usage import fetch_account_usage, render_account_usage_lines
+
+            base_url = (
+                getattr(agent, "base_url", None)
+                if agent is not None
+                else mirror.get("base_url")
+            )
+            api_key = getattr(agent, "api_key", None) if agent is not None else None
+            api_mode = (
+                getattr(agent, "api_mode", None)
+                if agent is not None
+                else mirror.get("api_mode")
+            )
+            account_snapshot = fetch_account_usage(
+                provider,
+                base_url=base_url,
+                api_key=api_key,
+                api_mode=api_mode,
+            )
+            if account_snapshot:
+                account_lines = render_account_usage_lines(account_snapshot)
+                if account_lines:
+                    usage["account_lines"] = account_lines
+        except Exception:
+            pass
+
+    # Nous credits are agent-independent. Keep this fetch isolated so a custom
+    # provider timeout or malformed response cannot hide a valid Nous balance.
     try:
         from agent.account_usage import nous_credits_lines
 

--- a/ui-tui/src/__tests__/usageCommand.test.ts
+++ b/ui-tui/src/__tests__/usageCommand.test.ts
@@ -69,6 +69,27 @@ describe('/usage slash command', () => {
     expect(printed(withBalance.sys)).toContain(USAGE_CTA)
   })
 
+  it('renders provider account limits even before the first API call', async () => {
+    const withProviderLimits = buildCtx({
+      'session.usage': baseUsage({
+        calls: 0,
+        account_lines: ['📈 Account limits', 'Antigravity Proxy', 'Gemini quota: 95% remaining']
+      })
+    })
+
+    await withProviderLimits.run('')
+
+    const sections = withProviderLimits.panel.mock.calls.find(c => c[0] === 'Provider limits')?.[1] as
+      | { text?: string }[]
+      | undefined
+
+    const body = (sections ?? []).map(section => section.text ?? '').join('\n')
+    expect(body).toContain('Antigravity Proxy')
+    expect(body).toContain('Gemini quota: 95% remaining')
+    expect(printed(withProviderLimits.sys)).not.toContain('no API calls yet')
+    expect(printed(withProviderLimits.sys)).toContain(USAGE_CTA)
+  })
+
   it('renders the dollar two-bar model (no "credits" wording) when available', async () => {
     const { panel, run } = buildCtx({
       'session.usage': baseUsage({

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -659,6 +659,13 @@ export const sessionCommands: SlashCommand[] = [
           })
         }
 
+        const accountLines = r?.account_lines ?? []
+        const showedAccount = accountLines.length > 0
+
+        if (showedAccount) {
+          ctx.transcript.panel('Provider limits', [{ text: accountLines.join('\n') }])
+        }
+
         // Nous balance block is agent-independent (a portal fetch), so it shows
         // even with zero API calls or on a resumed session. Prefer the shared
         // dollar usage model (two-bar view, dollars-only); fall back to the
@@ -701,7 +708,7 @@ export const sessionCommands: SlashCommand[] = [
         }
 
         if (!r?.calls) {
-          if (!showedBalance) {
+          if (!showedBalance && !showedAccount) {
             sys('no API calls yet')
           }
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -259,6 +259,7 @@ export interface SessionUndoResponse {
 }
 
 export interface SessionUsageResponse {
+  account_lines?: string[]
   active_subagents?: number
   cache_read?: number
   cache_write?: number


### PR DESCRIPTION
## Summary

- Add account-usage support for `custom` / `custom:*` providers exposing a `/v1/usage` endpoint.
- Resolve persisted custom sessions through the current `providers:` / legacy `custom_providers:` schema, including `key_env`, credential pools, `extra_headers`, query parameters, and provider TLS settings.
- Keep endpoint and credential selection atomic: partial caller metadata never borrows a key from another route, live URL/key pairs are preserved, and pool lookup uses non-mutating `peek()` rather than rotating `select()`.
- Reuse the main Anthropic transport auth contract (`x-api-key` vs Bearer) and preserve path-prefixed proxy routes such as `/anthropic/v1/usage`.
- Render provider limits in gateway `/usage`, interactive CLI, RPC `session.usage`, Ink TUI/dashboard, and Desktop.
- Keep Nous balance retrieval independent, so a provider timeout cannot hide a valid Nous balance and vice versa.
- Reject non-finite percentages and fail open on malformed/unavailable usage responses.

## Root cause

`fetch_account_usage()` previously returned `None` for custom providers. The original PR mocks also missed several real runtime contracts:

1. persisted sessions can have a base URL but no live key;
2. provider credentials may come from `providers[].key_env` or a pool;
3. inference may require endpoint-scoped extra headers/TLS/auth behavior;
4. Desktop and Ink TUI ignored the new RPC payload even when the backend fetched it;
5. execution-time provider resolution mutates round-robin pools and is unsuitable for read-only `/usage`.

This change uses a dedicated read-only custom usage path and carries the result through every client surface.

## Security properties

- Only `http`/`https` provider endpoints are queried; URL userinfo is rejected.
- Path and query identity are preserved when matching provider metadata.
- Config credentials/headers/TLS are attached only to the exact selected endpoint.
- A partial URL/key pair is replaced only by one uniquely identified config entry.
- Bare persisted `custom` routes fail closed on ambiguous same-URL providers.
- Usage checks do not rotate credential pools.

## Verification

- `516 passed`:
  - `tests/agent/test_account_usage.py`
  - `tests/gateway/test_usage_command.py`
  - `tests/test_tui_gateway_server.py`
- Ink TUI usage command: `4 passed`
- Desktop usage renderer: `34 passed`
- Python Ruff and `git diff --check`: passed
- Ink TUI + Desktop TypeScript typechecks: passed
- ESLint + Prettier for changed TypeScript: passed
- Live smoke tests:
  - antigravity proxy: 2 quota windows, 4 rendered lines;
  - Anthropic/Claude account: 2 quota windows;
  - persisted bare-`custom` `session.usage`: 4 account lines;
  - credential-pool head unchanged before/after usage lookup.
