### PR TITLE
Add durable webhook completion callbacks

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -37,19 +37,24 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 import re
 import subprocess
 import sys
 import time
 from collections import deque
+from pathlib import Path
 from typing import Any, Deque, Dict, List, Optional
+from urllib.parse import urlparse
 
 try:
-    from aiohttp import web
+    from aiohttp import ClientSession, ClientTimeout, web
 
     AIOHTTP_AVAILABLE = True
 except ImportError:
     AIOHTTP_AVAILABLE = False
+    ClientSession = None  # type: ignore[assignment,misc]
+    ClientTimeout = None  # type: ignore[assignment,misc]
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
@@ -57,12 +62,14 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
     SendResult,
 )
 from gateway.platforms.webhook_filters import (
     DEFAULT_SCRIPT_TIMEOUT_SECONDS,
     WebhookRouteProcessor,
 )
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +108,14 @@ DEFAULT_PORT = 8644
 _INSECURE_NO_AUTH = "INSECURE_NO_AUTH"
 _DYNAMIC_ROUTES_FILENAME = "webhook_subscriptions.json"
 _RATE_WINDOW_SECONDS = 60.0
+_CALLBACK_EVENT_TYPE = "hermes_webhook_completion"
+_CALLBACK_CONFIG_KEYS = {
+    "include_payload_fields",
+    "max_attempts",
+    "secret",
+    "timeout_seconds",
+    "url",
+}
 # Hostnames/IP literals that only serve connections originating on the same
 # machine. Anything else is treated as a public bind for safety-rail purposes.
 _LOOPBACK_HOSTS = frozenset({
@@ -210,6 +225,7 @@ class WebhookAdapter(BasePlatformAdapter):
         self._route_processor = WebhookRouteProcessor(
             script_timeout_seconds=self._script_timeout_seconds
         )
+        self._callback_replay_task: Optional[asyncio.Task] = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -252,6 +268,7 @@ class WebhookAdapter(BasePlatformAdapter):
                         f"deliver is '{deliver}'. Direct delivery requires a "
                         f"real target (telegram, discord, slack, github_comment, etc.)."
                     )
+            self._completion_callback_config(name, route)
 
         # client_max_size makes aiohttp enforce the cap on every read path,
         # including Transfer-Encoding: chunked bodies that carry no
@@ -303,6 +320,11 @@ class WebhookAdapter(BasePlatformAdapter):
             )
             return False
         self._mark_connected()
+        self._callback_replay_task = asyncio.create_task(
+            self._replay_completion_callbacks()
+        )
+        self._background_tasks.add(self._callback_replay_task)
+        self._callback_replay_task.add_done_callback(self._background_tasks.discard)
 
         route_names = ", ".join(self._routes.keys()) or "(none configured)"
         logger.info(
@@ -550,6 +572,19 @@ class WebhookAdapter(BasePlatformAdapter):
         if route_config.get("enabled", True) is False:
             return web.json_response(
                 {"error": f"Route disabled: {route_name}"}, status=403
+            )
+
+        try:
+            callback_config = self._completion_callback_config(
+                route_name, route_config
+            )
+        except ValueError:
+            logger.exception(
+                "[webhook] Invalid completion callback configuration for route %s",
+                route_name,
+            )
+            return web.json_response(
+                {"error": "Completion callback is misconfigured"}, status=503
             )
 
         # ── Auth-before-body ─────────────────────────────────────
@@ -810,7 +845,22 @@ class WebhookAdapter(BasePlatformAdapter):
             "deliver_extra": self._render_delivery_extra(
                 route_config.get("deliver_extra", {}), payload
             ),
+            "route_name": route_name,
+            "delivery_id": delivery_id,
         }
+        if callback_config:
+            correlation = {}
+            for field in callback_config["include_payload_fields"]:
+                value = payload.get(field)
+                if not isinstance(value, (str, int, float, bool, type(None))):
+                    self._seen_deliveries.pop(delivery_id, None)
+                    return web.json_response(
+                        {"error": "Completion callback field must be scalar"},
+                        status=400,
+                    )
+                correlation[field] = value
+            deliver_config["completion_callback"] = callback_config
+            deliver_config["completion_correlation"] = correlation
         self._delivery_info[session_chat_id] = deliver_config
         self._delivery_info_created[session_chat_id] = now
         self._delivery_info_order.append((now, session_chat_id))
@@ -862,6 +912,235 @@ class WebhookAdapter(BasePlatformAdapter):
             status=202,
         )
 
