### PR TITLE
fix(session-context): clear cron auto-delivery vars in clear_session_vars

### DIFF
--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -274,13 +274,15 @@ def set_session_vars(
 def clear_session_vars(tokens: list) -> None:
     """Mark session context variables as explicitly cleared.
 
-    Sets all variables to ``""`` so that ``get_session_env`` returns an empty
-    string instead of falling back to (potentially stale) ``os.environ``
-    values.  The *tokens* argument is accepted for API compatibility with
-    callers that saved the return value of ``set_session_vars``, but the
-    actual clearing uses ``var.set("")`` rather than ``var.reset(token)``
-    to ensure the "explicitly cleared" state is distinguishable from
-    "never set" (which holds the ``_UNSET`` sentinel).
+    Sets all session context variables — including the cron auto-delivery
+    vars (``HERMES_CRON_AUTO_DELIVER_*``) — to ``""`` so that
+    ``get_session_env`` returns an empty string instead of falling back to
+    (potentially stale) ``os.environ`` values.  The *tokens* argument is
+    accepted for API compatibility with callers that saved the return value
+    of ``set_session_vars``, but the actual clearing uses
+    ``var.set("")`` rather than ``var.reset(token)`` to ensure the
+    "explicitly cleared" state is distinguishable from "never set" (which
+    holds the ``_UNSET`` sentinel).
     """
     for var in (
         _SESSION_PLATFORM,
@@ -297,6 +299,9 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_MESSAGE_ID,
         _SESSION_PROFILE,
         _CRON_SESSION,
+        _CRON_AUTO_DELIVER_PLATFORM,
+        _CRON_AUTO_DELIVER_CHAT_ID,
+        _CRON_AUTO_DELIVER_THREAD_ID,
     ):
         var.set("")
     # Reset async-delivery capability to the "never set" sentinel rather than a

--- a/tests/tools/test_local_env_session_leak.py
+++ b/tests/tools/test_local_env_session_leak.py
@@ -231,3 +231,49 @@ def test_hermes_subprocess_env_unengaged_preserves_fallback(monkeypatch):
     # not engaged (autouse fixture leaves _session_context_engaged False)
     env = hermes_subprocess_env()
     assert env.get("HERMES_SESSION_KEY") == "cli-fallback-key"
+
+
+def test_clear_session_vars_clears_cron_delivery_vars(monkeypatch):
+    """clear_session_vars must also clear HERMES_CRON_AUTO_DELIVER_* vars.
+
+    The cron auto-delivery context variables (HERMES_CRON_AUTO_DELIVER_PLATFORM,
+    HERMES_CRON_AUTO_DELIVER_CHAT_ID, HERMES_CRON_AUTO_DELIVER_THREAD_ID) are
+    part of _VAR_MAP but were previously omitted from the explicit clearing
+    loop in clear_session_vars.  After a cron job sets these and a handler
+    finishes, the delivery vars must NOT retain stale values.
+    """
+    from gateway.session_context import (
+        _CRON_AUTO_DELIVER_CHAT_ID,
+        _CRON_AUTO_DELIVER_PLATFORM,
+        _CRON_AUTO_DELIVER_THREAD_ID,
+        _UNSET,
+    )
+
+    tokens = set_session_vars(
+        session_key="cron-job:main",
+        platform="telegram",
+        chat_id="cron_chat",
+    )
+    # Simulate the cron scheduler setting delivery target after set_session_vars
+    _CRON_AUTO_DELIVER_PLATFORM.set("telegram")
+    _CRON_AUTO_DELIVER_CHAT_ID.set("12345")
+    _CRON_AUTO_DELIVER_THREAD_ID.set("thread-99")
+
+    # Verify the vars are set before clearing
+    assert _CRON_AUTO_DELIVER_PLATFORM.get() == "telegram"
+    assert _CRON_AUTO_DELIVER_CHAT_ID.get() == "12345"
+    assert _CRON_AUTO_DELIVER_THREAD_ID.get() == "thread-99"
+
+    clear_session_vars(tokens)
+
+    # After clearing, cron delivery vars must be "" (explicitly cleared),
+    # NOT the stale values from the cron job.
+    assert _CRON_AUTO_DELIVER_PLATFORM.get() == "", (
+        f"Cron platform var not cleared: {_CRON_AUTO_DELIVER_PLATFORM.get()!r}"
+    )
+    assert _CRON_AUTO_DELIVER_CHAT_ID.get() == "", (
+        f"Cron chat_id var not cleared: {_CRON_AUTO_DELIVER_CHAT_ID.get()!r}"
+    )
+    assert _CRON_AUTO_DELIVER_THREAD_ID.get() == "", (
+        f"Cron thread_id var not cleared: {_CRON_AUTO_DELIVER_THREAD_ID.get()!r}"
+    )


### PR DESCRIPTION
Closed due to 12+ days with no maintainer decision. Sweeper review confirmed correctness (salvageability=high). CI was green. No human engagement despite multiple pings (Jul 30, Aug 2, Aug 3, Aug 5).

Thanks for the fix @Yoliani — this will need to be resubmitted when maintainer availability picks up.