### PR TITLE
fix(desktop): Branch button silently does nothing inside a branched chat tile

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -71,7 +71,7 @@ interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   onCancel: () => Promise<void> | void
   onAddContextRef: (refText: string, label?: string, detail?: string) => void
   onAddUrl: (url: string) => void
-  onBranchInNewChat: (messageId: string) => void
+  onBranchInNewChat?: (messageId: string) => void
   maxVoiceRecordingSeconds?: number
   onAttachImageBlob: (blob: Blob) => Promise<boolean | void> | boolean | void
   onAttachDroppedItems: (candidates: DroppedFile[]) => Promise<boolean | void> | boolean | void

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -170,7 +170,6 @@ function TileChat({
           onAddUrl={url => composer.addContextRefAttachment(`@url:${formatRefValue(url)}`, url)}
           onAttachDroppedItems={composer.attachDroppedItems}
           onAttachImageBlob={composer.attachImageBlob}
-          onBranchInNewChat={() => undefined}
           onCancel={actions.cancelRun}
           onDeleteSelectedSession={() => undefined}
           onDismissError={actions.dismissError}

--- a/apps/desktop/src/app/contrib/latest-actions.ts
+++ b/apps/desktop/src/app/contrib/latest-actions.ts
@@ -34,7 +34,7 @@ export function latestChatActions(actions: ChatActions): ChatActions {
     onAddUrl: (...args) => actions.onAddUrl(...args),
     onAttachDroppedItems: (...args) => actions.onAttachDroppedItems(...args),
     onAttachImageBlob: (...args) => actions.onAttachImageBlob(...args),
-    onBranchInNewChat: (...args) => actions.onBranchInNewChat(...args),
+    onBranchInNewChat: latestOptional(() => actions.onBranchInNewChat),
     onCancel: (...args) => actions.onCancel(...args),
     onDeleteSelectedSession: (...args) => actions.onDeleteSelectedSession(...args),
     onDismissError: latestOptional(() => actions.onDismissError),

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -1,0 +1,90 @@
+// Bug #2: the Branch-in-new-chat button used to render unconditionally even
+// when its handler was a no-op (session-tile.tsx passed `() => undefined`
+// for branched/tiled chats, where nested branching isn't supported). That
+// left a visibly clickable button that silently did nothing. The fix makes
+// AssistantMessage's action bar hide the button entirely when no handler is
+// supplied, matching how onDismissError/onRestoreToMessage already behave.
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Thread } from '.'
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('CSS', { escape: (str: string) => str })
+Element.prototype.scrollTo = function scrollTo() {}
+
+afterEach(() => {
+  cleanup()
+})
+
+function userMessage(): ThreadMessage {
+  return {
+    id: 'user-1',
+    role: 'user',
+    content: [{ type: 'text', text: 'question one' }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: {} }
+  } as ThreadMessage
+}
+
+function assistantMessage(): ThreadMessage {
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: [{ type: 'text', text: 'done' }],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+}
+
+function Harness({ onBranchInNewChat }: { onBranchInNewChat?: (messageId: string) => void }) {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: [userMessage(), assistantMessage()],
+    isRunning: false,
+    onNew: async () => {}
+  })
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread onBranchInNewChat={onBranchInNewChat} />
+    </AssistantRuntimeProvider>
+  )
+}
+
+describe('AssistantMessage branch button visibility (bug #2 fix)', () => {
+  it('shows the Branch in new chat button when a handler is provided (open chat)', async () => {
+    render(<Harness onBranchInNewChat={() => undefined} />)
+
+    expect(await screen.findByRole('button', { name: 'Branch in new chat' })).toBeTruthy()
+  })
+
+  it('hides the Branch in new chat button when no handler is provided (session-tile / branched chat)', async () => {
+    render(<Harness />)
+
+    // Wait for the assistant message to actually mount before asserting
+    // absence, so a missing button isn't just a false negative from an
+    // unrendered message.
+    await screen.findByText('done')
+
+    expect(screen.queryByRole('button', { name: 'Branch in new chat' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -151,15 +151,17 @@ const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText,
         data-slot="aui_msg-actions"
       >
         <MessageAge />
-        <TooltipIconButton
-          onClick={() => {
-            triggerHaptic('selection')
-            onBranchInNewChat?.(messageId)
-          }}
-          tooltip={copy.branchNewChat}
-        >
-          <GitForkIcon className="size-3.5" />
-        </TooltipIconButton>
+        {onBranchInNewChat && (
+          <TooltipIconButton
+            onClick={() => {
+              triggerHaptic('selection')
+              onBranchInNewChat(messageId)
+            }}
+            tooltip={copy.branchNewChat}
+          >
+            <GitForkIcon className="size-3.5" />
+          </TooltipIconButton>
+        )}
         <CopyButton appearance="icon" buttonSize="icon" label={copy.copy} text={getMessageText} />
         <ReadAloudButton getText={getMessageText} messageId={messageId} />
         <ActionBarPrimitive.Reload asChild>


### PR DESCRIPTION
## What does this PR do?

Fixes a dead-button UX bug: inside a session opened as a **tile** (i.e. a chat that was itself created via **Branch in new chat**), the Branch button on assistant replies is fully visible and looks clickable — but clicking it does absolutely nothing, with no error, no toast, no feedback of any kind.

Nested branching from a tile isn't supported by design (`session-tile.tsx` intentionally wires `onBranchInNewChat` to a no-op), but the button itself rendered unconditionally regardless of whether a real handler existed, so the "unsupported here" state was invisible to the user. This is the same class of problem as an earlier fixed bug where a dead Refresh button gave no feedback either.

## Related Issue
Fixes #
<!-- no existing issue number - happy to open one first if maintainers prefer that workflow -->

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx`: the Branch button in `AssistantActionBar` now only renders when `onBranchInNewChat` is actually provided (`{onBranchInNewChat && (...)}`), matching the existing pattern already used for `onDismissError` and `onRestoreToMessage` — both of which are conditionally rendered for the same reason (per the comment in `latest-actions.ts`: presence, not just callability, is what these children gate on).
- `apps/desktop/src/app/chat/session-tile.tsx`: no longer passes a no-op `onBranchInNewChat={() => undefined}` for tiled/branched chats; the prop is simply omitted, so the button now doesn't render there at all instead of rendering dead.
- `apps/desktop/src/app/chat/index.tsx`: `onBranchInNewChat` on `ChatViewProps` is now optional (`?`), since omitting it is now a legitimate, intentional state rather than something every caller had to fake with a no-op.
- `apps/desktop/src/app/contrib/latest-actions.ts`: the `latestChatActions` passthrough wrapper now uses the existing `latestOptional` helper for `onBranchInNewChat` instead of an unconditional call, consistent with how `onDismissError`/`onRestoreToMessage` are already wrapped.
- `apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx` (new): covers both states — button visible when a handler is passed, button absent when it isn't.

## How to Test

1. Open a normal chat, send a message, hover an assistant reply — the Branch icon is visible and clickable, as before (no regression).
2. Use **Branch in new chat** to open a branched tab/tile.
3. Hover an assistant reply inside that branched tile — before this fix, the Branch icon was visible and clicking it did nothing; after the fix, the icon isn't shown at all for messages in a tile, so there's nothing misleading to click.
4. Run the new test file directly: `npx vitest run src/components/assistant-ui/thread/assistant-message.test.tsx`

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<img width="1252" height="571" alt="image" src="https://github.com/user-attachments/assets/3a7ea5d2-9437-4560-a9ca-218e9f9d6da7" />