### PR TITLE
fix(telegram): preserve authorization union across group sources

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -455,7 +455,7 @@ class GatewayAuthorizationMixin:
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
             }.get(source.platform, "")
             if chat_allowlist_env:
-                raw_chat_allowlist = os.getenv(chat_allowlist_env, "").strip()
+                raw_chat_allowlist = _auth_env(chat_allowlist_env)
                 if raw_chat_allowlist:
                     allowed_group_ids = {
                         cid.strip()

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -614,7 +614,7 @@ class GatewayAuthorizationMixin:
         platform_allowlist = _auth_env(platform_env_map.get(source.platform, ""))
         group_user_allowlist = ""
         group_chat_allowlist = ""
-        if source.chat_type in {"group", "forum"}:
+        if source.chat_type in {"group", "forum", "channel"}:
             group_user_allowlist = _auth_env(platform_group_user_env_map.get(source.platform, ""))
             group_chat_allowlist = _auth_env(platform_group_chat_env_map.get(source.platform, ""))
         global_allowlist = _auth_env("GATEWAY_ALLOWED_USERS")
@@ -686,8 +686,12 @@ class GatewayAuthorizationMixin:
 
         # Telegram can optionally authorize group traffic by chat ID.
         # Keep this separate from TELEGRAM_GROUP_ALLOWED_USERS, which gates
-        # the sender user ID for group/forum messages.
-        if group_chat_allowlist and source.chat_type in {"group", "forum"} and source.chat_id:
+        # the sender user ID for group/forum/channel messages.
+        if (
+            group_chat_allowlist
+            and source.chat_type in {"group", "forum", "channel"}
+            and source.chat_id
+        ):
             allowed_group_ids = {
                 chat_id.strip() for chat_id in group_chat_allowlist.split(",") if chat_id.strip()
             }
@@ -703,7 +707,7 @@ class GatewayAuthorizationMixin:
         if (
             source.platform == Platform.TELEGRAM
             and group_user_allowlist
-            and source.chat_type in {"group", "forum"}
+            and source.chat_type in {"group", "forum", "channel"}
             and source.chat_id
         ):
             legacy_chat_ids = {
@@ -724,7 +728,7 @@ class GatewayAuthorizationMixin:
                 if source.chat_id in legacy_chat_ids:
                     return True
 
-        # Check if user is in any allowlist. In group/forum chats,
+        # Check if user is in any allowlist. In group/forum/channel chats,
         # TELEGRAM_GROUP_ALLOWED_USERS is the scoped allowlist and should not
         # imply DM access; TELEGRAM_ALLOWED_USERS remains the platform-wide
         # allowlist and still works everywhere for backward compatibility.

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -99,16 +99,35 @@ def _telegram_config_authorizes_source(source: SessionSource, extra: object) -> 
 class GatewayAuthorizationMixin:
     """User/chat authorization methods for ``GatewayRunner``."""
 
-    def _is_user_authorized_for_adapter_intake(self, source: SessionSource) -> bool:
-        """Run an adapter's early auth check under the routed profile scope."""
+    def _adapter_intake_authorization_decision(
+        self,
+        source: SessionSource,
+        *,
+        config_authorized: Optional[bool] = None,
+    ) -> Optional[bool]:
+        """Return a scoped early-auth decision, or ``None`` to preserve pairing."""
+        def decide() -> Optional[bool]:
+            if source.platform == Platform.TELEGRAM:
+                keys = (
+                    "TELEGRAM_ALLOWED_USERS",
+                    "TELEGRAM_GROUP_ALLOWED_USERS",
+                    "TELEGRAM_GROUP_ALLOWED_CHATS",
+                    "TELEGRAM_ALLOW_ALL_USERS",
+                    "GATEWAY_ALLOWED_USERS",
+                    "GATEWAY_ALLOW_ALL_USERS",
+                )
+                if config_authorized is None and not any(_auth_env(key) for key in keys):
+                    return None
+            return self._is_user_authorized(source)
+
         config = getattr(self, "config", None)
         if getattr(config, "multiplex_profiles", False):
             from gateway.run import _profile_runtime_scope
 
             profile_home = self._resolve_profile_home_for_source(source)
             with _profile_runtime_scope(profile_home):
-                return self._is_user_authorized(source)
-        return self._is_user_authorized(source)
+                return decide()
+        return decide()
 
     def _authorization_adapter(
         self,

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -99,6 +99,17 @@ def _telegram_config_authorizes_source(source: SessionSource, extra: object) -> 
 class GatewayAuthorizationMixin:
     """User/chat authorization methods for ``GatewayRunner``."""
 
+    def _is_user_authorized_for_adapter_intake(self, source: SessionSource) -> bool:
+        """Run an adapter's early auth check under the routed profile scope."""
+        config = getattr(self, "config", None)
+        if getattr(config, "multiplex_profiles", False):
+            from gateway.run import _profile_runtime_scope
+
+            profile_home = self._resolve_profile_home_for_source(source)
+            with _profile_runtime_scope(profile_home):
+                return self._is_user_authorized(source)
+        return self._is_user_authorized(source)
+
     def _authorization_adapter(
         self,
         platform: Optional[Platform],

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -33,11 +33,19 @@ def _auth_env(name: str, default: str = "") -> str:
     if not name:
         return default
     try:
-        from agent.secret_scope import get_secret
+        from agent.secret_scope import UnscopedSecretError, get_secret
+    except Exception:
+        return (os.getenv(name) or default).strip()
 
+    try:
         val = get_secret(name)
         if val is not None and str(val).strip():
             return str(val).strip()
+    except UnscopedSecretError:
+        # Multiplex mode intentionally rejects unscoped credential reads. Do
+        # not defeat that isolation boundary by falling through to another
+        # profile's process-global environment.
+        return default
     except Exception:
         pass
     return (os.getenv(name) or default).strip()

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -58,6 +58,44 @@ def _coerce_allow_set(raw) -> set[str]:
     return {part.strip() for part in str(raw).split(",") if part.strip()}
 
 
+def _telegram_config_authorizes_source(source: SessionSource, extra: object) -> Optional[bool]:
+    """Apply Telegram's config allowlists with their documented scopes.
+
+    ``allow_from`` applies in every chat type; ``group_allow_from`` and
+    ``group_allowed_chats`` only add grants for group-like sources.  Returning
+    ``None`` distinguishes a source with no non-empty applicable config
+    allowlist from a sender that was explicitly rejected by one. Empty lists
+    are common config defaults and contribute neither a grant nor a rejection.
+    """
+    if not isinstance(extra, dict):
+        return None
+
+    user_id = str(source.user_id or "").strip()
+    global_allowed = _coerce_allow_set(extra.get("allow_from"))
+    applicable_allowlists = [global_allowed]
+
+    if source.chat_type in {"group", "forum", "channel"}:
+        group_users = _coerce_allow_set(extra.get("group_allow_from"))
+        group_chats = _coerce_allow_set(extra.get("group_allowed_chats"))
+        applicable_allowlists.extend((group_users, group_chats))
+
+    if not any(applicable_allowlists):
+        return None
+
+    if user_id and ("*" in global_allowed or user_id in global_allowed):
+        return True
+
+    if source.chat_type in {"group", "forum", "channel"}:
+        if user_id and ("*" in group_users or user_id in group_users):
+            return True
+
+        chat_id = str(source.chat_id or "").strip()
+        if chat_id and ("*" in group_chats or chat_id in group_chats):
+            return True
+
+    return False
+
+
 class GatewayAuthorizationMixin:
     """User/chat authorization methods for ``GatewayRunner``."""
 
@@ -427,21 +465,22 @@ class GatewayAuthorizationMixin:
                     if "*" in allowed_group_ids or source.chat_id in allowed_group_ids:
                         return True
 
-            # Fallback: also check adapter-level config (config.yaml)
-            # for platforms.<platform>.extra.group_allowed_chats.
-            # The Telegram observe-unmentioned mode strips user_id from
-            # triggered group messages (_apply_telegram_group_observe_attribution),
-            # so the env-var-only check above misses config.yaml-configured
-            # allowlists.  Read the live adapter's config.extra as a fallback.
+            # Fallback: also check adapter-level config (config.yaml). The
+            # Telegram observe-unmentioned mode strips user_id from triggered
+            # group messages, so this must happen before the no-user-id guard.
             try:
                 adapter = self._adapter_for_source(source)
                 if adapter is not None:
                     extra = getattr(getattr(adapter, "config", None), "extra", None) or {}
-                    adapter_group_allowed = extra.get("group_allowed_chats")
-                    if adapter_group_allowed:
-                        allowed = _coerce_allow_set(adapter_group_allowed)
-                        if "*" in allowed or source.chat_id in allowed:
+                    if source.platform == Platform.TELEGRAM:
+                        if _telegram_config_authorizes_source(source, extra) is True:
                             return True
+                    else:
+                        adapter_group_allowed = extra.get("group_allowed_chats")
+                        if adapter_group_allowed:
+                            allowed = _coerce_allow_set(adapter_group_allowed)
+                            if "*" in allowed or source.chat_id in allowed:
+                                return True
             except Exception:
                 pass
 
@@ -558,6 +597,19 @@ class GatewayAuthorizationMixin:
         if pairing_store is not None and pairing_store.is_approved(platform_name, user_id):
             return True
 
+        # Telegram config allowlists are grants in the same union as pairing
+        # and environment allowlists. Evaluate them before the env-only branch
+        # so mixed YAML/environment configurations cannot hide a config grant.
+        if source.platform == Platform.TELEGRAM:
+            try:
+                adapter = self._adapter_for_source(source)
+                if adapter is not None:
+                    extra = getattr(getattr(adapter, "config", None), "extra", None) or {}
+                    if _telegram_config_authorizes_source(source, extra) is True:
+                        return True
+            except Exception:
+                pass
+
         # Check platform-specific and global allowlists
         platform_allowlist = _auth_env(platform_env_map.get(source.platform, ""))
         group_user_allowlist = ""
@@ -613,21 +665,22 @@ class GatewayAuthorizationMixin:
                     )
                 if effective_policy == "allowlist":
                     return True
-            # Some adapters (e.g. Telegram) gate access via config.extra.allow_from /
-            # group_allow_from at intake but do not override enforces_own_access_policy.
-            # Check their allowlist here so config.yaml-configured allow_from works
-            # without requiring a separate {PLATFORM}_ALLOWED_USERS env var.
-            adapter = self._adapter_for_source(source)
-            if adapter is not None:
-                extra = getattr(getattr(adapter, "config", None), "extra", None) or {}
-                if source.chat_type in {"group", "forum", "channel"}:
-                    adapter_allow = extra.get("group_allow_from")
-                else:
-                    adapter_allow = extra.get("allow_from")
-                if adapter_allow:
-                    allowed = _coerce_allow_set(adapter_allow)
-                    if user_id in allowed or "*" in allowed:
-                        return True
+            # Some adapters (e.g. Telegram) gate access via config allowlists
+            # at intake but do not override enforces_own_access_policy. Keep
+            # the global and group-scoped Telegram grants as an OR-union here
+            # so the runner agrees with the intake gate for config-only setups.
+            if source.platform != Platform.TELEGRAM:
+                adapter = self._adapter_for_source(source)
+                if adapter is not None:
+                    extra = getattr(getattr(adapter, "config", None), "extra", None) or {}
+                    if source.chat_type in {"group", "forum", "channel"}:
+                        adapter_allow = extra.get("group_allow_from")
+                    else:
+                        adapter_allow = extra.get("allow_from")
+                    if adapter_allow:
+                        allowed = _coerce_allow_set(adapter_allow)
+                        if user_id in allowed or "*" in allowed:
+                            return True
             # No allowlists configured -- check global allow-all flag
             return _auth_env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10127,6 +10127,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         platform: Platform,
     ) -> None:
         """Install the profile-scoped handlers shared by startup and reconnect."""
+        adapter._gateway_profile_name = profile_name
         adapter.set_message_handler(self._make_profile_message_handler(profile_name))
         adapter.set_fatal_error_handler(
             self._make_profile_fatal_error_handler(profile_name, platform)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10879,12 +10879,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 == "pair"
             ):
                 platform_name = source.platform.value if source.platform else "unknown"
+                pairing_store = self._pairing_store_for(source)
+                if pairing_store is None:
+                    logger.error(
+                        "No pairing store available for %s profile=%s",
+                        platform_name,
+                        source.profile or "default",
+                    )
+                    return None
                 # Rate-limit ALL pairing responses (code or rejection) to
                 # prevent spamming the user with repeated messages when
                 # multiple DMs arrive in quick succession.
-                if self.pairing_store._is_rate_limited(platform_name, source.user_id):
+                if pairing_store._is_rate_limited(platform_name, source.user_id):
                     return None
-                code = self.pairing_store.generate_code(
+                code = pairing_store.generate_code(
                     platform_name, source.user_id, source.user_name or ""
                 )
                 if code:
@@ -10906,7 +10914,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Please try again later!"
                         )
                     # Record rate limit so subsequent messages are silently ignored
-                    self.pairing_store._record_rate_limit(platform_name, source.user_id)
+                    pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
         
         # Intercept messages that are responses to a pending /update prompt.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1078,8 +1078,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     source,
                     config_authorized=config_authorized,
                 )
-                if intake_decision is not None:
-                    return bool(intake_decision)
+                # ``None`` is the scoped runner's explicit instruction to
+                # preserve the pairing path. It is terminal: continuing here
+                # would evaluate fallback auth outside the routed profile's
+                # runtime scope and could consult another profile's state.
+                return True if intake_decision is None else bool(intake_decision)
             except Exception:
                 logger.debug(
                     "[Telegram] Falling back after scoped auth failed for user %s",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -985,13 +985,29 @@ class TelegramAdapter(BasePlatformAdapter):
             elif chat_type == "dm" and is_topic_message:
                 thread_id = str(thread_id_raw)
 
-        source = self.build_source(
-            chat_id=chat_id or "",
-            chat_type=chat_type,
-            user_id=user_id,
-            user_name=user_name,
-            thread_id=thread_id,
-        )
+        if getattr(self, "platform", None) is None:
+            # A few defensive cold paths deliberately construct an adapter via
+            # ``object.__new__`` (for example, oversized-media rejection before
+            # normal adapter initialization). Preserve that identityless path
+            # without weakening profile routing for initialized adapters.
+            from gateway.session import SessionSource
+
+            source = SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id=chat_id or "",
+                chat_type=chat_type,
+                user_id=user_id,
+                user_name=user_name,
+                thread_id=thread_id,
+            )
+        else:
+            source = self.build_source(
+                chat_id=chat_id or "",
+                chat_type=chat_type,
+                user_id=user_id,
+                user_name=user_name,
+                thread_id=thread_id,
+            )
         if not source.profile:
             source.profile = getattr(self, "_gateway_profile_name", None)
         return source

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -260,7 +260,7 @@ import sys
 from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
-from gateway.authz_mixin import _telegram_config_authorizes_source
+from gateway.authz_mixin import _auth_env, _telegram_config_authorizes_source
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -997,7 +997,7 @@ class TelegramAdapter(BasePlatformAdapter):
         )
 
     def _telegram_auth_env_configured(self) -> bool:
