### PR TITLE
fix(approval): close wrapper-carried hardline bypasses

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -748,6 +748,36 @@ _ABS_PATH_ALLOW = [
     "env --chdir /tmp/reboot /bin/echo ok",
     "env --chdir /tmp/reboot echo ok",
     "env --argv0 /tmp/reboot /bin/echo ok",
+    "env -C /sbin/reboot /bin/echo ok",
+    # sudo option operands are data; only the command after them executes.
+    "sudo -D /sbin/reboot /bin/echo ok",
+    "sudo -D/sbin/reboot /bin/echo ok",
+    "sudo --chdir /sbin/reboot /bin/echo ok",
+    "sudo --chroot=/sbin/reboot /bin/echo ok",
+    # Exact `-h` only consumes a following non-option, non-assignment host.
+    # With an option-looking/assignment next word it selects help mode, so no
+    # later executable runs even when an option operand resembles one.
+    "sudo -h -D /sbin/reboot /bin/echo ok",
+    "sudo -h --chdir /sbin/reboot /bin/echo ok",
+    "sudo -h -D/sbin/reboot /bin/echo ok",
+    "sudo -h VAR=x /sbin/reboot",
+    "sudo -h 1VAR=x /sbin/reboot",
+    "sudo -h -- /sbin/reboot",
+    "sudo -nh host /sbin/reboot",
+    # sudo only treats an equals-bearing word as environment data when its
+    # first byte is neither '/' nor '='; these are command words instead.
+    "sudo /tmp=x /sbin/reboot",
+    "sudo =x /sbin/reboot",
+    "sudo -- 1VAR=x /sbin/reboot",
+    # Shell assignment syntax does not restart after an ordinary wrapper.
+    "exec VAR=x /sbin/reboot",
+    "nohup VAR=x /sbin/reboot",
+    # GNU env stops option parsing at the first NAME=VALUE operand. Later
+    # option-shaped words are a command (or another assignment), not options.
+    "env 1VAR=x -S /sbin/reboot",
+    "env 1VAR=x --split-string /sbin/reboot",
+    "env 1VAR=x --split-string=/sbin/reboot",
+    "/usr/bin/env 1VAR=x -S /sbin/reboot",
     # `}` is not a shell metacharacter: it can end a legitimate word
     "/tmp/reboot}",
 ]
@@ -772,6 +802,75 @@ def test_abs_path_hardline_not_bypassed_by_yolo(clean_session, monkeypatch):
     result = check_all_command_guards("/sbin/shutdown -h now", "local")
     assert result["approved"] is False
     assert result.get("hardline") is True
