### PR TITLE
fix(telegram): shield batch flush from follow-up cancel

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8573,7 +8573,20 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[Telegram] Flushing text batch %s (%d chars)",
                 key, len(event.text or ""),
             )
-            await self.handle_message(event)
+            # Shield the downstream dispatch so that a subsequent chunk
+            # arriving while handle_message is mid-flight cannot cancel it.
+            # _enqueue_* always cancels the prior flush task when a new chunk
+            # lands, and the event has already been popped out of the pending
+            # buffer above — so without this shield the popped message is in no
+            # buffer, was never dispatched, and asyncio never reports the
+            # cancelled task: the user's message is silently lost.  The new
+            # chunk is handled by the fresh flush task regardless.
+            await asyncio.shield(self.handle_message(event))
+        except asyncio.CancelledError:
+            # Only reached if the cancel landed before the pop — the shielded
+            # handle_message is unaffected either way.  Let the task exit
+            # cleanly so the finally block cleans up.
+            pass
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
@@ -8607,7 +8620,20 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.debug("[Telegram] Dropping photo batch flush after disconnect started")
                 return
             logger.info("[Telegram] Flushing photo batch %s with %d image(s)", batch_key, len(event.media_urls))
-            await self.handle_message(event)
+            # Shield the downstream dispatch so that a subsequent chunk
+            # arriving while handle_message is mid-flight cannot cancel it.
+            # _enqueue_* always cancels the prior flush task when a new chunk
+            # lands, and the event has already been popped out of the pending
+            # buffer above — so without this shield the popped message is in no
+            # buffer, was never dispatched, and asyncio never reports the
+            # cancelled task: the user's message is silently lost.  The new
+            # chunk is handled by the fresh flush task regardless.
+            await asyncio.shield(self.handle_message(event))
+        except asyncio.CancelledError:
+            # Only reached if the cancel landed before the pop — the shielded
+            # handle_message is unaffected either way.  Let the task exit
+            # cleanly so the finally block cleans up.
+            pass
         finally:
             if self._pending_photo_batch_tasks.get(batch_key) is current_task:
                 self._pending_photo_batch_tasks.pop(batch_key, None)
@@ -8952,7 +8978,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 if self._should_drop_delayed_delivery():
                     logger.debug("[Telegram] Dropping media group flush after disconnect started")
                     return
-                await self.handle_message(event)
+                # Shield the dispatch: _enqueue_media_group_event cancels the
+                # prior flush task on every album item, and the event has
+                # already been popped — an unshielded cancel would silently
+                # drop the album (its caption rides on the first item).
+                await asyncio.shield(self.handle_message(event))
         except asyncio.CancelledError:
             return
         finally:

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -326,3 +326,98 @@ class TestTextBatching:
         assert adapter._media_group_events == {}
         assert adapter._media_group_tasks == {}
         assert adapter._polling_error_task is None
+
+
+class TestBatchFlushNotCancelledByFollowUp:
+    """A follow-up chunk must never cancel a dispatch that is already running.
+
+    ``_enqueue_*`` unconditionally cancels the prior flush task, and the flush
+    pops the event out of its pending buffer *before* awaiting
+    ``handle_message``.  Without a shield the popped event is in no buffer, was
+    never dispatched, and asyncio does not report cancelled tasks — so the
+    user's message is lost silently.  The Discord adapter already shields this
+    exact path (#12444); these cover the Telegram equivalents.
+
+    ``handle_message`` must really suspend here: the production path awaits
+    ``asyncio.to_thread(self._apply_topic_recovery, event)`` before it durably
+    queues anything, so the cancellation window is always open.  An
+    ``AsyncMock`` never suspends, which is why the existing tests miss this.
+    """
+
+    @staticmethod
+    def _tracking_handler(entered, completed):
+        async def _handle(event):
+            label = event.text or f"<{len(event.media_urls)} media>"
+            entered.append(label)
+            await asyncio.sleep(0.3)
+            completed.append(label)
+        return _handle
+
+    @pytest.mark.asyncio
+    async def test_text_follow_up_does_not_drop_in_flight_message(self):
+        adapter = _make_adapter()
+        entered, completed = [], []
+        adapter.handle_message = self._tracking_handler(entered, completed)
+
+        adapter._enqueue_text_event(_make_event("first message"))
+        await asyncio.sleep(0.15)  # flush fired at ~0.1s; dispatch is in flight
+        adapter._enqueue_text_event(_make_event("second message"))
+        await asyncio.sleep(0.8)
+
+        assert entered == ["first message", "second message"]
+        assert completed == ["first message", "second message"], (
+            "the in-flight first message was cancelled and silently lost"
+        )
+
+    @pytest.mark.asyncio
+    async def test_photo_follow_up_does_not_drop_in_flight_batch(self):
+        adapter = _make_adapter()
+        adapter._media_batch_delay_seconds = 0.1
+        entered, completed = [], []
+        adapter.handle_message = self._tracking_handler(entered, completed)
+
+        first = _make_event("photo one")
+        first.media_urls = ["u1"]
+        first.media_types = ["image"]
+        adapter._enqueue_photo_event("k", first)
+        await asyncio.sleep(0.15)
+        second = _make_event("photo two")
+        second.media_urls = ["u2"]
+        second.media_types = ["image"]
+        adapter._enqueue_photo_event("k", second)
+        await asyncio.sleep(0.8)
+
+        assert completed == ["photo one", "photo two"], (
+            "the in-flight photo batch was cancelled and silently lost"
+        )
+
+    @pytest.mark.asyncio
+    async def test_media_group_follow_up_does_not_drop_in_flight_album(self):
+        adapter = _make_adapter()
+        adapter.MEDIA_GROUP_WAIT_SECONDS = 0.1
+        entered, completed = [], []
+        adapter.handle_message = self._tracking_handler(entered, completed)
+
+        first = _make_event("album caption")
+        first.media_urls = ["u1"]
+        first.media_types = ["image"]
+        adapter._media_group_events["mg1"] = first
+        adapter._media_group_tasks["mg1"] = asyncio.create_task(
+            adapter._flush_media_group_event("mg1")
+        )
+        await asyncio.sleep(0.15)
+        second = _make_event("")
+        second.media_urls = ["u2"]
+        second.media_types = ["image"]
+        adapter._media_group_events["mg1"] = second
+        prior = adapter._media_group_tasks.get("mg1")
+        if prior:
+            prior.cancel()
+        adapter._media_group_tasks["mg1"] = asyncio.create_task(
+            adapter._flush_media_group_event("mg1")
+        )
+        await asyncio.sleep(0.8)
+
+        assert "album caption" in completed, (
+            "the in-flight album (carrying the caption) was cancelled and lost"
+        )