-        """Return True when Telegram auth env vars make an early decision safe."""
+        """Return True when profile-scoped auth vars make an early decision safe."""
         keys = (
             "TELEGRAM_ALLOWED_USERS",
             "TELEGRAM_GROUP_ALLOWED_USERS",
@@ -1006,7 +1006,7 @@ class TelegramAdapter(BasePlatformAdapter):
             "GATEWAY_ALLOWED_USERS",
             "GATEWAY_ALLOW_ALL_USERS",
         )
-        return any(os.getenv(key, "").strip() for key in keys)
+        return any(_auth_env(key) for key in keys)
 
     def _is_user_authorized_from_message(self, message: Message) -> bool:
         """Check if the sender of a Telegram message is authorized.
@@ -1054,13 +1054,32 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
+        auth_is_configured = (
+            config_authorized is not None or self._telegram_auth_env_configured()
+        )
+
+        # The gateway registers a profile-bound callback on every adapter.
+        # Prefer it over introspecting the message handler: multiplex handlers
+        # are closures, not bound runner methods, while this callback preserves
+        # the profile's pairing store and secret scope.
+        registered_auth = getattr(self, "_authorization_check", None)
+        if callable(registered_auth) and auth_is_configured:
+            try:
+                return bool(registered_auth(user_id, source.chat_type, source.chat_id))
+            except Exception:
+                logger.debug(
+                    "[Telegram] Falling back after registered auth failed for user %s",
+                    user_id,
+                    exc_info=True,
+                )
+
         runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
             # Only make an early decision via the runner when an allowlist
             # actually exists; otherwise unknown DMs must reach the pairing
             # flow rather than being default-denied here.
-            if config_authorized is None and not self._telegram_auth_env_configured():
+            if not auth_is_configured:
                 return True
             try:
                 return bool(auth_fn(source))
@@ -1071,9 +1090,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
 
-        if os.getenv("TELEGRAM_ALLOW_ALL_USERS", "").lower().strip() in {"true", "1", "yes"}:
+        if _auth_env("TELEGRAM_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}:
             return True
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower().strip() in {"true", "1", "yes"}:
+        if _auth_env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}:
             return True
 
         # Bare adapters have no runner to combine config and environment
@@ -1084,13 +1103,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 "allow_from": ",".join(
                     value
                     for value in (
-                        os.getenv("TELEGRAM_ALLOWED_USERS", "").strip(),
-                        os.getenv("GATEWAY_ALLOWED_USERS", "").strip(),
+                        _auth_env("TELEGRAM_ALLOWED_USERS"),
+                        _auth_env("GATEWAY_ALLOWED_USERS"),
                     )
                     if value
                 ),
-                "group_allow_from": os.getenv("TELEGRAM_GROUP_ALLOWED_USERS", "").strip(),
-                "group_allowed_chats": os.getenv("TELEGRAM_GROUP_ALLOWED_CHATS", "").strip(),
+                "group_allow_from": _auth_env("TELEGRAM_GROUP_ALLOWED_USERS"),
+                "group_allowed_chats": _auth_env("TELEGRAM_GROUP_ALLOWED_CHATS"),
             },
         )
         if env_authorized is True:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -260,7 +260,7 @@ import sys
 from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
-from gateway.authz_mixin import _coerce_allow_set
+from gateway.authz_mixin import _telegram_config_authorizes_source
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -1028,16 +1028,12 @@ class TelegramAdapter(BasePlatformAdapter):
         if not user_id:
             return True
 
-        # Adapter-level allow_from / group_allow_from: when set, they are the
-        # sole authority.  Group chats use group_allow_from; DMs use allow_from.
-        chat_type = source.chat_type or ""
-        if chat_type in ("group", "forum", "channel"):
-            adapter_allow_from = self.config.extra.get("group_allow_from")
-        else:
-            adapter_allow_from = self.config.extra.get("allow_from")
-        if adapter_allow_from is not None:
-            allowed = _coerce_allow_set(adapter_allow_from)
-            return user_id in allowed or "*" in allowed
+        # Config allowlists use the same union as runner authorization: global
+        # users work everywhere, while group users and allowed group chats add
+        # scoped grants without widening direct-message access.
+        config_authorized = _telegram_config_authorizes_source(source, self.config.extra)
+        if config_authorized is True:
+            return True
 
         # Test/custom injection only. The class method named
         # _is_callback_user_authorized is for inline button callbacks and must
@@ -1064,7 +1060,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # Only make an early decision via the runner when an allowlist
             # actually exists; otherwise unknown DMs must reach the pairing
             # flow rather than being default-denied here.
-            if not self._telegram_auth_env_configured():
+            if config_authorized is None and not self._telegram_auth_env_configured():
                 return True
             try:
                 return bool(auth_fn(source))
@@ -1075,11 +1071,33 @@ class TelegramAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
 
-        allowed_csv = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
-        if not allowed_csv:
+        if os.getenv("TELEGRAM_ALLOW_ALL_USERS", "").lower().strip() in {"true", "1", "yes"}:
             return True
-        allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
-        return "*" in allowed_ids or user_id in allowed_ids
+        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower().strip() in {"true", "1", "yes"}:
+            return True
+
+        # Bare adapters have no runner to combine config and environment
+        # grants. Apply the same scoped union locally as a safe fallback.
+        env_authorized = _telegram_config_authorizes_source(
+            source,
+            {
+                "allow_from": ",".join(
+                    value
+                    for value in (
+                        os.getenv("TELEGRAM_ALLOWED_USERS", "").strip(),
+                        os.getenv("GATEWAY_ALLOWED_USERS", "").strip(),
+                    )
+                    if value
+                ),
+                "group_allow_from": os.getenv("TELEGRAM_GROUP_ALLOWED_USERS", "").strip(),
+                "group_allowed_chats": os.getenv("TELEGRAM_GROUP_ALLOWED_CHATS", "").strip(),
+            },
+        )
+        if env_authorized is True:
+            return True
+        if config_authorized is False or env_authorized is False:
+            return False
+        return True
 
     @classmethod
     def _metadata_thread_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -987,7 +987,7 @@ class TelegramAdapter(BasePlatformAdapter):
             elif chat_type == "dm" and is_topic_message:
                 thread_id = str(thread_id_raw)
 
-        return SessionSource(
+        source = SessionSource(
             platform=Platform.TELEGRAM,
             chat_id=chat_id or "",
             chat_type=chat_type,
@@ -995,6 +995,18 @@ class TelegramAdapter(BasePlatformAdapter):
             user_name=user_name,
             thread_id=thread_id,
         )
+        runner = getattr(self, "gateway_runner", None)
+        if runner is not None:
+            try:
+                source.profile = runner._profile_name_for_source(source)
+            except Exception:
+                logger.debug(
+                    "[Telegram] Profile routing failed during intake auth",
+                    exc_info=True,
+                )
+        if not source.profile:
+            source.profile = getattr(self, "_gateway_profile_name", None)
+        return source
 
     def _telegram_auth_env_configured(self) -> bool:
         """Return True when profile-scoped auth vars make an early decision safe."""
@@ -1058,10 +1070,23 @@ class TelegramAdapter(BasePlatformAdapter):
             config_authorized is not None or self._telegram_auth_env_configured()
         )
 
-        # The gateway registers a profile-bound callback on every adapter.
-        # Prefer it over introspecting the message handler: multiplex handlers
-        # are closures, not bound runner methods, while this callback preserves
-        # the profile's pairing store and secret scope.
+        runner = getattr(self, "gateway_runner", None)
+        if runner is None:
+            runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        intake_auth = getattr(runner, "_is_user_authorized_for_adapter_intake", None)
+        if callable(intake_auth) and auth_is_configured:
+            try:
+                return bool(intake_auth(source))
+            except Exception:
+                logger.debug(
+                    "[Telegram] Falling back after scoped auth failed for user %s",
+                    user_id,
+                    exc_info=True,
+                )
+
+        # The gateway also registers a profile-bound callback on every adapter.
+        # Keep it as the fallback for lightweight runners and adapter contexts
+        # that do not expose the source-aware intake authority above.
         registered_auth = getattr(self, "_authorization_check", None)
         if callable(registered_auth) and auth_is_configured:
             try:
@@ -1073,7 +1098,6 @@ class TelegramAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
 
-        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
             # Only make an early decision via the runner when an allowlist

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -944,8 +944,6 @@ class TelegramAdapter(BasePlatformAdapter):
         carry no ``from_user``) so a removed/unauthorized channel cannot
         inject content via the broadcast path either.
         """
