### PR TITLE
fix(slack): read real SDK responses and deliver YAML plugin settings

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3815,6 +3815,8 @@ class SlackAdapter(BasePlatformAdapter):
             )
             result = await client.users_info(user=user_id)
             if not isinstance(result, dict):
+                result = getattr(result, "data", None)
+            if not isinstance(result, dict):
                 self._user_is_bot_cache[cache_key] = False
                 self._user_name_cache[cache_key] = user_id
                 return user_id
@@ -3983,6 +3985,8 @@ class SlackAdapter(BasePlatformAdapter):
                 else self._app.client
             )
             result = await client.users_info(user=user_id)
+            if not isinstance(result, dict):
+                result = getattr(result, "data", None)
             if not isinstance(result, dict):
                 self._user_is_bot_cache[cache_key] = False
                 self._user_name_cache.setdefault(cache_key, user_id)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3854,6 +3854,8 @@ class SlackAdapter(BasePlatformAdapter):
             resp = await self._get_client(
                 channel_id, team_id=team_id or None
             ).conversations_info(channel=channel_id)
+            if not isinstance(resp, dict):
+                resp = getattr(resp, "data", None)
             if not isinstance(resp, dict) or not resp.get("ok"):
                 name = channel_id
             else:
@@ -7718,8 +7720,12 @@ class SlackAdapter(BasePlatformAdapter):
                 user_id,
             )
             return
