### PR TITLE
fix(ui-tui): preserve reasoning on resumed assistant turns

### DIFF
--- a/ui-tui/src/__tests__/messages.test.ts
+++ b/ui-tui/src/__tests__/messages.test.ts
@@ -83,6 +83,107 @@ describe('toTranscriptMessages', () => {
     expect(result[0]?.kind).toBe('event')
     expect(result[0]?.text).toBe('background agent work finished')
   })
+
+  it('keeps reasoning on a resumed assistant turn that also has visible text', () => {
+    const rows = [
+      { role: 'user', text: 'explain qubits' },
+      { role: 'assistant', text: 'A qubit holds superposition.', reasoning: 'Start from the classical bit.' }
+    ]
+
+    const result = toTranscriptMessages(rows)
+    expect(result).toHaveLength(2)
+    expect(result[1]?.role).toBe('assistant')
+    expect(result[1]?.text).toBe('A qubit holds superposition.')
+    expect(result[1]?.thinking).toBe('Start from the classical bit.')
+    expect(result[1]?.thinkingTokens).toBeGreaterThan(0)
+  })
+
+  it('retains a reasoning-only assistant turn as a trail block instead of dropping it', () => {
+    const rows = [
+      { role: 'user', text: 'think first' },
+      { role: 'assistant', text: '', reasoning_content: 'Weighing two approaches before answering.' },
+      { role: 'assistant', text: 'Approach B.' }
+    ]
+
+    const result = toTranscriptMessages(rows)
+    expect(result.map(msg => [msg.kind, msg.role, msg.text])).toEqual([
+      [undefined, 'user', 'think first'],
+      ['trail', 'system', ''],
+      [undefined, 'assistant', 'Approach B.']
+    ])
+    expect(result[1]?.thinking).toBe('Weighing two approaches before answering.')
+  })
+
+  it('still drops a genuinely empty assistant row', () => {
+    const rows = [
+      { role: 'user', text: 'hi' },
+      { role: 'assistant', text: '' },
+      { role: 'assistant', text: '   ', reasoning: '', reasoning_details: [], codex_reasoning_items: [] },
+      { role: 'assistant', text: 'hello' }
+    ]
+
+    expect(toTranscriptMessages(rows).map(msg => [msg.role, msg.text])).toEqual([
+      ['user', 'hi'],
+      ['assistant', 'hello']
+    ])
+  })
+
+  it('flattens structured reasoning_details entries instead of stringifying them', () => {
+    const rows = [
+      {
+        role: 'assistant',
+        text: '',
+        reasoning_details: [
+          { type: 'reasoning.summary', summary: 'Checked the failing test first.' },
+          { type: 'reasoning.encrypted_content', encrypted_content: 'AAAAB3NzaC1yc2E' },
+          { type: 'reasoning.text', text: 'Then read the stack trace.' }
+        ]
+      }
+    ]
+
+    const result = toTranscriptMessages(rows)
+    expect(result[0]?.thinking).toBe('Checked the failing test first.\n\nThen read the stack trace.')
+    expect(result[0]?.thinking).not.toContain('object Object')
+    expect(result[0]?.thinking).not.toContain('AAAAB3NzaC1yc2E')
+  })
+
+  it('reads Codex reasoning items through their summary parts and skips encrypted-only items', () => {
+    const rows = [
+      {
+        role: 'assistant',
+        text: 'done',
+        codex_reasoning_items: [
+          {
+            type: 'reasoning',
+            id: 'rs_a',
+            encrypted_content: 'enc_blob_a',
+            summary: [{ type: 'summary_text', text: 'Planned the edit.' }]
+          },
+          { type: 'reasoning', id: 'rs_b', encrypted_content: 'enc_blob_b' }
+        ]
+      }
+    ]
+
+    const result = toTranscriptMessages(rows)
+    expect(result[0]?.thinking).toBe('Planned the edit.')
+    expect(result[0]?.thinking).not.toContain('enc_blob')
+  })
+
+  it('does not double a Claude turn that reports the same thinking twice', () => {
+    const rows = [
+      {
+        role: 'assistant',
+        text: 'answer',
+        reasoning: 'Let me re-read the contract.',
+        reasoning_details: [
+          { type: 'thinking', thinking: 'Let me re-read the contract.', signature: 'sig-abc' },
+          { type: 'redacted_thinking', data: 'opaque-payload' }
+        ]
+      }
+    ]
+
+    expect(toTranscriptMessages(rows)[0]?.thinking).toBe('Let me re-read the contract.')
+  })
 })
 
 describe('MessageLine', () => {

--- a/ui-tui/src/domain/messages.ts
+++ b/ui-tui/src/domain/messages.ts
@@ -1,5 +1,6 @@
 import { LONG_MSG } from '../config/limits.js'
-import { buildToolTrailLine } from '../lib/text.js'
+import { flattenReasoning, type ReasoningFields } from '../lib/reasoning.js'
+import { buildToolTrailLine, estimateTokensRough } from '../lib/text.js'
 import type { Msg, SessionInfo } from '../types.js'
 
 export const introMsg = (info: SessionInfo): Msg => ({ info, kind: 'intro', role: 'system', text: '' })
@@ -37,7 +38,15 @@ export const toTranscriptMessages = (rows: unknown): Msg[] => {
       continue
     }
 
-    if (typeof text !== 'string' || !text.trim()) {
+    const thinking = role === 'assistant' ? flattenReasoning(row as TranscriptRow) : ''
+
+    // An extended-thinking turn is persisted with its reasoning fields and no
+    // visible text, and `_history_to_messages` deliberately keeps it on the
+    // wire (tui_gateway/server.py — `not content_text.strip() and not
+    // has_reasoning`). Dropping it here as "empty" is what made it vanish from
+    // the resumed transcript while the gateway had already sent it. Only a
+    // genuinely empty row — no text and no reasoning — is skipped.
+    if (typeof text !== 'string' || (!text.trim() && !thinking)) {
       continue
     }
 
@@ -77,7 +86,15 @@ export const toTranscriptMessages = (rows: unknown): Msg[] => {
     }
 
     if (role === 'assistant') {
-      out.push({ role, text, ...(pending.length && { tools: pending }) })
+      // Match the live convention (turnController.flushStreamingSegment): a
+      // turn with visible text is an `assistant` message, a reasoning-only one
+      // is a `trail` block, so a resumed turn renders exactly like the one the
+      // user just watched stream.
+      out.push({
+        ...(text.trim() ? { role, text } : { kind: 'trail' as const, role: 'system' as const, text: '' }),
+        ...(thinking && { thinking, thinkingTokens: estimateTokensRough(thinking) }),
+        ...(pending.length && { tools: pending })
+      })
       pending = []
     } else if (role === 'user' || role === 'system') {
       out.push({ role, text })
@@ -97,7 +114,7 @@ export const fmtDuration = (ms: number) => {
   return h > 0 ? `${h}h ${m}m` : m > 0 ? `${m}m ${s}s` : `${s}s`
 }
 
-interface TranscriptRow {
+interface TranscriptRow extends ReasoningFields {
   context?: string
   display_kind?: string
   display_metadata?: { task_count?: number; [key: string]: unknown }

--- a/ui-tui/src/lib/reasoning.ts
+++ b/ui-tui/src/lib/reasoning.ts
@@ -5,6 +5,99 @@ export interface SplitReasoning {
   text: string
 }
 
+// Assistant-message keys the gateway forwards verbatim out of persisted
+// history. Keep in sync with `reasoning_keys` in `_history_to_messages`
+// (tui_gateway/server.py) — that tuple is the wire contract, and the two
+// structured members are provider replay payloads, not plain strings.
+export interface ReasoningFields {
+  codex_reasoning_items?: unknown
+  reasoning?: unknown
+  reasoning_content?: unknown
+  reasoning_details?: unknown
+}
+
+// Human-readable fields on a structured reasoning entry, in the precedence
+// `extract_reasoning` (agent/agent_runtime_helpers.py) already uses:
+//   * Anthropic thinking block  → {type: 'thinking', thinking, signature}
+//   * OpenRouter summary/text   → {type: 'reasoning.summary', summary} etc.
+//   * Codex Responses item      → {type: 'reasoning', summary: [{text}], …}
+// `signature`, `data` and `encrypted_content` are deliberately absent: those
+// are opaque replay blobs (redacted_thinking, reasoning.encrypted_content,
+// Codex encrypted reasoning) that would render as base64 noise, so an entry
+// carrying only those contributes nothing to the displayed text.
+const DETAIL_TEXT_FIELDS = ['summary', 'thinking', 'content', 'text'] as const
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+// A readable field is either prose or a list of `{text}` parts (Codex stores
+// `summary` as `[{type: 'summary_text', text}]`, OpenRouter as a bare string).
+const readableText = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map(part => (isRecord(part) && typeof part.text === 'string' ? part.text : ''))
+      .filter(Boolean)
+      .join('\n')
+  }
+
+  return ''
+}
+
+/**
+ * Flatten a persisted assistant row's reasoning fields into the single
+ * `Msg.thinking` string the transcript renders.
+ *
+ * Mirrors `extract_reasoning`: prose fields first, then each structured
+ * entry's readable member, de-duplicated and joined with a blank line. The
+ * de-duplication is load-bearing rather than cosmetic — the Anthropic
+ * transport populates `reasoning` *and* `reasoning_details` from the same
+ * thinking blocks, so a resumed Claude turn would otherwise show its
+ * reasoning twice.
+ */
+export const flattenReasoning = (row: ReasoningFields): string => {
+  const parts: string[] = []
+
+  const add = (value: unknown) => {
+    const text = readableText(value).trim()
+
+    if (text && !parts.includes(text)) {
+      parts.push(text)
+    }
+  }
+
+  add(row.reasoning)
+  add(row.reasoning_content)
+
+  // `reasoning_details` before `codex_reasoning_items`, matching the order the
+  // gateway walks its `reasoning_keys` tuple.
+  for (const entries of [row.reasoning_details, row.codex_reasoning_items]) {
+    if (!Array.isArray(entries)) {
+      continue
+    }
+
+    for (const entry of entries) {
+      if (!isRecord(entry)) {
+        continue
+      }
+
+      // First readable member wins — an entry never carries two of these.
+      for (const name of DETAIL_TEXT_FIELDS) {
+        if (readableText(entry[name]).trim()) {
+          add(entry[name])
+
+          break
+        }
+      }
+    }
+  }
+
+  return parts.join('\n\n')
+}
+
 export function splitReasoning(input: string): SplitReasoning {
   let text = input
   const reasoning: string[] = []


### PR DESCRIPTION
## Supersedes #18501

@liuhao1024's #18501 identified the right bug but has been unattended since the 2026-07-12 review. This is a clean re-do against current `main`, addressing both problems named in that review:

- **It is frontend-only.** #18501's backend hunk predates the current logic and would have replaced it. The gateway side has been correct since `2667601c05cd` (*fix(tui): keep reasoning-only assistant turns visible on session resume*), so `tui_gateway/server.py` is untouched here.
- **It adapts to the current `reasoning_keys` path instead of a stale two-key assumption.** #18501 flattened `reasoning || reasoning_content` in the backend and had the frontend read a `thinking` field. Current `main` never emits a `thinking` key — `_history_to_messages` forwards `reasoning`, `reasoning_content`, `reasoning_details` and `codex_reasoning_items` verbatim — so that frontend hunk is a no-op today. This reads all four.
- **It covers the reasoning-only and genuinely-empty rows** the review asked for, which #18501 did not.

## What does this PR do?

Restores reasoning content in the TUI transcript after `/resume` or a session reload.

`_history_to_messages` (`tui_gateway/server.py:6193`) deliberately keeps an assistant row whose only content is reasoning — `if not content_text.strip() and not has_reasoning: continue` — and forwards every present member of `reasoning_keys = ("reasoning", "reasoning_content", "reasoning_details", "codex_reasoning_items")` onto the wire message, with an in-tree comment explaining that dropping such a row *"makes it vanish from the resumed/reloaded session view"*.

`toTranscriptMessages` (`ui-tui/src/domain/messages.ts:34`) then threw all of it away:

- `:47` destructured only `context`, `display_kind`, `name`, `role`, `text` — no reasoning field at all;
- `:55` `if (typeof text !== 'string' || !text.trim()) { continue }` dropped a reasoning-only row before anything could pass through;
- `:88` pushed `{ role, text, ...tools }` with no `thinking`.

So on `/resume` every extended-thinking turn loses its reasoning, and a reasoning-only turn disappears from the transcript entirely even though the gateway went out of its way to send it. The renderer was already waiting: `Msg.thinking` exists at `ui-tui/src/types.ts:122` and is consumed by `components/thinking.tsx` and `components/messageLine.tsx`.

**Why these shapes, specifically.** `reasoning_details` and `codex_reasoning_items` are provider *replay* arrays, not strings — naively stringifying them puts `[object Object]` or base64 in the transcript. The flattening mirrors `extract_reasoning` (`agent/agent_runtime_helpers.py:1615`): prose fields first, then the first readable member (`summary` / `thinking` / `content` / `text`) of each structured entry, de-duplicated and joined with a blank line. Opaque members are deliberately not readable fields:

| shape | source | rendered |
|---|---|---|
| `{type: 'thinking', thinking, signature}` | Anthropic | `thinking` |
| `{type: 'redacted_thinking', data}` | Anthropic | nothing (opaque) |
| `{type: 'reasoning.summary', summary}` | OpenRouter | `summary` |
| `{type: 'reasoning.text', text}` | OpenRouter | `text` |
| `{type: 'reasoning.encrypted_content', encrypted_content}` | OpenRouter | nothing (opaque) |
| `{type: 'reasoning', encrypted_content, summary: [{text}]}` | Codex Responses | `summary[].text` |

De-duplication is load-bearing rather than cosmetic: `agent/transports/anthropic.py` populates `reasoning` *and* `reasoning_details` from the same thinking blocks, so without it a resumed Claude turn would show its reasoning twice.

A resumed turn is also shaped like a live one. `turnController.flushStreamingSegment` lands a textless reasoning segment as a `kind: 'trail'` / `role: 'system'` block and a text-bearing one as an `assistant` message; `toTranscriptMessages` now does the same, so a restored turn renders identically to the one the user just watched stream instead of leaving a bare glyph row.

## Related Issue

Fixes #18414

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/lib/reasoning.ts` — add `ReasoningFields` (the wire contract, kept in sync with the gateway's `reasoning_keys`) and `flattenReasoning`, which folds the four keys into the single `Msg.thinking` string, reading structured entries through their readable member and skipping opaque replay blobs.
- `ui-tui/src/domain/messages.ts` — `toTranscriptMessages` now derives `thinking` for assistant rows, only skips a row that has *neither* visible text *nor* reasoning, and emits a reasoning-only row as a `trail` block. `TranscriptRow extends ReasoningFields`.
- `ui-tui/src/__tests__/messages.test.ts` — six cases covering the three row classes plus the structured shapes.

`tui_gateway/server.py` is intentionally not touched.

## How to Test

1. `hermes --tui` with a reasoning-capable model; send a prompt that produces thinking.
2. `/new`, then `/resume` the previous session.
3. Assistant turns now show their thinking blocks again, and a turn that produced only reasoning is present instead of missing.

Automated, from `ui-tui/`:

```
npm run check   # build:ink && typecheck && test && lint
```

`129 test files, 1395 passed, 1 skipped`; typecheck, eslint and prettier clean.

Regression evidence — the new tests were run against the unpatched projection:

| reverting | failing new tests |
|---|---|
| all of `domain/messages.ts` | 5 of 6 (`… visible text`, `… trail block`, `… reasoning_details`, `… Codex`, `… twice`) |
| only the `:55` empty-row guard | 2 (`… trail block`, `… reasoning_details`) — isolates the retention half |
| nothing (patched) | 0 |

`still drops a genuinely empty assistant row` passes in **both** directions by design — it is the guard that keeps the empty-row filter honest, so widening it cannot start admitting blank rows.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, TypeScript-only change; ran `npm run check` in `ui-tui/` instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Node 22)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure data projection, no platform-dependent code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Related / Positioning

- #33627 (`fix(tui): stabilize transcript row identity`) touches the same `out.push` calls in this function but fixes message *identity*, not reasoning. The diff here is kept narrow so the two remain mechanically compatible.
- #28756 fixes reasoning-only output on the **live** path (`turnController.ts`); this is the resume/reload path and the two do not overlap.
