### PR TITLE
feat(whatsapp): support externally managed bridge hosts

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -991,6 +991,11 @@ platform_toolsets:
 #       # Route scripts default to a 30 second timeout. Scripts must live under
 #       # the active profile's scripts directory and receive webhook JSON on stdin.
 #       script_timeout_seconds: 30
+#   whatsapp:
+#     extra:
+#       # Use an externally managed bridge (for example, a host-side bridge
+#       # reachable from a Dockerized Hermes gateway).
+#       bridge_host: "172.17.0.1"
 #
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1337,7 +1337,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             import aiohttp
 
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/read",
+                f"{self._bridge_url}/read",
                 json={"key": key},
                 timeout=aiohttp.ClientTimeout(total=5),
             ) as resp:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -398,6 +398,19 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             WhatsAppAdapter._DEFAULT_BRIDGE_DIR = resolve_whatsapp_bridge_dir()
         self._bridge_process: Optional[subprocess.Popen] = None
         self._bridge_port: int = config.extra.get("bridge_port", 3000)
+        # A non-loopback bridge host is an explicitly externally managed
+        # bridge (for example, Hermes in Docker talking to a host bridge).
+        # Keep the historic loopback endpoint and lifecycle as the default.
+        self._bridge_host = str(
+            config.extra.get("bridge_host")
+            or os.getenv("WHATSAPP_BRIDGE_HOST", "127.0.0.1")
+        ).strip() or "127.0.0.1"
+        self._bridge_host = self._bridge_host.strip("[]")
+        url_host = f"[{self._bridge_host}]" if ":" in self._bridge_host else self._bridge_host
+        self._bridge_url = f"http://{url_host}:{self._bridge_port}"
+        self._external_bridge = self._bridge_host.lower() not in {
+            "localhost", "127.0.0.1", "::1",
+        }
         self._bridge_script: Optional[str] = config.extra.get(
             "bridge_script",
             str(self._DEFAULT_BRIDGE_DIR / "bridge.js"),
@@ -473,6 +486,28 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         
         This launches the Node.js bridge process and waits for it to be ready.
         """
+        if getattr(self, "_external_bridge", False):
+            # Do not inspect local credentials, install npm packages, or kill
+            # a port when another machine owns the bridge lifecycle.
+            try:
+                import aiohttp
+
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(
+                        f"{self._bridge_url}/health",
+                        timeout=aiohttp.ClientTimeout(total=5),
+                    ) as resp:
+                        if resp.status != 200:
+                            raise RuntimeError(f"HTTP {resp.status}")
+                self._http_session = aiohttp.ClientSession()
+                self._poll_task = asyncio.create_task(self._poll_messages())
+                self._mark_connected()
+                print(f"[{self.name}] Using external bridge at {self._bridge_url}")
+                return True
+            except Exception as e:
+                logger.warning("[%s] External WhatsApp bridge unavailable at %s: %s", self.name, self._bridge_url, e)
+                return False
+
         if not check_whatsapp_requirements():
             logger.warning("[%s] Node.js not found. WhatsApp requires Node.js.", self.name)
             self._set_fatal_error(
@@ -580,7 +615,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             try:
                 async with aiohttp.ClientSession() as session:
                     async with session.get(
-                        f"http://127.0.0.1:{self._bridge_port}/health",
+                        f"{self._bridge_url}/health",
                         timeout=aiohttp.ClientTimeout(total=2)
                     ) as resp:
                         if resp.status == 200:
@@ -690,7 +725,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 try:
                     async with aiohttp.ClientSession() as session:
                         async with session.get(
-                            f"http://127.0.0.1:{self._bridge_port}/health",
+                            f"{self._bridge_url}/health",
                             timeout=aiohttp.ClientTimeout(total=2)
                         ) as resp:
                             if resp.status == 200:
@@ -722,7 +757,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     try:
                         async with aiohttp.ClientSession() as session:
                             async with session.get(
-                                f"http://127.0.0.1:{self._bridge_port}/health",
+                                f"{self._bridge_url}/health",
                                 timeout=aiohttp.ClientTimeout(total=2)
                             ) as resp:
                                 if resp.status == 200:
@@ -893,7 +928,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     payload["replyTo"] = reply_to
 
                 async with self._http_session.post(
-                    f"http://127.0.0.1:{self._bridge_port}/send",
+                    f"{self._bridge_url}/send",
                     json=payload,
                     timeout=aiohttp.ClientTimeout(total=30)
                 ) as resp:
@@ -936,7 +971,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         try:
             import aiohttp
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/edit",
+                f"{self._bridge_url}/edit",
                 json={
                     "chatId": to_whatsapp_jid(chat_id),
                     "messageId": message_id,
@@ -983,7 +1018,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 payload["fileName"] = file_name
 
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/send-media",
+                f"{self._bridge_url}/send-media",
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=120),
             ) as resp:
@@ -1030,7 +1065,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "selectableCount": selectable_count,
             }
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/send-poll",
+                f"{self._bridge_url}/send-poll",
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
@@ -1117,7 +1152,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if address:
                 payload["address"] = address
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/send-location",
+                f"{self._bridge_url}/send-location",
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
@@ -1216,7 +1251,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # leaves the response object alive until GC, holding its TCP
             # socket in CLOSE_WAIT. See #18451.
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/typing",
+                f"{self._bridge_url}/typing",
                 json={"chatId": to_whatsapp_jid(chat_id)},
                 timeout=aiohttp.ClientTimeout(total=5)
             ):
@@ -1235,7 +1270,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             import aiohttp
 
             async with self._http_session.get(
-                f"http://127.0.0.1:{self._bridge_port}/chat/{to_whatsapp_jid(chat_id)}",
+                f"{self._bridge_url}/chat/{to_whatsapp_jid(chat_id)}",
                 timeout=aiohttp.ClientTimeout(total=10)
             ) as resp:
                 if resp.status == 200:
@@ -1263,7 +1298,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 break
             try:
                 async with self._http_session.get(
-                    f"http://127.0.0.1:{self._bridge_port}/messages",
+                    f"{self._bridge_url}/messages",
                     timeout=aiohttp.ClientTimeout(total=30)
                 ) as resp:
                     if resp.status == 200:
@@ -1647,6 +1682,12 @@ async def _standalone_send(
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         bridge_port = extra.get("bridge_port", 3000)
+        bridge_host = str(
+            extra.get("bridge_host")
+            or os.getenv("WHATSAPP_BRIDGE_HOST", "localhost")
+        ).strip().strip("[]") or "localhost"
+        url_host = f"[{bridge_host}]" if ":" in bridge_host else bridge_host
+        bridge_url = f"http://{url_host}:{bridge_port}"
         normalized_chat_id = to_whatsapp_jid(chat_id)
         media = media_files or []
         text = message or ""
@@ -1659,7 +1700,7 @@ async def _standalone_send(
             #    or when the text is delivered as the media caption instead).
             if text.strip() and not media_caption:
                 async with session.post(
-                    f"http://localhost:{bridge_port}/send",
+                    f"{bridge_url}/send",
                     json={"chatId": normalized_chat_id, "message": text},
                     timeout=aiohttp.ClientTimeout(total=30),
                 ) as resp:
@@ -1682,7 +1723,7 @@ async def _standalone_send(
                     if media_caption:
                         try:
                             async with session.post(
-                                f"http://localhost:{bridge_port}/send",
+                                f"{bridge_url}/send",
                                 json={"chatId": normalized_chat_id, "message": media_caption},
                                 timeout=aiohttp.ClientTimeout(total=30),
                             ) as resp:
@@ -1702,7 +1743,7 @@ async def _standalone_send(
                 if media_caption:
                     payload["caption"] = media_caption
                 async with session.post(
-                    f"http://localhost:{bridge_port}/send-media",
+                    f"{bridge_url}/send-media",
                     json=payload,
                     timeout=aiohttp.ClientTimeout(total=120),
                 ) as resp:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -778,17 +778,30 @@ const app = express();
 app.use(express.json());
 
 // Host-header validation — defends against DNS rebinding.
-// The bridge binds loopback-only (127.0.0.1) but a victim browser on
-// the same machine could be tricked into fetching from an attacker
-// hostname that TTL-flips to 127.0.0.1. Reject any request whose Host
-// header doesn't resolve to a loopback alias.
+// By default the bridge binds loopback-only. A victim browser could be
+// tricked into fetching an attacker hostname that DNS-rebinds to the local
+// bridge, so accept only explicitly configured Host values. Host validation
+// is a DNS-rebinding defence, not network access control: never expose this
+// unauthenticated bridge to an untrusted network.
 // See GHSA-ppp5-vxwm-4cf7.
+const HOST = process.env.WHATSAPP_BRIDGE_BIND || '127.0.0.1';
 const _ACCEPTED_HOST_VALUES = new Set([
   'localhost',
   '127.0.0.1',
-  '[::1]',
   '::1',
 ]);
+for (const value of (process.env.WHATSAPP_BRIDGE_ACCEPTED_HOSTS || '').split(',')) {
+  const host = value.trim().replace(/^\[|\]$/g, '').toLowerCase();
+  if (host) _ACCEPTED_HOST_VALUES.add(host);
+}
+// A specific non-loopback bind is safe to accept by default: clients reaching
+// that address naturally send it in Host. Wildcard binds deliberately require
+// WHATSAPP_BRIDGE_ACCEPTED_HOSTS because they do not identify one origin.
+const _NORMALIZED_BIND_HOST = HOST.trim().replace(/^\[|\]$/g, '').toLowerCase();
+if (!_ACCEPTED_HOST_VALUES.has(_NORMALIZED_BIND_HOST)
+    && !['0.0.0.0', '::'].includes(_NORMALIZED_BIND_HOST)) {
+  _ACCEPTED_HOST_VALUES.add(_NORMALIZED_BIND_HOST);
+}
 
 app.use((req, res, next) => {
   const raw = (req.headers.host || '').trim();
@@ -1127,8 +1140,8 @@ if (PAIR_ONLY) {
     process.exit(1);
   });
 } else {
-  app.listen(PORT, '127.0.0.1', () => {
-    console.log(`🌉 WhatsApp bridge listening on port ${PORT} (mode: ${WHATSAPP_MODE})`);
+  app.listen(PORT, HOST, () => {
+    console.log(`🌉 WhatsApp bridge listening on ${HOST}:${PORT} (mode: ${WHATSAPP_MODE})`);
     console.log(`📁 Session stored in: ${SESSION_DIR}`);
     if (ALLOWED_USERS.size > 0) {
       console.log(`🔒 Allowed users: ${Array.from(ALLOWED_USERS).join(', ')}`);

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -47,6 +47,8 @@ def _make_adapter():
     adapter.platform = Platform.WHATSAPP
     adapter.config = MagicMock()
     adapter._bridge_port = 19876
+    adapter._bridge_url = "http://127.0.0.1:19876"
+    adapter._external_bridge = False
     adapter._bridge_script = "/tmp/test-bridge.js"
     adapter._session_path = Path("/tmp/test-wa-session")
     adapter._bridge_log_fh = None
@@ -166,6 +168,27 @@ class TestDataInitialized:
         # connect() returns True (warn-and-proceed path)
         assert result is True
         assert adapter._running is True
+
+
+class TestExternalBridge:
+    """An explicitly remote bridge must not be managed as a local child."""
+
+    @pytest.mark.asyncio
+    async def test_connect_uses_external_bridge_without_local_bootstrap(self):
+        adapter = _make_adapter()
+        adapter._external_bridge = True
+        adapter._bridge_url = "http://172.17.0.1:19876"
+        mock_client_cls = _mock_aiohttp(status=200, json_data={"status": "connected"})
+
+        with patch("aiohttp.ClientSession", mock_client_cls), \
+             patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements") as requirements, \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.create_task") as create_task:
+            result = await adapter.connect()
+
+        assert result is True
+        assert adapter._running is True
+        requirements.assert_not_called()
+        create_task.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_whatsapp_reply_prefix.py
+++ b/tests/gateway/test_whatsapp_reply_prefix.py
@@ -85,11 +85,18 @@ class TestAdapterInit:
 
 class TestReadReceiptPolicyOrdering:
     @pytest.mark.asyncio
-    async def test_accepted_receipt_key_is_sent_to_bridge(self):
+    async def test_accepted_receipt_key_is_sent_to_external_bridge(self):
         from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 
         adapter = WhatsAppAdapter(
-            PlatformConfig(enabled=True, extra={"send_read_receipts": True})
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "bridge_host": "172.17.0.1",
+                    "bridge_port": 19876,
+                    "send_read_receipts": True,
+                },
+            )
         )
         response = SimpleNamespace(status=200)
         session = MagicMock()
@@ -105,7 +112,7 @@ class TestReadReceiptPolicyOrdering:
         await adapter._send_read_receipt({"readReceiptKey": key})
 
         assert session.post.call_args.kwargs["json"] == {"key": key}
-        assert session.post.call_args.args[0].endswith("/read")
+        assert session.post.call_args.args[0] == "http://172.17.0.1:19876/read"
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -362,6 +362,9 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL` | Expected Google service account email for HTTP event bearer tokens |
 | `WHATSAPP_ENABLED` | Enable the WhatsApp bridge (`true`/`false`) |
 | `WHATSAPP_MODE` | `bot` (separate number) or `self-chat` (message yourself) |
+| `WHATSAPP_BRIDGE_HOST` | Externally managed bridge host for container deployments (default: `127.0.0.1`) |
+| `WHATSAPP_BRIDGE_BIND` | Bridge listen address when it is launched by Hermes (default: `127.0.0.1`) |
+| `WHATSAPP_BRIDGE_ACCEPTED_HOSTS` | Extra comma-separated Host header values accepted by the bridge; required for wildcard binds |
 | `WHATSAPP_ALLOWED_USERS` | Comma-separated phone numbers (with country code, no `+`), or `*` to allow all senders |
 | `WHATSAPP_ALLOW_ALL_USERS` | Allow all WhatsApp senders without an allowlist (`true`/`false`) |
 | `WHATSAPP_HOME_CHANNEL` | Default chat ID for cron / notification delivery. |


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in way for Hermes running in Docker to use a WhatsApp Baileys bridge running on the host.

Today, the bridge binds to `127.0.0.1` and the Python adapter assumes every bridge request should use loopback. Inside Docker, `localhost` refers to the container rather than the host, so the adapter cannot reach a host-side bridge.

This preserves the existing loopback-only behavior by default. Docker users can explicitly configure a reachable bridge address, such as the Linux Docker gateway (`172.17.0.1`).

When a non-loopback bridge host is configured, the adapter treats the bridge as externally managed. It does not start a duplicate local bridge, install local bridge dependencies, or kill a listener in the container.

## Related Issue

Closes #71477

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/whatsapp-bridge/bridge.js`
  - Add `WHATSAPP_BRIDGE_BIND`, defaulting to `127.0.0.1`.
  - Add optional comma-separated `WHATSAPP_BRIDGE_ACCEPTED_HOSTS`.
  - Automatically accept a specific non-loopback bind address as a Host value.
  - Do not automatically accept wildcard binds (`0.0.0.0` / `::`), preserving the DNS-rebinding security model.

- `plugins/platforms/whatsapp/adapter.py`
  - Add `WHATSAPP_BRIDGE_HOST` and `platforms.whatsapp.extra.bridge_host`.
  - Route health checks, polling, sends, edits, media, typing, polls, locations, chat lookup, and standalone delivery through the configured bridge endpoint.
  - Treat non-loopback bridge hosts as externally managed.

- `tests/gateway/test_whatsapp_connect.py`
  - Add regression coverage confirming an external bridge is used without local Node/npm bootstrap.
  - Preserve compatibility with minimal test adapter instances that bypass `__init__`.

- `website/docs/reference/environment-variables.md`
  - Document the bridge host, bind, and accepted-host configuration.

- `cli-config.yaml.example`
  - Add a commented `platforms.whatsapp.extra.bridge_host` example.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_whatsapp_connect.py -q`.
   Expected result: 30 tests pass.

2. Run `ruff check plugins/platforms/whatsapp/adapter.py tests/gateway/test_whatsapp_connect.py`.
   Expected result: all checks pass.

3. For a Linux Docker deployment, start an already paired host-side bridge with `WHATSAPP_BRIDGE_BIND=172.17.0.1`.

4. Configure the Hermes container with `WHATSAPP_BRIDGE_HOST=172.17.0.1`, then start the gateway.

5. Confirm Hermes reports that it is using an external bridge and does not attempt local npm installation or launch a second bridge.

6. Send and receive a WhatsApp message through the gateway.

Note: host-side bridge deployments need shared/mounted media-cache paths for inbound and outbound media files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: EndeavourOS Linux (build 2025.03.19, Arch-based), Docker bridge gateway deployment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
