### PR TITLE
fix(prompt): treat path literals as opaque (no segment respelling)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -970,7 +970,23 @@ WSL_ENVIRONMENT_HINT = (
     "/mnt/c/Users/<username>/Desktop/, Documents/, Downloads/, etc. "
     "When the user references Windows paths or desktop files, translate "
     "to the /mnt/c/ equivalent. You can list /mnt/c/Users/ to discover "
-    "the Windows username if needed."
+    "the Windows username if needed. "
+    "Mount translation only changes the drive prefix (e.g. `C:\\…` → "
+    "`/mnt/c/…`); path *segments* stay byte-for-byte identical."
+)
+
+
+# Universal: models sometimes "helpfully" respell path segments (diacritics,
+# spacing, casing) when a directory name looks like a word in another language.
+# That invents paths that do not exist on disk (see #71943). File tools pass
+# path args through unchanged — the failure is almost always the model.
+PATH_LITERAL_GUIDANCE = (
+    "Path literals are opaque. Never correct spelling, diacritics, casing, or "
+    "spacing inside path segments the user supplied or that tools returned "
+    "(for example do not turn `felsokning` into `felsökning` or "
+    "`f elsökning`). Separator/mount translation (`C:\\` ↔ `/mnt/c/`, "
+    "`C:\\` ↔ `/c/`) is fine; renaming path components is not. "
+    "If a path fails, re-list the parent directory and copy the exact name."
 )
 
 
@@ -1236,6 +1252,10 @@ def build_environment_hints() -> str:
 
     if is_wsl():
         hints.append(WSL_ENVIRONMENT_HINT)
+
+    # Always-on: path segments are opaque (model-side respelling is a common
+    # footgun on WSL + native Windows with non-English directory names).
+    hints.append(PATH_LITERAL_GUIDANCE)
 
     # Embedder-supplied environment description. Lets a host that wraps Hermes
     # (e.g. a sandbox runner / managed platform) explain the environment the

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -33,6 +33,7 @@ from agent.prompt_builder import (
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
+    PATH_LITERAL_GUIDANCE,
 )
 from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
 
@@ -678,9 +679,29 @@ class TestPromptBuilderConstants:
 
 class TestEnvironmentHints:
 
+    def test_wsl_hint_constant_mentions_mnt(self):
+        assert "/mnt/c/" in WSL_ENVIRONMENT_HINT
+        assert "WSL" in WSL_ENVIRONMENT_HINT
+        # Mount translate must not invite segment respelling (#71943).
+        assert "segments" in WSL_ENVIRONMENT_HINT.lower()
 
+    def test_path_literal_guidance_blocks_segment_respelling(self):
+        assert "opaque" in PATH_LITERAL_GUIDANCE.lower()
+        assert "felsokning" in PATH_LITERAL_GUIDANCE
+        assert "felsökning" in PATH_LITERAL_GUIDANCE
+        assert "f elsökning" in PATH_LITERAL_GUIDANCE
+        # Separator/mount translation stays allowed.
+        assert "/mnt/c/" in PATH_LITERAL_GUIDANCE
 
-
+    def test_build_environment_hints_includes_path_literal_guidance(self, monkeypatch):
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("HERMES_ENVIRONMENT_HINT", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Path literals are opaque" in result
+        assert "felsokning" in result
 
     def test_build_environment_hints_suppresses_host_on_docker_backend(self, monkeypatch):
         """Docker/remote backends must hide host info — the agent can only touch the backend."""
@@ -701,6 +722,8 @@ class TestEnvironmentHints:
         # Backend info must appear instead.
         assert "Terminal backend: docker" in result
         assert "inside" in result.lower()
+        # Universal path-literal guard still applies on remote backends.
+        assert "Path literals are opaque" in result
 
     def test_build_environment_hints_uses_terminal_cwd_over_launch_dir(self, monkeypatch, tmp_path):
         """THE BUG: gateway/cron set TERMINAL_CWD but the prompt emitted os.getcwd()


### PR DESCRIPTION
## What does this PR do?

Stops models from "helpfully" respelling filesystem path *segments* (diacritics, spacing, casing) when a directory name looks like a word in another language.

Reported failure mode (#71943): user path `/mnt/c/Sources/felsokning/` became `/mnt/c/Sources/f elsökning` in tool calls — a non-existent path. Investigation showed:

- There is **no** Hermes "Language Auto-Correction" feature mutating paths (related feature request #31514 is unimplemented).
- Desktop composer already sets `spellCheck={false}` / `autoCorrect="off"`.
- File tools pass path args through unchanged on this host.
- Reporter's debug dump used local `ornith:35b`; agent.log shows repeated `ls` of invented `f elsökning` while the real directory listing contained ASCII `felsokning`.

This PR adds always-on environment-hint guidance: path literals are opaque; mount/separator translation is fine; segment respelling is not. WSL hint clarified that `/mnt/c` translation is prefix-only.

## Related Issue

Fixes #71943

Related: #31514 (feature request only — not the same as a code-layer path rewriter)

## Type of Change

- [x] Bug fix (non-breaking)
- [x] Tests

## Changes Made

- `agent/prompt_builder.py`
  - `PATH_LITERAL_GUIDANCE` constant
  - injected from `build_environment_hints()` for all backends
  - WSL hint: mount translation is prefix-only
- `tests/agent/test_prompt_builder.py`
  - constant content + injection on WSL/Linux/Windows local builds

## How to Test

```bash
pytest tests/agent/test_prompt_builder.py::TestEnvironmentHints -o addopts= -q
```

Expected: **17 passed** (verified on native Win11 / Python 3.11.15).

## Checklist

- [x] Conventional Commits
- [x] Searched open PRs — no competing path-literal / autocorrect path PR
- [x] Focused tests pass
- [x] Cross-platform: guidance is universal; WSL clarification is additive
- [x] No new core tools / env vars / secrets
