### PR TITLE
fix(cli): don't list providers whose only credential has an unusable format

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -171,6 +171,46 @@ class ProviderConfig:
     api_key_env_vars: tuple = ()
     # Optional env var for base URL override
     base_url_env_var: str = ""
+    # Optional offline format check for a credential, returning (usable, reason).
+    # Declare one only where the provider documents its token shapes precisely
+    # enough that a mismatch cannot possibly work: rejecting a credential that
+    # does work hides the provider from every picker, which is worse than
+    # listing one that later fails. Consumed via provider_credential_format_ok().
+    token_format_validator: Optional[Callable[[str], Tuple[bool, str]]] = None
+
+
+def _validate_copilot_token_format(token: str) -> Tuple[bool, str]:
+    """Adapter so the registry can point at copilot_auth without importing it
+    at module load (copilot_auth pulls in the subprocess/OAuth machinery)."""
+    from hermes_cli.copilot_auth import validate_copilot_token
+
+    return validate_copilot_token(token)
+
+
+def provider_credential_format_ok(provider_id: str, token: str) -> bool:
+    """Return False only when ``token`` cannot be a credential for ``provider_id``.
+
+    Offline, format-only: no network, no auth store. Providers that declare no
+    ``token_format_validator`` always pass, so a provider we have no rule for
+    keeps whatever behaviour the caller had before. Errors inside a validator
+    fail open for the same reason.
+    """
+    token = str(token or "").strip()
+    if not token:
+        return False
+    pconfig = PROVIDER_REGISTRY.get(provider_id)
+    validator = pconfig.token_format_validator if pconfig else None
+    if validator is None:
+        return True
+    try:
+        usable, _reason = validator(token)
+    except Exception:
+        logger.debug(
+            "Credential format check failed for %s; treating as usable",
+            provider_id, exc_info=True,
+        )
+        return True
+    return bool(usable)
 
 
 PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
@@ -224,6 +264,9 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=DEFAULT_GITHUB_MODELS_BASE_URL,
         api_key_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
         base_url_env_var="COPILOT_API_BASE_URL",
