### PR TITLE
fix(gateway): expand env vars in _resolve_gateway_model (#71710)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2850,7 +2850,7 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     back to the hardcoded default which fails when the active provider is
     openai-codex.
     """
-    cfg = config if config is not None else _load_gateway_config()
+    cfg = config if config is not None else _load_gateway_runtime_config()
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, str):
         return model_cfg


### PR DESCRIPTION
## Summary
Fixes #71710.

`_resolve_gateway_model` called `_load_gateway_config()` which returns raw YAML without `${VAR}` expansion. When `model.default` contains an env var reference like `${LM_MODEL}`, the literal string was passed as the model identifier, causing failures on Telegram/Discord/Slack gateway channels.

## Changes
- `gateway/run.py`: `_resolve_gateway_model` now uses `_load_gateway_runtime_config()` instead of `_load_gateway_config()`, which applies `_expand_env_vars` to resolve `${VAR}` references

## Testing
- The `_load_gateway_runtime_config` helper is already used by other runtime paths (checkpoint config, etc.) and is well-tested
- `py_compile` passes

