### PR TITLE
fix(state): sessions repair should detect incomplete FTS schema, not just unopenable DBs

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -938,14 +938,43 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
             except sqlite3.Error:
                 pass
             msg = str(exc).lower()
-            if "no such table" in msg or "no such column" in msg:
-                return None
             if "no such tokenizer: cjk_unicode61" in msg:
                 # This probe process couldn't load the cjk extension while
                 # the DB carries the cjk index — capability gap, not
                 # corruption. A tokenizer-capable SessionDB serves it fine;
                 # a tokenizer-less one self-heals by dropping the triggers.
                 return None
+            if "no such table" in msg or "no such column" in msg:
+                # A brand-new file mid-init genuinely has no sessions/messages
+                # tables yet, and that must not be reported as damage. But the
+                # SAME error text is produced by a structurally BROKEN store:
+                # an FTS trigger that outlived the virtual table it writes to
+                # (interrupted migration, partially-applied schema change,
+                # manual DROP). In that state every INSERT INTO messages
+                # fails, so the store cannot record a single new message — yet
+                # returning None here reported it as "opens cleanly — no
+                # repair needed", leaving the user with no actionable signal.
+                #
+                # Distinguish the two by asking whether the base tables exist.
+                # If they do, this is not a fresh file, and a "no such table"
+                # from the write probe is a real, actionable schema fault.
+                try:
+                    base_tables = {
+                        r[0] for r in conn.execute(
+                            "SELECT name FROM sqlite_master WHERE type = 'table' "
+                            "AND name IN ('sessions', 'messages')"
+                        ).fetchall()
+                    }
+                except sqlite3.DatabaseError:
+                    return None
+                if {"sessions", "messages"} - base_tables:
+                    # Genuinely mid-init / not a populated store.
+                    return None
+                return (
+                    f"incomplete FTS schema — message writes fail: {exc}. "
+                    "An FTS trigger references a table that no longer exists "
+                    "(interrupted migration or partial schema change)."
+                )
             return str(exc)
         return None
     except sqlite3.DatabaseError as exc:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -7704,3 +7704,104 @@ class TestDisplayMetadataReadPaths:
         )
         assert db.get_messages_as_conversation("s1")[0]["display_metadata"] == self.META
 
+
+class TestRepairDetectsIncompleteFtsSchema:
+    """`sessions repair --check-only` must not call a write-broken store healthy.
+
+    _db_opens_cleanly() drives a rolled-back message write through the FTS
+    triggers. When a trigger outlives the virtual table it writes to, that
+    write fails with "no such table" — the same text a brand-new file
+    mid-init produces — and the probe used to treat both as "not yet a
+    populated DB" and report the database as clean.
+    """
+
+    @staticmethod
+    def _seed(db_path, n=60):
+        seeded = SessionDB(db_path=db_path)
+        try:
+            seeded.create_session(session_id="s1", source="cli")
+            for i in range(n):
+                seeded.append_message(
+                    "s1",
+                    role=("user" if i % 3 == 0
+                          else "assistant" if i % 3 == 1 else "tool"),
+                    content=f"sentinel payload {i} zebra",
+                )
+            high_water = seeded._conn.execute(
+                "SELECT COALESCE(MAX(id), 0) FROM messages"
+            ).fetchone()[0]
+        finally:
+            seeded.close()
+        return high_water
+
+    def test_repair_check_detects_trigger_without_its_fts_table(self, tmp_path):
+        """A populated store whose message writes fail is NOT 'healthy'.
+
+        When an FTS trigger outlives the virtual table it writes to, every
+        ``INSERT INTO messages`` fails. ``_db_opens_cleanly()`` used to treat
+        the resulting "no such table" as "brand new file mid-init" and return
+        None, so ``hermes sessions repair --check-only`` reported the DB as
+        clean while the store could not record a single new message.
+        """
+        db_path = tmp_path / "state.db"
+        self._seed(db_path, n=10)
+
+        # Drop the trigram table but leave its triggers behind.
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute("DROP TABLE IF EXISTS messages_fts_trigram")
+            conn.commit()
+            surviving = [
+                r[0] for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'trigger' "
+                    "AND name LIKE 'messages_fts_trigram%'"
+                ).fetchall()
+            ]
+            assert surviving, "setup: triggers must outlive the table"
+
+            # Ground truth: the store really cannot accept a message.
+            with pytest.raises(sqlite3.OperationalError):
+                conn.execute(
+                    "INSERT INTO sessions (id, source, started_at) "
+                    "VALUES ('s2', 'cli', 0)"
+                )
+                conn.execute(
+                    "INSERT INTO messages (session_id, role, content, timestamp) "
+                    "VALUES ('s2', 'user', 'x', 0)"
+                )
+            conn.rollback()
+        finally:
+            conn.close()
+
+        reason = hermes_state._db_opens_cleanly(db_path)
+        assert reason is not None, (
+            "repair reported a write-broken store as opening cleanly"
+        )
+        assert "messages_fts_trigram" in reason
+
+    def test_repair_check_still_passes_a_healthy_store(self, tmp_path):
+        """The narrowed guard must not flag an intact populated store.
+
+        The write probe's "no such table" branch is the one being narrowed, so
+        the invariant that matters is that a normal, fully-initialised DB —
+        with and without the trigram index — still reports clean.
+        """
+        db_path = tmp_path / "state.db"
+        self._seed(db_path, n=10)
+        assert hermes_state._db_opens_cleanly(db_path) is None
+
+        # Same store with the trigram index cleanly removed (table AND its
+        # triggers) — the supported trigram-disabled shape, not damage.
+        conn = sqlite3.connect(str(db_path))
+        try:
+            for trigger in (
+                "messages_fts_trigram_insert",
+                "messages_fts_trigram_delete",
+                "messages_fts_trigram_update",
+            ):
+                conn.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+            conn.execute("DROP TABLE IF EXISTS messages_fts_trigram")
+            conn.commit()
+        finally:
+            conn.close()
+        assert hermes_state._db_opens_cleanly(db_path) is None


