### PR TITLE
fix(clarify): normalize serialized object choices

### DIFF
--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -111,6 +111,15 @@ class TestClarifyDictChoices:
         assert _flatten_choice({"label": "Short", "description": "Long"}) == "Short"
 
 
+    def test_flatten_unwraps_serialized_json_value(self):
+        assert _flatten_choice('{"value": "Use OAuth"}') == "Use OAuth"
+
+    def test_flatten_unwraps_serialized_json_description(self):
+        assert _flatten_choice('{"description": "Use API key"}') == "Use API key"
+
+    def test_flatten_keeps_non_object_json_string(self):
+        assert _flatten_choice('{not valid json}') == "{not valid json}"
+
     def test_dict_choices_reach_callback_as_clean_text(self):
         """The whole point: the UI callback never sees a dict repr."""
         seen = []

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -111,11 +111,13 @@ class TestClarifyDictChoices:
         assert _flatten_choice({"label": "Short", "description": "Long"}) == "Short"
 
 
-    def test_flatten_accepts_value_only_dict(self):
-        assert _flatten_choice({"value": "Use OAuth"}) == "Use OAuth"
+    def test_flatten_drops_value_only_dict(self):
+        """Lone 'value' is component-shaped, not user-facing — drop it."""
+        assert _flatten_choice({"value": "Use OAuth"}) == ""
 
-    def test_flatten_unwraps_serialized_json_value(self):
-        assert _flatten_choice('{"value": "Use OAuth"}') == "Use OAuth"
+    def test_flatten_drops_serialized_value_only_dict(self):
+        """Serialized value-only JSON is also component-shaped — drop it."""
+        assert _flatten_choice('{"value": "Use OAuth"}') == ""
 
     def test_flatten_unwraps_serialized_json_description(self):
         assert _flatten_choice('{"description": "Use API key"}') == "Use API key"

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -111,13 +111,16 @@ class TestClarifyDictChoices:
         assert _flatten_choice({"label": "Short", "description": "Long"}) == "Short"
 
 
+    def test_flatten_accepts_value_only_dict(self):
+        assert _flatten_choice({"value": "Use OAuth"}) == "Use OAuth"
+
     def test_flatten_unwraps_serialized_json_value(self):
         assert _flatten_choice('{"value": "Use OAuth"}') == "Use OAuth"
 
     def test_flatten_unwraps_serialized_json_description(self):
         assert _flatten_choice('{"description": "Use API key"}') == "Use API key"
 
-    def test_flatten_keeps_non_object_json_string(self):
+    def test_flatten_keeps_malformed_json_braces_as_plain_text(self):
         assert _flatten_choice('{not valid json}') == "{not valid json}"
 
     def test_dict_choices_reach_callback_as_clean_text(self):

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -200,11 +200,13 @@ class TestClarifyDictChoices:
         assert _flatten_choice(7) == "7"
         assert _flatten_choice(None) == ""
 
-    def test_flatten_accepts_value_only_dict(self):
-        assert _flatten_choice({"value": "Use OAuth"}) == "Use OAuth"
+    def test_flatten_drops_value_only_dict(self):
+        """Lone 'value' is component-shaped, not user-facing — drop it."""
+        assert _flatten_choice({"value": "Use OAuth"}) == ""
 
-    def test_flatten_unwraps_serialized_json_value(self):
-        assert _flatten_choice('{"value": "Use OAuth"}') == "Use OAuth"
+    def test_flatten_drops_serialized_value_only_dict(self):
+        """Serialized value-only JSON is also component-shaped — drop it."""
+        assert _flatten_choice('{"value": "Use OAuth"}') == ""
 
     def test_flatten_unwraps_serialized_json_description(self):
         assert _flatten_choice('{"description": "Use API key"}') == "Use API key"

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -200,6 +200,15 @@ class TestClarifyDictChoices:
         assert _flatten_choice(7) == "7"
         assert _flatten_choice(None) == ""
 
+    def test_flatten_unwraps_serialized_json_value(self):
+        assert _flatten_choice('{"value": "Use OAuth"}') == "Use OAuth"
+
+    def test_flatten_unwraps_serialized_json_description(self):
+        assert _flatten_choice('{"description": "Use API key"}') == "Use API key"
+
+    def test_flatten_keeps_non_object_json_string(self):
+        assert _flatten_choice('{not valid json}') == "{not valid json}"
+
     def test_dict_choices_reach_callback_as_clean_text(self):
         """The whole point: the UI callback never sees a dict repr."""
         seen = []

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -200,13 +200,16 @@ class TestClarifyDictChoices:
         assert _flatten_choice(7) == "7"
         assert _flatten_choice(None) == ""
 
+    def test_flatten_accepts_value_only_dict(self):
+        assert _flatten_choice({"value": "Use OAuth"}) == "Use OAuth"
+
     def test_flatten_unwraps_serialized_json_value(self):
         assert _flatten_choice('{"value": "Use OAuth"}') == "Use OAuth"
 
     def test_flatten_unwraps_serialized_json_description(self):
         assert _flatten_choice('{"description": "Use API key"}') == "Use API key"
 
