### PR TITLE
fix(agent): read Telegram rich_messages config from correct path

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -914,7 +914,8 @@ PLATFORM_HINTS = {
 }
 
 # Telegram rich-messages extension — only injected when the user has opted in
-# to ``platforms.telegram.extra.rich_messages: true``.  The base
+# to ``gateway.platforms.telegram.extra.rich_messages: true`` (or the
+# top-level ``platforms.telegram.extra.rich_messages``).  The base
 # PLATFORM_HINTS["telegram"] covers MarkdownV2-compatible constructs; this
 # extension adds the Bot API 10.1 rich-Markdown guidance (tables, task lists,
 # collapsible details, math, etc.).

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -453,8 +453,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         try:
             from hermes_cli.config import load_config_readonly
             _cfg = load_config_readonly()
-            _gw_tg_extra = (((_cfg.get("gateway") or {}).get("platforms") or {}).get("telegram") or {}).get("extra") or {}
-            _top_tg_extra = ((_cfg.get("platforms") or {}).get("telegram") or {}).get("extra") or {}
+            _gw_tg_extra = (((_cfg.get("gateway") or {}).get("platforms") or {}).get("telegram") or {}).get("extra")
+            _top_tg_extra = ((_cfg.get("platforms") or {}).get("telegram") or {}).get("extra")
+            if not isinstance(_gw_tg_extra, dict):
+                _gw_tg_extra = {}
+            if not isinstance(_top_tg_extra, dict):
+                _top_tg_extra = {}
             _tg_extra = {**_gw_tg_extra, **_top_tg_extra}
             if _tg_extra.get("rich_messages"):
                 _default_hint = _default_hint.rstrip() + " " + TELEGRAM_RICH_MESSAGES_HINT

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -444,18 +444,22 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             pass
 
     # For Telegram: append the rich-messages extension only when the user has
-    # opted in to ``platforms.telegram.extra.rich_messages: true``.  The base
-    # hint covers MarkdownV2-compatible constructs; the extension adds Bot API
-    # 10.1 guidance (tables, task lists, math, collapsible details, etc.).
+    # opted in to ``gateway.platforms.telegram.extra.rich_messages: true``
+    # (the canonical location the adapter reads from).  Merge with the
+    # top-level ``platforms.telegram.extra`` so config-wizard writes and
+    # dashboard-setup keys are also visible — same precedence the adapter
+    # uses: top-level platform overrides gateway.platforms at the leaf.
     if platform_key == "telegram" and _default_hint:
         try:
             from hermes_cli.config import load_config_readonly
             _cfg = load_config_readonly()
-            _tg_extra = ((_cfg.get("platforms") or {}).get("telegram") or {}).get("extra") or {}
+            _gw_tg_extra = (((_cfg.get("gateway") or {}).get("platforms") or {}).get("telegram") or {}).get("extra") or {}
+            _top_tg_extra = ((_cfg.get("platforms") or {}).get("telegram") or {}).get("extra") or {}
+            _tg_extra = {**_gw_tg_extra, **_top_tg_extra}
             if _tg_extra.get("rich_messages"):
                 _default_hint = _default_hint.rstrip() + " " + TELEGRAM_RICH_MESSAGES_HINT
-        except Exception:
-            pass  # Config read failure — fall back to base hint only
+        except ImportError:
+            pass  # Config module not available — fall back to base hint only
 
     _effective_hint = _resolve_platform_hint(agent, platform_key, _default_hint)
     if platform_key == "tui" and _effective_hint:

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -257,3 +257,44 @@ class TestTelegramRichMessagesHint:
             stable = _stable_prompt(agent)
         assert "Standard Markdown is automatically converted" in stable
         assert "lean into it" not in stable
+
+    def test_gateway_rich_messages_integration_via_real_config(self, tmp_path, monkeypatch):
+        """End-to-end through the real config-resolution chain: a config.yaml
+        under HERMES_HOME with ``gateway.platforms.telegram.extra.rich_messages``
+        must activate the rich hint. ``load_config_readonly`` is NOT mocked here,
+        so this guards against the exact path-mismatch bug this PR fixes.
+        """
+        config_yaml = (
+            "gateway:\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      extra:\n"
+            "        rich_messages: true\n"
+        )
+        home = tmp_path / "hermes_home"
+        home.mkdir()
+        (home / "config.yaml").write_text(config_yaml)
+
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        # Point config resolution at the temp file without mocking the loader:
+        # mirror the pattern used in test_config_env_expansion.py.
+        from hermes_cli import config as _cfgmod
+        monkeypatch.setattr(_cfgmod, "get_config_path", lambda: home / "config.yaml")
+
+        agent = _make_agent(platform="telegram")
+        stable = _stable_prompt(agent)
+        assert "lean into it" in stable
+        assert "task lists" in stable
+
+    def test_malformed_extra_value_falls_back_to_base_hint(self, tmp_path, monkeypatch):
+        """A truthy non-mapping ``extra`` must not crash prompt construction —
+        it should fail open to the base hint (Tek's fail-open concern).
+        """
+        agent = _make_agent(platform="telegram")
+        with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
+            mock_cfg.return_value = {
+                "gateway": {"platforms": {"telegram": {"extra": "not-a-map"}}}
+            }
+            stable = _stable_prompt(agent)
+        assert "Standard Markdown is automatically converted" in stable
+        assert "lean into it" not in stable

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -189,34 +189,65 @@ class TestTelegramRichMessagesHint:
     """Verify that TELEGRAM_RICH_MESSAGES_HINT is conditionally included."""
 
     def test_base_hint_without_rich_messages(self, monkeypatch):
