### PR TITLE
feat(slack): render generic interactive reply controls

### DIFF
--- a/docs/superpowers/plans/2026-07-26-slack-interactive-replies-plan.md
+++ b/docs/superpowers/plans/2026-07-26-slack-interactive-replies-plan.md
@@ -260,26 +260,34 @@ async def test_post_failure_discards_unbound_card(adapter, client):
     assert adapter._interactive_reply_store.pending_count() == 0
 ```
 
-- [ ] **Step 2: Run the exact focused suites**
+- [x] **Step 2: Run the exact focused suites**
 
 Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py tests/gateway/test_slack_block_kit_adapter.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_clarify_buttons.py tests/gateway/test_slack_plugin_action_handlers.py tests/tools/test_send_message_slack.py -q`
 
 Expected: PASS with no test deselection caused by the new feature.
 
-Actual (2026-07-26): **BLOCKED.** The exact wrapper command discovered 6 files
-and approximately 144 tests. It reported 150 passed and 1 failed. The new
-`test_post_failure_discards_unbound_card` failed because
-`InteractiveReplyStore` has no `pending_count()` method. Task 1's declared
-store interface contains only `create_card`, `bind_message`, `discard`, and
-`consume`. The repository suite was not run after this focused gate failed.
+Actual (2026-07-26): **PASS.** The test-first red run reported 31 passed and 1
+failed because `InteractiveReplyStore.pending_count()` was absent. After the
+minimal read-only method was added, the single-file green run reported 32
+passed and 0 failed. The exact six-file focused command then reported 151
+passed and 0 failed with all 6 requested files selected.
 
-- [ ] **Step 3: Run the repository suite required by the contributor guide**
+- [x] **Step 3: Run the repository suite required by the contributor guide**
 
 Run: `scripts/run_tests.sh`
 
 Expected: PASS. If an unrelated existing failure appears, capture its exact output and stop for review rather than relabeling it as a feature pass.
 
