### PR TITLE
fix(terminal): keep agent Python installs inside the Hermes venv

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1945,7 +1945,9 @@ function Install-Venv {
     # normal progress such as "Using CPython ..." on stderr; under Windows
     # PowerShell 5.1 with EAP=Stop that stderr is a NativeCommandError unless
     # we temporarily relax EAP and trust $LASTEXITCODE for real failures.
-    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $PythonVersion }
+    # --seed adds pip (uv leaves it out), keeping the venv in lockstep with
+    # install.sh so `pip install` from the agent targets the Hermes venv (#7309).
+    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $PythonVersion --seed }
     # Relaxing EAP above means a *genuine* uv-venv failure (exit != 0) no longer
     # aborts on its own. Capture $LASTEXITCODE immediately and fail fast, so the
     # `venv` stage can't falsely report success (and Invoke-Stage can't emit

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1345,8 +1345,12 @@ setup_venv() {
         rm -rf venv
     fi
 
-    # uv creates the venv and pins the Python version in one step
-    $UV_CMD venv venv --python "$PYTHON_VERSION"
+    # uv creates the venv and pins the Python version in one step.  --seed adds
+    # pip, which uv otherwise leaves out: the terminal tool puts venv/bin first
+    # on PATH, so without a pip there the agent's `pip install` falls through to
+    # whatever interpreter the host exposes (a pyenv shim, the system Python)
+    # and packages land outside the Hermes venv (#7309).
+    $UV_CMD venv venv --python "$PYTHON_VERSION" --seed
 
     # Neutralize any inherited UV_PYTHON (e.g. UV_PYTHON=3.14 left in the
     # user's shell env). uv honours UV_PYTHON over an existing venv for the

--- a/tests/test_install_venv_seeds_pip.py
+++ b/tests/test_install_venv_seeds_pip.py
@@ -1,0 +1,31 @@
+"""Regression test for #7309: the Hermes venv must ship pip.
+
+``uv venv`` creates a venv without pip.  The terminal tool puts the venv's
+bin dir at the front of PATH so the agent's Python installs stay inside the
+Hermes environment — but with no pip in there, ``pip install`` falls through
+to the next interpreter on PATH (a pyenv shim, the system Python) and the
+packages land outside the venv again.  Both installers seed it with ``--seed``.
+"""
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def test_install_sh_creates_the_venv_with_pip() -> None:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    assert re.search(
+        r'\$UV_CMD venv venv --python "\$PYTHON_VERSION" --seed', text
+    ), "install.sh must pass --seed to `uv venv` so the venv gets pip"
+
+
+def test_install_ps1_creates_the_venv_with_pip() -> None:
+    """Installer parity — install.sh and install.ps1 stay in lockstep."""
+    text = INSTALL_PS1.read_text(encoding="utf-8")
+    assert re.search(
+        r"& \$UvCmd venv venv --python \$PythonVersion --seed", text
+    ), "install.ps1 must pass --seed to `uv venv` so the venv gets pip"

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -469,14 +469,17 @@ class TestSanePathIncludesHomebrew:
     @pytest.fixture(autouse=True)
     def _disable_hermes_bin_injection(self):
         """These tests assert the sane-path merge in isolation. Disable the
-        hermes-install-dir prepend (a separate concern, covered by
-        TestHermesBinDirOnPath) so a real ``hermes`` on the test runner's PATH
-        doesn't shift the asserted PATH layout."""
+        hermes-install-dir and Hermes-venv prepends (separate concerns, covered
+        by TestHermesBinDirOnPath and test_local_venv_path_precedence.py) so the
+        test runner's own install layout doesn't shift the asserted PATH."""
         from tools.environments import local as local_mod
         saved = local_mod._HERMES_BIN_DIR
+        saved_venv = local_mod._HERMES_VENV_BIN_DIR
         local_mod._HERMES_BIN_DIR = None  # resolved -> no dir to inject
+        local_mod._HERMES_VENV_BIN_DIR = None
         yield
         local_mod._HERMES_BIN_DIR = saved
+        local_mod._HERMES_VENV_BIN_DIR = saved_venv
 
     def test_sane_path_includes_homebrew_bin(self):
         from tools.environments.local import _SANE_PATH

--- a/tests/tools/test_local_venv_path_precedence.py
+++ b/tests/tools/test_local_venv_path_precedence.py
@@ -1,0 +1,210 @@
+"""Tests for #7309: the terminal tool's ``pip`` must resolve to the Hermes venv.
+
+The POSIX installer exposes Hermes through a launcher shim in ``~/.local/bin``,
+so the venv's own ``bin`` dir never reaches the user's PATH.  With pyenv
+installed, its shims sit at the front of the login shell's PATH, that PATH is
+what the session snapshot captures, and every ``pip install`` the agent runs
+lands in the user's pyenv-global site-packages instead of the Hermes venv.
+"""
+
+import os
+import stat
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments import local as local_mod
+from tools.environments.local import (
+    LocalEnvironment,
+    _make_run_env,
+    _prepend_venv_bin_path_guard,
+    _resolve_hermes_venv_bin_dir,
+)
+
+
+def _write_executable(path, body):
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+class TestResolveHermesVenvBinDir:
+    def _reset_cache(self):
+        local_mod._HERMES_VENV_BIN_DIR = local_mod._SENTINEL
+
+    def test_resolves_interpreter_dir_inside_venv(self, monkeypatch, tmp_path):
+        self._reset_cache()
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        monkeypatch.setattr(local_mod.sys, "prefix", str(tmp_path / "venv"))
+        monkeypatch.setattr(local_mod.sys, "base_prefix", "/usr")
+        monkeypatch.setattr(local_mod.sys, "executable", str(venv_bin / "python"))
+        assert _resolve_hermes_venv_bin_dir() == str(venv_bin)
+
+    def test_returns_none_outside_a_venv(self, monkeypatch):
+        """A ``--no-venv`` / system-wide install has no Hermes env to prefer."""
+        self._reset_cache()
+        monkeypatch.setattr(local_mod.sys, "prefix", "/usr")
+        monkeypatch.setattr(local_mod.sys, "base_prefix", "/usr")
+        assert _resolve_hermes_venv_bin_dir() is None
+
+    def test_result_is_cached(self, monkeypatch, tmp_path):
+        self._reset_cache()
+        local_mod._HERMES_VENV_BIN_DIR = str(tmp_path)
+        monkeypatch.setattr(local_mod.sys, "prefix", "/usr")
+        monkeypatch.setattr(local_mod.sys, "base_prefix", "/usr")
+        assert _resolve_hermes_venv_bin_dir() == str(tmp_path)
+
+    def teardown_method(self):
+        local_mod._HERMES_VENV_BIN_DIR = local_mod._SENTINEL
+
+
+class TestMakeRunEnvVenvPrecedence:
+    def teardown_method(self):
+        local_mod._HERMES_VENV_BIN_DIR = local_mod._SENTINEL
+        local_mod._HERMES_BIN_DIR = local_mod._SENTINEL
+
+    def test_venv_bin_outranks_pyenv_shims(self, monkeypatch):
+        local_mod._HERMES_VENV_BIN_DIR = "/opt/hermes/venv/bin"
+        local_mod._HERMES_BIN_DIR = None
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        with patch.dict(
+            os.environ, {"PATH": "/home/u/.pyenv/shims:/usr/bin:/bin"}, clear=True
+        ):
+            entries = _make_run_env({})["PATH"].split(os.pathsep)
+        assert entries.index("/opt/hermes/venv/bin") < entries.index("/home/u/.pyenv/shims")
+
+    def test_no_duplicate_when_already_present(self, monkeypatch):
+        local_mod._HERMES_VENV_BIN_DIR = "/opt/hermes/venv/bin"
+        local_mod._HERMES_BIN_DIR = None
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        with patch.dict(
+            os.environ, {"PATH": "/opt/hermes/venv/bin:/usr/bin"}, clear=True
+        ):
+            entries = _make_run_env({})["PATH"].split(os.pathsep)
+        assert entries.count("/opt/hermes/venv/bin") == 1
+
+    def test_noop_outside_a_venv(self, monkeypatch):
+        local_mod._HERMES_VENV_BIN_DIR = None
+        local_mod._HERMES_BIN_DIR = None
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=True):
+            entries = _make_run_env({})["PATH"].split(os.pathsep)
+        assert entries[0] == "/usr/bin"
+
+
+class TestVenvBinPathGuard:
+    def teardown_method(self):
+        local_mod._HERMES_VENV_BIN_DIR = local_mod._SENTINEL
+
+    def test_guard_exports_path_before_the_script(self, monkeypatch):
+        local_mod._HERMES_VENV_BIN_DIR = "/opt/hermes/venv/bin"
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        out = _prepend_venv_bin_path_guard("echo hi")
+        assert out.endswith("echo hi")
+        assert "/opt/hermes/venv/bin" in out
+        assert "export PATH" in out
+
+    def test_guard_escapes_single_quotes(self, monkeypatch):
+        local_mod._HERMES_VENV_BIN_DIR = "/opt/o'malley/venv/bin"
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        out = _prepend_venv_bin_path_guard("echo hi")
+        assert "o'\\''malley" in out
+
+    def test_guard_noop_outside_a_venv(self, monkeypatch):
+        local_mod._HERMES_VENV_BIN_DIR = None
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        assert _prepend_venv_bin_path_guard("echo hi") == "echo hi"
+
+    def test_guard_noop_on_windows(self, monkeypatch):
+        local_mod._HERMES_VENV_BIN_DIR = r"C:\hermes\venv\Scripts"
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert _prepend_venv_bin_path_guard("echo hi") == "echo hi"
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX login-shell profile behaviour"
+)
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true" and not os.path.isfile("/bin/bash"),
+    reason="Requires bash; CI sandbox may strip it.",
+)
+class TestPyenvShimsEndToEnd:
+    """Real LocalEnvironment against a pyenv-style ``~/.profile``."""
+
+    def teardown_method(self):
+        local_mod._HERMES_VENV_BIN_DIR = local_mod._SENTINEL
+
+    def _fake_host(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        shims = home / ".pyenv" / "shims"
+        shims.mkdir(parents=True)
+        _write_executable(shims / "pip", "#!/bin/sh\necho pyenv-global-pip\n")
+
+        venv_bin = tmp_path / "hermes" / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        _write_executable(venv_bin / "pip", "#!/bin/sh\necho hermes-venv-pip\n")
+
+        # What `eval "$(pyenv init -)"` effectively leaves in the profile.
+        (home / ".profile").write_text(
+            f'export PATH="{shims}:$PATH"\n', encoding="utf-8"
+        )
+        return home, shims, venv_bin
+
+    def _run(self, tmp_path, command):
+        with patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([], True),
+        ):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=20)
+            try:
+                return env.execute(command)
+            finally:
+                env.cleanup()
+
+    def test_pip_resolves_to_hermes_venv_despite_pyenv_shims(
+        self, tmp_path, monkeypatch
+    ):
+        home, _shims, venv_bin = self._fake_host(tmp_path)
+        monkeypatch.setenv("HOME", str(home))
+        local_mod._HERMES_VENV_BIN_DIR = str(venv_bin)
+
+        result = self._run(tmp_path, "command -v pip; pip")
+
+        output = result.get("output", "")
+        assert str(venv_bin / "pip") in output
+        assert "hermes-venv-pip" in output
+        assert "pyenv-global-pip" not in output
+
+    def test_project_venv_activation_still_wins(self, tmp_path, monkeypatch):
+        """The guard sets the session baseline; it must not fight the agent.
+
+        Activating a project venv mid-session has to keep working, otherwise
+        the agent can no longer install into the project it is working on.
+        """
+        home, _shims, venv_bin = self._fake_host(tmp_path)
+        monkeypatch.setenv("HOME", str(home))
+        local_mod._HERMES_VENV_BIN_DIR = str(venv_bin)
+
+        project_bin = tmp_path / "project" / ".venv" / "bin"
+        project_bin.mkdir(parents=True)
+        _write_executable(project_bin / "pip", "#!/bin/sh\necho project-pip\n")
+        (project_bin / "activate").write_text(
+            f'export PATH="{project_bin}:$PATH"\n', encoding="utf-8"
+        )
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([], True),
+        ):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=20)
+            try:
+                env.execute(f"source {project_bin / 'activate'}")
+                result = env.execute("command -v pip; pip")
+            finally:
+                env.cleanup()
+
+        output = result.get("output", "")
+        assert str(project_bin / "pip") in output
+        assert "project-pip" in output

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -984,6 +984,9 @@ _SANE_PATH = (
 _SENTINEL = object()
 _HERMES_BIN_DIR: "str | None | object" = _SENTINEL
 
+# Cached ``bin`` / ``Scripts`` dir of the venv Hermes itself runs from.
+_HERMES_VENV_BIN_DIR: "str | None | object" = _SENTINEL
+
 
 def _resolve_hermes_bin_dir() -> str | None:
     """Return the directory holding the ``hermes`` console-script, or None.
@@ -1042,14 +1045,41 @@ def _resolve_hermes_bin_dir() -> str | None:
     return candidate
 
 
-def _prepend_hermes_bin_dir(existing_path: str) -> str:
-    """Prepend the hermes install dir to ``existing_path`` if it's missing.
+def _resolve_hermes_venv_bin_dir() -> str | None:
+    """Return the ``bin``/``Scripts`` dir of the venv Hermes runs from, or None.
+
+    The POSIX installer creates the venv with ``uv venv`` and exposes Hermes
+    through a launcher shim in ``~/.local/bin`` (or ``/usr/local/bin``), so the
+    venv's own ``bin`` dir never reaches the user's PATH — unlike the Windows
+    installer, which puts ``venv\\Scripts`` on the user PATH directly.  Terminal
+    commands therefore resolve ``python``/``pip`` from whatever the login shell
+    provides, and with pyenv installed its shims win: ``pip install`` writes to
+    the user's pyenv-global site-packages instead of the Hermes venv (#7309).
+
+    Returns None when Hermes is not running from a venv (``--no-venv`` or a
+    system-wide install), where there is no Hermes environment to prefer.
+    """
+    global _HERMES_VENV_BIN_DIR
+    if _HERMES_VENV_BIN_DIR is not _SENTINEL:
+        return _HERMES_VENV_BIN_DIR  # type: ignore[return-value]
+
+    candidate: str | None = None
+    if sys.prefix != getattr(sys, "base_prefix", sys.prefix) and sys.executable:
+        exe_dir = os.path.dirname(sys.executable)
+        if exe_dir and os.path.isdir(exe_dir):
+            candidate = exe_dir
+
+    _HERMES_VENV_BIN_DIR = candidate
+    return candidate
+
+
+def _prepend_path_dir(existing_path: str, bin_dir: "str | None") -> str:
+    """Prepend ``bin_dir`` to ``existing_path`` if it's missing.
 
     Cross-platform (uses ``os.pathsep``). First-occurrence wins, so a PATH
     that already contains the dir is returned unchanged. Returns the input
-    unchanged when the install dir can't be resolved.
+    unchanged when ``bin_dir`` is empty/unresolved.
     """
-    bin_dir = _resolve_hermes_bin_dir()
     if not bin_dir:
         return existing_path
     sep = os.pathsep
@@ -1057,6 +1087,16 @@ def _prepend_hermes_bin_dir(existing_path: str) -> str:
     if bin_dir in entries:
         return existing_path
     return sep.join([bin_dir, *entries])
+
+
+def _prepend_hermes_bin_dir(existing_path: str) -> str:
+    """Prepend the hermes install dir to ``existing_path`` if it's missing."""
+    return _prepend_path_dir(existing_path, _resolve_hermes_bin_dir())
+
+
+def _prepend_hermes_venv_bin_dir(existing_path: str) -> str:
+    """Prepend the Hermes venv bin dir to ``existing_path`` if it's missing."""
+    return _prepend_path_dir(existing_path, _resolve_hermes_venv_bin_dir())
 
 
 def _append_missing_sane_path_entries(existing_path: str) -> str:
@@ -1177,6 +1217,10 @@ def _make_run_env(env: dict) -> dict:
         # error / exit 127).  No-op off Windows and when a login snapshot is
         # healthy (the snapshot re-exports the full PATH inside the shell).
         new_path = _prepend_git_bash_dirs(new_path)
+        # Ensure ``python``/``pip`` resolve to the Hermes venv rather than to
+        # whatever interpreter the host happens to expose, so packages the
+        # agent installs land in the Hermes environment (#7309).
+        new_path = _prepend_hermes_venv_bin_dir(new_path)
         # Ensure the hermes install dir is reachable so plugins can shell out
         # to bare ``hermes`` via the terminal tool even when the gateway was
         # launched without it on PATH (systemd, service managers, cron, etc.).
@@ -1285,6 +1329,43 @@ def _prepend_shell_init(cmd_string: str, files: list[str]) -> str:
     return prelude + cmd_string
 
 
+def _prepend_venv_bin_path_guard(cmd_string: str) -> str:
+    """Re-assert the Hermes venv bin dir at the front of PATH in a login shell.
+
+    ``_make_run_env`` already puts that dir on the subprocess PATH, but a login
+    shell re-exports its own: pyenv/asdf/conda init snippets in the user's
+    profile *prepend* their shim dirs, so the shim wins and ``pip install``
+    writes to the user's global interpreter instead of the Hermes venv (#7309).
+    Re-prepending after the profile has been sourced restores the venv's
+    precedence in the captured session snapshot.
+
+    Applied to login invocations only — that is, while the snapshot is being
+    built — never per command, so a later ``source .venv/bin/activate`` inside
+    the session still wins exactly as it would in the user's own terminal.
+
+    No-op on Windows: bash there receives a native ``;``-separated PATH that it
+    converts itself, and the Windows installer already puts ``venv\\Scripts`` on
+    the user PATH, so there is nothing to restore.
+    """
+    if _IS_WINDOWS:
+        return cmd_string
+    bin_dir = _resolve_hermes_venv_bin_dir()
+    if not bin_dir:
+        return cmd_string
+    # Same defensive quote escaping as _prepend_shell_init — the value comes
+    # from sys.executable, so it is a concrete absolute path.
+    safe = bin_dir.replace("'", "'\\''")
+    guard = (
+        f"__hermes_venv_bin='{safe}'\n"
+        'case "$PATH" in\n'
+        '  "$__hermes_venv_bin"|"$__hermes_venv_bin":*) ;;\n'
+        '  *) PATH="$__hermes_venv_bin:$PATH"; export PATH ;;\n'
+        'esac\n'
+        'unset __hermes_venv_bin\n'
+    )
+    return guard + cmd_string
+
+
 class LocalEnvironment(BaseEnvironment):
     """Run commands directly on the host machine.
 
@@ -1367,6 +1448,10 @@ class LocalEnvironment(BaseEnvironment):
         # don't need this.
         if login:
             init_files = _resolve_shell_init_files()
+            # The PATH guard is applied first so the source lines land ABOVE
+            # it: rc files run, then the Hermes venv is restored to the front
+            # of PATH before the environment is dumped into the snapshot.
+            cmd_string = _prepend_venv_bin_path_guard(cmd_string)
             if init_files:
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]


### PR DESCRIPTION
Fixes #7309.

## Maintainer decision needed — read this first

The PATH half of this fix means that on POSIX, bare `python` / `python3` and every console script in the Hermes venv now take precedence in agent shell commands, where previously the host's did. That is deliberate parity with what `install.ps1` has always done on Windows, and activating a project venv still overrides it — but it is the highest-blast-radius part of this diff and deserves an explicit call from a maintainer rather than a silent merge.

If you would prefer a narrower fix, the `--seed` change alone is independently useful and could land separately.

## Root cause

Three things compose. None of it is stale — this is current `main` behaviour.

1. **The venv bin dir is never on PATH (POSIX only).** `_make_run_env()` (`tools/environments/local.py:1191`) builds the subshell PATH from `_SANE_PATH` + Git-Bash dirs + `_prepend_hermes_bin_dir()`. `_resolve_hermes_bin_dir()` (`local.py:991`) resolves via `shutil.which("hermes")`, which on POSIX finds the bash launcher shim written by `scripts/install.sh:1659` — not the venv. `install.ps1:2259` adds `venv\Scripts` to the user PATH directly, so Windows was never affected. Merged PR #50534 prepends the *shim* dir, which is a different directory.

2. **Even on PATH it would lose.** `base.py:575` builds the session snapshot with `bash -l` plus the `~/.profile`/`~/.bashrc` prelude (`local.py:1449`), dumps it via `export -p`, and `base.py:672` sources that snapshot before every command. `eval "$(pyenv init -)"` *prepends* `~/.pyenv/shims`, so the snapshot's PATH has the shims first regardless of what Hermes put in the Popen env.

3. **There was no pip to find.** `scripts/install.sh:1348` created the venv with `uv venv` and no `--seed`.

Verified empirically before touching anything: with a fake `~/.profile` doing pyenv-style prepending, `command -v pip` inside `LocalEnvironment` resolved to the shim even with the venv bin on the subprocess PATH.

`local.py:342` already asserts as an invariant that "the Hermes venv stays reachable via PATH (its bin dir is first)" — the `VIRTUAL_ENV`-stripping fix for #23473 relies on that claim. It simply was not true on POSIX. This makes it true.

## Change

- `_resolve_hermes_venv_bin_dir()` (`local.py:1048`) — cached; returns `dirname(sys.executable)` only when `sys.prefix != sys.base_prefix`, `None` for `--no-venv`/system installs.
- `_make_run_env()` (`local.py:1223`) prepends it *below* the hermes launcher dir, so #50534's behaviour is unchanged. The existing 6-line prepend body was extracted into `_prepend_path_dir()` so both callers share it — no other refactor.
- `_prepend_venv_bin_path_guard()` (`local.py:1332`, wired at `:1454`) — a POSIX `case`-guarded `PATH=…; export PATH` snippet injected into **login** invocations only, positioned after the rc-sourcing prelude so it re-asserts precedence once pyenv/asdf/conda have run, and before `export -p` captures the snapshot. Snapshot-build time only; a later `source .venv/bin/activate` still wins. No-op on Windows and outside a venv.
- `scripts/install.sh:1353` / `scripts/install.ps1:1950` — `uv venv … --seed` so the venv actually has a pip. Kept in lockstep per the CONTRIBUTING rule. Termux already used stdlib `venv`, which seeds pip.

## How to test

```
./scripts/run_tests.sh tests/tools/test_local_venv_path_precedence.py tests/test_install_venv_seeds_pip.py
```
→ 2 files, 14 tests passed.

`test_local_venv_path_precedence.py` includes two real-bash e2e tests: `test_pip_resolves_to_hermes_venv_despite_pyenv_shims` (the repro) and `test_project_venv_activation_still_wins` (guards against over-reach). They skip on `win32`.

Regression value verified by neutralizing only the two integration points and leaving the helpers in place: exactly 2 tests fail, including the repro, with the reported symptom —
`assert '…/hermes/venv/bin/pip' in '…/home/.pyenv/shims/pip\npyenv-global-pip\n'`. All 12 pass with them restored.

No regressions:
```
./scripts/run_tests.sh <all tests/test_install*.py>   → 20 files, 67 passed, 0 failed
./scripts/run_tests.sh tests/test_subprocess_home_isolation.py \
  tests/gateway/test_session_context_inheritance.py tests/gateway/test_session_api.py \
  tests/gateway/test_raft_adapter.py                 → 4 files, 80 passed, 0 failed
```
`tests/tools` (17) and `tests/agent` (18) have pre-existing failures unrelated to this change — every failing file was re-run on a stashed tree and produced an identical list (browser hybrid routing, file_tools, approval, execution-flag `man`/`sort`, web providers, computer_use, anthropic/bedrock credentials).

`scripts/check-windows-footguns.py` clean, `ruff check` clean, `bash -n scripts/install.sh` OK.

## Known limitations

- **Existing installs don't get pip retroactively.** `--seed` only applies when the venv is (re)created; until then the documented `uv pip install --python <venv> pip` workaround is still needed. The PATH half is already active for them.
- **Background/PTY spawns are not covered.** `tools/process_registry.py:737,781` runs `[shell, "-lic", …]` with env from `_sanitize_subprocess_env` and no snapshot, so a *backgrounded* `pip install` can still reach a pyenv shim. Wrapping a user command string on the PTY path is a separate and riskier change; left out to keep this focused.
- `--seed` adds roughly 1–2s to fresh installs.

## Platforms

Guard is POSIX-only by design. Resolver and `_make_run_env` prepend are cross-platform (`os.pathsep`, `dirname(sys.executable)` → `Scripts` on Windows). Developed and tested on macOS (arm64, Python 3.13); Windows path exercised via unit tests only.