+    def _completion_callback_config(
+        self, route_name: str, route_config: dict
+    ) -> Optional[dict]:
+        callback = route_config.get("completion_callback")
+        if callback is None:
+            return None
+        if not isinstance(callback, dict) or set(callback) - _CALLBACK_CONFIG_KEYS:
+            raise ValueError(
+                f"[webhook] Route '{route_name}' has invalid completion_callback keys"
+            )
+        url = callback.get("url")
+        secret = callback.get("secret")
+        fields = callback.get("include_payload_fields")
+        parsed = urlparse(url) if isinstance(url, str) else None
+        if (
+            parsed is None
+            or parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username
+            or parsed.password
+            or parsed.fragment
+        ):
+            raise ValueError(
+                f"[webhook] Route '{route_name}' has invalid completion callback URL"
+            )
+        if not isinstance(secret, str) or len(secret) < 32:
+            raise ValueError(
+                f"[webhook] Route '{route_name}' completion callback secret is too short"
+            )
+        if (
+            not isinstance(fields, list)
+            or not 1 <= len(fields) <= 8
+            or len(fields) != len(set(fields))
+            or any(
+                not isinstance(field, str)
+                or re.fullmatch(r"[A-Za-z0-9_]{1,64}", field) is None
+                for field in fields
+            )
+        ):
+            raise ValueError(
+                f"[webhook] Route '{route_name}' has invalid callback payload fields"
+            )
+        attempts = callback.get("max_attempts", 3)
+        timeout = callback.get("timeout_seconds", 5)
+        if not isinstance(attempts, int) or not 1 <= attempts <= 5:
+            raise ValueError(
+                f"[webhook] Route '{route_name}' callback max_attempts must be 1..5"
+            )
+        if not isinstance(timeout, (int, float)) or not 1 <= timeout <= 30:
+            raise ValueError(
+                f"[webhook] Route '{route_name}' callback timeout must be 1..30s"
+            )
+        return {
+            "url": url,
+            "secret": secret,
+            "include_payload_fields": list(fields),
+            "max_attempts": attempts,
+            "timeout_seconds": float(timeout),
+        }
+
+    def _completion_callback_body(
+        self, event: "MessageEvent", status: str
+    ) -> Optional[dict]:
+        delivery = self._delivery_info.get(event.source.chat_id, {})
+        if not delivery.get("completion_callback"):
+            return None
+        return {
+            "correlation": delivery.get("completion_correlation", {}),
+            "delivery_id": delivery.get("delivery_id") or event.message_id,
+            "error_code": {
+                "running": None,
+                "completed": None,
+                "failed": "processing_failed",
+                "cancelled": "processing_cancelled",
+            }[status],
+            "event_type": _CALLBACK_EVENT_TYPE,
+            "occurred_at": int(time.time()),
+            "route": delivery.get("route_name", ""),
+            "status": status,
+        }
+
+    async def _emit_final_completion_callback(
+        self, event: "MessageEvent", outcome: Any
+    ) -> None:
+        status = (
+            "completed"
+            if outcome == ProcessingOutcome.SUCCESS
+            else "cancelled"
+            if outcome == ProcessingOutcome.CANCELLED
+            else "failed"
+        )
+        body = self._completion_callback_body(event, status)
+        if body is None:
+            return
+        try:
+            path = self._spool_completion_callback(
+                self._delivery_info[event.source.chat_id]["route_name"], body
+            )
+            if await self._send_completion_callback(event.source.chat_id, body):
+                path.unlink(missing_ok=True)
+        except Exception:
+            logger.exception(
+                "[webhook] Failed to emit completion callback delivery=%s status=%s",
+                body.get("delivery_id"),
+                status,
+            )
+
+    def _callback_outbox_dir(self) -> Path:
+        return get_hermes_home() / "webhook_callback_outbox"
+
+    def _spool_completion_callback(self, route_name: str, body: dict) -> Path:
+        outbox = self._callback_outbox_dir()
+        outbox.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(outbox, 0o700)
+        key = hashlib.sha256(
+            f"{route_name}:{body['delivery_id']}:{body['status']}".encode()
+        ).hexdigest()
+        path = outbox / f"{key}.json"
+        entry = json.dumps(
+            {"body": body, "route": route_name},
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+        if path.exists():
+            existing = path.read_bytes()
+            if existing != entry:
+                raise ValueError("completion callback spool conflict")
+            return path
+        tmp = outbox / f".{key}.{os.getpid()}.{time.time_ns()}.tmp"
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(entry)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, path)
+            os.chmod(path, 0o600)
+        finally:
+            tmp.unlink(missing_ok=True)
+        return path
+
+    async def _send_completion_callback(
+        self, session_chat_id: str, body: dict
+    ) -> bool:
+        delivery = self._delivery_info.get(session_chat_id, {})
+        callback = delivery.get("completion_callback")
+        if not callback:
+            return False
+        raw = json.dumps(body, separators=(",", ":"), sort_keys=True).encode()
+        for attempt in range(callback["max_attempts"]):
+            timestamp = str(int(time.time()))
+            signature = hmac.new(
+                callback["secret"].encode(),
+                timestamp.encode() + b"." + raw,
+                hashlib.sha256,
+            ).hexdigest()
+            try:
+                timeout = ClientTimeout(total=callback["timeout_seconds"])
+                async with ClientSession(timeout=timeout) as session:
+                    async with session.post(
+                        callback["url"],
+                        data=raw,
+                        headers={
+                            "Content-Type": "application/json",
+                            "X-Webhook-Signature-V2": signature,
+                            "X-Webhook-Timestamp": timestamp,
+                        },
+                        allow_redirects=False,
+                    ) as response:
+                        await response.read()
+                        if 200 <= response.status < 300:
+                            return True
+            except Exception as exc:
+                logger.warning(
+                    "[webhook] Completion callback attempt failed "
+                    "delivery=%s attempt=%d error=%s",
+                    body.get("delivery_id"),
+                    attempt + 1,
+                    type(exc).__name__,
+                )
+            if attempt + 1 < callback["max_attempts"]:
+                await asyncio.sleep(0.5 * (2**attempt))
+        logger.error(
+            "[webhook] Completion callback retained for replay "
+            "delivery=%s status=%s",
+            body.get("delivery_id"),
+            body.get("status"),
+        )
+        return False
+
+    async def _replay_completion_callbacks(self) -> None:
+        outbox = self._callback_outbox_dir()
+        if not outbox.exists():
+            return
+        for path in sorted(outbox.glob("*.json")):
+            try:
+                if path.is_symlink() or path.stat().st_mode & 0o077:
+                    logger.error(
+                        "[webhook] Refusing insecure callback spool file %s", path
+                    )
+                    continue
+                entry = json.loads(path.read_text())
+                if not isinstance(entry, dict) or set(entry) != {"body", "route"}:
+                    raise ValueError("invalid callback spool schema")
+                route_name = entry["route"]
+                route = self._routes.get(route_name)
+                callback = (
+                    self._completion_callback_config(route_name, route)
+                    if isinstance(route, dict)
+                    else None
+                )
+                if callback is None:
+                    continue
+                body = entry["body"]
+                session_chat_id = (
+                    f"webhook:{route_name}:{body['delivery_id']}"
+                )
+                self._delivery_info[session_chat_id] = {
+                    "completion_callback": callback,
+                    "delivery_id": body["delivery_id"],
+                    "route_name": route_name,
+                }
+                if await self._send_completion_callback(session_chat_id, body):
+                    path.unlink(missing_ok=True)
+            except Exception:
+                logger.exception(
+                    "[webhook] Failed to replay callback spool %s", path
+                )
+
     async def on_processing_complete(
         self, event: "MessageEvent", outcome: Any
     ) -> None:
@@ -884,7 +1163,16 @@ class WebhookAdapter(BasePlatformAdapter):
         ``end_session()`` is first-reason-wins and no-ops on an already-ended
         row, so this never clobbers a ``compression``/``agent_close`` reason.
         """
-        await self._end_webhook_session(event, event.source.chat_id)
+        try:
+            await self._emit_final_completion_callback(event, outcome)
+        finally:
+            await self._end_webhook_session(event, event.source.chat_id)
+
+    async def on_processing_start(self, event: "MessageEvent") -> None:
+        """Best-effort running callback; final callbacks are durably spooled."""
+        body = self._completion_callback_body(event, "running")
+        if body is not None:
+            await self._send_completion_callback(event.source.chat_id, body)
 
     async def _end_webhook_session(
         self, event: "MessageEvent", session_chat_id: str

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -226,6 +226,13 @@ class WebhookAdapter(BasePlatformAdapter):
             script_timeout_seconds=self._script_timeout_seconds
         )
         self._callback_replay_task: Optional[asyncio.Task] = None
+        self._callback_replay_interval: int = int(
+            config.extra.get("callback_replay_interval_seconds", 60)
+        )
+        if not 10 <= self._callback_replay_interval <= 3600:
+            raise ValueError(
+                "[webhook] callback_replay_interval_seconds must be 10..3600"
+            )
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -321,7 +328,7 @@ class WebhookAdapter(BasePlatformAdapter):
             return False
         self._mark_connected()
         self._callback_replay_task = asyncio.create_task(
-            self._replay_completion_callbacks()
+            self._completion_callback_replay_loop()
         )
         self._background_tasks.add(self._callback_replay_task)
         self._callback_replay_task.add_done_callback(self._background_tasks.discard)
@@ -336,6 +343,12 @@ class WebhookAdapter(BasePlatformAdapter):
         return True
 
     async def disconnect(self) -> None:
+        if self._callback_replay_task:
+            self._callback_replay_task.cancel()
+            await asyncio.gather(
+                self._callback_replay_task, return_exceptions=True
+            )
+            self._callback_replay_task = None
         if self._runner:
             await self._runner.cleanup()
             self._runner = None
@@ -1006,11 +1019,19 @@ class WebhookAdapter(BasePlatformAdapter):
         body = self._completion_callback_body(event, status)
         if body is None:
             return
+        path: Optional[Path] = None
         try:
             path = self._spool_completion_callback(
                 self._delivery_info[event.source.chat_id]["route_name"], body
             )
-            if await self._send_completion_callback(event.source.chat_id, body):
+        except Exception:
+            logger.exception(
+                "[webhook] Failed to persist completion callback delivery=%s status=%s",
+                body.get("delivery_id"),
+                status,
+            )
+        try:
+            if await self._send_completion_callback(event.source.chat_id, body) and path:
                 path.unlink(missing_ok=True)
         except Exception:
             logger.exception(
@@ -1102,6 +1123,16 @@ class WebhookAdapter(BasePlatformAdapter):
         )
         return False
 
+    async def _completion_callback_replay_loop(self) -> None:
+        while True:
+            try:
+                await self._replay_completion_callbacks()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("[webhook] Completion callback replay loop failed")
+            await asyncio.sleep(self._callback_replay_interval)
+
     async def _replay_completion_callbacks(self) -> None:
         outbox = self._callback_outbox_dir()
         if not outbox.exists():
@@ -1134,8 +1165,11 @@ class WebhookAdapter(BasePlatformAdapter):
                     "delivery_id": body["delivery_id"],
                     "route_name": route_name,
                 }
-                if await self._send_completion_callback(session_chat_id, body):
-                    path.unlink(missing_ok=True)
+                try:
+                    if await self._send_completion_callback(session_chat_id, body):
+                        path.unlink(missing_ok=True)
+                finally:
+                    self._delivery_info.pop(session_chat_id, None)
             except Exception:
                 logger.exception(
                     "[webhook] Failed to replay callback spool %s", path

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -898,6 +898,23 @@ class WebhookAdapter(BasePlatformAdapter):
         self._delivery_info_created[session_chat_id] = now
         self._delivery_info_order.append((now, session_chat_id))
         self._prune_delivery_info(now)
+        if callback_config:
+            try:
+                self._spool_completion_intent(route_name, deliver_config)
+            except Exception:
+                self._seen_deliveries.pop(delivery_id, None)
+                self._delivery_info.pop(session_chat_id, None)
+                self._delivery_info_created.pop(session_chat_id, None)
+                logger.exception(
+                    "[webhook] Refusing callback-enabled request because "
+                    "accepted intent could not be persisted route=%s delivery=%s",
+                    route_name,
+                    delivery_id,
+                )
+                return web.json_response(
+                    {"error": "Completion callback intent could not be persisted"},
+                    status=503,
+                )
 
         # Build source and event
         source = self.build_source(
@@ -1044,11 +1061,14 @@ class WebhookAdapter(BasePlatformAdapter):
         body = self._completion_callback_body(event, status)
         if body is None:
             return
+        route_name = str(delivery["route_name"])
+        intent_path = self._completion_intent_path(
+            route_name, str(body["delivery_id"])
+        )
         path: Optional[Path] = None
+        delivered = False
         try:
-            path = self._spool_completion_callback(
-                self._delivery_info[event.source.chat_id]["route_name"], body
-            )
+            path = self._spool_completion_callback(route_name, body)
         except Exception:
             logger.exception(
                 "[webhook] Failed to persist completion callback delivery=%s status=%s",
@@ -1056,37 +1076,54 @@ class WebhookAdapter(BasePlatformAdapter):
                 status,
             )
         try:
-            if await self._send_completion_callback(event.source.chat_id, body) and path:
-                path.unlink(missing_ok=True)
+            delivered = await self._send_completion_callback(
+                event.source.chat_id, body
+            )
+            if delivered and path:
+                self._remove_callback_spool(path)
         except Exception:
             logger.exception(
                 "[webhook] Failed to emit completion callback delivery=%s status=%s",
                 body.get("delivery_id"),
                 status,
             )
+        finally:
+            if path is not None or delivered:
+                self._remove_callback_spool(intent_path)
 
     def _callback_outbox_dir(self) -> Path:
         return get_hermes_home() / "webhook_callback_outbox"
 
-    def _spool_completion_callback(self, route_name: str, body: dict) -> Path:
+    @staticmethod
+    def _fsync_directory(path: Path) -> None:
+        try:
+            descriptor = os.open(path, os.O_RDONLY)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+        except OSError:
+            logger.debug("[webhook] Directory fsync unavailable for %s", path)
+
+    def _ensure_callback_outbox(self) -> Path:
         outbox = self._callback_outbox_dir()
+        created = not outbox.exists()
         outbox.mkdir(mode=0o700, parents=True, exist_ok=True)
         os.chmod(outbox, 0o700)
-        key = hashlib.sha256(
-            f"{route_name}:{body['delivery_id']}:{body['status']}".encode()
-        ).hexdigest()
-        path = outbox / f"{key}.json"
-        entry = json.dumps(
-            {"body": body, "route": route_name},
-            separators=(",", ":"),
-            sort_keys=True,
-        ).encode()
+        if created:
+            self._fsync_directory(outbox.parent)
+        return outbox
+
+    def _write_callback_spool(self, path: Path, entry: bytes) -> Path:
+        outbox = self._ensure_callback_outbox()
+        if path.parent != outbox:
+            raise ValueError("callback spool path outside outbox")
         if path.exists():
             existing = path.read_bytes()
             if existing != entry:
                 raise ValueError("completion callback spool conflict")
             return path
-        tmp = outbox / f".{key}.{os.getpid()}.{time.time_ns()}.tmp"
+        tmp = outbox / f".{path.stem}.{os.getpid()}.{time.time_ns()}.tmp"
         fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
         try:
             with os.fdopen(fd, "wb") as handle:
@@ -1095,9 +1132,53 @@ class WebhookAdapter(BasePlatformAdapter):
                 os.fsync(handle.fileno())
             os.replace(tmp, path)
             os.chmod(path, 0o600)
+            self._fsync_directory(outbox)
         finally:
             tmp.unlink(missing_ok=True)
         return path
+
+    def _remove_callback_spool(self, path: Path) -> None:
+        if path.exists():
+            path.unlink()
+            self._fsync_directory(path.parent)
+
+    def _completion_intent_path(self, route_name: str, delivery_id: str) -> Path:
+        key = hashlib.sha256(f"{route_name}:{delivery_id}".encode()).hexdigest()
+        return self._callback_outbox_dir() / f"intent-{key}.json"
+
+    def _completion_callback_path(
+        self, route_name: str, delivery_id: str, status: str
+    ) -> Path:
+        key = hashlib.sha256(
+            f"{route_name}:{delivery_id}:{status}".encode()
+        ).hexdigest()
+        return self._callback_outbox_dir() / f"{key}.json"
+
+    def _spool_completion_intent(self, route_name: str, delivery: dict) -> Path:
+        delivery_id = str(delivery["delivery_id"])
+        path = self._completion_intent_path(route_name, delivery_id)
+        entry = json.dumps(
+            {
+                "accepted_at": int(time.time()),
+                "correlation": delivery["completion_correlation"],
+                "delivery_id": delivery_id,
+                "route": route_name,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+        return self._write_callback_spool(path, entry)
+
+    def _spool_completion_callback(self, route_name: str, body: dict) -> Path:
+        path = self._completion_callback_path(
+            route_name, str(body["delivery_id"]), str(body["status"])
+        )
+        entry = json.dumps(
+            {"body": body, "route": route_name},
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+        return self._write_callback_spool(path, entry)
 
     async def _send_completion_callback(
         self, session_chat_id: str, body: dict
@@ -1148,7 +1229,64 @@ class WebhookAdapter(BasePlatformAdapter):
         )
         return False
 
+    async def _recover_completion_callback_intents(self) -> None:
+        outbox = self._callback_outbox_dir()
+        if not outbox.exists():
+            return
+        for path in sorted(outbox.glob("intent-*.json")):
+            try:
+                if path.is_symlink() or path.stat().st_mode & 0o077:
+                    logger.error(
+                        "[webhook] Refusing insecure callback intent file %s", path
+                    )
+                    continue
+                entry = json.loads(path.read_text())
+                if not isinstance(entry, dict) or set(entry) != {
+                    "accepted_at",
+                    "correlation",
+                    "delivery_id",
+                    "route",
+                }:
+                    raise ValueError("invalid callback intent schema")
+                route_name = entry["route"]
+                delivery_id = entry["delivery_id"]
+                correlation = entry["correlation"]
+                if (
+                    not isinstance(route_name, str)
+                    or not route_name
+                    or not isinstance(delivery_id, str)
+                    or not delivery_id
+                    or not isinstance(correlation, dict)
+                    or not isinstance(entry["accepted_at"], int)
+                ):
+                    raise ValueError("invalid callback intent values")
+                terminal_exists = any(
+                    self._completion_callback_path(
+                        route_name, delivery_id, terminal_status
+                    ).exists()
+                    for terminal_status in ("completed", "failed", "cancelled")
+                )
+                if not terminal_exists:
+                    self._spool_completion_callback(
+                        route_name,
+                        {
+                            "correlation": correlation,
+                            "delivery_id": delivery_id,
+                            "error_code": "processing_failed",
+                            "event_type": _CALLBACK_EVENT_TYPE,
+                            "occurred_at": int(time.time()),
+                            "route": route_name,
+                            "status": "failed",
+                        },
+                    )
+                self._remove_callback_spool(path)
+            except Exception:
+                logger.exception(
+                    "[webhook] Failed to recover callback intent %s", path
+                )
+
     async def _completion_callback_replay_loop(self) -> None:
+        await self._recover_completion_callback_intents()
         while True:
             try:
                 await self._replay_completion_callbacks()
@@ -1163,6 +1301,8 @@ class WebhookAdapter(BasePlatformAdapter):
         if not outbox.exists():
             return
         for path in sorted(outbox.glob("*.json")):
+            if path.name.startswith("intent-"):
+                continue
             try:
                 if path.is_symlink() or path.stat().st_mode & 0o077:
                     logger.error(
@@ -1192,7 +1332,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 }
                 try:
                     if await self._send_completion_callback(session_chat_id, body):
-                        path.unlink(missing_ok=True)
+                        self._remove_callback_spool(path)
                 finally:
                     self._delivery_info.pop(session_chat_id, None)
             except Exception:

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -376,10 +376,14 @@ class WebhookAdapter(BasePlatformAdapter):
 
         if deliver_type == "log":
             logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
-            return SendResult(success=True)
+            result = SendResult(success=True)
+            self._record_completion_delivery(delivery, metadata, result)
+            return result
 
         if deliver_type == "github_comment":
-            return await self._deliver_github_comment(content, delivery)
+            result = await self._deliver_github_comment(content, delivery)
+            self._record_completion_delivery(delivery, metadata, result)
+            return result
 
         # Cross-platform delivery — any platform with a gateway adapter.
         # Check both built-in names and plugin-registered platforms.
@@ -391,14 +395,30 @@ class WebhookAdapter(BasePlatformAdapter):
             except Exception:
                 pass
         if self.gateway_runner and _is_known_platform:
-            return await self._deliver_cross_platform(
+            result = await self._deliver_cross_platform(
                 deliver_type, content, delivery
             )
+            self._record_completion_delivery(delivery, metadata, result)
+            return result
 
         logger.warning("[webhook] Unknown deliver type: %s", deliver_type)
-        return SendResult(
+        result = SendResult(
             success=False, error=f"Unknown deliver type: {deliver_type}"
         )
+        self._record_completion_delivery(delivery, metadata, result)
+        return result
+
+    @staticmethod
+    def _record_completion_delivery(
+        delivery: dict,
+        metadata: Optional[Dict[str, Any]],
+        result: SendResult,
+    ) -> None:
+        """Track the final user-visible send, excluding interim status messages."""
+        if not (metadata or {}).get("notify"):
+            return
+        delivery["completion_delivery_attempted"] = True
+        delivery["completion_delivery_succeeded"] = bool(result.success)
 
     def _prune_delivery_info(self, now: float) -> None:
         """Drop delivery_info entries older than the idempotency TTL.
