### PR TITLE
fix: redact API keys from error messages before persisting to auth.json

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -357,7 +357,11 @@ def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[st
         normalized["reason"] = reason.strip()
     message = error_context.get("message")
     if isinstance(message, str) and message.strip():
-        normalized["message"] = message.strip()
+        try:
+            from agent.redact import redact_sensitive_text
+            normalized["message"] = redact_sensitive_text(message.strip())
+        except Exception:
+            normalized["message"] = message.strip()
     reset_at = (
         error_context.get("reset_at")
         or error_context.get("resets_at")

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -359,9 +359,10 @@ def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[st
     if isinstance(message, str) and message.strip():
         try:
             from agent.redact import redact_sensitive_text
-            normalized["message"] = redact_sensitive_text(message.strip())
+            normalized["message"] = redact_sensitive_text(message.strip(), force=True)
         except Exception:
-            normalized["message"] = message.strip()
+            # Fail closed at the auth.json persistence boundary.
+            pass
     reset_at = (
         error_context.get("reset_at")
         or error_context.get("resets_at")

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -334,8 +334,15 @@ def test_explicit_reset_timestamp_overrides_default_429_ttl(tmp_path, monkeypatc
     assert pool.select() is None
 
 
-def test_mark_exhausted_and_rotate_persists_status(tmp_path, monkeypatch):
+def test_mark_exhausted_and_rotate_force_redacts_persisted_message(
+    tmp_path, monkeypatch
+):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    import agent.redact as redact_mod
+
+    monkeypatch.setattr(redact_mod, "_REDACT_ENABLED", False)
+    secret = "sk-ant-api03-upstream-secret-1234567890"
+    error_message = f"Request failed with API key {secret}"
     _write_auth_store(
         tmp_path,
         {
@@ -368,15 +375,71 @@ def test_mark_exhausted_and_rotate_persists_status(tmp_path, monkeypatch):
     pool = load_pool("anthropic")
     assert pool.select().id == "cred-1"
 
-    next_entry = pool.mark_exhausted_and_rotate(status_code=402)
+    next_entry = pool.mark_exhausted_and_rotate(
+        status_code=402,
+        error_context={"message": error_message},
+    )
 
     assert next_entry is not None
     assert next_entry.id == "cred-2"
 
-    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    auth_text = (tmp_path / "hermes" / "auth.json").read_text()
+    auth_payload = json.loads(auth_text)
     persisted = auth_payload["credential_pool"]["anthropic"][0]
+    assert secret not in auth_text
     assert persisted["last_status"] == "exhausted"
     assert persisted["last_error_code"] == 402
+    persisted_message = persisted["last_error_message"]
+    assert isinstance(persisted_message, str)
+    assert persisted_message
+    assert persisted_message != error_message
+
+
+def test_mark_exhausted_and_rotate_omits_message_when_redaction_fails(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-ant-api-primary",
+                    }
+                ]
+            },
+        },
+    )
+
+    import agent.redact as redact_mod
+    from agent.credential_pool import load_pool
+
+    def fail_redaction(*_args, **_kwargs):
+        raise RuntimeError("redaction failed")
+
+    monkeypatch.setattr(redact_mod, "redact_sensitive_text", fail_redaction)
+    secret = "sk-ant-api03-upstream-secret-0987654321"
+
+    pool = load_pool("anthropic")
+    assert pool.select().id == "cred-1"
+
+    pool.mark_exhausted_and_rotate(
+        status_code=429,
+        error_context={"message": f"Request failed with API key {secret}"},
+    )
+
+    auth_text = (tmp_path / "hermes" / "auth.json").read_text()
+    auth_payload = json.loads(auth_text)
+    persisted = auth_payload["credential_pool"]["anthropic"][0]
+    assert secret not in auth_text
+    assert persisted["last_error_message"] is None
 
 
 def test_billing_rotation_marks_all_entries_sharing_failed_key(tmp_path, monkeypatch):


### PR DESCRIPTION
When a provider API call fails, the upstream error message sometimes echoes back the API key (e.g. `Invalid API key: sk-ant-...`). These messages were being stored verbatim in `last_error_message` and flushed to `~/.hermes/auth.json` with no redaction.

This PR applies `redact_sensitive_text` in `_normalize_error_context` so keys are scrubbed before they reach the persisted credential pool state.

The fix is minimal — 4 lines added in `agent/credential_pool.py`, using the existing `agent.redact` module that already has patterns for all major provider key formats.

Fixes #71994