### PR TITLE
fix(installer): preserve safe managed SQLite runtime

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2273,6 +2273,27 @@ function Install-Venv {
     }
 
     Write-Info "Creating virtual environment with Python $PythonVersion..."
+
+    # Desktop self-update invokes this script again. Preserve an existing venv
+    # when it already has the requested Python minor; Install-Dependencies will
+    # sync packages and Repair-ManagedRuntime will verify SQLite afterwards.
+    # Probe failures fall through to the existing fail-closed recreation path.
+    $preserveExistingVenv = $false
+    $venvPythonExe = Join-Path $InstallDir "venv\Scripts\python.exe"
+    if (Test-Path $venvPythonExe) {
+        $previousEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        try {
+            $existingPythonVersion = (& $venvPythonExe -I -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null | Select-Object -Last 1)
+            $probeExitCode = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $previousEAP
+        }
+        if ($probeExitCode -eq 0 -and ("$existingPythonVersion").Trim() -eq $PythonVersion) {
+            $preserveExistingVenv = $true
+            $env:UV_PYTHON = $venvPythonExe
+        }
+    }
     
     Push-Location $InstallDir
 
@@ -2282,14 +2303,23 @@ function Install-Venv {
     $gatewayTasksDisabled = @()
     try {
     if (Test-Path "venv") {
-        Write-Info "Virtual environment already exists, recreating..."
+        if ($preserveExistingVenv) {
+            Write-Info "Compatible virtual environment already exists; preserving it..."
+        } else {
+            Write-Info "Virtual environment already exists, recreating..."
+        }
         # On Windows, native Python extensions (e.g. _bcrypt.pyd, tornado's
         # speedups.pyd) are loaded as DLLs by any running hermes process.
         # Windows denies deletion of loaded DLLs, so every process running out
         # of this venv must be stopped before removing it -- otherwise
         # Remove-Item fails with "Access to the path '...' is denied" and the
         # whole install/update aborts at this stage.
+        # Preserving the live venv means dependency sync will mutate it in place.
+        # On Windows that is safe only after process-holder discovery and stop
+        # have been verified; recreation has its own rename/delete failure gate.
+        $holderSweepVerified = $true
         if ($env:OS -eq "Windows_NT") {
+            $holderSweepVerified = $false
             $myPid = $PID
             Write-Info "Stopping any running hermes processes before recreating venv..."
             # Disarm the respawner FIRST: the gateway autostart Scheduled Task
@@ -2358,41 +2388,49 @@ function Install-Venv {
                             & taskkill /F /T /PID $treePid 2>$null | Out-Null
                         }
                 } catch {
-                    Write-Warn "Could not enumerate venv processes: $($_.Exception.Message)"
+                    Write-Warn "Could not verify or stop venv processes: $($_.Exception.Message)"
                     break
                 }
                 if ($found -eq 0) { $cleanPasses++ } else { $cleanPasses = 0 }
                 Start-Sleep -Milliseconds 400
             }
-        }
-        # Rename-then-delete: on Windows a directory RENAME succeeds even while
-        # files inside it are mapped as DLLs (only in-place delete/replace of
-        # the mapped file is denied, and only same-volume renames are atomic
-        # moves). Moving the old venv aside means `uv venv` can create a fresh
-        # one immediately even if some straggler still holds a .pyd from the
-        # old tree; the renamed dir is deleted best-effort (now, and by the
-        # cleanup pass below on the NEXT install if a handle outlives this one).
-        $staleName = "venv.stale.{0}" -f (Get-Date -Format "yyyyMMddHHmmss")
-        $renamed = $false
-        try {
-            Rename-Item -Path "venv" -NewName $staleName -ErrorAction Stop
-            $renamed = $true
-        } catch {
-            Write-Warn "Could not rename venv aside ($($_.Exception.Message)); falling back to in-place delete"
-        }
-        if ($renamed) {
-            Remove-Item -Recurse -Force $staleName -ErrorAction SilentlyContinue
-            if (Test-Path $staleName) {
-                Write-Warn "Old venv parked at $staleName (a process still holds files in it); it will be cleaned up on the next install"
+            if ($cleanPasses -ge 3) {
+                $holderSweepVerified = $true
             }
-        } else {
-            Remove-Item -Recurse -Force "venv" -ErrorAction SilentlyContinue
-            # A killed process can take a moment to release its file handles, so a
-            # first Remove-Item may still hit a locked .pyd. Retry once after a short
-            # pause before giving up and letting the stage fail loudly.
-            if (Test-Path "venv") {
-                Start-Sleep -Seconds 2
-                Remove-Item -Recurse -Force "venv"
+        }
+        if ($preserveExistingVenv -and -not $holderSweepVerified) {
+            throw "Cannot safely preserve virtual environment: running process holders could not be cleared"
+        }
+        if (-not $preserveExistingVenv) {
+            # Rename-then-delete: on Windows a directory RENAME succeeds even while
+            # files inside it are mapped as DLLs (only in-place delete/replace of
+            # the mapped file is denied, and only same-volume renames are atomic
+            # moves). Moving the old venv aside means `uv venv` can create a fresh
+            # one immediately even if some straggler still holds a .pyd from the
+            # old tree; the renamed dir is deleted best-effort (now, and by the
+            # cleanup pass below on the NEXT install if a handle outlives this one).
+            $staleName = "venv.stale.{0}" -f (Get-Date -Format "yyyyMMddHHmmss")
+            $renamed = $false
+            try {
+                Rename-Item -Path "venv" -NewName $staleName -ErrorAction Stop
+                $renamed = $true
+            } catch {
+                Write-Warn "Could not rename venv aside ($($_.Exception.Message)); falling back to in-place delete"
+            }
+            if ($renamed) {
+                Remove-Item -Recurse -Force $staleName -ErrorAction SilentlyContinue
+                if (Test-Path $staleName) {
+                    Write-Warn "Old venv parked at $staleName (a process still holds files in it); it will be cleaned up on the next install"
+                }
+            } else {
+                Remove-Item -Recurse -Force "venv" -ErrorAction SilentlyContinue
+                # A killed process can take a moment to release its file handles, so a
+                # first Remove-Item may still hit a locked .pyd. Retry once after a short
+                # pause before giving up and letting the stage fail loudly.
+                if (Test-Path "venv") {
+                    Start-Sleep -Seconds 2
+                    Remove-Item -Recurse -Force "venv"
+                }
             }
         }
     }
@@ -2403,18 +2441,19 @@ function Install-Venv {
         Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
     }
     
-    # uv creates the venv and pins the Python version in one step.  uv emits
-    # normal progress such as "Using CPython ..." on stderr; under Windows
-    # PowerShell 5.1 with EAP=Stop that stderr is a NativeCommandError unless
-    # we temporarily relax EAP and trust $LASTEXITCODE for real failures.
-    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $PythonVersion }
-    # Relaxing EAP above means a *genuine* uv-venv failure (exit != 0) no longer
-    # aborts on its own. Capture $LASTEXITCODE immediately and fail fast, so the
-    # `venv` stage can't falsely report success (and Invoke-Stage can't emit
-    # ok=true) when the venv was never created.
-    $venvExitCode = $LASTEXITCODE
-    if ($venvExitCode -ne 0) {
-        throw "Failed to create virtual environment (uv venv exited with $venvExitCode)"
+    if (-not $preserveExistingVenv) {
+        # uv creates the venv and pins the Python version in one step. uv emits
+        # normal progress such as "Using CPython ..." on stderr; under Windows
+        # PowerShell 5.1 with EAP=Stop that stderr is a NativeCommandError unless
+        # we temporarily relax EAP and trust $LASTEXITCODE for real failures.
+        Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $PythonVersion }
+        # Relaxing EAP above means a genuine uv-venv failure (exit != 0) no longer
+        # aborts on its own. Capture $LASTEXITCODE immediately and fail fast, so the
+        # venv stage cannot falsely report success when creation failed.
+        $venvExitCode = $LASTEXITCODE
+        if ($venvExitCode -ne 0) {
+            throw "Failed to create virtual environment (uv venv exited with $venvExitCode)"
+        }
     }
 
     # Neutralize any inherited UV_PYTHON (e.g. $env:UV_PYTHON = "3.14" left in
@@ -2925,6 +2964,44 @@ You are Hermes Agent, an intelligent AI assistant created by Nous Research. You 
             }
         }
     }