-- [ ] **Step 4: Inspect and commit verification evidence**
+Actual (2026-07-26): **NON-PASS due to unrelated environment and platform
+failures.** The wrapper completed with exit 1 after 520.5 seconds: 2,307 files,
+45,497 tests passed, and 596 failed. It reported 121 files with failures and 84
+files where no tests ran. Representative causes were missing optional/runtime
+dependencies (`acp`, `prompt_toolkit`, `croniter`, `psutil`, `wcwidth`, `mcp`,
+`node`, `setuptools`, and `fire`), macOS `/tmp` versus `/private/tmp` path
+expectations, Linux-only systemd abstract sockets, and live-system signal
+guards. No full-suite pass is claimed.
+
+- [x] **Step 4: Inspect and commit verification evidence**
 
 ```bash
 git diff origin/main...HEAD --check

--- a/docs/superpowers/plans/2026-07-26-slack-interactive-replies-plan.md
+++ b/docs/superpowers/plans/2026-07-26-slack-interactive-replies-plan.md
@@ -1,0 +1,290 @@
+# Slack Interactive Replies Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render validated Slack button directives as real Block Kit controls and safely relay one click into the original authenticated Slack conversation.
+
+**Architecture:** A focused Slack-plugin helper owns directive parsing, opaque card records, and safe action-block construction. The Slack adapter and standalone sender both use that helper; the adapter alone consumes a click and creates a normal user-sourced `MessageEvent`, so policy remains with the receiving agent.
+
+**Tech Stack:** Python 3.11+, Slack Bolt/Slack Web API, existing Hermes profile storage, pytest through `scripts/run_tests.sh`.
+
+## Global Constraints
+
+- Keep this a generic Hermes Slack transport feature; do not name Sorpio, HubSpot, AgentMail, or Brokerkit code in the runtime.
+- Use `get_hermes_home()` for every persistent path and support the repository's cross-platform lock fallback pattern.
+- A click is an ordinary non-internal user event; it must not call tools or bypass gateway authorization.
+- Require an opaque, expiry-bound, channel-bound, message-bound, single-use record before accepting a click.
+- Preserve Slack `text` fallbacks, existing Block Kit rejection fallback, and existing approval, clarification, and feedback controls.
+- Support both `SlackAdapter.send` and plugin `_standalone_send`; malformed directives stay literal text.
+- Use only `scripts/run_tests.sh` for tests.
+
+---
+
+## File Structure
+
+- Create `plugins/platforms/slack/interactive_replies.py` — directive parser, opaque action-record store, and safe action-block builder.
+- Modify `plugins/platforms/slack/adapter.py` — attach interactive actions to adapter sends, register the Slack callback, and relay accepted clicks as normal `MessageEvent` instances.
+- Modify `plugins/platforms/slack/adapter.py::_standalone_send` — attach the same interactive actions for out-of-process Slack delivery and discard records if posting fails.
+- Create `tests/gateway/test_slack_interactive_replies.py` — pure parser/store tests and adapter rendering/click-routing tests.
+- Modify `tests/tools/test_send_message_slack.py` — standalone sender compatibility test.
+
+### Task 1: Define the isolated interactive-reply contract
+
+**Files:**
+- Create: `plugins/platforms/slack/interactive_replies.py`
+- Test: `tests/gateway/test_slack_interactive_replies.py`
+
+**Interfaces:**
+- Produces: `parse_interactive_reply(content: str) -> InteractiveReply | None`.
+- Produces: `InteractiveReplyStore.create_card(channel_id: str, thread_ts: str | None, buttons: tuple[InteractiveButton, ...]) -> PreparedInteractiveReply`.
+- Produces: `InteractiveReplyStore.bind_message(card_id: str, message_ts: str) -> bool`, `discard(card_id: str) -> None`, and `consume(button_token: str, channel_id: str, message_ts: str) -> ConsumedInteractiveAction | None`.
+- Produces: `append_actions_block(blocks: list[dict], prepared: PreparedInteractiveReply) -> list[dict]`.
+
+- [ ] **Step 1: Write the failing parser and store tests**
+
+```python
+def test_parse_valid_directive_strips_it_and_preserves_visible_reply():
+    reply = parse_interactive_reply(
+        "Approved lead.\n[[slack_buttons: Enroll:enroll, Skip:skip]]"
+    )
+    assert reply.visible_content == "Approved lead."
+    assert [button.action_id for button in reply.buttons] == ["enroll", "skip"]
+
+def test_consume_requires_bound_message_and_is_single_use(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    store = InteractiveReplyStore(ttl_seconds=60)
+    prepared = store.create_card("C1", "T1", (InteractiveButton("Enroll", "enroll"),))
+    assert store.consume(prepared.buttons[0].token, "C1", "M1") is None
+    assert store.bind_message(prepared.card_id, "M1") is True
+    assert store.consume(prepared.buttons[0].token, "C1", "M1").action_id == "enroll"
+    assert store.consume(prepared.buttons[0].token, "C1", "M1") is None
+```
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py -q`
+
+Expected: FAIL because the module and its contract do not exist.
+
+- [ ] **Step 3: Write the minimal parser and store**
+
+```python
+@dataclass(frozen=True)
+class InteractiveButton:
+    label: str
+    action_id: str
+
+def parse_interactive_reply(content: str) -> InteractiveReply | None:
+    """Return a validated reply only when the whole directive is well-formed."""
+
+class InteractiveReplyStore:
+    def consume(self, button_token: str, channel_id: str, message_ts: str) -> ConsumedInteractiveAction | None:
+        """Atomically validate and consume one bound token, else return None."""
+```
+
+Use a random opaque value for each button, a card record with expected channel/thread/message and action mapping, atomic replacement for writes, and the repository's `fcntl`/`msvcrt` lock fallback. Clean expired cards while holding the lock. Reject blank labels, duplicate action IDs, invalid identifier characters, over-limit button counts, and malformed syntax by returning `None` so callers retain literal content.
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py -q`
+
+Expected: PASS for parser validity, malformed literal fallback, expiry, binding, cross-channel rejection, and replay rejection.
+
+- [ ] **Step 5: Commit the isolated contract**
+
+```bash
+git add plugins/platforms/slack/interactive_replies.py tests/gateway/test_slack_interactive_replies.py
+git commit -m "feat: add Slack interactive reply store"
+```
+
+### Task 2: Render valid directives on every Slack send path
+
+**Files:**
+- Modify: `plugins/platforms/slack/adapter.py:SlackAdapter.send`
+- Modify: `plugins/platforms/slack/adapter.py::_standalone_send`
+- Modify: `tests/gateway/test_slack_interactive_replies.py`
+- Modify: `tests/tools/test_send_message_slack.py`
+
+**Interfaces:**
+- Consumes: `parse_interactive_reply`, `InteractiveReplyStore.create_card`, `bind_message`, `discard`, and `append_actions_block` from Task 1.
+- Produces: an outbound Slack payload with non-empty `text`, visible content without a valid directive, and one `hermes_interactive_reply` actions block.
+
+- [ ] **Step 1: Write failing adapter and standalone-send tests**
+
+```python
+@pytest.mark.asyncio
+async def test_adapter_send_posts_buttons_without_literal_directive():
+    adapter, client = _make_adapter()
+    await adapter.send("C1", "Lead ready\n[[slack_buttons: Enroll:enroll]]")
+    posted = client.chat_postMessage.await_args.kwargs
+    assert "[[slack_buttons:" not in posted["text"]
+    assert posted["blocks"][-1]["type"] == "actions"
+    assert posted["blocks"][-1]["elements"][0]["action_id"] == "hermes_interactive_reply"
+
+def test_standalone_send_posts_the_same_action_block(monkeypatch, _standalone_send):
+    result = asyncio.run(_standalone_send(pconfig, "C123", "x\n[[slack_buttons: Go:go]]"))
+    assert result["success"] is True
+    assert fake_session.calls[0][1]["blocks"][-1]["type"] == "actions"
+```
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py tests/tools/test_send_message_slack.py -q`
+
+Expected: FAIL because neither send path interprets the directive.
+
+- [ ] **Step 3: Integrate the helper without changing ordinary messages**
+
+```python
+interactive = parse_interactive_reply(content)
+if interactive is not None:
+    visible_content = interactive.visible_content
+    formatted_visible = self.format_message(visible_content)
+    prepared = self._interactive_reply_store.create_card(chat_id, thread_ts, interactive.buttons)
+    blocks = append_actions_block(self._maybe_blocks(visible_content) or [
+        {"type": "section", "text": {"type": "mrkdwn", "text": formatted_visible}}
+    ], prepared)
+```
+
+Use `interactive.visible_content` for formatting, truncation, block rendering, and accessibility fallback. Bind the card only after `chat_postMessage` returns its timestamp; discard it after any post or retry failure. In `_standalone_send`, use the same helper and bind/discard lifecycle around the direct Web API call. Preserve ordinary text and current rich/markdown block behavior when parsing returns `None`.
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py tests/tools/test_send_message_slack.py -q`
+
+Expected: PASS; both sends produce real buttons, retain `text`, and leave malformed directives literal.
+
+- [ ] **Step 5: Commit outbound rendering**
+
+```bash
+git add plugins/platforms/slack/adapter.py tests/gateway/test_slack_interactive_replies.py tests/tools/test_send_message_slack.py
+git commit -m "feat: render Slack interactive reply buttons"
+```
+
+### Task 3: Relay only a validated click into the normal gateway path
+
+**Files:**
+- Modify: `plugins/platforms/slack/adapter.py:SlackAdapter.connect`
+- Modify: `plugins/platforms/slack/adapter.py:SlackAdapter`
+- Modify: `tests/gateway/test_slack_interactive_replies.py`
+
+**Interfaces:**
+- Consumes: `InteractiveReplyStore.consume` from Task 1.
+- Produces: `SlackAdapter._handle_interactive_reply_action(ack, body, action) -> None`.
+- Produces: a regular `MessageEvent` with `text == "Slack button action: go"` and `internal is False`.
+
+- [ ] **Step 1: Write failing callback tests**
+
+```python
+@pytest.mark.asyncio
+async def test_valid_click_relays_as_user_event_in_original_thread(adapter):
+    prepared = adapter._interactive_reply_store.create_card("C1", "T1", (InteractiveButton("Go", "go"),))
+    adapter._interactive_reply_store.bind_message(prepared.card_id, "M1")
+    await adapter._handle_interactive_reply_action(
+        AsyncMock(), _click_body(channel="C1", message_ts="M1", thread_ts="T1", user="U1"),
+        {"action_id": "hermes_interactive_reply", "value": prepared.buttons[0].token},
+    )
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "Slack button action: go"
+    assert event.source.user_id == "U1"
+    assert event.source.thread_id == "T1"
+    assert event.internal is False
+
+@pytest.mark.asyncio
+async def test_forged_or_replayed_click_never_reaches_handle_message(adapter):
+    await adapter._handle_interactive_reply_action(AsyncMock(), _click_body(), {"value": "forged"})
+    adapter.handle_message.assert_not_awaited()
+```
+
+- [ ] **Step 2: Run the focused callback tests to verify they fail**
+
+Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py -q`
+
+Expected: FAIL because no generic interactive action handler is registered or implemented.
+
+- [ ] **Step 3: Register and implement the fail-closed callback**
+
+```python
+self._app.action("hermes_interactive_reply")(self._handle_interactive_reply_action)
+
+async def _handle_interactive_reply_action(self, ack, body, action) -> None:
+    await ack()
+    accepted = self._interactive_reply_store.consume(str(action.get("value") or ""), channel_id, message_ts)
+    if accepted is None:
+        return
+    await self.handle_message(MessageEvent(
+        text=f"Slack button action: {accepted.action_id}",
+        source=source,
+        raw_message=body,
+        message_id=message_ts,
+        reply_to_message_id=thread_ts if thread_ts != message_ts else None,
+        channel_prompt=channel_prompt,
+        auto_skill=auto_skill,
+        metadata=metadata,
+    ))
+```
+
+Build `source`, prompt, skills, workspace scope, and thread metadata from the callback using the same adapter helpers used for normal messages. Update the clicked card to remove its action block after consumption; failure to update must not restore the record or emit another event. Never set `internal=True` and never resolve an action name directly from the Slack payload.
+
+- [ ] **Step 4: Run callback and regression tests to verify they pass**
+
+Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_clarify_buttons.py tests/gateway/test_slack_plugin_action_handlers.py -q`
+
+Expected: PASS; valid clicks relay once, invalid clicks fail closed, and existing controls remain wired.
+
+- [ ] **Step 5: Commit click routing**
+
+```bash
+git add plugins/platforms/slack/adapter.py tests/gateway/test_slack_interactive_replies.py
+git commit -m "feat: relay validated Slack button clicks"
+```
+
+### Task 4: Verify the completed contribution
+
+**Files:**
+- Modify: `tests/gateway/test_slack_interactive_replies.py`
+- Modify: `docs/superpowers/plans/2026-07-26-slack-interactive-replies-plan.md` by checking completed steps and recording exact verification evidence.
+
+**Interfaces:**
+- Consumes: all production code and tests from Tasks 1–3.
+- Produces: an evidence-backed, review-ready branch with no uncommitted implementation changes.
+
+- [ ] **Step 1: Add a post-failure cleanup regression**
+
+```python
+@pytest.mark.asyncio
+async def test_post_failure_discards_unbound_card(adapter, client):
+    client.chat_postMessage.side_effect = RuntimeError("slack unavailable")
+    result = await adapter.send("C1", "x\n[[slack_buttons: Go:go]]")
+    assert result.success is False
+    assert adapter._interactive_reply_store.pending_count() == 0
+```
+
+- [ ] **Step 2: Run the exact focused suites**
+
+Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py tests/gateway/test_slack_block_kit_adapter.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_clarify_buttons.py tests/gateway/test_slack_plugin_action_handlers.py tests/tools/test_send_message_slack.py -q`
+
+Expected: PASS with no test deselection caused by the new feature.
+
+- [ ] **Step 3: Run the repository suite required by the contributor guide**
+
+Run: `scripts/run_tests.sh`
+
+Expected: PASS. If an unrelated existing failure appears, capture its exact output and stop for review rather than relabeling it as a feature pass.
+
+- [ ] **Step 4: Inspect and commit verification evidence**
+
+```bash
+git diff origin/main...HEAD --check
+git status --short
+git add docs/superpowers/plans/2026-07-26-slack-interactive-replies-plan.md
+git commit -m "docs: record Slack interactive reply verification"
+```
+
+Expected: the whitespace check passes and the worktree is clean after the commit.
+
+## Plan Self-Review
+
+- Spec coverage: Task 1 implements parsing, opaque records, profile-safe storage, expiry, binding, and replay prevention. Task 2 covers both outbound paths and fallback behavior. Task 3 covers normal authenticated click routing. Task 4 covers cleanup and the required suites.
+- Placeholder scan: all implementation and test steps name concrete files, interfaces, commands, and assertions.
+- Type consistency: every later use of `InteractiveReplyStore`, `PreparedInteractiveReply`, `InteractiveButton`, and `ConsumedInteractiveAction` is defined by Task 1; every click uses `consume(button_token, channel_id, message_ts)` from that contract.

--- a/docs/superpowers/plans/2026-07-26-slack-interactive-replies-plan.md
+++ b/docs/superpowers/plans/2026-07-26-slack-interactive-replies-plan.md
@@ -249,7 +249,7 @@ git commit -m "feat: relay validated Slack button clicks"
 - Consumes: all production code and tests from Tasks 1–3.
 - Produces: an evidence-backed, review-ready branch with no uncommitted implementation changes.
 
-- [ ] **Step 1: Add a post-failure cleanup regression**
+- [x] **Step 1: Add a post-failure cleanup regression**
 
 ```python
 @pytest.mark.asyncio
@@ -265,6 +265,13 @@ async def test_post_failure_discards_unbound_card(adapter, client):
 Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py tests/gateway/test_slack_block_kit_adapter.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_clarify_buttons.py tests/gateway/test_slack_plugin_action_handlers.py tests/tools/test_send_message_slack.py -q`
 
 Expected: PASS with no test deselection caused by the new feature.
+
+Actual (2026-07-26): **BLOCKED.** The exact wrapper command discovered 6 files
+and approximately 144 tests. It reported 150 passed and 1 failed. The new
+`test_post_failure_discards_unbound_card` failed because
+`InteractiveReplyStore` has no `pending_count()` method. Task 1's declared
+store interface contains only `create_card`, `bind_message`, `discard`, and
+`consume`. The repository suite was not run after this focused gate failed.
 
 - [ ] **Step 3: Run the repository suite required by the contributor guide**
 

--- a/docs/superpowers/plans/2026-07-26-slack-interactive-replies-plan.md
+++ b/docs/superpowers/plans/2026-07-26-slack-interactive-replies-plan.md
@@ -40,7 +40,7 @@
 - Produces: `InteractiveReplyStore.bind_message(card_id: str, message_ts: str) -> bool`, `discard(card_id: str) -> None`, and `consume(button_token: str, channel_id: str, message_ts: str) -> ConsumedInteractiveAction | None`.
 - Produces: `append_actions_block(blocks: list[dict], prepared: PreparedInteractiveReply) -> list[dict]`.
 
-- [ ] **Step 1: Write the failing parser and store tests**
+- [x] **Step 1: Write the failing parser and store tests**
 
 ```python
 def test_parse_valid_directive_strips_it_and_preserves_visible_reply():
@@ -60,13 +60,13 @@ def test_consume_requires_bound_message_and_is_single_use(tmp_path, monkeypatch)
     assert store.consume(prepared.buttons[0].token, "C1", "M1") is None
 ```
 
-- [ ] **Step 2: Run the focused tests to verify they fail**
+- [x] **Step 2: Run the focused tests to verify they fail**
 
 Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py -q`
 
 Expected: FAIL because the module and its contract do not exist.
 
-- [ ] **Step 3: Write the minimal parser and store**
+- [x] **Step 3: Write the minimal parser and store**
 
 ```python
 @dataclass(frozen=True)
@@ -84,13 +84,13 @@ class InteractiveReplyStore:
 
 Use a random opaque value for each button, a card record with expected channel/thread/message and action mapping, atomic replacement for writes, and the repository's `fcntl`/`msvcrt` lock fallback. Clean expired cards while holding the lock. Reject blank labels, duplicate action IDs, invalid identifier characters, over-limit button counts, and malformed syntax by returning `None` so callers retain literal content.
 
-- [ ] **Step 4: Run the focused tests to verify they pass**
+- [x] **Step 4: Run the focused tests to verify they pass**
 
 Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py -q`
 
 Expected: PASS for parser validity, malformed literal fallback, expiry, binding, cross-channel rejection, and replay rejection.
 
-- [ ] **Step 5: Commit the isolated contract**
+- [x] **Step 5: Commit the isolated contract**
 
 ```bash
 git add plugins/platforms/slack/interactive_replies.py tests/gateway/test_slack_interactive_replies.py
@@ -109,7 +109,7 @@ git commit -m "feat: add Slack interactive reply store"
 - Consumes: `parse_interactive_reply`, `InteractiveReplyStore.create_card`, `bind_message`, `discard`, and `append_actions_block` from Task 1.
 - Produces: an outbound Slack payload with non-empty `text`, visible content without a valid directive, and one `hermes_interactive_reply` actions block.
 
-- [ ] **Step 1: Write failing adapter and standalone-send tests**
+- [x] **Step 1: Write failing adapter and standalone-send tests**
 
 ```python
 @pytest.mark.asyncio
@@ -127,13 +127,13 @@ def test_standalone_send_posts_the_same_action_block(monkeypatch, _standalone_se
     assert fake_session.calls[0][1]["blocks"][-1]["type"] == "actions"
 ```
 
-- [ ] **Step 2: Run the focused tests to verify they fail**
+- [x] **Step 2: Run the focused tests to verify they fail**
 
 Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py tests/tools/test_send_message_slack.py -q`
 
 Expected: FAIL because neither send path interprets the directive.
 
-- [ ] **Step 3: Integrate the helper without changing ordinary messages**
+- [x] **Step 3: Integrate the helper without changing ordinary messages**
 
 ```python
 interactive = parse_interactive_reply(content)
@@ -148,13 +148,13 @@ if interactive is not None:
 
 Use `interactive.visible_content` for formatting, truncation, block rendering, and accessibility fallback. Bind the card only after `chat_postMessage` returns its timestamp; discard it after any post or retry failure. In `_standalone_send`, use the same helper and bind/discard lifecycle around the direct Web API call. Preserve ordinary text and current rich/markdown block behavior when parsing returns `None`.
 
-- [ ] **Step 4: Run the focused tests to verify they pass**
+- [x] **Step 4: Run the focused tests to verify they pass**
 
 Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py tests/tools/test_send_message_slack.py -q`
 
 Expected: PASS; both sends produce real buttons, retain `text`, and leave malformed directives literal.
 
-- [ ] **Step 5: Commit outbound rendering**
+- [x] **Step 5: Commit outbound rendering**
 
 ```bash
 git add plugins/platforms/slack/adapter.py tests/gateway/test_slack_interactive_replies.py tests/tools/test_send_message_slack.py
@@ -173,7 +173,7 @@ git commit -m "feat: render Slack interactive reply buttons"
 - Produces: `SlackAdapter._handle_interactive_reply_action(ack, body, action) -> None`.
 - Produces: a regular `MessageEvent` with `text == "Slack button action: go"` and `internal is False`.
 
-- [ ] **Step 1: Write failing callback tests**
+- [x] **Step 1: Write failing callback tests**
 
 ```python
 @pytest.mark.asyncio
@@ -196,13 +196,13 @@ async def test_forged_or_replayed_click_never_reaches_handle_message(adapter):
     adapter.handle_message.assert_not_awaited()
 ```
 
-- [ ] **Step 2: Run the focused callback tests to verify they fail**
+- [x] **Step 2: Run the focused callback tests to verify they fail**
 
 Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py -q`
 
 Expected: FAIL because no generic interactive action handler is registered or implemented.
 
-- [ ] **Step 3: Register and implement the fail-closed callback**
+- [x] **Step 3: Register and implement the fail-closed callback**
 
 ```python
 self._app.action("hermes_interactive_reply")(self._handle_interactive_reply_action)
@@ -226,13 +226,13 @@ async def _handle_interactive_reply_action(self, ack, body, action) -> None:
 
 Build `source`, prompt, skills, workspace scope, and thread metadata from the callback using the same adapter helpers used for normal messages. Update the clicked card to remove its action block after consumption; failure to update must not restore the record or emit another event. Never set `internal=True` and never resolve an action name directly from the Slack payload.
 
-- [ ] **Step 4: Run callback and regression tests to verify they pass**
+- [x] **Step 4: Run callback and regression tests to verify they pass**
 
 Run: `scripts/run_tests.sh tests/gateway/test_slack_interactive_replies.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack_clarify_buttons.py tests/gateway/test_slack_plugin_action_handlers.py -q`
 
 Expected: PASS; valid clicks relay once, invalid clicks fail closed, and existing controls remain wired.
 
-- [ ] **Step 5: Commit click routing**
+- [x] **Step 5: Commit click routing**
 
 ```bash
 git add plugins/platforms/slack/adapter.py tests/gateway/test_slack_interactive_replies.py
@@ -297,6 +297,29 @@ git commit -m "docs: record Slack interactive reply verification"
 ```
 
 Expected: the whitespace check passes and the worktree is clean after the commit.
+
+### Final review outcome (2026-07-26)
+
+The initial final review was **BLOCKED** on three issues:
+
+1. The generic callback consumed its opaque one-time record before applying
+   the existing interactive-user authorization rule, so an unauthorized viewer
+   could prevent a later authorized selection.
+2. The slash interactive helper selected a client without the resolved
+   `team_id`, so an ambiguous Slack-local channel ID shared by two workspaces
+   could fall back to the primary workspace client.
+3. The post-consumption card update preserved unrelated controls but did not
+   add an immutable non-action acknowledgement naming the clicker.
+
+Commit `24ce52719` (`fix: secure Slack interactive reply completion`) remediated
+all three findings test-first. The RED gate produced 3 expected failures; the
+targeted GREEN gate passed 3/3; and a fresh affected regression run passed 118
+tests with 0 failures. The scoped re-review then **APPROVED** the remediation.
+
+The repository-wide local suite remains **NON-PASS**: 45,497 tests passed and
+596 environment/platform-dependent tests failed, as recorded in Step 3 above.
+A successful upstream GitHub CI run is still required and is pending; no CI
+pass is claimed here. No live Slack action or Sorpio action was performed.
 
 ## Plan Self-Review
 

--- a/docs/superpowers/specs/2026-07-26-slack-interactive-replies-design.md
+++ b/docs/superpowers/specs/2026-07-26-slack-interactive-replies-design.md
@@ -1,0 +1,69 @@
+# Slack Interactive Replies Design
+
+**Date:** 2026-07-26
+**Status:** approved for design; implementation pending written-spec review
+
+## Purpose
+
+Render Hermes's existing `[[slack_buttons: Label:action_id, ...]]` reply directive as real Slack Block Kit buttons and safely route a click back to the originating agent conversation. The work fixes a Slack transport boundary only. It does not add a Sorpio integration, change enrollment policy, send outreach, or grant an action click any execution privilege.
+
+## Scope
+
+The feature applies to Slack messages emitted through both supported paths:
+
+1. `SlackAdapter.send`, used for gateway replies and cron deliveries.
+2. The direct Slack branch of `send_message`, used for one-shot cross-platform sends.
+
+Other platforms retain their current text-only behavior. Malformed directives remain visible as ordinary text rather than being interpreted.
+
+## Design
+
+### Directive parsing and rendering
+
+Introduce a small pure helper that recognizes exactly one or more well-formed button directives, strips them from the visible reply text, and returns validated button specifications. A specification has a short Slack label and an action name matching a conservative identifier grammar. The renderer limits the number of buttons to Slack's actions-block limit and supplies normal text as Block Kit fallback text.
+
+When valid buttons are present, both send paths post a section block for the formatted message plus an actions block whose buttons all use one Hermes-owned Slack action ID. The action name is never trusted from the Slack callback; it remains in an internal record. When no valid directive is present, the existing send behavior is unchanged.
+
+### Opaque, short-lived action records
+
+Before posting the block, Hermes creates a cryptographically random opaque token in a profile-scoped, atomically updated action store. The record contains only the approved action names, channel, expected message timestamp, thread timestamp, expiration, and consumed state. Once Slack returns the message timestamp, Hermes binds it to that record.
+
+The record expires after a short fixed interval and is single-use. Hermes validates all of the following before accepting a click:
+
+- the token exists and has not expired or been consumed;
+- the Slack callback's channel and message timestamp match the stored record;
+- the callback's requested action is one of that card's stored actions; and
+- the record can be atomically consumed exactly once.
+
+Missing, malformed, expired, replayed, cross-channel, and cross-message callbacks fail closed. A gateway restart with an unavailable record also fails closed. The store uses `get_hermes_home()` and is therefore profile-safe.
+
+### Click routing and authorization
+
+Register a single Slack Block Kit action handler for the Hermes-owned action ID. After record validation, it creates the same kind of user-sourced, non-internal `MessageEvent` that an ordinary Slack thread message creates: the clicker's Slack identity, source channel, thread, channel prompt, and auto-skill resolution are retained. Its normalized text is `Slack button action: <action_id>`.
+
+The event enters the normal gateway message path, so existing user authorization and every agent-level policy remain in force. The handler neither calls tools nor maps an action name to a privileged operation. An agent that receives `sorpio_enroll`, for example, must still apply its own qualification, duplicate-prevention, and enabled-switch checks.
+
+On a valid click, Hermes replaces the action block with an immutable acknowledgement naming the clicker. If the message update fails, the consumed record remains consumed; a repeated click cannot create a second event.
+
+## Error handling
+
+Slack post failures remove the unbound action record. Parsing errors leave the content untouched and are logged without exposing tokens or Slack credentials. Store I/O errors prevent button creation or click acceptance rather than falling back to an unverified action. All logging is token-free and uses profile-safe paths.
+
+## Tests
+
+Tests will prove the following behavior:
+
+- parser acceptance, validation, and literal fallback for malformed directives;
+- Block Kit payload construction and directive removal for `SlackAdapter.send` and direct `send_message` delivery;
+- profile-scoped persistence, expiry, channel/message binding, and one-time consumption;
+- valid click creation of a normal user-sourced event in the original thread;
+- rejection of forged, malformed, expired, replayed, cross-channel, and cross-message clicks; and
+- no regression to existing approval and slash-confirm buttons.
+
+Tests use the repository's `scripts/run_tests.sh` wrapper. A live Slack smoke will use a harmless test action while Sorpio enrollment remains disabled; no prospect or enrollment mutation is part of this Hermes change.
+
+## Non-goals
+
+- No Sorpio-specific code, configuration, or policy in Hermes.
+- No arbitrary tool execution, direct API mutation, or approval bypass from a click.
+- No changes to Slack scopes, app manifest, AgentMail, HubSpot, Outreach Log, OpenProject, or other repositories.

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1646,6 +1646,68 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=None)
         except Exception as e:
             return SendResult(success=False, error=str(e))
