### PR TITLE
fix(install): ignore stale code-scoped docker stamp on non-container hosts (#71153)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -447,7 +447,9 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
     # 1. Code-scoped stamp — authoritative, immune to shared $HERMES_HOME.
     try:
         method = (root / ".install_method").read_text(encoding="utf-8").strip().lower()
-        if method in supported_methods:
+        if method in supported_methods and not (
+            method == "docker" and not _running_in_container()
+        ):
             return method
     except OSError:
         pass


### PR DESCRIPTION
## Summary

When a host install has a stale `docker` stamp in the code-scoped `.install_method` file (e.g. from a previous container-based run or manual `echo "docker" > .install_method`), `detect_install_method()` returned `"docker"` even on non-containerized hosts. This caused `hermes update` to print the Docker pull guidance and exit, blocking legitimate updates.

## Root Cause

The code-scoped stamp check (line 449) didn't verify whether the process was actually running inside a container before accepting a `docker` value. The legacy home-scoped stamp check (line 466) already had this guard — the code-scoped path was simply missing it.

## Fix

Apply the same container guard to the code-scoped stamp: only honour a `docker` value from the code-scoped `.install_method` file when `_running_in_container()` returns True. On a host install, a stale `docker` stamp now falls through to `.git` detection, returning `"git"` as expected.

## Testing

- `tests/hermes_cli/test_cmd_update_docker.py`: 8/8 passed
- `tests/test_install_sh_install_method_stamp.py`: 1/1 passed
- `tests/tools/test_dockerfile_immutable_install.py`: 6/6 passed

Fixes #71153