### PR TITLE
feat(plugins): add fail-closed human-intervention bridge

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9958,15 +9958,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # Check for plugin-registered slash commands
             elif base_cmd.lstrip("/") in _get_plugin_cmd_handler_names():
                 from hermes_cli.plugins import (
-                    get_plugin_command_handler,
+                    invoke_plugin_command,
                     resolve_plugin_command_result,
                 )
-                plugin_handler = get_plugin_command_handler(base_cmd.lstrip("/"))
-                if plugin_handler:
+                plugin_name = base_cmd.lstrip("/")
+                if plugin_name:
                     user_args = cmd_original[len(base_cmd):].strip()
                     try:
                         result = resolve_plugin_command_result(
-                            plugin_handler(user_args)
+                            invoke_plugin_command(
+                                plugin_name,
+                                user_args,
+                                context={
+                                    "surface": "cli",
+                                    "session_key": str(getattr(self, "session_id", "") or ""),
+                                },
+                            )
                         )
                         if result:
                             _cprint(str(result))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12239,17 +12239,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     return f"Quick command '/{command}' has unsupported type (supported: 'exec', 'alias')."
 
-        # Plugin-registered slash commands
+        # Plugin-registered slash commands. Gateway authorization has already
+        # passed at this point; contextual handlers receive only the trusted
+        # metadata needed for their own fine-grained policy checks.
         if command:
             try:
-                from hermes_cli.plugins import get_plugin_command_handler
+                from hermes_cli.plugins import (
+                    get_plugin_command_handler,
+                    invoke_plugin_command,
+                )
                 # Normalize underscores to hyphens so Telegram's underscored
                 # autocomplete form matches plugin commands registered with
                 # hyphens. See hermes_cli/commands.py:_build_telegram_menu.
-                plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
-                if plugin_handler:
+                plugin_name = command.replace("_", "-")
+                if get_plugin_command_handler(plugin_name):
                     user_args = event.get_command_args().strip()
-                    result = plugin_handler(user_args)
+                    platform = getattr(getattr(source, "platform", None), "value", None)
+                    context = {
+                        "surface": "gateway",
+                        "platform": str(platform or ""),
+                        "user_id": str(getattr(source, "user_id", "") or ""),
+                        "chat_id": str(getattr(source, "chat_id", "") or ""),
+                    }
+                    result = invoke_plugin_command(plugin_name, user_args, context=context)
                     if asyncio.iscoroutine(result):
                         result = await result
                     return str(result) if result else None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11476,6 +11476,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return ("Agent is running — wait or /stop first, then "
                         "change runtime.")
 
+            # Explicit plugin control-plane commands can resolve an external
+            # wait without interrupting the active agent. They are opt-in,
+            # remain behind the normal gateway authorization gate, and never
+            # enter the model/agent loop.
+            if _evt_cmd:
+                try:
+                    from hermes_cli.plugins import (
+                        get_plugin_command_handler,
+                        invoke_plugin_command,
+                        is_plugin_control_plane_command,
+                    )
+                    plugin_name = _evt_cmd.replace("_", "-")
+                    if is_plugin_control_plane_command(plugin_name):
+                        _denied = self._check_slash_access(source, plugin_name)
+                        if _denied is not None:
+                            return _denied
+                    if (
+                        is_plugin_control_plane_command(plugin_name)
+                        and get_plugin_command_handler(plugin_name)
+                    ):
+                        platform = getattr(getattr(source, "platform", None), "value", None)
+                        context = {
+                            "surface": "gateway",
+                            "platform": str(platform or ""),
+                            "user_id": str(getattr(source, "user_id", "") or ""),
+                            "chat_id": str(getattr(source, "chat_id", "") or ""),
+                        }
+                        result = invoke_plugin_command(
+                            plugin_name,
+                            event.get_command_args().strip(),
+                            context=context,
+                        )
+                        if asyncio.iscoroutine(result):
+                            result = await result
+                        return str(result) if result else None
+                except Exception as exc:
+                    logger.warning("Plugin control-plane command failed: %s", exc)
+                    return "Plugin control-plane command failed safely."
+
             # /approve and /deny must bypass the running-agent interrupt path.
             # The agent thread is blocked on a threading.Event inside
             # tools/approval.py — sending an interrupt won't unblock it.