+        # GITHUB_TOKEN is commonly a classic ghp_ PAT set for git/gh, which the
+        # Copilot API rejects outright — don't advertise Copilot on one (#8826).
+        token_format_validator=_validate_copilot_token_format,
     ),
     "copilot-acp": ProviderConfig(
         id="copilot-acp",

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1755,7 +1755,7 @@ def list_authenticated_providers(
         fetch_models_dev,
         get_provider_info as _mdev_pinfo,
     )
-    from hermes_cli.auth import PROVIDER_REGISTRY
+    from hermes_cli.auth import PROVIDER_REGISTRY, provider_credential_format_ok
     from hermes_cli.models import (
         OPENROUTER_MODELS, _PROVIDER_MODELS,
         _MODELS_DEV_PREFERRED, _merge_with_models_dev, cached_provider_model_ids,
@@ -1796,6 +1796,20 @@ def list_authenticated_providers(
 
     def _norm_url(url: str) -> str:
         return str(url or "").strip().rstrip("/").lower()
+
+    def _has_env_creds(provider_id: str, env_vars) -> bool:
+        """Whether any of ``env_vars`` holds a credential worth listing.
+
+        A bare "the variable is non-empty" test advertised providers that
+        cannot possibly work — GITHUB_TOKEN is routinely a classic ghp_ PAT
+        set for git, which the Copilot API rejects, so /model listed Copilot
+        and the first request failed (#8826). Providers that declare no
+        format rule are unaffected.
+        """
+        return any(
+            provider_credential_format_ok(provider_id, os.environ.get(ev, ""))
+            for ev in env_vars
+        )
 
     def _record_builtin_endpoint(slug: str) -> None:
         """Record the effective base URL for a built-in provider row.
@@ -1974,8 +1988,8 @@ def list_authenticated_providers(
             if not isinstance(env_vars, list):
                 continue
 
-        # Check if any env var is set
-        has_creds = any(os.environ.get(ev) for ev in env_vars)
+        # Check if any env var holds a plausibly usable credential
+        has_creds = _has_env_creds(hermes_id, env_vars)
         if not has_creds:
             try:
                 from hermes_cli.auth import _load_auth_store
@@ -2070,13 +2084,13 @@ def list_authenticated_providers(
             except Exception as exc:
                 logger.debug("Vertex credential check failed: %s", exc)
         elif overlay.extra_env_vars:
-            has_creds = any(os.environ.get(ev) for ev in overlay.extra_env_vars)
+            has_creds = _has_env_creds(hermes_slug, overlay.extra_env_vars)
         # Also check api_key_env_vars from PROVIDER_REGISTRY for api_key auth_type
         if not has_creds and overlay.auth_type == "api_key":
             for _key in (pid, hermes_slug):
                 pcfg = _auth_registry.get(_key)
                 if pcfg and pcfg.api_key_env_vars:
-                    if any(os.environ.get(ev) for ev in pcfg.api_key_env_vars):
+                    if _has_env_creds(_key, pcfg.api_key_env_vars):
                         has_creds = True
                         break
         # Check auth store and credential pool for non-env-var credentials.
@@ -2240,7 +2254,7 @@ def list_authenticated_providers(
         _cp_config = _auth_registry.get(_cp.slug)
         _cp_has_creds = False
         if _cp_config and _cp_config.api_key_env_vars:
-            _cp_has_creds = any(os.environ.get(ev) for ev in _cp_config.api_key_env_vars)
+            _cp_has_creds = _has_env_creds(_cp.slug, _cp_config.api_key_env_vars)
         # Also check auth store and credential pool
         if not _cp_has_creds:
             try:

--- a/tests/hermes_cli/test_model_picker_token_format.py
+++ b/tests/hermes_cli/test_model_picker_token_format.py
@@ -1,0 +1,111 @@
+"""Regression tests for #8826 — the /model picker must not advertise a
+provider whose only credential has a definitively unusable format.
+
+``list_authenticated_providers()`` gated provider rows on a bare truthiness
+check over the provider's env vars, so ``GITHUB_TOKEN=ghp_...`` (a classic
+PAT, which the Copilot API rejects) made GitHub Copilot look authenticated
+in the picker and then fail on first use.
+
+Only formats the provider itself documents as unusable are rejected — a
+provider with no declared validator keeps its old behaviour, so this can
+never hide an endpoint we have no rule for.
+
+No network calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.auth import PROVIDER_REGISTRY, provider_credential_format_ok
+from hermes_cli.model_switch import list_authenticated_providers
+
+# Shapes only — none of these are real credentials.
+CLASSIC_PAT = "ghp_" + "A" * 36
+OAUTH_TOKEN = "gho_" + "B" * 36
+FINE_GRAINED_PAT = "github_pat_" + "C" * 70
+APP_TOKEN = "ghu_" + "D" * 36
+
+COPILOT_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Blank every credential env var the assertions depend on."""
+    for var in COPILOT_ENV_VARS + ("OPENAI_API_KEY", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+def _picker_slugs(**kwargs) -> set[str]:
+    """Run the picker with every non-env credential source turned off."""
+    with patch("hermes_cli.model_switch._credential_pool_is_usable", return_value=False), \
+         patch("hermes_cli.auth._load_auth_store", return_value={}):
+        rows = list_authenticated_providers(current_provider="openrouter", max_models=5, **kwargs)
+    return {row["slug"] for row in rows}
+
+
+def test_copilot_hidden_when_only_credential_is_a_classic_pat(clean_env):
+    """The exact #8826 repro: ghp_* in GITHUB_TOKEN must not list Copilot."""
+    clean_env.setenv("GITHUB_TOKEN", CLASSIC_PAT)
+
+    assert "copilot" not in _picker_slugs()
+
+
+@pytest.mark.parametrize("env_var", COPILOT_ENV_VARS)
+def test_copilot_hidden_for_classic_pat_in_any_env_var(clean_env, env_var):
+    """All three Copilot env vars go through the same format gate."""
+    clean_env.setenv(env_var, CLASSIC_PAT)
+
+    assert "copilot" not in _picker_slugs()
+
+
+@pytest.mark.parametrize("token", [OAUTH_TOKEN, FINE_GRAINED_PAT, APP_TOKEN])
+def test_copilot_listed_for_supported_token_shapes(clean_env, token):
+    """Supported prefixes must keep listing Copilot — no false negatives."""
+    clean_env.setenv("GITHUB_TOKEN", token)
+
+    assert "copilot" in _picker_slugs()
+
+
+def test_one_usable_token_is_enough(clean_env):
+    """A rejected token in one var must not mask a usable one in another."""
+    clean_env.setenv("GITHUB_TOKEN", CLASSIC_PAT)
+    clean_env.setenv("COPILOT_GITHUB_TOKEN", OAUTH_TOKEN)
+
+    assert "copilot" in _picker_slugs()
+
+
+def test_provider_without_a_format_rule_is_unaffected(clean_env):
+    """Providers that declare no validator keep the old truthiness behaviour."""
+    clean_env.setenv("OPENAI_API_KEY", "not-a-recognizable-shape")
+
+    assert "openai-api" in _picker_slugs()
+
+
+def test_registry_helper_passes_providers_without_a_validator():
+    """Unknown/undeclared providers must never be rejected on format."""
+    assert provider_credential_format_ok("openai-api", "anything-at-all")
+    assert provider_credential_format_ok("not-a-real-provider", "anything-at-all")
+
+
+def test_registry_helper_rejects_blank_values():
+    assert not provider_credential_format_ok("copilot", "")
+    assert not provider_credential_format_ok("copilot", "   ")
+
+
+def test_registry_helper_uses_the_copilot_validator():
+    assert PROVIDER_REGISTRY["copilot"].token_format_validator is not None
+    assert not provider_credential_format_ok("copilot", CLASSIC_PAT)
+    assert provider_credential_format_ok("copilot", OAUTH_TOKEN)
+
+
+def test_registry_helper_allows_token_when_validator_raises():
+    """A broken validator must fail open — hiding a working provider is worse."""
+    def _boom(_token):
+        raise RuntimeError("validator exploded")
+
+    with patch.object(PROVIDER_REGISTRY["copilot"], "token_format_validator", _boom):
+        assert provider_credential_format_ok("copilot", CLASSIC_PAT)


### PR DESCRIPTION
Fixes #8826.

## Not a duplicate of #13538 / #13988 — please read this first

A previous attempt at this issue (#24991) was closed as *"likely duplicate of #13538 (and near-duplicate #13988)"*. That triage was mistaken, and this PR will hit the same wall unless the distinction is clear:

| PR | Files touched |
|---|---|
| #13538 (open) | `hermes_cli/copilot_auth.py` + 2 test files |
| #13988 (open) | `hermes_cli/copilot_auth.py` |
| **this PR** | `hermes_cli/auth.py`, `hermes_cli/model_switch.py` |

Both of those PRs improve `validate_copilot_token()`. **Neither wires it into the picker.** `list_authenticated_providers()` never calls the validator, so the reported symptom survives both of them unchanged. This PR is the missing wiring, and it is deliberately built on top of their validator rather than around it — whichever of them lands makes this stricter for free.

## What was wrong

`hermes_cli/model_switch.py`, in `list_authenticated_providers()` and three sibling spots:

```python
has_creds = any(os.environ.get(ev) for ev in env_vars)
```

`PROVIDER_REGISTRY["copilot"].api_key_env_vars` includes `GITHUB_TOKEN`, so any non-empty string lists Copilot as authenticated. With a classic `ghp_` PAT the row appears, then the provider fails immediately on use.

The codebase already knows this token is unusable at the moment it lists it — `copilot_auth` logs *"Classic Personal Access Tokens (ghp_\*) are not supported by the Copilot API"* twice during the same picker call that renders the row.

## Approach

Instead of a parallel prefix table in `model_switch.py`, the format rule lives with the registry that already owns credentials:

- `hermes_cli/auth.py` — optional `ProviderConfig.token_format_validator`, a lazily-imported adapter around `copilot_auth.validate_copilot_token` (avoids pulling the OAuth/subprocess module in at load time), and `provider_credential_format_ok(provider_id, token)`. Only the `copilot` entry declares a validator.
- `hermes_cli/model_switch.py` — one `_has_env_creds()` helper replaces all four truthiness checks.

Net +43/-26, no new prefix constants.

## False-negative risk

Hiding a provider the user can actually use would be worse than the bug, so every ambiguous case fails open:

- No validator declared → always `True`. Every provider except Copilot is byte-identical, except that a whitespace-only env var no longer counts as a credential.
- Validator raises → `True`, logged at debug. Covered by a test.
- Any one usable env var wins — a junk `GITHUB_TOKEN` cannot mask a good `COPILOT_GITHUB_TOKEN`. Covered by a test.
- Auth-store and credential-pool fallbacks are untouched, so a user authenticated via `gh auth token` still sees Copilot (`_seed_from_singletons("copilot")` → `resolve_copilot_token()` already skips `ghp_` env vars and falls back to the gh CLI).

Known residual gap, pre-existing and not introduced here: the pool fallback is gated on `raw_pool_present`, so a user whose *only* credentials are a `ghp_` env token plus a gh-CLI login, who has never persisted a pool entry, would now see Copilot hidden. Closing that would mean forcing pool seeding (network) on every picker open.

## How to test

```
./scripts/run_tests.sh tests/hermes_cli/test_model_picker_token_format.py
```
→ 13 tests passed. Covers the exact #8826 repro, `ghp_` in each of the three Copilot env vars, all three supported shapes still listing, mixed-token precedence, an unaffected non-Copilot provider, and the registry helper's pass/blank/reject/fail-open paths.

Regression value verified: reverting only `model_switch.py` (keeping `auth.py` so imports still resolve) fails exactly the 4 behavioural tests; the 9 registry-helper tests still pass.

Wider run, no regressions:
```
./scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py \
  tests/hermes_cli/test_model_picker_token_format.py tests/hermes_cli/test_copilot_auth.py \
  tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_inventory.py \
  tests/hermes_cli/test_list_picker_providers.py tests/agent/test_auxiliary_client.py \
  tests/agent/test_auxiliary_client_resolve_dedup.py \
  tests/tools/test_credential_pool_env_fallback.py tests/test_copilot_initiator.py --file-timeout 900
```
→ 10 files, 729 tests passed, 0 failed.

`scripts/check-windows-footguns.py` and `ruff check` clean on all three changed files.

## Platforms

Pure Python string/registry logic, no platform-specific paths. Suite run on macOS (arm64, Python 3.13).
