### PR TITLE
fix(docker): ship a WAL-reset-safe SQLite runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,45 @@
+# Debian 13 still ships SQLite 3.46.1, which contains the upstream WAL-reset
+# corruption bug. Build a pinned shared library for the runtime image instead
+# of relying on a distro backport that trixie does not currently provide.
+# See #70480 and https://sqlite.org/wal.html#walresetbug.
+FROM debian:13.4 AS sqlite_build
+ARG SQLITE_AUTOCONF_VERSION=3530400
+ARG SQLITE_SHA256=0e9483900e92cd5de8fd48d16bf9200145a61f7fd5be542a5ac81d8a9516eb9c
+RUN apt-get -o Acquire::Retries=3 update && \
+    apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+        build-essential ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    (curl -fsSL --retry 1 --retry-all-errors --connect-timeout 15 --max-time 60 \
+        -o /tmp/sqlite.tar.gz \
+        "https://sqlite.org/2026/sqlite-autoconf-${SQLITE_AUTOCONF_VERSION}.tar.gz" || \
+     curl -fsSL --retry 3 --retry-all-errors --connect-timeout 15 --max-time 120 \
+        -o /tmp/sqlite.tar.gz \
+        "https://sources.buildroot.net/sqlite/sqlite-autoconf-${SQLITE_AUTOCONF_VERSION}.tar.gz") && \
+    printf '%s  %s\n' "${SQLITE_SHA256}" /tmp/sqlite.tar.gz > /tmp/sqlite.sha256 && \
+    sha256sum -c /tmp/sqlite.sha256 && \
+    tar -xzf /tmp/sqlite.tar.gz -C /tmp && \
+    cd "/tmp/sqlite-autoconf-${SQLITE_AUTOCONF_VERSION}" && \
+    CFLAGS="-O2 \
+        -DSQLITE_ENABLE_FTS3 \
+        -DSQLITE_ENABLE_FTS3_PARENTHESIS \
+        -DSQLITE_ENABLE_FTS4 \
+        -DSQLITE_ENABLE_FTS5 \
+        -DSQLITE_ENABLE_RTREE \
+        -DSQLITE_ENABLE_GEOPOLY \
+        -DSQLITE_ENABLE_COLUMN_METADATA \
+        -DSQLITE_ENABLE_UNLOCK_NOTIFY \
+        -DSQLITE_ENABLE_DBSTAT_VTAB \
+        -DSQLITE_ENABLE_DBPAGE_VTAB \
+        -DSQLITE_ENABLE_MATH_FUNCTIONS \
+        -DSQLITE_ENABLE_PREUPDATE_HOOK \
+        -DSQLITE_ENABLE_SESSION \
+        -DSQLITE_SECURE_DELETE \
+        -DSQLITE_THREADSAFE=1 \
+        -DSQLITE_MAX_VARIABLE_NUMBER=250000" \
+        ./configure --prefix=/opt/sqlite-fixed --disable-static && \
+    make -j"$(nproc)" && \
+    make install
+
 FROM ghcr.io/astral-sh/uv:0.11.6-python3.13-trixie@sha256:b3c543b6c4f23a5f2df22866bd7857e5d304b67a564f4feab6ac22044dde719b AS uv_source
 # Node 22 LTS source stage. Debian trixie's bundled nodejs is pinned to 20.x
 # which reached EOL in April 2026 — we copy node + npm + corepack from the
