### PR TITLE
feat(routing): centralize turn routing across gateway, cli, cron, and subagents

### DIFF
--- a/agent/model_routing.py
+++ b/agent/model_routing.py
@@ -1,0 +1,665 @@
+"""Centralized task-to-model routing for Hermes turn execution.
+
+This module is the single routing decision point for gateway, CLI, cron, and
+delegated subagent tasks. It keeps routing policy deterministic and applies a
+strict precedence order:
+
+1) explicit user override
+2) workflow-specific route
+3) safety/risk escalation
+4) automatic task classification
+5) default route
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import re
+from typing import Any, Dict, Iterable, Optional
+
+from hermes_constants import parse_reasoning_effort
+
+
+logger = logging.getLogger(__name__)
+
+_REASONING_LEVELS = {
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+    "ultra",
+}
+_MODEL_TIERS = {"luna", "terra", "sol"}
+_PROFILE_STRENGTH = {
+    "deterministic": 0,
+    "fast": 1,
+    "fast_plus": 2,
+    "balanced": 3,
+    "creative": 4,
+    "strong": 5,
+    "maximum": 6,
+    "ultra": 7,
+}
+
+_DEFAULT_PROFILES: Dict[str, Dict[str, str]] = {
+    "deterministic": {"model": "luna", "reasoning": "none"},
+    "fast": {"model": "luna", "reasoning": "low"},
+    "fast_plus": {"model": "luna", "reasoning": "medium"},
+    "balanced": {"model": "terra", "reasoning": "medium"},
+    "creative": {"model": "terra", "reasoning": "high"},
+    "strong": {"model": "sol", "reasoning": "high"},
+    "maximum": {"model": "sol", "reasoning": "max"},
+    "ultra": {"model": "sol", "reasoning": "ultra"},
+}
+
+_DEFAULT_WORKFLOW_ROUTES: tuple[tuple[str, str], ...] = (
+    ("youtube editor handoff", "fast"),
+    ("send editor email", "fast"),
+    ("send editor iphone message", "fast"),
+    ("create lead magnet task", "fast"),
+    ("create youtube description draft", "fast"),
+    ("create email draft", "fast"),
+    ("update notion", "fast"),
+    ("update project status", "fast"),
+    ("organize assets", "fast"),
+    ("send routine confirmations", "fast"),
+)
+
+_APPROVED_EXECUTION_RE = re.compile(
+    r"^(?:send it|send|do it|do this|do that|go ahead|approved|"
+    r"yes send|yes,? send|ship it|run it|run this|execute|execute it|"
+    r"execute this|proceed|make it happen)$",
+    re.IGNORECASE,
+)
+_FACT_PATTERNS = (
+    re.compile(
+        r"^(?:what(?:'?s| is)|tell me) the (?:current )?"
+        r"(?:time|date|day|weather|temperature)"
+        r"(?: (?:in|at) [\w\s,.'-]+)?\??$",
+        re.IGNORECASE,
+    ),
+    re.compile(r"^what time is it(?: (?:in|at) [\w\s,.'-]+)?\??$", re.IGNORECASE),
+    re.compile(r"^current time(?: (?:in|at) [\w\s,.'-]+)?\??$", re.IGNORECASE),
+    re.compile(
+        r"^(?:what(?:'?s| is) )?(?:the )?"
+        r"(?:tallest|largest|biggest|smallest|highest|longest|shortest|"
+        r"deepest|widest|oldest|newest|fastest|richest|heaviest|lightest)"
+        r" [\w\s'-]+\??$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^(?:how (?:far|long|tall|big|old|deep|wide|high) "
+        r"(?:is|are|to|from) [\w\s,.'-]+\??|distance (?:to|from|between) [\w\s,.'-]+\??)$",
+        re.IGNORECASE,
+    ),
+)
+_DETERMINISTIC_HINT_RE = re.compile(
+    r"\b(?:validate|validation|dedup|deduplicate|retry|poll(?:ing)?|"
+    r"date math|arithmetic|status mapping|payload formatting|"
+    r"check whether|verify whether|file exists|deployment succeeded|"
+    r"url validation|required-field)\b",
+    re.IGNORECASE,
+)
+_TRIVIAL_UTILITY_RE = re.compile(
+    r"\b(?:save this|save that|find (?:the )?(?:email|file)|summarize|"
+    r"translate|nearest|closest|store hours|run (?:the )?.*workflow)\b",
+    re.IGNORECASE,
+)
+_AMBIGUOUS_HINT_RE = re.compile(
+    r"\b(?:several|multiple|ambiguous|which one|which file|which email|"
+    r"could match|might match|more than one)\b",
+    re.IGNORECASE,
+)
+_WORKER_RE = re.compile(
+    r"\b(?:build (?:a )?new automation|modify (?:the )?(?:existing )?workflow|"
+    r"github|cloudflare|webflow|ordinary implementation|normal coding|"
+    r"troubleshoot|draft (?:the )?email sequence (?:from|based on) (?:an )?approved|"
+    r"research testimonials?|incorporate testimonials?|synthesi[sz]e information)\b",
+    re.IGNORECASE,
+)
+_CREATIVE_RE = re.compile(
+    r"\b(?:youtube (?:video )?packet|notion flashcards?|title generation|"
+    r"thumbnail copy|a/?b testing ideas?|brand-specific youtube|youtube outliers?|"
+    r"youtube trend analysis|deeper research|polished execution plan|"
+    r"complicated implementation planning|multi-repository|higher-risk code changes)\b",
+    re.IGNORECASE,
+)
+_STRATEGY_RE = re.compile(
+    r"\b(?:launch strategy|offer construction|pricing strategy|"
+    r"product positioning|campaign direction|business strategy|"
+    r"architecture|system design|difficult debugging|production incident|"
+    r"major migration|high-stakes|final review|major launch|flagship youtube|"
+    r"terra failed|tried twice)\b",
+    re.IGNORECASE,
+)
+_EXCEPTIONAL_RE = re.compile(
+    r"\b(?:extremely difficult debugging|major architecture migration|"
+    r"security-sensitive review|major production failure|comprehensive launch postmortem|"
+    r"substantial financial consequences|conflicting research needing deep resolution)\b",
+    re.IGNORECASE,
+)
+_ULTRA_RE = re.compile(
+    r"\b(?:parallel subagents?|simultaneously|multi-stream investigation|"
+    r"across several services|across multiple repositories|compare several major strategies)\b",
+    re.IGNORECASE,
+)
+_HIGH_RISK_RE = re.compile(
+    r"\b(?:purchase|financial commitment|delete important data|publish publicly|"
+    r"full email campaign|major production deploy(?:ment)?|"
+    r"change permissions|change credentials|irreversible)\b",
+    re.IGNORECASE,
+)
+
+_INLINE_ROUTE_RE = re.compile(
+    r"\[\[?\s*route\s*:\s*(?P<body>[^\]]+?)\s*\]?\]",
+    re.IGNORECASE,
+)
+_GPT56_TIER_RE = re.compile(
+    r"^(?P<prefix>.*?gpt-5\.6-)(?P<tier>luna|terra|sol)(?P<suffix>(?:-pro)?)$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class InlineRouteOverride:
+    """Per-message explicit routing directive parsed from the user prompt."""
+
+    model_tier: Optional[str] = None
+    reasoning_tier: Optional[str] = None
+    profile: Optional[str] = None
+    no_escalation: bool = False
+    maximum_quality: bool = False
+    raw: str = ""
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    """Normalized result consumed by each surface-specific route wrapper."""
+
+    model: str
+    reasoning_config: Optional[dict]
+    profile: str
+    category: str
+    reason: str
+    override_used: bool
+    escalation_reason: Optional[str]
+    no_escalation: bool
+    retry_count: int
+    workflow_match: Optional[str]
+    clean_message: str
+
+    def as_dict(self) -> dict:
+        return {
+            "model": self.model,
+            "reasoning_config": self.reasoning_config,
+            "profile": self.profile,
+            "category": self.category,
+            "reason": self.reason,
+            "override_used": self.override_used,
+            "escalation_reason": self.escalation_reason,
+            "no_escalation": self.no_escalation,
+            "retry_count": self.retry_count,
+            "workflow_match": self.workflow_match,
+            "clean_message": self.clean_message,
+        }
+
+
+def _message_to_text(message: Any) -> str:
+    """Extract a routing-friendly text representation from a user message."""
+    if isinstance(message, str):
+        return message
+    if isinstance(message, list):
+        chunks: list[str] = []
+        for item in message:
+            if isinstance(item, str):
+                chunks.append(item)
+            elif isinstance(item, dict):
+                if item.get("type") == "text":
+                    text = item.get("text")
+                    if isinstance(text, str):
+                        chunks.append(text)
+        return " ".join(chunks)
+    return str(message or "")
+
+
+def _normalize_text(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def _reasoning_label(reasoning_config: Optional[dict]) -> str:
+    if not isinstance(reasoning_config, dict):
+        return ""
+    if reasoning_config.get("enabled") is False:
+        return "none"
+    effort = str(reasoning_config.get("effort") or "").strip().lower()
+    return effort if effort in _REASONING_LEVELS else ""
+
+
+def _derive_tier_model(base_model: str, tier: str) -> Optional[str]:
+    """Derive a Luna/Terra/Sol sibling model from the active base model."""
+    if tier not in _MODEL_TIERS:
+        return None
+    model = str(base_model or "").strip()
+    if not model:
+        return None
+    match = _GPT56_TIER_RE.match(model)
+    if match:
+        return f"{match.group('prefix')}{tier}{match.group('suffix')}"
+    return None
+
+
+def _parse_inline_override(message_text: str) -> tuple[str, Optional[InlineRouteOverride]]:
+    """Parse and strip an inline routing directive.
+
+    Syntax (shared across Telegram/CLI/cron prompts):
+        [[route: luna high no-escalation]]
+        [route: profile=creative]
+        [[route: maximum-quality]]
+    """
+    match = _INLINE_ROUTE_RE.search(message_text or "")
+    if not match:
+        return message_text, None
+    raw_directive = match.group("body") or ""
+    lowered = raw_directive.lower()
+    tokens = [tok for tok in re.split(r"[\s,]+", lowered) if tok]
+
+    model_tier: Optional[str] = None
+    reasoning_tier: Optional[str] = None
+    profile: Optional[str] = None
+    no_escalation = False
+    maximum_quality = False
+
+    for token in tokens:
+        token = token.strip()
+        if not token:
+            continue
+        if token in {"no-escalation", "no_escalation", "noescalation"}:
+            no_escalation = True
+            continue
+        if token in {"maximum-quality", "maximum_quality", "max-quality", "max_quality"}:
+            maximum_quality = True
+            continue
+        if token.startswith("model=") or token.startswith("tier="):
+            _, value = token.split("=", 1)
+            value = value.strip().lower()
+            if value in _MODEL_TIERS:
+                model_tier = value
+            continue
+        if token.startswith("reasoning=") or token.startswith("effort="):
+            _, value = token.split("=", 1)
+            value = value.strip().lower()
+            if value in _REASONING_LEVELS:
+                reasoning_tier = value
+            continue
+        if token.startswith("profile="):
+            _, value = token.split("=", 1)
+            value = value.strip().lower()
+            if value:
+                profile = value
+            continue
+        if token in _MODEL_TIERS:
+            model_tier = token
+            continue
+        if token in _REASONING_LEVELS:
+            reasoning_tier = token
+            continue
+        if token in _PROFILE_STRENGTH:
+            profile = token
+
+    if "maximum quality" in lowered or "max quality" in lowered:
+        maximum_quality = True
+
+    override = InlineRouteOverride(
+        model_tier=model_tier,
+        reasoning_tier=reasoning_tier,
+        profile=profile,
+        no_escalation=no_escalation,
+        maximum_quality=maximum_quality,
+        raw=raw_directive.strip(),
+    )
+    clean_message = (message_text[: match.start()] + message_text[match.end() :]).strip()
+    return clean_message, override
+
+
+def _normalize_profiles(
+    *,
+    policy_profiles: Any,
+    legacy_turn_routing: Optional[dict],
+) -> Dict[str, Dict[str, str]]:
+    apply_legacy_bridge = not isinstance(policy_profiles, dict) or not policy_profiles
+    profiles: Dict[str, Dict[str, str]] = {
+        name: dict(values) for name, values in _DEFAULT_PROFILES.items()
+    }
+    if isinstance(policy_profiles, dict):
+        for name, raw in policy_profiles.items():
+            key = str(name or "").strip().lower()
+            if key not in profiles:
+                continue
+            if isinstance(raw, dict):
+                model = str(raw.get("model") or "").strip()
+                reasoning = str(raw.get("reasoning") or "").strip().lower()
+                if model:
+                    profiles[key]["model"] = model
+                if reasoning:
+                    profiles[key]["reasoning"] = reasoning
+            elif isinstance(raw, str):
+                profiles[key]["model"] = raw.strip()
+
+    # Backward-compatible bridge from agent.turn_routing to routing profiles.
+    if apply_legacy_bridge and isinstance(legacy_turn_routing, dict):
+        bridge = {
+            "fast": ("trivial_model", "trivial_reasoning"),
+            "balanced": ("moderate_model", "moderate_reasoning"),
+            "creative": ("high_model", "high_reasoning"),
+        }
+        for profile_name, (m_key, r_key) in bridge.items():
+            model = str(legacy_turn_routing.get(m_key) or "").strip()
+            reasoning = str(legacy_turn_routing.get(r_key) or "").strip().lower()
+            if model:
+                profiles[profile_name]["model"] = model
+            if reasoning:
+                profiles[profile_name]["reasoning"] = reasoning
+
+    return profiles
+
+
+def _normalize_workflow_routes(configured_routes: Any) -> list[tuple[str, str]]:
+    routes: list[tuple[str, str]] = list(_DEFAULT_WORKFLOW_ROUTES)
+    if isinstance(configured_routes, dict):
+        for match_text, profile in configured_routes.items():
+            m = str(match_text or "").strip().lower()
+            p = str(profile or "").strip().lower()
+            if m and p in _PROFILE_STRENGTH:
+                routes.append((m, p))
+    elif isinstance(configured_routes, list):
+        for entry in configured_routes:
+            if not isinstance(entry, dict):
+                continue
+            m = str(entry.get("match") or "").strip().lower()
+            p = str(entry.get("profile") or "").strip().lower()
+            if m and p in _PROFILE_STRENGTH:
+                routes.append((m, p))
+    # Deduplicate while keeping first-wins ordering.
+    seen: set[tuple[str, str]] = set()
+    deduped: list[tuple[str, str]] = []
+    for route in routes:
+        if route in seen:
+            continue
+        seen.add(route)
+        deduped.append(route)
+    return deduped
+
+
+def _profile_model(
+    profile: str,
+    *,
+    profiles: Dict[str, Dict[str, str]],
+    base_model: str,
+) -> str:
+    cfg = profiles.get(profile) or {}
+    configured = str(cfg.get("model") or "").strip().lower()
+    if configured in _MODEL_TIERS:
+        return _derive_tier_model(base_model, configured) or f"gpt-5.6-{configured}"
+    if configured:
+        return str(cfg.get("model")).strip()
+    # Fallback to tier-derived sibling when possible, otherwise keep base model.
+    tier = str((_DEFAULT_PROFILES.get(profile) or {}).get("model") or "").strip().lower()
+    if tier in _MODEL_TIERS:
+        return _derive_tier_model(base_model, tier) or base_model
+    return base_model
+
+
+def _profile_reasoning(
+    profile: str,
+    *,
+    profiles: Dict[str, Dict[str, str]],
+    fallback_reasoning: Optional[dict],
+) -> Optional[dict]:
+    cfg = profiles.get(profile) or {}
+    value = str(cfg.get("reasoning") or "").strip().lower()
+    if not value:
+        return fallback_reasoning
+    parsed = parse_reasoning_effort(value)
+    return parsed if parsed is not None else fallback_reasoning
+
+
+def _classify_profile(message_text: str) -> tuple[str, str, str]:
+    text = _normalize_text(message_text).lower()
+    if not text:
+        return "fast", "trivial.empty", "Empty/whitespace-only request"
+    if len(text) <= 80 and _APPROVED_EXECUTION_RE.match(text):
+        return "fast", "trivial.approved_execution", "Short approved execution confirmation"
+    if _DETERMINISTIC_HINT_RE.search(text):
+        return "deterministic", "trivial.deterministic", "Deterministic validation/mapping/retry task"
+    if len(text) <= 140 and any(p.match(text) for p in _FACT_PATTERNS):
+        return "fast", "trivial.fact_lookup", "Quick factual lookup request"
+    if _TRIVIAL_UTILITY_RE.search(text):
+        if _AMBIGUOUS_HINT_RE.search(text):
+            return "fast_plus", "trivial.ambiguous", "Light ambiguity in otherwise fast utility task"
+        return "fast", "trivial.utility", "Low-judgment utility/retrieval/workflow request"
+    if _ULTRA_RE.search(text):
+        return "ultra", "strategy.parallel_ultra", "Parallel multi-stream investigation requested"
+    if _EXCEPTIONAL_RE.search(text):
+        return "maximum", "strategy.exceptional", "Exceptional high-stakes technical/strategic request"
+    if _STRATEGY_RE.search(text):
+        return "strong", "strategy.high_stakes", "High-stakes strategy/architecture/debugging request"
+    if _CREATIVE_RE.search(text):
+        return "creative", "creative.deep_work", "Creative/research-heavy production task"
+    if _WORKER_RE.search(text):
+        return "balanced", "worker.general", "General implementation/workflow task"
+    return "balanced", "worker.default", "Fallback balanced worker route"
+
+
+def _workflow_profile(message_text: str, workflow_routes: Iterable[tuple[str, str]]) -> tuple[Optional[str], Optional[str]]:
+    text = _normalize_text(message_text).lower()
+    if not text:
+        return None, None
+    for phrase, profile in workflow_routes:
+        if phrase and phrase in text:
+            return profile, phrase
+    return None, None
+
+
+def _risk_escalation_profile(
+    *,
+    selected_profile: str,
+    message_text: str,
+    allow_escalation: bool,
+    no_escalation: bool,
+) -> tuple[str, Optional[str]]:
+    if not allow_escalation or no_escalation:
+        return selected_profile, None
+    text = _normalize_text(message_text)
+    if not text or selected_profile not in _PROFILE_STRENGTH:
+        return selected_profile, None
+    if not _HIGH_RISK_RE.search(text):
+        return selected_profile, None
+    if _PROFILE_STRENGTH[selected_profile] >= _PROFILE_STRENGTH["strong"]:
+        return selected_profile, None
+    return "strong", "High-risk action keywords detected"
+
+
+def classify_turn_complexity(message: Any) -> str:
+    """Legacy compatibility shim for callers that still consume 3 buckets."""
+    profile, _category, _reason = _classify_profile(_message_to_text(message))
+    if profile in {"deterministic", "fast", "fast_plus"}:
+        return "trivial"
+    if profile == "balanced":
+        return "moderate"
+    return "high"
+
+
+def resolve_routing_decision(
+    *,
+    message: Any,
+    base_model: str,
+    fallback_reasoning_config: Optional[dict],
+    config: Optional[dict],
+    surface: str,
+    retry_count: int = 0,
+    workflow_model_override: Optional[str] = None,
+    workflow_reasoning_override: Optional[dict] = None,
+) -> RoutingDecision:
+    """Return the centralized routing decision for a single turn/task."""
+    cfg = config if isinstance(config, dict) else {}
+    routing_cfg = cfg.get("routing") if isinstance(cfg.get("routing"), dict) else {}
+    legacy_turn_cfg = (
+        cfg.get("agent", {}).get("turn_routing")
+        if isinstance(cfg.get("agent"), dict)
+        and isinstance(cfg.get("agent", {}).get("turn_routing"), dict)
+        else {}
+    )
+    routing_enabled = routing_cfg.get("enabled")
+    if routing_enabled is None:
+        routing_enabled = bool(legacy_turn_cfg.get("enabled"))
+    else:
+        routing_enabled = bool(routing_enabled)
+    allow_escalation = bool(routing_cfg.get("allow_escalation", True))
+    default_profile = str(routing_cfg.get("default_profile") or "balanced").strip().lower()
+    if default_profile not in _PROFILE_STRENGTH:
+        default_profile = "balanced"
+
+    raw_message = _message_to_text(message)
+    clean_message, inline_override = _parse_inline_override(raw_message)
+    no_escalation = bool(getattr(inline_override, "no_escalation", False))
+    explicit_override_used = False
+    workflow_override_applied = False
+    escalation_reason: Optional[str] = None
+    workflow_match: Optional[str] = None
+
+    profiles = _normalize_profiles(
+        policy_profiles=routing_cfg.get("profiles"),
+        legacy_turn_routing=legacy_turn_cfg if routing_enabled else None,
+    )
+    workflow_routes = _normalize_workflow_routes(routing_cfg.get("workflow_routes"))
+
+    selected_profile = default_profile if routing_enabled else "session"
+    category = "default"
+    reason = "Routing disabled; using session/default route"
+
+    # Priority 1: explicit inline override.
+    if routing_enabled and inline_override:
+        forced_profile: Optional[str] = None
+        if inline_override.maximum_quality:
+            forced_profile = "maximum"
+        elif inline_override.profile in _PROFILE_STRENGTH:
+            forced_profile = inline_override.profile
+        elif inline_override.model_tier in _MODEL_TIERS:
+            forced_profile = {
+                "luna": "fast",
+                "terra": "balanced",
+                "sol": "strong",
+            }[inline_override.model_tier]
+        if forced_profile:
+            selected_profile = forced_profile
+            category = "override.explicit"
+            reason = "Explicit inline route directive"
+            explicit_override_used = True
+
+    # Priority 2: workflow route (or explicit caller workflow pin).
+    if routing_enabled and not explicit_override_used:
+        if workflow_model_override:
+            selected_profile = default_profile
+            category = "workflow.model_pin"
+            reason = "Workflow-level model override supplied by caller"
+            workflow_override_applied = True
+        else:
+            matched_profile, matched_phrase = _workflow_profile(clean_message, workflow_routes)
+            if matched_profile:
+                selected_profile = matched_profile
+                category = "workflow.known"
+                reason = f"Workflow route matched '{matched_phrase}'"
+                workflow_match = matched_phrase
+
+    # Priority 3 and 4: risk escalation and automatic classification.
+    if routing_enabled and not explicit_override_used and not workflow_override_applied and category == "default":
+        selected_profile, category, reason = _classify_profile(clean_message)
+        selected_profile, escalation_reason = _risk_escalation_profile(
+            selected_profile=selected_profile,
+            message_text=clean_message,
+            allow_escalation=allow_escalation,
+            no_escalation=no_escalation,
+        )
+        if escalation_reason:
+            category = "escalation.risk"
+            reason = escalation_reason
+
+    # Priority 5: fallback/default route is already encoded above.
+    model = base_model
+    reasoning_config = fallback_reasoning_config
+
+    if routing_enabled:
+        model = _profile_model(
+            selected_profile,
+            profiles=profiles,
+            base_model=base_model,
+        ) or base_model
+        reasoning_config = _profile_reasoning(
+            selected_profile,
+            profiles=profiles,
+            fallback_reasoning=fallback_reasoning_config,
+        )
+
+        # Apply explicit override field-level adjustments after profile mapping.
+        if inline_override:
+            if inline_override.model_tier in _MODEL_TIERS:
+                derived = _derive_tier_model(model or base_model, inline_override.model_tier)
+                if derived:
+                    model = derived
+                else:
+                    model = f"gpt-5.6-{inline_override.model_tier}"
+            if inline_override.reasoning_tier in _REASONING_LEVELS:
+                parsed = parse_reasoning_effort(inline_override.reasoning_tier)
+                if parsed is not None:
+                    reasoning_config = parsed
+
+    if workflow_model_override and not explicit_override_used:
+        model = str(workflow_model_override).strip() or model
+    if workflow_reasoning_override is not None and not explicit_override_used:
+        reasoning_config = workflow_reasoning_override
+
+    if not model:
+        model = base_model
+
+    reasoning_label = _reasoning_label(reasoning_config) or "session-default"
+    logger.info(
+        "Routing decision surface=%s profile=%s model=%s reasoning=%s category=%s "
+        "override=%s no_escalation=%s escalation=%s workflow=%s retry_count=%s reason=%s",
+        surface,
+        selected_profile,
+        model,
+        reasoning_label,
+        category,
+        explicit_override_used,
+        no_escalation,
+        escalation_reason or "",
+        workflow_match or "",
+        retry_count,
+        reason,
+    )
+
+    return RoutingDecision(
+        model=model,
+        reasoning_config=reasoning_config,
+        profile=selected_profile,
+        category=category,
+        reason=reason,
+        override_used=explicit_override_used,
+        escalation_reason=escalation_reason,
+        no_escalation=no_escalation,
+        retry_count=max(0, int(retry_count or 0)),
+        workflow_match=workflow_match,
+        clean_message=clean_message,
+    )
+
+
+__all__ = [
+    "InlineRouteOverride",
+    "RoutingDecision",
+    "classify_turn_complexity",
+    "resolve_routing_decision",
+]

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -140,6 +140,35 @@ model:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
 
 # =============================================================================
+# Centralized Routing (gateway/CLI/cron/subagents)
+# =============================================================================
+# Shared model/reasoning router used across Hermes surfaces.
+# Priority: explicit override > workflow route > safety escalation > classifier > default.
+# Inline explicit override syntax in a user prompt:
+#   [[route: luna high]]
+#   [[route: profile=creative]]
+#   [[route: maximum-quality]]
+#   [[route: no-escalation]]
+#
+# routing:
+#   enabled: true
+#   default_profile: balanced      # deterministic|fast|fast_plus|balanced|creative|strong|maximum|ultra
+#   allow_escalation: true
+#   profiles:
+#     deterministic: { model: "luna",  reasoning: "none" }
+#     fast:          { model: "luna",  reasoning: "low" }
+#     fast_plus:     { model: "luna",  reasoning: "medium" }
+#     balanced:      { model: "terra", reasoning: "medium" }
+#     creative:      { model: "terra", reasoning: "high" }
+#     strong:        { model: "sol",   reasoning: "high" }
+#     maximum:       { model: "sol",   reasoning: "max" }
+#     ultra:         { model: "sol",   reasoning: "ultra" }
+#   # Optional substring→profile map for known workflows.
+#   # workflow_routes:
+#   #   "youtube editor handoff": "fast"
+#   #   "launch strategy": "strong"
+
+# =============================================================================
 # OpenRouter Provider Routing (only applies when using OpenRouter)
 # =============================================================================
 # Control how requests are routed across providers on OpenRouter.
@@ -792,6 +821,24 @@ agent:
   # Fires once per run when inactivity reaches this threshold (seconds).
   # Set to 0 to disable the warning.
   # gateway_timeout_warning: 900
+
+  # Long-running "still working" heartbeats.
+  # Two modes, listed here in order of precedence:
+  #
+  #   gateway_notify_schedule: [180, 420, 900, 1800, 3600]
+  #     Cumulative elapsed-second checkpoints. One fresh notification per
+  #     checkpoint (no edit-in-place), then the gateway stays quiet after
+  #     the last entry. The example above pings at 3 min, 7 min, 15 min,
+  #     30 min, and 1 h — after that a genuinely stuck run does not spam.
+  #     Each ping is plain English: the current task + which chat/thread
+  #     it belongs to.
+  #
+  #   gateway_notify_interval: 180
+  #     Legacy periodic mode. Fires every N seconds and edits a single
+  #     heartbeat message in place. Used only when gateway_notify_schedule
+  #     is unset or empty. 0 disables notifications entirely.
+  # gateway_notify_schedule: []
+  # gateway_notify_interval: 180
 
   # Graceful drain timeout for gateway stop/restart (seconds).
   # Default 0 = no drain: a restart interrupts in-flight agents immediately,

--- a/cli.py
+++ b/cli.py
@@ -12279,6 +12279,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return None
 
         turn_route = self._resolve_turn_agent_config(message)
+        _clean_message = turn_route.get("clean_message")
+        if (
+            isinstance(message, str)
+            and isinstance(_clean_message, str)
+            and _clean_message
+        ):
+            message = _clean_message
         if turn_route["signature"] != self._active_agent_route_signature:
             self.agent = None
 
@@ -16526,6 +16533,13 @@ def main(
                                 announce=False,
                             )
                     turn_route = cli._resolve_turn_agent_config(effective_query)
+                    _clean_query = turn_route.get("clean_message")
+                    if (
+                        isinstance(effective_query, str)
+                        and isinstance(_clean_query, str)
+                        and _clean_query
+                    ):
+                        effective_query = _clean_query
                     if turn_route["signature"] != cli._active_agent_route_signature:
                         cli.agent = None
                     if cli._init_agent(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -40,6 +40,7 @@ from typing import Any, List, Optional
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from hermes_constants import get_hermes_home
+from agent.model_routing import resolve_routing_decision
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_cli.fallback_config import get_fallback_chain
@@ -3411,6 +3412,39 @@ def run_job(
                 f"job_id={job_id} provider=<provider> model=<model>` "
                 f"(or pin the original values to keep them). See #44585."
             )
+
+        # Shared centralized turn routing (same policy as gateway/CLI).
+        # Job-level model pins are treated as workflow-level overrides that
+        # still yield to explicit inline route directives in the prompt.
+        try:
+            _route_message = str(job.get("prompt") or prompt or "")
+            _workflow_model_override = str(job.get("model") or "").strip() or None
+            decision = resolve_routing_decision(
+                message=_route_message,
+                base_model=str(model),
+                fallback_reasoning_config=reasoning_config,
+                config=_cfg if isinstance(_cfg, dict) else {},
+                surface="cron",
+                workflow_model_override=_workflow_model_override,
+            )
+            model = decision.model or model
+            if isinstance(decision.reasoning_config, dict):
+                reasoning_config = decision.reasoning_config
+            logger.info(
+                "Cron routing: profile=%s category=%s model=%s reasoning=%s "
+                "override=%s escalation=%s workflow=%s reason=%s",
+                decision.profile,
+                decision.category,
+                model,
+                (reasoning_config or {}).get("effort", "none")
+                if reasoning_config is not None else "session",
+                decision.override_used,
+                decision.escalation_reason or "",
+                decision.workflow_match or "",
+                decision.reason,
+            )
+        except Exception:
+            logger.debug("Cron centralized routing failed; using resolved model", exc_info=True)
 
         fallback_model = get_fallback_chain(_cfg) or None
         credential_pool = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -67,6 +67,10 @@ from agent.conversation_compression import (
 )
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
+from agent.model_routing import (
+    classify_turn_complexity as _classify_turn_complexity_shared,
+    resolve_routing_decision,
+)
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -803,6 +807,75 @@ def _float_env(name: str, default: float) -> float:
         return float(raw)
     except (TypeError, ValueError):
         return float(default)
+
+
+def _parse_notify_schedule(raw: Optional[str]) -> List[float]:
+    """Parse a checkpoint schedule from a string or JSON list.
+
+    Accepts either ``"180,420,900"`` or ``"[180, 420, 900]"`` shapes. Any
+    non-positive or unparseable entry is silently dropped. The returned
+    list is deduplicated and sorted ascending — callers rely on that to
+    walk cumulative checkpoints in order.
+    """
+    if not raw:
+        return []
+    text = raw.strip()
+    if not text:
+        return []
+    parsed: List[float] = []
+    try:
+        if text.startswith("["):
+            loaded = json.loads(text)
+            if isinstance(loaded, (list, tuple)):
+                for item in loaded:
+                    try:
+                        v = float(item)
+                    except (TypeError, ValueError):
+                        continue
+                    if v > 0:
+                        parsed.append(v)
+    except (ValueError, TypeError):
+        parsed = []
+    if not parsed:
+        for token in text.replace(";", ",").split(","):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                v = float(token)
+            except ValueError:
+                continue
+            if v > 0:
+                parsed.append(v)
+    parsed = sorted({round(v, 6) for v in parsed})
+    return parsed
+
+
+_TASK_DESC_MAX_LEN = 120
+
+
+def _sanitize_task_description(
+    text: Optional[str],
+    *,
+    max_len: int = _TASK_DESC_MAX_LEN,
+) -> str:
+    """Collapse whitespace and cap a user-turn text for status readouts.
+
+    Never treated as a prompt; downstream code only ever renders this
+    inside a plain-English "Working on: X" line, so control characters
+    and leading slashes stay literal (no instruction interpretation).
+    """
+    if not text:
+        return ""
+    try:
+        collapsed = " ".join(str(text).split()).strip()
+    except Exception:
+        return ""
+    if not collapsed:
+        return ""
+    if len(collapsed) > max_len:
+        collapsed = collapsed[: max(1, max_len - 1)].rstrip() + "…"
+    return collapsed
 
 
 def _is_fresh_gateway_interruption(
@@ -1933,6 +2006,14 @@ if _config_path.exists():
                 os.environ["HERMES_AGENT_TIMEOUT_WARNING"] = str(_agent_cfg["gateway_timeout_warning"])
             if "gateway_notify_interval" in _agent_cfg:
                 os.environ["HERMES_AGENT_NOTIFY_INTERVAL"] = str(_agent_cfg["gateway_notify_interval"])
+            if "gateway_notify_schedule" in _agent_cfg:
+                _sched_cfg = _agent_cfg["gateway_notify_schedule"]
+                if isinstance(_sched_cfg, (list, tuple)):
+                    os.environ["HERMES_AGENT_NOTIFY_SCHEDULE"] = ",".join(
+                        str(x) for x in _sched_cfg
+                    )
+                elif isinstance(_sched_cfg, str):
+                    os.environ["HERMES_AGENT_NOTIFY_SCHEDULE"] = _sched_cfg
             if "restart_drain_timeout" in _agent_cfg:
                 os.environ["HERMES_RESTART_DRAIN_TIMEOUT"] = str(_agent_cfg["restart_drain_timeout"])
             if "gateway_auto_continue_freshness" in _agent_cfg:
@@ -3418,6 +3499,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
+        # Sanitized, capped user-turn text per running session — surfaced by
+        # /agents and the long-running heartbeat as plain-English "working
+        # on X" context. Cleared with the rest of the running-agent slot
+        # in _release_all_running_agent_state_for.
+        self._running_agents_task: Dict[str, str] = {}
         self._active_session_leases: Dict[str, Any] = {}
         # Per-SESSION_ID turn lease (#64934): serializes the
         # [load history → run → flush] region when two ROUTING KEYS resolve
@@ -4513,13 +4599,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return model, runtime_kwargs
 
+    @staticmethod
+    def _classify_turn_complexity(user_message: str) -> str:
+        """Legacy compatibility shim around the shared centralized classifier."""
+        return _classify_turn_complexity_shared(user_message)
+
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
         """Build the effective model/runtime config for a single turn.
