### PR TITLE
fix(session-search): prefer interactive sessions in browse

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -1,9 +1,10 @@
 """Tests for the single-shape session_search tool.
 
-Three calling shapes:
+Four calling shapes:
   1. DISCOVERY — pass query → FTS5 + anchored window + bookends per hit
   2. SCROLL    — pass session_id + around_message_id → just the window
-  3. BROWSE    — no args → recent sessions chronologically
+  3. READ      — pass session_id → the session transcript
+  4. BROWSE    — no args → recent sessions, interactive sources first
 
 All run zero LLM calls.
 """
@@ -97,6 +98,12 @@ class TestSchema:
         # Must explain how to scroll
         assert "scroll FORWARD" in desc or "messages[-1]" in desc
 
+    def test_session_id_schema_teaches_read_and_scroll(self):
+        desc = SESSION_SEARCH_SCHEMA["parameters"]["properties"]["session_id"]["description"]
+        assert "around_message_id" in desc
+        assert "without it" in desc
+        assert "reads the session" in desc
+
     def test_no_llm_promise_in_description(self):
         # The new design never calls an LLM
         desc = SESSION_SEARCH_SCHEMA["description"].lower()
@@ -152,6 +159,73 @@ class TestBrowseShape:
         result = json.loads(session_search(db=db))
         titles = [r.get("title") for r in result["results"]]
         assert any("Modpack" in (t or "") for t in titles)
+
+
+class TestBrowseDemotion:
+    def _seed_newer_automation(self, db, count=12):
+        now = time.time()
+        db.create_session("interactive", source="cli")
+        db.append_message(
+            "interactive", role="user", content="interactive project work", timestamp=now - 10_000
+        )
+        for index in range(count):
+            session_id = f"cron_{index}"
+            db.create_session(session_id, source="cron")
+            db.append_message(
+                session_id,
+                role="user",
+                content="automated project status",
+                timestamp=now - index,
+            )
+        db._conn.commit()
+
+    def test_browse_prefers_interactive_sessions_over_newer_automation(self, db):
+        self._seed_newer_automation(db)
+
+        result = json.loads(session_search(db=db, limit=1))
+
+        assert [row["session_id"] for row in result["results"]] == ["interactive"]
+
+    def test_browse_finds_interactive_session_beyond_300_newer_automation_rows(self, db):
+        self._seed_newer_automation(db, count=301)
+
+        result = json.loads(session_search(db=db, limit=1))
+
+        assert [row["session_id"] for row in result["results"]] == ["interactive"]
+
+    def test_browse_backfills_with_automation_after_interactive_sessions(self, db):
+        self._seed_newer_automation(db)
+
+        result = json.loads(session_search(db=db, limit=3))
+
+        assert [row["source"] for row in result["results"]] == ["cli", "cron", "cron"]
+
+    def test_browse_returns_automation_when_it_is_all_that_exists(self, db):
+        self._seed_newer_automation(db, count=3)
+        db.delete_session("interactive")
+
+        result = json.loads(session_search(db=db, limit=3))
+
+        assert result["count"] == 3
+        assert {row["source"] for row in result["results"]} == {"cron"}
+
+    def test_browse_keeps_hidden_current_and_child_sessions_excluded(self, db):
+        now = time.time()
+        db.create_session("visible", source="cli")
+        db.append_message("visible", role="user", content="visible", timestamp=now - 4)
+        db.create_session("current", source="cli")
+        db.append_message("current", role="user", content="current", timestamp=now - 3)
+        db.create_session("child", source="cli", parent_session_id="visible")
+        db.append_message("child", role="user", content="child", timestamp=now - 2)
+        for source in _HIDDEN_SESSION_SOURCES:
+            db.create_session(source, source=source)
+            db.append_message(source, role="user", content=source, timestamp=now - 1)
+        db._conn.commit()
+
+        result = json.loads(session_search(db=db, current_session_id="current", limit=10))
+        session_ids = {row["session_id"] for row in result["results"]}
+
+        assert session_ids == {"visible"}
 
 
 # =========================================================================
