### PR TITLE
fix(agent): keep system cache breakpoints across provider failover

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -774,6 +774,41 @@ def _compression_deferred_result(
     }
 
 
+def _rewrite_system_content_blocks(system_message: dict, effective: str) -> bool:
+    """Rewrite a cache-decorated system message in place, keeping its blocks.
+
+    ``apply_anthropic_cache_control`` runs once per call block, *before* the
+    retry loop, and splits the system prompt into ``[static prefix, volatile
+    tail]`` text blocks carrying the cache_control breakpoints. Assigning a bare
+    string over that list drops both breakpoints, so the failover retry ships
+    the whole system prompt uncached and re-bills it in full.
+
+    ``rewrite_prompt_model_identity`` only touches the LAST ``Model:`` /
+    ``Provider:`` lines, and those live in the volatile tail — so the static
+    prefix stays byte-identical and its cache entry keeps matching. Returns
+    False when the shape is not one we can safely patch, so the caller falls
+    back to the plain-string assignment.
+    """
+    content = system_message.get("content")
+    if not isinstance(content, list) or not content:
+        return False
+    if not all(
+        isinstance(part, dict) and part.get("type") == "text" for part in content
+    ):
+        return False
+    if len(content) == 1:
+        content[0]["text"] = effective
+        return True
+    if len(content) == 2:
+        head = content[0].get("text") or ""
+        if head and effective.startswith(head):
+            tail = effective[len(head):]
+            if tail:
+                content[1]["text"] = tail
+                return True
+    return False
+
+
 def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     """Refresh the in-flight system message after a provider failover.
 
@@ -796,7 +831,8 @@ def _sync_failover_system_message(agent, api_messages, active_system_prompt):
         effective = sp
         if agent.ephemeral_system_prompt:
             effective = (effective + "\n\n" + agent.ephemeral_system_prompt).strip()
-        api_messages[0]["content"] = effective
+        if not _rewrite_system_content_blocks(api_messages[0], effective):
+            api_messages[0]["content"] = effective
     return sp
 
 

--- a/tests/agent/test_failover_identity.py
+++ b/tests/agent/test_failover_identity.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 
 from agent.chat_completion_helpers import rewrite_prompt_model_identity
 from agent.conversation_loop import _sync_failover_system_message
+from agent.prompt_caching import apply_anthropic_cache_control
 
 
 _PROMPT = (
@@ -102,3 +103,89 @@ class TestSyncFailoverSystemMessage:
         assert api_messages == [{"role": "user", "content": "hi"}]
         # Still returns the cached prompt for subsequent call-block rebuilds.
         assert result == agent._cached_system_prompt
+
+
+class TestSyncFailoverPreservesCacheDecoration:
+    """The sync must not flatten a cache-decorated system message.
+
+    ``apply_anthropic_cache_control`` runs once per call block, before the retry
+    loop, splitting the system prompt into ``[static prefix, volatile tail]``
+    blocks that carry the cache_control breakpoints. A failover fires *inside*
+    that retry loop, so overwriting the list with a bare string drops both
+    breakpoints and the retried request re-bills the whole system prompt.
+    """
+
+    _STATIC = "You are a helpful assistant.\n\nStable brief.\n"
+
+    def _decorated(self, prompt):
+        messages = [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": "what model are you?"},
+        ]
+        return apply_anthropic_cache_control(
+            messages,
+            cache_ttl=None,
+            native_anthropic=True,
+            static_system_prefix=self._STATIC,
+        )
+
+    def test_keeps_breakpoints_and_static_prefix(self):
+        prompt = self._STATIC + "Model: gpt-5.4-mini\nProvider: openai-codex"
+        agent = _agent(prompt=prompt)
+        api_messages = self._decorated(prompt)
+        assert isinstance(api_messages[0]["content"], list)
+
+        rewrite_prompt_model_identity(agent, "gemma4:e2b-mlx", "custom")
+        _sync_failover_system_message(agent, api_messages, prompt)
+
+        content = api_messages[0]["content"]
+        assert isinstance(content, list), "cache decoration was flattened to a string"
+        assert len(content) == 2
+        assert all(part.get("cache_control") for part in content), (
+            "the failover retry would ship zero system cache breakpoints"
+        )
+        # The static prefix must stay byte-identical or its cache entry misses.
+        assert content[0]["text"] == self._STATIC
+        # The identity refresh still lands, in the volatile tail.
+        assert "Model: gemma4:e2b-mlx" in content[1]["text"]
+        assert "Provider: custom" in content[1]["text"]
+
+    def test_keeps_single_block_shape(self):
+        prompt = "Model: gpt-5.4-mini\nProvider: openai-codex"
+        agent = _agent(prompt=prompt)
+        # No static prefix match -> the single-block fallback layout.
+        api_messages = apply_anthropic_cache_control(
+            [{"role": "system", "content": prompt}],
+            cache_ttl=None,
+            native_anthropic=True,
+            static_system_prefix=None,
+        )
+        assert isinstance(api_messages[0]["content"], list)
+        assert len(api_messages[0]["content"]) == 1
+
+        rewrite_prompt_model_identity(agent, "gemma4:e2b-mlx", "custom")
+        _sync_failover_system_message(agent, api_messages, prompt)
+
+        content = api_messages[0]["content"]
+        assert isinstance(content, list) and len(content) == 1
+        assert content[0].get("cache_control")
+        assert "Model: gemma4:e2b-mlx" in content[0]["text"]
+
+    def test_ephemeral_prompt_lands_in_the_volatile_tail(self):
+        prompt = self._STATIC + "Model: gpt-5.4-mini\nProvider: openai-codex"
+        agent = _agent(prompt=prompt, ephemeral="Stay terse.")
+        api_messages = self._decorated(prompt)
+
+        _sync_failover_system_message(agent, api_messages, prompt)
+
+        content = api_messages[0]["content"]
+        assert content[0]["text"] == self._STATIC
+        assert content[1]["text"].endswith("Stay terse.")
+
+    def test_unknown_block_shape_falls_back_to_string(self):
+        agent = _agent()
+        api_messages = [
+            {"role": "system", "content": [{"type": "image", "source": {}}]},
+        ]
+        _sync_failover_system_message(agent, api_messages, _PROMPT)
+        assert api_messages[0]["content"] == agent._cached_system_prompt


### PR DESCRIPTION
## Summary

`_sync_failover_system_message` assigns a bare string over
`api_messages[0]["content"]` to refresh the `Model:`/`Provider:` identity lines
after a failover. When prompt caching is on, that content is a decorated block
list — so the assignment drops both system cache breakpoints and the retried
request ships the whole system prompt uncached.

A failover therefore re-bills the entire system prompt at full write price and
writes nothing to cache, so the following call misses too.

## Problem

`apply_anthropic_cache_control` runs **once per call block**, at
`agent/conversation_loop.py`, *before* the retry loop:

```python
if agent._use_prompt_caching:
    _static_system_prefix = getattr(agent, "_cached_system_prompt_static", None)
    api_messages = apply_anthropic_cache_control(
        api_messages, cache_ttl=agent._cache_ttl,
        native_anthropic=agent._use_native_cache_layout,
        static_system_prefix=...,
    )
```

`_apply_system_cache_markers` splits the system prompt into two text blocks —
`[static prefix, volatile tail]` — each carrying a `cache_control` marker.

A failover fires **inside** the retry loop, and the sync flattens that list:

```python
api_messages[0]["content"] = effective      # a plain str
```

`convert_messages_to_anthropic` only emits system cache blocks when the content
is a list:

```python
if isinstance(content, list):
    has_cache = any(p.get("cache_control") for p in content if isinstance(p, dict))
    if has_cache:
        system = [p for p in content if isinstance(p, dict)]
    ...
else:
    system = content        # plain string -> no breakpoints at all
```

Measured by running the real `apply_anthropic_cache_control` and
`_sync_failover_system_message` over the same history, native Anthropic layout:

| | system wire shape | system breakpoints |
|---|---|---|
| normal turn | `BLOCK LIST (2 blocks)` | 2 |
| after failover | `plain string` | 0 |

The function's own docstring notes this path runs on "every gateway turn, since
fallback re-activates per message while the primary is down" — so a gateway
running on a degraded primary pays this on **every message**, not once.

Cost shape per failover-recovered call: the full system prompt (SOUL.md, skills
index, coding brief, context files, memory — commonly 10–30K tokens) is billed
at write price with no cache write, so the next call misses as well. Two
full-price prompts instead of one write plus one read.

### Prior art in the same loop

The retry loop already guards this exact class for a neighbouring field, eight
lines below the gap:

```python
# api_messages is built once, before this retry loop, while the primary
# provider is active.  A mid-conversation fallback can switch to a
# require-side provider (DeepSeek / Kimi / MiMo) that rejects assistant
# turns lacking reasoning_content. [...] so the fallback request isn't sent
# with stale, primary-shaped reasoning fields.
agent._reapply_reasoning_echo_for_provider(api_messages)
```

There is no equivalent for the cache decoration.

## Fix

Rewrite the decorated blocks in place instead of flattening them.

`rewrite_prompt_model_identity` only touches the **last** `Model:`/`Provider:`
lines, and its docstring states those "live in the volatile tail of the
prompt". So the static prefix is unaffected by the identity refresh: keeping
block 0 byte-identical preserves its cache entry, and only the trailing block's
text is rewritten.

The failover retry then keeps **both** breakpoints *and* the warm prefix, which
is strictly better than re-deriving the decoration from scratch.

Shapes that cannot be safely patched (non-text blocks, a prefix that no longer
matches) fall back to the existing plain-string assignment, so behaviour is
unchanged wherever the fix does not clearly apply.

## Scope

- `agent/conversation_loop.py` — new `_rewrite_system_content_blocks` helper +
  one call in `_sync_failover_system_message`.
- `tests/agent/test_failover_identity.py` — 4 regression tests.

No signature changes; no change to the decoration pass or the adapters.

## Testing

New `TestSyncFailoverPreservesCacheDecoration`, driving the real
`apply_anthropic_cache_control` → `rewrite_prompt_model_identity` →
`_sync_failover_system_message` sequence:

- `test_keeps_breakpoints_and_static_prefix` — content stays a 2-block list,
  both blocks keep `cache_control`, block 0 is byte-identical to the static
  prefix, and the new identity lands in the tail.
- `test_keeps_single_block_shape` — the no-static-prefix single-block layout.
- `test_ephemeral_prompt_lands_in_the_volatile_tail` — the ephemeral prompt is
  appended to the tail, not to the cacheable prefix.
- `test_unknown_block_shape_falls_back_to_string` — unpatchable shapes keep the
  old behaviour.

Against `main` the first three fail (`cache decoration was flattened to a
string`); with the fix all four pass. The four existing
`TestSyncFailoverSystemMessage` tests pass unchanged in both — they use
plain-string content, which the fix leaves alone.

## Note — related, not fixed here

`try_activate_fallback` re-resolves `_use_prompt_caching` /
`_use_native_cache_layout` for the new backend, but the message-level markers
were already applied under the *old* layout and are never re-normalised. On a
native-Anthropic → OpenRouter failover the top-level `cache_control` that
`_apply_cache_marker` puts on `role:"tool"` messages rides an OpenAI-wire
request — which `prompt_caching.py`'s own comment says "OpenRouter rejects
[...] (silent hang)" — and `agent/transports/chat_completions.py` strips
`tool_name`, `extra_content` and `_`-prefixed keys but not `cache_control`.
Happy to fold that in if you'd prefer one PR; it needs a layout-change check
rather than a shape-preserving rewrite.
