### PR TITLE
fix(auxiliary_client): apply the slash-compat guard on the cold cache path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8288,7 +8288,16 @@ def _get_cached_client(
                 # This concurrently built loser was never exposed to a caller,
                 # so it is safe to close immediately.
                 _close_cached_client(built_client, close_async=async_mode)
-    return client, model or default_model
+    # Apply the SAME slash-compat guard the cache-hit paths above use. Without
+    # this the cold path (cache miss) returns the caller's raw ``model`` while
+    # a warm path returns ``_compat_model(...)`` for the identical arguments —
+    # so the FIRST auxiliary call with a namespaced id like
+    # ``anthropic/claude-haiku-4-5`` sends it un-stripped to a provider that
+    # does not accept vendor-prefixed ids (404 "model not found"), and every
+    # later call silently succeeds. ``_compat_model`` still honors caller-wins
+    # for clients that DO accept slash ids (OpenRouter, or a default that is
+    # itself namespaced), so legitimate aggregator slugs are untouched.
+    return client, _compat_model(client, model, default_model)
 
 
 # Aliases that target direct REST APIs not modeled as first-class providers

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6404,7 +6404,16 @@ def _get_cached_client(
                 # This concurrently built loser was never exposed to a caller,
                 # so it is safe to close immediately.
                 _close_cached_client(built_client)
-    return client, model or default_model
+    # Apply the SAME slash-compat guard the cache-hit paths above use. Without
+    # this the cold path (cache miss) returns the caller's raw ``model`` while
+    # a warm path returns ``_compat_model(...)`` for the identical arguments —
+    # so the FIRST auxiliary call with a namespaced id like
+    # ``anthropic/claude-haiku-4-5`` sends it un-stripped to a provider that
+    # does not accept vendor-prefixed ids (404 "model not found"), and every
+    # later call silently succeeds. ``_compat_model`` still honors caller-wins
+    # for clients that DO accept slash ids (OpenRouter, or a default that is
+    # itself namespaced), so legitimate aggregator slugs are untouched.
+    return client, _compat_model(client, model, default_model)
 
 
 # Aliases that target direct REST APIs not modeled as first-class providers

--- a/tests/agent/test_aux_cached_client_model_symmetry.py
+++ b/tests/agent/test_aux_cached_client_model_symmetry.py
@@ -1,0 +1,104 @@
+"""Cold-path / warm-path model-resolution symmetry in ``_get_cached_client``.
+
+Regression coverage for a cache-order-dependent bug: the cache-HIT paths ran the
+caller-passed ``model`` through :func:`_compat_model` (which drops a
+vendor-namespaced id for a client that cannot accept one), but the cache-MISS
+(cold) path returned the raw ``model`` unchanged. The observable symptom was a
+first auxiliary call failing with a provider 404 on a namespaced model id while
+every subsequent call with identical arguments succeeded.
+
+These are behavior contracts on the (client, resolved_model) pair, not snapshots
+of any particular model list.
+"""
+
+import pytest
+
+import agent.auxiliary_client as ac
+
+
+class _NonSlashClient:
+    """A client whose endpoint rejects ``vendor/model`` ids (e.g. Anthropic)."""
+
+    base_url = "https://api.anthropic.com"
+
+
+class _OpenRouterClient:
+    """A client whose endpoint REQUIRES ``vendor/model`` ids."""
+
+    base_url = "https://openrouter.ai/api/v1"
+
+
+@pytest.fixture
+def stub_resolver(monkeypatch):
+    """Replace the network-touching resolver and isolate the module cache."""
+    monkeypatch.setattr(ac, "_client_cache", {})
+
+    def _install(client, default_model):
+        monkeypatch.setattr(
+            ac,
+            "resolve_provider_client",
+            lambda *a, **k: (client, default_model),
+        )
+
+    yield _install
+
+
+def test_cold_and_warm_paths_agree_for_namespaced_model(stub_resolver):
+    """The first call and the second must resolve the SAME model id.
+
+    This is the core invariant: whether the client cache is cold or warm is an
+    internal performance detail and must never change what gets sent on the wire.
+    """
+    stub_resolver(_NonSlashClient(), "claude-haiku-4-5")
+
+    _, cold = ac._get_cached_client("anthropic", model="anthropic/claude-haiku-4-5")
+    _, warm = ac._get_cached_client("anthropic", model="anthropic/claude-haiku-4-5")
+
+    assert cold == warm
+
+
+def test_cold_path_drops_namespace_for_a_client_that_cannot_accept_it(stub_resolver):
+    """A non-slash client gets the resolver's normalized default, not the raw id."""
+    stub_resolver(_NonSlashClient(), "claude-haiku-4-5")
+
+    _, resolved = ac._get_cached_client("anthropic", model="anthropic/claude-haiku-4-5")
+
+    assert "/" not in resolved
+    assert resolved == "claude-haiku-4-5"
+
+
+def test_caller_wins_is_preserved_for_a_slash_capable_client(stub_resolver):
+    """OpenRouter-style aggregator slugs must survive untouched on BOTH paths.
+
+    Guards against over-correcting: the fix must not strip namespaces that the
+    endpoint actually requires.
+    """
+    stub_resolver(_OpenRouterClient(), "openai/gpt-5.4")
+
+    _, cold = ac._get_cached_client("openrouter", model="anthropic/claude-sonnet-4.5")
+    _, warm = ac._get_cached_client("openrouter", model="anthropic/claude-sonnet-4.5")
+
+    assert cold == "anthropic/claude-sonnet-4.5"
+    assert warm == cold
+
+
+def test_plain_model_override_still_wins_over_the_default(stub_resolver):
+    """A non-namespaced caller override is unaffected by the compat guard."""
+    stub_resolver(_NonSlashClient(), "claude-haiku-4-5")
+
+    _, cold = ac._get_cached_client("anthropic", model="claude-opus-4-1")
+    _, warm = ac._get_cached_client("anthropic", model="claude-opus-4-1")
+
+    assert cold == "claude-opus-4-1"
+    assert warm == cold
+
+
+def test_no_model_argument_falls_back_to_the_resolver_default(stub_resolver):
+    """Omitting ``model`` returns the provider default on both paths."""
+    stub_resolver(_NonSlashClient(), "claude-haiku-4-5")
+
+    _, cold = ac._get_cached_client("anthropic")
+    _, warm = ac._get_cached_client("anthropic")
+
+    assert cold == "claude-haiku-4-5"
+    assert warm == cold


### PR DESCRIPTION
## Problem

`_get_cached_client()` resolves the returned model differently depending on whether the client cache is warm.

Both cache-**hit** paths run the caller-passed `model` through `_compat_model()`, which substitutes the resolver's already-normalized default when the model carries a `/` and the client cannot accept a vendor-prefixed id:

- `agent/auxiliary_client.py:6354` — async hit, loop still valid
- `agent/auxiliary_client.py:6359` — sync hit

The cache-**miss** (cold) path returned the raw value instead:

```python
return client, model or default_model     # agent/auxiliary_client.py:6407
```

So for identical arguments the two paths disagree.

## Symptom

The **first** auxiliary call made with a vendor-namespaced model id — e.g. `anthropic/claude-haiku-4-5`, which `_PROVIDER_MODELS` advertises for some providers and which fallback chains routinely produce — sends the un-stripped id to a provider that does not accept vendor prefixes, and gets a 404 "model not found". Every subsequent call with the same arguments hits the warm cache, receives the compat-guarded value, and silently succeeds.

The failure therefore reads as intermittent and cache-order dependent rather than deterministic, which is why it survived: retrying "fixes" it.

Reproduced on current `main` (`eb5276056`) with a stubbed resolver:

```
COLD (cache miss): anthropic/claude-haiku-4-5
WARM (cache hit):  claude-haiku-4-5
SYMMETRIC? False
```

## Fix

Return `_compat_model(client, model, default_model)` on the cold path too.

This reuses the guard that already exists rather than introducing a second normalization policy — deliberately *not* a fresh `_normalize_resolved_model()` call, which would be a parallel mechanism that could drift from the cache-hit behavior later.

Caller-wins semantics are preserved. `_compat_model` only substitutes the resolver default when the model carries a slash **and** `_cached_client_accepts_slash_models()` is false (not an OpenRouter client, and the resolved default is not itself namespaced). Legitimate aggregator slugs such as `anthropic/claude-sonnet-4.5` on OpenRouter are untouched — there is a regression test pinning exactly that.

## Verification

New file `tests/agent/test_aux_cached_client_model_symmetry.py` (5 tests):

| Test | Unpatched main | With fix |
|---|---|---|
| cold and warm paths agree for a namespaced model | **FAIL** | pass |
| cold path drops the namespace for a non-slash client | **FAIL** | pass |
| caller-wins preserved for a slash-capable (OpenRouter) client | pass | pass |
| plain model override still wins over the default | pass | pass |
| no model argument falls back to the resolver default | pass | pass |

The three that pass both ways are guard-rails against over-correcting; they must not change.

Neighbor suites on this branch:

```
tests/agent/test_auxiliary_client.py
tests/agent/test_auxiliary_client_resolve_dedup.py
tests/agent/test_auxiliary_client_anthropic_custom.py
→ 369 passed, 1 failed
```

The single failure is `TestCodexAuxiliaryAdapterTimeout::test_enforces_total_timeout_while_stream_keeps_emitting_events`, a wall-clock assertion (`elapsed < 0.14`). It reproduces identically on a clean `origin/main` worktree at the same SHA with no changes applied, so it is pre-existing host-timing flake and unrelated to this diff.

## Supersedes

This replaces **#24599** and its resubmission **#34297** (identical title and file, both open, both flagged as duplicates of each other by @alt-glitch). Those branches are ~8,800–10,500 commits behind and hard-conflict on apply; the function they patch has moved from ~3,773 to 6,290 in a file that has roughly doubled in size, so a rebase would be a re-port rather than a replay.

This PR is that re-port, against current `main`, and it also addresses the review finding raised on both of them — @teknium1 noted the original approach "uses the raw provider, so `provider=\"main\"` → Anthropic isn't normalized" and suggested returning the resolver-produced value on the cold path. That is what this does, via the existing `_compat_model` guard rather than a second normalizer call. Both older PRs also shipped with no regression coverage; this one adds it.

Happy to close #24599 and #34297 in favor of this once maintainers confirm the approach.

---

### Note on the one neighbor failure (pre-existing, not from this diff)

`TestCodexAuxiliaryAdapterTimeout::test_enforces_total_timeout_while_stream_keeps_emitting_events`
(`tests/agent/test_auxiliary_client.py:5279`) is a load-sensitive wall-clock assertion,
`assert time.monotonic() - started < 0.14`. Three independent proofs it is unrelated to this change:

1. **It fails on clean `origin/main` with zero changes applied.** Interleaved A/B, same SHA, same box,
   alternating runs: clean main failed **5 of 6**, this branch **3 of 6**. The branch fails *less
   often*, which is noise in both directions, not signal.
2. **The diff cannot reach it.** The change is a single line inside `_get_cached_client`. An AST scan
   of `_CodexCompletionsAdapter` shows it references neither `_get_cached_client`, `_compat_model`,
   nor `_cached_client_accepts_slash_models`. `tests/agent/test_auxiliary_client.py` is also
   byte-identical to `origin/main` on this branch (`git diff --quiet origin/main HEAD --` → same).
3. **The bound sits just above the natural distribution.** Driving the adapter directly 8× on an idle
   box: 70, 82, 84, 67, 61, 62, 89, 68 ms — median 69 ms against a 140 ms ceiling. A ~2x margin is
   comfortably inside what a busy CI runner erases.

With that test deselected, the neighbor run is **369 passed, 0 failed**. I have deliberately *not*
bundled a fix for it into this PR — converting a stopwatch assertion into a deterministic barrier is
a separate concern from a resolver correctness fix, and mixing them would make both harder to review.
Happy to open that as its own PR if useful.
