### PR TITLE
fix(desktop): always allow unsafe custom binary for simple-git

### DIFF
--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -46,16 +46,15 @@ function gitFor(cwd, gitBin) {
   // `gitBin` is resolved inside the Electron main process from known install
   // locations or PATH — never renderer/user input. simple-git's custom-binary
   // validation rejects paths containing spaces (the default Windows install is
-  // `C:\Program Files\Git\cmd\git.exe`), which silently broke the Review pane.
-  // For spaced paths, opt into simple-git's trusted-binary escape hatch instead
-  // of falling back to PATH (often absent in GUI-launched apps, and PATH lookup
-  // could resolve a repo-local git.exe).
+  // `C:\Program Files\Git\cmd\git.exe`) and also rejects non-standard paths
+  // from MSYS/WSL shims. Always opt into the trusted-binary escape hatch —
+  // the binary path is trusted since it comes from our own resolver, not user input.
   return simpleGit({
     baseDir: cwd,
     binary: gitBin || 'git',
     maxConcurrentProcesses: 4,
     trimmed: false,
-    ...(gitBin && /\s/.test(gitBin) ? { unsafe: { allowUnsafeCustomBinary: true } } : {})
+    unsafe: { allowUnsafeCustomBinary: true }
   })
 }
 


### PR DESCRIPTION
## Problem

On Windows, `simple-git`'s custom-binary validation rejects git paths containing spaces (the default install is `C:\Program Files\Git\cmd\git.exe`) and also rejects non-standard paths from MSYS/WSL shims.

The previous fix enabled `allowUnsafeCustomBinary` only when the git binary path contained whitespace — but the regex check also rejects other characters, so the error still fires for MSYS-style paths like `/c/Program Files/Git/cmd/git.exe`.

## Fix

Unconditionally enable `unsafe.allowUnsafeCustomBinary: true` in `gitFor()`. This is safe because `gitBin` is resolved by the Electron main process from known install locations and PATH — never from renderer/user input.

## Files Changed

- `apps/desktop/electron/git-review-ops.ts` — `gitFor()` now always passes the unsafe escape hatch to `simpleGit()`

## Error eliminated

```
Invalid value supplied for custom binary, restricted characters must be removed or supply the unsafe.allowUnsafeCustomBinary option
```