--- a/hermes_cli/human_intervention.py
+++ b/hermes_cli/human_intervention.py
@@ -1,0 +1,129 @@
+"""Fail-closed bridge for optional plugin-backed human intervention.
+
+The CLI owns modal UI state, local input queues, deadlines, command risk, and
+all final approval decisions. An optional provider may only create an external
+wait record and return a constrained candidate signal for the CLI to validate.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Literal
+
+InterventionKind = Literal["approval", "sudo", "clarify", "computer_use"]
+InterventionAction = Literal["deny", "extend", "approve_once"]
+InterventionOutcome = Literal[
+    "local_response",
+    "remote_deny",
+    "remote_approve_once",
+    "timeout",
+    "cancelled",
+]
+
+# This is a non-configurable authorization floor. A plugin record or user
+# configuration may narrow permissions, but may never make critical commands
+# remotely approvable.
+NEVER_REMOTE_APPROVE_LEVELS = frozenset({"critical"})
+
+
+@dataclass(frozen=True)
+class HumanInterventionRequest:
+    """Core-sanitized description of a local wait exposed to a provider."""
+
+    kind: InterventionKind
+    session_key: str
+    title: str
+    preview: str
+    timeout_seconds: int | None
+    risk_level: str = ""
+    allowed_actions: frozenset[InterventionAction] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True)
+class HumanInterventionSignal:
+    """A provider's candidate decision, subject to core validation."""
+
+    action: InterventionAction
+    extend_seconds: int = 0
+    source: str = ""
+
+
+class HumanInterventionProvider(ABC):
+    """Optional external control channel for a CLI-owned local wait.
+
+    Providers must never receive passwords, clarify answers, local queue
+    objects, or authority to return session/permanent approvals.
+    """
+
+    @abstractmethod
+    def begin(self, request: HumanInterventionRequest) -> object | None:
+        """Best-effort open; return a provider-private handle or ``None``."""
+
+    @abstractmethod
+    def poll(self, handle: object) -> HumanInterventionSignal | None:
+        """Return at most one non-blocking candidate signal."""
+
+    @abstractmethod
+    def finish(self, handle: object, outcome: InterventionOutcome) -> None:
+        """Best-effort idempotent cleanup; exceptions are always contained."""
+
+
+def begin_human_intervention(
+    provider: HumanInterventionProvider | None,
+    request: HumanInterventionRequest,
+) -> object | None:
+    """Open a provider record without allowing provider failure to affect UI."""
+    if provider is None:
+        return None
+    try:
+        return provider.begin(request)
+    except Exception:
+        return None
+
+
+def take_remote_signal(
+    provider: HumanInterventionProvider | None,
+    handle: object | None,
+    request: HumanInterventionRequest,
+) -> HumanInterventionSignal | None:
+    """Poll and fail-closed validate one provider candidate signal.
+
+    This function deliberately does not make a local UI decision. Callers must
+    check their local response queue before claiming a remote signal so local
+    input always wins the race.
+    """
+    if provider is None or handle is None:
+        return None
+    try:
+        signal = provider.poll(handle)
+    except Exception:
+        return None
+    if not isinstance(signal, HumanInterventionSignal):
+        return None
+    if signal.action not in request.allowed_actions:
+        return None
+    if signal.action == "extend":
+        return signal if signal.extend_seconds > 0 else None
+    if signal.action == "deny":
+        return signal
+    if signal.action != "approve_once":
+        return None
+    if request.kind != "approval":
+        return None
+    if request.risk_level.strip().lower() in NEVER_REMOTE_APPROVE_LEVELS:
+        return None
+    return signal
+
+
+def finish_human_intervention(
+    provider: HumanInterventionProvider | None,
+    handle: object | None,
+    outcome: InterventionOutcome,
+) -> None:
+    """Best-effort provider cleanup that cannot change local wait semantics."""
+    if provider is None or handle is None:
+        return
+    try:
+        provider.finish(handle, outcome)
+    except Exception:
+        return

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -611,6 +611,35 @@ class PluginContext:
 
         return registry.dispatch(tool_name, args, **kwargs)
 
