### PR TITLE
fix(kanban): worktree reuse must honor the requested branch

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6282,12 +6282,42 @@ def _repo_root_for_worktree_target(path: Path) -> Optional[Path]:
 
 
 def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> None:
-    """Materialize ``target`` as a linked git worktree under ``repo_root``."""
+    """Materialize ``target`` as a linked git worktree under ``repo_root``.
+
+    When ``target`` already exists as a linked worktree of ``repo_root``,
+    reuse it — but only after confirming it is checked out on ``branch_name``.
+    A previous failed or interrupted dispatch of the same task can leave the
+    canonical ``<repo>/.worktrees/<id>`` path on a stale or unrelated branch;
+    silently reusing it would run this task's work on the wrong branch. If the
+    branch differs, switch it back (creating the branch if needed) so the
+    reused checkout matches the requested branch, and raise if the switch
+    fails rather than proceeding on the wrong tree.
+    """
     target = target.expanduser()
     repo_common = _git_common_dir(repo_root)
     if target.exists() and repo_common is not None:
         target_common = _git_common_dir(target)
         if target_common == repo_common:
+            if _git_current_branch(target) == branch_name:
+                return
+            # Reused worktree is on the wrong branch — realign it.
+            if _git_branch_exists(repo_root, branch_name):
+                switch_cmd = ["git", "-C", str(target), "checkout", branch_name]
+            else:
+                switch_cmd = ["git", "-C", str(target), "checkout", "-b", branch_name]
+            switch = subprocess.run(
+                switch_cmd,
+                capture_output=True,
+                text=True, encoding='utf-8', errors='replace',
+                timeout=60,
+                check=False,
+            )
+            if switch.returncode != 0:
+                stderr = (switch.stderr or switch.stdout or "").strip()
+                raise RuntimeError(
+                    f"git checkout {branch_name} failed for reused worktree "
+                    f"{target}: {stderr}"
+                )
             return
     target.parent.mkdir(parents=True, exist_ok=True)
     if _git_branch_exists(repo_root, branch_name):

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -196,3 +196,99 @@ def test_resolve_worktree_own_path_on_foreign_branch_keeps_legacy_reuse(
     workspace, branch = kb._resolve_worktree_workspace(task)
     assert workspace == own.resolve()
     assert branch == "wt/foreign"
+
+
+# --- _ensure_git_worktree: stale-branch realign on reuse ----------------------
+#
+# ``_ensure_git_worktree`` reuses ``target`` whenever it is a linked worktree of
+# the same repo -- WITHOUT checking which branch it is on. A previous failed or
+# interrupted dispatch of the same task leaves the canonical
+# ``<repo>/.worktrees/<id>`` path on a stale branch, so the next dispatch of
+# that task silently runs on the wrong branch. The per-task fallback in
+# ``_resolve_worktree_workspace`` routes right back to this same canonical path,
+# so it cannot heal the case either -- this is the last gap.
+
+
+def test_ensure_git_worktree_realigns_a_stale_reused_branch(tmp_path):
+    repo = _make_repo(tmp_path)
+    target = repo / ".worktrees" / "t_abc"
+    # A previous dispatch left the canonical path on some other branch.
+    _add_worktree(repo, target, "wt/stale-previous-run")
+    assert kb._git_current_branch(target) == "wt/stale-previous-run"
+
+    kb._ensure_git_worktree(repo, target, "wt/t_abc")
+
+    assert kb._git_current_branch(target) == "wt/t_abc", (
+        "a reused worktree left on a stale branch must be realigned to the "
+        "task's own branch, not silently run on the previous run's branch"
+    )
+
+
+def test_ensure_git_worktree_same_branch_reuse_is_a_noop(tmp_path):
+    """Control: the common path (already on the right branch) must not churn."""
+    repo = _make_repo(tmp_path)
+    target = repo / ".worktrees" / "t_abc"
+    _add_worktree(repo, target, "wt/t_abc")
+    (target / "work-in-progress.txt").write_text("uncommitted\n", encoding="utf-8")
+
+    kb._ensure_git_worktree(repo, target, "wt/t_abc")
+
+    assert kb._git_current_branch(target) == "wt/t_abc"
+    # No checkout was issued, so uncommitted work is untouched.
+    assert (target / "work-in-progress.txt").exists()
+
+
+def test_ensure_git_worktree_realign_reuses_an_existing_branch(tmp_path):
+    """Realigning onto a branch that already exists must check it out, not
+    fail trying to create a duplicate."""
+    repo = _make_repo(tmp_path)
+    other = repo / ".worktrees" / "other"
+    _add_worktree(repo, other, "wt/t_target")   # branch exists, checked out elsewhere
+    _git(other, "checkout", "-b", "wt/parked")  # free the branch again
+
+    target = repo / ".worktrees" / "t_target"
+    _add_worktree(repo, target, "wt/stale")
+
+    kb._ensure_git_worktree(repo, target, "wt/t_target")
+    assert kb._git_current_branch(target) == "wt/t_target"
+
+
+def test_resolve_no_path_worktree_task_realigns_a_stale_canonical_checkout(
+    kanban_home, tmp_path, monkeypatch
+):
+    """E2E through the real resolver: a no-``workspace_path`` worktree task
+    whose canonical ``<repo>/.worktrees/<id>`` was left on a stale branch by an
+    interrupted run must come back checked out on ITS OWN branch.
+
+    This is the user-visible contract -- a worker cd's into the returned path
+    and commits there. Pre-fix, ``_ensure_git_worktree`` saw a linked worktree
+    of the right repo and returned immediately, so the worker committed to the
+    previous run's branch.
+    """
+    repo = _make_repo(tmp_path)
+    kb.write_board_metadata("default", default_workdir=str(repo))
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="resume me", assignee="w", workspace_kind="worktree",
+        )
+        conn.execute(
+            "UPDATE tasks SET workspace_path = NULL WHERE id = ?", (tid,)
+        )
+        conn.commit()
+        task = kb.get_task(conn, tid)
+
+    # A previous interrupted dispatch of THIS task left its canonical path on
+    # an unrelated branch.
+    target = _add_worktree(repo, repo / ".worktrees" / tid, "wt/interrupted-run")
+    assert kb._git_current_branch(target) == "wt/interrupted-run"
+
+    resolved, branch = kb._resolve_worktree_workspace(task, board="default")
+
+    assert Path(resolved).resolve() == target.resolve()
+    assert branch == f"wt/{tid}"
+    assert kb._git_current_branch(Path(resolved)) == f"wt/{tid}", (
+        f"resolver returned {resolved} on branch "
+        f"{kb._git_current_branch(Path(resolved))!r}; a worker would commit to "
+        "the previous run's branch"
+    )


