### PR TITLE
fix(tui): honor destructive slash confirmation config

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2082,8 +2082,9 @@ DEFAULT_CONFIG = {
         # through tools.slash_confirm — native yes/no buttons on Telegram,
         # Discord, and Slack; text fallback elsewhere.  Users click "Always
         # Approve" to silence the prompt permanently; that flips this key to
-        # false.  TUI has its own modal overlay (HERMES_TUI_NO_CONFIRM=1 to
-        # opt out there).
+        # false.  TUI also honors this setting for its /clear, /new, and /reset
+        # modal; HERMES_TUI_NO_CONFIRM=1 force-skips that modal regardless of
+        # the configured value.
         "destructive_slash_confirm": True,
     },
 

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -482,6 +482,19 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.rpc).not.toHaveBeenCalled()
   })
 
+  it.each([
+    ['/new sprint planning', 'new session started', 'sprint planning'],
+    ['/clear', undefined, undefined]
+  ])('skips the confirmation for %s when config disables it', (command, message, title) => {
+    patchUiState({ destructiveSlashConfirm: false })
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)(command)).toBe(true)
+
+    expect(getOverlayState().confirm).toBeNull()
+    expect(ctx.session.newSession).toHaveBeenCalledWith(message, title)
+  })
+
   it('routes the /reset catalog alias through the local fresh-session lifecycle', () => {
     const ctx = buildCtx({
       local: {
@@ -499,6 +512,26 @@ describe('createSlashHandler', () => {
 
     expect(ctx.session.newSession).toHaveBeenCalledWith('new session started', undefined)
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
+  it('skips the confirmation for the /reset alias when config disables it', () => {
+    patchUiState({ destructiveSlashConfirm: false })
+
+    const ctx = buildCtx({
+      local: {
+        catalog: {
+          canon: {
+            '/new': '/new',
+            '/reset': '/new'
+          }
+        }
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/reset')).toBe(true)
+
+    expect(getOverlayState().confirm).toBeNull()
+    expect(ctx.session.newSession).toHaveBeenCalledWith('new session started', undefined)
   })
 
   it('keeps visible scrollback when branching a TUI session', async () => {

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -47,6 +47,54 @@ describe('applyDisplay', () => {
     expect(s.streaming).toBe(false)
   })
 
+  it('hydrates the destructive slash confirmation policy from approvals', () => {
+    const setBell = vi.fn()
+
+    applyDisplay(
+      {
+        config: {
+          approvals: { destructive_slash_confirm: false },
+          display: {}
+        }
+      },
+      setBell
+    )
+
+    expect($uiState.get().destructiveSlashConfirm).toBe(false)
+
+    applyDisplay(
+      {
+        config: {
+          approvals: { destructive_slash_confirm: true },
+          display: {}
+        }
+      },
+      setBell
+    )
+
+    expect($uiState.get().destructiveSlashConfirm).toBe(true)
+  })
+
+  it('defaults destructive slash confirmation on and preserves it across config RPC failure', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: {} } }, setBell)
+    expect($uiState.get().destructiveSlashConfirm).toBe(true)
+
+    applyDisplay(
+      {
+        config: {
+          approvals: { destructive_slash_confirm: false },
+          display: {}
+        }
+      },
+      setBell
+    )
+    applyDisplay(null, setBell)
+
+    expect($uiState.get().destructiveSlashConfirm).toBe(false)
+  })
+
   it('coerces legacy true + "on" alias to top', () => {
     const setBell = vi.fn()
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -322,6 +322,7 @@ export interface UiState {
   busy: boolean
   busyInputMode: BusyInputMode
   compact: boolean
+  destructiveSlashConfirm: boolean
   detailsMode: DetailsMode
   detailsModeCommandOverride: boolean
   // Focus view (/focus) — display-only reduced-output mode. Drives the

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -199,7 +199,7 @@ export const coreCommands: SlashCommand[] = [
         ctx.session.newSession(isNew ? 'new session started' : undefined, requestedTitle || undefined)
       }
 
-      if (NO_CONFIRM_DESTRUCTIVE) {
+      if (NO_CONFIRM_DESTRUCTIVE || !ctx.ui.destructiveSlashConfirm) {
         return commit()
       }
 

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -14,6 +14,7 @@ const buildUiState = (): UiState => ({
   busy: false,
   busyInputMode: 'queue',
   compact: false,
+  destructiveSlashConfirm: true,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,
   focusView: false,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -253,6 +253,7 @@ export const applyDisplay = (
   setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void
 ) => {
   const d = cfg?.config?.display ?? {}
+  const approvals = cfg?.config?.approvals
 
   setBell(!!d.bell_on_complete)
 
@@ -273,6 +274,10 @@ export const applyDisplay = (
     battery: !!d.battery,
     busyInputMode: normalizeBusyInputMode(d.busy_input_mode),
     compact: !!d.tui_compact,
+    // Fail safe: only YAML boolean false disables the prompt. A transient
+    // config RPC failure (cfg=null) preserves the last known policy instead
+    // of silently changing approval behavior until the next successful poll.
+    ...(cfg ? { destructiveSlashConfirm: approvals?.destructive_slash_confirm !== false } : {}),
     detailsMode: resolveDetailsMode(d),
     detailsModeCommandOverride: false,
     focusView: !!d.focus_view,

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -118,8 +118,14 @@ export interface ConfigVoiceConfig {
   record_key?: unknown
 }
 
+export interface ConfigApprovalsConfig {
+  // Raw config value: only the explicit boolean false disables the safety gate.
+  destructive_slash_confirm?: unknown
+}
+
 export interface ConfigFullResponse {
   config?: {
+    approvals?: ConfigApprovalsConfig
     display?: ConfigDisplayConfig
     voice?: ConfigVoiceConfig
     paste_collapse_threshold?: number

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -46,7 +46,7 @@ The full set of keys:
 | `timeout` | `300` | Seconds Hermes waits for an approval reply before timing out. |
 | `cron_mode` | `deny` | How [cron jobs](./features/cron.md) behave headlessly when they trigger a dangerous-command prompt. `deny` blocks the command (the agent must find another path); `approve` auto-approves everything in cron context. |
 | `mcp_reload_confirm` | `true` | When true, `/reload-mcp` asks before rebuilding the MCP tool set. Rebuilding invalidates the provider prompt cache (tool schemas live in the system prompt), so the next message re-sends full input tokens. Users who click **Always Approve** flip this key to `false`. |
-| `destructive_slash_confirm` | `true` | When true, destructive session slash commands (`/clear`, `/new`, `/reset`, `/undo`) prompt before discarding conversation state. Three-option dialog (Approve Once / Always Approve / Cancel) routed through native yes/no buttons on Telegram, Discord, and Slack; text fallback elsewhere. Users who click **Always Approve** flip this key to `false`. TUI uses its own modal overlay (set `HERMES_TUI_NO_CONFIRM=1` to opt out there). |
+| `destructive_slash_confirm` | `true` | When true, destructive session slash commands (`/clear`, `/new`, `/reset`, `/undo`) prompt before discarding conversation state. Three-option dialog (Approve Once / Always Approve / Cancel) routed through native yes/no buttons on Telegram, Discord, and Slack; text fallback elsewhere. Users who click **Always Approve** flip this key to `false`. The TUI also honors this setting for its `/clear`, `/new`, and `/reset` modal; `HERMES_TUI_NO_CONFIRM=1` force-skips that modal regardless of the configured value. |
 
 | Mode | Behavior |
 |------|----------|


### PR DESCRIPTION
## Summary

- hydrate `approvals.destructive_slash_confirm` through the TUI's existing full-config sync
- keep confirmation enabled by default and preserve the last known value across transient config RPC failures
- let literal YAML `false` skip the `/new`, `/clear`, and `/reset` confirmation overlay
- retain `HERMES_TUI_NO_CONFIRM=1` as the force-skip environment override
- document the config-backed TUI behavior and the force-skip override

## Why

The Python CLI already honored `approvals.destructive_slash_confirm`, but the TUI only checked its module-level environment override. The full configuration was already refreshed in the TUI, yet the approval setting was not represented in local UI state, so users still saw confirmation prompts after disabling them in config.

## Impact

The three destructive session-reset commands now follow the same configured policy in the TUI while remaining fail-safe: missing values default to confirmation, and a temporary configuration read failure does not silently change the active policy.

## Validation

- based on `upstream/main` at `4a99ba195`; GitHub reports the PR mergeable
- focused Vitest suite (`createSlashHandler.test.ts`, `useConfigSync.test.ts`) — 123 passed
- TypeScript `tsc --noEmit -p tsconfig.json` — passed
- ESLint on all changed TypeScript files — passed
- Prettier check on all changed TypeScript files — passed
- `git diff --check` — passed

Fixes #70675
