### PR TITLE
fix(tui): send gateway ready before MCP discovery

### DIFF
--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -9,17 +9,23 @@ from tui_gateway import server
 from tui_gateway import ws as ws_mod
 
 
-def test_ws_startup_starts_background_mcp_discovery(monkeypatch):
+def test_ws_sends_ready_before_starting_background_mcp_discovery(monkeypatch):
     """The desktop app and dashboard chat reach the agent through this WS
     sidecar, not through tui_gateway.entry.main() (which spawns the discovery
     thread for the stdio TUI). handle_ws must start discovery itself, otherwise
     _make_agent's wait_for_mcp_discovery no-ops and the agent snapshots an
     MCP-less tool list. Regression test for #38945."""
     calls = []
+    events = []
+
+    def record_discovery(**kwargs):
+        calls.append(kwargs)
+        events.append("mcp_discovery")
+
     monkeypatch.setattr(
         mcp_startup,
         "start_background_mcp_discovery",
-        lambda **kw: calls.append(kw),
+        record_discovery,
     )
 
     class FakeWS:
@@ -27,7 +33,7 @@ def test_ws_startup_starts_background_mcp_discovery(monkeypatch):
             pass
 
         async def send_text(self, line):
-            pass
+            events.append(json.loads(line)["params"]["type"])
 
         async def receive_text(self):
             raise ws_mod._WebSocketDisconnect()
@@ -42,6 +48,7 @@ def test_ws_startup_starts_background_mcp_discovery(monkeypatch):
         server._sessions.clear()
 
     assert calls == [{"logger": ws_mod._log, "thread_name": "tui-ws-mcp-discovery"}]
+    assert events == ["gateway.ready", "mcp_discovery"]
 
 
 def _run_disconnect(monkeypatch, seed):

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -303,22 +303,6 @@ async def handle_ws(ws: Any) -> None:
 
         transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer)
 
-        # The desktop app and dashboard chat reach the agent through this WS
-        # sidecar, NOT through tui_gateway.entry.main() (the stdio TUI path that
-        # spawns the background MCP discovery thread). Without starting it here,
-        # discovery never runs in this process: _make_agent only *waits* on the
-        # thread (wait_for_mcp_discovery), which no-ops when it was never
-        # created, so the agent snapshots an MCP-less tool list and the only way
-        # to surface MCP tools is a manual /reload-mcp. Start it once per
-        # process here (idempotent, config-gated) before gateway.ready so the
-        # first agent build can pick up already-spawning servers. (#38945)
-        from hermes_cli.mcp_startup import start_background_mcp_discovery
-
-        start_background_mcp_discovery(
-            logger=_log,
-            thread_name="tui-ws-mcp-discovery",
-        )
-
         ready_ok = await transport.write_async(
             {
                 "jsonrpc": "2.0",
@@ -340,6 +324,24 @@ async def handle_ws(ws: Any) -> None:
             send_failures += 1
             _log.error("ws ready frame send failed peer=%s", peer)
             return
+
+        # The desktop app and dashboard chat reach the agent through this WS
+        # sidecar, NOT through tui_gateway.entry.main() (the stdio TUI path that
+        # spawns the background MCP discovery thread). Without starting it here,
+        # discovery never runs in this process: _make_agent only *waits* on the
+        # thread (wait_for_mcp_discovery), which no-ops when it was never
+        # created, so the agent snapshots an MCP-less tool list and the only way
+        # to surface MCP tools is a manual /reload-mcp. Start it once per
+        # process here (idempotent and config-gated), but only after the ready
+        # frame is on the wire: cold imports/config reads can hold the GIL long
+        # enough for a Desktop client to give up before receiving that frame.
+        # This still runs before the receive loop processes the first request.
+        from hermes_cli.mcp_startup import start_background_mcp_discovery
+
+        start_background_mcp_discovery(
+            logger=_log,
+            thread_name="tui-ws-mcp-discovery",
+        )
 
         while True:
             try:


### PR DESCRIPTION
## What does this PR do?

Sends the WebSocket `gateway.ready` frame before starting MCP discovery. Cold MCP imports and config reads can stall the server event loop long enough for Hermes Desktop to abandon an accepted connection; discovery retains its existing process-wide, config-gated behavior and starts before the handler accepts a request.

## Related Issue

Fixes #71226

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tui_gateway/ws.py`: emit and validate `gateway.ready` before the cold MCP-discovery import and startup path.
- `tests/test_tui_gateway_ws.py`: assert the ready event is written before discovery begins.

## How to Test

1. Run `/opt/homebrew/bin/timeout -k 30 480 "$VIRTUAL_ENV/bin/python" -m pytest tests/test_tui_gateway_ws.py tests/tui_gateway/test_inline_rpc_gil_starvation.py -q --timeout=60`.
2. Confirm all 17 tests pass.
3. Run `$VIRTUAL_ENV/bin/ruff check tui_gateway/ws.py tests/test_tui_gateway_ws.py` and `$VIRTUAL_ENV/bin/python scripts/check-windows-footguns.py tui_gateway/ws.py tests/test_tui_gateway_ws.py`.

The broad test command was attempted twice. Both runs stopped at pre-existing ACP approval assertions in `tests/acp/test_approval_isolation.py` before this handler's coverage; the direct WebSocket suite above passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

<!-- autocontrib:worker-id=issue-new-d5d4408d kind=pr-open -->