### PR TITLE
fix(cron): handle string repeat values like "forever" without TypeError (#71993)

### DIFF
--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -948,8 +948,13 @@ def cronjob(
                         )
                 updates["no_agent"] = target_no_agent
             if repeat is not None:
-                # Normalize: treat 0 or negative as None (infinite)
-                normalized_repeat = None if repeat <= 0 else repeat
+                # Normalize: coerce string values like "forever" to None
+                # (infinite), and treat 0 or negative as None (GH-71993).
+                try:
+                    repeat = int(repeat)
+                except (TypeError, ValueError):
+                    repeat = None
+                normalized_repeat = None if repeat is None or repeat <= 0 else repeat
                 repeat_state = dict(job.get("repeat") or {})
                 repeat_state["times"] = normalized_repeat
                 updates["repeat"] = repeat_state


### PR DESCRIPTION
## Summary
Fixes #71993.

The cronjob update path compared `repeat <= 0` directly, which raises `TypeError` when `repeat` is a non-numeric string like `"forever"`.

## Changes
- `tools/cronjob_tools.py`: Coerce `repeat` to `int` first, falling back to `None` (infinite) for non-numeric strings

## Testing
- 7 cronjob immediate tests pass
- 766 cron tests pass
