### PR TITLE
fix(desktop): don't trust the behind-count on any shallow checkout

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2406,34 +2406,28 @@ async function checkUpdates() {
 
   const git = args => runGit(args, { cwd: updateRoot }).then(r => r.stdout.trim())
 
-  const [currentSha, targetSha, dirtyStr, currentBranch, shallowStr, mergeBaseStr] = await Promise.all([
+  const [currentSha, targetSha, dirtyStr, currentBranch, shallowStr] = await Promise.all([
     git(['rev-parse', 'HEAD']),
     git(['rev-parse', `origin/${branch}`]),
     git(['status', '--porcelain']),
     git(['rev-parse', '--abbrev-ref', 'HEAD']),
-    git(['rev-parse', '--is-shallow-repository']),
-    // merge-base exits non-zero with empty stdout when HEAD shares no common
-    // ancestor with the freshly fetched tip — exactly the shallow-clone case.
-    git(['merge-base', 'HEAD', `origin/${branch}`])
+    git(['rev-parse', '--is-shallow-repository'])
   ])
 
   const isShallow = shallowStr === 'true'
-  const hasMergeBase = Boolean(mergeBaseStr)
 
   // Only enumerate the commit count when it is meaningful. On a shallow checkout
-  // with no merge-base, `rev-list --count` walks the entire remote ancestry
-  // (thousands of commits, see #51922) and resolveBehindCount discards the
-  // result anyway in favour of a SHA compare — so skip the expensive query.
-  const countStr = shouldCountCommits({ isShallow, hasMergeBase })
-    ? await git(['rev-list', `HEAD..origin/${branch}`, '--count'])
-    : ''
+  // the graft boundary stops git from excluding local history, so
+  // `rev-list --count` walks nearly the entire remote ancestry and returns a
+  // bogus huge number (#51922) that resolveBehindCount discards in favour of a
+  // SHA compare — so skip the expensive query.
+  const countStr = shouldCountCommits({ isShallow }) ? await git(['rev-list', `HEAD..origin/${branch}`, '--count']) : ''
 
   const behind = resolveBehindCount({
     countStr,
     currentSha,
     targetSha,
-    isShallow,
-    hasMergeBase
+    isShallow
   })
 
   const commits = behind > 0 ? await readCommitLog(updateRoot, branch) : []

--- a/apps/desktop/electron/update-count.test.ts
+++ b/apps/desktop/electron/update-count.test.ts
@@ -4,45 +4,58 @@ import { test } from 'vitest'
 
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 
-// FAIL-BEFORE: pre-fix the function did `Number.parseInt(countStr) || 0`
-// unconditionally, so a shallow checkout with no merge-base surfaced the bogus
-// rev-list count (e.g. 12104). This asserts the new shallow/no-merge-base branch.
+// FAIL-BEFORE: this is the case the original #51922 guard missed. A shallow
+// installer clone whose grafted HEAD is an ancestor of the fetched tip reports
+// `merge-base HEAD origin/main` == HEAD, so the old `isShallow && !hasMergeBase`
+// predicate saw a merge-base, opened the gate, and let the bogus rev-list count
+// reach the UI as "v0.19.0 (+17570)" on a repo that was really 143 behind.
+//
+// Observed on a real Windows install (2026-07-26):
+//   rev-parse --is-shallow-repository -> true
+//   rev-list --count HEAD             -> 1        (HEAD is in .git/shallow)
+//   rev-list --count origin/main      -> 17571
+//   rev-list HEAD..origin/main --count-> 17570    (= 17571 - 1, bogus)
+//   merge-base HEAD origin/main       -> HEAD itself
+//   true distance, measured on a full clone of the same repo -> 143
+test('shallow checkout whose HEAD is its own merge-base does NOT trust the bogus count', () => {
+  // `hasMergeBase: true` is what the real broken install reported, and it is
+  // what the superseded predicate keyed on. Passing it keeps this a genuine
+  // fail-before against the old guard instead of passing by accident on an
+  // absent field. Bound to a variable so TS excess-property checks (which only
+  // apply to inline literals) don't reject the now-unused field.
+  const brokenInstall = {
+    countStr: '17570',
+    currentSha: 'deadbeef',
+    targetSha: 'cafebabe',
+    isShallow: true,
+    hasMergeBase: true
+  }
+
+  assert.equal(resolveBehindCount(brokenInstall), 1)
+  assert.equal(shouldCountCommits(brokenInstall), false)
+})
+
 test('shallow checkout with no merge-base does NOT trust the bogus rev-list count', () => {
   assert.equal(
     resolveBehindCount({
       countStr: '12104',
       currentSha: 'aaa',
       targetSha: 'bbb',
-      isShallow: true,
-      hasMergeBase: false
+      isShallow: true
     }),
     1
   )
 })
 
-test('shallow checkout with no merge-base but identical SHA reports up-to-date', () => {
+test('shallow checkout with an identical SHA reports up-to-date', () => {
   assert.equal(
     resolveBehindCount({
       countStr: '12104',
       currentSha: 'abc',
       targetSha: 'abc',
-      isShallow: true,
-      hasMergeBase: false
+      isShallow: true
     }),
     0
-  )
-})
-
-test('shallow checkout WITH a merge-base keeps the exact count (reliable)', () => {
-  assert.equal(
-    resolveBehindCount({
-      countStr: '3',
-      currentSha: 'aaa',
-      targetSha: 'bbb',
-      isShallow: true,
-      hasMergeBase: true
-    }),
-    3
   )
 })
 
@@ -52,8 +65,7 @@ test('full (non-shallow) clone keeps the exact count path unchanged', () => {
       countStr: '7',
       currentSha: 'aaa',
       targetSha: 'bbb',
-      isShallow: false,
-      hasMergeBase: true
+      isShallow: false
     }),
     7
   )
@@ -65,8 +77,7 @@ test('up-to-date full clone reports 0', () => {
       countStr: '0',
       currentSha: 'x',
       targetSha: 'x',
-      isShallow: false,
-      hasMergeBase: true
+      isShallow: false
     }),
     0
   )
@@ -78,28 +89,34 @@ test('non-numeric count falls back to 0 (defensive, unchanged behaviour)', () =>
       countStr: '',
       currentSha: 'aaa',
       targetSha: 'bbb',
-      isShallow: false,
-      hasMergeBase: true
+      isShallow: false
     }),
     0
   )
 })
 
