### PR TITLE
fix(cli): collapse timeline markers, /skill invocations, and compaction handoffs in the resume preview

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -753,6 +753,8 @@ class CLIAgentSetupMixin:
         from cli import CLI_CONFIG, _record_output_history_entry, _strip_reasoning_tags, _suspend_output_history
         from tools.ansi_strip import sanitize_display_text as _sanitize_display_text
         from agent.skill_commands import describe_skill_invocation
+        from agent.compaction_display import project_compaction_message_for_display
+        from agent.context_compressor import is_compaction_summary_message
         display_history = getattr(self, "_resume_display_history", self.conversation_history)
         if not display_history:
             return
@@ -774,6 +776,24 @@ class CLIAgentSetupMixin:
         _last_asst_idx = None       # index of last assistant entry
         _last_asst_full = None      # un-truncated display text for last assistant
         for msg in display_history:
+            if is_compaction_summary_message(msg):
+                # Model-only compaction carrier (handoff boilerplate,
+                # inherited tool_calls/reasoning) — every other client-facing
+                # history surface (tui_gateway, gateway/run.py, the
+                # OpenAI-compatible api_server, the dashboard) already
+                # projects this away via project_compaction_message_for_
+                # display(); this recap builds its own history independently
+                # and never picked up an equivalent projection. A standalone
+                # handoff has no real content and is dropped entirely
+                # (mirrors display_kind == "hidden" below); a merged handoff
+                # keeps only the real prior-tail content that precedes the
+                # internal summary delimiter, with inherited
+                # tool_calls/reasoning stripped.
+                projected = project_compaction_message_for_display(msg)
+                if projected is None:
+                    continue
+                msg = projected
+
             role = msg.get("role", "")
             display_kind = msg.get("display_kind")
             content = msg.get("content")

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -752,6 +752,7 @@ class CLIAgentSetupMixin:
         """
         from cli import CLI_CONFIG, _record_output_history_entry, _strip_reasoning_tags, _suspend_output_history
         from tools.ansi_strip import sanitize_display_text as _sanitize_display_text
+        from agent.skill_commands import describe_skill_invocation
         display_history = getattr(self, "_resume_display_history", self.conversation_history)
         if not display_history:
             return
@@ -789,6 +790,33 @@ class CLIAgentSetupMixin:
             if display_kind == "auto_continue":
                 entries.append(("event", "resumed interrupted turn"))
                 continue
+
+            # Gateway bookkeeping notices (personality change/clear) are
+            # persisted as role=user "[System: ...]" rows so strict
+            # OpenAI-compatible providers accept them mid-history — they are
+            # model-facing runtime metadata, not a user turn. The model-switch
+            # marker carries display_kind="model_switch" and is handled above;
+            # the personality marker carries no display_kind and would
+            # otherwise fall through to the role=="user" branch below and
+            # render as a fake "You: [System: ...]" bubble. Mirrors
+            # tui_gateway/server.py::_is_display_hidden_marker — keep both in
+            # sync if the marker wording/role ever changes.
+            if role == "user" and str(content or "").lstrip().startswith("[System:"):
+                continue
+
+            # A /skill invocation is persisted expanded — activation note plus
+            # the entire skill body — so without this it recaps as if the
+            # user had typed the skill's own prose (same class as the
+            # tui_gateway/server.py::_history_to_messages projection that
+            # every OTHER surface — desktop, TUI, web — already reads through;
+            # this CLI recap builds its own history independently and never
+            # picked up an equivalent projection). Render the invocation the
+            # user actually typed instead, e.g. "/work — fix the leak".
+            if role == "user" and isinstance(content, str):
+                invocation = describe_skill_invocation(content)
+                if invocation:
+                    entries.append(("event", f"skill invoked: {invocation}"))
+                    continue
 
             if role == "system":
                 continue

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -239,7 +239,84 @@ class TestDisplayResumedHistory:
         assert "SPIN UP A WORKTREE" not in output
         assert "◈ skill invoked: /work" in output
 
+    def test_standalone_compaction_handoff_dropped_not_shown_as_user_message(self):
+        """A standalone compaction-summary handoff (role=user, the full
+        "[CONTEXT COMPACTION — REFERENCE ONLY] ..." boilerplate) must not
+        render as a fake "You:" bubble — every other client-facing history
+        surface (tui_gateway, gateway/run.py, the OpenAI-compatible
+        api_server, the dashboard) already drops/hides this via
+        project_compaction_message_for_display(); this recap builds its own
+        history independently and never picked up an equivalent projection."""
+        from agent.context_compressor import (
+            HISTORICAL_TASK_HEADING,
+            SUMMARY_PREFIX,
+            _SUMMARY_END_MARKER,
+        )
 
+        standalone_summary = (
+            f"{SUMMARY_PREFIX}\n\n"
+            f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+            f"{_SUMMARY_END_MARKER}"
+        )
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": standalone_summary},
+            {"role": "user", "content": "test the browser controller again"},
+            {"role": "assistant", "content": "on it"},
+        ]
+
+        output = self._capture_display(cli)
+
+        assert "CONTEXT COMPACTION" not in output
+        assert "REFERENCE ONLY" not in output
+        assert "old work" not in output
+        assert "test the browser controller again" in output
+        assert "on it" in output
+
+    def test_merged_compaction_carrier_shows_only_real_prior_content(self):
+        """A merged compaction carrier (a real assistant reply with an
+        inherited handoff summary appended, plus stale tool_calls from the
+        pre-compaction turn) must show only the real prior-tail text — not
+        the internal summary delimiter/boilerplate, and not the inherited
+        tool_calls as if they were a live action in this turn."""
+        from agent.context_compressor import (
+            HISTORICAL_TASK_HEADING,
+            SUMMARY_PREFIX,
+            _MERGED_PRIOR_CONTEXT_HEADER,
+            _MERGED_SUMMARY_DELIMITER,
+            _SUMMARY_END_MARKER,
+        )
+
+        standalone_summary = (
+            f"{SUMMARY_PREFIX}\n\n"
+            f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+            f"{_SUMMARY_END_MARKER}"
+        )
+        merged_carrier = (
+            f"{_MERGED_PRIOR_CONTEXT_HEADER}\n"
+            "Refactor complete.\n\n"
+            f"{_MERGED_SUMMARY_DELIMITER}\n\n"
+            f"{standalone_summary}"
+        )
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "how's the refactor going?"},
+            {
+                "role": "assistant",
+                "content": merged_carrier,
+                "tool_calls": [{"id": "stale-prior-call"}],
+            },
+        ]
+
+        output = self._capture_display(cli)
+
+        assert "Refactor complete." in output
+        assert "PRIOR CONTEXT" not in output
+        assert "CONTEXT COMPACTION" not in output
+        assert "REFERENCE ONLY" not in output
+        assert "old work" not in output
+        assert "tool call" not in output
+        assert "stale-prior-call" not in output
 
     def test_tool_only_message_skipped_by_default(self):
         """Assistant messages with only tool_calls (no text) are skipped when

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -150,6 +150,95 @@ class TestDisplayResumedHistory:
         assert "You:" not in output
         assert "opaque" not in output
 
