### PR TITLE
fix(desktop): reconcile live project sessions across lanes

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -116,7 +116,6 @@ import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
 import {
   orderProjectsByIds,
-  overlayLiveLanes,
   overlayLivePreviews,
   PROJECT_PREVIEW_COUNT,
   ProjectBackRow,
@@ -685,21 +684,11 @@ export function ChatSidebar({
         ? enteredProjectTree
         : overviewEnteredProject
 
-    // The live-session overlay (creates/evictions) is applied per-repo in
-    // RepoFlatSection, AFTER the visual git-worktree lanes are merged in (so
-    // out-of-tree worktrees can be placed). Here we just order the snapshot.
+    // Here we only order the backend snapshot. SidebarSessionsSection merges
+    // visual worktree lanes and applies one project-wide live overlay before
+    // deciding whether the entered project has content.
     return { ...hydrated, repos: orderRepos(hydrated.repos) }
   }, [overviewEnteredProject, enteredProjectTree, orderRepos])
-
-  // Overlay live `$sessions` onto the entered project so a just-created session
-  // (which the backend snapshot hasn't folded in yet) counts as content and
-  // renders immediately — same optimistic layer as the overview previews. The
-  // backend now seeds each project folder as an (empty) repo, so the overlay
-  // always has a lane to place a new in-project session into.
-  const enteredProjectContent = useMemo(
-    () => (enteredProject ? overlayLiveLanes(enteredProject, agentSessions, removedSessionIds) : undefined),
-    [enteredProject, agentSessions, removedSessionIds]
-  )
 
   const scopedRepoPaths = useMemo(
     () =>
@@ -1410,7 +1399,7 @@ export function ChatSidebar({
                 projectBackRow={
                   inProject ? <ProjectBackRow label={s.projects.back} onClick={exitProjectScope} /> : undefined
                 }
-                projectContent={inProject ? enteredProjectContent : undefined}
+                projectContent={inProject ? enteredProject : undefined}
                 projectOverview={projectOverview}
                 projectOverviewPreviews={overviewPreviews}
                 projectRepoWorktrees={inProject ? scopedRepoWorktrees : undefined}

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -23,13 +23,7 @@ import { SidebarRowStack } from '../chrome'
 
 import { useWorkspaceNodeOpen } from './model'
 import { SidebarWorkspaceGroup } from './workspace-group'
-import {
-  mergeRepoWorktreeGroups,
-  overlayRepoLanes,
-  type SidebarProjectTree,
-  type SidebarSessionGroup,
-  type SidebarWorkspaceTree
-} from './workspace-groups'
+import { type SidebarProjectTree, type SidebarSessionGroup, type SidebarWorkspaceTree } from './workspace-groups'
 import { WorkspaceAddButton, WorkspaceHeader } from './workspace-header'
 
 // The entered project's body. Main-checkout sessions render directly — no
@@ -40,16 +34,12 @@ export function EnteredProjectContent({
   project,
   renderRows,
   onNewSession,
-  repoWorktrees,
-  liveSessions,
-  removedSessionIds
+  repoWorktrees
 }: {
   project: SidebarProjectTree
   renderRows: (sessions: SessionInfo[]) => React.ReactNode
   onNewSession?: (path: null | string) => void
   repoWorktrees?: Record<string, HermesGitWorktree[]>
-  liveSessions?: SessionInfo[]
-  removedSessionIds?: ReadonlySet<string>
 }) {
   if (!project.repos.length) {
     return null
@@ -63,9 +53,7 @@ export function EnteredProjectContent({
         <RepoFlatSection
           discoveredWorktrees={repo.path ? repoWorktrees?.[repo.path] : undefined}
           key={repo.id}
-          liveSessions={liveSessions}
           onNewSession={onNewSession}
-          removedSessionIds={removedSessionIds}
           renderRows={renderRows}
           repo={repo}
           showHeader={!single}
@@ -80,40 +68,22 @@ function RepoFlatSection({
   showHeader,
   renderRows,
   onNewSession,
-  discoveredWorktrees,
-  liveSessions,
-  removedSessionIds
+  discoveredWorktrees
 }: {
   repo: SidebarWorkspaceTree
   showHeader: boolean
   renderRows: (sessions: SessionInfo[]) => React.ReactNode
   onNewSession?: (path: null | string) => void
   discoveredWorktrees?: HermesGitWorktree[]
-  liveSessions?: SessionInfo[]
-  removedSessionIds?: ReadonlySet<string>
 }) {
   const { t } = useI18n()
   const s = t.sidebar
   const [open, toggleOpen] = useWorkspaceNodeOpen(repo.id)
   const dismissedWorktrees = useStore($dismissedWorktreeIds)
 
-  // The repo's session lanes already come fully built from the backend; this
-  // only injects empty VISUAL lanes from a live `git worktree list`.
-  const mergedGroups = useMemo(() => mergeRepoWorktreeGroups(repo, discoveredWorktrees), [repo, discoveredWorktrees])
-
-  // Optimistic placement runs against the MERGED lane set (backend + visual
-  // git-worktree lanes) so out-of-tree/sibling worktrees — which exist as visual
-  // lanes before the snapshot carries their sessions — get the new row. The
-  // overlay drops lanes it empties, so re-merge to restore still-real worktrees.
-  const overlaidGroups = useMemo(() => {
-    if (!(liveSessions?.length || removedSessionIds?.size)) {
-      return mergedGroups
-    }
-
-    const { groups } = overlayRepoLanes({ ...repo, groups: mergedGroups }, liveSessions ?? [], removedSessionIds)
-
-    return mergeRepoWorktreeGroups({ id: repo.id, path: repo.path, groups }, discoveredWorktrees)
-  }, [repo, mergedGroups, discoveredWorktrees, liveSessions, removedSessionIds])
+  // Visual lanes and live rows were already reconciled once before the
+  // SidebarSessionsSection empty-state gate.
+  const overlaidGroups = repo.groups
 
   const discoveredWorktreePaths = useMemo(
     () =>

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -13,6 +13,7 @@ export { SidebarWorkspaceGroup } from './workspace-group'
 export {
   overlayLiveLanes,
   overlayLivePreviews,
+  overlayProjectLiveLanes,
   sessionRecency,
   type SidebarProjectTree,
   type SidebarSessionGroup,

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -676,6 +676,45 @@ describe('overlayLiveLanes', () => {
     expect(overlaid.repos[0].groups.flatMap(g => g.sessions.map(s => s.id))).toEqual(['dup'])
   })
 
+  it('does not mirror a snapshot session into another inferred live lane', () => {
+    // Older/pre-git-context rows can already be present in the backend's real
+    // repo lane while the live cache still carries a fallback cwd that would
+    // infer a second lane (the Windows "main" + "default" duplicate report).
+    const snapshot = makeSession('/home/user/.hermes/hermes-agent', { id: 'dup', git_branch: 'main' })
+    const live = makeSession('/home/user/default', { id: 'dup' })
+
+    const project = projectNode({
+      id: '/home/user/.hermes/hermes-agent',
+      repos: [
+        {
+          id: '/home/user/.hermes/hermes-agent',
+          label: 'hermes-agent',
+          path: '/home/user/.hermes/hermes-agent',
+          sessionCount: 1,
+          groups: [
+            lane({
+              id: '/home/user/.hermes/hermes-agent::branch::main',
+              label: 'main',
+              isMain: true,
+              path: '/home/user/.hermes/hermes-agent',
+              sessions: [snapshot]
+            }),
+            lane({
+              id: '/home/user/default::branch::default',
+              label: 'default',
+              isMain: true,
+              path: '/home/user/default'
+            })
+          ]
+        }
+      ]
+    })
+
+    const overlaid = overlayLiveLanes(project, [live])
+
+    expect(overlaid.repos[0].groups.flatMap(g => g.sessions.map(s => s.id))).toEqual(['dup'])
+  })
+
   it('adds a new session to an existing worktree lane keyed by a divergent id (matches by path)', () => {
     // Backend keyed the worktree lane off a branch-style id (no live git probe),
     // but the lane PATH is the worktree dir. A new session under that worktree

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -10,6 +10,7 @@ import {
   mergeRepoWorktreeGroups,
   overlayLiveLanes,
   overlayLivePreviews,
+  overlayProjectLiveLanes,
   sessionProjectColor,
   type SidebarProjectTree,
   type SidebarSessionGroup,
@@ -676,43 +677,158 @@ describe('overlayLiveLanes', () => {
     expect(overlaid.repos[0].groups.flatMap(g => g.sessions.map(s => s.id))).toEqual(['dup'])
   })
 
-  it('does not mirror a snapshot session into another inferred live lane', () => {
-    // Older/pre-git-context rows can already be present in the backend's real
-    // repo lane while the live cache still carries a fallback cwd that would
-    // infer a second lane (the Windows "main" + "default" duplicate report).
-    const snapshot = makeSession('/home/user/.hermes/hermes-agent', { id: 'dup', git_branch: 'main' })
-    const live = makeSession('/home/user/default', { id: 'dup' })
+  it('keeps a live row in its authoritative backend lane when optimistic metadata disagrees', () => {
+    const snapshot = makeSession('/www/app', { id: 'dup', git_branch: 'historical' })
+    const live = makeSession('/www/app', { id: 'dup', git_branch: null, title: 'updated live row' })
 
     const project = projectNode({
-      id: '/home/user/.hermes/hermes-agent',
+      id: '/www/app',
       repos: [
         {
-          id: '/home/user/.hermes/hermes-agent',
-          label: 'hermes-agent',
-          path: '/home/user/.hermes/hermes-agent',
+          id: '/www/app',
+          label: 'app',
+          path: '/www/app',
           sessionCount: 1,
-          groups: [
-            lane({
-              id: '/home/user/.hermes/hermes-agent::branch::main',
-              label: 'main',
-              isMain: true,
-              path: '/home/user/.hermes/hermes-agent',
-              sessions: [snapshot]
-            }),
-            lane({
-              id: '/home/user/default::branch::default',
-              label: 'default',
-              isMain: true,
-              path: '/home/user/default'
-            })
-          ]
+          groups: [lane({ id: '/www/app', label: 'app', isMain: true, path: '/www/app', sessions: [snapshot] })]
+        }
+      ]
+    })
+
+    const overlaid = overlayLiveLanes(project, [live])
+    const rows = overlaid.repos[0].groups.flatMap(group => group.sessions)
+
+    expect(rows.map(session => session.id)).toEqual(['dup'])
+    expect(rows[0].title).toBe('updated live row')
+    expect(overlaid.repos[0].groups.map(group => group.id)).toEqual(['/www/app'])
+    expect(overlaid.sessionCount).toBe(1)
+  })
+
+  it('refreshes an authoritative backend row when its live cwd is temporarily absent', () => {
+    const snapshot = makeSession('/www/app', { id: 'dup', title: 'snapshot title' })
+    const live = makeSession(null, { id: 'dup', title: 'updated live row' })
+
+    const project = projectNode({
+      id: '/www/app',
+      repos: [
+        {
+          id: '/www/app',
+          label: 'app',
+          path: '/www/app',
+          sessionCount: 1,
+          groups: [lane({ id: '/www/app', label: 'app', isMain: true, path: '/www/app', sessions: [snapshot] })]
+        }
+      ]
+    })
+
+    const overlaid = overlayLiveLanes(project, [live])
+    const rows = overlaid.repos[0].groups.flatMap(group => group.sessions)
+
+    expect(rows.map(session => session.id)).toEqual(['dup'])
+    expect(rows[0].title).toBe('updated live row')
+    expect(overlaid.sessionCount).toBe(1)
+  })
+
+  it('does not path-place a backend-owned session into a second repo', () => {
+    const snapshot = makeSession('/www/a', { id: 'dup', title: 'snapshot title' })
+    const live = makeSession('/www/b', { id: 'dup', title: 'updated live row' })
+
+    const project = projectNode({
+      id: '/www',
+      repos: [
+        {
+          id: '/www/a',
+          label: 'a',
+          path: '/www/a',
+          sessionCount: 1,
+          groups: [lane({ id: '/www/a', label: 'a', isMain: true, path: '/www/a', sessions: [snapshot] })]
+        },
+        { id: '/www/b', label: 'b', path: '/www/b', sessionCount: 0, groups: [] }
+      ]
+    })
+
+    const overlaid = overlayLiveLanes(project, [live])
+
+    expect(overlaid.repos[0].groups.flatMap(group => group.sessions).map(session => session.id)).toEqual(['dup'])
+    expect(overlaid.repos[0].groups[0].sessions[0].title).toBe('updated live row')
+    expect(overlaid.repos[1].groups).toEqual([])
+    expect(overlaid.sessionCount).toBe(1)
+  })
+
+  it('routes a new optimistic row to only the most specific nested repo', () => {
+    const live = makeSession('/www/nested/src', { id: 'fresh' })
+
+    const project = projectNode({
+      id: '/www',
+      repos: [
+        {
+          id: '/www',
+          label: 'www',
+          path: '/www',
+          sessionCount: 0,
+          groups: [lane({ id: '/www::branch::main', label: 'main', isMain: true, path: '/www' })]
+        },
+        {
+          id: '/www/nested',
+          label: 'nested',
+          path: '/www/nested',
+          sessionCount: 0,
+          groups: [lane({ id: '/www/nested::branch::main', label: 'main', isMain: true, path: '/www/nested' })]
         }
       ]
     })
 
     const overlaid = overlayLiveLanes(project, [live])
 
-    expect(overlaid.repos[0].groups.flatMap(g => g.sessions.map(s => s.id))).toEqual(['dup'])
+    expect(overlaid.repos[0].groups.flatMap(group => group.sessions)).toEqual([])
+    expect(overlaid.repos[1].groups.flatMap(group => group.sessions).map(session => session.id)).toEqual(['fresh'])
+    expect(overlaid.sessionCount).toBe(1)
+  })
+
+  it('places a new row into an out-of-tree visual worktree at project scope', () => {
+    const live = makeSession('/outside/repo-feature/src', { id: 'fresh' })
+
+    const project = projectNode({
+      id: '/repo',
+      repos: [
+        {
+          id: '/repo',
+          label: 'repo',
+          path: '/repo',
+          sessionCount: 0,
+          groups: [lane({ id: '/repo::branch::main', label: 'main', isMain: true, path: '/repo' })]
+        }
+      ]
+    })
+
+    const repoWorktrees: Record<string, HermesGitWorktree[]> = {
+      '/repo': [
+        { branch: 'main', detached: false, isMain: true, locked: false, path: '/repo' },
+        { branch: 'feature', detached: false, isMain: false, locked: false, path: '/outside/repo-feature' }
+      ]
+    }
+
+    const overlaid = overlayProjectLiveLanes(project, [live], repoWorktrees)
+    const feature = overlaid.repos[0].groups.find(group => group.path === '/outside/repo-feature')
+
+    expect(feature?.sessions.map(session => session.id)).toEqual(['fresh'])
+    expect(overlaid.sessionCount).toBe(1)
+  })
+
+  it('preserves the project reference when visual merge and live overlay are semantic no-ops', () => {
+    const project = projectNode({
+      id: '/repo',
+      repos: [
+        {
+          id: '/repo',
+          label: 'repo',
+          path: '/repo',
+          sessionCount: 0,
+          groups: [lane({ id: '/repo::branch::main', label: 'main', isMain: true, path: '/repo' })]
+        }
+      ]
+    })
+
+    expect(overlayProjectLiveLanes(project, [])).toBe(project)
   })
 
   it('adds a new session to an existing worktree lane keyed by a divergent id (matches by path)', () => {

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -550,7 +550,17 @@ export function overlayRepoLanes(
       }
     }
 
+    const laneHasSession = lane.sessions.some(row => row.id === session.id)
+
+    const existsInAnotherLane =
+      !laneHasSession && lanes.some(g => g !== lane && g.sessions.some(row => row.id === session.id))
+
+    if (existsInAnotherLane) {
+      continue
+    }
+
     lane.sessions = upsertSession(lane.sessions, session)
+
     changed = true
   }
 

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -94,6 +94,16 @@ const comparisonSegments = (path: string): string[] => {
 /** Canonical per-host comparison key (separator/case/trailing-slash agnostic). */
 const pathKey = (path: null | string | undefined): string => comparisonSegments(path ?? '').join('/')
 
+/** Matched root depth, or -1 when `path` is outside `root`. */
+const pathDepthWithin = (path: null | string | undefined, root: null | string | undefined): number => {
+  const pathSegments = comparisonSegments(path ?? '')
+  const rootSegments = comparisonSegments(root ?? '')
+
+  return rootSegments.length && rootSegments.every((segment, index) => pathSegments[index] === segment)
+    ? rootSegments.length
+    : -1
+}
+
 /** Last path segment. */
 export const baseName = (path: string): string | undefined => segments(path).pop()
 
@@ -497,34 +507,44 @@ export function overlayRepoLanes(
   for (const session of live) {
     const cwd = (session.cwd || '').trim()
 
-    if (removed.has(session.id) || !cwd) {
+    if (removed.has(session.id)) {
       continue
     }
 
-    // (1) Join an EXISTING worktree lane by its own path. A linked worktree can
-    // live anywhere on disk (often a repo sibling, e.g. `repo-ci`), so nesting
-    // under the repo root isn't reliable — but the lane carries its real dir.
-    // Longest match wins; skip the root lane so an in-tree `.worktrees/<slug>`
-    // session isn't swallowed by main.
-    let lane: SidebarSessionGroup | undefined
+    // (1) A backend snapshot already owns this durable session id. Keep that
+    // authoritative lane even when the optimistic row's incomplete/stale Git
+    // metadata would compute a different lane; only refresh the row contents.
+    let lane = lanes.find(group => group.sessions.some(row => row.id === session.id))
+
+    if (!lane && !cwd) {
+      continue
+    }
+
+    // (2) Otherwise join an EXISTING worktree lane by its own path. A linked
+    // worktree can live anywhere on disk (often a repo sibling, e.g. `repo-ci`),
+    // so nesting under the repo root isn't reliable — but the lane carries its
+    // real dir. Longest match wins; skip the root lane so an in-tree
+    // `.worktrees/<slug>` session isn't swallowed by main.
     let bestLen = -1
 
-    for (const g of lanes) {
-      const lanePath = normalizePath(g.path)
+    if (!lane) {
+      for (const g of lanes) {
+        const lanePath = normalizePath(g.path)
 
-      if (!lanePath || pathKey(lanePath) === repoRootKey || !isPathUnder(lanePath, cwd)) {
-        continue
-      }
+        if (!lanePath || pathKey(lanePath) === repoRootKey || !isPathUnder(lanePath, cwd)) {
+          continue
+        }
 
-      const len = segments(lanePath).length
+        const len = segments(lanePath).length
 
-      if (len > bestLen) {
-        bestLen = len
-        lane = g
+        if (len > bestLen) {
+          bestLen = len
+          lane = g
+        }
       }
     }
 
-    // (2) Else place under the repo root via a computed lane (main / branch /
+    // (3) Else place under the repo root via a computed lane (main / branch /
     // in-tree `.worktrees` / kanban). Match by id, then path (the backend may
     // key a worktree lane off the git-probed root OR a branch-style id), then
     // the main-lane label; create it when the snapshot lacked it.
@@ -550,17 +570,7 @@ export function overlayRepoLanes(
       }
     }
 
-    const laneHasSession = lane.sessions.some(row => row.id === session.id)
-
-    const existsInAnotherLane =
-      !laneHasSession && lanes.some(g => g !== lane && g.sessions.some(row => row.id === session.id))
-
-    if (existsInAnotherLane) {
-      continue
-    }
-
     lane.sessions = upsertSession(lane.sessions, session)
-
     changed = true
   }
 
@@ -583,8 +593,58 @@ export function overlayLiveLanes(
 ): SidebarProjectTree {
   let changed = false
 
-  const repos = project.repos.map(repo => {
-    const next = overlayRepoLanes(repo, live, removed)
+  // A snapshot session belongs to exactly one backend-selected repo. Route its
+  // live row only to that owner so another repo cannot path-place the same id.
+  const snapshotRepoBySessionId = new Map<string, number>()
+
+  for (const [repoIndex, repo] of project.repos.entries()) {
+    for (const group of repo.groups) {
+      for (const session of group.sessions) {
+        if (!snapshotRepoBySessionId.has(session.id)) {
+          snapshotRepoBySessionId.set(session.id, repoIndex)
+        }
+      }
+    }
+  }
+
+  const bestOptimisticRepo = (session: SessionInfo): number | undefined => {
+    let best: { depth: number; isRepoRoot: boolean; repoIndex: number } | undefined
+
+    for (const [repoIndex, repo] of project.repos.entries()) {
+      const candidates = [
+        { isRepoRoot: true, path: repo.path },
+        ...repo.groups.map(group => ({ isRepoRoot: false, path: group.path }))
+      ]
+
+      for (const candidate of candidates) {
+        const depth = pathDepthWithin(session.cwd, candidate.path)
+
+        if (
+          depth < 0 ||
+          (best && (depth < best.depth || (depth === best.depth && (!candidate.isRepoRoot || best.isRepoRoot))))
+        ) {
+          continue
+        }
+
+        best = { depth, isRepoRoot: candidate.isRepoRoot, repoIndex }
+      }
+    }
+
+    return best?.repoIndex
+  }
+
+  const liveByRepo = project.repos.map(() => [] as SessionInfo[])
+
+  for (const session of live) {
+    const repoIndex = snapshotRepoBySessionId.get(session.id) ?? bestOptimisticRepo(session)
+
+    if (repoIndex !== undefined) {
+      liveByRepo[repoIndex].push(session)
+    }
+  }
+
+  const repos = project.repos.map((repo, repoIndex) => {
+    const next = overlayRepoLanes(repo, liveByRepo[repoIndex], removed)
 
     changed ||= next !== repo
 
@@ -596,6 +656,64 @@ export function overlayLiveLanes(
   }
 
   return { ...project, repos, sessionCount: repos.reduce((n, repo) => n + repo.sessionCount, 0) }
+}
+
+/**
+ * Entered-project composition: merge visual-only worktree lanes before the
+ * optimistic overlay can place rows into them, reconcile once at project scope,
+ * then restore any still-real empty visual lanes the overlay pruned.
+ */
+export function overlayProjectLiveLanes(
+  project: SidebarProjectTree,
+  live: SessionInfo[],
+  repoWorktrees?: Readonly<Record<string, HermesGitWorktree[]>>,
+  removed: ReadonlySet<string> = new Set()
+): SidebarProjectTree {
+  const sameGroups = (before: SidebarSessionGroup[], after: SidebarSessionGroup[]): boolean =>
+    before.length === after.length &&
+    before.every((group, index) => {
+      const next = after[index]
+      const keys = new Set([...Object.keys(group), ...Object.keys(next)])
+
+      for (const key of keys) {
+        if (key === 'sessions') {
+          continue
+        }
+
+        if (
+          !Object.is(
+            (group as unknown as Record<string, unknown>)[key],
+            (next as unknown as Record<string, unknown>)[key]
+          )
+        ) {
+          return false
+        }
+      }
+
+      return (
+        group.sessions.length === next.sessions.length &&
+        group.sessions.every((session, sessionIndex) => session === next.sessions[sessionIndex])
+      )
+    })
+
+  const mergeVisualLanes = (repo: SidebarWorkspaceTree): SidebarWorkspaceTree => {
+    const groups = mergeRepoWorktreeGroups(repo, repo.path ? repoWorktrees?.[repo.path] : undefined)
+
+    return sameGroups(repo.groups, groups) ? repo : { ...repo, groups }
+  }
+
+  const visualRepos = project.repos.map(mergeVisualLanes)
+
+  const withVisualLanes = visualRepos.every((repo, index) => repo === project.repos[index])
+    ? project
+    : { ...project, repos: visualRepos }
+
+  const overlaid = overlayLiveLanes(withVisualLanes, live, removed)
+  const restoredRepos = overlaid.repos.map(mergeVisualLanes)
+
+  return restoredRepos.every((repo, index) => repo === overlaid.repos[index])
+    ? overlaid
+    : { ...overlaid, repos: restoredRepos }
 }
 
 /** Merge live sessions into per-project overview previews, keyed by project path. */

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -1,0 +1,117 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesGitWorktree } from '@/global'
+import type { SessionInfo } from '@/hermes'
+
+import type { SidebarProjectTree } from './projects'
+import { SidebarSessionsSection } from './sessions-section'
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({ t: { sidebar: { dateDivider: {} } } })
+}))
+
+vi.mock('./projects', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+
+  return {
+    ...actual,
+    EnteredProjectContent: ({ project }: { project: SidebarProjectTree }) => (
+      <pre data-testid="entered-project">
+        {JSON.stringify(
+          project.repos.map(repo => ({
+            id: repo.id,
+            rows: repo.groups.flatMap(group => group.sessions.map(session => session.id))
+          }))
+        )}
+      </pre>
+    ),
+    ProjectOverviewRow: () => null,
+    SidebarWorkspaceGroup: () => null
+  }
+})
+
+afterEach(cleanup)
+
+const noop = vi.fn()
+
+function session(id: string, cwd: string): SessionInfo {
+  return { cwd, id, last_active: 2, started_at: 1 } as unknown as SessionInfo
+}
+
+function project(repos: SidebarProjectTree['repos']): SidebarProjectTree {
+  return { id: 'project', label: 'Project', path: null, repos, sessionCount: 0 }
+}
+
+function repo(id: string, path: string): SidebarProjectTree['repos'][number] {
+  return {
+    groups: [{ id: `${id}::branch::main`, isMain: true, label: 'main', path, sessions: [] }],
+    id,
+    label: id,
+    path,
+    sessionCount: 0
+  }
+}
+
+function renderProject(
+  projectContent: SidebarProjectTree,
+  liveSessions: SessionInfo[],
+  projectRepoWorktrees: Record<string, HermesGitWorktree[]>
+) {
+  render(
+    <SidebarSessionsSection
+      activeSessionId={null}
+      emptyState={<div>empty project</div>}
+      label="Sessions"
+      liveSessions={liveSessions}
+      onArchiveSession={noop}
+      onDeleteSession={noop}
+      onResumeSession={noop}
+      onToggle={noop}
+      onTogglePin={noop}
+      open
+      pinned={false}
+      projectContent={projectContent}
+      projectRepoWorktrees={projectRepoWorktrees}
+      sessions={[]}
+      workingSessionIdSet={new Set()}
+    />
+  )
+}
+
+describe('SidebarSessionsSection entered-project composition', () => {
+  it('checks the empty state only after placing a live row in an out-of-tree visual worktree', () => {
+    const tree = project([repo('/repo', '/repo')])
+
+    const worktrees = {
+      '/repo': [
+        { branch: 'main', detached: false, isMain: true, locked: false, path: '/repo' },
+        { branch: 'feature', detached: false, isMain: false, locked: false, path: '/outside/repo-feature' }
+      ]
+    }
+
+    renderProject(tree, [session('fresh', '/outside/repo-feature/src')], worktrees)
+
+    expect(screen.getByTestId('entered-project').textContent).toContain('fresh')
+    expect(screen.queryByText('empty project')).toBeNull()
+  })
+
+  it('routes a fresh row to a more specific visual-worktree repo before assigning snapshot ownership', () => {
+    const tree = project([repo('broad', '/workspace'), repo('specific', '/repo')])
+
+    const worktrees = {
+      '/workspace': [{ branch: 'main', detached: false, isMain: true, locked: false, path: '/workspace' }],
+      '/repo': [
+        { branch: 'main', detached: false, isMain: true, locked: false, path: '/repo' },
+        { branch: 'feature', detached: false, isMain: false, locked: false, path: '/workspace/specific-wt' }
+      ]
+    }
+
+    renderProject(tree, [session('fresh', '/workspace/specific-wt/src')], worktrees)
+
+    expect(JSON.parse(screen.getByTestId('entered-project').textContent ?? '[]')).toEqual([
+      { id: 'broad', rows: [] },
+      { id: 'specific', rows: ['fresh'] }
+    ])
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -17,6 +17,7 @@ import { sessionPinId } from '@/store/session'
 import { SidebarCount, SidebarDateDivider } from './chrome'
 import {
   EnteredProjectContent,
+  overlayProjectLiveLanes,
   ProjectOverviewRow,
   type SidebarProjectTree,
   type SidebarSessionGroup,
@@ -197,7 +198,22 @@ export function SidebarSessionsSection({
   // A defined project list is itself content (even an empty project should
   // render as a drill-in row so the user can see it exists).
   const hasProjectOverview = Boolean(projectOverview?.length)
-  const hasProjectContent = Boolean(projectContent && projectContent.sessionCount > 0)
+
+  // Entered-project membership must be reconciled exactly once, after visual
+  // worktree lanes exist and before the empty-state gate. A pre-overlay in the
+  // parent would make an unseen row look backend-owned by a less-specific repo;
+  // gating first would hide an out-of-tree row before it can be placed.
+  const renderedProjectContent = useMemo(
+    () =>
+      projectContent
+        ? overlayProjectLiveLanes(projectContent, liveSessions ?? [], projectRepoWorktrees, removedSessionIds)
+        : undefined,
+    [projectContent, liveSessions, projectRepoWorktrees, removedSessionIds]
+  )
+
+  const hasProjectContent = Boolean(
+    renderedProjectContent?.repos.some(repo => repo.groups.some(group => group.sessions.length > 0))
+  )
 
   const showEmptyState =
     forceEmptyState || (!hasGroupedSessions && !hasProjectOverview && !hasProjectContent && sessions.length === 0)
@@ -279,12 +295,10 @@ export function SidebarSessionsSection({
     inner = (
       <>
         {projectBackRow}
-        {hasProjectContent ? (
+        {hasProjectContent && renderedProjectContent ? (
           <EnteredProjectContent
-            liveSessions={liveSessions}
             onNewSession={onNewSessionInWorkspace}
-            project={projectContent}
-            removedSessionIds={removedSessionIds}
+            project={renderedProjectContent}
             renderRows={renderRowsDated}
             repoWorktrees={projectRepoWorktrees}
           />


### PR DESCRIPTION
## Summary

- Keep a live session with the backend-selected repo/lane when optimistic `cwd` or Git metadata temporarily disagrees.
- Route a new optimistic row to exactly one most-specific repo/worktree path instead of every matching nested repo.
- Reconcile the entered project exactly once, after visual `git worktree list` lanes are merged and before the empty-state gate.
- Add pure and component regressions for stale metadata, missing `cwd`, cross-repo ownership, nested repos, out-of-tree worktrees, and no-op identity.

The backend snapshot remains authoritative for durable identity and membership; the Desktop overlay only refreshes row contents or performs temporary placement for rows the snapshot has not seen yet.

## Relationship to open fixes

- Builds on and preserves the author of #58122, which introduced the core invariant that an existing backend lane owns its session ID. This PR extends that invariant through the real project-wide render composition and refreshes the owning row instead of dropping newer live fields.
- Intentionally does not adopt #55736's live-driven cross-lane eviction contract: transient or stale live metadata must not move a backend-owned row. A real lane move becomes authoritative on the next backend tree refresh.
- #70749 addresses cross-project ownership for linked worktrees; this change is scoped to reconciliation among repositories/worktrees inside the already-entered project.
- #71889 normalizes backend Windows lane roots and is complementary to this Desktop reconciliation fix.

## Related Issue / PR

Related to #71837. Complementary to #71889: that PR canonicalizes backend lane IDs; this PR hardens the Desktop's separately-clocked optimistic overlay so stale/incomplete live metadata cannot duplicate a backend-owned session.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [x] Tests

## Changes Made

- Build project-wide backend ownership by `session.id` before reconciling live rows.
- Refresh an owned row even when its live `cwd` is temporarily empty.
- For unseen rows, choose one repo by longest matching normalized repo/group path, with repo roots winning equal-depth ties.
- Add `overlayProjectLiveLanes` to compose visual worktree discovery and optimistic reconciliation without dropping project context.
- Pass the raw ordered backend tree from `index.tsx`, perform the one overlay in `SidebarSessionsSection` before its content gate, and keep `EnteredProjectContent` render-only.
- Preserve the original project reference when visual merge and live reconciliation are semantic no-ops.

## How to Test

### Reproduction

1. Hydrate a project whose backend snapshot owns session `dup` in repo A.
2. Supply a live row with the same ID but stale metadata pointing at repo B, or with `cwd = null`.
3. Supply a new row under nested repo B and a new row under an out-of-tree visual worktree.
4. Verify each ID renders once, owned rows remain in their snapshot repo/lane, and new rows use the most-specific available repo/worktree path.

### Commands run

```bash
npm test -- --project ui \
  src/app/chat/sidebar/projects/workspace-groups.test.ts \
  src/app/chat/sidebar/sessions-section.test.tsx
# 56 passed

npm run typecheck
# passed

npx eslint \
  src/app/chat/sidebar/index.tsx \
  src/app/chat/sidebar/sessions-section.tsx \
  src/app/chat/sidebar/sessions-section.test.tsx \
  src/app/chat/sidebar/projects/entered-content.tsx \
  src/app/chat/sidebar/projects/index.ts \
  src/app/chat/sidebar/projects/workspace-groups.ts \
  src/app/chat/sidebar/projects/workspace-groups.test.ts
# passed with no warnings/errors in touched files

npx prettier --check \
  src/app/chat/sidebar/index.tsx \
  src/app/chat/sidebar/sessions-section.tsx \
  src/app/chat/sidebar/sessions-section.test.tsx \
  src/app/chat/sidebar/projects/entered-content.tsx \
  src/app/chat/sidebar/projects/index.ts \
  src/app/chat/sidebar/projects/workspace-groups.ts \
  src/app/chat/sidebar/projects/workspace-groups.test.ts
# passed

node --input-type=module -e "import { build } from 'vite'; await build();"
# production renderer build passed
```

A live-data integration against `projects.project_sessions` produced one lane, matching backend/rendered session counts, and no duplicate IDs.

### Local baseline limitations

- The full UI suite completed with `2334 passed`, `1 skipped`, and `6 failed`. Re-running the five failing files in the clean installed checkout reproduced the same six failures: one markdown fuzz timeout, three locale-sensitive assertions, and two billing fixture/timing assertions. The two modified test modules pass completely (`56 passed`).
- Electron platform tests require `git init -b`, unavailable in the host's Git 2.25.1; the same test fails on `origin/main`.
- Native `node-pty` packaging requires C++20, unavailable in the host's `g++` 9.4.0; the renderer production build itself passes.

## Checklist

### Code Quality

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have searched all open and closed issues and PRs for duplicates
- [x] My changes generate no new warnings
- [x] The changes are focused and minimal
- [x] Commit messages follow Conventional Commits format

### Testing

- [ ] All existing tests pass locally (`pytest tests/ -q`) — not applicable to this Desktop-only change; no Python files changed
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally for the modified module
- [x] I have tested on Ubuntu 20.04 / Node 22.23.1

### Documentation

- [x] Documentation is not required for this internal reconciliation fix
- [x] No configuration changes
- [x] No AGENTS.md changes required

### Platform / Security

- [x] Cross-platform path handling considered; matching reuses the existing Windows case/separator normalization and keeps POSIX case-sensitive
- [x] No platform-specific assumptions were introduced
- [x] No credentials, secrets, or external I/O were added
- [x] No tool schemas changed