+}
+
+function Repair-ManagedRuntime {
+    if ($NoVenv) {
+        return
+    }
+
+    $venvPythonExe = Join-Path $InstallDir "venv\Scripts\python.exe"
+    if (-not (Test-Path $venvPythonExe)) {
+        throw "Cannot verify managed SQLite runtime: $venvPythonExe is missing"
+    }
+
+    Write-Info "Verifying managed Python/SQLite runtime..."
+    $repairScript = @'
+import sys
+from pathlib import Path
+
+import hermes_cli.main  # Register the Windows venv-holder detector.
+from hermes_cli.managed_uv import repair_vulnerable_runtime
+
+result = repair_vulnerable_runtime(sys.argv[1], project_root=Path(sys.argv[2]))
+if result.status not in {"safe", "repaired"}:
+    detail = result.detail or "runtime safety could not be established"
+    print(f"Managed SQLite runtime verification failed: {detail}", file=sys.stderr)
+    raise SystemExit(1)
+'@
+    Invoke-NativeWithRelaxedErrorAction {
+        & $venvPythonExe -I -c $repairScript $UvCmd $InstallDir
+    }
+    $repairExitCode = $LASTEXITCODE
+    if ($repairExitCode -ne 0) {
+        throw "Managed Python/SQLite runtime is not safe"
+    }
+
+    # The repair may atomically replace the venv. Pin later uv invocations to
+    # the newly installed live interpreter rather than this stage's old process.
+    $env:UV_PYTHON = $venvPythonExe
+    Write-Success "Managed Python/SQLite runtime verified"
 }
 
 function Install-NodeDeps {
@@ -4074,7 +4151,7 @@ function Stage-Node             {
 function Stage-SystemPackages   { Install-SystemPackages }
 function Stage-Repository       { Install-Repository }
 function Stage-Venv             { Resolve-UvCmd; Install-Venv }
-function Stage-Dependencies     { Resolve-UvCmd; Install-Dependencies }
+function Stage-Dependencies     { Resolve-UvCmd; Install-Dependencies; Repair-ManagedRuntime }
 function Stage-NodeDeps         { Install-NodeDeps }
 function Stage-Desktop          { Install-DesktopVoiceDeps; Install-Desktop }
 function Stage-Path             { Set-PathVariable }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1418,8 +1418,27 @@ setup_venv() {
 
     log_info "Creating virtual environment with Python $PYTHON_VERSION..."
 
+    # Desktop self-update invokes install.sh again. Preserve an existing venv
+    # when it already has the requested Python minor: install_deps() will sync
+    # packages and repair a vulnerable SQLite runtime atomically afterwards.
+    # Recreating unconditionally used to discard that repaired runtime and let
+    # uv's minor-only resolver select an older cached Python/SQLite again.
+    if [ -x "$INSTALL_DIR/venv/bin/python" ]; then
+        local existing_python_version
+        if existing_python_version="$(
+            "$INSTALL_DIR/venv/bin/python" -I -c \
+                'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' \
+                2>/dev/null
+        )" && [ "$existing_python_version" = "$PYTHON_VERSION" ]; then
+            log_info "Compatible virtual environment already exists; preserving it..."
+            export UV_PYTHON="$INSTALL_DIR/venv/bin/python"
+            log_success "Virtual environment ready (Python $PYTHON_VERSION)"
+            return 0
+        fi
+    fi
+
     if [ -d "venv" ]; then
-        log_info "Virtual environment already exists, recreating..."
+        log_info "Existing virtual environment is incompatible; recreating..."
         rm -rf venv
     fi
 
@@ -1438,6 +1457,41 @@ setup_venv() {
     fi
 
     log_success "Virtual environment ready (Python $PYTHON_VERSION)"
+}
+
+repair_managed_runtime() {
+    if [ "$USE_VENV" != true ] || [ "$DISTRO" = "termux" ]; then
+        return 0
+    fi
+
+    local venv_python="$INSTALL_DIR/venv/bin/python"
+    if [ ! -x "$venv_python" ]; then
+        log_error "Cannot verify managed SQLite runtime: $venv_python is missing"
+        return 1
+    fi
+
+    log_info "Verifying managed Python/SQLite runtime..."
+    if ! "$venv_python" -I - "$UV_CMD" "$INSTALL_DIR" <<'PY'
+import sys
+from pathlib import Path
+
+from hermes_cli.managed_uv import repair_vulnerable_runtime
+
+result = repair_vulnerable_runtime(sys.argv[1], project_root=Path(sys.argv[2]))
+if result.status not in {"safe", "repaired"}:
+    detail = result.detail or "runtime safety could not be established"
+    print(f"  ✗ Managed SQLite runtime verification failed: {detail}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+    then
+        log_error "Managed Python/SQLite runtime is not safe"
+        return 1
+    fi
+
+    # repair_vulnerable_runtime may have atomically replaced the venv. Keep all
+    # later uv commands pinned to the newly installed live interpreter.
+    export UV_PYTHON="$INSTALL_DIR/venv/bin/python"
+    log_success "Managed Python/SQLite runtime verified"
 }
 
 install_deps() {
@@ -3215,6 +3269,7 @@ run_stage_body() {
             install_uv
             check_python
             install_deps
+            repair_managed_runtime
             ;;
         node-deps)
             detect_os
@@ -3336,6 +3391,7 @@ main() {
     clone_repo
     setup_venv
     install_deps
+    repair_managed_runtime
     install_node_deps
     setup_path
     copy_config_templates

--- a/tests/test_install_ps1_sqlite_runtime.py
+++ b/tests/test_install_ps1_sqlite_runtime.py
@@ -1,0 +1,75 @@
+"""Regression tests for safe managed SQLite runtime handling on Windows.
+
+The Desktop stage driver invokes ``install.ps1`` one stage per PowerShell
+process. A compatible repaired venv must survive the venv stage, and the
+subsequent dependencies stage must fail closed unless the managed runtime is
+verified safe.
+"""
+
+from pathlib import Path
+
+import pytest
+
+_INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
+
+
+@pytest.fixture(scope="module")
+def source() -> str:
+    return _INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def _function_body(source: str, name: str) -> str:
+    """Return a PowerShell ``function <name> { ... }`` block."""
+    start = source.index(f"function {name}")
+    brace = source.index("{", start)
+    depth = 0
+    for index in range(brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace : index + 1]
+    raise AssertionError(f"unterminated function body for {name}")
+
+
+def test_install_venv_preserves_compatible_runtime_before_teardown(source: str) -> None:
+    body = _function_body(source, "Install-Venv")
+    probe_at = body.find("$existingPythonVersion")
+    teardown_at = body.find('if (Test-Path "venv")')
+
+    assert probe_at != -1, "Install-Venv must probe the existing venv interpreter"
+    assert teardown_at != -1, "expected the existing venv teardown branch"
+    assert probe_at < teardown_at, "the compatibility probe must run before teardown"
+    assert '"$existingPythonVersion"' in body
+    assert ").Trim() -eq $PythonVersion" in body
+    assert '$preserveExistingVenv = $true' in body
+    assert '$env:UV_PYTHON = $venvPythonExe' in body
+    assert "if (-not $preserveExistingVenv)" in body
+
+
+def test_windows_preserve_requires_verified_holder_sweep(source: str) -> None:
+    """In-place dependency sync must not race an unverifiable venv holder."""
+    body = _function_body(source, "Install-Venv")
+    stop_at = body.index("Stop-Process")
+    verify_at = body.index("$holderSweepVerified = $true", stop_at)
+    preserve_gate_at = body.index(
+        "$preserveExistingVenv -and -not $holderSweepVerified"
+    )
+    teardown_at = body.index("if (-not $preserveExistingVenv)")
+
+    assert "$holderSweepVerified = $false" in body
+    assert "-ErrorAction Stop" in body[stop_at:verify_at]
+    assert stop_at < verify_at < preserve_gate_at < teardown_at
+    assert "Cannot safely preserve virtual environment" in body
+
+
+def test_dependencies_stage_repairs_managed_runtime(source: str) -> None:
+    repair = _function_body(source, "Repair-ManagedRuntime")
+    stage = _function_body(source, "Stage-Dependencies")
+
+    assert "repair_vulnerable_runtime" in repair
+    assert '$repairExitCode -ne 0' in repair
+    assert "throw" in repair
+    assert '$env:UV_PYTHON = $venvPythonExe' in repair
+    assert stage.find("Install-Dependencies") < stage.find("Repair-ManagedRuntime")

--- a/tests/test_install_ps1_sqlite_runtime.py
+++ b/tests/test_install_ps1_sqlite_runtime.py
@@ -1,75 +1,307 @@
-"""Regression tests for safe managed SQLite runtime handling on Windows.
+"""Behavioral PowerShell installer coverage for managed runtime safety.
 
-The Desktop stage driver invokes ``install.ps1`` one stage per PowerShell
-process. A compatible repaired venv must survive the venv stage, and the
-subsequent dependencies stage must fail closed unless the managed runtime is
-verified safe.
+The tests execute ``install.ps1 -Stage`` through PowerShell.  They use a
+contract-only disposable managed runtime and external uv/process fixtures;
+PowerShell functions are never parsed, extracted, or replaced.
 """
 
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import venv
 from pathlib import Path
 
 import pytest
 
-_INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+POWERSHELL = os.environ.get("POWERSHELL_UNDER_TEST") or next(
+    (candidate for candidate in ("pwsh", "powershell") if shutil.which(candidate)),
+    None,
+)
+
+pytestmark = [
+    pytest.mark.live_system_guard_bypass,
+    pytest.mark.skipif(
+        os.name == "nt" or POWERSHELL is None,
+        reason="behavioral install.ps1 coverage needs PowerShell on a POSIX host",
+    ),
+]
 
 
-@pytest.fixture(scope="module")
-def source() -> str:
-    return _INSTALL_PS1.read_text(encoding="utf-8")
+def _write_executable(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o755)
 
 
-def _function_body(source: str, name: str) -> str:
-    """Return a PowerShell ``function <name> { ... }`` block."""
-    start = source.index(f"function {name}")
-    brace = source.index("{", start)
-    depth = 0
-    for index in range(brace, len(source)):
-        if source[index] == "{":
-            depth += 1
-        elif source[index] == "}":
-            depth -= 1
-            if depth == 0:
-                return source[brace : index + 1]
-    raise AssertionError(f"unterminated function body for {name}")
-
-
-def test_install_venv_preserves_compatible_runtime_before_teardown(source: str) -> None:
-    body = _function_body(source, "Install-Venv")
-    probe_at = body.find("$existingPythonVersion")
-    teardown_at = body.find('if (Test-Path "venv")')
-
-    assert probe_at != -1, "Install-Venv must probe the existing venv interpreter"
-    assert teardown_at != -1, "expected the existing venv teardown branch"
-    assert probe_at < teardown_at, "the compatibility probe must run before teardown"
-    assert '"$existingPythonVersion"' in body
-    assert ").Trim() -eq $PythonVersion" in body
-    assert '$preserveExistingVenv = $true' in body
-    assert '$env:UV_PYTHON = $venvPythonExe' in body
-    assert "if (-not $preserveExistingVenv)" in body
-
-
-def test_windows_preserve_requires_verified_holder_sweep(source: str) -> None:
-    """In-place dependency sync must not race an unverifiable venv holder."""
-    body = _function_body(source, "Install-Venv")
-    stop_at = body.index("Stop-Process")
-    verify_at = body.index("$holderSweepVerified = $true", stop_at)
-    preserve_gate_at = body.index(
-        "$preserveExistingVenv -and -not $holderSweepVerified"
+def _uv_stub(home: Path, *, python: Path, venv_rc: int = 0) -> Path:
+    uv = home / "bin" / "uv.exe"
+    _write_executable(
+        uv,
+        "#!/bin/bash\n"
+        'printf \'%s\\n\' "$*" >> "$HERMES_TEST_UV_LOG"\n'
+        'case "${1:-}" in\n'
+        "  --version) echo 'uv 0.test'; exit 0 ;;\n"
+        "  python)\n"
+        '    case "${2:-}" in\n'
+        f"      find) printf '%s\\n' {str(python)!r}; exit 0 ;;\n"
+        "      install) exit 0 ;;\n"
+        "    esac ;;\n"
+        f"  venv) exit {venv_rc} ;;\n"
+        "  sync) exit 0 ;;\n"
+        "  pip) exit 0 ;;\n"
+        "esac\n"
+        "exit 0\n",
     )
-    teardown_at = body.index("if (-not $preserveExistingVenv)")
-
-    assert "$holderSweepVerified = $false" in body
-    assert "-ErrorAction Stop" in body[stop_at:verify_at]
-    assert stop_at < verify_at < preserve_gate_at < teardown_at
-    assert "Cannot safely preserve virtual environment" in body
+    return uv
 
 
-def test_dependencies_stage_repairs_managed_runtime(source: str) -> None:
-    repair = _function_body(source, "Repair-ManagedRuntime")
-    stage = _function_body(source, "Stage-Dependencies")
+def _run_stage(
+    root: Path,
+    home: Path,
+    stage: str,
+    *,
+    holder_probe: str = "skip",
+    **extra_env: str,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ | {
+        "OS": "HERMES_TEST" if holder_probe == "skip" else "Windows_NT",
+        **extra_env,
+    }
+    command = [str(POWERSHELL), "-NoProfile", "-NonInteractive"]
+    if holder_probe == "skip":
+        command += ["-File", str(INSTALL_PS1)]
+    else:
+        host = root.parent / f"host-{holder_probe}.ps1"
+        cim = (
+            "throw 'fixture holder enumeration failed'"
+            if holder_probe == "fail"
+            else "return @()"
+        )
+        host.write_text(
+            "param($Installer,$StageName,$Root,$HomeDir)\n"
+            "function global:schtasks { return @() }\n"
+            "function global:taskkill { return }\n"
+            "function global:Start-Sleep { return }\n"
+            f"function global:Get-CimInstance {{ {cim} }}\n"
+            "& $Installer -Stage $StageName -Json -NonInteractive "
+            "-InstallDir $Root -HermesHome $HomeDir\n"
+            "exit $LASTEXITCODE\n",
+            encoding="utf-8",
+        )
+        command += [
+            "-File",
+            str(host),
+            "-Installer",
+            str(INSTALL_PS1),
+            "-StageName",
+            stage,
+            "-Root",
+            str(root),
+            "-HomeDir",
+            str(home),
+        ]
+        return subprocess.run(
+            command,
+            cwd=root.parent,
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    command += [
+        "-Stage",
+        stage,
+        "-Json",
+        "-NonInteractive",
+        "-InstallDir",
+        str(root),
+        "-HermesHome",
+        str(home),
+    ]
+    return subprocess.run(
+        command,
+        cwd=root.parent,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
 
-    assert "repair_vulnerable_runtime" in repair
-    assert '$repairExitCode -ne 0' in repair
-    assert "throw" in repair
-    assert '$env:UV_PYTHON = $venvPythonExe' in repair
-    assert stage.find("Install-Dependencies") < stage.find("Repair-ManagedRuntime")
+
+def _frame(proc: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    frames: list[dict[str, object]] = []
+    for line in proc.stdout.splitlines():
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict) and value.get("stage"):
+            frames.append(value)
+    assert len(frames) == 1, (proc.stdout, proc.stderr)
+    return frames[0]
+
+
+def _compatible_venv_fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    root = tmp_path / "checkout"
+    python = root / "venv" / "Scripts" / "python.exe"
+    _write_executable(
+        python,
+        "#!/bin/bash\n"
+        "if [ \"${1:-}\" = '--version' ]; then "
+        "echo 'Python 3.11.99'; else echo '3.11'; fi\n",
+    )
+    sentinel = root / "venv" / "keep-me"
+    sentinel.write_text("preserved", encoding="utf-8")
+    home = tmp_path / "home"
+    uv_log = tmp_path / "uv.log"
+    _uv_stub(home, python=python, venv_rc=97)
+    return root, home, uv_log, sentinel
+
+
+def test_venv_stage_preserves_compatible_runtime(tmp_path: Path) -> None:
+    root, home, uv_log, sentinel = _compatible_venv_fixture(tmp_path)
+
+    proc = _run_stage(
+        root,
+        home,
+        "venv",
+        holder_probe="empty",
+        HERMES_TEST_UV_LOG=str(uv_log),
+    )
+
+    assert proc.returncode == 0, (proc.stdout, proc.stderr)
+    assert _frame(proc)["ok"] is True
+    assert sentinel.read_text(encoding="utf-8") == "preserved"
+    assert not any(
+        line.startswith("venv ")
+        for line in uv_log.read_text(encoding="utf-8").splitlines()
+    )
+
+
+def test_venv_stage_fails_closed_when_holder_sweep_is_unverifiable(
+    tmp_path: Path,
+) -> None:
+    root, home, uv_log, sentinel = _compatible_venv_fixture(tmp_path)
+
+    proc = _run_stage(
+        root,
+        home,
+        "venv",
+        holder_probe="fail",
+        HERMES_TEST_UV_LOG=str(uv_log),
+    )
+
+    assert proc.returncode == 1, (proc.stdout, proc.stderr)
+    frame = _frame(proc)
+    assert frame["ok"] is False
+    assert "Cannot safely preserve virtual environment" in str(frame["reason"])
+    assert sentinel.read_text(encoding="utf-8") == "preserved"
+    assert not any(
+        line.startswith("venv ")
+        for line in uv_log.read_text(encoding="utf-8").splitlines()
+    )
+
+
+def _contract_runtime(root: Path) -> Path:
+    builder = venv.EnvBuilder(with_pip=False, symlinks=True)
+    builder.create(root / "venv")
+    python = root / "venv" / "bin" / "python"
+    windows_python = root / "venv" / "Scripts" / "python.exe"
+    windows_python.parent.mkdir(parents=True, exist_ok=True)
+    windows_python.symlink_to(Path("..") / "bin" / "python")
+
+    version = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    site = root / "venv" / "lib" / version / "site-packages"
+    package = site / "hermes_cli"
+    package.mkdir(parents=True, exist_ok=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "main.py").write_text(
+        "def _detect_venv_python_processes():\n    return []\n", encoding="utf-8"
+    )
+    (package / "managed_uv.py").write_text(
+        "import json, os\n"
+        "from pathlib import Path\n"
+        "class Result:\n"
+        "    def __init__(self, status):\n"
+        "        self.status = status\n"
+        "        self.detail = 'fixture-' + status\n"
+        "def repair_vulnerable_runtime(uv_bin, *, project_root):\n"
+        "    status = os.environ['HERMES_TEST_RUNTIME_STATUS']\n"
+        "    Path(os.environ['HERMES_TEST_REPAIR_LOG']).write_text(json.dumps({\n"
+        "        'status': status, 'uv_bin': str(uv_bin), "
+        "'project_root': str(project_root)\n"
+        "    }), encoding='utf-8')\n"
+        "    return Result(status)\n",
+        encoding="utf-8",
+    )
+    for module in (
+        "dotenv",
+        "fastapi",
+        "openai",
+        "prompt_toolkit",
+        "rich",
+        "uvicorn",
+    ):
+        (site / f"{module}.py").write_text("", encoding="utf-8")
+    return windows_python
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_rc"), [("safe", 0), ("repaired", 0), ("failed", 1)]
+)
+def test_dependencies_stage_maps_runtime_repair_contract(
+    tmp_path: Path, status: str, expected_rc: int
+) -> None:
+    root = tmp_path / "checkout"
+    root.mkdir()
+    (root / "pyproject.toml").write_text(
+        "[project]\nname='fixture'\nversion='0'\n"
+        "[project.optional-dependencies]\nall=[]\n",
+        encoding="utf-8",
+    )
+    (root / "uv.lock").write_text("fixture", encoding="utf-8")
+    source_package = root / "hermes_cli"
+    source_package.mkdir()
+    (source_package / "web_server.py").write_text("pass\n", encoding="utf-8")
+    # install.ps1 deliberately uses a Windows-native backslash argument; Unix
+    # PowerShell passes that spelling literally to Python.
+    Path(str(root) + "\\hermes_cli\\web_server.py").write_text(
+        "pass\n", encoding="utf-8"
+    )
+    event_log = tmp_path / "repair.json"
+    python = _contract_runtime(root)
+    sentinel = root / "venv" / "keep-me"
+    sentinel.write_text("preserved", encoding="utf-8")
+    home = tmp_path / "home"
+    uv_log = tmp_path / "uv.log"
+    uv = _uv_stub(home, python=python)
+
+    proc = _run_stage(
+        root,
+        home,
+        "dependencies",
+        HERMES_TEST_UV_LOG=str(uv_log),
+        HERMES_TEST_RUNTIME_STATUS=status,
+        HERMES_TEST_REPAIR_LOG=str(event_log),
+    )
+
+    assert proc.returncode == expected_rc, (proc.stdout, proc.stderr)
+    frame = _frame(proc)
+    assert frame["ok"] is (expected_rc == 0)
+    event = json.loads(event_log.read_text(encoding="utf-8"))
+    assert event == {
+        "status": status,
+        "uv_bin": str(uv),
+        "project_root": str(root),
+    }
+    assert sentinel.read_text(encoding="utf-8") == "preserved"
+    if expected_rc:
+        assert frame["reason"] == "Managed Python/SQLite runtime is not safe"

--- a/tests/test_install_sh_sqlite_runtime.py
+++ b/tests/test_install_sh_sqlite_runtime.py
@@ -1,0 +1,233 @@
+"""Regression tests for Desktop installer SQLite runtime preservation."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_function(name: str) -> str:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    match = re.search(
+        rf"^{re.escape(name)}\(\) \{{.*?^\}}",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"{name}() not found in install.sh"
+    return match.group(0)
+
+
+def test_setup_venv_preserves_existing_python_311_runtime(tmp_path: Path) -> None:
+    """A Desktop update must not delete a usable 3.11 venv before safety repair."""
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("#!/bin/bash\necho 3.11\n", encoding="utf-8")
+    venv_python.chmod(0o755)
+    sentinel = tmp_path / "venv" / "keep-me"
+    sentinel.write_text("preserved", encoding="utf-8")
+
+    uv_log = tmp_path / "uv.log"
+    uv_stub = tmp_path / "uv-stub"
+    uv_stub.write_text(
+        "#!/bin/bash\n"
+        f"echo called >> {uv_log!s}\n"
+        "exit 97\n",
+        encoding="utf-8",
+    )
+    uv_stub.chmod(0o755)
+
+    harness = f"""
+set -e
+USE_VENV=true
+DISTRO=macos
+INSTALL_DIR={str(tmp_path)!r}
+PYTHON_VERSION=3.11
+UV_CMD={str(uv_stub)!r}
+log_info() {{ :; }}
+log_success() {{ :; }}
+{_extract_function('setup_venv')}
+cd "$INSTALL_DIR"
+setup_venv
+printf 'UV_PYTHON=%s\n' "$UV_PYTHON"
+"""
+    proc = subprocess.run(
+        ["bash", "-c", harness],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=os.environ.copy(),
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert sentinel.read_text(encoding="utf-8") == "preserved"
+    assert not uv_log.exists(), "uv must not recreate an existing Python 3.11 venv"
+    assert f"UV_PYTHON={venv_python}" in proc.stdout
+
+
+def test_desktop_python_deps_stage_repairs_managed_runtime() -> None:
+    """Every staged Desktop install must run the managed SQLite repair gate."""
+    harness = f"""
+set -e
+EVENTS=$(mktemp)
+trap 'rm -f "$EVENTS"' EXIT
+log_event() {{ echo "$1" >> "$EVENTS"; }}
+detect_os() {{ :; }}
+resolve_install_layout() {{ :; }}
+require_install_dir() {{ :; }}
+install_uv() {{ :; }}
+check_python() {{ :; }}
+install_deps() {{ log_event deps; }}
+repair_managed_runtime() {{ log_event repair; }}
+{_extract_function('run_stage_body')}
+run_stage_body python-deps
+tr '\n' ' ' < "$EVENTS"
+"""
+    proc = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, encoding="utf-8", errors="replace")
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "deps repair"
+
+
+def test_setup_venv_recreates_unprobeable_runtime(tmp_path: Path) -> None:
+    """An interpreter that cannot report its version must not be preserved."""
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text(
+        "#!/bin/bash\necho 3.11\nexit 42\n",
+        encoding="utf-8",
+    )
+    venv_python.chmod(0o755)
+    sentinel = tmp_path / "venv" / "remove-me"
+    sentinel.write_text("stale", encoding="utf-8")
+
+    uv_log = tmp_path / "uv.log"
+    uv_stub = tmp_path / "uv-stub"
+    uv_stub.write_text(
+        "#!/bin/bash\n"
+        f"echo called >> {uv_log!s}\n"
+        'mkdir -p "$2/bin"\n'
+        'printf \'#!/bin/bash\\necho 3.11\\n\' > "$2/bin/python"\n'
+        'chmod +x "$2/bin/python"\n',
+        encoding="utf-8",
+    )
+    uv_stub.chmod(0o755)
+
+    harness = f"""
+set -e
+USE_VENV=true
+DISTRO=macos
+INSTALL_DIR={str(tmp_path)!r}
+PYTHON_VERSION=3.11
+UV_CMD={str(uv_stub)!r}
+log_info() {{ :; }}
+log_success() {{ :; }}
+{_extract_function('setup_venv')}
+cd "$INSTALL_DIR"
+setup_venv
+printf 'UV_PYTHON=%s\n' "$UV_PYTHON"
+"""
+    proc = subprocess.run(
+        ["bash", "-c", harness],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=os.environ.copy(),
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert not sentinel.exists()
+    assert uv_log.exists(), "uv must recreate an unprobeable venv"
+    assert f"UV_PYTHON={venv_python}" in proc.stdout
+
+
+def test_runtime_repair_failure_reaches_stage_protocol() -> None:
+    """The Desktop stage protocol must emit failure when safety is unknown."""
+    harness = f"""
+set -e
+JSON_OUTPUT=true
+NON_INTERACTIVE=false
+stage_needs_user_input() {{ return 1; }}
+emit_stage_json() {{ printf '%s|%s|%s|%s\n' "$1" "$2" "$3" "${{4:-}}"; }}
+detect_os() {{ :; }}
+resolve_install_layout() {{ :; }}
+require_install_dir() {{ :; }}
+install_uv() {{ :; }}
+check_python() {{ :; }}
+install_deps() {{ :; }}
+repair_managed_runtime() {{ return 23; }}
+{_extract_function('run_stage_body')}
+{_extract_function('run_stage_protocol')}
+run_stage_protocol python-deps
+"""
+    proc = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, encoding="utf-8", errors="replace")
+
+    assert proc.returncode == 23
+    assert proc.stdout.strip() == "python-deps|false|false|exit code 23"
+
+
+def test_runtime_repair_failure_stops_monolithic_install() -> None:
+    """The non-staged installer must not continue after repair uncertainty."""
+    noops = " ".join(
+        [
+            "print_banner",
+            "detect_os",
+            "resolve_install_layout",
+            "install_uv",
+            "check_python",
+            "check_git",
+            "check_node",
+            "check_network_prerequisites",
+            "install_system_packages",
+            "clone_repo",
+            "setup_venv",
+            "install_deps",
+            "install_node_deps",
+            "setup_path",
+            "copy_config_templates",
+            "run_setup_wizard",
+            "maybe_start_gateway",
+            "install_desktop",
+            "print_success",
+        ]
+    )
+    harness = f"""
+set -e
+INSTALL_DIR=$(mktemp -d)
+trap 'rm -rf "$INSTALL_DIR"' EXIT
+INCLUDE_DESKTOP=false
+for name in {noops}; do eval "$name() {{ :; }}"; done
+repair_managed_runtime() {{ return 31; }}
+{_extract_function('main')}
+main
+"""
+    proc = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, encoding="utf-8", errors="replace")
+
+    assert proc.returncode == 31
+
+
+def test_runtime_repair_bypasses_unmanaged_and_termux_installs(tmp_path: Path) -> None:
+    """The repair gate applies only to managed non-Termux venv installs."""
+    function = _extract_function("repair_managed_runtime")
+    for use_venv, distro in (("false", "macos"), ("true", "termux")):
+        harness = f"""
+set -e
+USE_VENV={use_venv}
+DISTRO={distro}
+INSTALL_DIR={str(tmp_path)!r}
+UV_CMD=uv
+log_error() {{ :; }}
+log_info() {{ :; }}
+log_success() {{ :; }}
+{function}
+repair_managed_runtime
+"""
+        proc = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, encoding="utf-8", errors="replace")
+        assert proc.returncode == 0, proc.stderr

--- a/tests/test_install_sh_sqlite_runtime.py
+++ b/tests/test_install_sh_sqlite_runtime.py
@@ -1,233 +1,299 @@
-"""Regression tests for Desktop installer SQLite runtime preservation."""
+"""Behavioral installer coverage for managed SQLite runtime preservation.
+
+The tests execute the public ``--stage`` protocol.  Only external executables
+(Python and uv) are replaced with disposable shims; installer shell functions
+are never extracted, sourced, or stubbed.
+"""
 
 from __future__ import annotations
 
+import json
 import os
-from pathlib import Path
-import re
+import shutil
 import subprocess
+import sys
+from pathlib import Path
 
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+REAL_PYTHON = Path(sys.executable).absolute()
 
-
-def _extract_function(name: str) -> str:
-    text = INSTALL_SH.read_text(encoding="utf-8")
-    match = re.search(
-        rf"^{re.escape(name)}\(\) \{{.*?^\}}",
-        text,
-        re.MULTILINE | re.DOTALL,
-    )
-    assert match is not None, f"{name}() not found in install.sh"
-    return match.group(0)
-
-
-def test_setup_venv_preserves_existing_python_311_runtime(tmp_path: Path) -> None:
-    """A Desktop update must not delete a usable 3.11 venv before safety repair."""
-    venv_python = tmp_path / "venv" / "bin" / "python"
-    venv_python.parent.mkdir(parents=True)
-    venv_python.write_text("#!/bin/bash\necho 3.11\n", encoding="utf-8")
-    venv_python.chmod(0o755)
-    sentinel = tmp_path / "venv" / "keep-me"
-    sentinel.write_text("preserved", encoding="utf-8")
-
-    uv_log = tmp_path / "uv.log"
-    uv_stub = tmp_path / "uv-stub"
-    uv_stub.write_text(
-        "#!/bin/bash\n"
-        f"echo called >> {uv_log!s}\n"
-        "exit 97\n",
-        encoding="utf-8",
-    )
-    uv_stub.chmod(0o755)
-
-    harness = f"""
+_LIVE_PYTHON = r"""#!/bin/bash
 set -e
-USE_VENV=true
-DISTRO=macos
-INSTALL_DIR={str(tmp_path)!r}
-PYTHON_VERSION=3.11
-UV_CMD={str(uv_stub)!r}
-log_info() {{ :; }}
-log_success() {{ :; }}
-{_extract_function('setup_venv')}
-cd "$INSTALL_DIR"
-setup_venv
-printf 'UV_PYTHON=%s\n' "$UV_PYTHON"
+if [ "$1" = "-I" ] && [ "$2" = "-c" ] && [[ "$3" == *"sqlite_source_id"* ]]; then
+  if [ "${HERMES_TEST_REPAIR_OUTCOME:-safe}" = "safe" ]; then
+    sqlite="3.53.1"
+  else
+    sqlite="3.50.4"
+  fi
+  printf '{"base_prefix":"/test","executable":"%s","python_version":[3,11,14],"sqlite_version":[%s],"sqlite_version_string":"%s","sqlite_source_id":"test-live"}\n' \
+    "$0" "${sqlite//./,}" "$sqlite"
+  exit 0
+fi
+exec __REAL_PYTHON__ "$@"
 """
-    proc = subprocess.run(
-        ["bash", "-c", harness],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        env=os.environ.copy(),
-    )
 
-    assert proc.returncode == 0, proc.stderr
-    assert sentinel.read_text(encoding="utf-8") == "preserved"
-    assert not uv_log.exists(), "uv must not recreate an existing Python 3.11 venv"
-    assert f"UV_PYTHON={venv_python}" in proc.stdout
-
-
-def test_desktop_python_deps_stage_repairs_managed_runtime() -> None:
-    """Every staged Desktop install must run the managed SQLite repair gate."""
-    harness = f"""
+_CANDIDATE_PYTHON = r"""#!/bin/bash
 set -e
-EVENTS=$(mktemp)
-trap 'rm -f "$EVENTS"' EXIT
-log_event() {{ echo "$1" >> "$EVENTS"; }}
-detect_os() {{ :; }}
-resolve_install_layout() {{ :; }}
-require_install_dir() {{ :; }}
-install_uv() {{ :; }}
-check_python() {{ :; }}
-install_deps() {{ log_event deps; }}
-repair_managed_runtime() {{ log_event repair; }}
-{_extract_function('run_stage_body')}
-run_stage_body python-deps
-tr '\n' ' ' < "$EVENTS"
+if [ "$1" = "-I" ] && [ "$2" = "-c" ] && [[ "$3" == *"sqlite_source_id"* ]]; then
+  printf '{"base_prefix":"/test","executable":"%s","python_version":[3,11,15],"sqlite_version":[3,53,1],"sqlite_version_string":"3.53.1","sqlite_source_id":"test-fixed"}\n' "$0"
+  exit 0
+fi
+# The repairer's smoke command validates imports.  Dependency installation is
+# the uv shim's responsibility in this integration harness, so report success.
+if [ "$1" = "-I" ] && [ "$2" = "-c" ]; then
+  exit 0
+fi
+exec __REAL_PYTHON__ "$@"
 """
-    proc = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, encoding="utf-8", errors="replace")
 
-    assert proc.returncode == 0, proc.stderr
-    assert proc.stdout.strip() == "deps repair"
-
-
-def test_setup_venv_recreates_unprobeable_runtime(tmp_path: Path) -> None:
-    """An interpreter that cannot report its version must not be preserved."""
-    venv_python = tmp_path / "venv" / "bin" / "python"
-    venv_python.parent.mkdir(parents=True)
-    venv_python.write_text(
-        "#!/bin/bash\necho 3.11\nexit 42\n",
-        encoding="utf-8",
-    )
-    venv_python.chmod(0o755)
-    sentinel = tmp_path / "venv" / "remove-me"
-    sentinel.write_text("stale", encoding="utf-8")
-
-    uv_log = tmp_path / "uv.log"
-    uv_stub = tmp_path / "uv-stub"
-    uv_stub.write_text(
-        "#!/bin/bash\n"
-        f"echo called >> {uv_log!s}\n"
-        'mkdir -p "$2/bin"\n'
-        'printf \'#!/bin/bash\\necho 3.11\\n\' > "$2/bin/python"\n'
-        'chmod +x "$2/bin/python"\n',
-        encoding="utf-8",
-    )
-    uv_stub.chmod(0o755)
-
-    harness = f"""
+_MANAGED_UV = r"""#!/bin/bash
 set -e
-USE_VENV=true
-DISTRO=macos
-INSTALL_DIR={str(tmp_path)!r}
-PYTHON_VERSION=3.11
-UV_CMD={str(uv_stub)!r}
-log_info() {{ :; }}
-log_success() {{ :; }}
-{_extract_function('setup_venv')}
-cd "$INSTALL_DIR"
-setup_venv
-printf 'UV_PYTHON=%s\n' "$UV_PYTHON"
+printf '%s\n' "$*" >> "${HERMES_TEST_UV_LOG}"
+if [ "$1" = "--version" ]; then
+  echo 'uv test'
+  exit 0
+fi
+if [ "$1" = "python" ] && [ "$2" = "find" ]; then
+  if [[ " $* " == *" --managed-python "* ]]; then
+    printf '%s\n' "${UV_PYTHON_INSTALL_DIR}/cpython-3.11.15/bin/python"
+  else
+    printf '%s\n' "__REAL_PYTHON__"
+  fi
+  exit 0
+fi
+if [ "$1" = "python" ] && [ "$2" = "install" ]; then
+  candidate="${UV_PYTHON_INSTALL_DIR}/cpython-3.11.15/bin/python"
+  mkdir -p "$(dirname "$candidate")"
+  cat > "$candidate" <<'PY'
+__CANDIDATE_PYTHON__
+PY
+  chmod +x "$candidate"
+  exit 0
+fi
+if [ "$1" = "venv" ]; then
+  candidate="$2/bin/python"
+  mkdir -p "$(dirname "$candidate")"
+  cat > "$candidate" <<'PY'
+__CANDIDATE_PYTHON__
+PY
+  chmod +x "$candidate"
+  exit 0
+fi
+if [ "$1" = "sync" ] && [[ " $* " == *" --python "* ]] && \
+   [ "${HERMES_TEST_REPAIR_OUTCOME}" = "failure" ]; then
+  echo 'simulated candidate dependency sync failure' >&2
+  exit 17
+fi
+exit 0
 """
-    proc = subprocess.run(
-        ["bash", "-c", harness],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        env=os.environ.copy(),
-    )
 
-    assert proc.returncode == 0, proc.stderr
-    assert not sentinel.exists()
-    assert uv_log.exists(), "uv must recreate an unprobeable venv"
-    assert f"UV_PYTHON={venv_python}" in proc.stdout
+_VENV_PYTHON = r"""#!/bin/bash
+if [ "$1" = "--version" ]; then
+  echo 'Python __VERSION__.0'
+  exit 0
+fi
+if [ "$1" = "-I" ] && [ "$2" = "-c" ]; then
+  if [ "__PROBE_FAILURE__" = "true" ]; then
+    exit 9
+  fi
+  echo '__VERSION__'
+  exit 0
+fi
+exit 0
+"""
 
-
-def test_runtime_repair_failure_reaches_stage_protocol() -> None:
-    """The Desktop stage protocol must emit failure when safety is unknown."""
-    harness = f"""
+_VENV_UV = r"""#!/bin/bash
 set -e
-JSON_OUTPUT=true
-NON_INTERACTIVE=false
-stage_needs_user_input() {{ return 1; }}
-emit_stage_json() {{ printf '%s|%s|%s|%s\n' "$1" "$2" "$3" "${{4:-}}"; }}
-detect_os() {{ :; }}
-resolve_install_layout() {{ :; }}
-require_install_dir() {{ :; }}
-install_uv() {{ :; }}
-check_python() {{ :; }}
-install_deps() {{ :; }}
-repair_managed_runtime() {{ return 23; }}
-{_extract_function('run_stage_body')}
-{_extract_function('run_stage_protocol')}
-run_stage_protocol python-deps
+printf '%s\n' "$*" >> "${HERMES_TEST_UV_LOG}"
+if [ "$1" = "--version" ]; then
+  echo 'uv test'
+elif [ "$1" = "python" ] && [ "$2" = "find" ]; then
+  printf '%s\n' "${HERMES_INSTALL_DIR}/venv/bin/python"
+elif [ "$1" = "venv" ]; then
+  mkdir -p venv/bin
+  printf '#!/bin/bash\nexit 0\n' > venv/bin/python
+  chmod +x venv/bin/python
+fi
+exit 0
 """
-    proc = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, encoding="utf-8", errors="replace")
-
-    assert proc.returncode == 23
-    assert proc.stdout.strip() == "python-deps|false|false|exit code 23"
 
 
-def test_runtime_repair_failure_stops_monolithic_install() -> None:
-    """The non-staged installer must not continue after repair uncertainty."""
-    noops = " ".join(
+def _write_executable(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _json_frame(stdout: str) -> dict[str, object]:
+    frames: list[dict[str, object]] = []
+    for line in stdout.splitlines():
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict) and value.get("stage"):
+            frames.append(value)
+    assert len(frames) == 1, stdout
+    return frames[0]
+
+
+def _run_stage(
+    tmp_path: Path, stage: str, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
         [
-            "print_banner",
-            "detect_os",
-            "resolve_install_layout",
-            "install_uv",
-            "check_python",
-            "check_git",
-            "check_node",
-            "check_network_prerequisites",
-            "install_system_packages",
-            "clone_repo",
-            "setup_venv",
-            "install_deps",
-            "install_node_deps",
-            "setup_path",
-            "copy_config_templates",
-            "run_setup_wizard",
-            "maybe_start_gateway",
-            "install_desktop",
-            "print_success",
-        ]
+            "bash",
+            str(INSTALL_SH),
+            "--stage",
+            stage,
+            "--json",
+            "--non-interactive",
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
     )
-    harness = f"""
-set -e
-INSTALL_DIR=$(mktemp -d)
-trap 'rm -rf "$INSTALL_DIR"' EXIT
-INCLUDE_DESKTOP=false
-for name in {noops}; do eval "$name() {{ :; }}"; done
-repair_managed_runtime() {{ return 31; }}
-{_extract_function('main')}
-main
-"""
-    proc = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, encoding="utf-8", errors="replace")
-
-    assert proc.returncode == 31
 
 
-def test_runtime_repair_bypasses_unmanaged_and_termux_installs(tmp_path: Path) -> None:
-    """The repair gate applies only to managed non-Termux venv installs."""
-    function = _extract_function("repair_managed_runtime")
-    for use_venv, distro in (("false", "macos"), ("true", "termux")):
-        harness = f"""
-set -e
-USE_VENV={use_venv}
-DISTRO={distro}
-INSTALL_DIR={str(tmp_path)!r}
-UV_CMD=uv
-log_error() {{ :; }}
-log_info() {{ :; }}
-log_success() {{ :; }}
-{function}
-repair_managed_runtime
-"""
-        proc = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, encoding="utf-8", errors="replace")
-        assert proc.returncode == 0, proc.stderr
+def _runtime_stage_fixture(
+    tmp_path: Path, outcome: str
+) -> tuple[Path, dict[str, str], Path]:
+    root = tmp_path / "checkout"
+    (root / "venv" / "bin").mkdir(parents=True)
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "installer-runtime-test"\nversion = "0"\n',
+        encoding="utf-8",
+    )
+    (root / "uv.lock").write_text(
+        'version = 1\nrevision = 1\nrequires-python = ">=3.11"\n',
+        encoding="utf-8",
+    )
+    live_python = _LIVE_PYTHON.replace("__REAL_PYTHON__", str(REAL_PYTHON))
+    _write_executable(root / "venv" / "bin" / "python", live_python)
+    (root / "venv" / "sentinel").write_text("live", encoding="utf-8")
+
+    home = tmp_path / "hermes-home"
+    candidate_python = _CANDIDATE_PYTHON.replace("__REAL_PYTHON__", str(REAL_PYTHON))
+    managed_uv = _MANAGED_UV.replace("__REAL_PYTHON__", str(REAL_PYTHON)).replace(
+        "__CANDIDATE_PYTHON__", candidate_python
+    )
+    _write_executable(home / "bin" / "uv", managed_uv)
+
+    uv_log = tmp_path / "uv.log"
+    env = os.environ | {
+        "HERMES_HOME": str(home),
+        "HERMES_INSTALL_DIR": str(root),
+        "HERMES_TEST_REPAIR_OUTCOME": outcome,
+        "HERMES_TEST_UV_LOG": str(uv_log),
+    }
+    return root, env, uv_log
+
+
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.skipif(
+    shutil.which("bash") is None or not REAL_PYTHON.is_file(),
+    reason="needs bash and the repository test venv",
+)
+@pytest.mark.parametrize(
+    ("outcome", "expected_ok"),
+    [("safe", True), ("repaired", True), ("failure", False)],
+)
+def test_python_deps_stage_runs_real_runtime_repair(
+    tmp_path: Path, outcome: str, expected_ok: bool
+) -> None:
+    root, env, uv_log = _runtime_stage_fixture(tmp_path, outcome)
+
+    result = _run_stage(tmp_path, "python-deps", env)
+
+    frame = _json_frame(result.stdout)
+    assert frame["stage"] == "python-deps"
+    assert frame["ok"] is expected_ok
+    assert (result.returncode == 0) is expected_ok
+    calls = uv_log.read_text(encoding="utf-8")
+    assert "sync --extra all --locked" in calls
+
+    sentinel = root / "venv" / "sentinel"
+    if outcome == "safe":
+        assert sentinel.read_text(encoding="utf-8") == "live"
+        assert "python install" not in calls
+        assert "Managed Python/SQLite runtime verified" in result.stdout
+    elif outcome == "repaired":
+        assert not sentinel.exists()
+        assert "python install 3.11" in calls
+        assert "Managed Python runtime repaired (SQLite 3.50.4" in result.stdout
+    else:
+        assert sentinel.read_text(encoding="utf-8") == "live"
+        assert "sync --extra all --locked --python" in calls
+        assert "Managed Python/SQLite runtime is not safe" in result.stdout
+        assert "replacement environment did not pass" in result.stderr
+        assert frame["reason"] == "exit code 1"
+
+
+def _venv_stage_fixture(
+    tmp_path: Path, *, version: str, probe_failure: bool = False
+) -> tuple[Path, dict[str, str], Path]:
+    root = tmp_path / "checkout"
+    python = root / "venv" / "bin" / "python"
+    _write_executable(
+        python,
+        _VENV_PYTHON.replace("__VERSION__", version).replace(
+            "__PROBE_FAILURE__", str(probe_failure).lower()
+        ),
+    )
+    (root / "venv" / "sentinel").write_text("keep", encoding="utf-8")
+
+    home = tmp_path / "hermes-home"
+    uv_log = tmp_path / "uv.log"
+    _write_executable(home / "bin" / "uv", _VENV_UV)
+    env = os.environ | {
+        "HERMES_HOME": str(home),
+        "HERMES_INSTALL_DIR": str(root),
+        "HERMES_TEST_UV_LOG": str(uv_log),
+    }
+    return root, env, uv_log
+
+
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+def test_venv_stage_preserves_compatible_existing_environment(tmp_path: Path) -> None:
+    root, env, uv_log = _venv_stage_fixture(tmp_path, version="3.11")
+
+    result = _run_stage(tmp_path, "venv", env)
+
+    assert result.returncode == 0, result.stderr
+    assert _json_frame(result.stdout)["ok"] is True
+    assert (root / "venv" / "sentinel").read_text(encoding="utf-8") == "keep"
+    assert (
+        "Compatible virtual environment already exists; preserving it" in result.stdout
+    )
+    assert not any(
+        line.startswith("venv ")
+        for line in uv_log.read_text(encoding="utf-8").splitlines()
+    )
+
+
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+@pytest.mark.parametrize(
+    ("version", "probe_failure"), [("3.12", False), ("3.11", True)]
+)
+def test_venv_stage_recreates_unusable_existing_environment(
+    tmp_path: Path, version: str, probe_failure: bool
+) -> None:
+    root, env, uv_log = _venv_stage_fixture(
+        tmp_path, version=version, probe_failure=probe_failure
+    )
+
+    result = _run_stage(tmp_path, "venv", env)
+
+    assert result.returncode == 0, result.stderr
+    assert _json_frame(result.stdout)["ok"] is True
+    assert not (root / "venv" / "sentinel").exists()
+    assert any(
+        line.startswith("venv ")
+        for line in uv_log.read_text(encoding="utf-8").splitlines()
+    )