+    # -- human intervention provider registration --------------------------
+
+    def register_human_intervention_provider(self, provider) -> None:
+        """Register one optional fail-closed external wait controller.
+
+        The provider can notify or offer constrained remote signals, but the
+        core CLI retains local queues and final authorization. First valid
+        provider wins so separate plugins cannot race the same modal prompt.
+        """
+        from hermes_cli.human_intervention import HumanInterventionProvider
+
+        if not isinstance(provider, HumanInterventionProvider):
+            logger.warning(
+                "Plugin '%s' tried to register an invalid human-intervention provider.",
+                self.manifest.name,
+            )
+            return
+        if self._manager._human_intervention_provider is not None:
+            logger.warning(
+                "Plugin '%s' tried to register a human-intervention provider, "
+                "but one is already active. Ignoring.",
+                self.manifest.name,
+            )
+            return
+        self._manager._human_intervention_provider = provider
+        logger.info(
+            "Plugin '%s' registered a human-intervention provider.", self.manifest.name
+        )
+
     # -- context engine registration -----------------------------------------
 
     def register_context_engine(self, engine) -> None:
@@ -1256,6 +1285,7 @@ class PluginManager:
         self._plugin_platform_names: Set[str] = set()
         self._cli_commands: Dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
+        self._human_intervention_provider = None  # Optional exclusive plugin provider
         self._plugin_commands: Dict[str, dict] = {}  # Slash commands registered by plugins
         self._discovered: bool = False
         self._cli_ref = None  # Set by CLI after plugin discovery
@@ -1301,6 +1331,7 @@ class PluginManager:
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
             self._context_engine = None
+            self._human_intervention_provider = None
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep
         # raises so a failed scan is NOT cached as "discovered with an empty
@@ -2340,6 +2371,11 @@ def _ensure_plugins_discovered(force: bool = False) -> PluginManager:
 def get_plugin_context_engine():
     """Return the plugin-registered context engine, or None."""
     return _ensure_plugins_discovered()._context_engine
+
+
+def get_human_intervention_provider():
+    """Return the one optional plugin-backed human-intervention provider."""
+    return _ensure_plugins_discovered()._human_intervention_provider
 
 
 def is_plugin_control_plane_command(name: str) -> bool:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -534,6 +534,7 @@ class PluginContext:
         args_hint: str = "",
         *,
         accepts_context: bool = False,
+        control_plane: bool = False,
     ) -> None:
         """Register an in-session slash command for CLI and gateway sessions.
 
@@ -542,6 +543,11 @@ class PluginContext:
         context is supplied only by the dispatch surface and contains trusted
         local metadata such as the gateway platform and authenticated user ID;
         legacy handlers are never called with an unexpected second argument.
+
+        ``control_plane=True`` opts the command into gateway dispatch while an
+        agent is running. It remains subject to normal gateway authorization
+        and cannot override a built-in command; use it only for bounded,
+        non-agent control actions such as resolving an external wait.
         """
         clean = name.lower().strip().lstrip("/").replace(" ", "-")
         if not clean:
@@ -570,6 +576,7 @@ class PluginContext:
             "plugin": self.manifest.name,
             "args_hint": (args_hint or "").strip(),
             "accepts_context": bool(accepts_context),
+            "control_plane": bool(control_plane),
         }
         logger.debug("Plugin %s registered command: /%s", self.manifest.name, clean)
 
@@ -2333,6 +2340,12 @@ def _ensure_plugins_discovered(force: bool = False) -> PluginManager:
 def get_plugin_context_engine():
     """Return the plugin-registered context engine, or None."""
     return _ensure_plugins_discovered()._context_engine
