### PR TITLE
fix(environments): keep the delegated-child marker out of the terminal snapshot

### DIFF
--- a/tests/tools/test_snapshot_delegated_marker_leak.py
+++ b/tests/tools/test_snapshot_delegated_marker_leak.py
@@ -1,0 +1,122 @@
+"""Delegated-child marker leaking into the shared bash snapshot (issue #71941).
+
+``delegate_task`` children run inside ``delegated_child_context()``, and
+``delegated_child_subprocess_env()`` materializes
+``HERMES_DELEGATED_CHILD_CONTEXT=1`` into the env of every subprocess spawned
+while that context is active. ``tools/terminal_tool.py::_resolve_container_task_id``
+deliberately collapses ordinary delegated children onto the ``"default"``
+environment key, so parent and child share ONE ``LocalEnvironment`` — and one
+bash session snapshot.
+
+``export -p`` exports the whole process env, so the child's marker was dumped
+into that shared snapshot. The next *ordinary* command sourced the declaration
+and was indistinguishable from a delegated child to the Kanban mutation guards
+(``hermes_cli/kanban.py``, ``hermes_cli/kanban_db.py``), which deny
+dispatcher-owned mutations for delegated children. Because that command
+re-dumped the snapshot, the stale marker survived for the lifetime of the
+cached environment.
+
+The fix adds the marker to ``_SNAPSHOT_EXCLUDED_ENV_REGEX`` in
+``tools/environments/base.py``, alongside the per-session bridged vars. It is
+lossless: a genuinely delegated spawn gets the marker re-injected by
+``delegated_child_subprocess_env`` every time.
+"""
+
+import sys
+
+import pytest
+
+from agent.delegation_context import (
+    DELEGATED_CHILD_ENV_MARKER,
+    delegated_child_context,
+)
+from tools.environments.base import _export_dump_excluding_session_vars
+
+
+# ---------------------------------------------------------------------------
+# Unit: the emitted dump filters the marker by name.
+#
+# Asserted against the generated shell snippet rather than the filter constant
+# itself: #71464 proposes replacing the line regex with shell ``case`` globs,
+# and this regression is orthogonal to how the filtering is expressed.
+# ---------------------------------------------------------------------------
+
+def test_dump_snippet_filters_the_marker_by_name():
+    snippet = _export_dump_excluding_session_vars("/tmp/snap.tmp.$BASHPID")
+    assert DELEGATED_CHILD_ENV_MARKER in snippet, (
+        "the snapshot dump does not filter the delegation marker"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration: real LocalEnvironment, delegated call then ordinary call.
+# ---------------------------------------------------------------------------
+
+def _probe(env):
+    """Report whether the marker is set in the command's shell, and its value."""
+    result = env.execute(
+        f'printf "presence=%s value=%s\\n" '
+        f'"${{{DELEGATED_CHILD_ENV_MARKER}+set}}" '
+        f'"${{{DELEGATED_CHILD_ENV_MARKER}-unset}}"'
+    )
+    return result.get("output", "").strip()
+
+
+def _snapshot_has_marker(env) -> bool:
+    with open(env._snapshot_path, encoding="utf-8", errors="replace") as fh:
+        return DELEGATED_CHILD_ENV_MARKER in fh.read()
+
+
+@pytest.fixture
+def local_env(tmp_path, monkeypatch):
+    from tools.environments.local import LocalEnvironment
+
+    # A delegated ancestor in the real process env would make every command
+    # look delegated regardless of the snapshot.
+    monkeypatch.delenv(DELEGATED_CHILD_ENV_MARKER, raising=False)
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+    try:
+        yield env
+    finally:
+        env.cleanup()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_delegated_marker_does_not_survive_into_the_next_command(local_env):
+    """The reproduction from issue #71941, start to finish."""
+    assert not _snapshot_has_marker(local_env), "marker present before delegation"
+
+    with delegated_child_context():
+        child_output = _probe(local_env)
+
+    # The feature still works: the delegated command itself sees the marker.
+    assert child_output == "presence=set value=1", child_output
+    assert not _snapshot_has_marker(local_env), (
+        "the delegated command persisted the marker into the shared snapshot"
+    )
+
+    # The ordinary command that follows must not inherit it.
+    parent_output = _probe(local_env)
+    assert parent_output == "presence= value=unset", parent_output
+    assert not _snapshot_has_marker(local_env)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_marker_excluded_from_the_bootstrap_snapshot(tmp_path, monkeypatch):
+    """init_session dumps the snapshot too — cover that site as well.
+
+    An environment first created *during* a delegated turn writes its initial
+    snapshot from an env that already carries the marker.
+    """
+    from tools.environments.local import LocalEnvironment
+
+    monkeypatch.delenv(DELEGATED_CHILD_ENV_MARKER, raising=False)
+    with delegated_child_context():
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+        try:
+            env.init_session()
+            assert not _snapshot_has_marker(env), (
+                "the bootstrap snapshot captured the delegation marker"
+            )
+        finally:
+            env.cleanup()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -398,8 +398,24 @@ def _cwd_marker(session_id: str) -> str:
 #
 # Kept in sync with gateway.session_context._VAR_MAP: every bridged name starts
 # with one of these prefixes.
+#
+# HERMES_DELEGATED_CHILD_CONTEXT is invocation-scoped in the same way but
+# reaches the child from a different place: agent.delegation_context marks a
+# delegate_task child with a ContextVar, and delegated_child_subprocess_env()
+# materializes the marker into the env of every subprocess spawned while that
+# context is active. tools/terminal_tool.py::_resolve_container_task_id()
+# deliberately collapses ordinary delegated children onto the "default"
+# environment key, so parent and child share ONE LocalEnvironment and one
+# snapshot — and ``export -p`` in the child dumped the marker into it. The
+# next ordinary command sourced that declaration and was indistinguishable
+# from a delegated child to the Kanban mutation guards in hermes_cli/kanban.py
+# and kanban_db.py, which deny dispatcher-owned mutations for delegated
+# children (issue #71941). Dropping it here is lossless for the same reason as
+# the bridged vars: delegated_child_subprocess_env() re-supplies it on every
+# spawn that genuinely is delegated.
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
-    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_)"
+    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_"
+    "|HERMES_DELEGATED_CHILD_CONTEXT)"
 )
 
 


