### PR TITLE
fix(kanban): pass the worker's task identity into the hermes-tools MCP callback

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -122,6 +122,45 @@ class CodexAppServerClient:
                     "sandbox_workspace_write.network_access=false",
                 ]
             )
+            # ...and the handoff tools must be able to IDENTIFY the task before
+            # they can write it. Codex replaces the MCP child's environment with
+            # the static ``env`` table from config.toml rather than extending
+            # this process's, so the per-worker HERMES_KANBAN_* vars never reach
+            # the hermes-tools callback. kanban_complete / kanban_block /
+            # kanban_heartbeat then resolve no task id at all
+            # ("task_id is required (or set HERMES_KANBAN_TASK in the env)"),
+            # so the worker does its work but can never report it — it hangs
+            # until the dispatcher reclaims the run, forever. A static config
+            # cannot carry a per-worker value, but a ``-c`` override can: it is
+            # merged into the server's env table, leaving HERMES_QUIET and
+            # HERMES_REDACT_SECRETS from config.toml intact.
+            #
+            # HERMES_KANBAN_DB matters twice over: without it the callback
+            # falls back to the DEFAULT board, so a worker's completion lands
+            # on the wrong board. Passing it also re-arms the worker-vs-
+            # orchestrator gate in tools/kanban_tools.py, which otherwise fails
+            # open and hands task workers the orchestrator-only kanban_list /
+            # kanban_unblock surface.
+            for _kanban_var in (
+                "HERMES_KANBAN_TASK",
+                "HERMES_KANBAN_RUN_ID",
+                "HERMES_KANBAN_DB",
+                "HERMES_KANBAN_BOARD",
+                "HERMES_KANBAN_CLAIM_LOCK",
+                "HERMES_SESSION_ID",
+            ):
+                _kanban_val = spawn_env.get(_kanban_var)
+                if not _kanban_val:
+                    continue
+                # TOML basic string — escape backslashes and quotes so Windows
+                # paths and odd board slugs cannot break the override parse.
+                _escaped = str(_kanban_val).replace("\\", "\\\\").replace('"', '\\"')
+                app_server_args.extend(
+                    [
+                        "-c",
+                        f'mcp_servers.hermes-tools.env.{_kanban_var}="{_escaped}"',
+                    ]
+                )
 
         cmd = [codex_bin, "app-server"] + app_server_args
         # Codex emits tracing to stderr; default WARN keeps it quiet for users.

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -296,6 +296,104 @@ class TestSpawnEnvIsolation:
         assert "sandbox_workspace_write.network_access=false" in cmd
         assert all("danger" not in part for part in cmd)
 