+
+
+def is_plugin_control_plane_command(name: str) -> bool:
+    """Return whether a plugin command explicitly opts into busy-time dispatch."""
+    entry = _ensure_plugins_discovered()._plugin_commands.get(name)
+    return bool(entry and entry.get("control_plane", False))
 
 
 def invoke_plugin_command(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -532,24 +532,16 @@ class PluginContext:
         handler: Callable,
         description: str = "",
         args_hint: str = "",
+        *,
+        accepts_context: bool = False,
     ) -> None:
-        """Register a slash command (e.g. ``/lcm``) available in CLI and gateway sessions.
+        """Register an in-session slash command for CLI and gateway sessions.
 
-        The handler signature is ``fn(raw_args: str) -> str | None``.
-        It may also be an async callable — the gateway dispatch handles both.
-
-        Unlike ``register_cli_command()`` (which creates ``hermes <subcommand>``
-        terminal commands), this registers in-session slash commands that users
-        invoke during a conversation.
-
-        ``args_hint`` is an optional short string (e.g. ``"<file>"`` or
-        ``"dias:7 formato:json"``) used by gateway adapters to surface the
-        command with an argument field — for example Discord's native slash
-        command picker. Plugin commands without ``args_hint`` register as
-        parameterless in Discord and still accept trailing text when invoked
-        as free-form chat.
-
-        Names conflicting with built-in commands are rejected with a warning.
+        ``handler`` normally receives ``fn(raw_args: str)``. Set
+        ``accepts_context=True`` to opt into ``fn(raw_args, context)``. The
+        context is supplied only by the dispatch surface and contains trusted
+        local metadata such as the gateway platform and authenticated user ID;
+        legacy handlers are never called with an unexpected second argument.
         """
         clean = name.lower().strip().lstrip("/").replace(" ", "-")
         if not clean:
@@ -577,6 +569,7 @@ class PluginContext:
             "description": description or "Plugin command",
             "plugin": self.manifest.name,
             "args_hint": (args_hint or "").strip(),
+            "accepts_context": bool(accepts_context),
         }
         logger.debug("Plugin %s registered command: /%s", self.manifest.name, clean)
 
@@ -2340,6 +2333,29 @@ def _ensure_plugins_discovered(force: bool = False) -> PluginManager:
 def get_plugin_context_engine():
     """Return the plugin-registered context engine, or None."""
     return _ensure_plugins_discovered()._context_engine
+
+
+def invoke_plugin_command(
+    name: str,
+    raw_args: str,
+    *,
+    context: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """Invoke a registered command with optional trusted dispatch context.
+
+    A plugin must explicitly opt in through ``register_command(...,
+    accepts_context=True)`` before receiving the second argument. This keeps
+    every existing ``handler(raw_args)`` plugin API-compatible.
+    """
+    entry = _ensure_plugins_discovered()._plugin_commands.get(name)
+    if entry is None:
+        return None
+    handler = entry.get("handler")
+    if not callable(handler):
+        return None
+    if entry.get("accepts_context", False):
+        return handler(raw_args, dict(context or {}))
+    return handler(raw_args)
 
 
 def get_plugin_command_handler(name: str) -> Optional[Callable]:

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -316,6 +316,37 @@ async def test_plugin_registered_command_is_gated(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_gateway_contextual_plugin_command_receives_trusted_source(monkeypatch):
+    """A context-opted plugin gets platform/user/chat metadata after gateway auth."""
+    runner = _make_runner()
+    source = _make_source(user_id="111", chat_id="222")
+    received = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        lambda name: object() if name == "contextual" else None,
+    )
+
+    def _invoke(name, raw_args, *, context):
+        received.update(name=name, raw_args=raw_args, context=context)
+        return "context-ok"
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_plugin_command", _invoke)
+
+    result = await runner._handle_message(_make_event("/contextual approve 1234", source))
+
+    assert result == "context-ok"
+    assert received["name"] == "contextual"
+    assert received["raw_args"] == "approve 1234"
+    assert received["context"] == {
+        "surface": "gateway",
+        "platform": source.platform.value,
+        "user_id": "111",
+        "chat_id": "222",
+    }
+
+
+@pytest.mark.asyncio
 async def test_non_admin_denied_for_unlisted_quick_command_exec():
     """A non-admin must not reach the quick_commands exec sink for a command
     that isn't in user_allowed_commands. Regression for #44727 — quick

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -414,6 +414,60 @@ async def test_admin_runs_quick_command_when_gating_enabled():
     assert result == "quick-command-admin"
 
 
