### PR TITLE
fix(mcp): reap orphaned parked server task in _connect_server

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -4562,3 +4562,113 @@ class TestMcpParallelToolCalls:
             register_mcp_servers(config_off)
         with _lock:
             assert sanitize_mcp_name_component("toggle_srv") not in _parallel_safe_servers
+
+
+class TestConnectServerOrphanReaping:
+    """_connect_server() must not leak an orphaned MCPServerTask when
+    server.start() raises after the task has already parked.
+
+    Root cause: start() spawns self._task = ensure_future(self.run(config)),
+    then awaits self._ready.wait(). When the initial connection fails
+    _MAX_INITIAL_CONNECT_RETRIES times (or hits certain auth/URL-validation
+    failures), run() sets self._error and self._ready, then PARKS in
+    _wait_for_reconnect_or_shutdown() to self-probe periodically rather than
+    returning. start() sees _ready set, sees _error set, and raises it -- but
+    self._task is still alive and parked. _connect_server() never returned
+    `server` to its caller on this path, so nothing holds a reference to call
+    shutdown() on it: the task runs forever as an orphan, invisible to
+    shutdown_mcp_servers() (never added to _servers), and gets abandoned
+    rather than cleanly finished when the MCP loop is closed at process exit.
+    """
+
+    @pytest.mark.asyncio
+    async def test_start_failure_reaps_orphaned_parked_task(self):
+        from tools.mcp_tool import MCPServerTask, _connect_server
+
+        server = MCPServerTask("flaky")
+        shutdown_calls = []
+
+        async def fake_run(self, config):
+            # Simulate run() parking after exhausting initial retries:
+            # sets _error + _ready, but the task itself keeps running
+            # (awaiting a park sleep) rather than returning.
+            self._error = ConnectionError("simulated initial-connect failure")
+            self._ready.set()
+            await self._shutdown_event.wait()
+
+        async def fake_shutdown(self):
+            shutdown_calls.append(True)
+            self._shutdown_event.set()
+            if self._task and not self._task.done():
+                self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+
+        with patch.object(MCPServerTask, "run", fake_run), \
+             patch.object(MCPServerTask, "shutdown", fake_shutdown), \
+             patch("tools.mcp_tool.MCPServerTask", return_value=server):
+            with pytest.raises(ConnectionError):
+                await _connect_server("flaky", {"command": "echo"})
+
+        # The orphaned task must have been reaped (shutdown called), not
+        # left running detached on the event loop.
+        assert shutdown_calls == [True]
+        assert server._task is not None and server._task.done()
+
+    @pytest.mark.asyncio
+    async def test_start_success_does_not_call_shutdown(self):
+        """A clean successful start must not trigger the reaping path."""
+        from tools.mcp_tool import MCPServerTask, _connect_server
+
+        server = MCPServerTask("healthy")
+        shutdown_calls = []
+
+        async def fake_run(self, config):
+            self._ready.set()
+            await self._shutdown_event.wait()
+
+        async def fake_shutdown(self):
+            shutdown_calls.append(True)
+
+        with patch.object(MCPServerTask, "run", fake_run), \
+             patch.object(MCPServerTask, "shutdown", fake_shutdown), \
+             patch("tools.mcp_tool.MCPServerTask", return_value=server):
+            result = await _connect_server("healthy", {"command": "echo"})
+
+        assert result is server
+        assert shutdown_calls == []
+        server._shutdown_event.set()
+        if server._task and not server._task.done():
+            server._task.cancel()
+            try:
+                await server._task
+            except asyncio.CancelledError:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_still_propagates_without_double_shutdown(self):
+        """A CancelledError from start() (external cancel, e.g. connect
+        timeout) must propagate untouched -- start() already reaps its own
+        task on this path (see start()'s own CancelledError handler), so
+        _connect_server() must not call shutdown() again on top of it.
+        """
+        from tools.mcp_tool import MCPServerTask, _connect_server
+
+        server = MCPServerTask("timeout-case")
+        shutdown_calls = []
+
+        async def fake_start(self, config):
+            raise asyncio.CancelledError()
+
+        async def fake_shutdown(self):
+            shutdown_calls.append(True)
+
+        with patch.object(MCPServerTask, "start", fake_start), \
+             patch.object(MCPServerTask, "shutdown", fake_shutdown), \
+             patch("tools.mcp_tool.MCPServerTask", return_value=server):
+            with pytest.raises(asyncio.CancelledError):
+                await _connect_server("timeout-case", {"command": "echo"})
+
+        assert shutdown_calls == []

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -4672,3 +4672,40 @@ class TestConnectServerOrphanReaping:
                 await _connect_server("timeout-case", {"command": "echo"})
 
         assert shutdown_calls == []