+        channel_name = await self._resolve_channel_name(
+            channel_id, team_id=team_id
+        )
         source = self.build_source(
             chat_id=channel_id,
+            chat_name=channel_name,
             chat_type="dm" if is_dm else "group",
             user_id=user_id,
             thread_id=thread_id,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -77,6 +77,7 @@ except Exception:
 _HERMES_SLACK_USER_AGENT_PREFIX = f"HermesAgent/{_HERMES_VERSION}"
 
 _SLACK_ERROR_BODY_LIMIT_BYTES = 8 * 1024
+_SLACK_EMOJI_NAME_RE = re.compile(r"[A-Za-z0-9_+\-]{1,100}")
 
 
 async def _read_error_text_limited(
@@ -3743,6 +3744,15 @@ class SlackAdapter(BasePlatformAdapter):
         """Check if message reactions are enabled via config/env."""
         return os.getenv("SLACK_REACTIONS", "true").lower() not in {"false", "0", "no"}
 
+    @staticmethod
+    def _validated_slack_emoji_name(value: Any) -> str:
+        """Return a safe Slack emoji name with a stable success fallback."""
+        if isinstance(value, str):
+            candidate = value.strip()
+            if _SLACK_EMOJI_NAME_RE.fullmatch(candidate):
+                return candidate
+        return "white_check_mark"
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction when message processing begins."""
         if not self._reactions_enabled():
@@ -3773,7 +3783,10 @@ class SlackAdapter(BasePlatformAdapter):
             return
         await self._remove_reaction(channel_id, ts, "eyes", team_id)
         if outcome == ProcessingOutcome.SUCCESS:
-            await self._add_reaction(channel_id, ts, "white_check_mark", team_id)
+            success_reaction = self._validated_slack_emoji_name(
+                self.config.extra.get("success_reaction", "white_check_mark")
+            )
+            await self._add_reaction(channel_id, ts, success_reaction, team_id)
         elif outcome == ProcessingOutcome.FAILURE:
             await self._add_reaction(channel_id, ts, "x", team_id)
 
@@ -5528,6 +5541,7 @@ class SlackAdapter(BasePlatformAdapter):
                 chat_type="dm" if is_dm else "group",
                 user_id=user_id,
                 user_name="",
+                is_bot=sender_is_bot,
             )
             if not _auth_fn(_source):
                 logger.warning(
@@ -5645,6 +5659,19 @@ class SlackAdapter(BasePlatformAdapter):
             if allowed_channels and channel_id not in allowed_channels:
                 logger.debug(
                     "[Slack] Ignoring message in non-allowed channel: %s", channel_id
+                )
+                return
+
+            if (
+                not force_process
+                and not is_mentioned
+                and self._slack_message_matches_other_agent_patterns(routing_text)
+            ):
+                logger.debug(
+                    "[Slack] Ignoring message addressed to another configured agent: "
+                    "channel=%s thread_ts=%s",
+                    channel_id,
+                    event_thread_ts,
                 )
                 return
 
@@ -6212,7 +6239,7 @@ class SlackAdapter(BasePlatformAdapter):
             # subtype=bot_message with user=None; flag them so the
             # gateway SLACK_ALLOW_BOTS bypass can authorize them
             # (they carry no user_id to match against the allowlist).
-            is_bot=bool(event.get("bot_id")) or event.get("subtype") == "bot_message",
+            is_bot=sender_is_bot,
         )
 
         # Per-channel ephemeral prompt
@@ -8466,6 +8493,35 @@ class SlackAdapter(BasePlatformAdapter):
             return False
         return any(pattern.search(text) for pattern in self._slack_mention_patterns())
 
+    def _slack_other_agent_patterns(self) -> List["re.Pattern"]:
+        """Compile optional leading-address patterns for peer agents."""
+        cached = getattr(self, "_compiled_other_agent_patterns", None)
+        if cached is not None:
+            return cached
+        raw = (self.config.extra or {}).get("other_agent_patterns")
+        if isinstance(raw, str):
+            raw = [raw]
+        compiled: List["re.Pattern"] = []
+        for pattern in raw if isinstance(raw, list) else []:
+            if not isinstance(pattern, str) or not pattern.strip():
+                continue
+            try:
+                compiled.append(re.compile(pattern, re.IGNORECASE))
+            except re.error as exc:
+                logger.warning(
+                    "[Slack] Invalid other_agent_patterns entry %r: %s",
+                    pattern,
+                    exc,
+                )
+        self._compiled_other_agent_patterns = compiled
+        return compiled
+
+    def _slack_message_matches_other_agent_patterns(self, text: str) -> bool:
+        """Return whether a configured peer-agent pattern matches at the start."""
+        return bool(text) and any(
+            pattern.match(text) for pattern in self._slack_other_agent_patterns()
+        )
+
 
 # ──────────────────────────────────────────────────────────────────────────
 # Plugin migration glue (#41112 / #3823)
@@ -8975,8 +9031,8 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
     existing env-driven model and owns the YAML→env translation here, next to
     the adapter that consumes it. Env vars take precedence over YAML — every
     assignment is guarded by ``not os.getenv(...)`` so explicit env vars
-    survive a config.yaml update. Returns ``None`` because no extras are
-    seeded into ``PlatformConfig.extra`` directly (everything flows through env).
+    survive a config.yaml update. Plugin settings without legacy env consumers
+    are returned for ``PlatformConfig.extra``.
     """
     if "require_mention" in slack_cfg and not os.getenv("SLACK_REQUIRE_MENTION"):
         os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
@@ -9028,7 +9084,11 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         if isinstance(ic, list):
             ic = ",".join(str(v) for v in ic)
         os.environ["SLACK_IGNORED_CHANNELS"] = str(ic)
-    return None  # all settings flow through env; nothing to merge into extras
+    return {
+        key: slack_cfg[key]
+        for key in ("success_reaction", "other_agent_patterns")
+        if key in slack_cfg
+    }
 
 
 def _is_connected(config) -> bool:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3432,6 +3432,51 @@ class TestMessageRouting:
         assert msg_event.source.user_name == "AIDx Engineer"
 
     @pytest.mark.asyncio
+    async def test_resolved_bot_identity_reaches_early_auth_and_final_source(
+        self, adapter
+    ):
+        adapter.config.extra["allow_bots"] = "mentions"
+        adapter._app.client.users_info = AsyncMock(
+            return_value={
+                "user": {
+                    "is_bot": True,
+                    "profile": {"display_name": "Router Bot"},
+                }
+            }
+        )
+
+        class Runner:
+            def __init__(self):
+                self.sources = []
+
+            def _is_user_authorized(self, source):
+                self.sources.append(source)
+                return source.is_bot
+
+            async def handle(self, _event):
+                return None
+
+        runner = Runner()
+        adapter._message_handler = runner.handle
+        event = {
+            "text": "<@U_BOT> route this",
+            "user": "U_ROUTER_BOT",
+            "channel": "C123",
+            "channel_type": "channel",
+            "team": "T123",
+            "ts": "123.999",
+        }
+
+        await adapter._handle_slack_message(event)
+
+        assert len(runner.sources) == 1
+        assert runner.sources[0].is_bot is True
+        routed = adapter.handle_message.await_args.args[0]
+        assert routed.source.is_bot is True
+        assert routed.source.user_name == "Router Bot"
+        adapter._app.client.users_info.assert_awaited_once_with(user="U_ROUTER_BOT")
+
+    @pytest.mark.asyncio
     async def test_app_authored_messages_without_client_msg_id_are_ignored(self, adapter):
         """Slack app-authored events can arrive without bot_id/subtype markers."""
         adapter._app.client.users_info = AsyncMock(
@@ -3558,6 +3603,122 @@ class TestMessageRouting:
         await adapter._handle_slack_message(edited_event)
 
         adapter.handle_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestOtherAgentPatternRouting
+# ---------------------------------------------------------------------------
+
+
+class TestOtherAgentPatternRouting:
+    @staticmethod
+    def _event(text, *, channel_type="channel", thread_ts=None, force_process=False):
+        event = {
+            "text": text,
+            "user": "U_USER",
+            "channel": "D123" if channel_type == "im" else "C123",
+            "channel_type": channel_type,
+            "team": "T_TEAM",
+            "ts": "123.456",
+            "client_msg_id": "client-message-id",
+        }
+        if thread_ts is not None:
+            event["thread_ts"] = thread_ts
+        if force_process:
+            event["_hermes_force_process"] = True
+        return event
+
+    @staticmethod
+    def _configure(adapter):
+        adapter.config.extra.update(
+            {
+                "other_agent_patterns": [r"Friday\b"],
+                "mention_patterns": [],
+                "require_mention": True,
+            }
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("active", [False, True], ids=["cold", "active"])
+    async def test_thread_is_ignored_before_wake_logic(self, adapter, active):
+        self._configure(adapter)
+        adapter._has_active_session_for_thread = MagicMock(return_value=active)
+        adapter._should_wake_on_unmentioned_message = AsyncMock(return_value=True)
+
+        await adapter._handle_slack_message(
+            self._event("Friday, take this", thread_ts="123.000")
+        )
+
+        adapter.handle_message.assert_not_called()
+        adapter._should_wake_on_unmentioned_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("text", "mention_patterns"),
+        [
+            ("Friday, <@U_BOT> take this", []),
+            ("Friday, take this", [r"Friday\b"]),
+        ],
+        ids=["literal-bot-mention", "configured-mention-pattern"],
+    )
+    async def test_explicit_wake_precedence_over_peer_pattern(
+        self, adapter, text, mention_patterns
+    ):
+        self._configure(adapter)
+        adapter.config.extra["mention_patterns"] = mention_patterns
+
+        await adapter._handle_slack_message(self._event(text))
+
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_force_process_precedence_over_peer_pattern(self, adapter):
+        self._configure(adapter)
+
+        await adapter._handle_slack_message(
+            self._event("Friday, take this", force_process=True)
+        )
+
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_non_leading_peer_pattern_does_not_suppress(self, adapter):
+        self._configure(adapter)
+        adapter.config.extra["free_response_channels"] = ["C123"]
+
+        await adapter._handle_slack_message(
+            self._event("Could Friday take this instead?")
+        )
+
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dm_is_not_suppressed(self, adapter):
+        self._configure(adapter)
+
+        await adapter._handle_slack_message(
+            self._event("Friday, take this", channel_type="im")
+        )
+
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_invalid_pattern_logs_skips_and_is_cached(self, adapter, caplog):
+        self._configure(adapter)
+        adapter.config.extra.update(
+            {
+                "other_agent_patterns": ["("],
+                "free_response_channels": ["C123"],
+            }
+        )
+
+        await adapter._handle_slack_message(self._event("Friday, take this"))
+
+        adapter.handle_message.assert_called_once()
+        assert "Invalid other_agent_patterns entry" in caplog.text
+        cached = adapter._slack_other_agent_patterns()
+        assert cached == []
+        assert adapter._slack_other_agent_patterns() is cached
 
 
 # ---------------------------------------------------------------------------
@@ -4841,6 +5002,71 @@ class TestReactions:
 
         # Message ID should be cleaned up
         assert "1234567890.000001" not in adapter._reacting_message_ids
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [
+            ("thumbsup", "thumbsup"),
+            (" +1 ", "+1"),
+            ("", "white_check_mark"),
+            (" :thumbsup: ", "white_check_mark"),
+            ("two words", "white_check_mark"),
+            ("a" * 101, "white_check_mark"),
+            (["thumbsup"], "white_check_mark"),
+            (None, "white_check_mark"),
+        ],
+    )
+    async def test_success_reaction_accepts_only_safe_bounded_emoji_names(
+        self, adapter, configured, expected
+    ):
+        from gateway.platforms.base import (
+            MessageEvent,
+            MessageType,
+            ProcessingOutcome,
+            SessionSource,
+        )
+        from gateway.config import Platform
+
+        adapter.config.extra["success_reaction"] = configured
+        adapter._app.client.reactions_add = AsyncMock()
+        adapter._app.client.reactions_remove = AsyncMock()
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="dm",
+            user_id="U_USER",
+        )
+        message_id = "1234567890.000009"
+        adapter._reacting_message_ids.add(message_id)
+        msg_event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=message_id,
+        )
+
+        await adapter.on_processing_complete(msg_event, ProcessingOutcome.SUCCESS)
+
+        assert adapter._app.client.reactions_add.call_args.kwargs["name"] == expected
+
+    def test_yaml_bridge_seeds_only_residual_slack_extras(self):
+        from plugins.platforms.slack.adapter import _apply_yaml_config
+
+        seeded = _apply_yaml_config(
+            {},
+            {
+                "success_reaction": "thumbsup",
+                "other_agent_patterns": [r"Friday\b"],
+                "mention_patterns": [r"Sunday\b"],
+                "unrelated": True,
+            },
+        )
+
+        assert seeded == {
+            "success_reaction": "thumbsup",
+            "other_agent_patterns": [r"Friday\b"],
+        }
 
     @pytest.mark.asyncio
     async def test_reactions_failure_outcome(self, adapter):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3477,6 +3477,45 @@ class TestMessageRouting:
         adapter._app.client.users_info.assert_awaited_once_with(user="U_ROUTER_BOT")
 
     @pytest.mark.asyncio
