### PR TITLE
feat(picker): model.picker hide + order config, applied on every picker surface

### DIFF
--- a/contributors/emails/Kyzcreig@users.noreply.github.com
+++ b/contributors/emails/Kyzcreig@users.noreply.github.com
@@ -1,0 +1,1 @@
+Kyzcreig

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -125,6 +125,7 @@ def build_models_payload(
     probe_custom_providers: bool = True,
     probe_current_custom_provider: bool = False,
     for_picker: bool = False,
+    apply_picker_prefs: bool = False,
     max_models: int | None = None,
 ) -> dict:
     """Build the ``{providers, model, provider}`` shape every consumer
@@ -174,6 +175,13 @@ def build_models_payload(
       list. Rate limits are per-model, so a different model under the same
       provider may still work; hiding the provider strands the user. Set for
       any surface a human is choosing from, not for programmatic resolution.
+    - ``apply_picker_prefs``: apply the user's ``model.picker`` config
+      (``hide`` + ``order``), exactly as the interactive CLI/Discord picker
+      (:func:`hermes_cli.model_switch.list_picker_providers`) already does. Off
+      by default so non-picker consumers see the full set; picker surfaces set
+      it True so every picker honors the same config. Purely cosmetic — typed
+      ``/model <slug>/...`` and every provider stay reachable, and the
+      currently-active provider is never hidden.
     """
     from hermes_cli.model_switch import list_authenticated_providers
 