@@ -1016,6 +1036,11 @@ class WebhookAdapter(BasePlatformAdapter):
             if outcome == ProcessingOutcome.CANCELLED
             else "failed"
         )
+        delivery = self._delivery_info.get(event.source.chat_id, {})
+        if status == "completed" and not delivery.get(
+            "completion_delivery_succeeded", False
+        ):
+            status = "failed"
         body = self._completion_callback_body(event, status)
         if body is None:
             return

--- a/tests/gateway/test_webhook_completion_callback.py
+++ b/tests/gateway/test_webhook_completion_callback.py
@@ -1,0 +1,171 @@
+import hashlib
+import hmac
+import json
+import stat
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+from gateway.platforms.webhook import WebhookAdapter
+
+SECRET = "callback-secret-long-enough-for-production-tests"
+ROUTE = "ridge-hill-utility-investigation"
+DELIVERY = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+
+
+def callback_config(url: str = "http://127.0.0.1:8765/callback") -> dict:
+    return {
+        "url": url,
+        "secret": SECRET,
+        "include_payload_fields": [
+            "investigation_id",
+            "review_id",
+            "discord_thread_id",
+        ],
+        "max_attempts": 2,
+        "timeout_seconds": 2,
+    }
+
+
+def make_adapter(callback: dict | None = None) -> WebhookAdapter:
+    route = {"secret": "incoming-secret", "prompt": "x", "deliver": "log"}
+    if callback is not None:
+        route["completion_callback"] = callback
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"host": "127.0.0.1", "port": 0, "routes": {ROUTE: route}},
+        )
+    )
+
+
+def make_event(adapter: WebhookAdapter) -> MessageEvent:
+    chat_id = f"webhook:{ROUTE}:{DELIVERY}"
+    adapter._delivery_info[chat_id] = {
+        "completion_callback": callback_config(),
+        "completion_correlation": {
+            "investigation_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "review_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+            "discord_thread_id": "1530677153690161303",
+        },
+        "delivery_id": DELIVERY,
+        "route_name": ROUTE,
+    }
+    source = adapter.build_source(
+        chat_id=chat_id,
+        chat_name=f"webhook/{ROUTE}",
+        chat_type="webhook",
+        user_id=f"webhook:{ROUTE}",
+        user_name=ROUTE,
+    )
+    return MessageEvent(
+        text="investigate",
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message={},
+        message_id=DELIVERY,
+    )
+
+
+def test_completion_callback_config_fails_closed():
+    adapter = make_adapter()
+    with pytest.raises(ValueError, match="too short"):
+        adapter._completion_callback_config(
+            ROUTE,
+            {"completion_callback": {**callback_config(), "secret": "short"}},
+        )
+    with pytest.raises(ValueError, match="URL"):
+        adapter._completion_callback_config(
+            ROUTE,
+            {
+                "completion_callback": callback_config(
+                    "http://user:password@127.0.0.1/callback"
+                )
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_completion_callback_is_hmac_signed_and_retries_after_500():
+    requests = []
+
+    async def receive(request: web.Request) -> web.Response:
+        raw = await request.read()
+        timestamp = request.headers["X-Webhook-Timestamp"]
+        expected = hmac.new(
+            SECRET.encode(), timestamp.encode() + b"." + raw, hashlib.sha256
+        ).hexdigest()
+        assert hmac.compare_digest(
+            request.headers["X-Webhook-Signature-V2"], expected
+        )
+        requests.append(json.loads(raw))
+        return web.Response(status=500 if len(requests) == 1 else 200)
+
+    app = web.Application()
+    app.router.add_post("/callback", receive)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    adapter = make_adapter()
+    event = make_event(adapter)
+    adapter._delivery_info[event.source.chat_id]["completion_callback"] = (
+        callback_config(f"http://127.0.0.1:{port}/callback")
+    )
+    body = adapter._completion_callback_body(event, "completed")
+    try:
+        assert await adapter._send_completion_callback(event.source.chat_id, body)
+    finally:
+        await runner.cleanup()
+    assert len(requests) == 2
+    assert requests[0] == requests[1]
+    assert requests[1]["status"] == "completed"
+    assert requests[1]["delivery_id"] == DELIVERY
+
+
+@pytest.mark.asyncio
+async def test_final_callback_is_spooled_then_removed_after_ack(tmp_path):
+    adapter = make_adapter(callback_config())
+    event = make_event(adapter)
+    adapter._callback_outbox_dir = lambda: tmp_path / "outbox"
+    adapter._send_completion_callback = AsyncMock(return_value=True)
+    adapter._end_webhook_session = AsyncMock()
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    sent = adapter._send_completion_callback.await_args.args[1]
+    assert sent["status"] == "completed"
+    assert not list((tmp_path / "outbox").glob("*.json"))
+    adapter._end_webhook_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_failed_callback_survives_and_replays_after_restart(tmp_path):
+    adapter = make_adapter(callback_config())
+    event = make_event(adapter)
+    adapter._callback_outbox_dir = lambda: tmp_path / "outbox"
+    adapter._send_completion_callback = AsyncMock(return_value=False)
+    adapter._end_webhook_session = AsyncMock()
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    files = list((tmp_path / "outbox").glob("*.json"))
+    assert len(files) == 1
+    assert stat.S_IMODE(files[0].stat().st_mode) == 0o600
+    entry = json.loads(files[0].read_text())
+    assert entry["body"]["status"] == "failed"
+    assert entry["body"]["error_code"] == "processing_failed"
+    assert "secret" not in entry and SECRET not in files[0].read_text()
+
+    restarted = make_adapter(callback_config())
+    restarted._callback_outbox_dir = lambda: tmp_path / "outbox"
+    restarted._send_completion_callback = AsyncMock(return_value=True)
+    await restarted._replay_completion_callbacks()
+
+    assert not list((tmp_path / "outbox").glob("*.json"))
+    replayed = restarted._send_completion_callback.await_args.args[1]
+    assert replayed == entry["body"]

--- a/tests/gateway/test_webhook_completion_callback.py
+++ b/tests/gateway/test_webhook_completion_callback.py
@@ -2,6 +2,7 @@ import hashlib
 import hmac
 import json
 import stat
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -169,3 +170,21 @@ async def test_failed_callback_survives_and_replays_after_restart(tmp_path):
     assert not list((tmp_path / "outbox").glob("*.json"))
     replayed = restarted._send_completion_callback.await_args.args[1]
     assert replayed == entry["body"]
+
+
+@pytest.mark.asyncio
+async def test_retained_callbacks_retry_periodically_without_restart():
+    adapter = make_adapter(callback_config())
+    adapter._callback_replay_interval = 0.01
+    adapter._replay_completion_callbacks = AsyncMock()
+    task = asyncio.create_task(adapter._completion_callback_replay_loop())
+    try:
+        for _ in range(100):
+            if adapter._replay_completion_callbacks.await_count >= 2:
+                break
+            await asyncio.sleep(0.002)
+        assert adapter._replay_completion_callbacks.await_count >= 2
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task

--- a/tests/gateway/test_webhook_completion_callback.py
+++ b/tests/gateway/test_webhook_completion_callback.py
@@ -136,12 +136,35 @@ async def test_final_callback_is_spooled_then_removed_after_ack(tmp_path):
     adapter._send_completion_callback = AsyncMock(return_value=True)
     adapter._end_webhook_session = AsyncMock()
 
+    await adapter.send(event.source.chat_id, "progress", metadata={})
+    assert "completion_delivery_succeeded" not in adapter._delivery_info[
+        event.source.chat_id
+    ]
+    await adapter.send(
+        event.source.chat_id, "final report", metadata={"notify": True}
+    )
+
     await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
 
     sent = adapter._send_completion_callback.await_args.args[1]
     assert sent["status"] == "completed"
     assert not list((tmp_path / "outbox").glob("*.json"))
     adapter._end_webhook_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_success_without_final_delivery_callbacks_failed(tmp_path):
+    adapter = make_adapter(callback_config())
+    event = make_event(adapter)
+    adapter._callback_outbox_dir = lambda: tmp_path / "outbox"
+    adapter._send_completion_callback = AsyncMock(return_value=True)
+    adapter._end_webhook_session = AsyncMock()
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    sent = adapter._send_completion_callback.await_args.args[1]
+    assert sent["status"] == "failed"
+    assert sent["error_code"] == "processing_failed"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_webhook_completion_callback.py
+++ b/tests/gateway/test_webhook_completion_callback.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
@@ -71,6 +72,25 @@ def make_event(adapter: WebhookAdapter) -> MessageEvent:
     )
 
 
+def inbound_payload() -> dict:
+    return {
+        "delivery_id": DELIVERY,
+        "discord_thread_id": "1530677153690161303",
+        "event_type": "utility_review_investigation",
+        "investigation_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "requested_by": "234137250441592832",
+        "review_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    }
+
+
+async def webhook_client(adapter: WebhookAdapter) -> TestClient:
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client
+
+
 def test_completion_callback_config_fails_closed():
     adapter = make_adapter()
     with pytest.raises(ValueError, match="too short"):
@@ -87,6 +107,63 @@ def test_completion_callback_config_fails_closed():
                 )
             },
         )