### PR DESCRIPTION
# fix(state): `sessions repair` must not report a write-broken FTS schema as healthy

## Summary

`hermes sessions repair --check-only` reports

```
✓ /Users/…/.hermes/state.db opens cleanly — no repair needed.
```

on a database that **cannot record a single new message**. Every
`INSERT INTO messages` fails with `no such table: messages_fts_trigram`, but the health
probe returns "clean", so the one diagnostic a user is told to reach for actively points
them away from the real fault.

## The bug

`_db_opens_cleanly()` deliberately drives a rolled-back message write through the FTS
triggers, precisely so that FTS damage which leaves reads and `integrity_check` passing is
still caught (#50502). That probe works. The problem is how its failure is classified:

```python
msg = str(exc).lower()
if "no such table" in msg or "no such column" in msg:
    return None          # assumed: brand-new file mid-init
```

The assumption holds for a genuinely fresh file, which has no `sessions`/`messages` tables
yet. But the **same error text** is produced by a structurally broken store: an FTS
trigger that outlived the virtual table it writes to. That happens after an interrupted
migration, a partially-applied schema change, or a manual `DROP` — and in that state the
store is completely unable to accept writes.

Both cases returned `None`, so a fully-populated database whose every message write fails
was reported as healthy.

The probe already validates **openability**; it did not validate that the FTS schema is
internally consistent. That gap is what makes this failure class hard to diagnose: the
user runs the recommended repair command, is told nothing is wrong, and has no next step.

## Reproduction on `main`

Seed a normal store, drop `messages_fts_trigram` but leave its triggers, then ask the
repair probe what it thinks:

```
[broken] trigram table present: False; surviving triggers:
         ['messages_fts_trigram_insert', 'messages_fts_trigram_delete',
          'messages_fts_trigram_update']
[ground truth] INSERT INTO messages -> OperationalError: no such table: main.messages_fts_trigram

[_db_opens_cleanly] -> None
RED  ✗ repair reports 'opens cleanly — no repair needed'
        …while every message write fails. False negative.
```

With this patch, unchanged harness:

```
[_db_opens_cleanly] -> 'incomplete FTS schema — message writes fail: no such table:
  main.messages_fts_trigram. An FTS trigger references a table that no longer exists
  (interrupted migration or partial schema change).'
GREEN ✓ repair flags the DB as needing repair and names the cause
```

## The fix

Narrow the `no such table` / `no such column` branch so it only absolves a database that
is *actually* mid-init. If the base tables exist, the store is populated and a failing
write probe is a real, actionable fault:

```python
try:
    base_tables = {r[0] for r in conn.execute(
        "SELECT name FROM sqlite_master WHERE type = 'table' "
        "AND name IN ('sessions', 'messages')").fetchall()}
except sqlite3.DatabaseError:
    return None
if {"sessions", "messages"} - base_tables:
    return None                      # genuinely mid-init
return (f"incomplete FTS schema — message writes fail: {exc}. "
        "An FTS trigger references a table that no longer exists "
        "(interrupted migration or partial schema change).")
```

Two deliberate details:

- **The `cjk_unicode61` check moved above this branch.** That error is a
  *capability* gap on the probing process, not damage, and must keep returning `None`
  regardless of whether the base tables exist. Reordering keeps it unconditional.
- **The returned string names the missing table**, so the reason surfaced by
  `sessions repair` is actionable rather than a bare sqlite error.

Once the check reports the fault, the existing repair pipeline handles it: Strategy 0
(`rebuild_fts`) re-creates the FTS schema from the canonical `messages` table, which is
the correct, least-destructive recovery for this shape.

## Blast radius

This makes the health probe **stricter**, so the risk is false positives on databases that
are fine. Guarded by construction and by test:

- The `sessions`/`messages` existence check means fresh and mid-init databases are
  unchanged.
- A **healthy store with the trigram index cleanly removed** (table *and* triggers — the
  supported trigram-disabled shape) still reports clean, because nothing writes to a
  missing table. That is asserted explicitly, and it is the configuration that would
  otherwise be most at risk of a spurious flag.
- The `cjk_unicode61` capability path is preserved.

## Tests

`TestRepairDetectsIncompleteFtsSchema` in `tests/test_hermes_state.py`:

- `test_repair_check_detects_trigger_without_its_fts_table` — establishes **ground truth**
  first (asserts the raw `INSERT INTO messages` genuinely fails), then asserts
  `_db_opens_cleanly()` returns a reason naming the missing table. Fails on `main`.
- `test_repair_check_still_passes_a_healthy_store` — the false-positive guard. Asserts a
  normal store reports clean, *and* that the same store with the trigram index cleanly
  removed still reports clean. Passes both before and after, by design: it exists to
  constrain this change, not to demonstrate it.

`tests/test_hermes_state.py` passes in full. `ruff` clean.

## Scope

Detection only. This PR does not change what `repair` *does* once a fault is found — the
existing `rebuild_fts` strategy already covers this shape.

Companion PR: `fix(state): skip the trigram sweep in _fts_rebuild_finish when the trigram
index is unavailable` fixes the `optimize-storage` crash that produces this schema state
in the first place. Independent; either can land first.
