### PR TITLE
fix(agent): rotate Codex credentials on model entitlement rejection

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1006,6 +1006,19 @@ def recover_with_credential_pool(
             )
         return False, has_retried_429
 
+    if effective_reason == FailoverReason.entitlement:
+        if pool_provider != "openai-codex":
+            return False, has_retried_429
+        next_entry = pool.mark_entitlement_unavailable_and_rotate(
+            model=str(getattr(agent, "model", "") or ""),
+            api_key_hint=_api_key_hint,
+            credential_id=_credential_id,
+        )
+        if next_entry is None:
+            return False, has_retried_429
+        agent._swap_credential(next_entry)
+        return True, False
+
     if effective_reason == FailoverReason.billing:
         rotate_status = status_code if status_code is not None else 402
         # Runtime credentials can be resolved by a separate pool instance,

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1923,6 +1923,36 @@ class CredentialPool:
                 logger.info("credential pool: rotated to %s", _next_label)
             return next_entry
 
+    def mark_entitlement_unavailable_and_rotate(
+        self, *, model: str, api_key_hint: Optional[str] = None,
+        credential_id: Optional[str] = None,
+    ) -> Optional[PooledCredential]:
+        """Exclude one Codex credential for one model without exhausting it.
+
+        The marker is persisted in ``extra`` using the pool's existing atomic
+        write path. It deliberately leaves the credential otherwise healthy so
+        a different model remains selectable.
+        """
+        if self.provider != "openai-codex" or not isinstance(model, str) or not model.strip():
+            return None
+        with self._lock:
+            entry = next((e for e in self._entries if credential_id and e.id == credential_id), None)
+            entry = entry or next((e for e in self._entries if api_key_hint and e.runtime_api_key == api_key_hint), None)
+            entry = entry or self._current_unlocked()
+            if entry is None:
+                return None
+            blocked = set(entry.extra.get("unavailable_models", []))
+            blocked.add(model)
+            updated = replace(entry, extra={**entry.extra, "unavailable_models": sorted(blocked)})
+            self._replace_entry(entry, updated)
+            self._persist()
+            candidates = [
+                candidate for candidate in self._available_entries()
+                if model not in set(candidate.extra.get("unavailable_models", []))
+            ]
+            self._current_id = candidates[0].id if candidates else None
+            return candidates[0] if candidates else None
+
     def acquire_lease(self, credential_id: Optional[str] = None) -> Optional[str]:
         """Acquire a soft lease on a credential.
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1937,8 +1937,11 @@ class CredentialPool:
             return None
         with self._lock:
             identity_supplied = bool(credential_id or api_key_hint)
-            entry = next((e for e in self._entries if credential_id and e.id == credential_id), None)
-            entry = entry or next((e for e in self._entries if api_key_hint and e.runtime_api_key == api_key_hint), None)
+            id_entry = next((e for e in self._entries if credential_id and e.id == credential_id), None)
+            key_entry = next((e for e in self._entries if api_key_hint and e.runtime_api_key == api_key_hint), None)
+            if credential_id and api_key_hint and (id_entry is None or key_entry is None or id_entry.id != key_entry.id):
+                return None
+            entry = id_entry or key_entry
             if entry is None and identity_supplied:
                 return None
             entry = entry or self._current_unlocked()

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1936,8 +1936,11 @@ class CredentialPool:
         if self.provider != "openai-codex" or not isinstance(model, str) or not model.strip():
             return None
         with self._lock:
+            identity_supplied = bool(credential_id or api_key_hint)
             entry = next((e for e in self._entries if credential_id and e.id == credential_id), None)
             entry = entry or next((e for e in self._entries if api_key_hint and e.runtime_api_key == api_key_hint), None)
+            if entry is None and identity_supplied:
+                return None
             entry = entry or self._current_unlocked()
             if entry is None:
                 return None
@@ -2054,7 +2057,9 @@ class CredentialPool:
             count = 0
             new_entries = []
             for entry in self._entries:
-                if entry.last_status or entry.last_status_at or entry.last_error_code:
+                has_model_marker = bool(entry.extra.get("unavailable_models"))
+                if entry.last_status or entry.last_status_at or entry.last_error_code or has_model_marker:
+                    extra = {key: value for key, value in entry.extra.items() if key != "unavailable_models"}
                     new_entries.append(
                         replace(
                             entry,
@@ -2064,6 +2069,7 @@ class CredentialPool:
                             last_error_reason=None,
                             last_error_message=None,
                             last_error_reset_at=None,
+                            extra=extra,
                         )
                     )
                     count += 1

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -260,7 +260,7 @@ _MULTIMODAL_TOOL_CONTENT_PATTERNS = [
 ]
 
 _CHATGPT_ACCOUNT_MODEL_REJECTION = re.compile(
-    r'^\s*this\s+model\s+is\s+only\s+available\s+to\s+chatgpt\s+accounts\s*:\s*[\'\"][^\s\'\"]+[\'\"]\s*$',
+    r"^\s*the\s+['\"][^\s'\"]+['\"]\s+model\s+is\s+not\s+supported\s+when\s+using\s+codex\s+with\s+a\s+chatgpt\s+account\.\s*$",
     re.IGNORECASE,
 )
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1250,7 +1250,20 @@ def _classify_400(
             should_fallback=False,
         )
 
-    if _CHATGPT_ACCOUNT_MODEL_REJECTION.fullmatch(error_msg):
+    entitlement_messages = [error_msg]
+    if isinstance(body, dict):
+        flat_detail = body.get("detail")
+        if isinstance(flat_detail, str):
+            entitlement_messages.append(flat_detail.lower())
+        nested_error = body.get("error")
+        if isinstance(nested_error, dict):
+            nested_message = nested_error.get("message")
+            if isinstance(nested_message, str):
+                entitlement_messages.append(nested_message.lower())
+    if any(
+        _CHATGPT_ACCOUNT_MODEL_REJECTION.fullmatch(message)
+        for message in entitlement_messages
+    ):
         return result_fn(
             FailoverReason.entitlement,
             retryable=False,

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import enum
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
@@ -56,6 +57,7 @@ class FailoverReason(enum.Enum):
     model_not_found = "model_not_found"  # 404 or invalid model — fallback to different model
     provider_policy_blocked = "provider_policy_blocked"  # Aggregator (e.g. OpenRouter) blocked the only endpoint due to account data/privacy policy
     content_policy_blocked = "content_policy_blocked"  # Provider safety filter rejected this prompt — deterministic per-request, don't retry unchanged
+    entitlement = "entitlement"          # Account does not hold the named model entitlement — fail over
 
     # Request format
     format_error = "format_error"        # 400 bad request — abort or strip + retry
@@ -256,6 +258,11 @@ _MULTIMODAL_TOOL_CONTENT_PATTERNS = [
     # Alibaba/DashScope variant
     "tool_call.content must be string",
 ]
+
+_CHATGPT_ACCOUNT_MODEL_REJECTION = re.compile(
+    r'^\s*this\s+model\s+is\s+only\s+available\s+to\s+chatgpt\s+accounts\s*:\s*[\'\"][^\s\'\"]+[\'\"]\s*$',
+    re.IGNORECASE,
+)
 
 # Context overflow patterns
 _CONTEXT_OVERFLOW_PATTERNS = [
@@ -1241,6 +1248,13 @@ def _classify_400(
             FailoverReason.invalid_encrypted_content,
             retryable=True,
             should_fallback=False,
+        )
+
+    if _CHATGPT_ACCOUNT_MODEL_REJECTION.fullmatch(error_msg):
+        return result_fn(
+            FailoverReason.entitlement,
+            retryable=False,
+            should_fallback=True,
         )
 
     # Request-validation errors (unsupported / unknown parameter) MUST be

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -379,6 +379,20 @@ def test_mark_exhausted_and_rotate_persists_status(tmp_path, monkeypatch):
     assert persisted["last_error_code"] == 402
 
 
+def test_codex_entitlement_rotates_only_for_failed_model(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "credential_pool": {"openai-codex": [
+        {"id": "a", "label": "a", "auth_type": "api_key", "priority": 0, "source": "manual", "access_token": "a"},
+        {"id": "b", "label": "b", "auth_type": "api_key", "priority": 1, "source": "manual", "access_token": "b"},
+    ]}})
+    from agent.credential_pool import load_pool
+    pool = load_pool("openai-codex")
+    assert pool.select().id == "a"
+    assert pool.mark_entitlement_unavailable_and_rotate(model="model-a", credential_id="a").id == "b"
+    assert pool.mark_entitlement_unavailable_and_rotate(model="model-a", credential_id="b") is None
+    assert next(entry for entry in pool.entries() if entry.id == "a").extra["unavailable_models"] == ["model-a"]
+
+
 def test_billing_rotation_marks_all_entries_sharing_failed_key(tmp_path, monkeypatch):
     """A 402 must exhaust every pool entry backed by the same API key.
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -393,6 +393,20 @@ def test_codex_entitlement_rotates_only_for_failed_model(tmp_path, monkeypatch):
     assert next(entry for entry in pool.entries() if entry.id == "a").extra["unavailable_models"] == ["model-a"]
 
 
