### PR TITLE
feat(statusbar): show days in session duration when >24h

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1307,8 +1307,9 @@ def format_duration_compact(seconds: float) -> str:
     if hours < 24:
         remaining_min = int(minutes % 60)
         return f"{int(hours)}h {remaining_min}m" if remaining_min else f"{int(hours)}h"
-    days = hours / 24
-    return f"{days:.1f}d"
+    days = int(hours // 24)
+    remaining_hours = int(hours % 24)
+    return f"{days}d {remaining_hours}h" if remaining_hours else f"{days}d"
 
 
 def format_token_count_compact(value: int) -> str:

--- a/cli.py
+++ b/cli.py
@@ -115,8 +115,9 @@ def format_duration_compact(*args, **kwargs):
     if hours < 24:
         remaining_min = int(minutes % 60)
         return f"{int(hours)}h {remaining_min}m" if remaining_min else f"{int(hours)}h"
-    days = hours / 24
-    return f"{days:.1f}d"
+    days = int(hours // 24)
+    remaining_hours = int(hours % 24)
+    return f"{days}d {remaining_hours}h" if remaining_hours else f"{days}d"
 
 
 # Cached reverse map of config.yaml ``model_aliases:`` so the TUI can show

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -206,7 +206,11 @@ class TestFormatDuration:
 
     def test_days(self):
         result = _format_duration(172800)  # 2 days
-        assert result == "2.0d"
+        assert result == "2d"
+
+    def test_days_with_hours(self):
+        result = _format_duration(129600)  # 1.5 days = 1d 12h
+        assert result == "1d 12h"
 
 
 class TestBarChart:

--- a/ui-tui/src/__tests__/messages.test.ts
+++ b/ui-tui/src/__tests__/messages.test.ts
@@ -5,7 +5,7 @@ import React from 'react'
 import { describe, expect, it } from 'vitest'
 
 import { MessageLine } from '../components/messageLine.js'
-import { toTranscriptMessages } from '../domain/messages.js'
+import { fmtDuration, toTranscriptMessages } from '../domain/messages.js'
 import { upsert } from '../lib/messages.js'
 import { stripAnsi } from '../lib/text.js'
 import { DEFAULT_THEME } from '../theme.js'
@@ -146,5 +146,43 @@ describe('upsert', () => {
     const prev = [{ role: 'user' as const, text: 'hi' }]
     upsert(prev, 'assistant', 'yo')
     expect(prev).toHaveLength(1)
+  })
+})
+
+describe('fmtDuration', () => {
+  it('formats under a minute as plain seconds', () => {
+    expect(fmtDuration(0)).toBe('0s')
+    expect(fmtDuration(42_000)).toBe('42s')
+    expect(fmtDuration(59_400)).toBe('59s')
+  })
+
+  it('formats whole minutes with trailing seconds', () => {
+    expect(fmtDuration(60_000)).toBe('1m 0s')
+    expect(fmtDuration(180_000)).toBe('3m 0s')
+  })
+
+  it('mixes minutes and seconds', () => {
+    expect(fmtDuration(134_000)).toBe('2m 14s')
+    expect(fmtDuration(605_000)).toBe('10m 5s')
+  })
+
+  it('formats whole hours with trailing minutes', () => {
+    expect(fmtDuration(3_600_000)).toBe('1h 0m')
+    expect(fmtDuration(7_200_000)).toBe('2h 0m')
+  })
+
+  it('mixes hours and minutes', () => {
+    expect(fmtDuration(5_400_000)).toBe('1h 30m')
+    expect(fmtDuration(3_960_000)).toBe('1h 6m')
+  })
+
+  it('formats whole days without trailing hours', () => {
+    expect(fmtDuration(86_400_000)).toBe('1d')
+    expect(fmtDuration(172_800_000)).toBe('2d')
+  })
+
+  it('mixes days and hours', () => {
+    expect(fmtDuration(129_600_000)).toBe('1d 12h') // 1.5 days
+    expect(fmtDuration(97_200_000)).toBe('1d 3h') // 1d 3h
   })
 })

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -97,11 +97,12 @@ const indicatorFrameWidth = (style: IndicatorStyle): number => {
 
 // Bounded width of the elapsed-time clock, derived from `fmtDuration` itself so
 // the reservation/budget stays consistent with what actually renders (it emits
-// a space between units, e.g. `59m 59s` / `99h 59m`). Durations beyond this
-// (100h+) are left to clip rather than reserving unbounded width.
+// a space between units, e.g. `59m 59s` / `99h 59m` / `999d 23h`). Durations
+// beyond this are left to clip rather than reserving unbounded width.
 export const MAX_DURATION_WIDTH = Math.max(
   stringWidth(fmtDuration(59 * 60_000 + 59_000)), // "59m 59s"
-  stringWidth(fmtDuration(99 * 3_600_000 + 59 * 60_000)) // "99h 59m"
+  stringWidth(fmtDuration(99 * 3_600_000 + 59 * 60_000)), // "99h 59m"
+  stringWidth(fmtDuration(999 * 86_400_000 + 23 * 3_600_000)) // "999d 23h"
 )
 
 // Display width to reserve for the busy indicator so its verb + elapsed-time

--- a/ui-tui/src/domain/messages.ts
+++ b/ui-tui/src/domain/messages.ts
@@ -98,10 +98,14 @@ export const toTranscriptMessages = (rows: unknown): Msg[] => {
 
 export const fmtDuration = (ms: number) => {
   const t = Math.max(0, Math.floor(ms / 1000))
-  const h = Math.floor(t / 3600)
+  const d = Math.floor(t / 86400)
+  const h = Math.floor((t % 86400) / 3600)
   const m = Math.floor((t % 3600) / 60)
   const s = t % 60
 
+  if (d > 0) {
+    return h > 0 ? `${d}d ${h}h` : `${d}d`
+  }
   return h > 0 ? `${h}h ${m}m` : m > 0 ? `${m}m ${s}s` : `${s}s`
 }
 


### PR DESCRIPTION
## Summary

Session durations exceeding 24 hours now display as `1d 12h` instead of the previous `1.5d` decimal format (classic CLI) or `25h 30m` unbounded-hour format (TUI).

Both status bar renderers are updated for parity:

- **Classic CLI** (`format_duration_compact` in `agent/usage_pricing.py` + `cli.py`): changed from `1.5d` decimal to `1d 12h` days+hours
- **TUI** (`fmtDuration` in `ui-tui/src/domain/messages.ts`): added day support — durations ≥24h now show `1d 12h` instead of `25h 30m`
- **TUI width budget** (`MAX_DURATION_WIDTH` in `appChrome.tsx`): updated to account for the new `999d 23h` max-width case

## Before / After

| Duration | Before (CLI) | After (CLI) | Before (TUI) | After (TUI) |
|---|---|---|---|---|
| 23h 59m | `23h 59m` | `23h 59m` | `23h 59m` | `23h 59m` |
| 24h | `1.0d` | `1d` | `24h 0m` | `1d` |
| 36h | `1.5d` | `1d 12h` | `36h 0m` | `1d 12h` |
| 48h | `2.0d` | `2d` | `48h 0m` | `2d` |

## Testing

- **Python**: `tests/agent/test_insights.py::TestFormatDuration` — 6/6 passed (updated `test_days` assertion from `2.0d` → `2d`, added `test_days_with_hours`)
- **Python**: `tests/cli/test_cli_status_bar.py` — 45/45 passed (no regressions)
- **TUI**: `ui-tui/src/__tests__/messages.test.ts` — 17/17 passed (added `fmtDuration` test suite covering seconds through days+hours)