-        from gateway.session import SessionSource
-
         user = getattr(message, "from_user", None)
         chat = getattr(message, "chat", None)
         user_id = str(getattr(user, "id", "")).strip() or None
@@ -987,23 +985,13 @@ class TelegramAdapter(BasePlatformAdapter):
             elif chat_type == "dm" and is_topic_message:
                 thread_id = str(thread_id_raw)
 
-        source = SessionSource(
-            platform=Platform.TELEGRAM,
+        source = self.build_source(
             chat_id=chat_id or "",
             chat_type=chat_type,
             user_id=user_id,
             user_name=user_name,
             thread_id=thread_id,
         )
-        runner = getattr(self, "gateway_runner", None)
-        if runner is not None:
-            try:
-                source.profile = runner._profile_name_for_source(source)
-            except Exception:
-                logger.debug(
-                    "[Telegram] Profile routing failed during intake auth",
-                    exc_info=True,
-                )
         if not source.profile:
             source.profile = getattr(self, "_gateway_profile_name", None)
         return source
@@ -1044,8 +1032,6 @@ class TelegramAdapter(BasePlatformAdapter):
         # users work everywhere, while group users and allowed group chats add
         # scoped grants without widening direct-message access.
         config_authorized = _telegram_config_authorizes_source(source, self.config.extra)
-        if config_authorized is True:
-            return True
 
         # Test/custom injection only. The class method named
         # _is_callback_user_authorized is for inline button callbacks and must
@@ -1066,23 +1052,31 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
-        auth_is_configured = (
-            config_authorized is not None or self._telegram_auth_env_configured()
-        )
-
         runner = getattr(self, "gateway_runner", None)
         if runner is None:
             runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
-        intake_auth = getattr(runner, "_is_user_authorized_for_adapter_intake", None)
-        if callable(intake_auth) and auth_is_configured:
+        intake_auth = getattr(runner, "_adapter_intake_authorization_decision", None)
+        if callable(intake_auth):
             try:
-                return bool(intake_auth(source))
+                intake_decision = intake_auth(
+                    source,
+                    config_authorized=config_authorized,
+                )
+                if intake_decision is not None:
+                    return bool(intake_decision)
             except Exception:
                 logger.debug(
                     "[Telegram] Falling back after scoped auth failed for user %s",
                     user_id,
                     exc_info=True,
                 )
+
+        if config_authorized is True:
+            return True
+
+        auth_is_configured = (
+            config_authorized is not None or self._telegram_auth_env_configured()
+        )
 
         # The gateway also registers a profile-bound callback on every adapter.
         # Keep it as the fallback for lightweight runners and adapter contexts

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -592,6 +592,49 @@ def test_routed_profile_restriction_is_checked_before_early_pass(monkeypatch):
     ) is False
 
 
