### PR TITLE
fix(acp): redact fs/read_text_file as file content

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -719,7 +719,9 @@ class CopilotACPClient:
                     end = start + limit if isinstance(limit, int) and limit > 0 else None
                     content = "".join(lines[start:end])
                 if content:
-                    content = redact_sensitive_text(content, force=True)
+                    content = redact_sensitive_text(
+                        content, force=True, file_read=True
+                    )
                 response = {
                     "jsonrpc": "2.0",
                     "id": message_id,

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -203,6 +203,38 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertNotIn("abc123def456", content)
         self.assertIn("OPENAI_API_KEY=", content)
 
+    def test_read_text_file_preserves_source_code_constants(self) -> None:
+        """``fs/read_text_file`` hands file *content* to the agent, which can
+        write it straight back over ``fs/write_text_file``. Redacting without
+        ``file_read=True`` leaves the ENV/YAML/JSON assignment passes enabled,
+        so ordinary source constants came back as ``max_tokens=***`` — trailing
+        punctuation included — and the agent then wrote that mangled text back
+        over the user's file."""
+        source = (
+            "MAX_TOKENS = 8000\n"
+            "params = dict(\n"
+            "    max_tokens=4096,\n"
+            ")\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            target = root / "settings.py"
+            target.write_text(source, encoding="utf-8")
+
+            with patch("agent.redact._REDACT_ENABLED", True):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 4,
+                        "method": "fs/read_text_file",
+                        "params": {"path": str(target)},
+                    },
+                    cwd=str(root),
+                )
+
+        content = ((response.get("result") or {}).get("content") or "")
+        self.assertEqual(content, source)
+
     def test_fs_read_text_file_decodes_as_utf8_under_non_utf8_locale(self) -> None:
         """Regression for #18637 (bug 2): fs/read_text_file used
         ``path.read_text()`` with no explicit encoding, so on Windows


### PR DESCRIPTION
## Summary

The ACP `fs/read_text_file` handler returns file content to the editing
agent, which can write it straight back over `fs/write_text_file` on the
same channel, but it called `redact_sensitive_text(content, force=True)`
without `file_read=True`.

Without that flag the source-code false-positive passes (ENV / YAML / JSON
assignment) stay enabled, so ordinary source constants come back mangled --
`max_tokens=4096,` returns as `max_tokens=***`, trailing punctuation eaten.
The agent edits from that mangled text and writes it back, silently
corrupting the user's file.

## Problem

`agent/copilot_acp_client.py:722` is the only agent-facing file-content read
in the repo that omits `file_read=True`. The three other such call sites --
`tools/file_tools.py:1184`, `:1318`, `:1908` (read_file, read_file offset
path, search_files) -- all pass it.

`redact.py:568-578` documents the flag as the mode for file *content*
returned to the agent, and `redact.py:597-604` shows what skipping it costs:
the ENV/JSON/YAML assignment passes stay on, and real secrets get the
head/tail mask instead of the non-reusable sentinel.

Measured against the current handler (`HERMES_REDACT_SECRETS` on):

| file content | returned today | with `file_read=True` |
|---|---|---|
| `    max_tokens=4096,` | `    max_tokens=***` | unchanged |
| `MAX_TOKENS = 8000` | `MAX_TOKENS=***` | unchanged |
| `max_tokens: 4096` (YAML) | `max_tokens: ***` | unchanged |
| `const MAX_TOKENS_PER_REQ = 32000;` | `const MAX_TOKENS_PER_REQ=***` | unchanged |
| `"token": "placeholder-fixme"` | `"token": "***"` | unchanged |
| `` `ghp_S1abcdefghijklmnop0123` `` | `` `ghp_S1...0123` `` | `«redacted:ghp_…»` |

The trailing `,` and `;` are consumed, so the agent receives syntactically
invalid Python/TypeScript. `max_tokens` is ubiquitous in exactly the
AI-adjacent code these users edit.

Both capabilities are advertised together at `copilot_acp_client.py:625-628`,
and the write path (`:732-746`) writes verbatim after
`_ensure_path_within_cwd` + `get_write_denied_error` -- nothing re-reads or
diffs against the on-disk original, so the corruption is silent.

The last row is the same class as #35519: a head/tail mask "looked like a
real-but-truncated key, so an agent reading it from config.yaml and writing
it back silently corrupted the stored credential into a dead 13-char value
-> 401" (`redact.py:568-578`).

## Fix

Pass `file_read=True` at `agent/copilot_acp_client.py:722`, matching the
three canonical call sites. `file_read=True` implies `code_file=True`.

## Scope

- `agent/copilot_acp_client.py` -- one argument
- `tests/agent/test_copilot_acp_client.py` -- regression test

Tradeoff worth naming: `file_read=True` skips the ENV-assignment pass, so a
prefix-less secret (`MY_SERVICE_TOKEN=abc123randomstring`) in a `.env` read
over ACP is no longer masked on this path. That is not a new hole -- it is
precisely the policy `read_file` already ships, so this aligns ACP with the
repo's existing bar rather than lowering it. Recognized-prefix secrets
(`sk-`, `ghp_`, ...) are still redacted, and with the stronger non-reusable
sentinel.

## Testing

New `test_read_text_file_preserves_source_code_constants` asserts a read of

```python
MAX_TOKENS = 8000
params = dict(
    max_tokens=4096,
)
```

returns byte-identical content.

- Before the fix it fails:
  `'MAX_TOKENS=***\nparams = dict(\n    max_tokens=***\n)\n' != 'MAX_TOKENS = 8000\nparams = dict(\n    max_tokens=4096,\n)\n'`
- After the fix both it and the existing
  `test_read_text_file_redacts_sensitive_content` pass.

The existing secret test is unaffected: `OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012`
returns `OPENAI_API_KEY=«redacted:sk-…»`, so `assertNotIn("abc123def456")`
and `assertIn("OPENAI_API_KEY=")` both still hold.