-
-        Always uses the session's primary model/provider.  If `/fast` is
-        enabled and the model supports Priority Processing / Anthropic fast
-        mode, attach `request_overrides` so the API call is marked
-        accordingly.
+        Uses the centralized routing module so gateway behavior matches CLI,
+        cron, and subagent delegation.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
 
@@ -4534,11 +4622,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "credential_pool": runtime_kwargs.get("credential_pool"),
             "max_tokens": runtime_kwargs.get("max_tokens"),
         }
+
+        selected_model = model
+        route_class = "session"
+        reasoning_config = None
+        route_profile = "session"
+        route_category = "session"
+        route_reason = "Session/default model"
+        escalation_reason = None
+        workflow_match = None
+        override_used = False
+        clean_message = str(user_message or "")
+        try:
+            user_config = _load_gateway_config()
+            decision = resolve_routing_decision(
+                message=user_message,
+                base_model=model,
+                fallback_reasoning_config=getattr(self, "_reasoning_config", None),
+                config=user_config,
+                surface="gateway",
+            )
+            selected_model = decision.model
+            reasoning_config = decision.reasoning_config
+            route_profile = decision.profile
+            route_category = decision.category
+            route_reason = decision.reason
+            escalation_reason = decision.escalation_reason
+            workflow_match = decision.workflow_match
+            override_used = decision.override_used
+            clean_message = decision.clean_message
+            route_class = _classify_turn_complexity_shared(clean_message)
+        except Exception:
+            pass
+
         route = {
-            "model": model,
+            "model": selected_model,
+            "route_class": route_class,
+            "route_profile": route_profile,
+            "route_category": route_category,
+            "route_reason": route_reason,
+            "route_override": override_used,
+            "route_escalation_reason": escalation_reason,
+            "route_workflow_match": workflow_match,
+            "reasoning_config": reasoning_config,
             "runtime": runtime,
+            "clean_message": clean_message,
             "signature": (
-                model,
+                selected_model,
                 runtime["provider"],
                 runtime["requested_provider"],
                 runtime["base_url"],
@@ -4547,6 +4677,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 tuple(runtime["args"]),
             ),
         }
