### PR TITLE
fix(compression): don't dead-end compaction when no codex thread exists

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3456,6 +3456,16 @@ FOCUS TOPIC: "{focus_topic}"
 This compaction should PRIORITISE preserving all information related to the focus topic above. For content related to "{focus_topic}", include full detail — exact values, file paths, command outputs, error messages, and decisions. For content NOT related to the focus topic, summarise more aggressively (brief one-liners or omit if truly irrelevant). The focus topic sections should receive roughly 60-70% of the summary token budget. Even for the focus topic, NEVER preserve API keys, tokens, passwords, or credentials — use [REDACTED]."""
 
         try:
+            # codex_app_server is a stateful thread transport with no one-shot
+            # completion surface; the auxiliary client has no route for it and
+            # would fall through to a plain chat.completions call against the
+            # Codex backend, which fails. The summary call is a single stateless
+            # request, so downgrade to the Responses wire — same credentials,
+            # same billing, same model. Mirrors the identical downgrade in
+            # ``agent/background_review.py::_resolve_review_runtime``.
+            _summary_api_mode = self.api_mode
+            if _summary_api_mode == "codex_app_server":
+                _summary_api_mode = "codex_responses"
             call_kwargs = {
                 "task": "compression",
                 "main_runtime": {
@@ -3463,7 +3473,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                     "provider": self.provider,
                     "base_url": self.base_url,
                     "api_key": self.api_key,
-                    "api_mode": self.api_mode,
+                    "api_mode": _summary_api_mode,
                 },
                 "messages": [{"role": "user", "content": prompt}],
                 # NO max_tokens: the output cap must never truncate a summary.

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1340,7 +1340,22 @@ def compress_context(
     # The memory-provider context handoff below is intentionally Hermes-only:
     # the app server does not expose its native summary prompt, so there is no
     # truthful injection point for ``on_pre_compress()`` return text here.
-    if getattr(agent, "api_mode", None) == "codex_app_server":
+    #
+    # Only divert when a live codex thread actually exists to compact. Without
+    # one there is nothing for the app server to shrink, and
+    # ``_compress_context_via_codex_app_server()`` returns the transcript
+    # unchanged — so diverting here would make compaction a silent permanent
+    # no-op. Two routine cases hit that: gateway session-hygiene builds a fresh
+    # throwaway AIAgent (it never owns a thread), and preflight compaction runs
+    # before a retired thread has been re-established. In both the local
+    # transcript IS the whole context that seeds the next thread, so Hermes'
+    # own in-place compaction is the correct — and only — way to shrink it.
+    # Falling through here also keeps the count-based hard safety valve
+    # (``compression.hygiene_hard_message_limit``) able to do its job.
+    if (
+        getattr(agent, "api_mode", None) == "codex_app_server"
+        and getattr(agent, "_codex_session", None) is not None
+    ):
         _codex_fence_entered = False
         if commit_fence is not None:
             _codex_fence_entered = commit_fence.begin_commit()

--- a/tests/run_agent/test_codex_app_server_compaction.py
+++ b/tests/run_agent/test_codex_app_server_compaction.py
@@ -292,3 +292,75 @@ def test_codex_native_boundary_clears_stale_hermes_fallback_streak():
     assert _record_codex_app_server_compaction(agent, turn) is True
     assert compressor._fallback_compression_streak == 0
     assert compressor._verify_compaction_cleared_threshold is True
+
+
+def test_codex_app_server_without_live_thread_falls_through_to_hermes_compaction(
+    monkeypatch,
+):
+    """No codex thread => Hermes must compact its own transcript instead.
+
+    Diverting to the app server when ``_codex_session`` is None made
+    compaction a permanent silent no-op: the app-server helper returns the
+    transcript unchanged, so the caller saw neither a rotation nor an in-place
+    compaction and preserved the full history. Two routine paths hit this on
+    every cycle — gateway session-hygiene builds a fresh throwaway AIAgent that
+    never owns a thread, and preflight compaction runs before a retired thread
+    is re-established. The transcript then grows without bound until the replay
+    is too large for the app server, which retires the thread again: a spiral
+    that never self-recovers and reads to the user as the agent losing its
+    memory between messages.
+    """
+    agent = DummyAgent(TurnResult(thread_id="thread-1", turn_id="compact-turn-1"))
+    agent._codex_session = None
+
+    diverted = []
+    monkeypatch.setattr(
+        "agent.conversation_compression._compress_context_via_codex_app_server",
+        lambda *a, **kw: diverted.append(True) or (a[1], "cached prompt"),
+    )
+    # Stop the fall-through at its first guard so the assertion is about the
+    # routing decision only, not the whole local compression pipeline (which
+    # needs a full AIAgent). Reaching this sentinel IS the pass condition.
+    class ReachedHermesPath(Exception):
+        pass
+
+    def _guard(*_a, **_kw):
+        raise ReachedHermesPath
+
+    monkeypatch.setattr(
+        "agent.conversation_compression._refresh_persisted_compression_guards",
+        _guard,
+    )
+
+    with pytest.raises(ReachedHermesPath):
+        compress_context(
+            agent,
+            [{"role": "user", "content": "hi"}],
+            "system",
+            approx_tokens=100000,
+            task_id="test",
+        )
+
+    assert diverted == [], "must not divert to the app server with no live thread"
+
+
+def test_codex_app_server_with_live_thread_still_routes_to_codex(monkeypatch):
+    """The fall-through must not regress native thread compaction."""
+    agent = DummyAgent(TurnResult(thread_id="thread-1", turn_id="compact-turn-1"))
+
+    diverted = []
+    monkeypatch.setattr(
+        "agent.conversation_compression._compress_context_via_codex_app_server",
+        lambda *a, **kw: diverted.append(True) or (a[1], "cached prompt"),
+    )
+
+    compress_context(
+        agent,
+        [{"role": "user", "content": "hi"}],
+        "system",
+        approx_tokens=100000,
+        task_id="test",
+        force=True,
+    )
+
+    assert diverted == [True]


### PR DESCRIPTION
## Problem

Under `model.openai_runtime: codex_app_server`, `compress_context()` diverts **all** compaction to `_compress_context_via_codex_app_server()`. That helper returns the transcript unchanged when `agent._codex_session is None` — and two routine paths always satisfy that condition:

1. **Gateway session-hygiene** builds a fresh throwaway `AIAgent` purely to compress (`gateway/run.py`, the `_hyg_agent` block). It has never owned a codex thread.
2. **Preflight compaction** runs before a retired thread has been re-established.

In both cases the caller sees neither a rotation nor an in-place compaction, so it preserves the full history and logs a success-shaped line that is actually a no-op:

```
INFO  Session hygiene: compressed 834 -> 834 msgs, ~325,877 -> ~325,877 tokens
WARN  ...did not rotate or compact in place (no session_db on the hygiene agent)
      -- preserving the original transcript instead of overwriting it with the summary (#21301).
```

Two things make this hard to diagnose:

- The warning's `no session_db on the hygiene agent` text is misleading. `session_db` **was** present and correctly wired; the transcript was never compacted because the app-server helper declined. The `else` branch attributes the outcome to the wrong cause.
- The `INFO` line reports `N -> N` as a normal compression result, so nothing looks like a failure.

`compression.hygiene_hard_message_limit` cannot save the session either: it only *triggers* the attempt, which then hits the same dead end.

### Observed impact

On a long-lived Telegram session the local transcript grew monotonically:

```
messages=541  tokens=~1,457,663
messages=677  tokens=~1,664,508
messages=771  tokens=~1,750,341
messages=836  tokens=~1,958,426
```

24 consecutive `codex app-server compaction skipped: no active codex thread` entries in one session. Once the transcript is too large to replay, the app server goes silent and the thread is retired (`codex went silent for 90s after a tool result`) — which re-enters the same skip, so **the spiral never self-recovers**. User-visible symptom: the agent appears to lose its memory between messages and cannot carry a task across turns.

## Fix

Only divert to the app server when a live thread actually exists to compact. Without one, the local transcript *is* the whole context that seeds the next thread, so Hermes' own in-place compaction is the correct — and only — way to shrink it. This also restores the count-based safety valve.

Second change: downgrade `codex_app_server` -> `codex_responses` for the summariser call in `ContextCompressor`. `codex_app_server` is a stateful thread transport with no one-shot completion surface; `auxiliary_client` has no route for it, so the call fell through to a plain `chat.completions` request against the Codex backend and failed. This mirrors the identical downgrade already present in `background_review.py::_resolve_review_runtime`.

## Verification

Integration-checked against a copy of an affected production database (971-message session, ~1.96M tokens), running the real code path with only the summariser LLM call stubbed:

```
BEFORE  active=971  archived=0
AFTER   active=234  archived=971
in_place flag: True

active set shrank ................ PASS (971 -> 234)
old turns archived, not deleted .. PASS (0 -> 971)
no rows lost ..................... PASS
```

The same path returned `971 -> 971` before the change. `archive_and_compact()`'s non-destructive contract holds — all pre-compaction turns remain on disk and searchable.

Test suites: `tests/run_agent/test_codex_app_server_compaction.py` and `tests/gateway/test_session_hygiene.py` pass (39), plus the broader `tests/agent` compression/compaction selection.

## Tests added

- `test_codex_app_server_without_live_thread_falls_through_to_hermes_compaction` — asserts the app-server helper is **not** called and Hermes' own path is reached. Verified to fail without the fix (`DID NOT RAISE`).
- `test_codex_app_server_with_live_thread_still_routes_to_codex` — guards against regressing native thread compaction.

There was no existing coverage for `_codex_session is None`, which is why this shipped.

## Note

The misleading `no session_db on the hygiene agent` wording in `gateway/run.py` is left untouched to keep this diff minimal, but it is worth rewording separately — it sent me down an unrelated FTS-corruption investigation before I found the real cause.