### PR TITLE
fix(gateway): distinguish compression lookup failures

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8233,8 +8233,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             return False
 
-    async def _session_has_compression_in_flight(self, session_key: str) -> bool:
-        """Return True when a compression lock is held for this session's id.
+    async def _session_has_compression_in_flight(self, session_key: str) -> Optional[bool]:
+        """Return the compression-lock state for this session.
+
+        ``True`` means the lock is held, ``False`` means it is not held, and
+        ``None`` means the state could not be read. Callers must queue on
+        ``None`` to preserve parent-session rotation safety, but must not report
+        that compression is active when storage itself is unavailable.
 
         Context compression is interrupt-protected (#23975) but gateway
         ``interrupt`` busy-input mode can still start a follow-up turn against
@@ -8249,21 +8254,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_store = getattr(self, "session_store", None)
         if not session_key or session_store is None:
             return False
+        missing = object()
+        required_store_attrs = ("_lock", "_ensure_loaded_locked", "_entries")
+        try:
+            if any(
+                inspect.getattr_static(session_store, attr, missing) is missing
+                for attr in required_store_attrs
+            ):
+                return False
+        except Exception:
+            logger.warning(
+                "Compression in-flight check failed while inspecting session "
+                "store for %s; compression state is unavailable",
+                session_key,
+                exc_info=True,
+            )
+            return None
         try:
             session_id = await asyncio.to_thread(
                 self._lookup_session_id_under_store_lock, session_store, session_key
             )
-        except (AttributeError, TypeError):
-            return False
         except Exception:
             logger.warning(
                 "Compression in-flight check failed while reading session %s; "
-                "treating compression as active to avoid interrupting a possible "
-                "parent-session rotation",
+                "compression state is unavailable",
                 session_key,
                 exc_info=True,
             )
-            return True
+            return None
         if not session_id:
             return False
         session_db = getattr(self, "_session_db", None)
@@ -8271,21 +8289,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
         raw_db = getattr(session_db, "_db", session_db)
         try:
-            holder = await asyncio.to_thread(
-                raw_db.get_compression_lock_holder, str(session_id)
-            )
+            if (
+                inspect.getattr_static(
+                    raw_db, "get_compression_lock_holder", missing
+                )
+                is missing
+            ):
+                return False
+            get_lock_holder = getattr(raw_db, "get_compression_lock_holder")
+            if not callable(get_lock_holder):
+                raise TypeError("compression lock helper is not callable")
+            holder = await asyncio.to_thread(get_lock_holder, str(session_id))
             return bool(holder)
-        except (AttributeError, TypeError):
-            return False
         except Exception:
             logger.warning(
                 "Compression in-flight check failed while reading lock holder "
-                "for session %s; treating compression as active to avoid "
-                "interrupting a possible parent-session rotation",
+                "for session %s; compression state is unavailable",
                 session_id,
                 exc_info=True,
             )
-            return True
+            return None
 
     @staticmethod
     def _lookup_session_id_under_store_lock(session_store, session_key: str):
@@ -8554,14 +8577,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key,
             )
             effective_mode = "queue"
-        demoted_for_compression = (
-            effective_mode == "interrupt"
-            and await self._session_has_compression_in_flight(session_key)
-        )
+        compression_state = False
+        if effective_mode == "interrupt":
+            compression_state = await self._session_has_compression_in_flight(session_key)
+        demoted_for_compression = compression_state is True
+        demoted_for_state_unavailable = compression_state is None
         if demoted_for_compression:
             logger.info(
                 "Demoting busy_input_mode 'interrupt' to 'queue' for session %s "
                 "because context compression is in flight (#56391)",
+                session_key,
+            )
+            effective_mode = "queue"
+        elif demoted_for_state_unavailable:
+            logger.info(
+                "Demoting busy_input_mode 'interrupt' to 'queue' for session %s "
+                "because compression state is unavailable",
                 session_key,
             )
             effective_mode = "queue"