+        logger.info(
+            "Turn routing: class=%s profile=%s category=%s model=%s reasoning=%s "
+            "override=%s escalation=%s workflow=%s reason=%s",
+            route_class,
+            route_profile,
+            route_category,
+            selected_model,
+            (reasoning_config or {}).get("effort", "none")
+            if reasoning_config is not None else "session",
+            override_used,
+            escalation_reason or "",
+            workflow_match or "",
+            route_reason,
+        )
 
         service_tier = getattr(self, "_service_tier", None)
         if not service_tier:
@@ -6845,6 +6989,71 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
         return True
 
+    def _record_running_task_description(
+        self,
+        session_key: Optional[str],
+        raw_text: Optional[str],
+    ) -> None:
+        """Store a sanitized, capped one-liner of the current turn's task.
+
+        Feeds both the /agents readout and the long-running heartbeat.
+        Untrusted inbound text is never treated as an instruction — it is
+        collapsed to a single line and only ever rendered as content.
+        """
+        if not session_key:
+            return
+        store = getattr(self, "_running_agents_task", None)
+        if store is None:
+            store = {}
+            self._running_agents_task = store
+        desc = _sanitize_task_description(raw_text)
+        if desc:
+            store[session_key] = desc
+        else:
+            store.pop(session_key, None)
+
+    def _humanize_session_source(self, source: Any) -> str:
+        """Return a plain-English "which chat/thread" label for a source.
+
+        Preferred order: cached SessionSource.description (already handles
+        DM / group / channel / thread), then chat_name, then platform.
+        Falls back to a generic label rather than exposing raw internal
+        keys.
+        """
+        if source is None:
+            return "an active chat"
+        try:
+            desc = str(getattr(source, "description", "") or "").strip()
+        except Exception:
+            desc = ""
+        if desc:
+            return desc
+        chat_name = str(getattr(source, "chat_name", "") or "").strip()
+        if chat_name:
+            return chat_name
+        platform = getattr(source, "platform", None)
+        plat_label = getattr(platform, "value", None) or str(platform or "").strip()
+        if plat_label and plat_label.lower() != "none":
+            return f"{plat_label} chat"
+        return "an active chat"
+
+    def _humanize_session_key(self, session_key: Optional[str]) -> str:
+        """Look up the human-readable label for a session_key.
+
+        Uses the cached SessionSource populated on message ingestion; if
+        the key isn't cached (e.g. the session was created before this
+        runner booted), degrades to a generic label so no internal
+        session key is leaked to the user.
+        """
+        if not session_key:
+            return "an active chat"
+        cached = getattr(self, "_session_sources", None)
+        if cached is not None:
+            source = cached.get(session_key)
+            if source is not None:
+                return self._humanize_session_source(source)
+        return "an active chat"
+
     # Upper bound on off-loop agent-resource cleanup invoked from coroutines
     # running on the gateway's event loop (session-expiry sweep, in-turn
     # cache-hygiene re-eviction). _cleanup_agent_resources is synchronous and
