### PR TITLE
fix: Electron updater rebuild fails when npm not on PATH (macOS)

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -744,10 +744,20 @@ fn update_child_env(install_root: &Path) -> Vec<(String, OsString)> {
     // a frozen stage, and users cancel a healthy update. Force line-by-line
     // output instead.
     envs.push(("PYTHONUNBUFFERED".to_string(), OsString::from("1")));
-    if let Some(path) = path_with_prepended_entries(&[
+    // On macOS, Electron -> Rust child processes inherit a stripped PATH
+    // that typically lacks /usr/local/bin and /opt/homebrew/bin, so
+    // `hermes desktop --build-only` (run in the rebuild stage) cannot find
+    // npm. Prepend those paths so the desktop rebuild always has access to
+    // a system Node.js runtime, regardless of how the updater was launched.
+    let mut extra_paths = vec![
         hermes_home.join("node").join("bin"),
         venv_bin_dir(install_root),
-    ]) {
+    ];
+    if cfg!(target_os = "macos") {
+        extra_paths.push(PathBuf::from("/usr/local/bin"));
+        extra_paths.push(PathBuf::from("/opt/homebrew/bin"));
+    }
+    if let Some(path) = path_with_prepended_entries(&extra_paths) {
         envs.push(("PATH".to_string(), path));
     }
     envs

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -490,13 +490,41 @@ def find_hermes_node_executable(command: str) -> str | None:
 def find_node_executable_on_path(command: str) -> str | None:
     """Return a Node/npm executable from PATH with Windows shim ordering.
 
-    ``shutil.which("npm")`` can resolve an extensionless npm shim before the
+    ``shutil.which(\"npm\")`` can resolve an extensionless npm shim before the
     ``.cmd`` shim on Windows. Python's CreateProcess cannot execute that shim
     directly, so prefer the launchable variants explicitly for Hermes-owned
     subprocesses.
+
+    On non-Windows, when ``shutil.which`` fails (e.g. the Electron updater
+    chain Desktop -> Rust -> Python strips PATH of common locations), fall
+    back to scanning known Node.js installation directories so the desktop
+    rebuild can find npm regardless of the process's inherited PATH.
     """
     if sys.platform != "win32":
-        return shutil.which(command)
+        resolved = shutil.which(command)
+        if resolved:
+            return resolved
+        # Fallback: scan known Node.js installation paths on macOS/Linux.
+        for name in _candidate_node_command_names(command):
+            for known_dir in (
+                "/usr/local/bin",
+                "/opt/homebrew/bin",
+                "/opt/local/bin",
+                os.path.expanduser("~/.nvm/versions/node/*/bin"),
+            ):
+                if "*" in known_dir:
+                    # glob expansion for nvm-style versioned paths.
+                    import glob as _glob
+
+                    for match in sorted(_glob.glob(known_dir), reverse=True):
+                        candidate = Path(match) / name
+                        if candidate.is_file():
+                            return str(candidate)
+                else:
+                    candidate = Path(known_dir) / name
+                    if candidate.is_file():
+                        return str(candidate)
+        return None
 
     command_str = str(command)
     has_path_separator = any(
@@ -532,7 +560,13 @@ def find_node_executable(command: str) -> str | None:
 
 
 def with_hermes_node_path(env: dict[str, str] | None = None) -> dict[str, str]:
-    """Return *env* with Hermes-managed Node directories prepended to PATH."""
+    """Return *env* with Hermes-managed Node directories prepended to PATH.
+
+    When no managed tree is present, also prepend common system Node.js
+    installation directories so npm subprocesses can find ``node`` even
+    when the inherited PATH is stripped (e.g. the Electron updater chain
+    Desktop -> Rust -> Python).
+    """
     merged = dict(os.environ if env is None else env)
     existing = merged.get("PATH", "")
     parts = [p for p in existing.split(os.pathsep) if p]
@@ -540,6 +574,16 @@ def with_hermes_node_path(env: dict[str, str] | None = None) -> dict[str, str]:
     for entry in reversed(managed):
         if entry not in parts:
             parts.insert(0, entry)
+    # If no managed Node tree exists, prepend common system Node.js bin dirs
+    # so npm subprocesses (which shell out to ``node``) find the runtime.
+    if not managed:
+        for common_dir in (
+            "/usr/local/bin",
+            "/opt/homebrew/bin",
+            "/opt/local/bin",
+        ):
+            if common_dir not in parts:
+                parts.insert(0, common_dir)
     merged["PATH"] = os.pathsep.join(parts)
     return merged
 

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -159,7 +159,7 @@ def test_gui_exits_when_npm_missing(tmp_path, monkeypatch, capsys):
     root = _make_desktop_tree(tmp_path)
     monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
 
-    with patch("hermes_cli.main.shutil.which", return_value=None), \
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value=None), \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns())
 


### PR DESCRIPTION
## Problem

When clicking "Update" in the Hermes desktop app on macOS, the rebuild stage (`hermes desktop --build-only`) fails with:

```
Desktop GUI requires Node.js/npm, but npm was not found on PATH.
```

## Root Cause

The update chain is: **Electron app → hermes-setup (Rust bootstrap installer) → `hermes desktop --build-only`**. On macOS, child processes spawned by Electron inherit a stripped PATH that typically lacks `/usr/local/bin` and `/opt/homebrew/bin`. The Rust `update_child_env` function in `update.rs` only prepends the managed Node bin dir and the venv bin dir — neither of which contains the system npm.

## Fix (3 parts)

### 1. Rust: `apps/bootstrap-installer/src-tauri/src/update.rs`

`update_child_env` now also prepends `/usr/local/bin` and `/opt/homebrew/bin` to PATH on macOS, so the desktop rebuild always has access to a system Node.js runtime.

### 2. Python: `hermes_constants.py`

Two defensive changes that help even outside the updater chain:

- **`find_node_executable_on_path`**: When `shutil.which` fails, falls back to scanning known paths (`/usr/local/bin`, `/opt/homebrew/bin`, `/opt/local/bin`, `~/.nvm/versions/node/*/bin`).
- **`with_hermes_node_path`**: When no managed Node tree exists, prepends common system Node.js bin dirs to PATH so npm subprocesses (which shell out to `node`) find the runtime.

### 3. Test: `tests/hermes_cli/test_gui_command.py`

Updated `test_gui_exits_when_npm_missing` to mock `_resolve_node_runtime_npm` instead of `shutil.which`, since the fallback paths now bypass a bare `shutil.which` mock.

## Testing

- Simulated Electron child process environment (PATH stripped of `/usr/local/bin`) → `hermes desktop --build-only` succeeds
- All 238 tests in `test_hermes_constants.py`, `test_gui_command.py`, `test_cmd_update.py` pass
- Rebuilt Rust bootstrap installer and verified the new binary resolves npm correctly