-// shouldCountCommits gates the expensive `rev-list --count` in checkUpdates().
-// FAIL-BEFORE: in the shallow + no-merge-base case the caller ran rev-list
-// unconditionally and discarded the bogus result; this predicate lets the
-// caller SKIP the whole-ancestry enumeration in exactly that case (#51922).
-test('shallow checkout with no merge-base SKIPS the rev-list count', () => {
-  assert.equal(shouldCountCommits({ isShallow: true, hasMergeBase: false }), false)
+// A full clone that genuinely has no merge-base (unrelated histories, e.g. a
+// fork rebuilt from scratch) still has walkable local ancestry, so the count is
+// real and must be preserved. Shallowness, not merge-base, is the signal.
+test('full clone with unrelated history still keeps its exact count', () => {
+  assert.equal(
+    resolveBehindCount({
+      countStr: '42',
+      currentSha: 'aaa',
+      targetSha: 'bbb',
+      isShallow: false
+    }),
+    42
+  )
 })
 
-test('shallow checkout WITH a merge-base still runs the count', () => {
-  assert.equal(shouldCountCommits({ isShallow: true, hasMergeBase: true }), true)
+// shouldCountCommits gates the expensive `rev-list --count` in checkUpdates().
+test('any shallow checkout SKIPS the rev-list count', () => {
+  assert.equal(shouldCountCommits({ isShallow: true }), false)
 })
 
 test('full (non-shallow) clone always runs the count', () => {
-  assert.equal(shouldCountCommits({ isShallow: false, hasMergeBase: true }), true)
-  assert.equal(shouldCountCommits({ isShallow: false, hasMergeBase: false }), true)
+  assert.equal(shouldCountCommits({ isShallow: false }), true)
 })
 
 // The skip path produces an empty countStr; resolveBehindCount must NOT trust
@@ -110,8 +127,7 @@ test('skipped-count path resolves via SHA compare, never via empty countStr', ()
       countStr: '',
       currentSha: 'aaa',
       targetSha: 'bbb',
-      isShallow: true,
-      hasMergeBase: false
+      isShallow: true
     }),
     1
   )
@@ -120,8 +136,7 @@ test('skipped-count path resolves via SHA compare, never via empty countStr', ()
       countStr: '',
       currentSha: 'same',
       targetSha: 'same',
-      isShallow: true,
-      hasMergeBase: false
+      isShallow: true
     }),
     0
   )

--- a/apps/desktop/electron/update-count.ts
+++ b/apps/desktop/electron/update-count.ts
@@ -1,22 +1,34 @@
 // Whether `git rev-list HEAD..origin/<branch> --count` produces a meaningful