+    async def _post_slash_interactive_ephemeral(
+        self,
+        chat_id: str,
+        ctx: Dict[str, Any],
+        content: str,
+    ) -> "SendResult":
+        """Post a slash reply with one usable ephemeral interactive control."""
+        user_id = ctx.get("user_id", "")
+        interactive = parse_interactive_reply(content)
+        if not user_id or interactive is None:
+            return SendResult(success=False, error="interactive slash context unavailable")
+
+        visible_content = interactive.visible_content or "Interactive reply options"
+        formatted = self.format_message(visible_content)
+        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH) or [formatted]
+        client = self._get_client(chat_id)
+        prepared = None
+        try:
+            for chunk in chunks:
+                result = await client.chat_postEphemeral(
+                    channel=chat_id,
+                    user=user_id,
+                    text=chunk,
+                )
+                if not (isinstance(result, dict) and result.get("ok")):
+                    error = result.get("error", "unknown_error") if isinstance(result, dict) else "unexpected_response"
+                    return SendResult(success=False, error=f"chat.postEphemeral failed: {error}")
+
+            prepared = self._interactive_reply_store.create_card(
+                chat_id, None, interactive.buttons
+            )
+            control_result = await client.chat_postEphemeral(
+                channel=chat_id,
+                user=user_id,
+                text="Interactive reply options",
+                blocks=append_actions_block(
+                    [
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": "Interactive reply options",
+                            },
+                        }
+                    ],
+                    prepared,
+                ),
+            )
+            if not (isinstance(control_result, dict) and control_result.get("ok")):
+                error = control_result.get("error", "unknown_error") if isinstance(control_result, dict) else "unexpected_response"
+                return SendResult(success=False, error=f"chat.postEphemeral failed: {error}")
+            message_ts = control_result.get("message_ts") or control_result.get("ts")
+            if not message_ts:
+                return SendResult(success=False, error="chat.postEphemeral returned no message timestamp")
+            self._interactive_reply_store.bind_message(prepared.card_id, message_ts)
+            prepared = None
+            return SendResult(success=True, message_id=message_ts)
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+        finally:
+            if prepared is not None:
+                self._interactive_reply_store.discard(prepared.card_id)
 
     def _warn_if_missing_group_dm_scopes(self, auth_response, team_name: str) -> None:
         """Nudge existing installs to reinstall when group-DM scopes are absent.
@@ -2472,26 +2534,21 @@ class SlackAdapter(BasePlatformAdapter):
             # the actual command reply ephemerally instead of posting publicly.
             slash_ctx = self._pop_slash_context(chat_id, team_id)
             if slash_ctx:
-                ephemeral_result = await self._send_slash_ephemeral(
-                    slash_ctx,
-                    content,
-                )
+                if parse_interactive_reply(content) is not None:
+                    ephemeral_result = await self._post_slash_interactive_ephemeral(
+                        chat_id, slash_ctx, content
+                    )
+                else:
+                    ephemeral_result = await self._send_slash_ephemeral(
+                        slash_ctx,
+                        content,
+                    )
                 if ephemeral_result.success:
-                    # Ephemeral replies do not count as thread replies, so
-                    # Slack never auto-clears the Assistant status for them.
-                    # Clear it explicitly or a command run inside an
-                    # assistant thread leaves "is thinking..." forever.
                     await self._clear_thread_status_quietly(chat_id, metadata)
                     return ephemeral_result
-                # response_url delivery failed (#19688): fall back to
-                # chat.postEphemeral — an independent API path that keeps
-                # the reply private ("Only visible to you"). We do NOT fall
-                # back to a public channel post: a slash reply the user
-                # expects to be ephemeral must never surface to the whole
-                # channel just because a delivery path failed.
                 logger.warning(
-                    "[Slack] response_url slash reply failed (%s); retrying "
-                    "via chat.postEphemeral",
+                    "[Slack] Interactive slash reply failed (%s); retrying "
+                    "with literal ephemeral content",
                     ephemeral_result.error,
                 )
                 fallback_result = await self._post_ephemeral_fallback(
@@ -2502,14 +2559,10 @@ class SlackAdapter(BasePlatformAdapter):
                 if fallback_result.success:
                     await self._clear_thread_status_quietly(chat_id, metadata)
                     return fallback_result
-                # Both ephemeral paths failed — surface the failure instead
-                # of leaking the reply publicly. The user still has the
-                # "Running /cmd…" ack; the error is logged and returned so
-                # the gateway can react (retry surfacing happens upstream).
                 logger.error(
                     "[Slack] Ephemeral slash reply failed on both "
-                    "response_url and chat.postEphemeral (%s); dropping "
-                    "rather than posting publicly",
+                    "interactive and fallback paths (%s); dropping rather "
+                    "than posting publicly",
                     fallback_result.error,
                 )
                 return fallback_result
@@ -2609,6 +2662,42 @@ class SlackAdapter(BasePlatformAdapter):
                     )
                 else:
                     self._interactive_reply_store.discard(prepared_interactive.card_id)
+                prepared_interactive = None
+
+            if interactive and len(chunks) > 1:
+                prepared_interactive = self._interactive_reply_store.create_card(
+                    chat_id, thread_ts, interactive.buttons
+                )
+                control_kwargs = {
+                    "channel": chat_id,
+                    "text": "Interactive reply options",
+                    "mrkdwn": True,
+                    "blocks": append_actions_block(
+                        [
+                            {
+                                "type": "section",
+                                "text": {
+                                    "type": "mrkdwn",
+                                    "text": "Interactive reply options",
+                                },
+                            }
+                        ],
+                        prepared_interactive,
+                    ),
+                }
+                if thread_ts:
+                    control_kwargs["thread_ts"] = thread_ts
+                last_result = await self._get_client(
+                    chat_id, team_id=team_id
+                ).chat_postMessage(**control_kwargs)
+                sent_ts = last_result.get("ts") if last_result else None
+                if sent_ts:
+                    self._interactive_reply_store.bind_message(
+                        prepared_interactive.card_id, sent_ts
+                    )
+                else:
+                    self._interactive_reply_store.discard(prepared_interactive.card_id)
+                prepared_interactive = None
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
@@ -8735,6 +8824,7 @@ async def _standalone_send(
         client = _AsyncWebClient(token=token)
         _apply_slack_proxy(client, resolve_proxy_url())
         last_message_id = None
+        media_interactive_posted = False
 
         # Caption mode: skip a separate text post; comment rides the upload.
         text_to_send = "" if formatted_caption else (formatted or "")
@@ -8744,18 +8834,46 @@ async def _standalone_send(
                 "text": text_to_send,
                 "mrkdwn": True,
             }
+            interactive_store = None
+            prepared_interactive = None
+            if interactive:
+                interactive_store = InteractiveReplyStore()
+                prepared_interactive = interactive_store.create_card(
+                    chat_id, thread_id, interactive.buttons
+                )
+                post_kwargs["blocks"] = append_actions_block(
+                    [
+                        {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": text_to_send},
+                        }
+                    ],
+                    prepared_interactive,
+                )
             if thread_id:
                 post_kwargs["thread_ts"] = thread_id
             try:
                 post_resp = await client.chat_postMessage(**post_kwargs)
                 if isinstance(post_resp, dict) and not post_resp.get("ok", True):
+                    if prepared_interactive is not None:
+                        interactive_store.discard(prepared_interactive.card_id)
                     return {
                         "error": f"Slack API error: {post_resp.get('error', 'unknown')}"
                     }
                 last_message_id = (
                     post_resp.get("ts") if isinstance(post_resp, dict) else None
                 )
+                if prepared_interactive is not None:
+                    if last_message_id:
+                        interactive_store.bind_message(
+                            prepared_interactive.card_id, last_message_id
+                        )
+                        media_interactive_posted = True
+                    else:
+                        interactive_store.discard(prepared_interactive.card_id)
             except Exception as e:
+                if prepared_interactive is not None:
+                    interactive_store.discard(prepared_interactive.card_id)
                 return {"error": f"Slack send failed: {e}"}
 
         caption_pending = bool(formatted_caption)
@@ -8805,6 +8923,55 @@ async def _standalone_send(
                 warning = f"Failed to send media {media_path}: {e}"
                 logger.error("[Slack] %s", warning, exc_info=True)
                 warnings.append(warning)
+
+        if interactive and not media_interactive_posted and uploaded_any:
+            interactive_store = InteractiveReplyStore()
+            prepared_interactive = interactive_store.create_card(
+                chat_id, thread_id, interactive.buttons
+            )
+            control_kwargs: Dict[str, Any] = {
+                "channel": chat_id,
+                "text": "Interactive reply options",
+                "mrkdwn": True,
+                "blocks": append_actions_block(
+                    [
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": "Interactive reply options",
+                            },
+                        }
+                    ],
+                    prepared_interactive,
+                ),
+            }
+            if thread_id:
+                control_kwargs["thread_ts"] = thread_id
+            try:
+                control_result = await client.chat_postMessage(**control_kwargs)
+                if not (
+                    isinstance(control_result, dict)
+                    and control_result.get("ok", True)
+                ):
+                    error = (
+                        control_result.get("error", "unknown")
+                        if isinstance(control_result, dict)
+                        else "unexpected_response"
+                    )
+                    return {"error": f"Slack API error: {error}"}
+                control_ts = control_result.get("ts")
+                if not control_ts:
+                    return {"error": "Slack interactive control returned no timestamp"}
+                interactive_store.bind_message(prepared_interactive.card_id, control_ts)
+                last_message_id = control_ts
+                media_interactive_posted = True
+                prepared_interactive = None
+            except Exception as e:
+                return {"error": f"Slack send failed: {e}"}
+            finally:
+                if prepared_interactive is not None:
+                    interactive_store.discard(prepared_interactive.card_id)
 
         if last_message_id is None and not uploaded_any and not text_to_send.strip():
             error = "No deliverable text or media remained after processing"

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1651,6 +1651,7 @@ class SlackAdapter(BasePlatformAdapter):
         chat_id: str,
         ctx: Dict[str, Any],
         content: str,
+        team_id: str = "",
     ) -> "SendResult":
         """Post a slash reply with one usable ephemeral interactive control."""
         user_id = ctx.get("user_id", "")
@@ -1661,7 +1662,7 @@ class SlackAdapter(BasePlatformAdapter):
         visible_content = interactive.visible_content or "Interactive reply options"
         formatted = self.format_message(visible_content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH) or [formatted]
-        client = self._get_client(chat_id)
+        client = self._get_client(chat_id, team_id=team_id or None)
         prepared = None
         try:
             for chunk in chunks:
@@ -2539,7 +2540,7 @@ class SlackAdapter(BasePlatformAdapter):
             if slash_ctx:
                 if parse_interactive_reply(content) is not None:
                     ephemeral_result = await self._post_slash_interactive_ephemeral(
-                        chat_id, slash_ctx, content
+                        chat_id, slash_ctx, content, team_id=team_id
                     )
                 else:
                     ephemeral_result = await self._send_slash_ephemeral(
@@ -7092,6 +7093,18 @@ class SlackAdapter(BasePlatformAdapter):
             and channel_id not in allowed_channels
         ):
             return
+        if not self._is_interactive_user_authorized(
+            user_id,
+            channel_id=channel_id,
+            user_name=user.get("name"),
+            team_id=team_id,
+        ):
+            logger.warning(
+                "[Slack] Unauthorized interactive reply click by %s (%s) - ignoring",
+                user.get("name") or "unknown",
+                user_id,
+            )
+            return
 
         accepted = self._interactive_reply_store.consume(
             button_token, channel_id, message_ts
@@ -7165,6 +7178,17 @@ class SlackAdapter(BasePlatformAdapter):
                 updated_blocks.append(block)
             elif remaining_elements:
                 updated_blocks.append({**block, "elements": remaining_elements})
+        updated_blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"Selected by <@{user_id}>",
+                    }
+                ],
+            }
+        )
         try:
             await self._get_client(
                 channel_id, team_id=team_id or None

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2690,13 +2690,15 @@ class SlackAdapter(BasePlatformAdapter):
                 last_result = await self._get_client(
                     chat_id, team_id=team_id
                 ).chat_postMessage(**control_kwargs)
+                if isinstance(last_result, dict) and not last_result.get("ok", True):
+                    error = last_result.get("error", "unknown")
+                    raise RuntimeError(f"Slack interactive control failed: {error}")
                 sent_ts = last_result.get("ts") if last_result else None
-                if sent_ts:
-                    self._interactive_reply_store.bind_message(
-                        prepared_interactive.card_id, sent_ts
-                    )
-                else:
-                    self._interactive_reply_store.discard(prepared_interactive.card_id)
+                if not sent_ts:
+                    raise RuntimeError("Slack interactive control returned no timestamp")
+                self._interactive_reply_store.bind_message(
+                    prepared_interactive.card_id, sent_ts
+                )
                 prepared_interactive = None
 
             # Clear Slack Assistant status as soon as the final message is posted.
@@ -8886,9 +8888,12 @@ async def _standalone_send(
                 if caption_pending:
                     # Keep caption deliverable even when the file is missing.
                     try:
+                        fallback_text = formatted_caption
+                        if interactive:
+                            fallback_text = f"{formatted_caption}\n{message}"
                         fallback_kwargs: Dict[str, Any] = {
                             "channel": chat_id,
-                            "text": formatted_caption,
+                            "text": fallback_text,
                             "mrkdwn": True,
                         }
                         if thread_id:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4039,18 +4039,45 @@ class SlackAdapter(BasePlatformAdapter):
                 exc,
             )
             return None
-        if not isinstance(response, dict) or not response.get("ok"):
+        response_get = getattr(response, "get", None)
+        if not callable(response_get):
             logger.warning(
                 "[Slack] Could not classify interactive callback channel %s",
                 channel_id,
             )
             return None
-        channel = response.get("channel") or {}
-        if not isinstance(channel, dict):
+        try:
+            ok = response_get("ok")
+            channel = response_get("channel")
+        except Exception:
+            logger.warning(
+                "[Slack] Could not read interactive callback channel %s",
+                channel_id,
+                exc_info=True,
+            )
             return None
-        if channel.get("is_im"):
+        if ok is not True:
+            logger.warning(
+                "[Slack] Could not classify interactive callback channel %s",
+                channel_id,
+            )
+            return None
+        channel_get = getattr(channel, "get", None)
+        if not callable(channel_get):
+            return None
+        missing = object()
+        try:
+            is_im = channel_get("is_im", missing)
+            is_mpim = channel_get("is_mpim", missing)
+        except Exception:
+            return None
+        if not isinstance(is_im, bool) or not isinstance(is_mpim, bool):
+            return None
+        if is_im and is_mpim:
+            return None
+        if is_im:
             return "im"
-        if channel.get("is_mpim"):
+        if is_mpim:
             return "mpim"
         return "channel"
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4014,6 +4014,46 @@ class SlackAdapter(BasePlatformAdapter):
         )
         return name
 
+    async def _resolve_interactive_channel_type(
+        self, channel_id: str, team_id: str = ""
+    ) -> Optional[str]:
+        """Resolve callback channel type before consuming a one-time card.
+
+        Slack message events carry ``channel_type`` directly, but Block Kit
+        callback payloads do not reliably include it.  A 1:1 IM can be
+        identified by its stable ``D`` prefix; other conversations require
+        ``conversations.info`` so ``G``-prefixed MPIMs are not mistaken for
+        ordinary group channels.  Failure returns ``None`` so callers can
+        reject without consuming rather than bypass DM/channel policy.
+        """
+        if channel_id.startswith("D"):
+            return "im"
+        try:
+            response = await self._get_client(
+                channel_id, team_id=team_id or None
+            ).conversations_info(channel=channel_id)
+        except Exception as exc:
+            logger.warning(
+                "[Slack] Failed to classify interactive callback channel %s: %s",
+                channel_id,
+                exc,
+            )
+            return None
+        if not isinstance(response, dict) or not response.get("ok"):
+            logger.warning(
+                "[Slack] Could not classify interactive callback channel %s",
+                channel_id,
+            )
+            return None
+        channel = response.get("channel") or {}
+        if not isinstance(channel, dict):
+            return None
+        if channel.get("is_im"):
+            return "im"
+        if channel.get("is_mpim"):
+            return "mpim"
+        return "channel"
+
     async def _humanize_user_mentions(
         self, text: str, chat_id: str = "", team_id: str = ""
     ) -> str:
@@ -6993,11 +7033,37 @@ class SlackAdapter(BasePlatformAdapter):
         if not all(isinstance(value, dict) for value in (message, channel, user)):
             return
 
-        channel_id = str(channel.get("id") or "")
-        message_ts = str(message.get("ts") or "")
-        user_id = str(user.get("id") or "")
-        button_token = str(action.get("value") or "")
-        if not channel_id or not message_ts or not user_id or not button_token:
+        channel_id = channel.get("id")
+        message_ts = message.get("ts")
+        user_id = user.get("id")
+        button_token = action.get("value")
+        required_fields = (channel_id, message_ts, user_id, button_token)
+        if any(
+            not isinstance(value, str) or not value.strip()
+            for value in required_fields
+        ):
+            return
+
+        if self._is_ignored_channel(channel_id):
+            return
+
+        team_id = self._event_team_id({}, body)
+        if not team_id:
+            team_id = self._channel_team.get(channel_id, "")
+        channel_type = await self._resolve_interactive_channel_type(
+            channel_id, team_id=team_id
+        )
+        if channel_type is None:
+            return
+        is_dm = channel_type in {"im", "mpim"}
+        if is_dm and self._slack_disable_dms():
+            return
+        allowed_channels = self._slack_allowed_channels()
+        if (
+            channel_type != "im"
+            and allowed_channels
+            and channel_id not in allowed_channels
+        ):
             return
 
         accepted = self._interactive_reply_store.consume(
@@ -7006,9 +7072,6 @@ class SlackAdapter(BasePlatformAdapter):
         if accepted is None:
             return
 
-        team_id = self._event_team_id({}, body)
-        if not team_id:
-            team_id = self._channel_team.get(channel_id, "")
         if team_id:
             self._remember_channel_team(channel_id, team_id)
 
@@ -7022,7 +7085,7 @@ class SlackAdapter(BasePlatformAdapter):
         source = self.build_source(
             chat_id=channel_id,
             chat_name=channel_name,
-            chat_type="dm" if channel_id.startswith("D") else "group",
+            chat_type="dm" if is_dm else "group",
             user_id=user_id,
             user_name=user_name,
             thread_id=thread_ts,
@@ -7052,19 +7115,29 @@ class SlackAdapter(BasePlatformAdapter):
         # card's action block is only a presentation update: a Slack API
         # failure must neither restore the record nor suppress the user turn.
         original_blocks = message.get("blocks") or []
-        updated_blocks = [
-            block
-            for block in original_blocks
-            if not (
-                isinstance(block, dict)
-                and block.get("type") == "actions"
-                and any(
+        if not isinstance(original_blocks, list):
+            original_blocks = []
+        updated_blocks = []
+        for block in original_blocks:
+            if not isinstance(block, dict) or block.get("type") != "actions":
+                updated_blocks.append(block)
+                continue
+            elements = block.get("elements")
+            if not isinstance(elements, list):
+                updated_blocks.append(block)
+                continue
+            remaining_elements = [
+                element
+                for element in elements
+                if not (
                     isinstance(element, dict)
                     and element.get("action_id") == "hermes_interactive_reply"
-                    for element in (block.get("elements") or [])
                 )
-            )
-        ]
+            ]
+            if len(remaining_elements) == len(elements):
+                updated_blocks.append(block)
+            elif remaining_elements:
+                updated_blocks.append({**block, "elements": remaining_elements})
         try:
             await self._get_client(
                 channel_id, team_id=team_id or None

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2158,6 +2158,9 @@ class SlackAdapter(BasePlatformAdapter):
                 self._app.action(_action_id)(self._handle_slash_confirm_action)
 
             self._app.action("hermes_feedback")(self._handle_feedback_action)
+            self._app.action("hermes_interactive_reply")(
+                self._handle_interactive_reply_action
+            )
 
             # Register Block Kit action handlers for clarify buttons
             # (interactive multiple-choice prompts; see tools/clarify_gateway.py).
@@ -6973,6 +6976,128 @@ class SlackAdapter(BasePlatformAdapter):
             user_id,
             channel_id,
             message.get("ts", ""),
+        )
+
+    async def _handle_interactive_reply_action(self, ack, body, action) -> None:
+        """Relay one validated generic reply click through normal message handling."""
+        await ack()
+
+        if not isinstance(body, dict) or not isinstance(action, dict):
+            return
+        if action.get("action_id") != "hermes_interactive_reply":
+            return
+
+        message = body.get("message") or {}
+        channel = body.get("channel") or {}
+        user = body.get("user") or {}
+        if not all(isinstance(value, dict) for value in (message, channel, user)):
+            return
+
+        channel_id = str(channel.get("id") or "")
+        message_ts = str(message.get("ts") or "")
+        user_id = str(user.get("id") or "")
+        button_token = str(action.get("value") or "")
+        if not channel_id or not message_ts or not user_id or not button_token:
+            return
+
+        accepted = self._interactive_reply_store.consume(
+            button_token, channel_id, message_ts
+        )
+        if accepted is None:
+            return
+
+        team_id = self._event_team_id({}, body)
+        if not team_id:
+            team_id = self._channel_team.get(channel_id, "")
+        if team_id:
+            self._remember_channel_team(channel_id, team_id)
+
+        user_name = await self._resolve_user_name(
+            user_id, chat_id=channel_id, team_id=team_id
+        )
+        channel_name = await self._resolve_channel_name(
+            channel_id, team_id=team_id
+        )
+        thread_ts = accepted.thread_ts
+        source = self.build_source(
+            chat_id=channel_id,
+            chat_name=channel_name,
+            chat_type="dm" if channel_id.startswith("D") else "group",
+            user_id=user_id,
+            user_name=user_name,
+            thread_id=thread_ts,
+            scope_id=str(team_id) if team_id else None,
+        )
+
+        from gateway.platforms.base import (
+            resolve_channel_prompt,
+            resolve_channel_skills,
+        )
+
+        channel_prompt = resolve_channel_prompt(
+            self.config.extra, channel_id, None
+        )
+        identity_prompt = self._build_identity_prompt(team_id)
+        if identity_prompt:
+            channel_prompt = (
+                f"{identity_prompt}\n\n{channel_prompt}".strip()
+                if channel_prompt
+                else identity_prompt
+            )
+        auto_skill = resolve_channel_skills(
+            self.config.extra, channel_id, None
+        )
+
+        # Consumption is already durable and one-time. Removing the clicked
+        # card's action block is only a presentation update: a Slack API
+        # failure must neither restore the record nor suppress the user turn.
+        original_blocks = message.get("blocks") or []
+        updated_blocks = [
+            block
+            for block in original_blocks
+            if not (
+                isinstance(block, dict)
+                and block.get("type") == "actions"
+                and any(
+                    isinstance(element, dict)
+                    and element.get("action_id") == "hermes_interactive_reply"
+                    for element in (block.get("elements") or [])
+                )
+            )
+        ]
+        try:
+            await self._get_client(
+                channel_id, team_id=team_id or None
+            ).chat_update(
+                channel=channel_id,
+                ts=message_ts,
+                text=str(message.get("text") or "Interactive reply selected"),
+                blocks=sanitize_blocks(updated_blocks),
+            )
+        except Exception as exc:
+            logger.warning(
+                "[Slack] Failed to update consumed interactive reply card: %s",
+                exc,
+            )
+
+        await self.handle_message(
+            MessageEvent(
+                text=f"Slack button action: {accepted.action_id}",
+                source=source,
+                raw_message=body,
+                message_id=message_ts,
+                reply_to_message_id=(
+                    thread_ts if thread_ts != message_ts else None
+                ),
+                channel_prompt=channel_prompt,
+                auto_skill=auto_skill,
+                internal=False,
+                metadata={
+                    "slack_team_id": team_id,
+                    "slack_channel_id": channel_id,
+                    "slack_thread_ts": thread_ts,
+                },
+            )
         )
 
     async def _handle_approval_action(self, ack, body, action) -> None:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -64,6 +64,11 @@ try:  # sibling module; support both package and flat plugin-dir import
 except ImportError:  # pragma: no cover - plugin loaded outside package context
     from block_kit import render_blocks, sanitize_blocks  # type: ignore
 
+try:  # sibling module; support both package and flat plugin-dir import
+    from .interactive_replies import InteractiveReplyStore, append_actions_block, parse_interactive_reply
+except ImportError:  # pragma: no cover - plugin loaded outside package context
+    from interactive_replies import InteractiveReplyStore, append_actions_block, parse_interactive_reply  # type: ignore
+
 
 logger = logging.getLogger(__name__)
 
@@ -1016,6 +1021,7 @@ class SlackAdapter(BasePlatformAdapter):
         # cross-user collisions. The two-part form remains readable only for
         # commands that arrived without a workspace id.
         # Each value: {"response_url": str, "ts": float}
+        self._interactive_reply_store = InteractiveReplyStore()
         self._slash_command_contexts: Dict[Tuple[str, ...], Dict[str, Any]] = {}
         # Socket Mode resilience: track runtime connection state so we can
         # self-heal when Slack silently drops the websocket.
@@ -2508,8 +2514,14 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 return fallback_result
 
-            # Convert standard markdown → Slack mrkdwn
-            formatted = self.format_message(content)
+            interactive = parse_interactive_reply(content)
+            visible_content = interactive.visible_content if interactive else content
+            if interactive and (not visible_content or not visible_content.strip()):
+                visible_content = "Interactive reply options"
+
+            # Convert standard markdown → Slack mrkdwn. Directives are control
+            # syntax, so valid ones are never included in visible Slack text.
+            formatted = self.format_message(visible_content)
 
             # Guard against empty/whitespace-only messages — Slack API
             # returns ``no_text`` for chat.postMessage with blank text.
@@ -2536,7 +2548,22 @@ class SlackAdapter(BasePlatformAdapter):
             # that had to be split is pathological for Block Kit's 50-block /
             # 3000-char limits, so those fall back to plain text. The ``text``
             # field is always kept as the notification/accessibility fallback.
-            blocks = self._maybe_blocks(content) if len(chunks) == 1 else None
+            prepared_interactive = None
+            blocks = self._maybe_blocks(visible_content) if len(chunks) == 1 else None
+            if interactive and len(chunks) == 1:
+                prepared_interactive = self._interactive_reply_store.create_card(
+                    chat_id, thread_ts, interactive.buttons
+                )
+                blocks = append_actions_block(
+                    blocks
+                    or [
+                        {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": formatted},
+                        }
+                    ],
+                    prepared_interactive,
+                )
 
             for i, chunk in enumerate(chunks):
                 kwargs = {
@@ -2567,8 +2594,21 @@ class SlackAdapter(BasePlatformAdapter):
                         last_result = await self._get_client(
                             chat_id, team_id=team_id
                         ).chat_postMessage(**retry_kwargs)
+                        if "prepared_interactive" in locals() and prepared_interactive is not None:
+                            self._interactive_reply_store.discard(
+                                prepared_interactive.card_id
+                            )
+                            prepared_interactive = None
                     else:
                         raise
+            if prepared_interactive is not None:
+                sent_ts = last_result.get("ts") if last_result else None
+                if sent_ts:
+                    self._interactive_reply_store.bind_message(
+                        prepared_interactive.card_id, sent_ts
+                    )
+                else:
+                    self._interactive_reply_store.discard(prepared_interactive.card_id)
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
@@ -2595,6 +2635,8 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
         except Exception as e:  # pragma: no cover - defensive logging
+            if "prepared_interactive" in locals() and prepared_interactive is not None:
+                self._interactive_reply_store.discard(prepared_interactive.card_id)
             # Clear the assistant status even when the failure happened
             # BEFORE thread_ts was resolved (formatting, slash-context, DM
             # resolution): stop_typing falls back to metadata / the uniquely
@@ -8668,7 +8710,11 @@ async def _standalone_send(
             )
             return text
 
-    formatted = _format_mrkdwn(message) if message else message
+    interactive = parse_interactive_reply(message) if message else None
+    visible_message = interactive.visible_content if interactive else message
+    if interactive and (not visible_message or not visible_message.strip()):
+        visible_message = "Interactive reply options"
+    formatted = _format_mrkdwn(visible_message) if visible_message else visible_message
     formatted_caption = _format_mrkdwn(caption) if caption else caption
 
     # --- Media path: AsyncWebClient.files_upload_v2 (+ optional text) ---
@@ -8810,7 +8856,23 @@ async def _standalone_send(
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30), **_sess_kw
         ) as session:
+            interactive_store = None
+            prepared_interactive = None
             payload = {"channel": chat_id, "text": formatted, "mrkdwn": True}
+            if interactive:
+                interactive_store = InteractiveReplyStore()
+                prepared_interactive = interactive_store.create_card(
+                    chat_id, thread_id, interactive.buttons
+                )
+                payload["blocks"] = append_actions_block(
+                    [
+                        {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": formatted},
+                        }
+                    ],
+                    prepared_interactive,
+                )
             if thread_id:
                 payload["thread_ts"] = thread_id
             for tok in tokens:
@@ -8823,17 +8885,29 @@ async def _standalone_send(
                 ) as resp:
                     data = await resp.json()
                 if data.get("ok"):
+                    message_ts = data.get("ts")
+                    if prepared_interactive is not None:
+                        if message_ts:
+                            interactive_store.bind_message(
+                                prepared_interactive.card_id, message_ts
+                            )
+                        else:
+                            interactive_store.discard(prepared_interactive.card_id)
                     return {
                         "success": True,
                         "platform": "slack",
                         "chat_id": chat_id,
-                        "message_id": data.get("ts"),
+                        "message_id": message_ts,
                     }
                 last_error = data.get("error", "unknown")
                 if last_error not in retryable_token_errors:
                     break
+        if prepared_interactive is not None:
+            interactive_store.discard(prepared_interactive.card_id)
         return {"error": f"Slack API error: {last_error}"}
     except Exception as e:
+        if "prepared_interactive" in locals() and prepared_interactive is not None:
+            interactive_store.discard(prepared_interactive.card_id)
         return {"error": f"Slack send failed: {e}"}
 
 

--- a/plugins/platforms/slack/interactive_replies.py
+++ b/plugins/platforms/slack/interactive_replies.py
@@ -1,0 +1,295 @@
+"""Parse and persist one-use Slack interactive reply buttons."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import tempfile
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
+
+from hermes_constants import get_hermes_home
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows fallback
+    fcntl = None
+    try:
+        import msvcrt
+    except ImportError:  # pragma: no cover - unusual platform
+        msvcrt = None
+else:
+    msvcrt = None
+
+
+_MAX_BUTTONS = 25
+_MAX_LABEL_LENGTH = 75
+_MAX_ACTION_ID_LENGTH = 255
+_ACTION_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_DIRECTIVE_RE = re.compile(
+    r"(?:^|\n)\[\[slack_buttons:\s*(?P<buttons>[^\]\n]+)\]\]\s*$"
+)
+
+
+@dataclass(frozen=True)
+class InteractiveButton:
+    label: str
+    action_id: str
+
+
+@dataclass(frozen=True)
+class InteractiveReply:
+    visible_content: str
+    buttons: tuple[InteractiveButton, ...]
+
+
+@dataclass(frozen=True)
+class PreparedInteractiveButton:
+    label: str
+    action_id: str
+    token: str
+
+
+@dataclass(frozen=True)
+class PreparedInteractiveReply:
+    card_id: str
+    buttons: tuple[PreparedInteractiveButton, ...]
+
+
+@dataclass(frozen=True)
+class ConsumedInteractiveAction:
+    card_id: str
+    action_id: str
+    channel_id: str
+    thread_ts: str | None
+    message_ts: str
+
+
+def _validate_buttons(buttons: tuple[InteractiveButton, ...]) -> bool:
+    if not buttons or len(buttons) > _MAX_BUTTONS:
+        return False
+    action_ids: set[str] = set()
+    for button in buttons:
+        label = button.label.strip()
+        action_id = button.action_id.strip()
+        if not label or len(label) > _MAX_LABEL_LENGTH:
+            return False
+        if (
+            not action_id
+            or len(action_id) > _MAX_ACTION_ID_LENGTH
+            or not _ACTION_ID_RE.fullmatch(action_id)
+            or action_id in action_ids
+        ):
+            return False
+        action_ids.add(action_id)
+    return True
+
+
+def parse_interactive_reply(content: str) -> InteractiveReply | None:
+    """Return a validated reply only when the whole directive is well-formed.
+
+    Invalid directives deliberately return ``None`` so callers can send the
+    original content literally instead of accidentally dropping agent output.
+    """
+    match = _DIRECTIVE_RE.search(content)
+    if not match:
+        return None
+
+    buttons: list[InteractiveButton] = []
+    for item in match.group("buttons").split(","):
+        if ":" not in item:
+            return None
+        label, action_id = item.rsplit(":", 1)
+        buttons.append(InteractiveButton(label.strip(), action_id.strip()))
+
+    parsed_buttons = tuple(buttons)
+    if not _validate_buttons(parsed_buttons):
+        return None
+    return InteractiveReply(content[: match.start()].rstrip(), parsed_buttons)
+
+
+@contextmanager
+def _file_lock(lock_path: Path) -> Iterator[None]:
+    """Serialize state changes with fcntl on Unix and msvcrt on Windows."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    if fcntl is None and msvcrt is None:
+        yield
+        return
+
+    if msvcrt and (not lock_path.exists() or lock_path.stat().st_size == 0):
+        lock_path.write_text(" ", encoding="utf-8")
+    lock_file = lock_path.open("r+" if msvcrt else "a+", encoding="utf-8")
+    try:
+        if fcntl:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        else:
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+        yield
+    finally:
+        if fcntl:
+            try:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+        elif msvcrt:
+            try:
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+        lock_file.close()
+
+
+class InteractiveReplyStore:
+    """Profile-scoped, file-backed store for unbound and one-use Slack cards."""
+
+    def __init__(self, ttl_seconds: float = 15 * 60) -> None:
+        self._ttl_seconds = ttl_seconds
+        self._state_path = get_hermes_home() / "slack_interactive_replies.json"
+        self._lock_path = self._state_path.with_suffix(".json.lock")
+
+    def _read_state(self) -> dict[str, Any]:
+        try:
+            state = json.loads(self._state_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            return {"cards": {}}
+        cards = state.get("cards") if isinstance(state, dict) else None
+        return {"cards": cards} if isinstance(cards, dict) else {"cards": {}}
+
+    def _write_state(self, state: dict[str, Any]) -> None:
+        self._state_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temporary_path = tempfile.mkstemp(
+            dir=self._state_path.parent,
+            prefix=f".{self._state_path.name}.",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as temporary_file:
+                json.dump(state, temporary_file, separators=(",", ":"), sort_keys=True)
+                temporary_file.flush()
+                os.fsync(temporary_file.fileno())
+            os.replace(temporary_path, self._state_path)
+        finally:
+            try:
+                os.unlink(temporary_path)
+            except FileNotFoundError:
+                pass
+
+    @staticmethod
+    def _clean_expired(state: dict[str, Any], now: float) -> bool:
+        cards = state["cards"]
+        expired = [
+            card_id
+            for card_id, card in cards.items()
+            if not isinstance(card, dict) or float(card.get("expires_at", 0)) <= now
+        ]
+        for card_id in expired:
+            del cards[card_id]
+        return bool(expired)
+
+    def create_card(
+        self,
+        channel_id: str,
+        thread_ts: str | None,
+        buttons: tuple[InteractiveButton, ...],
+    ) -> PreparedInteractiveReply:
+        if not _validate_buttons(buttons):
+            raise ValueError("interactive reply buttons must be valid and unique")
+        if not channel_id:
+            raise ValueError("channel_id must not be blank")
+
+        prepared_buttons = tuple(
+            PreparedInteractiveButton(button.label.strip(), button.action_id.strip(), secrets.token_urlsafe(24))
+            for button in buttons
+        )
+        with _file_lock(self._lock_path):
+            state = self._read_state()
+            self._clean_expired(state, time.time())
+            card_id = secrets.token_urlsafe(24)
+            while card_id in state["cards"]:
+                card_id = secrets.token_urlsafe(24)
+            state["cards"][card_id] = {
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+                "message_ts": None,
+                "expires_at": time.time() + self._ttl_seconds,
+                "buttons": [
+                    {"label": button.label, "action_id": button.action_id, "token": button.token}
+                    for button in prepared_buttons
+                ],
+            }
+            self._write_state(state)
+        return PreparedInteractiveReply(card_id, prepared_buttons)
+
+    def bind_message(self, card_id: str, message_ts: str) -> bool:
+        if not message_ts:
+            return False
+        with _file_lock(self._lock_path):
+            state = self._read_state()
+            self._clean_expired(state, time.time())
+            card = state["cards"].get(card_id)
+            if not isinstance(card, dict) or card.get("message_ts") is not None:
+                self._write_state(state)
+                return False
+            card["message_ts"] = message_ts
+            self._write_state(state)
+            return True
+
+    def discard(self, card_id: str) -> None:
+        with _file_lock(self._lock_path):
+            state = self._read_state()
+            self._clean_expired(state, time.time())
+            state["cards"].pop(card_id, None)
+            self._write_state(state)
+
+    def consume(
+        self, button_token: str, channel_id: str, message_ts: str
+    ) -> ConsumedInteractiveAction | None:
+        """Atomically validate and consume one bound token, else return ``None``."""
+        with _file_lock(self._lock_path):
+            state = self._read_state()
+            self._clean_expired(state, time.time())
+            for card_id, card in state["cards"].items():
+                if not isinstance(card, dict):
+                    continue
+                if card.get("channel_id") != channel_id or card.get("message_ts") != message_ts:
+                    continue
+                for button in card.get("buttons", []):
+                    if isinstance(button, dict) and button.get("token") == button_token:
+                        action = ConsumedInteractiveAction(
+                            card_id=card_id,
+                            action_id=str(button["action_id"]),
+                            channel_id=channel_id,
+                            thread_ts=card.get("thread_ts"),
+                            message_ts=message_ts,
+                        )
+                        del state["cards"][card_id]
+                        self._write_state(state)
+                        return action
+            self._write_state(state)
+            return None
+
+
+def append_actions_block(
+    blocks: list[dict[str, Any]], prepared: PreparedInteractiveReply
+) -> list[dict[str, Any]]:
+    """Return a copy of *blocks* with the prepared Slack actions block appended."""
+    actions = {
+        "type": "actions",
+        "elements": [
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "text": button.label, "emoji": True},
+                "action_id": button.action_id,
+                "value": button.token,
+            }
+            for button in prepared.buttons
+        ],
+    }
+    return [*blocks, actions]

--- a/plugins/platforms/slack/interactive_replies.py
+++ b/plugins/platforms/slack/interactive_replies.py
@@ -259,6 +259,13 @@ class InteractiveReplyStore:
             state["cards"].pop(card_id, None)
             self._write_state(state)
 
+    def pending_count(self) -> int:
+        """Return the number of unexpired cards without modifying stored state."""
+        with _file_lock(self._lock_path):
+            state = self._read_state()
+            self._clean_expired(state, time.time())
+            return len(state["cards"])
+
     def consume(
         self, button_token: str, channel_id: str, message_ts: str
     ) -> ConsumedInteractiveAction | None:

--- a/plugins/platforms/slack/interactive_replies.py
+++ b/plugins/platforms/slack/interactive_replies.py
@@ -96,21 +96,32 @@ def parse_interactive_reply(content: str) -> InteractiveReply | None:
     Invalid directives deliberately return ``None`` so callers can send the
     original content literally instead of accidentally dropping agent output.
     """
