### PR TITLE
fix(delegation): distinguish a lost owner-exit from a post-delivery one

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2418,6 +2418,13 @@ DEFAULT_CONFIG = {
                                        # delegation units. New async dispatches beyond the cap
                                        # fall back to synchronous execution. Floor of 1, no ceiling.
                                        # (Replaces the deprecated max_async_children.)
+        # When a background delegation's owner process exits AFTER its consolidated
+        # result was already delivered to the parent surface, the leftover row is
+        # pure bookkeeping — nothing was lost. True (default) settles it silently;
+        # False re-enters it in the conversation as an informational record.
+        # Genuinely-lost delegations (children still unaccounted) ALWAYS re-enter
+        # the conversation regardless of this setting.
+        "suppress_delivered_owner_exit_tombstones": True,
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth
         # and _get_orchestrator_enabled).  Floored at 1, no upper ceiling —
         # raise deliberately, each level multiplies API cost.

--- a/tests/tools/test_async_delegation_owner_exit_tombstone.py
+++ b/tests/tools/test_async_delegation_owner_exit_tombstone.py
@@ -1,0 +1,296 @@
+"""Owner-exit tombstones must distinguish real loss from bookkeeping.
+
+The reaper (``recover_abandoned_delegations``) sees two OPPOSITE situations:
+
+* the owner died with children still unaccounted for — real lost work that
+  needs re-dispatch; and
+* the owner died after its consolidated result was already delivered to the
+  parent surface — pure bookkeeping, nothing was lost.
+
+Historically both produced a byte-identical terminal record
+("Delegation owner exited before recording a terminal result; outcome
+unknown."), so a run of harmless bookkeeping records trained the reader to
+ignore the one that mattered.
+
+These are behavior contracts, not snapshots: they assert how the tombstone
+must RELATE to the per-child state the store already holds, never a frozen
+message string.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+
+@pytest.fixture()
+def ad(tmp_path, monkeypatch):
+    """Import the module against an isolated HERMES_HOME."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    import tools.async_delegation as module
+
+    monkeypatch.setattr(module, "get_hermes_home", lambda: tmp_path)
+    # Default the config gate on; individual tests override it. raising=False
+    # so a build WITHOUT the fix fails on BEHAVIOR (the assertions below),
+    # not on a missing symbol — the RED must prove the contract, not the shape.
+    monkeypatch.setattr(
+        module, "_suppress_delivered_tombstones", lambda: True, raising=False
+    )
+    return module
+
+
+def _seed(
+    ad,
+    delegation_id: str,
+    *,
+    delivery_state: str,
+    result: dict | None,
+    goals: list[str],
+    state: str = "running",
+) -> None:
+    """Insert a row owned by a pid that cannot be alive."""
+    with ad._connect() as conn:
+        conn.execute(
+            """INSERT INTO async_delegations
+               (delegation_id, origin_session, origin_ui_session_id,
+                parent_session_id, state, dispatched_at, updated_at,
+                delivery_state, delivery_attempts, owner_pid,
+                owner_started_at, task_json, origin_session_id, result_json)
+               VALUES (?, 'sk', '', NULL, ?, 1.0, 1.0, ?, 0, ?, NULL, ?, '', ?)""",
+            (
+                delegation_id,
+                state,
+                delivery_state,
+                2_000_000_000,  # a pid that cannot exist
+                json.dumps({"goals": goals, "is_batch": True}),
+                json.dumps(result) if result is not None else None,
+            ),
+        )
+        conn.commit()
+
+
+def _row(ad, delegation_id: str) -> sqlite3.Row:
+    with ad._connect() as conn:
+        return conn.execute(
+            """SELECT state, delivery_state, event_json, result_json
+               FROM async_delegations WHERE delegation_id=?""",
+            (delegation_id,),
+        ).fetchone()
+
+
+def _event(ad, delegation_id: str) -> dict:
+    return json.loads(_row(ad, delegation_id)[2] or "{}")
+
+
+# ---------------------------------------------------------------------------
+# Direction 1 — owner killed MID-FLIGHT: must be LOUD and name the children
+# ---------------------------------------------------------------------------
+
+def test_mid_flight_owner_exit_names_unaccounted_children(ad):
+    """A batch interrupted mid-work must name WHICH children died."""
+    _seed(
+        ad,
+        "deleg_lost",
+        delivery_state="pending",
+        result={
+            "results": [
+                {"status": "interrupted", "exit_reason": "interrupted", "goal": "alpha"},
+                {"status": "completed", "exit_reason": "completed", "goal": "bravo"},
+                {"status": "interrupted", "exit_reason": "interrupted", "goal": "charlie"},
+            ]
+        },
+        goals=["alpha", "bravo", "charlie"],
+    )
+
+    assert ad.recover_abandoned_delegations() == 1
+
+    state, delivery_state, _, result_json = _row(ad, "deleg_lost")
+    event = _event(ad, "deleg_lost")
+
+    # It re-enters the conversation.
+    assert delivery_state == "pending"
+    assert state == "unknown"
+    assert event["owner_exit_delivered"] is False
+
+    # It names the unaccounted children — by index and by goal — and does NOT
+    # implicate the child that finished.
+    unaccounted = event["unaccounted_children"]
+    assert [c["index"] for c in unaccounted] == [0, 2]
+    assert {c["goal"] for c in unaccounted} == {"alpha", "charlie"}
+    assert all(c["status"] == "interrupted" for c in unaccounted)
+
+    # The message must carry the actionable content, not a fixed literal.
+    for token in ("#0", "#2", "re-dispatch", "interrupted"):
+        assert token in event["error"], (token, event["error"])
+    assert "#1" not in event["error"]
+
+    # Per-child terminal states are preserved in BOTH the event and the result.
+    assert [c["status"] for c in event["child_states"]] == [
+        "interrupted", "completed", "interrupted",
+    ]
+    assert json.loads(result_json)["child_states"] == event["child_states"]
+
+
+def test_child_that_never_reported_is_counted_unaccounted(ad):
+    """A dispatched goal with no recorded result is the clearest loss case."""
+    _seed(
+        ad,
+        "deleg_partial",
+        delivery_state="pending",
+        result={"results": [{"status": "completed", "goal": "alpha"}]},
+        goals=["alpha", "bravo"],
+    )
+
+    assert ad.recover_abandoned_delegations() == 1
+    event = _event(ad, "deleg_partial")
+
+    assert len(event["child_states"]) == 2
+    assert [c["index"] for c in event["unaccounted_children"]] == [1]
+    assert event["child_states"][1]["goal"] == "bravo"
+
+
+def test_no_recorded_child_state_still_reports_unknown(ad):
+    """With nothing recorded, the honest answer is still 'outcome unknown'."""
+    _seed(ad, "deleg_bare", delivery_state="pending", result=None, goals=[])
+
+    assert ad.recover_abandoned_delegations() == 1
+    event = _event(ad, "deleg_bare")
+
+    assert event["status"] == "unknown"
+    assert event["child_states"] == []
+    assert "unknown" in event["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Direction 2 — owner killed POST-DELIVERY: must be QUIET
+# ---------------------------------------------------------------------------
+
+def test_post_delivery_owner_exit_does_not_re_enter_conversation(ad):
+    """A delivered result must never be resurrected as 'outcome unknown'."""
+    _seed(
+        ad,
+        "deleg_delivered",
+        delivery_state="delivered",
+        result={"results": [{"status": "completed", "goal": "alpha"}]},
+        goals=["alpha"],
+    )
+
+    ad.recover_abandoned_delegations()
+
+    state, delivery_state, event_json, _ = _row(ad, "deleg_delivered")
+
+    # THE regression: the row must not be flipped back to pending.
+    assert delivery_state == "delivered"
+    assert state not in ("running", "finalizing")  # settled, never re-reaped
+
+    # And nothing is queued for restart recovery.
+    import queue
+
+    q = queue.Queue()
+    ad.restore_undelivered_completions(q)
+    assert q.empty()
+
+
+def test_post_delivery_tombstone_is_idempotent(ad):
+    """Re-running the reaper cannot resurrect a settled delivered row."""
+    _seed(
+        ad,
+        "deleg_delivered2",
+        delivery_state="delivered",
+        result={"results": [{"status": "completed", "goal": "alpha"}]},
+        goals=["alpha"],
+    )
+    ad.recover_abandoned_delegations()
+    first = _row(ad, "deleg_delivered2")
+    ad.recover_abandoned_delegations()
+    assert _row(ad, "deleg_delivered2")[:2] == first[:2]
+
+
+def test_delivered_tombstone_is_distinguishable_when_not_suppressed(ad, monkeypatch):
+    """With suppression off the record still differs from a real loss."""
+    monkeypatch.setattr(
+        ad, "_suppress_delivered_tombstones", lambda: False, raising=False
+    )
+    _seed(
+        ad,
+        "deleg_delivered3",
+        delivery_state="delivered",
+        result={"results": [{"status": "completed", "goal": "alpha"}]},
+        goals=["alpha"],
+    )
+    _seed(
+        ad,
+        "deleg_lost3",
+        delivery_state="pending",
+        result={"results": [{"status": "interrupted", "goal": "alpha"}]},
+        goals=["alpha"],
+    )
+
+    assert ad.recover_abandoned_delegations() == 2
+
+    delivered = _event(ad, "deleg_delivered3")
+    lost = _event(ad, "deleg_lost3")
+
+    # The contract: opposite situations produce distinguishable records.
+    assert delivered["status"] != lost["status"]
+    assert delivered["error"] != lost["error"]
+    assert delivered["owner_exit_delivered"] is True
+    assert lost["owner_exit_delivered"] is False
+    assert delivered["unaccounted_children"] == []
+    assert lost["unaccounted_children"] != []
+    # Per-child state travels EITHER way.
+    assert delivered["child_states"] and lost["child_states"]
+
+
+# ---------------------------------------------------------------------------
+# The bug class, stated as one invariant
+# ---------------------------------------------------------------------------
+
+def test_reaper_never_downgrades_a_delivered_row_to_pending(ad):
+    """No reaper pass may move delivery_state from 'delivered' back to 'pending'.
+
+    This is the whole bug class: delivery is tracked on a column orthogonal to
+    ``state``, so any recovery path that keys only on ``state`` can clobber an
+    already-delivered result.
+    """
+    for index in range(3):
+        _seed(
+            ad,
+            f"deleg_d{index}",
+            delivery_state="delivered",
+            result={"results": [{"status": "completed", "goal": "g"}]},
+            goals=["g"],
+            state="running" if index % 2 == 0 else "finalizing",
+        )
+
+    for _ in range(3):
+        ad.recover_abandoned_delegations()
+
+    with ad._connect() as conn:
+        downgraded = conn.execute(
+            "SELECT COUNT(*) FROM async_delegations WHERE delivery_state='pending'"
+        ).fetchone()[0]
+    assert downgraded == 0
+
+
+def test_config_default_gates_suppression_without_an_env_var():
+    """The knob is a config.yaml setting; behavioral config is never an env var."""
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    delegation = DEFAULT_CONFIG["delegation"]
+    assert "suppress_delivered_owner_exit_tombstones" in delegation
+    assert isinstance(delegation["suppress_delivered_owner_exit_tombstones"], bool)
+
+    import tools.async_delegation as module
+
+    # The module default must agree with the shipped config default, so the
+    # two can never drift (read the live value, don't freeze a literal).
+    assert (
+        module._DEFAULT_SUPPRESS_DELIVERED_TOMBSTONES
+        == delegation["suppress_delivered_owner_exit_tombstones"]
+    )

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -85,6 +85,31 @@ _MAX_DURABLE_PENDING = 1000
 _MAX_DELIVERY_ATTEMPTS = 8
 _DB_LOCK = threading.Lock()
 
+#: Default for ``delegation.suppress_delivered_owner_exit_tombstones``.
+_DEFAULT_SUPPRESS_DELIVERED_TOMBSTONES = True
+
+
+def _suppress_delivered_tombstones() -> bool:
+    """Whether a post-delivery owner-exit tombstone stays out of the chat.
+
+    Behavioral setting, so it lives in ``config.yaml`` under
+    ``delegation.suppress_delivered_owner_exit_tombstones`` (never a new env
+    var — ``.env`` is for secrets). Defaults to ``True``: the parent surface
+    already received the consolidated result, so re-entering the conversation
+    to say "and the owner process later exited" is noise that trains the
+    reader to ignore the genuinely-lost case. Set it ``False`` to keep the
+    bookkeeping record visible.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        value = (load_config() or {}).get("delegation", {})
+        if isinstance(value, dict) and "suppress_delivered_owner_exit_tombstones" in value:
+            return bool(value["suppress_delivered_owner_exit_tombstones"])
+    except Exception:  # pragma: no cover - config must never break recovery
+        logger.debug("suppress_delivered_owner_exit_tombstones lookup failed", exc_info=True)
+    return _DEFAULT_SUPPRESS_DELIVERED_TOMBSTONES
+
 
 def _db_path():
     return get_hermes_home() / "state.db"
@@ -260,24 +285,146 @@ def _note_delivery_attempt(delegation_id: str) -> None:
         )
 
 
+#: Terminal statuses a *child* may report. Anything else (or a missing child
+#: record entirely) means that child never reached a terminal state and its
+#: work is genuinely unaccounted for.
+_CHILD_ACCOUNTED_STATUSES = frozenset({"completed", "success"})
+
+
+def _child_terminal_states(result: Any, task: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Per-child terminal states already recorded for a delegation.
+
+    The row's ``result_json`` carries whatever the owner managed to persist
+    before it died. For a batch that is a ``results`` list with one entry per
+    child; for a single delegation it is that one child's own result dict.
+    Returns a normalized list of ``{index, goal, status, exit_reason, summary}``
+    so a tombstone can *name* which children died and how far they got instead
+    of discarding information the store already holds.
+    """
+    goals = task.get("goals") or ([task["goal"]] if task.get("goal") else [])
+    raw: List[Any] = []
+    if isinstance(result, dict):
+        if isinstance(result.get("results"), list):
+            raw = result["results"]
+        elif result.get("status"):
+            raw = [result]
+    children: List[Dict[str, Any]] = []
+    # Iterate over the DISPATCHED goals, not just the recorded results: a child
+    # that never reported at all is exactly the one we must surface.
+    total = max(len(raw), len(goals))
+    for index in range(total):
+        entry = raw[index] if index < len(raw) and isinstance(raw[index], dict) else {}
+        goal = entry.get("goal") or (goals[index] if index < len(goals) else "")
+        children.append({
+            "index": index,
+            "goal": str(goal or "")[:120],
+            "status": entry.get("status") or "unknown",
+            "exit_reason": entry.get("exit_reason"),
+            "summary": entry.get("summary"),
+        })
+    return children
+
+
+def _tombstone_for(
+    *,
+    delivered: bool,
+    children: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build the terminal record for an owner that exited without finalizing.
+
+    Two OPPOSITE situations reach this point and they must not be reported
+    identically:
+
+    * the owner died *after* its consolidated result was already delivered to
+      the parent surface — pure bookkeeping, nothing was lost; and
+    * the owner died with children still unaccounted for — real lost work that
+      needs re-dispatch.
+
+    Returns ``{"status", "error", "unaccounted", "children"}``.
+    """
+    unaccounted = [
+        child for child in children
+        if str(child.get("status") or "") not in _CHILD_ACCOUNTED_STATUSES
+    ]
+    if delivered:
+        return {
+            "status": "delivered_owner_exited",
+            "error": (
+                "Delegation owner exited AFTER its result was delivered; "
+                "no action needed (bookkeeping only)."
+            ),
+            "unaccounted": [],
+            "children": children,
+        }
+    if not children:
+        # No per-child state was ever recorded — the honest legacy answer.
+        return {
+            "status": "unknown",
+            "error": (
+                "Delegation owner exited before recording a terminal result "
+                "and no per-child state was recorded; outcome unknown."
+            ),
+            "unaccounted": [],
+            "children": [],
+        }
+    if not unaccounted:
+        return {
+            "status": "unknown",
+            "error": (
+                f"Delegation owner exited before recording a terminal result, but all "
+                f"{len(children)} child task(s) reached a terminal state; "
+                f"results may not have reached the conversation."
+            ),
+            "unaccounted": [],
+            "children": children,
+        }
+    detail = "; ".join(
+        f"#{child['index']} {child['status']}"
+        + (f"/{child['exit_reason']}" if child.get("exit_reason") else "")
+        + (f" ({child['goal']})" if child.get("goal") else "")
+        for child in unaccounted
+    )
+    ids = ", ".join(f"#{child['index']}" for child in unaccounted)
+    return {
+        "status": "unknown",
+        "error": (
+            f"Delegation owner exited with {len(unaccounted)} of {len(children)} "
+            f"child task(s) unaccounted (re-dispatch {ids}): {detail}"
+        ),
+        "unaccounted": unaccounted,
+        "children": children,
+    }
+
+
 def recover_abandoned_delegations() -> int:
-    """Classify records whose owning process disappeared as outcome unknown."""
+    """Classify records whose owning process disappeared.
+
+    A row is only re-entered into the conversation when its outcome is
+    genuinely in doubt. Delivery is tracked on ``delivery_state``, which is
+    orthogonal to ``state``: a batch whose consolidated summary already
+    reached the parent surface can still be sitting at ``state='running'``
+    when its owner dies, and re-reaping it as "outcome unknown" produces a
+    phantom alarm indistinguishable from a real loss.
+    """
     try:
         from gateway.status import _pid_exists, get_process_start_time
     except Exception:
         return 0
     now = time.time()
     recovered = 0
+    suppress_delivered = _suppress_delivered_tombstones()
     with _DB_LOCK, _transaction() as conn:
         rows = conn.execute(
             """SELECT delegation_id, origin_session, origin_ui_session_id,
                       parent_session_id, dispatched_at, owner_pid,
-                      owner_started_at, task_json, origin_session_id
+                      owner_started_at, task_json, origin_session_id,
+                      delivery_state, result_json
                FROM async_delegations WHERE state IN ('running','finalizing')"""
         ).fetchall()
         for row in rows:
             (delegation_id, session_key, origin_ui, parent_id, dispatched_at,
-             pid, started, task_json, origin_session_id) = row
+             pid, started, task_json, origin_session_id,
+             delivery_state, result_json) = row
             live = False
             if pid:
                 live = _pid_exists(int(pid))
@@ -286,6 +433,29 @@ def recover_abandoned_delegations() -> int:
             if live:
                 continue
             task = json.loads(task_json or "{}")
+            try:
+                prior_result = json.loads(result_json or "null")
+            except (TypeError, ValueError):
+                prior_result = None
+            delivered = str(delivery_state or "") == "delivered"
+            children = _child_terminal_states(prior_result, task)
+            tombstone = _tombstone_for(delivered=delivered, children=children)
+            if delivered and suppress_delivered:
+                # Terminal-DELIVERED: settle the row so it is never re-reaped,
+                # but do NOT re-enter a conversation that already has the
+                # result. delivery_state stays 'delivered' so restart recovery
+                # (which only restores 'pending' rows) skips it.
+                conn.execute(
+                    """UPDATE async_delegations SET state=?, completed_at=?,
+                       updated_at=? WHERE delegation_id=?""",
+                    (tombstone["status"], now, now, delegation_id),
+                )
+                logger.info(
+                    "async_delegation_tombstone delegation_id=%s disposition=delivered_suppressed",
+                    delegation_id,
+                )
+                recovered += 1
+                continue
             event = {
                 "type": "async_delegation", "delegation_id": delegation_id,
                 "session_key": session_key, "origin_ui_session_id": origin_ui,
@@ -296,16 +466,33 @@ def recover_abandoned_delegations() -> int:
                 "goals": task.get("goals"), "context": task.get("context"),
                 "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
-                "status": "unknown", "summary": None,
-                "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
+                "status": tombstone["status"], "summary": None,
+                "error": tombstone["error"],
+                # Per-child terminal states travel with the tombstone in BOTH
+                # directions, so a consumer never has to guess what was lost.
+                "owner_exit_delivered": delivered,
+                "child_states": tombstone["children"],
+                "unaccounted_children": tombstone["unaccounted"],
                 "dispatched_at": dispatched_at, "completed_at": now,
             }
-            result = {"status": "unknown", "summary": None, "error": event["error"]}
+            result = {
+                "status": tombstone["status"], "summary": None,
+                "error": tombstone["error"],
+                "child_states": tombstone["children"],
+                "unaccounted_children": tombstone["unaccounted"],
+            }
             conn.execute(
-                """UPDATE async_delegations SET state='unknown', completed_at=?,
+                """UPDATE async_delegations SET state=?, completed_at=?,
                    updated_at=?, event_json=?, result_json=?, delivery_state='pending'
                    WHERE delegation_id=?""",
-                (now, now, json.dumps(event), json.dumps(result), delegation_id),
+                (tombstone["status"], now, now, json.dumps(event),
+                 json.dumps(result), delegation_id),
+            )
+            logger.info(
+                "async_delegation_tombstone delegation_id=%s disposition=%s unaccounted=%d",
+                delegation_id,
+                "delivered" if delivered else "lost",
+                len(tombstone["unaccounted"]),
             )
             recovered += 1
     return recovered
@@ -343,7 +530,8 @@ def mark_completion_delivered(delegation_id: str) -> bool:
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
         cur = conn.execute(
-            """UPDATE async_delegations SET delivery_state='delivered', delivered_at=?, updated_at=?
+            """UPDATE async_delegations SET delivery_state='delivered', delivered_at=?, updated_at=?,
+                      state=CASE WHEN state IN ('running','finalizing') THEN 'delivered' ELSE state END
                WHERE delegation_id=? AND delivery_state!='delivered'""",
             (now, now, delegation_id),
         )


### PR DESCRIPTION
# fix(delegation): distinguish a lost owner-exit from a post-delivery one

## The symptom

The owner-liveness reaper emits an **identical terminal record for two opposite states**:

> Delegation owner exited before recording a terminal result; outcome unknown.

Observed in one session: **nine** completed background batches re-entered the conversation with
that message simultaneously — all phantoms (every task log present, all deliverables on disk) —
and then a **tenth** fired for a batch that was genuinely interrupted mid-work with four children
dead at 652s. Same message, opposite meaning. Nine false alarms is exactly how the real one gets
ignored.

## Root cause

### 1. The reaper keys on `state` and ignores `delivery_state`

```sql
SELECT ... FROM async_delegations WHERE state IN ('running','finalizing')
```

`delivery_state` is **orthogonal** to `state` and written by a different path: `_persist_completion`
sets `state` (the work outcome) while `complete_completion_delivery` / `mark_completion_delivered`
set `delivery_state='delivered'` (the handoff to the parent surface). There is no terminal-DELIVERED
concept, so a batch whose consolidated summary already reached the parent can still be sitting at
`state='running'` when its owner process dies. The reaper then writes:

```sql
UPDATE async_delegations SET state='unknown', ..., delivery_state='pending'
```

downgrading `delivered → pending`, which `restore_undelivered_completions` re-enqueues as a fresh
turn. That is the phantom.

### 2. The tombstone discards state the row already holds

The payload was a fixed literal (`status='unknown'`, `summary=None`, one constant error string).
The same row carries `result_json` with per-child `status`/`exit_reason`/`summary` and `task_json`
with the dispatched `goals`. None of it reached the tombstone, so a genuinely interrupted batch
could not say *which* children died or how far they got — precisely what a reader needs to decide
on re-dispatch.

## Reproduced on clean `main`

```
in-flight                 [('deleg_c780eb4f','running','pending')]
claim while running: True
delivered-while-running   [('deleg_c780eb4f','running','delivered')]
REAPER (owner alive): 0
REAPER (owner dead):  1
after-reaper              [('deleg_c780eb4f','unknown','pending')]   <-- delivered -> pending
```

## The fix

- Read `delivery_state` and `result_json` in the reaper.
- `_child_terminal_states()` derives per-child terminal state from the recorded results **unioned
  with the dispatched goals**, so a child that never reported at all is surfaced as unaccounted
  rather than silently omitted.
- `_tombstone_for()` emits distinguishable records:
  - **delivered** → `state='delivered_owner_exited'`, *"owner exited AFTER its result was delivered;
    no action needed (bookkeeping only)"*. `delivery_state` stays `delivered`, so the row is neither
    re-reaped nor restored (restart recovery only restores `pending`).
  - **lost** → *"owner exited with 4 of 4 child task(s) unaccounted (re-dispatch #0, #1, #2, #3):
    #0 interrupted/interrupted (…); …"*
  - all children terminal but undelivered → its own third message.
  - nothing recorded → the honest legacy "outcome unknown".
- Per-child states ride the event **either way** as `child_states` / `unaccounted_children` /
  `owner_exit_delivered`.

## Should a post-delivery tombstone re-enter the parent conversation at all?

**No — suppressed by default, and it is gated in `config.yaml`, not an env var.**

The parent surface already received the consolidated result. Re-entering the conversation to add
"…and the owner process later exited" carries **zero actionable information** while consuming a turn
and, worse, *training the reader that this message class is noise*. That habituation is the actual
harm: it is what nearly buried the one genuine interruption behind nine phantoms. An alarm that
fires when nothing is wrong is not a conservative default — it is a defect that degrades the alarm
channel.

The event is not discarded, only kept out of the conversation: the row is settled terminally at
`state='delivered_owner_exited'` (audit-queryable via `get_durable_delegation`) and an INFO line is
logged with the disposition. Operators who want the bookkeeping record visible set:

```yaml
delegation:
  suppress_delivered_owner_exit_tombstones: false
```

With suppression off the record is still **distinguishable** from a real loss (different `status`,
different message, `owner_exit_delivered: true`, empty `unaccounted_children`) — suppression is a
volume control, not the fix. The fix is that the two cases stopped being identical.

Per the contribution rubric, this is a behavioral setting, so it lives in `config.yaml` with a
documented default in `DEFAULT_CONFIG["delegation"]`; `.env` is for secrets only. **No new env var
is introduced.** A test asserts the module default and the shipped config default agree by reading
the live value, so the two cannot drift.

**Genuinely-lost delegations always re-enter the conversation regardless of this setting.**

## Whole bug class, sibling call paths included

`recover_abandoned_delegations` was the **only** writer that reset `delivery_state` to `'pending'`
on an already-terminal row. Every sibling path was audited and is correctly guarded:

| Path | Guard | Verdict |
|---|---|---|
| `release_completion_delivery` | `WHERE delivery_state='pending'` | safe |
| `drop_completion_delivery` | `WHERE delivery_state='pending'` | safe |
| `complete_completion_delivery` | `WHERE delivery_state='pending'` | safe |
| `_persist_completion` | sets `pending` at genuine completion | correct by design |
| `restore_undelivered_completions` | restores only `pending` | fixing the reaper is sufficient |

The class-level invariant is locked as a behavior contract:
**no reaper pass may move `delivery_state` from `'delivered'` back to `'pending'`.**

## Tests

Behavior contracts, not snapshots — they assert how the tombstone must *relate* to the per-child
state the store already holds, never a frozen message string.

**RED (fix surgically reverted, tests kept):** `7 failed, 1 passed`. Every failure is a behavior
failure, including `assert 'unknown' != 'unknown'` (the two opposite situations are literally
identical) and `assert 'pending' == 'delivered'` (the delivered row was downgraded).

**GREEN:** `8 passed`.

**Neighbors, no regressions:** `7 files, 190 tests passed, 0 failed` across
`test_async_delegation.py`, `test_async_delegation_fd_leak.py`,
`test_restored_delegation_ownership.py`, `test_cli_async_delegation_delivery.py`,
`test_completion_delivery.py`, `test_process_registry.py`.

**E2E on the real fixture**, seeding a genuinely-interrupted batch and a delivered phantom into the
*same* reaper pass against a real `state.db`:

```
--- deleg_f8a84aa8  state=unknown  delivery_state=pending
    ERROR: Delegation owner exited with 4 of 4 child task(s) unaccounted
           (re-dispatch #0, #1, #2, #3): #0 interrupted/interrupted (…); …
--- deleg_5b249e43  state=delivered_owner_exited  delivery_state=delivered
    QUIET — nothing re-entered the conversation

RESTORED INTO CONVERSATION: ['deleg_f8a84aa8']
```

Kill the owner mid-flight → loud, and it names which children died. Kill it post-delivery → quiet.

## Backward compatibility

No schema change — `delivery_state` and `result_json` already exist. New event keys are additive;
consumers that ignore them see the same shape with a more informative `error`. Rows previously
reaped into `state='unknown'` are untouched.