@@ -7699,6 +7908,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # instead of spinning up a duplicate AIAgent (#45456).
             self._running_agents[entry.session_key] = _AGENT_PENDING_SENTINEL
             self._running_agents_ts[entry.session_key] = time.time()
+            self._record_running_task_description(
+                entry.session_key, "resuming previous turn"
+            )
             self._persist_active_agents()
 
             # Empty-text internal event — the _is_resume_pending branch in
@@ -12245,6 +12457,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._active_session_leases[_quick_key] = _active_session_lease
         self._running_agents[_quick_key] = _AGENT_PENDING_SENTINEL
         self._running_agents_ts[_quick_key] = time.time()
+        self._record_running_task_description(_quick_key, getattr(event, "text", ""))
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
 
@@ -15720,12 +15933,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             pr = self._provider_routing
             max_iterations = _current_max_iterations()
-            reasoning_config = self._resolve_session_reasoning_config(
+            reasoning_config: Dict[str, Any] = dict(self._resolve_session_reasoning_config(
                 source=source, model=model
-            )
+            ) or {})
             self._reasoning_config = reasoning_config
             self._service_tier = self._resolve_session_service_tier(source=source)
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            _clean_prompt = turn_route.get("clean_message")
+            if isinstance(_clean_prompt, str) and _clean_prompt:
+                prompt = _clean_prompt
+            _routed_reasoning = turn_route.get("reasoning_config")
+            if isinstance(_routed_reasoning, dict):
+                reasoning_config = dict(_routed_reasoning)
+                self._reasoning_config = reasoning_config
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
@@ -18769,6 +18989,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("Failed to release active session slot", exc_info=True)
         self._running_agents.pop(session_key, None)
         self._running_agents_ts.pop(session_key, None)
+        if hasattr(self, "_running_agents_task"):
+            self._running_agents_task.pop(session_key, None)
         if hasattr(self, "_busy_ack_ts"):
             self._busy_ack_ts.pop(session_key, None)
         # Turn boundary: a running-agent slot was just released.  Persist the
@@ -21217,11 +21439,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 }
 
             pr = self._provider_routing