+
+
+@pytest.mark.asyncio
+async def test_callback_intent_is_durable_before_202(tmp_path):
+    adapter = make_adapter(callback_config())
+    adapter._callback_outbox_dir = lambda: tmp_path / "outbox"
+    adapter.handle_message = AsyncMock()
+    client = await webhook_client(adapter)
+    raw = json.dumps(inbound_payload(), separators=(",", ":")).encode()
+    signature = hmac.new(b"incoming-secret", raw, hashlib.sha256).hexdigest()
+    try:
+        response = await client.post(
+            f"/webhooks/{ROUTE}",
+            data=raw,
+            headers={
+                "Content-Type": "application/json",
+                "X-Request-ID": DELIVERY,
+                "X-Webhook-Signature": signature,
+            },
+        )
+        assert response.status == 202
+        intents = list((tmp_path / "outbox").glob("intent-*.json"))
+        assert len(intents) == 1
+        assert stat.S_IMODE(intents[0].stat().st_mode) == 0o600
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_intent_persistence_failure_returns_503_without_consuming_delivery(
+    tmp_path,
+):
+    adapter = make_adapter(callback_config())
+    adapter._callback_outbox_dir = lambda: tmp_path / "outbox"
+    adapter.handle_message = AsyncMock()
+    original = adapter._spool_completion_intent
+
+    def fail_intent(*_args):
+        raise OSError("disk full")
+
+    adapter._spool_completion_intent = fail_intent
+    client = await webhook_client(adapter)
+    raw = json.dumps(inbound_payload(), separators=(",", ":")).encode()
+    signature = hmac.new(b"incoming-secret", raw, hashlib.sha256).hexdigest()
+    headers = {
+        "Content-Type": "application/json",
+        "X-Request-ID": DELIVERY,
+        "X-Webhook-Signature": signature,
+    }
+    try:
+        response = await client.post(f"/webhooks/{ROUTE}", data=raw, headers=headers)
+        assert response.status == 503
+        adapter._spool_completion_intent = original
+        response = await client.post(f"/webhooks/{ROUTE}", data=raw, headers=headers)
+        assert response.status == 202
+    finally:
+        await client.close()
 
 
 @pytest.mark.asyncio
