### PR TITLE
fix(codex): disable built-in app-server personality

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -342,7 +342,10 @@ class CodexAppServerSession:
         # codex CLI workflow and avoids fighting codex's own validation.
         # Users who want a write-capable profile configure it in their
         # ~/.codex/config.toml the same way they would for any codex usage.
-        params: dict[str, Any] = {"cwd": self._cwd}
+        # Hermes supplies its own agent identity and personality through the
+        # workspace/system prompt. Disable Codex's built-in personality layer
+        # so it cannot compete with those higher-level instructions.
+        params: dict[str, Any] = {"cwd": self._cwd, "personality": "none"}
         result = self._client.request("thread/start", params, timeout=15)
         # Cross-fill thread.id/sessionId — different codex versions have
         # serialized this under either key. Mirrors openclaw beta.8's

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -162,8 +162,10 @@ class TestLifecycle:
         method_calls = [m for (m, _) in client.requests if m == "thread/start"]
         assert len(method_calls) == 1
 
-    def test_thread_start_passes_cwd_only(self):
-        """thread/start carries cwd. We intentionally do NOT pass `permissions`
+    def test_thread_start_passes_cwd_and_disables_codex_personality(self):
+        """thread/start carries cwd and disables Codex's built-in personality.
+
+        We intentionally do NOT pass `permissions`
         on this codex version (experimentalApi-gated + requires matching
         config.toml [permissions] table). Letting codex use its default
         (read-only unless user configures otherwise) is the documented path."""
@@ -172,6 +174,7 @@ class TestLifecycle:
         s.ensure_started()
         method, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["cwd"] == "/tmp"
+        assert params["personality"] == "none"
         assert "permissions" not in params  # see session.ensure_started() comment
 
     def test_close_idempotent(self):


### PR DESCRIPTION
## What does this PR do?

Prevents the optional Codex app-server runtime from layering Codex's built-in personality over Hermes' own workspace/system personality. `thread/start` now explicitly requests `personality: none`, while keeping Codex-native execution behavior and existing permission handling unchanged.

## Related Issue

Fixes #72104

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Add `personality: none` to `agent/transports/codex_app_server_session.py` thread startup params.
- Assert the app-server request contract in `tests/agent/transports/test_codex_app_server_session.py`.

## How to Test

1. Run `uv run pytest -q tests/agent/transports/test_codex_app_server_session.py`.
2. Confirm all 72 tests pass.
3. Run `uv run ruff check agent/transports/codex_app_server_session.py tests/agent/transports/test_codex_app_server_session.py`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (focused suite run: 72 passed)
- [x] I've added tests for my changes
- [x] I've tested on Windows 11 / Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation update N/A; behavior is internal and covered by an inline rationale
- [x] `cli-config.yaml.example` N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; JSON-RPC request behavior is platform independent
- [x] Tool descriptions/schemas N/A; no tool behavior changed

## Screenshots / Logs

```text
uv run pytest -q tests/agent/transports/test_codex_app_server_session.py
72 passed in 16.19s

uv run ruff check agent/transports/codex_app_server_session.py tests/agent/transports/test_codex_app_server_session.py
All checks passed!
```