+@pytest.mark.asyncio
+async def test_control_plane_plugin_command_bypasses_running_agent_guard(monkeypatch):
+    """An opted-in plugin control command resolves an external wait mid-run."""
+    runner = _make_runner()
+    source = _make_source(user_id="111", chat_id="222")
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = MagicMock()
+    runner._running_agents_ts[session_key] = 0
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.is_plugin_control_plane_command",
+        lambda name: name == "control",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        lambda name: object() if name == "control" else None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_plugin_command",
+        lambda name, raw_args, *, context: "control-ok",
+    )
+
+    result = await runner._handle_message(_make_event("/control deny 1234", source))
+
+    assert result == "control-ok"
+
+
+@pytest.mark.asyncio
+async def test_control_plane_plugin_command_still_requires_gateway_authorization(monkeypatch):
+    runner = _make_runner(
+        platform_extra={"allow_admin_from": ["111"], "user_allowed_commands": []}
+    )
+    source = _make_source(user_id="999", chat_id="222")
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = MagicMock()
+    runner._running_agents_ts[session_key] = 0
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.is_plugin_control_plane_command",
+        lambda name: name == "control",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        lambda name: object() if name == "control" else None,
+    )
+    invoked = MagicMock(return_value="must-not-run")
+    monkeypatch.setattr("hermes_cli.plugins.invoke_plugin_command", invoked)
+
+    result = await runner._handle_message(_make_event("/control deny 1234", source))
+
+    assert "⛔" in result
+    invoked.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Running-agent fast-path gating — admin/user split must hold even when an
 # agent is already running. The fast-path block in _handle_message dispatches

