### PR TITLE
fix(kanban): reclaim_task must not launder a blocked card into ready

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1830,13 +1830,23 @@ def _cmd_reclaim(args: argparse.Namespace) -> int:
             conn, args.task_id,
             reason=getattr(args, "reason", None),
         )
+        task = kb.get_task(conn, args.task_id) if ok else None
     if not ok:
         print(
             f"cannot reclaim {args.task_id} (not running or unknown id)",
             file=sys.stderr,
         )
         return 1
-    print(f"Reclaimed {args.task_id}")
+    status = task.status if task else None
+    if status in ("blocked", "triage", "scheduled"):
+        # A reclaim releases the claim; it does not promote. Say so, or the
+        # operator assumes the card is queued and waits for a worker forever.
+        print(
+            f"Reclaimed {args.task_id} (status held at {status!r} — "
+            f"run 'hermes kanban unblock {args.task_id}' to re-queue it)"
+        )
+    else:
+        print(f"Reclaimed {args.task_id}" + (f" ({status})" if status else ""))
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4475,6 +4475,12 @@ def reclaim_task(
     when an operator wants to abort a running worker without waiting
     for the TTL to expire (e.g. after seeing a hallucination warning).
 
+    A reclaim releases a *claim*; it never promotes. Rows parked in
+    ``blocked`` / ``triage`` / ``scheduled`` keep that status and only shed
+    their stale claim residue — promoting them here would feed them straight
+    back to the dispatcher and defeat the block. Use :func:`unblock_task` or
+    :func:`promote_task` to actually re-queue one.
+
     Returns True if a reclaim happened, False if the task isn't in a
     reclaimable state (not running, or doesn't exist).
     """
@@ -4491,13 +4497,27 @@ def reclaim_task(
     termination = _terminate_reclaimed_worker(
         row["worker_pid"], prev_lock, signal_fn=signal_fn,
     )
+    # A reclaim RELEASES A CLAIM; it is not a promotion. Laundering a
+    # ``blocked`` / ``triage`` / ``scheduled`` row into ``ready`` here hands it
+    # straight to the dispatcher, which claims and spawns a worker on the next
+    # tick — silently defeating ``--initial-status blocked``, a worker's
+    # ``review-required`` handoff, and the spawn-failure circuit breaker alike.
+    # Those rows keep their status and only lose the stale claim residue.
+    # Reclaiming a blocked card is also invisible to ``_has_sticky_block`` (it
+    # emits ``reclaimed``, never ``unblocked``), so the pre-fix path produced a
+    # genuinely incoherent row: ``status='ready'`` while still sticky-blocked,
+    # which ``recompute_ready`` and the dispatcher then disagree about.
+    # ``unblock_task`` / ``promote_task`` remain the only ways out of blocked.
+    held_status = row["status"]
+    preserve_status = held_status in ("blocked", "triage", "scheduled")
     with write_txn(conn):
         cur = conn.execute(
-            "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+            "UPDATE tasks SET status = ?, claim_lock = NULL, "
             "claim_expires = NULL, worker_pid = NULL "
-            "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
+            "WHERE id = ? AND status IN ('running', 'ready', 'blocked', "
+            "'triage', 'scheduled') "
             "AND claim_lock IS ?",
-            (task_id, prev_lock),
+            (held_status if preserve_status else "ready", task_id, prev_lock),
         )
         if cur.rowcount != 1:
             return False
@@ -4515,6 +4535,10 @@ def reclaim_task(
             "reason": reason,
             "prev_lock": prev_lock,
         }
+        if preserve_status:
+            # Make the non-promotion explicit in board history so an operator
+            # who reclaims a blocked card can see why it did NOT go ready.
+            payload["status_preserved"] = held_status
         payload.update(termination)
         _append_event(
             conn, task_id, "reclaimed",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3183,6 +3183,22 @@ def create_task(
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
+                if task_status == "blocked":
+                    # Parking a card in blocked at creation time is an explicit
+                    # operator decision (the documented purpose of
+                    # ``--initial-status blocked`` is the human-ops gate). Emit
+                    # the same "blocked" event ``block_task`` emits so
+                    # ``_has_sticky_block`` treats it as sticky — otherwise
+                    # ``recompute_ready`` auto-promotes a parentless blocked
+                    # card to ready on the next dispatcher tick and a worker
+                    # gets spawned, defeating the flag entirely.
+                    # ``unblock_task`` remains the legitimate exit.
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"reason": "created with initial_status=blocked"},
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4999,3 +4999,88 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+def test_initial_status_blocked_is_sticky_across_recompute(kanban_home):
+    """A task created with ``initial_status='blocked'`` must survive
+    ``recompute_ready`` — the flag's documented purpose is parking a card for
+    human ops, so the dispatcher must not auto-promote it.
+
+    Regression: ``create_task`` set ``status='blocked'`` but emitted no
+    ``blocked`` event, so ``_has_sticky_block`` returned False and
+    ``recompute_ready`` promoted the (parentless) card to ready on the next
+    dispatcher tick, spawning a worker for a card that explicitly asked not to
+    be dispatched.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="parked", initial_status="blocked")
+        assert kb.get_task(conn, t).status == "blocked"
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 0
+        assert kb.get_task(conn, t).status == "blocked"
+        # The card must be sticky by the same predicate an operator block uses.
+        assert kb._has_sticky_block(conn, t) is True
+        row = conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? "
+            "AND kind IN ('blocked', 'unblocked') ORDER BY id DESC LIMIT 1",
+            (t,),
+        ).fetchone()
+        assert row is not None and row["kind"] == "blocked"
+
+
+def test_initial_status_blocked_survives_a_real_dispatcher_pass(
+    kanban_home, all_assignees_spawnable
+):
+    """E2E: the dispatcher must not spawn a worker on a created-blocked card.
+
+    ``recompute_ready`` runs inside ``dispatch_once``, so the promotion above
+    is not academic: it hands the card to the claim + spawn path on the very
+    next tick.
+    """
+    spawned = []
+
+    def fake_spawn(task, workspace):
+        spawned.append(task.id)
+
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn, title="do not dispatch me", assignee="alice",
+            initial_status="blocked",
+        )
+        kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        assert spawned == [], (
+            "a card created with initial_status=blocked must never be spawned"
+        )
+        assert kb.get_task(conn, t).status == "blocked"
+
+
+def test_initial_status_blocked_unblock_releases(kanban_home):
+    """``unblock_task`` is the legitimate exit from a created-blocked card —
+    after an explicit unblock, normal flow may promote it."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="parked", initial_status="blocked")
+        assert kb.unblock_task(conn, t)
+        assert kb.get_task(conn, t).status in ("ready", "todo")
+        # And it stays promotable: recompute must not re-block it.
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, t).status in ("ready", "todo")
+        assert kb._has_sticky_block(conn, t) is False
+
+
+def test_initial_status_blocked_with_done_parents_stays_blocked(kanban_home):
+    """Sticky beats the parents-are-done promotion rule.
+
+    ``recompute_ready`` promotes a blocked task whose parents are all done.
+    An explicitly parked card must not be promoted by that rule either --
+    otherwise completing an unrelated parent silently releases the gate.
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        kb.claim_task(conn, parent)
+        kb.complete_task(conn, parent)
+        child = kb.create_task(
+            conn, title="parked child", parents=[parent],
+            initial_status="blocked",
+        )
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "blocked"