+    def test_personality_change_marker_hidden_not_shown_as_user_message(self):
+        """The personality-change/clear bookkeeping notice (tui_gateway.server's
+        _set_personality) is persisted as role=user "[System: ...]" with NO
+        display_kind — unlike the model-switch marker, there is no "◈ event"
+        branch to catch it, so it must be dropped outright rather than
+        rendered as a fake "You:" bubble (#71916-adjacent gap)."""
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "What's up?"},
+            {
+                "role": "user",
+                "content": (
+                    "[System: The user has changed the assistant's personality. "
+                    "From this point forward, adopt the following persona and "
+                    "respond accordingly: grumpy pirate]"
+                ),
+            },
+            {"role": "assistant", "content": "Not much, arr."},
+        ]
+
+        output = self._capture_display(cli)
+
+        assert "[System:" not in output
+        assert "grumpy pirate" not in output
+        assert "What's up?" in output
+        assert "Not much, arr." in output
+
+    def test_personality_cleared_marker_hidden(self):
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "user",
+                "content": (
+                    "[System: The user has cleared the personality overlay. "
+                    "From this point forward, respond in your normal default style.]"
+                ),
+            },
+            {"role": "assistant", "content": "hi there"},
+        ]
+
+        output = self._capture_display(cli)
+
+        assert "[System:" not in output
+        assert "cleared the personality" not in output
+
+    def test_skill_invocation_collapsed_not_shown_as_expanded_body(self):
+        """A /skill turn is persisted EXPANDED — activation note plus the
+        entire skill body. tui_gateway/server.py::_history_to_messages (the
+        desktop/TUI/web display projection) already collapses this onto the
+        invocation the user typed; the CLI's _display_resumed_history builds
+        its recap independently and never picked up an equivalent projection,
+        so it rendered the whole skill body as if the user had written it."""
+        cli = _make_cli()
+        scaffolded = (
+            '[IMPORTANT: The user has invoked the "work" skill, indicating they '
+            "want you to follow its instructions. The full skill content is "
+            "loaded below.]\n\n"
+            "# /work\n\nSPIN UP A WORKTREE, never the primary checkout.\n\n"
+            "The user has provided the following instruction alongside the skill "
+            "invocation: fix the title leak"
+        )
+        cli.conversation_history = [
+            {"role": "user", "content": scaffolded},
+            {"role": "assistant", "content": "on it"},
+        ]
+
+        output = self._capture_display(cli)
+
+        assert "SPIN UP A WORKTREE" not in output
+        assert "IMPORTANT: The user has invoked" not in output
+        assert "You:" not in output
+        assert "◈ skill invoked: /work" in output
+        assert "fix the title leak" in output
+
+    def test_bare_skill_invocation_collapsed_to_command(self):
+        cli = _make_cli()
+        scaffolded = (
+            '[IMPORTANT: The user has invoked the "work" skill, indicating they '
+            "want you to follow its instructions. The full skill content is "
+            "loaded below.]\n\n# /work\n\nSPIN UP A WORKTREE."
+        )
+        cli.conversation_history = [{"role": "user", "content": scaffolded}]
+
+        output = self._capture_display(cli)
+
+        assert "SPIN UP A WORKTREE" not in output
+        assert "◈ skill invoked: /work" in output
+
 
 
     def test_tool_only_message_skipped_by_default(self):