+
+
+_EXECUTABLE_WRAPPER_OPERAND_BLOCK = [
+    # GNU env -S parses its operand into the command it executes. Until that
+    # separate grammar is modeled, every split-string spelling must fail safe.
+    "env -S /sbin/reboot",
+    "env -S/sbin/reboot",
+    "env -vS'/sbin/reboot -h now'",
+    "env --split-string /sbin/reboot",
+    "env --split-string=/sbin/reboot",
+    "env --sp=/sbin/reboot",
+    # sudo options below consume data before the command word. Short clusters,
+    # attached operands, and unique long-option abbreviations use sudo's real
+    # getopt grammar and must still expose the executable that follows.
+    "sudo -D /tmp /sbin/reboot",
+    "sudo -nD /tmp /sbin/reboot",
+    "sudo -ED /tmp /sbin/reboot",
+    "sudo -D/tmp /sbin/reboot",
+    "sudo --chdir /tmp /sbin/reboot",
+    "sudo --chd /tmp /sbin/reboot",
+    "sudo -R /tmp /sbin/reboot",
+    "sudo -r staff_r /sbin/reboot",
+    "sudo -T 5 /sbin/reboot",
+    "sudo -t staff_t /sbin/reboot",
+    # sudo's historical separated host form applies only to an exact `-h`.
+    # Attached hosts and a following ordinary host still leave a real command.
+    "sudo -h host /sbin/reboot",
+    "sudo -hhost /sbin/reboot",
+    "sudo -h-D /sbin/reboot",
+    "sudo -hD /sbin/reboot",
+    "sudo -h /tmp=x /sbin/reboot",
+    "sudo -h =x /sbin/reboot",
+    # Wrapper-owned assignments are not limited to shell identifiers. sudo's
+    # `is_envar` and GNU env both consume digit/dash-leading NAME=VALUE words
+    # before resuming option/command parsing. Cover bare and path spellings so
+    # both command-position walkers share the same state transition.
+    "sudo 1VAR=x -D /tmp /sbin/reboot",
+    "sudo name-with-dash=x -D /tmp /sbin/reboot",
+    "/usr/bin/sudo 1VAR=x -D /tmp /sbin/reboot",
+    "env 1VAR=x /sbin/reboot",
+    "env name-with-dash=x /sbin/reboot",
+    "env -- 1VAR=x /sbin/reboot",
+    "/usr/bin/env 1VAR=x /sbin/reboot",
+    # Uppercase -A is a flag, not lowercase -a with an operand.
+    "sudo -A /sbin/reboot",
+    # Ambiguous and unknown long options cannot place the command word safely.
+    "sudo --ch /tmp /sbin/reboot",
+    "sudo --not-a-sudo-option /sbin/reboot",
+]
+
+
+@pytest.mark.parametrize("command", _EXECUTABLE_WRAPPER_OPERAND_BLOCK)
+def test_executable_wrapper_operand_is_hardline_blocked(command):
+    is_hl, desc = detect_hardline_command(command)
+
+    assert is_hl, f"wrapper operand bypassed the floor: {command!r}"
+    assert desc, "hardline match must provide a description"
+
+
+@pytest.mark.parametrize("command", _EXECUTABLE_WRAPPER_OPERAND_BLOCK)
+def test_executable_wrapper_operand_not_bypassed_by_yolo(
+    clean_session, command
+):
+    enable_session_yolo("hardline_test")
+
+    result = check_all_command_guards(command, "local")
+
+    assert result["approved"] is False, command
+    assert result.get("hardline") is True, command
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -721,12 +721,12 @@ _ABS_PATH_ALLOW = [
     "command -pv /sbin/reboot",
     # a word outside a wrapper's option list is the program name, and the
     # shell fails to run it — blocking these would be a false positive
+    # (time/setsid are the exception: their unknown options fail safe, see
+    # the time/setsid section below)
     "exec -x /sbin/reboot",
     "exec -- -c /sbin/reboot",
     "nohup -x /sbin/reboot",
     "nohup -- -x /sbin/reboot",
-    "setsid -x /sbin/reboot",
-    "time -x /sbin/reboot",
     "builtin -x /sbin/reboot",
     "builtin -- -x /sbin/reboot",
     "echo /sbin/shutdown",
@@ -813,3 +813,137 @@ def test_pass_through_launcher_wrappers_resolve_command_word_under_yolo(
 
     assert result["approved"] is approved, command
     assert bool(result.get("hardline")) is hardline, command
+
+
+# -------------------------------------------------------------------------
+# time / setsid option grammar
+# -------------------------------------------------------------------------
+#
+# `time` and `setsid` accept options of their own ahead of the program word
+# (GNU time: -p/-a/-v/-q/-V, -f/-o with an operand; setsid: -c/-f/-w/-V/-h).
+# Without a grammar for them the walker treats the option itself as the
+# command word and never inspects the executable behind it.
+
+_TIME_SETSID_BLOCK = [
+    "time -p /sbin/reboot",
+    "setsid -f /sbin/reboot",
+    "setsid -w -c /sbin/reboot",
+    "setsid -fw /sbin/reboot",
+    "setsid --fork /sbin/reboot",
+    "time --quiet /sbin/reboot",
+    # an option's operand is skipped as data, then the executable resolves
+    "time -o /tmp/x /sbin/reboot",
+    "time -f '%e' /sbin/reboot",
+    "time --format=%e /sbin/reboot",
+    "time -p -- /sbin/reboot",
+]
+
+
+@pytest.mark.parametrize("command", _TIME_SETSID_BLOCK)
+def test_time_setsid_options_resolve_command_word(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"time/setsid option hid the executable: {command!r}"
+    assert desc, "hardline match must provide a description"
+
+
+_TIME_SETSID_ALLOW = [
+    # an option's operand is data, not the command word
+    "time -o /sbin/reboot /bin/echo hi",
+    "time -f /sbin/reboot /bin/echo hi",
+    "time --output=/sbin/reboot /bin/echo hi",
+    # ordinary launches keep working
+    "time -p /bin/echo hi",
+    "setsid -f /bin/echo hi",
+    "setsid -w sleep 1",
+    # a lone wrapper word has no command to resolve
+    "time",
+    "setsid",
+]
+
+
+@pytest.mark.parametrize("command", _TIME_SETSID_ALLOW)
+def test_time_setsid_option_operands_are_data(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert not is_hl, f"time/setsid false positive: {command!r} (got: {desc})"
+
+
+# An option word we do NOT model (`time -Z`) means the walker cannot tell
+# where the program word starts. That must fail safe (detected), never fall
+# back to "the option is the program" — that misread is exactly how
+# `time -p /sbin/reboot` walked past the floor.
+_TIME_SETSID_UNKNOWN_OPTION = [
+    "time -Z /sbin/reboot",
+    "time -x /sbin/reboot",
+    "time --bogus /sbin/reboot",
+    "setsid -x /sbin/reboot",
+    "setsid --bogus /sbin/reboot",
+]
+
+
+@pytest.mark.parametrize("command", _TIME_SETSID_UNKNOWN_OPTION)
+def test_unknown_time_setsid_option_fails_safe(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"unknown time/setsid option fell open: {command!r}"
+    assert desc
+
+
+def test_time_setsid_hardline_under_yolo(clean_session, monkeypatch):
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    for cmd in ("time -p /sbin/reboot", "setsid -f /sbin/reboot"):
+        result = check_all_command_guards(cmd, "local")
+        assert result["approved"] is False, f"yolo leaked {cmd!r}"
+        assert result.get("hardline") is True, cmd
+
+
+# -------------------------------------------------------------------------
+# Walker termination: no pass-through exit
+# -------------------------------------------------------------------------
+#
+# The walk over the command prefix must end in exactly three ways: the
+# command word resolves, the input ends, or the defensive word cap trips and
+# the command is treated as unresolvable (detected). A fixed wrapper budget
+# used to be a fourth exit that silently gave up and let the executable
+# through uninspected.
+
+def test_wrapper_chain_depth_is_not_a_bypass():
+    import tools.approval as approval_mod
+
+    capped = {approval_mod._PARSER_LIMIT_DESCRIPTION,
+              approval_mod._MALFORMED_EXEC_DESCRIPTION}
+    for depth in (11, 12, 13):
+        command = "env " * depth + "/sbin/reboot"
+        is_hl, desc = detect_hardline_command(command)
+        assert is_hl, f"{depth} wrappers let the executable through"
+        assert desc not in capped, (
+            f"{depth} wrappers should resolve fully, not hit the cap: {desc!r}"
+        )
+
+
+def test_wrapper_chain_depth_bypass_closed_under_yolo(clean_session, monkeypatch):
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    command = "env " * 12 + "/sbin/reboot"
+    result = check_all_command_guards(command, "local")
+    assert result["approved"] is False, "12 wrappers leaked under yolo"
+    assert result.get("hardline") is True
+
+
+def test_walker_word_cap_fails_safe_never_open():
+    import tools.approval as approval_mod
+
+    capped = {approval_mod._PARSER_LIMIT_DESCRIPTION,
+              approval_mod._MALFORMED_EXEC_DESCRIPTION}
+    max_words = approval_mod._WALKER_MAX_WORDS
+    for total_words, resolves in ((max_words - 1, True),
+                                  (max_words, False),
+                                  (max_words + 1, False)):
+        command = "env " * (total_words - 1) + "/sbin/reboot"
+        is_hl, desc = detect_hardline_command(command)
+        assert is_hl, f"{total_words}-word walk fell open"
+        if resolves:
+            assert desc not in capped, (
+                f"{total_words} words is under the cap and must resolve: {desc!r}"
+            )
+        else:
+            assert desc in capped, (
+                f"{total_words} words must trip the defensive cap: {desc!r}"
+            )

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -691,9 +691,44 @@ _ABS_PATH_BLOCK = [
     "`/sbin/reboot`",
     "{ /sbin/reboot; }",
     "env -u FOO /sbin/reboot",
+    # `command` takes options too, and they sit before the executable
+    "command -p /sbin/reboot",
+    "command -- /sbin/reboot",
+    "command -p -- /sbin/reboot",
+    # `--` ends the option list of the wrappers whose options we model, so
+    # the path after it is the program
+    "exec -- /sbin/reboot",
+    "nohup -- /sbin/reboot",
+    "setsid -- /sbin/reboot",
+    "time -- /sbin/reboot",
+    "builtin -- command -p /sbin/reboot",
+    # `exec -a NAME` consumes NAME; -c and -l take no operand
+    "exec -a custom /sbin/reboot",
+    "exec -c /sbin/reboot",
+    "exec -l /sbin/reboot",
+    # assignment prefixes are unbounded in shell grammar, so a fixed walk
+    # budget must not run out and let the executable through unprojected
+    " ".join(f"A{i}=1" for i in range(12)) + " /sbin/reboot",
+    " ".join(f"A{i}=1" for i in range(40)) + " /sbin/reboot",
 ]
 
 _ABS_PATH_ALLOW = [
+    # `command -v` / `-V` only look the command up; nothing is executed, and
+    # `command`'s short options are just p/v/V so a cluster carrying v is
+    # lookup-only as well
+    "command -v /sbin/reboot",
+    "command -V /sbin/reboot",
+    "command -pv /sbin/reboot",
+    # a word outside a wrapper's option list is the program name, and the
+    # shell fails to run it — blocking these would be a false positive
+    "exec -x /sbin/reboot",
+    "exec -- -c /sbin/reboot",
+    "nohup -x /sbin/reboot",
+    "nohup -- -x /sbin/reboot",
+    "setsid -x /sbin/reboot",
+    "time -x /sbin/reboot",
+    "builtin -x /sbin/reboot",
+    "builtin -- -x /sbin/reboot",
     "echo /sbin/shutdown",
     "ls -la /sbin/shutdown",
     "grep 'shutdown' /var/log/syslog",

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -648,3 +648,92 @@ def test_sudo_stdin_guard_container_bypass(clean_session):
         for cmd in _SUDO_STDIN_BLOCK:
             result = check_all_command_guards(cmd, env)
             assert result["approved"] is True, f"container {env} should bypass sudo guard on {cmd!r}"
+
+
+# Absolute-path invocations must not defeat the floor. _CMDPOS only accepted
+# "start | separator | subshell opener | sudo/env-style wrappers" before the
+# command word, so spelling the binary by path — the natural form on systems
+# where PATH is unreliable, and the default an LLM produces for Windows
+# tools — returned (False, None) for every hardline pattern. Regression set
+# pins both directions: path-spelled commands at command position are
+# blocked, the same strings as data arguments stay allowed.
+_ABS_PATH_BLOCK = [
+    "/sbin/shutdown -h now",
+    "/usr/sbin/reboot",
+    "/sbin/halt",
+    "/sbin/init 6",
+    "/bin/rm -rf /",
+    "sudo /sbin/shutdown -h now",
+    "env LC_ALL=C /sbin/reboot",
+    "echo done; /sbin/shutdown -h now",
+    "true && /usr/sbin/poweroff",
+    r"C:\Windows\System32\shutdown.exe /s /t 0",
+    "C:/Windows/System32/shutdown.exe /s /t 0",
+    r'"C:\Program Files\Git\usr\bin\rm.exe" -rf /',
+    r"C:\Windows\System32\shutdown.EXE /s",
+    # path-spelled wrapper chains resolve in the single projection pass
+    "/usr/bin/sudo /sbin/shutdown -h now",
+    "/usr/bin/env /usr/bin/sudo /sbin/shutdown -h now",
+    "exec /sbin/reboot",
+    "( /sbin/shutdown -h now )",
+    "/sbin/telinit 6",
+    "./shutdown -h now",
+    "shutdown.exe /s",
+    # composed spellings reduce through the same collapsing as r\m detection
+    "'/sbin/'shutdown -h now",
+    "/sbin/shut\\down -h now",
+    # a payload's executable can be path-spelled too
+    "bash -c '/sbin/shutdown -h now'",
+    "exec bash -c '/bin/rm -rf /'",
+    # group/substitution closers stay outside the projected word
+    "(/sbin/reboot)",
+    "$(/sbin/reboot)",
+    "`/sbin/reboot`",
+    "{ /sbin/reboot; }",
+    "env -u FOO /sbin/reboot",
+]
+
+_ABS_PATH_ALLOW = [
+    "echo /sbin/shutdown",
+    "ls -la /sbin/shutdown",
+    "grep 'shutdown' /var/log/syslog",
+    "stat /usr/sbin/reboot",
+    r"stat C:\Windows\System32\shutdown.exe",
+    "cat /bin/rm",
+    'echo "/sbin/init 6"',
+    "md5sum /sbin/halt",
+    # basename must match the pattern word exactly, not a near-miss
+    "/usr/local/bin/rebooter --dry-run",
+    "./deploy.sh shutdown",
+    "cat /etc/init.d/reboot",
+    # a bare assignment prefix is data — projecting its value manufactured
+    # a False->True flip in the first cut of this fix (Sol round 2)
+    "X=/sbin/shutdown echo ok",
+    # a wrapper option's operand is data, not the command word
+    "env --chdir /tmp/reboot /bin/echo ok",
+    "env --chdir /tmp/reboot echo ok",
+    "env --argv0 /tmp/reboot /bin/echo ok",
+    # `}` is not a shell metacharacter: it can end a legitimate word
+    "/tmp/reboot}",
+]
+
+
+@pytest.mark.parametrize("command", _ABS_PATH_BLOCK)
+def test_abs_path_invocation_is_hardline_blocked(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"absolute-path spelling bypassed the floor: {command!r}"
+    assert desc, "hardline match must provide a description"
+
+
+@pytest.mark.parametrize("command", _ABS_PATH_ALLOW)
+def test_abs_path_as_data_is_not_hardline(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert not is_hl, f"path-as-data false positive: {command!r} (got: {desc})"
+
+
+def test_abs_path_hardline_not_bypassed_by_yolo(clean_session, monkeypatch):
+    """The floor must hold for path-spelled commands under yolo too."""
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    result = check_all_command_guards("/sbin/shutdown -h now", "local")
+    assert result["approved"] is False
+    assert result.get("hardline") is True

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -772,3 +772,44 @@ def test_abs_path_hardline_not_bypassed_by_yolo(clean_session, monkeypatch):
     result = check_all_command_guards("/sbin/shutdown -h now", "local")
     assert result["approved"] is False
     assert result.get("hardline") is True
+
+
+@pytest.mark.parametrize(
+    "command,approved,hardline",
+    [
+        ("timeout 5 /bin/rm -rf /", False, True),
+        ("timeout -k 3 5s rm -rf /", False, True),
+        ("timeout -k3 5s rm -rf /", False, True),
+        ("timeout -sTERM 5s rm -rf /", False, True),
+        ("timeout -vk3 5s rm -rf /", False, True),
+        ("timeout -vsTERM 5s rm -rf /", False, True),
+        ("timeout --preserve-status 5 /bin/rm -rf /", False, True),
+        ("timeout -p 5 /bin/rm -rf /", False, True),
+        ("timeout -f 5 rm -rf /", False, True),
+        ("timeout -pf 5 rm -rf /", False, True),
+        ("timeout -vpf 5 rm -rf /", False, True),
+        ("nice /bin/rm -rf /", False, True),
+        ("nice -n 10 rm -rf /", False, True),
+        ("nice -n10 rm -rf /", False, True),
+        ("nice -10 rm -rf /", False, True),
+        ("stdbuf -oL /bin/rm -rf /", False, True),
+        ("stdbuf -o L rm -rf /", False, True),
+        ("timeout 5 nice rm -rf /", False, True),
+        ("echo timeout 5 rm -rf /", True, False),
+        ("timeout 5 ls", True, False),
+        ("nice -n 10 make build", True, False),
+        ("timeout -vx 5s rm -rf /", True, False),
+        ("timeout 5 -vsTERM rm -rf /", True, False),
+        ("nice -vn10 rm -rf /", True, False),
+        ("nice -10x rm -rf /", True, False),
+    ],
+)
+def test_pass_through_launcher_wrappers_resolve_command_word_under_yolo(
+    clean_session, monkeypatch, command, approved, hardline
+):
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+
+    result = check_all_command_guards(command, "local")
+
+    assert result["approved"] is approved, command
+    assert bool(result.get("hardline")) is hardline, command

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -907,6 +907,36 @@ _ABS_PATH_ALLOW = [
     "env --chdir /tmp/reboot /bin/echo ok",
     "env --chdir /tmp/reboot echo ok",
     "env --argv0 /tmp/reboot /bin/echo ok",
+    "env -C /sbin/reboot /bin/echo ok",
+    # sudo option operands are data; only the command after them executes.
+    "sudo -D /sbin/reboot /bin/echo ok",
+    "sudo -D/sbin/reboot /bin/echo ok",
+    "sudo --chdir /sbin/reboot /bin/echo ok",
+    "sudo --chroot=/sbin/reboot /bin/echo ok",
+    # Exact `-h` only consumes a following non-option, non-assignment host.
+    # With an option-looking/assignment next word it selects help mode, so no
+    # later executable runs even when an option operand resembles one.
+    "sudo -h -D /sbin/reboot /bin/echo ok",
+    "sudo -h --chdir /sbin/reboot /bin/echo ok",
+    "sudo -h -D/sbin/reboot /bin/echo ok",
+    "sudo -h VAR=x /sbin/reboot",
+    "sudo -h 1VAR=x /sbin/reboot",
+    "sudo -h -- /sbin/reboot",
+    "sudo -nh host /sbin/reboot",
+    # sudo only treats an equals-bearing word as environment data when its
+    # first byte is neither '/' nor '='; these are command words instead.
+    "sudo /tmp=x /sbin/reboot",
+    "sudo =x /sbin/reboot",
+    "sudo -- 1VAR=x /sbin/reboot",
+    # Shell assignment syntax does not restart after an ordinary wrapper.
+    "exec VAR=x /sbin/reboot",
+    "nohup VAR=x /sbin/reboot",
+    # GNU env stops option parsing at the first NAME=VALUE operand. Later
+    # option-shaped words are a command (or another assignment), not options.
+    "env 1VAR=x -S /sbin/reboot",
+    "env 1VAR=x --split-string /sbin/reboot",
+    "env 1VAR=x --split-string=/sbin/reboot",
+    "/usr/bin/env 1VAR=x -S /sbin/reboot",
     # `}` is not a shell metacharacter: it can end a legitimate word
     "/tmp/reboot}",
 ]
@@ -931,6 +961,75 @@ def test_abs_path_hardline_not_bypassed_by_yolo(clean_session, monkeypatch):
     result = check_all_command_guards("/sbin/shutdown -h now", "local")
     assert result["approved"] is False
     assert result.get("hardline") is True
+
+
+_EXECUTABLE_WRAPPER_OPERAND_BLOCK = [
+    # GNU env -S parses its operand into the command it executes. Until that
+    # separate grammar is modeled, every split-string spelling must fail safe.
+    "env -S /sbin/reboot",
+    "env -S/sbin/reboot",
+    "env -vS'/sbin/reboot -h now'",
+    "env --split-string /sbin/reboot",
+    "env --split-string=/sbin/reboot",
+    "env --sp=/sbin/reboot",
+    # sudo options below consume data before the command word. Short clusters,
+    # attached operands, and unique long-option abbreviations use sudo's real
+    # getopt grammar and must still expose the executable that follows.
+    "sudo -D /tmp /sbin/reboot",
+    "sudo -nD /tmp /sbin/reboot",
+    "sudo -ED /tmp /sbin/reboot",
+    "sudo -D/tmp /sbin/reboot",
+    "sudo --chdir /tmp /sbin/reboot",
+    "sudo --chd /tmp /sbin/reboot",
+    "sudo -R /tmp /sbin/reboot",
+    "sudo -r staff_r /sbin/reboot",
+    "sudo -T 5 /sbin/reboot",
+    "sudo -t staff_t /sbin/reboot",
+    # sudo's historical separated host form applies only to an exact `-h`.
+    # Attached hosts and a following ordinary host still leave a real command.
+    "sudo -h host /sbin/reboot",
+    "sudo -hhost /sbin/reboot",
+    "sudo -h-D /sbin/reboot",
+    "sudo -hD /sbin/reboot",
+    "sudo -h /tmp=x /sbin/reboot",
+    "sudo -h =x /sbin/reboot",
+    # Wrapper-owned assignments are not limited to shell identifiers. sudo's
+    # `is_envar` and GNU env both consume digit/dash-leading NAME=VALUE words
+    # before resuming option/command parsing. Cover bare and path spellings so
+    # both command-position walkers share the same state transition.
+    "sudo 1VAR=x -D /tmp /sbin/reboot",
+    "sudo name-with-dash=x -D /tmp /sbin/reboot",
+    "/usr/bin/sudo 1VAR=x -D /tmp /sbin/reboot",
+    "env 1VAR=x /sbin/reboot",
+    "env name-with-dash=x /sbin/reboot",
+    "env -- 1VAR=x /sbin/reboot",
+    "/usr/bin/env 1VAR=x /sbin/reboot",
+    # Uppercase -A is a flag, not lowercase -a with an operand.
+    "sudo -A /sbin/reboot",
+    # Ambiguous and unknown long options cannot place the command word safely.
+    "sudo --ch /tmp /sbin/reboot",
+    "sudo --not-a-sudo-option /sbin/reboot",
+]
+
+
+@pytest.mark.parametrize("command", _EXECUTABLE_WRAPPER_OPERAND_BLOCK)
+def test_executable_wrapper_operand_is_hardline_blocked(command):
+    is_hl, desc = detect_hardline_command(command)
+
+    assert is_hl, f"wrapper operand bypassed the floor: {command!r}"
+    assert desc, "hardline match must provide a description"
+
+
+@pytest.mark.parametrize("command", _EXECUTABLE_WRAPPER_OPERAND_BLOCK)
+def test_executable_wrapper_operand_not_bypassed_by_yolo(
+    clean_session, command
+):
+    enable_session_yolo("hardline_test")
+
+    result = check_all_command_guards(command, "local")
+
+    assert result["approved"] is False, command
+    assert result.get("hardline") is True, command
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -931,3 +931,44 @@ def test_abs_path_hardline_not_bypassed_by_yolo(clean_session, monkeypatch):
     result = check_all_command_guards("/sbin/shutdown -h now", "local")
     assert result["approved"] is False
     assert result.get("hardline") is True
+
+
+@pytest.mark.parametrize(
+    "command,approved,hardline",
+    [
+        ("timeout 5 /bin/rm -rf /", False, True),
+        ("timeout -k 3 5s rm -rf /", False, True),
+        ("timeout -k3 5s rm -rf /", False, True),
+        ("timeout -sTERM 5s rm -rf /", False, True),
+        ("timeout -vk3 5s rm -rf /", False, True),
+        ("timeout -vsTERM 5s rm -rf /", False, True),
+        ("timeout --preserve-status 5 /bin/rm -rf /", False, True),
+        ("timeout -p 5 /bin/rm -rf /", False, True),
+        ("timeout -f 5 rm -rf /", False, True),
+        ("timeout -pf 5 rm -rf /", False, True),
+        ("timeout -vpf 5 rm -rf /", False, True),
+        ("nice /bin/rm -rf /", False, True),
+        ("nice -n 10 rm -rf /", False, True),
+        ("nice -n10 rm -rf /", False, True),
+        ("nice -10 rm -rf /", False, True),
+        ("stdbuf -oL /bin/rm -rf /", False, True),
+        ("stdbuf -o L rm -rf /", False, True),
+        ("timeout 5 nice rm -rf /", False, True),
+        ("echo timeout 5 rm -rf /", True, False),
+        ("timeout 5 ls", True, False),
+        ("nice -n 10 make build", True, False),
+        ("timeout -vx 5s rm -rf /", True, False),
+        ("timeout 5 -vsTERM rm -rf /", True, False),
+        ("nice -vn10 rm -rf /", True, False),
+        ("nice -10x rm -rf /", True, False),
+    ],
+)
+def test_pass_through_launcher_wrappers_resolve_command_word_under_yolo(
+    clean_session, monkeypatch, command, approved, hardline
+):
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+
+    result = check_all_command_guards(command, "local")
+
+    assert result["approved"] is approved, command
+    assert bool(result.get("hardline")) is hardline, command

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -850,9 +850,44 @@ _ABS_PATH_BLOCK = [
     "`/sbin/reboot`",
     "{ /sbin/reboot; }",
     "env -u FOO /sbin/reboot",
+    # `command` takes options too, and they sit before the executable
+    "command -p /sbin/reboot",
+    "command -- /sbin/reboot",
+    "command -p -- /sbin/reboot",
+    # `--` ends the option list of the wrappers whose options we model, so
+    # the path after it is the program
+    "exec -- /sbin/reboot",
+    "nohup -- /sbin/reboot",
+    "setsid -- /sbin/reboot",
+    "time -- /sbin/reboot",
+    "builtin -- command -p /sbin/reboot",
+    # `exec -a NAME` consumes NAME; -c and -l take no operand
+    "exec -a custom /sbin/reboot",
+    "exec -c /sbin/reboot",
+    "exec -l /sbin/reboot",
+    # assignment prefixes are unbounded in shell grammar, so a fixed walk
+    # budget must not run out and let the executable through unprojected
+    " ".join(f"A{i}=1" for i in range(12)) + " /sbin/reboot",
+    " ".join(f"A{i}=1" for i in range(40)) + " /sbin/reboot",
 ]
 
 _ABS_PATH_ALLOW = [
+    # `command -v` / `-V` only look the command up; nothing is executed, and
+    # `command`'s short options are just p/v/V so a cluster carrying v is
+    # lookup-only as well
+    "command -v /sbin/reboot",
+    "command -V /sbin/reboot",
+    "command -pv /sbin/reboot",
+    # a word outside a wrapper's option list is the program name, and the
+    # shell fails to run it — blocking these would be a false positive
+    "exec -x /sbin/reboot",
+    "exec -- -c /sbin/reboot",
+    "nohup -x /sbin/reboot",
+    "nohup -- -x /sbin/reboot",
+    "setsid -x /sbin/reboot",
+    "time -x /sbin/reboot",
+    "builtin -x /sbin/reboot",
+    "builtin -- -x /sbin/reboot",
     "echo /sbin/shutdown",
     "ls -la /sbin/shutdown",
     "grep 'shutdown' /var/log/syslog",

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -807,3 +807,92 @@ def test_sudo_stdin_guard_container_bypass(clean_session):
         for cmd in _SUDO_STDIN_BLOCK:
             result = check_all_command_guards(cmd, env)
             assert result["approved"] is True, f"container {env} should bypass sudo guard on {cmd!r}"
+
+
+# Absolute-path invocations must not defeat the floor. _CMDPOS only accepted
+# "start | separator | subshell opener | sudo/env-style wrappers" before the
+# command word, so spelling the binary by path — the natural form on systems
+# where PATH is unreliable, and the default an LLM produces for Windows
+# tools — returned (False, None) for every hardline pattern. Regression set
+# pins both directions: path-spelled commands at command position are
+# blocked, the same strings as data arguments stay allowed.
+_ABS_PATH_BLOCK = [
+    "/sbin/shutdown -h now",
+    "/usr/sbin/reboot",
+    "/sbin/halt",
+    "/sbin/init 6",
+    "/bin/rm -rf /",
+    "sudo /sbin/shutdown -h now",
+    "env LC_ALL=C /sbin/reboot",
+    "echo done; /sbin/shutdown -h now",
+    "true && /usr/sbin/poweroff",
+    r"C:\Windows\System32\shutdown.exe /s /t 0",
+    "C:/Windows/System32/shutdown.exe /s /t 0",
+    r'"C:\Program Files\Git\usr\bin\rm.exe" -rf /',
+    r"C:\Windows\System32\shutdown.EXE /s",
+    # path-spelled wrapper chains resolve in the single projection pass
+    "/usr/bin/sudo /sbin/shutdown -h now",
+    "/usr/bin/env /usr/bin/sudo /sbin/shutdown -h now",
+    "exec /sbin/reboot",
+    "( /sbin/shutdown -h now )",
+    "/sbin/telinit 6",
+    "./shutdown -h now",
+    "shutdown.exe /s",
+    # composed spellings reduce through the same collapsing as r\m detection
+    "'/sbin/'shutdown -h now",
+    "/sbin/shut\\down -h now",
+    # a payload's executable can be path-spelled too
+    "bash -c '/sbin/shutdown -h now'",
+    "exec bash -c '/bin/rm -rf /'",
+    # group/substitution closers stay outside the projected word
+    "(/sbin/reboot)",
+    "$(/sbin/reboot)",
+    "`/sbin/reboot`",
+    "{ /sbin/reboot; }",
+    "env -u FOO /sbin/reboot",
+]
+
+_ABS_PATH_ALLOW = [
+    "echo /sbin/shutdown",
+    "ls -la /sbin/shutdown",
+    "grep 'shutdown' /var/log/syslog",
+    "stat /usr/sbin/reboot",
+    r"stat C:\Windows\System32\shutdown.exe",
+    "cat /bin/rm",
+    'echo "/sbin/init 6"',
+    "md5sum /sbin/halt",
+    # basename must match the pattern word exactly, not a near-miss
+    "/usr/local/bin/rebooter --dry-run",
+    "./deploy.sh shutdown",
+    "cat /etc/init.d/reboot",
+    # a bare assignment prefix is data — projecting its value manufactured
+    # a False->True flip in the first cut of this fix (Sol round 2)
+    "X=/sbin/shutdown echo ok",
+    # a wrapper option's operand is data, not the command word
+    "env --chdir /tmp/reboot /bin/echo ok",
+    "env --chdir /tmp/reboot echo ok",
+    "env --argv0 /tmp/reboot /bin/echo ok",
+    # `}` is not a shell metacharacter: it can end a legitimate word
+    "/tmp/reboot}",
+]
+
+
+@pytest.mark.parametrize("command", _ABS_PATH_BLOCK)
+def test_abs_path_invocation_is_hardline_blocked(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"absolute-path spelling bypassed the floor: {command!r}"
+    assert desc, "hardline match must provide a description"
+
+
+@pytest.mark.parametrize("command", _ABS_PATH_ALLOW)
+def test_abs_path_as_data_is_not_hardline(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert not is_hl, f"path-as-data false positive: {command!r} (got: {desc})"
+
+
+def test_abs_path_hardline_not_bypassed_by_yolo(clean_session, monkeypatch):
+    """The floor must hold for path-spelled commands under yolo too."""
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    result = check_all_command_guards("/sbin/shutdown -h now", "local")
+    assert result["approved"] is False
+    assert result.get("hardline") is True

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -880,12 +880,12 @@ _ABS_PATH_ALLOW = [
     "command -pv /sbin/reboot",
     # a word outside a wrapper's option list is the program name, and the
     # shell fails to run it — blocking these would be a false positive
+    # (time/setsid are the exception: their unknown options fail safe, see
+    # the time/setsid section below)
     "exec -x /sbin/reboot",
     "exec -- -c /sbin/reboot",
     "nohup -x /sbin/reboot",
     "nohup -- -x /sbin/reboot",
-    "setsid -x /sbin/reboot",
-    "time -x /sbin/reboot",
     "builtin -x /sbin/reboot",
     "builtin -- -x /sbin/reboot",
     "echo /sbin/shutdown",
@@ -972,3 +972,137 @@ def test_pass_through_launcher_wrappers_resolve_command_word_under_yolo(
 
     assert result["approved"] is approved, command
     assert bool(result.get("hardline")) is hardline, command
+
+
+# -------------------------------------------------------------------------
+# time / setsid option grammar
+# -------------------------------------------------------------------------
+#
+# `time` and `setsid` accept options of their own ahead of the program word
+# (GNU time: -p/-a/-v/-q/-V, -f/-o with an operand; setsid: -c/-f/-w/-V/-h).
+# Without a grammar for them the walker treats the option itself as the
+# command word and never inspects the executable behind it.
+
+_TIME_SETSID_BLOCK = [
+    "time -p /sbin/reboot",
+    "setsid -f /sbin/reboot",
+    "setsid -w -c /sbin/reboot",
+    "setsid -fw /sbin/reboot",
+    "setsid --fork /sbin/reboot",
+    "time --quiet /sbin/reboot",
+    # an option's operand is skipped as data, then the executable resolves
+    "time -o /tmp/x /sbin/reboot",
+    "time -f '%e' /sbin/reboot",
+    "time --format=%e /sbin/reboot",
+    "time -p -- /sbin/reboot",
+]
+
+
+@pytest.mark.parametrize("command", _TIME_SETSID_BLOCK)
+def test_time_setsid_options_resolve_command_word(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"time/setsid option hid the executable: {command!r}"
+    assert desc, "hardline match must provide a description"
+
+
+_TIME_SETSID_ALLOW = [
+    # an option's operand is data, not the command word
+    "time -o /sbin/reboot /bin/echo hi",
+    "time -f /sbin/reboot /bin/echo hi",
+    "time --output=/sbin/reboot /bin/echo hi",
+    # ordinary launches keep working
+    "time -p /bin/echo hi",
+    "setsid -f /bin/echo hi",
+    "setsid -w sleep 1",
+    # a lone wrapper word has no command to resolve
+    "time",
+    "setsid",
+]
+
+
+@pytest.mark.parametrize("command", _TIME_SETSID_ALLOW)
+def test_time_setsid_option_operands_are_data(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert not is_hl, f"time/setsid false positive: {command!r} (got: {desc})"
+
+
+# An option word we do NOT model (`time -Z`) means the walker cannot tell
+# where the program word starts. That must fail safe (detected), never fall
+# back to "the option is the program" — that misread is exactly how
+# `time -p /sbin/reboot` walked past the floor.
+_TIME_SETSID_UNKNOWN_OPTION = [
+    "time -Z /sbin/reboot",
+    "time -x /sbin/reboot",
+    "time --bogus /sbin/reboot",
+    "setsid -x /sbin/reboot",
+    "setsid --bogus /sbin/reboot",
+]
+
+
+@pytest.mark.parametrize("command", _TIME_SETSID_UNKNOWN_OPTION)
+def test_unknown_time_setsid_option_fails_safe(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"unknown time/setsid option fell open: {command!r}"
+    assert desc
+
+
+def test_time_setsid_hardline_under_yolo(clean_session, monkeypatch):
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    for cmd in ("time -p /sbin/reboot", "setsid -f /sbin/reboot"):
+        result = check_all_command_guards(cmd, "local")
+        assert result["approved"] is False, f"yolo leaked {cmd!r}"
+        assert result.get("hardline") is True, cmd
+
+
+# -------------------------------------------------------------------------
+# Walker termination: no pass-through exit
+# -------------------------------------------------------------------------
+#
+# The walk over the command prefix must end in exactly three ways: the
+# command word resolves, the input ends, or the defensive word cap trips and
+# the command is treated as unresolvable (detected). A fixed wrapper budget
+# used to be a fourth exit that silently gave up and let the executable
+# through uninspected.
+
+def test_wrapper_chain_depth_is_not_a_bypass():
+    import tools.approval as approval_mod
+
+    capped = {approval_mod._PARSER_LIMIT_DESCRIPTION,
+              approval_mod._MALFORMED_EXEC_DESCRIPTION}
+    for depth in (11, 12, 13):
+        command = "env " * depth + "/sbin/reboot"
+        is_hl, desc = detect_hardline_command(command)
+        assert is_hl, f"{depth} wrappers let the executable through"
+        assert desc not in capped, (
+            f"{depth} wrappers should resolve fully, not hit the cap: {desc!r}"
+        )
+
+
+def test_wrapper_chain_depth_bypass_closed_under_yolo(clean_session, monkeypatch):
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    command = "env " * 12 + "/sbin/reboot"
+    result = check_all_command_guards(command, "local")
+    assert result["approved"] is False, "12 wrappers leaked under yolo"
+    assert result.get("hardline") is True
+
+
+def test_walker_word_cap_fails_safe_never_open():
+    import tools.approval as approval_mod
+
+    capped = {approval_mod._PARSER_LIMIT_DESCRIPTION,
+              approval_mod._MALFORMED_EXEC_DESCRIPTION}
+    max_words = approval_mod._WALKER_MAX_WORDS
+    for total_words, resolves in ((max_words - 1, True),
+                                  (max_words, False),
+                                  (max_words + 1, False)):
+        command = "env " * (total_words - 1) + "/sbin/reboot"
+        is_hl, desc = detect_hardline_command(command)
+        assert is_hl, f"{total_words}-word walk fell open"
+        if resolves:
+            assert desc not in capped, (
+                f"{total_words} words is under the cap and must resolve: {desc!r}"
+            )
+        else:
+            assert desc in capped, (
+                f"{total_words} words must trip the defensive cap: {desc!r}"
+            )

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1057,26 +1057,36 @@ _COMMAND_WRAPPER_WORDS = {
     "nice",
     "stdbuf",
 }
-_SUDO_OPTIONS_WITH_ARG = {
-    "-c", "--close-from",
-    "-g", "--group",
-    "-h", "--host",
-    "-p", "--prompt",
-    "-u", "--user",
-}
-# GNU env options whose value arrives as the NEXT word. Their operand is
-# data (`env --chdir /tmp/reboot /bin/echo` never executes reboot), so the
-# projection walker must not treat it as the command word. `=`-attached
-# forms are already handled by the generic option check. `-S/--split-string`
-# is listed here only for the walker's word skipping — its payload is
-# executable-bearing, but parsing it is a separate fail-closed change
-# (same verdict as the design review); skipping keeps parity with main.
-_ENV_OPTIONS_WITH_ARG = {
-    "-a", "--argv0",
-    "-c", "--chdir",
-    "-s", "--split-string",
-    "-u", "--unset",
-}
+# sudo uses getopt_long and its short options are case-sensitive. Keep the
+# complete option namespace here so unique long abbreviations can be resolved
+# exactly as sudo resolves them. Unknown or ambiguous spellings fail closed.
+_SUDO_LONG_OPTIONS_WITH_ARG = frozenset({
+    "auth-type", "close-from", "login-class", "chdir", "group", "host",
+    "prompt", "chroot", "role", "command-timeout", "type", "other-user",
+    "user",
+})
+_SUDO_LONG_OPTIONS = _SUDO_LONG_OPTIONS_WITH_ARG | frozenset({
+    "background", "preserve-env", "edit", "set-home", "login",
+    "remove-timestamp", "list", "preserve-groups", "shell", "validate",
+    "askpass", "bell", "help", "reset-timestamp", "no-update",
+    "non-interactive", "stdin", "version",
+})
+_SUDO_SHORT_FLAGS = frozenset("ABbEeHiKklNnPSsVv")
+_SUDO_SHORT_OPTIONS_WITH_ARG = frozenset("aCcDgpRrTtUu")
+
+# GNU env has its own case-sensitive getopt grammar. Split-string is not a
+# data operand: env parses it into the argv it executes. Its quoting,
+# expansion, escaping, and comment rules differ from shell parsing, so the
+# safe bounded behavior is to mark every recognized -S/--split-string form
+# unresolved instead of attempting a partial parser here.
+_ENV_LONG_OPTIONS_WITH_ARG = frozenset({"argv0", "unset", "chdir"})
+_ENV_LONG_OPTIONS = _ENV_LONG_OPTIONS_WITH_ARG | frozenset({
+    "null", "ignore-environment", "default-signal", "ignore-signal",
+    "block-signal", "list-signal-handling", "debug", "split-string",
+    "help", "version",
+})
+_ENV_SHORT_FLAGS = frozenset("0iv")
+_ENV_SHORT_OPTIONS_WITH_ARG = frozenset("aCu")
 
 # `command` takes options of its own before the executable, and none of them
 # take a separate operand: `command -p /sbin/reboot` and `command -- ...`
@@ -1204,20 +1214,100 @@ def _short_wrapper_option_action(
     return ("skip", False)
 
 
+def _resolve_unique_long_option(
+    word: str, options: frozenset[str]
+) -> str | None:
+    """Resolve an exact or unambiguous getopt_long option name."""
+    option_name = word[2:].split("=", 1)[0]
+    if not option_name:
+        return None
+    if option_name in options:
+        return option_name
+    matches = [option for option in options if option.startswith(option_name)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _sudo_option_action(word: str) -> tuple[str, bool]:
+    """Classify one sudo option using sudo's case-sensitive getopt grammar."""
+    if word.startswith("--"):
+        option = _resolve_unique_long_option(word, _SUDO_LONG_OPTIONS)
+        if option is None:
+            return ("unresolved", False)
+        return (
+            "skip",
+            "=" not in word and option in _SUDO_LONG_OPTIONS_WITH_ARG,
+        )
+
+    cluster = word[1:]
+    if not cluster:
+        return ("unresolved", False)
+    for index, option in enumerate(cluster):
+        has_attached_operand = index < len(cluster) - 1
+        if option in _SUDO_SHORT_OPTIONS_WITH_ARG:
+            return ("skip", not has_attached_operand)
+        if option == "h":
+            if has_attached_operand:
+                return ("skip", False)
+            # Only an exact `-h` may consume the next ordinary word as sudo's
+            # historical remote-host operand. A bundled `-nh` selects help,
+            # and exact `-h` also selects help when the next word is another
+            # option or an environment assignment. The walkers perform that
+            # one-word lookahead before deciding whether execution continues.
+            return (
+                "sudo_host_or_help" if word == "-h" else "stop",
+                False,
+            )
+        if option not in _SUDO_SHORT_FLAGS:
+            return ("unresolved", False)
+    return ("skip", False)
+
+
+def _env_option_action(word: str) -> tuple[str, bool]:
+    """Classify one GNU env option without parsing executable -S payloads."""
+    if word == "-":
+        return ("skip", False)
+    if word.startswith("--"):
+        option = _resolve_unique_long_option(word, _ENV_LONG_OPTIONS)
+        if option is None or option == "split-string":
+            return ("unresolved", False)
+        return (
+            "skip",
+            "=" not in word and option in _ENV_LONG_OPTIONS_WITH_ARG,
+        )
+
+    cluster = word[1:]
+    if not cluster:
+        return ("unresolved", False)
+    for index, option in enumerate(cluster):
+        if option == "S":
+            return ("unresolved", False)
+        if option in _ENV_SHORT_OPTIONS_WITH_ARG:
+            return ("skip", index == len(cluster) - 1)
+        if option not in _ENV_SHORT_FLAGS:
+            return ("unresolved", False)
+    return ("skip", False)
+
+
 def _wrapper_option_action(wrapper: str, word: str) -> tuple[str | None, bool]:
     """Classify one option-shaped word for a pass-through wrapper.
 
     The action is ``skip`` for a recognized option, ``end`` for ``--``,
-    ``stop`` for command lookup-only modes, ``unresolved`` for an option the
-    wrapper's exhaustive grammar does not know (the walker cannot place the
-    program word and must fail safe), and ``None`` when the word is the
-    program name rather than an option. The boolean reports whether the next
-    word is the option's separate operand.
+    ``stop`` for non-executing modes, ``sudo_host_or_help`` when exact ``-h``
+    needs one-word lookahead, ``unresolved`` for an option the wrapper's
+    exhaustive grammar does not know (the walker cannot place the program word
+    and must fail safe), and ``None`` when the word is the program name rather
+    than an option. The boolean reports whether the next word is the option's
+    separate operand.
     """
+    if word == "--":
+        return ("end", False)
+    if wrapper == "sudo":
+        return _sudo_option_action(word)
+    if wrapper == "env":
+        return _env_option_action(word)
+
     lowered = word.lower()
     option_name = lowered.split("=", 1)[0]
-    if lowered == "--":
-        return ("end", False)
     if wrapper == "command" and _is_lookup_only_option(option_name):
         return ("stop", False)
     if wrapper == "nice" and re.fullmatch(r"-\d+", lowered):
@@ -1228,13 +1318,7 @@ def _wrapper_option_action(wrapper: str, word: str) -> tuple[str | None, bool]:
     if short_action is not None:
         return short_action
 
-    if wrapper == "sudo":
-        options = None
-        options_with_arg = _SUDO_OPTIONS_WITH_ARG
-    elif wrapper == "env":
-        options = None
-        options_with_arg = _ENV_OPTIONS_WITH_ARG
-    elif wrapper == "command":
+    if wrapper == "command":
         options = _COMMAND_OPTIONS
         options_with_arg = frozenset()
     elif wrapper == "exec":
@@ -1266,6 +1350,59 @@ def _wrapper_option_action(wrapper: str, word: str) -> tuple[str | None, bool]:
     return (
         "skip",
         "=" not in lowered and option_name in options_with_arg,
+    )
+
+
+def _wrapper_assignment_is_data(
+    wrapper: str, word: str, *, options_enabled: bool
+) -> bool:
+    """Return whether ``word`` is assignment data owned by ``wrapper``.
+
+    Shell assignment prefixes, sudo's interspersed environment entries, and
+    GNU env's NAME=VALUE operands have different grammars. Keep the wrapper
+    grammars here so both command-position walkers make the same transition.
+    """
+    if wrapper == "sudo":
+        # sudo parse_args.c:is_envar. `--` disables this interspersed form.
+        return (
+            options_enabled
+            and bool(word)
+            and word[0] not in {"/", "="}
+            and "=" in word
+        )
+    if wrapper == "env":
+        # GNU env consumes every equals-bearing operand before COMMAND, even
+        # after `--`; putenv itself decides whether the name is acceptable.
+        return "=" in word
+    return False
+
+
+def _wrapper_prefix_action(
+    wrapper: str, word: str, *, options_enabled: bool
+) -> tuple[str | None, bool, bool]:
+    """Classify one wrapper-prefix word at the shared state-machine choke point."""
+    # getopt owns option-shaped words before NAME=VALUE processing. This order
+    # is load-bearing for forms such as `env --split-string=PAYLOAD`.
+    if options_enabled and word.startswith("-"):
+        action, skip_next = _wrapper_option_action(wrapper, word)
+        return (action, skip_next, False if action == "end" else options_enabled)
+    if _wrapper_assignment_is_data(
+        wrapper, word, options_enabled=options_enabled
+    ):
+        # sudo resumes getopt after each interspersed assignment. GNU env's
+        # first NAME=VALUE permanently ends its option phase.
+        return ("skip", False, False if wrapper == "env" else options_enabled)
+    return (None, False, options_enabled)
+
+
+def _sudo_historical_host_follows(command: str, pos: int) -> bool:
+    """Return whether exact ``sudo -h`` consumes the next word as a host."""
+    word_start, word_end, word = _read_shell_word(command, pos)
+    if word_start == word_end:
+        return False
+    deobfuscated = _deobfuscate_shell_word_for_detection(word)
+    return not deobfuscated.startswith("-") and not _wrapper_assignment_is_data(
+        "sudo", deobfuscated, options_enabled=True
     )
 
 _INTERPRETER_EXEC_FLAGS = {
@@ -2137,9 +2274,15 @@ def _iter_shell_command_word_spans(command: str):
                 skip_next_wrapper_arg = False
                 pos = word_end
                 continue
-            if skip_wrapper_options and lower_word.startswith("-"):
-                action, skip_next_wrapper_arg = _wrapper_option_action(
-                    active_wrapper, lower_word
+            if active_wrapper:
+                (
+                    action,
+                    skip_next_wrapper_arg,
+                    skip_wrapper_options,
+                ) = _wrapper_prefix_action(
+                    active_wrapper,
+                    deobfuscated,
+                    options_enabled=skip_wrapper_options,
                 )
                 if action == "unresolved":
                     raise _UnresolvedCommandWalk(
@@ -2147,9 +2290,12 @@ def _iter_shell_command_word_spans(command: str):
                     )
                 if action == "stop":
                     break
+                if action == "sudo_host_or_help":
+                    if _sudo_historical_host_follows(command, word_end):
+                        skip_next_wrapper_arg = True
+                    else:
+                        break
                 if action is not None:
-                    if action == "end":
-                        skip_wrapper_options = False
                     pos = word_end
                     continue
             if skip_timeout_duration:
@@ -2166,7 +2312,7 @@ def _iter_shell_command_word_spans(command: str):
                 skip_timeout_duration = lower_word == "timeout"
                 pos = word_end
                 continue
-            if _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
+            if not active_wrapper and _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
                 active_wrapper = ""
                 skip_wrapper_options = False
                 pos = word_end
@@ -2272,11 +2418,15 @@ def _project_path_spelled_executables(command: str) -> str | None:
                 skip_next_wrapper_arg = False
                 continue
             deobfuscated = _deobfuscate_shell_word_for_detection(word) or word
-            if _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
-                continue  # VAR=value prefix: data, keep walking
-            if skip_wrapper_options and deobfuscated.startswith("-"):
-                action, skip_next_wrapper_arg = _wrapper_option_action(
-                    active_wrapper, deobfuscated
+            if active_wrapper:
+                (
+                    action,
+                    skip_next_wrapper_arg,
+                    skip_wrapper_options,
+                ) = _wrapper_prefix_action(
+                    active_wrapper,
+                    deobfuscated,
+                    options_enabled=skip_wrapper_options,
                 )
                 if action == "unresolved":
                     raise _UnresolvedCommandWalk(
@@ -2284,10 +2434,15 @@ def _project_path_spelled_executables(command: str) -> str | None:
                     )
                 if action == "stop":
                     break
+                if action == "sudo_host_or_help":
+                    if _sudo_historical_host_follows(command, pos):
+                        skip_next_wrapper_arg = True
+                    else:
+                        break
                 if action is not None:
-                    if action == "end":
-                        skip_wrapper_options = False
                     continue
+            if not active_wrapper and _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
+                continue  # shell VAR=value prefix: data, keep walking
             if skip_timeout_duration:
                 skip_timeout_duration = False
                 skip_wrapper_options = False

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -514,11 +514,14 @@ def detect_hardline_command(command: str) -> tuple:
     _, malformed_grep = _grep_safe_detection_variant(normalized)
     if malformed_grep:
         return (True, _MALFORMED_EXEC_DESCRIPTION)
-    for command_variant in _command_detection_variants(command):
-        variant_lower = command_variant.lower()
-        for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
-            if pattern_re.search(variant_lower):
-                return (True, description)
+    try:
+        for command_variant in _command_detection_variants(command):
+            variant_lower = command_variant.lower()
+            for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
+                if pattern_re.search(variant_lower):
+                    return (True, description)
+    except _UnresolvedCommandWalk as unresolved:
+        return (True, unresolved.description)
     return (False, None)
 
 
@@ -546,11 +549,16 @@ def _match_user_deny_rule(command: str) -> str | None:
              if isinstance(p, str) and p.strip()]
     if not globs:
         return None
-    for command_variant in _command_detection_variants(command):
-        candidate = command_variant.lower().strip()
-        for pattern in globs:
-            if fnmatch.fnmatchcase(candidate, pattern.lower()):
-                return pattern
+    try:
+        for command_variant in _command_detection_variants(command):
+            candidate = command_variant.lower().strip()
+            for pattern in globs:
+                if fnmatch.fnmatchcase(candidate, pattern.lower()):
+                    return pattern
+    except _UnresolvedCommandWalk:
+        # No deny rule can be confirmed on an unresolvable command; the
+        # hardline detector already fails it safe.
+        return None
     return None
 
 
@@ -1109,6 +1117,41 @@ _STDBUF_OPTIONS_WITH_ARG = frozenset({
 })
 _STDBUF_OPTIONS = _STDBUF_OPTIONS_WITH_ARG
 
+# `time` is both a bash reserved word (accepting only -p) and GNU time
+# (-f/--format and -o/--output take an operand; -p -a -v -q -V do not). The
+# walker only sees the spelling, so it accepts the union of both grammars.
+# Option names are matched lowercased, so -V folds onto -v (both take no
+# operand under either spelling).
+_TIME_OPTIONS_WITH_ARG = frozenset({
+    "-f", "--format",
+    "-o", "--output",
+})
+_TIME_OPTIONS = _TIME_OPTIONS_WITH_ARG | frozenset({
+    "-p", "--portability",
+    "-a", "--append",
+    "-v", "--verbose",
+    "-q", "--quiet",
+    "--version",
+    "--help",
+})
+
+# util-linux setsid's getopt string is "+Vhcfw" — every option is a flag,
+# and the leading "+" stops option parsing at the first non-option word.
+_SETSID_OPTIONS = frozenset({
+    "-c", "--ctty",
+    "-f", "--fork",
+    "-w", "--wait",
+    "-v", "--version",
+    "-h", "--help",
+})
+
+# For these wrappers the option grammar above is exhaustive, so an option
+# word outside it means the walker cannot tell where the program word
+# starts. Resolving anyway risks projecting an option (or its operand) as
+# the command word, so the walk reports the command as unresolvable and the
+# caller fails safe.
+_WRAPPERS_UNRESOLVED_ON_UNKNOWN_OPTION = frozenset({"time", "setsid"})
+
 _WRAPPER_SHORT_FLAGS = {
     "command": frozenset("pv"),
     "exec": frozenset("cl"),
@@ -1116,12 +1159,15 @@ _WRAPPER_SHORT_FLAGS = {
     # --preserve-status, so v/f/p are the no-argument short flags that can
     # appear bundled (-vpf) ahead of the duration.
     "timeout": frozenset("vfp"),
+    "time": frozenset("pavq"),
+    "setsid": frozenset("cfwvh"),
 }
 _WRAPPER_SHORT_OPTIONS_WITH_ARG = {
     "exec": frozenset("a"),
     "timeout": frozenset("ks"),
     "nice": frozenset("n"),
     "stdbuf": frozenset("ioe"),
+    "time": frozenset("fo"),
 }
 
 
@@ -1162,7 +1208,9 @@ def _wrapper_option_action(wrapper: str, word: str) -> tuple[str | None, bool]:
     """Classify one option-shaped word for a pass-through wrapper.
 
     The action is ``skip`` for a recognized option, ``end`` for ``--``,
-    ``stop`` for command lookup-only modes, and ``None`` when the word is the
+    ``stop`` for command lookup-only modes, ``unresolved`` for an option the
+    wrapper's exhaustive grammar does not know (the walker cannot place the
+    program word and must fail safe), and ``None`` when the word is the
     program name rather than an option. The boolean reports whether the next
     word is the option's separate operand.
     """
@@ -1201,11 +1249,19 @@ def _wrapper_option_action(wrapper: str, word: str) -> tuple[str | None, bool]:
     elif wrapper == "stdbuf":
         options = _STDBUF_OPTIONS
         options_with_arg = _STDBUF_OPTIONS_WITH_ARG
+    elif wrapper == "time":
+        options = _TIME_OPTIONS
+        options_with_arg = _TIME_OPTIONS_WITH_ARG
+    elif wrapper == "setsid":
+        options = _SETSID_OPTIONS
+        options_with_arg = frozenset()
     else:
         options = frozenset()
         options_with_arg = frozenset()
 
     if options is not None and option_name not in options:
+        if wrapper in _WRAPPERS_UNRESOLVED_ON_UNKNOWN_OPTION:
+            return ("unresolved", False)
         return (None, False)
     return (
         "skip",
@@ -1278,6 +1334,30 @@ _MAX_SEPARATOR_FREE_COMMAND_CHARS = 4_096
 _MAX_DETECTION_SEGMENTS = 25_000
 _PARSER_LIMIT_DESCRIPTION = "command parser limit exceeded"
 _MALFORMED_EXEC_DESCRIPTION = "command parser limit or malformed executable payload"
+_UNRESOLVED_WRAPPER_OPTION_DESCRIPTION = (
+    "unrecognized wrapper option ahead of the command word"
+)
+
+# Defensive cap on the words a command-position walk may consume per command
+# start. It is not a termination condition — every iteration consumes at
+# least one word, so the walk already terminates on input length — it bounds
+# the work spent on pathological prefixes. Reaching it means the command
+# word was never resolved, and that must surface as "unresolvable" (callers
+# fail safe), never as a silent pass-through.
+_WALKER_MAX_WORDS = 256
+
+
+class _UnresolvedCommandWalk(Exception):
+    """A command-position walk could not resolve the command word.
+
+    Raised when the walk hits ``_WALKER_MAX_WORDS`` or an option the
+    wrapper grammar cannot place. Detection entry points map this to a
+    positive detection: an uninspectable command must not run uninspected.
+    """
+
+    def __init__(self, description: str) -> None:
+        super().__init__(description)
+        self.description = description
 
 
 
@@ -1381,7 +1461,11 @@ def _quoted_grep_pattern_spans(command: str) -> tuple[list[tuple[int, int]], boo
     for segment in _iter_top_level_shell_segments(command):
         segment_at = command.find(segment, offset)
         offset = segment_at + len(segment)
-        for start, _, word in _iter_shell_command_word_spans(segment):
+        try:
+            command_words = list(_iter_shell_command_word_spans(segment))
+        except _UnresolvedCommandWalk:
+            return [], True
+        for start, _, word in command_words:
             if os.path.basename(_deobfuscate_shell_word_for_detection(word)).lower() not in {
                 "grep", "egrep",
             }:
@@ -1663,7 +1747,12 @@ def _read_tool_exec_flag(tool: str, args: list[str]) -> tuple[str, str] | None:
 def _execution_flag_findings(command: str):
     """Yield scoped execution mechanisms and any executable payloads."""
     for segment in _iter_top_level_shell_segments(command):
-        for start, _, word in _iter_shell_command_word_spans(segment):
+        try:
+            command_words = list(_iter_shell_command_word_spans(segment))
+        except _UnresolvedCommandWalk:
+            yield (_MALFORMED_EXEC_DESCRIPTION, None)
+            continue
+        for start, _, word in command_words:
             executable = _deobfuscate_shell_word_for_detection(word)
             tokens = _shell_segment_tokens(segment, start)
             executable_name = os.path.basename(executable).lower()
@@ -2030,43 +2119,46 @@ def _iter_shell_command_word_spans(command: str):
     """Yield command-position words that may be executable names."""
     for command_start in _iter_shell_command_starts(command):
         pos = command_start
-        prefix_words = 0
+        words_walked = 0
         active_wrapper = ""
         skip_wrapper_options = False
         skip_next_wrapper_arg = False
         skip_timeout_duration = False
-        while prefix_words < 12:
+        while True:
             word_start, word_end, word = _read_shell_word(command, pos)
             if word_start == word_end:
                 break
+            words_walked += 1
+            if words_walked >= _WALKER_MAX_WORDS:
+                raise _UnresolvedCommandWalk(_PARSER_LIMIT_DESCRIPTION)
             deobfuscated = _deobfuscate_shell_word_for_detection(word)
             lower_word = deobfuscated.lower()
             if skip_next_wrapper_arg:
                 skip_next_wrapper_arg = False
                 pos = word_end
-                prefix_words += 1
                 continue
             if skip_wrapper_options and lower_word.startswith("-"):
                 action, skip_next_wrapper_arg = _wrapper_option_action(
                     active_wrapper, lower_word
                 )
+                if action == "unresolved":
+                    raise _UnresolvedCommandWalk(
+                        _UNRESOLVED_WRAPPER_OPTION_DESCRIPTION
+                    )
                 if action == "stop":
                     break
                 if action is not None:
                     if action == "end":
                         skip_wrapper_options = False
                     pos = word_end
-                    prefix_words += 1
                     continue
             if skip_timeout_duration:
                 skip_timeout_duration = False
                 skip_wrapper_options = False
                 pos = word_end
-                prefix_words += 1
                 continue
 
             yield (word_start, word_end, word)
-            prefix_words += 1
 
             if lower_word in _COMMAND_WRAPPER_WORDS:
                 active_wrapper = lower_word
@@ -2153,17 +2245,19 @@ def _project_path_spelled_executables(command: str) -> str | None:
         skip_wrapper_options = False
         skip_next_wrapper_arg = False
         skip_timeout_duration = False
-        # Bound the WRAPPER chain, not the whole prefix: shell grammar puts no
-        # limit on assignment prefixes or on a wrapper option list, so counting
-        # those let a caller push the executable past a fixed budget and out of
-        # the projection (`A0=1 ... A11=1 /sbin/reboot` — egilewski on #71996;
-        # eleven repeated options — Sol). Only a wrapper word spends budget; the
-        # walk still terminates because every iteration consumes input.
-        wrapper_budget = 12
-        while wrapper_budget > 0:
+        # Shell grammar puts no limit on assignment prefixes, wrapper chains,
+        # or wrapper option lists, so no fixed budget may end this walk — any
+        # such exit lets a caller push the executable out of the projection.
+        # The walk terminates because every iteration consumes input; the
+        # shared word cap only bounds pathological prefixes and fails safe.
+        words_walked = 0
+        while True:
             word_start, raw_end, _raw_word = _read_shell_word(command, pos)
             if word_start == raw_end:
                 break
+            words_walked += 1
+            if words_walked >= _WALKER_MAX_WORDS:
+                raise _UnresolvedCommandWalk(_PARSER_LIMIT_DESCRIPTION)
             pos = raw_end
             # Trim group/substitution closers the word reader keeps
             # (`(/sbin/reboot)` reads as `/sbin/reboot)`); the closer stays
@@ -2184,6 +2278,10 @@ def _project_path_spelled_executables(command: str) -> str | None:
                 action, skip_next_wrapper_arg = _wrapper_option_action(
                     active_wrapper, deobfuscated
                 )
+                if action == "unresolved":
+                    raise _UnresolvedCommandWalk(
+                        _UNRESOLVED_WRAPPER_OPTION_DESCRIPTION
+                    )
                 if action == "stop":
                     break
                 if action is not None:
@@ -2199,7 +2297,6 @@ def _project_path_spelled_executables(command: str) -> str | None:
             if basename is not None and word_start not in replacements:
                 replacements[word_start] = (word_end, basename)
             if effective in _COMMAND_WRAPPER_WORDS:
-                wrapper_budget -= 1  # only the wrapper CHAIN is bounded
                 active_wrapper = effective
                 resolved_through_wrapper = True
                 skip_wrapper_options = True
@@ -2335,12 +2432,15 @@ def detect_dangerous_command(command: str) -> tuple:
     if _is_verification_artifact_cleanup(command):
         return (False, None, None)
 
-    for command_variant in _command_detection_variants(command):
-        command_lower = command_variant.lower()
-        for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
-            if pattern_re.search(command_lower):
-                pattern_key = description
-                return (True, pattern_key, description)
+    try:
+        for command_variant in _command_detection_variants(command):
+            command_lower = command_variant.lower()
+            for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
+                if pattern_re.search(command_lower):
+                    pattern_key = description
+                    return (True, pattern_key, description)
+    except _UnresolvedCommandWalk as unresolved:
+        return (True, unresolved.description, unresolved.description)
     normalized = _normalize_command_for_detection(command)
     for description, _ in _execution_flag_findings(normalized):
         return (True, description, description)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1067,6 +1067,26 @@ _ENV_OPTIONS_WITH_ARG = {
     "-u", "--unset",
 }
 
+# `command` takes options of its own before the executable, and none of them
+# take a separate operand: `command -p /sbin/reboot` and `command -- ...`
+# both run the executable. `-v`/`-V` are the exception — they only look the
+# command up and print it, so nothing is executed and the walker must stop
+# rather than project a word that never runs. `command`'s only short options
+# are `p`, `v` and `V`, so any cluster carrying v/V (`-pv`) is lookup-only too.
+_COMMAND_LOOKUP_ONLY_SHORT = frozenset("vV")
+_COMMAND_OPTIONS = frozenset({"-p", "-v", "-V"})
+
+# `exec -a NAME` consumes the following word as the argv[0] to use; `-c` and
+# `-l` take no operand. Anything else after `exec` is the program.
+_EXEC_OPTIONS = frozenset({"-a", "-c", "-l"})
+_EXEC_OPTIONS_WITH_ARG = frozenset({"-a"})
+
+
+def _is_lookup_only_option(option_name: str) -> bool:
+    if option_name.startswith("--"):
+        return False
+    return bool(set(option_name[1:]) & _COMMAND_LOOKUP_ONLY_SHORT)
+
 _INTERPRETER_EXEC_FLAGS = {
     "python": {"-c"},
     "node": {"-e", "--eval", "-p", "--print"},
@@ -1990,9 +2010,18 @@ def _project_path_spelled_executables(command: str) -> str | None:
     for command_start in _iter_shell_command_starts(command):
         pos = command_start
         wrapper_arg_options: frozenset | set = frozenset()
+        wrapper_options: frozenset | set | None = frozenset()
+        command_option_grammar = False
         skip_wrapper_options = False
         skip_next_wrapper_arg = False
-        for _ in range(12):
+        # Bound the WRAPPER chain, not the whole prefix: shell grammar puts no
+        # limit on assignment prefixes or on a wrapper option list, so counting
+        # those let a caller push the executable past a fixed budget and out of
+        # the projection (`A0=1 ... A11=1 /sbin/reboot` — egilewski on #71996;
+        # eleven repeated options — Sol). Only a wrapper word spends budget; the
+        # walk still terminates because every iteration consumes input.
+        wrapper_budget = 12
+        while wrapper_budget > 0:
             word_start, raw_end, _raw_word = _read_shell_word(command, pos)
             if word_start == raw_end:
                 break
@@ -2014,21 +2043,58 @@ def _project_path_spelled_executables(command: str) -> str | None:
                 continue  # VAR=value prefix: data, keep walking
             if skip_wrapper_options and deobfuscated.startswith("-"):
                 option_name = deobfuscated.lower().split("=", 1)[0]
-                skip_next_wrapper_arg = (
-                    "=" not in deobfuscated
-                    and option_name in wrapper_arg_options
-                )
-                continue
+                if wrapper_options is None:
+                    # sudo/env: their option lists are large and largely
+                    # long-form, so every dash word is still skipped. Left as
+                    # it was — narrowing them is a separate change.
+                    skip_next_wrapper_arg = (
+                        "=" not in deobfuscated
+                        and option_name in wrapper_arg_options
+                    )
+                    continue
+                # Wrappers whose option list is small enough to model exactly.
+                # `--` ends it: whatever follows is the program name even when
+                # it looks like an option (`command -- -p x` runs `-p`), and a
+                # word outside the list is not an option at all, so it falls
+                # through and is read as the program — which is what the shell
+                # does. Both directions matter: skipping every dash word
+                # blocked spellings the shell never executes.
+                if deobfuscated == "--":
+                    skip_wrapper_options = False
+                    continue
+                if command_option_grammar and _is_lookup_only_option(option_name):
+                    break  # `command -v`: a lookup, nothing is executed
+                if option_name in wrapper_options:
+                    skip_next_wrapper_arg = (
+                        "=" not in deobfuscated
+                        and option_name in wrapper_arg_options
+                    )
+                    continue
             basename = _projected_executable_basename(word)
             effective = (basename or deobfuscated).lower()
             if basename is not None and word_start not in replacements:
                 replacements[word_start] = (word_end, basename)
             if effective in _COMMAND_WRAPPER_WORDS:
-                skip_wrapper_options = effective in {"sudo", "env"}
+                wrapper_budget -= 1  # only the wrapper CHAIN is bounded
+                skip_wrapper_options = True
+                command_option_grammar = effective == "command"
                 if effective == "sudo":
+                    wrapper_options = None  # keep the existing skip-everything
                     wrapper_arg_options = _SUDO_OPTIONS_WITH_ARG
                 elif effective == "env":
+                    wrapper_options = None
                     wrapper_arg_options = _ENV_OPTIONS_WITH_ARG
+                elif effective == "command":
+                    wrapper_options = _COMMAND_OPTIONS
+                    wrapper_arg_options = frozenset()
+                elif effective == "exec":
+                    wrapper_options = _EXEC_OPTIONS
+                    wrapper_arg_options = _EXEC_OPTIONS_WITH_ARG
+                else:
+                    # nohup/setsid/time/builtin: nothing option-shaped precedes
+                    # the program, so a dash word is the program itself.
+                    wrapper_options = frozenset()
+                    wrapper_arg_options = frozenset()
                 continue  # wrapper (bare or path-spelled): walk to the command
             break
     if not replacements:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1053,6 +1053,19 @@ _SUDO_OPTIONS_WITH_ARG = {
     "-p", "--prompt",
     "-u", "--user",
 }
+# GNU env options whose value arrives as the NEXT word. Their operand is
+# data (`env --chdir /tmp/reboot /bin/echo` never executes reboot), so the
+# projection walker must not treat it as the command word. `=`-attached
+# forms are already handled by the generic option check. `-S/--split-string`
+# is listed here only for the walker's word skipping — its payload is
+# executable-bearing, but parsing it is a separate fail-closed change
+# (same verdict as the design review); skipping keeps parity with main.
+_ENV_OPTIONS_WITH_ARG = {
+    "-a", "--argv0",
+    "-c", "--chdir",
+    "-s", "--split-string",
+    "-u", "--unset",
+}
 
 _INTERPRETER_EXEC_FLAGS = {
     "python": {"-c"},
@@ -1910,6 +1923,123 @@ def _iter_shell_command_word_spans(command: str):
             break
 
 
+_EXECUTABLE_LAUNCHER_SUFFIXES = (".exe", ".bat", ".cmd")
+_PROJECTED_BASENAME_RE = re.compile(r"[A-Za-z0-9_][\w.+-]*\Z")
+_WINDOWS_ABSOLUTE_RE = re.compile(r"[A-Za-z]:[\\/]|\\\\")
+# `_read_shell_word` stops at whitespace and `;&|`, so a command that ends
+# at a substitution/subshell closer keeps that byte in the word:
+# `(/sbin/reboot)` reads as `/sbin/reboot)`. Trim the closers before the
+# basename check or the stray byte makes the word look like something other
+# than a program name and the projection silently declines. Only `)` and
+# the backtick qualify: both are shell metacharacters that can never sit
+# inside an unquoted word. `}` is NOT one (`echo foo}` prints `foo}`, and
+# a brace group's `}` is its own word behind `;`), so trimming it would
+# rewrite legitimate names like `/tmp/reboot}`.
+_WORD_TAIL_CLOSERS = ")`"
+
+
+def _projected_executable_basename(word: str) -> str | None:
+    """Reduce one command-position word to the bare program name a shell
+    would resolve, or None when the word already is one (or can't be one).
+
+    A Windows-absolute word (drive or UNC prefix) is split on both
+    separators BEFORE any escape collapsing — the deobfuscation pass treats
+    backslashes as shell escapes and would dissolve the path. Everything
+    else goes through the same quote/escape collapsing the r\\m detection
+    uses, so composed spellings (``'/sbin/'shutdown``, ``/sbin/shut\\down``)
+    reduce like their plain forms."""
+    stripped = _strip_optional_shell_quotes(word)
+    if _WINDOWS_ABSOLUTE_RE.match(stripped):
+        basename = stripped.replace("\\", "/").rsplit("/", 1)[-1]
+    else:
+        collapsed = _deobfuscate_shell_word_for_detection(word) or word
+        basename = _strip_optional_shell_quotes(collapsed).rsplit("/", 1)[-1]
+    lowered = basename.lower()
+    for suffix in _EXECUTABLE_LAUNCHER_SUFFIXES:
+        if lowered.endswith(suffix):
+            basename = basename[: -len(suffix)]
+            break
+    if basename == word:
+        return None  # already a bare name — nothing to project
+    # Refuse anything that doesn't reduce to a plain program name (empty
+    # basename from a trailing slash, expansion debris): projecting those
+    # could only manufacture command words a shell would not actually run.
+    if not _PROJECTED_BASENAME_RE.fullmatch(basename):
+        return None
+    return basename
+
+
+def _project_path_spelled_executables(command: str) -> str | None:
+    """Detection-only variant: rewrite command-position executables that are
+    spelled by path (POSIX or Windows, quoted or bare, with or without a
+    launcher suffix) to ``\\n<basename>`` so the flat ``_CMDPOS``-anchored
+    patterns see the same command word a bare spelling would produce —
+    ``/sbin/shutdown``, ``C:\\Windows\\System32\\shutdown.exe`` and
+    ``"C:\\Program Files\\Git\\usr\\bin\\rm.exe"`` must behave exactly like
+    ``shutdown`` / ``rm``. Must run on the RAW command: the global
+    normalization strips backslashes and fuses a Windows path into one word
+    before the basename could be recovered.
+
+    The walk mirrors ``_iter_shell_command_word_spans`` but recognizes
+    wrappers by their PROJECTED basename, so a path-spelled wrapper chain
+    (``/usr/bin/env /usr/bin/sudo /sbin/shutdown``) resolves in this single
+    pass — no fixpoint, no overlapping re-splice. Assignment-shaped words
+    (``X=/sbin/shutdown``) are prefix data, never executables. Returns None
+    when nothing needed rewriting."""
+    replacements: dict[int, tuple[int, str]] = {}
+    for command_start in _iter_shell_command_starts(command):
+        pos = command_start
+        wrapper_arg_options: frozenset | set = frozenset()
+        skip_wrapper_options = False
+        skip_next_wrapper_arg = False
+        for _ in range(12):
+            word_start, raw_end, _raw_word = _read_shell_word(command, pos)
+            if word_start == raw_end:
+                break
+            pos = raw_end
+            # Trim group/substitution closers the word reader keeps
+            # (`(/sbin/reboot)` reads as `/sbin/reboot)`); the closer stays
+            # outside the replacement span so the splice preserves it.
+            word_end = raw_end
+            while word_end > word_start and command[word_end - 1] in _WORD_TAIL_CLOSERS:
+                word_end -= 1
+            if word_end == word_start:
+                continue  # bare closer: structure, not a word
+            word = command[word_start:word_end]
+            if skip_next_wrapper_arg:
+                skip_next_wrapper_arg = False
+                continue
+            deobfuscated = _deobfuscate_shell_word_for_detection(word) or word
+            if _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
+                continue  # VAR=value prefix: data, keep walking
+            if skip_wrapper_options and deobfuscated.startswith("-"):
+                option_name = deobfuscated.lower().split("=", 1)[0]
+                skip_next_wrapper_arg = (
+                    "=" not in deobfuscated
+                    and option_name in wrapper_arg_options
+                )
+                continue
+            basename = _projected_executable_basename(word)
+            effective = (basename or deobfuscated).lower()
+            if basename is not None and word_start not in replacements:
+                replacements[word_start] = (word_end, basename)
+            if effective in _COMMAND_WRAPPER_WORDS:
+                skip_wrapper_options = effective in {"sudo", "env"}
+                if effective == "sudo":
+                    wrapper_arg_options = _SUDO_OPTIONS_WITH_ARG
+                elif effective == "env":
+                    wrapper_arg_options = _ENV_OPTIONS_WITH_ARG
+                continue  # wrapper (bare or path-spelled): walk to the command
+            break
+    if not replacements:
+        return None
+    projected = command
+    for word_start in sorted(replacements, reverse=True):
+        word_end, basename = replacements[word_start]
+        projected = projected[:word_start] + "\n" + basename + projected[word_end:]
+    return projected
+
+
 def _command_detection_variants(command: str):
     normalized = _normalize_command_for_detection(command)
     # Quote-aware grep parsing hides only structurally identified pattern
@@ -1934,6 +2064,16 @@ def _command_detection_variants(command: str):
                 if marked_payload != payload and marked_payload not in seen:
                     seen.add(marked_payload)
                     yield marked_payload
+                # A payload's own executable can be path-spelled too
+                # (`bash -c '/sbin/shutdown -h now'`), so it needs the same
+                # basename projection as the outer command. POSIX paths
+                # survive the normalization the payload came through;
+                # backslash Windows paths inside payloads stay out of reach
+                # until normalization preserves separators (#71919).
+                projected_payload = _project_path_spelled_executables(payload)
+                if projected_payload is not None and projected_payload not in seen:
+                    seen.add(projected_payload)
+                    yield projected_payload
                 pending.append(payload)
     # Subshell `(cmd)` and brace-group `{ cmd; }` openers put `cmd` at a real
     # command position, but the flat `_CMDPOS`-anchored patterns can't see it:
@@ -1950,6 +2090,21 @@ def _command_detection_variants(command: str):
     if marked != grep_safe and marked not in seen:
         seen.add(marked)
         yield marked
+    # Absolute-path spellings bypass every _CMDPOS-anchored rule the same
+    # way subshell openers did: the anchor class knows wrappers but not
+    # paths, so `/sbin/shutdown` or `C:\Windows\System32\shutdown.exe`
+    # never reaches `shutdown\b`. Project command-position executables to
+    # `\n<basename>` from the RAW command (normalization strips backslashes
+    # and fuses Windows paths before a basename could be recovered), then
+    # feed the projection through the standard normalize/grep-safe pipe.
+    projected = _project_path_spelled_executables(command)
+    if projected is not None:
+        projected_variant, _ = _grep_safe_detection_variant(
+            _normalize_command_for_detection(projected)
+        )
+        if projected_variant not in seen:
+            seen.add(projected_variant)
+            yield projected_variant
     # Shell quoting/escaping can spell a dangerous executable name in pieces
     # (for example r\m or r''m). Keep that deobfuscation scoped to command
     # words so similarly shaped arguments do not become false positives.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1045,6 +1045,9 @@ _COMMAND_WRAPPER_WORDS = {
     "time",
     "command",
     "builtin",
+    "timeout",
+    "nice",
+    "stdbuf",
 }
 _SUDO_OPTIONS_WITH_ARG = {
     "-c", "--close-from",
@@ -1081,11 +1084,133 @@ _COMMAND_OPTIONS = frozenset({"-p", "-v", "-V"})
 _EXEC_OPTIONS = frozenset({"-a", "-c", "-l"})
 _EXEC_OPTIONS_WITH_ARG = frozenset({"-a"})
 
+# `timeout` consumes one duration operand after its options, then launches the
+# remaining command. Options in this set take their value from the next word
+# unless it is attached with `=`.
+_TIMEOUT_OPTIONS_WITH_ARG = frozenset({
+    "-k", "--kill-after",
+    "-s", "--signal",
+})
+_TIMEOUT_OPTIONS = _TIMEOUT_OPTIONS_WITH_ARG | frozenset({
+    # Short spellings included: coreutils' getopt string is "+k:s:vf" plus
+    # -p for --preserve-status, so `timeout -p 5 cmd` and `timeout -f 5 cmd`
+    # are valid and must not strand the walker on the option word.
+    "-p", "--preserve-status",
+    "-f", "--foreground",
+    "-v", "--verbose",
+})
+
+_NICE_OPTIONS_WITH_ARG = frozenset({"-n", "--adjustment"})
+_NICE_OPTIONS = _NICE_OPTIONS_WITH_ARG
+
+_STDBUF_OPTIONS_WITH_ARG = frozenset({
+    "-i", "-o", "-e",
+    "--input", "--output", "--error",
+})
+_STDBUF_OPTIONS = _STDBUF_OPTIONS_WITH_ARG
+
+_WRAPPER_SHORT_FLAGS = {
+    "command": frozenset("pv"),
+    "exec": frozenset("cl"),
+    # coreutils' timeout getopt string is "+k:s:vf" and -p is accepted for
+    # --preserve-status, so v/f/p are the no-argument short flags that can
+    # appear bundled (-vpf) ahead of the duration.
+    "timeout": frozenset("vfp"),
+}
+_WRAPPER_SHORT_OPTIONS_WITH_ARG = {
+    "exec": frozenset("a"),
+    "timeout": frozenset("ks"),
+    "nice": frozenset("n"),
+    "stdbuf": frozenset("ioe"),
+}
+
 
 def _is_lookup_only_option(option_name: str) -> bool:
     if option_name.startswith("--"):
         return False
     return bool(set(option_name[1:]) & _COMMAND_LOOKUP_ONLY_SHORT)
+
+
+def _short_wrapper_option_action(
+    wrapper: str, word: str
+) -> tuple[str, bool] | None:
+    """Parse one GNU-style short-option cluster for a wrapper."""
+    if (
+        len(word) <= 1
+        or word.startswith("--")
+        or not word.startswith("-")
+        or "=" in word
+    ):
+        return None
+    flags = _WRAPPER_SHORT_FLAGS.get(wrapper, frozenset())
+    options_with_arg = _WRAPPER_SHORT_OPTIONS_WITH_ARG.get(
+        wrapper, frozenset()
+    )
+    if not flags and not options_with_arg:
+        return None
+
+    cluster = word[1:]
+    for index, option in enumerate(cluster):
+        if option in options_with_arg:
+            return ("skip", index == len(cluster) - 1)
+        if option not in flags:
+            return None
+    return ("skip", False)
+
+
+def _wrapper_option_action(wrapper: str, word: str) -> tuple[str | None, bool]:
+    """Classify one option-shaped word for a pass-through wrapper.
+
+    The action is ``skip`` for a recognized option, ``end`` for ``--``,
+    ``stop`` for command lookup-only modes, and ``None`` when the word is the
+    program name rather than an option. The boolean reports whether the next
+    word is the option's separate operand.
+    """
+    lowered = word.lower()
+    option_name = lowered.split("=", 1)[0]
+    if lowered == "--":
+        return ("end", False)
+    if wrapper == "command" and _is_lookup_only_option(option_name):
+        return ("stop", False)
+    if wrapper == "nice" and re.fullmatch(r"-\d+", lowered):
+        # GNU nice's obsolete but still-supported `-ADJUSTMENT` spelling.
+        return ("skip", False)
+
+    short_action = _short_wrapper_option_action(wrapper, lowered)
+    if short_action is not None:
+        return short_action
+
+    if wrapper == "sudo":
+        options = None
+        options_with_arg = _SUDO_OPTIONS_WITH_ARG
+    elif wrapper == "env":
+        options = None
+        options_with_arg = _ENV_OPTIONS_WITH_ARG
+    elif wrapper == "command":
+        options = _COMMAND_OPTIONS
+        options_with_arg = frozenset()
+    elif wrapper == "exec":
+        options = _EXEC_OPTIONS
+        options_with_arg = _EXEC_OPTIONS_WITH_ARG
+    elif wrapper == "timeout":
+        options = _TIMEOUT_OPTIONS
+        options_with_arg = _TIMEOUT_OPTIONS_WITH_ARG
+    elif wrapper == "nice":
+        options = _NICE_OPTIONS
+        options_with_arg = _NICE_OPTIONS_WITH_ARG
+    elif wrapper == "stdbuf":
+        options = _STDBUF_OPTIONS
+        options_with_arg = _STDBUF_OPTIONS_WITH_ARG
+    else:
+        options = frozenset()
+        options_with_arg = frozenset()
+
+    if options is not None and option_name not in options:
+        return (None, False)
+    return (
+        "skip",
+        "=" not in lowered and option_name in options_with_arg,
+    )
 
 _INTERPRETER_EXEC_FLAGS = {
     "python": {"-c"},
@@ -1906,8 +2031,10 @@ def _iter_shell_command_word_spans(command: str):
     for command_start in _iter_shell_command_starts(command):
         pos = command_start
         prefix_words = 0
+        active_wrapper = ""
         skip_wrapper_options = False
         skip_next_wrapper_arg = False
+        skip_timeout_duration = False
         while prefix_words < 12:
             word_start, word_end, word = _read_shell_word(command, pos)
             if word_start == word_end:
@@ -1920,11 +2047,20 @@ def _iter_shell_command_word_spans(command: str):
                 prefix_words += 1
                 continue
             if skip_wrapper_options and lower_word.startswith("-"):
-                option_name = lower_word.split("=", 1)[0]
-                skip_next_wrapper_arg = (
-                    "=" not in lower_word
-                    and option_name in _SUDO_OPTIONS_WITH_ARG
+                action, skip_next_wrapper_arg = _wrapper_option_action(
+                    active_wrapper, lower_word
                 )
+                if action == "stop":
+                    break
+                if action is not None:
+                    if action == "end":
+                        skip_wrapper_options = False
+                    pos = word_end
+                    prefix_words += 1
+                    continue
+            if skip_timeout_duration:
+                skip_timeout_duration = False
+                skip_wrapper_options = False
                 pos = word_end
                 prefix_words += 1
                 continue
@@ -1933,10 +2069,13 @@ def _iter_shell_command_word_spans(command: str):
             prefix_words += 1
 
             if lower_word in _COMMAND_WRAPPER_WORDS:
-                skip_wrapper_options = lower_word in {"sudo", "env"}
+                active_wrapper = lower_word
+                skip_wrapper_options = True
+                skip_timeout_duration = lower_word == "timeout"
                 pos = word_end
                 continue
             if _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
+                active_wrapper = ""
                 skip_wrapper_options = False
                 pos = word_end
                 continue
@@ -2009,11 +2148,11 @@ def _project_path_spelled_executables(command: str) -> str | None:
     replacements: dict[int, tuple[int, str]] = {}
     for command_start in _iter_shell_command_starts(command):
         pos = command_start
-        wrapper_arg_options: frozenset | set = frozenset()
-        wrapper_options: frozenset | set | None = frozenset()
-        command_option_grammar = False
+        active_wrapper = ""
+        resolved_through_wrapper = False
         skip_wrapper_options = False
         skip_next_wrapper_arg = False
+        skip_timeout_duration = False
         # Bound the WRAPPER chain, not the whole prefix: shell grammar puts no
         # limit on assignment prefixes or on a wrapper option list, so counting
         # those let a caller push the executable past a fixed budget and out of
@@ -2042,60 +2181,39 @@ def _project_path_spelled_executables(command: str) -> str | None:
             if _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
                 continue  # VAR=value prefix: data, keep walking
             if skip_wrapper_options and deobfuscated.startswith("-"):
-                option_name = deobfuscated.lower().split("=", 1)[0]
-                if wrapper_options is None:
-                    # sudo/env: their option lists are large and largely
-                    # long-form, so every dash word is still skipped. Left as
-                    # it was — narrowing them is a separate change.
-                    skip_next_wrapper_arg = (
-                        "=" not in deobfuscated
-                        and option_name in wrapper_arg_options
-                    )
+                action, skip_next_wrapper_arg = _wrapper_option_action(
+                    active_wrapper, deobfuscated
+                )
+                if action == "stop":
+                    break
+                if action is not None:
+                    if action == "end":
+                        skip_wrapper_options = False
                     continue
-                # Wrappers whose option list is small enough to model exactly.
-                # `--` ends it: whatever follows is the program name even when
-                # it looks like an option (`command -- -p x` runs `-p`), and a
-                # word outside the list is not an option at all, so it falls
-                # through and is read as the program — which is what the shell
-                # does. Both directions matter: skipping every dash word
-                # blocked spellings the shell never executes.
-                if deobfuscated == "--":
-                    skip_wrapper_options = False
-                    continue
-                if command_option_grammar and _is_lookup_only_option(option_name):
-                    break  # `command -v`: a lookup, nothing is executed
-                if option_name in wrapper_options:
-                    skip_next_wrapper_arg = (
-                        "=" not in deobfuscated
-                        and option_name in wrapper_arg_options
-                    )
-                    continue
+            if skip_timeout_duration:
+                skip_timeout_duration = False
+                skip_wrapper_options = False
+                continue
             basename = _projected_executable_basename(word)
             effective = (basename or deobfuscated).lower()
             if basename is not None and word_start not in replacements:
                 replacements[word_start] = (word_end, basename)
             if effective in _COMMAND_WRAPPER_WORDS:
                 wrapper_budget -= 1  # only the wrapper CHAIN is bounded
+                active_wrapper = effective
+                resolved_through_wrapper = True
                 skip_wrapper_options = True
-                command_option_grammar = effective == "command"
-                if effective == "sudo":
-                    wrapper_options = None  # keep the existing skip-everything
-                    wrapper_arg_options = _SUDO_OPTIONS_WITH_ARG
-                elif effective == "env":
-                    wrapper_options = None
-                    wrapper_arg_options = _ENV_OPTIONS_WITH_ARG
-                elif effective == "command":
-                    wrapper_options = _COMMAND_OPTIONS
-                    wrapper_arg_options = frozenset()
-                elif effective == "exec":
-                    wrapper_options = _EXEC_OPTIONS
-                    wrapper_arg_options = _EXEC_OPTIONS_WITH_ARG
-                else:
-                    # nohup/setsid/time/builtin: nothing option-shaped precedes
-                    # the program, so a dash word is the program itself.
-                    wrapper_options = frozenset()
-                    wrapper_arg_options = frozenset()
+                skip_timeout_duration = effective == "timeout"
                 continue  # wrapper (bare or path-spelled): walk to the command
+            if (
+                resolved_through_wrapper
+                and basename is None
+                and word_start not in replacements
+            ):
+                # Wrappers absent from the flat `_CMDPOS` grammar still need
+                # their resolved bare command surfaced at a real command
+                # position (`timeout 5 nice rm -rf /`).
+                replacements[word_start] = (word_end, deobfuscated)
             break
     if not replacements:
         return None

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -729,29 +729,32 @@ def detect_hardline_command(command: str) -> tuple:
     _, malformed_grep = _grep_safe_detection_variant(normalized)
     if malformed_grep:
         return (True, _MALFORMED_EXEC_DESCRIPTION)
-    for command_variant in _command_detection_variants(command):
-        variant_lower = command_variant.lower()
-        masked_lower: str | None = None
-        for pattern_re, description, quote_masked in HARDLINE_PATTERNS_COMPILED:
-            if quote_masked:
-                # Positionless rules (redirect-to-block-device, fork bomb)
-                # match a quote-masked variant so quoted prose in echo /
-                # git commit -m / gh --body arguments is DATA (#93392).
-                # Shell-carrying commands (sh/bash -c, eval, source) hand
-                # their quoted argument to another parser, so those scan
-                # the raw variant — quoting is not a bypass. bash/sh -c
-                # payloads additionally surface as their own raw variants
-                # via _execution_flag_findings.
-                if masked_lower is None:
-                    if _contains_shell_carrier(command_variant):
-                        masked_lower = variant_lower
-                    else:
-                        masked_lower = _mask_quoted_prose(command_variant).lower()
-                haystack = masked_lower
-            else:
-                haystack = variant_lower
-            if pattern_re.search(haystack):
-                return (True, description)
+    try:
+        for command_variant in _command_detection_variants(command):
+            variant_lower = command_variant.lower()
+            masked_lower: str | None = None
+            for pattern_re, description, quote_masked in HARDLINE_PATTERNS_COMPILED:
+                if quote_masked:
+                    # Positionless rules (redirect-to-block-device, fork bomb)
+                    # match a quote-masked variant so quoted prose in echo /
+                    # git commit -m / gh --body arguments is DATA (#93392).
+                    # Shell-carrying commands (sh/bash -c, eval, source) hand
+                    # their quoted argument to another parser, so those scan
+                    # the raw variant — quoting is not a bypass. bash/sh -c
+                    # payloads additionally surface as their own raw variants
+                    # via _execution_flag_findings.
+                    if masked_lower is None:
+                        if _contains_shell_carrier(command_variant):
+                            masked_lower = variant_lower
+                        else:
+                            masked_lower = _mask_quoted_prose(command_variant).lower()
+                    haystack = masked_lower
+                else:
+                    haystack = variant_lower
+                if pattern_re.search(haystack):
+                    return (True, description)
+    except _UnresolvedCommandWalk as unresolved:
+        return (True, unresolved.description)
     return (False, None)
 
 
@@ -779,11 +782,16 @@ def _match_user_deny_rule(command: str) -> str | None:
              if isinstance(p, str) and p.strip()]
     if not globs:
         return None
-    for command_variant in _command_detection_variants(command):
-        candidate = command_variant.lower().strip()
-        for pattern in globs:
-            if fnmatch.fnmatchcase(candidate, pattern.lower()):
-                return pattern
+    try:
+        for command_variant in _command_detection_variants(command):
+            candidate = command_variant.lower().strip()
+            for pattern in globs:
+                if fnmatch.fnmatchcase(candidate, pattern.lower()):
+                    return pattern
+    except _UnresolvedCommandWalk:
+        # No deny rule can be confirmed on an unresolvable command; the
+        # hardline detector already fails it safe.
+        return None
     return None
 
 
@@ -1528,6 +1536,41 @@ _STDBUF_OPTIONS_WITH_ARG = frozenset({
 })
 _STDBUF_OPTIONS = _STDBUF_OPTIONS_WITH_ARG
 
+# `time` is both a bash reserved word (accepting only -p) and GNU time
+# (-f/--format and -o/--output take an operand; -p -a -v -q -V do not). The
+# walker only sees the spelling, so it accepts the union of both grammars.
+# Option names are matched lowercased, so -V folds onto -v (both take no
+# operand under either spelling).
+_TIME_OPTIONS_WITH_ARG = frozenset({
+    "-f", "--format",
+    "-o", "--output",
+})
+_TIME_OPTIONS = _TIME_OPTIONS_WITH_ARG | frozenset({
+    "-p", "--portability",
+    "-a", "--append",
+    "-v", "--verbose",
+    "-q", "--quiet",
+    "--version",
+    "--help",
+})
+
+# util-linux setsid's getopt string is "+Vhcfw" — every option is a flag,
+# and the leading "+" stops option parsing at the first non-option word.
+_SETSID_OPTIONS = frozenset({
+    "-c", "--ctty",
+    "-f", "--fork",
+    "-w", "--wait",
+    "-v", "--version",
+    "-h", "--help",
+})
+
+# For these wrappers the option grammar above is exhaustive, so an option
+# word outside it means the walker cannot tell where the program word
+# starts. Resolving anyway risks projecting an option (or its operand) as
+# the command word, so the walk reports the command as unresolvable and the
+# caller fails safe.
+_WRAPPERS_UNRESOLVED_ON_UNKNOWN_OPTION = frozenset({"time", "setsid"})
+
 _WRAPPER_SHORT_FLAGS = {
     "command": frozenset("pv"),
     "exec": frozenset("cl"),
@@ -1535,12 +1578,15 @@ _WRAPPER_SHORT_FLAGS = {
     # --preserve-status, so v/f/p are the no-argument short flags that can
     # appear bundled (-vpf) ahead of the duration.
     "timeout": frozenset("vfp"),
+    "time": frozenset("pavq"),
+    "setsid": frozenset("cfwvh"),
 }
 _WRAPPER_SHORT_OPTIONS_WITH_ARG = {
     "exec": frozenset("a"),
     "timeout": frozenset("ks"),
     "nice": frozenset("n"),
     "stdbuf": frozenset("ioe"),
+    "time": frozenset("fo"),
 }
 
 
@@ -1581,7 +1627,9 @@ def _wrapper_option_action(wrapper: str, word: str) -> tuple[str | None, bool]:
     """Classify one option-shaped word for a pass-through wrapper.
 
     The action is ``skip`` for a recognized option, ``end`` for ``--``,
-    ``stop`` for command lookup-only modes, and ``None`` when the word is the
+    ``stop`` for command lookup-only modes, ``unresolved`` for an option the
+    wrapper's exhaustive grammar does not know (the walker cannot place the
+    program word and must fail safe), and ``None`` when the word is the
     program name rather than an option. The boolean reports whether the next
     word is the option's separate operand.
     """
@@ -1620,11 +1668,19 @@ def _wrapper_option_action(wrapper: str, word: str) -> tuple[str | None, bool]:
     elif wrapper == "stdbuf":
         options = _STDBUF_OPTIONS
         options_with_arg = _STDBUF_OPTIONS_WITH_ARG
+    elif wrapper == "time":
+        options = _TIME_OPTIONS
+        options_with_arg = _TIME_OPTIONS_WITH_ARG
+    elif wrapper == "setsid":
+        options = _SETSID_OPTIONS
+        options_with_arg = frozenset()
     else:
         options = frozenset()
         options_with_arg = frozenset()
 
     if options is not None and option_name not in options:
+        if wrapper in _WRAPPERS_UNRESOLVED_ON_UNKNOWN_OPTION:
+            return ("unresolved", False)
         return (None, False)
     return (
         "skip",
@@ -1697,6 +1753,30 @@ _MAX_SEPARATOR_FREE_COMMAND_CHARS = 4_096
 _MAX_DETECTION_SEGMENTS = 25_000
 _PARSER_LIMIT_DESCRIPTION = "command parser limit exceeded"
 _MALFORMED_EXEC_DESCRIPTION = "command parser limit or malformed executable payload"
+_UNRESOLVED_WRAPPER_OPTION_DESCRIPTION = (
+    "unrecognized wrapper option ahead of the command word"
+)
+
+# Defensive cap on the words a command-position walk may consume per command
+# start. It is not a termination condition — every iteration consumes at
+# least one word, so the walk already terminates on input length — it bounds
+# the work spent on pathological prefixes. Reaching it means the command
+# word was never resolved, and that must surface as "unresolvable" (callers
+# fail safe), never as a silent pass-through.
+_WALKER_MAX_WORDS = 256
+
+
+class _UnresolvedCommandWalk(Exception):
+    """A command-position walk could not resolve the command word.
+
+    Raised when the walk hits ``_WALKER_MAX_WORDS`` or an option the
+    wrapper grammar cannot place. Detection entry points map this to a
+    positive detection: an uninspectable command must not run uninspected.
+    """
+
+    def __init__(self, description: str) -> None:
+        super().__init__(description)
+        self.description = description
 
 
 
@@ -1800,7 +1880,11 @@ def _quoted_grep_pattern_spans(command: str) -> tuple[list[tuple[int, int]], boo
     for segment in _iter_top_level_shell_segments(command):
         segment_at = command.find(segment, offset)
         offset = segment_at + len(segment)
-        for start, _, word in _iter_shell_command_word_spans(segment):
+        try:
+            command_words = list(_iter_shell_command_word_spans(segment))
+        except _UnresolvedCommandWalk:
+            return [], True
+        for start, _, word in command_words:
             if os.path.basename(_deobfuscate_shell_word_for_detection(word)).lower() not in {
                 "grep", "egrep",
             }:
@@ -2082,7 +2166,12 @@ def _read_tool_exec_flag(tool: str, args: list[str]) -> tuple[str, str] | None:
 def _execution_flag_findings(command: str):
     """Yield scoped execution mechanisms and any executable payloads."""
     for segment in _iter_top_level_shell_segments(command):
-        for start, _, word in _iter_shell_command_word_spans(segment):
+        try:
+            command_words = list(_iter_shell_command_word_spans(segment))
+        except _UnresolvedCommandWalk:
+            yield (_MALFORMED_EXEC_DESCRIPTION, None)
+            continue
+        for start, _, word in command_words:
             executable = _deobfuscate_shell_word_for_detection(word)
             tokens = _shell_segment_tokens(segment, start)
             executable_name = os.path.basename(executable).lower()
@@ -2493,43 +2582,46 @@ def _iter_shell_command_word_spans(command: str):
     """Yield command-position words that may be executable names."""
     for command_start in _iter_shell_command_starts(command):
         pos = command_start
-        prefix_words = 0
+        words_walked = 0
         active_wrapper = ""
         skip_wrapper_options = False
         skip_next_wrapper_arg = False
         skip_timeout_duration = False
-        while prefix_words < 12:
+        while True:
             word_start, word_end, word = _read_shell_word(command, pos)
             if word_start == word_end:
                 break
+            words_walked += 1
+            if words_walked >= _WALKER_MAX_WORDS:
+                raise _UnresolvedCommandWalk(_PARSER_LIMIT_DESCRIPTION)
             deobfuscated = _deobfuscate_shell_word_for_detection(word)
             lower_word = deobfuscated.lower()
             if skip_next_wrapper_arg:
                 skip_next_wrapper_arg = False
                 pos = word_end
-                prefix_words += 1
                 continue
             if skip_wrapper_options and lower_word.startswith("-"):
                 action, skip_next_wrapper_arg = _wrapper_option_action(
                     active_wrapper, lower_word
                 )
+                if action == "unresolved":
+                    raise _UnresolvedCommandWalk(
+                        _UNRESOLVED_WRAPPER_OPTION_DESCRIPTION
+                    )
                 if action == "stop":
                     break
                 if action is not None:
                     if action == "end":
                         skip_wrapper_options = False
                     pos = word_end
-                    prefix_words += 1
                     continue
             if skip_timeout_duration:
                 skip_timeout_duration = False
                 skip_wrapper_options = False
                 pos = word_end
-                prefix_words += 1
                 continue
 
             yield (word_start, word_end, word)
-            prefix_words += 1
 
             if lower_word in _COMMAND_WRAPPER_WORDS:
                 active_wrapper = lower_word
@@ -2616,17 +2708,19 @@ def _project_path_spelled_executables(command: str) -> str | None:
         skip_wrapper_options = False
         skip_next_wrapper_arg = False
         skip_timeout_duration = False
-        # Bound the WRAPPER chain, not the whole prefix: shell grammar puts no
-        # limit on assignment prefixes or on a wrapper option list, so counting
-        # those let a caller push the executable past a fixed budget and out of
-        # the projection (`A0=1 ... A11=1 /sbin/reboot` — egilewski on #71996;
-        # eleven repeated options — Sol). Only a wrapper word spends budget; the
-        # walk still terminates because every iteration consumes input.
-        wrapper_budget = 12
-        while wrapper_budget > 0:
+        # Shell grammar puts no limit on assignment prefixes, wrapper chains,
+        # or wrapper option lists, so no fixed budget may end this walk — any
+        # such exit lets a caller push the executable out of the projection.
+        # The walk terminates because every iteration consumes input; the
+        # shared word cap only bounds pathological prefixes and fails safe.
+        words_walked = 0
+        while True:
             word_start, raw_end, _raw_word = _read_shell_word(command, pos)
             if word_start == raw_end:
                 break
+            words_walked += 1
+            if words_walked >= _WALKER_MAX_WORDS:
+                raise _UnresolvedCommandWalk(_PARSER_LIMIT_DESCRIPTION)
             pos = raw_end
             # Trim group/substitution closers the word reader keeps
             # (`(/sbin/reboot)` reads as `/sbin/reboot)`); the closer stays
@@ -2647,6 +2741,10 @@ def _project_path_spelled_executables(command: str) -> str | None:
                 action, skip_next_wrapper_arg = _wrapper_option_action(
                     active_wrapper, deobfuscated
                 )
+                if action == "unresolved":
+                    raise _UnresolvedCommandWalk(
+                        _UNRESOLVED_WRAPPER_OPTION_DESCRIPTION
+                    )
                 if action == "stop":
                     break
                 if action is not None:
@@ -2662,7 +2760,6 @@ def _project_path_spelled_executables(command: str) -> str | None:
             if basename is not None and word_start not in replacements:
                 replacements[word_start] = (word_end, basename)
             if effective in _COMMAND_WRAPPER_WORDS:
-                wrapper_budget -= 1  # only the wrapper CHAIN is bounded
                 active_wrapper = effective
                 resolved_through_wrapper = True
                 skip_wrapper_options = True
@@ -2852,12 +2949,15 @@ def detect_dangerous_command(command: str) -> tuple:
     if _is_verification_artifact_cleanup(command):
         return (False, None, None)
 
-    for command_variant in _command_detection_variants(command):
-        command_lower = command_variant.lower()
-        for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
-            if pattern_re.search(command_lower):
-                pattern_key = description
-                return (True, pattern_key, description)
+    try:
+        for command_variant in _command_detection_variants(command):
+            command_lower = command_variant.lower()
+            for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
+                if pattern_re.search(command_lower):
+                    pattern_key = description
+                    return (True, pattern_key, description)
+    except _UnresolvedCommandWalk as unresolved:
+        return (True, unresolved.description, unresolved.description)
     normalized = _normalize_command_for_detection(command)
     for description, _ in _execution_flag_findings(normalized):
         return (True, description, description)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1486,6 +1486,26 @@ _ENV_OPTIONS_WITH_ARG = {
     "-u", "--unset",
 }
 
+# `command` takes options of its own before the executable, and none of them
+# take a separate operand: `command -p /sbin/reboot` and `command -- ...`
+# both run the executable. `-v`/`-V` are the exception — they only look the
+# command up and print it, so nothing is executed and the walker must stop
+# rather than project a word that never runs. `command`'s only short options
+# are `p`, `v` and `V`, so any cluster carrying v/V (`-pv`) is lookup-only too.
+_COMMAND_LOOKUP_ONLY_SHORT = frozenset("vV")
+_COMMAND_OPTIONS = frozenset({"-p", "-v", "-V"})
+
+# `exec -a NAME` consumes the following word as the argv[0] to use; `-c` and
+# `-l` take no operand. Anything else after `exec` is the program.
+_EXEC_OPTIONS = frozenset({"-a", "-c", "-l"})
+_EXEC_OPTIONS_WITH_ARG = frozenset({"-a"})
+
+
+def _is_lookup_only_option(option_name: str) -> bool:
+    if option_name.startswith("--"):
+        return False
+    return bool(set(option_name[1:]) & _COMMAND_LOOKUP_ONLY_SHORT)
+
 _INTERPRETER_EXEC_FLAGS = {
     "python": {"-c"},
     "node": {"-e", "--eval", "-p", "--print"},
@@ -2453,9 +2473,18 @@ def _project_path_spelled_executables(command: str) -> str | None:
     for command_start in _iter_shell_command_starts(command):
         pos = command_start
         wrapper_arg_options: frozenset | set = frozenset()
+        wrapper_options: frozenset | set | None = frozenset()
+        command_option_grammar = False
         skip_wrapper_options = False
         skip_next_wrapper_arg = False
-        for _ in range(12):
+        # Bound the WRAPPER chain, not the whole prefix: shell grammar puts no
+        # limit on assignment prefixes or on a wrapper option list, so counting
+        # those let a caller push the executable past a fixed budget and out of
+        # the projection (`A0=1 ... A11=1 /sbin/reboot` — egilewski on #71996;
+        # eleven repeated options — Sol). Only a wrapper word spends budget; the
+        # walk still terminates because every iteration consumes input.
+        wrapper_budget = 12
+        while wrapper_budget > 0:
             word_start, raw_end, _raw_word = _read_shell_word(command, pos)
             if word_start == raw_end:
                 break
@@ -2477,21 +2506,58 @@ def _project_path_spelled_executables(command: str) -> str | None:
                 continue  # VAR=value prefix: data, keep walking
             if skip_wrapper_options and deobfuscated.startswith("-"):
                 option_name = deobfuscated.lower().split("=", 1)[0]
-                skip_next_wrapper_arg = (
-                    "=" not in deobfuscated
-                    and option_name in wrapper_arg_options
-                )
-                continue
+                if wrapper_options is None:
+                    # sudo/env: their option lists are large and largely
+                    # long-form, so every dash word is still skipped. Left as
+                    # it was — narrowing them is a separate change.
+                    skip_next_wrapper_arg = (
+                        "=" not in deobfuscated
+                        and option_name in wrapper_arg_options
+                    )
+                    continue
+                # Wrappers whose option list is small enough to model exactly.
+                # `--` ends it: whatever follows is the program name even when
+                # it looks like an option (`command -- -p x` runs `-p`), and a
+                # word outside the list is not an option at all, so it falls
+                # through and is read as the program — which is what the shell
+                # does. Both directions matter: skipping every dash word
+                # blocked spellings the shell never executes.
+                if deobfuscated == "--":
+                    skip_wrapper_options = False
+                    continue
+                if command_option_grammar and _is_lookup_only_option(option_name):
+                    break  # `command -v`: a lookup, nothing is executed
+                if option_name in wrapper_options:
+                    skip_next_wrapper_arg = (
+                        "=" not in deobfuscated
+                        and option_name in wrapper_arg_options
+                    )
+                    continue
             basename = _projected_executable_basename(word)
             effective = (basename or deobfuscated).lower()
             if basename is not None and word_start not in replacements:
                 replacements[word_start] = (word_end, basename)
             if effective in _COMMAND_WRAPPER_WORDS:
-                skip_wrapper_options = effective in {"sudo", "env"}
+                wrapper_budget -= 1  # only the wrapper CHAIN is bounded
+                skip_wrapper_options = True
+                command_option_grammar = effective == "command"
                 if effective == "sudo":
+                    wrapper_options = None  # keep the existing skip-everything
                     wrapper_arg_options = _SUDO_OPTIONS_WITH_ARG
                 elif effective == "env":
+                    wrapper_options = None
                     wrapper_arg_options = _ENV_OPTIONS_WITH_ARG
+                elif effective == "command":
+                    wrapper_options = _COMMAND_OPTIONS
+                    wrapper_arg_options = frozenset()
+                elif effective == "exec":
+                    wrapper_options = _EXEC_OPTIONS
+                    wrapper_arg_options = _EXEC_OPTIONS_WITH_ARG
+                else:
+                    # nohup/setsid/time/builtin: nothing option-shaped precedes
+                    # the program, so a dash word is the program itself.
+                    wrapper_options = frozenset()
+                    wrapper_arg_options = frozenset()
                 continue  # wrapper (bare or path-spelled): walk to the command
             break
     if not replacements:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1476,26 +1476,36 @@ _COMMAND_WRAPPER_WORDS = {
     "nice",
     "stdbuf",
 }
-_SUDO_OPTIONS_WITH_ARG = {
-    "-c", "--close-from",
-    "-g", "--group",
-    "-h", "--host",
-    "-p", "--prompt",
-    "-u", "--user",
-}
-# GNU env options whose value arrives as the NEXT word. Their operand is
-# data (`env --chdir /tmp/reboot /bin/echo` never executes reboot), so the
-# projection walker must not treat it as the command word. `=`-attached
-# forms are already handled by the generic option check. `-S/--split-string`
-# is listed here only for the walker's word skipping — its payload is
-# executable-bearing, but parsing it is a separate fail-closed change
-# (same verdict as the design review); skipping keeps parity with main.
-_ENV_OPTIONS_WITH_ARG = {
-    "-a", "--argv0",
-    "-c", "--chdir",
-    "-s", "--split-string",
-    "-u", "--unset",
-}
+# sudo uses getopt_long and its short options are case-sensitive. Keep the
+# complete option namespace here so unique long abbreviations can be resolved
+# exactly as sudo resolves them. Unknown or ambiguous spellings fail closed.
+_SUDO_LONG_OPTIONS_WITH_ARG = frozenset({
+    "auth-type", "close-from", "login-class", "chdir", "group", "host",
+    "prompt", "chroot", "role", "command-timeout", "type", "other-user",
+    "user",
+})
+_SUDO_LONG_OPTIONS = _SUDO_LONG_OPTIONS_WITH_ARG | frozenset({
+    "background", "preserve-env", "edit", "set-home", "login",
+    "remove-timestamp", "list", "preserve-groups", "shell", "validate",
+    "askpass", "bell", "help", "reset-timestamp", "no-update",
+    "non-interactive", "stdin", "version",
+})
+_SUDO_SHORT_FLAGS = frozenset("ABbEeHiKklNnPSsVv")
+_SUDO_SHORT_OPTIONS_WITH_ARG = frozenset("aCcDgpRrTtUu")
+
+# GNU env has its own case-sensitive getopt grammar. Split-string is not a
+# data operand: env parses it into the argv it executes. Its quoting,
+# expansion, escaping, and comment rules differ from shell parsing, so the
+# safe bounded behavior is to mark every recognized -S/--split-string form
+# unresolved instead of attempting a partial parser here.
+_ENV_LONG_OPTIONS_WITH_ARG = frozenset({"argv0", "unset", "chdir"})
+_ENV_LONG_OPTIONS = _ENV_LONG_OPTIONS_WITH_ARG | frozenset({
+    "null", "ignore-environment", "default-signal", "ignore-signal",
+    "block-signal", "list-signal-handling", "debug", "split-string",
+    "help", "version",
+})
+_ENV_SHORT_FLAGS = frozenset("0iv")
+_ENV_SHORT_OPTIONS_WITH_ARG = frozenset("aCu")
 
 # `command` takes options of its own before the executable, and none of them
 # take a separate operand: `command -p /sbin/reboot` and `command -- ...`
@@ -1623,20 +1633,100 @@ def _short_wrapper_option_action(
     return ("skip", False)
 
 
+def _resolve_unique_long_option(
+    word: str, options: frozenset[str]
+) -> str | None:
+    """Resolve an exact or unambiguous getopt_long option name."""
+    option_name = word[2:].split("=", 1)[0]
+    if not option_name:
+        return None
+    if option_name in options:
+        return option_name
+    matches = [option for option in options if option.startswith(option_name)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _sudo_option_action(word: str) -> tuple[str, bool]:
+    """Classify one sudo option using sudo's case-sensitive getopt grammar."""
+    if word.startswith("--"):
+        option = _resolve_unique_long_option(word, _SUDO_LONG_OPTIONS)
+        if option is None:
+            return ("unresolved", False)
+        return (
+            "skip",
+            "=" not in word and option in _SUDO_LONG_OPTIONS_WITH_ARG,
+        )
+
+    cluster = word[1:]
+    if not cluster:
+        return ("unresolved", False)
+    for index, option in enumerate(cluster):
+        has_attached_operand = index < len(cluster) - 1
+        if option in _SUDO_SHORT_OPTIONS_WITH_ARG:
+            return ("skip", not has_attached_operand)
+        if option == "h":
+            if has_attached_operand:
+                return ("skip", False)
+            # Only an exact `-h` may consume the next ordinary word as sudo's
+            # historical remote-host operand. A bundled `-nh` selects help,
+            # and exact `-h` also selects help when the next word is another
+            # option or an environment assignment. The walkers perform that
+            # one-word lookahead before deciding whether execution continues.
+            return (
+                "sudo_host_or_help" if word == "-h" else "stop",
+                False,
+            )
+        if option not in _SUDO_SHORT_FLAGS:
+            return ("unresolved", False)
+    return ("skip", False)
+
+
+def _env_option_action(word: str) -> tuple[str, bool]:
+    """Classify one GNU env option without parsing executable -S payloads."""
+    if word == "-":
+        return ("skip", False)
+    if word.startswith("--"):
+        option = _resolve_unique_long_option(word, _ENV_LONG_OPTIONS)
+        if option is None or option == "split-string":
+            return ("unresolved", False)
+        return (
+            "skip",
+            "=" not in word and option in _ENV_LONG_OPTIONS_WITH_ARG,
+        )
+
+    cluster = word[1:]
+    if not cluster:
+        return ("unresolved", False)
+    for index, option in enumerate(cluster):
+        if option == "S":
+            return ("unresolved", False)
+        if option in _ENV_SHORT_OPTIONS_WITH_ARG:
+            return ("skip", index == len(cluster) - 1)
+        if option not in _ENV_SHORT_FLAGS:
+            return ("unresolved", False)
+    return ("skip", False)
+
+
 def _wrapper_option_action(wrapper: str, word: str) -> tuple[str | None, bool]:
     """Classify one option-shaped word for a pass-through wrapper.
 
     The action is ``skip`` for a recognized option, ``end`` for ``--``,
-    ``stop`` for command lookup-only modes, ``unresolved`` for an option the
-    wrapper's exhaustive grammar does not know (the walker cannot place the
-    program word and must fail safe), and ``None`` when the word is the
-    program name rather than an option. The boolean reports whether the next
-    word is the option's separate operand.
+    ``stop`` for non-executing modes, ``sudo_host_or_help`` when exact ``-h``
+    needs one-word lookahead, ``unresolved`` for an option the wrapper's
+    exhaustive grammar does not know (the walker cannot place the program word
+    and must fail safe), and ``None`` when the word is the program name rather
+    than an option. The boolean reports whether the next word is the option's
+    separate operand.
     """
+    if word == "--":
+        return ("end", False)
+    if wrapper == "sudo":
+        return _sudo_option_action(word)
+    if wrapper == "env":
+        return _env_option_action(word)
+
     lowered = word.lower()
     option_name = lowered.split("=", 1)[0]
-    if lowered == "--":
-        return ("end", False)
     if wrapper == "command" and _is_lookup_only_option(option_name):
         return ("stop", False)
     if wrapper == "nice" and re.fullmatch(r"-\d+", lowered):
@@ -1647,13 +1737,7 @@ def _wrapper_option_action(wrapper: str, word: str) -> tuple[str | None, bool]:
     if short_action is not None:
         return short_action
 
-    if wrapper == "sudo":
-        options = None
-        options_with_arg = _SUDO_OPTIONS_WITH_ARG
-    elif wrapper == "env":
-        options = None
-        options_with_arg = _ENV_OPTIONS_WITH_ARG
-    elif wrapper == "command":
+    if wrapper == "command":
         options = _COMMAND_OPTIONS
         options_with_arg = frozenset()
     elif wrapper == "exec":
@@ -1685,6 +1769,59 @@ def _wrapper_option_action(wrapper: str, word: str) -> tuple[str | None, bool]:
     return (
         "skip",
         "=" not in lowered and option_name in options_with_arg,
+    )
+
+
+def _wrapper_assignment_is_data(
+    wrapper: str, word: str, *, options_enabled: bool
+) -> bool:
+    """Return whether ``word`` is assignment data owned by ``wrapper``.
+
+    Shell assignment prefixes, sudo's interspersed environment entries, and
+    GNU env's NAME=VALUE operands have different grammars. Keep the wrapper
+    grammars here so both command-position walkers make the same transition.
+    """
+    if wrapper == "sudo":
+        # sudo parse_args.c:is_envar. `--` disables this interspersed form.
+        return (
+            options_enabled
+            and bool(word)
+            and word[0] not in {"/", "="}
+            and "=" in word
+        )
+    if wrapper == "env":
+        # GNU env consumes every equals-bearing operand before COMMAND, even
+        # after `--`; putenv itself decides whether the name is acceptable.
+        return "=" in word
+    return False
+
+
+def _wrapper_prefix_action(
+    wrapper: str, word: str, *, options_enabled: bool
+) -> tuple[str | None, bool, bool]:
+    """Classify one wrapper-prefix word at the shared state-machine choke point."""
+    # getopt owns option-shaped words before NAME=VALUE processing. This order
+    # is load-bearing for forms such as `env --split-string=PAYLOAD`.
+    if options_enabled and word.startswith("-"):
+        action, skip_next = _wrapper_option_action(wrapper, word)
+        return (action, skip_next, False if action == "end" else options_enabled)
+    if _wrapper_assignment_is_data(
+        wrapper, word, options_enabled=options_enabled
+    ):
+        # sudo resumes getopt after each interspersed assignment. GNU env's
+        # first NAME=VALUE permanently ends its option phase.
+        return ("skip", False, False if wrapper == "env" else options_enabled)
+    return (None, False, options_enabled)
+
+
+def _sudo_historical_host_follows(command: str, pos: int) -> bool:
+    """Return whether exact ``sudo -h`` consumes the next word as a host."""
+    word_start, word_end, word = _read_shell_word(command, pos)
+    if word_start == word_end:
+        return False
+    deobfuscated = _deobfuscate_shell_word_for_detection(word)
+    return not deobfuscated.startswith("-") and not _wrapper_assignment_is_data(
+        "sudo", deobfuscated, options_enabled=True
     )
 
 _INTERPRETER_EXEC_FLAGS = {
@@ -2600,9 +2737,15 @@ def _iter_shell_command_word_spans(command: str):
                 skip_next_wrapper_arg = False
                 pos = word_end
                 continue
-            if skip_wrapper_options and lower_word.startswith("-"):
-                action, skip_next_wrapper_arg = _wrapper_option_action(
-                    active_wrapper, lower_word
+            if active_wrapper:
+                (
+                    action,
+                    skip_next_wrapper_arg,
+                    skip_wrapper_options,
+                ) = _wrapper_prefix_action(
+                    active_wrapper,
+                    deobfuscated,
+                    options_enabled=skip_wrapper_options,
                 )
                 if action == "unresolved":
                     raise _UnresolvedCommandWalk(
@@ -2610,9 +2753,12 @@ def _iter_shell_command_word_spans(command: str):
                     )
                 if action == "stop":
                     break
+                if action == "sudo_host_or_help":
+                    if _sudo_historical_host_follows(command, word_end):
+                        skip_next_wrapper_arg = True
+                    else:
+                        break
                 if action is not None:
-                    if action == "end":
-                        skip_wrapper_options = False
                     pos = word_end
                     continue
             if skip_timeout_duration:
@@ -2629,7 +2775,7 @@ def _iter_shell_command_word_spans(command: str):
                 skip_timeout_duration = lower_word == "timeout"
                 pos = word_end
                 continue
-            if _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
+            if not active_wrapper and _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
                 active_wrapper = ""
                 skip_wrapper_options = False
                 pos = word_end
@@ -2735,11 +2881,15 @@ def _project_path_spelled_executables(command: str) -> str | None:
                 skip_next_wrapper_arg = False
                 continue
             deobfuscated = _deobfuscate_shell_word_for_detection(word) or word
-            if _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
-                continue  # VAR=value prefix: data, keep walking
-            if skip_wrapper_options and deobfuscated.startswith("-"):
-                action, skip_next_wrapper_arg = _wrapper_option_action(
-                    active_wrapper, deobfuscated
+            if active_wrapper:
+                (
+                    action,
+                    skip_next_wrapper_arg,
+                    skip_wrapper_options,
+                ) = _wrapper_prefix_action(
+                    active_wrapper,
+                    deobfuscated,
+                    options_enabled=skip_wrapper_options,
                 )
                 if action == "unresolved":
                     raise _UnresolvedCommandWalk(
@@ -2747,10 +2897,15 @@ def _project_path_spelled_executables(command: str) -> str | None:
                     )
                 if action == "stop":
                     break
+                if action == "sudo_host_or_help":
+                    if _sudo_historical_host_follows(command, pos):
+                        skip_next_wrapper_arg = True
+                    else:
+                        break
                 if action is not None:
-                    if action == "end":
-                        skip_wrapper_options = False
                     continue
+            if not active_wrapper and _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
+                continue  # shell VAR=value prefix: data, keep walking
             if skip_timeout_duration:
                 skip_timeout_duration = False
                 skip_wrapper_options = False

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1464,6 +1464,9 @@ _COMMAND_WRAPPER_WORDS = {
     "time",
     "command",
     "builtin",
+    "timeout",
+    "nice",
+    "stdbuf",
 }
 _SUDO_OPTIONS_WITH_ARG = {
     "-c", "--close-from",
@@ -1500,11 +1503,133 @@ _COMMAND_OPTIONS = frozenset({"-p", "-v", "-V"})
 _EXEC_OPTIONS = frozenset({"-a", "-c", "-l"})
 _EXEC_OPTIONS_WITH_ARG = frozenset({"-a"})
 
+# `timeout` consumes one duration operand after its options, then launches the
+# remaining command. Options in this set take their value from the next word
+# unless it is attached with `=`.
+_TIMEOUT_OPTIONS_WITH_ARG = frozenset({
+    "-k", "--kill-after",
+    "-s", "--signal",
+})
+_TIMEOUT_OPTIONS = _TIMEOUT_OPTIONS_WITH_ARG | frozenset({
+    # Short spellings included: coreutils' getopt string is "+k:s:vf" plus
+    # -p for --preserve-status, so `timeout -p 5 cmd` and `timeout -f 5 cmd`
+    # are valid and must not strand the walker on the option word.
+    "-p", "--preserve-status",
+    "-f", "--foreground",
+    "-v", "--verbose",
+})
+
+_NICE_OPTIONS_WITH_ARG = frozenset({"-n", "--adjustment"})
+_NICE_OPTIONS = _NICE_OPTIONS_WITH_ARG
+
+_STDBUF_OPTIONS_WITH_ARG = frozenset({
+    "-i", "-o", "-e",
+    "--input", "--output", "--error",
+})
+_STDBUF_OPTIONS = _STDBUF_OPTIONS_WITH_ARG
+
+_WRAPPER_SHORT_FLAGS = {
+    "command": frozenset("pv"),
+    "exec": frozenset("cl"),
+    # coreutils' timeout getopt string is "+k:s:vf" and -p is accepted for
+    # --preserve-status, so v/f/p are the no-argument short flags that can
+    # appear bundled (-vpf) ahead of the duration.
+    "timeout": frozenset("vfp"),
+}
+_WRAPPER_SHORT_OPTIONS_WITH_ARG = {
+    "exec": frozenset("a"),
+    "timeout": frozenset("ks"),
+    "nice": frozenset("n"),
+    "stdbuf": frozenset("ioe"),
+}
+
 
 def _is_lookup_only_option(option_name: str) -> bool:
     if option_name.startswith("--"):
         return False
     return bool(set(option_name[1:]) & _COMMAND_LOOKUP_ONLY_SHORT)
+
+
+def _short_wrapper_option_action(
+    wrapper: str, word: str
+) -> tuple[str, bool] | None:
+    """Parse one GNU-style short-option cluster for a wrapper."""
+    if (
+        len(word) <= 1
+        or word.startswith("--")
+        or not word.startswith("-")
+        or "=" in word
+    ):
+        return None
+    flags = _WRAPPER_SHORT_FLAGS.get(wrapper, frozenset())
+    options_with_arg = _WRAPPER_SHORT_OPTIONS_WITH_ARG.get(
+        wrapper, frozenset()
+    )
+    if not flags and not options_with_arg:
+        return None
+
+    cluster = word[1:]
+    for index, option in enumerate(cluster):
+        if option in options_with_arg:
+            return ("skip", index == len(cluster) - 1)
+        if option not in flags:
+            return None
+    return ("skip", False)
+
+
+def _wrapper_option_action(wrapper: str, word: str) -> tuple[str | None, bool]:
+    """Classify one option-shaped word for a pass-through wrapper.
+
+    The action is ``skip`` for a recognized option, ``end`` for ``--``,
+    ``stop`` for command lookup-only modes, and ``None`` when the word is the
+    program name rather than an option. The boolean reports whether the next
+    word is the option's separate operand.
+    """
+    lowered = word.lower()
+    option_name = lowered.split("=", 1)[0]
+    if lowered == "--":
+        return ("end", False)
+    if wrapper == "command" and _is_lookup_only_option(option_name):
+        return ("stop", False)
+    if wrapper == "nice" and re.fullmatch(r"-\d+", lowered):
+        # GNU nice's obsolete but still-supported `-ADJUSTMENT` spelling.
+        return ("skip", False)
+
+    short_action = _short_wrapper_option_action(wrapper, lowered)
+    if short_action is not None:
+        return short_action
+
+    if wrapper == "sudo":
+        options = None
+        options_with_arg = _SUDO_OPTIONS_WITH_ARG
+    elif wrapper == "env":
+        options = None
+        options_with_arg = _ENV_OPTIONS_WITH_ARG
+    elif wrapper == "command":
+        options = _COMMAND_OPTIONS
+        options_with_arg = frozenset()
+    elif wrapper == "exec":
+        options = _EXEC_OPTIONS
+        options_with_arg = _EXEC_OPTIONS_WITH_ARG
+    elif wrapper == "timeout":
+        options = _TIMEOUT_OPTIONS
+        options_with_arg = _TIMEOUT_OPTIONS_WITH_ARG
+    elif wrapper == "nice":
+        options = _NICE_OPTIONS
+        options_with_arg = _NICE_OPTIONS_WITH_ARG
+    elif wrapper == "stdbuf":
+        options = _STDBUF_OPTIONS
+        options_with_arg = _STDBUF_OPTIONS_WITH_ARG
+    else:
+        options = frozenset()
+        options_with_arg = frozenset()
+
+    if options is not None and option_name not in options:
+        return (None, False)
+    return (
+        "skip",
+        "=" not in lowered and option_name in options_with_arg,
+    )
 
 _INTERPRETER_EXEC_FLAGS = {
     "python": {"-c"},
@@ -2369,8 +2494,10 @@ def _iter_shell_command_word_spans(command: str):
     for command_start in _iter_shell_command_starts(command):
         pos = command_start
         prefix_words = 0
+        active_wrapper = ""
         skip_wrapper_options = False
         skip_next_wrapper_arg = False
+        skip_timeout_duration = False
         while prefix_words < 12:
             word_start, word_end, word = _read_shell_word(command, pos)
             if word_start == word_end:
@@ -2383,11 +2510,20 @@ def _iter_shell_command_word_spans(command: str):
                 prefix_words += 1
                 continue
             if skip_wrapper_options and lower_word.startswith("-"):
-                option_name = lower_word.split("=", 1)[0]
-                skip_next_wrapper_arg = (
-                    "=" not in lower_word
-                    and option_name in _SUDO_OPTIONS_WITH_ARG
+                action, skip_next_wrapper_arg = _wrapper_option_action(
+                    active_wrapper, lower_word
                 )
+                if action == "stop":
+                    break
+                if action is not None:
+                    if action == "end":
+                        skip_wrapper_options = False
+                    pos = word_end
+                    prefix_words += 1
+                    continue
+            if skip_timeout_duration:
+                skip_timeout_duration = False
+                skip_wrapper_options = False
                 pos = word_end
                 prefix_words += 1
                 continue
@@ -2396,10 +2532,13 @@ def _iter_shell_command_word_spans(command: str):
             prefix_words += 1
 
             if lower_word in _COMMAND_WRAPPER_WORDS:
-                skip_wrapper_options = lower_word in {"sudo", "env"}
+                active_wrapper = lower_word
+                skip_wrapper_options = True
+                skip_timeout_duration = lower_word == "timeout"
                 pos = word_end
                 continue
             if _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
+                active_wrapper = ""
                 skip_wrapper_options = False
                 pos = word_end
                 continue
@@ -2472,11 +2611,11 @@ def _project_path_spelled_executables(command: str) -> str | None:
     replacements: dict[int, tuple[int, str]] = {}
     for command_start in _iter_shell_command_starts(command):
         pos = command_start
-        wrapper_arg_options: frozenset | set = frozenset()
-        wrapper_options: frozenset | set | None = frozenset()
-        command_option_grammar = False
+        active_wrapper = ""
+        resolved_through_wrapper = False
         skip_wrapper_options = False
         skip_next_wrapper_arg = False
+        skip_timeout_duration = False
         # Bound the WRAPPER chain, not the whole prefix: shell grammar puts no
         # limit on assignment prefixes or on a wrapper option list, so counting
         # those let a caller push the executable past a fixed budget and out of
@@ -2505,60 +2644,39 @@ def _project_path_spelled_executables(command: str) -> str | None:
             if _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
                 continue  # VAR=value prefix: data, keep walking
             if skip_wrapper_options and deobfuscated.startswith("-"):
-                option_name = deobfuscated.lower().split("=", 1)[0]
-                if wrapper_options is None:
-                    # sudo/env: their option lists are large and largely
-                    # long-form, so every dash word is still skipped. Left as
-                    # it was — narrowing them is a separate change.
-                    skip_next_wrapper_arg = (
-                        "=" not in deobfuscated
-                        and option_name in wrapper_arg_options
-                    )
+                action, skip_next_wrapper_arg = _wrapper_option_action(
+                    active_wrapper, deobfuscated
+                )
+                if action == "stop":
+                    break
+                if action is not None:
+                    if action == "end":
+                        skip_wrapper_options = False
                     continue
-                # Wrappers whose option list is small enough to model exactly.
-                # `--` ends it: whatever follows is the program name even when
-                # it looks like an option (`command -- -p x` runs `-p`), and a
-                # word outside the list is not an option at all, so it falls
-                # through and is read as the program — which is what the shell
-                # does. Both directions matter: skipping every dash word
-                # blocked spellings the shell never executes.
-                if deobfuscated == "--":
-                    skip_wrapper_options = False
-                    continue
-                if command_option_grammar and _is_lookup_only_option(option_name):
-                    break  # `command -v`: a lookup, nothing is executed
-                if option_name in wrapper_options:
-                    skip_next_wrapper_arg = (
-                        "=" not in deobfuscated
-                        and option_name in wrapper_arg_options
-                    )
-                    continue
+            if skip_timeout_duration:
+                skip_timeout_duration = False
+                skip_wrapper_options = False
+                continue
             basename = _projected_executable_basename(word)
             effective = (basename or deobfuscated).lower()
             if basename is not None and word_start not in replacements:
                 replacements[word_start] = (word_end, basename)
             if effective in _COMMAND_WRAPPER_WORDS:
                 wrapper_budget -= 1  # only the wrapper CHAIN is bounded
+                active_wrapper = effective
+                resolved_through_wrapper = True
                 skip_wrapper_options = True
-                command_option_grammar = effective == "command"
-                if effective == "sudo":
-                    wrapper_options = None  # keep the existing skip-everything
-                    wrapper_arg_options = _SUDO_OPTIONS_WITH_ARG
-                elif effective == "env":
-                    wrapper_options = None
-                    wrapper_arg_options = _ENV_OPTIONS_WITH_ARG
-                elif effective == "command":
-                    wrapper_options = _COMMAND_OPTIONS
-                    wrapper_arg_options = frozenset()
-                elif effective == "exec":
-                    wrapper_options = _EXEC_OPTIONS
-                    wrapper_arg_options = _EXEC_OPTIONS_WITH_ARG
-                else:
-                    # nohup/setsid/time/builtin: nothing option-shaped precedes
-                    # the program, so a dash word is the program itself.
-                    wrapper_options = frozenset()
-                    wrapper_arg_options = frozenset()
+                skip_timeout_duration = effective == "timeout"
                 continue  # wrapper (bare or path-spelled): walk to the command
+            if (
+                resolved_through_wrapper
+                and basename is None
+                and word_start not in replacements
+            ):
+                # Wrappers absent from the flat `_CMDPOS` grammar still need
+                # their resolved bare command surfaced at a real command
+                # position (`timeout 5 nice rm -rf /`).
+                replacements[word_start] = (word_end, deobfuscated)
             break
     if not replacements:
         return None

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1472,6 +1472,19 @@ _SUDO_OPTIONS_WITH_ARG = {
     "-p", "--prompt",
     "-u", "--user",
 }
+# GNU env options whose value arrives as the NEXT word. Their operand is
+# data (`env --chdir /tmp/reboot /bin/echo` never executes reboot), so the
+# projection walker must not treat it as the command word. `=`-attached
+# forms are already handled by the generic option check. `-S/--split-string`
+# is listed here only for the walker's word skipping — its payload is
+# executable-bearing, but parsing it is a separate fail-closed change
+# (same verdict as the design review); skipping keeps parity with main.
+_ENV_OPTIONS_WITH_ARG = {
+    "-a", "--argv0",
+    "-c", "--chdir",
+    "-s", "--split-string",
+    "-u", "--unset",
+}
 
 _INTERPRETER_EXEC_FLAGS = {
     "python": {"-c"},
@@ -2373,6 +2386,123 @@ def _iter_shell_command_word_spans(command: str):
             break
 
 
+_EXECUTABLE_LAUNCHER_SUFFIXES = (".exe", ".bat", ".cmd")
+_PROJECTED_BASENAME_RE = re.compile(r"[A-Za-z0-9_][\w.+-]*\Z")
+_WINDOWS_ABSOLUTE_RE = re.compile(r"[A-Za-z]:[\\/]|\\\\")
+# `_read_shell_word` stops at whitespace and `;&|`, so a command that ends
+# at a substitution/subshell closer keeps that byte in the word:
+# `(/sbin/reboot)` reads as `/sbin/reboot)`. Trim the closers before the
+# basename check or the stray byte makes the word look like something other
+# than a program name and the projection silently declines. Only `)` and
+# the backtick qualify: both are shell metacharacters that can never sit
+# inside an unquoted word. `}` is NOT one (`echo foo}` prints `foo}`, and
+# a brace group's `}` is its own word behind `;`), so trimming it would
+# rewrite legitimate names like `/tmp/reboot}`.
+_WORD_TAIL_CLOSERS = ")`"
+
+
+def _projected_executable_basename(word: str) -> str | None:
+    """Reduce one command-position word to the bare program name a shell
+    would resolve, or None when the word already is one (or can't be one).
+
+    A Windows-absolute word (drive or UNC prefix) is split on both
+    separators BEFORE any escape collapsing — the deobfuscation pass treats
+    backslashes as shell escapes and would dissolve the path. Everything
+    else goes through the same quote/escape collapsing the r\\m detection
+    uses, so composed spellings (``'/sbin/'shutdown``, ``/sbin/shut\\down``)
+    reduce like their plain forms."""
+    stripped = _strip_optional_shell_quotes(word)
+    if _WINDOWS_ABSOLUTE_RE.match(stripped):
+        basename = stripped.replace("\\", "/").rsplit("/", 1)[-1]
+    else:
+        collapsed = _deobfuscate_shell_word_for_detection(word) or word
+        basename = _strip_optional_shell_quotes(collapsed).rsplit("/", 1)[-1]
+    lowered = basename.lower()
+    for suffix in _EXECUTABLE_LAUNCHER_SUFFIXES:
+        if lowered.endswith(suffix):
+            basename = basename[: -len(suffix)]
+            break
+    if basename == word:
+        return None  # already a bare name — nothing to project
+    # Refuse anything that doesn't reduce to a plain program name (empty
+    # basename from a trailing slash, expansion debris): projecting those
+    # could only manufacture command words a shell would not actually run.
+    if not _PROJECTED_BASENAME_RE.fullmatch(basename):
+        return None
+    return basename
+
+
+def _project_path_spelled_executables(command: str) -> str | None:
+    """Detection-only variant: rewrite command-position executables that are
+    spelled by path (POSIX or Windows, quoted or bare, with or without a
+    launcher suffix) to ``\\n<basename>`` so the flat ``_CMDPOS``-anchored
+    patterns see the same command word a bare spelling would produce —
+    ``/sbin/shutdown``, ``C:\\Windows\\System32\\shutdown.exe`` and
+    ``"C:\\Program Files\\Git\\usr\\bin\\rm.exe"`` must behave exactly like
+    ``shutdown`` / ``rm``. Must run on the RAW command: the global
+    normalization strips backslashes and fuses a Windows path into one word
+    before the basename could be recovered.
+
+    The walk mirrors ``_iter_shell_command_word_spans`` but recognizes
+    wrappers by their PROJECTED basename, so a path-spelled wrapper chain
+    (``/usr/bin/env /usr/bin/sudo /sbin/shutdown``) resolves in this single
+    pass — no fixpoint, no overlapping re-splice. Assignment-shaped words
+    (``X=/sbin/shutdown``) are prefix data, never executables. Returns None
+    when nothing needed rewriting."""
+    replacements: dict[int, tuple[int, str]] = {}
+    for command_start in _iter_shell_command_starts(command):
+        pos = command_start
+        wrapper_arg_options: frozenset | set = frozenset()
+        skip_wrapper_options = False
+        skip_next_wrapper_arg = False
+        for _ in range(12):
+            word_start, raw_end, _raw_word = _read_shell_word(command, pos)
+            if word_start == raw_end:
+                break
+            pos = raw_end
+            # Trim group/substitution closers the word reader keeps
+            # (`(/sbin/reboot)` reads as `/sbin/reboot)`); the closer stays
+            # outside the replacement span so the splice preserves it.
+            word_end = raw_end
+            while word_end > word_start and command[word_end - 1] in _WORD_TAIL_CLOSERS:
+                word_end -= 1
+            if word_end == word_start:
+                continue  # bare closer: structure, not a word
+            word = command[word_start:word_end]
+            if skip_next_wrapper_arg:
+                skip_next_wrapper_arg = False
+                continue
+            deobfuscated = _deobfuscate_shell_word_for_detection(word) or word
+            if _ENV_ASSIGNMENT_RE.fullmatch(deobfuscated):
+                continue  # VAR=value prefix: data, keep walking
+            if skip_wrapper_options and deobfuscated.startswith("-"):
+                option_name = deobfuscated.lower().split("=", 1)[0]
+                skip_next_wrapper_arg = (
+                    "=" not in deobfuscated
+                    and option_name in wrapper_arg_options
+                )
+                continue
+            basename = _projected_executable_basename(word)
+            effective = (basename or deobfuscated).lower()
+            if basename is not None and word_start not in replacements:
+                replacements[word_start] = (word_end, basename)
+            if effective in _COMMAND_WRAPPER_WORDS:
+                skip_wrapper_options = effective in {"sudo", "env"}
+                if effective == "sudo":
+                    wrapper_arg_options = _SUDO_OPTIONS_WITH_ARG
+                elif effective == "env":
+                    wrapper_arg_options = _ENV_OPTIONS_WITH_ARG
+                continue  # wrapper (bare or path-spelled): walk to the command
+            break
+    if not replacements:
+        return None
+    projected = command
+    for word_start in sorted(replacements, reverse=True):
+        word_end, basename = replacements[word_start]
+        projected = projected[:word_start] + "\n" + basename + projected[word_end:]
+    return projected
+
+
 def _command_detection_variants(command: str):
     # Mask quoted newlines BEFORE normalization: normalization strips
     # backslash-escapes (\" -> ") and empty-string pairs (""), which would
@@ -2419,6 +2549,16 @@ def _command_detection_variants(command: str):
                 if marked_payload != payload and marked_payload not in seen:
                     seen.add(marked_payload)
                     yield marked_payload
+                # A payload's own executable can be path-spelled too
+                # (`bash -c '/sbin/shutdown -h now'`), so it needs the same
+                # basename projection as the outer command. POSIX paths
+                # survive the normalization the payload came through;
+                # backslash Windows paths inside payloads stay out of reach
+                # until normalization preserves separators (#71919).
+                projected_payload = _project_path_spelled_executables(payload)
+                if projected_payload is not None and projected_payload not in seen:
+                    seen.add(projected_payload)
+                    yield projected_payload
                 pending.append(payload)
     # Subshell `(cmd)` and brace-group `{ cmd; }` openers put `cmd` at a real
     # command position, but the flat `_CMDPOS`-anchored patterns can't see it:
@@ -2435,6 +2575,21 @@ def _command_detection_variants(command: str):
     if marked != grep_safe and marked not in seen:
         seen.add(marked)
         yield marked
+    # Absolute-path spellings bypass every _CMDPOS-anchored rule the same
+    # way subshell openers did: the anchor class knows wrappers but not
+    # paths, so `/sbin/shutdown` or `C:\Windows\System32\shutdown.exe`
+    # never reaches `shutdown\b`. Project command-position executables to
+    # `\n<basename>` from the RAW command (normalization strips backslashes
+    # and fuses Windows paths before a basename could be recovered), then
+    # feed the projection through the standard normalize/grep-safe pipe.
+    projected = _project_path_spelled_executables(command)
+    if projected is not None:
+        projected_variant, _ = _grep_safe_detection_variant(
+            _normalize_command_for_detection(projected)
+        )
+        if projected_variant not in seen:
+            seen.add(projected_variant)
+            yield projected_variant
     # Shell quoting/escaping can spell a dangerous executable name in pieces
     # (for example r\m or r''m). Keep that deobfuscation scoped to command
     # words so similarly shaped arguments do not become false positives.


### PR DESCRIPTION
Absolute-path floor: #82830.

This branch still includes that first commit (`adfe67fcd2`) plus the wrapper-walker follow-ups. GitHub vs main cannot hide the floor until #82830 lands.

The extra commits close wrapper option lists and operand bypasses (`command -p`, `timeout`, `env -S`, `sudo`) and the fail-open 12-word walk.

Refs #71995
