### PR TITLE
fix(kanban): stop the false "check profile health" stall warning on a benign decline

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -109,6 +109,62 @@ def _release_singleton_lock(handle) -> None:
         pass
 
 
+# Benign-decline buckets on a ``DispatchResult``: the dispatcher looked at the
+# board and chose NOT to spawn for a self-clearing reason (a concurrency cap is
+# saturated, a worker bounced off a provider rate-limit / quota wall, another
+# process holds the board lock, or a respawn guard is cooling a task down).
+# None of these are operator-actionable — the work resumes on a later tick — so
+# a zero-spawn tick explained by any of them must NOT count toward the "stuck"
+# streak. See the field docstrings on ``kanban_db.DispatchResult``.
+_BENIGN_DECLINE_FIELDS = (
+    "skipped_per_profile_capped",
+    "rate_limited",
+    "respawn_guarded",
+    "skipped_locked",
+)
+# Genuine-fault buckets: the dispatcher TRIED to spawn and the attempt failed.
+# ``spawn_failed`` is populated on EVERY spawn failure this tick (workspace
+# resolution or worker launch), so an early, pre-circuit-breaker failure on one
+# board is a fault immediately — it can't be masked by a benign decline on a
+# different board and silently reset the streak. ``auto_blocked`` is the subset
+# that additionally tripped the circuit breaker (broken venv / PATH / credential
+# loss -> repeated spawn_failed). Either forces the tick to count.
+_FAULT_FIELDS = (
+    "spawn_failed",
+    "auto_blocked",
+)
+
+
+def _stall_streak_is_bad(ready_pending, any_spawned, results) -> bool:
+    """Decide whether a dispatcher tick counts toward the "stuck" streak.
+
+    A tick is "bad" (stall-suspect) only when there is spawnable work,
+    nothing was spawned, AND the zero-spawn is not explained by a benign,
+    self-clearing decline (concurrency cap saturated / provider rate-limit /
+    board lock held / respawn guard). A genuine hard fault (a spawn attempt
+    that was made and failed, or a circuit-breaker ``auto_blocked``) always
+    counts, even when a benign decline co-occurs on another board.
+
+    This is the fix for the false "check profile health (venv, PATH,
+    credentials)" warning that fires while the dispatcher is healthy but
+    throttled -- e.g. for the whole duration of a provider 429 window.
+    """
+    if not ready_pending or any_spawned:
+        return False
+    declined_benign = False
+    fault_seen = False
+    for _slug, res in (results or []):
+        if res is None:
+            continue
+        for name in _FAULT_FIELDS:
+            if getattr(res, name, None):
+                fault_seen = True
+        for name in _BENIGN_DECLINE_FIELDS:
+            if getattr(res, name, None):
+                declined_benign = True
+    return fault_seen or not declined_benign
+
+
 class GatewayKanbanWatchersMixin:
     """Kanban watcher / notifier / dispatcher loops for GatewayRunner."""
 
@@ -1371,9 +1427,25 @@ class GatewayKanbanWatchersMixin:
                             res.promoted,
                             len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
                         )
-                # Health telemetry (aggregate across boards)
+                # Health telemetry (aggregate across boards).
+                #
+                # A tick with ready work but zero spawns is only a REAL stall
+                # when the dispatcher tried and FAILED (broken venv/PATH/creds
+                # -> spawn_failed / circuit-breaker auto_block). It is NOT a
+                # stall when the dispatcher DECLINED for a benign, self-clearing
+                # reason: every eligible profile is at its concurrency cap, a
+                # worker bailed on a provider rate-limit / quota wall (released
+                # back to ``ready`` without counting a failure), or another
+                # process holds the board's dispatch lock. Those "declined"
+                # states look identical to a hard failure through the
+                # ``not any_spawned`` lens, which mis-fires the "check profile
+                # health (venv, PATH, credentials)" warning for the whole
+                # duration of a large fan-out or a provider-side 429 window --
+                # the assignee is simply throttled, not broken.
+                # ``_stall_streak_is_bad`` consults the DispatchResult buckets
+                # so telemetry can tell "busy/throttled" from "genuinely stuck".
                 ready_pending = await asyncio.to_thread(_ready_nonempty)