### PR DESCRIPTION
## Summary

- preserve an existing Desktop install venv when it already uses the requested Python minor instead of deleting it unconditionally
- after dependency sync, reuse `hermes_cli.managed_uv.repair_vulnerable_runtime()` to verify or atomically replace a vulnerable SQLite runtime
- apply the same policy to POSIX and Windows bootstrap stages, failing closed when the interpreter or Windows process-holder state cannot be verified
- keep unmanaged and Termux installs on their existing paths

## Why

A CLI update can repair the managed venv to a Python build linked against a fixed SQLite, but a later Desktop bootstrap previously deleted that venv and recreated it from a minor-only `uv venv --python 3.11` request. If the available catalog or cache still selected an older build, that regressed the install from a fixed SQLite runtime to a vulnerable one.

The repair must happen after dependencies are installed because the installer invokes `venv` and `python-deps` as separate stages. Both the staged and monolithic installer paths propagate repair uncertainty as failure instead of reporting a safe install.

## Existing PR overlap

PR #70200 covers the same runtime-migration area. Current `main` already has the atomic `repair_vulnerable_runtime()` implementation and its unit tests. This PR stays scoped to wiring that implementation into Desktop bootstrap and preserving a verified venv.

## Safety details

- a POSIX compatibility probe must both print the requested minor and exit successfully
- an incompatible or unprobeable interpreter is recreated
- Windows preservation requires three consecutive clean holder sweeps; enumeration or process-stop failures abort before in-place dependency sync
- only `safe` and `repaired` runtime results are accepted
- repair may replace the venv atomically, so later `uv` calls are repinned to the new live interpreter