+def test_codex_entitlement_unmatched_identity_fails_closed_and_reset_clears_marker(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "credential_pool": {"openai-codex": [
+        {"id": "a", "label": "a", "auth_type": "api_key", "priority": 0, "source": "manual", "access_token": "a"},
+    ]}})
+    from agent.credential_pool import load_pool
+    pool = load_pool("openai-codex")
+    assert pool.mark_entitlement_unavailable_and_rotate(model="model-a", credential_id="missing") is None
+    assert pool.entries()[0].extra.get("unavailable_models") is None
+    pool.mark_entitlement_unavailable_and_rotate(model="model-a", credential_id="a")
+    assert pool.reset_statuses() == 1
+    assert load_pool("openai-codex").entries()[0].extra.get("unavailable_models") is None
+
+
 def test_billing_rotation_marks_all_entries_sharing_failed_key(tmp_path, monkeypatch):
     """A 402 must exhaust every pool entry backed by the same API key.
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -407,6 +407,19 @@ def test_codex_entitlement_unmatched_identity_fails_closed_and_reset_clears_mark
     assert load_pool("openai-codex").entries()[0].extra.get("unavailable_models") is None
 
 
+def test_codex_entitlement_requires_consistent_id_and_key_attribution(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "credential_pool": {"openai-codex": [
+        {"id": "a", "label": "a", "auth_type": "api_key", "priority": 0, "source": "manual", "access_token": "a"},
+        {"id": "b", "label": "b", "auth_type": "api_key", "priority": 1, "source": "manual", "access_token": "b"},
+    ]}})
+    from agent.credential_pool import load_pool
+    pool = load_pool("openai-codex")
+    assert pool.mark_entitlement_unavailable_and_rotate(model="m", credential_id="a", api_key_hint="b") is None
+    assert all(not entry.extra.get("unavailable_models") for entry in pool.entries())
+    assert pool.mark_entitlement_unavailable_and_rotate(model="m", credential_id="a", api_key_hint="a").id == "b"
+
+
 def test_billing_rotation_marks_all_entries_sharing_failed_key(tmp_path, monkeypatch):
     """A 402 must exhaust every pool entry backed by the same API key.
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -234,8 +234,8 @@ class TestClassifyApiError:
     # ── Auth errors ──
 
     @pytest.mark.parametrize("message", [
-        "This model is only available to ChatGPT accounts: 'gpt-5.6-sol'",
-        "  THIS MODEL  IS ONLY AVAILABLE TO CHATGPT ACCOUNTS:  \"gpt-5.6-sol\"  ",
+        "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+        "  THE  'gpt-5.6-sol'  MODEL IS NOT SUPPORTED WHEN USING CODEX WITH A CHATGPT ACCOUNT.  ",
     ])
     def test_400_exact_chatgpt_account_model_rejection_is_entitlement(self, message):
         result = classify_api_error(MockAPIError(message, status_code=400))