+        # The sandbox lets the handoff tools WRITE the board; these overrides
+        # let them IDENTIFY the task in the first place. Codex replaces the MCP
+        # child's env with the static `env` table from config.toml rather than
+        # extending this process's, so without them kanban_complete /
+        # kanban_block / kanban_heartbeat resolve no task id at all and the
+        # worker hangs until the dispatcher reclaims the run.
+        assert 'mcp_servers.hermes-tools.env.HERMES_KANBAN_TASK="t_smoke"' in cmd
+        # HERMES_KANBAN_DB must travel too, or the callback falls back to the
+        # DEFAULT board and a worker's completion lands on the wrong one.
+        assert (
+            'mcp_servers.hermes-tools.env.HERMES_KANBAN_DB='
+            '"/users/alice/.hermes/kanban/boards/smoke/kanban.db"'
+        ) in cmd
+
+    @staticmethod
+    def test_kanban_env_overrides_are_omitted_outside_worker_context(monkeypatch):
+        """No HERMES_KANBAN_TASK => no kanban plumbing at all."""
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["cmd"] = list(cmd)
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+
+        client = cas.CodexAppServerClient(codex_bin="codex")
+        client._closed = True
+
+        cmd = captured["cmd"]
+        assert not any("mcp_servers.hermes-tools.env." in part for part in cmd)
+        assert not any("sandbox_workspace_write" in part for part in cmd)
+
+    @staticmethod
+    def test_kanban_env_override_values_are_toml_escaped(monkeypatch):
+        """Quotes/backslashes in a value must not break the override parse."""
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["cmd"] = list(cmd)
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_smoke")
+        # Contains both a backslash and a double quote.
+        monkeypatch.setenv("HERMES_KANBAN_DB", 'C:\\boards\\od"d\\kanban.db')
+
+        client = cas.CodexAppServerClient(codex_bin="codex")
+        client._closed = True
+
+        override = next(
+            part for part in captured["cmd"]
+            if part.startswith("mcp_servers.hermes-tools.env.HERMES_KANBAN_DB=")
+        )
+        assert r"\\boards\\od" in override
+        assert r'\"' in override
+
 
 class TestSpawnEnvSecretStripping:
     """codex app-server routes its spawn env through hermes_subprocess_env(


### PR DESCRIPTION
## Problem

Kanban workers on the `codex_app_server` runtime can do their work but never report it. The task hangs until the dispatcher reclaims the run, is re-dispatched, hangs again — indefinitely.

`agent/transports/codex_app_server.py` already widens the Codex sandbox for a worker so the handoff tools can **write** the board DB (which lives outside the per-task workspace). But those tools must **identify** the task before they can write it, and that half is missing: Codex replaces an MCP child's environment with the static `env` table from `config.toml` rather than extending the spawning process's, so the per-worker `HERMES_KANBAN_*` variables never reach the `hermes-tools` callback.

Observed on a live install — the variable is present in the worker and in the app-server, and gone one hop later:

```
worker            HERMES_KANBAN_TASK=t_...
codex app-server  HERMES_KANBAN_TASK=t_...
hermes-tools MCP  HERMES_QUIET=1            <- only this
```

Reproduced by spawning `agent.transports.hermes_tools_mcp_server` with each environment in turn and calling `kanban_heartbeat` against the real board:

```
static config env (reality) -> {"error": "task_id is required (or set HERMES_KANBAN_TASK in the env)"}
worker's real env (control) -> {"ok": true, "task_id": "t_..."}
```

The control run also updated `task_runs.last_heartbeat_at`; the reality run could not. That matches the symptom exactly: `last_heartbeat_at` was `NULL` on *every* run of an affected task across seven consecutive dispatch/reclaim cycles.

This is the failure mode already anticipated in `hermes_tools_mcp_server.py`:

> *Without these in the callback, a worker spawned with `openai_runtime=codex_app_server` could do the work but couldn't report completion back to the kernel, making it hang until timeout.*

Exposing the tools was necessary but not sufficient — they still need the task identity.

### Two further consequences

- **Wrong board.** Without `HERMES_KANBAN_DB` the callback falls back to the DEFAULT board, so a worker's completion lands on the wrong one.
- **Gate fails open.** `tools/kanban_tools.py` hides the orchestrator-only surface from task workers by checking `HERMES_KANBAN_TASK`. With the variable absent, that check fails open: an affected worker was offered **26 tools including `kanban_list` / `kanban_unblock`**, versus 24 correctly scoped ones with the env present.

## Fix

A static config cannot carry a per-worker value, but a `-c` override can — it is merged into the server's `env` table, leaving `HERMES_QUIET` and `HERMES_REDACT_SECRETS` from `config.toml` intact. Confirmed end to end: the override reaches the MCP child's `environ`, and on a live gateway the worker's MCP child now carries `HERMES_KANBAN_TASK`, `HERMES_KANBAN_RUN_ID` and `HERMES_KANBAN_DB` alongside the config's own `HERMES_QUIET`.

Injected at the existing worker-detection branch, right beside the sandbox overrides it complements. Values are escaped as TOML basic strings so Windows paths and unusual board slugs cannot break the override parse.

## Tests

- overrides present for a worker, including `HERMES_KANBAN_DB`
- overrides absent outside worker context (no `HERMES_KANBAN_TASK` => no kanban plumbing at all)
- values TOML-escaped

The first and third fail without this change.