### PR TITLE
docs(context-files): note SOUL.md is per profile and AGENTS.md is not

### DIFF
--- a/website/docs/user-guide/features/context-files.md
+++ b/website/docs/user-guide/features/context-files.md
@@ -27,6 +27,8 @@ Only **one** project context type is loaded per session (first match wins): `.he
 
 `AGENTS.md` is the primary project context file. It tells the agent how your project is structured, what conventions to follow, and any special instructions.
 
+`AGENTS.md` is project context and resolves from the working directory, so it is not scoped to a profile. For instructions that belong to a profile rather than a project, use that profile's `SOUL.md`. For a scheduled job that needs project context, set the job's working directory and Hermes injects that directory's `AGENTS.md`, `CLAUDE.md` and `.cursorrules`.
+
 ### Progressive Subdirectory Discovery
 
 At session start, Hermes loads the `AGENTS.md` from your working directory into the system prompt. As the agent navigates into subdirectories during the session (via `read_file`, `terminal`, `search_files`, etc.), it **progressively discovers** context files in those directories and injects them into the conversation at the moment they become relevant.
@@ -85,6 +87,8 @@ This is a Next.js 14 web application with a Python FastAPI backend.
 
 - `~/.hermes/SOUL.md`
 - or `$HERMES_HOME/SOUL.md` if you run Hermes with a custom home directory
+
+Profiles set `HERMES_HOME` to their own directory, so each profile has its own `SOUL.md` at `~/.hermes/profiles/<name>/SOUL.md`. Switching profiles switches which `SOUL.md` is loaded.
 
 Important details:
 

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -10,6 +10,8 @@ Run multiple independent Hermes agents on the same machine — each with its own
 
 A profile is a separate Hermes home directory. Each profile gets its own directory containing its own `config.yaml`, `.env`, `SOUL.md`, memories, sessions, skills, cron jobs, and state database. Profiles let you run separate agents for different purposes — a coding assistant, a personal bot, a research agent — without mixing up Hermes state.
 
+Because a profile is its own Hermes home directory, its `SOUL.md` is the one Hermes loads while that profile is active. See [Context Files](/user-guide/features/context-files) for the full list of what gets loaded into a session and where each file is read from.
+
 When you create a profile, it automatically becomes its own command. Create a profile called `coder` and you immediately have `coder chat`, `coder setup`, `coder gateway start`, etc.
 
 ## Quick start


### PR DESCRIPTION
## What does this PR do?

fixes a contradiction between two docs pages that leads readers to an inverted mental model of `SOUL.md` and `AGENTS.md`.

`/user-guide/profiles` tells you to edit `~/.hermes/profiles/coder/SOUL.md`. `/user-guide/features/context-files` says `SOUL.md` is loaded "only from `HERMES_HOME`" and never mentions profiles. read together those look incompatible, so a reader concludes `SOUL.md` must be one global file and `AGENTS.md` must be the per-profile one. both halves of that are wrong, and someone stated exactly that model on [r/hermesagent](https://www.reddit.com/r/hermesagent/comments/1v4t56u/where_should_agentsmd_live_for_nonproject_profiles/) on 2026-07-23.

the two pages are reconciled by one fact neither of them states: an active profile is its own `HERMES_HOME`.

- `agent/prompt_builder.py:1809` — `soul_path = get_hermes_home() / "SOUL.md"`
- `hermes_constants.py:55` — `get_hermes_home()` reads a context-local override, then the `HERMES_HOME` env var, then the platform default
- `hermes_cli/container_boot.py:156` — `SOUL.md` is always seeded by `hermes profile create`

## Changes

**`website/docs/user-guide/features/context-files.md`**

- `SOUL.md` section: profiles set `HERMES_HOME` to their own directory, so each profile has its own `SOUL.md`, and switching profiles switches which one is loaded.
- `AGENTS.md` section: `AGENTS.md` resolves from the working directory and is therefore not profile-scoped. profile-level instructions belong in that profile's `SOUL.md`. a scheduled job that needs project context should set its working directory.

**`website/docs/user-guide/profiles.md`**

- one cross-reference to the context-files page where `SOUL.md` is first mentioned.

docs only, no behaviour change. `+6 / -0`.

## Related

behaviour requests already open and deliberately not re-litigated here: #32395, #39061, #11763.