-            reasoning_config = self._resolve_session_reasoning_config(
+            reasoning_config: Dict[str, Any] = dict(self._resolve_session_reasoning_config(
                 source=source,
                 session_key=session_key,
                 model=model,
-            )
+            ) or {})
             self._reasoning_config = reasoning_config
             self._service_tier = self._resolve_session_service_tier(
                 source=source, session_key=session_key
@@ -21341,6 +21563,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            _clean_message = turn_route.get("clean_message")
+            if (
+                isinstance(message, str)
+                and isinstance(_clean_message, str)
+                and _clean_message
+            ):
+                message = _clean_message
+            _routed_reasoning = turn_route.get("reasoning_config")
+            if isinstance(_routed_reasoning, dict):
+                reasoning_config = dict(_routed_reasoning)
+                self._reasoning_config = reasoning_config
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -22606,12 +22839,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         interrupt_monitor = asyncio.create_task(monitor_for_interrupt())
 
         # Periodic "still working" notifications for long-running tasks.
-        # Fires every N seconds so the user knows the agent hasn't died.
-        # Config: agent.gateway_notify_interval in config.yaml, or
-        # HERMES_AGENT_NOTIFY_INTERVAL env var.  Default 180s (3 min).
-        # 0 = disable notifications.
+        # Two modes:
+        #   1) SCHEDULE — agent.gateway_notify_schedule (or
+        #      HERMES_AGENT_NOTIFY_SCHEDULE) is a cumulative list of elapsed
+        #      seconds. Sends ONE fresh notification at each checkpoint and
+        #      stops after the last (e.g. [180,420,900,1800,3600] pings at
+        #      3/7/15/30/60 min, then stays quiet).
+        #   2) INTERVAL fallback — legacy agent.gateway_notify_interval
+        #      (HERMES_AGENT_NOTIFY_INTERVAL) fires every N seconds and
+        #      edits a single heartbeat message in place. Preserved for
+        #      backward compatibility with users who never migrated.
+        # 0 (or invalid) disables notifications entirely.
         _NOTIFY_INTERVAL_RAW = _float_env("HERMES_AGENT_NOTIFY_INTERVAL", 180)
         _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
+        _NOTIFY_SCHEDULE = _parse_notify_schedule(
+            os.environ.get("HERMES_AGENT_NOTIFY_SCHEDULE")
+        )
         _long_running_mode = _display_surface_mode(
             "long_running_notifications",
             default=True,
@@ -22619,28 +22862,104 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         if _long_running_mode == "off":
             _NOTIFY_INTERVAL = None
+            _NOTIFY_SCHEDULE = []
         _notify_start = time.time()
 
-        async def _notify_long_running():
+        def _build_heartbeat_text() -> str:
+            _elapsed_mins = int((time.time() - _notify_start) // 60)
+            _agent_ref = agent_holder[0]
+            _status_detail = ""
+            _want_iteration_detail = bool(
+                resolve_display_setting(
+                    user_config,
+                    platform_key,
+                    "busy_ack_detail",
+                    True,
+                )
+            )
+            if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):
+                try:
+                    _a = _agent_ref.get_activity_summary()
+                    _parts = []
+                    if _want_iteration_detail:
+                        _parts.append(
+                            f"iteration {_a['api_call_count']}/{_a['max_iterations']}"
+                        )
+                    _action = _a.get("current_tool") or _a.get("last_activity_desc")
+                    if _action:
+                        _parts.append(str(_action))
+                    if _parts:
+                        _status_detail = " — " + ", ".join(_parts)
+                except Exception:
+                    pass
+            if _long_running_mode == "generic":
+                return _generic_status_phrase("status")
+            _task_desc = ""
+            try:
+                _task_desc = (getattr(self, "_running_agents_task", {}) or {}).get(
+                    session_key, ""
+                )
+            except Exception:
+                _task_desc = ""
+            _thread_label = self._humanize_session_source(source)
+            # Plain-English checkpoint: no internal session keys, no model
+            # names, no raw commands. Task line is sanitized upstream.
+            _lines = [f"⏳ Still working — {_elapsed_mins} min so far{_status_detail}"]
+            if _task_desc:
+                _lines.append(f"Task: {_task_desc}")
+            if _thread_label:
+                _lines.append(f"Thread: {_thread_label}")
+            return "\n".join(_lines)
+
+        async def _send_heartbeat_new(_notify_adapter) -> None:
+            """Post a fresh heartbeat message (used by schedule mode)."""
+            _text = _build_heartbeat_text()
+            try:
+                _res = await _notify_adapter.send(
+                    source.chat_id,
+                    _text,
+                    metadata=_non_conversational_metadata(
+                        _status_thread_metadata, platform=source.platform
+                    ),
+                )
+                if getattr(_res, "success", False) and getattr(
+                    _res, "message_id", None
+                ):
+                    _mid = str(_res.message_id)
+                    if _cleanup_progress:
+                        _cleanup_msg_ids.append(_mid)
+            except Exception as _ne:
+                logger.debug("Scheduled long-running notification error: %s", _ne)
+
+        async def _notify_long_running_schedule():
+            """Cumulative one-shot notifications — no edit-in-place."""
+            _notify_adapter = self._adapter_for_source(source)
+            if not _notify_adapter:
+                return
+            for _checkpoint in _NOTIFY_SCHEDULE:
+                _remaining = _checkpoint - (time.time() - _notify_start)
+                if _remaining > 0:
+                    await asyncio.sleep(_remaining)
+                try:
+                    _exec_ref = _executor_task
+                except NameError:
+                    _exec_ref = None
+                if not self._should_emit_long_running_notification(
+                    session_key, agent_holder[0], _exec_ref
+                ):
+                    return
+                await _send_heartbeat_new(_notify_adapter)
+
+        async def _notify_long_running_interval():
+            """Legacy interval mode — edits one heartbeat in place."""
             if _NOTIFY_INTERVAL is None:
                 return  # Notifications disabled (gateway_notify_interval: 0)
             _notify_adapter = self._adapter_for_source(source)
             if not _notify_adapter:
                 return
-            # Track the heartbeat message id so we can edit-in-place on
-            # platforms that support it (Telegram, Discord, Slack, etc.)
-            # instead of spamming a new "Still working" bubble every
-            # interval. Falls back to send-new when edit fails or isn't
-            # supported by the adapter.
             _heartbeat_msg_id: Optional[str] = None
             while True:
                 await asyncio.sleep(_NOTIFY_INTERVAL)
-                # Stop heartbeating once this run no longer owns the session
-                # slot or the executor has finished — otherwise a stale
-                # "running: delegate_task" bubble can outlive the run that
-                # spawned it (#12029). _executor_task is a closure var bound
-                # just after this task is scheduled; tolerate the brief window
-                # before then (the first wake is _NOTIFY_INTERVAL away anyway).
                 try:
                     _exec_ref = _executor_task
                 except NameError:
@@ -22649,41 +22968,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key, agent_holder[0], _exec_ref
                 ):
                     break
-                _elapsed_mins = int((time.time() - _notify_start) // 60)
-                # Include agent activity context if available. Default
-                # heartbeat is terse: elapsed + current tool. Verbose
-                # iteration counter is gated on busy_ack_detail so users
-                # who want it can opt in per platform.
-                _agent_ref = agent_holder[0]
-                _status_detail = ""
-                _want_iteration_detail = bool(
-                    resolve_display_setting(
-                        user_config,
-                        platform_key,
-                        "busy_ack_detail",
-                        True,
-                    )
-                )
-                if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):
-                    try:
-                        _a = _agent_ref.get_activity_summary()
-                        _parts = []
-                        if _want_iteration_detail:
-                            _parts.append(
-                                f"iteration {_a['api_call_count']}/{_a['max_iterations']}"
-                            )
-                        _action = _a.get("current_tool") or _a.get("last_activity_desc")
-                        if _action:
-                            _parts.append(str(_action))
-                        if _parts:
-                            _status_detail = " — " + ", ".join(_parts)
-                    except Exception:
-                        pass
-                _heartbeat_text = (
-                    _generic_status_phrase("status")
-                    if _long_running_mode == "generic"
-                    else f"⏳ Working — {_elapsed_mins} min{_status_detail}"
-                )
+                _heartbeat_text = _build_heartbeat_text()
                 try:
                     _notify_res = None
                     if _heartbeat_msg_id:
@@ -22711,7 +22996,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception as _ne:
                     logger.debug("Long-running notification error: %s", _ne)
 
-        _notify_task = asyncio.create_task(_notify_long_running())
+        if _NOTIFY_SCHEDULE:
+            _notify_task = asyncio.create_task(_notify_long_running_schedule())
+        else:
+            _notify_task = asyncio.create_task(_notify_long_running_interval())
 
         def _stream_confirmed_final_delivery(
             consumer,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -977,7 +977,14 @@ class GatewaySlashCommandsMixin:
         return await self._resume_target_allowed(source, sid, allow_override=False)
 
     async def _handle_agents_command(self, event: MessageEvent) -> str:
-        """Handle /agents command - list active agents and running tasks."""
+        """Handle /agents (aka /tasks) — plain-English overview of what
+        the bot is currently working on across every active chat/thread.
+
+        Deliberately omits internal session keys, session IDs, model
+        names, and raw process commands from the default readout — those
+        are debug detail the user asking "what are you doing?" doesn't
+        want. Verbose IDs are reserved for /debug-style commands.
+        """
         from gateway.run import _AGENT_PENDING_SENTINEL
         from tools.process_registry import format_uptime_short, process_registry
 
@@ -986,19 +993,23 @@ class GatewaySlashCommandsMixin:
 
         running_agents: dict = getattr(self, "_running_agents", {}) or {}
         running_started: dict = getattr(self, "_running_agents_ts", {}) or {}
+        running_task: dict = getattr(self, "_running_agents_task", {}) or {}
+
+        humanize = getattr(self, "_humanize_session_key", None)
 
         agent_rows: list[dict] = []
         for session_key, agent in running_agents.items():
             started = float(running_started.get(session_key, now))
             elapsed = max(0, int(now - started))
             is_pending = agent is _AGENT_PENDING_SENTINEL
+            thread_label = humanize(session_key) if callable(humanize) else "an active chat"
             agent_rows.append(
                 {
                     "session_key": session_key,
                     "elapsed": elapsed,
                     "state": t("gateway.agents.state_starting") if is_pending else t("gateway.agents.state_running"),
-                    "session_id": "" if is_pending else str(getattr(agent, "session_id", "") or ""),
-                    "model": "" if is_pending else str(getattr(agent, "model", "") or ""),
+                    "thread": thread_label,
+                    "task": running_task.get(session_key, ""),
                 }
             )
 
@@ -1027,11 +1038,11 @@ class GatewaySlashCommandsMixin:
         if agent_rows:
             for idx, row in enumerate(agent_rows[:12], 1):
                 current = t("gateway.agents.this_chat") if row["session_key"] == current_session_key else ""
-                sid = f" · `{row['session_id']}`" if row["session_id"] else ""
-                model = f" · `{row['model']}`" if row["model"] else ""
+                task = (row["task"] or "").strip()
+                task_suffix = f" — {task}" if task else ""
                 lines.append(
-                    f"{idx}. `{row['session_key']}` · {row['state']} · "
-                    f"{format_uptime_short(row['elapsed'])}{sid}{model}{current}"
+                    f"{idx}. {row['thread']}{current} · {row['state']} for "
+                    f"{format_uptime_short(row['elapsed'])}{task_suffix}"
                 )
             if len(agent_rows) > 12:
                 lines.append(t("gateway.agents.more", count=len(agent_rows) - 12))
@@ -1044,12 +1055,21 @@ class GatewaySlashCommandsMixin:
         )
         if running_processes:
             for proc in running_processes[:12]:
-                cmd = " ".join(str(proc.get("command", "")).split())
-                if len(cmd) > 90:
-                    cmd = cmd[:87] + "..."
+                # Prefer a human-readable goal/purpose over the raw shell
+                # command so /agents stays plain-English by default.
+                goal = ""
+                for key in ("goal", "task", "description", "purpose", "label", "name"):
+                    val = proc.get(key)
+                    if val:
+                        goal = " ".join(str(val).split())
+                        break
+                if not goal:
+                    goal = t("gateway.agents.state_running")
+                if len(goal) > 90:
+                    goal = goal[:87] + "..."
                 lines.append(
-                    f"- `{proc.get('session_id', '?')}` · "
-                    f"{format_uptime_short(int(proc.get('uptime_seconds', 0)))} · `{cmd}`"
+                    f"- {goal} · "
+                    f"{format_uptime_short(int(proc.get('uptime_seconds', 0)))}"
                 )
             if len(running_processes) > 12:
                 lines.append(t("gateway.agents.more", count=len(running_processes) - 12))
@@ -1060,6 +1080,29 @@ class GatewaySlashCommandsMixin:
                 t("gateway.agents.async_jobs", count=len(background_tasks)),
             ]
         )