@@ -258,6 +266,8 @@ def build_models_payload(
         _apply_picker_hints(rows)
     if canonical_order:
         rows = _reorder_canonical(rows)
+    if apply_picker_prefs:
+        rows = _apply_picker_prefs_rows(rows, current_provider=ctx.current_provider)
     if pricing:
         _apply_pricing(rows, force_fresh_nous_tier=force_fresh_nous_tier)
     if capabilities:
@@ -294,6 +304,7 @@ def build_model_options_payload(
         include_unconfigured=bool(include_unconfigured),
         picker_hints=True,
         canonical_order=True,
+        apply_picker_prefs=True,
         pricing=True,
         capabilities=True,
         refresh=refresh,
@@ -349,6 +360,7 @@ def build_aux_picker_rows(
     rows = build_models_payload(
         ctx,
         for_picker=True,
+        apply_picker_prefs=True,
         probe_custom_providers=False,
         probe_current_custom_provider=True,
         max_models=max_models,
@@ -578,6 +590,31 @@ def _raw_config_has_enabled_moa_preset() -> bool:
         "fanout",
     }
     return any(key in moa for key in legacy_keys) and bool(moa.get("enabled", True))
+
+
+def _apply_picker_prefs_rows(
+    rows: list[dict], *, current_provider: str = ""
+) -> list[dict]:
+    """Apply the ``model.picker`` prefs (hide + order) to payload rows.
+
+    Brings the desktop / TUI / dashboard ``build_models_payload`` pickers in
+    line with the CLI + Discord ``list_picker_providers`` picker. Delegates to
+    the same :func:`hermes_cli.model_switch._apply_picker_preferences` helper
+    that picker already uses, so the surfaces cannot drift apart. Cosmetic
+    only: the currently-active provider is never hidden, and typed
+    ``/model <slug>/...`` reaches every provider regardless. Best-effort — any
+    failure returns ``rows`` unchanged rather than breaking the picker.
+    """
+    try:
+        from hermes_cli.model_switch import _apply_picker_preferences
+    except Exception:
+        return rows
+    try:
+        return _apply_picker_preferences(
+            rows, current_provider=str(current_provider or "").strip().lower()
+        )
+    except Exception:
+        return rows
 
 
 def _apply_picker_hints(rows: list[dict]) -> None:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -20,6 +20,7 @@ OpenRouter variant suffixes (``:free``, ``:extended``, ``:fast``).
 
 from __future__ import annotations
 
+import fnmatch
 import logging
 import re
 from dataclasses import dataclass
@@ -2930,4 +2931,98 @@ def list_picker_providers(
             continue
         filtered.append(p)
 
-    return filtered
+    return _apply_picker_preferences(
+        filtered, current_provider=str(current_provider or "").strip().lower()
+    )
+
+
+def _apply_picker_preferences(
+    rows: List[dict], *, current_provider: str = ""
+) -> List[dict]:
+    """Apply the user's ``model.picker`` config (hide + order) to picker rows.
+
+    Two optional, purely-cosmetic config knobs let a user tailor the
+    interactive ``/model`` dropdown without changing which providers are
+    *usable* — typed ``/model <slug>/...`` and every provider stay reachable
+    regardless::
+
+        model:
+          picker:
+            hide:  [openai-api, "claude-apx-*"]   # slugs/globs to drop
+            order: [anthropic, openai-codex]      # front-anchored order
+
+    - ``hide``: drop matching provider rows (by slug, case-insensitive). An
+      entry may be an exact slug (``openai-api``) or a glob pattern
+      (``claude-apx-*``, ``*-preview``) — a glob collapses a whole noisy
+      provider family (e.g. numbered auto-failover lanes) into one config
+      line. The **currently-active** provider is NEVER hidden: you must
+      always be able to see and switch off whatever you are on. Unknown
+      slugs / non-matching patterns are ignored.
+    - ``order``: rows whose slug appears here move to the front in the given
+      order; every other row keeps its original relative order after them.
+      Unknown slugs in ``order`` are ignored. Rows not listed are NOT hidden
+      — ordering and hiding are independent knobs.
+
+    Missing or malformed config is a no-op (returns ``rows`` unchanged); this
+    never raises into the picker path.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        picker_cfg = (load_config().get("model") or {}).get("picker") or {}
+    except Exception:
+        return rows
+    if not isinstance(picker_cfg, dict):
+        return rows
+
+    _cur = str(current_provider or "").strip().lower()
+
+    hide = picker_cfg.get("hide") or []
+    if isinstance(hide, (list, tuple)):
+        # Two kinds of hide entry: an exact slug ("openai-api") or a glob
+        # pattern ("claude-apx-*"). Globs let a user collapse a whole noisy
+        # provider family into one config line instead of listing each slug.
+        # An entry is a pattern iff it contains a glob metacharacter;
+        # everything else stays an exact case-insensitive match.
+        exact: set[str] = set()
+        patterns: list[str] = []
+        for s in hide:
+            token = str(s).strip().lower()
+            if not token:
+                continue
+            if any(ch in token for ch in "*?["):
+                patterns.append(token)
+            else:
+                exact.add(token)
+        if exact or patterns:
+
+            def _is_hidden(slug: str) -> bool:
+                if slug in exact:
+                    return True
+                return any(fnmatch.fnmatchcase(slug, pat) for pat in patterns)
+
+            rows = [
+                r
+                for r in rows
+                if not _is_hidden(str(r.get("slug", "")).strip().lower())
+                # never hide the provider you are currently on
+                or str(r.get("slug", "")).strip().lower() == _cur
+            ]
+
+    order = picker_cfg.get("order") or []
+    if isinstance(order, (list, tuple)) and order:
+        rank = {
+            str(s).strip().lower(): i for i, s in enumerate(order) if str(s).strip()
+        }
+        # Stable sort: listed slugs by rank (front), unlisted keep their
+        # original order after them. The fallback sentinel is len(order)+1 —
+        # strictly greater than any real rank index (which is < len(order))
+        # even when `order` contains blank entries filtered out of `rank`.
+        rows = sorted(
+            rows,
+            key=lambda r: rank.get(
+                str(r.get("slug", "")).strip().lower(), len(order) + 1
+            ),
+        )
+
+    return rows

--- a/tests/hermes_cli/test_model_picker_prefs.py
+++ b/tests/hermes_cli/test_model_picker_prefs.py
@@ -1,0 +1,208 @@
+"""Tests for ``model.picker`` hide + order preferences.
+
+The interactive ``/model`` picker honors two optional, purely-cosmetic config
+knobs::
+
+    model:
+      picker:
+        hide:  [openai-api, "claude-apx-*"]
+        order: [anthropic, openai-codex]
+
+These tests pin the behavior contract rather than any current provider list:
+
+- hide drops matching rows (exact slug *or* glob), except the active provider
+- order front-anchors listed slugs and leaves everything else stably behind
+- hide and order are independent (an unlisted row is not hidden by `order`)
+- malformed / missing config is always a no-op, never an exception
+- every picker surface applies the same prefs (CLI/Discord and payload pickers
+  share one helper, so they cannot drift)
+"""
+
+import pytest
+
+from hermes_cli import inventory
+from hermes_cli import model_switch
+from hermes_cli.model_switch import _apply_picker_preferences
+
+
+def _row(slug, models=("m1",)):
+    return {"slug": slug, "models": list(models), "total_models": len(models)}
+
+
+def _slugs(rows):
+    return [r["slug"] for r in rows]
+
+
+@pytest.fixture
+def cfg(monkeypatch):
+    """Install a config dict that `_apply_picker_preferences` will read."""
+
+    def _install(picker):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"picker": picker}},
+        )
+
+    return _install
+
+
+# ─── hide: exact slugs ──────────────────────────────────────────────────
+
+
+def test_hide_drops_exact_slug(cfg):
+    cfg({"hide": ["openai-api"]})
+    rows = [_row("anthropic"), _row("openai-api"), _row("openrouter")]
+    assert _slugs(_apply_picker_preferences(rows)) == ["anthropic", "openrouter"]
+
+
+def test_hide_is_case_insensitive(cfg):
+    cfg({"hide": ["OpenAI-API"]})
+    rows = [_row("anthropic"), _row("openai-api")]
+    assert _slugs(_apply_picker_preferences(rows)) == ["anthropic"]
+
+
+def test_hide_never_drops_the_current_provider(cfg):
+    """You must always be able to see and switch off what you're on."""
+    cfg({"hide": ["openai-api"]})
+    rows = [_row("anthropic"), _row("openai-api")]
+    out = _apply_picker_preferences(rows, current_provider="openai-api")
+    assert _slugs(out) == ["anthropic", "openai-api"]
+
+
+def test_hide_ignores_unknown_slugs(cfg):
+    cfg({"hide": ["not-a-real-provider"]})
+    rows = [_row("anthropic"), _row("openrouter")]
+    assert _slugs(_apply_picker_preferences(rows)) == ["anthropic", "openrouter"]
+
+
+# ─── hide: glob patterns ────────────────────────────────────────────────
+
+
+def test_hide_glob_collapses_a_provider_family(cfg):
+    """One glob line replaces listing every numbered failover lane."""
+    cfg({"hide": ["claude-apx-*"]})
+    rows = [
+        _row("openrouter"),
+        _row("claude-apx-0"),
+        _row("claude-apx-1"),
+        _row("claude-apx-10"),
+        _row("claude-apr"),  # not a *-N lane, must be kept
+    ]
+    assert _slugs(_apply_picker_preferences(rows)) == ["openrouter", "claude-apr"]
+
+
+def test_hide_glob_and_exact_entries_coexist(cfg):
+    cfg({"hide": ["claude-apx-*", "openai-api"]})
+    rows = [_row("claude-apx-0"), _row("openai-api"), _row("anthropic")]
+    assert _slugs(_apply_picker_preferences(rows)) == ["anthropic"]
+
+
+def test_hide_glob_still_spares_the_current_provider(cfg):
+    cfg({"hide": ["claude-apx-*"]})
+    rows = [_row("claude-apx-0"), _row("claude-apx-1"), _row("anthropic")]
+    out = _apply_picker_preferences(rows, current_provider="claude-apx-1")
+    assert _slugs(out) == ["claude-apx-1", "anthropic"]
+
+
+def test_hide_suffix_glob(cfg):
+    cfg({"hide": ["*-preview"]})
+    rows = [_row("gemini-preview"), _row("gemini"), _row("anthropic")]
+    assert _slugs(_apply_picker_preferences(rows)) == ["gemini", "anthropic"]
+
+
+# ─── order ──────────────────────────────────────────────────────────────
+
+
+def test_order_front_anchors_listed_slugs(cfg):
+    cfg({"order": ["openrouter", "anthropic"]})
+    rows = [_row("anthropic"), _row("openai-api"), _row("openrouter")]
+    assert _slugs(_apply_picker_preferences(rows)) == [
+        "openrouter",
+        "anthropic",
+        "openai-api",
+    ]
+
+
+def test_order_keeps_unlisted_rows_in_original_relative_order(cfg):
+    cfg({"order": ["zzz"]})
+    rows = [_row("a"), _row("b"), _row("c")]
+    assert _slugs(_apply_picker_preferences(rows)) == ["a", "b", "c"]
+
+
+def test_order_does_not_hide_unlisted_rows(cfg):
+    """Ordering and hiding are independent knobs."""
+    cfg({"order": ["anthropic"]})
+    rows = [_row("openai-api"), _row("anthropic")]
+    assert set(_slugs(_apply_picker_preferences(rows))) == {"openai-api", "anthropic"}
+
+
+def test_order_ignores_blank_entries_without_collision(cfg):
+    """A blank entry must not collide with a real rank and reshuffle rows."""
+    cfg({"order": ["", "anthropic", "  "]})
+    rows = [_row("openai-api"), _row("anthropic"), _row("openrouter")]
+    assert _slugs(_apply_picker_preferences(rows))[0] == "anthropic"
+
+
+def test_hide_and_order_compose(cfg):
+    cfg({"hide": ["openai-api"], "order": ["openrouter"]})
+    rows = [_row("anthropic"), _row("openai-api"), _row("openrouter")]
+    assert _slugs(_apply_picker_preferences(rows)) == ["openrouter", "anthropic"]
+
+
+# ─── robustness: never raise into the picker path ───────────────────────
+
+
+@pytest.mark.parametrize(
+    "picker",
+    [
+        {},
+        {"hide": None},
+        {"hide": "not-a-list"},
+        {"order": "not-a-list"},
+        {"hide": [None, ""]},
+        "not-a-dict",
+    ],
+)
+def test_malformed_config_is_a_noop(cfg, picker):
+    cfg(picker)
+    rows = [_row("a"), _row("b")]
+    assert _slugs(_apply_picker_preferences(rows)) == ["a", "b"]
+
+
+def test_config_load_failure_is_a_noop(monkeypatch):
+    def _boom():
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _boom)
+    rows = [_row("a"), _row("b")]
+    assert _slugs(_apply_picker_preferences(rows)) == ["a", "b"]
+
+
+# ─── surface parity: payload pickers apply the same prefs ───────────────
+
+
+def test_payload_helper_delegates_to_the_shared_picker_helper(cfg):
+    """`inventory` must not grow a second, drift-prone implementation."""
+    cfg({"hide": ["openai-api"], "order": ["openrouter"]})
+    rows = [_row("anthropic"), _row("openai-api"), _row("openrouter")]
+    assert inventory._apply_picker_prefs_rows(rows) == _apply_picker_preferences(rows)
+
+
+def test_payload_helper_survives_a_broken_shared_helper(monkeypatch):
+    """Best-effort: a failure in the shared helper must not break the picker."""
+
+    def _boom(*a, **kw):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(model_switch, "_apply_picker_preferences", _boom)
+    rows = [_row("a"), _row("b")]
+    assert _slugs(inventory._apply_picker_prefs_rows(rows)) == ["a", "b"]
+
+
+def test_build_models_payload_exposes_the_pref_switch():
+    """The knob exists and defaults OFF for non-picker consumers."""
+    import inspect
+
+    sig = inspect.signature(inventory.build_models_payload)
+    assert "apply_picker_prefs" in sig.parameters
+    assert sig.parameters["apply_picker_prefs"].default is False

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -161,6 +161,24 @@ When `fallback_chain` is absent, `auto` uses the top-level `fallback_providers` 
 
 Changes never invalidate prompt caches on running sessions. That's deliberate: swapping the main model inside a session requires a cache reset (the system prompt contains model-specific content), and we reserve that for the explicit `/model` slash command inside chat.
 
+## Tidying the model picker (`model.picker`)
+
+If you have a lot of authenticated providers, the `/model` picker can get noisy — numbered auto-failover lanes are a common offender. Two optional keys let you tailor the dropdown:
+
+```yaml
+model:
+  picker:
+    hide:  [openai-api, "claude-apx-*"]     # drop from the dropdown
+    order: [anthropic, openai-codex]        # pin to the front
+```
+
+- **`hide`** takes exact slugs (`openai-api`) or glob patterns (`claude-apx-*`, `*-preview`), so one line can collapse a whole provider family. Matching is case-insensitive; unknown slugs are ignored.
+- **`order`** front-anchors the slugs you list, in the order you list them. Everything else keeps its existing relative order behind them. Listing a provider in `order` does **not** hide the others — the two knobs are independent.
+
+Both are **purely cosmetic**. Hiding a provider does not disable it: typed `/model <slug>/<model>` still reaches it, and it remains available to the resolver and to auxiliary tasks. The provider you are **currently on is never hidden**, so you can always see and switch off it.
+
+These prefs apply to every picker surface — the CLI and Discord `/model` pickers, and the desktop / TUI / dashboard model dialogs.
+
 ## Troubleshooting
 
 ### "No authenticated providers" in the picker


### PR DESCRIPTION
Adds two optional, purely-cosmetic config knobs for tidying the `/model` picker when a lot of providers are authenticated:

```yaml
model:
  picker:
    hide:  [openai-api, "claude-apx-*"]     # drop from the dropdown
    order: [anthropic, openai-codex]        # pin to the front
```

- **`hide`** takes exact slugs or **glob patterns**. A glob collapses a whole noisy provider family — numbered auto-failover lanes (`claude-apx-0`, `-1`, `-10`, …) are the motivating case — into one config line instead of enumerating each slug. Case-insensitive; unknown slugs and non-matching patterns are ignored.
- **`order`** front-anchors the slugs you list, in the order listed. Everything else keeps its original relative order behind them. Independent of `hide` — listing some providers in `order` does not hide the rest.

## Nothing becomes unusable

Both knobs are cosmetic. Hiding a provider does **not** disable it:

- typed `/model <slug>/<model>` still reaches every provider
- the runtime resolver and auxiliary tasks are untouched
- **the currently-active provider is never hidden** — you must always be able to see and switch off whatever you are on

Malformed or missing config is a no-op, and the helper never raises into the picker path.

## Applied on *every* picker surface

This is the part the superseded PRs got wrong. `list_picker_providers` (CLI + Discord) applies the prefs directly. `build_models_payload` gains an `apply_picker_prefs` flag — **off by default**, so programmatic consumers still see the full provider set — which the desktop / TUI / dashboard picker entry points set to `True`.

Both routes delegate to the same `_apply_picker_preferences` helper, so the surfaces cannot drift apart.

## Supersedes #64324 + #64325

Those two were stacked (base feature, then globs) and are ~3,247 commits behind with hard conflicts — `list_picker_providers` and `build_models_payload` have both moved substantially, so a rebase would be a re-authoring rather than a replay. This lands them as one coherent change and fixes what they were missing:

- the every-surface wiring (their reviews flagged that the picker feature never reached the payload-based pickers)
- `fnmatch` imported at module scope instead of inside the filter loop
- user-facing documentation for the two keys
- one test file covering both halves instead of two overlapping ones

## Verification

RED-proven before writing the fix — on current `main` the feature is absent entirely:

```
build_models_payload params: [... 'for_picker', 'max_models']
apply_picker_prefs present: False
_apply_picker_preferences in model_switch: False
```

and with the implementation reverted the new suite fails at collection (`ImportError: cannot import name '_apply_picker_preferences'`).

Green with the fix, including the two pre-existing picker suites (no regressions):

```
tests/hermes_cli/test_model_picker_prefs.py
tests/hermes_cli/test_inventory.py
tests/hermes_cli/test_list_picker_providers.py
80 passed
```

Tests assert behavior contracts (hide-except-current, glob-collapses-family, order-is-independent-of-hide, malformed-config-is-a-noop, both-surfaces-agree) rather than freezing any current provider list.

## One unrelated file

`contributors/emails/Kyzcreig@users.noreply.github.com` — the attribution gate auto-resolves the canonical `<id>+<login>@users.noreply.github.com` form but not the bare-handle variant that older branches were authored under. Additive and conflict-free; happy to split it out if you would rather.
