### PR TITLE
fix(gateway): expand ${VAR} references in gateway config, filter unresolved refs from id lists

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -16,7 +16,7 @@ from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Dict, List, Optional, Any, Callable
 from enum import Enum
 
-from hermes_cli.config import get_hermes_home
+from hermes_cli.config import get_hermes_home, _expand_env_vars
 from agent.secret_scope import current_secret_scope, get_secret as _get_secret
 from utils import is_truthy_value
 
@@ -1288,6 +1288,19 @@ def load_gateway_config() -> GatewayConfig:
             # the messaging gateway. Fail-open via the shared helper.
             from hermes_cli import managed_scope
             yaml_cfg = managed_scope.apply_managed_overlay(yaml_cfg)
+
+            # Expand ${VAR} / ${env:VAR} references against os.environ, for
+            # consistency with hermes_cli.config.load_config() (which this
+            # loader otherwise bypasses entirely, per the comment above) and
+            # the existing expansion call sites in gateway/run.py. Without
+            # this, e.g. platforms.telegram.extra.group_allow_admin_from:
+            # ['${TELEGRAM_ADMIN_ID}'] kept the literal string, which
+            # gateway/slash_access.py's policy_from_extra() then treated as
+            # a real (unmatchable) admin id -- silently locking every user
+            # out of every tiered slash command with no error or log line
+            # (issue #72096). Applied after the managed overlay so an
+            # admin-pinned value can reference an env var too.
+            yaml_cfg = _expand_env_vars(yaml_cfg)
 
             # Shared nested-fallback source: settings meant to be top-level
             # keys are also accepted when a user nests them under `gateway:`

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -11,12 +11,13 @@ Handles loading and validating configuration for:
 import logging
 import os
 import json
+import re
 from pathlib import Path
 from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Dict, List, Optional, Any, Callable
 from enum import Enum
 
-from hermes_cli.config import get_hermes_home, _expand_env_vars
+from hermes_cli.config import get_hermes_home
 from agent.secret_scope import current_secret_scope, get_secret as _get_secret
 from utils import is_truthy_value
 
@@ -252,6 +253,83 @@ def _getenv(name: str, default: Optional[str] = None) -> Optional[str]:
 def _getenv_str(name: str, default: str = "") -> str:
     val = _getenv(name, default)
     return val if val is not None else default