+        if background_tasks:
+            for task in background_tasks[:12]:
+                # asyncio tasks expose get_name(); anonymous tasks default
+                # to Task-N which is still nicer than a repr(). Use it as a
+                # last-resort human label.
+                label = ""
+                try:
+                    for attr in ("goal", "task_description", "description", "task_name"):
+                        val = getattr(task, attr, None)
+                        if val:
+                            label = " ".join(str(val).split())
+                            break
+                    if not label:
+                        get_name = getattr(task, "get_name", None)
+                        if callable(get_name):
+                            label = str(get_name())
+                except Exception:
+                    label = ""
+                if not label:
+                    label = t("gateway.agents.state_running")
+                if len(label) > 90:
+                    label = label[:87] + "..."
+                lines.append(f"- {label}")
 
         if not agent_rows and not running_processes and not background_tasks:
             lines.append("")

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -181,12 +181,15 @@ class CLIAgentSetupMixin:
 
     def _resolve_turn_agent_config(self, user_message: str) -> dict:
         """Build the effective model/runtime config for a single user turn.
-
-        Always uses the session's primary model/provider.  If the user has
-        toggled `/fast` on and the current model supports Priority
-        Processing / Anthropic fast mode, attach `request_overrides` so the
-        API call is marked accordingly.
+        Uses the centralized routing module so CLI routing behavior matches
+        gateway/cron/subagent routing decisions.
         """
+        from agent.model_routing import (
+            classify_turn_complexity as _classify_turn_complexity_shared,
+            resolve_routing_decision,
+        )
+        from hermes_cli.config import load_config_readonly
+        from hermes_constants import resolve_reasoning_config
         from hermes_cli.models import resolve_fast_mode_overrides
 
         runtime = {
@@ -201,11 +204,32 @@ class CLIAgentSetupMixin:
             "args": list(self.acp_args or []),
             "credential_pool": getattr(self, "_credential_pool", None),
         }