-    def test_flatten_keeps_non_object_json_string(self):
+    def test_flatten_keeps_malformed_json_braces_as_plain_text(self):
         assert _flatten_choice('{not valid json}') == "{not valid json}"
 
     def test_dict_choices_reach_callback_as_clean_text(self):

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -21,9 +21,19 @@ def _flatten_choice(c) -> str:
     """Coerce one choice to display text. LLMs sometimes emit dict-shaped choices and ``str(c)``
     would leak the repr onto every surface and back as the answer; unwrap order ``label`` >
     ``description`` > ``text`` > ``title`` (``name``/``value`` excluded: raw component enums,
-    not labels). No match -> "" and dropped: no choice beats a garbage label."""
+    not labels). String choices that arrive as serialized JSON objects (e.g.
+    ``'{"description": "x"}'``) are parsed and unwrapped so JSON never leaks onto UI labels.
+    No match -> "" and dropped: no choice beats a garbage label."""
     if isinstance(c, str):
-        return c.strip()
+        text = c.strip()
+        # Some model/tool bridges serialize object-shaped choices before they
+        # reach the tool, e.g. '{"value": "Use OAuth"}'. Parse that
+        # representation so JSON does not leak onto UI labels.
+        if text.startswith("{") and text.endswith("}"):
+            parsed = _json_as(text, dict)
+            if parsed is not None:
+                return _flatten_choice(parsed)
+        return text
     if isinstance(c, dict):
         return next((v.strip() for k in ("label", "description", "text", "title")
                      if isinstance(v := c.get(k), str) and v.strip()), "")

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -32,12 +32,11 @@ def _flatten_choice(c) -> str:
     fixes the whole class in one place instead of per-adapter.
 
     Dict unwrap order is the canonical LLM tool-call user-facing keys:
-    ``label`` → ``description`` → ``text`` → ``title``. A lone ``value`` is
-    accepted as a fallback because some model bridges emit that shape, but
-    component-shaped ``{name, value}`` mappings remain rejected: those fields
-    may carry raw enum values or short identifiers rather than human-readable
-    labels. A dict with no accepted key is dropped (returns ""), since a
-    garbage label is worse than no choice at all.
+    ``label`` → ``description`` → ``text`` → ``title``. ``name`` and ``value``
+    are deliberately excluded — they are component-shaped fields that may carry
+    raw enum values or short identifiers, not human-readable labels. A dict with
+    no accepted key is dropped (returns ""), since a garbage label is worse than
+    no choice at all.
     """
     if c is None:
         return ""
@@ -57,12 +56,6 @@ def _flatten_choice(c) -> str:
     if isinstance(c, dict):
         for key in ("label", "description", "text", "title"):
             v = c.get(key)
-            if isinstance(v, str) and v.strip():
-                return v.strip()
-        # Accept value for serialized choice objects, but keep rejecting
-        # component-shaped {name, value} objects used elsewhere in the UI.
-        if "name" not in c:
-            v = c.get("value")
             if isinstance(v, str) and v.strip():
                 return v.strip()
         return ""

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -32,19 +32,37 @@ def _flatten_choice(c) -> str:
     fixes the whole class in one place instead of per-adapter.
 
     Dict unwrap order is the canonical LLM tool-call user-facing keys:
-    ``label`` → ``description`` → ``text`` → ``title``. ``name`` and ``value``
-    are deliberately excluded — they're component-shaped fields that could
-    carry raw enum values or short identifiers, not human-readable labels. A
-    dict with none of the canonical keys is dropped (returns ""), since a
+    ``label`` → ``description`` → ``text`` → ``title``. A lone ``value`` is
+    accepted as a fallback because some model bridges emit that shape, but
+    component-shaped ``{name, value}`` mappings remain rejected: those fields
+    may carry raw enum values or short identifiers rather than human-readable
+    labels. A dict with no accepted key is dropped (returns ""), since a
     garbage label is worse than no choice at all.
     """
     if c is None:
         return ""
     if isinstance(c, str):
-        return c.strip()
+        text = c.strip()
+        # Some model/tool bridges serialize object-shaped choices before they
+        # reach the tool, e.g. '{"value": "Use OAuth"}'. Parse that
+        # representation so JSON does not leak onto UI labels.
+        if text.startswith("{") and text.endswith("}"):
+            try:
+                parsed = json.loads(text)
+            except (TypeError, ValueError):
+                parsed = None
+            if isinstance(parsed, dict):
+                return _flatten_choice(parsed)
+        return text
     if isinstance(c, dict):
         for key in ("label", "description", "text", "title"):
             v = c.get(key)
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+        # Accept value for serialized choice objects, but keep rejecting
+        # component-shaped {name, value} objects used elsewhere in the UI.
+        if "name" not in c:
+            v = c.get("value")
             if isinstance(v, str) and v.strip():
                 return v.strip()
         return ""


### PR DESCRIPTION
## Summary

- Normalize JSON-serialized object choices before rendering clarify options.
- Accept value-only choice objects while continuing to reject component-shaped `name`/`value` mappings.
- Add regression tests for serialized choices, value fallback, and malformed JSON-looking strings.

## Problem

Some model/provider bridges serialize an object-shaped clarify choice as a string, for example:

```json
"{\"value\":\"Use OAuth\"}"
```

The existing normalizer treated this as plain text, causing raw JSON to appear on Discord buttons and other clarify surfaces.

## Testing

- 32 `test_clarify_tool.py` tests passed.
- 91 focused clarify/Discord integration tests passed during preparation.
- `git diff --check` passed.
