### PR TITLE
docs(acp): document non-editor ACP clients (remote / mobile)

### DIFF
--- a/website/docs/user-guide/features/acp.md
+++ b/website/docs/user-guide/features/acp.md
@@ -1,10 +1,10 @@
 ---
 sidebar_position: 11
-title: "ACP Editor Integration"
-description: "Use Hermes Agent inside ACP-compatible editors such as VS Code, Zed, and JetBrains"
+title: "ACP Integration"
+description: "Use Hermes Agent from ACP-compatible editors such as VS Code, Zed, and JetBrains, and from other ACP clients"
 ---
 
-# ACP Editor Integration
+# ACP Integration
 
 Hermes Agent can run as an ACP server, letting ACP-compatible editors talk to Hermes over stdio and render:
 
@@ -144,6 +144,25 @@ Prerequisites:
 ### JetBrains
 
 Use an ACP-compatible plugin and point it at `hermes acp` or `hermes-acp`.
+
+## Other ACP clients
+
+ACP hosts are not limited to editors. Any client that speaks ACP over stdio can launch `hermes acp`, so remote and mobile clients work against Hermes without needing a Hermes-specific integration.
+
+Verified example, using [Happy](https://github.com/slopus/happy)'s generic ACP runner:
+
+```bash
+happy acp -- hermes acp
+```
+
+That negotiates ACP protocol v1 and brings up the full Hermes surface: the `hermes-acp` toolset, `available_models` for the host's model picker, session modes carrying the edit-approval policy, and the Hermes slash commands (`/help`, `/model`, `/tools`, `/context`, `/reset`, `/compact`, `/steer`, `/queue`) delivered as `available_commands_update`.
+
+Use `--check` as the pre-flight before wiring up any host. A `hermes` binary on `PATH` does not imply the `[acp]` extra is installed, so probing for the binary alone can pass and then fail during the handshake:
+
+```bash
+$ hermes acp --check
+Hermes ACP check OK
+```
 
 ## Configuration and credentials
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/acp.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/acp.md
@@ -1,10 +1,10 @@
 ---
 sidebar_position: 11
-title: "ACP 编辑器集成"
-description: "在 VS Code、Zed 和 JetBrains 等兼容 ACP 的编辑器中使用 Hermes Agent"
+title: "ACP 集成"
+description: "在 VS Code、Zed 和 JetBrains 等兼容 ACP 的编辑器中使用 Hermes Agent，也可从其他 ACP 客户端接入"
 ---
 
-# ACP 编辑器集成
+# ACP 集成
 
 Hermes Agent 可作为 ACP 服务器运行，让兼容 ACP 的编辑器通过 stdio 与 Hermes 通信并渲染：
 
@@ -142,6 +142,25 @@ hermes acp --setup-browser --yes     # 非交互式接受下载
 ### JetBrains
 
 使用兼容 ACP 的插件并将其指向 `hermes acp` 或 `hermes-acp`。
+
+## 其他 ACP 客户端
+
+ACP 宿主并不限于编辑器。任何通过 stdio 讲 ACP 的客户端都可以启动 `hermes acp`，因此远程与移动端客户端无需针对 Hermes 做专门集成即可接入。
+
+已验证的示例，使用 [Happy](https://github.com/slopus/happy) 的通用 ACP runner：
+
+```bash
+happy acp -- hermes acp
+```
+
+该组合会协商 ACP protocol v1，并带起完整的 Hermes 表面：`hermes-acp` 工具集、供宿主模型选择器使用的 `available_models`、承载编辑审批策略的会话模式，以及通过 `available_commands_update` 下发的 Hermes 斜杠命令（`/help`、`/model`、`/tools`、`/context`、`/reset`、`/compact`、`/steer`、`/queue`）。
+
+接入任何宿主之前请先用 `--check` 做预检。`PATH` 上存在 `hermes` 二进制并不代表已安装 `[acp]` extra，只探测二进制可能通过检查、随后在握手阶段失败：
+
+```bash
+$ hermes acp --check
+Hermes ACP check OK
+```
 
 ## 配置与凭据
 


### PR DESCRIPTION
## What does this PR do?

`website/docs/user-guide/features/acp.md` documents `hermes acp` exclusively as an editor feature: the title is "ACP Editor Integration", the description names VS Code / Zed / JetBrains, and the only setup section is "Editor setup". Nothing in it says an ACP host can be something other than an editor.

That understates what already ships. `acp_adapter` is a general ACP server, and a non-editor ACP client connects to it today with no Hermes-side change. This PR adds a short "Other ACP clients" section documenting that, with a verified example, and broadens the page title/description to match what the page now covers.

The gap has a visible cost: there are currently 16 open PRs matching `feat(mobile)` and 11 matching `apps/mobile`, several of them large from-scratch remote clients, none merged. A user who wants to reach Hermes from a phone has no documented path to the shipped one, so they write a new client instead. This PR is the cheapest half of that problem.

**Scope note:** this PR is deliberately factual and takes no position on whether a first-party mobile/remote client should exist. I raised that as a separate direction question in #72011 and it stays there for a maintainer to answer. Nothing here presumes an answer.

## Related Issue

Related to #72011 (direction question on the remote/mobile client category, where I posted the verification trace below). Not a fix for it: this PR documents existing behavior and leaves the direction question open.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/features/acp.md`
  - New `## Other ACP clients` section: ACP hosts are not limited to editors; verified `happy acp -- hermes acp` example; what comes up over the wire (`hermes-acp` toolset, `available_models`, session modes, `available_commands_update`); `hermes acp --check` as the correct pre-flight.
  - `title` "ACP Editor Integration" → "ACP Integration", `description` and `<h1>` matched. **This rename is separable** — say the word and I'll drop it and keep the section only. The file path and doc URL are unchanged, so no links break.
- `website/i18n/zh-Hans/.../user-guide/features/acp.md` — same section and front-matter change, translated, keeping the pair in sync.

Naming a third-party client follows what the page already does: it links the VS Code `acp-client` marketplace extension and gives a Zed `agent_servers` config block.

## How to Test

Verified on `hermes` v0.17.0 (2026.6.19), Python 3.11.14, macOS 15 arm64, against `happy` 1.1.9-beta.0.

1. `cd ~/.hermes/hermes-agent && uv pip install -e '.[acp]'`
2. `hermes acp --check` → `Hermes ACP check OK` (exit 0)
3. `happy acp -- hermes acp` → session reaches `idle`

Handshake, from the client's log:

```
[AcpBackend] Initializing connection (timeout: 60000ms)...
acp_adapter.server: ACP client connected
acp_adapter.server: Initialize from happy-cli (protocol v1)
[AcpBackend] Initialize completed
acp_adapter.session: Created ACP session 6584d2cc-...
tools.mcp_tool: MCP server 'happy' (stdio): registered 1 tool(s): mcp_happy_change_title
acp_adapter.server: refreshed tool surface after ACP MCP registration (26 tools)
[AcpBackend] Session created
```

Two things worth noting because they are stronger than I expected and are what the new section claims:

- **The MCP bridge runs both ways.** The client's MCP server registered *into* Hermes and `acp_adapter` refreshed its tool surface to include it.
- **`available_commands_update` carries a real command surface**: `help`, `model`, `tools`, `context`, `reset`, `compact`, `steer`, `queue`, `version`. `usage_update` streams token accounting (`{"size":272000,"used":11462}`).

Protocol v1 negotiated cleanly even though Hermes pins the Python `agent-client-protocol==0.9.0` and that client is on the npm SDK. I expected that to be the failure mode and it was not, which is why the section says "verified" rather than "should work".

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`docs(acp): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] N/A — `pytest tests/ -q` not run. Docs-only change, no Python touched. I did not run the suite and am not claiming otherwise; the commands in the new section were each executed as shown above.
- [ ] N/A — no tests added. There is no test surface for a Markdown docs page in this tree.
- [x] I've tested on my platform: macOS 15 (arm64, M1), Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation — this PR *is* the documentation change, canonical + zh-Hans
- [ ] N/A — `cli-config.yaml.example`: no config keys added or changed
- [ ] N/A — `CONTRIBUTING.md` / `AGENTS.md`: no architecture or workflow change
- [x] Cross-platform impact considered — the added commands (`hermes acp`, `hermes acp --check`) are the page's existing platform-neutral entry points; nothing platform-specific was added. Verified on macOS only, and the section makes no OS-specific claim.
- [ ] N/A — no tool descriptions or schemas changed

## Screenshots / Logs

Log output is inline under "How to Test" above.
