### PR TITLE
fix(agent): deliver pre_llm_call/memory context on multimodal turns (#71998)

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -49,6 +49,26 @@ from agent.model_metadata import (
 logger = logging.getLogger(__name__)
 
 
+def _context_injection_parts(
+    ext_prefetch_cache: str,
+    plugin_user_context: str,
+) -> list[str]:
+    """The ephemeral context pieces (memory prefetch + ``pre_llm_call``).
+
+    Shared by the string sidecar (:func:`compose_user_api_content`) and the
+    multimodal text-part (:func:`compose_multimodal_context_part`) paths so
+    both inject byte-identical context regardless of the turn's content shape.
+    """
+    injections: list[str] = []
+    if ext_prefetch_cache:
+        fenced = build_memory_context_block(ext_prefetch_cache)
+        if fenced:
+            injections.append(fenced)
+    if plugin_user_context:
+        injections.append(plugin_user_context)
+    return injections
+
+
 def compose_user_api_content(
     content: Any,
     ext_prefetch_cache: str,
@@ -68,20 +88,35 @@ def compose_user_api_content(
     what turn N sends must be what turn N+1 replays.
 
     Returns ``None`` when nothing is injected (multimodal/non-string content,
-    or no ephemeral context), meaning the message is sent as-is.
+    or no ephemeral context), meaning the message is sent as-is. Multimodal
+    (list) turns take the injection via :func:`compose_multimodal_context_part`
+    instead, since the string sidecar can't ride on list content.
     """
     if not isinstance(content, str):
         return None
-    injections = []
-    if ext_prefetch_cache:
-        fenced = build_memory_context_block(ext_prefetch_cache)
-        if fenced:
-            injections.append(fenced)
-    if plugin_user_context:
-        injections.append(plugin_user_context)
+    injections = _context_injection_parts(ext_prefetch_cache, plugin_user_context)
     if not injections:
         return None
     return content + "\n\n" + "\n\n".join(injections)
+
+
+def compose_multimodal_context_part(
+    ext_prefetch_cache: str,
+    plugin_user_context: str,
+) -> Optional[str]:
+    """The memory-prefetch + ``pre_llm_call`` context as a single text part.
+
+    :func:`compose_user_api_content` returns ``None`` for multimodal (list)
+    turns, so the string ``api_content`` sidecar can't carry this context and
+    it would silently drop on image/attachment turns (#71998). Callers append
+    the returned text as a durable content part instead — the same channel the
+    gateway must-deliver notes use (:func:`append_notes_to_multimodal_content`)
+    — so an image-only turn still reaches the model with the injected context.
+
+    Returns ``None`` when nothing is injected.
+    """
+    injections = _context_injection_parts(ext_prefetch_cache, plugin_user_context)
+    return "\n\n".join(injections) if injections else None
 
 
 def substitute_api_content(api_msg: Dict[str, Any]) -> Optional[str]:
@@ -1163,9 +1198,25 @@ def build_turn_context(
         and messages[current_turn_user_idx].get("role") == "user"
     ):
         _turn_user_msg = messages[current_turn_user_idx]
-        _api_content = compose_user_api_content(
-            _turn_user_msg.get("content", ""), ext_prefetch_cache, plugin_user_context
-        )
+        _turn_content = _turn_user_msg.get("content", "")
+        if isinstance(_turn_content, list):
+            # Multimodal (image/attachment) turn: the string api_content
+            # sidecar can't ride on list content (compose_user_api_content
+            # returns None), so the memory/plugin context would silently drop
+            # on an image-only turn (#71998). Deliver it as a durable text part
+            # instead — the same channel the gateway must-deliver notes use
+            # above — so the injected context reaches the model and the wire
+            # stays byte-identical to the persisted/replayed transcript.
+            _mm_ctx = compose_multimodal_context_part(
+                ext_prefetch_cache, plugin_user_context
+            )
+            if _mm_ctx:
+                append_notes_to_multimodal_content(_turn_content, _mm_ctx)
+            _api_content = None
+        else:
+            _api_content = compose_user_api_content(
+                _turn_content, ext_prefetch_cache, plugin_user_context
+            )
         if _api_content is not None and _api_content != _turn_user_msg.get("content"):
             _turn_user_msg["api_content"] = _api_content
             # In-place preflight compaction has ALREADY inserted this turn's

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -30,7 +30,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent.memory_manager import build_memory_context_block
-from agent.turn_context import build_turn_context, compose_user_api_content
+from agent.turn_context import (
+    build_turn_context,
+    compose_multimodal_context_part,
+    compose_user_api_content,
+)
 from hermes_state import SessionDB
 
 
@@ -58,6 +62,29 @@ class TestComposeUserApiContent:
         a = compose_user_api_content("hello", "likes tea", "CTX")
         b = compose_user_api_content("hello", "likes tea", "CTX")
         assert a == b
+
+
+class TestComposeMultimodalContextPart:
+    """#71998: the injection composed as a standalone text part for the
+    multimodal (list) content path, mirroring the string sidecar's sources."""
+
+    def test_none_when_nothing_to_inject(self):
+        assert compose_multimodal_context_part("", "") is None
+
+    def test_plugin_context_only(self):
+        assert compose_multimodal_context_part("", "CTX") == "CTX"
+
+    def test_memory_block_and_plugin_context(self):
+        out = compose_multimodal_context_part("likes tea", "CTX")
+        fenced = build_memory_context_block("likes tea")
+        assert out == fenced + "\n\n" + "CTX"
+
+    def test_matches_string_sidecar_injection_tail(self):
+        # The multimodal part is exactly the string sidecar minus the leading
+        # content + separator, so both paths inject byte-identical context.
+        sidecar = compose_user_api_content("hello", "likes tea", "CTX")
+        part = compose_multimodal_context_part("likes tea", "CTX")
+        assert sidecar == "hello\n\n" + part
 
 
 # ---------------------------------------------------------------------------
@@ -313,6 +340,46 @@ class TestPrologueStamping:
             return_value=[{"context": "PLUGIN-CTX"}],
         ):
             ctx = _build(agent)
+        assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
+
+    def test_appends_context_part_for_multimodal_turn(self):
+        """#71998: pre_llm_call context must reach an image-only (multimodal)
+        turn as a durable text part, not silently drop.
+
+        The string api_content sidecar can't ride on list content, so the
+        context is appended to the content list (the gateway must-deliver-note
+        channel) — durable, so wire == persisted == replay."""
+        agent = _FakeAgent()
+        blocks = [{"type": "image_url", "image_url": {"url": "data:img"}}]
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[{"context": "PLUGIN-CTX"}],
+        ):
+            ctx = _build(
+                agent,
+                user_message=blocks,
+                summarize_user_message_for_log=lambda _m: "[image]",
+            )
+        content = ctx.messages[ctx.current_turn_user_idx]["content"]
+        assert isinstance(content, list)
+        # Original image part preserved; plugin context appended as a text part.
+        assert content[0] == {"type": "image_url", "image_url": {"url": "data:img"}}
+        assert content[-1] == {"type": "text", "text": "PLUGIN-CTX"}
+        # Multimodal turns carry the context durably, not via the string sidecar.
+        assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
+
+    def test_no_context_part_for_multimodal_without_injections(self):
+        """A multimodal turn with no ephemeral context is left untouched."""
+        agent = _FakeAgent()
+        blocks = [{"type": "image_url", "image_url": {"url": "data:img"}}]
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            ctx = _build(
+                agent,
+                user_message=blocks,
+                summarize_user_message_for_log=lambda _m: "[image]",
+            )
+        content = ctx.messages[ctx.current_turn_user_idx]["content"]
+        assert content == blocks  # no stray text part appended
         assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
 
 


### PR DESCRIPTION
## Problem

A `pre_llm_call` plugin hook can return `{"context": "..."}` to inject
routing/context into the current user turn, and this is documented as working
across CLI and gateway sessions. But the context is **silently dropped when the
current user turn is multimodal** (e.g. an image-only Desktop/CLI attachment
turn).

Root cause: `compose_user_api_content()` returns `None` for non-string content,
so the `plugin_user_context` (from `pre_llm_call`) and the memory-prefetch block
— both of which ride the string `api_content` sidecar — never reach an
image-only turn. A profile plugin can therefore route text/slash-command turns
to a specialized skill but cannot deterministically route the same request from
an image-only turn.

Verified against `NousResearch/hermes-agent` `main` (2026-07-26).

## Fix

Deliver the composed context as a **durable text part** on multimodal turns via
the existing `append_notes_to_multimodal_content()` channel — the same one the
gateway must-deliver notes already use. Because it becomes durable message
content (persisted and replayed as-is), the wire stays byte-identical to the
transcript, preserving the prompt-cache invariant.

- New `compose_multimodal_context_part()` composes the injection (memory block +
  plugin context) as a standalone text part.
- The shared composition is extracted into `_context_injection_parts()`, so the
  string-sidecar and multimodal paths inject **byte-identical** context.
- String turns keep the `api_content` sidecar path unchanged; the
  `moa_active` / `codex_app_server` guards are preserved (those turns bypass the
  `api_messages` build, so injecting there would persist bytes never sent).

## Tests

`tests/agent/test_api_content_sidecar.py`:
- `TestComposeMultimodalContextPart` — the new helper's composition, and that it
  equals the string sidecar minus the leading `content + "\n\n"`.
- `test_appends_context_part_for_multimodal_turn` — an image-only turn with a
  `pre_llm_call` context ends with the injected text part; image part preserved;
  no string sidecar stamped.
- `test_no_context_part_for_multimodal_without_injections` — no stray part when
  there is nothing to inject.
- The existing `test_none_for_multimodal_content` (compose returns `None` for
  lists) still holds.

Affected suites pass locally (`test_api_content_sidecar.py`,
`test_turn_context.py`); ruff + ty clean.

Fixes #71998