### PR DESCRIPTION
## What does this PR do?

Stops `HERMES_DELEGATED_CHILD_CONTEXT` from being persisted into the shared bash session snapshot, so an ordinary terminal call can no longer inherit a delegated child's invocation identity.

`delegate_task` children run inside `delegated_child_context()`, and `delegated_child_subprocess_env()` materializes `HERMES_DELEGATED_CHILD_CONTEXT=1` into the env of every subprocess spawned while that context is active. `tools/terminal_tool.py::_resolve_container_task_id()` deliberately collapses ordinary delegated children onto the `"default"` environment key, so parent and child share one `LocalEnvironment` — and one snapshot file.

`export -p` dumps the whole exported process env, so the child's marker landed in that snapshot. The next *ordinary* command sourced the declaration and became indistinguishable from a delegated child to the mutation guards in `hermes_cli/kanban.py:1151` and `hermes_cli/kanban_db.py:157`, which deny dispatcher-owned Kanban mutations for delegated children. Because that command re-dumped the snapshot, the stale marker persisted for the lifetime of the cached environment.

## Related Issue

Fixes #71941

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/base.py` — add `HERMES_DELEGATED_CHILD_CONTEXT` to `_SNAPSHOT_EXCLUDED_ENV_REGEX`, alongside the per-session vars the gateway bridges, and document why an invocation-scoped marker owned by `agent.delegation_context` belongs in a list whose comment previously pointed only at `gateway.session_context._VAR_MAP`.
- `tests/tools/test_snapshot_delegated_marker_leak.py` — new regression coverage.

Both dump sites — the `init_session` bootstrap and the per-command re-dump — already route through `_export_dump_excluding_session_vars`, so the single entry covers both. No extra shell runs per command.

**Why this is lossless:** the same argument that justifies excluding `HERMES_SESSION_*`. The value is re-supplied on every spawn that genuinely is delegated, by `delegated_child_subprocess_env()` → `scrub_kanban_env()`, which sets the marker unconditionally while the ContextVar is active. The snapshot should only carry the user's own shell state, not Hermes' per-invocation identity.

**Scope.** The issue also asks that a *pre-existing* stale declaration in a snapshot not affect an ordinary invocation. That is not addressed here, and I don't think it needs to be: `_snapshot_path` is `{temp_dir}/hermes-snap-{uuid4}.sh`, freshly generated per `BaseEnvironment` instance (`tools/environments/base.py:465-467`), so a snapshot never outlives the environment that wrote it. With both dump sites filtered, no snapshot can acquire the marker in the first place. An `unset` sweep after `source` — as #64214 proposes for the cron vars — would add shell to every command to defend a state that can no longer be reached. The follow-up suggestion to audit `HERMES_KANBAN_*` under the same rule is also left out deliberately: those are scrubbed by `scrub_kanban_env()` on the way in rather than bridged per call, so the reasoning differs and it deserves its own change.

**Interaction with the open snapshot work.** #71306 / #71414 / #71464 rework the same dump path for #71296 (multiline values in `export -p` rendering as executable continuation lines); #71464 in particular replaces `_SNAPSHOT_EXCLUDED_ENV_REGEX` with shell `case` globs. This change is orthogonal — it adds a name to whichever filter exists — and the tests deliberately assert against the emitted dump snippet and end-to-end behaviour rather than the filter constant, so they survive that redesign. If any of those land first this rebases to a one-line change in the new structure; happy to do it in whatever order you prefer.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_snapshot_delegated_marker_leak.py -q` — 4 passed.
2. `scripts/run_tests.sh tests/tools/test_snapshot_session_id_leak.py -q` — 4 passed (neighbouring coverage for the same mechanism, unchanged).
3. `ruff check tools/environments/base.py tests/tools/test_snapshot_delegated_marker_leak.py` — passed.
4. The standalone probe from the issue now prints exactly the "Expected probe output" from the report:

```json
{
  "initial_snapshot_has_marker": false,
  "child_output": "presence=set value=1",
  "snapshot_after_child_has_marker": false,
  "parent_output": "presence= value=unset",
  "snapshot_after_parent_has_marker": false
}
```

The three new tests were run against `main` first and fail there — on the snippet filter, on the end-to-end delegated→ordinary sequence, and on the bootstrap snapshot.

## Checklist

### Code

- [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the full suite was not run; the targeted tests listed above were
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 x86_64, Python 3.12.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the change is one entry in an existing exclusion list, documented in place
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [[compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the integration tests skip on `win32` (POSIX bash snapshot path), matching `tests/tools/test_snapshot_session_id_leak.py`; the filter itself is platform-independent