### PR TITLE
fix(cli): clean stale active-session temp files

### DIFF
--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import time
 import uuid
 from dataclasses import dataclass
@@ -19,6 +20,8 @@ from typing import Any, Optional
 from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
+
+_STALE_TEMP_FILE_AGE_SECONDS = 300
 
 
 def coerce_max_concurrent_sessions(value: Any, key: str = "max_concurrent_sessions") -> Optional[int]:
@@ -194,12 +197,46 @@ def _read_entries(path: Path) -> list[dict[str, Any]]:
     return [entry for entry in entries if isinstance(entry, dict)]
 
 
+def _cleanup_stale_temp_files(path: Path) -> int:
+    """Remove abandoned atomic-write files created for *path*."""
+    pattern = re.compile(
+        rf"^{re.escape(path.name)}\.[0-9]+\.[0-9a-f]{{32}}\.tmp$",
+        re.IGNORECASE,
+    )
+    cutoff = time.time() - _STALE_TEMP_FILE_AGE_SECONDS
+    removed = 0
+    for candidate in path.parent.glob(f"{path.name}.*.tmp"):
+        if not pattern.fullmatch(candidate.name):
+            continue
+        try:
+            if candidate.stat().st_mtime > cutoff:
+                continue
+            candidate.unlink()
+            removed += 1
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            logger.debug("Could not remove stale active-session temp file %s: %s", candidate, exc)
+    return removed
+
+
 def _write_entries(path: Path, entries: list[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    removed = _cleanup_stale_temp_files(path)
+    if removed:
+        logger.info("Removed %d stale active-session temp file(s)", removed)
     tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
-    with open(tmp, "w", encoding="utf-8") as fh:
-        json.dump({"entries": entries}, fh, sort_keys=True)
-    os.replace(tmp, path)
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump({"entries": entries}, fh, sort_keys=True)
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.debug("Could not remove active-session temp file %s: %s", tmp, exc)
 
 
 def _process_start_time(pid: int) -> Optional[float]:

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import time
 import uuid
 from dataclasses import dataclass
@@ -19,6 +20,8 @@ from typing import Any, Optional
 from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
+
+_STALE_TEMP_FILE_AGE_SECONDS = 300
 
 
 def coerce_max_concurrent_sessions(value: Any, key: str = "max_concurrent_sessions") -> Optional[int]:
@@ -157,12 +160,46 @@ def _read_entries(path: Path) -> list[dict[str, Any]]:
     return [entry for entry in entries if isinstance(entry, dict)]
 
 
+def _cleanup_stale_temp_files(path: Path) -> int:
+    """Remove abandoned atomic-write files created for *path*."""
+    pattern = re.compile(
+        rf"^{re.escape(path.name)}\.\d+\.[0-9a-f]{{32}}\.tmp$",
+        re.IGNORECASE,
+    )
+    cutoff = time.time() - _STALE_TEMP_FILE_AGE_SECONDS
+    removed = 0
+    for candidate in path.parent.glob(f"{path.name}.*.tmp"):
+        if not pattern.fullmatch(candidate.name):
+            continue
+        try:
+            if candidate.stat().st_mtime > cutoff:
+                continue
+            candidate.unlink()
+            removed += 1
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            logger.debug("Could not remove stale active-session temp file %s: %s", candidate, exc)
+    return removed
+
+
 def _write_entries(path: Path, entries: list[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    removed = _cleanup_stale_temp_files(path)
+    if removed:
+        logger.info("Removed %d stale active-session temp file(s)", removed)
     tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
-    with open(tmp, "w", encoding="utf-8") as fh:
-        json.dump({"entries": entries}, fh, sort_keys=True)
-    os.replace(tmp, path)
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump({"entries": entries}, fh, sort_keys=True)
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.debug("Could not remove active-session temp file %s: %s", tmp, exc)
 
 
 def _process_start_time(pid: int) -> Optional[float]:

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -6,7 +6,58 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import pytest
+
 from hermes_cli import active_sessions
+
+
+def test_write_entries_removes_only_stale_owned_temp_files(tmp_path):
+    state_path = tmp_path / "active_sessions.json"
+    stale = tmp_path / f"{state_path.name}.123.{'a' * 32}.tmp"
+    fresh = tmp_path / f"{state_path.name}.456.{'b' * 32}.tmp"
+    unrelated = tmp_path / f"{state_path.name}.１２３.{'c' * 32}.tmp"
+    stale.write_text("stale", encoding="utf-8")
+    fresh.write_text("fresh", encoding="utf-8")
+    unrelated.write_text("keep", encoding="utf-8")
+    old = time.time() - active_sessions._STALE_TEMP_FILE_AGE_SECONDS - 1
+    os.utime(stale, (old, old))
+
+    active_sessions._write_entries(state_path, [])
+
+    assert not stale.exists()
+    assert fresh.read_text(encoding="utf-8") == "fresh"
+    assert unrelated.read_text(encoding="utf-8") == "keep"
+
+
+def test_write_entries_removes_current_temp_after_replace_failure(tmp_path, monkeypatch):
+    state_path = tmp_path / "active_sessions.json"
+
+    def fail_replace(_src, _dst):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(active_sessions.os, "replace", fail_replace)
+
+    try:
+        active_sessions._write_entries(state_path, [])
+    except OSError as exc:
+        assert str(exc) == "replace failed"
+    else:
+        raise AssertionError("expected os.replace failure")
+
+    assert list(tmp_path.glob(f"{state_path.name}.*.tmp")) == []
+
+
+def test_write_entries_removes_current_temp_after_dump_failure(tmp_path, monkeypatch):
+    state_path = tmp_path / "active_sessions.json"
+
+    def fail_dump(*_args, **_kwargs):
+        raise OSError("dump failed")
+
+    monkeypatch.setattr(active_sessions.json, "dump", fail_dump)
+    with pytest.raises(OSError, match="dump failed"):
+        active_sessions._write_entries(state_path, [])
+
+    assert list(tmp_path.glob(f"{state_path.name}.*.tmp")) == []
 
 
 def test_resolve_max_concurrent_sessions_values(caplog):

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -9,6 +9,42 @@ from pathlib import Path
 from hermes_cli import active_sessions
 
 
+def test_write_entries_removes_only_stale_owned_temp_files(tmp_path):
+    state_path = tmp_path / "active_sessions.json"
+    stale = tmp_path / f"{state_path.name}.123.{'a' * 32}.tmp"
+    fresh = tmp_path / f"{state_path.name}.456.{'b' * 32}.tmp"
+    unrelated = tmp_path / f"{state_path.name}.manual.tmp"
+    stale.write_text("stale", encoding="utf-8")
+    fresh.write_text("fresh", encoding="utf-8")
+    unrelated.write_text("keep", encoding="utf-8")
+    old = time.time() - active_sessions._STALE_TEMP_FILE_AGE_SECONDS - 1
+    os.utime(stale, (old, old))
+
+    active_sessions._write_entries(state_path, [])
+
+    assert not stale.exists()
+    assert fresh.read_text(encoding="utf-8") == "fresh"
+    assert unrelated.read_text(encoding="utf-8") == "keep"
+
+
+def test_write_entries_removes_current_temp_after_replace_failure(tmp_path, monkeypatch):
+    state_path = tmp_path / "active_sessions.json"
+
+    def fail_replace(_src, _dst):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(active_sessions.os, "replace", fail_replace)
+
+    try:
+        active_sessions._write_entries(state_path, [])
+    except OSError as exc:
+        assert str(exc) == "replace failed"
+    else:
+        raise AssertionError("expected os.replace failure")
+
+    assert list(tmp_path.glob(f"{state_path.name}.*.tmp")) == []
+
+
 def test_resolve_max_concurrent_sessions_values(caplog):
     assert active_sessions.resolve_max_concurrent_sessions({}) is None
     assert active_sessions.resolve_max_concurrent_sessions({"max_concurrent_sessions": None}) is None


### PR DESCRIPTION
## Summary

- remove abandoned `active_sessions.json.<pid>.<uuid>.tmp` files after a five-minute safety window
- delete the current write's temp file when a normal write or replace failure unwinds
- restrict cleanup to the active-session registry's exact generated filename shape

Fixes #72057

## Tests

- `python -m pytest tests/hermes_cli/test_active_sessions.py -q` (11 passed)
- `python -m ruff check hermes_cli/active_sessions.py tests/hermes_cli/test_active_sessions.py`
- `git diff --check`

## Scope

Cleanup runs only when the active-session registry is written. Fresh temp files and unrelated `.tmp` files are preserved; registry contents and lease semantics are unchanged.