### PR TITLE
fix(desktop): keep remote OAuth sessions alive across recovery

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6109,6 +6109,20 @@ function fetchJsonViaOauthSession(url, options: any = {}) {
 
     request.on('response', res => {
       const chunks = []
+
+      // A remote that drops the connection mid-response (gateway restart, tunnel
+      // teardown) emits 'error' on the response stream, not the request. Without
+      // this the promise never settles and the caller hangs until its own timeout,
+      // which for the liveness probe means a stalled reconnect rather than a
+      // reported failure.
+      res.on('error', error => {
+        if (timedOut) {
+          return
+        }
+
+        clearTimeout(timer)
+        reject(error)
+      })
       res.on('data', chunk => chunks.push(Buffer.from(chunk)))
       res.on('end', () => {
         if (timedOut) {
@@ -9390,7 +9404,13 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
         connectionPromise,
         currentConnectionPromise: () => backendConnectionState.getPromise(),
         log: rememberLog,
-        probe: fetchPublicJson,
+        // Probe through Electron's network stack, not Node's. fetchPublicJson uses
+        // Node's https client and therefore Node's own CA bundle, which rejects a
+        // remote fronted by a private/internal CA that the OS trusts -- the liveness
+        // probe then fails forever and drops a perfectly healthy connection. Going
+        // through the OAuth session makes the probe honour exactly the same trust
+        // store as the OAuth ticket and the REST requests that follow it.
+        probe: fetchJsonViaOauthSession,
         resetConnection: resetHermesConnection,
         tracker: remoteLiveness
       }),

--- a/apps/desktop/electron/oauth-session-request.test.ts
+++ b/apps/desktop/electron/oauth-session-request.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Regression coverage for the OAuth-session Electron net.request path.
+ *
+ * Electron net rejects manual Content-Length/Host headers with
+ * net::ERR_INVALID_ARGUMENT. Node HTTP helpers may still set Content-Length;
+ * this guard is scoped to fetchJsonViaOauthSession only.
+ */
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { test } from 'vitest'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const source = fs.readFileSync(path.join(__dirname, 'main.ts'), 'utf8')
+
+function extractFetchJsonViaOauthSession() {
+  const start = source.indexOf('function fetchJsonViaOauthSession')
+  const end = source.indexOf('// Mint a single-use WS ticket', start)
+  assert.notEqual(start, -1, 'fetchJsonViaOauthSession should exist')
+  assert.notEqual(end, -1, 'fetchJsonViaOauthSession boundary should exist')
+
+  return source.slice(start, end)
+}
+
+test('OAuth Electron net request does not set forbidden Content-Length header', () => {
+  const fn = extractFetchJsonViaOauthSession()
+
+  assert.match(fn, /electronNet\.request/)
+  assert.doesNotMatch(fn, /setHeader\((['"])Content-Length\1/)
+  assert.match(fn, /request\.write\(body\)/)
+})
+
+test('OAuth Electron net request handles truncated response errors', () => {
+  const fn = extractFetchJsonViaOauthSession()
+
+  assert.match(fn, /res\.on\(['"]error['"], error =>/)
+  assert.match(fn, /if \(timedOut\)/)
+})
+
+test('remote revalidation uses Electron networking for OS-trusted CAs', () => {
+  const start = source.indexOf("ipcMain.handle('hermes:connection:revalidate'")
+  const end = source.indexOf("ipcMain.handle('hermes:backend:touch'", start)
+  assert.notEqual(start, -1, 'revalidation handler should exist')
+  assert.notEqual(end, -1, 'revalidation handler boundary should exist')
+
+  // Strip line comments first: this test reasons about the CODE in the handler,
+  // and the comment explaining *why* we avoid the Node-https probe legitimately
+  // names it. Matching raw source would fail on the explanation itself.
+  const handler = source.slice(start, end).replace(/^[^\S\n]*\/\/.*$/gm, '')
+  assert.match(handler, /fetchJsonViaOauthSession/)
+  assert.doesNotMatch(handler, /fetchPublicJson/)
+})

--- a/apps/desktop/src/components/boot-failure-overlay.test.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
 import { $desktopOnboarding } from '@/store/onboarding'
@@ -45,6 +45,14 @@ const remoteToken = {
   remoteTokenSet: true,
   remoteUrl: 'http://100.116.104.53:9191',
   cloudOrg: ''
+}
+
+const remoteOauth = {
+  ...remoteToken,
+  remoteAuthMode: 'oauth',
+  remoteOauthConnected: false,
+  remoteTokenSet: false,
+  remoteUrl: 'https://gateway.example.com'
 }
 
 beforeEach(() => {
@@ -96,6 +104,35 @@ describe('BootFailureOverlay', () => {
       expect(screen.getByRole('button', { name: /use local gateway/i })).toBeTruthy()
     } finally {
       restore()
+    }
+  })
+
+  it('retries OAuth sign-in without deleting an existing session', async () => {
+    const original = window.hermesDesktop
+    const oauthLogin = vi.fn(async () => ({ ok: true, baseUrl: remoteOauth.remoteUrl, connected: true }))
+    const oauthLogout = vi.fn(async () => ({ ok: true, connected: false }))
+    const resetBootstrap = vi.fn(async () => ({ ok: true }))
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        getRecentLogs: async () => ({ lines: [] }),
+        getConnectionConfig: async () => remoteOauth,
+        probeConnectionConfig: async () => ({ providers: [] }),
+        oauthLoginConnectionConfig: oauthLogin,
+        oauthLogoutConnectionConfig: oauthLogout,
+        resetBootstrap
+      }
+    })
+    $desktopBoot.set({ ...$desktopBoot.get(), error: 'Your remote gateway session has expired.' })
+
+    try {
+      render(<BootFailureOverlay />)
+      fireEvent.click(await screen.findByRole('button', { name: /sign in again/i }))
+      await waitFor(() => expect(oauthLogin).toHaveBeenCalledWith(remoteOauth.remoteUrl))
+      expect(oauthLogout).not.toHaveBeenCalled()
+      expect(resetBootstrap).toHaveBeenCalled()
+    } finally {
+      Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: original })
     }
   })
 })

--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -162,12 +162,9 @@ export function BootFailureOverlay() {
     setBusy(null)
   }
 
-  // Clear the OAuth partition first, then open the gateway's login window
-  // (username/password form or OAuth redirect — the desktop drives both). A
-  // partition-wide sign-out drops stale gateway AND identity-provider cookies so
-  // an expired session can't silently bounce us back into the same state. On a
-  // successful sign-in the cookie is re-established; reload so boot mints a fresh
-  // ticket against a live session.
+  // Open the gateway login without clearing the OAuth partition first. A true
+  // expiry is already cleared by the backend, while deleting here can erase a
+  // newly refreshed session when recovery is clicked twice.
   const signInRemote = async () => {
     if (!remoteReauth) {
       return
@@ -176,11 +173,13 @@ export function BootFailureOverlay() {
     setBusy('signin')
 
     try {
-      await window.hermesDesktop?.oauthLogoutConnectionConfig?.()
       const result = await window.hermesDesktop?.oauthLoginConnectionConfig(remoteReauth.url)
 
       if (result?.connected) {
         notify({ kind: 'success', title: t.boot.failure.signedInTitle, message: t.boot.failure.signedInMessage })
+        // Reloading the renderer alone leaves a failed backend latched in the
+        // Electron main process, so the fresh OAuth session is never retried.
+        await window.hermesDesktop?.resetBootstrap().catch(() => undefined)
         window.location.reload()
 
         return

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -95,8 +95,8 @@ export const en: Translations = {
       openLogs: 'Open logs',
       repairHint: 'Repair re-runs the installer and can take a few minutes on a fresh machine.',
       remoteSignInHint: signInLabel =>
-        `Signs out of the saved remote browser session, then opens ${signInLabel}. Use local gateway to switch to the bundled backend instead.`,
-      signOutAndSignIn: 'Sign out & sign in',
+        `Opens ${signInLabel} without clearing your saved session. Use local gateway to switch to the bundled backend instead.`,
+      signOutAndSignIn: 'Sign in again',
       remoteFailureHint: 'Check the gateway URL and sign-in under Gateway settings, or switch to the local gateway.',
       hideRecentLogs: 'Hide recent logs',
       showRecentLogs: 'Show recent logs',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -95,10 +95,9 @@ export const ja = defineLocale({
       openLogs: 'ログを開く',
       repairHint: '修復はインストーラーを再実行します。新しいマシンでは数分かかる場合があります。',
       remoteSignInHint: signInLabel =>
-        `保存済みのリモートブラウザセッションからサインアウトし、${signInLabel}を開きます。代わりにバンドルされたバックエンドに切り替えるには「ローカルゲートウェイを使用」を選択してください。`,
-      signOutAndSignIn: 'サインアウトして再サインイン',
-      remoteFailureHint:
-        '「ゲートウェイ設定」でゲートウェイの URL とサインインを確認するか、ローカルゲートウェイに切り替えてください。',
+        `保存済みのセッションを消去せずに${signInLabel}を開きます。代わりにバンドルされたバックエンドに切り替えるには「ローカルゲートウェイを使用」を選択してください。`,
+      signOutAndSignIn: '再度サインイン',
+      remoteFailureHint: '「ゲートウェイ設定」でゲートウェイの URL とサインインを確認するか、ローカルゲートウェイに切り替えてください。',
       hideRecentLogs: '最近のログを非表示',
       showRecentLogs: '最近のログを表示',
       signedInTitle: 'サインインしました',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -93,8 +93,8 @@ export const zhHant = defineLocale({
       openLogs: '開啟記錄',
       repairHint: '修復會重新執行安裝程式，在新機器上可能需要幾分鐘。',
       remoteSignInHint: signInLabel =>
-        `先登出已儲存的遠端瀏覽器工作階段，然後開啟${signInLabel}。使用本機閘道可切換至內建後端。`,
-      signOutAndSignIn: '登出並重新登入',
+        `開啟${signInLabel}，但不清除已儲存的工作階段。使用本機閘道可切換至內建後端。`,
+      signOutAndSignIn: '重新登入',
       remoteFailureHint: '在「閘道設定」中檢查閘道 URL 與登入，或切換至本機閘道。',
       hideRecentLogs: '隱藏最近記錄',
       showRecentLogs: '顯示最近記錄',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -93,8 +93,8 @@ export const zh: Translations = {
       openLogs: '打开日志',
       repairHint: '修复会重新运行安装器，在新机器上可能需要几分钟。',
       remoteSignInHint: signInLabel =>
-        `先退出已保存的远程浏览器会话，然后打开${signInLabel}。也可以使用本地网关切换到随应用提供的后端。`,
-      signOutAndSignIn: '退出并重新登录',
+        `打开${signInLabel}，但不清除已保存的会话。也可以使用本地网关切换到随应用提供的后端。`,
+      signOutAndSignIn: '重新登录',
       remoteFailureHint: '在“网关设置”中检查网关 URL 和登录，或切换到本地网关。',
       hideRecentLogs: '隐藏最近日志',
       showRecentLogs: '显示最近日志',


### PR DESCRIPTION
## Summary

Three failures on a remote OAuth gateway, each leaving the composer stuck on "Starting Hermes…" with no route forward but restarting the app. Split out of #63492, where they were bundled with unrelated YouTube-embed work by accident of a shared working branch.

Root causes, in order of how hard they are to spot:

1. **Truncated response streams never settled.** `fetchJsonViaOauthSession` listened for `error` on the *request* only. A remote that drops the connection mid-response (gateway restart, tunnel teardown) emits `error` on the **response** stream, so the promise never settled and the caller hung until its own timeout — for the liveness probe, a stalled reconnect instead of a reported failure.
2. **Liveness probed with the wrong network stack.** `revalidateRemoteConnection` was passed `probe: fetchPublicJson`, which uses Node's `https` client and therefore Node's own CA bundle. A remote fronted by a private CA that the OS trusts is rejected outright, so the probe failed *every* time and dropped a healthy connection on each reconnect tick. Publicly-trusted remotes were unaffected, which is why it went unnoticed.
3. **Recovery destroyed the credentials it needed.** The boot-failure action signed the user out before reopening sign-in, discarding a still-valid session, so the retry had nothing left to authenticate with.

## Changes

- `apps/desktop/electron/main.ts`: add the missing `res.on('error')` handler in `fetchJsonViaOauthSession` (clears the timer, rejects, no-ops if already timed out); switch the revalidation `probe` to `fetchJsonViaOauthSession` so it uses Electron's network stack and the OS trust store.
- `apps/desktop/src/components/boot-failure-overlay.tsx`: reopen sign-in **without** clearing the saved session, and retry the backend once gateway login completes.
- `apps/desktop/src/i18n/{en,ja,zh,zh-hant}.ts`: copy follows the behaviour — "Sign in again" rather than "Sign out & sign in", and the description no longer promises to clear the session.
- `apps/desktop/electron/oauth-session-request.test.ts` (new, 3 tests), `src/components/boot-failure-overlay.test.tsx` (+tests).

## Validation

| Check | Result |
|---|---|
| `vitest run electron/oauth-session-request.test.ts src/components/boot-failure-overlay.test.tsx` | 7/7 pass |
| `tsc -p tsconfig.electron.json --noEmit` and `tsc -p . --noEmit` | clean |

End-to-end against a remote OAuth gateway behind a private CA — the recovery path in the desktop log, which previously terminated at the first line:

```
[boot] Desktop boot failed: Remote Hermes gateway uses OAuth, but you are not signed in.
[bootstrap] reset requested by renderer; clearing latched failure
[boot] Connecting to remote Hermes backend at <gateway>
[boot] Remote Hermes backend is ready
```

| Scenario | Before | After |
|---|---|---|
| remote behind a private/internal CA | liveness probe fails every tick, healthy connection dropped | probe succeeds via the OS trust store |
| remote drops connection mid-response | promise never settles; caller hangs to its own timeout | rejects promptly, reported as a failure |
| boot failure → sign in again | session cleared first, retry has no credentials | session preserved, backend retried after login |

## Notes

- **Test change flagged explicitly**: the regression for (2) asserted against raw handler source and tripped on a comment that legitimately names the Node-https probe while explaining why we avoid it. It now strips line comments before matching, so it reasons about code rather than prose. The assertion itself is unchanged — flagging so it isn't read as weakening it.
- **Duplicate check**: searched open and merged PRs for OAuth-recovery/liveness work. #63057 (24h session TTL fallback) is adjacent but addresses session lifetime, not probe transport or recovery credentials. Related but distinct: #56750 reports the same `Missing PKCE state cookie` symptom from a `SameSite=Lax` redirect-chain bug — a different cause, untouched here.