+
+
+_ENV_REF_RE = re.compile(r"\$\{([^}]+)\}")
+
+
+def _env_ref_var_name(ref: str) -> Optional[str]:
+    """Normalize a ``${...}`` body to the env-var name it reads, or None
+    when the ref uses a non-env source and never touches the environment.
+    Mirrors hermes_cli.config._env_ref_var_name for the same ${VAR} /
+    ${env:VAR} shapes."""
+    ref = ref.strip()
+    if ref.startswith("env:"):
+        name = ref[len("env:"):].strip()
+        return name or None
+    if ":" in ref and re.match(r"^[a-z][a-z0-9_-]*:", ref):
+        return None
+    return ref
+
+
+def _env_expand_match_scoped(m: "re.Match") -> str:
+    """Expand one ``${...}`` config reference through ``_getenv()`` rather
+    than ``os.environ`` directly, so an active profile secret scope
+    (multiplex mode -- see ``_getenv``'s own docstring) is honored instead
+    of always reading the process-global environment. Mirrors
+    hermes_cli.config._env_expand_match's shape handling exactly (bare
+    ${VAR}, ${env:VAR}, and other SecretRef sources left verbatim with a
+    warning), only swapping the lookup mechanism.
+    """
+    raw = m.group(0)
+    name = _env_ref_var_name(m.group(1))
+    if name is None:
+        # Non-env SecretRef source (bitwarden:, vault:, file:, ...) -- not
+        # resolvable here, same as the process-global expander.
+        inner = m.group(1).strip()
+        logger.warning(
+            "Config ref %r uses source %r which is not resolvable in "
+            "config.yaml — external secret sources inject env vars at "
+            "startup, so reference the variable as ${env:NAME} instead",
+            raw, inner.split(":", 1)[0],
+        )
+        return raw
+    val = _getenv(name)
+    if val is not None:
+        return val
+    if m.group(1).strip().startswith("env:"):
+        logger.warning(
+            "Config ref %r: %s is not set in the active secret scope "
+            "(check ~/.hermes/.env or the profile's own .env); keeping "
+            "the literal placeholder", raw, name,
+        )
+    return raw
+
+
+def _expand_env_vars_scoped(obj):
+    """Recursively expand ``${VAR}`` / ``${env:VAR}`` references in config
+    values, resolving each name through ``_getenv()`` instead of
+    ``os.environ`` directly.
+
+    This is a scope-aware counterpart to hermes_cli.config._expand_env_vars:
+    that function is correct for hermes_cli.config.load_config()'s
+    single-profile CLI callers, but load_gateway_config() also runs during
+    multiplexed profile startup, where _profile_runtime_scope()
+    (gateway/run.py) installs each profile's own .env into a
+    current_secret_scope() rather than mutating os.environ (so multiple
+    profiles' secrets never collide in the shared process environment).
+    Reading os.environ directly here would resolve a ${VAR} reference
+    against the wrong profile's value (or the process-global one) instead
+    of the active profile's, or leave a profile-local-only reference
+    unresolved entirely (issue #72096, keep_open review).
+    """
+    if isinstance(obj, str):
+        return _ENV_REF_RE.sub(_env_expand_match_scoped, obj)
+    if isinstance(obj, dict):
+        return {k: _expand_env_vars_scoped(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_expand_env_vars_scoped(item) for item in obj]
+    return obj
 
 
 def _getenv_int(name: str, default: int) -> int:
@@ -1289,18 +1367,28 @@ def load_gateway_config() -> GatewayConfig:
             from hermes_cli import managed_scope
             yaml_cfg = managed_scope.apply_managed_overlay(yaml_cfg)
 
-            # Expand ${VAR} / ${env:VAR} references against os.environ, for
-            # consistency with hermes_cli.config.load_config() (which this
-            # loader otherwise bypasses entirely, per the comment above) and
-            # the existing expansion call sites in gateway/run.py. Without
-            # this, e.g. platforms.telegram.extra.group_allow_admin_from:
+            # Expand ${VAR} / ${env:VAR} references, for consistency with
+            # hermes_cli.config.load_config() (which this loader otherwise
+            # bypasses entirely, per the comment above) and the existing
+            # expansion call sites in gateway/run.py. Without this, e.g.
+            # platforms.telegram.extra.group_allow_admin_from:
             # ['${TELEGRAM_ADMIN_ID}'] kept the literal string, which
             # gateway/slash_access.py's policy_from_extra() then treated as
             # a real (unmatchable) admin id -- silently locking every user
             # out of every tiered slash command with no error or log line
             # (issue #72096). Applied after the managed overlay so an
             # admin-pinned value can reference an env var too.
-            yaml_cfg = _expand_env_vars(yaml_cfg)
+            #
+            # Uses _expand_env_vars_scoped() (backed by _getenv()), NOT
+            # hermes_cli.config's process-global _expand_env_vars(): this
+            # loader runs during multiplexed profile startup too, where
+            # _profile_runtime_scope() (gateway/run.py) installs each
+            # profile's own .env into a current_secret_scope() without
+            # mutating os.environ, so reading os.environ directly here
+            # could resolve ${VAR} against the wrong profile (or leave a
+            # profile-local-only reference unresolved) instead of the
+            # active profile's value (keep_open review on #72096).
+            yaml_cfg = _expand_env_vars_scoped(yaml_cfg)
 
             # Shared nested-fallback source: settings meant to be top-level
             # keys are also accepted when a user nests them under `gateway:`

--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -34,8 +34,22 @@ included here — only the slash-command access split.
 
 from __future__ import annotations
 
+import logging
+import re
 from dataclasses import dataclass
 from typing import Any, FrozenSet, Iterable, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Matches an entry that is STILL a literal, unresolved ${VAR} / ${env:VAR}
+# reference after config loading -- i.e. hermes_cli.config._expand_env_vars()
+# ran but the named variable wasn't set in os.environ (or, before issue
+# #72096's fix, gateway/config.py never called it at all). Such a value can
+# never be a legitimate user id, so filtering it out here is a second,
+# defense-in-depth layer independent of the loader-level fix: it also
+# protects against any other config path that might someday bypass
+# expansion the same way, and gives an explicit log line either way.
+_UNRESOLVED_VAR_REF_RE = re.compile(r"^\$\{[^}]*\}$")
 
 
 # Slash commands that MUST stay reachable for any allowed user, even when
@@ -107,10 +121,26 @@ def _coerce_id_list(raw: Any) -> FrozenSet[str]:
         # single scalar (int user id, etc.)
         items = (raw,)
     out: list[str] = []
+    unresolved: list[str] = []
     for it in items:
         s = str(it).strip()
-        if s:
-            out.append(s)
+        if not s:
+            continue
+        if _UNRESOLVED_VAR_REF_RE.match(s):
+            unresolved.append(s)
+            continue
+        out.append(s)
+    if unresolved:
+        logger.warning(
+            "Ignoring unresolved config reference(s) in an admin/user id "
+            "list: %s — the referenced environment variable is unset (or "
+            "wasn't expanded before this list was built). A literal "
+            "'${...}' can never match a real user id, so it would "
+            "otherwise silently enable gating with an admin list nothing "
+            "can satisfy (issue #72096). Set the variable, or remove the "
+            "reference if it's no longer needed.",
+            ", ".join(unresolved),
+        )
     return frozenset(out)
 
 

--- a/tests/gateway/test_slash_access.py
+++ b/tests/gateway/test_slash_access.py
@@ -286,3 +286,52 @@ class TestPolicyForSource:
         p = policy_for_source(cfg, tg_src)
         assert p.enabled is False
         assert p.can_run("999", "stop") is True
+
+
+class TestUnresolvedEnvVarReference:
+    """Regression tests for issue #72096: a literal, unresolved ${VAR} /
+    ${env:VAR} reference in an admin list must never be treated as a real
+    (unmatchable) user id -- it must be filtered out, so the policy falls
+    back to 'disabled' rather than silently locking out every user with an
+    admin list nothing can ever satisfy.
+    """
+
+    def test_sole_unresolved_reference_disables_gating(self):
+        p = policy_from_extra({"allow_admin_from": ["${TELEGRAM_ADMIN_ID}"]}, "dm")
+        assert p.enabled is False
+        assert p.admin_user_ids == frozenset()
+        # And gating being off means everyone can run everything, matching
+        # the "misconfiguration should fail open to old behavior" intent.
+        assert p.can_run("anyone", "stop") is True
+
+    def test_env_style_reference_also_filtered(self):
+        p = policy_from_extra({"allow_admin_from": ["${env:TELEGRAM_ADMIN_ID}"]}, "dm")
+        assert p.enabled is False
+
+    def test_mixed_resolved_and_unresolved_keeps_only_resolved(self):
+        """A real id alongside a stray unresolved reference: the real id
+        must still work, the bogus one must not silently expand the
+        matchable set to include a string nobody can ever send."""
+        p = policy_from_extra(
+            {"allow_admin_from": ["111", "${SOME_UNSET_VAR}"]}, "dm"
+        )
+        assert p.enabled is True
+        assert p.admin_user_ids == frozenset({"111"})
+        assert p.is_admin("111") is True
+
+    def test_resolved_value_is_not_filtered(self):
+        """Sanity: a value that HAPPENS to contain literal braces but isn't
+        the exact ${...} shape (e.g. already-expanded content) must not be
+        mistakenly filtered."""
+        p = policy_from_extra({"allow_admin_from": ["555444333"]}, "dm")
+        assert p.enabled is True
+        assert p.admin_user_ids == frozenset({"555444333"})
+
+    def test_unresolved_reference_logs_a_warning(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING, logger="gateway.slash_access"):
+            policy_from_extra({"allow_admin_from": ["${TELEGRAM_ADMIN_ID}"]}, "dm")
+        assert any(
+            "TELEGRAM_ADMIN_ID" in r.message and r.levelname == "WARNING"
+            for r in caplog.records
+        ), [r.message for r in caplog.records]

--- a/tests/hermes_cli/test_config_env_expansion.py
+++ b/tests/hermes_cli/test_config_env_expansion.py
@@ -196,3 +196,115 @@ class TestLoadCliConfigExpansion:
         config = load_cli_config()
 
         assert config["auxiliary"]["vision"]["api_key"] == "${UNSET_CLI_VAR_ABC}"
+
+
+class TestGatewayConfigExpandsEnvVars:
+    """Regression tests for issue #72096: gateway/config.py::load_gateway_config()
+    read config.yaml directly with yaml.safe_load() and never called
+    _expand_env_vars(), unlike hermes_cli.config.load_config() and the
+    existing expansion call sites in gateway/run.py. platforms.<name>.extra
+    values therefore kept literal ${VAR} text, which gateway/slash_access.py's
+    policy_from_extra() then treated as a real (unmatchable) admin id --
+    silently enabling slash-command gating with an admin list nothing could
+    satisfy.
+    """
+
+    def test_platform_extra_admin_list_var_is_expanded(self, monkeypatch, tmp_path):
+        from gateway.config import load_gateway_config, Platform
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    enabled: true\n"
+            "    token: xxx\n"
+            "    extra:\n"
+            "      group_allow_admin_from:\n"
+            "        - '${TELEGRAM_ADMIN_ID}'\n"
+            "      group_user_allowed_commands:\n"
+            "        - status\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TELEGRAM_ADMIN_ID", "555444333")
+
+        config = load_gateway_config()
+
+        extra = config.platforms[Platform.TELEGRAM].extra
+        assert extra["group_allow_admin_from"] == ["555444333"], (
+            "The ${TELEGRAM_ADMIN_ID} reference must resolve to the real "
+            "env var value, not stay as the literal string"
+        )
+
+    def test_platform_extra_var_used_in_slash_access_policy(self, monkeypatch, tmp_path):
+        """End-to-end: the exact reported scenario -- resolving the
+        reference must let the configured admin actually match, rather
+        than locking every user out of every tiered slash command."""
+        from gateway.config import load_gateway_config, Platform
+        from gateway.slash_access import policy_from_extra
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    enabled: true\n"
+            "    token: xxx\n"
+            "    extra:\n"
+            "      group_allow_admin_from:\n"
+            "        - '${TELEGRAM_ADMIN_ID}'\n"
+            "      group_user_allowed_commands:\n"
+            "        - status\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TELEGRAM_ADMIN_ID", "555444333")
+
+        config = load_gateway_config()
+        extra = config.platforms[Platform.TELEGRAM].extra
+        policy = policy_from_extra(extra, "group")
+
+        assert policy.enabled is True
+        assert policy.is_admin("555444333") is True, (
+            "The admin's real id must match the resolved policy -- this "
+            "was the silent-lockout bug: the admin got refused with the "
+            "same message as a non-admin"
+        )
+
+    def test_unresolved_var_reference_does_not_enable_impossible_admin_gate(
+        self, monkeypatch, tmp_path
+    ):
+        """If the env var is genuinely unset (operator error, or a var name
+        typo), the reference stays unresolved after loading -- the
+        defense-in-depth filter in gateway.slash_access._coerce_id_list()
+        must then treat it as no admin configured (policy disabled), not
+        as an admin list nothing can ever match."""
+        from gateway.config import load_gateway_config, Platform
+        from gateway.slash_access import policy_from_extra
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    enabled: true\n"
+            "    token: xxx\n"
+            "    extra:\n"
+            "      group_allow_admin_from:\n"
+            "        - '${TELEGRAM_ADMIN_ID_TYPO}'\n"
+            "      group_user_allowed_commands:\n"
+            "        - status\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("TELEGRAM_ADMIN_ID_TYPO", raising=False)
+
+        config = load_gateway_config()
+        extra = config.platforms[Platform.TELEGRAM].extra
+        policy = policy_from_extra(extra, "group")
+
+        assert policy.enabled is False, (
+            "An admin list consisting only of an unresolved ${VAR} must "
+            "not silently enable gating with an admin nothing can match"
+        )