@@ -193,6 +270,47 @@ async def test_failed_callback_survives_and_replays_after_restart(tmp_path):
     assert not list((tmp_path / "outbox").glob("*.json"))
     replayed = restarted._send_completion_callback.await_args.args[1]
     assert replayed == entry["body"]
+
+
+@pytest.mark.asyncio
+async def test_unfinished_accepted_intent_recovers_as_failed(tmp_path):
+    adapter = make_adapter(callback_config())
+    event = make_event(adapter)
+    adapter._callback_outbox_dir = lambda: tmp_path / "outbox"
+    intent = adapter._spool_completion_intent(
+        ROUTE, adapter._delivery_info[event.source.chat_id]
+    )
+    assert intent.exists()
+
+    restarted = make_adapter(callback_config())
+    restarted._callback_outbox_dir = lambda: tmp_path / "outbox"
+    await restarted._recover_completion_callback_intents()
+
+    assert not list((tmp_path / "outbox").glob("intent-*.json"))
+    terminal = list((tmp_path / "outbox").glob("*.json"))
+    assert len(terminal) == 1
+    recovered = json.loads(terminal[0].read_text())["body"]
+    assert recovered["status"] == "failed"
+    assert recovered["error_code"] == "processing_failed"
+
+
+@pytest.mark.asyncio
+async def test_existing_terminal_spool_wins_over_stale_intent(tmp_path):
+    adapter = make_adapter(callback_config())
+    event = make_event(adapter)
+    adapter._callback_outbox_dir = lambda: tmp_path / "outbox"
+    adapter._spool_completion_intent(
+        ROUTE, adapter._delivery_info[event.source.chat_id]
+    )
+    completed = adapter._completion_callback_body(event, "completed")
+    adapter._spool_completion_callback(ROUTE, completed)
+
+    await adapter._recover_completion_callback_intents()
+
+    assert not list((tmp_path / "outbox").glob("intent-*.json"))
+    terminal = list((tmp_path / "outbox").glob("*.json"))
+    assert len(terminal) == 1
+    assert json.loads(terminal[0].read_text())["body"]["status"] == "completed"
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -145,12 +145,17 @@ Callbacks use `X-Webhook-Timestamp` plus `X-Webhook-Signature-V2`, an HMAC-SHA25
 sanitized error code, and the selected fields under `correlation`. Receivers should enforce the
 five-minute timestamp window and use `(delivery_id,status)` as an idempotency key.
 
