### PR TITLE
fix(vertex): route us/eu to multi-region hosts

### DIFF
--- a/agent/vertex_adapter.py
+++ b/agent/vertex_adapter.py
@@ -191,11 +191,17 @@ def build_vertex_base_url(project_id: str, region: str = DEFAULT_REGION) -> str:
     """Build the OpenAI-compatible base URL for Vertex AI.
 
     The `global` location uses a bare `aiplatform.googleapis.com` hostname,
-    while regional locations use `{region}-aiplatform.googleapis.com`.
+    the `us` and `eu` multi-regions use `aiplatform.{region}.rep.googleapis.com`,
+    and regional locations use `{region}-aiplatform.googleapis.com`.
     Gemini 3.x preview models are only served via the global endpoint at
     the time of writing.
     """
-    host = "aiplatform.googleapis.com" if region == "global" else f"{region}-aiplatform.googleapis.com"
+    if region == "global":
+        host = "aiplatform.googleapis.com"
+    elif region in {"us", "eu"}:
+        host = f"aiplatform.{region}.rep.googleapis.com"
+    else:
+        host = f"{region}-aiplatform.googleapis.com"
     return f"https://{host}/v1beta1/projects/{project_id}/locations/{region}/endpoints/openapi"
 
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2599,12 +2599,14 @@ def _model_flow_vertex(config, current_model=""):
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",
     ]
+    if region == "global":
+        vertex_host = "aiplatform.googleapis.com"
+    elif region in {"us", "eu"}:
+        vertex_host = f"aiplatform.{region}.rep.googleapis.com"
+    else:
+        vertex_host = f"{region}-aiplatform.googleapis.com"
     base_url_preview = (
-        "https://aiplatform.googleapis.com/v1beta1/projects/<project>/"
-        f"locations/{region}/endpoints/openapi"
-        if region == "global"
-        else f"https://{region}-aiplatform.googleapis.com/v1beta1/projects/<project>/"
-        f"locations/{region}/endpoints/openapi"
+        f"https://{vertex_host}/v1beta1/projects/<project>/locations/{region}/endpoints/openapi"
     )
     selected = _prompt_model_selection(
         model_list,

--- a/tests/agent/test_vertex_adapter.py
+++ b/tests/agent/test_vertex_adapter.py
@@ -97,6 +97,15 @@ def test_build_base_url_regional(vertex_adapter):
     )
 
 
+@pytest.mark.parametrize("region", ["us", "eu"])
+def test_build_base_url_multi_regional(vertex_adapter, region):
+    url = vertex_adapter.build_vertex_base_url("proj", region)
+    assert url == (
+        f"https://aiplatform.{region}.rep.googleapis.com/v1beta1/projects/proj/"
+        f"locations/{region}/endpoints/openapi"
+    )
+
+
 def test_get_vertex_config_uses_adc_and_default_region(vertex_adapter):
     token, base = vertex_adapter.get_vertex_config()
     assert token == "ya29.FAKE"

--- a/tests/agent/test_vertex_adapter.py
+++ b/tests/agent/test_vertex_adapter.py
@@ -85,6 +85,13 @@ def vertex_adapter(monkeypatch):
 
 
 
+@pytest.mark.parametrize("region", ["us", "eu"])
+def test_build_base_url_multi_regional(vertex_adapter, region):
+    url = vertex_adapter.build_vertex_base_url("proj", region)
+    assert url == (
+        f"https://aiplatform.{region}.rep.googleapis.com/v1beta1/projects/proj/"
+        f"locations/{region}/endpoints/openapi"
+    )
 
 
 

--- a/website/docs/guides/google-vertex.md
+++ b/website/docs/guides/google-vertex.md
@@ -80,6 +80,7 @@ vertex:
    https://aiplatform.googleapis.com/v1beta1/projects/{project}/locations/{region}/endpoints/openapi
    ```
    Regional locations use a `{region}-aiplatform.googleapis.com` host instead.
+   The `us` and `eu` multi-regions use `aiplatform.{region}.rep.googleapis.com`.
 4. If a session runs longer than the token lifetime and a request returns `401`, Hermes re-mints the token and retries automatically. On a long-running gateway, if ADC's refresh token has itself expired, Hermes falls back to the service-account JSON when one is configured.
 
 ## Available Models


### PR DESCRIPTION
## Summary

- route Vertex `us` and `eu` multi-region locations to their REP API hosts
- preserve the existing `global` and single-region endpoint shapes
- add focused coverage for both supported multi-region identifiers

Fixes #72063

## Root cause

`build_vertex_base_url()` treated every location except `global` as a single region and prefixed it onto `aiplatform.googleapis.com`. Google assigns `us` and `eu` dedicated multi-region hosts instead: `aiplatform.{location}.rep.googleapis.com`.

## Tests

```text
python -m pytest tests/agent/test_vertex_adapter.py -q
15 passed in 2.09s

python -m ruff check agent/vertex_adapter.py tests/agent/test_vertex_adapter.py
All checks passed!

git diff --check
clean
```

## Scope

No authentication, token refresh, provider selection, request path, global endpoint, or normal regional endpoint behavior changes.