### PR TITLE
fix(anthropic): non-whitespace placeholder for synthesized leading user turn

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2529,7 +2529,19 @@ def _ensure_leading_user_turn(result: List[Dict[str, Any]]) -> None:
     (convert_messages_to_converse).
     """
     if result and result[0].get("role") != "user":
-        result.insert(0, {"role": "user", "content": [{"type": "text", "text": " "}]})
+        # NOTE: the placeholder text MUST be non-whitespace. Anthropic's
+        # Messages API rejects text content blocks that are empty or
+        # whitespace-only ("messages: text content blocks must contain
+        # non-whitespace text", HTTP 400). A single space here deadlocks
+        # any conversation whose compacted window starts with an assistant
+        # turn — the bad block is re-sent every turn and never self-heals.
+        result.insert(
+            0,
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": _EMPTY_TEXT_PLACEHOLDER}],
+            },
+        )
 
 
 def convert_messages_to_anthropic(

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -10,6 +10,7 @@ import pytest
 
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
+    _EMPTY_TEXT_PLACEHOLDER,
     _is_azure_anthropic_endpoint,
     _is_oauth_token,
     _refresh_oauth_token,
@@ -1414,7 +1415,7 @@ class TestConvertMessages:
 
         assert system == "You are helpful."
         assert result[0]["role"] == "user"
-        assert result[0]["content"] == [{"type": "text", "text": " "}]
+        assert result[0]["content"] == [{"type": "text", "text": _EMPTY_TEXT_PLACEHOLDER}]
         assert result[1]["role"] == "assistant"
         assert any(
             m["role"] == "assistant" and "Context compaction summary" in str(m["content"])
@@ -1438,7 +1439,7 @@ class TestConvertMessages:
 
         assert system is None
         assert result[0]["role"] == "user"
-        assert result[0]["content"] == [{"type": "text", "text": " "}]
+        assert result[0]["content"] == [{"type": "text", "text": _EMPTY_TEXT_PLACEHOLDER}]
         assert result[1]["role"] == "assistant"
         assert "Context compaction summary" in str(result[1]["content"])
 

--- a/tests/agent/test_anthropic_whitespace_text_blocks.py
+++ b/tests/agent/test_anthropic_whitespace_text_blocks.py
@@ -17,6 +17,7 @@ from agent.anthropic_adapter import (
     _safe_text,
     _sanitize_replay_block,
     _convert_assistant_message,
+    _ensure_leading_user_turn,
 )
 
 
@@ -116,3 +117,34 @@ class TestConvertAssistantMessageWhitespace:
         out = _convert_assistant_message(msg)
         thinking = [b for b in out["content"] if b.get("type") == "thinking"]
         assert thinking == [{"type": "thinking", "thinking": "  ", "signature": "sig-B"}]
+
+
+class TestEnsureLeadingUserTurn:
+    """A compacted window can start with an assistant turn; Anthropic requires
+    messages[0].role == user, so a placeholder user turn is prepended. That
+    placeholder's text MUST be non-whitespace or the request 400s on every turn
+    and the session wedges permanently. Ref #69512 / whitespace-block deadlock.
+    """
+
+    def test_prepends_user_turn_when_first_is_assistant(self):
+        result = [{"role": "assistant", "content": [{"type": "text", "text": "summary"}]}]
+        _ensure_leading_user_turn(result)
+        assert result[0]["role"] == "user"
+        assert len(result) == 2
+
+    def test_placeholder_text_is_non_whitespace(self):
+        result = [{"role": "assistant", "content": [{"type": "text", "text": "x"}]}]
+        _ensure_leading_user_turn(result)
+        _assert_no_blank_text(result[0])
+        assert _text_blocks(result[0]) == [{"type": "text", "text": _EMPTY_TEXT_PLACEHOLDER}]
+
+    def test_noop_when_first_is_already_user(self):
+        result = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        _ensure_leading_user_turn(result)
+        assert len(result) == 1
+        assert result[0]["content"] == [{"type": "text", "text": "hi"}]
+
+    def test_empty_list_is_left_alone(self):
+        result = []
+        _ensure_leading_user_turn(result)
+        assert result == []


### PR DESCRIPTION
## Problem

`_ensure_leading_user_turn()` in `agent/anthropic_adapter.py` prepends a synthetic user turn when a compacted message window starts with an assistant message (Anthropic requires `messages[0].role == "user"`). The placeholder text was a **single space** `" "`.

Anthropic's Messages API rejects empty/whitespace-only text content blocks:

```
HTTP 400 invalid_request_error
messages: text content blocks must contain non-whitespace text
```

Because `messages[0]` is re-sent on every turn, any conversation whose compacted window leads with an assistant turn (e.g. after a second context compaction where `protect_head` has decayed to 0) **wedges permanently** behind the same 400. Both the primary model and the fallback receive the identical malformed payload and fail identically — a non-retryable client error — so the user only ever sees repeated "model provider failed / switching to fallback" banners with no recovery.

Observed live in a long-lived gateway (Discord) session: every inbound message 400'd across restarts until the placeholder was fixed. It never self-heals because the offending block is structural, not content the user can edit away.

## Fix

Use the module's existing `_EMPTY_TEXT_PLACEHOLDER` (`"(empty)"`) — the same non-whitespace placeholder already used by the sanitize paths (`_safe_text`, `_sanitize_replay_block`, `_convert_assistant_message`). This is a one-line behavioral change; the surrounding whitespace-coercion machinery was already in place (ref #69512) but this synthesis site was missed.

## Tests

- New `TestEnsureLeadingUserTurn` in `tests/agent/test_anthropic_whitespace_text_blocks.py` (4 cases): prepends when first is assistant, placeholder is non-whitespace, no-op when already user-led, empty list untouched.
- Updated two change-detector assertions in `tests/agent/test_anthropic_adapter.py` that had frozen the buggy `" "` value to assert `_EMPTY_TEXT_PLACEHOLDER` instead.

`scripts/run_tests.sh tests/agent/test_anthropic_whitespace_text_blocks.py tests/agent/test_anthropic_adapter.py` → 198 passed. (3 unrelated `TestRunOauthSetupToken` failures are pre-existing on `main` — a pytest-9 MagicMock/`json.loads` interaction — and are untouched by this change.)

Ref #69512.
