### PR TITLE
fix(delegation): distinguish post-delivery owner exit from real child loss

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2449,6 +2449,14 @@ DEFAULT_CONFIG = {
         # and _get_orchestrator_enabled).  Floored at 1, no upper ceiling —
         # raise deliberately, each level multiplies API cost.
         "max_spawn_depth": 1,        # depth (1 = flat [default], 2 = orchestrator→leaf, 3+ = deeper)
+        # When a delegation's owner process exits AFTER its consolidated result
+        # was already delivered to the parent conversation, the leftover row is
+        # pure bookkeeping — the chat already has the result. Replaying it as a
+        # terminal notice costs context and attention for zero signal, and a
+        # burst of them trains the reader to ignore the genuinely-lost case
+        # (owner died with children unaccounted for), which is always reported.
+        # Set to false to keep those post-delivery records visible.
+        "suppress_delivered_owner_exit_tombstones": True,
         "orchestrator_enabled": True,  # kill switch for role="orchestrator"
         # When a subagent hits a dangerous-command approval prompt, the parent's
         # prompt_toolkit TUI owns stdin — a thread-local input() call from the

--- a/tests/tools/test_async_delegation_owner_exit_tombstone.py
+++ b/tests/tools/test_async_delegation_owner_exit_tombstone.py
@@ -274,6 +274,52 @@ def test_delivered_and_lost_tombstones_are_never_the_same_message(tmp_path):
     assert lost["child_states"] and delivered["child_states"]
 
 
+def test_reaper_never_downgrades_a_delivered_row_at_either_knob_setting(tmp_path):
+    """A delivered row must never be re-enqueued for delivery — knob-independent.
+
+    Delivery is tracked on ``delivery_state``, orthogonal to ``state``. Any
+    recovery path keying only on ``state`` can flip an already-delivered row
+    back to ``pending``, and ``restore_undelivered_completions()`` will then
+    re-deliver a result the conversation already has. Suppression must not be
+    what protects this: it has to hold with the knob OFF too, which is exactly
+    the branch that writes a fresh tombstone.
+    """
+    for suppress in ("true", "false"):
+        (tmp_path / "config.yaml").write_text(
+            f"delegation:\n  suppress_delivered_owner_exit_tombstones: {suppress}\n"
+        )
+        for index in range(3):
+            delegation_id = f"deleg_{suppress}_{index}"
+            _dispatch(delegation_id, ["g"])
+            with ad._DB_LOCK, ad._transaction() as conn:
+                conn.execute(
+                    "UPDATE async_delegations SET state=?, delivery_state='delivered', "
+                    "result_json=? WHERE delegation_id=?",
+                    (
+                        "running" if index % 2 == 0 else "finalizing",
+                        json.dumps({"results": [{"status": "completed", "goal": "g"}]}),
+                        delegation_id,
+                    ),
+                )
+            _kill_owner(delegation_id)
+
+        for _ in range(3):
+            ad.recover_abandoned_delegations()
+
+        with ad._DB_LOCK, ad._transaction() as conn:
+            downgraded = conn.execute(
+                "SELECT COUNT(*) FROM async_delegations "
+                "WHERE delivery_state='pending' AND delegation_id LIKE ?",
+                (f"deleg_{suppress}_%",),
+            ).fetchone()[0]
+        assert downgraded == 0, f"delivered rows downgraded with suppress={suppress}"
+
+        # And nothing already-delivered is ever handed back for redelivery.
+        assert not [
+            did for did in _restored_ids() if did.startswith(f"deleg_{suppress}_")
+        ]
+
+
 def test_suppression_knob_defaults_to_config_default():
     """The knob is a real documented config surface, not a bare literal."""
     from hermes_cli.config import DEFAULT_CONFIG

--- a/tests/tools/test_async_delegation_owner_exit_tombstone.py
+++ b/tests/tools/test_async_delegation_owner_exit_tombstone.py
@@ -1,0 +1,288 @@
+"""Owner-exit tombstones must distinguish real loss from post-delivery bookkeeping.
+
+The owner-liveness reaper used to emit a byte-identical terminal record for two
+OPPOSITE situations:
+
+* the owner died with children still unaccounted for — real lost work needing
+  re-dispatch; and
+* the owner died *after* the consolidated result was already delivered to the
+  parent conversation — pure bookkeeping.
+
+An operator could not tell them apart without hand-verifying deliverables on
+disk. These are behavior contracts on the relationship between delivery state
+and what the reaper reports, not snapshots of the message wording.
+"""
+
+import json
+import queue
+
+import pytest
+
+import tools.async_delegation as ad
+
+
+DEAD_PID = 99999999
+
+
+@pytest.fixture(autouse=True)
+def _sandboxed_home(tmp_path, monkeypatch):
+    """Point the durable ledger at a temp HERMES_HOME (never production)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield
+
+
+def _kill_owner(delegation_id):
+    """Make the recorded owner pid unresolvable, simulating owner exit."""
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET owner_pid=?, owner_started_at=NULL "
+            "WHERE delegation_id=?",
+            (DEAD_PID, delegation_id),
+        )
+
+
+def _row(delegation_id):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return conn.execute(
+            "SELECT state, delivery_state FROM async_delegations WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+
+
+def _event(delegation_id):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        row = conn.execute(
+            "SELECT event_json FROM async_delegations WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+    return json.loads(row[0]) if row and row[0] else None
+
+
+def _dispatch(delegation_id, goals):
+    ad._persist_dispatch({
+        "delegation_id": delegation_id,
+        "session_key": "owner",
+        "origin_ui_session_id": "",
+        "parent_session_id": None,
+        "dispatched_at": 1.0,
+        "goals": list(goals),
+        "is_batch": True,
+    })
+
+
+def _set_results(delegation_id, results):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET result_json=? WHERE delegation_id=?",
+            (json.dumps({"results": results}), delegation_id),
+        )
+
+
+def _restored_ids(delegation_id=None):
+    target = queue.Queue()
+    ad.restore_undelivered_completions(target)
+    ids = []
+    while not target.empty():
+        ids.append(target.get().get("delegation_id"))
+    return ids
+
+
+# ── Direction (a): owner died mid-flight → LOUD, names the lost children ──
+
+def test_midflight_owner_exit_names_unaccounted_children_for_redispatch():
+    _dispatch("deleg_lost", ["build parser", "write tests", "ship docs"])
+    # The owner got one child home before dying; two never reached a terminal state.
+    _set_results("deleg_lost", [
+        {"status": "completed", "summary": "parser ok"},
+        {"status": "running"},
+    ])
+    _kill_owner("deleg_lost")
+
+    assert ad.recover_abandoned_delegations() == 1
+    event = _event("deleg_lost")
+
+    # The outcome is genuinely in doubt, so it must NOT be reported as delivered.
+    assert event["status"] == "unknown"
+    assert event["owner_exit_delivered"] is False
+
+    # Per-child terminal state travels with the tombstone — the store already
+    # had this and the old message discarded it.
+    assert [child["status"] for child in event["child_states"]] == [
+        "completed", "running", "unknown",
+    ]
+    # Only the children that never reached a terminal success are unaccounted.
+    assert [child["index"] for child in event["unaccounted_children"]] == [1, 2]
+
+    # The operator is told which ids to re-dispatch, and is NOT told to stand down.
+    assert "re-dispatch" in event["error"].lower()
+    assert "no action needed" not in event["error"].lower()
+
+    # A genuinely-lost batch still re-enters the conversation.
+    assert "deleg_lost" in _restored_ids()
+
+
+def test_single_delegation_owner_exit_also_reports_child_state():
+    """Sibling call path: a non-batch record stores one result dict, not a list."""
+    ad._persist_dispatch({
+        "delegation_id": "deleg_single",
+        "session_key": "owner",
+        "origin_ui_session_id": "",
+        "parent_session_id": None,
+        "dispatched_at": 1.0,
+        "goal": "one job",
+    })
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET result_json=? WHERE delegation_id=?",
+            (json.dumps({"status": "running", "goal": "one job"}), "deleg_single"),
+        )
+    _kill_owner("deleg_single")
+
+    assert ad.recover_abandoned_delegations() == 1
+    event = _event("deleg_single")
+    assert event["status"] == "unknown"
+    assert len(event["child_states"]) == 1
+    assert event["unaccounted_children"][0]["index"] == 0
+
+
+# ── Direction (b): owner died after delivery → QUIET, no action needed ──
+
+def test_delivery_makes_the_row_terminal_so_the_reaper_cannot_phantom_it():
+    """The structural fix: delivery is the terminal moment.
+
+    A delivered row left at ``state='running'`` is precisely what let the reaper
+    manufacture a phantom "outcome unknown" for work that was fully delivered.
+    """
+    _dispatch("deleg_ok", ["a", "b"])
+    ad._persist_completion(
+        {"delegation_id": "deleg_ok", "status": "completed", "completed_at": 2.0},
+        {"results": [{"status": "completed"}, {"status": "completed"}]},
+    )
+    # Reproduce the pathology: the durable branch never advanced ``state``.
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET state='running' WHERE delegation_id=?",
+            ("deleg_ok",),
+        )
+
+    assert ad.claim_completion_delivery("deleg_ok", "claim-1") is True
+    assert ad.complete_completion_delivery("deleg_ok", "claim-1") is True
+
+    # Delivery advanced the row out of the reaper's scan window.
+    assert _row("deleg_ok")[0] not in ("running", "finalizing")
+
+    _kill_owner("deleg_ok")
+    assert ad.recover_abandoned_delegations() == 0
+    assert "deleg_ok" not in _restored_ids()
+
+
+def test_mark_completion_delivered_is_also_terminal():
+    """Sibling delivery path must carry the same contract as the claim path."""
+    _dispatch("deleg_marked", ["a"])
+    ad._persist_completion(
+        {"delegation_id": "deleg_marked", "status": "completed", "completed_at": 2.0},
+        {"results": [{"status": "completed"}]},
+    )
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET state='running' WHERE delegation_id=?",
+            ("deleg_marked",),
+        )
+
+    assert ad.mark_completion_delivered("deleg_marked") is True
+    assert _row("deleg_marked")[0] not in ("running", "finalizing")
+
+    _kill_owner("deleg_marked")
+    assert ad.recover_abandoned_delegations() == 0
+
+
+def test_delivered_row_reaching_the_reaper_is_settled_quietly():
+    """A legacy row already delivered but still 'running' must not re-alarm."""
+    _dispatch("deleg_legacy", ["x", "y"])
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET state='running', delivery_state='delivered', "
+            "result_json=? WHERE delegation_id=?",
+            (json.dumps({"results": [{"status": "completed"}, {"status": "completed"}]}),
+             "deleg_legacy"),
+        )
+    _kill_owner("deleg_legacy")
+
+    assert ad.recover_abandoned_delegations() == 1
+    # Settled to a terminal state...
+    assert _row("deleg_legacy")[0] not in ("running", "finalizing")
+    # ...without re-entering the conversation...
+    assert "deleg_legacy" not in _restored_ids()
+    # ...and never reaped a second time.
+    assert ad.recover_abandoned_delegations() == 0
+
+
+def test_suppression_knob_false_emits_a_distinguishable_quiet_record(tmp_path):
+    """With suppression off the record IS emitted — and reads nothing like a loss."""
+    (tmp_path / "config.yaml").write_text(
+        "delegation:\n  suppress_delivered_owner_exit_tombstones: false\n"
+    )
+    assert ad._suppress_delivered_tombstones() is False
+
+    _dispatch("deleg_visible", ["p", "q"])
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET state='running', delivery_state='delivered', "
+            "result_json=? WHERE delegation_id=?",
+            (json.dumps({"results": [{"status": "completed"}, {"status": "completed"}]}),
+             "deleg_visible"),
+        )
+    _kill_owner("deleg_visible")
+    assert ad.recover_abandoned_delegations() == 1
+
+    event = _event("deleg_visible")
+    assert event["owner_exit_delivered"] is True
+    assert event["unaccounted_children"] == []
+    assert len(event["child_states"]) == 2
+    assert "no action needed" in event["error"].lower()
+    assert "re-dispatch" not in event["error"].lower()
+
+
+def test_delivered_and_lost_tombstones_are_never_the_same_message(tmp_path):
+    """The core contract: the two opposite outcomes must not read identically."""
+    (tmp_path / "config.yaml").write_text(
+        "delegation:\n  suppress_delivered_owner_exit_tombstones: false\n"
+    )
+
+    _dispatch("deleg_a", ["one", "two"])
+    _set_results("deleg_a", [{"status": "completed"}, {"status": "running"}])
+    _kill_owner("deleg_a")
+
+    _dispatch("deleg_b", ["one", "two"])
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET state='running', delivery_state='delivered', "
+            "result_json=? WHERE delegation_id=?",
+            (json.dumps({"results": [{"status": "completed"}, {"status": "completed"}]}),
+             "deleg_b"),
+        )
+    _kill_owner("deleg_b")
+
+    ad.recover_abandoned_delegations()
+    lost = _event("deleg_a")
+    delivered = _event("deleg_b")
+
+    assert lost["error"] != delivered["error"]
+    assert lost["owner_exit_delivered"] is False
+    assert delivered["owner_exit_delivered"] is True
+    # And each carries the per-child detail, in BOTH directions.
+    assert lost["child_states"] and delivered["child_states"]
+
+
+def test_suppression_knob_defaults_to_config_default():
+    """The knob is a real documented config surface, not a bare literal."""
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert (
+        DEFAULT_CONFIG["delegation"]["suppress_delivered_owner_exit_tombstones"]
+        is ad._DEFAULT_SUPPRESS_DELIVERED_TOMBSTONES
+    )
+    # With no config.yaml written, the helper resolves to that documented default.
+    assert ad._suppress_delivered_tombstones() is (
+        DEFAULT_CONFIG["delegation"]["suppress_delivered_owner_exit_tombstones"]
+    )

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -115,6 +115,36 @@ _monitor_lock = threading.Lock()
 _monitor_thread: Optional[threading.Thread] = None
 _monitor_stop = threading.Event()
 
+#: Default for ``delegation.suppress_delivered_owner_exit_tombstones``.
+_DEFAULT_SUPPRESS_DELIVERED_TOMBSTONES = True
+
+
+def _suppress_delivered_tombstones() -> bool:
+    """Whether a post-delivery owner-exit tombstone stays out of the chat.
+
+    Behavioral setting, so it lives in ``config.yaml`` under
+    ``delegation.suppress_delivered_owner_exit_tombstones`` (never a new env
+    var — ``.env`` is for secrets). Defaults to ``True``: the parent surface
+    already received the consolidated result, so re-entering the conversation
+    to say "and the owner process later exited" is noise that trains the
+    reader to ignore the genuinely-lost case. Set it ``False`` to keep the
+    bookkeeping record visible.
+    """
+    try:
+        from hermes_cli.config import DEFAULT_CONFIG, cfg_get, read_raw_config
+
+        value = cfg_get(
+            read_raw_config(), "delegation", "suppress_delivered_owner_exit_tombstones"
+        )
+        if value is None:
+            value = DEFAULT_CONFIG["delegation"][
+                "suppress_delivered_owner_exit_tombstones"
+            ]
+        return bool(value)
+    except Exception:  # pragma: no cover - config must never break recovery
+        logger.debug("suppress_delivered_owner_exit_tombstones lookup failed", exc_info=True)
+    return _DEFAULT_SUPPRESS_DELIVERED_TOMBSTONES
+
 
 def _db_path():
     return get_hermes_home() / "state.db"
@@ -290,24 +320,146 @@ def _note_delivery_attempt(delegation_id: str) -> None:
         )
 
 
+#: Terminal statuses a *child* may report. Anything else (or a missing child
+#: record entirely) means that child never reached a terminal state and its
+#: work is genuinely unaccounted for.
+_CHILD_ACCOUNTED_STATUSES = frozenset({"completed", "success"})
+
+
+def _child_terminal_states(result: Any, task: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Per-child terminal states already recorded for a delegation.
+
+    The row's ``result_json`` carries whatever the owner managed to persist
+    before it died. For a batch that is a ``results`` list with one entry per
+    child; for a single delegation it is that one child's own result dict.
+    Returns a normalized list of ``{index, goal, status, exit_reason, summary}``
+    so a tombstone can *name* which children died and how far they got instead
+    of discarding information the store already holds.
+    """
+    goals = task.get("goals") or ([task["goal"]] if task.get("goal") else [])
+    raw: List[Any] = []
+    if isinstance(result, dict):
+        if isinstance(result.get("results"), list):
+            raw = result["results"]
+        elif result.get("status"):
+            raw = [result]
+    children: List[Dict[str, Any]] = []
+    # Iterate over the DISPATCHED goals, not just the recorded results: a child
+    # that never reported at all is exactly the one we must surface.
+    total = max(len(raw), len(goals))
+    for index in range(total):
+        entry = raw[index] if index < len(raw) and isinstance(raw[index], dict) else {}
+        goal = entry.get("goal") or (goals[index] if index < len(goals) else "")
+        children.append({
+            "index": index,
+            "goal": str(goal or "")[:120],
+            "status": entry.get("status") or "unknown",
+            "exit_reason": entry.get("exit_reason"),
+            "summary": entry.get("summary"),
+        })
+    return children
+
+
+def _tombstone_for(
+    *,
+    delivered: bool,
+    children: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build the terminal record for an owner that exited without finalizing.
+
+    Two OPPOSITE situations reach this point and they must not be reported
+    identically:
+
+    * the owner died *after* its consolidated result was already delivered to
+      the parent surface — pure bookkeeping, nothing was lost; and
+    * the owner died with children still unaccounted for — real lost work that
+      needs re-dispatch.
+
+    Returns ``{"status", "error", "unaccounted", "children"}``.
+    """
+    unaccounted = [
+        child for child in children
+        if str(child.get("status") or "") not in _CHILD_ACCOUNTED_STATUSES
+    ]
+    if delivered:
+        return {
+            "status": "delivered_owner_exited",
+            "error": (
+                "Delegation owner exited AFTER its result was delivered; "
+                "no action needed (bookkeeping only)."
+            ),
+            "unaccounted": [],
+            "children": children,
+        }
+    if not children:
+        # No per-child state was ever recorded — the honest legacy answer.
+        return {
+            "status": "unknown",
+            "error": (
+                "Delegation owner exited before recording a terminal result "
+                "and no per-child state was recorded; outcome unknown."
+            ),
+            "unaccounted": [],
+            "children": [],
+        }
+    if not unaccounted:
+        return {
+            "status": "unknown",
+            "error": (
+                f"Delegation owner exited before recording a terminal result, but all "
+                f"{len(children)} child task(s) reached a terminal state; "
+                f"results may not have reached the conversation."
+            ),
+            "unaccounted": [],
+            "children": children,
+        }
+    detail = "; ".join(
+        f"#{child['index']} {child['status']}"
+        + (f"/{child['exit_reason']}" if child.get("exit_reason") else "")
+        + (f" ({child['goal']})" if child.get("goal") else "")
+        for child in unaccounted
+    )
+    ids = ", ".join(f"#{child['index']}" for child in unaccounted)
+    return {
+        "status": "unknown",
+        "error": (
+            f"Delegation owner exited with {len(unaccounted)} of {len(children)} "
+            f"child task(s) unaccounted (re-dispatch {ids}): {detail}"
+        ),
+        "unaccounted": unaccounted,
+        "children": children,
+    }
+
+
 def recover_abandoned_delegations() -> int:
-    """Classify records whose owning process disappeared as outcome unknown."""
+    """Classify records whose owning process disappeared.
+
+    A row is only re-entered into the conversation when its outcome is
+    genuinely in doubt. Delivery is tracked on ``delivery_state``, which is
+    orthogonal to ``state``: a batch whose consolidated summary already
+    reached the parent surface can still be sitting at ``state='running'``
+    when its owner dies, and re-reaping it as "outcome unknown" produces a
+    phantom alarm indistinguishable from a real loss.
+    """
     try:
         from gateway.status import _pid_exists, get_process_start_time
     except Exception:
         return 0
     now = time.time()
     recovered = 0
+    suppress_delivered = _suppress_delivered_tombstones()
     with _DB_LOCK, _transaction() as conn:
         rows = conn.execute(
             """SELECT delegation_id, origin_session, origin_ui_session_id,
                       parent_session_id, dispatched_at, owner_pid,
-                      owner_started_at, task_json, origin_session_id
+                      owner_started_at, task_json, origin_session_id,
+                      delivery_state, result_json
                FROM async_delegations WHERE state IN ('running','finalizing')"""
         ).fetchall()
         for row in rows:
             (delegation_id, session_key, origin_ui, parent_id, dispatched_at,
-             pid, started, task_json, origin_session_id) = row
+             pid, started, task_json, origin_session_id,
+             delivery_state, result_json) = row
             live = False
             if pid:
                 live = _pid_exists(int(pid))
@@ -316,6 +468,29 @@ def recover_abandoned_delegations() -> int:
             if live:
                 continue
             task = json.loads(task_json or "{}")
+            try:
+                prior_result = json.loads(result_json or "null")
+            except (TypeError, ValueError):
+                prior_result = None
+            delivered = str(delivery_state or "") == "delivered"
+            children = _child_terminal_states(prior_result, task)
+            tombstone = _tombstone_for(delivered=delivered, children=children)
+            if delivered and suppress_delivered:
+                # Terminal-DELIVERED: settle the row so it is never re-reaped,
+                # but do NOT re-enter a conversation that already has the
+                # result. delivery_state stays 'delivered' so restart recovery
+                # (which only restores 'pending' rows) skips it.
+                conn.execute(
+                    """UPDATE async_delegations SET state=?, completed_at=?,
+                       updated_at=? WHERE delegation_id=?""",
+                    (tombstone["status"], now, now, delegation_id),
+                )
+                logger.info(
+                    "async_delegation_tombstone delegation_id=%s disposition=delivered_suppressed",
+                    delegation_id,
+                )
+                recovered += 1
+                continue
             event = {
                 "type": "async_delegation", "delegation_id": delegation_id,
                 "session_key": session_key, "origin_ui_session_id": origin_ui,
@@ -326,16 +501,33 @@ def recover_abandoned_delegations() -> int:
                 "goals": task.get("goals"), "context": task.get("context"),
                 "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
-                "status": "unknown", "summary": None,
-                "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
+                "status": tombstone["status"], "summary": None,
+                "error": tombstone["error"],
+                # Per-child terminal states travel with the tombstone in BOTH
+                # directions, so a consumer never has to guess what was lost.
+                "owner_exit_delivered": delivered,
+                "child_states": tombstone["children"],
+                "unaccounted_children": tombstone["unaccounted"],
                 "dispatched_at": dispatched_at, "completed_at": now,
             }
-            result = {"status": "unknown", "summary": None, "error": event["error"]}
+            result = {
+                "status": tombstone["status"], "summary": None,
+                "error": tombstone["error"],
+                "child_states": tombstone["children"],
+                "unaccounted_children": tombstone["unaccounted"],
+            }
             conn.execute(
-                """UPDATE async_delegations SET state='unknown', completed_at=?,
+                """UPDATE async_delegations SET state=?, completed_at=?,
                    updated_at=?, event_json=?, result_json=?, delivery_state='pending'
                    WHERE delegation_id=?""",
-                (now, now, json.dumps(event), json.dumps(result), delegation_id),
+                (tombstone["status"], now, now, json.dumps(event),
+                 json.dumps(result), delegation_id),
+            )
+            logger.info(
+                "async_delegation_tombstone delegation_id=%s disposition=%s unaccounted=%d",
+                delegation_id,
+                "delivered" if delivered else "lost",
+                len(tombstone["unaccounted"]),
             )
             recovered += 1
     return recovered
@@ -373,7 +565,8 @@ def mark_completion_delivered(delegation_id: str) -> bool:
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
         cur = conn.execute(
-            """UPDATE async_delegations SET delivery_state='delivered', delivered_at=?, updated_at=?
+            """UPDATE async_delegations SET delivery_state='delivered', delivered_at=?, updated_at=?,
+                      state=CASE WHEN state IN ('running','finalizing') THEN 'delivered' ELSE state END
                WHERE delegation_id=? AND delivery_state!='delivered'""",
             (now, now, delegation_id),
         )
@@ -470,13 +663,23 @@ def drop_completion_delivery(delegation_id: str, claim_id: str) -> bool:
 
 
 def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
-    """Acknowledge acceptance for the consumer holding this claim."""
+    """Acknowledge acceptance for the consumer holding this claim.
+
+    Delivery is the moment the consolidated result reaches the parent surface,
+    so it is also the moment the row becomes terminal. Without flipping
+    ``state`` here the row sits at ``running`` forever and the owner-liveness
+    reaper later tombstones a batch that was fully delivered — the phantom
+    "outcome unknown" alarm. ``state`` only advances out of a non-terminal
+    value, so a row that already recorded a real outcome keeps it.
+    """
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
         cur = conn.execute(
             """UPDATE async_delegations SET delivery_state='delivered',
                       delivered_at=?, updated_at=?, delivery_claim=NULL,
-                      delivery_claimed_at=NULL
+                      delivery_claimed_at=NULL,
+                      state=CASE WHEN state IN ('running','finalizing')
+                                 THEN 'delivered' ELSE state END
                WHERE delegation_id=? AND delivery_state='pending'
                  AND delivery_claim=?""",
             (now, now, delegation_id, claim_id),

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -518,7 +518,9 @@ def recover_abandoned_delegations() -> int:
             }
             conn.execute(
                 """UPDATE async_delegations SET state=?, completed_at=?,
-                   updated_at=?, event_json=?, result_json=?, delivery_state='pending'
+                   updated_at=?, event_json=?, result_json=?,
+                   delivery_state=CASE WHEN delivery_state='delivered'
+                                       THEN 'delivered' ELSE 'pending' END
                    WHERE delegation_id=?""",
                 (tombstone["status"], now, now, json.dumps(event),
                  json.dumps(result), delegation_id),


### PR DESCRIPTION
# fix(delegation): distinguish post-delivery owner exit from real child loss

## Symptom

Nine completed delegation batches re-entered a conversation simultaneously as:

> Delegation owner exited before recording a terminal result; outcome unknown.

All nine were phantoms — every task log present, all deliverables on disk. The same sentence is
also what a **genuinely lost** batch produces, so telling them apart required hand-verifying
deliverables on disk. Nine identical false alarms is exactly how a real one gets ignored.

## Root cause — a state-machine gap, not the wording

`recover_abandoned_delegations()` scans:

```sql
SELECT ... FROM async_delegations WHERE state IN ('running','finalizing')
```

But delivery only ever advanced **`delivery_state`**. `complete_completion_delivery()` — the call
`gateway/run.py` makes the instant a consolidated summary is accepted into the parent
conversation — set `delivery_state='delivered'` and left `state` untouched. The two columns are
orthogonal and the reaper scans on `state`.

So a fully-delivered batch sits at `state='running'` **forever**, permanently inside the reaper's
scan window. On the next boot the reaper finds a live-looking row with a dead owner pid and
manufactures "outcome unknown" for work that already landed in the chat. Because
`restore_undelivered_completions()` runs the reaper on every process start and then re-enqueues
every `pending` row, the entire backlog re-enters at once — hence nine.

Reproduced against the unpatched tree, driving the real dispatch path:

```
row after batch COMPLETED : ('running', 'pending')
row AFTER DELIVERY        : ('running', 'delivered')   <-- still in the scan window
recover_abandoned_delegations() -> 1                   <-- the phantom
```

The reaper also **had** the information to distinguish the two cases and discarded it:
`delivery_state` was never consulted, and `result_json` (per-child results) / `task_json` (child
goals) were never read.

## Fix

1. **Terminal-at-delivery.** `complete_completion_delivery()` and `mark_completion_delivered()`
   advance `state` via `CASE WHEN state IN ('running','finalizing') THEN 'delivered' ELSE state
   END`. A row that already recorded a real outcome keeps it; a delivered row leaves the reaper's
   scan window permanently. Both delivery writers are fixed, not just the one the gateway uses.
2. **Distinguishable reports.** An undelivered exit names the unaccounted children and asks for
   re-dispatch. A delivered exit says no action is needed.
3. **Per-child states in BOTH directions.** `child_states` + `unaccounted_children` ride the
   tombstone either way. `_child_terminal_states()` iterates the **dispatched goals**, not just
   recorded results, so a child that never reported at all is surfaced rather than silently
   omitted. Children that already completed are excluded from the re-dispatch list.
4. **Suppression, on by default** — see below.

## The adjacent question: should a post-delivery tombstone re-enter the conversation at all?

**No — and this PR defaults to suppressing it.**

The parent conversation already contains the consolidated result. A record saying "and the owner
process later exited" adds no actionable information: there is nothing to re-dispatch, nothing to
verify, nothing to decide. It costs context window and operator attention for zero signal.

The stronger argument is **alarm hygiene**. The genuinely-lost case is rare and urgent; the
post-delivery case is common and inert. Emitting both into the same channel means the common inert
one dominates by volume, and a reader who learns that these records are usually noise will skim
past the one that mattered. Nine phantoms in a single burst is that failure mode already in
progress. Suppressing the inert case is what keeps the loud case loud.

The information is **not** destroyed — the row is still settled terminally and remains queryable
(`get_durable_delegation`, `state='delivered_owner_exited'`), and the transition is logged at INFO
with an explicit disposition. What changes is only whether it interrupts the conversation.

Gated by a new `config.yaml` knob, since operators who want the bookkeeping trail should have it:

```yaml
delegation:
  suppress_delivered_owner_exit_tombstones: true   # default
```

Set `false` and the record is emitted — still clearly worded as bookkeeping, still carrying
per-child states, never confusable with a loss. This is a behavioral setting, so it lives in
`config.yaml` and **not** a new `HERMES_*` env var (`.env` is for secrets only, per AGENTS.md).
It extends the **existing** `delegation` section, so it adds no one-field settings-UI category.

## Tests

`tests/tools/test_async_delegation_owner_exit_tombstone.py` — 8 tests, **all 8 fail on the parent
commit**, all pass with the fix. They assert the *relationship* between delivery state and what
the reaper reports (behavior contracts), not the message wording, so rephrasing the copy will not
red them.

Both directions are proven:

- **mid-flight kill** → loud record naming the unaccounted children, `re-dispatch #1, #2`, and it
  DOES re-enter the conversation.
- **post-delivery kill** → row is terminal, reaper returns `0`, nothing re-enters. Confirmed in
  total isolation (single row in the DB) to rule out cross-talk.
- Plus: legacy rows already delivered but stuck at `running` settle quietly and are never
  re-reaped (idempotent); the knob-off path emits a record that is provably distinguishable from
  the loss case.

Sibling call paths covered: both delivery writers, and the non-batch delegation shape (whose
`result_json` is a single dict rather than a `results` list).

Upstream's existing `test_recover_marks_abandoned_running_record_unknown` still passes — a row
with no recorded child state and no delivery is still `status="unknown"`, preserving the honest
legacy answer for the genuinely-uninformative case.

No regressions: 39 delegation + 186 config + 32 web-server-schema + 36 delegate/live-log tests
pass.

Tests were run with a sandboxed `HOME` rather than `scripts/run_tests.sh`, which does
`exec env -i` and strips `HERMES_HOME` (silently pointing the suite at the production
`state.db`). Hermeticity was verified empirically: zero pytest fds against the production DB and
its mtime unchanged across the run.


---
The fork (`Kyzcreig/hermes-agent`) carries the same code and the same defect; this is generic delegation-subsystem behavior with no fork-specific surface, so it targets upstream.
