### PR TITLE
fix: recover session_reset sessions from unclean gateway shutdown (#71916)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1388,15 +1388,27 @@ class SessionStore:
                     # save otherwise leaves Telegram with no resumable mapping, so
                     # queued/resume-pending work disappears until the user sends a
                     # fresh message.
-                    if recovered_entry is not None and recovered_entry.session_id != entry.session_id:
-                        logger.warning(
-                            "gateway.session: repointing stale sessions.json entry "
-                            "%r from ended %s (end_reason=%r) to recovered %s",
-                            key,
-                            entry.session_id,
-                            row["end_reason"],
-                            recovered_entry.session_id,
-                        )
+                    #
+                    # Similarly, if recovery reopens the same session (e.g. a
+                    # session_reset from an unclean gateway shutdown), keep the
+                    # routing entry — the DB row is now live again and the
+                    # transcript is intact.
+                    if recovered_entry is not None:
+                        if recovered_entry.session_id != entry.session_id:
+                            logger.warning(
+                                "gateway.session: repointing stale sessions.json entry "
+                                "%r from ended %s (end_reason=%r) to recovered %s",
+                                key,
+                                entry.session_id,
+                                row["end_reason"],
+                                recovered_entry.session_id,
+                            )
+                        else:
+                            logger.info(
+                                "gateway.session: keeping recovered sessions.json entry "
+                                "%r -> %s (end_reason=%r); session reopened from DB",
+                                key, entry.session_id, row["end_reason"],
+                            )
                         self._entries[key] = recovered_entry
                         recovered_keys += 1
                         continue

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4124,9 +4124,10 @@ class SessionDB:
         pruned after process-level restart bugs.  New gateway sessions persist
         the deterministic ``session_key`` on the durable session row so the
         mapping can be rebuilt exactly.  Rows ended only by older gateway
-        cleanup's ``agent_close`` bug or a mistaken TUI ``ws_orphan_reap``
-        (dashboard viewer disconnect before #60609) are treated as recoverable;
-        explicit conversation boundaries such as /new, /resume switches, and
+        cleanup's ``agent_close`` bug, a mistaken TUI ``ws_orphan_reap``
+        (dashboard viewer disconnect before #60609), or a ``session_reset``
+        from an unclean gateway shutdown are treated as recoverable; explicit
+        conversation boundaries such as /new, /resume switches, and
         compression splits are not.
         """
         if not session_key:
@@ -4137,7 +4138,7 @@ class SessionDB:
                 SELECT * FROM sessions
                 WHERE session_key = ?
                   AND source = ?
-                  AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap'))
+                  AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap', 'session_reset'))
                   AND (COALESCE(message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
                   ))
@@ -4162,7 +4163,7 @@ class SessionDB:
                   AND COALESCE(chat_id, '') = COALESCE(?, '')
                   AND COALESCE(chat_type, '') = COALESCE(?, '')
                   AND COALESCE(thread_id, '') = COALESCE(?, '')
-                  AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap'))
+                  AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap', 'session_reset'))
                   AND (COALESCE(message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
                   ))
@@ -4348,11 +4349,12 @@ class SessionDB:
         Promotes *only* live rows (``ended_at IS NULL``) or rows carrying an
         accidental end_reason that the recovery query
         (``find_latest_gateway_session_for_peer``) treats as recoverable:
-        ``agent_close`` (older gateway cleanup bug) and ``ws_orphan_reap``
-        (mistaken TUI reaper).  Explicit conversation boundaries such as
-        ``compression``, ``session_reset``, ``session_switch``, etc. are
-        preserved — the first writer wins for those, and a later expiry
-        finalization must not silently overwrite them.
+        ``agent_close`` (older gateway cleanup bug), ``ws_orphan_reap``
+        (mistaken TUI reaper), and ``session_reset`` (unclean shutdown).
+        Explicit conversation boundaries such as ``compression``,
+        ``session_switch``, etc. are preserved — the first writer wins for
+        those, and a later expiry finalization must not silently overwrite
+        them.
 
         Plain ``end_session()`` is NOT sufficient for reset boundaries: it
         no-ops on an already-ended row, so a row that agent cleanup already

--- a/tests/gateway/test_session_store_expiry_finalized.py
+++ b/tests/gateway/test_session_store_expiry_finalized.py
@@ -140,7 +140,8 @@ class TestPromotionBlocksRecovery:
         assert recovered is not None
         assert recovered["id"] == "sid-pre"
 
-    def test_promoted_session_not_recoverable(self, db: SessionDB) -> None:
+    def test_promoted_session_now_recoverable(self, db: SessionDB) -> None:
+        """session_reset is in the recovery set — unclean shutdown recovery."""
         db.create_session(
             "sid-post", _SOURCE,
             user_id=_USER_ID, session_key=_SESSION_KEY,
@@ -153,10 +154,10 @@ class TestPromotionBlocksRecovery:
             source=_SOURCE, session_key=_SESSION_KEY,
             user_id=_USER_ID, chat_id="8494508720", chat_type="dm",
         )
-        # session_reset rows are not in the recovery set
-        assert recovered is None
+        assert recovered is not None
+        assert recovered["id"] == "sid-post"
 
-    def test_agent_close_session_recoverable_but_not_after_promotion(
+    def test_agent_close_session_recoverable_and_stays_after_promotion(
         self, db: SessionDB
     ) -> None:
         db.create_session(
@@ -175,10 +176,11 @@ class TestPromotionBlocksRecovery:
         assert recovered is not None
         assert recovered["id"] == "sid-ac-rec"
 
-        # After promotion, it is no longer recoverable
+        # After promotion to session_reset, still recoverable (unclean shutdown recovery)
         db.promote_to_session_reset("sid-ac-rec")
         recovered2 = db.find_latest_gateway_session_for_peer(
             source=_SOURCE, session_key=_SESSION_KEY,
             user_id=_USER_ID, chat_id="8494508720", chat_type="dm",
         )
-        assert recovered2 is None
+        assert recovered2 is not None
+        assert recovered2["id"] == "sid-ac-rec"

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -137,7 +137,13 @@ class TestPruneStaleSessionsLocked:
         db.find_latest_gateway_session_for_peer.assert_called_once()
         db.reopen_session.assert_called_once_with("sid_child")
 
-    def test_prunes_stale_entry_when_recovery_only_finds_same_ended_session(self, tmp_path):
+    def test_keeps_recovered_entry_when_recovery_reopens_same_session(self, tmp_path):
+        """When recovery reopens the same ended session, keep it in routing.
+
+        A session ended by ``agent_close`` (old gateway cleanup bug) or
+        ``session_reset`` (unclean shutdown) should be reopened and kept in
+        the routing index — the transcript is intact and the user can resume.
+        """
         key = "agent:main:telegram:dm:5140768830"
         db = _db_returning({"sid_parent": {"end_reason": "agent_close", "id": "sid_parent"}})
         db.find_latest_gateway_session_for_peer.return_value = {
@@ -149,7 +155,8 @@ class TestPruneStaleSessionsLocked:
 
         store._prune_stale_sessions_locked()
 
-        assert key not in store._entries
+        assert key in store._entries
+        db.reopen_session.assert_called_once_with("sid_parent")
 
     def test_keeps_stale_entry_when_recovery_lookup_raises(self, tmp_path):
         """Indeterminate recovery must not delete the only routing handle.

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -7000,13 +7000,17 @@ def test_gateway_session_recovery_reopens_legacy_agent_close_rows(db):
     )
     db._conn.commit()
 
-    assert db.find_latest_gateway_session_for_peer(
+    # session_reset is also recoverable — unclean gateway shutdown marks
+    # active sessions as session_reset and the transcript should survive.
+    recovered_after_reset = db.find_latest_gateway_session_for_peer(
         source="telegram",
         user_id="user-1",
         session_key="agent:main:telegram:dm:chat-1",
         chat_id="chat-1",
         chat_type="dm",
-    ) is None
+    )
+    assert recovered_after_reset is not None
+    assert recovered_after_reset["id"] == "closed-gw-session"
 
 
 def test_gateway_metadata_display_name_origin_round_trip(db):


### PR DESCRIPTION
## Summary

Fixes #71916 — sessions ended by `session_reset` (unclean gateway shutdown) were pruned from the routing index on startup, making them invisible to `/resume` even though their transcripts remained intact in `state.db`.

## Root Cause

Two interacting gaps:

1. **Recovery set exclusion**: `find_latest_gateway_session_for_peer()` only allowed `agent_close` and `ws_orphan_reap` in its `end_reason IN (...)` clause. Sessions ended by `session_reset` (unclean shutdown) were excluded, so recovery returned `None`.

2. **Same-session pruning**: `_prune_stale_sessions_locked()` only kept routing entries when recovery returned a **different** session_id (compression rotation case). When recovery returned the same session_id (reopened the same row), the entry was still pruned.

## Changes

### `hermes_state.py`
- Added `'session_reset'` to both SQL queries in `find_latest_gateway_session_for_peer()` so sessions ended by unclean shutdown can be recovered.

### `gateway/session.py`
- Modified `_prune_stale_sessions_locked()` to keep routing entries when recovery succeeds with the same session_id (not just when it returns a different child session). The DB row is reopened via `reopen_session()` and the transcript is intact.

### Tests updated
- `test_session_store_stale_prune.py`: Renamed `test_prunes_stale_entry_when_recovery_only_finds_same_ended_session` → `test_keeps_recovered_entry_when_recovery_reopens_same_session`
- `test_session_store_expiry_finalized.py`: Updated `test_promoted_session_not_recoverable` → `test_promoted_session_now_recoverable` and `test_agent_close_session_recoverable_but_not_after_promotion` → `test_agent_close_session_recoverable_and_stays_after_promotion`
- `test_hermes_state.py`: Updated `test_gateway_session_recovery_reopens_legacy_agent_close_rows` to expect `session_reset` rows to be recoverable

## Test Plan
- [x] 45 related tests pass (stale_prune, runtime_stale_guard, expiry_finalized, multiplex, hermes_state)
- [ ] CI passes

## Safety Analysis

- **`/new` command unaffected**: After `/new`, the routing entry is replaced with the new session. The old `session_reset` session is not in `_entries` during pruning.
- **Compression rotation unaffected**: The existing repoint logic (different session_id) still works the same way.
- **`promote_to_session_reset` unchanged**: Its WHERE clause still only promotes from live or accidentally-ended rows (`agent_close`, `ws_orphan_reap`).