### PR TITLE
fix(metadata): accept camelCase contextWindow

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -414,6 +414,7 @@ def grok_supports_reasoning_effort(model: str) -> bool:
 _CONTEXT_LENGTH_KEYS = (
     "context_length",
     "context_window",
+    "contextwindow",
     "context_size",
     "max_context_length",
     "max_position_embeddings",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -20,6 +20,7 @@ from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
     DEFAULT_FALLBACK_CONTEXT,
+    _extract_context_length,
     _strip_provider_prefix,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
@@ -174,6 +175,9 @@ class TestEstimateRequestTokensRough:
 # =========================================================================
 
 class TestDefaultContextLengths:
+    def test_extracts_openai_compatible_camelcase_context_window(self):
+        assert _extract_context_length({"contextWindow": 200_000}) == 200_000
+
     def test_k3_context_is_scoped_to_confirmed_coding_endpoint(self):
         """The bare ``k3`` slug's 1 Mi context must not leak to unverified endpoints.
 


### PR DESCRIPTION
## What does this PR do?

Teaches the existing endpoint metadata extractor to accept `contextWindow`, the camelCase field returned by OpenAI-compatible model registries such as 9Router. Without this alias, `/v1/models` can advertise the correct window while Hermes silently falls through to cached/default sizing.

This complements #45061: cache refresh only helps when the refreshed payload is parseable. It does not add a provider-specific path or change cache/session behavior.

## Type of change

- [x] Bug fix (non-breaking)

## Verification

- Added a focused regression test against `_extract_context_length({"contextWindow": 200000})`.
- `python -m pytest -q tests/agent/test_model_metadata.py`
- Result: `133 passed`.

## Checklist

- [x] Existing metadata extraction path extended; no new core surface
- [x] Behavior contract test added
- [x] No config, secret, prompt-cache, or session mutation changes
- [x] Conventional commit used
