### PR TITLE
docs(gateway): correct Windows detached-daemon guidance to console py…

### DIFF
--- a/CONTRIBUTING.es.md
+++ b/CONTRIBUTING.es.md
@@ -480,7 +480,7 @@ que toca el SO, asume que *cualquier* plataforma puede alcanzar tu ruta de códi
 
 9. **Los modos de archivo POSIX (0o600, 0o644, etc.) NO se aplican en NTFS** por defecto.
 
-10. **Los daemons de fondo desacoplados en Windows necesitan `pythonw.exe`, NO `python.exe`.**
+10. **Los daemons de fondo desacoplados en Windows usan `python.exe` de consola, NO `pythonw.exe`.** Con `CREATE_NO_WINDOW` el daemon obtiene su propia consola *oculta*, que sus procesos descendientes heredan en lugar de abrir ventanas visibles (#54220/#56747). Usa `windows_detach_flags()` de `hermes_cli/_subprocess_compat.py`; no añadas `DETACHED_PROCESS`, ya que anula `CREATE_NO_WINDOW`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -796,14 +796,20 @@ that touches the OS, assume *any* platform can hit your code path.
    Windows — the concept doesn't translate. Use ACLs (`icacls`, `pywin32`)
    for Windows secret-file protection if needed.
 
-10. **Detached background daemons on Windows need `pythonw.exe`, NOT
-    `python.exe`.** `python.exe` always allocates or attaches to a console,
-    which makes it vulnerable to `CTRL_C_EVENT` broadcasts from any sibling
-    process. `pythonw.exe` is the no-console variant. Combine with
-    `CREATE_NO_WINDOW | DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP |
-    CREATE_BREAKAWAY_FROM_JOB` in `subprocess.Popen(creationflags=...)`.
-    See `hermes_cli/gateway_windows.py::_spawn_detached` for the reference
-    implementation.
+10. **Detached background daemons on Windows use console `python.exe`, NOT
+    `pythonw.exe`.** A GUI-subsystem `pythonw.exe` daemon has *no* console,
+    so every console-subsystem descendant it spawns (git, gh, cmd, node,
+    …) allocates its own visible one and flashes a window (#54220/#56747).
+    Spawn console `python.exe` under `CREATE_NO_WINDOW` instead: the daemon
+    owns a *hidden* console that its descendants inherit, and it is still
+    detached from the launching shell's console lifetime. Take the flags
+    from `windows_detach_flags()` in `hermes_cli/_subprocess_compat.py`
+    rather than assembling them by hand — it returns
+    `CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`.
+    Do **not** add `DETACHED_PROCESS`: MSDN specifies `CREATE_NO_WINDOW` is
+    ignored when the two are combined, which silently turns the hide bit
+    into a no-op. See `hermes_cli/gateway_windows.py::_resolve_detached_python`
+    and `::_spawn_detached` for the reference implementation.
 
 11. **`subprocess.Popen` with `.cmd` or `.bat` shims needs `shutil.which`
     to resolve.** Passing `"agent-browser"` to `Popen` on Windows finds

--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -178,9 +178,9 @@ What happens under the hood:
 
 1. `schtasks /Create /SC ONLOGON /RL LIMITED /TN HermesGateway` — registers a task that runs at your login with standard (non-elevated) permissions. No UAC prompt.
 2. If schtasks is blocked by group policy, falls back to writing a `start /min cmd.exe /d /c <wrapper>` shortcut into `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup`. Same effect, slightly cruder.
-3. Spawns the gateway **detached via `pythonw.exe`** — not `python.exe`. `pythonw.exe` has no console attached, which immunizes it against `CTRL_C_EVENT` broadcasts from sibling processes (a real issue that used to kill the gateway when you Ctrl+C'd anything in the same process group).
+3. Spawns the gateway **detached via console `python.exe`** — not `pythonw.exe`. `CREATE_NO_WINDOW` gives it its own *hidden* console, so it is detached from the launching shell's console lifetime and every console-subsystem descendant it spawns (git, gh, cmd, node) inherits that hidden console instead of flashing a visible one. `CREATE_NEW_PROCESS_GROUP` is what shields it from `CTRL_C_EVENT` broadcasts by sibling processes.
 
-Flags used when spawning: `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`.
+Flags used when spawning: `CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`. `DETACHED_PROCESS` is deliberately absent — MSDN specifies `CREATE_NO_WINDOW` is ignored when combined with it.
 
 ### Manage
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/windows-native.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/windows-native.md
@@ -178,9 +178,9 @@ hermes gateway install
 
 1. `schtasks /Create /SC ONLOGON /RL LIMITED /TN HermesGateway` — 注册一个在你登录时以标准（非提升）权限运行的任务。无 UAC 提示。
 2. 如果 schtasks 被组策略阻止，则回退到在 `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup` 中写入 `start /min cmd.exe /d /c <wrapper>` 快捷方式。效果相同，稍显粗糙。
-3. 通过 **`pythonw.exe`** 以分离方式生成 gateway——而非 `python.exe`。`pythonw.exe` 没有附加控制台，可免疫来自同一进程组中兄弟进程的 `CTRL_C_EVENT` 广播（这是一个真实问题，曾导致在同一进程组中 Ctrl+C 任何进程时 gateway 被杀死）。
+3. 通过控制台版 **`python.exe`** 以分离方式生成 gateway——而非 `pythonw.exe`。`CREATE_NO_WINDOW` 会为它分配一个专属的*隐藏*控制台，使其脱离启动它的 shell 的控制台生命周期，同时它派生的每个控制台子系统子进程（git、gh、cmd、node）都会继承该隐藏控制台，而不会各自闪现可见窗口。真正使其免疫兄弟进程 `CTRL_C_EVENT` 广播的是 `CREATE_NEW_PROCESS_GROUP`。
 
-生成时使用的标志：`DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`。
+生成时使用的标志：`CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`。这里刻意不使用 `DETACHED_PROCESS`——MSDN 指出，两者组合时 `CREATE_NO_WINDOW` 会被忽略。
 
 ### 管理
 


### PR DESCRIPTION
…thon.exe

CONTRIBUTING.md rule 10 and the Windows native user guide both tell readers to spawn the detached gateway with pythonw.exe and to pair CREATE_NO_WINDOW with DETACHED_PROCESS. Both are the opposite of what the code does, and following either re-creates a bug that was already fixed.

_resolve_detached_python() returns the venv's console python.exe "deliberately NOT pythonw.exe": a GUI-subsystem daemon has no console at all, so every console-subsystem descendant it spawns allocates its own visible one and flashes a window (#54220/#56747).

windows_detach_flags() returns CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB and omits DETACHED_PROCESS because MSDN specifies CREATE_NO_WINDOW is ignored when the two are combined -- the documented bundle would silently turn the hide bit into a no-op.

Rule 10 also cited _spawn_detached as its reference implementation, whose own docstring reads "this is why we don't use console-less pythonw.exe here".

Corrects all four places the claim appears: CONTRIBUTING.md, CONTRIBUTING.es.md, and the en + zh-Hans Windows native guides.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

