### PR TITLE
fix: [[as_document]] directive now works for video files

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5396,17 +5396,21 @@ class BasePlatformAdapter(ABC):
                                 audio_path=media_path,
                                 metadata=_final_thread_metadata,
                             )
-                        elif ext in _VIDEO_EXTS:
+                        elif ext in _VIDEO_EXTS and not force_document_attachments:
                             media_result = await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=media_path,
                                 metadata=_final_thread_metadata,
                             )
                         else:
+                            _doc_kwargs = {}
+                            if force_document_attachments:
+                                _doc_kwargs['disable_content_type_detection'] = True
                             media_result = await self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=media_path,
                                 metadata=_final_thread_metadata,
+                                **_doc_kwargs,
                             )
 
                         if not media_result.success:
@@ -5420,17 +5424,21 @@ class BasePlatformAdapter(ABC):
                         await asyncio.sleep(human_delay)
                     try:
                         ext = Path(file_path).suffix.lower()
-                        if ext in _VIDEO_EXTS:
+                        if ext in _VIDEO_EXTS and not force_document_attachments:
                             await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=file_path,
                                 metadata=_final_thread_metadata,
                             )
                         else:
+                            _doc_kwargs = {}
+                            if force_document_attachments:
+                                _doc_kwargs['disable_content_type_detection'] = True
                             await self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=file_path,
                                 metadata=_final_thread_metadata,
+                                **_doc_kwargs,
                             )
                     except Exception as file_err:
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15168,17 +15168,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             audio_path=media_path,
                             metadata=_thread_meta,
                         )
-                    elif ext in _VIDEO_EXTS:
+                    elif ext in _VIDEO_EXTS and not force_document_attachments:
                         await adapter.send_video(
                             chat_id=event.source.chat_id,
                             video_path=media_path,
                             metadata=_thread_meta,
                         )
                     else:
+                        _doc_kwargs = {}
+                        if force_document_attachments:
+                            _doc_kwargs['disable_content_type_detection'] = True
                         await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=media_path,
                             metadata=_thread_meta,
+                            **_doc_kwargs,
                         )
                 except Exception as e:
                     logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
@@ -15382,7 +15386,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 audio_path=media_path,
                                 metadata=_thread_metadata,
                             )
-                        elif _ext in _VIDEO_EXTS:
+                        elif _ext in _VIDEO_EXTS and not force_document_attachments:
                             await adapter.send_video(
                                 chat_id=source.chat_id,
                                 video_path=media_path,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6795,17 +6795,20 @@ class TelegramAdapter(BasePlatformAdapter):
             )
 
             with open(file_path, "rb") as f:
+                payload = {
+                    "chat_id": normalize_telegram_chat_id(chat_id),
+                    "document": f,
+                    "filename": display_name,
+                    "caption": caption[:1024] if caption else None,
+                    "reply_to_message_id": reply_to_id,
+                    **thread_kwargs,
+                    **self._notification_kwargs(metadata),
+                }
+                if kwargs.get("disable_content_type_detection"):
+                    payload["disable_content_type_detection"] = True
                 msg = await self._send_with_dm_topic_reply_anchor_retry(
                     self._bot.send_document,
-                    {
-                        "chat_id": normalize_telegram_chat_id(chat_id),
-                        "document": f,
-                        "filename": display_name,
-                        "caption": caption[:1024] if caption else None,
-                        "reply_to_message_id": reply_to_id,
-                        **thread_kwargs,
-                        **self._notification_kwargs(metadata),
-                    },
+                    payload,
                     metadata,
                     reply_to_id,
                     "document",


### PR DESCRIPTION
## Problem

The [[as_document]] directive only worked for images. Videos always used send_video.

## Fix

- Video dispatch guards in 4 locations (base.py x2, run.py x2)
- disable_content_type_detection now conditional via kwargs
- Passed only when force_document_attachments=True

## Result
- MEDIA:video.mp4 → inline player (unchanged)
- MEDIA:video.mp4 + [[as_document]] → document attachment