--- a/tests/hermes_cli/test_kanban_reclaim_blocked_status_guard.py
+++ b/tests/hermes_cli/test_kanban_reclaim_blocked_status_guard.py
@@ -1,0 +1,254 @@
+"""Tests: ``reclaim_task`` releases a CLAIM, it never promotes a blocked card.
+
+Regression for the dispatcher blocked-status bug: a card parked in ``blocked``
+(via ``--initial-status blocked``, a worker's ``review-required`` handoff, or the
+circuit breaker) that still carried stale claim residue could be laundered into
+``ready`` by an operator reclaim. ``reclaim_task`` unconditionally wrote
+``status='ready'`` while accepting ``blocked`` in its WHERE clause, so the next
+dispatcher tick claimed the row and spawned a worker on a card that was supposed
+to be held — defeating the block entirely and burning worker budget.
+
+The reclaim also emitted only a ``reclaimed`` event, never ``unblocked``, so
+``_has_sticky_block`` still reported True: the row ended up ``status='ready'``
+AND sticky-blocked at the same time, an incoherent state no other writer can
+produce.
+
+``unblock_task`` / ``promote_task`` remain the only ways out of ``blocked``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def conn(kanban_home, monkeypatch):
+    # The dispatcher refuses to spawn for an assignee that isn't a real Hermes
+    # profile. Without this the "did not spawn" assertions below would pass
+    # trivially (skipped_nonspawnable) instead of proving the status guard.
+    import hermes_cli.profiles as _profiles
+
+    monkeypatch.setattr(_profiles, "profile_exists", lambda name: True)
+    with kb.connect() as c:
+        yield c
+
+
+def _status(conn, tid):
+    return conn.execute(
+        "SELECT status FROM tasks WHERE id = ?", (tid,)
+    ).fetchone()["status"]
+
+
+def _stamp_stale_claim(conn, tid, lock="ghost-host:4242"):
+    """Leave a dead worker's claim residue on the row without touching status."""
+    conn.execute(
+        "UPDATE tasks SET claim_lock = ?, worker_pid = ? WHERE id = ?",
+        (lock, 999999, tid),
+    )
+    conn.commit()
+
+
+def test_reclaim_does_not_promote_initial_status_blocked_card(conn):
+    """A card created ``--initial-status blocked`` stays blocked across a reclaim."""
+    tid = kb.create_task(
+        conn, title="held card", assignee="w", initial_status="blocked",
+    )
+    assert _status(conn, tid) == "blocked"
+    _stamp_stale_claim(conn, tid)
+
+    assert kb.reclaim_task(conn, tid) is True
+
+    # The claim residue is gone...
+    row = conn.execute(
+        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?", (tid,)
+    ).fetchone()
+    assert row["claim_lock"] is None
+    assert row["worker_pid"] is None
+    # ...but the block held. Pre-fix this was 'ready'.
+    assert row["status"] == "blocked"
+
+
+def test_dispatcher_does_not_spawn_a_reclaimed_blocked_card(conn):
+    """End-to-end: reclaim a blocked card, then run a real dispatcher pass."""
+    tid = kb.create_task(
+        conn, title="do not dispatch me", assignee="w", initial_status="blocked",
+    )
+    _stamp_stale_claim(conn, tid)
+    kb.reclaim_task(conn, tid)
+
+    spawned: list[str] = []
+
+    def spawn_fn(task, workspace, board=None, **kwargs):
+        spawned.append(task.id)
+        return 4242
+
+    kb.dispatch_once(conn, spawn_fn=spawn_fn)
+
+    # Pre-fix: the reclaim left it 'ready', the dispatcher claimed it and
+    # spawned a worker on a card the operator had explicitly held.
+    assert spawned == []
+    assert _status(conn, tid) == "blocked"
+
+
+def test_reclaim_leaves_blocked_card_coherent_with_sticky_block(conn):
+    """A reclaimed blocked card must not be 'ready' while still sticky-blocked."""
+    tid = kb.create_task(
+        conn, title="sticky", assignee="w", initial_status="blocked",
+    )
+    _stamp_stale_claim(conn, tid)
+    kb.reclaim_task(conn, tid)
+
+    # reclaim emits 'reclaimed', never 'unblocked' — so the task is still
+    # sticky-blocked. Status must agree with that, or recompute_ready and the
+    # dispatcher disagree about whether the card is available.
+    assert kb._has_sticky_block(conn, tid) is True
+    assert _status(conn, tid) == "blocked"
+
+
+def test_reclaim_preserves_worker_review_required_block(conn):
+    """The ``review-required`` handoff survives a reclaim (real incident shape)."""
+    tid = kb.create_task(conn, title="review handoff", assignee="w")
+    kb.claim_task(conn, tid)
+    assert kb.block_task(
+        conn, tid, reason="review-required: needs a human look",
+    ) is True
+    assert _status(conn, tid) == "blocked"
+
+    _stamp_stale_claim(conn, tid)
+    kb.reclaim_task(conn, tid)
+
+    assert _status(conn, tid) == "blocked"
+
+
+def test_reclaim_records_the_preserved_status_in_board_history(conn):
+    """Operators can see why a reclaimed blocked card did not go ready."""
+    tid = kb.create_task(
+        conn, title="held", assignee="w", initial_status="blocked",
+    )
+    _stamp_stale_claim(conn, tid)
+    kb.reclaim_task(conn, tid)
+
+    payloads = [
+        r["payload"] for r in conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'reclaimed'",
+            (tid,),
+        )
+    ]
+    assert payloads, "reclaim should append a 'reclaimed' event"
+    assert any("status_preserved" in (p or "") for p in payloads)
+
+
+def test_reclaim_still_returns_a_running_task_to_ready(conn):
+    """The primary reclaim contract is unchanged: running -> ready."""
+    tid = kb.create_task(conn, title="live worker", assignee="w")
+    kb.claim_task(conn, tid)
+    assert _status(conn, tid) == "running"
+
+    assert kb.reclaim_task(conn, tid) is True
+    assert _status(conn, tid) == "ready"
+
+    spawned: list[str] = []
+
+    def spawn_fn(task, workspace, board=None, **kwargs):
+        spawned.append(task.id)
+        return 4242
+
+    kb.dispatch_once(conn, spawn_fn=spawn_fn)
+    # A genuinely reclaimed running task MUST become dispatchable again.
+    assert spawned == [tid]
+
+
+def test_reclaim_does_not_promote_a_triage_card(conn):
+    """Same bug class: ``triage`` is a pre-dispatch parking column too.
+
+    ``reclaim_task``'s WHERE clause did not accept ``triage``, so a triage row
+    carrying stale claim residue could not be reclaimed at ALL (returned
+    False). It must now be reclaimable *without* being promoted -- the
+    specifier/decomposer owns the triage -> todo transition.
+    """
+    tid = kb.create_task(conn, title="unspecified idea", assignee="w", triage=True)
+    assert _status(conn, tid) == "triage"
+    _stamp_stale_claim(conn, tid)
+
+    assert kb.reclaim_task(conn, tid) is True
+    row = conn.execute(
+        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?", (tid,)
+    ).fetchone()
+    assert row["claim_lock"] is None and row["worker_pid"] is None
+    assert row["status"] == "triage"
+
+
+def test_no_claim_release_path_promotes_a_parked_row(conn):
+    """Whole-bug-class invariant over the module source.
+
+    A claim-release UPDATE that writes a LITERAL ``status = 'ready'`` while
+    accepting a parking status (``blocked`` / ``triage`` / ``scheduled``) in its
+    WHERE clause is the exact shape of this bug: it launders a held card into
+    the dispatcher's queue. The sibling paths (``release_stale_claims``,
+    ``detect_crashed_workers``, ``enforce_max_runtime``) are all scoped to
+    ``status = 'running'``, so ``reclaim_task`` was the only offender -- pin
+    that, so a future writer widening a sibling's WHERE clause has to confront
+    this test instead of silently reintroducing the bug on another path.
+    """
+    import inspect
+    import re
+
+    src = inspect.getsource(kb)
+    parked = ("blocked", "triage", "scheduled")
+    offenders = []
+    # Each claim-clearing UPDATE, from the SET through the end of the SQL string
+    # group (the call's closing paren).
+    for m in re.finditer(r'"UPDATE tasks SET status = ', src):
+        chunk = src[m.start():m.start() + 700]
+        chunk = chunk[:chunk.find(")\n") + 1] or chunk
+        if "claim_lock = NULL" not in chunk:
+            continue
+        writes_ready_literal = "status = 'ready'" in chunk
+        accepts_parked = any(f"'{p}'" in chunk.split("WHERE", 1)[-1] for p in parked)
+        if writes_ready_literal and accepts_parked:
+            offenders.append(chunk.splitlines()[0].strip())
+    assert not offenders, (
+        "claim-release UPDATE promotes a parked row to a literal 'ready': "
+        + repr(offenders)
+    )
+
+
+def test_cli_reclaim_tells_the_operator_the_card_is_still_held(conn, capsys):
+    """The CLI must not print a bare 'Reclaimed <id>' for a held card.
+
+    A bare success line reads as 'it's queued again', so the operator waits for
+    a worker that will never come. Point at ``unblock`` instead.
+    """
+    import argparse
+
+    from hermes_cli import kanban as kcli
+
+    tid = kb.create_task(
+        conn, title="held", assignee="w", initial_status="blocked",
+    )
+    _stamp_stale_claim(conn, tid)
+
+    rc = kcli._cmd_reclaim(argparse.Namespace(task_id=tid, reason=None))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "blocked" in out and "unblock" in out, out


