### PR TITLE
fix(banner): include local HEAD in the update-check cache key

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -197,6 +197,21 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
+def _local_head_sha() -> Optional[str]:
+    """Return the active checkout's HEAD SHA, or None for non-git installs.
+
+    Used as part of the update-check cache key so an in-place ``git pull`` /
+    rebase that moves HEAD without changing ``VERSION`` or ``HERMES_REVISION``
+    (the common case for source installs tracking a fork, where both are
+    ``None``) self-invalidates the cached "commits behind" count instead of
+    serving a stale value for the full 6-hour TTL.
+    """
+    repo_dir = _resolve_repo_dir()
+    if repo_dir is None:
+        return None
+    return _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir) or None
+
+
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
@@ -287,6 +302,12 @@ def check_for_updates() -> Optional[int]:
     except Exception:
         pass
 
+    # HEAD SHA participates in the cache key so an in-place `git pull` / rebase
+    # that moves HEAD without changing VERSION or HERMES_REVISION self-invalidates
+    # the cached count. Computed AFTER the docker short-circuit above so
+    # containers (which have no .git) never shell out to git here.
+    head_sha = _local_head_sha()
+
     # Read cache — invalidate if the embedded rev OR installed version has
     # changed since the last check.
     now = time.time()
@@ -297,6 +318,7 @@ def check_for_updates() -> Optional[int]:
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
                 and cached.get("rev") == embedded_rev
                 and cached.get("ver") == VERSION
+                and cached.get("head") == head_sha
             ):
                 return cached.get("behind")
     except Exception:
@@ -321,7 +343,7 @@ def check_for_updates() -> Optional[int]:
 
     try:
         cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
+            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION, "head": head_sha}),
             encoding="utf-8",
         )
     except Exception:

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -17,7 +17,13 @@ def test_version_string_no_v_prefix():
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
+    """When the cache is fresh AND HEAD matches, return it without a fetch.
+
+    The cache key includes the local HEAD SHA, so the cached entry must carry
+    the current HEAD for the fast path to fire. A cheap ``git rev-parse HEAD``
+    still runs to read the current HEAD, but no ``git fetch`` / ``rev-list``
+    network work happens.
+    """
     from hermes_cli.banner import check_for_updates
     from hermes_cli import __version__
 
@@ -26,15 +32,64 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
 