--- a/tests/hermes_cli/test_human_intervention.py
+++ b/tests/hermes_cli/test_human_intervention.py
@@ -1,0 +1,91 @@
+from hermes_cli.human_intervention import (
+    HumanInterventionProvider,
+    HumanInterventionRequest,
+    HumanInterventionSignal,
+    begin_human_intervention,
+    finish_human_intervention,
+    take_remote_signal,
+)
+
+
+class StubProvider(HumanInterventionProvider):
+    def __init__(self, signal=None, *, raise_begin=False, raise_poll=False, raise_finish=False):
+        self.signal = signal
+        self.raise_begin = raise_begin
+        self.raise_poll = raise_poll
+        self.raise_finish = raise_finish
+        self.finished = []
+
+    def begin(self, request):
+        if self.raise_begin:
+            raise RuntimeError("begin failure")
+        return "handle"
+
+    def poll(self, handle):
+        if self.raise_poll:
+            raise RuntimeError("poll failure")
+        assert handle == "handle"
+        return self.signal
+
+    def finish(self, handle, outcome):
+        if self.raise_finish:
+            raise RuntimeError("finish failure")
+        self.finished.append((handle, outcome))
+
+
+def _request(kind="approval", risk_level="medium", actions=frozenset({"deny", "extend", "approve_once"})):
+    return HumanInterventionRequest(
+        kind=kind,
+        session_key="test",
+        title="Test",
+        preview="safe preview",
+        timeout_seconds=30,
+        risk_level=risk_level,
+        allowed_actions=actions,
+    )
+
+
+def test_begin_and_finish_are_best_effort():
+    provider = StubProvider()
+    handle = begin_human_intervention(provider, _request())
+    assert handle == "handle"
+    finish_human_intervention(provider, handle, "local_response")
+    assert provider.finished == [("handle", "local_response")]
+
+
+def test_provider_failures_do_not_affect_local_wait():
+    assert begin_human_intervention(StubProvider(raise_begin=True), _request()) is None
+    assert take_remote_signal(StubProvider(raise_poll=True), "handle", _request()) is None
+    finish_human_intervention(StubProvider(raise_finish=True), "handle", "timeout")
+
+
+def test_extend_requires_positive_duration_and_explicit_capability():
+    request = _request(actions=frozenset({"extend"}))
+    assert take_remote_signal(
+        StubProvider(HumanInterventionSignal("extend", extend_seconds=0)), "handle", request
+    ) is None
+    signal = take_remote_signal(
+        StubProvider(HumanInterventionSignal("extend", extend_seconds=60)), "handle", request
+    )
+    assert signal is not None and signal.extend_seconds == 60
+
+
+def test_critical_remote_approve_is_a_core_rejection():
+    request = _request(risk_level="critical")
+    assert take_remote_signal(
+        StubProvider(HumanInterventionSignal("approve_once")), "handle", request
+    ) is None
+
+
+def test_only_approval_kind_can_accept_remote_approve_once():
+    for kind in ("sudo", "clarify", "computer_use"):
+        assert take_remote_signal(
+            StubProvider(HumanInterventionSignal("approve_once")), "handle", _request(kind=kind)
+        ) is None
+
+
+def test_signal_must_be_in_core_allowed_actions():
+    request = _request(actions=frozenset({"deny"}))
+    assert take_remote_signal(
+        StubProvider(HumanInterventionSignal("approve_once")), "handle", request
+    ) is None

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
+from hermes_cli.human_intervention import HumanInterventionProvider
 from hermes_cli.plugins import (
     ENTRY_POINTS_GROUP,
     VALID_HOOKS,
@@ -17,6 +18,7 @@ from hermes_cli.plugins import (
     PluginManifest,
     get_plugin_command_handler,
     get_plugin_commands,
+    get_human_intervention_provider,
     invoke_plugin_command,
     is_plugin_control_plane_command,
     get_pre_tool_call_block_message,
@@ -2122,6 +2124,31 @@ class TestPluginCommands:
             assert is_plugin_control_plane_command("control") is True
             assert is_plugin_control_plane_command("normal") is False
             assert is_plugin_control_plane_command("missing") is False
+
+
+class TestHumanInterventionProviderRegistration:
+    class _Provider(HumanInterventionProvider):
+        def begin(self, request):
+            return None
+
+        def poll(self, handle):
+            return None
+
+        def finish(self, handle, outcome):
+            return None
+
+    def test_first_valid_provider_wins(self):
+        mgr = PluginManager()
+        first = self._Provider()
+        second = self._Provider()
+        ctx = PluginContext(PluginManifest(name="first", source="user"), mgr)
+        other_ctx = PluginContext(PluginManifest(name="second", source="user"), mgr)
+
+        ctx.register_human_intervention_provider(first)
+        other_ctx.register_human_intervention_provider(second)
+
+        with patch("hermes_cli.plugins._plugin_manager", mgr):
+            assert get_human_intervention_provider() is first
 
 
 class TestPluginCommandResultResolution:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -18,6 +18,7 @@ from hermes_cli.plugins import (
     get_plugin_command_handler,
     get_plugin_commands,
     invoke_plugin_command,
+    is_plugin_control_plane_command,
     get_pre_tool_call_block_message,
     get_pre_verify_continue_message,
     has_middleware,
@@ -2108,6 +2109,19 @@ class TestPluginCommands:
         mgr = PluginManager()
         with patch("hermes_cli.plugins._plugin_manager", mgr):
             assert invoke_plugin_command("missing", "x", context={}) is None
+
+
+    def test_control_plane_registration_is_explicit_and_queryable(self):
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+        ctx.register_command("control", lambda args: args, control_plane=True)
+        ctx.register_command("normal", lambda args: args)
+
+        with patch("hermes_cli.plugins._plugin_manager", mgr):
+            assert is_plugin_control_plane_command("control") is True
+            assert is_plugin_control_plane_command("normal") is False
+            assert is_plugin_control_plane_command("missing") is False
 
 
 class TestPluginCommandResultResolution:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -17,6 +17,7 @@ from hermes_cli.plugins import (
     PluginManifest,
     get_plugin_command_handler,
     get_plugin_commands,
+    invoke_plugin_command,
     get_pre_tool_call_block_message,
     get_pre_verify_continue_message,
     has_middleware,
@@ -2067,6 +2068,46 @@ class TestPluginCommands:
         assert "cmd-b" in mgr._plugin_commands
         assert mgr._plugin_commands["cmd-a"]["plugin"] == "plugin-a"
         assert mgr._plugin_commands["cmd-b"]["plugin"] == "plugin-b"
+
+    def test_invoke_plugin_command_preserves_legacy_one_arg_handler(self):
+        """Handlers without context continue to receive exactly their raw args."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+        seen = []
+        ctx.register_command("legacy", lambda args: seen.append(args) or "ok")
+
+        with patch("hermes_cli.plugins._plugin_manager", mgr):
+            result = invoke_plugin_command(
+                "legacy", "hello", context={"surface": "gateway", "platform": "telegram"}
+            )
+
+        assert result == "ok"
+        assert seen == ["hello"]
+
+    def test_invoke_plugin_command_passes_context_only_when_opted_in(self):
+        """Opted-in handlers receive trusted dispatch context as a second argument."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+        seen = []
+        ctx.register_command(
+            "contextual",
+            lambda args, context: seen.append((args, context)) or "ok",
+            accepts_context=True,
+        )
+        context = {"surface": "gateway", "platform": "telegram", "user_id": "42"}
+
+        with patch("hermes_cli.plugins._plugin_manager", mgr):
+            result = invoke_plugin_command("contextual", "approve 1234", context=context)
+
+        assert result == "ok"
+        assert seen == [("approve 1234", context)]
+
+    def test_invoke_plugin_command_returns_none_for_unknown_name(self):
+        mgr = PluginManager()
+        with patch("hermes_cli.plugins._plugin_manager", mgr):
+            assert invoke_plugin_command("missing", "x", context={}) is None
 
 
 class TestPluginCommandResultResolution:


### PR DESCRIPTION
## Summary

Adds three small, generic plugin extension points needed to move a local human-intervention remote-control implementation out of Hermes core:

1. **Context-aware plugin commands** — opt-in handlers may receive authenticated gateway metadata (`surface`, `platform`, `user_id`, `chat_id`) while legacy one-argument handlers remain unchanged.
2. **Explicit control-plane commands** — an opt-in plugin command may run while an agent is busy, but only after ordinary gateway slash-command authorization and without entering the agent loop.
3. **Fail-closed human-intervention provider bridge** — a single optional provider can open/poll/finish an external wait record. The core validates candidate signals and retains local UI queues and all final authorization decisions.

This is designed for a standalone plugin that owns transport, persistence, notifications, redaction, and `/iv` UX. It does not add a product-specific plugin to this repository.

## Safety properties

- Legacy plugin command handlers remain API-compatible.
- Control-plane commands are explicit opt-in and still call gateway authorization.
- Only one intervention provider may register.
- Provider errors, malformed values, unknown actions, and non-positive extensions fail closed.
- `critical` remote approval is rejected in core, independent of plugin/config.
- Only `approval` requests can accept `approve_once`; sudo, clarify, and computer-use cannot.
- The bridge exposes no sudo password, clarify answer, session approval, or permanent approval capability.

## Validation

```text
151 passed in 6.65s
```

Focused suites:
- `tests/hermes_cli/test_human_intervention.py`
- `tests/hermes_cli/test_plugins.py`
- `tests/gateway/test_slash_access_dispatch.py`

Also ran `git diff --check` and `py_compile` for changed modules.

## Follow-up

A companion standalone human-intervention plugin will implement the provider and `/iv` control UX. CLI wait-loop integration and standalone-plugin E2E validation will be supplied as follow-up work before retiring any local production feature patches.
