### PR TITLE
fix(agent): preserve pooled credential during transport recovery

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1240,27 +1240,23 @@ def try_recover_primary_transport(
             except Exception:
                 pass
 
-        # Rebuild from primary snapshot
-        rt = agent._primary_runtime
-        agent._client_kwargs = dict(rt["client_kwargs"])
-        agent.model = rt["model"]
-        agent.provider = rt["provider"]
-        agent.requested_provider = rt.get("requested_provider", agent.provider)
-        agent.base_url = rt["base_url"]
-        agent.api_mode = rt["api_mode"]
+        # Rebuild the live primary runtime in place.  ``_primary_runtime`` is a
+        # primary snapshot that may predate a credential-pool rotation. Restoring
+        # it here would retry a stale key while ``_credential_pool_entry_id``
+        # continues to identify the healthy replacement, so a subsequent
+        # 401/402/429 could quarantine the wrong entry. Fallback runtimes are
+        # rejected above, therefore the live fields already describe the primary
+        # route we need to recover.
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
-        agent.api_key = rt["api_key"]
 
         if agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
-            agent._anthropic_api_key = rt["anthropic_api_key"]
-            agent._anthropic_base_url = rt["anthropic_base_url"]
             agent._anthropic_client = build_anthropic_client(
-                rt["anthropic_api_key"], rt["anthropic_base_url"],
+                agent._anthropic_api_key,
+                agent._anthropic_base_url,
                 timeout=get_provider_request_timeout(agent.provider, agent.model),
             )
-            agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
             agent.client = None
         elif (agent.provider or "").strip().lower() == "moa":
             # MoA is a virtual provider with empty client_kwargs — rebuilding
@@ -1272,7 +1268,7 @@ def try_recover_primary_transport(
             agent.client = build_moa_facade(agent, agent.model)
         else:
             agent.client = agent._create_openai_client(
-                dict(rt["client_kwargs"]),
+                dict(agent._client_kwargs),
                 reason="primary_recovery",
                 shared=True,
             )

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -441,6 +441,59 @@ class TestTryRecoverPrimaryTransport:
 
         assert result is True
 
+    def test_recovery_preserves_rotated_pool_credential(self):
+        """Transport recovery must not restore a pre-rotation snapshot key.
+
+        A credential pool can rotate after the primary runtime snapshot is
+        created.  Rebuilding the transport should preserve the live pool entry;
+        otherwise a rate-limited old key is retried while failures are attributed
+        to the healthy entry still stored in ``_credential_pool_entry_id``.
+        """
+
+        class _Entry:
+            id = "backup-entry"
+            label = "backup"
+            provider = "custom"
+            runtime_api_key = "backup-key"
+            runtime_base_url = "https://my-llm.example.com/v1"
+            access_token = runtime_api_key
+
+        class _Pool:
+            provider = "custom"
+
+            def entries(self):
+                return [_Entry()]
+
+        agent = _make_agent(provider="custom")
+        primary_runtime = getattr(agent, "_primary_runtime")
+        snapshot_key = primary_runtime["api_key"]
+        assert snapshot_key != _Entry.runtime_api_key
+
+        # Simulate a successful credential rotation after construction.  The
+        # immutable primary snapshot still contains the original key.
+        setattr(agent, "_credential_pool", _Pool())
+        setattr(agent, "_credential_pool_entry_id", _Entry.id)
+        agent.api_key = _Entry.runtime_api_key
+        client_kwargs = getattr(agent, "_client_kwargs")
+        client_kwargs["api_key"] = _Entry.runtime_api_key
+
+        error = _make_transport_error("APIConnectionError")
+        with (
+            patch.object(
+                agent, "_create_openai_client", return_value=MagicMock()
+            ) as create_client,
+            patch("time.sleep"),
+        ):
+            result = agent._try_recover_primary_transport(
+                error, retry_count=3, max_retries=3,
+            )
+
+        assert result is True
+        assert agent.api_key == _Entry.runtime_api_key
+        assert client_kwargs["api_key"] == _Entry.runtime_api_key
+        assert create_client.call_args.args[0]["api_key"] == _Entry.runtime_api_key
+        assert getattr(agent, "_credential_pool_entry_id") == _Entry.id
+
     def test_recovers_on_connect_timeout(self):
         agent = _make_agent(provider="custom")
         error = _make_transport_error("ConnectTimeout")


### PR DESCRIPTION
## Summary

Transport recovery currently rebuilds the client from `_primary_runtime`, a primary snapshot that may predate the latest credential-pool rotation. When a credential pool has rotated since that snapshot, it contains the stale credential while `_credential_pool_entry_id` still identifies the healthy replacement. A later auth, billing, or rate-limit response can therefore be attributed to the wrong pool entry.

This PR rebuilds the live primary runtime in place instead. The fallback guard already guarantees that this path is not running on a fallback route, so the live fields are the authoritative primary provider, model, endpoint, and credential.

## What this PR does

**1. Preserve the live pooled credential during transport recovery** — `try_recover_primary_transport()` no longer overwrites the current key, base URL, provider, model, API mode, or client kwargs with a potentially stale primary snapshot.

**2. Preserve live Anthropic credential state** — Anthropic transport recovery rebuilds from the current `_anthropic_api_key` and `_anthropic_base_url`, matching the OpenAI-compatible path's live-runtime behavior.

**3. Add a regression test** — the test rotates the live runtime to a second pool entry while leaving the original key in `_primary_runtime`, triggers `APIConnectionError` recovery, and asserts that both the rebuilt client and stable credential entry ID still reference the rotated entry.

## Failure sequence

1. Credential A receives a quota/rate-limit response and the pool rotates to B.
2. B successfully serves requests.
3. A transient transport error triggers `primary_recovery`.
4. Recovery restores A from `_primary_runtime`, but the stable pool entry ID remains B.
5. A subsequent 401/402/429 can quarantine B because the request key and entry ID now disagree.

After this change, step 4 rebuilds B's live client and the key/entry ID remain consistent.

## Test plan

- [x] New regression test failed before the implementation (`agent.api_key` reverted to the pre-rotation snapshot key).
- [x] `pytest tests/run_agent -q` — 2351 passed, 4 skipped, 3 deselected.
- [x] `pytest tests/run_agent/test_primary_runtime_restore.py tests/agent/test_credential_pool_routing.py tests/run_agent/test_32646_fallback_429_after_timeout.py -q` — 62 passed.
- [x] `ruff check agent/agent_runtime_helpers.py tests/run_agent/test_primary_runtime_restore.py` — passed.
- [x] `git diff --check` — passed.

## Related

- #70644 — stable credential entry IDs and stale-key recovery protections
- #70993 — shared OpenAI client retirement during transport recovery