+    head = "a" * 40
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}))
+    cache_file.write_text(
+        json.dumps({"ts": time.time(), "behind": 3, "ver": __version__, "head": head})
+    )
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+
+    def fake_run(cmd, *a, **k):
+        # Only the HEAD read should occur; fetch/rev-list must NOT.
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout=head + "\n")
+        raise AssertionError(f"unexpected git call on cache hit: {cmd}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
         result = check_for_updates()
 
     assert result == 3
-    mock_run.assert_not_called()
+
+
+def test_check_for_updates_invalidates_when_head_moved(tmp_path, monkeypatch):
+    """An in-place `git pull` that moves HEAD must invalidate the cached count.
+
+    VERSION and HERMES_REVISION are both unchanged (and are ``None`` for source
+    installs tracking a fork), so HEAD is the only signal that the checkout
+    advanced. Without it the stale "N commits behind" survives the full 6h TTL
+    and `hermes --version` keeps reporting a count the user just fixed.
+    """
+    from hermes_cli.banner import check_for_updates
+    from hermes_cli import __version__
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(
+        json.dumps(
+            # Fresh timestamp, same version — only HEAD differs from reality.
+            {"ts": time.time(), "behind": 182, "ver": __version__, "head": "o" * 40}
+        )
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def fake_run(cmd, *a, **k):
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="n" * 40 + "\n")
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return MagicMock(returncode=0, stdout="0\n")
+        return MagicMock(returncode=0, stdout="")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = check_for_updates()
+
+    # Recomputed against the NEW head, not the stale cached 182.
+    assert result == 0
+    assert json.loads(cache_file.read_text())["head"] == "n" * 40
 
 
 def test_check_for_updates_invalidates_on_version_change(tmp_path, monkeypatch):
@@ -74,7 +129,11 @@ def test_check_for_updates_invalidates_on_version_change(tmp_path, monkeypatch):
 
 
 def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
-    """When cache is expired, check_for_updates should call git fetch."""
+    """When cache is expired, check_for_updates should call git fetch.
+
+    Call sequence now: cache-key HEAD read + origin probe + shallow probe +
+    fetch + rev-list = 5 subprocess calls.
+    """
     from hermes_cli.banner import check_for_updates
 
     repo_dir = tmp_path / "hermes-agent"
@@ -92,8 +151,8 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
         result = check_for_updates()
 
     assert result == 5
-    # origin probe + is-shallow probe + git fetch + git rev-list
-    assert mock_run.call_count == 4
+    # cache-key HEAD + origin probe + is-shallow probe + git fetch + git rev-list
+    assert mock_run.call_count == 5
 
 
 def test_check_for_updates_official_ssh_origin_uses_https_probe(tmp_path):


### PR DESCRIPTION
## Problem

`check_for_updates()` caches the "commits behind" count for 6 hours, keyed on `{rev, ver}`:

```python
# hermes_cli/banner.py:296-300
now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
and cached.get("rev") == embedded_rev
and cached.get("ver") == VERSION
```

Neither component changes when a user updates in place:

- `HERMES_REVISION` is nix-only, so `embedded_rev` is `None` for source installs.
- `VERSION` only moves on a release bump, not on a `git pull`.

So an in-place `git pull` / rebase moves `HEAD` while the cache key stays constant. The stale count then survives the full TTL, and `hermes --version` keeps printing e.g. "182 commits behind" immediately after a successful update that brought the checkout up to date. `hermes update` calls `_invalidate_update_cache()` explicitly and is unaffected; this is the manual-git path.

## Fix

Add the active checkout's `HEAD` SHA to the cache key, so an in-place update self-invalidates.

Two implementation details that matter:

- **Computed after the docker short-circuit.** Docker images ship without `.git` (see `.dockerignore`) and already return `None` earlier in the function; placing the read below that guard means containers never shell out to git for this.
- **Reuses the existing helpers.** `_resolve_repo_dir()` (banner.py:333) and `_git_stdout()` (banner.py:157) already exist on `main` and already handle the not-a-git-install and the Windows-encoding cases, so `_local_head_sha()` is four lines rather than a second `subprocess.run` wrapper with its own timeout/encoding policy.

No new config key, no new env var.

## Test changes

Two existing tests asserted the *old* call sequence and had to move with it. Both were tightened rather than loosened:

- **`test_check_for_updates_uses_cache`** previously asserted `mock_run.assert_not_called()` — "no git at all". A `git rev-parse HEAD` now legitimately runs on the fast path. Rather than relax the assertion to a call count, the test now uses a `side_effect` that returns the HEAD and **raises `AssertionError` on any other git invocation**. That is a strictly stronger claim than the original: it proves no `fetch` and no `rev-list` happen, and it names which call is allowed.
- **`test_check_for_updates_expired_cache`** counted 4 subprocess calls (origin probe + shallow probe + fetch + rev-list); it is now 5 with the cache-key HEAD read. The comment enumerating them was updated to match.

New: **`test_check_for_updates_invalidates_when_head_moved`** pins the actual bug — fresh timestamp, same `VERSION`, different `HEAD` must recompute and must rewrite the cache with the new head. It fails on unpatched `main`.

## Verification

```
# RED — implementation reverted, tests kept
tests/hermes_cli/test_update_check.py → 2 failed, 13 passed
  FAILED test_check_for_updates_invalidates_when_head_moved
  FAILED test_check_for_updates_expired_cache

# GREEN — with the fix
tests/hermes_cli/test_update_check.py → 15 passed
```

Neighbor suites on this branch:

```
tests/hermes_cli/test_banner.py
tests/hermes_cli/test_banner_git_state.py
tests/hermes_cli/test_update_check.py
tests/hermes_cli/test_update_stale_dashboard.py
tests/hermes_cli/test_cmd_update_docker.py
→ 68 passed, 0 failed
```

`test_cmd_update_docker.py` is included deliberately, since the placement of the HEAD read relative to the docker short-circuit is the one behavioral risk in the diff.

## Supersedes

This replaces **#40157** (same fix, same premise). That branch is 3,406 commits behind and hard-conflicts on apply. The premise was re-verified on current `main` before writing this: the cache key at `banner.py:298-299` is still `{rev, ver}` only, and the write at `:324` still omits `head`, so the bug is unfixed upstream.

The re-port is also smaller than the original: #40157 had to introduce its own `subprocess.run` block because `_resolve_repo_dir()`/`_git_stdout()` did not exist yet at the time. They do now, so this version delegates to them.

The review on #40157 noted one gap — no test for the actual HEAD-mismatch transition. `test_check_for_updates_invalidates_when_head_moved` is that test.

Happy to close #40157 in favor of this once maintainers confirm the approach.