### PR DESCRIPTION
## Summary

`_enqueue_text_event` / `_enqueue_photo_event` / `_enqueue_media_group_event`
unconditionally cancel the prior flush task whenever a new chunk lands, and
each `_flush_*` pops its event out of the pending buffer **before** awaiting
`handle_message`. A cancel that arrives after that pop destroys a message that
is in no buffer and was never dispatched.

The user sends two Telegram messages back to back; the agent only ever answers
the second. The first gets no reply and no error.

The Discord adapter already shields this exact path, and its comment describes
this precise failure (#12444). Telegram was never updated.

## Problem

`_flush_text_batch` (`plugins/platforms/telegram/adapter.py`):

```python
await asyncio.sleep(delay)
event = self._pending_text_batches.pop(key, None)   # event leaves the buffer
if not event:
    return
...
await self.handle_message(event)                    # cancellable, unshielded
```

`_enqueue_text_event`:

```python
prior_task = self._pending_text_batch_tasks.get(key)
if prior_task and not prior_task.done():            # a task inside
    prior_task.cancel()                             # handle_message is NOT done
```

When the follow-up lands *after* the pop, `_pending_text_batches` no longer
holds the first event, so the new enqueue starts a fresh batch containing only
the second message — and the cancel tears down the dispatch of the first.

The window is open on every flush, because `handle_message` always suspends
before it durably queues anything: `gateway/platforms/base.py` awaits
`asyncio.to_thread(self._apply_topic_recovery, event)` as its first step. It
widens sharply on exactly the path where users send follow-ups — the busy path
(`_handle_active_session_busy_message`) awaits two further `to_thread` round
trips (session-store lock read, then a SQLite compression-lock query) *before*
`_queue_or_replace_pending_event` durably queues the event.

Nothing recovers the message:

- **No error surfaces.** The flush has only `try`/`finally`, no
  `except asyncio.CancelledError`; the task is fire-and-forget via
  `asyncio.create_task`, and asyncio never reports cancelled tasks.
- **No redelivery.** `_handle_text_message` returns immediately after the
  synchronous enqueue, so python-telegram-bot has already advanced the polling
  offset — Telegram will not resend.
- **No backfill.** Unlike Discord (`_iter_missed_message_backfill_candidates`),
  the Telegram adapter has no missed-message recovery.
- **No workaround.** The batcher cannot be disabled:
  `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS` is clamped to a `0.08` floor, and
  lowering the delay only shifts when the window opens.

The log still prints `[Telegram] Flushing text batch <key> (N chars)` for the
lost message, so it looks delivered.

The same shape exists in two sibling paths in this file:
`_flush_photo_batch`, and `_flush_media_group_event` (whose enqueue cancels
without even a `.done()` check) — for an album the dropped item is the first
one, which is the one carrying the caption.

## Fix

Wrap the dispatch in `asyncio.shield` in all three flushes, mirroring
`plugins/platforms/discord/adapter.py`, and add the matching
`except asyncio.CancelledError` arm so a cancel that lands *before* the pop
still exits cleanly.

Aggregation is unchanged: when the follow-up arrives before the flush fires
(the common case — a Telegram client splitting a long message), the cancel hits
the new `CancelledError` arm, nothing was popped, and the chunks still merge
into a single dispatch.

## Scope

- `plugins/platforms/telegram/adapter.py` — `asyncio.shield` + a
  `CancelledError` arm in `_flush_text_batch`, `_flush_photo_batch`,
  `_flush_media_group_event`.
- `tests/gateway/test_telegram_text_batching.py` — 3 regression tests.

No signature or config changes.

## Testing

Three new tests in `TestBatchFlushNotCancelledByFollowUp` (text, photo, album).
They give `handle_message` a real suspension point — the existing tests stub it
with `AsyncMock`, which never suspends, which is why they miss this.

Verified by running the actual `_enqueue_*` / `_flush_*` bodies from `main`
against the same scenario (first message enqueued, flush fires, follow-up sent
while the dispatch is in flight):

| path | on `main` | with the fix |
|---|---|---|
| text batch | `completed=['second message']` — first lost | `['first message', 'second message']` |
| photo batch | `completed=['photo two']` — first lost | `['photo one', 'photo two']` |
| media group | `completed=['<1 media>']` — caption item lost | `['album caption', '<1 media>']` |

The existing batching scenarios were replayed against the patched code and all
still pass: `single_message_dispatched`, `split_messages_aggregated`,
`three_way_split_aggregated`, `different_chats_not_merged`,
`batch_cleans_up_after_flush`.