+def test_routed_profile_pairing_decision_does_not_resume_global_fallback(monkeypatch):
+    """A scoped ``None`` decision must preserve pairing without cross-profile auth."""
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "default-profile-owner")
+    fallback_calls = []
+
+    class Runner:
+        @staticmethod
+        def _profile_name_for_source(_source):
+            return "pairing-profile"
+
+        @staticmethod
+        def _adapter_intake_authorization_decision(source, *, config_authorized=None):
+            assert source.profile == "pairing-profile"
+            assert config_authorized is None
+            return None
+
+    adapter = _make_adapter()
+    adapter.gateway_runner = Runner()
+    adapter.set_authorization_check(
+        lambda *_args: fallback_calls.append("default-profile") or False
+    )
+
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id="new-user", chat_id="new-user", chat_type="private")
+    ) is True
+    assert fallback_calls == []
+
+
+def test_unscoped_multiplex_auth_env_does_not_leak_process_global(monkeypatch):
+    """Unscoped multiplex auth reads must honor secret-scope fail-closed behavior."""
+    from agent import secret_scope
+    from gateway.authz_mixin import _auth_env
+
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "default-profile-owner")
+    token = secret_scope.set_secret_scope(None)
+    secret_scope.set_multiplex_active(True)
+    try:
+        assert _auth_env("TELEGRAM_ALLOWED_USERS") == ""
+    finally:
+        secret_scope.set_multiplex_active(False)
+        secret_scope.reset_secret_scope(token)
+
+
 def test_profile_secret_scope_restriction_is_enforced_at_intake(monkeypatch):
     """Multiplex profile allowlists must gate before event construction."""
     from agent.secret_scope import reset_secret_scope, set_secret_scope

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -530,7 +530,7 @@ def test_profile_route_selects_scoped_authority_before_default_callback(monkeypa
             return "routed-profile"
 
         @staticmethod
-        def _is_user_authorized_for_adapter_intake(source):
+        def _adapter_intake_authorization_decision(source, *, config_authorized=None):
             seen.append(source)
             return source.profile == "routed-profile" and source.user_id == "paired-user"
 
@@ -545,6 +545,38 @@ def test_profile_route_selects_scoped_authority_before_default_callback(monkeypa
 
     assert adapter._is_user_authorized_from_message(message) is True
     assert seen and seen[0].profile == "routed-profile"
+    assert seen[0]._transport_adapter_ref() is adapter
+
+
+def test_routed_profile_restriction_is_checked_before_early_pass(monkeypatch):
+    """A routed profile's env restriction must not pass intake as unconfigured."""
+    for key in (
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    class Runner:
+        @staticmethod
+        def _profile_name_for_source(_source):
+            return "restricted-profile"
+
+        @staticmethod
+        def _adapter_intake_authorization_decision(source, *, config_authorized=None):
+            assert source.profile == "restricted-profile"
+            assert config_authorized is None
+            return False
+
+    adapter = _make_adapter()
+    adapter.gateway_runner = Runner()
+
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id="attacker", chat_id=-100, chat_type="group")
+    ) is False
 
 
 def test_profile_secret_scope_restriction_is_enforced_at_intake(monkeypatch):

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -227,6 +227,51 @@ def test_is_user_authorized_from_message_group_allow_from():
     assert adapter._is_user_authorized_from_message(msg) is False
 
 
+@pytest.mark.parametrize("forum", [False, True])
+def test_global_allow_from_remains_a_grant_in_group_context(forum):
+    """The platform-wide list is ORed with group-only sender grants."""
+    adapter = _make_adapter(
+        allow_from=["111"],
+        group_allow_from=["222"],
+    )
+    msg = _make_message(from_user_id=111, chat_id=-100, chat_type="supergroup")
+    if forum:
+        msg.chat.is_forum = True
+        msg.is_topic_message = True
+        msg.message_thread_id = 7
+
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+
+@pytest.mark.parametrize("forum", [False, True])
+def test_group_allowed_chat_is_ored_with_group_sender_list(forum):
+    """A listed chat authorizes every member even when a sender list exists."""
+    adapter = _make_adapter(
+        group_allow_from=["222"],
+        group_allowed_chats=["-100"],
+    )
+    msg = _make_message(from_user_id=111, chat_id=-100, chat_type="supergroup")
+    if forum:
+        msg.chat.is_forum = True
+        msg.is_topic_message = True
+        msg.message_thread_id = 7
+
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+
+def test_empty_group_config_lists_defer_to_injected_authority():
+    """Empty YAML defaults must not become a sole-authority rejection."""
+    adapter = _make_adapter(
+        group_allow_from=[],
+        group_allowed_chats=[],
+        callback_auth=lambda uid, **_kw: uid == "111",
+    )
+
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id=111, chat_id=-100, chat_type="group")
+    ) is True
+
+
 def test_is_user_authorized_from_message_wildcard():
     """_is_user_authorized_from_message should accept wildcard '*'."""
     adapter = _make_adapter(allow_from=["*"])

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -485,6 +485,109 @@ def test_unknown_dm_with_no_allowlist_passes_to_pairing(monkeypatch):
     assert adapter._is_user_authorized_from_message(msg) is True
 
 