+    async def test_real_sdk_response_marks_unlabeled_peer_bot_on_source(self, adapter):
+        try:
+            from slack_sdk.web.async_slack_response import AsyncSlackResponse
+        except ImportError:
+            pytest.skip("slack-sdk is not installed")
+
+        adapter.config.extra["allow_bots"] = "all"
+        response = AsyncSlackResponse(
+            client=adapter._app.client,
+            http_verb="GET",
+            api_url="https://slack.com/api/users.info",
+            req_args={"params": {"user": "U_PEER_BOT"}},
+            data={
+                "ok": True,
+                "user": {
+                    "is_bot": True,
+                    "profile": {"display_name": "Peer Bot"},
+                },
+            },
+            headers={},
+            status_code=200,
+        )
+        adapter._app.client.users_info = AsyncMock(return_value=response)
+        event = {
+            "text": "peer response",
+            "user": "U_PEER_BOT",
+            "channel": "D123",
+            "channel_type": "im",
+            "ts": "123.1000",
+        }
+
+        await adapter._handle_slack_message(event)
+
+        routed = adapter.handle_message.await_args.args[0]
+        assert routed.source.is_bot is True
+        assert routed.source.user_name == "Peer Bot"
+        adapter._app.client.users_info.assert_awaited_once_with(user="U_PEER_BOT")
+
+    @pytest.mark.asyncio
     async def test_app_authored_messages_without_client_msg_id_are_ignored(self, adapter):
         """Slack app-authored events can arrive without bot_id/subtype markers."""
         adapter._app.client.users_info = AsyncMock(
@@ -6046,6 +6085,40 @@ class TestChannelNameResolution:
 
         assert name == "project-x"
         team_client.conversations_info.assert_awaited_once_with(channel="C123")
+
+    @pytest.mark.asyncio
+    async def test_resolves_dm_peer_from_real_users_info_response(self, adapter):
+        try:
+            from slack_sdk.web.async_slack_response import AsyncSlackResponse
+        except ImportError:
+            pytest.skip("slack-sdk is not installed")
+
+        team_client = AsyncMock()
+        team_client.conversations_info = AsyncMock(
+            return_value={
+                "ok": True,
+                "channel": {"is_im": True, "user": "U_PEER"},
+            }
+        )
+        response = AsyncSlackResponse(
+            client=team_client,
+            http_verb="GET",
+            api_url="https://slack.com/api/users.info",
+            req_args={"params": {"user": "U_PEER"}},
+            data={
+                "ok": True,
+                "user": {"profile": {"display_name": "Peer Person"}},
+            },
+            headers={},
+            status_code=200,
+        )
+        team_client.users_info = AsyncMock(return_value=response)
+        adapter._team_clients["T123"] = team_client
+
+        name = await adapter._resolve_channel_name("D123", team_id="T123")
+
+        assert name == "Peer Person"
+        team_client.users_info.assert_awaited_once_with(user="U_PEER")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -304,10 +304,14 @@ class TestBotEventDiagnostics:
 class TestSlashCommandSessionIsolation:
     @pytest.mark.asyncio
     async def test_channel_slash_command_uses_group_session_semantics(self, adapter):
+        adapter._app.client.conversations_info = AsyncMock(
+            return_value={"ok": True, "channel": {"name": "project-x"}}
+        )
         command = {
             "text": "hello",
             "user_id": "U123",
             "channel_id": "C123",
+            "channel_name": "privategroup",
             "team_id": "T123",
         }
 
@@ -317,15 +321,27 @@ class TestSlashCommandSessionIsolation:
         event = adapter.handle_message.await_args.args[0]
         assert event.source.chat_type == "group"
         assert event.source.chat_id == "C123"
+        assert event.source.chat_name == "project-x"
+        assert event.source.description == "group: project-x"
         assert event.source.user_id == "U123"
         assert event.source.scope_id == "T123"
 
     @pytest.mark.asyncio
     async def test_dm_slash_command_keeps_dm_session_semantics(self, adapter):
+        adapter._app.client.conversations_info = AsyncMock(
+            return_value={
+                "ok": True,
+                "channel": {"is_im": True, "user": "U_PEER"},
+            }
+        )
+        adapter._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Peer Person"}}}
+        )
         command = {
             "text": "hello",
             "user_id": "U123",
             "channel_id": "D123",
+            "channel_name": "directmessage",
             "team_id": "T123",
         }
 
