### PR TITLE
fix(desktop): preserve streamed reasoning on late fallback

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -242,6 +242,25 @@ def _ra():
     return run_agent
 
 
+def _relay_available_reasoning(agent, assistant_content: str) -> None:
+    """Relay completed inline reasoning without truncating the live fallback."""
+    think_text = re.sub(
+        r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', assistant_content.strip()
+    ).strip()
+    first_line = think_text.split('\n')[0][:80] if think_text else ""
+
+    if first_line and getattr(agent, '_delegate_depth', 0) > 0:
+        try:
+            agent.tool_progress_callback("_thinking", first_line)
+        except Exception:
+            pass
+    elif think_text:
+        try:
+            agent.tool_progress_callback("reasoning.available", "_thinking", think_text, None)
+        except Exception:
+            pass
+
+
 def _nous_entitlement_message(capability: str) -> str:
     try:
         from hermes_cli.nous_account import (
@@ -5278,24 +5297,7 @@ def run_conversation(
             # Notify progress callback of model's thinking (used by subagent
             # delegation to relay the child's reasoning to the parent display).
             if (assistant_message.content and agent.tool_progress_callback):
-                _think_text = assistant_message.content.strip()
-                # Strip reasoning XML tags that shouldn't leak to parent display
-                _think_text = re.sub(
-                    r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text
-                ).strip()
-                # For subagents: relay first line to parent display (existing behaviour).
-                # For all agents with a structured callback: emit reasoning.available event.
-                first_line = _think_text.split('\n')[0][:80] if _think_text else ""
-                if first_line and getattr(agent, '_delegate_depth', 0) > 0:
-                    try:
-                        agent.tool_progress_callback("_thinking", first_line)
-                    except Exception:
-                        pass
-                elif _think_text:
-                    try:
-                        agent.tool_progress_callback("reasoning.available", "_thinking", _think_text[:500], None)
-                    except Exception:
-                        pass
+                _relay_available_reasoning(agent, assistant_message.content)
             
             # Check for incomplete <REASONING_SCRATCHPAD> (opened but never closed)
             # This means the model ran out of output tokens mid-reasoning — retry up to 2 times

--- a/apps/desktop/src/app/session/hooks/use-message-stream.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { reasoningPart, textPart } from '@/lib/chat-messages'
+
+import { applyReasoningAvailable } from './use-message-stream'
+
+describe('applyReasoningAvailable', () => {
+  it('inserts available reasoning before existing assistant text', () => {
+    const parts = applyReasoningAvailable([textPart('Final answer.')], 'Late reasoning.')
+
+    expect(parts.map(part => part.type)).toEqual(['reasoning', 'text'])
+    expect(parts[0]).toEqual(reasoningPart('Late reasoning.'))
+    expect(parts[1]).toEqual(textPart('Final answer.'))
+  })
+
+  it('keeps the current reasoning part when one already exists', () => {
+    const existing = [reasoningPart('Streaming reasoning.'), textPart('Final answer.')]
+    const parts = applyReasoningAvailable(existing, 'Late reasoning.')
+
+    expect(parts).toBe(existing)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -128,6 +128,7 @@ interface GatewayEventDeps {
   lastCwdInfoSessionRef: MutableRefObject<string | null>
   nativeSubagentSessionsRef: MutableRefObject<Set<string>>
   appendAssistantDelta: (sessionId: string, delta: string) => void
+  appendReasoningAvailable: (sessionId: string, text: string) => void
   appendReasoningDelta: (sessionId: string, delta: string, replace?: boolean) => void
   completeAssistantMessage: (
     sessionId: string,
@@ -159,6 +160,7 @@ interface GatewayEventDeps {
 export function useGatewayEventHandler(deps: GatewayEventDeps) {
   const {
     appendAssistantDelta,
+    appendReasoningAvailable,
     appendReasoningDelta,
     activeGatewayProfile,
     activeSessionIdRef,
@@ -515,7 +517,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         }
       } else if (event.type === 'reasoning.available') {
         if (sessionId) {
-          appendReasoningDelta(sessionId, coerceThinkingText(payload?.text), true)
+          appendReasoningAvailable(sessionId, coerceThinkingText(payload?.text))
         }
 
         if (isActiveEvent) {
@@ -1024,6 +1026,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
     },
     [
       appendAssistantDelta,
+      appendReasoningAvailable,
       appendReasoningDelta,
       activeSessionIdRef,
       activeGatewayProfile,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -62,6 +62,20 @@ let streamMessageSeq = 0
 
 const nextStreamMessageId = (prefix: string) => `${prefix}-${Date.now()}-${++streamMessageSeq}`
 
+export function applyReasoningAvailable(parts: ChatMessagePart[], text: string): ChatMessagePart[] {
+  if (parts.some(part => part.type === 'reasoning')) {
+    return parts
+  }
+
+  const textIndex = parts.findIndex(part => part.type === 'text')
+
+  if (textIndex < 0) {
+    return [...parts, reasoningPart(text)]
+  }
+
+  return [...parts.slice(0, textIndex), reasoningPart(text), ...parts.slice(textIndex)]
+}
+
 export function useMessageStream({
   activeGatewayProfile = 'default',
   activeSessionIdRef,
@@ -321,17 +335,7 @@ export function useMessageStream({
 
       mutateStream(
         sessionId,
-        (parts, message) => {
-          if (replace && chatMessageText(message).trim()) {
-            return parts
-          }
-
-          if (replace) {
-            return [...parts.filter(part => part.type !== 'reasoning'), reasoningPart(delta)]
-          }
-
-          return appendReasoningPart(parts, delta)
-        },
+        parts => (replace ? applyReasoningAvailable(parts, delta) : appendReasoningPart(parts, delta)),
         () => [reasoningPart(delta)]
       )
     },

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -335,11 +335,33 @@ export function useMessageStream({
 
       mutateStream(
         sessionId,
-        parts => (replace ? applyReasoningAvailable(parts, delta) : appendReasoningPart(parts, delta)),
+        (parts, message) => {
+          if (chatMessageText(message).trim()) {
+            return parts
+          }
+
+          return [...parts.filter(part => part.type !== 'reasoning'), reasoningPart(delta)]
+        },
         () => [reasoningPart(delta)]
       )
     },
     [flushQueuedDeltas, mutateStream, queueDelta]
+  )
+
+  const appendReasoningAvailable = useCallback(
+    (sessionId: string, text: string) => {
+      if (!text) {
+        return
+      }
+
+      flushQueuedDeltas(sessionId)
+      mutateStream(
+        sessionId,
+        parts => applyReasoningAvailable(parts, text),
+        () => [reasoningPart(text)]
+      )
+    },
+    [flushQueuedDeltas, mutateStream]
   )
 
   const upsertToolCall = useCallback(
@@ -651,6 +673,7 @@ export function useMessageStream({
   const handleGatewayEvent = useGatewayEventHandler({
     activeGatewayProfile,
     appendAssistantDelta,
+    appendReasoningAvailable,
     appendReasoningDelta,
     activeSessionIdRef,
     compactedTurnRef,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/reasoning-available-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/reasoning-available-event.test.tsx
@@ -1,0 +1,106 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import type { ChatMessagePart } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-1'
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let sessionStateByRuntimeId: Map<string, ClientSessionState>
+let reasoningSnapshots: ChatMessagePart[]
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(sessionStateByRuntimeId)
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      const message = next.messages.find(item => item.id === next.streamId)
+      const reasoning = message?.parts.find(part => part.type === 'reasoning')
+
+      if (reasoning) {
+        reasoningSnapshots.push(reasoning)
+      }
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}) {
+  act(() => handleEvent!({ payload, session_id: SID, type }))
+}
+
+function streamedParts(): ChatMessagePart[] {
+  const state = sessionStateByRuntimeId.get(SID)
+  const message = state?.messages.find(item => item.id === state.streamId)
+
+  return message?.parts ?? []
+}
+
+describe('useMessageStream reasoning.available fallback', () => {
+  beforeEach(() => {
+    handleEvent = null
+    sessionStateByRuntimeId = new Map()
+    reasoningSnapshots = []
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('preserves streamed reasoning when the late available fallback arrives', async () => {
+    await mountStream()
+    const streamedReasoning = 'streamed reasoning '.repeat(40)
+
+    emit('reasoning.delta', { text: streamedReasoning })
+    emit('reasoning.available', { text: streamedReasoning.slice(0, 500) })
+
+    const reasoningParts = streamedParts().filter(part => part.type === 'reasoning')
+
+    expect(reasoningParts).toHaveLength(1)
+    expect(reasoningParts[0]).toMatchObject({ text: streamedReasoning })
+    expect(reasoningSnapshots.at(-1)).toBe(reasoningSnapshots.at(-2))
+  })
+
+  it('inserts late available reasoning before assistant text when no delta streamed', async () => {
+    await mountStream()
+
+    emit('message.delta', { text: 'Final answer.' })
+    emit('reasoning.available', { text: 'Late reasoning.' })
+
+    expect(streamedParts()).toMatchObject([
+      { text: 'Late reasoning.', type: 'reasoning' },
+      { text: 'Final answer.', type: 'text' }
+    ])
+  })
+})

--- a/tests/agent/test_reasoning_available.py
+++ b/tests/agent/test_reasoning_available.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+from agent.conversation_loop import _relay_available_reasoning
+
+
+def test_available_reasoning_relay_preserves_full_content():
+    events = []
+    reasoning = "reasoning " * 80
+    agent = SimpleNamespace(
+        _delegate_depth=0,
+        tool_progress_callback=lambda *args: events.append(args),
+    )
+
+    _relay_available_reasoning(
+        agent,
+        f"<REASONING_SCRATCHPAD>{reasoning}</REASONING_SCRATCHPAD>",
+    )
+
+    assert events == [("reasoning.available", "_thinking", reasoning.strip(), None)]
+    assert len(events[0][2]) > 500
+
+
+def test_available_reasoning_relay_keeps_subagent_preview_bounded():
+    events = []
+    agent = SimpleNamespace(
+        _delegate_depth=1,
+        tool_progress_callback=lambda *args: events.append(args),
+    )
+
+    _relay_available_reasoning(agent, "first line " * 20 + "\nsecond line")
+
+    assert events == [("_thinking", ("first line " * 20)[:80])]


### PR DESCRIPTION
## What does this PR do?

Prevents a late `reasoning.available` fallback from replacing reasoning that already arrived through `reasoning.delta`. If no reasoning was streamed, the fallback is inserted before assistant text instead.

The backend now relays the complete fallback rather than truncating it to 500 characters. The fallback has its own update path, so MoA events keep their existing replacement semantics.

This rebuilds the closed #65432 work on current main. The two original commits and author metadata from @skyc1e and @rasitakyol are preserved; the follow-up commit fixes the MoA regression found during the current-main review.

## Related Issue

Fixes #64995

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/conversation_loop.py`: relay the complete structured reasoning fallback while keeping delegated-subagent previews bounded.
- `apps/desktop/src/app/session/hooks/use-message-stream/index.ts`: preserve an existing streamed reasoning part and place a missing fallback before assistant text.
- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts`: route `reasoning.available` through the fallback-specific path without changing MoA replacement behavior.
- Add reducer, event-timeline, and backend regression tests.

## How to Test

1. Stream reasoning through `reasoning.delta`, then emit `reasoning.available`; the existing reasoning part must remain unchanged.
2. Emit `reasoning.available` without prior reasoning; it must appear before assistant text and retain more than 500 characters.
3. Run:

   ```bash
   cd apps/desktop
   npm exec vitest -- run --project ui src/app/session/hooks/use-message-stream.test.ts src/app/session/hooks/use-message-stream/reasoning-available-event.test.tsx src/app/session/hooks/use-message-stream/moa-progress-event.test.tsx
   npm run typecheck
   ```

4. Run:

   ```bash
   scripts/run_tests.sh tests/agent/test_reasoning_available.py -q
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and preserved the original authorship from closed #65432
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete Python suite; the focused backend regression passes
- [x] I've added tests for the changed behavior
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered; the renderer and callback semantics are platform-neutral
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

```text
Targeted Desktop UI: 3 files passed, 8 tests passed
Desktop TypeScript: all three typecheck configurations passed
ESLint / Prettier: passed for touched Desktop files
Python regression: 1 file, 2 tests passed
Ruff: passed for touched Python files
```

A full Desktop UI run exposed the MoA replacement regression in the closed implementation; the fallback-specific path in the final commit fixes it, and the MoA regression file now passes 4/4. Re-running the other failed files with one worker left four unrelated current-main failures: three host-locale assertions tracked by #71659 / #71750 and the existing Dialog/Select dismiss repro.