+
+    @pytest.mark.asyncio
+    async def test_real_shutdown_interrupts_a_genuinely_parked_task_promptly(self):
+        """Exercise the REAL shutdown()/_wait_for_reconnect_or_shutdown()
+        machinery (not a fake) against a task actually parked there, to
+        prove the reap in _connect_server's except-Exception branch can't
+        stall on _PARKED_RETRY_INTERVAL. Only `run()` is faked here -- it
+        parks by awaiting the real _wait_for_reconnect_or_shutdown() coroutine
+        directly, the same one the production run() loop parks in.
+        """
+        from tools.mcp_tool import MCPServerTask, _connect_server
+
+        server = MCPServerTask("really-parked")
+
+        async def fake_run(self, config):
+            self._error = ConnectionError("simulated initial-connect failure")
+            self._ready.set()
+            # Actually parks in the real helper, same as production run()
+            # does after exhausting _MAX_INITIAL_CONNECT_RETRIES -- this is
+            # an asyncio.wait() on _shutdown_event/_reconnect_event, NOT a
+            # blind sleep, so shutdown() must be able to interrupt it fast.
+            await self._wait_for_reconnect_or_shutdown()
+
+        with patch.object(MCPServerTask, "run", fake_run), \
+             patch("tools.mcp_tool.MCPServerTask", return_value=server):
+            with pytest.raises(ConnectionError):
+                # The real shutdown() must interrupt the real park via
+                # _shutdown_event, not block on a timeout/sleep -- bound
+                # the whole call tightly enough that a regression to
+                # polling/sleeping would fail this test rather than just
+                # running slow.
+                await asyncio.wait_for(
+                    _connect_server("really-parked", {"command": "echo"}),
+                    timeout=2.0,
+                )
+
+        assert server._task is not None and server._task.done()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4496,8 +4496,14 @@ async def _connect_server(name: str, config: dict) -> MCPServerTask:
         # eventually garbage-collected. Reap it here before propagating.
         try:
             await server.shutdown()