@@ -245,8 +245,8 @@ class TestClassifyApiError:
 
     @pytest.mark.parametrize("message", [
         "Bad request",
-        "prefix This model is only available to ChatGPT accounts: 'gpt-5.6-sol'",
-        "This model is only available to ChatGPT accounts: 'gpt-5.6-sol' suffix",
+        "prefix The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+        "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account. suffix",
     ])
     def test_400_nonexact_chatgpt_account_text_remains_format_error(self, message):
         result = classify_api_error(MockAPIError(message, status_code=400))
@@ -254,7 +254,7 @@ class TestClassifyApiError:
 
     def test_400_structured_replay_code_beats_chatgpt_account_text(self):
         result = classify_api_error(MockAPIError(
-            "This model is only available to ChatGPT accounts: 'gpt-5.6-sol'",
+            "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
             status_code=400,
             body={"error": {"code": "invalid_encrypted_content"}},
         ))

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1,5 +1,7 @@
 """Tests for agent.error_classifier — structured API error classification."""
 
+import httpx
+import openai
 import pytest
 from agent.error_classifier import (
     ClassifiedError,
@@ -239,6 +241,33 @@ class TestClassifyApiError:
     ])
     def test_400_exact_chatgpt_account_model_rejection_is_entitlement(self, message):
         result = classify_api_error(MockAPIError(message, status_code=400))
