### PR TITLE
fix(backup): clear stale SQLite sidecars on snapshot restore

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1305,6 +1305,17 @@ def restore_quick_snapshot(
                 tmp = dst.parent / f".{dst.name}.snap_restore"
                 shutil.copy2(src, tmp)
                 dst.unlink(missing_ok=True)
+                # Drop the destination's sidecars before installing the
+                # snapshot. The snapshot is a checkpointed ``sqlite3.backup()``
+                # image (see ``_safe_copy_db``) that owns no WAL, so any
+                # ``-wal``/``-shm`` still sitting here describes the database we
+                # just unlinked — an ungracefully killed gateway leaves them
+                # behind, which is exactly when a restore gets run. SQLite
+                # replays that foreign WAL over the restored file on the next
+                # open and the database comes up "malformed". Same reasoning as
+                # ``_EXCLUDED_SUFFIXES``, applied to the restore destination.
+                for _sidecar_suffix in ("-wal", "-shm", "-journal"):
+                    dst.with_name(dst.name + _sidecar_suffix).unlink(missing_ok=True)
                 shutil.move(str(tmp), str(dst))
             else:
                 shutil.copy2(src, dst)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7433,6 +7433,13 @@ def _update_via_zip(args):
                                 try:
                                     import shutil as _shutil
 
+                                    # Stale -wal/-shm from the crashed process
+                                    # would be replayed over the snapshot image
+                                    # and fail the integrity check below.
+                                    for _sfx in ("-wal", "-shm", "-journal"):
+                                        _state_path.with_name(
+                                            _state_path.name + _sfx
+                                        ).unlink(missing_ok=True)
                                     _shutil.copy2(_snap_state, _state_path)
                                     _restored_ok = verify_sqlite_integrity(
                                         _state_path,
@@ -11900,6 +11907,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                 try:
                                     import shutil as _shutil
 
+                                    # Stale -wal/-shm from the crashed process
+                                    # would be replayed over the snapshot image
+                                    # and fail the integrity check below.
+                                    for _sfx in ("-wal", "-shm", "-journal"):
+                                        _state_path.with_name(
+                                            _state_path.name + _sfx
+                                        ).unlink(missing_ok=True)
                                     _shutil.copy2(_snap_state, _state_path)
                                     _restored_ok = verify_sqlite_integrity(
                                         _state_path,

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -2848,3 +2848,70 @@ class TestMemoryProviderExternalPaths:
 
         paths = HindsightMemoryProvider().backup_paths()
         assert str(tmp_path / ".hindsight") in paths
+
+
+class TestQuickSnapshotRestoreSidecars:
+    """A restore must not leave the destination's stale WAL/SHM in place.
+
+    The snapshot is a checkpointed ``sqlite3.backup()`` image that owns no WAL,
+    so a leftover ``-wal`` from an ungracefully killed gateway describes a
+    *different* page image.  Replacing only the main ``.db`` makes SQLite replay
+    that foreign WAL on the next open and the database comes up malformed.
+    """
+
+    @pytest.fixture
+    def hermes_home(self, tmp_path):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        db_path = home / "state.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY, data TEXT)")
+        for i in range(2000):
+            conn.execute("INSERT INTO sessions(data) VALUES (?)", ("seed" * 40,))
+        conn.commit()
+        conn.execute("PRAGMA wal_checkpoint(FULL)")
+        conn.close()
+        return home
+
+    def test_restore_clears_stale_sidecars(self, hermes_home):
+        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
+
+        db_path = hermes_home / "state.db"
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+        assert snap_id is not None
+
+        # Churn after the snapshot, then strand the sidecars on disk the way a
+        # SIGKILLed gateway does (copy them aside, let close() clean up, put
+        # them back) so they describe pages the snapshot image does not have.
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA journal_mode=WAL")
+        for i in range(4000):
+            conn.execute("INSERT INTO sessions(data) VALUES (?)", ("churn" * 40,))
+        conn.commit()
+        conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+        for i in range(4000):
+            conn.execute("INSERT INTO sessions(data) VALUES (?)", ("more" * 40,))
+        conn.commit()
+        stranded = {}
+        for suffix in ("-wal", "-shm"):
+            sidecar = db_path.with_name(db_path.name + suffix)
+            assert sidecar.exists(), f"expected a live {suffix} before close"
+            stranded[suffix] = sidecar.read_bytes()
+        conn.close()
+        for suffix, blob in stranded.items():
+            db_path.with_name(db_path.name + suffix).write_bytes(blob)
+
+        assert restore_quick_snapshot(snap_id, hermes_home=hermes_home) is True
+
+        for suffix in ("-wal", "-shm"):
+            assert not db_path.with_name(db_path.name + suffix).exists(), (
+                f"stale {suffix} survived the restore and will be replayed"
+            )
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+            assert conn.execute("SELECT count(*) FROM sessions").fetchone()[0] == 2000
+        finally:
+            conn.close()


### PR DESCRIPTION
## Summary

`restore_quick_snapshot` swaps only the main `.db` file and leaves the
destination's `state.db-wal` / `state.db-shm` in place. The snapshot is a
checkpointed `sqlite3.backup()` image that owns no WAL, so those sidecars
describe the database that was just unlinked — SQLite replays that foreign WAL
over the restored file on the next open.

The restore reports success and returns `True` while leaving `state.db`
malformed.

## Problem

`hermes_cli/backup.py`, in `restore_quick_snapshot`:

```python
if dst.suffix == ".db":
    # Atomic-ish replace for databases
    tmp = dst.parent / f".{dst.name}.snap_restore"
    shutil.copy2(src, tmp)
    dst.unlink(missing_ok=True)
    shutil.move(str(tmp), str(dst))     # -wal / -shm still sitting next to dst
```

The snapshot side is correct: `_safe_copy_db` produces a consistent standalone
image via `conn.backup(backup_conn)`. So a leftover `-wal` never belongs to it.

An ungracefully killed gateway — SIGKILL, OOM, power loss, `docker stop`
timeout — strands `state.db-wal` + `state.db-shm` on disk. That is exactly the
situation in which an operator reaches for `/snapshot restore`.

The module already documents this hazard — for the *archive*, in
`_EXCLUDED_SUFFIXES`:

> SQLite sidecar files — the backup takes a consistent snapshot of `*.db` via
> `sqlite3.backup()`, so shipping the live WAL / shared-memory / rollback-journal
> alongside would pair a fresh snapshot with stale sidecar state and produce a
> torn restore on the next open.

That reasoning was never applied to the restore *destination*.

### Reproduced against the real functions

Seed a WAL database, snapshot it, churn it, strand the sidecars the way a
SIGKILLed gateway does, then call the shipped `restore_quick_snapshot`:

| | `restore` returned | sidecars left | `PRAGMA integrity_check` | rows |
|---|---|---|---|---|
| `main` | `True` | `['-wal', '-shm']` | `*** in database main *** Tree 2 page 295: btreeInitPage() returns error code 11` | `DatabaseError: database disk image is malformed` |
| patched | `True` | none | `ok` | `2000` |

`btreeInitPage() error 11` is the same corruption signature `hermes_state.py`
records for #30636.

### Why it does not self-heal

- `SessionDB.__init__` then fails on every start and routes to
  `repair_state_db_schema`, which only rebuilds `sqlite_master`/FTS — the damage
  is in the `sessions`/`messages` b-trees, so it re-raises and the agent reports
  "Session database not available" on every boot.
- The pre-restore `state.db` was already `unlink()`ed.
- The stale `-wal` **survives the restore**, so re-running the restore corrupts
  the file again identically. The documented last-resort recovery is wedged.

### Same shape, unattended: `hermes update`

Both post-update auto-restore sites in `hermes_cli/main.py` do
`copy2(_snap_state, _state_path)` with the sidecars still present, then run
`verify_sqlite_integrity` — which fails and prints
`✗ Auto-restore FAILED — restored copy also failed integrity`. The branch that
reports the failure is already in the code; this bug is what triggers it.

## Fix

Unlink the destination's `-wal` / `-shm` / `-journal` before installing the
snapshot image, in all three restore paths.

This matches what every other DB-move site in the repo already does —
`hermes_state.py:742` (`_backup_db_file`), `hermes_state.py:1698`
(`quarantine_zeroed_state_db`), `hermes_cli/kanban_db.py:1759`,
`hermes_cli/session_recovery.py:60` (`_SIDECAR_SUFFIXES`).
`restore_quick_snapshot` was the outlier.

## Scope

- `hermes_cli/backup.py` — `restore_quick_snapshot`
- `hermes_cli/main.py` — the two `hermes update` auto-restore sites
- `tests/hermes_cli/test_backup.py` — regression test

No signature or behaviour change beyond removing sidecars that are invalid for
the restored image.

## Testing

`TestQuickSnapshotRestoreSidecars::test_restore_clears_stale_sidecars` seeds a
WAL database, takes a real snapshot, churns it, strands the sidecars
deterministically (copy aside → `close()` → copy back, no SIGKILL needed), runs
the real `restore_quick_snapshot`, then asserts the sidecars are gone,
`PRAGMA integrity_check` is `ok`, and the row count matches the snapshot.

It fails on `main` (`database disk image is malformed`) and passes with the fix.

## Note — related, not fixed here

On the capture side, the `kanban/boards` walk tests `sub.suffix == ".db"`, but
`Path("kanban.db-wal").suffix` is `".db-wal"`, so live board sidecars are raw-copied
*into* the snapshot. That installs a stale WAL on restore even when the
destination had none. Happy to fold it in if you'd prefer one PR.

Related open work on this function, which does not cover this case: #65960 /
#65947 restore through the SQLite backup API (its review notes sidecar handling
is unaddressed), #41753 corrupt-manifest handling.
