### PR TITLE
fix(windows): add missing encoding to livetest2 result write_text

### DIFF
--- a/scripts/tool_search_livetest2.py
+++ b/scripts/tool_search_livetest2.py
@@ -187,7 +187,7 @@ def run_one(scenario: Dict[str, Any], mode: str, rep: int, out_dir: Path) -> Dic
         "final_response": base._redact_secrets(final_response)[:500],
     }
     out_path = out_dir / f"{scenario['id']}__{'enabled' if enabled else 'disabled'}__rep{rep}.json"
-    out_path.write_text(json.dumps(rec, indent=1))
+    out_path.write_text(json.dumps(rec, indent=1), encoding="utf-8")
     shutil.rmtree(Path(os.environ["HERMES_HOME"]).parent, ignore_errors=True)
     return rec
 


### PR DESCRIPTION
## What does this PR do?

Unbreaks the `check-windows-footguns.py --all` CI gate, which currently fails for every PR.

a2c42be93 (`fix(lint): explicit encoding on write_text in livetest harness (PLW1514)`) added encodings to the livetest harness but missed the per-scenario result write in `_run_one`, leaving one bare `Path.write_text()` on `scripts/tool_search_livetest2.py:190`. Since the CI job scans with `--all`, that single pre-existing miss now fails the gate for unrelated PRs (observed on #72094).

## Related Issue

Part of the #71014 / #37423 `read_text`/`write_text` encoding campaign.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/tool_search_livetest2.py`: `out_path.write_text(..., encoding="utf-8")` — the one call a2c42be93 missed.

## How to Test

```bash
python3 scripts/check-windows-footguns.py --all
```

## Validation Results

- Before: `✗ 1 Windows footgun(s) found across 818 file(s) scanned.` (scripts/tool_search_livetest2.py:190)
- After: `✓ No Windows footguns found (818 file(s) scanned).`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open and merged issues/PRs; no open PR fixes this line
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes — N/A: one-line encoding argument, covered by the CI gate itself
- [x] I've tested on Ubuntu 22.04 x86_64 with Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation N/A
- [x] `cli-config.yaml.example` N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A
- [x] Cross-platform impact considered; `scripts/check-windows-footguns.py --all` passes

## Screenshots / Logs

```text
$ python3 scripts/check-windows-footguns.py --all
✓ No Windows footguns found (818 file(s) scanned).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
