### PR TITLE
feat(delegation): opt-in persistent sub-agent soul injection

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1215,6 +1215,14 @@ delegation:
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
+  # persistent_agent: false                   # Prepend a persistent "soul" contract to EVERY delegated child's
+  #                                           # system prompt (default: false = upstream behavior, no injection).
+  #                                           # Use for a mechanical/tool-executor sub-engine that must always obey
+  #                                           # a fixed output-format contract, or a house style guide.
+  # persistent_agent_soul_path: ""            # Path to the soul file when persistent_agent=true. Resolution order:
+  #                                           # this key > HERMES_SUB_ENGINE_SOUL_PATH env >
+  #                                           # <hermes_home>/profiles/sub-engine/SUB_ENGINE_SOUL.md (default).
+  #                                           # Missing/unreadable/empty file degrades gracefully (logs a warning).
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/tests/tools/test_delegate_sub_engine_soul.py
+++ b/tests/tools/test_delegate_sub_engine_soul.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Tests for the opt-in persistent sub-agent soul injection.
+
+Covers the ``delegation.persistent_agent`` feature: when enabled, a soul
+contract read from disk (config path > HERMES_SUB_ENGINE_SOUL_PATH env >
+<hermes_home>/profiles/sub-engine/SUB_ENGINE_SOUL.md) is prepended to every
+delegated child's system prompt. When disabled (the default) behavior is
+identical to upstream. The loader degrades gracefully when the file is absent,
+empty, or unreadable.
+
+Run with:  python -m pytest tests/tools/test_delegate_sub_engine_soul.py -v
+"""
+
+import logging
+import os
+
+import pytest
+
+from hermes_constants import get_hermes_home
+from tools.delegate_tool import (
+    _build_child_system_prompt,
+    _load_sub_engine_soul,
+    _persistent_agent_config,
+    _resolve_sub_engine_soul_path,
+    _SUB_ENGINE_SOUL_RELPATH,
+)
+
+CONTRACT = (
+    "# SUB_ENGINE_SOUL.md — mechanical sub-engine contract\n"
+    "Every response is a <tool_execution>, <skill_execution_report>, or "
+    "<mechanical_block> and nothing else."
+)
+
+
+@pytest.fixture
+def soul_file(tmp_path, monkeypatch):
+    """Write a contract file and point the env override at it."""
+    path = tmp_path / "profiles" / "sub-engine" / "SUB_ENGINE_SOUL.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(CONTRACT, encoding="utf-8")
+    monkeypatch.setenv("HERMES_SUB_ENGINE_SOUL_PATH", str(path))
+    return path
+
+
+# ── path resolution ─────────────────────────────────────────────────────────
+
+def test_resolve_default_path_uses_hermes_home(monkeypatch, tmp_path):
+    monkeypatch.delenv("HERMES_SUB_ENGINE_SOUL_PATH", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    resolved = _resolve_sub_engine_soul_path()
+    assert "~" not in resolved
+    assert resolved == str(get_hermes_home().joinpath(*_SUB_ENGINE_SOUL_RELPATH))
+    assert resolved.endswith("profiles/sub-engine/SUB_ENGINE_SOUL.md")
+
+
+def test_resolve_env_override(tmp_path, monkeypatch):
+    target = tmp_path / "custom.md"
+    monkeypatch.setenv("HERMES_SUB_ENGINE_SOUL_PATH", str(target))
+    assert _resolve_sub_engine_soul_path() == str(target)
+
+
+def test_resolve_explicit_config_path_wins_over_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_SUB_ENGINE_SOUL_PATH", str(tmp_path / "env.md"))
+    explicit = tmp_path / "from-config.md"
+    assert _resolve_sub_engine_soul_path(str(explicit)) == str(explicit)
+
+
+# ── loader ──────────────────────────────────────────────────────────────────
+
+def test_load_returns_stripped_contents(soul_file):
+    assert _load_sub_engine_soul() == CONTRACT
+    soul_file.write_text(CONTRACT + "\n\n", encoding="utf-8")
+    assert _load_sub_engine_soul() == CONTRACT
+
+
+def test_load_missing_file_returns_none_and_warns(tmp_path, monkeypatch, caplog):
+    missing = tmp_path / "nope" / "SUB_ENGINE_SOUL.md"
+    monkeypatch.setenv("HERMES_SUB_ENGINE_SOUL_PATH", str(missing))
+    with caplog.at_level(logging.WARNING, logger="tools.delegate_tool"):
+        assert _load_sub_engine_soul() is None
+    assert any("not found" in r.message for r in caplog.records)
+
+
+def test_load_empty_file_returns_none_and_warns(soul_file, caplog):
+    soul_file.write_text("   \n\t\n", encoding="utf-8")
+    with caplog.at_level(logging.WARNING, logger="tools.delegate_tool"):
+        assert _load_sub_engine_soul() is None
+    assert any("empty" in r.message for r in caplog.records)
+
+
+def test_load_unreadable_path_returns_none_and_warns(tmp_path, monkeypatch, caplog):
+    as_dir = tmp_path / "SUB_ENGINE_SOUL.md"
+    as_dir.mkdir()  # a directory at the path → OSError on open()
+    monkeypatch.setenv("HERMES_SUB_ENGINE_SOUL_PATH", str(as_dir))
+    with caplog.at_level(logging.WARNING, logger="tools.delegate_tool"):
+        assert _load_sub_engine_soul() is None
+    assert any(
+        ("could not read" in r.message.lower()) or ("unexpected error" in r.message.lower())
+        for r in caplog.records
+    )
+
+
+# ── the feature gate in _build_child_system_prompt ──────────────────────────
+
+def test_disabled_by_default_no_injection_even_when_file_present(soul_file):
+    # Default persistent_agent=False → upstream behavior, contract NOT injected.
+    prompt = _build_child_system_prompt("Resolve a d20 attack", context="AC 15")
+    assert CONTRACT not in prompt
+    assert prompt.startswith("You are a focused subagent")
+    assert "YOUR TASK:\nResolve a d20 attack" in prompt
+
+
+def test_enabled_prepends_contract(soul_file):
+    prompt = _build_child_system_prompt(
+        "Resolve a d20 attack", context="AC 15", persistent_agent=True
+    )
+    assert prompt.startswith(CONTRACT)
+    assert "You are a focused subagent" in prompt
+    assert "YOUR TASK:\nResolve a d20 attack" in prompt
+    assert "CONTEXT:\nAC 15" in prompt
+    assert prompt.index(CONTRACT) < prompt.index("YOUR TASK:")
+
+
+def test_enabled_but_missing_file_falls_back(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_SUB_ENGINE_SOUL_PATH", str(tmp_path / "absent.md"))
+    prompt = _build_child_system_prompt("Do a thing", persistent_agent=True)
+    assert CONTRACT not in prompt
+    assert prompt.startswith("You are a focused subagent")
+    assert "YOUR TASK:\nDo a thing" in prompt
+
+
+def test_enabled_with_explicit_path_arg(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_SUB_ENGINE_SOUL_PATH", raising=False)
+    p = tmp_path / "one-off.md"
+    p.write_text(CONTRACT, encoding="utf-8")
+    prompt = _build_child_system_prompt(
+        "Task", persistent_agent=True, sub_engine_soul_path=str(p)
+    )
+    assert prompt.startswith(CONTRACT)
+
+
+def test_enabled_orchestrator_role(soul_file):
+    prompt = _build_child_system_prompt(
+        "Coordinate research",
+        role="orchestrator",
+        child_depth=1,
+        max_spawn_depth=2,
+        persistent_agent=True,
+    )
+    assert prompt.startswith(CONTRACT)
+    assert "Subagent Spawning (Orchestrator Role)" in prompt
+
+
+# ── config read (_persistent_agent_config) ──────────────────────────────────
+
+def test_config_off_by_default(monkeypatch):
+    monkeypatch.setattr("tools.delegate_tool._load_config", lambda: {})
+    assert _persistent_agent_config() == (False, None)
+
+
+def test_config_enabled_with_path(monkeypatch):
+    monkeypatch.setattr(
+        "tools.delegate_tool._load_config",
+        lambda: {"persistent_agent": True, "persistent_agent_soul_path": "/x/soul.md"},
+    )
+    assert _persistent_agent_config() == (True, "/x/soul.md")
+
+
+def test_config_truthy_string_enables(monkeypatch):
+    monkeypatch.setattr(
+        "tools.delegate_tool._load_config", lambda: {"persistent_agent": "true"}
+    )
+    enabled, path = _persistent_agent_config()
+    assert enabled is True and path is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -55,6 +55,113 @@ DELEGATE_BLOCKED_TOOLS = frozenset(
 
 
 # ---------------------------------------------------------------------------
+# Persistent sub-agent soul injection (opt-in)
+# ---------------------------------------------------------------------------
+# By default a delegated child's system prompt is built fresh per task (see
+# _build_child_system_prompt) and Hermes does NOT load a persistent SOUL file
+# for children the way it loads <hermes_home>/SOUL.md for the main agent. Some
+# deployments want a *fixed* contract prepended to every delegated child — e.g.
+# a strict output-format spec for a mechanical/tool-executor sub-engine, or a
+# house style guide. The ``delegation.persistent_agent`` switch (bool, default
+# False) enables that: when true, the contents of a soul file are prepended to
+# every child's system prompt.
+#
+# This is strictly opt-in and non-breaking: with the switch off (the default),
+# behavior is byte-identical to upstream.
+#
+# Soul-file path resolution (highest priority first):
+#   1. delegation.persistent_agent_soul_path   (config)
+#   2. HERMES_SUB_ENGINE_SOUL_PATH             (env)
+#   3. <hermes_home>/profiles/sub-engine/SUB_ENGINE_SOUL.md   (default)
+_SUB_ENGINE_SOUL_RELPATH = ("profiles", "sub-engine", "SUB_ENGINE_SOUL.md")
+
+
+def _resolve_sub_engine_soul_path(explicit: Optional[str] = None) -> str:
+    """Resolve the persistent sub-agent soul path.
+
+    Resolved fresh on every call (not cached at import) so a changed
+    config/env/HERMES_HOME, or a live edit, takes effect without a process
+    restart. ``~`` and env vars in the path are expanded. Priority: ``explicit``
+    (config) > ``HERMES_SUB_ENGINE_SOUL_PATH`` env >
+    ``<hermes_home>/profiles/sub-engine/SUB_ENGINE_SOUL.md``. Using
+    get_hermes_home() (not a hardcoded ~/.hermes) keeps this correct under
+    HERMES_HOME isolation and profile overrides.
+    """
+    if explicit is not None and str(explicit).strip():
+        return os.path.expanduser(os.path.expandvars(str(explicit)))
+    env_override = os.environ.get("HERMES_SUB_ENGINE_SOUL_PATH")
+    if env_override:
+        return os.path.expanduser(os.path.expandvars(env_override))
+    # Local import mirrors the deferred-import pattern used elsewhere in this
+    # module for hermes_constants, avoiding any import-time cost/cycle.
+    from hermes_constants import get_hermes_home
+
+    return str(get_hermes_home().joinpath(*_SUB_ENGINE_SOUL_RELPATH))
+
+
+def _load_sub_engine_soul(path: Optional[str] = None) -> Optional[str]:
+    """Read the persistent sub-agent soul contract from disk.
+
+    Returns the file's text (stripped) so the caller can prepend it to a
+    delegated child's system prompt. On any failure — missing file, permission
+    or decode error, or an empty file — logs a warning and returns ``None`` so
+    the caller falls back to the standard dynamically-built prompt. Never
+    raises: a broken/absent soul must degrade to normal delegation, not take
+    down the delegate_task call.
+    """
+    resolved = _resolve_sub_engine_soul_path(path)
+    try:
+        with open(resolved, "r", encoding="utf-8") as fh:
+            text = fh.read().strip()
+    except FileNotFoundError:
+        logger.warning(
+            "Persistent sub-agent soul file not found at %s; delegated child "
+            "will use the standard dynamic prompt only.",
+            resolved,
+        )
+        return None
+    except OSError as exc:
+        logger.warning(
+            "Could not read persistent sub-agent soul file at %s (%s); "
+            "delegated child will use the standard dynamic prompt only.",
+            resolved,
+            exc,
+        )
+        return None
+    except Exception as exc:  # defensive: decode errors, etc.
+        logger.warning(
+            "Unexpected error reading persistent sub-agent soul file at %s "
+            "(%s); delegated child will use the standard dynamic prompt only.",
+            resolved,
+            exc,
+        )
+        return None
+
+    if not text:
+        logger.warning(
+            "Persistent sub-agent soul file at %s is empty; delegated child "
+            "will use the standard dynamic prompt only.",
+            resolved,
+        )
+        return None
+    return text
+
+
+def _persistent_agent_config() -> tuple:
+    """Return ``(enabled, soul_path_override)`` for the persistent-agent feature.
+
+    Reads ``delegation.persistent_agent`` (bool, default False) and the optional
+    ``delegation.persistent_agent_soul_path`` via the same ``_load_config()``
+    path as the rest of delegate_task. Off by default so upstream behavior is
+    preserved.
+    """
+    cfg = _load_config()
+    enabled = is_truthy_value(cfg.get("persistent_agent", False))
+    path = cfg.get("persistent_agent_soul_path") or None
+    return enabled, path
+
+
+# ---------------------------------------------------------------------------
 # Subagent approval callbacks
 # ---------------------------------------------------------------------------
 # Subagents run inside a ThreadPoolExecutor worker. The CLI's interactive
@@ -666,6 +773,8 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    persistent_agent: bool = False,
+    sub_engine_soul_path: Optional[str] = None,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -674,12 +783,31 @@ def _build_child_system_prompt(
     inspiration/openclaw/src/agents/subagent-system-prompt.ts:63-95).
     The depth note is literal truth (grounded in the passed config) so
     the LLM doesn't confabulate nesting capabilities that don't exist.
+
+    When ``persistent_agent`` is True (from ``delegation.persistent_agent``),
+    the contents of the persistent sub-agent soul file
+    (``sub_engine_soul_path`` → env → default) are prepended ahead of the
+    per-task framing. Off by default → identical to upstream; a missing or
+    unreadable soul file degrades gracefully to the standard prompt.
     """
