### PR TITLE
fix(webhook): don't mark a restart-cancelled run as webhook_complete

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -883,7 +883,35 @@ class WebhookAdapter(BasePlatformAdapter):
         fire-and-forget; wrapping IT closes before the run even starts.)
         ``end_session()`` is first-reason-wins and no-ops on an already-ended
         row, so this never clobbers a ``compression``/``agent_close`` reason.
+
+        ``CANCELLED`` is the one outcome we must NOT close on.  A gateway
+        restart drains in-flight work through
+        ``BasePlatformAdapter.cancel_background_tasks()``, which cancels the
+        processing task — so a webhook run that a restart interrupted
+        mid-investigation arrives here as ``CANCELLED``, not ``SUCCESS``.
+        Stamping ``webhook_complete`` on it makes the row unrecoverable:
+        stale-route recovery in ``gateway/session.py`` only reopens rows that
+        are live or ended with ``agent_close``/``ws_orphan_reap``
+        (``find_latest_gateway_session_for_peer``), so the restart's
+        auto-resume pass cannot find the interrupted transcript.  It then
+        creates a BRAND NEW session for the routing key and synthesizes an
+        empty-text turn into it, and the agent — with no payload and no
+        history — answers "nothing came through" and ends.  The real work is
+        silently abandoned: for the ``helper-events`` route that means a
+        support ticket that was mid-investigation is never answered, while its
+        claim lock survives and blocks every later lane from picking it up.
+        Leaving a cancelled row live keeps it recoverable, and the ghost-leak
+        this hook exists to prevent is unaffected — a genuinely abandoned
+        session still gets reaped by the resume-pending expiry path.
         """
+        if getattr(outcome, "value", outcome) == "cancelled":
+            logger.info(
+                "[webhook] Not closing session for %s: run was CANCELLED "
+                "(likely a gateway restart drain). Leaving the row live so "
+                "restart auto-resume can recover the interrupted work.",
+                event.source.chat_id,
+            )
+            return
         await self._end_webhook_session(event, event.source.chat_id)
 
     async def _end_webhook_session(

--- a/tests/gateway/test_webhook_session_close.py
+++ b/tests/gateway/test_webhook_session_close.py
@@ -210,3 +210,80 @@ async def test_end_webhook_session_awaits_async_session_db(tmp_path):
     assert row["ended_at"] is not None
     assert row["end_reason"] == "webhook_complete"
     store._db.close()
+
+
+@pytest.mark.asyncio
+async def test_restart_cancelled_webhook_run_stays_recoverable(tmp_path):
+    """A run cancelled by a restart drain must NOT be closed.
+
+    Counterpart invariant to the ghost-leak tests above, and the reason the
+    CANCELLED outcome is carved out.  A gateway restart drains in-flight work
+    via ``cancel_background_tasks()``, so a webhook run that was interrupted
+    mid-investigation reaches ``on_processing_complete`` as CANCELLED.  If we
+    stamp ``webhook_complete`` on it, the row falls outside the recoverable set
+    in ``find_latest_gateway_session_for_peer`` (live / ``agent_close`` /
+    ``ws_orphan_reap``) and the restart's auto-resume pass can no longer find
+    the interrupted transcript — it silently starts a fresh empty session
+    instead and the real work is abandoned.
+
+    Asserted as a behavior contract on the recovery query itself, not on the
+    end_reason string, so the test still holds if the reason vocabulary
+    changes.  Goes through the REAL cancel path (``cancel_background_tasks``),
+    not a hand-called hook, so it also covers the drain wiring.
+    """
+    store = _make_store(tmp_path)
+    runner = _FakeRunner(store)
+
+    adapter = _make_adapter(
+        {"alerts": {"secret": _INSECURE_NO_AUTH, "prompt": "x", "deliver": "log"}}
+    )
+    adapter.gateway_runner = runner
+
+    created = {}
+    started = asyncio.Event()
+
+    async def _interrupted_by_restart(event: MessageEvent):
+        # Routing already created the row, and the run has produced real work
+        # (a transcript) before the restart lands on it.
+        entry = store.get_or_create_session(event.source)
+        created["session_id"] = entry.session_id
+        store._db.replace_messages(
+            entry.session_id, [{"role": "user", "content": "investigate ticket"}]
+        )
+        started.set()
+        # Mid-investigation when the drain cancels us.
+        await asyncio.sleep(30)
+        return ""
+
+    adapter._message_handler = _interrupted_by_restart
+
+    event = _make_event(adapter, "alert-restart-001", "x")
+    await adapter.handle_message(event)
+    await asyncio.wait_for(started.wait(), timeout=5.0)
+
+    # The real restart drain path.
+    await adapter.cancel_background_tasks()
+    await asyncio.sleep(0.05)
+
+    session_id = created["session_id"]
+    row = store._db.get_session(session_id)
+    assert row is not None
+
+    # INVARIANT: the interrupted row is still findable by the recovery query
+    # the restart auto-resume pass uses, so the transcript can be continued.
+    session_key = runner._session_key_for_source(event.source)
+    recovered = store._db.find_latest_gateway_session_for_peer(
+        session_key=session_key,
+        source="webhook",
+        user_id=event.source.user_id,
+        chat_id=event.source.chat_id,
+        chat_type=event.source.chat_type,
+        thread_id=event.source.thread_id,
+    )
+    assert recovered is not None, (
+        "a restart-cancelled webhook run was closed as completed, so stale-route "
+        "recovery can no longer find it — the interrupted work is abandoned and "
+        "the auto-resume pass will synthesize an empty session instead"
+    )
+    assert recovered["id"] == session_id
+    store._db.close()


### PR DESCRIPTION
## Problem

A gateway restart drains in-flight work through `BasePlatformAdapter.cancel_background_tasks()`, which cancels the processing task. That fires `on_processing_complete` with `ProcessingOutcome.CANCELLED` — and `WebhookAdapter.on_processing_complete` closed the session row as `webhook_complete` regardless of the outcome.

That end_reason is the problem. `find_latest_gateway_session_for_peer` only treats a row as recoverable when it is live or ended with `agent_close` / `ws_orphan_reap`:

```sql
AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap'))
```

So a `webhook_complete` row is unreachable to stale-route recovery. The restart's own auto-resume pass (`_schedule_resume_pending_sessions`) then cannot find the interrupted transcript for that routing key. It creates a **brand new** session and synthesizes an empty-text turn into it. The agent gets no payload and no history, replies "nothing came through", and ends — while the real, half-finished work is silently abandoned.

The empty-body replay isn't the bug, it's the symptom. The bug is that the interrupted session was made unrecoverable at cancellation time.

## Observed live

A restart interrupted four `helper-events` webhook runs mid-investigation. All four replayed as empty-body sessions that stood down in ~9s each, the original transcripts were unreachable, and the interrupted work was dropped. The gateway log shows both halves of it:

```
gateway.run: Scheduled auto-resume for 5 restart-interrupted session(s)
gateway.session: routing key 'agent:main:webhook:...:1785074688743:...' -> 20260726_100448_89149de1
  is ended in state.db but still live in sessions.json; dropping stale entry and
  recovering/recreating the session (#54878)
```

and the four originals in state.db, each stamped at the restart instant with real transcripts behind them:

```
20260726_100047_fa15b384|webhook_complete|2026-07-26 14:14:33|63 messages
20260726_100448_5827708d|webhook_complete|2026-07-26 14:14:33|91 messages
20260726_100448_89149de1|webhook_complete|2026-07-26 14:14:33|53 messages
20260726_101234_c1f87e05|webhook_complete|2026-07-26 14:14:33|10 messages
```

91 messages of investigation, closed as "complete", unreachable. Worse for any route whose runs hold an external lock or claim: the abandoned work item stays locked by a run that will never resume, so later deliveries are blocked from picking it up too.

## Fix

Skip the close when the outcome is `CANCELLED`, leaving the row live and therefore recoverable.

The ghost-session leak that this hook exists to prevent (#57370, #57423) is unaffected: a genuinely abandoned session is still reaped through the resume-pending expiry path, which promotes it to a `session_reset` boundary. `SUCCESS` and `FAILURE` still close exactly as before, so error runs are still reaped.

## Test

`test_restart_cancelled_webhook_run_stays_recoverable` drives the **real** cancel path (`cancel_background_tasks()`) rather than hand-calling the hook, so the drain wiring is covered too.

It asserts the behavior contract on the recovery query itself — "can the auto-resume pass still find this row?" — rather than freezing the `end_reason` string, so it stays valid if the reason vocabulary changes.

Verified RED on unmodified `main`:

```
E  AssertionError: a restart-cancelled webhook run was closed as completed, so
   stale-route recovery can no longer find it — the interrupted work is abandoned
   and the auto-resume pass will synthesize an empty session instead
E  assert None is not None
```

GREEN with the fix, and the three pre-existing ghost-leak tests in that file still pass:

```
tests/gateway/test_webhook_session_close.py .... 4 passed
```

Wider regression run:

```
tests/gateway/test_webhook_session_close.py
tests/gateway/test_restart_resume_pending.py
tests/gateway/test_platform_reconnect.py
136 passed in 23.78s
```