+        assert result.reason == FailoverReason.entitlement
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_400_openai_sdk_flat_detail_model_rejection_is_entitlement(self):
+        detail = (
+            "The 'gpt-5.6-sol' model is not supported when using Codex "
+            "with a ChatGPT account."
+        )
+        response = httpx.Response(
+            400,
+            request=httpx.Request(
+                "POST", "https://chatgpt.com/backend-api/codex/responses"
+            ),
+        )
+        error = openai.BadRequestError(
+            f"Error code: 400 - {{'detail': {detail!r}}}",
+            response=response,
+            body={"detail": detail},
+        )
+
+        result = classify_api_error(
+            error,
+            provider="openai-codex",
+            model="gpt-5.6-sol",
+        )
+
         assert result.reason == FailoverReason.entitlement
         assert result.retryable is False
         assert result.should_fallback is True

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -58,6 +58,7 @@ class TestFailoverReason:
             "ssl_cert_verification",
             "context_overflow", "payload_too_large", "image_too_large",
             "model_not_found", "format_error",
+            "entitlement",
             "invalid_encrypted_content",
             "multimodal_tool_content_unsupported",
             "provider_policy_blocked",
@@ -231,6 +232,38 @@ class TestClassifyApiError:
     """End-to-end classification tests."""
 
     # ── Auth errors ──
+
+    @pytest.mark.parametrize("message", [
+        "This model is only available to ChatGPT accounts: 'gpt-5.6-sol'",
+        "  THIS MODEL  IS ONLY AVAILABLE TO CHATGPT ACCOUNTS:  \"gpt-5.6-sol\"  ",
+    ])
+    def test_400_exact_chatgpt_account_model_rejection_is_entitlement(self, message):
+        result = classify_api_error(MockAPIError(message, status_code=400))
+        assert result.reason == FailoverReason.entitlement
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    @pytest.mark.parametrize("message", [
+        "Bad request",
+        "prefix This model is only available to ChatGPT accounts: 'gpt-5.6-sol'",
+        "This model is only available to ChatGPT accounts: 'gpt-5.6-sol' suffix",
+    ])
+    def test_400_nonexact_chatgpt_account_text_remains_format_error(self, message):
+        result = classify_api_error(MockAPIError(message, status_code=400))
+        assert result.reason == FailoverReason.format_error
+
+    def test_400_structured_replay_code_beats_chatgpt_account_text(self):
+        result = classify_api_error(MockAPIError(
+            "This model is only available to ChatGPT accounts: 'gpt-5.6-sol'",
+            status_code=400,
+            body={"error": {"code": "invalid_encrypted_content"}},
+        ))
+        assert result.reason == FailoverReason.invalid_encrypted_content
+
+    def test_401_429_and_503_keep_existing_classifications(self):
+        assert classify_api_error(MockAPIError("Unauthorized", status_code=401)).reason == FailoverReason.auth
+        assert classify_api_error(MockAPIError("Too Many Requests", status_code=429)).reason == FailoverReason.rate_limit
+        assert classify_api_error(MockAPIError("Service Unavailable", status_code=503)).reason == FailoverReason.overloaded
 
     def test_401_classified_as_auth(self):
         e = MockAPIError("Unauthorized", status_code=401)