### PR DESCRIPTION
# fix(kanban): verify the branch when reusing an existing worktree checkout

## Symptom

A kanban task with `workspace_kind=worktree` whose previous dispatch failed or
was interrupted runs its **next** attempt on the *previous run's branch*. The
worker cd's into the workspace and commits — the work lands on the wrong
branch, with no error and no warning.

## Root cause

`hermes_cli/kanban_db.py`, `_ensure_git_worktree`:

```python
target = target.expanduser()
repo_common = _git_common_dir(repo_root)
if target.exists() and repo_common is not None:
    target_common = _git_common_dir(target)
    if target_common == repo_common:
        return          # <-- reuse, without ever checking the branch
```

The reuse shortcut asks only *"is this a linked worktree of the same repo?"*
It never asks *"is it on `branch_name`?"* — the one parameter the function was
given to guarantee.

A previous failed or interrupted dispatch of the same task leaves the canonical
`<repo>/.worktrees/<task-id>` on whatever branch it died on. The next dispatch
of that task hits the shortcut and hands the worker a tree on the stale branch.

`_resolve_worktree_workspace`'s per-task fallback (added for the sibling-sharing
case) cannot heal this: the fallback path it computes for a task is
`<repo>/.worktrees/<task-id>` — the very path that is stale. It correctly
detects a *different* task's branch occupying a shared path; it has no answer
for the task's own canonical path being stale, because there is nowhere else to
go. Realigning in `_ensure_git_worktree` is the only place that closes it.

## Fix

On reuse, compare the checkout's current branch to `branch_name`. If it
differs, switch it (`checkout` when the branch exists, `checkout -b` when it
doesn't) and raise if the switch fails, rather than proceeding on the wrong
tree. Same-branch reuse is an early `return`, unchanged — the common path
issues no git command and touches no uncommitted work.

**+31/−1, one function.** No signature change, no new state.

### Deliberately NOT changed

`test_resolve_worktree_own_path_on_foreign_branch_keeps_legacy_reuse` pins the
behaviour where a task's *explicitly stored* `workspace_path` is a foreign-branch
checkout and the per-task fallback resolves to that same path: `main` keeps the
legacy reuse rather than failing dispatch. An earlier draft of this fix also
realigned that case and turned that test red. That is a **separate, deliberate**
upstream decision about explicitly-configured paths, so it is left alone; this
PR changes only the reuse shortcut inside `_ensure_git_worktree`, which every
*materialization* path funnels through.

## Tests

`tests/hermes_cli/test_kanban_worktree_isolation.py` — 4 new tests on the
file's existing real-git-repo helpers (no mocks; real `git init`, real
`git worktree add`):

1. **realigns a stale reused branch** — the direct unit case.
2. **same-branch reuse is a no-op** (control) — asserts uncommitted work in the
   checkout survives, proving no `checkout` is issued on the common path.
3. **realign reuses an existing branch** — the `checkout` vs `checkout -b`
   split; realigning onto an already-existing branch must check it out, not
   fail trying to create a duplicate.
4. **E2E through `_resolve_worktree_workspace`** — a no-`workspace_path`
   worktree task anchored on the board's `default_workdir`, whose canonical
   checkout was left on `wt/interrupted-run`, comes back on `wt/<task-id>`.
   This is the user-visible contract.

**RED proof** (reuse shortcut restored to the unconditional `return`, tests
unchanged): 3 of 4 fail. Test 2 is the control and passes in both states.

```
E   AssertionError: assert 'wt/interrupted-run' == 'wt/t_71c55937'
E     - wt/t_71c55937
E     + wt/interrupted-run
```

**GREEN:** 250 passed across `test_kanban_worktree_isolation.py`,
`test_kanban_decompose_db.py` and `test_kanban_db.py`. Zero pre-existing tests
modified.