## Behavioral coverage

- `install.sh --stage` executes the real worktree `repair_vulnerable_runtime()` path for `safe`, `repaired`, and candidate-sync failure outcomes
- `install.ps1 -Stage` executes through PowerShell and verifies compatible-venv preservation, fail-closed holder handling, and `safe` / `repaired` / failed status propagation
- the PowerShell tests run on a POSIX PowerShell host, matching the repository's `ubuntu-latest` CI environment where `pwsh` is preinstalled
- neither suite reads, parses, extracts, or replaces installer source functions

## Verification

- CI-equivalent per-file behavioral runner: **11 passed** (PowerShell 5, POSIX 6)
- full installer suite: **81 passed, 1 skipped**
- managed runtime suites:
  - `tests/hermes_cli/test_managed_uv.py`: **35 passed**
  - `tests/hermes_cli/test_sqlite_runtime.py`: **12 passed**
- current behavioral tests against `origin/main`: **9 failed, 2 passed**, demonstrating RED before the implementation
- Ruff check and format check
- Python bytecode compilation
- `bash -n scripts/install.sh`
- PowerShell AST parse
- Windows footgun check
- `git diff --check`
- added-line security-pattern scan
- independent exact-diff review: **CLEAN**

The upstream Actions run remains subject to the external-fork approval gate and is not counted as CI green.

## Checklist

- [x] Read `CONTRIBUTING.md`
- [x] Searched existing PRs and documented overlap
- [x] Replaced source-shape tests with behavioral stage-entrypoint coverage
- [x] Covered `safe`, `repaired`, and failure propagation
- [x] Kept the change scoped to Desktop installer runtime safety
- [x] Considered POSIX and Windows behavior
- [x] No config or schema changes
