### PR TITLE
feat(observability): add local decision trace evaluator

### DIFF
--- a/plugins/observability/decision_trace/__init__.py
+++ b/plugins/observability/decision_trace/__init__.py
@@ -1,0 +1,184 @@
+"""Local, opt-in DecisionTrace observer for Hermes.
+
+This plugin is intentionally metadata-only: it never stores prompts, model
+responses, tool arguments, tool results, credentials, or arbitrary payloads.
+It writes one compact JSON object per completed LLM turn to
+``$HERMES_HOME/telemetry/decision-traces.jsonl``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+_LOCK = threading.Lock()
+_TURNS: dict[str, dict[str, Any]] = {}
+_MAX_LIVE_TURNS = 256
+_LOGGER = logging.getLogger(__name__)
+
+
+def _home() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+        return Path(get_hermes_home())
+    except Exception:
+        return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+
+
+def _path() -> Path:
+    return _home() / "telemetry" / "decision-traces.jsonl"
+
+
+def _key(task_id: str, session_id: str, turn_id: str, api_request_id: str) -> str:
+    if turn_id:
+        return f"turn:{turn_id}"
+    if api_request_id:
+        return f"api:{api_request_id}"
+    return f"task:{task_id}:session:{session_id}"
+
+
+def _bounded_int(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _safe_status(finish_reason: Any, assistant_tool_call_count: Any) -> str:
+    if _bounded_int(assistant_tool_call_count):
+        return "tool_call"
+    return str(finish_reason or "completed")[:64]
+
+
+def _get_or_create(key: str, **fields: Any) -> dict[str, Any]:
+    state = _TURNS.get(key)
+    if state is None:
+        state = {
+            "trace_id": uuid.uuid4().hex,
+            "started_at": time.time(),
+            "api_calls": 0,
+            "tool_calls": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "estimated_cost_usd": 0.0,
+        }
+        _TURNS[key] = state
+    for name in ("task_id", "session_id", "turn_id", "model", "provider", "api_mode"):
+        value = fields.get(name)
+        if value and not state.get(name):
+            state[name] = str(value)[:256]
+    if len(_TURNS) > _MAX_LIVE_TURNS:
+        oldest = min(_TURNS, key=lambda item: _TURNS[item].get("started_at", 0.0))
+        _TURNS.pop(oldest, None)
+    return state
+
+
+def on_pre_api_request(*, task_id: str = "", session_id: str = "", turn_id: str = "",
+                       api_request_id: str = "", model: str = "", provider: str = "",
+                       api_mode: str = "", **_: Any) -> None:
+    key = _key(task_id, session_id, turn_id, api_request_id)
+    with _LOCK:
+        state = _get_or_create(
+            key, task_id=task_id, session_id=session_id, turn_id=turn_id,
+            model=model, provider=provider, api_mode=api_mode,
+        )
+        state["api_calls"] += 1
+        state["last_api_request_id"] = str(api_request_id or "")[:256]
+
+
+def on_post_api_request(*, task_id: str = "", session_id: str = "", turn_id: str = "",
+                        api_request_id: str = "", model: str = "", provider: str = "",
+                        api_mode: str = "", usage: Any = None, **_: Any) -> None:
+    key = _key(task_id, session_id, turn_id, api_request_id)
+    usage = usage if isinstance(usage, dict) else {}
+    with _LOCK:
+        state = _get_or_create(
+            key, task_id=task_id, session_id=session_id, turn_id=turn_id,
+            model=model, provider=provider, api_mode=api_mode,
+        )
+        state["input_tokens"] += _bounded_int(usage.get("input_tokens"))
+        state["output_tokens"] += _bounded_int(usage.get("output_tokens", usage.get("completion_tokens")))
+        state["cache_read_tokens"] += _bounded_int(usage.get("cache_read_tokens"))
+        state["cache_write_tokens"] += _bounded_int(usage.get("cache_write_tokens"))
+        try:
+            state["estimated_cost_usd"] += max(0.0, float(usage.get("estimated_cost_usd") or 0.0))
+        except (TypeError, ValueError):
+            pass
+
+
+def on_post_tool_call(*, task_id: str = "", session_id: str = "", turn_id: str = "",
+                      api_request_id: str = "", **_: Any) -> None:
+    key = _key(task_id, session_id, turn_id, api_request_id)
+    with _LOCK:
+        state = _get_or_create(key, task_id=task_id, session_id=session_id, turn_id=turn_id)
+        state["tool_calls"] += 1
+
+
+def _write(state: dict[str, Any], *, finish_reason: Any = "", assistant_tool_call_count: Any = 0,
+           api_duration: Any = 0.0) -> None:
+    now = time.time()
+    record = {
+        "schema_version": "hermes.decision_trace.v1",
+        "trace_id": state["trace_id"],
+        "task_id": state.get("task_id", ""),
+        "session_id": state.get("session_id", ""),
+        "turn_id": state.get("turn_id", ""),
+        "model": state.get("model", ""),
+        "provider": state.get("provider", ""),
+        "api_mode": state.get("api_mode", ""),
+        "started_at": state["started_at"],
+        "ended_at": now,
+        "duration_ms": round(max(0.0, now - state["started_at"]) * 1000),
+        "api_duration_ms": round(max(0.0, float(api_duration or 0.0)) * 1000),
+        "status": _safe_status(finish_reason, assistant_tool_call_count),
+        "api_calls": state["api_calls"],
+        "tool_calls": state["tool_calls"] + _bounded_int(assistant_tool_call_count),
+        "input_tokens": state["input_tokens"],
+        "output_tokens": state["output_tokens"],
+        "cache_read_tokens": state["cache_read_tokens"],
+        "cache_write_tokens": state["cache_write_tokens"],
+        "estimated_cost_usd": round(state["estimated_cost_usd"], 8),
+    }
+    path = _path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def on_post_llm_call(*, task_id: str = "", session_id: str = "", turn_id: str = "",
+                     api_request_id: str = "", finish_reason: str = "", usage: Any = None,
+                     assistant_tool_call_count: int = 0, api_duration: float = 0.0,
+                     model: str = "", provider: str = "", api_mode: str = "", **_: Any) -> None:
+    key = _key(task_id, session_id, turn_id, api_request_id)
+    with _LOCK:
+        state = _TURNS.pop(key, None)
+        if state is None:
+            state = _get_or_create(
+                key, task_id=task_id, session_id=session_id, turn_id=turn_id,
+                model=model, provider=provider, api_mode=api_mode,
+            )
+        # API-scoped hooks normally account for usage already. Only use the
+        # turn-scoped usage payload as a fallback when no API request was seen,
+        # avoiding double counting on current Hermes paths.
+        if state["api_calls"] == 0 and isinstance(usage, dict):
+            state["input_tokens"] += _bounded_int(usage.get("input_tokens"))
+            state["output_tokens"] += _bounded_int(usage.get("output_tokens", usage.get("completion_tokens")))
+        try:
+            _write(state, finish_reason=finish_reason, assistant_tool_call_count=assistant_tool_call_count,
+                   api_duration=api_duration)
+        except Exception as exc:  # observer must never break the agent loop
+            _LOGGER.debug("DecisionTrace write failed: %s", exc)
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_api_request", on_pre_api_request)
+    ctx.register_hook("post_api_request", on_post_api_request)
+    ctx.register_hook("post_llm_call", on_post_llm_call)
+    ctx.register_hook("post_tool_call", on_post_tool_call)

--- a/plugins/observability/decision_trace/evaluate.py
+++ b/plugins/observability/decision_trace/evaluate.py
@@ -1,0 +1,80 @@
+"""Offline evaluator for local Hermes DecisionTrace JSONL files."""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+from typing import Any, Iterable
+
+
+NUMERIC_FIELDS = (
+    "duration_ms",
+    "api_duration_ms",
+    "api_calls",
+    "tool_calls",
+    "input_tokens",
+    "output_tokens",
+    "cache_read_tokens",
+    "cache_write_tokens",
+    "estimated_cost_usd",
+)
+
+
+def load_records(path: str | Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        if not isinstance(value, dict):
+            raise ValueError("each JSONL line must be an object")
+        records.append(value)
+    return records
+
+
+def _mean(records: Iterable[dict[str, Any]], field: str) -> float:
+    values = [float(r.get(field) or 0) for r in records]
+    return round(statistics.fmean(values), 6) if values else 0.0
+
+
+def summarize(records: list[dict[str, Any]]) -> dict[str, Any]:
+    statuses: dict[str, int] = {}
+    for record in records:
+        status = str(record.get("status") or "unknown")
+        statuses[status] = statuses.get(status, 0) + 1
+    return {
+        "schema_versions": sorted({str(r.get("schema_version", "unknown")) for r in records}),
+        "records": len(records),
+        "statuses": statuses,
+        "averages": {field: _mean(records, field) for field in NUMERIC_FIELDS},
+        "totals": {
+            field: round(sum(float(r.get(field) or 0) for r in records), 6)
+            for field in NUMERIC_FIELDS
+        },
+    }
+
+
+def compare(left: list[dict[str, Any]], right: list[dict[str, Any]]) -> dict[str, Any]:
+    left_summary = summarize(left)
+    right_summary = summarize(right)
+    deltas = {}
+    for field in NUMERIC_FIELDS:
+        lval = left_summary["averages"][field]
+        rval = right_summary["averages"][field]
+        deltas[field] = round(rval - lval, 6)
+    return {"left": left_summary, "right": right_summary, "right_minus_left": deltas}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("trace_file", type=Path)
+    parser.add_argument("--compare", type=Path, help="compare against a second JSONL file")
+    args = parser.parse_args()
+    left = load_records(args.trace_file)
+    result = compare(left, load_records(args.compare)) if args.compare else summarize(left)
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/observability/decision_trace/plugin.yaml
+++ b/plugins/observability/decision_trace/plugin.yaml
@@ -1,0 +1,9 @@
+name: decision_trace
+version: "0.1.0"
+description: "Opt-in local DecisionTrace metadata for Hermes; no prompts or tool payloads are stored."
+author: NousResearch
+hooks:
+  - pre_api_request
+  - post_api_request
+  - post_llm_call
+  - post_tool_call

--- a/tests/plugins/test_decision_trace_plugin.py
+++ b/tests/plugins/test_decision_trace_plugin.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+
+
+MODULE = "plugins.observability.decision_trace"
+
+
+def fresh_module():
+    sys.modules.pop(MODULE, None)
+    return importlib.import_module(MODULE)
+
+
+def test_manifest_and_plugin_are_present():
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2] / "plugins/observability/decision_trace"
+    assert (root / "plugin.yaml").exists()
+    assert (root / "__init__.py").exists()
+
+
+def test_trace_is_local_metadata_only_and_aggregates_usage(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    mod = fresh_module()
+
+    mod.on_pre_api_request(
+        task_id="task-1", session_id="session-1", turn_id="turn-1",
+        api_request_id="api-1", model="local-model", provider="ollama",
+    )
+    mod.on_post_api_request(
+        task_id="task-1", session_id="session-1", turn_id="turn-1",
+        api_request_id="api-1", usage={
+            "input_tokens": 100, "output_tokens": 20,
+            "cache_read_tokens": 10, "cache_write_tokens": 5,
+        },
+    )
+    mod.on_post_tool_call(task_id="task-1", session_id="session-1", turn_id="turn-1")
+    mod.on_post_llm_call(
+        task_id="task-1", session_id="session-1", turn_id="turn-1",
+        finish_reason="stop", assistant_tool_call_count=0,
+        usage={"input_tokens": 999, "output_tokens": 999},
+    )
+
+    path = tmp_path / ".hermes/telemetry/decision-traces.jsonl"
+    records = [json.loads(line) for line in path.read_text().splitlines()]
+    assert len(records) == 1
+    record = records[0]
+    assert record["schema_version"] == "hermes.decision_trace.v1"
+    assert record["trace_id"]
+    assert record["model"] == "local-model"
+    assert record["provider"] == "ollama"
+    assert record["input_tokens"] == 100
+    assert record["output_tokens"] == 20
+    assert record["cache_read_tokens"] == 10
+    assert record["cache_write_tokens"] == 5
+    assert record["tool_calls"] == 1
+    assert all(key not in record for key in ("prompt", "response", "args", "result"))
+
+
+def test_trace_fail_open_when_path_cannot_be_written(monkeypatch):
+    mod = fresh_module()
+    monkeypatch.setattr(mod, "_path", lambda: __import__("pathlib").Path("/dev/null/trace.jsonl"))
+    mod.on_pre_api_request(task_id="t", session_id="s", turn_id="x")
+    mod.on_post_llm_call(task_id="t", session_id="s", turn_id="x", finish_reason="stop")
+    # The observer must not make a task fail when local persistence is broken.
+    assert True
+
+
+def test_offline_evaluator_summarizes_and_compares(tmp_path):
+    from plugins.observability.decision_trace.evaluate import compare, load_records, summarize
+
+    left_path = tmp_path / "left.jsonl"
+    right_path = tmp_path / "right.jsonl"
+    left_path.write_text(json.dumps({
+        "schema_version": "hermes.decision_trace.v1",
+        "status": "completed",
+        "duration_ms": 100,
+        "input_tokens": 10,
+        "output_tokens": 5,
+    }) + "\n")
+    right_path.write_text(json.dumps({
+        "schema_version": "hermes.decision_trace.v1",
+        "status": "completed",
+        "duration_ms": 80,
+        "input_tokens": 12,
+        "output_tokens": 4,
+    }) + "\n")
+
+    assert summarize(load_records(left_path))["records"] == 1
+    result = compare(load_records(left_path), load_records(right_path))
+    assert result["right_minus_left"]["duration_ms"] == -20.0
+    assert result["right_minus_left"]["input_tokens"] == 2.0


### PR DESCRIPTION
## Summary

- add an opt-in, metadata-only local DecisionTrace observer plugin
- aggregate API, tool, model, token, latency, and cost metadata per turn
- write sanitized JSONL traces under `$HERMES_HOME/telemetry/decision-traces.jsonl`
- add an offline evaluator for summaries and baseline/candidate comparisons
- keep all prompts, responses, tool arguments, tool results, credentials, and outbound telemetry out of the trace

## Design notes

- no new runtime dependencies
- no new model tools or prompt-schema changes
- fail-open if local trace persistence is unavailable
- plugin remains opt-in and is not enabled automatically

## Validation

- `uv run --with pytest pytest tests/plugins/test_decision_trace_plugin.py tests/plugins/test_langfuse_plugin.py -q -o addopts=`
  - 52 passed
- `uv run --with ruff ruff check plugins/observability/decision_trace tests/plugins/test_decision_trace_plugin.py`
  - All checks passed
- `python3 -m py_compile ...`
  - passed
- `git diff --check`
  - passed
