### PR TITLE
fix(gemini): preserve bridged tool response name

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -285,9 +285,13 @@ def _translate_tool_result_to_gemini(
 ) -> Dict[str, Any]:
     tool_name_by_call_id = tool_name_by_call_id or {}
     tool_call_id = str(message.get("tool_call_id") or "")
+    # A tool result can carry the unwrapped internal tool name (for example,
+    # an MCP tool invoked through the `tool_call` bridge). Gemini requires
+    # functionResponse.name to echo the matching functionCall.name, so the
+    # call-id mapping must take precedence over the internal result name.
     name = str(
-        message.get("name")
-        or tool_name_by_call_id.get(tool_call_id)
+        tool_name_by_call_id.get(tool_call_id)
+        or message.get("name")
         or tool_call_id
         or "tool"
     )

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -122,6 +122,48 @@ def test_build_native_request_uses_original_function_name_for_tool_result():
     assert tool_response["name"] == "get_weather"
 
 
+
+def test_build_native_request_prefers_call_name_over_unwrapped_result_name():
+    """Gemini must receive the bridge call name, not the internal MCP name."""
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "tool_call",
+                            "arguments": (
+                                '{"name": "mcp__github__create_issue", '
+                                '"arguments": {"title": "Regression"}}'
+                            ),
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "mcp__github__create_issue",
+                "tool_name": "mcp__github__create_issue",
+                "tool_call_id": "call_1",
+                "content": '{"number": 123}',
+            },
+        ],
+        tools=[],
+        tool_choice=None,
+    )
+
+    function_call = request["contents"][0]["parts"][0]["functionCall"]
+    function_response = request["contents"][1]["parts"][0]["functionResponse"]
+    assert function_call["name"] == "tool_call"
+    assert function_response["name"] == function_call["name"]
+
+
 def test_parallel_tool_results_merge_into_one_user_content():
     """Gemini requires strict user/model alternation; two consecutive `user`
     contents are rejected with HTTP 400. Parallel tool calls produce two tool


### PR DESCRIPTION
## Summary

Fixes #72089.

Native Gemini requests could serialize a deferred MCP/plugin call with `functionCall.name = "tool_call"`, then serialize the matching result with the unwrapped internal tool name such as `mcp__github__create_issue`.

This change makes the call-ID mapping take precedence when choosing `functionResponse.name`, so Gemini receives the same wire-visible name for the matching call and response.

## Root cause

The tool executor intentionally unwraps `tool_call` for dispatch, hooks, logging, and guardrails, and stores the underlying tool name on the result message. The native Gemini adapter then preferred that internal result name over the original call name recorded by `tool_call_id`.

As a result, a transcript could contain:

```text
functionCall.name     = tool_call
functionResponse.name = mcp__github__create_issue
```

Gemini requires the response name to match the corresponding call name. A rejection may therefore happen after the external tool has already executed, making retries capable of duplicating side effects.

## Changes

- Prefer the original call name mapped by `tool_call_id` when translating native Gemini tool results.
- Keep the result message name as a fallback for transcripts without a matching assistant call.
- Add a regression test covering a `tool_call` bridge invocation whose result carries an unwrapped MCP tool name.

## Validation

- `uv run pytest tests/agent/test_gemini_native_adapter.py tests/agent/test_gemini_free_tier_gate.py tests/hermes_cli/test_gemini_provider.py tests/hermes_cli/test_gemini_free_tier_setup_block.py tests/tools/test_tool_search.py -q`
  - `148 passed`
- `uv run ruff check agent/gemini_native_adapter.py tests/agent/test_gemini_native_adapter.py`
  - `All checks passed`
- `git diff --check`
  - passed