### PR TITLE
fix(slack): add reactions:write scope to generated app manifest (#71827)

### DIFF
--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -92,6 +92,7 @@ def _build_full_manifest(
         "mpim:history",
         "mpim:read",
         "reactions:read",
+        "reactions:write",
         "users:read",
     ]
 


### PR DESCRIPTION
## Summary
Fixes #71827.

The Slack app manifest generated by `hermes slack manifest` included `reactions:read` (for inbound `reaction_added`/`reaction_removed` events) but not `reactions:write` (for outbound `reactions.add`/`reactions.remove`). Processing-status reactions (👀/✅/❌) silently failed with `missing_scope` logged only at DEBUG level.

## Changes
- `hermes_cli/slack_cli.py`: Added `reactions:write` to `bot_scopes` list

## Testing
- `py_compile` passes
- `reactions:write` now appears alongside `reactions:read` in the manifest scopes