@@ -30,6 +72,23 @@ RUN apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
     ca-certificates curl iputils-ping python3 python-is-python3 ripgrep ffmpeg gcc g++ make cmake python3-dev python3-venv libffi-dev libolm-dev procps git openssh-client docker-cli xz-utils && \
     rm -rf /var/lib/apt/lists/*
+
+# Prefer the fixed SQLite over Debian's vulnerable libsqlite3.so.0. Keep the
+# public library name stable so both the system interpreter and the uv-created
+# venv resolve the replacement without changing Python import paths.
+COPY --from=sqlite_build /opt/sqlite-fixed/lib/libsqlite3.so.3.53.4 /usr/local/lib/
+RUN ln -sf libsqlite3.so.3.53.4 /usr/local/lib/libsqlite3.so.0 && \
+    ln -sf libsqlite3.so.3.53.4 /usr/local/lib/libsqlite3.so && \
+    printf '/usr/local/lib\n' > /etc/ld.so.conf.d/000-sqlite-fixed.conf && \
+    ldconfig && \
+    python3 -c "import sqlite3, sys; \
+v = sqlite3.sqlite_version_info; \
+sys.exit(f'linked SQLite {sqlite3.sqlite_version} still has the WAL-reset bug') if v < (3, 51, 3) else None; \
+db = sqlite3.connect(':memory:'); \
+db.execute(\"CREATE VIRTUAL TABLE docs USING fts5(content, tokenize='trigram')\"); \
+db.execute(\"INSERT INTO docs VALUES ('hermes')\"); \
+sys.exit('SQLite FTS5 trigram self-test failed') if db.execute(\"SELECT count(*) FROM docs WHERE docs MATCH 'erm'\").fetchone()[0] != 1 else None; \
+db.close()"
 
 # ---------- s6-overlay install ----------
 # s6-overlay provides supervision for the main hermes process, the dashboard,

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -10,7 +10,13 @@ import subprocess
 import shutil
 from pathlib import Path
 
-from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
+from hermes_cli.config import (
+    detect_install_method,
+    get_env_path,
+    get_hermes_home,
+    get_project_root,
+    recommended_update_command_for_method,
+)
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
 from hermes_constants import agent_browser_runnable
@@ -70,6 +76,22 @@ def _system_package_install_cmd(pkg: str) -> str:
     if sys.platform == "darwin":
         return f"brew install {pkg}"
     return f"sudo apt install {pkg}"
+
+
+def _sqlite_upgrade_hint(install_method: str | None = None) -> str:
+    """Return an actionable SQLite upgrade hint for this install layout."""
+    method = install_method or detect_install_method(PROJECT_ROOT)
+    if method == "docker":
+        command = recommended_update_command_for_method(method)
+        action = f"run `{command}`, then recreate all Hermes containers"
+    elif method in {"nix", "nixos"}:
+        action = recommended_update_command_for_method(method)
+    else:
+        action = "run `hermes update`"
+    return (
+        f"({action}; fixed versions: 3.51.3+ / 3.50.7 / 3.44.6 — "
+        "see https://sqlite.org/wal.html#walresetbug)"
+    )
 
 
 def _safe_which(cmd: str) -> str | None:
@@ -827,8 +849,7 @@ def run_doctor(args):
             # best-effort and unsupported installs may need manual action.
             check_warn(
                 f"SQLite {_sqlite_ver} (WAL-reset bug)",
-                "(run `hermes update`; fixed versions: 3.51.3+ / 3.50.7 / "
-                "3.44.6 — see https://sqlite.org/wal.html#walresetbug)",
+                _sqlite_upgrade_hint(),
             )
         else:
             check_ok(f"SQLite {_sqlite_ver}")

--- a/tests/docker/test_sqlite_runtime.py
+++ b/tests/docker/test_sqlite_runtime.py
@@ -1,0 +1,60 @@
+"""Runtime qualification for SQLite in the published Docker image."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+
+_SQLITE_PROBE = r"""
+import json
+import sqlite3
+
+from hermes_cli.sqlite_runtime import is_sqlite_wal_reset_vulnerable
+
+db = sqlite3.connect(":memory:")
+try:
+    db.execute("CREATE VIRTUAL TABLE docs USING fts5(content, tokenize='trigram')")
+    db.execute("INSERT INTO docs VALUES ('hermes')")
+    matches = db.execute(
+        "SELECT count(*) FROM docs WHERE docs MATCH 'erm'"
+    ).fetchone()[0]
+finally:
+    db.close()
+
+print(json.dumps({
+    "sqlite_version": sqlite3.sqlite_version,
+    "wal_reset_vulnerable": is_sqlite_wal_reset_vulnerable(
+        sqlite3.sqlite_version_info
+    ),
+    "trigram_matches": matches,
+}))
+"""
+
+
+def test_image_links_fixed_sqlite_with_fts5_trigram(built_image: str) -> None:
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--user",
+            "hermes",
+            "--entrypoint",
+            "/opt/hermes/.venv/bin/python",
+            built_image,
+            "-c",
+            _SQLITE_PROBE,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, (
+        f"SQLite runtime probe failed: stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )
+    payload = json.loads(result.stdout)
+    assert payload["wal_reset_vulnerable"] is False, payload
+    assert payload["trigram_matches"] == 1, payload

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -32,6 +32,26 @@ class TestDoctorPlatformHints:
         assert doctor._python_install_cmd() == "uv pip install"
         assert doctor._system_package_install_cmd("ripgrep") == "sudo apt install ripgrep"
 
+    def test_sqlite_upgrade_hint_recreates_docker_containers(self, monkeypatch):
+        monkeypatch.setattr(doctor, "detect_install_method", lambda _root: "docker")
+
+        hint = doctor._sqlite_upgrade_hint()
+
+        assert "docker pull nousresearch/hermes-agent:latest" in hint
+        assert "recreate all Hermes containers" in hint
+        assert "hermes update" not in hint
+
+    def test_sqlite_upgrade_hint_keeps_git_runtime_repair(self):
+        hint = doctor._sqlite_upgrade_hint("git")
+
+        assert "run `hermes update`" in hint
+
+    def test_sqlite_upgrade_hint_uses_nix_package_manager(self):
+        hint = doctor._sqlite_upgrade_hint("nix")
+
+        assert "Nix source that installed it" in hint
+        assert "hermes update" not in hint
+
 
 class TestProviderEnvDetection:
     def test_detects_openai_api_key(self):


### PR DESCRIPTION
## What does this PR do?

The published Debian 13 image currently links Python against SQLite 3.46.1, a version affected by SQLite's WAL-reset corruption bug. Docker users cannot repair that system library with `hermes update`, so recreating a container from the current image preserves the exposure.

This PR builds checksum-pinned SQLite 3.53.4 in a separate stage and places its shared library ahead of Debian's `libsqlite3.so.0`. The build preserves the SQLite features Hermes relies on and fails immediately unless the system interpreter links a fixed version and can execute an FTS5 trigram query. It also makes the doctor remediation install-aware so Docker users are told to pull the fixed image and recreate every Hermes container.

This complements the application-level WAL safeguards already on main; it fixes the runtime shipped in the official image rather than treating every reported corruption as proof of this specific upstream SQLite bug.

## Related Issue

Fixes #70480

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Add a multi-stage SQLite 3.53.4 build with a pinned SHA-256, bounded primary download, and checksum-verified fallback mirror.
- Preserve FTS3/4/5, trigram, RTREE/GEOPOLY, SESSION/PREUPDATE_HOOK, DBSTAT/DBPAGE, SECURE_DELETE, and Hermes' variable limit.
- Prefer the fixed shared library in the runtime image and assert Python linkage plus FTS5 trigram behavior during the image build.
- Give Docker, Git, and Nix installs valid SQLite upgrade guidance in `hermes doctor`.
- Add a Docker runtime test that probes the final venv as the non-root `hermes` user.

## How to Test

1. Build the image: `docker build --progress=plain -t hermes-agent-70480:latest .`
2. Run the image qualification test: `HERMES_TEST_IMAGE=hermes-agent-70480:latest pytest tests/docker/test_sqlite_runtime.py -q`
3. Run the focused unit and Dockerfile contract tests: `pytest tests/hermes_cli/test_doctor.py tests/tools/test_dockerfile_pid1_reaping.py tests/tools/test_dockerfile_immutable_install.py tests/tools/test_dockerfile_node_modules_perms.py -q`

Local ARM64 results:

```text
Full Docker image build: passed
Image runtime probe: {"sqlite_version": "3.53.4", "trigram_matches": 1}
tests/docker/test_sqlite_runtime.py: 1 passed
Focused unit/contract tests: 96 passed
Ruff: passed
git diff --check: passed
```

Local end-to-end validation used an ARM64 Debian 13.4 image under OrbStack. The repository Docker workflow will provide the amd64 build and runtime-test coverage as well as an independent arm64 run.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS host, OrbStack, Linux arm64 Debian 13.4 image

### Documentation & Housekeeping

- [x] I've updated relevant documentation, or N/A: N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A: N/A
- [x] I've considered cross-platform impact, or N/A: Docker build remains native multi-arch; CI covers amd64 and arm64
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A: N/A

## Screenshots / Logs

Not applicable; this changes the published Docker runtime and doctor remediation text.
