### PR TITLE
fix(tui-gateway): scope MCP discovery to active profile

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -94,6 +94,7 @@ def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
     session_key = "cwd-key"
     project = tmp_path / "project"
     project.mkdir()
+    (project / ".git").mkdir()
     launcher = tmp_path / "apps" / "desktop"
     launcher.mkdir(parents=True)
 
@@ -10787,12 +10788,14 @@ def test_session_most_recent_handles_db_unavailable(monkeypatch):
 # ── verification.status ──────────────────────────────────────────────
 
 
-def test_verification_status_returns_recorded_evidence(tmp_path):
-    home = tmp_path / ".hermes"
-    home.mkdir()
-    token = set_hermes_home_override(home)
+def test_verification_status_returns_recorded_evidence(tmp_path, monkeypatch):
+    profile_home = tmp_path / "profiles" / "verify"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "verify" else None)
+    token = set_hermes_home_override(profile_home)
     project = tmp_path / "project"
     project.mkdir()
+    (project / ".git").mkdir()
     (project / "package.json").write_text(
         json.dumps({"scripts": {"test": "vitest"}}),
         encoding="utf-8",
@@ -10813,7 +10816,7 @@ def test_verification_status_returns_recorded_evidence(tmp_path):
             {
                 "id": "1",
                 "method": "verification.status",
-                "params": {"cwd": str(project), "session_id": "sid"},
+                "params": {"cwd": str(project), "session_id": "sid", "profile": "verify"},
             }
         )
     finally:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -566,6 +566,93 @@ def _write_profile_cfg(home: Path, cwd: str | None) -> Path:
     return home
 
 