+        cfg = load_config_readonly()
+        fallback_reasoning = getattr(self, "reasoning_config", None)
+        if fallback_reasoning is None:
+            fallback_reasoning = resolve_reasoning_config(cfg, self.model)
+        decision = resolve_routing_decision(
+            message=user_message,
+            base_model=self.model,
+            fallback_reasoning_config=fallback_reasoning,
+            config=cfg,
+            surface="cli",
+        )
+        routed_model = decision.model or self.model
+        routed_reasoning = decision.reasoning_config
+        if isinstance(routed_reasoning, dict):
+            self.reasoning_config = dict(routed_reasoning)
         route = {
-            "model": self.model,
+            "model": routed_model,
+            "route_profile": decision.profile,
+            "route_category": decision.category,
+            "route_reason": decision.reason,
+            "route_class": _classify_turn_complexity_shared(user_message),
+            "reasoning_config": routed_reasoning,
+            "clean_message": decision.clean_message,
             "runtime": runtime,
             "signature": (
-                self.model,
+                routed_model,
                 runtime["provider"],
                 runtime["requested_provider"],
                 runtime["base_url"],

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -932,6 +932,28 @@ def _ensure_hermes_home_managed(home: Path):
 
 DEFAULT_CONFIG = {
     "model": "",
+    # Centralized per-turn/task routing policy shared by gateway, CLI, cron,
+    # oneshot, and subagent delegation. Disabled by default; when enabled,
+    # model/reasoning selection follows explicit override > workflow route >
+    # safety escalation > classifier > default_profile.
+    "routing": {
+        "enabled": False,
+        "default_profile": "balanced",
+        "allow_escalation": True,
+        "profiles": {
+            "deterministic": {"model": "luna", "reasoning": "none"},
+            "fast": {"model": "luna", "reasoning": "low"},
+            "fast_plus": {"model": "luna", "reasoning": "medium"},
+            "balanced": {"model": "terra", "reasoning": "medium"},
+            "creative": {"model": "terra", "reasoning": "high"},
+            "strong": {"model": "sol", "reasoning": "high"},
+            "maximum": {"model": "sol", "reasoning": "max"},
+            "ultra": {"model": "sol", "reasoning": "ultra"},
+        },
+        # Optional map of substring -> profile, e.g.:
+        #   {"youtube editor handoff": "fast"}
+        "workflow_routes": {},
+    },
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
@@ -1085,7 +1107,15 @@ DEFAULT_CONFIG = {
         # noise; 180s is a compromise that catches spinning weak-model runs
         # (60+ tool iterations with tiny output) before users assume the
         # bot is dead and /restart.
+        # Used as the fallback when gateway_notify_schedule is unset/empty.
         "gateway_notify_interval": 180,
+        # Cumulative "still working" checkpoint schedule (seconds since the
+        # turn started). When set to a non-empty list, the gateway sends
+        # ONE fresh notification at each elapsed checkpoint and stops after
+        # the last — e.g. [180, 420, 900, 1800, 3600] pings at 3 min, 7 min,
+        # 15 min, 30 min, and 1 h. Empty / invalid falls back to the older
+        # gateway_notify_interval behaviour.
+        "gateway_notify_schedule": [],
         # Freshness window for the gateway auto-continue note (seconds).
         # After a gateway crash/restart/SIGTERM mid-run, the next user
         # message gets a "[System note: your previous turn was

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -321,7 +321,9 @@ def _run_agent(
     run a single conversation.  Returns ``(final_response, run_result)``."""
     # Imports are local so they don't run when hermes is invoked for
     # other commands (keeps top-level CLI startup cheap).
+    from agent.model_routing import resolve_routing_decision
     from hermes_cli.config import load_config
+    from hermes_constants import resolve_reasoning_config
     from hermes_cli.models import detect_provider_for_model
     from hermes_cli.runtime_provider import resolve_runtime_provider
     from hermes_cli.tools_config import _get_platform_tools
@@ -337,7 +339,8 @@ def _run_agent(
         cfg_model = model_cfg.get("default") or model_cfg.get("model") or ""
 
     env_model = os.getenv("HERMES_INFERENCE_MODEL", "").strip()
-    effective_model = (model or "").strip() or env_model or cfg_model
+    explicit_model_input = (model or "").strip()
+    effective_model = explicit_model_input or env_model or cfg_model
 
     # Resolve effective provider: explicit arg → (auto-detect from model if
     # model was explicit) → env / config (handled inside resolve_runtime_provider).
@@ -382,6 +385,21 @@ def _run_agent(
                 if detected:
                     effective_provider, effective_model = detected
 
+    base_reasoning_config = resolve_reasoning_config(cfg, effective_model)
+    try:
+        routing_decision = resolve_routing_decision(
+            message=prompt,
+            base_model=effective_model,
+            fallback_reasoning_config=base_reasoning_config,
+            config=cfg,
+            surface="oneshot",
+            workflow_model_override=explicit_model_input or None,
+        )
+        effective_model = routing_decision.model or effective_model
+        reasoning_config = routing_decision.reasoning_config
+    except Exception:
+        reasoning_config = base_reasoning_config
+
     runtime = resolve_runtime_provider(
         requested=effective_provider,
         target_model=effective_model or None,
@@ -420,6 +438,7 @@ def _run_agent(
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
+            reasoning_config=reasoning_config,
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:
             #   - clarify  → returns a synthetic "pick a default" instruction

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -384,6 +384,15 @@ class TestFailureAttribution:
 
     def _make_pool(self, tmp_path, monkeypatch, entries):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        # Keep attribution tests deterministic: these scenarios model exactly
+        # the explicit entries below, so disable ambient anthropic auto-seeding
+        # from ~/.claude credentials and env vars in the local machine.
+        monkeypatch.setattr(
+            "hermes_cli.auth.is_provider_explicitly_configured",
+            lambda _provider: False,
+        )
+        for _var in ("ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"):
+            monkeypatch.delenv(_var, raising=False)
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir(parents=True, exist_ok=True)
         (hermes_home / "auth.json").write_text(

--- a/tests/agent/test_model_routing.py
+++ b/tests/agent/test_model_routing.py
@@ -1,0 +1,183 @@
+import pytest
+
+from agent.model_routing import resolve_routing_decision
+
+
+def _routing_cfg(**overrides):
+    cfg = {
+        "routing": {
+            "enabled": True,
+            "default_profile": "balanced",
+            "allow_escalation": True,
+        }
+    }
+    cfg["routing"].update(overrides)
+    return cfg
+
+
+def _decide(message: str, *, cfg=None, base_model="gpt-5.6-sol", fallback_reasoning=None, **kwargs):
+    if fallback_reasoning is None:
+        fallback_reasoning = {"enabled": True, "effort": "medium"}
+    return resolve_routing_decision(
+        message=message,
+        base_model=base_model,
+        fallback_reasoning_config=fallback_reasoning,
+        config=cfg if cfg is not None else _routing_cfg(),
+        surface="test",
+        **kwargs,
+    )
+
+
+def test_trivial_fact_routes_to_luna_low():
+    decision = _decide("what time is it in tokyo")
+    assert decision.profile == "fast"
+    assert decision.model == "gpt-5.6-luna"
+    assert decision.reasoning_config == {"enabled": True, "effort": "low"}
+
+
+def test_saved_workflow_execution_routes_to_luna_low():
+    decision = _decide("run the youtube editor handoff workflow")
+    assert decision.profile == "fast"
+    assert decision.category == "workflow.known"
+    assert decision.model == "gpt-5.6-luna"
+    assert decision.reasoning_config == {"enabled": True, "effort": "low"}
+
+
+def test_ambiguous_trivial_can_route_to_luna_medium():
+    decision = _decide("find email from John where multiple matches might exist")
+    assert decision.profile == "fast_plus"
+    assert decision.model == "gpt-5.6-luna"
+    assert decision.reasoning_config == {"enabled": True, "effort": "medium"}
+
+
+def test_new_automation_work_routes_to_terra_medium():
+    decision = _decide("build a new automation for lead tagging")
+    assert decision.profile == "balanced"
+    assert decision.model == "gpt-5.6-terra"
+    assert decision.reasoning_config == {"enabled": True, "effort": "medium"}
+
+
+def test_github_work_routes_to_terra_medium():
+    decision = _decide("make the requested GitHub changes")
+    assert decision.profile == "balanced"
+    assert decision.model == "gpt-5.6-terra"
+    assert decision.reasoning_config == {"enabled": True, "effort": "medium"}
+
+
+def test_youtube_packet_routes_to_terra_high():
+    decision = _decide("build a YouTube video packet with title and thumbnail options")
+    assert decision.profile == "creative"
+    assert decision.model == "gpt-5.6-terra"
+    assert decision.reasoning_config == {"enabled": True, "effort": "high"}
+
+
+def test_launch_strategy_routes_to_sol_high():
+    decision = _decide("build our launch strategy for next quarter")
+    assert decision.profile == "strong"
+    assert decision.model == "gpt-5.6-sol"
+    assert decision.reasoning_config == {"enabled": True, "effort": "high"}
+
+
+def test_failed_terra_work_escalates_to_sol():
+    decision = _decide("terra failed twice, solve this")
+    assert decision.profile == "strong"
+    assert decision.model == "gpt-5.6-sol"
+    assert decision.reasoning_config == {"enabled": True, "effort": "high"}
+
+
+def test_explicit_override_wins_over_classification():
+    decision = _decide(
+        "[[route: luna xhigh no-escalation]] build our launch strategy",
+    )
+    assert decision.override_used is True
+    assert decision.no_escalation is True
+    assert decision.profile == "fast"
+    assert decision.model == "gpt-5.6-luna"
+    assert decision.reasoning_config == {"enabled": True, "effort": "xhigh"}
+
+
+def test_workflow_model_pin_wins_over_auto_classification():
+    decision = _decide(
+        "build a launch strategy",
+        workflow_model_override="gpt-5.6-luna",
+    )
+    assert decision.override_used is False
+    assert decision.category == "workflow.model_pin"
+    assert decision.model == "gpt-5.6-luna"
+
+
+def test_explicit_override_beats_workflow_pin():
+    decision = _decide(
+        "[[route: sol high]] simple follow-up",
+        workflow_model_override="gpt-5.6-luna",
+    )
+    assert decision.override_used is True
+    assert decision.model == "gpt-5.6-sol"
+    assert decision.reasoning_config == {"enabled": True, "effort": "high"}
+
+
+def test_no_escalation_override_blocks_risk_escalation():
+    decision = _decide("[[route: no-escalation]] publish publicly and deploy production")
+    assert decision.profile != "strong"
+    assert decision.escalation_reason is None
+
+
+def test_risk_escalation_upgrades_to_strong():
+    decision = _decide("publish publicly and deploy production")
+    assert decision.profile == "strong"
+    assert decision.category == "escalation.risk"
+
+
+def test_routing_disabled_keeps_base_model_and_reasoning():
+    decision = _decide(
+        "build a launch strategy",
+        cfg={"routing": {"enabled": False}},
+        base_model="gpt-5.6-terra",
+        fallback_reasoning={"enabled": True, "effort": "low"},
+    )
+    assert decision.profile == "session"
+    assert decision.model == "gpt-5.6-terra"
+    assert decision.reasoning_config == {"enabled": True, "effort": "low"}
+
+
+def test_inline_override_is_stripped_from_clean_message():
+    decision = _decide("[[route: luna medium]] summarize this")
+    assert "[[route:" not in decision.clean_message.lower()
+    assert decision.clean_message == "summarize this"
+
+
+def test_legacy_turn_routing_bridge_when_new_profiles_missing():
+    cfg = {
+        "routing": {"enabled": True},
+        "agent": {
+            "turn_routing": {
+                "enabled": True,
+                "trivial_model": "gpt-5.5",
+                "trivial_reasoning": "none",
+            }
+        },
+    }
+    decision = _decide("what time is it", cfg=cfg)
+    assert decision.model == "gpt-5.5"
+    assert decision.reasoning_config == {"enabled": False}
+
+
+def test_legacy_turn_routing_bridge_not_applied_when_profiles_present():
+    cfg = {
+        "routing": {
+            "enabled": True,
+            "profiles": {
+                "fast": {"model": "luna", "reasoning": "low"},
+            },
+        },
+        "agent": {
+            "turn_routing": {
+                "enabled": True,
+                "trivial_model": "gpt-5.5",
+                "trivial_reasoning": "none",
+            }
+        },
+    }
+    decision = _decide("what time is it", cfg=cfg, base_model="gpt-5.6-sol")
+    assert decision.model == "gpt-5.6-luna"
+    assert decision.reasoning_config == {"enabled": True, "effort": "low"}

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -289,6 +289,7 @@ class TestRunBackgroundTask:
         image as a native image, and everything else as a document.
         """
         from gateway import run as gateway_run
+        from gateway.platforms.base import BasePlatformAdapter
 
         runner = _make_runner()
         runner._resolve_session_agent_runtime = MagicMock(
@@ -327,6 +328,11 @@ class TestRunBackgroundTask:
             (_png, False),
             (_pdf, False),
         ]
+        _ogg_safe = BasePlatformAdapter.validate_media_delivery_path(_ogg)
+        _mp4_safe = BasePlatformAdapter.validate_media_delivery_path(_mp4)
+        _png_safe = BasePlatformAdapter.validate_media_delivery_path(_png)
+        _pdf_safe = BasePlatformAdapter.validate_media_delivery_path(_pdf)
+        assert _ogg_safe and _mp4_safe and _png_safe and _pdf_safe
 
         mock_adapter = AsyncMock()
         mock_adapter.send = AsyncMock()
@@ -352,13 +358,13 @@ class TestRunBackgroundTask:
             await runner._run_background_task("make stuff", source, "bg_test")
 
             mock_adapter.send_voice.assert_called_once()
-            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _ogg
+            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _ogg_safe
             mock_adapter.send_video.assert_called_once()
-            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _mp4
+            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _mp4_safe
             mock_adapter.send_image_file.assert_called_once()
-            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _png
+            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _png_safe
             mock_adapter.send_document.assert_called_once()
-            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _pdf
+            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _pdf_safe
         finally:
             import shutil as _shutil
             _shutil.rmtree(_tmpdir, ignore_errors=True)

--- a/tests/gateway/test_centralized_routing_parity.py
+++ b/tests/gateway/test_centralized_routing_parity.py
@@ -1,0 +1,109 @@
+from types import SimpleNamespace
+
+import gateway.run as gateway_run
+from gateway.run import GatewayRunner
+from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+
+def _shared_config():
+    return {
+        "routing": {
+            "enabled": True,
+            "default_profile": "balanced",
+            "allow_escalation": True,
+        }
+    }
+
+
+def _gateway_runner():
+    runner = object.__new__(GatewayRunner)
+    runner._service_tier = None
+    runner._reasoning_config = {"enabled": True, "effort": "medium"}
+    return runner
+
+
+def _cli_stub():
+    return SimpleNamespace(
+        model="gpt-5.6-sol",
+        api_key="***",
+        base_url="https://openrouter.ai/api/v1",
+        provider="openrouter",
+        requested_provider="openrouter",
+        api_mode="chat_completions",
+        acp_command=None,
+        acp_args=[],
+        _credential_pool=None,
+        service_tier=None,
+        reasoning_config={"enabled": True, "effort": "medium"},
+    )
+
+
+def test_gateway_and_cli_match_for_auto_classification(monkeypatch):
+    cfg = _shared_config()
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: cfg)
+
+    runner = _gateway_runner()
+    gw_route = GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "build a YouTube video packet",
+        "gpt-5.6-sol",
+        {
+            "api_key": "***",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "openrouter",
+            "requested_provider": "openrouter",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        },
+    )
+
+    cli = _cli_stub()
+    cli_route = CLIAgentSetupMixin._resolve_turn_agent_config(
+        cli,
+        "build a YouTube video packet",
+    )
+
+    assert gw_route["model"] == cli_route["model"] == "gpt-5.6-terra"
+    assert gw_route["reasoning_config"] == cli_route["reasoning_config"] == {
+        "enabled": True,
+        "effort": "high",
+    }
+    assert gw_route["route_profile"] == cli_route["route_profile"] == "creative"
+
+
+def test_gateway_and_cli_match_for_explicit_override(monkeypatch):
+    cfg = _shared_config()
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: cfg)
+
+    message = "[[route: luna xhigh]] build our launch strategy"
+
+    runner = _gateway_runner()
+    gw_route = GatewayRunner._resolve_turn_agent_config(
+        runner,
+        message,
+        "gpt-5.6-sol",
+        {
+            "api_key": "***",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "openrouter",
+            "requested_provider": "openrouter",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        },
+    )
+
+    cli = _cli_stub()
+    cli_route = CLIAgentSetupMixin._resolve_turn_agent_config(cli, message)
+
+    assert gw_route["model"] == cli_route["model"] == "gpt-5.6-luna"
+    assert gw_route["reasoning_config"] == cli_route["reasoning_config"] == {
+        "enabled": True,
+        "effort": "xhigh",
+    }
+    assert gw_route["clean_message"] == cli_route["clean_message"] == "build our launch strategy"

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -104,9 +104,10 @@ def _make_event(text: str) -> MessageEvent:
     return MessageEvent(text=text, source=_make_source(), message_id="m1")
 
 
-def test_turn_route_injects_priority_processing_without_changing_runtime():
+def test_turn_route_injects_priority_processing_without_changing_runtime(monkeypatch):
     runner = _make_runner()
     runner._service_tier = "priority"
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
     runtime_kwargs = {
         "api_key": "***",
         "base_url": "https://openrouter.ai/api/v1",
@@ -124,9 +125,10 @@ def test_turn_route_injects_priority_processing_without_changing_runtime():
     assert route["request_overrides"] == {"service_tier": "priority"}
 
 
-def test_turn_route_skips_priority_processing_for_unsupported_models():
+def test_turn_route_skips_priority_processing_for_unsupported_models(monkeypatch):
     runner = _make_runner()
     runner._service_tier = "priority"
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
     runtime_kwargs = {
         "api_key": "***",
         "base_url": "https://openrouter.ai/api/v1",

--- a/tests/gateway/test_turn_complexity_classifier.py
+++ b/tests/gateway/test_turn_complexity_classifier.py
@@ -1,0 +1,149 @@
+"""Tests for gateway's legacy 3-bucket classifier shim.
+
+The centralized router resolves richer profiles and the gateway compatibility
+shim maps them to historic buckets:
+- trivial  -> deterministic/fast/fast_plus
+- moderate -> balanced
+- high     -> creative/strong/maximum/ultra
+"""
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+classify = GatewayRunner._classify_turn_complexity
+
+
+# ---------- trivial bucket ----------
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "execute this",
+        "send it",
+        "do it",
+        "go ahead",
+        "ship it",
+        "proceed",
+    ],
+)
+def test_approved_execution_is_trivial(message):
+    assert classify(message) == "trivial"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "what time is it",
+        "what's the time",
+        "current time",
+        "current time in Tokyo",
+        "what is the current date",
+    ],
+)
+def test_current_time_is_trivial(message):
+    assert classify(message) == "trivial"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "distance to Starbucks",
+        "distance to the nearest Starbucks",
+        "how far is the airport",
+        "how far to downtown Seattle",
+    ],
+)
+def test_distance_lookups_are_trivial(message):
+    assert classify(message) == "trivial"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "tallest building",
+        "the tallest building",
+        "what's the tallest building",
+        "what is the largest ocean",
+        "the fastest animal",
+    ],
+)
+def test_basic_fact_superlatives_are_trivial(message):
+    assert classify(message) == "trivial"
+
+
+def test_empty_message_is_trivial():
+    assert classify("") == "trivial"
+    assert classify("   ") == "trivial"
+
+
+# ---------- high (creative/strategy) bucket ----------
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "build a YouTube video packet for this topic",
+        "create title generation and thumbnail copy options",
+        "research YouTube outliers and recommend ideas",
+        "do deeper research and synthesize findings",
+        "build our July 4 launch strategy",
+        "rethink our offer and pricing strategy",
+        "design architecture for a new multi-service migration",
+        "terra failed twice, solve this now",
+    ],
+)
+def test_creative_and_strategy_routes_are_high(message):
+    assert classify(message) == "high"
+
+
+# ---------- moderate bucket ----------
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "debug the gateway",
+        "write a Python script to parse CSV",
+        "write a bash script to rotate logs",
+        "write a regex to match SKUs",
+        "investigate why the cron is failing",
+        "refactor the auth mixin",
+        "roll back the last migration",
+        "build a new automation for this workflow",
+        "modify the existing workflow and keep behavior stable",
+        "make the requested GitHub changes from this issue",
+        "fix an ordinary Cloudflare configuration issue",
+        "draft an email sequence from an approved strategy",
+        "research testimonials and incorporate them into existing copy",
+    ],
+)
+def test_operational_and_engineering_is_moderate(message):
+    assert classify(message) == "moderate"
+
+
+def test_long_operational_prompt_stays_moderate():
+    # Long multi-step implementation should remain moderate unless it carries
+    # explicit strategy/creative escalation signals.
+    message = (
+        "walk through the gateway startup path, then inspect the readiness "
+        "checks, then diff the current provider routing against last "
+        "week's snapshot, and finally propose a rollback plan for the "
+        "auth mixin change. This is production critical and touches "
+        "customer sessions."
+    )
+    assert classify(message) == "moderate"
+
+
+# ---------- key false positives ----------
+
+def test_write_python_script_is_not_escalated():
+    assert classify("write a Python script to parse CSV") == "moderate"
+
+
+def test_approved_strategy_email_stays_moderate():
+    assert classify("draft an email sequence from approved strategy") == "moderate"
+
+
+def test_write_config_file_is_not_writing():
+    # "write" + "config" is engineering/worker work, not strategic escalation.
+    assert classify("write a config file for the new worker") == "moderate"

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -410,6 +410,49 @@ class TestDelegateTask(unittest.TestCase):
         mock_run.assert_not_called()
 
     @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool.resolve_routing_decision")