-    parts = [
-        "You are a focused subagent working on a specific delegated task.",
-        "",
-        f"YOUR TASK:\n{goal}",
-    ]
+    parts = []
+    # Opt-in: prepend the persistent sub-agent soul contract ahead of the
+    # per-task framing so it governs every delegated child. Off by default
+    # (persistent_agent=False) → byte-identical to upstream. A missing/
+    # unreadable file makes _load_sub_engine_soul return None (warning already
+    # logged), so we fall through to the standard prompt below.
+    if persistent_agent:
+        soul = _load_sub_engine_soul(sub_engine_soul_path)
+        if soul:
+            parts.append(soul)
+            parts.append("\n---\n")
+    parts.extend(
+        [
+            "You are a focused subagent working on a specific delegated task.",
+            "",
+            f"YOUR TASK:\n{goal}",
+        ]
+    )
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
     if workspace_path and str(workspace_path).strip():
@@ -1188,6 +1316,10 @@ def _build_child_agent(
         child_toolsets.append("delegation")
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
+    # Opt-in persistent sub-agent soul (delegation.persistent_agent, default
+    # off). Resolved here from config and passed in so _build_child_system_prompt
+    # stays a pure function.
+    persistent_agent_enabled, persistent_agent_soul_path = _persistent_agent_config()
     child_prompt = _build_child_system_prompt(
         goal,
         context,
@@ -1195,6 +1327,8 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        persistent_agent=persistent_agent_enabled,
+        sub_engine_soul_path=persistent_agent_soul_path,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)


### PR DESCRIPTION
Add `delegation.persistent_agent` (bool, default false). When enabled, the contents of a soul file are prepended to every delegated child's system prompt, giving sub-agents a persistent contract — e.g. a strict output-format spec for a mechanical/tool-executor sub-engine, or a house style guide — instead of the per-task-only prompt.

Hermes delegation children (spawned by delegate_task) build their system prompt fresh per task and never load a persistent SOUL file the way the main agent loads <hermes_home>/SOUL.md. This adds that capability behind a switch, so it is strictly opt-in: with the flag off (the default) behavior is byte-identical to upstream.

Soul-file path resolution (highest priority first):
  1. delegation.persistent_agent_soul_path  (config)
  2. HERMES_SUB_ENGINE_SOUL_PATH            (env)
  3. <hermes_home>/profiles/sub-engine/SUB_ENGINE_SOUL.md  (default)
Missing/empty/unreadable files degrade gracefully (log a warning and fall
back to the standard prompt); the loader never raises, so a broken soul can
never take down a delegate_task call.

Changes:
- tools/delegate_tool.py: add _resolve_sub_engine_soul_path, _load_sub_engine_soul, _persistent_agent_config; add persistent_agent / sub_engine_soul_path params + gated injection to _build_child_system_prompt (kept pure); resolve the flag from config in _build_child_agent.
- cli-config.yaml.example: document persistent_agent + persistent_agent_soul_path.
- tests/tools/test_delegate_sub_engine_soul.py: 16 tests — gate on/off, path precedence, graceful fallback, config read.


Claude-Session: https://claude.ai/code/session_01RvnVaQMoDHEguqE4rQ5exQ

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