-                if ready_pending and not any_spawned:
+                if _stall_streak_is_bad(ready_pending, any_spawned, results):
                     bad_ticks += 1
                 else:
                     bad_ticks = 0
@@ -1382,8 +1454,9 @@ class GatewayKanbanWatchersMixin:
                     if now - last_warn_at >= 300:
                         logger.warning(
                             "kanban dispatcher stuck: ready queue non-empty for "
-                            "%d consecutive ticks but 0 workers spawned. Check "
-                            "profile health (venv, PATH, credentials) and "
+                            "%d consecutive ticks but 0 workers spawned, with no "
+                            "benign decline (cap/rate-limit/lock) to explain it. "
+                            "Check profile health (venv, PATH, credentials) and "
                             "`hermes kanban list --status ready`.",
                             bad_ticks,
                         )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6620,6 +6620,16 @@ class DispatchResult:
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
+    spawn_failed: list[str] = field(default_factory=list)
+    """Task ids whose spawn attempt failed THIS tick — recorded on every
+    failure (workspace resolution or worker launch), whether or not it was
+    the failure that tripped the circuit breaker. ``auto_blocked`` is the
+    subset that crossed ``failure_limit`` this tick; ``spawn_failed`` is the
+    superset including the earlier, pre-breaker failures. Health telemetry
+    consults this so a genuine early-phase spawn failure on one board is
+    visible as a fault immediately (failure #1), instead of staying invisible
+    until the breaker trips several ticks later — where a benign decline on a
+    DIFFERENT board could otherwise mask it and reset the stuck-streak."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
     stale: list[str] = field(default_factory=list)
@@ -8340,6 +8350,9 @@ def _dispatch_once_locked(
                 conn, claimed.id, f"workspace: {exc}",
                 failure_limit=failure_limit,
             )
+            # Record EVERY spawn failure (not just breaker trips) so a
+            # pre-circuit-breaker stall is visible to health telemetry.
+            result.spawn_failed.append(claimed.id)
             if auto:
                 result.auto_blocked.append(claimed.id)
             continue
@@ -8385,6 +8398,9 @@ def _dispatch_once_locked(
                 conn, claimed.id, str(exc),
                 failure_limit=failure_limit,
             )
+            # Record EVERY spawn failure (not just breaker trips) so a
+            # pre-circuit-breaker stall is visible to health telemetry.
+            result.spawn_failed.append(claimed.id)
             if auto:
                 result.auto_blocked.append(claimed.id)
 
@@ -8432,6 +8448,9 @@ def _dispatch_once_locked(
                 conn, claimed.id, f"workspace: {exc}",
                 failure_limit=failure_limit,
             )
+            # Record EVERY spawn failure (not just breaker trips) so a
+            # pre-circuit-breaker stall is visible to health telemetry.
+            result.spawn_failed.append(claimed.id)
             if auto:
                 result.auto_blocked.append(claimed.id)
             continue
@@ -8466,6 +8485,9 @@ def _dispatch_once_locked(
                 conn, claimed.id, str(exc),
                 failure_limit=failure_limit,
             )
+            # Record EVERY spawn failure (not just breaker trips) so a
+            # pre-circuit-breaker stall is visible to health telemetry.
+            result.spawn_failed.append(claimed.id)
             if auto:
                 result.auto_blocked.append(claimed.id)
     return result

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -67,3 +67,111 @@ def test_singleton_dispatcher_lock_is_exclusive(tmp_path):
     h3, st3 = _acquire_singleton_lock(lock)
     assert st3 == "held" and h3 is not None
     _release_singleton_lock(h3)
+
+
+# --- stuck-detector: benign decline vs genuine fault ---------------------------
+#
+# The dispatcher warns "check profile health (venv, PATH, credentials)" when the
+# ready queue is non-empty but nothing spawns for N consecutive ticks. That
+# condition is ALSO the healthy steady state when the dispatcher DECLINES to
+# spawn (every profile at its concurrency cap, an assignee 429-rate-limited, the
+# board lock held elsewhere, a respawn guard cooling a task down). The detector
+# must only count a tick as "bad" when the zero-spawn reflects a real fault --
+# otherwise a large fan-out or a provider 429 window mis-fires the warning for
+# as long as the throttle lasts.
+
+from gateway.kanban_watchers import (  # noqa: E402
+    _BENIGN_DECLINE_FIELDS,
+    _FAULT_FIELDS,
+    _stall_streak_is_bad,
+)
+
+
+def _result(**kw):
+    """A real ``DispatchResult`` so the detector is pinned to the real field
+    names -- a rename in kanban_db must break these tests, not silently turn
+    the detector into a no-op via ``getattr(..., default=None)``."""
+    from hermes_cli.kanban_db import DispatchResult
+
+    return DispatchResult(**kw)
+
+
+def test_stall_detector_consults_only_real_dispatchresult_fields():
+    """Invariant: every bucket the detector reads must exist on DispatchResult.
+
+    ``_stall_streak_is_bad`` reads its buckets with ``getattr(res, name, None)``
+    so a stale name degrades silently to "never fires". Pin the contract.
+    """
+    from hermes_cli.kanban_db import DispatchResult
+
+    fields = set(DispatchResult().__dataclass_fields__)
+    missing = [n for n in (_BENIGN_DECLINE_FIELDS + _FAULT_FIELDS) if n not in fields]
+    assert not missing, f"stuck-detector reads fields absent from DispatchResult: {missing}"
+
+
+def test_stall_idle_queue_is_not_bad():
+    # No spawnable work -> never a stall regardless of results.
+    assert _stall_streak_is_bad(False, False, [("b", _result())]) is False
+
+
+def test_stall_something_spawned_is_not_bad():
+    # We spawned this tick -> not a stall even with a full queue.
+    res = _result(spawned=[("t", "p", "/w")])
+    assert _stall_streak_is_bad(True, True, [("b", res)]) is False
+
+
+def test_stall_per_profile_cap_is_benign_not_bad():
+    # Ready work, zero spawns, but every eligible profile is at its
+    # kanban.max_in_progress_per_profile cap -> healthy, self-clearing.
+    res = _result(skipped_per_profile_capped=[("t1", "worker-a", 3)])
+    assert _stall_streak_is_bad(True, False, [("b", res)]) is False
+
+
+def test_stall_rate_limited_is_benign_not_bad():
+    # Assignee bounced off a provider 429/quota wall and the task was released
+    # back to ready WITHOUT counting a failure -> healthy, self-clearing.
+    res = _result(rate_limited=["t1"])
+    assert _stall_streak_is_bad(True, False, [("b", res)]) is False
+
+
+def test_stall_lock_held_is_benign_not_bad():
+    # Another dispatcher process holds the board's dispatch lock this tick;
+    # the lock holder is making progress on the same board -> healthy.
+    res = _result(skipped_locked=True)
+    assert _stall_streak_is_bad(True, False, [("b", res)]) is False
+
+
+def test_stall_respawn_guard_is_benign_not_bad():
+    # A respawn guard is cooling a task down -> healthy, self-clearing.
+    res = _result(respawn_guarded=[("t1", "recent_success")])
+    assert _stall_streak_is_bad(True, False, [("b", res)]) is False
+
+
+def test_stall_bare_zero_spawn_with_no_reason_IS_bad():
+    # Ready work, zero spawns, and NO benign decline to explain it -> genuine
+    # stall suspect. This is the true positive the warning exists to catch, and
+    # it must keep firing.
+    assert _stall_streak_is_bad(True, False, [("b", _result())]) is True
+
+
+def test_stall_auto_blocked_fault_IS_bad_even_with_benign_sibling():
+    # A circuit-breaker auto_block is a real fault and must count even when
+    # ANOTHER board declined benignly (cap saturated) the same tick.
+    faulted = _result(auto_blocked=["t1"])
+    capped = _result(skipped_per_profile_capped=[("t2", "worker-b", 2)])
+    assert _stall_streak_is_bad(True, False, [("b1", faulted), ("b2", capped)]) is True
+
+
+def test_stall_early_spawn_failure_IS_bad_even_with_benign_sibling():
+    # Cross-board masking: board A has an EARLY, pre-circuit-breaker spawn
+    # failure (spawn_failed populated but failure_limit not yet reached, so
+    # auto_blocked is still empty) while board B is benignly rate-limited the
+    # same tick. The benign decline on B must NOT mask the genuine fault on A.
+    early_fail = _result(spawn_failed=["t1"])  # not yet auto_blocked
+    rate_limited = _result(rate_limited=["t2"])
+    assert _stall_streak_is_bad(True, False, [("A", early_fail), ("B", rate_limited)]) is True
+
+
+def test_stall_none_results_bare_stall_is_bad():
+    # Defensive: a None board result contributes nothing; a bare stall counts.
+    assert _stall_streak_is_bad(True, False, [("b", None)]) is True

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4991,3 +4991,58 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+def test_dispatch_records_spawn_failure_before_the_breaker_trips(
+    kanban_home, all_assignees_spawnable
+):
+    """Every spawn failure lands in ``DispatchResult.spawn_failed`` on failure
+    #1 -- well before the circuit breaker's ``failure_limit`` auto-blocks it.
+
+    ``auto_blocked`` is only populated when the breaker TRIPS, so with it as
+    the sole fault signal the first ``failure_limit - 1`` failures of a broken
+    venv / PATH / credential set are invisible to the dispatcher's health
+    telemetry. ``spawn_failed`` is the superset that makes failure #1 visible.
+    """
+
+    def boom(task, workspace):
+        raise RuntimeError("no such venv: /nonexistent/bin/python")
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="broken-venv", assignee="alice")
+        res = kb.dispatch_once(conn, spawn_fn=boom, failure_limit=5)
+
+    assert t in res.spawn_failed, (
+        "an early spawn failure must be recorded in spawn_failed on failure #1; "
+        f"got spawn_failed={res.spawn_failed!r}"
+    )
+    assert t not in res.auto_blocked, (
+        "failure #1 of 5 must NOT trip the circuit breaker -- that gap is exactly "
+        "the window in which spawn_failed is the only fault signal available"
+    )
+
+
+def test_dispatch_spawn_failed_is_a_superset_of_auto_blocked(
+    kanban_home, all_assignees_spawnable
+):
+    """When the breaker finally trips, the task appears in BOTH buckets.
+
+    Pins the documented relationship (``auto_blocked`` is the breaker-trip
+    subset of ``spawn_failed``) so a future refactor cannot make them
+    disjoint and silently reintroduce the invisible-early-failure window.
+    """
+
+    def boom(task, workspace):
+        raise RuntimeError("no such venv: /nonexistent/bin/python")
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="breaker-trip", assignee="alice")
+        # failure_limit=1: the very first failure trips the breaker.
+        res = kb.dispatch_once(conn, spawn_fn=boom, failure_limit=1)
+
+    assert t in res.auto_blocked, "failure_limit=1 must auto-block on failure #1"
+    assert t in res.spawn_failed, (
+        "a breaker-tripping failure is still a spawn failure; auto_blocked must "
+        "remain a SUBSET of spawn_failed"
+    )
+    assert set(res.auto_blocked) <= set(res.spawn_failed)


### PR DESCRIPTION
# fix(kanban): stop the false "check profile health" stall warning when the dispatcher is throttled

## Symptom

The gateway kanban dispatcher logs, every 5 minutes:

```
kanban dispatcher stuck: ready queue non-empty for 6 consecutive ticks but 0
workers spawned. Check profile health (venv, PATH, credentials) and
`hermes kanban list --status ready`.
```

…for the entire duration of a provider rate-limit window, or of any large
fan-out where every eligible profile is at its concurrency cap. Nothing is
broken: the dispatcher resumes spawning normally the moment quota frees, and
there are **zero** `spawn_failed` events in the whole window. Users are told to
go audit their venv, PATH and credentials for a problem that does not exist.

## Root cause

`gateway/kanban_watchers.py`, in `_kanban_dispatcher_watcher`:

```python
ready_pending = await asyncio.to_thread(_ready_nonempty)
if ready_pending and not any_spawned:
    bad_ticks += 1
```

`ready_pending and not any_spawned` is not only the "stuck" condition — it is
*also* the healthy steady state whenever the dispatcher **declines** to spawn
for a benign, self-clearing reason:

| decline | `DispatchResult` bucket |
|---|---|
| every eligible profile is at `kanban.max_in_progress_per_profile` | `skipped_per_profile_capped` |
| assignee bounced off a provider rate-limit / quota wall (released back to `ready` without counting a failure) | `rate_limited` |
| another dispatcher process holds this board's dispatch lock this tick | `skipped_locked` |
| a respawn guard is cooling a task down | `respawn_guarded` |

`DispatchResult` already buckets each of those separately from real faults —
*precisely* so "busy/throttled" can be told apart from "genuinely stuck". Their
field docstrings say so verbatim (e.g. `skipped_per_profile_capped`: *"NOT an
operator-actionable failure … Separate bucket so telemetry / dashboards can
show 'this profile is busy' vs 'task is genuinely stuck'"*). The detector
simply never consulted them.

## Second defect found while fixing the first: cross-board fault masking

The detector aggregates across **all** boards in one tick. The only "genuine
fault" signal available was `DispatchResult.auto_blocked`, which is populated
**only when a board's spawn-failure circuit breaker trips** — after
`failure_limit` consecutive failures.

So an *early*, pre-breaker spawn failure on board A (broken venv / PATH /
credentials; failures `1 .. failure_limit-1`) was invisible as a fault. A
benign decline on board B in the same tick then reset the streak, masking A's
real stall until A's breaker finally tripped several ticks later. On a
multi-board gateway that alignment is routine, not theoretical — and it delays
the one warning a user actually needs.

## Fix

1. **`hermes_cli/kanban_db.py`** — add `DispatchResult.spawn_failed`, populated
   at **every** `_record_spawn_failure` call site (all four: workspace-resolution
   and worker-launch failures, in both the ready and the review dispatch
   columns), whether or not that failure tripped the breaker. `auto_blocked`
   stays the breaker-trip **subset**; `spawn_failed` is the superset including
   early failures. Purely additive: no existing field or call signature changes.

2. **`gateway/kanban_watchers.py`** — extract the bad-tick decision into a pure,
   unit-testable `_stall_streak_is_bad(ready_pending, any_spawned, results)`
   that counts a zero-spawn tick only when it is **not** explained by a benign
   decline, **or** when a genuine fault (`spawn_failed` / `auto_blocked`) is
   present anywhere in the tick. The true positive the warning exists to catch
   still fires — and now fires on failure **#1** instead of waiting for the
   breaker.

3. The warning text now states that no benign decline explains the streak, so a
   real fire is unambiguous rather than one more cry-wolf line.

## Tests

`tests/gateway/test_kanban_watchers_mixin.py` — 11 behavior-contract tests
covering both directions (each of the four benign declines stays quiet; a bare
unexplained zero-spawn, an `auto_blocked` fault alongside a benign sibling
board, and an early `spawn_failed` alongside a benign sibling board all count),
plus an invariant test asserting every bucket name the detector reads actually
exists on `DispatchResult` — the detector reads them via
`getattr(res, name, None)`, so a rename would otherwise degrade it silently to
"never fires".

The fake-result helper constructs a **real** `DispatchResult`, not a stand-in,
so the tests are pinned to the production dataclass.

`tests/hermes_cli/test_kanban_db.py` — 2 E2E tests through the real
`dispatch_once` with a failing `spawn_fn`: failure #1 of 5 lands in
`spawn_failed` and *not* in `auto_blocked` (the previously-invisible window),
and with `failure_limit=1` the task lands in **both**, pinning
`auto_blocked ⊆ spawn_failed`.

**RED proof** (production logic reverted to the pre-fix rule, tests unchanged):
6 of the 13 new tests fail — the four benign-decline cases and both E2E
`spawn_failed` cases. See `TEST-EVIDENCE.md`.

**GREEN:** `tests/gateway/test_kanban_watchers_mixin.py` +
`tests/hermes_cli/test_kanban_db.py` = **247 passed** (234 pre-existing on
clean `main`, +13 new). Zero pre-existing tests modified.