-    match = _DIRECTIVE_RE.search(content)
-    if not match:
-        return None
+    remaining = content
+    directives: list[tuple[InteractiveButton, ...]] = []
+    while match := _DIRECTIVE_RE.search(remaining):
+        buttons: list[InteractiveButton] = []
+        for item in match.group("buttons").split(","):
+            if ":" not in item:
+                break
+            label, action_id = item.rsplit(":", 1)
+            buttons.append(InteractiveButton(label.strip(), action_id.strip()))
+        else:
+            parsed_buttons = tuple(buttons)
+            if _validate_buttons(parsed_buttons):
+                directives.insert(0, parsed_buttons)
+                remaining = remaining[: match.start()].rstrip()
+                continue
 
-    buttons: list[InteractiveButton] = []
-    for item in match.group("buttons").split(","):
-        if ":" not in item:
+        if not directives:
             return None
-        label, action_id = item.rsplit(":", 1)
-        buttons.append(InteractiveButton(label.strip(), action_id.strip()))
+        break
 
-    parsed_buttons = tuple(buttons)
-    if not _validate_buttons(parsed_buttons):
+    if not directives:
         return None
-    return InteractiveReply(content[: match.start()].rstrip(), parsed_buttons)
+    all_buttons = tuple(button for directive in directives for button in directive)
+    if not _validate_buttons(all_buttons):
+        return None
+    return InteractiveReply(remaining, all_buttons)
 
 
 @contextmanager
