### PR TITLE
Show configured overlay models in the desktop picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2202,6 +2202,16 @@ def list_authenticated_providers(
                 model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
                 if hermes_slug in _MODELS_DEV_PREFERRED:
                     model_ids = _merge_with_models_dev(hermes_slug, model_ids)
+        # A providers.<overlay>.models block extends the configured overlay
+        # provider just as it does built-in provider rows above. Without this,
+        # explicitly configured Azure Foundry deployments are valid at runtime
+        # but invisible in Desktop's model picker.
+        configured_models: list[str] = []
+        if isinstance(user_providers, dict):
+            configured = user_providers.get(hermes_slug) or user_providers.get(pid)
+            if isinstance(configured, dict):
+                configured_models = _declared_model_ids(configured.get("models"))
+        model_ids = list(dict.fromkeys([*configured_models, *model_ids]))
         total = len(model_ids)
         if hermes_slug in _UNCAPPED_PICKER_PROVIDERS:
             top = model_ids  # Aggregator: show full catalog regardless of max_models

--- a/tests/hermes_cli/test_configured_overlay_models.py
+++ b/tests/hermes_cli/test_configured_overlay_models.py
@@ -1,0 +1,37 @@
+"""Configured models extend overlay picker rows."""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+def test_azure_foundry_overlay_merges_configured_models_before_picker_limit():
+    from hermes_cli.providers import HERMES_OVERLAYS
+
+    azure_foundry = HERMES_OVERLAYS["azure-foundry"]
+    with (
+        patch("agent.models_dev.fetch_models_dev", return_value={}),
+        patch("agent.models_dev.PROVIDER_TO_MODELS_DEV", {}),
+        patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=["live-a", "shared"],
+        ),
+        patch(
+            "hermes_cli.providers.HERMES_OVERLAYS",
+            {"azure-foundry": azure_foundry},
+        ),
+        patch.dict("os.environ", {"AZURE_FOUNDRY_API_KEY": "test-key"}),
+    ):
+        rows = list_authenticated_providers(
+            current_provider="azure-foundry",
+            user_providers={
+                "azure-foundry": {"models": ["configured-x", "shared"]},
+            },
+            max_models=2,
+        )
+
+    row = next(row for row in rows if row["slug"] == "azure-foundry")
+
+    assert row["source"] == "hermes"
+    assert row["models"] == ["configured-x", "shared"]
+    assert row["total_models"] == 3


### PR DESCRIPTION
## Summary
- Include `providers.<overlay>.models` declarations in Hermes overlay provider inventories.
- This makes Azure Foundry deployment IDs configured through the provider settings visible in the official Desktop model picker without relying on aliases.
- Add regression coverage proving configured Azure Foundry IDs are ordered before picker truncation and deduplicated against discovered IDs.

## Validation
- Picker payload with the configured Azure Foundry deployments included `gpt-5.6-sol` and `gpt-5.6-luna`.
- `scripts/run_tests.sh tests/hermes_cli/test_configured_overlay_models.py tests/hermes_cli/test_configured_builtin_models.py tests/hermes_cli/test_model_switch_configured_provider_routing.py tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_list_picker_providers.py -q` — 63 passed.
- Merge simulation against current `origin/main` — 19 focused tests passed.
- `py_compile hermes_cli/model_switch.py` and `git diff --check` passed.
