### PR TITLE
fix(tools): harden session-snapshot filter against multiline injection (#71296)

### DIFF
--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -56,11 +56,11 @@ def test_regex_preserves_user_env():
 def test_export_snippet_shape():
     snippet = _export_dump_excluding_session_vars("/tmp/snap.tmp.$BASHPID")
     assert "export -p" in snippet
-    assert "grep -vE" in snippet
+    assert "awk" in snippet
     assert "/tmp/snap.tmp.$BASHPID" in snippet
     # The redirection must be attached to a brace group wrapping the pipeline,
-    # NOT to the grep segment: a redirect on grep expands $BASHPID inside
-    # grep's pipeline subshell (a different PID than the parent shell that
+    # NOT to the awk segment: a redirect on awk expands $BASHPID inside
+    # awk's pipeline subshell (a different PID than the parent shell that
     # expands the follow-up ``mv`` operand), silently orphaning the dump and
     # breaking snapshot env persistence entirely.
     assert snippet.lstrip().startswith("{ ")
@@ -111,3 +111,45 @@ def test_shared_snapshot_no_cross_session_leak(tmp_path):
                 assert "HERMES_SESSION_ID" not in f.read()
     finally:
         env.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Security: multiline injection through export -p continuation lines.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_multiline_injection_filtered(tmp_path):
+    """Continuation lines from excluded vars must not leak into the snapshot.
+
+    Some bash versions emit multi-line values as raw continuation lines
+    without a ``declare -x`` prefix.  The awk state-machine must suppress
+    those continuation lines, not just the first line of each excluded var.
+    GH-71296.
+    """
+    import subprocess
+
+    # Build a fake export -p dump with an injected multiline value.
+    dump = (
+        'declare -x HERMES_SESSION_CHAT_NAME="demo\n'
+        "touch /tmp/pwned #\n"
+        'declare -x HERMES_SESSION_ID="abc123"\n'
+        'declare -x PATH="/usr/bin"\n'
+        'declare -x SAFE_VAR="hello"\n'
+    )
+    snap_file = tmp_path / "snap.sh"
+    out_file = tmp_path / "out.sh"
+    snap_file.write_text(dump)
+
+    snippet = _export_dump_excluding_session_vars(str(out_file))
+    # Replace ``export -p`` with ``cat <dump>`` so the test uses our fake data.
+    test_cmd = snippet.replace("export -p", f"cat {snap_file}")
+    result = subprocess.run(
+        ["bash", "-c", f"set +H; {test_cmd} && cat {out_file}"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0, f"command failed: {result.stderr}"
+    out = result.stdout
+    assert "pwned" not in out, f"injection leaked into snapshot: {out!r}"
+    assert "touch" not in out, f"continuation line leaked: {out!r}"
+    assert 'SAFE_VAR="hello"' in out, f"safe var was dropped: {out!r}"
+    assert 'PATH="/usr/bin"' in out, f"PATH was dropped: {out!r}"

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -409,22 +409,38 @@ def _export_dump_excluding_session_vars(tmp_path: str) -> str:
 
     ``export -p`` emits one ``declare -x NAME="value"`` line per exported var.
     We drop the HERMES_SESSION_* / UI / CRON_AUTO_DELIVER lines so they never
-    persist across sessions in the shared snapshot. ``grep -vE`` returns exit 1
-    when it filters everything, so ``|| true`` keeps the pipeline's success
-    contract intact for the callers that chain on it.
+    persist across sessions in the shared snapshot.
+
+    Some bash versions (notably 3.x on macOS) emit multi-line values as raw
+    continuation lines without a ``declare -x`` prefix.  A ``grep -vE`` only
+    removes the first line of such entries, allowing the continuation lines
+    to persist into the snapshot and execute on ``source`` (GH-71296).  An
+    awk state-machine is used instead: when a ``declare -x`` line matches an
+    excluded prefix, ``skip`` is set and the line is dropped; ``skip`` stays
+    true through continuation lines and resets on the next ``declare -x``
+    line of any variable.  awk returns exit 0 even when filtering everything
+    (unlike grep which returns 1), so the ``|| true`` is retained only as a
+    safety net for environments where awk is unavailable.
 
     The pipeline MUST be wrapped in a brace group with the redirection applied
     to the group, not to the last pipeline segment. *tmp_path* typically embeds
     ``$BASHPID`` for concurrency-safe temp names; a redirection attached
-    directly to ``grep`` is expanded inside grep's own pipeline subshell, where
-    ``$BASHPID`` resolves to the grep subshell's PID — while the caller's
+    directly to ``awk`` is expanded inside awk's own pipeline subshell, where
+    ``$BASHPID`` resolves to the awk subshell's PID — while the caller's
     follow-up ``mv $tmp`` expands in the parent shell to a DIFFERENT PID. The
     dump then lands in an orphaned temp file and the snapshot silently never
     updates (all exported-env persistence breaks). The brace-group redirect is
     expanded in the current shell, keeping both expansions consistent.
     """
+    # NOTE: the awk script is intentionally kept on one line to avoid
+    # backslash-newline complications inside the f-string.
+    awk_prog = (
+        "'/^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|"
+        "HERMES_CRON_AUTO_DELIVER_)/{skip=1;next} "
+        "/^declare -x /{skip=0} !skip{print}'"
+    )
     return (
-        f"{{ export -p | grep -vE '{_SNAPSHOT_EXCLUDED_ENV_REGEX}' || true; }} "
+        f"{{ export -p | awk {awk_prog} || true; }} "
         f"> {tmp_path}"
     )
 


### PR DESCRIPTION
## Summary
Fixes #71296 (SECURITY).

**Vulnerability:** Setting a Matrix room name or display name to a multi-line value containing shell commands causes those commands to execute on the gateway host whenever any terminal command runs in that session.

## Root Cause
`_export_dump_excluding_session_vars` used `grep -vE` to filter excluded env vars from `export -p` output. Some bash versions (notably 3.x on macOS) emit multi-line values as raw continuation lines without a `declare -x` prefix. `grep -vE` only removes the first line, allowing continuation lines with injected commands to persist into the snapshot and execute on `source`.

## Fix
Replaced `grep -vE` with an awk state-machine:
- Sets `skip=1` on `declare -x` lines matching excluded prefixes (`HERMES_SESSION_*`, `HERMES_UI_SESSION_ID`, `HERMES_CRON_AUTO_DELIVER_*`)
- Carries `skip` through continuation lines (no `declare -x` prefix)
- Resets `skip=0` on the next `declare -x` of any variable
- Returns exit 0 even when filtering everything (unlike grep which returns 1)

## Testing
Verified with simulated multi-line `export -p` output containing injection payload:
- **grep approach:** `touch /tmp/pwned #` leaks through (VULNERABLE)
- **awk approach:** Only safe vars remain (SAFE)