@@ -286,7 +297,7 @@ def append_actions_block(
             {
                 "type": "button",
                 "text": {"type": "plain_text", "text": button.label, "emoji": True},
-                "action_id": button.action_id,
+                "action_id": "hermes_interactive_reply",
                 "value": button.token,
             }
             for button in prepared.buttons

--- a/tests/gateway/test_slack_interactive_replies.py
+++ b/tests/gateway/test_slack_interactive_replies.py
@@ -19,9 +19,57 @@ def _make_adapter():
     adapter._app = MagicMock()
     client = AsyncMock()
     client.chat_postMessage = AsyncMock(return_value={"ts": "111.222"})
+    client.chat_update = AsyncMock(return_value={"ok": True})
+    client.users_info = AsyncMock(
+        return_value={
+            "ok": True,
+            "user": {
+                "id": "U1",
+                "name": "alice",
+                "profile": {"display_name": "Alice"},
+            },
+        }
+    )
+    client.conversations_info = AsyncMock(
+        return_value={"ok": True, "channel": {"id": "C1", "name": "leads"}}
+    )
     adapter._get_client = MagicMock(return_value=client)
     adapter.stop_typing = AsyncMock()
     return adapter, client
+
+
+def _click_body(
+    *,
+    channel: str = "C1",
+    message_ts: str = "M1",
+    thread_ts: str | None = "T1",
+    user: str = "U1",
+) -> dict:
+    message = {
+        "ts": message_ts,
+        "text": "Lead ready",
+        "blocks": [
+            {"type": "section", "text": {"type": "mrkdwn", "text": "Lead ready"}},
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "action_id": "hermes_interactive_reply",
+                        "value": "opaque",
+                    }
+                ],
+            },
+        ],
+    }
+    if thread_ts is not None:
+        message["thread_ts"] = thread_ts
+    return {
+        "team": {"id": "W1"},
+        "channel": {"id": channel, "name": "leads"},
+        "user": {"id": user, "name": "alice"},
+        "message": message,
+    }
 
 
 def test_parse_valid_directive_strips_it_and_preserves_visible_reply():