-        """When rich_messages is False (default), only the base hint is used."""
+        """When rich_messages is False, only the base hint is used."""
         agent = _make_agent(platform="telegram")
-        # Mock config to return rich_messages: false (default)
         with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
             mock_cfg.return_value = {
-                "platforms": {"telegram": {"extra": {"rich_messages": False}}}
+                "gateway": {"platforms": {"telegram": {"extra": {"rich_messages": False}}}}
             }
             stable = _stable_prompt(agent)
-        # Base hint should be present
         assert "Standard Markdown is automatically converted" in stable
-        # Rich-messages extension should NOT be present
         assert "lean into it" not in stable
         assert "task lists" not in stable
 
     def test_rich_hint_with_rich_messages_enabled(self, monkeypatch):
-        """When rich_messages is True, the rich-messages extension is appended."""
+        """When rich_messages is True in gateway.platforms, the extension
+        is appended (the canonical/primary location)."""
+        agent = _make_agent(platform="telegram")
+        with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
+            mock_cfg.return_value = {
+                "gateway": {"platforms": {"telegram": {"extra": {"rich_messages": True}}}}
+            }
+            stable = _stable_prompt(agent)
+        assert "lean into it" in stable
+        assert "task lists" in stable
+        assert "math/formulas" in stable
+
+    def test_rich_hint_from_top_level_platforms(self):
+        """Top-level ``platforms.telegram.extra.rich_messages`` is merged
+        alongside gateway.platforms, so it works on its own."""
         agent = _make_agent(platform="telegram")
         with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
             mock_cfg.return_value = {
                 "platforms": {"telegram": {"extra": {"rich_messages": True}}}
             }
             stable = _stable_prompt(agent)
-        # Base hint should be present
-        assert "Standard Markdown is automatically converted" in stable
-        # Rich-messages extension should be present
         assert "lean into it" in stable
         assert "task lists" in stable
-        assert "math/formulas" in stable
+
+    def test_top_level_overrides_gateway_rich_messages(self):
+        """Top-level ``platforms.telegram.extra`` wins over gateway.platforms
+        at the leaf, matching the adapter's merge precedence."""
+        agent = _make_agent(platform="telegram")
+        with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
+            mock_cfg.return_value = {
+                "gateway": {"platforms": {"telegram": {"extra": {"rich_messages": False}}}},
+                "platforms": {"telegram": {"extra": {"rich_messages": True}}},
+            }
+            stable = _stable_prompt(agent)
+        assert "lean into it" in stable
+
+    def test_gateway_extra_other_keys_does_not_block_top_level_rich_messages(self):
+        """When gateway.platforms.telegram.extra has other keys but not
+        rich_messages, the top-level rich_messages still activates."""
+        agent = _make_agent(platform="telegram")
+        with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
+            mock_cfg.return_value = {
+                "gateway": {"platforms": {"telegram": {"extra": {"disable_link_previews": True}}}},
+                "platforms": {"telegram": {"extra": {"rich_messages": True}}},
+            }
+            stable = _stable_prompt(agent)
+        assert "lean into it" in stable
 
     def test_base_hint_without_config(self, monkeypatch):
         """When config has no telegram section, only base hint is used."""


### PR DESCRIPTION
## What does this PR do?

Fixes a config-path mismatch that prevented Telegram's rich-Markdown hint extension from ever activating. Commit b45a217e0 gated the `TELEGRAM_RICH_MESSAGES_HINT` behind `platforms.telegram.extra.rich_messages` (a bare top-level key), but the Telegram adapter reads the same setting from `gateway.platforms.telegram.extra.rich_messages` (the canonical location). When users set `rich_messages: true` in the canonical location, the lookup returned `None`, the extension never fired, and the model degraded pipe tables → bullet lists, task lists → plain dashes, and never produced `<details>` blocks or block math.

The fix merges both `gateway.platforms.telegram.extra` and the top-level `platforms.telegram.extra` with the same precedence the adapter uses (top-level leaf wins), so config-wizard writes and dashboard-setup keys are visible alongside the canonical gateway location. Also narrows the except-guard to `ImportError`.

## Related Issue

None

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/system_prompt.py:446-461` — merge `gateway.platforms.telegram.extra` and top-level `platforms.telegram.extra` with correct precedence (top-level leaf wins, matching the adapter); narrow `except Exception` → `except ImportError`
- `agent/prompt_builder.py:917` — update stale comment referencing the old config path
- `tests/agent/test_system_prompt.py` — update existing tests to use canonical `gateway.platforms` path; add `test_top_level_overrides_gateway_rich_messages` and `test_gateway_extra_other_keys_does_not_block_top_level_rich_messages`

## How to Test

1. Set `gateway.platforms.telegram.extra.rich_messages: true` in `config.yaml` (canonical location, no top-level `platforms` key)
2. Start a new Telegram session (`/new`)
3. Ask the model to produce a comparison table; verify it uses pipe-table syntax rather than bullet-list degradation
4. Bonus: set `gateway.platforms.telegram.extra: {disable_link_previews: true}` and `platforms.telegram.extra.rich_messages: true` together — verify rich messages still activate (the merge doesn't silently skip the fallback)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x / Linux (server)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — comments updated in `system_prompt.py` and `prompt_builder.py`
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A** (existing config keys, new path)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — **N/A**
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — **N/A**