--- a/tests/hermes_cli/test_config_env_expansion.py
+++ b/tests/hermes_cli/test_config_env_expansion.py
@@ -308,3 +308,87 @@ class TestGatewayConfigExpandsEnvVars:
             "An admin list consisting only of an unresolved ${VAR} must "
             "not silently enable gating with an admin nothing can match"
         )
+
+    def test_multiplex_scope_wins_over_process_global_env(self, monkeypatch, tmp_path):
+        """Regression (review of #72096): in multiplex mode,
+        _profile_runtime_scope() installs each profile's own .env into a
+        current_secret_scope() WITHOUT mutating os.environ, so multiple
+        profiles' secrets never collide in the shared process environment.
+        The expansion in load_gateway_config() must resolve ${VAR} through
+        that active scope (via _getenv()), not read os.environ directly --
+        otherwise a profile-scoped admin ID gets silently ignored in favor
+        of whatever a DIFFERENT profile (or no profile at all) left in the
+        process-global environment.
+        """
+        from gateway.config import load_gateway_config, Platform
+        from gateway.slash_access import policy_from_extra
+        from agent.secret_scope import set_secret_scope, reset_secret_scope
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    enabled: true\n"
+            "    token: xxx\n"
+            "    extra:\n"
+            "      group_allow_admin_from:\n"
+            "        - '${TELEGRAM_ADMIN_ID}'\n"
+            "      group_user_allowed_commands:\n"
+            "        - status\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        # Deliberately conflicting values: a process-global one (as if some
+        # OTHER profile, or a pre-multiplex single-profile run, left it in
+        # os.environ) and a different one scoped to THIS profile.
+        monkeypatch.setenv("TELEGRAM_ADMIN_ID", "555000000")
+        token = set_secret_scope({"TELEGRAM_ADMIN_ID": "555999999"})
+        try:
+            config = load_gateway_config()
+        finally:
+            reset_secret_scope(token)
+
+        extra = config.platforms[Platform.TELEGRAM].extra
+        assert extra["group_allow_admin_from"] == ["555999999"], (
+            "Must resolve against the active profile's scoped secret "
+            "(555999999), not the conflicting process-global os.environ "
+            "value (555000000): " + str(extra["group_allow_admin_from"])
+        )
+
+        policy = policy_from_extra(extra, "group")
+        assert policy.is_admin("555999999") is True
+        assert policy.is_admin("555000000") is False, (
+            "The process-global value must NOT leak into the resolved "
+            "policy when a conflicting profile-scoped value is active"
+        )
+
+    def test_no_active_scope_falls_back_to_process_global_env(self, monkeypatch, tmp_path):
+        """Sanity: outside multiplex mode (no secret scope installed,
+        single-profile CLI/gateway startup), resolution must still fall
+        back to os.environ exactly as before -- this fix must not break
+        the common, unscoped case."""
+        from gateway.config import load_gateway_config, Platform
+        from agent.secret_scope import current_secret_scope
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    enabled: true\n"
+            "    token: xxx\n"
+            "    extra:\n"
+            "      group_allow_admin_from:\n"
+            "        - '${TELEGRAM_ADMIN_ID}'\n"
+            "      group_user_allowed_commands:\n"
+            "        - status\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TELEGRAM_ADMIN_ID", "555000000")
+        assert current_secret_scope() is None  # sanity: no scope active
+
+        config = load_gateway_config()
+        extra = config.platforms[Platform.TELEGRAM].extra
+        assert extra["group_allow_admin_from"] == ["555000000"]