@@ -210,3 +258,135 @@ async def test_adapter_slash_and_long_controls_are_single_and_opaque(tmp_path, m
     for actions in (slash_actions, long_actions):
         assert len(actions) == 1
         assert actions[0]["elements"][0]["value"] != "enroll"
+
+
+@pytest.mark.asyncio
+async def test_valid_click_relays_as_user_event_in_original_thread(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+    adapter.config.extra.update(
+        {
+            "channel_prompts": {"C1": "Treat this channel as lead operations."},
+            "channel_skill_bindings": [{"id": "C1", "skills": ["lead-ops"]}],
+        }
+    )
+    adapter._build_identity_prompt = MagicMock(return_value="Slack identity")
+    adapter.handle_message = AsyncMock()
+    prepared = adapter._interactive_reply_store.create_card(
+        "C1", "T1", (InteractiveButton("Go", "go"),)
+    )
+    assert adapter._interactive_reply_store.bind_message(prepared.card_id, "M1")
+    body = _click_body()
+    ack = AsyncMock()
+
+    await adapter._handle_interactive_reply_action(
+        ack,
+        body,
+        {
+            "action_id": "hermes_interactive_reply",
+            "value": prepared.buttons[0].token,
+        },
+    )
+
+    ack.assert_awaited_once_with()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "Slack button action: go"
+    assert event.source.chat_id == "C1"
+    assert event.source.chat_name == "leads"
+    assert event.source.chat_type == "group"
+    assert event.source.user_id == "U1"
+    assert event.source.user_name == "Alice"
+    assert event.source.thread_id == "T1"
+    assert event.source.scope_id == "W1"
+    assert event.message_id == "M1"
+    assert event.reply_to_message_id == "T1"
+    assert event.channel_prompt == (
+        "Slack identity\n\nTreat this channel as lead operations."
+    )
+    assert event.auto_skill == ["lead-ops"]
+    assert event.metadata == {
+        "slack_team_id": "W1",
+        "slack_channel_id": "C1",
+        "slack_thread_ts": "T1",
+    }
+    assert event.raw_message is body
+    assert event.internal is False
+    update = client.chat_update.await_args.kwargs
+    assert update["channel"] == "C1"
+    assert update["ts"] == "M1"
+    assert all(block["type"] != "actions" for block in update["blocks"])
+
+
+@pytest.mark.asyncio
+async def test_forged_or_replayed_click_never_reaches_handle_message(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, _client = _make_adapter()
+    adapter.handle_message = AsyncMock()
+    ack = AsyncMock()
+
+    await adapter._handle_interactive_reply_action(
+        ack, _click_body(), {"action_id": "hermes_interactive_reply", "value": "forged"}
+    )
+    adapter.handle_message.assert_not_awaited()
+
+    prepared = adapter._interactive_reply_store.create_card(
+        "C1", "T1", (InteractiveButton("Go", "go"),)
+    )
+    assert adapter._interactive_reply_store.bind_message(prepared.card_id, "M1")
+    action = {
+        "action_id": "hermes_interactive_reply",
+        "value": prepared.buttons[0].token,
+    }
+    await adapter._handle_interactive_reply_action(ack, _click_body(), action)
+    await adapter._handle_interactive_reply_action(ack, _click_body(), action)
+
+    assert adapter.handle_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cross_channel_or_wrong_action_id_click_fails_closed(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, _client = _make_adapter()
+    adapter.handle_message = AsyncMock()
+    prepared = adapter._interactive_reply_store.create_card(
+        "C1", "T1", (InteractiveButton("Go", "go"),)
+    )
+    assert adapter._interactive_reply_store.bind_message(prepared.card_id, "M1")
+
+    await adapter._handle_interactive_reply_action(
+        AsyncMock(),
+        _click_body(channel="C2"),
+        {
+            "action_id": "hermes_interactive_reply",
+            "value": prepared.buttons[0].token,
+        },
+    )
+    await adapter._handle_interactive_reply_action(
+        AsyncMock(),
+        _click_body(),
+        {"action_id": "untrusted_action", "value": prepared.buttons[0].token},
+    )
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_card_update_does_not_reopen_or_duplicate_event(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+    adapter.handle_message = AsyncMock()
+    client.chat_update = AsyncMock(side_effect=RuntimeError("update rejected"))
+    prepared = adapter._interactive_reply_store.create_card(
+        "C1", "T1", (InteractiveButton("Go", "go"),)
+    )
+    assert adapter._interactive_reply_store.bind_message(prepared.card_id, "M1")
+    action = {
+        "action_id": "hermes_interactive_reply",
+        "value": prepared.buttons[0].token,
+    }
+
+    await adapter._handle_interactive_reply_action(AsyncMock(), _click_body(), action)
+    await adapter._handle_interactive_reply_action(AsyncMock(), _click_body(), action)
+
+    assert adapter.handle_message.await_count == 1
+    assert client.chat_update.await_count == 1

--- a/tests/gateway/test_slack_interactive_replies.py
+++ b/tests/gateway/test_slack_interactive_replies.py
@@ -42,6 +42,7 @@ def _make_adapter():
         }
     )
     adapter._get_client = MagicMock(return_value=client)
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
     adapter.stop_typing = AsyncMock()
     return adapter, client
 
@@ -235,6 +236,44 @@ async def test_adapter_send_posts_slash_reply_buttons_ephemerally(tmp_path, monk
 
 
 @pytest.mark.asyncio
+async def test_slash_interactive_reply_uses_explicit_workspace_client_for_ambiguous_channel(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, _default_client = _make_adapter()
+    primary_client = AsyncMock()
+    target_client = AsyncMock()
+    primary_client.chat_postEphemeral = AsyncMock(
+        return_value={"ok": True, "message_ts": "111.222"}
+    )
+    target_client.chat_postEphemeral = AsyncMock(
+        return_value={"ok": True, "message_ts": "222.333"}
+    )
+    adapter._app.client = primary_client
+    adapter._team_clients = {
+        "W_PRIMARY": primary_client,
+        "W_TARGET": target_client,
+    }
+    adapter._channel_team.clear()
+    adapter._channel_teams.clear()
+    adapter._remember_channel_team("C_SHARED", "W_PRIMARY")
+    adapter._remember_channel_team("C_SHARED", "W_TARGET")
+    adapter._get_client = SlackAdapter._get_client.__get__(adapter)
+    adapter._pop_slash_context = MagicMock(return_value={"user_id": "U1"})
+    adapter._clear_thread_status_quietly = AsyncMock()
+
+    result = await adapter.send(
+        "C_SHARED",
+        "Lead ready\n[[slack_buttons: Enroll:enroll]]",
+        metadata={"slack_team_id": "W_TARGET"},
+    )
+
+    assert result.success is True
+    assert target_client.chat_postEphemeral.await_count == 2
+    primary_client.chat_postEphemeral.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_adapter_send_posts_one_button_control_after_long_reply(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
     adapter, client = _make_adapter()
@@ -354,6 +393,41 @@ async def test_valid_click_relays_as_user_event_in_original_thread(tmp_path, mon
     assert update["channel"] == "C1"
     assert update["ts"] == "M1"
     assert all(block["type"] != "actions" for block in update["blocks"])
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_click_preserves_card_for_authorized_user(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, _client = _make_adapter()
+    adapter._is_interactive_user_authorized = MagicMock(
+        side_effect=lambda user_id, **_kwargs: user_id == "U_ALLOWED"
+    )
+    adapter.handle_message = AsyncMock()
+    prepared = adapter._interactive_reply_store.create_card(
+        "C1", "T1", (InteractiveButton("Go", "go"),)
+    )
+    assert adapter._interactive_reply_store.bind_message(prepared.card_id, "M1")
+    action = {
+        "action_id": "hermes_interactive_reply",
+        "value": prepared.buttons[0].token,
+    }
+
+    await adapter._handle_interactive_reply_action(
+        AsyncMock(), _click_body(user="U_UNAUTHORIZED"), action
+    )
+
+    adapter.handle_message.assert_not_awaited()
+    assert adapter._interactive_reply_store.pending_count() == 1
+
+    await adapter._handle_interactive_reply_action(
+        AsyncMock(), _click_body(user="U_ALLOWED"), action
+    )
+
+    assert adapter.handle_message.await_count == 1
+    assert adapter.handle_message.await_args.args[0].source.user_id == "U_ALLOWED"
+    assert adapter._interactive_reply_store.pending_count() == 0
 
 
 @pytest.mark.asyncio
@@ -632,7 +706,7 @@ async def test_wrong_message_timestamp_does_not_consume_card(tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
-async def test_card_cleanup_preserves_unrelated_control_in_shared_actions_block(
+async def test_card_cleanup_preserves_unrelated_control_and_names_clicker(
     tmp_path, monkeypatch
 ):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
@@ -666,6 +740,15 @@ async def test_card_cleanup_preserves_unrelated_control_in_shared_actions_block(
     assert [element["action_id"] for element in actions[0]["elements"]] == [
         "unrelated_control"
     ]
+    acknowledgements = [
+        block
+        for block in updated_blocks
+        if block["type"] == "context"
+        and block.get("elements") == [
+            {"type": "mrkdwn", "text": "Selected by <@U1>"}
+        ]
+    ]
+    assert len(acknowledgements) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_slack_interactive_replies.py
+++ b/tests/gateway/test_slack_interactive_replies.py
@@ -160,3 +160,53 @@ async def test_adapter_send_posts_one_button_control_after_long_reply(tmp_path, 
     assert control["text"] == "Interactive reply options"
     assert control["blocks"][-1]["type"] == "actions"
     assert control["blocks"][-1]["elements"][0]["action_id"] == "hermes_interactive_reply"
+
+@pytest.mark.asyncio
+async def test_adapter_send_fails_when_long_reply_control_is_rejected(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+    client.chat_postMessage = AsyncMock(
+        side_effect=[
+            {"ts": "111.001"},
+            {"ts": "111.002"},
+            {"ok": False, "error": "invalid_blocks"},
+        ]
+    )
+    content = "x" * (adapter.MAX_MESSAGE_LENGTH + 1)
+
+    result = await adapter.send("C1", content + "\n[[slack_buttons: Enroll:enroll]]")
+
+    assert result.success is False
+    assert result.error == "Slack interactive control failed: invalid_blocks"
+
+@pytest.mark.asyncio
+async def test_adapter_slash_and_long_controls_are_single_and_opaque(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+
+    slash_adapter, slash_client = _make_adapter()
+    slash_client.chat_postEphemeral = AsyncMock(
+        return_value={"ok": True, "message_ts": "222.333"}
+    )
+    slash_adapter._pop_slash_context = MagicMock(return_value={"user_id": "U1"})
+    slash_adapter._clear_thread_status_quietly = AsyncMock()
+    await slash_adapter.send("C1", "Lead\n[[slack_buttons: Enroll:enroll]]")
+    slash_actions = [
+        block
+        for call in slash_client.chat_postEphemeral.await_args_list
+        for block in call.kwargs.get("blocks", [])
+        if block["type"] == "actions"
+    ]
+
+    long_adapter, long_client = _make_adapter()
+    content = "x" * (long_adapter.MAX_MESSAGE_LENGTH + 1)
+    await long_adapter.send("C1", content + "\n[[slack_buttons: Enroll:enroll]]")
+    long_actions = [
+        block
+        for call in long_client.chat_postMessage.await_args_list
+        for block in call.kwargs.get("blocks", [])
+        if block["type"] == "actions"
+    ]
+
+    for actions in (slash_actions, long_actions):
+        assert len(actions) == 1
+        assert actions[0]["elements"][0]["value"] != "enroll"

--- a/tests/gateway/test_slack_interactive_replies.py
+++ b/tests/gateway/test_slack_interactive_replies.py
@@ -72,6 +72,14 @@ def _click_body(
     }
 
 
+class _StringifiesTo:
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def __str__(self) -> str:
+        return self._value
+
+
 def test_parse_valid_directive_strips_it_and_preserves_visible_reply():
     reply = parse_interactive_reply(
         "Approved lead.\n[[slack_buttons: Enroll:enroll, Skip:skip]]"
@@ -390,3 +398,263 @@ async def test_failed_card_update_does_not_reopen_or_duplicate_event(tmp_path, m
 
     assert adapter.handle_message.await_count == 1
     assert client.chat_update.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ignored_channel_click_does_not_consume_card(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+    adapter.config.extra["ignored_channels"] = ["C1"]
+    adapter.handle_message = AsyncMock()
+    prepared = adapter._interactive_reply_store.create_card(
+        "C1", "T1", (InteractiveButton("Go", "go"),)
+    )
+    assert adapter._interactive_reply_store.bind_message(prepared.card_id, "M1")
+
+    await adapter._handle_interactive_reply_action(
+        AsyncMock(),
+        _click_body(),
+        {
+            "action_id": "hermes_interactive_reply",
+            "value": prepared.buttons[0].token,
+        },
+    )
+
+    adapter.handle_message.assert_not_awaited()
+    client.conversations_info.assert_not_awaited()
+    assert (
+        adapter._interactive_reply_store.consume(
+            prepared.buttons[0].token, "C1", "M1"
+        )
+        is not None
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("channel_id", "channel_record"),
+    [
+        ("D1", {"id": "D1", "is_im": True, "user": "U1"}),
+        ("G1", {"id": "G1", "name": "mpdm-team", "is_mpim": True}),
+    ],
+)
+async def test_disabled_dm_click_does_not_consume_card(
+    tmp_path, monkeypatch, channel_id, channel_record
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+    adapter.config.extra.update(
+        {"disable_dms": True, "allowed_channels": [channel_id]}
+    )
+    client.conversations_info = AsyncMock(
+        return_value={"ok": True, "channel": channel_record}
+    )
+    adapter.handle_message = AsyncMock()
+    prepared = adapter._interactive_reply_store.create_card(
+        channel_id, "T1", (InteractiveButton("Go", "go"),)
+    )
+    assert adapter._interactive_reply_store.bind_message(prepared.card_id, "M1")
+
+    await adapter._handle_interactive_reply_action(
+        AsyncMock(),
+        _click_body(channel=channel_id),
+        {
+            "action_id": "hermes_interactive_reply",
+            "value": prepared.buttons[0].token,
+        },
+    )
+
+    adapter.handle_message.assert_not_awaited()
+    assert (
+        adapter._interactive_reply_store.consume(
+            prepared.buttons[0].token, channel_id, "M1"
+        )
+        is not None
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_allowed_channel_click_does_not_consume_card(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+    adapter.config.extra["allowed_channels"] = ["C1"]
+    client.conversations_info = AsyncMock(
+        return_value={
+            "ok": True,
+            "channel": {"id": "C2", "name": "other-channel"},
+        }
+    )
+    adapter.handle_message = AsyncMock()
+    prepared = adapter._interactive_reply_store.create_card(
+        "C2", "T1", (InteractiveButton("Go", "go"),)
+    )
+    assert adapter._interactive_reply_store.bind_message(prepared.card_id, "M1")
+
+    await adapter._handle_interactive_reply_action(
+        AsyncMock(),
+        _click_body(channel="C2"),
+        {
+            "action_id": "hermes_interactive_reply",
+            "value": prepared.buttons[0].token,
+        },
+    )
+
+    adapter.handle_message.assert_not_awaited()
+    assert (
+        adapter._interactive_reply_store.consume(
+            prepared.buttons[0].token, "C2", "M1"
+        )
+        is not None
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["channel", "message_ts", "user", "token"])
+async def test_non_string_required_callback_field_does_not_consume_card(
+    tmp_path, monkeypatch, field
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+    client.conversations_info = AsyncMock(
+        return_value={
+            "ok": True,
+            "channel": {"id": "123", "name": "numbers"},
+        }
+    )
+    adapter.handle_message = AsyncMock()
+    prepared = adapter._interactive_reply_store.create_card(
+        "123", "T1", (InteractiveButton("Go", "go"),)
+    )
+    assert adapter._interactive_reply_store.bind_message(prepared.card_id, "456")
+    body = _click_body(channel="123", message_ts="456", user="789")
+    action = {
+        "action_id": "hermes_interactive_reply",
+        "value": prepared.buttons[0].token,
+    }
+    if field == "channel":
+        body["channel"]["id"] = 123
+    elif field == "message_ts":
+        body["message"]["ts"] = 456
+    elif field == "user":
+        body["user"]["id"] = 789
+    else:
+        action["value"] = _StringifiesTo(prepared.buttons[0].token)
+
+    await adapter._handle_interactive_reply_action(AsyncMock(), body, action)
+
+    adapter.handle_message.assert_not_awaited()
+    assert (
+        adapter._interactive_reply_store.consume(
+            prepared.buttons[0].token, "123", "456"
+        )
+        is not None
+    )
+
+
+@pytest.mark.asyncio
+async def test_wrong_message_timestamp_does_not_consume_card(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, _client = _make_adapter()
+    adapter.handle_message = AsyncMock()
+    prepared = adapter._interactive_reply_store.create_card(
+        "C1", "T1", (InteractiveButton("Go", "go"),)
+    )
+    assert adapter._interactive_reply_store.bind_message(prepared.card_id, "M1")
+
+    await adapter._handle_interactive_reply_action(
+        AsyncMock(),
+        _click_body(message_ts="M2"),
+        {
+            "action_id": "hermes_interactive_reply",
+            "value": prepared.buttons[0].token,
+        },
+    )
+
+    adapter.handle_message.assert_not_awaited()
+    assert (
+        adapter._interactive_reply_store.consume(
+            prepared.buttons[0].token, "C1", "M1"
+        )
+        is not None
+    )
+
+
+@pytest.mark.asyncio
+async def test_card_cleanup_preserves_unrelated_control_in_shared_actions_block(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+    adapter.handle_message = AsyncMock()
+    prepared = adapter._interactive_reply_store.create_card(
+        "C1", "T1", (InteractiveButton("Go", "go"),)
+    )
+    assert adapter._interactive_reply_store.bind_message(prepared.card_id, "M1")
+    body = _click_body()
+    body["message"]["blocks"][-1]["elements"].append(
+        {
+            "type": "button",
+            "action_id": "unrelated_control",
+            "value": "keep",
+        }
+    )
+
+    await adapter._handle_interactive_reply_action(
+        AsyncMock(),
+        body,
+        {
+            "action_id": "hermes_interactive_reply",
+            "value": prepared.buttons[0].token,
+        },
+    )
+
+    updated_blocks = client.chat_update.await_args.kwargs["blocks"]
+    actions = [block for block in updated_blocks if block["type"] == "actions"]
+    assert len(actions) == 1
+    assert [element["action_id"] for element in actions[0]["elements"]] == [
+        "unrelated_control"
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("channel_id", "channel_record", "allowed_channels"),
+    [
+        (
+            "D1",
+            {"id": "D1", "is_im": True, "user": "U1"},
+            ["C_OTHER"],
+        ),
+        (
+            "G1",
+            {"id": "G1", "is_mpim": True, "name": "mpdm-team"},
+            ["G1"],
+        ),
+    ],
+)
+async def test_im_and_mpim_clicks_use_dm_source_classification(
+    tmp_path, monkeypatch, channel_id, channel_record, allowed_channels
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+    adapter.config.extra["allowed_channels"] = allowed_channels
+    client.conversations_info = AsyncMock(
+        return_value={"ok": True, "channel": channel_record}
+    )
+    adapter.handle_message = AsyncMock()
+    prepared = adapter._interactive_reply_store.create_card(
+        channel_id, "T1", (InteractiveButton("Go", "go"),)
+    )
+    assert adapter._interactive_reply_store.bind_message(prepared.card_id, "M1")
+
+    await adapter._handle_interactive_reply_action(
+        AsyncMock(),
+        _click_body(channel=channel_id),
+        {
+            "action_id": "hermes_interactive_reply",
+            "value": prepared.buttons[0].token,
+        },
+    )
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "dm"

--- a/tests/gateway/test_slack_interactive_replies.py
+++ b/tests/gateway/test_slack_interactive_replies.py
@@ -18,6 +18,22 @@ def test_parse_valid_directive_strips_it_and_preserves_visible_reply():
     assert [button.action_id for button in reply.buttons] == ["enroll", "skip"]
 
 
+def test_parse_multiple_valid_trailing_directives_in_original_order():
+    reply = parse_interactive_reply(
+        "Approved lead.\n"
+        "[[slack_buttons: Enroll:enroll]]\n"
+        "[[slack_buttons: Skip:skip, Draft:draft]]"
+    )
+
+    assert reply is not None
+    assert reply.visible_content == "Approved lead."
+    assert [button.action_id for button in reply.buttons] == [
+        "enroll",
+        "skip",
+        "draft",
+    ]
+
+
 def test_parse_malformed_directives_return_none_for_literal_fallback():
     invalid = (
         "[[slack_buttons: :enroll]]",
@@ -74,7 +90,10 @@ def test_append_actions_block_returns_slack_buttons_without_mutating_input(tmp_p
     assert rendered[:-1] == blocks
     assert rendered is not blocks
     assert rendered[-1]["type"] == "actions"
-    assert [item["action_id"] for item in rendered[-1]["elements"]] == ["enroll", "skip"]
+    assert [item["action_id"] for item in rendered[-1]["elements"]] == [
+        "hermes_interactive_reply",
+        "hermes_interactive_reply",
+    ]
     assert [item["value"] for item in rendered[-1]["elements"]] == [
         button.token for button in prepared.buttons
     ]

--- a/tests/gateway/test_slack_interactive_replies.py
+++ b/tests/gateway/test_slack_interactive_replies.py
@@ -1,11 +1,27 @@
 """Behavior contracts for Slack interactive reply directives and storage."""
 
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.slack.adapter import SlackAdapter
 from plugins.platforms.slack.interactive_replies import (
     InteractiveButton,
     InteractiveReplyStore,
     append_actions_block,
     parse_interactive_reply,
 )
+
+
+def _make_adapter():
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+    adapter._app = MagicMock()
+    client = AsyncMock()
+    client.chat_postMessage = AsyncMock(return_value={"ts": "111.222"})
+    adapter._get_client = MagicMock(return_value=client)
+    adapter.stop_typing = AsyncMock()
+    return adapter, client
 
 
 def test_parse_valid_directive_strips_it_and_preserves_visible_reply():
@@ -97,3 +113,17 @@ def test_append_actions_block_returns_slack_buttons_without_mutating_input(tmp_p
     assert [item["value"] for item in rendered[-1]["elements"]] == [
         button.token for button in prepared.buttons
     ]
+
+
+@pytest.mark.asyncio
+async def test_adapter_send_posts_buttons_without_literal_directive(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+
+    await adapter.send("C1", "Lead ready\n[[slack_buttons: Enroll:enroll]]")
+
+    posted = client.chat_postMessage.await_args.kwargs
+    assert "[[slack_buttons:" not in posted["text"]
+    assert posted["text"]
+    assert posted["blocks"][-1]["type"] == "actions"
+    assert posted["blocks"][-1]["elements"][0]["action_id"] == "hermes_interactive_reply"

--- a/tests/gateway/test_slack_interactive_replies.py
+++ b/tests/gateway/test_slack_interactive_replies.py
@@ -31,7 +31,15 @@ def _make_adapter():
         }
     )
     client.conversations_info = AsyncMock(
-        return_value={"ok": True, "channel": {"id": "C1", "name": "leads"}}
+        return_value={
+            "ok": True,
+            "channel": {
+                "id": "C1",
+                "name": "leads",
+                "is_im": False,
+                "is_mpim": False,
+            },
+        }
     )
     adapter._get_client = MagicMock(return_value=client)
     adapter.stop_typing = AsyncMock()
@@ -78,6 +86,16 @@ class _StringifiesTo:
 
     def __str__(self) -> str:
         return self._value
+
+
+class _MappingLikeResponse:
+    """Minimal SlackResponse-shaped object: mapping access without dict identity."""
+
+    def __init__(self, data: dict) -> None:
+        self._data = data
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
 
 
 def test_parse_valid_directive_strips_it_and_preserves_visible_reply():
@@ -434,8 +452,19 @@ async def test_ignored_channel_click_does_not_consume_card(tmp_path, monkeypatch
 @pytest.mark.parametrize(
     ("channel_id", "channel_record"),
     [
-        ("D1", {"id": "D1", "is_im": True, "user": "U1"}),
-        ("G1", {"id": "G1", "name": "mpdm-team", "is_mpim": True}),
+        (
+            "D1",
+            {"id": "D1", "is_im": True, "is_mpim": False, "user": "U1"},
+        ),
+        (
+            "G1",
+            {
+                "id": "G1",
+                "name": "mpdm-team",
+                "is_im": False,
+                "is_mpim": True,
+            },
+        ),
     ],
 )
 async def test_disabled_dm_click_does_not_consume_card(
@@ -481,7 +510,12 @@ async def test_non_allowed_channel_click_does_not_consume_card(tmp_path, monkeyp
     client.conversations_info = AsyncMock(
         return_value={
             "ok": True,
-            "channel": {"id": "C2", "name": "other-channel"},
+            "channel": {
+                "id": "C2",
+                "name": "other-channel",
+                "is_im": False,
+                "is_mpim": False,
+            },
         }
     )
     adapter.handle_message = AsyncMock()
@@ -518,7 +552,12 @@ async def test_non_string_required_callback_field_does_not_consume_card(
     client.conversations_info = AsyncMock(
         return_value={
             "ok": True,
-            "channel": {"id": "123", "name": "numbers"},
+            "channel": {
+                "id": "123",
+                "name": "numbers",
+                "is_im": False,
+                "is_mpim": False,
+            },
         }
     )
     adapter.handle_message = AsyncMock()
@@ -622,12 +661,17 @@ async def test_card_cleanup_preserves_unrelated_control_in_shared_actions_block(
     [
         (
             "D1",
-            {"id": "D1", "is_im": True, "user": "U1"},
+            {"id": "D1", "is_im": True, "is_mpim": False, "user": "U1"},
             ["C_OTHER"],
         ),
         (
             "G1",
-            {"id": "G1", "is_mpim": True, "name": "mpdm-team"},
+            {
+                "id": "G1",
+                "is_im": False,
+                "is_mpim": True,
+                "name": "mpdm-team",
+            },
             ["G1"],
         ),
     ],
@@ -658,3 +702,104 @@ async def test_im_and_mpim_clicks_use_dm_source_classification(
 
     event = adapter.handle_message.await_args.args[0]
     assert event.source.chat_type == "dm"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("channel_id", "channel_record", "expected_chat_type"),
+    [
+        (
+            "G_MPIM",
+            {
+                "id": "G_MPIM",
+                "name": "mpdm-team",
+                "is_im": False,
+                "is_mpim": True,
+            },
+            "dm",
+        ),
+        (
+            "C_CHANNEL",
+            {
+                "id": "C_CHANNEL",
+                "name": "leads",
+                "is_im": False,
+                "is_mpim": False,
+            },
+            "group",
+        ),
+    ],
+)
+async def test_mapping_like_slack_response_classifies_non_d_callback(
+    tmp_path, monkeypatch, channel_id, channel_record, expected_chat_type
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+    adapter.config.extra["allowed_channels"] = [channel_id]
+    client.conversations_info = AsyncMock(
+        return_value=_MappingLikeResponse(
+            {"ok": True, "channel": channel_record}
+        )
+    )
+    adapter.handle_message = AsyncMock()
+    prepared = adapter._interactive_reply_store.create_card(
+        channel_id, "T1", (InteractiveButton("Go", "go"),)
+    )
+    assert adapter._interactive_reply_store.bind_message(prepared.card_id, "M1")
+
+    await adapter._handle_interactive_reply_action(
+        AsyncMock(),
+        _click_body(channel=channel_id),
+        {
+            "action_id": "hermes_interactive_reply",
+            "value": prepared.buttons[0].token,
+        },
+    )
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == expected_chat_type
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "channel_record",
+    [
+        {"id": "C1", "name": "leads", "is_im": False},
+        {
+            "id": "C1",
+            "name": "leads",
+            "is_im": "false",
+            "is_mpim": False,
+        },
+    ],
+)
+async def test_missing_or_malformed_channel_type_flags_do_not_consume_card(
+    tmp_path, monkeypatch, channel_record
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+    client.conversations_info = AsyncMock(
+        return_value={"ok": True, "channel": channel_record}
+    )
+    adapter.handle_message = AsyncMock()
+    prepared = adapter._interactive_reply_store.create_card(
+        "C1", "T1", (InteractiveButton("Go", "go"),)
+    )
+    assert adapter._interactive_reply_store.bind_message(prepared.card_id, "M1")
+
+    await adapter._handle_interactive_reply_action(
+        AsyncMock(),
+        _click_body(),
+        {
+            "action_id": "hermes_interactive_reply",
+            "value": prepared.buttons[0].token,
+        },
+    )
+
+    adapter.handle_message.assert_not_awaited()
+    assert (
+        adapter._interactive_reply_store.consume(
+            prepared.buttons[0].token, "C1", "M1"
+        )
+        is not None
+    )

--- a/tests/gateway/test_slack_interactive_replies.py
+++ b/tests/gateway/test_slack_interactive_replies.py
@@ -127,3 +127,36 @@ async def test_adapter_send_posts_buttons_without_literal_directive(tmp_path, mo
     assert posted["text"]
     assert posted["blocks"][-1]["type"] == "actions"
     assert posted["blocks"][-1]["elements"][0]["action_id"] == "hermes_interactive_reply"
+
+@pytest.mark.asyncio
+async def test_adapter_send_posts_slash_reply_buttons_ephemerally(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+    client.chat_postEphemeral = AsyncMock(
+        return_value={"ok": True, "message_ts": "222.333"}
+    )
+    adapter._pop_slash_context = MagicMock(return_value={"user_id": "U1"})
+    adapter._clear_thread_status_quietly = AsyncMock()
+
+    result = await adapter.send("C1", "Lead ready\n[[slack_buttons: Enroll:enroll]]")
+
+    assert result.success is True
+    posted = client.chat_postEphemeral.await_args.kwargs
+    assert "[[slack_buttons:" not in posted["text"]
+    assert posted["blocks"][-1]["type"] == "actions"
+    assert posted["blocks"][-1]["elements"][0]["action_id"] == "hermes_interactive_reply"
+
+
+@pytest.mark.asyncio
+async def test_adapter_send_posts_one_button_control_after_long_reply(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+    content = "x" * (adapter.MAX_MESSAGE_LENGTH + 1)
+
+    await adapter.send("C1", content + "\n[[slack_buttons: Enroll:enroll]]")
+
+    assert client.chat_postMessage.await_count >= 2
+    control = client.chat_postMessage.await_args.kwargs
+    assert control["text"] == "Interactive reply options"
+    assert control["blocks"][-1]["type"] == "actions"
+    assert control["blocks"][-1]["elements"][0]["action_id"] == "hermes_interactive_reply"

--- a/tests/gateway/test_slack_interactive_replies.py
+++ b/tests/gateway/test_slack_interactive_replies.py
@@ -1,0 +1,80 @@
+"""Behavior contracts for Slack interactive reply directives and storage."""
+
+from plugins.platforms.slack.interactive_replies import (
+    InteractiveButton,
+    InteractiveReplyStore,
+    append_actions_block,
+    parse_interactive_reply,
+)
+
+
+def test_parse_valid_directive_strips_it_and_preserves_visible_reply():
+    reply = parse_interactive_reply(
+        "Approved lead.\n[[slack_buttons: Enroll:enroll, Skip:skip]]"
+    )
+
+    assert reply is not None
+    assert reply.visible_content == "Approved lead."
+    assert [button.action_id for button in reply.buttons] == ["enroll", "skip"]
+
+
+def test_parse_malformed_directives_return_none_for_literal_fallback():
+    invalid = (
+        "[[slack_buttons: :enroll]]",
+        "[[slack_buttons: Enroll:]]",
+        "[[slack_buttons: Enroll:enroll, Again:enroll]]",
+        "[[slack_buttons: Enroll:not valid]]",
+        "[[slack_buttons: Enroll:enroll]]\ntrailing text",
+        "[[slack_buttons: " + ", ".join(f"B{i}:a{i}" for i in range(26)) + "]]",
+    )
+
+    for content in invalid:
+        assert parse_interactive_reply(content) is None
+
+
+def test_consume_requires_bound_message_and_is_single_use(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    store = InteractiveReplyStore(ttl_seconds=60)
+    prepared = store.create_card("C1", "T1", (InteractiveButton("Enroll", "enroll"),))
+
+    assert store.consume(prepared.buttons[0].token, "C1", "M1") is None
+    assert store.bind_message(prepared.card_id, "M1") is True
+    consumed = store.consume(prepared.buttons[0].token, "C1", "M1")
+    assert consumed is not None
+    assert consumed.action_id == "enroll"
+    assert store.consume(prepared.buttons[0].token, "C1", "M1") is None
+
+
+def test_consume_rejects_expired_and_cross_channel_cards(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    store = InteractiveReplyStore(ttl_seconds=60)
+    prepared = store.create_card("C1", None, (InteractiveButton("Skip", "skip"),))
+    assert store.bind_message(prepared.card_id, "M1") is True
+    assert store.consume(prepared.buttons[0].token, "C2", "M1") is None
+    assert store.consume(prepared.buttons[0].token, "C1", "M2") is None
+
+    expired_store = InteractiveReplyStore(ttl_seconds=-1)
+    expired = expired_store.create_card("C1", None, (InteractiveButton("Skip", "skip"),))
+    assert expired_store.bind_message(expired.card_id, "M2") is False
+    assert expired_store.consume(expired.buttons[0].token, "C1", "M2") is None
+
+
+def test_append_actions_block_returns_slack_buttons_without_mutating_input(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    store = InteractiveReplyStore()
+    prepared = store.create_card(
+        "C1",
+        None,
+        (InteractiveButton("Enroll", "enroll"), InteractiveButton("Skip", "skip")),
+    )
+    blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": "Lead"}}]
+
+    rendered = append_actions_block(blocks, prepared)
+
+    assert rendered[:-1] == blocks
+    assert rendered is not blocks
+    assert rendered[-1]["type"] == "actions"
+    assert [item["action_id"] for item in rendered[-1]["elements"]] == ["enroll", "skip"]
+    assert [item["value"] for item in rendered[-1]["elements"]] == [
+        button.token for button in prepared.buttons
+    ]

--- a/tests/gateway/test_slack_interactive_replies.py
+++ b/tests/gateway/test_slack_interactive_replies.py
@@ -202,6 +202,19 @@ async def test_adapter_send_posts_buttons_without_literal_directive(tmp_path, mo
     assert posted["blocks"][-1]["type"] == "actions"
     assert posted["blocks"][-1]["elements"][0]["action_id"] == "hermes_interactive_reply"
 
+
+@pytest.mark.asyncio
+async def test_post_failure_discards_unbound_card(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    adapter, client = _make_adapter()
+    client.chat_postMessage.side_effect = RuntimeError("slack unavailable")
+
+    result = await adapter.send("C1", "x\n[[slack_buttons: Go:go]]")
+
+    assert result.success is False
+    assert adapter._interactive_reply_store.pending_count() == 0
+
+
 @pytest.mark.asyncio
 async def test_adapter_send_posts_slash_reply_buttons_ephemerally(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))

--- a/tests/tools/test_send_message_slack.py
+++ b/tests/tools/test_send_message_slack.py
@@ -181,3 +181,44 @@ def test_standalone_send_posts_the_same_action_block(
     assert payload["text"]
     assert payload["blocks"][-1]["type"] == "actions"
     assert payload["blocks"][-1]["elements"][0]["action_id"] == "hermes_interactive_reply"
+
+class _MediaClient:
+    def __init__(self):
+        self.post_calls = []
+
+    async def chat_postMessage(self, **kwargs):
+        self.post_calls.append(kwargs)
+        return {"ok": True, "ts": "control-ts"}
+
+    async def files_upload_v2(self, **kwargs):
+        return {"ok": True, "file": {"timestamp": "upload-ts"}}
+
+
+def test_standalone_media_send_posts_the_same_action_block(
+    monkeypatch, _standalone_send, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    media_path = tmp_path / "lead.txt"
+    media_path.write_text("lead", encoding="utf-8")
+    client = _MediaClient()
+    monkeypatch.setattr(
+        sys.modules["slack_sdk.web.async_client"],
+        "AsyncWebClient",
+        lambda **kwargs: client,
+    )
+
+    pconfig = SimpleNamespace(enabled=True, token="good-token", extra={})
+    result = asyncio.run(
+        _standalone_send(
+            pconfig,
+            "C123",
+            "Lead ready\n[[slack_buttons: Enroll:enroll]]",
+            media_files=[(str(media_path), False)],
+        )
+    )
+
+    assert result["success"] is True
+    posted = client.post_calls[0]
+    assert "[[slack_buttons:" not in posted["text"]
+    assert posted["blocks"][-1]["type"] == "actions"
+    assert posted["blocks"][-1]["elements"][0]["action_id"] == "hermes_interactive_reply"

--- a/tests/tools/test_send_message_slack.py
+++ b/tests/tools/test_send_message_slack.py
@@ -161,3 +161,23 @@ def test_standalone_send_stops_on_non_token_error(monkeypatch, _standalone_send)
 
     assert result == {"error": "Slack API error: msg_too_long"}
     assert len(fake_session.calls) == 1
+
+
+def test_standalone_send_posts_the_same_action_block(
+    monkeypatch, _standalone_send, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    fake_session = _SlackSession()
+    monkeypatch.setattr("aiohttp.ClientSession", lambda *args, **kwargs: fake_session)
+
+    pconfig = SimpleNamespace(enabled=True, token="good-token", extra={})
+    result = asyncio.run(
+        _standalone_send(pconfig, "C123", "x\n[[slack_buttons: Go:go]]")
+    )
+
+    assert result["success"] is True
+    payload = fake_session.calls[0][1]
+    assert "[[slack_buttons:" not in payload["text"]
+    assert payload["text"]
+    assert payload["blocks"][-1]["type"] == "actions"
+    assert payload["blocks"][-1]["elements"][0]["action_id"] == "hermes_interactive_reply"

--- a/tests/tools/test_send_message_slack.py
+++ b/tests/tools/test_send_message_slack.py
@@ -222,3 +222,33 @@ def test_standalone_media_send_posts_the_same_action_block(
     assert "[[slack_buttons:" not in posted["text"]
     assert posted["blocks"][-1]["type"] == "actions"
     assert posted["blocks"][-1]["elements"][0]["action_id"] == "hermes_interactive_reply"
+    actions = [block for block in posted["blocks"] if block["type"] == "actions"]
+    assert len(actions) == 1
+    assert actions[0]["elements"][0]["value"] != "enroll"
+
+
+def test_standalone_missing_media_caption_keeps_interactive_directive_literal(
+    monkeypatch, _standalone_send, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    client = _MediaClient()
+    monkeypatch.setattr(
+        sys.modules["slack_sdk.web.async_client"],
+        "AsyncWebClient",
+        lambda **kwargs: client,
+    )
+    message = "Lead ready\n[[slack_buttons: Enroll:enroll]]"
+
+    result = asyncio.run(
+        _standalone_send(
+            SimpleNamespace(enabled=True, token="good-token", extra={}),
+            "C123",
+            message,
+            media_files=[(str(tmp_path / "missing.txt"), False)],
+            caption="Lead attachment unavailable",
+        )
+    )
+
+    assert result["success"] is True
+    assert client.post_calls[0]["text"].endswith(message)
+    assert "blocks" not in client.post_calls[0]


### PR DESCRIPTION
## Summary

Adds a generic Hermes Slack transport feature that converts validated trailing `[[slack_buttons: Label:action_id]]` directives into Block Kit controls and routes one validated click through the normal authenticated gateway path.

The feature is transport-generic: it does not contain Sorpio, HubSpot, AgentMail, or Brokerkit runtime logic.

## Safety and root-cause remediation

- Buttons use opaque expiry-bound, channel/message-bound, single-use tokens; the requested action remains server-side.
- Valid click events remain ordinary non-internal user events and retain normal policy, workspace, and skill routing.
- Final review remediation ensures the centralized interactive-user authorization check happens before token consumption, slash replies retain their resolved Slack `team_id`, and a consumed card retains unrelated controls while adding `Selected by <@user>` attribution.

## Verification

- Initial red remediation gate: 3 expected failures.
- Targeted green remediation gate: 3 passed.
- Fresh affected Slack regression gate: 118 passed, 0 failed.
- Exact six-file focused suite before remediation: 151 passed, 0 failed.
- `git diff --check`: clean.

The local full suite completed but is not green in the Mac Mini environment: 45,497 passed and 596 environment/platform-dependent failures (missing optional dependencies and OS-specific checks). This PR deliberately does not claim a full-suite pass; upstream GitHub CI is the required integration gate.

No live Slack, Sorpio, or enrollment action was performed.