-`running` is best effort. Before a terminal callback is sent, Hermes atomically writes it beneath
-`~/.hermes/webhook_callback_outbox/` with directory mode 0700 and file mode 0600. Only a 2xx
-response removes it; non-2xx responses, timeout, process exit, or restart leave it available for
-replay. Hermes retries retained entries every 60 seconds while the gateway is running; set global
+Terminal callbacks are durable; `running` is best effort. Before Hermes returns HTTP 202 for a
+callback-enabled route, it atomically writes an accepted-intent record beneath
+`~/.hermes/webhook_callback_outbox/`. If the gateway restarts before terminal processing, that
+unfinished intent becomes a signed `failed` callback instead of remaining stuck indefinitely.
+Before a normal terminal callback is sent, Hermes atomically replaces the intent with a terminal
+spool record. Files use mode 0600, the directory uses 0700, and file plus parent-directory metadata
+are fsynced. Only a 2xx response removes a terminal record; non-2xx responses, timeout, process
+exit, or restart leave it available for replay. Hermes retries retained entries every 60 seconds
+while the gateway is running; set global
 `platforms.webhook.extra.callback_replay_interval_seconds` to 10–3600 to adjust this. The spool
-contains the callback body and route name but never the callback URL or secret.
+contains correlation IDs, callback bodies, and route names but never the callback URL or secret.
 Redirects are not followed, preventing signature forwarding to a different host.
 
 ### Payload Filters

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -148,7 +148,9 @@ five-minute timestamp window and use `(delivery_id,status)` as an idempotency ke
 `running` is best effort. Before a terminal callback is sent, Hermes atomically writes it beneath
 `~/.hermes/webhook_callback_outbox/` with directory mode 0700 and file mode 0600. Only a 2xx
 response removes it; non-2xx responses, timeout, process exit, or restart leave it available for