### PR DESCRIPTION
## Summary

`_display_resumed_history()` (the CLI's "Previous Conversation" recap shown on `/resume` and `hermes --resume`) is a **separate** display projection from `tui_gateway/server.py::_history_to_messages` (the one desktop/TUI/web read). It special-cases the `display_kind` values it happens to know about, but three classes of bookkeeping/scaffolding rows fall through to the plain `role=="user"`/`role=="assistant"` branches and render as fake `You:`/`Hermes:` bubbles:

1. **Personality-change/clear marker** — `tui_gateway.server`'s `_set_personality()` writes a plain `role=user "[System: ...]"` row with **no `display_kind`**. `_history_to_messages` already hides it via `_is_display_hidden_marker()` (a role + `"[System:"` prefix check, independent of `display_kind`); the CLI's recap never picked up the same check.
2. **`/skill` invocations** — persisted expanded (activation note plus the entire skill body). `_history_to_messages` already collapses this onto the invocation the user typed via `describe_skill_invocation()`; the CLI's recap showed up to 300 raw characters of the expanded body as if the user had written it.
3. **Compaction handoff carriers** — `agent/compaction_display.py::project_compaction_message_for_display()` strips model-only compaction carrier state (handoff boilerplate, inherited `tool_calls`/reasoning) before history reaches a client. It's wired into `tui_gateway/server.py`, `gateway/run.py`, and `gateway/platforms/api_server.py`'s OpenAI-compatible endpoint (and now `hermes_cli/web_routers/sessions.py`, the dashboard, in a separate PR) — but the CLI's recap never picked up an equivalent projection either. A standalone handoff showed the full `"[CONTEXT COMPACTION — REFERENCE ONLY] ..."` boilerplate (~700 words) as a fake `You:` bubble; a merged carrier showed the internal `"[PRIOR CONTEXT — for reference only; not a new message]"` delimiter plus a stale inherited `tool_calls` summary as if it were a live action in that turn.

This is the third time this general bug class has been closed without covering the CLI path (personality/skill), and it turned out to have a fourth instance in the same function (compaction) once I looked closer — #68665 / #69861 fixed the duplicate-bubble symptom on desktop, and a same-day sibling commit widened `_history_to_messages` for "desktop, TUI, CLI, and web transcripts" even though that function is never on the CLI's `hermes --resume` code path.

## Fix

- Personality marker: same `role == "user"` + `"[System:"` prefix check as `_is_display_hidden_marker()`, added to `_display_resumed_history()`'s history loop. Positioned after the `display_kind` special cases (so `model_switch`'s "◈ model changed" event line is unaffected) and before the plain `role == "user"` handling.
- Skill invocations: `describe_skill_invocation()` (from `agent.skill_commands`, the same helper `tui_gateway/server.py` uses) is called on `role=="user"` content; a match renders as `"◈ skill invoked: /work — fix the leak"` instead of the expanded body, consistent with the existing model-switch / async-delegation event lines.
- Compaction handoffs: `is_compaction_summary_message()`/`project_compaction_message_for_display()` checked at the top of the history loop, before role/display_kind extraction. A standalone handoff (projection is `None`) is dropped entirely (mirrors the existing `display_kind == "hidden"` handling a few lines below); a merged carrier's loop variable is reassigned to the projected dict so `content`/`tool_calls`/`display_kind` are all read already-stripped, letting the existing role-based rendering handle the cleaned real content unmodified.