### PR DESCRIPTION
## Context

Fixes #72096.

## Problem

`gateway/config.py::load_gateway_config()` reads config.yaml directly with `yaml.safe_load()` and never called `_expand_env_vars()`, unlike `hermes_cli.config.load_config()` and the existing call sites in `gateway/run.py`. Values under `platforms.<name>.extra` kept literal `${VAR}` text.

For slash-command access control this silently inverted the intended behavior: `policy_from_extra()` stringifies every admin-list entry, so an unresolved `${TELEGRAM_ADMIN_ID}` became a one-element set that could never match a real user id -- switching gating ON with an admin list nothing could satisfy. An operator moving their user id to `.env` (the documented pattern for a published config repo) locked themselves out of every tiered slash command, with no error or log line.

## Fix

Two fixes, per the issue's "either or both" suggestion:

1. `load_gateway_config()` now calls `_expand_env_vars()` on the loaded YAML, after the managed-scope overlay and before any downstream platform-config parsing.
2. Defense in depth: `_coerce_id_list()` now filters out any entry still matching the literal `${...}` shape after loading, logging a warning naming the unresolved reference(s) -- so the policy falls back to disabled (not an impossible admin) and the failure is diagnosable either way.

## Verification

10 new tests pass (loader-level expansion reaching the real `GatewayConfig`, the end-to-end policy match, the unresolved-reference-disables-gating case, plus direct unit tests); 46/46 in the full `test_slash_access.py` + `test_config_env_expansion.py` files; 48/48 in two more dependent test files (no regression).