@@ -335,6 +351,7 @@ class TestSlashCommandSessionIsolation:
         event = adapter.handle_message.await_args.args[0]
         assert event.source.chat_type == "dm"
         assert event.source.chat_id == "D123"
+        assert event.source.chat_name == "Peer Person"
         assert event.source.user_id == "U123"
         assert event.source.scope_id == "T123"
 
@@ -5771,6 +5788,38 @@ class TestAssistantThreadLifecycle:
         await assistant_adapter._handle_slack_message(event)
 
         assistant_adapter._app.client.assistant_threads_setTitle.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestChannelNameResolution
+# ---------------------------------------------------------------------------
+
+
+class TestChannelNameResolution:
+    @pytest.mark.asyncio
+    async def test_resolves_real_async_slack_response(self, adapter):
+        try:
+            from slack_sdk.web.async_slack_response import AsyncSlackResponse
+        except ImportError:
+            pytest.skip("slack-sdk is not installed")
+
+        team_client = AsyncMock()
+        response = AsyncSlackResponse(
+            client=team_client,
+            http_verb="GET",
+            api_url="https://slack.com/api/conversations.info",
+            req_args={"params": {"channel": "C123"}},
+            data={"ok": True, "channel": {"name": "project-x"}},
+            headers={},
+            status_code=200,
+        )
+        team_client.conversations_info = AsyncMock(return_value=response)
+        adapter._team_clients["T123"] = team_client
+
+        name = await adapter._resolve_channel_name("C123", team_id="T123")
+
+        assert name == "project-x"
+        team_client.conversations_info.assert_awaited_once_with(channel="C123")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes three defects in the Slack adapter that only surface against the **real** Slack SDK, plus the plumbing bug that made two `config.yaml` plugin settings unreachable.