-// number worth computing. On a SHALLOW checkout (installer clones with
-// --depth 1) the local history often shares no merge-base with the freshly
-// fetched origin tip, so the count enumerates the entire remote ancestry and
-// returns a bogus huge number (e.g. 12104) — see #51922. resolveBehindCount
-// discards that bogus count in favour of a SHA compare, so the caller should
-// SKIP the expensive rev-list entirely in that case rather than run it and
-// throw the result away.
-function shouldCountCommits({ isShallow, hasMergeBase }) {
-  return !(isShallow && !hasMergeBase)
+// number worth computing. On a SHALLOW checkout (the installer clones with
+// --depth 1) the local history is truncated at a graft boundary, so git cannot
+// walk HEAD's ancestry to exclude it from the range. `rev-list --count` then
+// enumerates nearly the entire remote ancestry and returns a bogus huge number
+// — e.g. "v0.19.0 (+17570)" on a repo whose real gap was 143 commits (#51922).
+//
+// The tell is arithmetic: the reported count equals
+// `rev-list --count origin/<branch>` minus `rev-list --count HEAD`. It is not
+// finding new commits, it is failing to subtract the old ones.
+//
+// A merge-base probe cannot distinguish the safe case from the broken one. A
+// shallow clone whose grafted HEAD is an ancestor of the fetched tip reports
+// `merge-base HEAD origin/<branch>` == HEAD — a merge-base exists, yet the
+// count is still bogus because the ancestry behind the graft is still missing.
+// Shallowness alone is the reliable signal, which is what hermes_cli/banner.py
+// (`_check_via_local_git`) and hermes_cli/main.py (`cmd_check_update`) already
+// key on. resolveBehindCount discards the count for a shallow repo in favour of
+// a SHA compare, so the caller should SKIP the expensive rev-list entirely
+// rather than run it and throw the result away.
+function shouldCountCommits({ isShallow }) {
+  return !isShallow
 }
 
 // Resolve how many commits the local checkout is behind origin for the desktop
-// update indicator. When the count isn't meaningful (shallow + no merge-base)
-// fall back to a binary up-to-date check by SHA, exactly like the official-SSH
-// path in checkUpdates() and the CLI guard in hermes_cli/banner.py. Full clones
+// update indicator. When the count isn't meaningful (a shallow checkout) fall
+// back to a binary up-to-date check by SHA, exactly like the official-SSH path
+// in checkUpdates() and the CLI guard in hermes_cli/banner.py. Full clones
 // (developers / Docker dev images) keep the exact count path unchanged.
-function resolveBehindCount({ countStr, currentSha, targetSha, isShallow, hasMergeBase }) {
-  if (!shouldCountCommits({ isShallow, hasMergeBase })) {
+function resolveBehindCount({ countStr, currentSha, targetSha, isShallow }) {
+  if (!shouldCountCommits({ isShallow })) {
     if (currentSha && targetSha && currentSha === targetSha) {
       return 0
     }


### PR DESCRIPTION
## Summary

The desktop update indicator can report a five-figure "behind" count on a public install. A real Windows client showed **`v0.19.0 (+17570)`** for a checkout that was **143 commits** behind `main`.

#51922 already fixed this class for `shallow + no merge-base`, but the predicate it introduced does not cover the state an installer clone actually reaches. Probed on the affected machine:

| Probe | Value |
|---|---|
| `rev-parse --is-shallow-repository` | `true` |
| `rev-list --count HEAD` | **1** (HEAD is in `.git/shallow`) |
| `rev-list --count origin/main` | 17571 |
| `rev-list HEAD..origin/main --count` | **17570** |
| `merge-base HEAD origin/main` | **HEAD itself** |
| True distance (measured on a full clone of the same repo) | **143** |

`17571 - 1 = 17570`. That identity is the tell: the count is not finding new commits, it is failing to **exclude** local history.

## Root cause

Because a `hermes update` fetch deepens `origin/main`'s ancestry while HEAD stays grafted, `merge-base HEAD origin/main` resolves to HEAD itself. So `hasMergeBase` is `true`, the `isShallow && !hasMergeBase` guard opens, `rev-list` runs, and the bogus count reaches the UI.

The count is bogus for the same underlying reason in both cases: the graft boundary stops git from walking HEAD's ancestry, so `rev-list HEAD..origin/<branch>` cannot subtract local history and enumerates nearly the whole remote instead. **A merge-base probe cannot separate the safe case from the broken one** — shallowness alone is the reliable signal.

## The fix

Gate on shallowness alone, which is what the Python side already does — `_check_via_local_git` in `hermes_cli/banner.py` and the `is_shallow` branch of `cmd_check_update` in `hermes_cli/main.py` both skip counting on *any* shallow repo and compare tip SHAs. This aligns the desktop with the CLI rather than leaving a third divergent variant. (That divergence is also why the affected user's CLI banner said "update available" while the desktop screamed five figures.)

Full clones (developers, Docker dev images) keep the exact count path unchanged — including a full clone with genuinely unrelated history, whose local ancestry is walkable and whose count is therefore real. A test pins that case so the fix isn't over-applied.

Dropping `hasMergeBase` also removes one `git merge-base` subprocess from every passive update check.

## Test plan

- [x] **Fail-before:** the added regression reproduces the observed shallow + self-as-merge-base state and asserts `1`; against the previous predicate it fails with `AssertionError: 17570 !== 1`
- [x] **Green-after:** all 10 tests in `update-count.test.ts` pass with the change
- [x] Full desktop `electron` vitest project: **727 passing**, no new failures (2 pre-existing env-only failures — missing `simple-git` / `node-pty` — reproduce identically on untouched `main`)
- [x] `tsc --noEmit`: no diagnostics on either changed file
- [x] `prettier --check`: clean
- [x] Verified end-to-end on the affected machine: after `git fetch --unshallow`, the count dropped 17570 -> **143**, cross-confirmed against an independent full clone of the same repo reporting the same 143

Refs #51922