### PR DESCRIPTION
> **Stacked on #71977** — this branch is based on
> `fix(kanban): make --initial-status blocked sticky against recompute_ready`,
> so the diff shown here includes that commit until #71977 merges. The two are
> independent halves of the same hold-defeating bug (creation-time stickiness
> vs. reclaim-time promotion); either can merge first, and this branch will
> shrink to its own commit once #71977 lands. Review only
> `f511d3746` for this PR's change.

# fix(kanban): reclaim must not launder a blocked card into ready

> **Stacked on the `--initial-status blocked` sticky fix.** Review only the top
> commit; the diff includes the base PR until it merges. The base PR is what
> makes `initial_status="blocked"` sticky at all — without it, three of the
> tests here can't distinguish this bug from that one. Merge order: base, then
> this.

## Symptom

An operator reclaim on a card parked in `blocked` promotes it to `ready`,
handing it straight to the dispatcher, which claims it and spawns a worker on
the next tick. This silently defeats every hold mechanism the board has:
`--initial-status blocked`, a worker's `review-required` handoff, and the
spawn-failure circuit breaker alike.

## Root cause

`hermes_cli/kanban_db.py`, `reclaim_task`:

```python
cur = conn.execute(
    "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
    "claim_expires = NULL, worker_pid = NULL "
    "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
    "AND claim_lock IS ?",
    (task_id, prev_lock),
)
```