1. **`users_info` / `conversations_info` results are `AsyncSlackResponse`, not `dict`.** Three call sites guard with `isinstance(result, dict)` and take the failure branch when the real SDK object arrives. The visible effects are that channel names fall back to raw IDs (`C0…`) in session context, and every user is cached as a non-bot — which also defeats the `SLACK_ALLOW_BOTS` classification. Tests passed because they inject plain dicts.

2. **`_apply_yaml_config` returned `None` unconditionally**, so any `platforms.slack` setting without a legacy env consumer never reached `PlatformConfig.extra`. It was silently dropped.

3. **The source built for the early auth check hardcoded its own `is_bot` expression** instead of the `sender_is_bot` value already computed a few lines above, so a bot sender reached the auth callback as `is_bot=False` while the later source correctly flagged it.

With (2) fixed, two plugin settings become usable: `success_reaction` (validated against a bounded emoji-name pattern with a `white_check_mark` fallback, so a malformed value can never reach the reactions API) and `other_agent_patterns` (leading-address patterns for peer agents sharing a workspace — a message that opens by addressing another configured agent is ignored unless this agent is also mentioned, so two agents in one channel don't both answer). Invalid patterns are logged and skipped; the compiled list is cached.

Each fix is a separate commit and can be reviewed or dropped independently.

## Related Issue

No existing issue — these were found while running two Hermes agents against a live Slack workspace. Happy to open issues first if you prefer that order.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/slack/adapter.py`
  - `_resolve_channel_name`: normalize a non-dict response through `getattr(resp, "data", None)` before the dict check.
  - both `users_info` call sites: same normalization before the dict check.
  - slash-command path: pass the resolved `chat_name` when building the session source (the only path that omitted it).
  - `on_processing_complete`: use `config.extra["success_reaction"]` through the new `_validated_slack_emoji_name` guard.
  - new `_slack_other_agent_patterns` / `_slack_message_matches_other_agent_patterns`, applied only when the message is not a mention and not force-processed.
  - early-auth source: `is_bot=sender_is_bot`.
  - `_apply_yaml_config`: return the plugin-only keys (`success_reaction`, `other_agent_patterns`) for `PlatformConfig.extra`; docstring corrected.
- `tests/gateway/test_slack.py`: +423 lines of tests, including fixtures built from **real** `AsyncSlackResponse`-shaped objects rather than plain dicts.

No behavior changes for existing configs: both new settings are absent by default, and the emoji guard falls back to today's hardcoded `white_check_mark`.

## How to Test

1. `pytest tests/gateway/test_slack.py -q` → 448 passed.
2. Revert only the source file and re-run the same tests: `git checkout main -- plugins/platforms/slack/adapter.py && pytest tests/gateway/test_slack.py -q` → **12 failed**, each pointing at one of the defects above (channel-name resolution from a real response, bot identity reaching the early auth source, peer-agent pattern routing, `success_reaction` bounds, YAML→extras bridge). Restore with `git checkout HEAD -- plugins/platforms/slack/adapter.py`.
3. Optional live check: set `platforms.slack.other_agent_patterns` in `config.yaml`, address the other agent by name in a shared channel, and confirm only that agent answers.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **see note**: `pytest tests/gateway/test_slack.py -q` passes (448 passed), and the reverse check above fails 12 tests without the fix. The *whole* suite had not finished locally after 12 minutes on this machine, so I'm not claiming it; relying on CI for the full run and happy to post local results if useful.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (Apple silicon), Python 3.11.15

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — docstring of `_apply_yaml_config` corrected; no user-facing docs touched
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — happy to add `success_reaction` / `other_agent_patterns` examples if you want them documented there
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python, no platform primitives
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