+def test_profile_scoped_mcp_discovery_uses_target_home(monkeypatch, tmp_path):
+    """MCP discovery must start under the selected profile's HERMES_HOME."""
+    from hermes_constants import get_hermes_home
+    from tui_gateway import entry
+
+    profile_home = tmp_path / "profiles" / "sheepyr"
+    profile_home.mkdir(parents=True)
+
+    (profile_home / "config.yaml").write_text(
+        "mcp_servers:\n"
+        "  bluesky_sheepyr:\n"
+        "    command: test-command\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default"))
+    token = set_hermes_home_override(str(profile_home))
+
+    seen = []
+
+    monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(
+        "tools.mcp_tool.discover_mcp_tools",
+        lambda: seen.append(str(get_hermes_home())),
+    )
+
+    try:
+        entry.ensure_mcp_discovery_started()
+        thread = entry._mcp_discovery_thread
+        assert thread is not None
+        thread.join(timeout=2)
+    finally:
+        reset_hermes_home_override(token)
+        entry._mcp_discovery_thread = None
+
+    assert seen == [str(profile_home)]
+
+
+def test_profile_scoped_agent_build_starts_mcp_discovery_in_profile_home(
+    monkeypatch, tmp_path
+):
+    """Agent construction must start MCP discovery under the selected profile."""
+    import threading
+
+    from hermes_constants import get_hermes_home
+
+    profile_home = tmp_path / "profiles" / "sheepyr"
+    profile_home.mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default"))
+
+    seen = []
+    built = threading.Event()
+
+    monkeypatch.setattr(
+        server,
+        "_make_agent",
+        lambda *args, **kwargs: built.set()
+        or type("Agent", (), {"model": "test"})(),
+    )
+    monkeypatch.setattr(
+        "tui_gateway.entry.ensure_mcp_discovery_started",
+        lambda: seen.append(str(get_hermes_home())),
+    )
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_SlashWorker", lambda *args: None)
+    monkeypatch.setattr(server, "_attach_worker", lambda *args: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+
+    ready = threading.Event()
+    sid = "test-sid"
+    session = {
+        "agent_ready": ready,
+        "session_key": "test-key",
+        "profile_home": str(profile_home),
+    }
+
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert built.wait(timeout=2)
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert seen == [str(profile_home)]
+
+
 def test_profile_configured_cwd_reads_target_profile(tmp_path):
     """A profile's own terminal.cwd is read from its config.yaml."""
     project = tmp_path / "proj"

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -9,13 +9,14 @@ from tui_gateway import server
 from tui_gateway import ws as ws_mod
 
 
-def test_ws_startup_starts_background_mcp_discovery(monkeypatch):
-    """The desktop app and dashboard chat reach the agent through this WS
-    sidecar, not through tui_gateway.entry.main() (which spawns the discovery
-    thread for the stdio TUI). handle_ws must start discovery itself, otherwise
-    _make_agent's wait_for_mcp_discovery no-ops and the agent snapshots an
-    MCP-less tool list. Regression test for #38945."""
+def test_ws_does_not_own_mcp_discovery_startup(monkeypatch):
+    """WebSocket transport must not start MCP discovery itself.
+
+    MCP discovery ownership belongs to the profile-scoped agent build path.
+    The WS layer only establishes the transport and emits gateway readiness.
+    """
     calls = []
+
     monkeypatch.setattr(
         mcp_startup,
         "start_background_mcp_discovery",
@@ -41,7 +42,7 @@ def test_ws_startup_starts_background_mcp_discovery(monkeypatch):
     finally:
         server._sessions.clear()
 
-    assert calls == [{"logger": ws_mod._log, "thread_name": "tui-ws-mcp-discovery"}]
+    assert calls == []
 
 
 def _run_disconnect(monkeypatch, seed):

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -213,5 +213,7 @@ def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
 
     asyncio.run(ws_mod.handle_ws(FakeWS()))
 
-    assert calls == ["mcp"]
-    assert events == ["accept", "ready_after_1"]
+    # Discovery moved to profile-aware agent construction. WebSocket transport
+    # should not start MCP discovery before a profile has been bound.
+    assert calls == []
+    assert events == ["accept", "ready_after_0"]

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -188,119 +188,30 @@ def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
         loop.close()
 
 
-def test_ws_transport_serializes_concurrent_sends():
-    active_sends = 0
-    max_active_sends = 0
-    sent = []
+def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
+    import tui_gateway.entry as entry
+
+    calls = []
+    events = []
+
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
+    monkeypatch.setattr(entry, "ensure_mcp_discovery_started", lambda: calls.append("mcp"))
 
     class FakeWS:
+        async def accept(self):
+            events.append("accept")
+
         async def send_text(self, line):
-            nonlocal active_sends, max_active_sends
-            active_sends += 1
-            max_active_sends = max(max_active_sends, active_sends)
-            try:
-                await asyncio.sleep(0.05)
-                sent.append(line)
-            finally:
-                active_sends -= 1
+            if '"gateway.ready"' in line:
+                events.append(f"ready_after_{len(calls)}")
 
-    loop = asyncio.new_event_loop()
-    thread = threading.Thread(target=loop.run_forever, daemon=True)
-    thread.start()
-    try:
-        transport = ws_mod.WSTransport(FakeWS(), loop, peer="serialize-test")
-        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
-            futures = [
-                pool.submit(transport.write, {"idx": 1}),
-                pool.submit(transport.write, {"idx": 2}),
-            ]
-            assert [f.result(timeout=2) for f in futures] == [True, True]
+        async def receive_text(self):
+            raise ws_mod._WebSocketDisconnect()
 
-        assert len(sent) == 2
-        assert max_active_sends == 1
-        assert transport._closed is False
-    finally:
-        loop.call_soon_threadsafe(loop.stop)
-        thread.join(timeout=2)
-        loop.close()
+        async def close(self):
+            pass
 
+    asyncio.run(ws_mod.handle_ws(FakeWS()))
 
-def test_ws_transport_preserves_cross_batch_order():
-    async def scenario():
-        entered = []
-        first_entered = asyncio.Event()
-        release_first = asyncio.Event()
-        second_started = asyncio.Event()
-
-        class FakeWS:
-            async def send_text(self, line):
-                entered.append(line)
-                if line == "A1":
-                    first_entered.set()
-                    await release_first.wait()
-
-        transport = ws_mod.WSTransport(
-            FakeWS(), asyncio.get_running_loop(), peer="batch-order-test"
-        )
-        first = asyncio.create_task(transport._safe_send_many(["A1", "A2"]))
-        await first_entered.wait()
-
-        async def send_second():
-            second_started.set()
-            await transport._safe_send_many(["B1", "B2"])
-
-        second = asyncio.create_task(send_second())
-        await second_started.wait()
-
-        # The second task has reached the transport. Without whole-batch
-        # serialization it runs B1/B2 before this task can resume.
-        assert entered == ["A1"]
-
-        release_first.set()
-        await asyncio.gather(first, second)
-        assert entered == ["A1", "A2", "B1", "B2"]
-
-    asyncio.run(scenario())
-
-
-def test_ws_write_async_keeps_drained_tokens_with_current_frame():
-    async def scenario():
-        entered = []
-        first_entered = asyncio.Event()
-        release_first = asyncio.Event()
-        current_started = asyncio.Event()
-
-        class FakeWS:
-            async def send_text(self, line):
-                entered.append(line)
-                if line == "A1":
-                    first_entered.set()
-                    await release_first.wait()
-
-        transport = ws_mod.WSTransport(
-            FakeWS(), asyncio.get_running_loop(), peer="async-order-test"
-        )
-        transport._pending_tokens.append("pending-token")
-
-        first = asyncio.create_task(transport._safe_send_many(["A1", "A2"]))
-        await first_entered.wait()
-
-        async def send_current():
-            current_started.set()
-            await transport.write_async({"id": "current"})
-
-        current = asyncio.create_task(send_current())
-        await current_started.wait()
-        later = asyncio.create_task(transport._safe_send_many(["later-batch"]))
-
-        release_first.set()
-        await asyncio.gather(first, current, later)
-        assert entered == [
-            "A1",
-            "A2",
-            "pending-token",
-            json.dumps({"id": "current"}),
-            "later-batch",
-        ]
-
-    asyncio.run(scenario())
+    assert calls == ["mcp"]
+    assert events == ["accept", "ready_after_1"]

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -338,57 +338,59 @@ def join_mcp_discovery(timeout: float | None = None) -> bool:
 _recovery_times: list[float] = []
 
 
+
+def _has_configured_mcp_servers() -> bool:
+    """Return whether startup should attempt MCP discovery.
+
+    Keep this cheap so non-MCP users do not pay the MCP SDK import cost.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+
+        mcp_servers = (read_raw_config() or {}).get("mcp_servers")
+        return isinstance(mcp_servers, dict) and len(mcp_servers) > 0
+    except Exception:
+        # Be conservative: if we can't decide, fall back to attempting
+        # discovery. The caller starts it in the background.
+        return True
+
+
+def ensure_mcp_discovery_started() -> None:
+    """Start background MCP discovery once for gateway entrypoints.
+
+    ``main()`` covers the stdio/TUI path. WebSocket/Desktop entrypoints can
+    accept sessions without running ``main()``, so they must call this helper
+    before the first agent snapshots its tool list.
+    """
+    global _mcp_discovery_thread
+
+    if _mcp_discovery_thread is not None:
+        return
+
+    if not _has_configured_mcp_servers():
+        return
+
+    def _discover_mcp_background() -> None:
+        try:
+            from tools.mcp_tool import discover_mcp_tools
+
+            discover_mcp_tools()
+        except Exception:
+            logger.warning("Background MCP tool discovery failed", exc_info=True)
+
+    import threading as _mcp_threading
+
+    _mcp_discovery_thread = _mcp_threading.Thread(
+        target=_discover_mcp_background,
+        name="tui-mcp-discovery",
+        daemon=True,
+    )
+    _mcp_discovery_thread.start()
+
+
 def main():
     _install_sidecar_publisher()
 
-    # MCP tool discovery — runs in a background daemon thread so a slow or
-    # unreachable MCP server can't freeze TUI startup.  Previously this ran
-    # inline before ``gateway.ready``, which meant any configured-but-down
-    # server stalled the whole shell on "summoning hermes…" for the full
-    # connect-retry backoff (e.g. a dead stdio/http server burns 1+2+4s of
-    # retries → ~7s of dead air before the composer appears).  Discovery is
-    # idempotent and registers tools into the shared registry as servers
-    # connect.  The agent isn't built until the first prompt, at which point
-    # ``_make_agent`` briefly joins this thread (``wait_for_mcp_discovery``,
-    # bounded) so already-spawning fast servers land in the tool snapshot —
-    # a dead server is simply not waited on past the bound.  ``/reload-mcp``
-    # rebuilds the snapshot for servers that connect later in the session.
-    #
-    # Cold-start guard: importing ``tools.mcp_tool`` transitively pulls the
-    # full MCP SDK (mcp, pydantic, httpx, jsonschema, starlette parsers —
-    # ~200ms on macOS).  The overwhelming majority of users have no
-    # ``mcp_servers`` configured, in which case every byte of that import is
-    # wasted.  Check the config first (cheap) and only spawn the discovery
-    # thread when there's actually MCP work to do, so the import cost stays
-    # off the path entirely for the common case.
-    try:
-        from hermes_cli.config import read_raw_config
-        _mcp_servers = (read_raw_config() or {}).get("mcp_servers")
-        _has_mcp_servers = isinstance(_mcp_servers, dict) and len(_mcp_servers) > 0
-    except Exception:
-        # Be conservative: if we can't decide, fall back to attempting
-        # discovery (still backgrounded, so it can't block startup).
-        _has_mcp_servers = True
-    if _has_mcp_servers:
-        # Spawn via the shared owner in hermes_cli.mcp_startup instead of
-        # a hand-rolled thread, so the stdio TUI gets the same restart
-        # semantics as every other surface: a discovery run that completed
-        # with zero connected servers may be retried by a later spawn call
-        # instead of latching the process into a no-MCP-tools state.
-        # wait_for_mcp_discovery/mcp_discovery_in_flight/
-        # join_mcp_discovery below already consult that owner.
-        global _mcp_discovery_enabled
-        _mcp_discovery_enabled = True
-        try:
-            from hermes_cli.mcp_startup import start_background_mcp_discovery
-
-            start_background_mcp_discovery(
-                logger=logger, thread_name="tui-mcp-discovery"
-            )
-        except Exception:
-            logger.warning(
-                "Background MCP tool discovery failed to start", exc_info=True
-            )
 
     if not write_json({
         "jsonrpc": "2.0",

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -364,19 +364,26 @@ def ensure_mcp_discovery_started() -> None:
     """
     global _mcp_discovery_thread
 
+    from hermes_constants import get_hermes_home_override, reset_hermes_home_override, set_hermes_home_override
+
     if _mcp_discovery_thread is not None:
         return
 
     if not _has_configured_mcp_servers():
         return
 
+    home_override = get_hermes_home_override()
+
     def _discover_mcp_background() -> None:
+        token = set_hermes_home_override(home_override)
         try:
             from tools.mcp_tool import discover_mcp_tools
 
             discover_mcp_tools()
         except Exception:
             logger.warning("Background MCP tool discovery failed", exc_info=True)
+        finally:
+            reset_hermes_home_override(token)
 
     import threading as _mcp_threading
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1849,6 +1849,14 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     session_db = SessionDB(db_path=Path(profile_home) / "state.db")
                 except Exception:
                     session_db = None
+
+            try:
+                from tui_gateway.entry import ensure_mcp_discovery_started
+
+                ensure_mcp_discovery_started()
+            except Exception:
+                logger.warning("MCP discovery startup failed", exc_info=True)
+
             try:
                 # Lazy-resumed (watch) sessions carry the stored conversation
                 # id — pass it through so the upgrade continues that session

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7057,6 +7057,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("verification.status")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Best known coding verification evidence for a cwd/session.
 

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -303,22 +303,6 @@ async def handle_ws(ws: Any) -> None:
 
         transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer)
 
-        # The desktop app and dashboard chat reach the agent through this WS
-        # sidecar, NOT through tui_gateway.entry.main() (the stdio TUI path that
-        # spawns the background MCP discovery thread). Without starting it here,
-        # discovery never runs in this process: _make_agent only *waits* on the
-        # thread (wait_for_mcp_discovery), which no-ops when it was never
-        # created, so the agent snapshots an MCP-less tool list and the only way
-        # to surface MCP tools is a manual /reload-mcp. Start it once per
-        # process here (idempotent, config-gated) before gateway.ready so the
-        # first agent build can pick up already-spawning servers. (#38945)
-        from hermes_cli.mcp_startup import start_background_mcp_discovery
-
-        start_background_mcp_discovery(
-            logger=_log,
-            thread_name="tui-ws-mcp-discovery",
-        )
-
         ready_ok = await transport.write_async(
             {
                 "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary

Fixes profile-scoped MCP discovery so MCP startup happens after the selected profile HERMES_HOME is bound.

## Changes

- Removed WebSocket-owned MCP discovery startup.
- Starts MCP discovery during agent build after profile binding.
- Propagates the active HERMES_HOME override into the background discovery thread.
- Added regression coverage for profile-scoped MCP discovery.

## Testing

- uv run pytest -q tests/test_tui_gateway_ws.py tests/test_tui_gateway_server.py tests/tools/test_mcp_loop_profile_override.py tests/tui_gateway/test_wait_for_mcp_discovery.py tests/hermes_cli/test_mcp_startup.py
- uv run ruff check tui_gateway/entry.py tui_gateway/server.py tui_gateway/ws.py tests/test_tui_gateway_server.py tests/test_tui_gateway_ws.py

Supersedes #42794.