+def test_registered_gateway_authority_preserves_pairing_union(monkeypatch):
+    """A config miss must not hide a pairing grant from the gateway authority."""
+    for key in (
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    adapter = _make_adapter(allow_from=["owner"])
+    adapter.set_authorization_check(
+        lambda user_id, chat_type=None, chat_id=None: user_id == "paired-user"
+    )
+    msg = _make_message(
+        from_user_id="paired-user",
+        chat_id="paired-user",
+        chat_type="private",
+    )
+
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+
+def test_profile_secret_scope_restriction_is_enforced_at_intake(monkeypatch):
+    """Multiplex profile allowlists must gate before event construction."""
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    for key in (
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    adapter = _make_adapter()
+    seen = []
+    adapter.set_authorization_check(
+        lambda user_id, chat_type=None, chat_id=None: seen.append(
+            (user_id, chat_type, chat_id)
+        )
+        or False
+    )
+    token = set_secret_scope({"TELEGRAM_GROUP_ALLOWED_USERS": "owner"})
+    try:
+        assert adapter._is_user_authorized_from_message(
+            _make_message(from_user_id="attacker", chat_id=-100, chat_type="group")
+        ) is False
+    finally:
+        reset_secret_scope(token)
+
+    assert seen == [("attacker", "group", "-100")]
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value", "from_user_id", "chat_id"),
+    (
+        ("TELEGRAM_GROUP_ALLOWED_USERS", "channel-user", "channel-user", -100),
+        ("TELEGRAM_GROUP_ALLOWED_CHATS", "-100", "other-user", -100),
+    ),
+)
+def test_channel_environment_grants_match_group_scopes(
+    monkeypatch,
+    env_name,
+    env_value,
+    from_user_id,
+    chat_id,
+):
+    """Telegram channels retain the group-scoped env compatibility contract."""
+    from gateway.run import GatewayRunner
+
+    for key in (
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv(env_name, env_value)
+
+    adapter = _make_adapter()
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    adapter._message_handler = runner._is_user_authorized
+    message = _make_message(
+        from_user_id=from_user_id,
+        chat_id=chat_id,
+        chat_type="channel",
+    )
+
+    source = adapter._source_from_message_for_auth(message)
+    assert runner._is_user_authorized(source) is True
+    assert adapter._is_user_authorized_from_message(message) is True
+
+
 def test_runner_auth_gets_group_user_allowlist_context(monkeypatch):
     """Group user allowlists need a group-shaped source, not a DM-shaped one."""
     monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_USERS", "111")

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -543,6 +543,27 @@ def test_profile_secret_scope_restriction_is_enforced_at_intake(monkeypatch):
     assert seen == [("attacker", "group", "-100")]
 
 
+def test_profile_secret_scope_authorizes_identityless_allowed_chat(monkeypatch):
+    """Anonymous profile traffic must use the scoped chat list, not global env."""
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_CHATS", "-200")
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-100",
+        chat_type="channel",
+        user_id=None,
+    )
+    token = set_secret_scope({"TELEGRAM_GROUP_ALLOWED_CHATS": "-100"})
+    try:
+        assert runner._is_user_authorized(source) is True
+    finally:
+        reset_secret_scope(token)
+
+
 @pytest.mark.parametrize(
     ("env_name", "env_value", "from_user_id", "chat_id"),
     (

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -5,7 +5,7 @@ event building, or response generation occurs.
 """
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -272,6 +272,85 @@ def test_empty_group_config_lists_defer_to_injected_authority():
     ) is True
 
 
+def test_config_allowlists_authorize_the_documented_group_union():
+    """Global users, group users, and allowed chats are independent grants."""
+    adapter = _make_adapter(
+        allow_from=["global-user"],
+        group_allow_from=["group-user"],
+        group_allowed_chats=["-100"],
+    )
+
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id="global-user", chat_id=-200, chat_type="group")
+    ) is True
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id="group-user", chat_id=-200, chat_type="group")
+    ) is True
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id="unlisted-user", chat_id=-100, chat_type="group")
+    ) is True
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id="unlisted-user", chat_id=-200, chat_type="group")
+    ) is False
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id="group-user", chat_id=123, chat_type="private")
+    ) is False
+
+
+def test_runner_config_authorization_matches_telegram_intake_union(monkeypatch):
+    """YAML-config and environment allowlists produce the same intake result."""
+    from gateway.run import GatewayRunner
+
+    for key in (
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    adapter = _make_adapter(
+        allow_from=["global-user"],
+        group_allow_from=["group-user"],
+        group_allowed_chats=["-100"],
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+
+    cases = (
+        (_make_message(from_user_id="global-user", chat_id=-200, chat_type="group"), True),
+        (_make_message(from_user_id="group-user", chat_id=-200, chat_type="group"), True),
+        (_make_message(from_user_id="unlisted-user", chat_id=-100, chat_type="group"), True),
+        (_make_message(from_user_id="unlisted-user", chat_id=-200, chat_type="group"), False),
+        (_make_message(from_user_id="group-user", chat_id=123, chat_type="private"), False),
+    )
+    config_intake = []
+    for message, expected in cases:
+        source = adapter._source_from_message_for_auth(message)
+        config_intake.append(adapter._is_user_authorized_from_message(message))
+        assert runner._is_user_authorized(source) is expected
+
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "global-user")
+    monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_USERS", "group-user")
+    monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_CHATS", "-100")
+    env_adapter = _make_adapter()
+    env_runner = object.__new__(GatewayRunner)
+    env_runner.adapters = {Platform.TELEGRAM: env_adapter}
+    env_runner.pairing_store = MagicMock()
+    env_runner.pairing_store.is_approved.return_value = False
+    env_adapter._message_handler = env_runner._is_user_authorized
+
+    env_intake = [
+        env_adapter._is_user_authorized_from_message(message)
+        for message, _expected in cases
+    ]
+    assert config_intake == env_intake
+
+
 def test_is_user_authorized_from_message_wildcard():
     """_is_user_authorized_from_message should accept wildcard '*'."""
     adapter = _make_adapter(allow_from=["*"])
@@ -415,7 +494,7 @@ async def test_unmentioned_group_text_from_removed_user_not_observed():
     adapter = _make_adapter(
         group_allow_from=["222"],
         allowed_chats=["-100"],
-        group_allowed_chats=["-100"],
+        group_allowed_chats=["-200"],
         require_mention=True,
         observe_unmentioned_group_messages=True,
     )
@@ -436,7 +515,7 @@ async def test_unmentioned_group_location_from_removed_user_not_observed():
     adapter = _make_adapter(
         group_allow_from=["222"],
         allowed_chats=["-100"],
-        group_allowed_chats=["-100"],
+        group_allowed_chats=["-200"],
         require_mention=True,
         observe_unmentioned_group_messages=True,
     )

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -351,6 +351,94 @@ def test_runner_config_authorization_matches_telegram_intake_union(monkeypatch):
     assert config_intake == env_intake
 
 
+@pytest.mark.parametrize(
+    ("env_name", "env_value", "message"),
+    (
+        (
+            "TELEGRAM_GROUP_ALLOWED_USERS",
+            "group-user",
+            _make_message(from_user_id="group-user", chat_id=-200, chat_type="group"),
+        ),
+        (
+            "TELEGRAM_GROUP_ALLOWED_CHATS",
+            "-100",
+            _make_message(from_user_id="unlisted-user", chat_id=-100, chat_type="group"),
+        ),
+    ),
+)
+def test_mixed_yaml_and_environment_group_grants_are_unioned(
+    monkeypatch,
+    env_name,
+    env_value,
+    message,
+):
+    """A non-matching YAML global list must not hide an env group grant."""
+    from gateway.run import GatewayRunner
+
+    for key in (
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv(env_name, env_value)
+
+    adapter = _make_adapter(
+        allow_from=["global-user"],
+        group_allow_from=[],
+        group_allowed_chats=[],
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    adapter._message_handler = runner._is_user_authorized
+
+    assert adapter._is_user_authorized_from_message(message) is True
+    assert runner._is_user_authorized(adapter._source_from_message_for_auth(message)) is True
+
+
+def test_scalar_config_allowlists_match_sequence_semantics():
+    """Comma-separated YAML scalars use the same scoped union as sequences."""
+    adapter = _make_adapter(
+        allow_from="111, 222",
+        group_allow_from="333, 444",
+        group_allowed_chats="-100, -200",
+    )
+
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id=222, chat_id=-300, chat_type="group")
+    ) is True
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id=444, chat_id=-300, chat_type="group")
+    ) is True
+    assert adapter._is_user_authorized_from_message(
+        _make_message(from_user_id=555, chat_id=-200, chat_type="group")
+    ) is True
+
+
+@pytest.mark.parametrize(
+    ("extra", "message"),
+    (
+        (
+            {"group_allow_from": ["*"]},
+            _make_message(from_user_id=111, chat_id=-300, chat_type="group"),
+        ),
+        (
+            {"group_allowed_chats": ["*"]},
+            _make_message(from_user_id=111, chat_id=-300, chat_type="group"),
+        ),
+    ),
+)
+def test_group_scoped_wildcards_authorize(extra, message):
+    adapter = _make_adapter(**extra)
+
+    assert adapter._is_user_authorized_from_message(message) is True
+
+
 def test_is_user_authorized_from_message_wildcard():
     """_is_user_authorized_from_message should accept wildcard '*'."""
     adapter = _make_adapter(allow_from=["*"])

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -71,6 +71,19 @@ def _make_message(text="hello", *, from_user_id=111, chat_id=-100, chat_type="gr
     )
 
 
+def test_partially_initialized_adapter_preserves_identityless_cold_path():
+    """Pre-initialization media gates must not require ``adapter.platform``."""
+    try:
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+    except ModuleNotFoundError:  # PR branch before Telegram plugin extraction
+        from gateway.platforms.telegram import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    message = SimpleNamespace(from_user=None, sender_chat=None, chat=None)
+
+    assert adapter._is_user_authorized_from_message(message) is True
+
+
 @pytest.mark.asyncio
 async def test_unauthorized_user_blocked_before_event_building():
     """Unauthorized user's message should be blocked before _build_message_event."""

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -510,6 +510,43 @@ def test_registered_gateway_authority_preserves_pairing_union(monkeypatch):
     assert adapter._is_user_authorized_from_message(msg) is True
 
 
+def test_profile_route_selects_scoped_authority_before_default_callback(monkeypatch):
+    """Shared credentials must authorize against the chat's routed profile."""
+    for key in (
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    seen = []
+
+    class Runner:
+        @staticmethod
+        def _profile_name_for_source(_source):
+            return "routed-profile"
+
+        @staticmethod
+        def _is_user_authorized_for_adapter_intake(source):
+            seen.append(source)
+            return source.profile == "routed-profile" and source.user_id == "paired-user"
+
+    adapter = _make_adapter(allow_from=["owner"])
+    adapter.gateway_runner = Runner()
+    adapter.set_authorization_check(lambda *_args: False)
+    message = _make_message(
+        from_user_id="paired-user",
+        chat_id=-100,
+        chat_type="group",
+    )
+
+    assert adapter._is_user_authorized_from_message(message) is True
+    assert seen and seen[0].profile == "routed-profile"
+
+
 def test_profile_secret_scope_restriction_is_enforced_at_intake(monkeypatch):
     """Multiplex profile allowlists must gate before event construction."""
     from agent.secret_scope import reset_secret_scope, set_secret_scope

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -648,6 +648,38 @@ async def test_unauthorized_dm_pairs_by_default(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_routed_profile_dm_uses_profile_pairing_store(monkeypatch):
+    """Pairing generation and rate limiting must match profile-scoped auth."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        multiplex_profiles=True,
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
+    )
+    runner, adapter = _make_runner(Platform.TELEGRAM, config)
+    profile_store = MagicMock()
+    profile_store.is_approved.return_value = False
+    profile_store._is_rate_limited.return_value = False
+    profile_store.generate_code.return_value = "PROFILE1"
+    runner.pairing_stores = {"coder": profile_store}
+    runner._profile_adapters = {"coder": {Platform.TELEGRAM: adapter}}
+
+    event = _make_event(Platform.TELEGRAM, "new-user", "new-user")
+    event.source.profile = "coder"
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    profile_store._is_rate_limited.assert_called_once_with("telegram", "new-user")
+    profile_store.generate_code.assert_called_once_with(
+        "telegram", "new-user", "tester"
+    )
+    runner.pairing_store._is_rate_limited.assert_not_called()
+    runner.pairing_store.generate_code.assert_not_called()
+    adapter.send.assert_awaited_once()
+    assert "PROFILE1" in adapter.send.await_args.args[1]
+
+
+@pytest.mark.asyncio
 async def test_unauthorized_whatsapp_dm_can_be_ignored(monkeypatch):
     _clear_auth_env(monkeypatch)
     config = GatewayConfig(


### PR DESCRIPTION
## Summary

- preserve union semantics across global, group-user, allowed-chat, environment, and pairing authorization
- scope routed Telegram profile authorization and pairing state consistently
- retain pre-initialization media gating behavior

Resolves the behavior tracked internally as I-Ca-038 and supersedes the incomplete approach in #69617.

Fixes #68716.

## Validation

- 358 focused gateway/Telegram tests passed
- full suite: 47,703 passed, 13 failed; 12 failures reproduced unchanged on canonical main, and the one branch regression was fixed with dedicated coverage
- independent review: no findings
- Sting exact-config authorization matrix: 9/9 passed
- Sting gateway restarted successfully and remains active with zero automatic restarts