### PR TITLE
fix(x-search): clarify query guidance

### DIFF
--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -790,3 +790,14 @@ def test_x_search_not_degraded_when_no_filters_active(monkeypatch):
     assert result["degraded"] is False
     assert result["degraded_reason"] is None
 
+
+def test_x_search_query_schema_requires_meaningful_natural_language():
+    from tools.x_search_tool import X_SEARCH_SCHEMA
+
+    description = X_SEARCH_SCHEMA["parameters"]["properties"]["query"]["description"]
+
+    assert "meaningful" in description
+    assert "non-empty" in description
+    assert "natural-language instruction" in description
+    assert "Grok X-search agent" in description
+

--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -312,3 +312,15 @@ def test_x_search_not_degraded_when_no_filters_active(monkeypatch):
     assert result["degraded"] is False
     assert result["degraded_reason"] is None
 
+
+def test_x_search_query_schema_requires_meaningful_natural_language():
+    from tools.x_search_tool import X_SEARCH_SCHEMA
+
+    description = X_SEARCH_SCHEMA["parameters"]["properties"]["query"]["description"]
+
+    assert "meaningful" in description
+    assert "non-empty" in description
+    assert "natural-language instruction" in description
+    assert "Grok X-search agent" in description
+    assert "Handle/date filters narrow but never replace the query" in description
+

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -492,7 +492,10 @@ X_SEARCH_SCHEMA = {
         "properties": {
             "query": {
                 "type": "string",
-                "description": "What to look up on X.",
+                "description": (
+                    "A meaningful, non-empty natural-language instruction sent "
+                    "to the Grok X-search agent."
+                ),
             },
             "allowed_x_handles": {
                 "type": "array",

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -492,7 +492,11 @@ X_SEARCH_SCHEMA = {
         "properties": {
             "query": {
                 "type": "string",
-                "description": "What to look up on X.",
+                "description": (
+                    "A meaningful, non-empty natural-language instruction sent "
+                    "to the Grok X-search agent. Handle/date filters narrow "
+                    "but never replace the query."
+                ),
             },
             "allowed_x_handles": {
                 "type": "array",


### PR DESCRIPTION
## Summary

- clarify that `x_search.query` is the natural-language instruction sent to the Grok X-search agent
- state explicitly that the query must be meaningful and non-empty even when structured filters are supplied
- add schema regression coverage

Fixes #72042

## Tests

- `python -m pytest tests/tools/test_x_search_tool.py -q` (29 passed)
- `git diff --check`

## Scope

This changes model-facing schema guidance only. Runtime validation, request construction, filters, and authentication are unchanged.