### PR TITLE
fix(update): test runs never mutate the live checkout — pytest-guard the marker and repair paths

### DIFF
--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -171,6 +171,22 @@ def _run_repair_install(specs: list[str], project_root: Path) -> bool:
     return True
 
 
+def _pytest_owns_live_checkout(root: Path) -> bool:
+    """True when running under pytest AND ``root`` is this module's own
+    checkout — the one whose venv is executing the suite right now.
+
+    Lifecycle tests spawn real subprocesses that import ``hermes_cli.main``
+    with recovery armed; ``PYTEST_CURRENT_TEST`` rides the inherited env into
+    those children. Without this guard, a genuinely-broken dev venv gets a
+    REAL ``ensurepip`` + ``pip install --force-reinstall`` from inside a
+    running test suite. Tests that sandbox ``project_root`` to a tmp_path are
+    unaffected (same posture as ``managed_scope._under_pytest``)."""
+    return (
+        "PYTEST_CURRENT_TEST" in os.environ
+        and root == Path(__file__).resolve().parent.parent
+    )
+
+
 def recover_if_needed(
     project_root: Path | None = None,
     argv: list[str] | None = None,
@@ -193,6 +209,8 @@ def recover_if_needed(
         if "update" in args:
             return
         root = _project_root() if project_root is None else project_root
+        if _pytest_owns_live_checkout(root):
+            return
         core_marker = root / ".update-incomplete"
         lazy_marker = root / ".lazy-refresh-incomplete"
         if not core_marker.exists() and not lazy_marker.exists():

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7537,6 +7537,22 @@ def _lazy_refresh_marker_path() -> Path:
     return PROJECT_ROOT / ".lazy-refresh-incomplete"
 
 
+def _pytest_owns_live_checkout(root: Path) -> bool:
+    """True when running under pytest AND ``root`` is this checkout itself.
+
+    Tests that drive update/recovery without sandboxing ``PROJECT_ROOT``
+    must neither litter the live repo root with recovery breadcrumbs
+    (a leftover ``.lazy-refresh-incomplete`` / ``.update-incomplete``
+    false-arms recovery on the developer's next real launch) nor run a real
+    reinstall against the executing venv. Sandboxed tests point at a
+    tmp_path and are unaffected (same posture as
+    ``managed_scope._under_pytest``)."""
+    return (
+        "PYTEST_CURRENT_TEST" in os.environ
+        and root == Path(__file__).resolve().parent.parent
+    )
+
+
 def _clear_marker_file(path: Path, *, label: str) -> None:
     """Remove an update-recovery breadcrumb. Never raises."""
     try:
@@ -7583,6 +7599,8 @@ def _recover_from_interrupted_install() -> None:
     protocol stream (``hermes acp`` speaks JSON-RPC on stdout) must never get
     install noise on stdout.
     """
+    if _pytest_owns_live_checkout(PROJECT_ROOT):
+        return
     core_marker = _update_marker_path().exists()
     lazy_marker = _lazy_refresh_marker_path().exists()
     if not core_marker and not lazy_marker:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1392,6 +1392,9 @@ def _invalidate_update_cache():
 
 def _write_marker_file(path: Path, *, label: str) -> None:
     """Drop an update-recovery breadcrumb. Never raises."""
+    if _m()._pytest_owns_live_checkout(path.parent):
+        logger.debug("Skipping %s marker under pytest (live checkout)", label)
+        return
     try:
         path.write_text(
             f"started={_time.time()}\npid={os.getpid()}\n", encoding="utf-8"

--- a/tests/hermes_cli/test_checkout_mutation_guards.py
+++ b/tests/hermes_cli/test_checkout_mutation_guards.py
@@ -1,0 +1,108 @@
+"""The test suite must never mutate the LIVE checkout or its venv.
+
+Regression tests for the pytest-guards on the checkout-root mutation paths.
+Before the guards, tests that drove ``cmd_update``/recovery without
+sandboxing ``PROJECT_ROOT`` left ``.lazy-refresh-incomplete`` at the real
+repo root (observed after full-suite runs), and — on a venv with genuinely
+broken packages — test-spawned subprocesses importing ``hermes_cli.main``
+ran a REAL ``ensurepip`` + ``pip install --force-reinstall`` against the
+developer's executing environment mid-suite.
+
+The guard predicate requires BOTH conditions (under pytest AND the target is
+this checkout itself), so every tmp_path-sandboxed test keeps exercising the
+real code paths unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import hermes_cli.main as main_mod
+from hermes_cli import _early_recovery as er
+
+CHECKOUT_ROOT = Path(er.__file__).resolve().parent.parent
+
+
+class TestPredicate:
+    def test_true_for_live_checkout_under_pytest(self):
+        # PYTEST_CURRENT_TEST is set by pytest itself right now.
+        assert er._pytest_owns_live_checkout(CHECKOUT_ROOT) is True
+        assert main_mod._pytest_owns_live_checkout(CHECKOUT_ROOT) is True
+
+    def test_false_for_sandboxed_root(self, tmp_path):
+        assert er._pytest_owns_live_checkout(tmp_path) is False
+        assert main_mod._pytest_owns_live_checkout(tmp_path) is False
+
+    def test_false_outside_pytest(self, monkeypatch):
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        assert er._pytest_owns_live_checkout(CHECKOUT_ROOT) is False
+        assert main_mod._pytest_owns_live_checkout(CHECKOUT_ROOT) is False
+
+
+class TestMarkerWrites:
+    def test_refuses_breadcrumb_at_live_repo_root(self):
+        target = CHECKOUT_ROOT / ".lazy-refresh-incomplete"
+        # The marker may legitimately pre-exist: upstream currently TRACKS a
+        # littered copy in git (the exact pollution this guard prevents), so
+        # the contract is content-unchanged, not never-exists.
+        before = target.read_text(encoding="utf-8") if target.exists() else None
+        try:
+            main_mod._write_marker_file(target, label="lazy-refresh-incomplete")
+            after = (
+                target.read_text(encoding="utf-8") if target.exists() else None
+            )
+            assert after == before, (
+                "marker breadcrumb written into the LIVE checkout from a test"
+            )
+        finally:
+            # If the guard is broken (RED state), restore the pre-test state —
+            # leaving pollution behind is exactly the bug being pinned.
+            if before is None:
+                target.unlink(missing_ok=True)
+            else:
+                target.write_text(before, encoding="utf-8")
+
+    def test_still_writes_sandboxed(self, tmp_path):
+        target = tmp_path / ".lazy-refresh-incomplete"
+        main_mod._write_marker_file(target, label="lazy-refresh-incomplete")
+        assert target.exists()
+        assert "pid=" in target.read_text(encoding="utf-8")
+
+
+class TestEarlyRecovery:
+    def test_skips_live_checkout_before_any_probe_or_lock(self, monkeypatch):
+        # A probe call would mean recovery is proceeding against the live
+        # checkout; the guard must return before ANY side-effectful step.
+        def _boom():
+            raise AssertionError("probe ran against the live checkout")
+
+        monkeypatch.setattr(er, "_probe_broken_packages", _boom)
+        monkeypatch.setattr(er, "_run_repair_install", lambda *a, **k: _boom())
+        er.recover_if_needed(project_root=CHECKOUT_ROOT, argv=[])
+
+    def test_sandboxed_root_still_recovers(self, tmp_path, monkeypatch):
+        # The guard must not disable recovery for sandboxed roots: with a
+        # marker present and a broken probe, the repair path still runs.
+        (tmp_path / ".lazy-refresh-incomplete").write_text("started=1\npid=1\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+        monkeypatch.setattr(er, "_probe_broken_packages", lambda: ["PyYAML"])
+        monkeypatch.setattr(er, "_pinned_specs", lambda broken, root: broken)
+        installs = []
+        monkeypatch.setattr(
+            er, "_run_repair_install", lambda specs, root: installs.append(specs) or True
+        )
+        er.recover_if_needed(project_root=tmp_path, argv=[])
+        assert installs, "sandboxed recovery was wrongly disabled by the guard"
+
+
+class TestLaunchRecovery:
+    def test_recover_from_interrupted_install_noops_on_live_checkout(
+        self, monkeypatch
+    ):
+        # PROJECT_ROOT is the live checkout in-suite; the launch-time
+        # recovery must return before touching markers or spawning installs.
+        def _boom(*a, **k):
+            raise AssertionError("launch recovery ran against the live checkout")
+
+        monkeypatch.setattr(main_mod, "_update_marker_path", _boom)
+        main_mod._recover_from_interrupted_install()


### PR DESCRIPTION
## What does this PR do?

Makes the test suite incapable of mutating the LIVE checkout or the venv executing it. Three checkout-root mutation paths gain a two-condition pytest-guard (under pytest AND target == this checkout, the posture of `managed_scope._under_pytest`): the update/recovery marker writer, launch-time recovery, and the dependency-light early-recovery repair. tmp_path-sandboxed tests keep exercising every real code path unchanged.

## Related Issue

Fixes #72000

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/main.py`: `_pytest_owns_live_checkout` predicate; `_write_marker_file` refuses breadcrumbs at the live repo root under pytest (sandboxed paths unaffected); `_recover_from_interrupted_install` no-ops when `PROJECT_ROOT` is the live checkout under pytest (tests that monkeypatch `PROJECT_ROOT` to a tmp_path are unaffected).
- `hermes_cli/_early_recovery.py`: same predicate (module stays dependency-light, so it carries its own copy); `recover_if_needed` returns before any probe/lock/install when the target root is the live checkout under pytest — `PYTEST_CURRENT_TEST` rides the inherited env into test-spawned subprocesses, which is exactly the leak path.
- `tests/hermes_cli/test_checkout_mutation_guards.py`: new module — predicate truth table, live-root marker refusal (self-cleaning red proof), sandboxed writes still work, early recovery skips the live checkout before ANY side-effectful step, sandboxed recovery still repairs, launch recovery no-ops on the live checkout.

## How to Test

Reproduction (pre-fix): run the suite and watch the repo root — `.lazy-refresh-incomplete` appears mid-run (written by unsandboxed `cmd_update` tests) and is left behind whenever the lazy-refresh phase reports failure, false-arming recovery on the developer's next real launch. Worse: with a genuinely broken package in the dev venv, the `test_early_recovery.py` lifecycle subprocesses execute a real `ensurepip` + `pip install --force-reinstall` against the venv running the suite (observed live 2026-07-25: `uv.lock` regenerated and packages ripped mid-run by the suite itself).

Unit repro: `tests/hermes_cli/test_checkout_mutation_guards.py::TestMarkerWrites::test_refuses_breadcrumb_at_live_repo_root` — red before this change (marker lands in the live repo root; the test cleans up after itself), green after.

```
scripts/run_tests.sh tests/hermes_cli/test_checkout_mutation_guards.py tests/hermes_cli/test_early_recovery.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_interrupted_recovery.py
```

Full canonical suite (`scripts/run_tests.sh tests/agent/ tests/hermes_cli/ tests/hermes_state/ tests/test_state_db_malformed_repair.py`): 16,450 passed / 25 failed — the 25 are machine-environment tests, byte-identical to the failing set of a pristine `eb5276056` run on the same machine (set-diff verified, zero introduced failures; one unrelated `tests/agent/lsp/test_client_e2e.py` case flaked under load during the full run and passes 3/3 re-run in isolation).

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] My commit messages follow the Conventional Commits standard
- [x] I have searched existing PRs and issues for duplicates (none; #69867 introduced these recovery paths, no report covers the test-side mutation)
- [x] This PR contains only changes related to this fix
- [x] I ran the test suite — evidence above
- [x] I have added tests (required for bug fixes)
- [x] Tested on: macOS 15 (arm64), Python 3.12; guards are pure `os.environ`/`pathlib` checks (no platform-specific I/O; Windows/WSL2 unaffected)

## Screenshots / Logs

Observed during a full-suite run on the pre-fix code (live checkout root):
```
$ git status --short
 M uv.lock
?? .lazy-refresh-incomplete
$ cat .lazy-refresh-incomplete
started=1785031876.7306392
pid=25741
```