The WHERE clause **accepts** `blocked` while the SET writes an unconditional
literal `'ready'`. A reclaim releases a *claim*; it is not a promotion.

The row it produces is worse than merely promoted: `reclaim_task` emits only a
`reclaimed` event, never `unblocked`, so `_has_sticky_block` still reports
`True` afterwards. The card ends up `status='ready'` **and** sticky-blocked
simultaneously — a state no other writer can produce, and one that
`recompute_ready` and the dispatcher disagree about.

## Whole bug class

The sibling reclaim paths were already correct — `release_stale_claims`
(:4355), `detect_crashed_workers` (:7066, :7192), `enforce_max_runtime` (:7450)
and the failure-recording path (:7728) all scope their UPDATE to
`status = 'running'`. Only the operator-driven `reclaim_task` accepted a parking
status, so this is the whole class. A source-level invariant test pins that, so
a future writer widening a sibling's WHERE clause has to confront it.

`triage` and `scheduled` are the same category of pre-dispatch parking column
and get the same treatment. `triage` additionally gains the *ability* to be
reclaimed: it wasn't in the old WHERE clause at all, so a triage row carrying
stale claim residue simply returned `False` and stayed stuck.

## Fix

* Rows in `blocked` / `triage` / `scheduled` keep their status and shed only
  the stale claim residue (`claim_lock` / `claim_expires` / `worker_pid`).
  `unblock_task` and `promote_task` remain the only ways out of `blocked`.
