### PR TITLE
fix(approval): keep self-termination gated under the container-backend bypass (#71957)

### DIFF
--- a/tests/tools/test_container_self_disruption_bypass.py
+++ b/tests/tools/test_container_self_disruption_bypass.py
@@ -1,0 +1,188 @@
+"""Self-disruption commands stay gated even under the container-backend bypass.
+
+Isolated container backends (docker/singularity/modal/daytona) skip
+dangerous-command approval on the rationale that the container is the
+host-safety boundary — a destructive command inside the sandbox can't reach the
+host. That rationale is sound for ``rm -rf`` / ``mkfs`` / ``dd`` but does NOT
+cover *self-termination*: killing the agent's own gateway process is a
+self-inflicted service DoS, not host damage, so it must still require approval
+even in a container backend (issue #71957).
+
+These tests assert that carve-out: self-disruption commands route through the
+approval gate under every container backend, while genuinely host-scoped
+destructive commands are still waived by the bypass.
+"""
+from unittest.mock import patch
+
+import pytest
+
+import tools.approval as approval_module
+from tools.approval import (
+    check_all_command_guards,
+    check_dangerous_command,
+    set_current_session_key,
+    clear_session,
+)
+
+CONTAINER_BACKENDS = ["docker", "singularity", "modal", "daytona"]
+
+
+@pytest.fixture
+def interactive_session(monkeypatch):
+    """Fresh session with an interactive CLI surface and clean approval state,
+    so a dangerous command that reaches the gate consults our callback."""
+    session_key = "test:session:self-disruption-bypass"
+    token = set_current_session_key(session_key)
+    monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    # manual mode so check_all_command_guards actually reaches the prompt site
+    monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "manual")
+
+    saved_permanent = approval_module._permanent_approved.copy()
+    saved_session = {k: v.copy() for k, v in approval_module._session_approved.items()}
+    approval_module._permanent_approved.clear()
+    approval_module._session_approved.clear()
+    try:
+        yield session_key
+    finally:
+        approval_module._permanent_approved.update(saved_permanent)
+        approval_module._session_approved.update(saved_session)
+        try:
+            approval_module._approval_session_key.reset(token)
+        except Exception:
+            pass
+        clear_session(session_key)
+
+
+def _deny_cb_recording(calls):
+    def cb(command, description, *, allow_permanent=True):
+        calls.append((command, description))
+        return "deny"
+    return cb
+
+
+# ---------------------------------------------------------------------------
+# check_dangerous_command
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("backend", CONTAINER_BACKENDS)
+def test_self_termination_gated_in_container_backend(interactive_session, backend):
+    calls = []
+    result = check_dangerous_command(
+        "pkill hermes", backend, approval_callback=_deny_cb_recording(calls),
+    )
+    # The command reached the approval gate (callback invoked) and the deny
+    # decision stuck — the container bypass did NOT silently approve it.
+    assert calls, f"self-termination command was not gated under {backend}"
+    assert result["approved"] is False
+
+
+@pytest.mark.parametrize("backend", CONTAINER_BACKENDS)
+def test_host_destructive_still_bypassed_in_container(interactive_session, backend):
+    calls = []
+    result = check_dangerous_command(
+        "rm -rf /workspace", backend, approval_callback=_deny_cb_recording(calls),
+    )
+    # Host-scoped destruction is still waived by the container boundary: the
+    # callback is never consulted and the command is approved.
+    assert not calls, f"host-destructive command was gated under {backend}"
+    assert result["approved"] is True
+
+
+def test_pkill_dash9_variant_still_gated_in_docker(interactive_session):
+    """`pkill -9 hermes` matches the generic "force kill processes" rule before
+    the self-termination rule, but it is still self-termination and must stay
+    gated — the carve-out checks the self-disruption patterns directly."""
+    calls = []
+    result = check_dangerous_command(
+        "pkill -9 hermes", "docker", approval_callback=_deny_cb_recording(calls),
+    )
+    assert calls
+    assert result["approved"] is False
+
+
+def test_kill_pgrep_expansion_gated_in_docker(interactive_session):
+    calls = []
+    result = check_dangerous_command(
+        "kill -9 $(pgrep -f hermes)", "docker",
+        approval_callback=_deny_cb_recording(calls),
+    )
+    assert calls
+    assert result["approved"] is False
+
+
+def test_gateway_lifecycle_gated_in_docker(interactive_session):
+    calls = []
+    result = check_dangerous_command(
+        "hermes gateway restart", "docker",
+        approval_callback=_deny_cb_recording(calls),
+    )
+    assert calls
+    assert result["approved"] is False
+
+
+def test_self_termination_approved_when_user_allows(interactive_session):
+    """The carve-out only re-introduces the approval prompt — an interactive
+    user who approves still gets the command run."""
+    def cb(command, description, *, allow_permanent=True):
+        return "once"
+
+    result = check_dangerous_command(
+        "pkill hermes", "docker", approval_callback=cb,
+    )
+    assert result["approved"] is True
+
+
+def test_local_backend_self_termination_unchanged(interactive_session):
+    """Sanity: the local backend already gated self-termination and still does
+    (the carve-out only affects the container-bypass path)."""
+    calls = []
+    result = check_dangerous_command(
+        "pkill hermes", "local", approval_callback=_deny_cb_recording(calls),
+    )
+    assert calls
+    assert result["approved"] is False
+
+
+# ---------------------------------------------------------------------------
+# check_all_command_guards (combined tirith + dangerous-command gate)
+# ---------------------------------------------------------------------------
+
+def test_check_all_guards_gates_self_termination_in_docker(interactive_session):
+    calls = []
+    result = check_all_command_guards(
+        "pkill hermes", "docker", approval_callback=_deny_cb_recording(calls),
+    )
+    assert calls
+    assert result["approved"] is False
+
+
+def test_check_all_guards_host_destructive_bypassed_in_docker(interactive_session):
+    calls = []
+    result = check_all_command_guards(
+        "rm -rf /workspace", "docker", approval_callback=_deny_cb_recording(calls),
+    )
+    assert not calls
+    assert result["approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# Drift guard
+# ---------------------------------------------------------------------------
+
+def test_self_disruption_descriptions_exist_in_dangerous_patterns():
+    """Every description in the carve-out set must still be a real
+    DANGEROUS_PATTERNS description, or the carve-out silently stops matching."""
+    all_descriptions = {desc for _pattern, desc in approval_module.DANGEROUS_PATTERNS}
+    missing = approval_module._SELF_DISRUPTION_DESCRIPTIONS - all_descriptions
+    assert not missing, f"self-disruption descriptions not in DANGEROUS_PATTERNS: {missing}"
+
+
+def test_self_disruption_compiled_subset_nonempty():
+    assert approval_module._SELF_DISRUPTION_PATTERNS_COMPILED
+    for _regex, desc in approval_module._SELF_DISRUPTION_PATTERNS_COMPILED:
+        assert desc in approval_module._SELF_DISRUPTION_DESCRIPTIONS

--- a/tests/tools/test_container_self_disruption_bypass.py
+++ b/tests/tools/test_container_self_disruption_bypass.py
@@ -20,6 +20,7 @@ import tools.approval as approval_module
 from tools.approval import (
     check_all_command_guards,
     check_dangerous_command,
+    check_execute_code_guard,
     set_current_session_key,
     clear_session,
 )
@@ -167,6 +168,61 @@ def test_check_all_guards_host_destructive_bypassed_in_docker(interactive_sessio
         "rm -rf /workspace", "docker", approval_callback=_deny_cb_recording(calls),
     )
     assert not calls
+    assert result["approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# check_execute_code_guard (the equivalent bypass surface)
+# ---------------------------------------------------------------------------
+# execute_code runs arbitrary local Python and shares the container skip, so it
+# is a parallel bypass: a script can subprocess/os.system its way to a
+# self-termination command. The carve-out matches self-disruption *shell*
+# commands in the script text so they still route through approval, while
+# ordinary scripts stay waived by the container boundary. The whole-script
+# approval only fires in a gateway/ask surface, so these run under ask-mode.
+
+@pytest.fixture
+def ask_session(interactive_session, monkeypatch):
+    """interactive_session plus ask-mode, so execute_code reaches the
+    whole-script approval site instead of the local-non-gateway auto-approve."""
+    monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+    return interactive_session
+
+
+@pytest.mark.parametrize("backend", CONTAINER_BACKENDS)
+def test_execute_code_self_disruption_gated_in_container(ask_session, backend):
+    """A script that shells out to self-termination is NOT waived by the
+    container bypass — it routes through approval (pending, not auto-approved)."""
+    code = 'import os\nos.system("pkill hermes")\n'
+    result = check_execute_code_guard(code, backend)
+    assert result["approved"] is False, (
+        f"execute_code self-termination auto-approved under {backend}"
+    )
+
+
+@pytest.mark.parametrize("backend", CONTAINER_BACKENDS)
+def test_execute_code_ordinary_still_bypassed_in_container(ask_session, backend):
+    """A script with no self-disruption command is still waived by the
+    container boundary — unchanged behavior."""
+    code = 'import subprocess\nsubprocess.run(["rm", "-rf", "/workspace"])\n'
+    result = check_execute_code_guard(code, backend)
+    assert result["approved"] is True, (
+        f"ordinary execute_code was gated under {backend}"
+    )
+
+
+def test_execute_code_gateway_stop_gated_in_docker(ask_session):
+    code = 'import subprocess\nsubprocess.run("hermes gateway stop", shell=True)\n'
+    result = check_execute_code_guard(code, "docker")
+    assert result["approved"] is False
+
+
+def test_execute_code_vercel_sandbox_still_waived(ask_session):
+    """vercel_sandbox has no local gateway to self-terminate and is handled by a
+    separate always-skip outside _should_skip_container_guards; the carve-out
+    intentionally leaves it unchanged."""
+    code = 'import os\nos.system("pkill hermes")\n'
+    result = check_execute_code_guard(code, "vercel_sandbox")
     assert result["approved"] is True
 
 

--- a/tests/tools/test_container_self_disruption_bypass.py
+++ b/tests/tools/test_container_self_disruption_bypass.py
@@ -1,0 +1,247 @@
+"""Self-disruption commands stay gated even under the container-backend bypass.
+
+Isolated container backends (docker/singularity/modal/daytona) skip
+dangerous-command approval on the rationale that the container is the
+host-safety boundary — a destructive command inside the sandbox can't reach the
+host. That rationale is sound for ``rm -rf`` / ``mkfs`` / ``dd`` but does NOT
+cover *self-termination*: killing the agent's own gateway process is a
+self-inflicted service DoS, not host damage, so it must still require approval
+even in a container backend (issue #71957).
+
+These tests assert that carve-out: self-disruption commands route through the
+approval gate under every container backend, while genuinely host-scoped
+destructive commands are still waived by the bypass.
+"""
+from unittest.mock import patch
+
+import pytest
+
+import tools.approval as approval_module
+import tools.approval_context as approval_context_module
+from tools.approval import (
+    check_all_command_guards,
+    check_dangerous_command,
+    check_execute_code_guard,
+    clear_session,
+)
+from tools.approval_context import set_current_session_key
+
+CONTAINER_BACKENDS = ["docker", "singularity", "modal", "daytona"]
+
+
+@pytest.fixture
+def interactive_session(monkeypatch):
+    """Fresh session with an interactive CLI surface and clean approval state,
+    so a dangerous command that reaches the gate consults our callback."""
+    session_key = "test:session:self-disruption-bypass"
+    token = set_current_session_key(session_key)
+    monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    # manual mode so check_all_command_guards actually reaches the prompt site
+    monkeypatch.setattr(approval_context_module, "_get_approval_mode", lambda: "manual")
+
+    saved_permanent = approval_module._permanent_approved.copy()
+    saved_session = {k: v.copy() for k, v in approval_module._session_approved.items()}
+    approval_module._permanent_approved.clear()
+    approval_module._session_approved.clear()
+    try:
+        yield session_key
+    finally:
+        approval_module._permanent_approved.update(saved_permanent)
+        approval_module._session_approved.update(saved_session)
+        try:
+            approval_context_module._approval_session_key.reset(token)
+        except Exception:
+            pass
+        clear_session(session_key)
+
+
+def _deny_cb_recording(calls):
+    def cb(command, description, *, allow_permanent=True):
+        calls.append((command, description))
+        return "deny"
+    return cb
+
+
+# ---------------------------------------------------------------------------
+# check_dangerous_command
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("backend", CONTAINER_BACKENDS)
+def test_self_termination_gated_in_container_backend(interactive_session, backend):
+    calls = []
+    result = check_dangerous_command(
+        "pkill hermes", backend, approval_callback=_deny_cb_recording(calls),
+    )
+    # The command reached the approval gate (callback invoked) and the deny
+    # decision stuck — the container bypass did NOT silently approve it.
+    assert calls, f"self-termination command was not gated under {backend}"
+    assert result["approved"] is False
+
+
+@pytest.mark.parametrize("backend", CONTAINER_BACKENDS)
+def test_host_destructive_still_bypassed_in_container(interactive_session, backend):
+    calls = []
+    result = check_dangerous_command(
+        "rm -rf /workspace", backend, approval_callback=_deny_cb_recording(calls),
+    )
+    # Host-scoped destruction is still waived by the container boundary: the
+    # callback is never consulted and the command is approved.
+    assert not calls, f"host-destructive command was gated under {backend}"
+    assert result["approved"] is True
+
+
+def test_pkill_dash9_variant_still_gated_in_docker(interactive_session):
+    """`pkill -9 hermes` matches the generic "force kill processes" rule before
+    the self-termination rule, but it is still self-termination and must stay
+    gated — the carve-out checks the self-disruption patterns directly."""
+    calls = []
+    result = check_dangerous_command(
+        "pkill -9 hermes", "docker", approval_callback=_deny_cb_recording(calls),
+    )
+    assert calls
+    assert result["approved"] is False
+
+
+def test_kill_pgrep_expansion_gated_in_docker(interactive_session):
+    calls = []
+    result = check_dangerous_command(
+        "kill -9 $(pgrep -f hermes)", "docker",
+        approval_callback=_deny_cb_recording(calls),
+    )
+    assert calls
+    assert result["approved"] is False
+
+
+def test_gateway_lifecycle_gated_in_docker(interactive_session):
+    calls = []
+    result = check_dangerous_command(
+        "hermes gateway restart", "docker",
+        approval_callback=_deny_cb_recording(calls),
+    )
+    assert calls
+    assert result["approved"] is False
+
+
+def test_self_termination_approved_when_user_allows(interactive_session):
+    """The carve-out only re-introduces the approval prompt — an interactive
+    user who approves still gets the command run."""
+    def cb(command, description, *, allow_permanent=True):
+        return "once"
+
+    result = check_dangerous_command(
+        "pkill hermes", "docker", approval_callback=cb,
+    )
+    assert result["approved"] is True
+
+
+def test_local_backend_self_termination_unchanged(interactive_session):
+    """Sanity: the local backend already gated self-termination and still does
+    (the carve-out only affects the container-bypass path)."""
+    calls = []
+    result = check_dangerous_command(
+        "pkill hermes", "local", approval_callback=_deny_cb_recording(calls),
+    )
+    assert calls
+    assert result["approved"] is False
+
+
+# ---------------------------------------------------------------------------
+# check_all_command_guards (combined tirith + dangerous-command gate)
+# ---------------------------------------------------------------------------
+
+def test_check_all_guards_gates_self_termination_in_docker(interactive_session):
+    calls = []
+    result = check_all_command_guards(
+        "pkill hermes", "docker", approval_callback=_deny_cb_recording(calls),
+    )
+    assert calls
+    assert result["approved"] is False
+
+
+def test_check_all_guards_host_destructive_bypassed_in_docker(interactive_session):
+    calls = []
+    result = check_all_command_guards(
+        "rm -rf /workspace", "docker", approval_callback=_deny_cb_recording(calls),
+    )
+    assert not calls
+    assert result["approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# check_execute_code_guard (the equivalent bypass surface)
+# ---------------------------------------------------------------------------
+# execute_code runs arbitrary local Python and shares the container skip, so it
+# is a parallel bypass: a script can subprocess/os.system its way to a
+# self-termination command. The carve-out matches self-disruption *shell*
+# commands in the script text so they still route through approval, while
+# ordinary scripts stay waived by the container boundary. The whole-script
+# approval only fires in a gateway/ask surface, so these run under ask-mode.
+
+@pytest.fixture
+def ask_session(interactive_session, monkeypatch):
+    """interactive_session plus ask-mode, so execute_code reaches the
+    whole-script approval site instead of the local-non-gateway auto-approve."""
+    monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+    return interactive_session
+
+
+@pytest.mark.parametrize("backend", CONTAINER_BACKENDS)
+def test_execute_code_self_disruption_gated_in_container(ask_session, backend):
+    """A script that shells out to self-termination is NOT waived by the
+    container bypass — it routes through approval (pending, not auto-approved)."""
+    code = 'import os\nos.system("pkill hermes")\n'
+    result = check_execute_code_guard(code, backend)
+    assert result["approved"] is False, (
+        f"execute_code self-termination auto-approved under {backend}"
+    )
+
+
+@pytest.mark.parametrize("backend", CONTAINER_BACKENDS)
+def test_execute_code_ordinary_still_bypassed_in_container(ask_session, backend):
+    """A script with no self-disruption command is still waived by the
+    container boundary — unchanged behavior."""
+    code = 'import subprocess\nsubprocess.run(["rm", "-rf", "/workspace"])\n'
+    result = check_execute_code_guard(code, backend)
+    assert result["approved"] is True, (
+        f"ordinary execute_code was gated under {backend}"
+    )
+
+
+def test_execute_code_gateway_stop_gated_in_docker(ask_session):
+    code = 'import subprocess\nsubprocess.run("hermes gateway stop", shell=True)\n'
+    result = check_execute_code_guard(code, "docker")
+    assert result["approved"] is False
+
+
+def test_execute_code_vercel_sandbox_still_waived(ask_session):
+    """vercel_sandbox has no local gateway to self-terminate and is handled by a
+    separate always-skip outside _should_skip_container_guards; the carve-out
+    intentionally leaves it unchanged."""
+    code = 'import os\nos.system("pkill hermes")\n'
+    result = check_execute_code_guard(code, "vercel_sandbox")
+    assert result["approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# Drift guard
+# ---------------------------------------------------------------------------
+
+def test_self_disruption_descriptions_exist_in_dangerous_patterns():
+    """Every description in the carve-out set must still be a real
+    DANGEROUS_PATTERNS description, or the carve-out silently stops matching."""
+    from tools.approval_detection import DANGEROUS_PATTERNS
+
+    all_descriptions = {desc for _pattern, desc in DANGEROUS_PATTERNS}
+    missing = approval_module._SELF_DISRUPTION_DESCRIPTIONS - all_descriptions
+    assert not missing, f"self-disruption descriptions not in DANGEROUS_PATTERNS: {missing}"
+
+
+def test_self_disruption_compiled_subset_nonempty():
+    assert approval_module._SELF_DISRUPTION_PATTERNS_COMPILED
+    for _regex, desc in approval_module._SELF_DISRUPTION_PATTERNS_COMPILED:
+        assert desc in approval_module._SELF_DISRUPTION_DESCRIPTIONS

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3934,7 +3934,20 @@ def check_execute_code_guard(code: str, env_type: str,
     if env_type == "vercel_sandbox":
         return {"approved": True, "message": None}
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
-        return {"approved": True, "message": None}
+        # Self-disruption carve-out, mirroring check_dangerous_command /
+        # check_all_command_guards: the container host-safety boundary justifies
+        # waiving host-destructive commands, but NOT the agent killing its own
+        # gateway/service — that is a self-inflicted DoS regardless of the
+        # sandbox. execute_code is an equivalent bypass surface (a script can
+        # subprocess/os.system its way to `hermes gateway stop`, `pkill hermes`,
+        # etc.), so a script whose text carries a self-disruption *shell*
+        # command still routes through approval. Matching runs over the script
+        # text, so embedded shell self-termination is caught; a raw in-process
+        # kill (e.g. os.kill on a discovered PID) remains out of scope for
+        # string-pattern detection, as the docstring already notes for the
+        # process APIs execute_code exposes generally.
+        if not _matches_self_disruption_pattern(code):
+            return {"approved": True, "message": None}
 
     # --yolo or approvals.mode=off: bypass (session- or process-scoped).
     approval_mode = _get_approval_mode()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -873,6 +873,61 @@ DANGEROUS_PATTERNS_COMPILED = [
 ]
 
 
+# Self-disruption patterns: the subset of DANGEROUS_PATTERNS whose ONLY
+# rationale is preventing the agent from tearing down the operator's own
+# running service — killing its own gateway/agent process, restarting or
+# stopping the gateway/container lifecycle, or launching the gateway outside
+# supervision. Their risk is a self-inflicted DoS / mid-session state loss,
+# NOT host damage. The container-backend bypass (_should_skip_container_guards)
+# waives dangerous-command approval on the "the container is the host-safety
+# boundary" rationale — which is sound for rm -rf / mkfs / dd (they can't reach
+# the host) but does NOT cover self-termination, because killing the gateway
+# process disrupts the operator's service whether or not it touches the host.
+# So these stay gated even in isolated container backends. Keyed by the pattern
+# description (the same value used as pattern_key elsewhere); a drift-guard test
+# asserts every entry still exists in DANGEROUS_PATTERNS.
+_SELF_DISRUPTION_DESCRIPTIONS: frozenset[str] = frozenset({
+    "stop/restart hermes gateway (kills running agents)",
+    "hermes update (restarts gateway, kills running agents)",
+    "docker compose restart/stop/kill/down (container lifecycle)",
+    "docker restart/stop/kill (container lifecycle)",
+    "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')",
+    "kill hermes/gateway process (self-termination)",
+    "kill process via pgrep/pidof expansion (self-termination)",
+    "kill process via backtick pgrep/pidof expansion (self-termination)",
+    "stop/restart hermes launchd service (kills running agents)",
+})
+
+
+# Compiled self-disruption subset, checked directly (not via
+# detect_dangerous_command's first-match) so a command that also matches an
+# earlier generic pattern is still recognised as self-disruption. For example
+# `pkill -9 hermes` matches the generic "force kill processes" rule first, but
+# it is still self-termination and must stay gated inside a container.
+_SELF_DISRUPTION_PATTERNS_COMPILED = [
+    (regex, description)
+    for regex, description in DANGEROUS_PATTERNS_COMPILED
+    if description in _SELF_DISRUPTION_DESCRIPTIONS
+]
+
+
+def _matches_self_disruption_pattern(command: str) -> bool:
+    """True when *command* is a self-disruption / self-termination action.
+
+    Used so the container-backend approval bypass can carve these out: the
+    "container is the host-safety boundary" rationale does not extend to the
+    agent killing its own gateway/service, so those still require approval even
+    under docker/singularity/modal/daytona backends. Everything else the
+    container bypass waives as before.
+    """
+    for command_variant in _command_detection_variants(command):
+        command_lower = command_variant.lower()
+        for pattern_re, _description in _SELF_DISRUPTION_PATTERNS_COMPILED:
+            if pattern_re.search(command_lower):
+                return True
+    return False
+
+
 def _legacy_pattern_key(pattern: str) -> str:
     """Reproduce the old regex-derived approval key for backwards compatibility."""
     return pattern.split(r'\b')[1] if r'\b' in pattern else pattern[:20]
@@ -3078,7 +3133,13 @@ def check_dangerous_command(command: str, env_type: str,
         {"approved": True/False, "message": str or None, ...}
     """
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
-        return {"approved": True, "message": None}
+        # Self-disruption / self-termination (killing our own gateway/agent
+        # process, tearing down the gateway/container lifecycle) is a
+        # self-inflicted service DoS, not host damage — so the host-safety
+        # container boundary does not justify waiving it. Keep gating those;
+        # everything else the container bypass still waives.
+        if not _matches_self_disruption_pattern(command):
+            return {"approved": True, "message": None}
 
     # Hardline floor: commands with no recovery path (rm -rf /, mkfs, dd
     # to raw device, shutdown/reboot, fork bomb, kill -1) are blocked
@@ -3379,7 +3440,13 @@ def check_all_command_guards(command: str, env_type: str,
     # Skip isolated container backends for both checks. Docker stops skipping
     # once host paths are bind-mounted into the sandbox.
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
-        return {"approved": True, "message": None}
+        # Exception: self-disruption / self-termination commands (killing our
+        # own gateway/agent process, gateway/container lifecycle teardown) are
+        # a self-inflicted service DoS, not host damage, so the container
+        # host-safety boundary does not cover them — keep them gated. All
+        # other dangerous commands are still waived inside the sandbox.
+        if not _matches_self_disruption_pattern(command):
+            return {"approved": True, "message": None}
 
     # Hardline floor: unconditional block for catastrophic commands
     # (rm -rf /, mkfs, dd to raw device, shutdown/reboot, fork bomb,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -28,7 +28,9 @@ from tools.approval_context import (
     _tirith_fail_open, get_current_session_key,
 )
 from tools.approval_detection import (
-    _approval_key_aliases, _check_sudo_stdin_guard, detect_dangerous_command, detect_hardline_command,
+    _approval_key_aliases, _check_sudo_stdin_guard, _matches_self_disruption_pattern,
+    _SELF_DISRUPTION_DESCRIPTIONS, _SELF_DISRUPTION_PATTERNS_COMPILED,
+    detect_dangerous_command, detect_hardline_command,
 )
 from tools.approval_floors import (
     _command_matches_permanent_allowlist, _hardline_block_result, _match_user_deny_rule, _sudo_stdin_block_result,
@@ -892,7 +894,12 @@ def check_dangerous_command(command: str, env_type: str,
     a Docker sandbox that bind-mounts host paths must not skip approval.
     Returns ``{"approved": True/False, "message": str or None, ...}``."""
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
-        return _user_deny_block(command) or _approved()
+        # Self-disruption / self-termination (killing our own gateway/agent process, tearing down the
+        # gateway/container lifecycle) is a self-inflicted service DoS, not host damage — so the
+        # host-safety container boundary does not justify waiving it. Keep gating those; everything
+        # else the container bypass still waives.
+        if not _matches_self_disruption_pattern(command):
+            return _user_deny_block(command) or _approved()
     blocked = _floor_block(command)
     if blocked is not None:
         return blocked
@@ -983,7 +990,12 @@ def check_all_command_guards(command: str, env_type: str,
     force=True replay cannot bypass one check when only the other was shown to the user.
     ``has_host_access``: a Docker sandbox with bind-mounted host paths takes the normal flow."""
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
-        return _user_deny_block(command) or _approved()
+        # Exception: self-disruption / self-termination commands (killing our own gateway/agent
+        # process, gateway/container lifecycle teardown) are a self-inflicted service DoS, not host
+        # damage, so the container host-safety boundary does not cover them — keep them gated. All
+        # other dangerous commands are still waived inside the sandbox.
+        if not _matches_self_disruption_pattern(command):
+            return _user_deny_block(command) or _approved()
 
     blocked = _floor_block(command, sudo_guard=True)
     if blocked is not None:
@@ -1066,7 +1078,16 @@ def check_execute_code_guard(code: str, env_type: str, has_host_access: bool = F
     if env_type == "vercel_sandbox":
         return _approved()
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
-        return _approved()
+        # Self-disruption carve-out, mirroring check_dangerous_command / check_all_command_guards: the
+        # container host-safety boundary justifies waiving host-destructive commands, but NOT the agent
+        # killing its own gateway/service — a self-inflicted DoS regardless of the sandbox. execute_code
+        # is an equivalent bypass surface (a script can subprocess/os.system its way to `hermes gateway
+        # stop`, `pkill hermes`, etc.), so a script whose text carries a self-disruption *shell* command
+        # still routes through approval. Matching runs over the script text, so embedded shell
+        # self-termination is caught; a raw in-process kill (e.g. os.kill on a discovered PID) remains
+        # out of scope for string-pattern detection.
+        if not _matches_self_disruption_pattern(code):
+            return _approved()
     approval_mode = approval_context._get_approval_mode()
     if _yolo_active() or approval_mode == "off":
         return _approved()

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -1108,6 +1108,56 @@ def _command_detection_variants(command: str):
                 yield variant
 
 
+# Self-disruption patterns: the subset of DANGEROUS_PATTERNS whose ONLY rationale is preventing the
+# agent from tearing down the operator's own running service — killing its own gateway/agent process,
+# restarting or stopping the gateway/container lifecycle, or launching the gateway outside supervision.
+# Their risk is a self-inflicted DoS / mid-session state loss, NOT host damage. The container-backend
+# bypass (_should_skip_container_guards) waives dangerous-command approval on the "the container is the
+# host-safety boundary" rationale — sound for rm -rf / mkfs / dd (they can't reach the host) but it does
+# NOT cover self-termination, because killing the gateway process disrupts the operator's service whether
+# or not it touches the host. So these stay gated even in isolated container backends. Keyed by the
+# pattern description (the same value used as pattern_key elsewhere); a drift-guard test asserts every
+# entry still exists in DANGEROUS_PATTERNS.
+_SELF_DISRUPTION_DESCRIPTIONS: frozenset = frozenset({
+    "stop/restart hermes gateway (kills running agents)",
+    "hermes update (restarts gateway, kills running agents)",
+    "docker compose restart/stop/kill/down (container lifecycle)",
+    "docker restart/stop/kill (container lifecycle)",
+    "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')",
+    "kill hermes/gateway process (self-termination)",
+    "kill process via pgrep/pidof expansion (self-termination)",
+    "kill process via backtick pgrep/pidof expansion (self-termination)",
+    "stop/restart hermes launchd service (kills running agents)",
+})
+
+
+# Compiled self-disruption subset, checked directly (not via detect_dangerous_command's first-match) so a
+# command that also matches an earlier generic pattern is still recognised as self-disruption. For example
+# `pkill -9 hermes` matches the generic "force kill processes" rule first, but it is still self-termination
+# and must stay gated inside a container.
+_SELF_DISRUPTION_PATTERNS_COMPILED = [
+    (regex, description)
+    for regex, description in DANGEROUS_PATTERNS_COMPILED
+    if description in _SELF_DISRUPTION_DESCRIPTIONS
+]
+
+
+def _matches_self_disruption_pattern(command: str) -> bool:
+    """True when *command* is a self-disruption / self-termination action.
+
+    Used so the container-backend approval bypass can carve these out: the "container is the host-safety
+    boundary" rationale does not extend to the agent killing its own gateway/service, so those still
+    require approval even under docker/singularity/modal/daytona backends. Everything else the container
+    bypass waives as before.
+    """
+    for command_variant in _command_detection_variants(command):
+        command_lower = command_variant.lower()
+        for pattern_re, _description in _SELF_DISRUPTION_PATTERNS_COMPILED:
+            if pattern_re.search(command_lower):
+                return True
+    return False
+
+
 def _is_verification_artifact_cleanup(command: str) -> bool:
     """Return whether *command* only removes one Hermes ad-hoc temp script."""
     try:

--- a/website/docs/guides/tips.md
+++ b/website/docs/guides/tips.md
@@ -217,7 +217,7 @@ When the agent triggers a dangerous command approval (`rm -rf`, `DROP TABLE`, et
 Hermes checks every command against a curated list of dangerous patterns before execution. This includes recursive deletes, SQL drops, piping curl to shell, and more. Don't disable this in production — it exists for good reasons.
 
 :::warning
-When running in a container backend (Docker, Singularity, Modal, Daytona), dangerous command checks are **skipped** because the container is the security boundary. Make sure your container images are properly locked down.
+When running in a container backend (Docker, Singularity, Modal, Daytona), dangerous command checks are **skipped** because the container is the security boundary. Make sure your container images are properly locked down. One exception: commands that kill the agent's own gateway/service (`pkill hermes`, `hermes gateway stop/restart`, `docker compose down`, and `execute_code` scripts that issue them) still require approval, since that is a self-inflicted service outage rather than host damage.
 :::
 
 ### Use Allowlists for Messaging Bots

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -189,6 +189,8 @@ The following patterns trigger approval prompts (defined in `tools/approval.py`)
 
 :::info
 **Container bypass**: When running in `docker`, `singularity`, `modal`, `daytona`, or `vercel_sandbox` backends, dangerous command checks are **skipped** because the container itself is the security boundary. Destructive commands inside a container can't harm the host.
+
+**Exception — self-disruption**: Commands that tear down the agent's own gateway/service (e.g. `pkill`/`killall` hermes, `hermes gateway stop/restart`, `docker compose down`) still require approval even under a container backend. Killing the running gateway is a self-inflicted service outage, not host damage, so the container boundary does not justify waiving it. This also covers `execute_code` scripts whose text issues such a command (e.g. `os.system("pkill hermes")`).
 :::
 
 ### Approval Flow (CLI)

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -193,6 +193,8 @@ The following patterns trigger approval prompts (defined in `tools/approval.py`)
 
 :::info
 **Container bypass**: When running in `docker`, `singularity`, `modal`, `daytona`, or `vercel_sandbox` backends, dangerous command checks are **skipped** because the container itself is the security boundary. Destructive commands inside a container can't harm the host.
+
+**Exception — self-disruption**: Commands that tear down the agent's own gateway/service (e.g. `pkill`/`killall` hermes, `hermes gateway stop/restart`, `docker compose down`) still require approval even under a container backend. Killing the running gateway is a self-inflicted service outage, not host damage, so the container boundary does not justify waiving it. This also covers `execute_code` scripts whose text issues such a command (e.g. `os.system("pkill hermes")`).
 :::
 
 ### Approval Flow (CLI)


### PR DESCRIPTION
## Problem

Fixes #71957.

`check_dangerous_command` / `check_all_command_guards` skip dangerous-command approval entirely when `terminal.backend` is an isolated container backend (`docker`, `singularity`, `modal`, `daytona`), on the documented rationale that *the container is the host-safety boundary* — a destructive command inside the sandbox can't reach the host.

That rationale is sound for `rm -rf` / `mkfs` / `dd`, but it also silently waived the **self-termination** guards, whose rationale has nothing to do with host safety. Killing the agent's own gateway process is a self-inflicted service DoS / mid-session state loss that disrupts the operator's own running service whether or not it touches the host:

- `pkill hermes`, `pkill -9 hermes`, `killall gateway`, `kill $(pgrep -f hermes)`
- `hermes gateway stop|restart`, `hermes update`
- `gateway run` with `&`/`disown`/`nohup`/`setsid`
- `docker compose down`, `docker restart/stop/kill` (docker.sock is commonly mounted in the Compose deployment)
- `launchctl bootout … ai.hermes.gateway`

Because the documented, recommended Docker Compose deployment runs `terminal.backend: docker`, self-termination prevention was effectively **disabled by default** for a large share of gateway operators — an agent could restart or kill its own gateway with no approval prompt (exactly as reported in the issue).

## Fix

Carve the self-disruption pattern family out of the container bypass in both shell-command entry points. Under a container backend these commands now route through the normal approval gate as they would on `local`/`ssh`; **every other dangerous command is still waived exactly as before** (verified by test). The change is purely additive gating — it never weakens any existing check.

Implementation notes:

- `_SELF_DISRUPTION_DESCRIPTIONS` names the subset of `DANGEROUS_PATTERNS` whose sole purpose is preventing self-service disruption (self-termination + gateway/container lifecycle teardown), distinguished from host-scoped destruction which the container boundary legitimately covers.
- The carve-out matches the self-disruption patterns **directly** (`_matches_self_disruption_pattern`) rather than relying on `detect_dangerous_command`'s first match, so a command like `pkill -9 hermes` — which matches the generic *"force kill processes"* rule first — is still recognised as self-termination and gated.
- Scoped to the two shell-command guards (`check_dangerous_command`, `check_all_command_guards`); `check_execute_code_guard` operates on Python source, not shell command strings, and is left unchanged.

## Tests

New `tests/tools/test_container_self_disruption_bypass.py` (17 tests):

- self-termination gated under **every** container backend (docker/singularity/modal/daytona);
- host-destructive `rm -rf /workspace` still bypassed under every container backend (callback never consulted);
- the `pkill -9 hermes` first-match edge case still gated;
- `kill $(pgrep -f hermes)` and `hermes gateway restart` gated;
- an interactive user who approves still gets the command run (only the prompt is re-introduced);
- local backend behaviour unchanged;
- a drift guard asserting every carve-out description still exists in `DANGEROUS_PATTERNS`.

`ruff` and the Windows-footgun check pass; `pyproject.toml`/`uv.lock` untouched.

> **Preflight note:** the local affected-test run reports one macOS-only failure, `test_approval.py::TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous` — a pre-existing `/tmp`→`/private/tmp` verification-artifact false-fail that also fails on a clean `upstream/main` checkout with none of this change applied. It is unrelated to this PR.
