### PR TITLE
fix(agent): fallback to default provider when session's provider is missing

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -78,6 +78,40 @@ class CLIAgentSetupMixin:
                     except Exception:
                         continue
 
+        # Last-resort fallback: if the requested provider no longer exists
+        # in the registry (e.g. a session was created with provider X and X
+        # was later removed from config), fall back to "auto" so we use the
+        # current default provider instead of hard-failing.
+        # See: https://github.com/NousResearch/hermes-agent/issues/52943
+        if (
+            runtime is None
+            and _primary_exc is not None
+            and isinstance(_primary_exc, AuthError)
+            and getattr(_primary_exc, "code", None) == "invalid_provider"
+        ):
+            _old_requested = self.requested_provider
+            try:
+                runtime = resolve_runtime_provider(
+                    requested="auto",
+                    explicit_api_key=self._explicit_api_key,
+                    explicit_base_url=self._explicit_base_url,
+                )
+                if runtime is not None:
+                    _new_provider = runtime.get("provider", "auto")
+                    _cprint(
+                        f"⚠️  Previously used provider '{_old_requested}' is no longer "
+                        f"available. Falling back to: {_new_provider}"
+                    )
+                    logger.warning(
+                        "Session provider '%s' not in registry; "
+                        "falling back to '%s'",
+                        _old_requested, _new_provider,
+                    )
+                    self.requested_provider = _new_provider
+                    _primary_exc = None
+            except Exception:
+                runtime = None  # fall through to existing error handling
+
         if runtime is None:
             message = format_runtime_provider_error(_primary_exc) if _primary_exc else "Provider resolution failed."
             ChatConsole().print(f"[bold red]{message}[/]")
@@ -134,6 +168,12 @@ class CLIAgentSetupMixin:
         self._provider_source = runtime.get("source")
         self.api_key = api_key
         self.base_url = base_url
+
+        # Keep requested_provider in sync with the actually-resolved provider
+        # so that subsequent _ensure_runtime_credentials() calls don't retry
+        # a stale/invalid requested value.
+        if resolved_provider != self.requested_provider:
+            self.requested_provider = resolved_provider
 
         # When a custom_provider entry carries an explicit `model` field,
         # use it as the effective model name.  Without this, running


### PR DESCRIPTION
## What changed

When a session was created with provider X and X is later removed from `config.yaml`, resuming that session now falls back to the current default provider (`auto`) instead of raising `AuthError("Unknown provider X")`.

Only one file modified: `hermes_cli/cli_agent_setup_mixin.py` (+40 lines).

## Why

`_ensure_runtime_credentials()` already has fallback logic for `AuthError` (iterates `_fallback_model` chain), but when the error is specifically `code="invalid_provider"` (provider doesn't exist in registry at all) and no fallback entries are configured, it hard-fails. There's no last-resort fallback to `auto`.

The existing `requested_provider` sync was also missing — after successful resolution, `self.requested_provider` wasn't updated, so subsequent calls would retry the stale value.

## Changes

1. **Last-resort fallback** (after fallback chain, before give-up): when `_primary_exc.code == "invalid_provider"`, try `resolve_runtime_provider(requested="auto")`. On success, update `self.requested_provider` and warn the user.

2. **Sync requested_provider** in the normal path: after successful resolution, keep `self.requested_provider` in sync with the actually-resolved provider.

## How this differs from #52961 and #53247

| | #52961 | #53247 | This PR |
|-|--------|--------|--------|
| Updates `requested_provider` | No | No | **Yes** |
| Handles init path | Partial (wrong branch) | Yes | **Yes** (single shared path) |
| Handles interactive `/resume` | No | Partial | **Yes** (via shared `_ensure_runtime_credentials`) |
| Agent rebuild trigger | No | No (changes `self.provider` but not `requested_provider`) | **Yes** (`requested_provider` update triggers rebuild on next call) |
| Fallback mechanism | Warning only | Provider restore (doesn't work per review) | **`auto` resolution** |

## Fixes

Fixes #52943

## Testing

1. Create a session with a non-default provider
2. Remove that provider from `config.yaml`
3. Resume the session — should fall back to current default with a warning instead of erroring
