### PR TITLE
fix(gateway): add .3gp to MEDIA_DELIVERY_EXTS (#71621)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1478,7 +1478,7 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     # Images (embed inline)
     ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".svg",
     # Video (embed inline where supported)
-    ".mp4", ".mov", ".avi", ".mkv", ".webm",
+    ".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp",
     # Audio (delivered as voice/audio where supported)
     ".mp3", ".wav", ".ogg", ".opus", ".m4a", ".flac",
     # Documents (uploaded as file attachments)


### PR DESCRIPTION
## Summary
Fixes #71621.

`MEDIA_DELIVERY_EXTS` in `gateway/platforms/base.py` is the shared allowlist for media extraction and `MEDIA:` tag cleanup. It included `.webm` but omitted `.3gp`, while every per-platform `_VIDEO_EXTS` set already included `.3gp`.

## Changes
- `gateway/platforms/base.py`: Added `.3gp` to the video partition of `MEDIA_DELIVERY_EXTS`

## Impact
Without this fix, `MEDIA:/path/to/clip.3gp` was:
1. Not extracted for native video delivery
2. Not stripped by the MEDIA: cleanup regex, leaking as plain text

## Testing
- Verified `.3gp` now appears in `MEDIA_DELIVERY_EXTS`
- Confirmed `_VIDEO_EXTS` in the same file already contained `.3gp` (line 5394)
- `py_compile` passes

