### PR TITLE
fix(desktop): normalize live message timestamps

### DIFF
--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { ComposerAttachment } from '@/store/composer'
 
@@ -98,6 +98,29 @@ describe('toRuntimeMessage timestamps', () => {
     })
 
     expect(message.createdAt.getTime()).toBe(createdAt)
+  })
+
+  it('uses a Unix-seconds token embedded in a synthetic id', () => {
+    const message = toRuntimeMessage({
+      id: 'assistant-stream-1785064294-1',
+      parts: [],
+      role: 'assistant'
+    })
+
+    expect(message.createdAt.getTime()).toBe(1_785_064_294_000)
+  })
+
+  it('ignores non-timestamp digits in a synthetic id', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-26T13:30:00.000Z'))
+
+    try {
+      const message = toRuntimeMessage({ id: 'assistant-stream-rt9', parts: [], role: 'assistant' })
+
+      expect(message.createdAt.toISOString()).toBe('2026-07-26T13:30:00.000Z')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('converts persisted Unix seconds to milliseconds', () => {

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -8,7 +8,8 @@ import {
   coerceThinkingText,
   optimisticAttachmentRef,
   parseCommandDispatch,
-  parseSlashCommand
+  parseSlashCommand,
+  toRuntimeMessage
 } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
@@ -83,6 +84,26 @@ describe('coerceThinkingText', () => {
         "◉_◉ processing... I don't see any current rewritten thinking or next thinking to process. Could you provide the thinking content you'd like me to rewrite?"
       )
     ).toBe('')
+  })
+})
+
+describe('toRuntimeMessage timestamps', () => {
+  it('uses the millisecond timestamp embedded in a live stream id', () => {
+    const createdAt = 1_785_064_294_529
+
+    const message = toRuntimeMessage({
+      id: `assistant-stream-${createdAt}-1`,
+      parts: [],
+      role: 'assistant'
+    })
+
+    expect(message.createdAt.getTime()).toBe(createdAt)
+  })
+
+  it('converts persisted Unix seconds to milliseconds', () => {
+    const message = toRuntimeMessage({ id: 'stored-1', parts: [], role: 'assistant', timestamp: 1_785_064_294 })
+
+    expect(message.createdAt.getTime()).toBe(1_785_064_294_000)
   })
 })
 

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -369,7 +369,11 @@ export function toRuntimeMessage(message: ChatMessage): ThreadMessage {
   const role =
     message.role === 'user' || message.role === 'assistant' || message.role === 'system' ? message.role : 'assistant'
 
-  const createdAt = coerceTimestampDate(message.timestamp ?? message.id.match(/\d+/)?.[0]) ?? new Date()
+  // Synthetic live ids may carry a Unix timestamp as a complete dash-delimited
+  // token. Ignore arbitrary digits in session ids (`rt9`, counters, etc.) so
+  // they cannot turn into plausible-looking dates near the Unix epoch.
+  const idTimestamp = message.id.match(/(?:^|-)(\d{13}|\d{10})(?=-|$)/)?.[1]
+  const createdAt = coerceTimestampDate(message.timestamp ?? idTimestamp) ?? new Date()
 
   if (role === 'user') {
     return {

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -5,6 +5,7 @@ import type { ClientSessionState, CommandDispatchResponse } from '@/app/types'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { type ChatMessage, type ChatMessagePart, chatMessageText, textPart } from '@/lib/chat-messages'
 import { normalize } from '@/lib/text'
+import { coerceTimestampDate } from '@/lib/time'
 import type { ComposerAttachment } from '@/store/composer'
 import type { ModelOptionsResponse, SessionInfo } from '@/types/hermes'
 
@@ -368,9 +369,7 @@ export function toRuntimeMessage(message: ChatMessage): ThreadMessage {
   const role =
     message.role === 'user' || message.role === 'assistant' || message.role === 'system' ? message.role : 'assistant'
 
-  const createdAt = message.timestamp
-    ? new Date(message.timestamp * 1000)
-    : new Date(Number(message.id.match(/\d+/)?.[0]) || Date.now())
+  const createdAt = coerceTimestampDate(message.timestamp ?? message.id.match(/\d+/)?.[0]) ?? new Date()
 
   if (role === 'user') {
     return {

--- a/apps/desktop/src/lib/time.test.ts
+++ b/apps/desktop/src/lib/time.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from 'vitest'
 
-import { calendarBucket, DAY, formatAgo, HOUR, MINUTE, nominalDayStart, SECOND, sessionBucketLabel } from './time'
+import {
+  calendarBucket,
+  coerceTimestampDate,
+  DAY,
+  fmtMonth,
+  fmtMonthYear,
+  formatAgo,
+  HOUR,
+  MINUTE,
+  nominalDayStart,
+  SECOND,
+  sessionBucketLabel
+} from './time'
 
 const labels = {
   ageNow: 'now',
@@ -28,6 +40,25 @@ describe('formatAgo', () => {
 
   it('clamps future timestamps to "now"', () => {
     expect(ago(-HOUR)).toBe('now')
+  })
+})
+
+describe('coerceTimestampDate', () => {
+  const epochSeconds = 1_785_064_294
+  const epochMilliseconds = epochSeconds * SECOND
+
+  it('normalizes Unix seconds instead of interpreting them as January 1970 milliseconds', () => {
+    expect(coerceTimestampDate(epochSeconds)?.getTime()).toBe(epochMilliseconds)
+  })
+
+  it('preserves millisecond timestamps and Date instances', () => {
+    expect(coerceTimestampDate(epochMilliseconds)?.getTime()).toBe(epochMilliseconds)
+    expect(coerceTimestampDate(new Date(epochMilliseconds))?.getTime()).toBe(epochMilliseconds)
+  })
+
+  it('rejects invalid timestamps', () => {
+    expect(coerceTimestampDate(undefined)).toBeNull()
+    expect(coerceTimestampDate('not-a-date')).toBeNull()
   })
 })
 
@@ -117,8 +148,7 @@ describe('sessionBucketLabel', () => {
   })
 
   it('formats month (same year) and month + year (prior year) via Intl', () => {
-    // en-US default in the test env: month name, plus year for the prior year.
-    expect(labelAt(2026, 2, 3)).toBe('March')
-    expect(labelAt(2025, 11, 3)).toBe('December 2025')
+    expect(labelAt(2026, 2, 3)).toBe(fmtMonth.format(new Date(2026, 2, 3)))
+    expect(labelAt(2025, 11, 3)).toBe(fmtMonthYear.format(new Date(2025, 11, 3)))
   })
 })

--- a/apps/desktop/src/lib/time.ts
+++ b/apps/desktop/src/lib/time.ts
@@ -7,6 +7,31 @@ export const MINUTE = 60_000
 export const HOUR = 3_600_000
 export const DAY = 86_400_000
 
+// Hermes persists transcript timestamps as Unix seconds, while live renderer
+// message ids embed Date.now() milliseconds. Normalize both at the display
+// boundary so a live id is never multiplied by 1000 into the distant future.
+const MIN_PLAUSIBLE_MILLISECONDS = 100_000_000_000
+
+export function coerceTimestampDate(value: Date | number | string | null | undefined): Date | null {
+  if (value === null || value === undefined || value === '') {
+    return null
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : new Date(value.getTime())
+  }
+
+  const numeric = typeof value === 'number' ? value : Number(value)
+
+  if (!Number.isFinite(numeric)) {
+    return null
+  }
+
+  const date = new Date(Math.abs(numeric) < MIN_PLAUSIBLE_MILLISECONDS ? numeric * SECOND : numeric)
+
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
 // ── Absolute date/time formatters ──────────────────────────────────────────
 // `hh:mm` clock (thread today/yesterday lines).
 export const fmtClock = new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' })


### PR DESCRIPTION
## Summary
- normalize persisted Unix-second and live Date.now()-millisecond timestamps at the desktop display boundary
- prevent live assistant messages from rendering implausible multi-decade ages
- add regression coverage for both timestamp forms and invalid inputs
- make the existing Intl month-label test locale-independent

## Root cause
Persisted transcript messages carry timestamps in Unix seconds. Live renderer messages can omit that field and use IDs such as `assistant-stream-<Date.now()>-N`, where the embedded value is already milliseconds. `toRuntimeMessage` extracted that value and multiplied it by 1000 as if it were seconds, producing an invalid far-future display timestamp.

## Test plan
- `npx eslint src/lib/time.ts src/lib/time.test.ts src/lib/chat-runtime.ts src/lib/chat-runtime.test.ts`
- `npm run typecheck`
- `npm run test:ui -- --run src/lib/time.test.ts src/lib/chat-runtime.test.ts src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx` (45 passed)
- real Electron clarify E2E remained green while validating the reported UI path

## Notes
The full Desktop UI suite currently has two unrelated Billing test failures on this Windows checkout. The focused tests and type/lint gates for this change pass.