@@ -677,7 +751,7 @@ class TestCronDemotion:
         assert result["results"][0]["source"] == "telegram"
         assert result["results"][0]["session_id"] == "s_user"
 
-    def test_cron_still_reachable_when_only_match(self, db):
+    def test_discovery_still_finds_demoted_automation_when_it_is_the_only_match(self, db):
         """Demotion must not exclude cron — when only cron matches, it still
         comes back."""
         now = int(time.time())

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -15,11 +15,15 @@ mode parameter):
      scroll forward / backward, re-anchor on the last / first message id of
      the returned window.
 
-  3. BROWSE — no args. Returns recent sessions chronologically (titles,
-     previews, timestamps).
+  3. READ — pass ``session_id`` without an anchor. Returns the session's
+     transcript (head + tail when large).
 
-All three modes operate on the SQLite session DB via the FTS5 index and
-the get_anchored_view / get_messages_around primitives in hermes_state.
+  4. BROWSE — no args. Returns recent sessions with interactive sources ahead
+     of automation (titles, previews, timestamps).
+
+All four shapes operate on the SQLite session DB. Discovery uses FTS5;
+anchored reads use the get_anchored_view / get_messages_around primitives in
+hermes_state.
 No LLM calls anywhere — every shape returns actual messages from the DB.
 
 History: PR #20238 (JabberELF) seeded a fast/summary dual-mode split; the
@@ -408,13 +412,29 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
 
 
 def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_profile: str = None) -> str:
-    """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
+    """Return recent metadata, prioritizing interactive sources over automation."""
     try:
-        sessions = db.list_sessions_rich(
-            limit=limit + 5,
-            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+        fetch_limit = limit + 5  # enough to skip the active lineage
+        interactive_sessions = db.list_sessions_rich(
+            limit=fetch_limit,
+            exclude_sources=list(_HIDDEN_SESSION_SOURCES + _DEMOTED_SESSION_SOURCES),
             order_by_last_active=True,
-        )  # fetch extra so we can skip current
+            compact_rows=True,
+        )
+        demoted_sessions = []
+        for source in _DEMOTED_SESSION_SOURCES:
+            if source not in _HIDDEN_SESSION_SOURCES:
+                demoted_sessions.extend(db.list_sessions_rich(
+                    source=source,
+                    limit=fetch_limit,
+                    order_by_last_active=True,
+                    compact_rows=True,
+                ))
+        demoted_sessions.sort(
+            key=lambda session: session.get("last_active") or session.get("started_at") or 0,
+            reverse=True,
+        )
+        sessions = _order_for_recall(interactive_sessions + demoted_sessions)
 
         current_root = _resolve_lineage(db, current_session_id) if current_session_id else None
 
@@ -989,7 +1009,7 @@ SESSION_SEARCH_SCHEMA = {
         "and call session_search(session_id=id, profile=profile).\n\n"
         "  4) BROWSE — no args:\n"
         "     session_search()\n"
-        "     Returns recent sessions chronologically: titles, previews, timestamps. "
+        "     Returns recent sessions with interactive sources before automation: titles, previews, timestamps. "
         "Use when the user asks \"what was I working on\" without naming a topic.\n\n"
         "LINKING THE USER TO A SESSION\n\n"
         "  When you refer the user to a session, write its `link` value inline in "
@@ -1029,8 +1049,8 @@ SESSION_SEARCH_SCHEMA = {
             "limit": {
                 "type": "integer",
                 "description": (
-                    "Discovery shape only. Max sessions to return (default 3, max 10). "
-                    "Bump to 5–10 when the topic likely spans several sessions and you "
+                    "Discovery and browse shapes. Max sessions to return (default 3; clamped "
+                    "to 1–10). For discovery, use 5–10 when the topic likely spans several sessions and you "
                     "want to pick the right one to scroll into."
                 ),
                 "default": 3,
@@ -1050,9 +1070,9 @@ SESSION_SEARCH_SCHEMA = {
             "session_id": {
                 "type": "string",
                 "description": (
-                    "Scroll shape. Session to read inside. Use the session_id returned "
-                    "from a prior discovery call. Must be paired with "
-                    "around_message_id."
+                    "Read or scroll shape. Use a session_id returned from discovery. "
+                    "With around_message_id, returns a window centered on that message; "
+                    "without it, reads the session (head + tail when large)."
                 ),
             },
             "around_message_id": {

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -152,7 +152,7 @@ Tools for driving desktop [Projects](../user-guide/cli.md) — named, multi-fold
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `session_search` | Search past sessions stored in the local session DB, or scroll inside one. FTS5-backed retrieval; returns actual messages from the DB (no LLM calls). Three shapes: discovery (pass `query`), scroll (pass `session_id` + `around_message_id`), browse (no args). | — |
+| `session_search` | Search past sessions stored in the local session DB, or scroll inside one. FTS5-backed retrieval; returns actual messages from the DB (no LLM calls). Four shapes: discovery (pass `query`), scroll (pass `session_id` + `around_message_id`), read (pass `session_id`), browse (no args). | — |
 
 ## `skills` toolset
 

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -525,9 +525,9 @@ For deeper analytics — token usage, cost estimates, tool breakdown, and activi
 
 ## Session Search Tool
 
-The agent has a built-in `session_search` tool that performs full-text search across all past conversations using SQLite's FTS5 engine — and lets the agent scroll through any session it finds. No LLM calls, no summarization, no truncation. Every shape returns actual messages from the DB.
+The agent has a built-in `session_search` tool that performs full-text search across all past conversations using SQLite's FTS5 engine — and lets the agent scroll through any session it finds. No LLM calls or summarization. Every shape returns actual messages from the DB; large Read results are bounded to a head-and-tail view.
 
-### Three calling shapes
+### Four calling shapes
 
 The tool infers what you want from which arguments you set. There's no `mode` parameter.
 
@@ -563,13 +563,21 @@ Returns a window of ±`window` messages centered on the anchor. No FTS5, no book
 
 Typical wall time: 1–2ms per scroll call.
 
-**3. Browse — no args:**
+**3. Read — pass `session_id` without an anchor:**
+
+```python
+session_search(session_id="20260510_174648_805cc2")
+```
+
+Returns that session's transcript. Large sessions return the first 20 and last 10 messages; use the message IDs with the scroll shape to inspect the middle.
+
+**4. Browse — no args:**
 
 ```python
 session_search()
 ```
 
-Returns recent sessions chronologically (titles, previews, timestamps). Useful when the user asks "what was I working on" without naming a topic.
+Returns recent sessions with interactive sources before automation (titles, previews, timestamps). Within each group, sessions remain ordered by recent activity. Useful when the user asks "what was I working on" without naming a topic.
 
 ### FTS5 query syntax
 


### PR DESCRIPTION
## Summary

- make Browse prefer recent interactive sessions over demoted automation
- query interactive and demoted source classes separately with bounded reads, then backfill automation when needed
- preserve hidden/current/child/lineage handling and Discovery/Scroll/Read behavior
- align the public schema and session documentation with all four calling shapes

## Root cause

Browse previously fetched only the newest `limit + 5` sessions before any source-priority ordering. A sufficiently large stream of newer scheduled sessions could therefore keep older interactive sessions out of the candidate set entirely.

## Validation

- `scripts/run_tests_parallel.py tests/tools/test_session_search.py -q` — 98/98 passed
- `ruff check tools/session_search_tool.py tests/tools/test_session_search.py` — PASS
- `scripts/check-windows-footguns.py tools/session_search_tool.py tests/tools/test_session_search.py` — PASS (2 Python files)
- `git diff --check` — PASS
- independent read-only review of the final diff — clean

No database migration or runtime-state mutation is included.