* The `reclaimed` event records `status_preserved`, so board history shows why
  a reclaimed blocked card did not go ready.
* `hermes kanban reclaim` reports the held status and points at `unblock`,
  instead of printing a bare `Reclaimed <id>` that reads as "it's queued again"
  and leaves the operator waiting for a worker forever.

No new state, no signature changes. **+38/−4 across two files.**

## Tests

New `tests/hermes_cli/test_kanban_reclaim_blocked_status_guard.py`, 9 tests:

| test | proves |
|---|---|
| `..._initial_status_blocked_card` | claim residue cleared, status held at `blocked` |
| `test_dispatcher_does_not_spawn_a_reclaimed_blocked_card` | E2E through a real `dispatch_once`: `spawn_fn` never called |
| `..._coherent_with_sticky_block` | no `status='ready'` + sticky-blocked row |
| `..._preserves_worker_review_required_block` | the `review-required` handoff survives |
| `..._promote_a_triage_card` | `triage` is now reclaimable *and* not promoted |
| `test_no_claim_release_path_promotes_a_parked_row` | source invariant over every claim-release `UPDATE` |
| `..._records_the_preserved_status_in_board_history` (control) | `status_preserved` in the event payload |
| `test_reclaim_still_returns_a_running_task_to_ready` (control) | primary contract unchanged: `running` → `ready` → dispatchable |
| `test_cli_reclaim_tells_the_operator_the_card_is_still_held` | CLI no longer prints a misleading bare success line |

The `running` → `ready` → *actually spawns* control is deliberate: it caught an
earlier version of this suite that was false-greening on
`skipped_nonspawnable` (the dispatcher refuses assignees that aren't real
profiles, so "did not spawn" can pass trivially). The fixture patches
`profile_exists` so the negative assertions prove the status guard, not the
profile guard.

**RED proof** (both production changes reverted, tests unchanged): **7 of 9
fail**. The two survivors are the controls. See `TEST-EVIDENCE.md`.

**GREEN:** 259 passed across `test_kanban_db.py`, this file,
`test_kanban_decompose_db.py`, `test_kanban_worktree_isolation.py`.
