### PR TITLE
fix(plugins): register entry-point plugins declared as module:function

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1785,10 +1785,18 @@ class PluginManager:
             else:
                 module = self._load_entrypoint_module(manifest)
 
+            register_fn = None
+            if not isinstance(module, types.ModuleType) and callable(module):
+                # Entry points declared as ``module:function`` resolve to the
+                # function object itself via ``ep.load()``, not its module.
+                register_fn = module
+                module = sys.modules.get(getattr(register_fn, "__module__", ""))
+
             loaded.module = module
 
             # Call register()
-            register_fn = getattr(module, "register", None)
+            if register_fn is None:
+                register_fn = getattr(module, "register", None)
             if register_fn is None:
                 loaded.error = "no register() function"
                 logger.warning("Plugin '%s' has no register() function", manifest.name)
@@ -1886,8 +1894,15 @@ class PluginManager:
         spec.loader.exec_module(module)
         return module
 
-    def _load_entrypoint_module(self, manifest: PluginManifest) -> types.ModuleType:
-        """Load a pip-installed plugin via its entry-point reference."""
+    def _load_entrypoint_module(
+        self, manifest: PluginManifest
+    ) -> Union[types.ModuleType, Callable[..., Any]]:
+        """Load a pip-installed plugin via its entry-point reference.
+
+        Returns whatever ``ep.load()`` resolves to: the module for a bare
+        ``module`` entry point, or the referenced attribute (typically the
+        ``register`` callable) for the ``module:function`` form.
+        """
         eps = importlib.metadata.entry_points()
         if hasattr(eps, "select"):
             group_eps = eps.select(group=ENTRY_POINTS_GROUP)

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -187,6 +187,54 @@ class TestPluginDiscovery:
 
 
 
+    def test_entry_point_function_form_registers(self, tmp_path, monkeypatch):
+        """Entry points declared as ``module:function`` register via the callable.
+
+        Regression for #72052: real ``EntryPoint.load()`` returns the referenced
+        attribute for the ``module:function`` form, not the module. The loader
+        used to look for ``.register`` on that function object, find nothing,
+        and warn "no register() function" on every discovery pass.
+        """
+        hermes_home = tmp_path / "hermes_test"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        # Entry-point plugins load only when opted into plugins.enabled.
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["fn_plugin"]}})
+        )
+
+        fake_module = types.ModuleType("fake_fn_plugin")
+        register_calls = []
+
+        def register(ctx):
+            register_calls.append(ctx)
+
+        register.__module__ = "fake_fn_plugin"
+        fake_module.register = register  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "fake_fn_plugin", fake_module)
+
+        fake_ep = MagicMock()
+        fake_ep.name = "fn_plugin"
+        fake_ep.value = "fake_fn_plugin:register"
+        fake_ep.group = ENTRY_POINTS_GROUP
+        # Mirror real importlib behavior: load() resolves to the attribute.
+        fake_ep.load.return_value = register
+
+        def fake_entry_points():
+            result = MagicMock()
+            result.select = MagicMock(return_value=[fake_ep])
+            return result
+
+        with patch("importlib.metadata.entry_points", fake_entry_points):
+            mgr = PluginManager()
+            mgr.discover_and_load()
+
+        entry = mgr._plugins["fn_plugin"]
+        assert entry.error is None, entry.error
+        assert entry.enabled
+        assert len(register_calls) == 1
+        assert entry.module is fake_module
+
     def test_force_rediscover_clears_all_plugin_registries(self, monkeypatch):
         """force=True must clear every plugin-populated registry.
 


### PR DESCRIPTION
## What does this PR do?

Makes pip-installed plugins with `module:function` entry points actually register.

`importlib.metadata.EntryPoint.load()` resolves the `module:function` form to the referenced **attribute** (typically the `register` callable itself), not the module. `PluginManager._load_plugin()` then looked for a `.register` attribute on that function object, found none, and logged `Plugin '<name>' has no register() function` — once per discovery pass, which for a gateway with an every-minute cron tick means a warning per minute, forever. Such plugins could never register at all.

The loader now detects a non-module callable returned by `ep.load()` and uses it directly as the register function. `LoadedPlugin.module` is resolved from `sys.modules` via the callable's `__module__` so attribution and `hermes plugins list` reporting stay intact. Bare `module` entry points and directory plugins are unaffected.

## Related Issue

Fixes #72052

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins.py`
  - `_load_plugin()`: if the entry-point load result is a callable that is not a module, treat it as the `register` function directly and resolve the owning module from `sys.modules` for `LoadedPlugin.module`.
  - `_load_entrypoint_module()`: widen the return annotation and document that `ep.load()` returns the module for bare `module` entry points, or the referenced attribute for the `module:function` form.
- `tests/hermes_cli/test_plugins.py`
  - New regression test `test_entry_point_function_form_registers` whose mocked `ep.load()` returns the function — mirroring real `importlib` behavior. The pre-existing entry-point test masked this bug because its mock returned the module even though its declared entry-point value was `module:function`.

## How to Test

1. Install any pip plugin whose entry point is declared `name = package.module:register` (e.g. `mnemosyne-hermes`), enable it via `hermes plugins enable <name>`, and confirm it registers instead of warning `has no register() function` on every discovery pass.
2. Run the focused suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_plugins.py
```

3. Run the cross-platform check:

```bash
python3 scripts/check-windows-footguns.py --diff origin/main
```

## Validation Results

- `tests/hermes_cli/test_plugins.py`: **117 passed, 0 failed** (Python 3.11.15, Ubuntu 22.04 x86_64).
- The new regression test fails on unpatched `main` with exactly the reported error (`AssertionError: no register() function`) and passes with the fix.
- Windows-footgun diff check: **passed** (0 findings).
- The full repository suite was not run locally; hosted CI remains authoritative for the complete matrix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open and merged issues/PRs; no open PR addresses #72052
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — focused suite above is green; see the transparency note in Validation Results
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 22.04 x86_64 with Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation N/A — no user-facing command or configuration key was added
- [x] `cli-config.yaml.example` N/A — no configuration key was added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A — no architecture or contributor workflow changed
- [x] Cross-platform impact considered; `scripts/check-windows-footguns.py --diff origin/main` passes
- [x] Tool descriptions/schemas N/A — no tool API changed

## Screenshots / Logs

No UI changes. Loader behavior before/after on a `module:function` entry point:

```text
before: WARNING hermes_cli.plugins: Plugin 'fn_plugin' has no register() function   (every discovery pass)
after : registered — enabled=True, error=None, register(ctx) called once
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