@@ -2169,4 +2202,3 @@ class Test408RequestTimeout:
         assert result.retryable is False
         assert result.should_fallback is True
         assert result.should_compress is False
-

--- a/tests/run_agent/test_credential_pool_interrupt.py
+++ b/tests/run_agent/test_credential_pool_interrupt.py
@@ -79,6 +79,24 @@ def test_normal_retry_when_credential_not_exhausted():
     pool.mark_exhausted_and_rotate.assert_not_called()
 
 
+def test_codex_entitlement_rotates_once_then_allows_provider_fallback():
+    entries = [_make_entry(0), _make_entry(1)]
+    pool = _make_pool(entries)
+    pool.provider = "openai-codex"
+    pool.mark_entitlement_unavailable_and_rotate.return_value = entries[1]
+    from run_agent import AIAgent
+    agent = MagicMock(spec=AIAgent)
+    agent._credential_pool = pool
+    agent.provider = "openai-codex"
+    agent.model = "model-a"
+    agent.api_key = "key-0"
+    agent._credential_pool_entry_id = "cred-0"
+    agent._swap_credential = MagicMock()
+    recovered, _ = AIAgent._recover_with_credential_pool(agent, status_code=400, has_retried_429=False, classified_reason=FailoverReason.entitlement)
+    assert recovered is True
+    pool.mark_entitlement_unavailable_and_rotate.assert_called_once()
+
+
 def test_rotate_on_second_429_when_not_exhausted():
     """When credential is active and this is the second 429, rotate (existing behavior)."""
     entries = [_make_entry(0, last_status=None), _make_entry(1)]


### PR DESCRIPTION
## Summary

- classify the exact normalized ChatGPT-account Codex model rejection as a distinct entitlement failover reason
- persist model-scoped unavailability on the exact active `openai-codex` pool entry and rotate once to the next eligible credential
- fail closed on conflicting/missing credential attribution, preserve other-model eligibility, and clear model markers through the existing explicit pool reset lifecycle
- retain existing provider fallback after every same-provider credential rejects the requested model

Fixes #71970

## Root cause

The account-specific Codex HTTP 400 was treated as a generic request/format failure. Credential-pool recovery therefore had no narrow reason or model-scoped state with which to rotate a different credential, even when another configured ChatGPT subscription could use the requested model.

## Safety boundaries

- only the anchored, whitespace/case-normalized response `The '<model>' model is not supported when using Codex with a ChatGPT account.` is classified as entitlement
- arbitrary HTTP 400 responses do not rotate credentials
- HTTP 503 concurrency/overload remains transient and is not persisted as credential death
- 401 refresh, 429 reset-aware recovery, provider mismatch guards, and cross-provider fallback behavior are unchanged
- model markers are scoped to the exact pool entry + model; no token, account id, or stable identity is logged

## Tests

```text
scripts/run_tests.sh tests/agent/test_credential_pool.py tests/agent/test_error_classifier.py tests/run_agent/test_credential_pool_interrupt.py tests/run_agent/test_auth_provider_failover.py -q
# 321 passed, 0 failed; 7.2s runner wall

uv run ruff check agent/error_classifier.py agent/credential_pool.py agent/agent_runtime_helpers.py tests/agent/test_error_classifier.py tests/agent/test_credential_pool.py tests/run_agent/test_credential_pool_interrupt.py
# All checks passed

uv run python -m py_compile agent/error_classifier.py agent/credential_pool.py agent/agent_runtime_helpers.py
# passed
```

`ty check` on the touched large modules reports the repository's existing advisory diagnostics; the blocking Ruff gate and focused behavioral suites pass. Upstream CI can provide the canonical base-vs-head type-diagnostic diff.

## Related work

This complements static model compatibility fixes #61660 / #61665 and credential-pool work #31032 / #47096 / #68520. It is intentionally separate from quota-based `usage_limit_reached` handling in #45646 / #46915.

## Platform

Tested on macOS arm64 with Python 3.12 through the repository `uv` environment. No live credential or provider request was used by the tests.
