### PR TITLE
fix(gateway): release rejected native clarifies before steering

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10987,7 +10987,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Intercept messages that are responses to a pending clarify.
         # Open-ended prompts and "Other" responses are captured as free text;
         # direct replies to multi-choice prompts are accepted too ("2" maps
-        # to the second option, arbitrary text becomes a custom answer). Slash
+        # to the second option). Slash
         # commands still bypass this path so /stop and friends keep working.
         _clarify_mod = None
         try:
@@ -11031,6 +11031,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # the agent's response don't double-post.  The agent
                     # itself will produce the next user-facing message.
                     return ""
+                # Native-choice prompts deliberately reject unmatched prose
+                # so it can continue through normal busy-message routing.
+                # Release this clarify first: redirect() degrades to steer()
+                # while tools are executing, and that steer cannot drain until
+                # the clarify tool returns.
+                _clarify_mod.resolve_gateway_clarify(
+                    _pending_clarify.clarify_id,
+                    "",
+                )
 
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are

--- a/tests/gateway/test_clarify_thread_followup_not_swallowed.py
+++ b/tests/gateway/test_clarify_thread_followup_not_swallowed.py
@@ -123,11 +123,13 @@ async def test_thread_prose_not_swallowed_by_native_multi_choice_clarify():
     with pytest.raises(_FellThroughIntercept):
         await _dispatch(runner, _event("just checking the visual UI, no need to pass any data"))
 
-    # The clarify entry must still be pending and unresolved.
+    # The prose is not accepted as the answer, but the clarify must be
+    # released before normal busy routing so redirect-to-steer can drain.
     with cm._lock:
         entry = cm._entries.get("cl-native")
     assert entry is not None
-    assert not entry.event.is_set()
+    assert entry.event.is_set()
+    assert entry.response == ""
     _clear_clarify_state()
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the native-choice clarify deadlock described in #71946 without accepting unmatched prose as a choice.

When strict choice coercion rejects prose, the gateway now releases that specific clarify with the existing empty cancellation sentinel before continuing through normal busy-message routing. This preserves #62034 while allowing `redirect()`-to-`steer()` to drain after the clarify tool returns.

This intentionally does not change `/stop` cleanup, which is already covered by #71443.

## Related Issue

Fixes #71946

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Release a rejected native multi-choice clarify before routing the original prose as a normal busy message.
- Update the existing gateway regression to assert the prose is not accepted as the answer while the blocked clarify is released.

## How to Test

1. Register a native multi-choice clarify and block a waiter on it.
2. Submit unmatched prose while the agent is executing tools.
3. Verify the prose is rejected as the clarify answer, the waiter returns `""`, and the original prose remains available to active-turn steering.

```text
scripts/run_tests.sh tests/tools/test_clarify_gateway.py tests/gateway/test_clarify_thread_followup_not_swallowed.py -q
39 passed, 0 failed

ruff check gateway/run.py tests/gateway/test_clarify_thread_followup_not_swallowed.py
All checks passed!

scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_clarify_thread_followup_not_swallowed.py
No Windows footguns found

git diff --check
passed
```

Tested on macOS arm64 with Python 3.13. The behavior probe used an isolated temporary `HERMES_HOME`; no live Telegram credentials were required.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS arm64

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] Config example update — N/A
- [x] Architecture/workflow docs update — N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

Before the fix, the isolated probe reported:

```text
clarify_pending=True
pending_steer='Use 07:00 instead'
waiter_alive=True
```

After the fix:

```text
clarify_answer_accepted=False
pending_steer='Use 07:00 instead'
waiter_alive=False
clarify_result=['']
```

Disclosure: Codex assisted with repository analysis, implementation, and test execution; the published claims above are limited to commands actually run.
