### PR TITLE
fix(tools): inject items schema for array-typed parameters (#71804)

### DIFF
--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -249,6 +249,8 @@ def _sanitize_node(node: Any, path: str) -> Any:
                 "with {'type': %r}",
                 path, node, node,
             )
+            if node == "array":
+                return {"type": "array", "items": {}}
             return {"type": node} if node != "object" else {
                 "type": "object",
                 "properties": {},
@@ -334,6 +336,12 @@ def _sanitize_node(node: Any, path: str) -> Any:
             out[key] = copy.deepcopy(value) if isinstance(value, (list, dict)) else value
         else:
             out[key] = _sanitize_node(value, f"{path}.{key}") if isinstance(value, (dict, list)) else value
+
+    # Array nodes without items: inject permissive items schema.
+    # Gemini strictly validates function declarations and rejects array
+    # schemas that omit the ``items`` keyword (HTTP 400).
+    if out.get("type") == "array" and "items" not in out:
+        out["items"] = {}
 
     # Object nodes without properties: inject empty properties dict.
     # llama.cpp's grammar generator can't constrain a free-form object.


### PR DESCRIPTION
## Summary
Fixes #71804.

When Hermes sends tool declarations to a Gemini model through an OpenAI-compatible endpoint, Gemini strictly validates function schemas and rejects array parameters missing the `items` keyword with HTTP 400.

## Changes
- `tools/schema_sanitizer.py`:
  - `_sanitize_node` now injects `items: {}` into dict nodes with `type: "array"` that are missing `items`
  - Bare-string `"array"` schema now returns `{"type": "array", "items": {}}` instead of just `{"type": "array"}`

## Testing
- `py_compile` passes
- Regression: bare `{"type": "array"}` now gets `items: {}` injected
- Regression: bare string `"array"` now gets normalized to `{"type": "array", "items": {}}`

