### PR TITLE
fix(terminal): don't persist delegate_task lineage marker in the shared snapshot (#71941)

### DIFF
--- a/tests/tools/test_local_env_delegation_marker_snapshot.py
+++ b/tests/tools/test_local_env_delegation_marker_snapshot.py
@@ -77,6 +77,56 @@ def test_kanban_ownership_env_not_persisted_to_shared_snapshot(tmp_path, monkeyp
         env.cleanup()
 
 
+def test_user_kanban_config_survives_snapshot(tmp_path, monkeypatch):
+    # HERMES_KANBAN_HOME / HERMES_KANBAN_DISPATCH_IN_GATEWAY are user-authored
+    # config, NOT dispatcher-owned lineage (they are absent from KANBAN_ENV_KEYS),
+    # so a broad HERMES_KANBAN_* exclusion must not strip them: the snapshot has
+    # to preserve the user's own exports.
+    monkeypatch.setenv("HERMES_KANBAN_HOME", "/home/u/.hermes")
+    monkeypatch.setenv("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "0")
+    assert "HERMES_KANBAN_HOME" not in KANBAN_ENV_KEYS
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+    try:
+        env.execute("true", timeout=15)
+        probe = env.execute(_probe("HERMES_KANBAN_HOME"), timeout=15)
+        assert probe["returncode"] == 0
+        assert "presence=set value=/home/u/.hermes" in probe["output"]
+        dispatch = env.execute(_probe("HERMES_KANBAN_DISPATCH_IN_GATEWAY"), timeout=15)
+        assert "presence=set value=0" in dispatch["output"]
+    finally:
+        env.cleanup()
+
+
+def test_precontaminated_snapshot_marker_stripped_before_command(tmp_path, monkeypatch):
+    # topbronson's case: a snapshot persisted by an OLDER build still carries
+    # ``export HERMES_DELEGATED_CHILD_CONTEXT=1``. Sourcing it before a non-
+    # delegated command would leak the marker for that first post-upgrade
+    # command; the post-source cleanup must strip it so the command is not
+    # misidentified as a delegated child.
+    monkeypatch.delenv(_MARKER, raising=False)
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+    try:
+        snapshot = Path(env._snapshot_path)
+        # Simulate the contaminated on-disk snapshot from before the fix.
+        snapshot.write_text(
+            snapshot.read_text(encoding="utf-8") + f'\nexport {_MARKER}=1\n',
+            encoding="utf-8",
+        )
+        parent = env.execute(_probe(_MARKER), timeout=15)
+        assert parent["returncode"] == 0
+        assert "presence= value=unset" in parent["output"]
+
+        # A genuine delegated child on the SAME contaminated snapshot must still
+        # see the marker — the cleanup restores the authoritative process-env
+        # state, it does not blanket-drop it.
+        with delegated_child_context():
+            child = env.execute(_probe(_MARKER), timeout=15)
+        assert child["returncode"] == 0
+        assert "presence=set value=1" in child["output"]
+    finally:
+        env.cleanup()
+
+
 def test_export_dump_filter_drops_marker_and_kanban_keeps_user_exports():
     # Faithful check of the real ``unset``-before-``export -p`` filter, independent
     # of the backend plumbing: invocation-scoped Hermes identity/lineage vars are

--- a/tests/tools/test_local_env_delegation_marker_snapshot.py
+++ b/tests/tools/test_local_env_delegation_marker_snapshot.py
@@ -1,0 +1,109 @@
+"""Regression: the delegate_task lineage marker must not persist in the shared
+terminal snapshot.
+
+``HERMES_DELEGATED_CHILD_CONTEXT=1`` is invocation-scoped metadata describing the
+currently executing subprocess lineage: a terminal command run by a
+``delegate_task`` child should see it, an ordinary later command must not. But the
+local backend collapses parent and delegated child onto one cached
+``LocalEnvironment`` (the ``"default"`` key) whose ``export -p`` snapshot is
+re-sourced before every command. Before the fix the child's marker was serialized
+into that shared snapshot, so a subsequent *non-delegated* command sourced the
+stale value and was misidentified as a delegated child — e.g. Kanban mutation
+guards denying otherwise legitimate ops.
+
+Regression coverage for
+https://github.com/NousResearch/hermes-agent/issues/71941.
+"""
+
+import subprocess
+from pathlib import Path
+
+from agent.delegation_context import (
+    DELEGATED_CHILD_ENV_MARKER,
+    KANBAN_ENV_KEYS,
+    delegated_child_context,
+)
+from tools.environments.base import _export_dump_excluding_session_vars
+from tools.environments.local import LocalEnvironment
+
+_MARKER = DELEGATED_CHILD_ENV_MARKER
+
+
+def _probe(name: str) -> str:
+    # presence=set/unset, value=<value>/unset — same shape as the issue repro.
+    return (
+        f'printf "presence=%s value=%s\\n" '
+        f'"${{{name}+set}}" "${{{name}-unset}}"'
+    )
+
+
+def test_delegated_marker_not_persisted_to_shared_snapshot(tmp_path, monkeypatch):
+    monkeypatch.delenv(_MARKER, raising=False)
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+    try:
+        snapshot = Path(env._snapshot_path)
+        assert _MARKER not in snapshot.read_text(encoding="utf-8")
+
+        # A delegated child command must still SEE the marker...
+        with delegated_child_context():
+            child = env.execute(_probe(_MARKER), timeout=15)
+        assert child["returncode"] == 0
+        assert "presence=set value=1" in child["output"]
+
+        # ...but it must NOT leak into the reusable snapshot.
+        assert _MARKER not in snapshot.read_text(encoding="utf-8")
+
+        # A subsequent ordinary (non-delegated) command sees it as unset,
+        # and re-dumping keeps the snapshot clean.
+        parent = env.execute(_probe(_MARKER), timeout=15)
+        assert parent["returncode"] == 0
+        assert "presence= value=unset" in parent["output"]
+        assert _MARKER not in snapshot.read_text(encoding="utf-8")
+    finally:
+        env.cleanup()
+
+
+def test_kanban_ownership_env_not_persisted_to_shared_snapshot(tmp_path, monkeypatch):
+    # Kanban dispatcher-ownership vars are invocation-scoped too; a delegated
+    # child that inherits one in its process env must not persist it into the
+    # snapshot where a later turn would recover stale ownership.
+    key = KANBAN_ENV_KEYS[0]
+    monkeypatch.setenv(key, "board-owner-token")
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+    try:
+        env.execute("true", timeout=15)
+        assert key not in Path(env._snapshot_path).read_text(encoding="utf-8")
+    finally:
+        env.cleanup()
+
+
+def test_export_dump_filter_drops_marker_and_kanban_keeps_user_exports():
+    # Faithful check of the real ``unset``-before-``export -p`` filter, independent
+    # of the backend plumbing: invocation-scoped Hermes identity/lineage vars are
+    # dropped, ordinary user exports (incl. unrelated HERMES_HOME) survive. The
+    # dump unsets by name/prefix, so the vars must be genuinely exported in the
+    # shell the snippet runs in (a mocked ``export -p`` would never see the unset).
+    exports = "; ".join(
+        [
+            'export PATH="/usr/bin"',
+            'export HERMES_HOME="/home/u/.hermes"',
+            f'export {_MARKER}="1"',
+            f'export {KANBAN_ENV_KEYS[0]}="tok"',
+            'export HERMES_SESSION_ID="s1"',
+            'export MYVAR="keep"',
+        ]
+    )
+    snippet = _export_dump_excluding_session_vars("/dev/stdout")
+    out = subprocess.run(
+        ["bash", "-c", f"{exports}; {snippet}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+    assert f'declare -x {_MARKER}=' not in out
+    assert f'declare -x {KANBAN_ENV_KEYS[0]}=' not in out
+    assert 'declare -x HERMES_SESSION_ID=' not in out
+    assert 'declare -x PATH="/usr/bin"' in out
+    assert 'declare -x HERMES_HOME="/home/u/.hermes"' in out
+    assert 'declare -x MYVAR="keep"' in out

--- a/tests/tools/test_local_env_delegation_marker_snapshot.py
+++ b/tests/tools/test_local_env_delegation_marker_snapshot.py
@@ -1,0 +1,159 @@
+"""Regression: the delegate_task lineage marker must not persist in the shared
+terminal snapshot.
+
+``HERMES_DELEGATED_CHILD_CONTEXT=1`` is invocation-scoped metadata describing the
+currently executing subprocess lineage: a terminal command run by a
+``delegate_task`` child should see it, an ordinary later command must not. But the
+local backend collapses parent and delegated child onto one cached
+``LocalEnvironment`` (the ``"default"`` key) whose ``export -p`` snapshot is
+re-sourced before every command. Before the fix the child's marker was serialized
+into that shared snapshot, so a subsequent *non-delegated* command sourced the
+stale value and was misidentified as a delegated child — e.g. Kanban mutation
+guards denying otherwise legitimate ops.
+
+Regression coverage for
+https://github.com/NousResearch/hermes-agent/issues/71941.
+"""
+
+import subprocess
+from pathlib import Path
+
+from agent.delegation_context import (
+    DELEGATED_CHILD_ENV_MARKER,
+    KANBAN_ENV_KEYS,
+    delegated_child_context,
+)
+from tools.environments.base_session_env import _export_dump_excluding_session_vars
+from tools.environments.local import LocalEnvironment
+
+_MARKER = DELEGATED_CHILD_ENV_MARKER
+
+
+def _probe(name: str) -> str:
+    # presence=set/unset, value=<value>/unset — same shape as the issue repro.
+    return (
+        f'printf "presence=%s value=%s\\n" '
+        f'"${{{name}+set}}" "${{{name}-unset}}"'
+    )
+
+
+def test_delegated_marker_not_persisted_to_shared_snapshot(tmp_path, monkeypatch):
+    monkeypatch.delenv(_MARKER, raising=False)
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+    try:
+        snapshot = Path(env._snapshot_path)
+        assert _MARKER not in snapshot.read_text(encoding="utf-8")
+
+        # A delegated child command must still SEE the marker...
+        with delegated_child_context():
+            child = env.execute(_probe(_MARKER), timeout=15)
+        assert child["returncode"] == 0
+        assert "presence=set value=1" in child["output"]
+
+        # ...but it must NOT leak into the reusable snapshot.
+        assert _MARKER not in snapshot.read_text(encoding="utf-8")
+
+        # A subsequent ordinary (non-delegated) command sees it as unset,
+        # and re-dumping keeps the snapshot clean.
+        parent = env.execute(_probe(_MARKER), timeout=15)
+        assert parent["returncode"] == 0
+        assert "presence= value=unset" in parent["output"]
+        assert _MARKER not in snapshot.read_text(encoding="utf-8")
+    finally:
+        env.cleanup()
+
+
+def test_kanban_ownership_env_not_persisted_to_shared_snapshot(tmp_path, monkeypatch):
+    # Kanban dispatcher-ownership vars are invocation-scoped too; a delegated
+    # child that inherits one in its process env must not persist it into the
+    # snapshot where a later turn would recover stale ownership.
+    key = KANBAN_ENV_KEYS[0]
+    monkeypatch.setenv(key, "board-owner-token")
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+    try:
+        env.execute("true", timeout=15)
+        assert key not in Path(env._snapshot_path).read_text(encoding="utf-8")
+    finally:
+        env.cleanup()
+
+
+def test_user_kanban_config_survives_snapshot(tmp_path, monkeypatch):
+    # HERMES_KANBAN_HOME / HERMES_KANBAN_DISPATCH_IN_GATEWAY are user-authored
+    # config, NOT dispatcher-owned lineage (they are absent from KANBAN_ENV_KEYS),
+    # so a broad HERMES_KANBAN_* exclusion must not strip them: the snapshot has
+    # to preserve the user's own exports.
+    monkeypatch.setenv("HERMES_KANBAN_HOME", "/home/u/.hermes")
+    monkeypatch.setenv("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "0")
+    assert "HERMES_KANBAN_HOME" not in KANBAN_ENV_KEYS
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+    try:
+        env.execute("true", timeout=15)
+        probe = env.execute(_probe("HERMES_KANBAN_HOME"), timeout=15)
+        assert probe["returncode"] == 0
+        assert "presence=set value=/home/u/.hermes" in probe["output"]
+        dispatch = env.execute(_probe("HERMES_KANBAN_DISPATCH_IN_GATEWAY"), timeout=15)
+        assert "presence=set value=0" in dispatch["output"]
+    finally:
+        env.cleanup()
+
+
+def test_precontaminated_snapshot_marker_stripped_before_command(tmp_path, monkeypatch):
+    # topbronson's case: a snapshot persisted by an OLDER build still carries
+    # ``export HERMES_DELEGATED_CHILD_CONTEXT=1``. Sourcing it before a non-
+    # delegated command would leak the marker for that first post-upgrade
+    # command; the post-source cleanup must strip it so the command is not
+    # misidentified as a delegated child.
+    monkeypatch.delenv(_MARKER, raising=False)
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+    try:
+        snapshot = Path(env._snapshot_path)
+        # Simulate the contaminated on-disk snapshot from before the fix.
+        snapshot.write_text(
+            snapshot.read_text(encoding="utf-8") + f'\nexport {_MARKER}=1\n',
+            encoding="utf-8",
+        )
+        parent = env.execute(_probe(_MARKER), timeout=15)
+        assert parent["returncode"] == 0
+        assert "presence= value=unset" in parent["output"]
+
+        # A genuine delegated child on the SAME contaminated snapshot must still
+        # see the marker — the cleanup restores the authoritative process-env
+        # state, it does not blanket-drop it.
+        with delegated_child_context():
+            child = env.execute(_probe(_MARKER), timeout=15)
+        assert child["returncode"] == 0
+        assert "presence=set value=1" in child["output"]
+    finally:
+        env.cleanup()
+
+
+def test_export_dump_filter_drops_marker_and_kanban_keeps_user_exports():
+    # Faithful check of the real ``unset``-before-``export -p`` filter, independent
+    # of the backend plumbing: invocation-scoped Hermes identity/lineage vars are
+    # dropped, ordinary user exports (incl. unrelated HERMES_HOME) survive. The
+    # dump unsets by name/prefix, so the vars must be genuinely exported in the
+    # shell the snippet runs in (a mocked ``export -p`` would never see the unset).
+    exports = "; ".join(
+        [
+            'export PATH="/usr/bin"',
+            'export HERMES_HOME="/home/u/.hermes"',
+            f'export {_MARKER}="1"',
+            f'export {KANBAN_ENV_KEYS[0]}="tok"',
+            'export HERMES_SESSION_ID="s1"',
+            'export MYVAR="keep"',
+        ]
+    )
+    snippet = _export_dump_excluding_session_vars("/dev/stdout")
+    out = subprocess.run(
+        ["bash", "-c", f"{exports}; {snippet}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+    assert f'declare -x {_MARKER}=' not in out
+    assert f'declare -x {KANBAN_ENV_KEYS[0]}=' not in out
+    assert 'declare -x HERMES_SESSION_ID=' not in out
+    assert 'declare -x PATH="/usr/bin"' in out
+    assert 'declare -x HERMES_HOME="/home/u/.hermes"' in out
+    assert 'declare -x MYVAR="keep"' in out

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -22,6 +22,7 @@ from collections import deque
 from pathlib import Path
 from typing import IO, Callable, Iterable, Protocol
 
+from agent.delegation_context import DELEGATED_CHILD_ENV_MARKER, KANBAN_ENV_KEYS
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.interrupt import is_interrupted
@@ -480,13 +481,32 @@ def _cwd_marker(session_id: str) -> str:
 # lineage.
 #
 # Kept in sync with gateway.session_context._VAR_MAP and agent.delegation_context
-# (DELEGATED_CHILD_ENV_MARKER + KANBAN_ENV_KEYS): every owned name starts with one
-# of these prefixes (or is HERMES_UI_SESSION_ID). Used by unit tests as the
-# Python-side contract for the exclusion set; the dump path unsets by name/prefix
-# instead of grepping declare lines (see below / issue #71296).
+# (DELEGATED_CHILD_ENV_MARKER + KANBAN_ENV_KEYS). The session/cron families are
+# matched by prefix; the delegation marker and the dispatcher-owned Kanban keys
+# are matched by EXACT name imported from agent.delegation_context — a broad
+# ``HERMES_KANBAN_`` prefix would also strip user-authored, non-invocation config
+# such as HERMES_KANBAN_HOME / HERMES_KANBAN_DISPATCH_IN_GATEWAY, which a snapshot
+# must preserve. Used by unit tests as the Python-side contract for the exclusion
+# set; the dump path unsets by name/prefix instead of grepping declare lines
+# (see below / issue #71296).
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
-    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|HERMES_CRON_SESSION"
-    "|HERMES_DELEGATED_CHILD_CONTEXT|HERMES_KANBAN_)"
+    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|HERMES_CRON_SESSION|"
+    + "|".join((DELEGATED_CHILD_ENV_MARKER, *KANBAN_ENV_KEYS))
+    + ")"
+)
+
+# The exact shell token list of invocation-scoped names to ``unset``. Prefix
+# families use ${!PREFIX*} indirection; the marker and Kanban ownership keys are
+# unset by exact name so user-authored HERMES_KANBAN_HOME survives. Shared by the
+# export-dump filter and the post-source cleanup so the two never drift.
+_SNAPSHOT_EXCLUDED_UNSET_NAMES = " ".join(
+    (
+        "${!HERMES_SESSION_*}",
+        "${!HERMES_CRON_AUTO_DELIVER_*}",
+        "HERMES_UI_SESSION_ID",
+        DELEGATED_CHILD_ENV_MARKER,
+        *KANBAN_ENV_KEYS,
+    )
 )
 _SHELL_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -529,9 +549,7 @@ def _export_dump_excluding_session_vars(
         extra_unset = f" {extra_unset}"
     return (
         "{ ( "
-        "unset ${!HERMES_SESSION_*} ${!HERMES_CRON_AUTO_DELIVER_*} "
-        "${!HERMES_DELEGATED_CHILD_CONTEXT*} ${!HERMES_KANBAN_*} "
-        f"HERMES_UI_SESSION_ID{extra_unset} 2>/dev/null; "
+        f"unset {_SNAPSHOT_EXCLUDED_UNSET_NAMES}{extra_unset} 2>/dev/null; "
         "export -p; "
         ") || true; } "
         f"> {tmp_path}"
@@ -840,8 +858,30 @@ class BaseEnvironment(ABC):
         # vars into every tool response (issue #15459).  Linux bash is
         # silent here, but the redirect is harmless.
         if self._snapshot_ready:
+            # Capture the delegate_task lineage marker's AUTHORITATIVE state from
+            # this command's process env (set only for genuine delegated children
+            # by agent.delegation_context.delegated_child_subprocess_env) BEFORE
+            # sourcing. The export dump strips the marker on WRITE, but a snapshot
+            # persisted by an older build may still carry a stale
+            # HERMES_DELEGATED_CHILD_CONTEXT=1 that this ``source`` would leak
+            # until the next dump rewrites the file. Restoring the captured state
+            # afterwards keeps that one-command window from misidentifying a
+            # non-delegated command as a delegated child (issue #71941). Scoped to
+            # the marker alone: the session/Kanban vars are legitimately supplied
+            # per command via the process env, so a blanket post-source unset
+            # would drop the current command's own values.
+            _m = DELEGATED_CHILD_ENV_MARKER
+            parts.append(
+                f'if [ "${{{_m}+x}}" = x ]; then __hermes_dcc=${{{_m}}}; '
+                f"else __hermes_dcc=; fi"
+            )
             parts.append(
                 f"source {_quoted_snap} >/dev/null 2>&1 || true"
+            )
+            parts.append(
+                f'unset {_m}; '
+                f'[ -n "$__hermes_dcc" ] && export {_m}="$__hermes_dcc"; '
+                f"unset __hermes_dcc"
             )
 
         for name, present, value in saved_names:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -449,26 +449,44 @@ def _cwd_marker(session_id: str) -> str:
     return f"__HERMES_CWD_{session_id}__"
 
 
-# Per-session variables that the gateway bridges freshly onto every command's
-# process environment (via tools/environments/local._inject_session_context_env,
-# reading gateway.session_context._VAR_MAP). They must NEVER be persisted into
-# the shared bash session snapshot: a single long-lived backend serves many
-# concurrent sessions (the messaging gateway, TUI, desktop/web dashboard all
-# collapse the terminal to one "default" environment), so ``export -p`` dumping
-# the FIRST session's HERMES_SESSION_ID into the snapshot makes every LATER
-# session ``source`` that stale value and see a FOREIGN session's identity —
-# overriding the correct per-command Popen env (issue: cross-session
-# HERMES_SESSION_ID leak via the shared snapshot). Stripping them from the
-# snapshot is safe because they are re-injected on every command; a snapshot
-# should only carry the user's own shell state (PATH, functions, exports they
-# set), not Hermes' per-turn session identity.
+# Invocation-scoped Hermes variables that describe *who is running this one
+# command* — not reusable shell state — and are therefore freshly supplied on
+# every command's process environment rather than authored by the user. They
+# must NEVER be persisted into the shared bash session snapshot, because a
+# single long-lived backend serves many concurrent turns (the messaging
+# gateway, TUI, desktop/web dashboard all collapse the terminal to one
+# "default" environment) and re-``source``s the snapshot before each command.
+# Persisting any of them makes a LATER, unrelated turn ``source`` a stale value
+# and be misidentified. Two families:
 #
-# Kept in sync with gateway.session_context._VAR_MAP: every bridged name starts
-# with one of these prefixes (or is HERMES_UI_SESSION_ID). Used by unit tests
-# as the Python-side contract for the exclusion set; the dump path unsets by
-# name/prefix instead of grepping declare lines (see below / issue #71296).
+#   * ``HERMES_SESSION_*`` / ``HERMES_UI_SESSION_ID`` /
+#     ``HERMES_CRON_AUTO_DELIVER_*`` — bridged per command by
+#     tools/environments/local._inject_session_context_env (reading
+#     gateway.session_context._VAR_MAP). Left in the snapshot, the FIRST
+#     session's identity leaks into every later session (cross-session
+#     HERMES_SESSION_ID leak).
+#   * ``HERMES_DELEGATED_CHILD_CONTEXT`` and ``HERMES_KANBAN_*`` — the
+#     delegate_task lineage marker and Kanban dispatcher-ownership vars
+#     (agent/delegation_context.py). A delegated child shares the parent's
+#     cached "default" environment, so ``export -p`` would serialize its
+#     ``HERMES_DELEGATED_CHILD_CONTEXT=1`` into the snapshot; a later ordinary
+#     (non-delegated) command then sources the stale marker and is treated as a
+#     delegated child — e.g. Kanban mutation guards deny legitimate ops
+#     (issue #71941).
+#
+# Stripping them is safe because they are re-supplied on every command that
+# legitimately owns them; a snapshot should only carry the user's own shell
+# state (PATH, functions, exports they set), not Hermes' per-turn identity or
+# lineage.
+#
+# Kept in sync with gateway.session_context._VAR_MAP and agent.delegation_context
+# (DELEGATED_CHILD_ENV_MARKER + KANBAN_ENV_KEYS): every owned name starts with one
+# of these prefixes (or is HERMES_UI_SESSION_ID). Used by unit tests as the
+# Python-side contract for the exclusion set; the dump path unsets by name/prefix
+# instead of grepping declare lines (see below / issue #71296).
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
-    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|HERMES_CRON_SESSION)"
+    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|HERMES_CRON_SESSION"
+    "|HERMES_DELEGATED_CHILD_CONTEXT|HERMES_KANBAN_)"
 )
 _SHELL_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -512,6 +530,7 @@ def _export_dump_excluding_session_vars(
     return (
         "{ ( "
         "unset ${!HERMES_SESSION_*} ${!HERMES_CRON_AUTO_DELIVER_*} "
+        "${!HERMES_DELEGATED_CHILD_CONTEXT*} ${!HERMES_KANBAN_*} "
         f"HERMES_UI_SESSION_ID{extra_unset} 2>/dev/null; "
         "export -p; "
         ") || true; } "

--- a/tools/environments/base_session_env.py
+++ b/tools/environments/base_session_env.py
@@ -9,6 +9,8 @@ import re
 import shlex
 from typing import Iterable
 
+from agent.delegation_context import DELEGATED_CHILD_ENV_MARKER, KANBAN_ENV_KEYS
+
 # Bridged per-session vars (gateway.session_context._VAR_MAP) are injected fresh onto every
 # command's process env and must NEVER persist in the shared bash snapshot: one long-lived
 # backend serves many sessions, so a snapshot carrying the FIRST session's HERMES_SESSION_ID
@@ -26,9 +28,21 @@ from typing import Iterable
 # only carry the user's own shell state (PATH, functions, exports they set), not Hermes' per-turn session
 # identity. Used by unit tests as the Python-side contract for the exclusion set; the dump path unsets by
 # name/prefix instead of grepping declare lines (see below / issue #71296).
+#
+# The delegate_task lineage marker (HERMES_DELEGATED_CHILD_CONTEXT) and the Kanban dispatcher-ownership
+# vars (agent.delegation_context.KANBAN_ENV_KEYS) are invocation-scoped the same way: a delegated child
+# shares the parent's cached "default" environment, so ``export -p`` would serialize its marker into the
+# snapshot and a later ordinary command would source the stale value and be misidentified as a delegated
+# child (issue #71941). They are matched by EXACT name — a broad ``HERMES_KANBAN_`` prefix would also
+# strip user-authored config such as HERMES_KANBAN_HOME / HERMES_KANBAN_DISPATCH_IN_GATEWAY, which the
+# snapshot must preserve.
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
     "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|"
-    "HERMES_CRON_SESSION|HERMES_BROWSER_CONTROL_)")
+    "HERMES_CRON_SESSION|HERMES_BROWSER_CONTROL_|"
+    + "|".join((DELEGATED_CHILD_ENV_MARKER, *KANBAN_ENV_KEYS))
+    + ")")
+# Exact invocation-scoped names unset by name (not prefix) so user-authored HERMES_KANBAN_HOME survives.
+_SNAPSHOT_EXCLUDED_EXACT_NAMES = " ".join((DELEGATED_CHILD_ENV_MARKER, *KANBAN_ENV_KEYS))
 _SHELL_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 # mktemp template suffix + the shell variable holding the allocated temp path.
@@ -72,6 +86,9 @@ def _export_dump_excluding_session_vars(tmp_path: str, excluded_names: Iterable[
         # by every wrapper with ${VAR:-default} semantics; persisting them would
         # let the FIRST command's value override a later outer-harness value.
         "AI_AGENT HERMES_AGENT "
+        # Delegate lineage marker + Kanban dispatcher-ownership vars, unset by
+        # exact name so user-authored HERMES_KANBAN_HOME survives (issue #71941).
+        f"{_SNAPSHOT_EXCLUDED_EXACT_NAMES} "
         f"HERMES_UI_SESSION_ID{extra_unset} 2>/dev/null; "
         "export -p; ) || true; } "
         f"> {tmp_path}")
@@ -137,7 +154,21 @@ def _wrap_command_script(
     save, restore = _passthrough_save_restore(passthrough_names)
     parts = list(save)
     if snapshot_ready:
+        # Capture the delegate_task lineage marker's AUTHORITATIVE state from this command's
+        # process env (set only for genuine delegated children by delegated_child_subprocess_env)
+        # BEFORE sourcing. The export dump strips the marker on WRITE, but a snapshot persisted by
+        # an older build may still carry a stale HERMES_DELEGATED_CHILD_CONTEXT=1 that this ``source``
+        # would leak until the next dump rewrites the file. Restoring the captured state afterwards
+        # keeps that one-command window from misidentifying a non-delegated command as a delegated
+        # child (issue #71941). Scoped to the marker alone: the session/Kanban vars are legitimately
+        # supplied per command via the process env, so a blanket post-source unset would drop the
+        # current command's own values.
+        _m = DELEGATED_CHILD_ENV_MARKER
+        parts.append(
+            f'if [ "${{{_m}+x}}" = x ]; then __hermes_dcc=${{{_m}}}; else __hermes_dcc=; fi')
         parts.append(f"source {quoted_snap} >/dev/null 2>&1 || true")
+        parts.append(
+            f'unset {_m}; [ -n "$__hermes_dcc" ] && export {_m}="$__hermes_dcc"; unset __hermes_dcc')
     parts += restore
     parts += [
         'export AI_AGENT="${AI_AGENT:-hermes-agent}" HERMES_AGENT="${HERMES_AGENT:-true}"',


### PR DESCRIPTION
## Summary

Fixes #71941 — a delegated (`delegate_task`) child's `HERMES_DELEGATED_CHILD_CONTEXT=1` lineage marker persisted into the shared terminal snapshot, so a later ordinary command was misidentified as a delegated child.

The local backend collapses a `delegate_task` parent and its child onto one cached `LocalEnvironment` (the `"default"` key), whose `export -p` snapshot is re-`source`d before every command. When a delegated child runs a terminal command, its inherited `HERMES_DELEGATED_CHILD_CONTEXT=1` was serialized into that snapshot. A subsequent **non-delegated** command then sourced the stale marker and looked identical to a delegated invocation to code that consults it — e.g. Kanban mutation guards denying otherwise legitimate ops — and the stale value was re-persisted on every following dump, so the contamination outlived the delegation for the life of the cached environment.

## Fix

The snapshot dump already strips per-turn identity vars via `_SNAPSHOT_EXCLUDED_ENV_REGEX` (the `HERMES_SESSION_*` / `HERMES_UI_SESSION_ID` / `HERMES_CRON_AUTO_DELIVER_*` bridge vars, for the cross-session `HERMES_SESSION_ID` leak). This bug is the same class — invocation-scoped identity that must never become reusable shell state — so the fix extends that one exclusion to also drop:

- `HERMES_DELEGATED_CHILD_CONTEXT` — the delegate_task lineage marker, and
- `HERMES_KANBAN_*` — the dispatcher-ownership vars the issue asked to audit under the same rule.

Both are supplied fresh on every command that legitimately owns them (via the spawned process env, `agent/delegation_context.py`), so a delegated child still **sees** the marker for its own command — it just never persists in the shared snapshot. Matches the issue's expected probe output exactly:

```
snapshot_after_child_has_marker: false
parent_output: presence= value=unset
snapshot_after_parent_has_marker: false
```

This composes with, and is orthogonal to, the snapshot-injection hardening in #71296 / #71306 / #71464: those sanitize hostile *session-name* values; this drops invocation-scoped identity markers. No overlap in the lines touched (a single regex extension) or the vars handled.

## Test plan

New `tests/tools/test_local_env_delegation_marker_snapshot.py`:
- `test_delegated_marker_not_persisted_to_shared_snapshot` — the issue's deterministic repro against the real `LocalEnvironment`: the delegated child still sees `presence=set value=1`, the marker never lands in the snapshot, and a following ordinary command sees it unset.
- `test_kanban_ownership_env_not_persisted_to_shared_snapshot` — a `HERMES_KANBAN_*` var never persists into the snapshot.
- `test_export_dump_filter_drops_marker_and_kanban_keeps_user_exports` — drives the real `grep -vE` filter and asserts ordinary user exports (incl. unrelated `HERMES_HOME`) survive, guarding against over-matching.

Gates: `check-windows-footguns.py` ✓, `ruff` ✓, affected tests pass; sibling snapshot/session/delegation suites (`test_snapshot_session_id_leak`, `test_local_env_session_leak`, `test_delegate_kanban_isolation`, `test_modal_snapshot_isolation`) all green.

## Platforms

- macOS: full run of the new + sibling suites passes.
- POSIX-only surface (`export -p` snapshot); no frontend/Electron changes.