+    def test_delegation_applies_centralized_routing_to_child_model_and_reasoning(
+        self,
+        mock_route,
+        mock_run,
+    ):
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done!",
+            "api_calls": 1,
+            "duration_seconds": 1.0,
+        }
+        mock_route.return_value = types.SimpleNamespace(
+            model="gpt-5.6-terra",
+            reasoning_config={"enabled": True, "effort": "high"},
+            profile="creative",
+            category="creative.deep_work",
+            reason="test route",
+            override_used=False,
+            escalation_reason=None,
+            no_escalation=False,
+            retry_count=0,
+            workflow_match=None,
+            clean_message="build a YouTube video packet",
+        )
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "low"}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            delegate_task(goal="build a YouTube video packet", parent_agent=parent)
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "gpt-5.6-terra")
+            self.assertEqual(
+                kwargs["reasoning_config"],
+                {"enabled": True, "effort": "high"},
+            )
+
+    @patch("tools.delegate_tool._run_single_child")
     def test_batch_capped_at_3(self, mock_run):
         mock_run.return_value = {
             "task_index": 0, "status": "completed",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -30,6 +30,7 @@ from concurrent.futures import (
     TimeoutError as FuturesTimeoutError,
 )
 from typing import Any, Dict, List, Optional
+from agent.model_routing import resolve_routing_decision
 
 from toolsets import TOOLSETS
 
@@ -1086,6 +1087,7 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    routed_reasoning_config: Optional[Dict[str, Any]] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1295,27 +1297,28 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
-    # Resolve reasoning config: delegation override > parent inherit
+    # Resolve reasoning config: centralized routing result (if provided) wins.
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
-    child_reasoning = parent_reasoning
-    try:
-        # Keep the raw value — ``str(x or "")`` would coerce a YAML boolean
-        # False (``reasoning_effort: false``) to "" and inherit the parent
-        # instead of disabling thinking for children.
-        delegation_effort = delegation_cfg.get("reasoning_effort")
-        if delegation_effort or delegation_effort is False:
-            from hermes_constants import parse_reasoning_effort
+    child_reasoning = routed_reasoning_config if routed_reasoning_config is not None else parent_reasoning
+    if routed_reasoning_config is None:
+        try:
+            # Keep the raw value — ``str(x or "")`` would coerce a YAML boolean
+            # False (``reasoning_effort: false``) to "" and inherit the parent
+            # instead of disabling thinking for children.
+            delegation_effort = delegation_cfg.get("reasoning_effort")
+            if delegation_effort or delegation_effort is False:
+                from hermes_constants import parse_reasoning_effort
 
-            parsed = parse_reasoning_effort(delegation_effort)
-            if parsed is not None:
-                child_reasoning = parsed
-            else:
-                logger.warning(
-                    "Unknown delegation.reasoning_effort '%s', inheriting parent level",
-                    delegation_effort,
-                )
-    except Exception as exc:
-        logger.debug("Could not load delegation reasoning_effort: %s", exc)
+                parsed = parse_reasoning_effort(delegation_effort)
+                if parsed is not None:
+                    child_reasoning = parsed
+                else:
+                    logger.warning(
+                        "Unknown delegation.reasoning_effort '%s', inheriting parent level",
+                        delegation_effort,
+                    )
+        except Exception as exc:
+            logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
     # Inherit the parent's fallback provider chain so subagents can recover
     # from rate-limits and credential exhaustion exactly like the top-level
@@ -2595,6 +2598,24 @@ def delegate_task(
 
     _origin_wake_sid = _current_origin_session_id()
 
+    full_config = {}
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        full_config = load_config_readonly()
+    except Exception:
+        full_config = {}
+
+    workflow_reasoning_override = None
+    try:
+        from hermes_constants import parse_reasoning_effort
+
+        _delegation_effort = cfg.get("reasoning_effort")
+        if _delegation_effort or _delegation_effort is False:
+            workflow_reasoning_override = parse_reasoning_effort(_delegation_effort)
+    except Exception:
+        workflow_reasoning_override = None
+
     # Build all child agents on the main thread (thread-safe construction)
     # Wrapped in try/finally so the global is always restored even if a
     # child build raises (otherwise _last_resolved_tool_names stays corrupted).
@@ -2604,6 +2625,31 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            _base_model = creds["model"] or getattr(parent_agent, "model", None) or ""
+            _routed_model = _base_model
+            _routed_reasoning = getattr(parent_agent, "reasoning_config", None)
+            try:
+                _route_message = str(t["goal"])
+                _ctx = str(t.get("context") or "").strip()
+                if _ctx:
+                    _route_message = f"{_route_message}\n\n{_ctx}"
+                _decision = resolve_routing_decision(
+                    message=_route_message,
+                    base_model=_base_model,
+                    fallback_reasoning_config=_routed_reasoning,
+                    config=full_config,
+                    surface="subagent",
+                    workflow_model_override=creds["model"],
+                    workflow_reasoning_override=workflow_reasoning_override,
+                )
+                _routed_model = _decision.model or _base_model
+                _routed_reasoning = _decision.reasoning_config
+            except Exception:
+                logger.debug(
+                    "Subagent routing failed for task %s; falling back to inherited model",
+                    i,
+                    exc_info=True,
+                )
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
@@ -2611,7 +2657,7 @@ def delegate_task(
                 # Subagents always inherit the parent's toolsets; the model
                 # cannot choose or narrow them (no model-facing toolsets arg).
                 toolsets=None,
-                model=creds["model"],
+                model=_routed_model or None,
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
@@ -2624,6 +2670,7 @@ def delegate_task(
                 override_acp_command=creds.get("command"),
                 override_acp_args=creds.get("args"),
                 role=effective_role,
+                routed_reasoning_config=_routed_reasoning,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names


### PR DESCRIPTION
## Summary
- add a shared centralized routing module for per-turn model/reasoning selection
- wire centralized routing through gateway, CLI, cron, oneshot, and delegated subagents
- add focused parity/coverage tests for routing behavior, fast-mode interactions, and delegation paths

## Validation
- scripts/run_tests.sh tests/agent/test_model_routing.py tests/gateway/test_centralized_routing_parity.py tests/gateway/test_turn_complexity_classifier.py tests/gateway/test_fast_command.py tests/gateway/test_background_command.py tests/tools/test_delegate.py tests/agent/test_credential_pool_routing.py -q
- scripts/run_tests.sh tests/cli/test_fast_command.py tests/cron/test_codex_execution_paths.py tests/tui_gateway/test_fast_session_scope.py -q

Co-Authored-By: Oz <oz-agent@warp.dev>