### PR TITLE
feat(cron): support centrally managed inference source

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3162,12 +3162,18 @@ def run_job(
                 else str(delivery_target["thread_id"])
             )
 
-        # Model resolution precedence: per-job override > HERMES_MODEL env >
-        # config.yaml ``model:`` (string or ``{default: ...}``). The per-job
-        # value is intentionally re-read from storage every tick so a
+        # Default model resolution precedence: per-job override > HERMES_MODEL
+        # env > config.yaml ``model:`` (string or ``{default: ...}``). The
+        # per-job value is intentionally re-read from storage every tick so a
         # ``cronjob action=update model=...`` after a failed run takes effect
         # on the next tick — there is no in-memory cache.
+        #
+        # An operator can instead set cron.inference_source=global. That mode
+        # makes config.yaml the sole source and deliberately ignores per-job
+        # and HERMES_MODEL overrides.
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
+        _cron_inference_source = "job_or_global"
+        _use_global_inference = False
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
         _cfg = {}
@@ -3191,21 +3197,38 @@ def run_job(
                 # Coerce null/missing to {} so a falsy default never
                 # clobbers an already-resolved env value with ``None``.
                 _model_cfg = _cfg.get("model") or {}
-                if not job.get("model"):
-                    if isinstance(_model_cfg, str):
-                        model = _model_cfg
-                    elif isinstance(_model_cfg, dict):
-                        # Mirror the CLI/oneshot resolution: prefer ``default``,
-                        # accept a ``model`` alias, overwrite only when truthy.
-                        _default = _model_cfg.get("default") or _model_cfg.get("model")
-                        if _default:
-                            model = _default
+                _cron_cfg = _cfg.get("cron")
+                if not isinstance(_cron_cfg, dict):
+                    _cron_cfg = {}
+                _cron_inference_source = str(
+                    _cron_cfg.get("inference_source") or "job_or_global"
+                ).strip().lower()
+                _use_global_inference = _cron_inference_source == "global"
+                if isinstance(_model_cfg, str):
+                    _global_model = _model_cfg
+                elif isinstance(_model_cfg, dict):
+                    # Mirror the CLI/oneshot resolution: prefer ``default`` and
+                    # accept the legacy ``model`` alias.
+                    _global_model = (
+                        _model_cfg.get("default") or _model_cfg.get("model")
+                    )
+                else:
+                    _global_model = ""
+                if _use_global_inference:
+                    model = _global_model or ""
+                elif not job.get("model") and _global_model:
+                    model = _global_model
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 
         # Fail fast if no model resolved from job / env / config.yaml: an empty
         # model otherwise reaches the provider as an opaque 400 (#23979).
         if not (isinstance(model, str) and model.strip()):
+            if _use_global_inference:
+                raise RuntimeError(
+                    f"Cron job '{job_name}' requires the global inference "
+                    "source, but config.yaml model.default is missing or empty."
+                )
             raise RuntimeError(
                 f"Cron job '{job_name}' has no model configured "
                 f"(job.model={job.get('model')!r}, "
@@ -3271,7 +3294,8 @@ def run_job(
         # job persisted before that guard — or written directly to the jobs store
         # — reaches this sink unchecked. Fail closed before resolution so no
         # off-host call is ever made with a stored key.
-        _guard_job_credential_exfil(job)
+        if not _use_global_inference:
+            _guard_job_credential_exfil(job)
 
         primary_model_for_drift = model
         configured_provider_for_drift = (
@@ -3280,8 +3304,14 @@ def run_job(
             else ""
         )
         primary_provider_for_drift = (
-            str(job.get("provider") or "").strip().lower()
-            or configured_provider_for_drift
+            (
+                configured_provider_for_drift
+                if _use_global_inference
+                else (
+                    str(job.get("provider") or "").strip().lower()
+                    or configured_provider_for_drift
+                )
+            )
             or None
         )
         try:
@@ -3291,14 +3321,16 @@ def run_job(
             # circuits that precedence and can resurrect old providers (for
             # example DeepSeek) for cron jobs that do not pin provider/model.
             runtime_kwargs = {
-                "requested": job.get("provider"),
+                "requested": (
+                    None if _use_global_inference else job.get("provider")
+                ),
                 # Derive provider-specific api_mode from the model this job
-                # will actually run (per-job pin > env > config default), not
-                # the stale persisted default — mirrors the fallback path
-                # below, which already passes its fb_model.
+                # will actually run. Normal precedence is per-job pin > env >
+                # config default; global-source mode uses config only. This
+                # mirrors the fallback path below, which passes its fb_model.
                 "target_model": model,
             }
-            if job.get("base_url"):
+            if job.get("base_url") and not _use_global_inference:
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")
             runtime = resolve_runtime_provider(**runtime_kwargs)
             primary_provider_for_drift = (
@@ -3372,12 +3404,20 @@ def run_job(
         # fail closed: skip this run, make NO paid call, and deliver a loud,
         # actionable alert telling the user to pin the axis explicitly.
         #
+        # Operators that keep inference routing in a reviewed central config
+        # can explicitly set cron.inference_source=global. In that mode the
+        # current global provider/model is the desired route, per-job pins are
+        # ignored, and snapshots remain audit metadata. The default and every
+        # unknown value retain per-job precedence and fail closed on drift.
+        #
         # Back-compat: an axis with no snapshot (pre-existing jobs, no_agent, or
         # any axis whose creation-time resolution failed) behaves exactly as
         # before — the guard never engages for it. Pinned axes are unaffected.
         _drift: list[str] = []
         _provider_snapshot = (job.get("provider_snapshot") or "").strip().lower()
-        if _provider_snapshot and not (job.get("provider") or "").strip():
+        if _provider_snapshot and (
+            _use_global_inference or not (job.get("provider") or "").strip()
+        ):
             _current_provider = str(
                 primary_provider_for_drift or runtime.get("provider") or ""
             ).strip().lower()
@@ -3386,13 +3426,22 @@ def run_job(
                     f"provider '{_provider_snapshot}' -> '{_current_provider}'"
                 )
         _model_snapshot = (job.get("model_snapshot") or "").strip().lower()
-        if _model_snapshot and not (job.get("model") or "").strip():
+        if _model_snapshot and (
+            _use_global_inference or not (job.get("model") or "").strip()
+        ):
             _current_model = str(primary_model_for_drift or "").strip().lower()
             if _current_model and _current_model != _model_snapshot:
                 _drift.append(
                     f"model '{_model_snapshot}' -> '{_current_model}'"
                 )
-        if _drift:
+        if _drift and _use_global_inference:
+            logger.info(
+                "Job '%s': following centrally managed global inference "
+                "config despite creation snapshot drift (%s).",
+                job_id,
+                "; ".join(_drift),
+            )
+        elif _drift:
             _changes = "; ".join(_drift)
             logger.warning(
                 "Job '%s': SKIPPED — global inference config drifted since "

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2853,6 +2853,16 @@ DEFAULT_CONFIG = {
         # An unknown or unavailable provider falls back to the built-in, so cron
         # never loses its trigger.
         "provider": "",
+        # Where agent-backed cron jobs resolve their primary provider/model:
+        #   job_or_global — explicit per-job overrides win; otherwise use the
+        #                   global route and fail closed on snapshot drift
+        #                   (safe default).
+        #   global        — deliberately ignore all per-job provider/model
+        #                   overrides and resolve the current global route on
+        #                   every run. Use only when global config is a reviewed,
+        #                   operator-managed source of truth.
+        # Unknown values behave as job_or_global.
+        "inference_source": "job_or_global",
         # Chronos (NAS-mediated managed cron) settings. Only consulted when
         # provider == "chronos". All non-secret (URLs + the JWT audience): the
         # agent holds NO external-scheduler credentials. For hosted agents, NAS

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -243,12 +243,24 @@ class TestCreateJobSnapshot:
         assert job["model_snapshot"] is None
 
 
-def _run_with_current_provider_and_model(job, current_provider, current_model, tmp_path):
+def _run_with_current_provider_and_model(
+    job,
+    current_provider,
+    current_model,
+    tmp_path,
+    *,
+    inference_source=None,
+    capture=None,
+):
     """Drive run_job with resolved provider pinned and config.yaml model.default
     set to ``current_model`` (the unpinned-model fire-time source)."""
-    (tmp_path / "config.yaml").write_text(
-        f"model:\n  default: {current_model}\n"
-    )
+    config_text = f"model:\n  default: {current_model}\n"
+    if inference_source is not None:
+        config_text += (
+            "cron:\n"
+            f"  inference_source: {inference_source}\n"
+        )
+    (tmp_path / "config.yaml").write_text(config_text)
     fake_db = MagicMock()
     with patch("cron.scheduler._hermes_home", tmp_path), \
          patch("cron.scheduler._get_hermes_home", return_value=tmp_path), \
@@ -258,7 +270,11 @@ def _run_with_current_provider_and_model(job, current_provider, current_model, t
          patch("hermes_state.SessionDB", return_value=fake_db), \
          patch(
              "hermes_cli.runtime_provider.resolve_runtime_provider",
-             return_value={
+             side_effect=lambda **kwargs: (
+                 capture.update({"runtime_kwargs": kwargs})
+                 if capture is not None
+                 else None
+             ) or {
                  "api_key": "test-key",
                  "base_url": "https://example.invalid/v1",
                  "provider": current_provider,
@@ -271,6 +287,8 @@ def _run_with_current_provider_and_model(job, current_provider, current_model, t
         mock_agent_cls.return_value = mock_agent
         success, output, final_response, error = run_job(job)
         agent_constructed = mock_agent_cls.called
+        if capture is not None and mock_agent_cls.called:
+            capture["agent_model"] = mock_agent_cls.call_args.kwargs["model"]
     return success, output, final_response, error, agent_constructed
 
 
@@ -334,6 +352,51 @@ class TestModelDriftGuard:
             )
         assert agent_constructed is True
         assert success is True
+
+    def test_global_source_ignores_job_pins_and_snapshot_drift(self, tmp_path):
+        """The explicit central source wins over every stored job override."""
+        job = _base_job(
+            provider_snapshot="openrouter",
+            model_snapshot="old-model",
+            provider="per-job-provider",
+            model="per-job-model",
+            base_url="https://per-job.invalid/v1",
+        )
+        captured = {}
+        success, output, final_response, error, agent_constructed = \
+            _run_with_current_provider_and_model(
+                job,
+                "openai-codex",
+                "centrally-managed-model",
+                tmp_path,
+                inference_source="global",
+                capture=captured,
+            )
+        assert agent_constructed is True
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert captured["runtime_kwargs"]["requested"] is None
+        assert "explicit_base_url" not in captured["runtime_kwargs"]
+        assert captured["agent_model"] == "centrally-managed-model"
+
+    def test_unknown_source_still_fails_closed(self, tmp_path):
+        """Typos retain the safe job-or-global behavior."""
+        job = _base_job(
+            provider_snapshot="openrouter",
+            model_snapshot="old-model",
+        )
+        success, output, final_response, error, agent_constructed = \
+            _run_with_current_provider_and_model(
+                job,
+                "openai-codex",
+                "centrally-managed-model",
+                tmp_path,
+                inference_source="typo",
+            )
+        assert agent_constructed is False
+        assert success is False
+        assert error is not None
 
 
 class TestRuntimeResolutionTargetModel:

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -22,7 +22,9 @@ Cron jobs can:
 All of this is available to Hermes itself through the `cronjob` tool, so you can create, pause, edit, and remove jobs by asking in plain language — no CLI required.
 
 :::tip
-At creation, an unpinned job (one you don't give an explicit `provider`/`model`) follows the global default selected by `hermes model` — and Hermes **snapshots** that provider and model on the job. If the global default later changes, the job **fails closed**: it skips the run, makes no inference call, and sends an alert telling you to pin the provider/model explicitly (`cronjob action=update job_id=… provider=… model=…`) to proceed. This prevents an unattended job from silently inheriting a switch to a paid provider/model and spending money you didn't intend (#44585). To make a job deliberately track your global default, pin it to the new values after changing them. `hermes setup --portal` is the lowest-friction option for unattended runs since OAuth refresh is automatic. See [Nous Portal](/integrations/nous-portal).
+At creation, an unpinned job (one you don't give an explicit `provider`/`model`) follows the global default selected by `hermes model` — and Hermes **snapshots** that provider and model on the job. If the global default later changes, the job **fails closed** by default: it skips the run, makes no inference call, and sends an alert telling you to pin the provider/model explicitly (`cronjob action=update job_id=… provider=… model=…`) to proceed. This prevents an unattended job from silently inheriting a switch to a paid provider/model and spending money you didn't intend (#44585).
+
+If your global inference config is itself a reviewed, operator-managed source of truth and every cron job should use it, set `cron.inference_source: global` in `config.yaml`. This deliberately ignores all per-job provider/model overrides and makes the current global route authoritative on every run. The default is `job_or_global`; unknown values retain that safe default. `hermes setup --portal` is the lowest-friction option for unattended runs since OAuth refresh is automatic. See [Nous Portal](/integrations/nous-portal).
 :::
 
 :::warning


### PR DESCRIPTION
## Summary

- add `cron.inference_source` with a safe `job_or_global` default
- allow reviewed global configuration to be authoritative for all agent-backed Cron runs
- ignore stale per-job provider/model/base_url pins and creation snapshots in global mode
- keep unknown values fail-closed and preserve the existing safety behavior

## Verification

- `scripts/run_tests.sh tests/cron/test_cron_provider_pin.py tests/cron/test_scheduler_provider.py tests/hermes_cli/test_cron.py`
- 73 tests passed

The companion personal configuration change is in `jackojacko05/hermes-config` PR and must be applied after this support is deployed.