Deliberately **not** importing `tui_gateway.server` to reuse `_is_display_hidden_marker` directly — that module is not otherwise on the CLI's import graph and is a large gateway-oriented module. The duplicated prefix check is commented to point back at `_is_display_hidden_marker` so the two stay in sync if the marker wording/role ever changes.

## Changes

- `hermes_cli/cli_agent_setup_mixin.py`: skip `role=="user"` rows whose content starts with `"[System:"`; collapse `role=="user"` rows matching `describe_skill_invocation()` to an event line; drop/clean compaction-summary-shaped rows via the shared projection.
- `tests/cli/test_resume_display.py`: 6 regression tests total — personality-change marker, personality-cleared marker, skill invocation with instruction, bare skill invocation, standalone compaction handoff dropped, merged compaction carrier shows only real prior content. All assert the raw scaffolding never appears and the collapsed/hidden form renders correctly, while real conversation turns around them still render.

## Validation

- New tests pass; mutation-verify (each fix reverted independently) confirms all 6 fail with the exact bug's failure mode — the compaction pair confirmed against the file's actual pre-fix content (not assumed), showing the raw `"[CONTEXT COMPACTION — REFERENCE ONLY]..."` / `"[PRIOR CONTEXT...]"` text leaking through.
- Full `tests/cli/test_resume_display.py`: 21/21 passed.
- `tests/cli/test_cli_resume_command.py`, `tests/cli/test_resume_model_restore.py`, `tests/cli/test_cli_yolo_resume_persistence.py`, `tests/cli/test_resume_quiet_stderr.py`: 51/51 passed.
- Full `tests/cli/` (1301 tests): 1 pre-existing failure unrelated to this change (`test_resume_quiet_stderr.py::test_session_not_found_goes_to_stdout_in_full_mode`) — confirmed via stash-and-rerun to fail identically with or without this fix (test-order-pollution, passes in isolation).
- `ruff check`: clean.

## Competing PRs

Checked `gh pr list --search` with several keyword combinations right before pushing the compaction-handoff commit. No hits touch `hermes_cli/cli_agent_setup_mixin.py` or this specific projection mechanism — the closest matches (#86019, #53806, #85310, #19649, #51088) are all about the compression/compaction *pipeline itself*, not display projection, and don't overlap in file or intent.