-        except Exception:  # noqa: BLE001 -- best-effort cleanup, don't mask the real error
-            pass
+        except Exception as shutdown_exc:  # noqa: BLE001 -- best-effort cleanup, don't mask the real error
+            # Log (don't swallow silently): if shutdown() itself fails, the
+            # orphan-reap this except-branch exists for may not have actually
+            # happened, and that failure would otherwise leave zero trace.
+            logger.debug(
+                "MCP server '%s' shutdown during orphan-reap failed: %s",
+                name, shutdown_exc,
+            )
         raise
     return server
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4475,7 +4475,30 @@ async def _connect_server(name: str, config: dict) -> MCPServerTask:
         Exception: on connection or initialization failure.
     """
     server = MCPServerTask(name)
-    await server.start(config)
+    try:
+        await server.start(config)
+    except asyncio.CancelledError:
+        # start() already cancels/reaps server._task itself on this path
+        # (see the comment there) -- nothing further to clean up.
+        raise
+    except Exception:
+        # start() raised server._error (auth failure, invalid URL, or the
+        # "parked after _MAX_INITIAL_CONNECT_RETRIES failures" case). In all
+        # of these, server._ready was set but server._task is still alive --
+        # it has already moved on to _wait_for_reconnect_or_shutdown() to
+        # self-probe every _PARKED_RETRY_INTERVAL. Since we never return
+        # `server` to the caller on this path, nothing would ever hold a
+        # reference to call shutdown() on it: the task would run forever as
+        # an orphan invisible to shutdown_mcp_servers() (never added to
+        # _servers), and get abandoned rather than cleanly finished when the
+        # MCP loop is closed at process exit -- surfacing as a spurious
+        # "RuntimeError: Event loop is closed" from its finally block when
+        # eventually garbage-collected. Reap it here before propagating.
+        try:
+            await server.shutdown()
+        except Exception:  # noqa: BLE001 -- best-effort cleanup, don't mask the real error
+            pass
+        raise
     return server
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes an orphaned-task leak in `tools/mcp_tool.py`'s `_connect_server()`.

`_connect_server()` calls `MCPServerTask.start()`, which spawns
`self._task = asyncio.ensure_future(self.run(config))` and then awaits
`self._ready.wait()`. `run()` does not always exit on error: when the initial
connection fails `_MAX_INITIAL_CONNECT_RETRIES` times (or hits certain
auth/URL-validation failures), `run()` sets `self._error` and `self._ready`,
then **parks** in `_wait_for_reconnect_or_shutdown()` to self-probe
periodically, rather than returning.

`start()` sees `_ready` set, sees `_error` set, and raises it -- but
`self._task` is still alive and parked. `_connect_server()` had no exception
handling, so it never returned the `MCPServerTask` instance to its caller.
Nothing held a reference to it: the parked task ran forever, invisible to
`shutdown_mcp_servers()` (never inserted into `_servers`), a live orphan on
the MCP background loop. Each subsequent rediscovery attempt against the same
failing server (gated by the existing per-server backoff cooldown, so this
isn't unbounded, but does recur over a long-lived process) creates and leaks
another one on top.

At process exit, when the MCP loop is closed while one of these orphans is
still parked, later GC of the abandoned coroutine surfaces a confusing
`Exception ignored in: <coroutine MCPServerTask.run>` / `RuntimeError: Event
loop is closed` trace.

## Related Issue

Fixes #60197 (partially -- see Scope below)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: wrap `await server.start(config)` in `_connect_server()`
  in try/except. `CancelledError` re-raises untouched (`start()` already
  reaps its own task on that path -- see the existing comment there). Any
  other exception (the parked-orphan case) calls `await server.shutdown()`
  to reap the orphaned task before re-raising the original error.
- `tests/tools/test_mcp_tool.py`: added `TestConnectServerOrphanReaping` (3
  tests) -- a `start()` failure via `server._error` now leaves `server._task`
  fully done rather than orphaned; a clean successful start does not trigger
  the reaping path; a `CancelledError` from `start()` still propagates
  without a redundant double-shutdown call.

## Scope -- what this does and doesn't fix

This issue has a large existing PR cluster (#60104, #69420, #64114, #61466,
#71846, #62026, and several closed ones). I want to be explicit about scope
so this doesn't add more confusion to an already-crowded issue:

- **What this fixes:** the orphaned-task leak at its source (`_connect_server`
  never reaping a parked task before propagating its failure). This stops the
  leak/accumulation and the resulting spurious traceback at exit.
- **What this does NOT fix:** revival of a server that parked after an
  *initial* connection failure. That requires adopting the parked server into
  `_servers[name]` so the existing reconnect/revival machinery can find it --
  a materially different, larger change. **#62026** ("retain parked startup
  tasks for clean shutdown") already attempts this via a `contextvars`-based
  ownership-claim mechanism, but its current diff has drifted from `main`:
  6 of 8 hunks apply with pure line-number shift, but 2 hunks touch
  `_register_discovered_tools_if_needed()`, which `main` already patched
  independently in `106d1822e` (2026-07-19, one week after #62026's last
  update) using a different mechanism (`_servers.get(self.name) is self`
  rather than a `_connect_server_claim` contextvar) for the same "revival
  publishes zero tools" symptom. Reconciling those two overlapping-but-
  different ownership-tracking approaches is a design call for @mrzlab630 or
  a maintainer, not something I want to force through a rebase PR of someone
  else's branch. I did NOT modify `_register_discovered_tools_if_needed()`
  in this PR -- it's out of scope here.
- Most of the other PRs in this cluster (#60104, #69420, #64114, #61466,
  #71846) propose moving `t.cancel()` inside `try/except` in the three
  lifecycle-wait helper `finally` blocks. I checked: all three already guard
  `cancel()` correctly on current `main` (confirmed by diffing pre-existing
  code against a clean upstream checkout) -- that specific symptom doesn't
  reproduce from that cause anymore. This PR doesn't touch those helpers.

## How to Test

1. Configure an MCP server that will exhaust `_MAX_INITIAL_CONNECT_RETRIES`
   on startup (e.g. a stdio command with a bad executable, or a URL that
   403s).
2. Before this fix: the connection attempt's `MCPServerTask` leaks -- it's
   never in `_servers`, and at process exit you'll intermittently see
   `Exception ignored in: <coroutine MCPServerTask.run>` /
   `RuntimeError: Event loop is closed`.
3. After this fix: `_connect_server()` reaps the orphaned task via
   `server.shutdown()` before the connection failure propagates, so nothing
   is left running when the process exits.
4. `scripts/run_tests.sh tests/tools/test_mcp_tool.py -q` -- 219 passed (216
   pre-existing + 3 new in `TestConnectServerOrphanReaping`).

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs/issues (see Scope section above -- this is
      a large existing cluster; explained why this PR is additive, not a
      duplicate)
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` (targeted: `tests/tools/test_mcp_tool.py`,
      219 passed) and all tests pass
- [x] I've added tests for my changes
- [x] Tested on macOS
