### PR TITLE
fix(agent): redact API keys from error messages before persisting to auth.json (#71994)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import load_env
+from agent.redact import redact_sensitive_text
 from agent.secret_scope import get_secret as _get_secret
 from agent.credential_persistence import (
     is_borrowed_credential_source,
@@ -357,7 +358,13 @@ def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[st
         normalized["reason"] = reason.strip()
     message = error_context.get("message")
     if isinstance(message, str) and message.strip():
-        normalized["message"] = message.strip()
+        # Redact API keys and tokens from error messages before persisting.
+        # Upstream providers (Anthropic, OpenAI, xAI) sometimes echo back the
+        # key in error responses (e.g. "Invalid API key: sk-ant-...").  Without
+        # redaction, _mark_exhausted stores the raw message in
+        # last_error_message and to_dict() flushes it to auth.json on disk
+        # (GH-71994).
+        normalized["message"] = redact_sensitive_text(message.strip())
     reset_at = (
         error_context.get("reset_at")
         or error_context.get("resets_at")

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -3698,3 +3698,42 @@ class TestCredentialPoolQueryLocking:
             inner.release()
 
         assert done.wait(timeout=2.0), f"{method}() did not complete after lock release"
+
+
+# ---------------------------------------------------------------------------
+# Security: error messages must not leak API keys to auth.json (GH-71994).
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_error_context_redacts_api_keys():
+    """Error messages containing API keys must be redacted before persisting.
+
+    Upstream providers (Anthropic, OpenAI, xAI) sometimes echo back the key
+    in error responses.  _normalize_error_context must scrub these so
+    _mark_exhausted / to_dict never writes raw keys to auth.json.
+    """
+    from agent.credential_pool import _normalize_error_context
+
+    cases = [
+        ("Invalid API key: sk-ant-abc123def456ghi789", "sk-ant-abc123def456ghi789"),
+        ("Authentication failed: sk-proj-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef", "sk-proj-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef"),
+        ("Bad xai-key xai-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234", "xai-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234"),
+    ]
+    for raw_msg, full_secret in cases:
+        ctx = _normalize_error_context({"message": raw_msg})
+        result = ctx.get("message", "")
+        assert full_secret not in result, (
+            f"Full secret not redacted in: {result!r}"
+        )
+        # Redacted output should still contain some text (not empty)
+        assert len(result) > 0, f"Redaction produced empty message for: {raw_msg!r}"
+
+
+def test_normalize_error_context_preserves_non_secret_messages():
+    """Messages without secrets should pass through unchanged."""
+    from agent.credential_pool import _normalize_error_context
+
+    msg = "Rate limit exceeded. Retry after 60 seconds."
+    ctx = _normalize_error_context({"message": msg})
+    assert ctx["message"] == msg
+


### PR DESCRIPTION
## Summary
Fixes #71994.

Upstream providers (Anthropic, OpenAI, xAI) sometimes echo back the API key in error responses (e.g. "Invalid API key: sk-ant-..."). `_mark_exhausted` stored the raw message in `last_error_message` and `to_dict()` flushed it to `auth.json` on disk with no redaction.

## Changes
- `agent/credential_pool.py`: Import `redact_sensitive_text` from `agent.redact` and apply it to the error message in `_normalize_error_context` before it reaches the persistence path
- `tests/agent/test_credential_pool.py`: Added `test_normalize_error_context_redacts_api_keys` and `test_normalize_error_context_preserves_non_secret_messages`

## Testing
- 102 credential pool tests pass (100 existing + 2 new)
- Verified `sk-ant-*`, `sk-proj-*`, and `xai-*` keys are redacted from error messages
- Verified non-secret messages pass through unchanged
