### PR TITLE
fix(kanban): make --initial-status blocked sticky against recompute_ready

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3183,6 +3183,22 @@ def create_task(
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
+                if task_status == "blocked":
+                    # Parking a card in blocked at creation time is an explicit
+                    # operator decision (the documented purpose of
+                    # ``--initial-status blocked`` is the human-ops gate). Emit
+                    # the same "blocked" event ``block_task`` emits so
+                    # ``_has_sticky_block`` treats it as sticky — otherwise
+                    # ``recompute_ready`` auto-promotes a parentless blocked
+                    # card to ready on the next dispatcher tick and a worker
+                    # gets spawned, defeating the flag entirely.
+                    # ``unblock_task`` remains the legitimate exit.
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"reason": "created with initial_status=blocked"},
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4999,3 +4999,88 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+def test_initial_status_blocked_is_sticky_across_recompute(kanban_home):
+    """A task created with ``initial_status='blocked'`` must survive
+    ``recompute_ready`` — the flag's documented purpose is parking a card for
+    human ops, so the dispatcher must not auto-promote it.
+
+    Regression: ``create_task`` set ``status='blocked'`` but emitted no
+    ``blocked`` event, so ``_has_sticky_block`` returned False and
+    ``recompute_ready`` promoted the (parentless) card to ready on the next
+    dispatcher tick, spawning a worker for a card that explicitly asked not to
+    be dispatched.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="parked", initial_status="blocked")
+        assert kb.get_task(conn, t).status == "blocked"
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 0
+        assert kb.get_task(conn, t).status == "blocked"
+        # The card must be sticky by the same predicate an operator block uses.
+        assert kb._has_sticky_block(conn, t) is True
+        row = conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? "
+            "AND kind IN ('blocked', 'unblocked') ORDER BY id DESC LIMIT 1",
+            (t,),
+        ).fetchone()
+        assert row is not None and row["kind"] == "blocked"
+
+
+def test_initial_status_blocked_survives_a_real_dispatcher_pass(
+    kanban_home, all_assignees_spawnable
+):
+    """E2E: the dispatcher must not spawn a worker on a created-blocked card.
+
+    ``recompute_ready`` runs inside ``dispatch_once``, so the promotion above
+    is not academic: it hands the card to the claim + spawn path on the very
+    next tick.
+    """
+    spawned = []
+
+    def fake_spawn(task, workspace):
+        spawned.append(task.id)
+
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn, title="do not dispatch me", assignee="alice",
+            initial_status="blocked",
+        )
+        kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        assert spawned == [], (
+            "a card created with initial_status=blocked must never be spawned"
+        )
+        assert kb.get_task(conn, t).status == "blocked"
+
+
+def test_initial_status_blocked_unblock_releases(kanban_home):
+    """``unblock_task`` is the legitimate exit from a created-blocked card —
+    after an explicit unblock, normal flow may promote it."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="parked", initial_status="blocked")
+        assert kb.unblock_task(conn, t)
+        assert kb.get_task(conn, t).status in ("ready", "todo")
+        # And it stays promotable: recompute must not re-block it.
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, t).status in ("ready", "todo")
+        assert kb._has_sticky_block(conn, t) is False
+
+
+def test_initial_status_blocked_with_done_parents_stays_blocked(kanban_home):
+    """Sticky beats the parents-are-done promotion rule.
+
+    ``recompute_ready`` promotes a blocked task whose parents are all done.
+    An explicitly parked card must not be promoted by that rule either --
+    otherwise completing an unrelated parent silently releases the gate.
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        kb.claim_task(conn, parent)
+        kb.complete_task(conn, parent)
+        child = kb.create_task(
+            conn, title="parked child", parents=[parent],
+            initial_status="blocked",
+        )
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "blocked"


### PR DESCRIPTION
# fix(kanban): make `--initial-status blocked` sticky against `recompute_ready`

## Symptom

A card created with `hermes kanban add --initial-status blocked` (or
`create_task(..., initial_status="blocked")`) is promoted to `ready` on the
**next dispatcher tick**, claimed, and a worker is spawned on it — exactly the
outcome the flag exists to prevent.

Reproduced on current `main`:

```python
>>> t = kb.create_task(conn, title="held", initial_status="blocked")
>>> kb.get_task(conn, t).status
'blocked'
>>> kb._has_sticky_block(conn, t)
False                       # <-- not sticky
>>> kb.recompute_ready(conn)
>>> kb.get_task(conn, t).status
'ready'                     # <-- promoted, nothing was reclaimed or unblocked
```

`recompute_ready` runs **inside `dispatch_once`**, so this is not academic: the
promotion happens on the tick that then claims and spawns.

## Root cause

`_has_sticky_block` (added in the human-review-handoff work) distinguishes two
sources of `status='blocked'` by looking for the most recent
`blocked`/`unblocked` row in `task_events`:

* a deliberate operator/worker block — emits a `blocked` event → sticky, only
  `unblock_task` releases it;
* a circuit-breaker give-up — emits `gave_up`, not `blocked` → auto-recovers.

`create_task` sets `task_status = "blocked"` for `initial_status="blocked"` but
emits **only** a `created` event — never a `blocked` one. So the predicate falls
into its documented "no such event at all" branch and returns `False`, and
`recompute_ready` treats the card as auto-recoverable.

Every other writer that parks a task in `blocked` on purpose goes through
`block_task`, which does emit the event. `create_task` is the sole path that
produces a `blocked` row with no `blocked` event — a state no other writer can
create.

## Fix

Emit the same `blocked` event `block_task` emits when a task is created
directly in `blocked`. Fifteen lines, inside the existing `write_txn`, in the
same `if` that already knows `task_status == "blocked"`. No new state, no
signature change, no new config. `unblock_task` remains the legitimate exit.

## Tests

`tests/hermes_cli/test_kanban_db.py` — 4 new tests (the first coverage
`initial_status` has had):

1. **sticky across `recompute_ready`** — `promoted == 0`, status stays
   `blocked`, `_has_sticky_block` is `True`, and the newest block-event is
   `blocked`.
2. **E2E through a real `dispatch_once`** — asserts `spawn_fn` was never
   called. This is the user-visible harm: a worker process spawned on a card
   the operator explicitly parked.
3. **`unblock_task` still releases** (control) — after an explicit unblock the
   card is promotable and `_has_sticky_block` flips back to `False`.
4. **sticky beats the parents-are-done rule** — `recompute_ready` promotes a
   blocked task once all parents are `done`; an explicitly parked card must not
   be released by that rule either, or completing an unrelated parent silently
   opens the gate.

**RED proof** (production change neutered, tests unchanged): tests 1, 2 and 4
fail with `assert 'ready' == 'blocked'` / `assert ['t_…'] == []`. Test 3 is the
control and passes in both states by design.

**GREEN:** `tests/hermes_cli/test_kanban_db.py` = **234 passed** (230
pre-existing on clean `main`, +4 new). Zero pre-existing tests modified.