-replay. The spool contains the callback body and route name but never the callback URL or secret.
+replay. Hermes retries retained entries every 60 seconds while the gateway is running; set global
+`platforms.webhook.extra.callback_replay_interval_seconds` to 10–3600 to adjust this. The spool
+contains the callback body and route name but never the callback URL or secret.
 Redirects are not followed, preventing signature forwarding to a different host.
 
 ### Payload Filters

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -87,6 +87,7 @@ Routes define how different webhook sources are handled. Each route is a named e
 | `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
 | `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
 | `deliver_only` | No | If `true`, skip the agent entirely — the rendered `prompt` template becomes the literal message that gets delivered. Zero LLM cost, sub-second delivery. See [Direct Delivery Mode](#direct-delivery-mode) for use cases. Requires `deliver` to be a real target (not `log`). |
+| `completion_callback` | No | Signed lifecycle callback emitted at `running` and after terminal response delivery. Requires `url`, a separate 32+ character `secret`, and 1–8 scalar `include_payload_fields`; optional `max_attempts` (1–5, default 3) and `timeout_seconds` (1–30, default 5). Terminal callbacks are persisted mode-0600 and replayed after restart until acknowledged with 2xx. |
 
 ### Full example
 
@@ -123,6 +124,32 @@ platforms:
               equals: "refs/heads/main"
           deliver: "telegram"
 ```
+
+### Completion callbacks
+
+Use `completion_callback` when the system that submitted a webhook must durably learn whether the
+agent run and its final response delivery completed. The callback is sent from the processing
+lifecycle boundary—not from the model prompt—and contains only explicitly selected scalar fields:
+
+```yaml
+completion_callback:
+  url: "http://100.64.0.10:8765/v1/jobs/completion"
+  secret: "use-a-separate-random-secret-of-at-least-32-characters"
+  include_payload_fields: ["job_id", "thread_id"]
+  max_attempts: 3
+  timeout_seconds: 5
+```
+
+Callbacks use `X-Webhook-Timestamp` plus `X-Webhook-Signature-V2`, an HMAC-SHA256 over
+`<timestamp>.<raw-body>`. The body contains `delivery_id`, route, status, occurred time, a fixed
+sanitized error code, and the selected fields under `correlation`. Receivers should enforce the
+five-minute timestamp window and use `(delivery_id,status)` as an idempotency key.
+
+`running` is best effort. Before a terminal callback is sent, Hermes atomically writes it beneath
+`~/.hermes/webhook_callback_outbox/` with directory mode 0700 and file mode 0600. Only a 2xx
+response removes it; non-2xx responses, timeout, process exit, or restart leave it available for
+replay. The spool contains the callback body and route name but never the callback URL or secret.
+Redirects are not followed, preventing signature forwarding to a different host.
 
 ### Payload Filters
 


### PR DESCRIPTION
## Summary
- add optional route-scoped, timestamp-bound HMAC completion callbacks
- persist callback intent before returning HTTP 202; interrupted accepted runs recover as failed
- emit running and true post-delivery terminal outcomes with an explicit correlation allowlist
- require a successful final notify-marked delivery before reporting completed
- atomically spool terminal callbacks mode 0600 with file and directory fsync
- replay after restart and retry retained callbacks periodically while running
- bound timeout/retries, reject redirects, and never persist callback secrets
- document the route contract and add focused lifecycle/security tests

## Verification
- Ruff passed
- full `tests/gateway/test_webhook*.py`: 142 passed on current upstream and installed Hermes v0.19.0 backport
- py_compile and diff checks passed