### PR TITLE
fix(kanban): preserve initially blocked task holds

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3172,6 +3172,20 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                # A task explicitly parked in ``blocked`` at creation is an
+                # operator hold. Record the same durable lifecycle signal as
+                # ``block_task`` so ``recompute_ready`` cannot auto-promote it
+                # before its owner deliberately unblocks it.
+                if task_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": "initial-status: created-blocked",
+                            "source": "create_task",
+                        },
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -277,3 +277,34 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
 # (landed via #28754 / #28781).  The original PR shipped a duplicate test
 # here; dropped during salvage to avoid two assertions of the same contract.
 # ---------------------------------------------------------------------------
+
+
+def test_initially_blocked_task_stays_parked_across_recompute(
+    kanban_home: Path,
+) -> None:
+    """An operator-created blocked task is a durable hold, not dispatcher work.
+
+    The creating API must leave sticky lifecycle evidence. Otherwise the next
+    recompute tick silently changes a raw ``blocked`` row to ``ready``.
+    """
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="operator parked gate",
+            initial_status="blocked",
+        )
+
+        event_kinds = [
+            row["kind"]
+            for row in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id",
+                (task_id,),
+            ).fetchall()
+        ]
+        assert event_kinds == ["created", "blocked"]
+
+        assert kb.recompute_ready(conn) == 0
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+        assert kb.list_tasks(conn, status="ready") == []


### PR DESCRIPTION
## Why

Tasks created with `initial_status="blocked"` were persisted as blocked but emitted only a `created` lifecycle event. On the next `recompute_ready()` tick, the sticky-block guard could not identify the operator hold and promoted the task to `ready`.

## What

- Record a durable `blocked` lifecycle event when `create_task()` creates an initially blocked task.
- Add a regression covering event ordering, repeated recomputation, retained blocked status, and exclusion from the ready list.

## How

The creation path now records the same lifecycle signal consumed by the existing sticky-block guard. Normal task creation is unchanged. Explicit unblock and existing circuit-breaker recovery behavior remain covered by the surrounding lifecycle suites.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py -q`
  - 7 passed
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py -q`
  - 410 passed
- `git diff --check`

## Review focus

Please verify that a `blocked` event at creation is the correct durable signal for an explicit operator hold, while tasks blocked by ordinary circuit-breaker recovery remain eligible for their existing recovery path.
