### PR TITLE
fix(nix): update Electron headers sha256 hash to fix hermes-desktop nix build (#72095)

### DIFF
--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -31,7 +31,7 @@ let
 
   electronHeaders = pkgs.fetchurl {
     url = "https://artifacts.electronjs.org/headers/dist/v${electron.version}/node-v${electron.version}-headers.tar.gz";
-    sha256 = "sha256-zi/QMwRZ0+FwE9XTE+DiSIeJXAwxmLKEaBWD5W3pMOI=";
+    sha256 = "sha256-zOl8rx6woWh7aeRUOlkTMviKc/EAQQX6nr/MxAx1ZPI=";
   };
 
   # node-pty ships no Electron-tagged prebuild we can trust to match this


### PR DESCRIPTION
## Problem
`nix/desktop.nix` pins a stale `sha256` for the Electron node-gyp headers tarball. Building `hermes-desktop` with Nix fails with:

```
hash mismatch in fixed-output derivation
specified: sha256-zi/QMwRZ0+FwE9XTE+DiSIeJXAwxmLKEaBWD5W3pMOI=
got:      sha256-zOl8rx6woWh7aeRUOlkTMviKc/EAQQX6nr/MxAx1ZPI=
```

## Fix
Updated the pinned hash to the current correct value (the `got:` hash from the Nix error output).

## Verification
- One-line change to `nix/desktop.nix` — Nix file, no Python tests to run.
- Visual diff confirms only the hash string changed.

Closes #72095