@@ -8761,6 +8792,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             message = (
                 f"⏳ Compressing context{status_detail} — your message is queued for "
                 f"when it finishes (use /stop to cancel everything)."
+            )
+        elif is_queue_mode and demoted_for_state_unavailable:
+            message = (
+                f"⚠️ Session state unavailable{status_detail} — your message is queued "
+                f"until the current task finishes (use /stop to cancel everything)."
             )
         elif is_queue_mode:
             message = (
@@ -14168,7 +14204,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # the id out from under it, forking orphaned compression
             # siblings. Demote to queue semantics so the follow-up waits
             # for the in-flight compression + rotation to land.
-            if await self._session_has_compression_in_flight(_quick_key):
+            compression_state = await self._session_has_compression_in_flight(_quick_key)
+            if compression_state is True:
                 logger.info(
                     "PRIORITY interrupt demoted to queue for session %s "
                     "because context compression is in flight (#56391)",
@@ -14176,6 +14213,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 self._queue_or_replace_pending_event(_quick_key, event)
                 return None
+            if compression_state is None:
+                logger.info(
+                    "PRIORITY interrupt demoted to queue for session %s "
+                    "because compression state is unavailable",
+                    _quick_key,
+                )
+                self._queue_or_replace_pending_event(_quick_key, event)
+                return (
+                    "⚠️ Session state unavailable — your message is queued until "
+                    "the current task finishes (use /stop to cancel everything)."
+                )
             # Text-only corrections redirect the live turn (preserving
             # displayed context) when the runtime supports it; media/voice and
             # older runtimes fall back to the proven interrupt path below.

--- a/tests/gateway/test_compression_in_flight_check.py
+++ b/tests/gateway/test_compression_in_flight_check.py
@@ -49,6 +49,66 @@ async def test_returns_false_when_no_session_store():
 
 
 @pytest.mark.asyncio
+async def test_structural_lock_absence_still_fails_open():
+    runner = _make_runner(holder_value=None)
+    session_db = MagicMock()
+    session_db._db = MagicMock(spec=[])
+    runner._session_db = session_db
+
+    assert await runner._session_has_compression_in_flight("k") is False
+
+
+@pytest.mark.asyncio
+async def test_db_helper_instance_lookup_failure_reports_unknown():
+    runner = _make_runner(holder_value=None)
+
+    class BrokenLockLookupDB:
+        @property
+        def get_compression_lock_holder(self):
+            raise AttributeError("descriptor lookup failed")
+
+    session_db = MagicMock()
+    session_db._db = BrokenLockLookupDB()
+    runner._session_db = session_db
+
+    assert await runner._session_has_compression_in_flight("k") is None
+
+
+@pytest.mark.asyncio
+async def test_non_callable_db_helper_reports_unknown():
+    runner = _make_runner(holder_value=None)
+    raw_db = MagicMock()
+    raw_db.get_compression_lock_holder = "not-callable"
+    session_db = MagicMock()
+    session_db._db = raw_db
+    runner._session_db = session_db
+
+    assert await runner._session_has_compression_in_flight("k") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc_type", (RuntimeError, AttributeError, TypeError))
+async def test_db_lock_probe_error_reports_unknown(exc_type):
+    runner = _make_runner(holder_value=None)
+    runner._session_db._db.get_compression_lock_holder = MagicMock(
+        side_effect=exc_type("sqlite temporarily unavailable")
+    )
+
+    assert await runner._session_has_compression_in_flight("k") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc_type", (RuntimeError, AttributeError, TypeError))
+async def test_store_lookup_error_reports_unknown(exc_type):
+    runner = _make_runner(holder_value=None)
+    runner.session_store._ensure_loaded_locked = MagicMock(
+        side_effect=exc_type("routing index temporarily unavailable")
+    )
+
+    assert await runner._session_has_compression_in_flight("k") is None
+
+
+@pytest.mark.asyncio
 async def test_db_call_runs_off_event_loop():
     """Regression core: get_compression_lock_holder MUST execute in non-event-loop thread."""
     sink = {}

--- a/tests/gateway/test_compression_interrupt_demotion_56391.py
+++ b/tests/gateway/test_compression_interrupt_demotion_56391.py
@@ -76,9 +76,11 @@ def _make_runner(*, session_id: str = "parent-session") -> GatewayRunner:
     )
     session_store._ensure_loaded_locked = lambda: None
     runner.session_store = session_store
-    runner._session_db = MagicMock()
-    runner._session_db._db = MagicMock()
-    runner._session_db._db.get_compression_lock_holder.return_value = None
+    raw_db = MagicMock()
+    raw_db.get_compression_lock_holder = MagicMock(return_value=None)
+    session_db = MagicMock()
+    session_db._db = raw_db
+    runner._session_db = session_db
     return runner
 
 
@@ -105,14 +107,12 @@ def _make_parent_no_subagents() -> MagicMock:
 
 
 class TestSessionHasCompressionInFlight:
-
     @pytest.mark.asyncio
     async def test_returns_true_when_lock_held(self) -> None:
         runner = _make_runner()
         sk = build_session_key(_make_event().source)
         runner._session_db._db.get_compression_lock_holder.return_value = "holder-1"
         assert await runner._session_has_compression_in_flight(sk) is True
-
 
 class TestBusyHandlerDemotesInterruptForCompression:
     @pytest.mark.asyncio
@@ -153,5 +153,31 @@ class TestBusyHandlerDemotesInterruptForCompression:
         assert "queued" in content.lower()
         assert "/stop" in content
         assert "Interrupting" not in content
+
+
+    @pytest.mark.asyncio
+    async def test_lock_probe_error_does_not_interrupt_parent_session(self) -> None:
+        runner = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event(text="follow up while lock state is unavailable")
+        sk = build_session_key(event.source)
+        parent = _make_parent_no_subagents()
+        runner._running_agents[sk] = parent
+        runner.adapters[event.source.platform] = adapter
+        runner._session_db._db.get_compression_lock_holder.side_effect = RuntimeError(
+            "sqlite temporarily unavailable"
+        )
+
+        with patch("gateway.run.merge_pending_message_event"):
+            handled = await runner._handle_active_session_busy_message(event, sk)
+
+        assert handled is True
+        parent.interrupt.assert_not_called()
+        assert adapter._pending_messages.get(sk) is event
+        adapter._send_with_retry.assert_called_once()
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Session state unavailable" in content
+        assert "queued" in content.lower()
+        assert "Compressing context" not in content
 
 

--- a/tests/gateway/test_priority_path_compression_demotion_56391.py
+++ b/tests/gateway/test_priority_path_compression_demotion_56391.py
@@ -50,7 +50,7 @@ def _make_event(text: str) -> MessageEvent:
     return MessageEvent(text=text, source=_make_source(), message_id="m1")
 
 
-def _make_runner(*, compression_in_flight: bool):
+def _make_runner(*, compression_in_flight: bool | None):
     """Minimal GatewayRunner with an active running agent for this session.
 
     Mirrors tests/gateway/test_running_agent_session_toggles.py's harness
@@ -147,3 +147,17 @@ async def test_priority_path_does_not_interrupt_when_compression_in_flight():
     assert queued is not None and queued.text == "still there?"
 
 
+@pytest.mark.asyncio
+async def test_priority_path_queues_when_compression_state_is_unavailable():
+    """A failed lock probe must not masquerade as compression or interrupt."""
+    runner, agent_mock, sk = _make_runner(compression_in_flight=None)
+
+    result = await runner._handle_message(_make_event("still there?"))
+
+    agent_mock.interrupt.assert_not_called()
+    queued = runner.adapters[Platform.TELEGRAM]._pending_messages.get(sk)
+    assert queued is not None and queued.text == "still there?"
+    assert result is not None
+    assert "Session state unavailable" in result
+    assert "queued" in result.lower()
+    assert "Compressing context" not in result


### PR DESCRIPTION
## Summary

- make the gateway compression-lock probe tri-state: active, inactive, or state unavailable
- distinguish structural compatibility absence from failures inside an available session-store/SQLite helper
- keep true compression lock protection unchanged
- when session/SQLite state lookup fails, queue conservatively but report `Session state unavailable` instead of falsely reporting `Compressing context`
- apply the same policy to both the normal busy-input handler and the PRIORITY path

## Why

`_session_has_compression_in_flight()` previously returned `True` for every session-store or SQLite lookup exception. A damaged or temporarily unavailable state database therefore looked exactly like an active context compression:

1. interrupt mode was demoted to queue
2. the user saw a long-running `Compressing context` status
3. no real compression lock or completion event necessarily existed

Treating every lookup error as `False` would be unsafe: a real compression could still be rotating the parent session while storage is unavailable, and starting a follow-up against that parent can create orphaned compression siblings. The explicit unknown state preserves that safety boundary without making a false compression claim. `/stop` continues to use its dedicated command path.

## Behavior

- `True`: compression lock exists; queue and show `Compressing context`
- `False`: no compression lock, or the lock helper is structurally unavailable in an older runtime; retain the configured interrupt behavior
- `None`: an available session/lock helper failed while reading state; queue conservatively and show `Session state unavailable`

This PR does not repair a corrupted database itself. It prevents storage failures from being misrepresented as successful compression-state reads.

Related: #71480

## Existing PR overlap

PR #68437 changes broad SQLite contention and gateway persistence behavior but does not modify `_session_has_compression_in_flight()` or its error-state demotion paths.

## Latest-main conflict resolution

- rebased onto current `main`
- preserved the latest-main test pruning instead of restoring unrelated deleted controls
- retained the seven PR-specific regression functions covering structural absence, lookup failures, and both busy-input call paths

## Verification

- current-main differential probe: a session-store lookup `RuntimeError` returns `True` on `main` and `None` on this candidate
- focused PR regression suite: **18 passed**
- canonical five-file suite: **22 passed**
- related compression/busy/priority gateway suite: **127 passed**
- Ruff on all changed Python files
- Python bytecode compilation
- `git diff --check`
- conflict-marker and added-line security-pattern scans
- independent exact-diff adversarial review

## Full gateway suite

The macOS host's default soft file-descriptor limit (`256`) caused `Too many open files`, so the suite was rerun from the beginning with a process-local limit of `4096`:

- `4487 passed, 13 skipped, 7 failed`
- the seven failures are outside the changed files
- five Discord/session-store failures passed when rerun in isolation on both this candidate and latest `main`, indicating full-suite order/environment interaction
- the remaining async-diagnostic and systemd abstract-socket tests failed identically on this candidate and latest `main` on macOS

This result is recorded as a completed non-green broad run, not as passing CI evidence. The scoped suites covering the changed compression and busy-input paths are green.

## Checklist

- [x] Read `CONTRIBUTING.md`
- [x] Searched existing PRs and documented overlap
- [x] Added regression tests for both busy-input paths
- [x] No config, schema, or tool-surface changes
