### PR TITLE
feat(gateway): add authenticated dispatch for protected plugin actions

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2403,6 +2403,18 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     if not isinstance(function_args, dict):
         function_args = {}
 
+    # Protected model tools fail before request middleware or plugin hooks can
+    # observe, rewrite, or independently act on an unauthorized invocation.
+    from tools.registry import registry
+
+    authenticated_dispatch_error = registry.authenticated_gateway_dispatch_error(
+        function_name,
+        function_args,
+        getattr(agent, "_authenticated_gateway_context", None),
+    )
+    if authenticated_dispatch_error is not None:
+        return authenticated_dispatch_error
+
     _tool_middleware_trace = list(tool_request_middleware_trace or [])
     try:
         from hermes_cli.middleware import apply_tool_request_middleware
@@ -2583,6 +2595,15 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
+                **(
+                    {"authenticated_gateway_context": authenticated_context}
+                    if (
+                        authenticated_context := getattr(
+                            agent, "_authenticated_gateway_context", None
+                        )
+                    ) is not None
+                    else {}
+                ),
             )
 
     from hermes_cli.middleware import run_tool_execution_middleware

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -983,7 +983,16 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
-    tools_for_api = agent.tools
+    from tools.registry import registry
+
+    tools_for_api: Any = (
+        registry.filter_authenticated_gateway_tool_definitions(
+            agent.tools,
+            getattr(agent, "_authenticated_gateway_context", None),
+        )
+        if agent.tools is not None
+        else None
+    )
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -13,6 +13,7 @@ extracted functions reach back through the ``run_agent`` module via
 from __future__ import annotations
 
 import concurrent.futures
+from contextlib import ExitStack
 import json
 from pathlib import Path
 import logging
@@ -287,6 +288,87 @@ def _tool_search_scoped_names(agent) -> frozenset:
     return names
 
 
+def _authenticated_gateway_tool_denial(
+    agent,
+    *,
+    function_name: str,
+    function_args: dict,
+    tool_call_id: str = "",
+    lease_claims: ExitStack | None = None,
+    claim_sink: list[tuple[object, ExitStack]] | None = None,
+) -> Optional[str]:
+    """Claim protected authority or deny before any extension observer runs.
+
+    When an executor-owned ``ExitStack`` is supplied, a successful claim stays
+    live until that executor has finished the complete tool pipeline (including
+    middleware and post-processing), so revocation cannot overtake an already
+    admitted protected invocation.
+    """
+    from tools.registry import registry
+
+    entry = registry.get_entry(function_name)
+    if not entry or not entry.requires_authenticated_gateway:
+        return None
+
+    context = getattr(agent, "_authenticated_gateway_context", None)
+    denial = registry.authenticated_gateway_dispatch_error(
+        function_name,
+        function_args,
+        context,
+        tool_call_id=tool_call_id,
+        allow_admitted_claim=False,
+    )
+    if denial is not None or (lease_claims is None and claim_sink is None):
+        return denial
+
+    from gateway.authenticated_dispatch import (
+        bind_authenticated_gateway_tool_claim,
+        use_authenticated_gateway_tool_dispatch,
+    )
+
+    if claim_sink is not None:
+        claim_scope = ExitStack()
+        claim = claim_scope.enter_context(
+            use_authenticated_gateway_tool_dispatch(
+                context,
+                function_name,
+                tool_call_id=tool_call_id,
+            )
+        )
+        if not claim:
+            claim_scope.close()
+            return registry.authenticated_gateway_dispatch_error(
+                function_name,
+                function_args,
+                context,
+                tool_call_id=tool_call_id,
+                allow_admitted_claim=False,
+            )
+        claim_sink.append((claim, claim_scope))
+        if lease_claims is not None:
+            lease_claims.callback(claim_scope.close)
+        return None
+
+    assert lease_claims is not None
+    claim = lease_claims.enter_context(
+        use_authenticated_gateway_tool_dispatch(
+            context,
+            function_name,
+            tool_call_id=tool_call_id,
+        )
+    )
+    if not claim:
+        return registry.authenticated_gateway_dispatch_error(
+            function_name,
+            function_args,
+            context,
+            tool_call_id=tool_call_id,
+            allow_admitted_claim=False,
+        )
+    lease_claims.enter_context(bind_authenticated_gateway_tool_claim(claim))
+    return None
+
+
 def _apply_tool_request_middleware_for_agent(
     agent,
     *,
@@ -347,6 +429,19 @@ def _run_agent_tool_execution_middleware(
 
 
 def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:
+    with ExitStack() as lease_claims:
+        return _execute_tool_calls_concurrent(
+            agent,
+            assistant_message,
+            messages,
+            effective_task_id,
+            api_call_count,
+            finalize=finalize,
+            lease_claims=lease_claims,
+        )
+
+
+def _execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True, lease_claims: ExitStack) -> None:
     """Execute multiple tool calls concurrently using a thread pool.
 
     Results are collected in the original tool-call order and appended to
@@ -382,6 +477,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
     # ── Parse args + pre-execution bookkeeping ───────────────────────
     parsed_calls = []  # list of (tool_call, function_name, function_args, middleware_trace, block_result, blocked_by_guardrail)
+    authenticated_claims: dict[int, tuple[object, ExitStack]] = {}
     for tool_call in tool_calls:
         function_name = tool_call.function.name
 
@@ -442,6 +538,30 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         }, ensure_ascii=False)
         except Exception:
             pass
+
+        claim_sink: list[tuple[object, ExitStack]] = []
+        authenticated_denial = _authenticated_gateway_tool_denial(
+            agent,
+            function_name=function_name,
+            function_args=function_args,
+            tool_call_id=getattr(tool_call, "id", "") or "",
+            lease_claims=lease_claims,
+            claim_sink=claim_sink,
+        )
+        if claim_sink:
+            authenticated_claims[id(tool_call)] = claim_sink[0]
+        if authenticated_denial is not None:
+            parsed_calls.append(
+                (
+                    tool_call,
+                    function_name,
+                    function_args,
+                    [],
+                    authenticated_denial,
+                    False,
+                )
+            )
+            continue
 
         function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
             agent,
@@ -545,6 +665,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 except Exception:
                     pass
 
+        if block_result is not None:
+            admitted = authenticated_claims.pop(id(tool_call), None)
+            if admitted is not None:
+                admitted[1].close()
         parsed_calls.append((tool_call, function_name, function_args, middleware_trace, block_result, blocked_by_guardrail))
 
     # ── Logging / callbacks ──────────────────────────────────────────
@@ -589,10 +713,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         if block_result is not None:
             results[i] = (name, args, block_result, 0.0, True, True, middleware_trace)
 
-    # Touch activity before launching workers so the gateway knows
-    # we're executing tools (not stuck).
-    agent._current_tool = tool_names_str
-    agent._touch_activity(f"executing {num_tools} tools concurrently: {tool_names_str}")
+    # Touch activity only when at least one call will actually execute.  A
+    # protected-call denial is intentionally invisible to execution observers.
+    if any(block_result is None for _, _, _, _, block_result, _ in parsed_calls):
+        agent._current_tool = tool_names_str
+        agent._touch_activity(
+            f"executing {num_tools} tools concurrently: {tool_names_str}"
+        )
 
     def _run_tool(index, tool_call, function_name, function_args, middleware_trace):
         """Worker function executed in a thread."""
@@ -624,18 +751,36 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # ContextVars are propagated by propagate_context_to_thread() at the
         # submit site below (GHSA-qg5c-hvr5-hjgr, #13617).
         start = time.time()
+        admitted = authenticated_claims.pop(id(tool_call), None)
         try:
             try:
-                result = agent._invoke_tool(
-                    function_name,
-                    function_args,
-                    effective_task_id,
-                    tool_call.id,
-                    messages=messages,
-                    pre_tool_block_checked=True,
-                    skip_tool_request_middleware=True,
-                    tool_request_middleware_trace=list(middleware_trace),
-                )
+                if admitted is None:
+                    result = agent._invoke_tool(
+                        function_name,
+                        function_args,
+                        effective_task_id,
+                        tool_call.id,
+                        messages=messages,
+                        pre_tool_block_checked=True,
+                        skip_tool_request_middleware=True,
+                        tool_request_middleware_trace=list(middleware_trace),
+                    )
+                else:
+                    from gateway.authenticated_dispatch import (
+                        bind_authenticated_gateway_tool_claim,
+                    )
+
+                    with bind_authenticated_gateway_tool_claim(admitted[0]):
+                        result = agent._invoke_tool(
+                            function_name,
+                            function_args,
+                            effective_task_id,
+                            tool_call.id,
+                            messages=messages,
+                            pre_tool_block_checked=True,
+                            skip_tool_request_middleware=True,
+                            tool_request_middleware_trace=list(middleware_trace),
+                        )
             except KeyboardInterrupt:
                 try:
                     agent.interrupt("keyboard interrupt")
@@ -665,7 +810,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 logger.info("tool %s completed (%.2fs, %d chars)", function_name, duration, len(result))
             results[index] = (function_name, function_args, result, duration, is_error, False, middleware_trace)
         finally:
-            # Tear down worker-tid tracking.  Clear any interrupt bit we may
+            if admitted is not None:
+                admitted[1].close()
+            # Tear down worker-tid tracking. Clear any interrupt bit we may
             # have set so the next task scheduled onto this recycled tid
             # starts with a clean slate.  This MUST be in a finally block
             # because BaseException subclasses (CancelledError, KeyboardInterrupt)
@@ -717,6 +864,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         )
                     except RuntimeError as submit_error:
                         if not _is_interpreter_shutdown_submit_error(submit_error):
+                            abandon_executor = True
+                            for f in futures:
+                                f.cancel()
+                            for _i, _tc, _name, _args in runnable_calls[
+                                submit_index:
+                            ]:
+                                admitted = authenticated_claims.pop(id(_tc), None)
+                                if admitted is not None:
+                                    admitted[1].close()
                             raise
                         skipped_calls = runnable_calls[submit_index:]
                         logger.warning(
@@ -725,6 +881,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                             len(skipped_calls),
                         )
                         for skipped_i, _tc, skipped_name, skipped_args in skipped_calls:
+                            admitted = authenticated_claims.pop(id(_tc), None)
+                            if admitted is not None:
+                                admitted[1].close()
                             if results[skipped_i] is None:
                                 middleware_trace = parsed_calls[skipped_i][3]
                                 result = (
@@ -963,8 +1122,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 response_preview = _preview_str[:agent.log_prefix_chars] + "..." if len(_preview_str) > agent.log_prefix_chars else _preview_str
                 print(f"  ✅ Tool {i+1} completed in {tool_duration:.2f}s - {response_preview}")
 
-        agent._current_tool = None
-        agent._touch_activity(f"tool completed: {name} ({tool_duration:.1f}s)")
+        if not blocked:
+            agent._current_tool = None
+            agent._touch_activity(f"tool completed: {name} ({tool_duration:.1f}s)")
 
         if not blocked and agent.tool_complete_callback:
             try:
@@ -973,15 +1133,20 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
 
-        function_result = maybe_persist_tool_result(
-            content=function_result,
-            tool_name=name,
-            tool_use_id=tc.id,
-            env=get_active_env(effective_task_id),
-            config=_tool_budget,
-        ) if not _is_multimodal_tool_result(function_result) else function_result
+        if not blocked and not _is_multimodal_tool_result(function_result):
+            function_result = maybe_persist_tool_result(
+                content=function_result,
+                tool_name=name,
+                tool_use_id=tc.id,
+                env=get_active_env(effective_task_id),
+                config=_tool_budget,
+            )
 
-        subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
+        subdir_hints = (
+            agent._subdirectory_hints.check_tool_call(name, args)
+            if not blocked
+            else None
+        )
         if subdir_hints:
             if _is_multimodal_tool_result(function_result):
                 # Append the hint to the text summary part so the model
@@ -1010,6 +1175,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         if (
             risk_metadata is not None
             and risk_metadata.get("risk") != "low"
+            and not blocked
             and agent.tool_progress_callback
         ):
             try:
@@ -1050,6 +1216,19 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
 
 def execute_tool_calls_sequential(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:
+    with ExitStack() as lease_claims:
+        return _execute_tool_calls_sequential(
+            agent,
+            assistant_message,
+            messages,
+            effective_task_id,
+            api_call_count,
+            finalize=finalize,
+            lease_claims=lease_claims,
+        )
+
+
+def _execute_tool_calls_sequential(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True, lease_claims: ExitStack) -> None:
     """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools.
 
     ``finalize=False`` skips the end-of-batch aggregate budget enforcement
@@ -1122,18 +1301,46 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         except Exception:
             pass
 
-        function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
+        claim_sink: list[tuple[object, ExitStack]] = []
+        authenticated_denial = _authenticated_gateway_tool_denial(
             agent,
             function_name=function_name,
             function_args=function_args,
-            effective_task_id=effective_task_id,
             tool_call_id=getattr(tool_call, "id", "") or "",
+            lease_claims=lease_claims,
+            claim_sink=claim_sink,
         )
+        sequential_claim_scope = None
+        if claim_sink:
+            admitted_claim, sequential_claim_scope = claim_sink[0]
+            from gateway.authenticated_dispatch import (
+                bind_authenticated_gateway_tool_claim,
+            )
+
+            lease_claims.enter_context(
+                bind_authenticated_gateway_tool_claim(admitted_claim)
+            )
+        if authenticated_denial is not None:
+            middleware_trace = []
+        else:
+            function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+            )
 
         # Check plugin hooks for a block directive before executing.
-        _block_msg: Optional[str] = None
-        _block_error_type = "plugin_block"
-        if _ts_scope_block is not None:
+        _block_msg: Optional[str] = authenticated_denial
+        _block_error_type = (
+            "authenticated_gateway_required"
+            if authenticated_denial is not None
+            else "plugin_block"
+        )
+        if authenticated_denial is not None:
+            pass
+        elif _ts_scope_block is not None:
             _block_msg = _ts_scope_block
             _block_error_type = "tool_scope_block"
         else:
@@ -1161,6 +1368,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         _execution_blocked = _block_msg is not None or _guardrail_block_decision is not None
 
         if _execution_blocked:
+            if sequential_claim_scope is not None:
+                sequential_claim_scope.close()
+                sequential_claim_scope = None
             # Tool blocked by plugin or guardrail policy — skip counters,
             # callbacks, checkpointing, activity mutation, and real execution.
             pass
@@ -1236,21 +1446,28 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         tool_start_time = time.time()
 
         if _block_msg is not None:
-            # Tool blocked by plugin policy — return error without executing.
-            function_result = json.dumps({"error": _block_msg}, ensure_ascii=False)
-            tool_duration = 0.0
-            _emit_terminal_post_tool_call(
-                agent,
-                function_name=function_name,
-                function_args=function_args,
-                result=function_result,
-                effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
-                status="blocked",
-                error_type=_block_error_type,
-                error_message=_block_msg,
-                middleware_trace=list(middleware_trace),
+            # Authenticated denials preserve the registry's exact JSON result and
+            # are not published to extension callbacks. Other policy blocks keep
+            # their existing hook-visible behavior.
+            function_result = (
+                _block_msg
+                if authenticated_denial is not None
+                else json.dumps({"error": _block_msg}, ensure_ascii=False)
             )
+            tool_duration = 0.0
+            if authenticated_denial is None:
+                _emit_terminal_post_tool_call(
+                    agent,
+                    function_name=function_name,
+                    function_args=function_args,
+                    result=function_result,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    status="blocked",
+                    error_type=_block_error_type,
+                    error_message=_block_msg,
+                    middleware_trace=list(middleware_trace),
+                )
         elif _guardrail_block_decision is not None:
             # Tool blocked by tool-loop guardrail — synthesize exactly one
             # tool result for the original tool_call_id without executing.
@@ -1519,6 +1736,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                     disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                     tool_request_middleware_trace=list(middleware_trace),
+                    **(
+                        {"authenticated_gateway_context": authenticated_context}
+                        if (
+                            authenticated_context := getattr(
+                                agent, "_authenticated_gateway_context", None
+                            )
+                        ) is not None
+                        else {}
+                    ),
                 )
                 _spinner_result = function_result
             except KeyboardInterrupt:
@@ -1561,6 +1787,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                     disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                     tool_request_middleware_trace=list(middleware_trace),
+                    **(
+                        {"authenticated_gateway_context": authenticated_context}
+                        if (
+                            authenticated_context := getattr(
+                                agent, "_authenticated_gateway_context", None
+                            )
+                        ) is not None
+                        else {}
+                    ),
                 )
             except KeyboardInterrupt:
                 _emit_cancelled_terminal_post_tool_call(
@@ -1581,6 +1816,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
             tool_duration = time.time() - tool_start_time
+
+        if sequential_claim_scope is not None:
+            sequential_claim_scope.close()
 
         if isinstance(function_result, str):
             result_preview = function_result if agent.verbose_logging else (
@@ -1654,8 +1892,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
 
-        agent._current_tool = None
-        agent._touch_activity(f"tool completed: {function_name} ({tool_duration:.1f}s)")
+        if not _execution_blocked:
+            agent._current_tool = None
+            agent._touch_activity(
+                f"tool completed: {function_name} ({tool_duration:.1f}s)"
+            )
 
         if agent.verbose_logging:
             logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")
@@ -1669,16 +1910,21 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
 
-        function_result = maybe_persist_tool_result(
-            content=function_result,
-            tool_name=function_name,
-            tool_use_id=tool_call.id,
-            env=get_active_env(effective_task_id),
-            config=_tool_budget,
-        ) if not _is_multimodal_tool_result(function_result) else function_result
+        if not _execution_blocked and not _is_multimodal_tool_result(function_result):
+            function_result = maybe_persist_tool_result(
+                content=function_result,
+                tool_name=function_name,
+                tool_use_id=tool_call.id,
+                env=get_active_env(effective_task_id),
+                config=_tool_budget,
+            )
 
         # Discover subdirectory context files from tool arguments
-        subdir_hints = agent._subdirectory_hints.check_tool_call(function_name, function_args)
+        subdir_hints = (
+            agent._subdirectory_hints.check_tool_call(function_name, function_args)
+            if not _execution_blocked
+            else None
+        )
         if subdir_hints:
             if _is_multimodal_tool_result(function_result):
                 _append_subdir_hint_to_multimodal(function_result, subdir_hints)
@@ -1694,6 +1940,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         if (
             risk_metadata is not None
             and risk_metadata.get("risk") != "low"
+            and not _execution_blocked
             and agent.tool_progress_callback
         ):
             try:

--- a/docs/security/authenticated-gateway-dispatch.md
+++ b/docs/security/authenticated-gateway-dispatch.md
@@ -1,0 +1,88 @@
+# Authenticated gateway dispatch
+
+Authenticated gateway dispatch is a host-issued capability for plugin commands and model tools that must run only for an explicitly authorized inbound gateway event.
+
+It is not a generic authentication mechanism and is not available to CLI, TUI, local/synthetic plugin dispatch, delegated agents, Codex app-server turns, or model-supplied arguments. Installed plugin code remains trusted host code; this capability is not a sandbox against a malicious plugin.
+
+## Registering protected plugin entry points
+
+Plugin commands and tools opt in independently:
+
+```python
+context.register_command(
+    "admin-command",
+    handle_command,
+    requires_authenticated_gateway=True,
+)
+
+context.register_tool(
+    name="admin_tool",
+    schema={...},
+    handler=handle_tool,
+    requires_authenticated_gateway=True,
+)
+```
+
+A command registration requires a command capability. A protected tool requires a tool capability. The two capability kinds are not interchangeable.
+
+Protected tool handlers receive provenance only through the host-owned keyword argument:
+
+```python
+def handle_tool(args, *, tool_context):
+    platform = tool_context.platform
+```
+
+Protected command handlers receive the corresponding host-owned `command_context` keyword. Model arguments and command text cannot create or replace these values.
+
+## Capability contract
+
+A capability is:
+
+- created only by `gateway.authenticated_dispatch`;
+- sealed against direct construction, copying, mutation, and lookalike objects;
+- bound to one exact `dispatch_kind` (`command` or `tool`);
+- bound to the inbound platform, user, chat, optional thread, and triggering event message ID;
+- valid only while its issuer-owned lease is live;
+- rejected if source and event message IDs disagree;
+- revoked deterministically on scope exit or before an accepted busy-turn prompt mutation.
+
+Validation is identity-based and lease-based, not field-shape-based. An object with matching attributes is not authority.
+
+Lease admission and revocation are atomic. Revocation immediately prevents new admissions and returns without waiting; already-admitted uses may finish under their call-specific claims.
+
+## Tool execution boundary
+
+For protected tools, authorization occurs immediately after model arguments are parsed and any `tool_call` bridge wrapper is resolved. Unauthorized calls are denied before:
+
+- tool-request middleware;
+- plugin pre-tool hooks;
+- guardrails and approval checks;
+- checkpoints or activity publication;
+- tool start, progress, complete, or post-tool callbacks;
+- handler entry.
+
+The registry repeats authorization at dispatch as defense in depth.
+
+Only the host transport names `authenticated_gateway_context` and `tool_context` are recursively reserved in protected model schemas and protected model arguments. Domain fields such as `platform` or `message_id` remain valid application data and do not confer authority.
+
+## Model-visible surface
+
+Protected tool definitions are included in provider payloads only while a live tool lease is bound to the current native agent turn. They are also removed from deferred `tool_search` and `tool_describe` catalogs outside that scope.
+
+Command capabilities, stale capabilities, and absent capabilities do not expose protected model tools. Filtering is per request and does not mutate the agent's cached tool snapshot or system prompt.
+
+## Host integration
+
+Gateway integrations must pass the actual normalized inbound `MessageEvent.message_id` when issuing a protected command or tool turn. Reply anchors, thread roots, quoted-message IDs, and delivery-routing metadata must never be used as authorization provenance.
+
+The generic host APIs are in `gateway/authenticated_dispatch.py`:
+
+- `issue_authenticated_gateway_dispatch(...)`
+- `authenticated_gateway_turn(...)`
+- `bind_authenticated_gateway_dispatch(...)`
+- `validate_authenticated_gateway_command_dispatch(...)`
+- `validate_authenticated_gateway_tool_dispatch(...)`
+- `use_authenticated_gateway_tool_dispatch(...)`
+- `revoke_authenticated_gateway_dispatch(...)`
+
+Callers should normally use the context managers rather than manually coordinating issue, bind, use, and revoke operations.

--- a/gateway/authenticated_dispatch.py
+++ b/gateway/authenticated_dispatch.py
@@ -1,0 +1,464 @@
+"""Host-owned authenticated gateway dispatch provenance.
+
+This module provides a narrow capability object for plugin commands and tools
+that must only run for an authenticated gateway message. The object is not a
+credential and does not make installed plugin code a security boundary. Its
+purpose is to prevent model arguments, synthetic lookalikes, stale objects,
+direct registry calls, local CLI/TUI calls, and derived agents from being
+mistaken for an authenticated gateway dispatch.
+
+Contexts are issued as short-lived leases. Validation succeeds only for the
+exact object held in the live host registry; copies and reconstructed objects
+fail closed. Callers must keep the lease open only around one command handler
+or one top-level agent turn.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+import threading
+from typing import cast, Iterator, Optional
+import uuid
+
+
+AUTHENTICATED_GATEWAY_COMMAND_DISPATCH_VERSION = 1
+AUTHENTICATED_GATEWAY_TOOL_DISPATCH_VERSION = 1
+
+_CONSTRUCTION_SEAL = object()
+_live_lock = threading.RLock()
+_agent_authority_lock = threading.RLock()
+
+
+class _LiveLease:
+    __slots__ = ("context", "active_uses", "condition")
+
+    def __init__(self, context: "AuthenticatedGatewayDispatch") -> None:
+        self.context = context
+        self.active_uses = 0
+        self.condition = threading.Condition()
+
+
+_live_contexts: dict[str, _LiveLease] = {}
+
+
+class _AuthenticatedGatewayToolClaim:
+    """Private proof that one protected invocation passed atomic admission."""
+
+    __slots__ = (
+        "context",
+        "lease",
+        "tool_name",
+        "tool_call_id",
+        "active",
+        "consumed",
+        "lock",
+    )
+
+    def __init__(
+        self,
+        context: "AuthenticatedGatewayDispatch",
+        lease: _LiveLease,
+        tool_name: str,
+        tool_call_id: Optional[str],
+    ) -> None:
+        self.context = context
+        self.lease = lease
+        self.tool_name = tool_name
+        self.tool_call_id = tool_call_id
+        self.active = True
+        self.consumed = False
+        self.lock = threading.Lock()
+
+
+_current_tool_claim: ContextVar[tuple[_AuthenticatedGatewayToolClaim, ...]] = (
+    ContextVar("authenticated_gateway_tool_claim", default=())
+)
+
+
+class AuthenticatedGatewayDispatch:
+    """Immutable, non-serializable view of one authenticated gateway message."""
+
+    __slots__ = (
+        "_sealed",
+        "authorized",
+        "dispatch_kind",
+        "platform",
+        "user_id",
+        "chat_id",
+        "thread_id",
+        "message_id",
+        "turn_id",
+        "provenance_version",
+    )
+
+    def __init__(
+        self,
+        *,
+        platform: str,
+        user_id: str,
+        chat_id: str,
+        message_id: str,
+        dispatch_kind: str,
+        thread_id: Optional[str] = None,
+        _seal: object = None,
+        _turn_id: Optional[str] = None,
+    ) -> None:
+        if _seal is not _CONSTRUCTION_SEAL:
+            raise TypeError("Authenticated gateway dispatch is host-issued only")
+        object.__setattr__(self, "authorized", True)
+        object.__setattr__(self, "dispatch_kind", dispatch_kind)
+        object.__setattr__(self, "platform", platform)
+        object.__setattr__(self, "user_id", user_id)
+        object.__setattr__(self, "chat_id", chat_id)
+        object.__setattr__(self, "thread_id", thread_id)
+        object.__setattr__(self, "message_id", message_id)
+        object.__setattr__(self, "turn_id", _turn_id)
+        object.__setattr__(self, "provenance_version", 1)
+        object.__setattr__(self, "_sealed", True)
+
+    def __setattr__(self, _name: str, _value: object) -> None:
+        raise AttributeError("Authenticated gateway dispatch is immutable")
+
+    def __copy__(self):
+        raise TypeError("Authenticated gateway dispatch cannot be copied")
+
+    def __deepcopy__(self, _memo):
+        raise TypeError("Authenticated gateway dispatch cannot be copied")
+
+    def __reduce__(self):
+        raise TypeError("Authenticated gateway dispatch cannot be serialized")
+
+    def __repr__(self) -> str:
+        return "<AuthenticatedGatewayDispatch host-issued>"
+
+
+def _required_string(name: str, value: object) -> str:
+    if type(value) is not str:
+        raise TypeError(f"{name} must be a built-in string")
+    if not value:
+        raise ValueError(f"{name} must not be empty")
+    return value
+
+
+def validate_authenticated_gateway_dispatch(context: object) -> bool:
+    """Return whether *context* is the exact object in a current live lease."""
+    if type(context) is not AuthenticatedGatewayDispatch:
+        return False
+    if context.authorized is not True:
+        return False
+    if type(context.provenance_version) is not int or context.provenance_version != 1:
+        return False
+    if context.dispatch_kind not in {"command", "tool"}:
+        return False
+    if type(context.turn_id) is not str or not context.turn_id:
+        return False
+    with _live_lock:
+        lease = _live_contexts.get(context.turn_id)
+        return lease is not None and lease.context is context
+
+
+def validate_authenticated_gateway_command_dispatch(context: object) -> bool:
+    """Return whether *context* is an exact live command-only lease."""
+    if type(context) is not AuthenticatedGatewayDispatch:
+        return False
+    typed_context = cast(AuthenticatedGatewayDispatch, context)
+    return (
+        validate_authenticated_gateway_dispatch(typed_context)
+        and typed_context.dispatch_kind == "command"
+        and typed_context.provenance_version
+        == AUTHENTICATED_GATEWAY_COMMAND_DISPATCH_VERSION
+    )
+
+
+def validate_authenticated_gateway_tool_dispatch(context: object) -> bool:
+    """Return whether *context* is an exact live tool-only lease."""
+    if type(context) is not AuthenticatedGatewayDispatch:
+        return False
+    typed_context = cast(AuthenticatedGatewayDispatch, context)
+    return (
+        validate_authenticated_gateway_dispatch(typed_context)
+        and typed_context.dispatch_kind == "tool"
+        and typed_context.provenance_version
+        == AUTHENTICATED_GATEWAY_TOOL_DISPATCH_VERSION
+    )
+
+
+def revoke_authenticated_gateway_dispatch(context: object) -> bool:
+    """Close a lease to new claims without blocking already-admitted work.
+
+    Existing claims remain responsible for leaving their protected pipeline.
+    Control paths such as interrupt, timeout, and steering must never wait for
+    a handler that may itself require the interrupt signal in order to finish.
+    """
+    if type(context) is not AuthenticatedGatewayDispatch:
+        return False
+    turn_id = context.turn_id
+    if type(turn_id) is not str or not turn_id:
+        return False
+    with _live_lock:
+        lease = _live_contexts.get(turn_id)
+        if lease is None or lease.context is not context:
+            return False
+        del _live_contexts[turn_id]
+    return True
+
+
+def taint_and_revoke_authenticated_gateway_dispatch(agent: object) -> bool:
+    """Atomically taint an agent turn and close any published lease."""
+    with _agent_authority_lock:
+        taint = getattr(agent, "_authenticated_gateway_turn_tainted", None)
+        if taint is None:
+            taint = threading.Event()
+            setattr(agent, "_authenticated_gateway_turn_tainted", taint)
+        try:
+            taint.set()
+        except Exception:
+            # A malformed marker must deny future issuance.
+            setattr(agent, "_authenticated_gateway_turn_tainted", True)
+        context = getattr(agent, "_authenticated_gateway_context", None)
+        return revoke_authenticated_gateway_dispatch(context)
+
+
+@contextmanager
+def use_authenticated_gateway_tool_dispatch(
+    context: object,
+    tool_name: str,
+    *,
+    tool_call_id: Optional[str] = None,
+) -> Iterator[Optional[_AuthenticatedGatewayToolClaim]]:
+    """Atomically claim a live tool lease for one protected handler use."""
+    if type(context) is not AuthenticatedGatewayDispatch:
+        yield None
+        return
+    typed_context = cast(AuthenticatedGatewayDispatch, context)
+    claim: Optional[_AuthenticatedGatewayToolClaim] = None
+    with _live_lock:
+        lease = _live_contexts.get(typed_context.turn_id)
+        if (
+            lease is not None
+            and lease.context is typed_context
+            and validate_authenticated_gateway_tool_dispatch(typed_context)
+        ):
+            with lease.condition:
+                lease.active_uses += 1
+            claim = _AuthenticatedGatewayToolClaim(
+                typed_context,
+                lease,
+                tool_name,
+                tool_call_id,
+            )
+    if claim is None:
+        yield None
+        return
+    try:
+        yield claim
+    finally:
+        claim.active = False
+        with lease.condition:
+            lease.active_uses -= 1
+            if lease.active_uses == 0:
+                lease.condition.notify_all()
+
+
+def current_authenticated_gateway_tool_claim_is_bound() -> bool:
+    """Return whether this invocation context carries an admitted tool claim."""
+    return bool(_current_tool_claim.get())
+
+
+def current_authenticated_gateway_tool_claim_authorizes(
+    context: object,
+    tool_name: str,
+    *,
+    tool_call_id: Optional[str] = None,
+    consume: bool = False,
+) -> bool:
+    """Authorize exactly one downstream registry dispatch per admitted call."""
+    for claim in _current_tool_claim.get():
+        if (
+            type(claim) is not _AuthenticatedGatewayToolClaim
+            or claim.active is not True
+            or claim.context is not context
+            or claim.tool_name != tool_name
+            or (
+                claim.tool_call_id is not None
+                and claim.tool_call_id != tool_call_id
+            )
+        ):
+            continue
+        with claim.lock:
+            if claim.active is not True or claim.consumed:
+                continue
+            if consume:
+                claim.consumed = True
+            return True
+    return False
+
+
+@contextmanager
+def bind_authenticated_gateway_tool_claim(claim: object) -> Iterator[None]:
+    """Propagate one admitted claim through the downstream tool pipeline."""
+    if type(claim) is not _AuthenticatedGatewayToolClaim or claim.active is not True:
+        raise PermissionError("Authenticated gateway tool claim is not active")
+    token = _current_tool_claim.set((cast(_AuthenticatedGatewayToolClaim, claim),))
+    try:
+        yield
+    finally:
+        _current_tool_claim.reset(token)
+
+
+@contextmanager
+def issue_authenticated_gateway_dispatch(
+    *,
+    dispatch_kind: str,
+    platform: str,
+    user_id: str,
+    chat_id: str,
+    message_id: str,
+    thread_id: Optional[str] = None,
+) -> Iterator[AuthenticatedGatewayDispatch]:
+    """Issue one live context and revoke it deterministically on scope exit."""
+    dispatch_kind = _required_string("dispatch_kind", dispatch_kind)
+    if dispatch_kind not in {"command", "tool"}:
+        raise ValueError("dispatch_kind must be 'command' or 'tool'")
+    platform = _required_string("platform", platform)
+    user_id = _required_string("user_id", user_id)
+    chat_id = _required_string("chat_id", chat_id)
+    message_id = _required_string("message_id", message_id)
+    if thread_id is not None:
+        thread_id = _required_string("thread_id", thread_id)
+
+    turn_id = uuid.uuid4().hex
+    context = AuthenticatedGatewayDispatch(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        message_id=message_id,
+        dispatch_kind=dispatch_kind,
+        thread_id=thread_id,
+        _seal=_CONSTRUCTION_SEAL,
+        _turn_id=turn_id,
+    )
+    lease = _LiveLease(context)
+    with _live_lock:
+        _live_contexts[turn_id] = lease
+    try:
+        yield context
+    finally:
+        revoke_authenticated_gateway_dispatch(context)
+
+
+@contextmanager
+def bind_authenticated_gateway_dispatch(
+    agent: object,
+    context: object,
+) -> Iterator[None]:
+    """Bind one live lease to an agent and restore prior state on every exit."""
+    if context is not None and not validate_authenticated_gateway_dispatch(context):
+        raise PermissionError("Authenticated gateway turn lease is not live")
+    missing = object()
+    previous = getattr(agent, "_authenticated_gateway_context", missing)
+    setattr(agent, "_authenticated_gateway_context", context)
+    try:
+        yield
+    finally:
+        if previous is missing:
+            try:
+                delattr(agent, "_authenticated_gateway_context")
+            except AttributeError:
+                pass
+        else:
+            setattr(agent, "_authenticated_gateway_context", previous)
+
+
+@contextmanager
+def authenticated_gateway_turn(
+    agent: object,
+    source: object,
+    *,
+    authenticated_gateway_request: bool = False,
+    event_message_id: object = None,
+) -> Iterator[Optional[AuthenticatedGatewayDispatch]]:
+    """Issue a lease for one explicitly verified gateway request.
+
+    Unsupported agents, incomplete identities, and callers without the exact
+    post-authorization decision yield None. Source shape alone is never proof.
+    """
+    capability = getattr(
+        agent,
+        "authenticated_gateway_tool_dispatch_version",
+        None,
+    )
+    source_platform = getattr(source, "platform", None)
+    platform = getattr(source_platform, "value", source_platform)
+    user_id = getattr(source, "user_id", None)
+    chat_id = getattr(source, "chat_id", None)
+    thread_id = getattr(source, "thread_id", None)
+    source_message_id = getattr(source, "message_id", None)
+    message_id = event_message_id
+    mandatory_identity = (platform, user_id, chat_id, message_id)
+    valid_source_message_id = (
+        source_message_id is None
+        or (
+            type(source_message_id) is str
+            and bool(source_message_id)
+            and source_message_id == message_id
+        )
+    )
+    valid_thread = (
+        thread_id is None
+        or (type(thread_id) is str and bool(thread_id))
+    )
+    if not (
+        authenticated_gateway_request is True
+        and type(capability) is int
+        and capability == AUTHENTICATED_GATEWAY_TOOL_DISPATCH_VERSION
+        and all(type(value) is str and value for value in mandatory_identity)
+        and valid_source_message_id
+        and valid_thread
+    ):
+        yield None
+        return
+
+    missing = object()
+    context_manager = None
+    context = None
+    previous = missing
+    with _agent_authority_lock:
+        taint = getattr(agent, "_authenticated_gateway_turn_tainted", None)
+        if taint is None:
+            tainted = False
+        else:
+            try:
+                tainted = taint.is_set() is not False
+            except Exception:
+                tainted = True
+        if not tainted:
+            context_manager = issue_authenticated_gateway_dispatch(
+                dispatch_kind="tool",
+                platform=cast(str, platform),
+                user_id=cast(str, user_id),
+                chat_id=cast(str, chat_id),
+                thread_id=thread_id,
+                message_id=cast(str, message_id),
+            )
+            context = context_manager.__enter__()
+            previous = getattr(agent, "_authenticated_gateway_context", missing)
+            setattr(agent, "_authenticated_gateway_context", context)
+    if context is None:
+        yield None
+        return
+    try:
+        yield context
+    finally:
+        with _agent_authority_lock:
+            if getattr(agent, "_authenticated_gateway_context", None) is context:
+                if previous is missing:
+                    try:
+                        delattr(agent, "_authenticated_gateway_context")
+                    except AttributeError:
+                        pass
+                else:
+                    setattr(agent, "_authenticated_gateway_context", previous)
+            assert context_manager is not None
+            context_manager.__exit__(None, None, None)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1826,6 +1826,18 @@ class MessageEvent:
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
 
+    # Host-owned, post-authorization sidecar used only while an event is held
+    # in an in-memory busy-session queue. ``init=False`` prevents adapters or
+    # deserializers from asserting authenticated provenance at construction;
+    # GatewayRunner resets it at ingress and sets it only after its independent
+    # authorization check succeeds.
+    _authenticated_gateway_request: bool = field(
+        default=False,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
     # Free-form per-event metadata.  Adapters may set platform-specific
     # signals here (e.g. WhatsApp sets ``whatsapp_from_owner=True`` when
     # the bridge is configured to forward owner-typed messages).  Plugins
@@ -2165,6 +2177,11 @@ def merge_pending_message_event(
         incoming_has_media = bool(event.media_urls)
 
         if existing_is_photo and incoming_is_photo:
+            # A single-message capability cannot faithfully represent merged
+            # content from multiple gateway events, even when every event was
+            # independently authenticated.  Preserve the first message ID for
+            # reply/thread behavior, but fail closed for protected dispatch.
+            existing._authenticated_gateway_request = False
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
             if event.text:
@@ -2173,6 +2190,7 @@ def merge_pending_message_event(
             return
 
         if existing_has_media or incoming_has_media:
+            existing._authenticated_gateway_request = False
             if incoming_has_media:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
@@ -2196,6 +2214,7 @@ def merge_pending_message_event(
             and getattr(existing, "message_type", None) == MessageType.TEXT
             and event.message_type == MessageType.TEXT
         ):
+            existing._authenticated_gateway_request = False
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
             return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5802,6 +5802,63 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return None, None
 
     @staticmethod
+    def _revoke_authenticated_gateway_authority(running_agent: Any) -> None:
+        """Atomically taint the current turn and close its published lease."""
+        from gateway.authenticated_dispatch import (
+            taint_and_revoke_authenticated_gateway_dispatch,
+        )
+
+        taint_and_revoke_authenticated_gateway_dispatch(running_agent)
+
+    @staticmethod
+    def _interrupt_authenticated_gateway_turn(
+        running_agent: Any,
+        reason: Optional[str],
+    ) -> None:
+        """Revoke/taint before publishing an interrupt to the active agent."""
+        GatewayRunner._revoke_authenticated_gateway_authority(running_agent)
+        running_agent.interrupt(reason)
+
+    @staticmethod
+    def _authenticated_gateway_request_for_turn(
+        requested: bool,
+        agent: Any,
+    ) -> bool:
+        """Deny lease issuance after any accepted mutation of this turn."""
+        if requested is not True:
+            return False
+        taint = getattr(agent, "_authenticated_gateway_turn_tainted", None)
+        if taint is None:
+            return True
+        try:
+            return taint.is_set() is False
+        except Exception:
+            return False
+
+    @staticmethod
+    def _authenticated_gateway_mutation_kwargs(running_agent: Any) -> dict:
+        """Return the pre-mutation revocation callback for exact-capability agents."""
+        from gateway.authenticated_dispatch import (
+            AUTHENTICATED_GATEWAY_TOOL_DISPATCH_VERSION,
+        )
+
+        capability = getattr(
+            running_agent,
+            "authenticated_gateway_tool_dispatch_version",
+            None,
+        )
+        if (
+            type(capability) is int
+            and capability == AUTHENTICATED_GATEWAY_TOOL_DISPATCH_VERSION
+        ):
+            return {
+                "before_mutation": lambda: GatewayRunner._revoke_authenticated_gateway_authority(
+                    running_agent
+                )
+            }
+        return {}
+
+    @staticmethod
     def _agent_has_active_subagents(running_agent: Any) -> bool:
         """Return True when *running_agent* is currently driving subagents
         via the ``delegate_task`` tool.
@@ -5951,6 +6008,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
+        # The queue provenance sidecar is host-owned. Reset any dynamic value
+        # supplied by an adapter before making the independent auth decision.
+        event._authenticated_gateway_request = False
         # The cold path (_handle_message) checks _is_user_authorized before
         # creating a session.  The busy path must enforce the same check;
         # otherwise unauthorized users in shared threads (Slack/Telegram/Discord)
@@ -5965,6 +6025,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key,
             )
             return True  # handled (silently dropped); do not fall through
+
+        if not event.internal:
+            event._authenticated_gateway_request = True
 
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
@@ -6148,7 +6211,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             if can_steer:
                 try:
-                    steered = bool(running_agent.steer(steer_text))
+                    steered = bool(
+                        running_agent.steer(
+                            steer_text,
+                            **self._authenticated_gateway_mutation_kwargs(
+                                running_agent
+                            ),
+                        )
+                    )
                 except Exception as exc:
                     logger.warning("Gateway steer failed for session %s: %s", session_key, exc)
                     steered = False
@@ -6166,10 +6236,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             and hasattr(running_agent, "redirect")
         ):
             try:
-                redirected = bool(running_agent.redirect((event.text or "").strip()))
+                redirected = bool(
+                    running_agent.redirect(
+                        (event.text or "").strip(),
+                        **self._authenticated_gateway_mutation_kwargs(
+                            running_agent
+                        ),
+                    )
+                )
             except Exception as exc:
                 logger.warning("Gateway redirect failed for session %s: %s", session_key, exc)
                 redirected = False
+
+        if steered or redirected:
+            self._revoke_authenticated_gateway_authority(running_agent)
 
         # Store the message so it's processed as the next turn after the
         # current run finishes (or is interrupted).  Skip this for a
@@ -6202,6 +6282,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             and running_agent
             and running_agent is not _AGENT_PENDING_SENTINEL
         ):
+            self._revoke_authenticated_gateway_authority(running_agent)
             try:
                 _interrupt_text = event.text
                 _media_urls = getattr(event, "media_urls", None) or []
@@ -6441,6 +6522,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if agent is _AGENT_PENDING_SENTINEL:
                 continue
             try:
+                self._revoke_authenticated_gateway_authority(agent)
                 agent.interrupt(reason)
                 logger.debug("Interrupted running agent for session %s during shutdown", session_key)
             except Exception as e:
@@ -10456,7 +10538,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("reset_session_vars failed at handler entry", exc_info=True)
 
         # Internal events (e.g. background-process completion notifications)
-        # are system-generated and must skip user authorization.
+        # are system-generated and must skip user authorization. The queue
+        # provenance sidecar is host-owned, so clear any adapter-supplied value
+        # before this ingress makes its own authorization decision.
+        event._authenticated_gateway_request = False
         is_internal = bool(getattr(event, "internal", False))
 
         # Ignored-channel guard runs FIRST — before startup-restore queueing,
@@ -10588,7 +10673,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Record rate limit so subsequent messages are silently ignored
                     self.pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
-        
+
+        # This decision is the only authority input downstream. Internal events
+        # may bypass the user gate for delivery, but are never authenticated
+        # gateway requests. External events reach here only after authorization.
+        authenticated_gateway_request = not is_internal
+        event._authenticated_gateway_request = authenticated_gateway_request
+
         # Intercept messages that are responses to a pending /update prompt.
         # The update process (detached) wrote .update_prompt.json; the watcher
         # forwarded it to the user; now the user's reply goes back via
@@ -10924,6 +11015,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         internal=event.internal,
                         timestamp=event.timestamp,
                     )
+                    queued_event._authenticated_gateway_request = (
+                        event._authenticated_gateway_request is True
+                    )
                     self._enqueue_fifo(_quick_key, queued_event, adapter)
                 depth = self._queue_depth(_quick_key, adapter=self._adapter_for_source(source))
                 if depth <= 1:
@@ -10952,15 +11046,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             channel_prompt=event.channel_prompt,
                             channel_context=event.channel_context,
                         )
+                        queued_event._authenticated_gateway_request = (
+                            event._authenticated_gateway_request is True
+                        )
                         adapter._pending_messages[_quick_key] = queued_event
                     return "Agent still starting — /steer queued for the next turn."
                 if running_agent and hasattr(running_agent, "steer"):
                     try:
-                        accepted = running_agent.steer(steer_text)
+                        accepted = running_agent.steer(
+                            steer_text,
+                            **self._authenticated_gateway_mutation_kwargs(
+                                running_agent
+                            ),
+                        )
                     except Exception as exc:
                         logger.warning("Steer failed for session %s: %s", _quick_key, exc)
                         return f"⚠️ Steer failed: {exc}"
                     if accepted:
+                        self._revoke_authenticated_gateway_authority(running_agent)
                         preview = steer_text[:60] + ("..." if len(steer_text) > 60 else "")
                         return f"⏩ Steer queued — arrives after the next tool call: '{preview}'"
                     return "Steer rejected (empty payload)."
@@ -10974,6 +11077,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         message_id=event.message_id,
                         channel_prompt=event.channel_prompt,
                         channel_context=event.channel_context,
+                    )
+                    queued_event._authenticated_gateway_request = (
+                        event._authenticated_gateway_request is True
                     )
                     adapter._pending_messages[_quick_key] = queued_event
                 return "No active agent — /steer queued for the next turn."
@@ -11170,11 +11276,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     and hasattr(running_agent, "steer")
                 ):
                     try:
-                        steered = bool(running_agent.steer(steer_text))
+                        steered = bool(
+                        running_agent.steer(
+                            steer_text,
+                            **self._authenticated_gateway_mutation_kwargs(
+                                running_agent
+                            ),
+                        )
+                    )
                     except Exception as exc:
                         logger.warning("PRIORITY steer failed for session %s: %s", _quick_key, exc)
                         steered = False
                 if steered:
+                    self._revoke_authenticated_gateway_authority(running_agent)
                     logger.debug("PRIORITY steer for session %s", _quick_key)
                     return None
                 logger.debug("PRIORITY steer-fallback-to-queue for session %s", _quick_key)
@@ -11224,7 +11338,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 and hasattr(running_agent, "redirect")
             ):
                 try:
-                    if running_agent.redirect((event.text or "").strip()):
+                    if running_agent.redirect(
+                        (event.text or "").strip(),
+                        **self._authenticated_gateway_mutation_kwargs(
+                            running_agent
+                        ),
+                    ):
+                        self._revoke_authenticated_gateway_authority(running_agent)
                         logger.debug("PRIORITY redirect for session %s", _quick_key)
                         return None
                 except Exception as exc:
@@ -11234,6 +11354,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         exc,
                     )
             logger.debug("PRIORITY interrupt for session %s", _quick_key)
+            self._revoke_authenticated_gateway_authority(running_agent)
             _interrupt_text = event.text
             _media_urls = getattr(event, "media_urls", None) or []
             if self._pending_event_audio_paths(event):
@@ -11299,6 +11420,64 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _denied is not None:
                 return _denied
 
+        def _protected_plugin_command_status(name: Optional[str]) -> tuple[bool, bool]:
+            """Return (protected, authorized) before any command hook runs."""
+            if not name:
+                return False, False
+            try:
+                from hermes_cli.plugins import get_plugin_commands
+
+                entry = get_plugin_commands().get(name.replace("_", "-"))
+            except Exception:
+                # Plugin metadata is part of the security classification boundary.
+                # A failed lookup must not let an unknown command reach hooks and
+                # then become protected on a later successful discovery attempt.
+                try:
+                    from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS
+
+                    if name in GATEWAY_KNOWN_COMMANDS:
+                        return False, False
+                except Exception:
+                    pass
+                return True, False
+            if not isinstance(entry, dict) or entry.get(
+                "requires_authenticated_gateway"
+            ) is not True:
+                return False, False
+            platform = getattr(source.platform, "value", source.platform)
+            message_id = event.message_id
+            source_message_id = source.message_id
+            valid = (
+                authenticated_gateway_request is True
+                and type(platform) is str
+                and bool(platform)
+                and type(source.user_id) is str
+                and bool(source.user_id)
+                and type(source.chat_id) is str
+                and bool(source.chat_id)
+                and type(message_id) is str
+                and bool(message_id)
+                and (
+                    source.thread_id is None
+                    or (type(source.thread_id) is str and bool(source.thread_id))
+                )
+                and (
+                    source_message_id is None
+                    or (
+                        type(source_message_id) is str
+                        and bool(source_message_id)
+                        and source_message_id == message_id
+                    )
+                )
+            )
+            return True, valid
+
+        _hook_command_is_protected, _hook_command_is_authorized = (
+            _protected_plugin_command_status(canonical or command)
+        )
+        if _hook_command_is_protected and not _hook_command_is_authorized:
+            return "Authenticated gateway command dispatch denied."
+
         # Fire the ``command:<canonical>`` hook for any recognized slash
         # command — built-in OR plugin-registered. Handlers can return a
         # dict with ``{"decision": "deny" | "handled" | "rewrite", ...}``
@@ -11352,6 +11531,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     command = event.get_command()
                     _cmd_def = _resolve_cmd(command) if command else None
                     canonical = _cmd_def.name if _cmd_def else command
+                    _rewritten_is_protected, _rewritten_is_authorized = (
+                        _protected_plugin_command_status(canonical or command)
+                    )
+                    if _rewritten_is_protected and not _rewritten_is_authorized:
+                        return "Authenticated gateway command dispatch denied."
                     break
 
         if canonical == "new":
@@ -11714,20 +11898,76 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Plugin-registered slash commands
         if command:
+            normalized_command = command.replace("_", "-")
+            protected_command = False
             try:
-                from hermes_cli.plugins import get_plugin_command_handler
+                from hermes_cli.plugins import (
+                    get_plugin_commands,
+                    invoke_plugin_command,
+                )
+
                 # Normalize underscores to hyphens so Telegram's underscored
-                # autocomplete form matches plugin commands registered with
-                # hyphens. See hermes_cli/commands.py:_build_telegram_menu.
-                plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
-                if plugin_handler:
+                # autocomplete form matches hyphenated plugin commands.
+                entry = get_plugin_commands().get(normalized_command)
+                if entry:
+                    protected_command = (
+                        entry.get("requires_authenticated_gateway") is True
+                    )
                     user_args = event.get_command_args().strip()
-                    result = plugin_handler(user_args)
-                    if asyncio.iscoroutine(result):
-                        result = await result
+                    if protected_command:
+                        if authenticated_gateway_request is not True:
+                            raise PermissionError(
+                                "Authenticated gateway command dispatch required"
+                            )
+                        from gateway.authenticated_dispatch import (
+                            issue_authenticated_gateway_dispatch,
+                        )
+
+                        platform = getattr(source.platform, "value", source.platform)
+                        message_id = event.message_id
+                        source_message_id = source.message_id
+                        if not (
+                            type(message_id) is str
+                            and bool(message_id)
+                            and (
+                                source_message_id is None
+                                or (
+                                    type(source_message_id) is str
+                                    and bool(source_message_id)
+                                    and source_message_id == message_id
+                                )
+                            )
+                        ):
+                            raise PermissionError(
+                                "Authenticated gateway command dispatch requires "
+                                "matching trigger message provenance"
+                            )
+                        with issue_authenticated_gateway_dispatch(
+                            dispatch_kind="command",
+                            platform=platform,
+                            user_id=source.user_id,
+                            chat_id=source.chat_id,
+                            thread_id=source.thread_id,
+                            message_id=message_id,
+                        ) as authenticated_context:
+                            result = invoke_plugin_command(
+                                normalized_command,
+                                user_args,
+                                authenticated_gateway_context=authenticated_context,
+                            )
+                            if asyncio.iscoroutine(result):
+                                result = await result
+                    else:
+                        result = invoke_plugin_command(normalized_command, user_args)
+                        if asyncio.iscoroutine(result):
+                            result = await result
                     return str(result) if result else None
             except Exception as e:
                 logger.warning("Plugin command dispatch failed: %s", e)
+                if protected_command:
+                    # Never reinterpret a denied/failed protected command as a
+                    # skill or model prompt.
+                    return "Authenticated gateway command dispatch denied."
 
         # Skill slash commands: /skill-name loads the skill and sends to agent.
         # resolve_skill_command_key() handles the Telegram underscore/hyphen
@@ -11935,7 +12175,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _run_generation = self._begin_session_run_generation(_quick_key)
 
         try:
-            _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
+            if authenticated_gateway_request is True:
+                _agent_result = await self._handle_message_with_agent(
+                    event,
+                    source,
+                    _quick_key,
+                    _run_generation,
+                    authenticated_gateway_request=True,
+                )
+            else:
+                _agent_result = await self._handle_message_with_agent(
+                    event,
+                    source,
+                    _quick_key,
+                    _run_generation,
+                )
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
             # either mark it done, pause it (budget), or enqueue a
@@ -12506,7 +12760,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
-    async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
+    async def _handle_message_with_agent(
+        self,
+        event,
+        source,
+        _quick_key: str,
+        run_generation: int,
+        authenticated_gateway_request: bool = False,
+    ):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
@@ -13579,6 +13840,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key=session_key,
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
+                authenticated_gateway_message_id=event.message_id,
+                authenticated_gateway_request=authenticated_gateway_request,
                 channel_prompt=event.channel_prompt,
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
@@ -18648,6 +18911,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
         running_agent = self._running_agents.get(session_key)
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+            self._revoke_authenticated_gateway_authority(running_agent)
             running_agent.interrupt(interrupt_reason)
         self._invalidate_session_run_generation(session_key, reason=invalidation_reason)
         adapter = self._adapter_for_source(source)
@@ -19600,6 +19864,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         run_generation: Optional[int] = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
+        authenticated_gateway_message_id: Optional[str] = None,
+        authenticated_gateway_request: bool = False,
         channel_prompt: Optional[str] = None,
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
@@ -19614,11 +19880,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         multiplexing is off this is a transparent pass-through — zero behavior
         change for single-profile gateways.
         """
+        if authenticated_gateway_message_id is None and authenticated_gateway_request:
+            # Backward compatibility for direct callers that historically used
+            # event_message_id for both reply anchoring and security provenance.
+            authenticated_gateway_message_id = event_message_id
         if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
             return await self._run_agent_inner(
                 message, context_prompt, history, source, session_id,
                 session_key=session_key, run_generation=run_generation,
                 _interrupt_depth=_interrupt_depth, event_message_id=event_message_id,
+                authenticated_gateway_message_id=authenticated_gateway_message_id,
+                authenticated_gateway_request=authenticated_gateway_request,
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
@@ -19630,6 +19902,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message, context_prompt, history, source, session_id,
                 session_key=session_key, run_generation=run_generation,
                 _interrupt_depth=_interrupt_depth, event_message_id=event_message_id,
+                authenticated_gateway_message_id=authenticated_gateway_message_id,
+                authenticated_gateway_request=authenticated_gateway_request,
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
@@ -19750,6 +20024,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         run_generation: Optional[int] = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
+        authenticated_gateway_message_id: Optional[str] = None,
+        authenticated_gateway_request: bool = False,
         channel_prompt: Optional[str] = None,
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
@@ -20703,8 +20979,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     logger.error("Progress message error: %s", e)
                     await asyncio.sleep(1)
         
-        # We need to share the agent instance for interrupt support
+        # We need to share the agent instance for interrupt support. The taint
+        # is per run, not per cached agent: once an accepted steer/redirect or
+        # interrupt mutates this turn, later lease issuance for this same run
+        # must stay denied even if mutation won the pre-issuance race.
         agent_holder = [None]  # Mutable container for the agent instance
+        authenticated_gateway_turn_tainted = threading.Event()
         result_holder = [None]  # Mutable container for the result
         tools_holder = [None]   # Mutable container for the tool definitions
         stream_consumer_holder = [None]  # Mutable container for stream consumer
@@ -21490,6 +21770,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # tool_progress mode. Mattermost needs an explicit per-platform
             # opt-in so global scratch-text display does not leak into threads.
             agent.thinking_progress = _thinking_enabled
+            # Publish the per-run taint marker before exposing the real agent
+            # through agent_holder/_running_agents. An interrupt that wins this
+            # pre-issuance window permanently denies authority for this run.
+            setattr(
+                agent,
+                "_authenticated_gateway_turn_tainted",
+                authenticated_gateway_turn_tainted,
+            )
             # Store agent reference for interrupt support
             agent_holder[0] = agent
             # Capture the full tool definitions for transcript logging
@@ -21844,7 +22132,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["moa_config"] = moa_config
                 if _persist_user_timestamp_override is not None:
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
-                result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
+
+                from gateway.authenticated_dispatch import authenticated_gateway_turn
+
+                with authenticated_gateway_turn(
+                    agent,
+                    source,
+                    authenticated_gateway_request=(
+                        self._authenticated_gateway_request_for_turn(
+                            authenticated_gateway_request,
+                            agent,
+                        )
+                    ),
+                    event_message_id=authenticated_gateway_message_id,
+                ) as _authenticated_context:
+                    if _authenticated_context is not None:
+                        _conversation_kwargs["authenticated_gateway_context"] = (
+                            _authenticated_context
+                        )
+                    result = agent.run_conversation(
+                        _api_run_message,
+                        **_conversation_kwargs,
+                    )
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent
@@ -22245,7 +22554,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 elif not pending_text and _media_urls:
                                     pending_text = _build_media_placeholder(_peek_event)
                             logger.debug("Interrupt detected from adapter, signaling agent...")
-                            agent.interrupt(pending_text)
+                            self._interrupt_authenticated_gateway_turn(
+                                agent,
+                                pending_text,
+                            )
                             _interrupt_detected.set()
                             break
                 except asyncio.CancelledError:
@@ -22445,7 +22757,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 session_key,
                                 "done" if interrupt_monitor.done() else "running",
                             )
-                            _backup_agent.interrupt(_bp_text)
+                            self._interrupt_authenticated_gateway_turn(
+                                _backup_agent,
+                                _bp_text,
+                            )
                             _interrupt_detected.set()
             else:
                 # Poll loop: check the agent's built-in activity tracker
@@ -22518,7 +22833,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 session_key,
                                 "done" if interrupt_monitor.done() else "running",
                             )
-                            _backup_agent.interrupt(_bp_text)
+                            self._interrupt_authenticated_gateway_turn(
+                                _backup_agent,
+                                _bp_text,
+                            )
                             _interrupt_detected.set()
 
             if _inactivity_timeout:
@@ -22548,7 +22866,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Interrupt the agent if it's still running so the thread
                 # pool worker is freed.
                 if _timed_out_agent and hasattr(_timed_out_agent, "interrupt"):
-                    _timed_out_agent.interrupt(_INTERRUPT_REASON_TIMEOUT)
+                    self._interrupt_authenticated_gateway_turn(
+                        _timed_out_agent,
+                        _INTERRUPT_REASON_TIMEOUT,
+                    )
 
                 _timeout_mins = int(_agent_timeout // 60) or 1
 
@@ -22832,7 +23153,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 updated_history = result.get("messages", history)
                 next_source = source
                 next_message = pending
-                next_message_id = None
+                next_reply_anchor = None
+                next_authenticated_gateway_message_id = None
+                next_authenticated_gateway_request = False
                 next_channel_prompt = None
                 next_session_key = session_key
                 if pending_event is not None:
@@ -22864,7 +23187,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                     if next_message is None:
                         return result
-                    next_message_id = self._reply_anchor_for_event(pending_event)
+                    next_reply_anchor = self._reply_anchor_for_event(pending_event)
+                    # Security provenance uses the exact inbound event id, not
+                    # the platform-specific outbound reply anchor (which may be
+                    # None or identify a parent message in threaded channels).
+                    next_authenticated_gateway_message_id = pending_event.message_id
+                    next_authenticated_gateway_request = (
+                        pending_event._authenticated_gateway_request is True
+                    )
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
 
                 # Restart typing indicator so the user sees activity while
@@ -22905,7 +23235,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key=next_session_key,
                     run_generation=run_generation,
                     _interrupt_depth=_interrupt_depth + 1,
-                    event_message_id=next_message_id,
+                    event_message_id=next_reply_anchor,
+                    authenticated_gateway_message_id=(
+                        next_authenticated_gateway_message_id
+                    ),
+                    authenticated_gateway_request=next_authenticated_gateway_request,
                     channel_prompt=next_channel_prompt,
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -339,6 +339,11 @@ class LoadedPlugin:
 class PluginContext:
     """Facade given to plugins so they can register tools and hooks."""
 
+    # Separate, exact-version capabilities. Plugins must validate the exact
+    # built-in integer before registering a protected surface.
+    authenticated_gateway_dispatch_version = 1
+    authenticated_gateway_tool_dispatch_version = 1
+
     def __init__(self, manifest: PluginManifest, manager: "PluginManager"):
         self.manifest = manifest
         self._manager = manager
@@ -400,6 +405,7 @@ class PluginContext:
         description: str = "",
         emoji: str = "",
         override: bool = False,
+        requires_authenticated_gateway: bool = False,
     ) -> None:
         """Register a tool in the global registry **and** track it as plugin-provided.
 
@@ -438,6 +444,7 @@ class PluginContext:
             description=description,
             emoji=emoji,
             override=override,
+            requires_authenticated_gateway=requires_authenticated_gateway,
         )
         self._manager._plugin_tool_names.add(name)
         logger.debug(
@@ -532,11 +539,16 @@ class PluginContext:
         handler: Callable,
         description: str = "",
         args_hint: str = "",
+        requires_authenticated_gateway: bool = False,
     ) -> None:
         """Register a slash command (e.g. ``/lcm``) available in CLI and gateway sessions.
 
-        The handler signature is ``fn(raw_args: str) -> str | None``.
+        The legacy handler signature is ``fn(raw_args: str) -> str | None``.
         It may also be an async callable — the gateway dispatch handles both.
+
+        With ``requires_authenticated_gateway=True``, local and synthetic
+        dispatches are denied before handler entry. The protected handler gets
+        the live host-issued lease as keyword-only ``command_context``.
 
         Unlike ``register_cli_command()`` (which creates ``hermes <subcommand>``
         terminal commands), this registers in-session slash commands that users
@@ -551,6 +563,8 @@ class PluginContext:
 
         Names conflicting with built-in commands are rejected with a warning.
         """
+        if type(requires_authenticated_gateway) is not bool:
+            raise TypeError("requires_authenticated_gateway must be a built-in bool")
         clean = name.lower().strip().lstrip("/").replace(" ", "-")
         if not clean:
             logger.warning(
@@ -577,6 +591,7 @@ class PluginContext:
             "description": description or "Plugin command",
             "plugin": self.manifest.name,
             "args_hint": (args_hint or "").strip(),
+            "requires_authenticated_gateway": requires_authenticated_gateway,
         }
         logger.debug("Plugin %s registered command: /%s", self.manifest.name, clean)
 
@@ -599,6 +614,12 @@ class PluginContext:
             JSON string from the tool handler (same format as model tool calls).
         """
         from tools.registry import registry
+
+        # Plugin-initiated dispatch is not a protected model-tool dispatch.
+        # Strip any lease a plugin attempts to forward through this API.  Keep
+        # legacy ``tool_context`` kwargs for ordinary tools; the registry
+        # replaces them only when dispatching a protected tool.
+        kwargs.pop("authenticated_gateway_context", None)
 
         # Wire up parent agent context when available (CLI mode).
         # In gateway mode _cli_ref is None — tools degrade gracefully
@@ -2343,9 +2364,40 @@ def get_plugin_context_engine():
 
 
 def get_plugin_command_handler(name: str) -> Optional[Callable]:
-    """Return the handler for a plugin-registered slash command, or ``None``."""
+    """Return a handler while denying protected legacy dispatch before entry."""
     entry = _ensure_plugins_discovered()._plugin_commands.get(name)
-    return entry["handler"] if entry else None
+    if not entry:
+        return None
+    if entry.get("requires_authenticated_gateway") is True:
+        def _deny_protected_legacy_dispatch(_raw_args: str):
+            raise PermissionError("Authenticated gateway command dispatch required")
+
+        return _deny_protected_legacy_dispatch
+    return entry["handler"]
+
+
+def invoke_plugin_command(
+    name: str,
+    raw_args: str,
+    *,
+    authenticated_gateway_context: object = None,
+) -> Any:
+    """Invoke a command with centralized authenticated-provenance policy."""
+    entry = _ensure_plugins_discovered()._plugin_commands.get(name)
+    if not entry:
+        return None
+    handler = entry["handler"]
+    if entry.get("requires_authenticated_gateway") is True:
+        from gateway.authenticated_dispatch import (
+            validate_authenticated_gateway_command_dispatch,
+        )
+
+        if not validate_authenticated_gateway_command_dispatch(
+            authenticated_gateway_context
+        ):
+            raise PermissionError("Authenticated gateway command dispatch required")
+        return handler(raw_args, command_context=authenticated_gateway_context)
+    return handler(raw_args)
 
 
 _PLUGIN_COMMAND_AWAIT_TIMEOUT_SECS = 30.0

--- a/model_tools.py
+++ b/model_tools.py
@@ -1081,6 +1081,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    authenticated_gateway_context: object = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1111,6 +1112,15 @@ def handle_function_call(
     if not isinstance(function_args, dict):
         function_args = {}
     _tool_middleware_trace = list(tool_request_middleware_trace or [])
+
+    authenticated_dispatch_error = registry.authenticated_gateway_dispatch_error(
+        function_name,
+        function_args,
+        authenticated_gateway_context,
+        tool_call_id=tool_call_id,
+    )
+    if authenticated_dispatch_error is not None:
+        return authenticated_dispatch_error
 
     # ── Tool Search bridge dispatch ──────────────────────────────────
     # tool_search and tool_describe are pure catalog reads — handle them
@@ -1143,6 +1153,10 @@ def handle_function_call(
                 disabled_toolsets=disabled_toolsets,
                 quiet_mode=True, skip_tool_search_assembly=True,
             ) or []
+            current_defs = registry.filter_authenticated_gateway_tool_definitions(
+                current_defs,
+                authenticated_gateway_context,
+            )
         except Exception:
             current_defs = []
         if function_name == _ts_mod.TOOL_SEARCH_NAME:
@@ -1185,6 +1199,7 @@ def handle_function_call(
                 tool_request_middleware_trace=list(_tool_middleware_trace),
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
+                authenticated_gateway_context=authenticated_gateway_context,
             )
 
     _tool_original_args = dict(function_args)
@@ -1311,6 +1326,8 @@ def handle_function_call(
                         task_id=task_id,
                         session_id=session_id,
                         enabled_tools=sandbox_enabled,
+                        authenticated_gateway_context=authenticated_gateway_context,
+                        authenticated_gateway_tool_call_id=tool_call_id,
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
@@ -1319,6 +1336,8 @@ def handle_function_call(
                         task_id=task_id,
                         session_id=session_id,
                         user_task=user_task,
+                        authenticated_gateway_context=authenticated_gateway_context,
+                        authenticated_gateway_tool_call_id=tool_call_id,
                     )
             from hermes_cli.middleware import run_tool_execution_middleware
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -405,6 +405,11 @@ class AIAgent:
     for AI models that support function calling.
     """
 
+    # Exact-version capability checked by the gateway before passing a
+    # host-authenticated turn lease. Agent substitutes without this capability
+    # remain backward compatible and receive no protected authority.
+    authenticated_gateway_tool_dispatch_version = 1
+
     _TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER = (
         "[hermes-agent: tool call arguments were corrupted in this session and "
         "have been dropped to keep the conversation alive. See issue #15236.]"
@@ -2992,7 +2997,12 @@ class AIAgent:
                 self._pending_steer = None
         return True
 
-    def steer(self, text: str) -> bool:
+    def steer(
+        self,
+        text: str,
+        *,
+        before_mutation: Optional[Callable[[], None]] = None,
+    ) -> bool:
         """
         Inject a user message into the next tool result without interrupting.
 
@@ -3019,16 +3029,25 @@ class AIAgent:
             # Fall back to direct attribute set; no concurrent callers expected
             # in those stubs.
             existing = getattr(self, "_pending_steer", None)
+            if before_mutation is not None:
+                before_mutation()
             self._pending_steer = (existing + "\n" + cleaned) if existing else cleaned
             return True
         with _lock:
+            if before_mutation is not None:
+                before_mutation()
             if self._pending_steer:
                 self._pending_steer = self._pending_steer + "\n" + cleaned
             else:
                 self._pending_steer = cleaned
         return True
 
-    def redirect(self, text: str) -> bool:
+    def redirect(
+        self,
+        text: str,
+        *,
+        before_mutation: Optional[Callable[[], None]] = None,
+    ) -> bool:
         """Redirect the active turn without converting it into a new task.
 
         During a normal Hermes model request this cancels only that request;
@@ -3069,7 +3088,10 @@ class AIAgent:
         # existing steer drain puts it on the final tool result before the next
         # model decision, including delegate_task children.
         if getattr(self, "_executing_tools", False):
-            return self.steer(cleaned)
+            return self.steer(
+                cleaned,
+                before_mutation=before_mutation,
+            )
 
         _model_active = getattr(self, "_model_request_active", None)
         _redirect_lock = getattr(self, "_pending_redirect_lock", None)
@@ -3079,6 +3101,8 @@ class AIAgent:
             existing = getattr(self, "_pending_redirect", None)
             if self._interrupt_requested and not existing:
                 return False
+            if before_mutation is not None:
+                before_mutation()
             self._pending_redirect = (
                 f"{existing}\n\n[Additional user correction]\n{cleaned}"
                 if existing
@@ -3094,6 +3118,8 @@ class AIAgent:
                     return False
                 if self._interrupt_requested and not self._pending_redirect:
                     return False
+                if before_mutation is not None:
+                    before_mutation()
                 if self._pending_redirect:
                     self._pending_redirect = (
                         f"{self._pending_redirect}\n\n"
@@ -6620,6 +6646,7 @@ class AIAgent:
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        authenticated_gateway_context: object = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.aux_accounting import (
@@ -6631,41 +6658,54 @@ class AIAgent:
             reset_conversation_context,
             set_conversation_context,
         )
-        # Publish the conversation id for ambient Nous Portal tagging. Every
-        # LLM call made inside this turn — main loop, compression, vision,
-        # web_extract, session_search, MoA slots, background-review forks
-        # (which copy this Context into their thread) — inherits the
-        # ``conversation=<root>`` tag with zero per-call-site plumbing.
-        token = set_conversation_context(self._conversation_root_id())
-        # Publish the session accounting handles the same way so auxiliary
-        # calls record their token usage into session_model_usage (task
-        # dimension) — the fix for aux spend being invisible in analytics
-        # (issue #23270).
-        acct_token = set_accounting_context(
-            getattr(self, "_session_db", None), getattr(self, "session_id", None)
-        )
-        from agent.auxiliary_client import scoped_runtime_main
 
-        # The outer token restores the caller's Context even though turn setup
-        # replaces the value with the live runtime after fallback restoration.
-        # Keep the scope local instead of storing ContextVar tokens on the agent,
-        # which may be observed from another thread.
-        with scoped_runtime_main({}):
-            try:
-                return run_conversation(
-                    self,
-                    user_message,
-                    system_message,
-                    conversation_history,
-                    task_id,
-                    stream_callback,
-                    persist_user_message,
-                    persist_user_timestamp=persist_user_timestamp,
-                    moa_config=moa_config,
-                )
-            finally:
-                reset_accounting_context(acct_token)
-                reset_conversation_context(token)
+        # Bind authority to this one top-level Hermes turn. Codex app-server
+        # runs outside Hermes' tool dispatcher and intentionally receives none.
+        if getattr(self, "api_mode", None) == "codex_app_server":
+            authenticated_gateway_context = None
+        from gateway.authenticated_dispatch import (
+            bind_authenticated_gateway_dispatch,
+        )
+
+        with bind_authenticated_gateway_dispatch(
+            self,
+            authenticated_gateway_context,
+        ):
+            # Publish the conversation id for ambient Nous Portal tagging. Every
+            # LLM call made inside this turn — main loop, compression, vision,
+            # web_extract, session_search, MoA slots, background-review forks
+            # (which copy this Context into their thread) — inherits the
+            # ``conversation=<root>`` tag with zero per-call-site plumbing.
+            token = set_conversation_context(self._conversation_root_id())
+            # Publish the session accounting handles the same way so auxiliary
+            # calls record their token usage into session_model_usage (task
+            # dimension) — the fix for aux spend being invisible in analytics
+            # (issue #23270).
+            acct_token = set_accounting_context(
+                getattr(self, "_session_db", None), getattr(self, "session_id", None)
+            )
+            from agent.auxiliary_client import scoped_runtime_main
+
+            # The outer token restores the caller's Context even though turn setup
+            # replaces the value with the live runtime after fallback restoration.
+            # Keep the scope local instead of storing ContextVar tokens on the agent,
+            # which may be observed from another thread.
+            with scoped_runtime_main({}):
+                try:
+                    return run_conversation(
+                        self,
+                        user_message,
+                        system_message,
+                        conversation_history,
+                        task_id,
+                        stream_callback,
+                        persist_user_message,
+                        persist_user_timestamp=persist_user_timestamp,
+                        moa_config=moa_config,
+                    )
+                finally:
+                    reset_accounting_context(acct_token)
+                    reset_conversation_context(token)
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
         """

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -220,8 +220,6 @@ async def test_normal_path_skip_db_when_agent_has_session_db(
     monkeypatch, tmp_path
 ):
     runner = _bootstrap(monkeypatch, tmp_path)
-
-    # Agent succeeds with new messages
     runner._run_agent = AsyncMock(
         return_value={
             "final_response": "Hello!",
@@ -242,3 +240,33 @@ async def test_normal_path_skip_db_when_agent_has_session_db(
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
     )
+
+
+@pytest.mark.asyncio
+async def test_reply_anchor_is_separate_from_authenticated_message_provenance(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._reply_anchor_for_event = lambda _event: "parent-thread-message"
+    runner._run_agent = AsyncMock(
+        return_value={
+            "failed": True,
+            "final_response": None,
+            "error": "429 Too Many Requests",
+            "messages": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(),
+        _source(),
+        "agent:main:telegram:group:-1001:12345",
+        1,
+        authenticated_gateway_request=True,
+    )
+
+    kwargs = runner._run_agent.await_args.kwargs
+    assert kwargs["event_message_id"] == "parent-thread-message"
+    assert kwargs["authenticated_gateway_message_id"] == "msg-42"

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -221,15 +221,38 @@ class TestBusySessionAck:
 
         agent = MagicMock()
         agent._supports_active_turn_redirect = True
-        agent.redirect.return_value = True
+        agent.authenticated_gateway_tool_dispatch_version = 1
         agent._active_children = []
         agent.get_activity_summary.return_value = {}
         runner._running_agents[sk] = agent
         runner.adapters[event.source.platform] = adapter
 
-        assert await runner._handle_active_session_busy_message(event, sk) is True
+        from gateway.authenticated_dispatch import (
+            issue_authenticated_gateway_dispatch,
+            validate_authenticated_gateway_dispatch,
+        )
 
-        agent.redirect.assert_called_once_with("No, use Postgres")
+        with issue_authenticated_gateway_dispatch(
+            dispatch_kind="tool",
+            platform="telegram",
+            user_id="user-1",
+            chat_id="chat-1",
+            message_id="original-message",
+        ) as live:
+            agent._authenticated_gateway_context = live
+            def redirect(_text, *, before_mutation):
+                before_mutation()
+                return not validate_authenticated_gateway_dispatch(live)
+
+            agent.redirect.side_effect = redirect
+            assert validate_authenticated_gateway_dispatch(live)
+            assert await runner._handle_active_session_busy_message(event, sk) is True
+            assert not validate_authenticated_gateway_dispatch(live)
+
+        agent.redirect.assert_called_once()
+        redirect_args, redirect_kwargs = agent.redirect.call_args
+        assert redirect_args == ("No, use Postgres",)
+        assert callable(redirect_kwargs["before_mutation"])
         agent.interrupt.assert_not_called()
         assert sk not in adapter._pending_messages
         content = adapter._send_with_retry.call_args.kwargs.get("content", "")
@@ -655,8 +678,11 @@ class TestBusySessionAck:
         assert "10 min" in content  # elapsed
 
     @pytest.mark.asyncio
-    async def test_telegram_omits_status_detail_by_default(self):
+    async def test_telegram_omits_status_detail_by_default(self, monkeypatch):
         """Telegram busy acks stay concise unless busy_ack_detail is enabled."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
         runner, sentinel = _make_runner()
         runner._busy_input_mode = "interrupt"
         adapter = _make_adapter()

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -18,6 +18,7 @@ from gateway.session import SessionSource
 class _CapturingAgent:
     last_init = None
     last_run = None
+    authenticated_gateway_tool_dispatch_version = 1
 
     def __init__(self, *args, **kwargs):
         type(self).last_init = dict(kwargs)
@@ -30,13 +31,24 @@ class _CapturingAgent:
         task_id=None,
         persist_user_message=None,
         persist_user_timestamp=None,
+        authenticated_gateway_context=None,
     ):
+        from gateway.authenticated_dispatch import (
+            validate_authenticated_gateway_dispatch,
+        )
+
         type(self).last_run = {
             "user_message": user_message,
             "conversation_history": conversation_history,
             "task_id": task_id,
             "persist_user_message": persist_user_message,
             "persist_user_timestamp": persist_user_timestamp,
+            "authenticated_gateway_context": authenticated_gateway_context,
+            "authenticated_gateway_context_was_live": (
+                validate_authenticated_gateway_dispatch(
+                    authenticated_gateway_context
+                )
+            ),
         }
         return {
             "final_response": "ok",
@@ -253,6 +265,63 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     assert result["final_response"] == "ok"
     assert _CapturingAgent.last_init["service_tier"] == "priority"
     assert _CapturingAgent.last_init["request_overrides"] == {"service_tier": "priority"}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_issues_live_context_only_for_verified_gateway_request(
+    monkeypatch,
+    tmp_path,
+):
+    from gateway.authenticated_dispatch import (
+        validate_authenticated_gateway_dispatch,
+    )
+
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_gateway_model",
+        lambda config=None: "gpt-5.4",
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(
+        tools_config,
+        "_get_platform_tools",
+        lambda user_config, platform_key: {"core"},
+    )
+
+    await runner._run_agent(
+        message="hi",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:telegram:dm:12345",
+        event_message_id="event-message-1",
+        authenticated_gateway_request=True,
+    )
+
+    context = _CapturingAgent.last_run["authenticated_gateway_context"]
+    assert _CapturingAgent.last_run["authenticated_gateway_context_was_live"] is True
+    assert context.message_id == "event-message-1"
+    assert not validate_authenticated_gateway_dispatch(context)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_gateway_command_dispatch_minimal.py
+++ b/tests/gateway/test_gateway_command_dispatch_minimal.py
@@ -19,13 +19,13 @@ def _make_source() -> SessionSource:
     )
 
 
-def _make_event(text: str) -> MessageEvent:
+def _make_event(text: str, *, internal: bool = True) -> MessageEvent:
     return MessageEvent(
         text=text,
         message_type=MessageType.TEXT,
         source=_make_source(),
         message_id="m1",
-        internal=True,
+        internal=internal,
     )
 
 
@@ -146,3 +146,233 @@ async def test_idle_queue_without_payload_returns_usage():
     assert result == "Usage: /queue <prompt>"
     assert called is False
     assert runner._running_agents == {}
+
+
+@pytest.mark.asyncio
+async def test_protected_plugin_command_receives_live_context_and_revokes(monkeypatch):
+    import hermes_cli.plugins as plugins
+    from gateway.authenticated_dispatch import validate_authenticated_gateway_dispatch
+
+    runner, _adapter = _make_runner()
+    captured = {}
+
+    monkeypatch.setattr(
+        plugins,
+        "get_plugin_commands",
+        lambda: {"secure-test": {"requires_authenticated_gateway": True}},
+    )
+
+    def invoke(name, args, *, authenticated_gateway_context=None):
+        captured["name"] = name
+        captured["args"] = args
+        captured["context"] = authenticated_gateway_context
+        assert validate_authenticated_gateway_dispatch(authenticated_gateway_context)
+        return "accepted"
+
+    monkeypatch.setattr(plugins, "invoke_plugin_command", invoke)
+
+    result = await runner._handle_message(
+        _make_event("/secure_test payload", internal=False)
+    )
+
+    assert result == "accepted"
+    assert captured["name"] == "secure-test"
+    assert captured["args"] == "payload"
+    assert captured["context"].platform == "telegram"
+    assert captured["context"].user_id == "u1"
+    assert captured["context"].chat_id == "c1"
+    assert captured["context"].message_id == "m1"
+    assert not validate_authenticated_gateway_dispatch(captured["context"])
+
+
+@pytest.mark.asyncio
+async def test_protected_plugin_command_internal_event_denies_without_entry(monkeypatch):
+    import hermes_cli.plugins as plugins
+
+    runner, _adapter = _make_runner()
+    setattr(runner.hooks, "loaded_hooks", True)
+    entered = False
+
+    monkeypatch.setattr(
+        plugins,
+        "get_plugin_commands",
+        lambda: {"secure-test": {"requires_authenticated_gateway": True}},
+    )
+
+    def invoke(*args, **kwargs):
+        nonlocal entered
+        entered = True
+        return "unexpected"
+
+    monkeypatch.setattr(plugins, "invoke_plugin_command", invoke)
+    event = _make_event("/secure-test payload")
+    event.internal = True
+
+    result = await runner._handle_message(event)
+
+    assert result == "Authenticated gateway command dispatch denied."
+    assert entered is False
+    assert getattr(runner.hooks.emit_collect, "call_count") == 0
+
+
+@pytest.mark.asyncio
+async def test_protected_command_discovery_failure_denies_before_hooks_or_fallthrough(
+    monkeypatch,
+):
+    import hermes_cli.plugins as plugins
+
+    runner, _adapter = _make_runner()
+    setattr(runner.hooks, "loaded_hooks", True)
+    lookups = 0
+    entered = False
+    fell_through = False
+
+    def get_commands():
+        nonlocal lookups
+        lookups += 1
+        if lookups == 1:
+            # The slash-access lookup runs before the security classification.
+            return {}
+        if lookups == 2:
+            raise RuntimeError("transient security-classification failure")
+        return {"secure-test": {"requires_authenticated_gateway": True}}
+
+    def invoke(*args, **kwargs):
+        nonlocal entered
+        entered = True
+        return "unexpected"
+
+    async def fallback(*args, **kwargs):
+        nonlocal fell_through
+        fell_through = True
+        return {"final_response": "unexpected"}
+
+    monkeypatch.setattr(plugins, "get_plugin_commands", get_commands)
+    monkeypatch.setattr(plugins, "invoke_plugin_command", invoke)
+    runner._handle_message_with_agent = fallback
+
+    result = await runner._handle_message(_make_event("/secure-test payload"))
+
+    assert result == "Authenticated gateway command dispatch denied."
+    assert entered is False
+    assert fell_through is False
+    assert getattr(runner.hooks.emit_collect, "call_count") == 0
+
+
+@pytest.mark.asyncio
+async def test_protected_plugin_command_missing_identity_denies_without_entry_or_fallthrough(
+    monkeypatch,
+):
+    import hermes_cli.plugins as plugins
+
+    runner, _adapter = _make_runner()
+    entered = False
+    fell_through = False
+
+    monkeypatch.setattr(
+        plugins,
+        "get_plugin_commands",
+        lambda: {"secure-test": {"requires_authenticated_gateway": True}},
+    )
+
+    def invoke(*args, **kwargs):
+        nonlocal entered
+        entered = True
+        return "unexpected"
+
+    async def fallback(*args, **kwargs):
+        nonlocal fell_through
+        fell_through = True
+        return {"final_response": "unexpected"}
+
+    monkeypatch.setattr(plugins, "invoke_plugin_command", invoke)
+    runner._handle_message_with_agent = fallback
+
+    source = _make_source()
+    source.user_id = None
+    event = MessageEvent(
+        text="/secure_test payload",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+        internal=False,
+    )
+    result = await runner._handle_message(event)
+
+    assert result == "Authenticated gateway command dispatch denied."
+    assert entered is False
+    assert fell_through is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_message_id", "source_message_id"),
+    [(None, None), ("event-message", "different-source-message")],
+)
+async def test_protected_plugin_command_requires_matching_trigger_message_id(
+    monkeypatch,
+    event_message_id,
+    source_message_id,
+):
+    import hermes_cli.plugins as plugins
+
+    runner, _adapter = _make_runner()
+    entered = False
+    monkeypatch.setattr(
+        plugins,
+        "get_plugin_commands",
+        lambda: {"secure-test": {"requires_authenticated_gateway": True}},
+    )
+
+    def invoke(*args, **kwargs):
+        nonlocal entered
+        entered = True
+        return "unexpected"
+
+    monkeypatch.setattr(plugins, "invoke_plugin_command", invoke)
+    source = _make_source()
+    source.message_id = source_message_id
+    event = MessageEvent(
+        text="/secure_test payload",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id=event_message_id,
+        internal=False,
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "Authenticated gateway command dispatch denied."
+    assert entered is False
+
+
+@pytest.mark.asyncio
+async def test_protected_plugin_command_handler_failure_does_not_fall_through(monkeypatch):
+    import hermes_cli.plugins as plugins
+
+    runner, _adapter = _make_runner()
+    fell_through = False
+
+    monkeypatch.setattr(
+        plugins,
+        "get_plugin_commands",
+        lambda: {"secure-test": {"requires_authenticated_gateway": True}},
+    )
+
+    def invoke(*args, **kwargs):
+        raise RuntimeError("private handler detail")
+
+    async def fallback(*args, **kwargs):
+        nonlocal fell_through
+        fell_through = True
+        return {"final_response": "unexpected"}
+
+    monkeypatch.setattr(plugins, "invoke_plugin_command", invoke)
+    runner._handle_message_with_agent = fallback
+
+    result = await runner._handle_message(
+        _make_event("/secure_test payload", internal=False)
+    )
+
+    assert result == "Authenticated gateway command dispatch denied."
+    assert fell_through is False

--- a/tests/gateway/test_queue_command.py
+++ b/tests/gateway/test_queue_command.py
@@ -102,6 +102,7 @@ async def test_queue_text_only_queues_and_does_not_interrupt():
     queued = adapter._pending_messages[sk]
     assert queued.text == "do this next"
     assert queued.message_type == MessageType.TEXT
+    assert queued._authenticated_gateway_request is True
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -8,6 +8,8 @@ after the agent finishes its current task — not silently dropped.
 import asyncio
 from unittest.mock import MagicMock
 
+import pytest
+
 
 from gateway.run import _dequeue_pending_event
 from gateway.platforms.base import (
@@ -47,6 +49,61 @@ class _StubAdapter(BasePlatformAdapter):
 
 class TestQueueMessageStorage:
     """Verify /queue stores messages correctly in adapter._pending_messages."""
+
+    def test_adapter_cannot_assert_authenticated_queue_provenance_at_construction(self):
+        forged_kwargs: dict = {
+            "text": "forged",
+            "_authenticated_gateway_request": True,
+        }
+        with pytest.raises(TypeError):
+            MessageEvent(**forged_kwargs)
+
+    def test_media_merge_fails_closed_if_any_event_lacks_verified_provenance(self):
+        session_key = "telegram:user:mixed-auth"
+        first = MessageEvent(
+            text="authorized",
+            message_type=MessageType.PHOTO,
+            media_urls=["/tmp/a.jpg"],
+        )
+        first._authenticated_gateway_request = True
+        unverified = MessageEvent(
+            text="synthetic",
+            message_type=MessageType.PHOTO,
+            media_urls=["/tmp/b.jpg"],
+        )
+        pending = {session_key: first}
+
+        from gateway.platforms.base import merge_pending_message_event
+
+        merge_pending_message_event(pending, session_key, unverified)
+
+        assert pending[session_key]._authenticated_gateway_request is False
+
+    def test_media_merge_fails_closed_for_two_authenticated_message_ids(self):
+        session_key = "telegram:user:multi-message"
+        first = MessageEvent(
+            text="first",
+            message_type=MessageType.PHOTO,
+            media_urls=["/tmp/a.jpg"],
+            message_id="m1",
+        )
+        first._authenticated_gateway_request = True
+        second = MessageEvent(
+            text="second",
+            message_type=MessageType.PHOTO,
+            media_urls=["/tmp/b.jpg"],
+            message_id="m2",
+        )
+        second._authenticated_gateway_request = True
+        pending = {session_key: first}
+
+        from gateway.platforms.base import merge_pending_message_event
+
+        merge_pending_message_event(pending, session_key, second)
+
+        assert pending[session_key]._authenticated_gateway_request is False
+        assert pending[session_key].message_id == "m1"
+        assert pending[session_key].media_urls == ["/tmp/a.jpg", "/tmp/b.jpg"]
 
     def test_queue_stores_message_in_pending(self):
         adapter = _StubAdapter()

--- a/tests/gateway/test_queued_native_image_session_key.py
+++ b/tests/gateway/test_queued_native_image_session_key.py
@@ -1,8 +1,10 @@
 import base64
 import importlib
+import json
 import sys
 import types
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -51,17 +53,59 @@ class CaptureAdapter(BasePlatformAdapter):
 
 class CaptureQueuedNativeImageAgent:
     calls = []
+    authenticated_gateway_tool_dispatch_version = 1
 
     def __init__(self, **kwargs):
         self.tools = []
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
 
-    def run_conversation(self, message, conversation_history=None, task_id=None):
-        type(self).calls.append(message)
+    def run_conversation(
+        self,
+        message,
+        conversation_history=None,
+        task_id=None,
+        authenticated_gateway_context=None,
+    ):
+        type(self).calls.append(
+            {
+                "message": message,
+                "authenticated": authenticated_gateway_context is not None,
+                "message_id": getattr(authenticated_gateway_context, "message_id", None),
+            }
+        )
         return {
             "final_response": f"done-{len(type(self).calls)}",
             "messages": [],
             "api_calls": 1,
+        }
+
+
+class ProtectedDispatchE2EAgent:
+    authenticated_gateway_tool_dispatch_version = 1
+    registry: Any = None
+    captured_context = None
+
+    def __init__(self, **kwargs):
+        self.tools = []
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+
+    def run_conversation(
+        self,
+        message,
+        conversation_history=None,
+        task_id=None,
+        authenticated_gateway_context=None,
+    ):
+        type(self).captured_context = authenticated_gateway_context
+        dispatch_result = type(self).registry.dispatch(
+            "e2e-protected",
+            {"value": message},
+            authenticated_gateway_context=authenticated_gateway_context,
+        )
+        return {
+            "final_response": dispatch_result,
+            "messages": [],
+            "history_offset": 0,
         }
 
 
@@ -114,17 +158,19 @@ async def test_queued_followup_uses_pending_event_session_key_for_native_images(
 
     source = SessionSource(
         platform=Platform.TELEGRAM,
+        user_id="user-1",
         chat_id="-1001",
         chat_type="group",
     )
     pending_source = SessionSource(
         platform=Platform.TELEGRAM,
+        user_id="user-1",
         chat_id="-1001",
         chat_type="group",
         thread_id="17585",
     )
 
-    adapter._pending_messages["agent:main:telegram:group:-1001"] = MessageEvent(
+    pending_event = MessageEvent(
         text="describe this",
         message_type=MessageType.PHOTO,
         source=pending_source,
@@ -132,6 +178,11 @@ async def test_queued_followup_uses_pending_event_session_key_for_native_images(
         media_types=["image/png"],
         message_id="queued-1",
     )
+    # Simulate the host-owned post-authorization decision captured when this
+    # event entered the busy-session queue. Adapter-controlled source shape
+    # alone must never grant protected authority.
+    pending_event._authenticated_gateway_request = True
+    adapter._pending_messages["agent:main:telegram:group:-1001"] = pending_event
 
     result = await runner._run_agent(
         message="hello",
@@ -144,8 +195,100 @@ async def test_queued_followup_uses_pending_event_session_key_for_native_images(
 
     assert result["final_response"] == "done-2"
     assert len(CaptureQueuedNativeImageAgent.calls) == 2
-    queued_message = CaptureQueuedNativeImageAgent.calls[1]
+    assert CaptureQueuedNativeImageAgent.calls[0]["authenticated"] is False
+    assert CaptureQueuedNativeImageAgent.calls[1]["authenticated"] is True
+    assert CaptureQueuedNativeImageAgent.calls[1]["message_id"] == "queued-1"
+    queued_message = CaptureQueuedNativeImageAgent.calls[1]["message"]
     assert isinstance(queued_message, list)
     assert queued_message[0]["type"] == "text"
     assert queued_message[0]["text"].startswith("describe this")
     assert any(part.get("type") == "image_url" for part in queued_message)
+
+
+@pytest.mark.asyncio
+async def test_gateway_run_issues_exact_live_context_for_real_registry_dispatch(
+    monkeypatch,
+    tmp_path,
+):
+    from tools.registry import ToolRegistry
+
+    seen = []
+    registry = ToolRegistry()
+    registry.register(
+        name="e2e-protected",
+        toolset="test",
+        schema={
+            "name": "e2e-protected",
+            "description": "E2E protected dispatch",
+            "parameters": {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+            },
+        },
+        handler=lambda args, *, tool_context: seen.append(
+            (
+                args["value"],
+                tool_context.platform,
+                tool_context.user_id,
+                tool_context.chat_id,
+                tool_context.message_id,
+            )
+        ) or "protected-ok",
+        requires_authenticated_gateway=True,
+    )
+    ProtectedDispatchE2EAgent.registry = registry
+    ProtectedDispatchE2EAgent.captured_context = None
+
+    fake_dotenv = types.ModuleType("dotenv")
+    setattr(fake_dotenv, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    fake_run_agent = types.ModuleType("run_agent")
+    setattr(fake_run_agent, "AIAgent", ProtectedDispatchE2EAgent)
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***"},
+    )
+
+    runner = _make_runner(CaptureAdapter())
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="user-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    )
+
+    result = await runner._run_agent(
+        message="run protected",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="e2e-authenticated-dispatch",
+        session_key="agent:main:telegram:dm:chat-1",
+        event_message_id="exact-message-1",
+        authenticated_gateway_request=True,
+    )
+
+    assert result["final_response"] == "protected-ok"
+    assert seen == [
+        (
+            "run protected",
+            "telegram",
+            "user-1",
+            "chat-1",
+            "exact-message-1",
+        )
+    ]
+
+    stale_result = registry.dispatch(
+        "e2e-protected",
+        {"value": "stale"},
+        authenticated_gateway_context=ProtectedDispatchE2EAgent.captured_context,
+    )
+    assert isinstance(stale_result, str)
+    denied = json.loads(stale_result)
+    assert denied["error_type"] == "authenticated_gateway_required"

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -361,8 +361,8 @@ async def test_command_hook_rewrite_routes_to_plugin(monkeypatch):
     )
     monkeypatch.setattr(
         _plugins_mod,
-        "get_plugin_command_handler",
-        lambda name: (lambda args: f"metrics {args}") if name == "metricas" else None,
+        "invoke_plugin_command",
+        lambda name, args, **kwargs: f"metrics {args}" if name == "metricas" else None,
     )
 
     result = await runner._handle_message(_make_event("/status"))

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -2116,6 +2116,27 @@ class TestPluginDispatchTool:
 
         assert result == '{"result": "ok"}'
 
+    def test_dispatch_tool_forwards_legacy_tool_context_kwarg(self):
+        """Ordinary plugin dispatch preserves legacy handler context kwargs."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+        mock_registry = MagicMock()
+        mock_registry.dispatch.return_value = "ok"
+
+        with patch("tools.registry.registry", mock_registry):
+            assert ctx.dispatch_tool(
+                "ordinary_tool",
+                {},
+                tool_context="legacy-host-context",
+            ) == "ok"
+
+        mock_registry.dispatch.assert_called_once_with(
+            "ordinary_tool",
+            {},
+            tool_context="legacy-host-context",
+        )
+
     def test_dispatch_tool_injects_parent_agent_from_cli_ref(self):
         """When _cli_ref has an agent, it's passed as parent_agent."""
         mgr = PluginManager()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3689,7 +3689,7 @@ class TestAgentRuntimePostHookOwnershipSync:
         from agent.agent_runtime_helpers import AGENT_RUNTIME_POST_HOOK_TOOL_NAMES
 
         inline_names = self._extract_dispatch_chain_names(
-            tool_executor.execute_tool_calls_sequential
+            tool_executor._execute_tool_calls_sequential
         )
         assert inline_names, (
             "Could not find the dispatch chain (anchored on "
@@ -3719,7 +3719,7 @@ class TestAgentRuntimePostHookOwnershipSync:
             agent_runtime_helpers.invoke_tool
         )
         inline_names = self._extract_dispatch_chain_names(
-            tool_executor.execute_tool_calls_sequential
+            tool_executor._execute_tool_calls_sequential
         )
         assert invoke_tool_names == inline_names, (
             "Static `function_name == \"...\"` branches diverged between "

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -77,6 +77,100 @@ class TestSteerAcceptance:
         agent.steer("third note")
         assert agent._pending_steer == "first note\nsecond note\nthird note"
 
+    def test_callback_runs_before_accepted_steer_is_published(self):
+        agent = _bare_agent()
+        observed = []
+
+        assert agent.steer(
+            "change course",
+            before_mutation=lambda: observed.append(agent._pending_steer),
+        ) is True
+
+        assert observed == [None]
+        assert agent._pending_steer == "change course"
+
+    def test_callback_does_not_run_for_rejected_steer(self):
+        agent = _bare_agent()
+        observed = []
+
+        assert agent.steer("  ", before_mutation=lambda: observed.append(True)) is False
+
+        assert observed == []
+
+    def test_authority_revocation_does_not_block_steer_behind_active_handler(self):
+        from gateway.authenticated_dispatch import issue_authenticated_gateway_dispatch
+        from gateway.run import GatewayRunner
+        from tools.registry import ToolRegistry
+
+        agent = _bare_agent()
+        setattr(agent, "_authenticated_gateway_turn_tainted", threading.Event())
+        handler_started = threading.Event()
+        release_handler = threading.Event()
+        steer_done = threading.Event()
+        outcomes = []
+        registry = ToolRegistry()
+
+        def protected_handler(_args, *, tool_context):
+            handler_started.set()
+            assert release_handler.wait(timeout=2)
+            return "ok"
+
+        registry.register(
+            name="protected-steer-test",
+            toolset="test",
+            schema={
+                "name": "protected-steer-test",
+                "description": "test",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=protected_handler,
+            requires_authenticated_gateway=True,
+        )
+
+        with issue_authenticated_gateway_dispatch(
+            dispatch_kind="tool",
+            platform="telegram",
+            user_id="user-1",
+            chat_id="chat-1",
+            message_id="message-1",
+        ) as context:
+            setattr(agent, "_authenticated_gateway_context", context)
+            handler_thread = threading.Thread(
+                target=lambda: outcomes.append(
+                    registry.dispatch(
+                        "protected-steer-test",
+                        {},
+                        authenticated_gateway_context=context,
+                    )
+                )
+            )
+            handler_thread.start()
+            assert handler_started.wait(timeout=2)
+
+            def steer():
+                outcomes.append(
+                    agent.steer(
+                        "change course",
+                        before_mutation=lambda: GatewayRunner._revoke_authenticated_gateway_authority(
+                            agent
+                        ),
+                    )
+                )
+                steer_done.set()
+
+            steer_thread = threading.Thread(target=steer)
+            steer_thread.start()
+            assert steer_done.wait(timeout=1)
+            assert getattr(agent, "_authenticated_gateway_turn_tainted").is_set()
+
+            release_handler.set()
+            handler_thread.join(timeout=2)
+            steer_thread.join(timeout=2)
+            assert not handler_thread.is_alive()
+            assert not steer_thread.is_alive()
+
+        assert outcomes == [True, "ok"]
+
 
 class TestSteerDrain:
     def test_drain_returns_and_clears(self):
@@ -104,6 +198,30 @@ class TestActiveTurnRedirect:
         assert agent._pending_redirect == "use Postgres"
         assert agent._interrupt_requested is True
         assert agent._interrupt_message is None
+
+    def test_callback_runs_before_accepted_redirect_is_published(self):
+        agent = _bare_agent()
+        agent._model_request_active.set()
+        observed = []
+
+        assert agent.redirect(
+            "use Postgres",
+            before_mutation=lambda: observed.append(agent._pending_redirect),
+        ) is True
+
+        assert observed == [None]
+        assert agent._pending_redirect == "use Postgres"
+
+    def test_callback_does_not_run_when_redirect_has_no_live_turn(self):
+        agent = _bare_agent()
+        observed = []
+
+        assert agent.redirect(
+            "change course",
+            before_mutation=lambda: observed.append(True),
+        ) is False
+
+        assert observed == []
 
     def test_multiple_redirects_preserve_message_boundaries(self):
         agent = _bare_agent()

--- a/tests/test_authenticated_gateway_dispatch.py
+++ b/tests/test_authenticated_gateway_dispatch.py
@@ -1,0 +1,1947 @@
+"""Fail-closed contract tests for host-authenticated gateway dispatch.
+
+The authenticated context is host-owned state.  It is never model input, is
+valid only while its issuing lease is live, and is separately advertised for
+plugin commands and model tools.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+def _lease(**overrides):
+    from gateway.authenticated_dispatch import issue_authenticated_gateway_dispatch
+
+    values = {
+        "dispatch_kind": "tool",
+        "platform": "telegram",
+        "user_id": "user-1",
+        "chat_id": "chat-1",
+        "message_id": "message-1",
+        "thread_id": None,
+    }
+    values.update(overrides)
+    return issue_authenticated_gateway_dispatch(**values)
+
+
+def _schema(name: str, properties: dict | None = None) -> dict:
+    return {
+        "name": name,
+        "description": "authenticated test tool",
+        "parameters": {
+            "type": "object",
+            "properties": properties or {"value": {"type": "string"}},
+        },
+    }
+
+
+class TestSealedAuthenticatedGatewayDispatch:
+    def test_direct_construction_is_rejected(self):
+        from gateway.authenticated_dispatch import AuthenticatedGatewayDispatch
+
+        with pytest.raises(
+            TypeError,
+            match="Authenticated gateway dispatch is host-issued only",
+        ):
+            AuthenticatedGatewayDispatch(
+                platform="telegram",
+                user_id="user-1",
+                chat_id="chat-1",
+                message_id="message-1",
+                dispatch_kind="tool",
+                thread_id=None,
+            )
+
+    def test_live_context_has_immutable_exact_host_fields(self):
+        from gateway.authenticated_dispatch import validate_authenticated_gateway_dispatch
+
+        with _lease(thread_id="thread-1") as context:
+            assert validate_authenticated_gateway_dispatch(context) is True
+            assert context.authorized is True
+            assert context.platform == "telegram"
+            assert context.user_id == "user-1"
+            assert context.chat_id == "chat-1"
+            assert context.message_id == "message-1"
+            assert context.thread_id == "thread-1"
+            assert type(context.provenance_version) is int
+            assert context.provenance_version == 1
+            assert type(context.turn_id) is str and context.turn_id
+            with pytest.raises((AttributeError, TypeError)):
+                context.platform = "forged"
+
+        assert validate_authenticated_gateway_dispatch(context) is False
+
+    def test_copy_and_lookalike_cannot_forge_a_live_record(self):
+        from gateway.authenticated_dispatch import validate_authenticated_gateway_dispatch
+
+        class Lookalike:
+            authorized = True
+            platform = "telegram"
+            user_id = "user-1"
+            chat_id = "chat-1"
+            message_id = "message-1"
+            thread_id = None
+            provenance_version = 1
+            turn_id = "forged"
+
+        assert validate_authenticated_gateway_dispatch(Lookalike()) is False
+        with _lease() as context:
+            try:
+                cloned = copy.copy(context)
+            except TypeError:
+                cloned = None
+            assert cloned is None or validate_authenticated_gateway_dispatch(cloned) is False
+            assert validate_authenticated_gateway_dispatch(context) is True
+
+    def test_parallel_leases_are_isolated_and_revoked_independently(self):
+        from gateway.authenticated_dispatch import validate_authenticated_gateway_dispatch
+
+        with _lease(message_id="message-a") as first:
+            with _lease(message_id="message-b") as second:
+                assert first is not second
+                assert first.turn_id != second.turn_id
+                assert validate_authenticated_gateway_dispatch(first) is True
+                assert validate_authenticated_gateway_dispatch(second) is True
+            assert validate_authenticated_gateway_dispatch(first) is True
+            assert validate_authenticated_gateway_dispatch(second) is False
+        assert validate_authenticated_gateway_dispatch(first) is False
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("platform", ""),
+            ("platform", True),
+            ("user_id", ""),
+            ("user_id", None),
+            ("chat_id", ""),
+            ("chat_id", 1),
+            ("message_id", ""),
+            ("message_id", False),
+            ("thread_id", ""),
+            ("thread_id", 1),
+        ],
+    )
+    def test_invalid_source_fields_are_rejected(self, field, value):
+        with pytest.raises((TypeError, ValueError)):
+            with _lease(**{field: value}):
+                pass
+
+
+class TestGatewayInterruptRevocation:
+    def test_interrupt_taints_turn_and_revokes_before_agent_mutation(self):
+        import threading
+
+        from gateway.authenticated_dispatch import (
+            issue_authenticated_gateway_dispatch,
+            validate_authenticated_gateway_tool_dispatch,
+        )
+        from gateway.run import GatewayRunner
+
+        observations = []
+        taint = threading.Event()
+
+        class Agent:
+            _authenticated_gateway_turn_tainted = taint
+
+            def interrupt(self, reason):
+                observations.append(
+                    (
+                        reason,
+                        taint.is_set(),
+                        validate_authenticated_gateway_tool_dispatch(
+                            self._authenticated_gateway_context
+                        ),
+                    )
+                )
+
+        agent = Agent()
+        with issue_authenticated_gateway_dispatch(
+            dispatch_kind="tool",
+            platform="telegram",
+            user_id="user-1",
+            chat_id="chat-1",
+            message_id="message-1",
+        ) as context:
+            agent._authenticated_gateway_context = context
+            GatewayRunner._interrupt_authenticated_gateway_turn(agent, "correction")
+
+        assert observations == [("correction", True, False)]
+
+    def test_preissuance_taint_permanently_denies_authority_for_that_turn(self):
+        import threading
+
+        from gateway.run import GatewayRunner
+
+        class Agent:
+            authenticated_gateway_tool_dispatch_version = 1
+
+            def interrupt(self, _reason):
+                pass
+
+        agent = Agent()
+        agent._authenticated_gateway_turn_tainted = threading.Event()
+        GatewayRunner._interrupt_authenticated_gateway_turn(agent, "early correction")
+
+        assert GatewayRunner._authenticated_gateway_request_for_turn(True, agent) is False
+
+    def test_mutation_cannot_miss_a_lease_between_issue_and_publication(self, monkeypatch):
+        import threading
+        from contextlib import contextmanager
+        from types import SimpleNamespace
+
+        import gateway.authenticated_dispatch as dispatch
+
+        lease_issued = threading.Event()
+        publish_release = threading.Event()
+        mutation_done = threading.Event()
+        observations = []
+        real_issue = dispatch.issue_authenticated_gateway_dispatch
+
+        @contextmanager
+        def delayed_issue(**kwargs):
+            with real_issue(**kwargs) as context:
+                lease_issued.set()
+                assert publish_release.wait(timeout=2)
+                yield context
+
+        monkeypatch.setattr(
+            dispatch,
+            "issue_authenticated_gateway_dispatch",
+            delayed_issue,
+        )
+
+        class Agent:
+            authenticated_gateway_tool_dispatch_version = 1
+            _authenticated_gateway_turn_tainted = threading.Event()
+
+        agent = Agent()
+        source = SimpleNamespace(
+            platform="telegram",
+            user_id="user-1",
+            chat_id="chat-1",
+            thread_id=None,
+            message_id="message-1",
+        )
+
+        def run_turn():
+            with dispatch.authenticated_gateway_turn(
+                agent,
+                source,
+                authenticated_gateway_request=True,
+                event_message_id="message-1",
+            ) as context:
+                assert mutation_done.wait(timeout=2)
+                observations.append(
+                    (
+                        context is not None,
+                        dispatch.validate_authenticated_gateway_tool_dispatch(context),
+                        agent._authenticated_gateway_turn_tainted.is_set(),
+                    )
+                )
+
+        turn_thread = threading.Thread(target=run_turn)
+        turn_thread.start()
+        assert lease_issued.wait(timeout=2)
+
+        mutation_thread = threading.Thread(
+            target=lambda: (
+                dispatch.taint_and_revoke_authenticated_gateway_dispatch(agent),
+                mutation_done.set(),
+            )
+        )
+        mutation_thread.start()
+        assert not mutation_done.wait(timeout=0.1)
+        publish_release.set()
+
+        turn_thread.join(timeout=3)
+        mutation_thread.join(timeout=3)
+        assert not turn_thread.is_alive()
+        assert not mutation_thread.is_alive()
+        assert observations == [(True, False, True)]
+
+
+class TestAtomicLeaseUse:
+    def test_failed_claim_releases_global_lock_before_yielding_denial(self):
+        import threading
+
+        from gateway.authenticated_dispatch import (
+            issue_authenticated_gateway_dispatch,
+            revoke_authenticated_gateway_dispatch,
+            use_authenticated_gateway_tool_dispatch,
+        )
+
+        entered_denied_scope = threading.Event()
+        release_denied_scope = threading.Event()
+        second_issuance_finished = threading.Event()
+
+        with issue_authenticated_gateway_dispatch(
+            dispatch_kind="tool",
+            platform="telegram",
+            user_id="user-1",
+            chat_id="chat-1",
+            message_id="message-1",
+        ) as context:
+            assert revoke_authenticated_gateway_dispatch(context) is True
+
+            def hold_denied_scope():
+                with use_authenticated_gateway_tool_dispatch(
+                    context, "protected"
+                ) as claim:
+                    assert claim is None
+                    entered_denied_scope.set()
+                    assert release_denied_scope.wait(timeout=2)
+
+            denied_thread = threading.Thread(target=hold_denied_scope)
+            denied_thread.start()
+            assert entered_denied_scope.wait(timeout=1)
+
+            def issue_second_lease():
+                with issue_authenticated_gateway_dispatch(
+                    dispatch_kind="tool",
+                    platform="telegram",
+                    user_id="user-2",
+                    chat_id="chat-2",
+                    message_id="message-2",
+                ):
+                    second_issuance_finished.set()
+
+            issuance_thread = threading.Thread(target=issue_second_lease)
+            issuance_thread.start()
+            try:
+                assert second_issuance_finished.wait(timeout=0.5)
+            finally:
+                release_denied_scope.set()
+                denied_thread.join(timeout=2)
+                issuance_thread.join(timeout=2)
+
+            assert not denied_thread.is_alive()
+            assert not issuance_thread.is_alive()
+
+    def test_revocation_returns_immediately_and_blocks_later_entry(self):
+        import threading
+
+        from gateway.authenticated_dispatch import (
+            issue_authenticated_gateway_dispatch,
+            revoke_authenticated_gateway_dispatch,
+        )
+        from tools.registry import ToolRegistry
+
+        handler_started = threading.Event()
+        release_handler = threading.Event()
+        revocation_finished = threading.Event()
+        entered = []
+        registry = ToolRegistry()
+
+        def handler(args, *, tool_context):
+            entered.append(args["value"])
+            handler_started.set()
+            assert release_handler.wait(timeout=2)
+            return "ok"
+
+        registry.register(
+            name="protected",
+            toolset="test",
+            schema=_schema("protected"),
+            handler=handler,
+            requires_authenticated_gateway=True,
+        )
+
+        with issue_authenticated_gateway_dispatch(
+            dispatch_kind="tool",
+            platform="telegram",
+            user_id="user-1",
+            chat_id="chat-1",
+            message_id="message-1",
+        ) as context:
+            dispatch_thread = threading.Thread(
+                target=lambda: registry.dispatch(
+                    "protected",
+                    {"value": "first"},
+                    authenticated_gateway_context=context,
+                )
+            )
+            dispatch_thread.start()
+            assert handler_started.wait(timeout=2)
+
+            def revoke():
+                revoke_authenticated_gateway_dispatch(context)
+                revocation_finished.set()
+
+            revoke_thread = threading.Thread(target=revoke)
+            revoke_thread.start()
+            assert revocation_finished.wait(timeout=1)
+
+            release_handler.set()
+            dispatch_thread.join(timeout=2)
+            revoke_thread.join(timeout=2)
+            assert revocation_finished.is_set()
+
+            denied = json.loads(
+                registry.dispatch(
+                    "protected",
+                    {"value": "second"},
+                    authenticated_gateway_context=context,
+                )
+            )
+            assert denied["error_type"] == "authenticated_gateway_required"
+
+        assert entered == ["first"]
+
+    def test_existing_claim_cannot_admit_a_new_call_after_revocation(self):
+        from contextlib import ExitStack
+        from types import SimpleNamespace
+
+        from agent.tool_executor import _authenticated_gateway_tool_denial
+        from gateway.authenticated_dispatch import (
+            issue_authenticated_gateway_dispatch,
+            revoke_authenticated_gateway_dispatch,
+        )
+        from tools.registry import registry
+
+        name = "protected-no-claim-piggyback"
+        registry.register(
+            name=name,
+            toolset="test",
+            schema=_schema(name),
+            handler=lambda args, **kwargs: "ok",
+            requires_authenticated_gateway=True,
+        )
+        try:
+            with issue_authenticated_gateway_dispatch(
+                dispatch_kind="tool",
+                platform="telegram",
+                user_id="user-1",
+                chat_id="chat-1",
+                message_id="message-1",
+            ) as context:
+                agent = SimpleNamespace(_authenticated_gateway_context=context)
+                with ExitStack() as claims:
+                    assert _authenticated_gateway_tool_denial(
+                        agent,
+                        function_name=name,
+                        function_args={},
+                        lease_claims=claims,
+                    ) is None
+                    assert revoke_authenticated_gateway_dispatch(context) is True
+                    denied = _authenticated_gateway_tool_denial(
+                        agent,
+                        function_name=name,
+                        function_args={},
+                        lease_claims=claims,
+                    )
+                    assert isinstance(denied, str)
+                    assert json.loads(denied)["error_type"] == (
+                        "authenticated_gateway_required"
+                    )
+        finally:
+            registry.deregister(name)
+
+    def test_admitted_claim_authorizes_only_one_matching_registry_dispatch(self):
+        from gateway.authenticated_dispatch import (
+            bind_authenticated_gateway_tool_claim,
+            issue_authenticated_gateway_dispatch,
+            revoke_authenticated_gateway_dispatch,
+            use_authenticated_gateway_tool_dispatch,
+        )
+        from tools.registry import ToolRegistry
+
+        local_registry = ToolRegistry()
+        calls = []
+        local_registry.register(
+            name="protected-once",
+            toolset="test",
+            schema=_schema("protected-once"),
+            handler=lambda args, **kwargs: calls.append(args["value"]) or "ok",
+            requires_authenticated_gateway=True,
+        )
+
+        with issue_authenticated_gateway_dispatch(
+            dispatch_kind="tool",
+            platform="telegram",
+            user_id="user-1",
+            chat_id="chat-1",
+            message_id="message-1",
+        ) as context:
+            with use_authenticated_gateway_tool_dispatch(
+                context,
+                "protected-once",
+            ) as claim:
+                assert claim is not None
+                with bind_authenticated_gateway_tool_claim(claim):
+                    assert local_registry.dispatch(
+                        "protected-once",
+                        {"value": "first"},
+                        authenticated_gateway_context=context,
+                    ) == "ok"
+                    denied = local_registry.dispatch(
+                        "protected-once",
+                        {"value": "second"},
+                        authenticated_gateway_context=context,
+                    )
+
+        assert isinstance(denied, str)
+        assert json.loads(denied)["error_type"] == "authenticated_gateway_required"
+        assert calls == ["first"]
+
+    def test_nested_binding_exposes_only_the_innermost_call_claim(self):
+        from gateway.authenticated_dispatch import (
+            bind_authenticated_gateway_tool_claim,
+            issue_authenticated_gateway_dispatch,
+            revoke_authenticated_gateway_dispatch,
+            use_authenticated_gateway_tool_dispatch,
+        )
+        from tools.registry import ToolRegistry
+
+        local_registry = ToolRegistry()
+        calls = []
+        local_registry.register(
+            name="protected-sibling",
+            toolset="test",
+            schema=_schema("protected-sibling"),
+            handler=lambda args, **kwargs: calls.append(args["value"]) or "ok",
+            requires_authenticated_gateway=True,
+        )
+
+        with issue_authenticated_gateway_dispatch(
+            dispatch_kind="tool",
+            platform="telegram",
+            user_id="user-1",
+            chat_id="chat-1",
+            message_id="message-1",
+        ) as context:
+            with use_authenticated_gateway_tool_dispatch(
+                context, "protected-sibling", tool_call_id="call-1"
+            ) as first_claim, use_authenticated_gateway_tool_dispatch(
+                context, "protected-sibling", tool_call_id="call-2"
+            ) as second_claim:
+                assert first_claim is not None
+                assert second_claim is not None
+                with bind_authenticated_gateway_tool_claim(
+                    first_claim
+                ), bind_authenticated_gateway_tool_claim(second_claim):
+                    assert local_registry.dispatch(
+                        "protected-sibling",
+                        {"value": "second"},
+                        authenticated_gateway_context=context,
+                        authenticated_gateway_tool_call_id="call-2",
+                    ) == "ok"
+                    denied = local_registry.dispatch(
+                        "protected-sibling",
+                        {"value": "first-from-sibling"},
+                        authenticated_gateway_context=context,
+                        authenticated_gateway_tool_call_id="call-1",
+                    )
+
+        assert json.loads(denied)["error_type"] == "authenticated_gateway_required"
+        assert calls == ["second"]
+
+
+class TestSeparateCommandAndToolCapabilities:
+    def test_command_and_tool_leases_are_not_interchangeable(self):
+        from hermes_cli import plugins
+        from tools.registry import ToolRegistry
+        from gateway.authenticated_dispatch import issue_authenticated_gateway_dispatch
+
+        command_seen = []
+        tool_seen = []
+        manager = plugins.PluginManager()
+        manager._plugin_commands["protected-command"] = {
+            "handler": lambda args, *, command_context: command_seen.append(
+                command_context
+            ) or "command-ok",
+            "description": "protected command",
+            "plugin": "test",
+            "args_hint": "",
+            "requires_authenticated_gateway": True,
+        }
+        registry = ToolRegistry()
+        registry.register(
+            name="protected-tool",
+            toolset="test",
+            schema=_schema("protected-tool"),
+            handler=lambda args, *, tool_context, **kwargs: tool_seen.append(
+                tool_context
+            ) or "tool-ok",
+            requires_authenticated_gateway=True,
+        )
+        identity = {
+            "platform": "telegram",
+            "user_id": "user-1",
+            "chat_id": "chat-1",
+            "message_id": "message-1",
+        }
+
+        with patch("hermes_cli.plugins._plugin_manager", manager):
+            with issue_authenticated_gateway_dispatch(
+                dispatch_kind="command", **identity
+            ) as command_context:
+                assert plugins.invoke_plugin_command(
+                    "protected-command",
+                    "x",
+                    authenticated_gateway_context=command_context,
+                ) == "command-ok"
+                denied = json.loads(
+                    registry.dispatch(
+                        "protected-tool",
+                        {"value": "x"},
+                        authenticated_gateway_context=command_context,
+                    )
+                )
+                assert denied["error_type"] == "authenticated_gateway_required"
+
+            with issue_authenticated_gateway_dispatch(
+                dispatch_kind="tool", **identity
+            ) as tool_context:
+                with pytest.raises(PermissionError):
+                    plugins.invoke_plugin_command(
+                        "protected-command",
+                        "x",
+                        authenticated_gateway_context=tool_context,
+                    )
+                assert registry.dispatch(
+                    "protected-tool",
+                    {"value": "x"},
+                    authenticated_gateway_context=tool_context,
+                ) == "tool-ok"
+
+        assert command_seen == [command_context]
+        assert tool_seen == [tool_context]
+
+
+class TestToolContextCompatibility:
+    def test_registry_forwards_legacy_tool_context_to_ordinary_handler(self):
+        from tools.registry import ToolRegistry
+
+        seen = []
+        registry = ToolRegistry()
+        registry.register(
+            name="ordinary",
+            toolset="test",
+            schema=_schema("ordinary"),
+            handler=lambda args, *, tool_context: seen.append(tool_context) or "ok",
+        )
+
+        assert registry.dispatch(
+            "ordinary",
+            {"value": "x"},
+            tool_context="legacy-host-context",
+        ) == "ok"
+        assert seen == ["legacy-host-context"]
+
+    def test_plugin_context_cannot_upgrade_legacy_context_for_protected_tool(self):
+        from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+        from tools.registry import ToolRegistry
+
+        entered = []
+        registry = ToolRegistry()
+        registry.register(
+            name="protected",
+            toolset="test",
+            schema=_schema("protected"),
+            handler=lambda args, *, tool_context: entered.append(tool_context) or "ok",
+            requires_authenticated_gateway=True,
+        )
+        context = PluginContext(
+            PluginManifest(name="test-plugin", source="user"),
+            PluginManager(),
+        )
+
+        with patch("tools.registry.registry", registry):
+            denied = json.loads(
+                context.dispatch_tool(
+                    "protected",
+                    {"value": "x"},
+                    tool_context="forged-legacy-context",
+                )
+            )
+
+        assert denied["error_type"] == "authenticated_gateway_required"
+        assert entered == []
+
+
+class TestProtectedPluginCommandContract:
+    def _context(self):
+        from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+        manager = PluginManager()
+        context = PluginContext(
+            PluginManifest(name="authenticated-test", source="user"), manager
+        )
+        return manager, context
+
+    def test_command_and_tool_capabilities_are_separate_exact_integers(self):
+        _, context = self._context()
+
+        assert type(context.authenticated_gateway_dispatch_version) is int
+        assert context.authenticated_gateway_dispatch_version == 1
+        assert type(context.authenticated_gateway_tool_dispatch_version) is int
+        assert context.authenticated_gateway_tool_dispatch_version == 1
+
+    def test_protected_command_metadata_is_registered(self):
+        manager, context = self._context()
+        context.register_command(
+            "protected",
+            lambda _args, *, command_context=None: "ok",
+            requires_authenticated_gateway=True,
+        )
+
+        assert manager._plugin_commands["protected"]["requires_authenticated_gateway"] is True
+
+    def test_unprotected_command_keeps_legacy_one_argument_call(self):
+        from hermes_cli.plugins import invoke_plugin_command
+
+        manager, context = self._context()
+        seen = []
+        context.register_command("legacy", lambda args: seen.append(args) or "ok")
+
+        with patch("hermes_cli.plugins._plugin_manager", manager):
+            assert invoke_plugin_command("legacy", "hello") == "ok"
+        assert seen == ["hello"]
+
+    def test_absent_forged_and_stale_contexts_do_not_enter_handler(self):
+        from hermes_cli.plugins import invoke_plugin_command
+
+        manager, context = self._context()
+        seen = []
+        context.register_command(
+            "protected",
+            lambda args, *, command_context=None: seen.append((args, command_context)) or "ok",
+            requires_authenticated_gateway=True,
+        )
+
+        class Forged:
+            authorized = True
+
+        with patch("hermes_cli.plugins._plugin_manager", manager):
+            with pytest.raises(PermissionError):
+                invoke_plugin_command("protected", "x")
+            with pytest.raises(PermissionError):
+                invoke_plugin_command(
+                    "protected", "x", authenticated_gateway_context=Forged()
+                )
+            with _lease(dispatch_kind="command") as live:
+                assert invoke_plugin_command(
+                    "protected", "x", authenticated_gateway_context=live
+                ) == "ok"
+                assert seen == [("x", live)]
+            with pytest.raises(PermissionError):
+                invoke_plugin_command(
+                    "protected", "x", authenticated_gateway_context=live
+                )
+
+        assert seen == [("x", live)]
+
+    def test_legacy_handler_lookup_wraps_protected_commands_fail_closed(self):
+        from hermes_cli.plugins import get_plugin_command_handler
+
+        manager, context = self._context()
+        entered = []
+        context.register_command(
+            "protected",
+            lambda _args, *, command_context=None: entered.append(command_context) or "ok",
+            requires_authenticated_gateway=True,
+        )
+
+        with patch("hermes_cli.plugins._plugin_manager", manager):
+            handler = get_plugin_command_handler("protected")
+            assert handler is not None
+            with pytest.raises(PermissionError):
+                handler("forged local/TUI invocation")
+        assert entered == []
+
+
+class TestAuthenticatedPluginToolContract:
+    def test_reserved_provenance_fields_are_rejected_recursively_at_registration(self):
+        from tools.registry import ToolRegistry
+
+        reserved_schemas = [
+            _schema("protected_top_tool", {"tool_context": {"type": "object"}}),
+            _schema(
+                "protected_top_auth",
+                {"authenticated_gateway_context": {"type": "object"}},
+            ),
+            _schema(
+                "protected_nested_object",
+                {
+                    "request": {
+                        "type": "object",
+                        "properties": {"tool_context": {"type": "object"}},
+                    }
+                },
+            ),
+            _schema(
+                "protected_array_item",
+                {
+                    "requests": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "authenticated_gateway_context": {"type": "object"}
+                            },
+                        },
+                    }
+                },
+            ),
+            {
+                "name": "protected_combinator",
+                "description": "authenticated test tool",
+                "parameters": {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {"tool_context": {"type": "string"}},
+                        }
+                    ]
+                },
+            },
+        ]
+
+        for index, schema in enumerate(reserved_schemas):
+            registry = ToolRegistry()
+            with pytest.raises(ValueError):
+                registry.register(
+                    name=f"protected_{index}",
+                    toolset="plugin-test",
+                    schema=schema,
+                    handler=lambda _args, **_kwargs: "ok",
+                    requires_authenticated_gateway=True,
+                )
+
+    def test_dynamic_schema_overrides_cannot_expose_reserved_provenance_fields(self):
+        from tools.registry import ToolRegistry
+
+        registry = ToolRegistry()
+        registry.register(
+            name="protected_dynamic",
+            toolset="plugin-test",
+            schema=_schema("protected_dynamic"),
+            handler=lambda _args, **_kwargs: "ok",
+            dynamic_schema_overrides=lambda: {
+                "parameters": {
+                    "type": "object",
+                    "properties": {"tool_context": {"type": "object"}},
+                }
+            },
+            requires_authenticated_gateway=True,
+        )
+
+        assert registry.get_definitions({"protected_dynamic"}) == []
+
+    def test_domain_identity_fields_remain_valid_protected_tool_arguments(self):
+        from tools.registry import ToolRegistry
+
+        registry = ToolRegistry()
+        seen = []
+        registry.register(
+            name="protected_domain_fields",
+            toolset="plugin-test",
+            schema=_schema(
+                "protected_domain_fields",
+                {
+                    "platform": {"type": "string"},
+                    "request": {
+                        "type": "object",
+                        "properties": {"message_id": {"type": "string"}},
+                    },
+                },
+            ),
+            handler=lambda args, **kwargs: seen.append(args) or "ok",
+            requires_authenticated_gateway=True,
+        )
+        args = {
+            "platform": "business-domain",
+            "request": {"message_id": "domain-record"},
+        }
+        with _lease() as live:
+            assert registry.dispatch(
+                "protected_domain_fields",
+                args,
+                authenticated_gateway_context=live,
+            ) == "ok"
+        assert seen == [args]
+
+    def test_unprotected_tools_may_use_transport_looking_domain_fields(self):
+        from tools.registry import ToolRegistry
+
+        registry = ToolRegistry()
+        seen = []
+        registry.register(
+            name="ordinary_domain_fields",
+            toolset="plugin-test",
+            schema=_schema(
+                "ordinary_domain_fields",
+                {"tool_context": {"type": "string"}},
+            ),
+            handler=lambda args, **kwargs: seen.append(args) or "ok",
+        )
+        args = {"tool_context": "ordinary-domain-value"}
+        assert registry.dispatch("ordinary_domain_fields", args) == "ok"
+        assert seen == [args]
+
+    def test_unprotected_registry_dispatch_forwards_legacy_tool_context_kwarg(self):
+        from tools.registry import ToolRegistry
+
+        registry = ToolRegistry()
+        seen = []
+        registry.register(
+            name="ordinary_legacy_context",
+            toolset="plugin-test",
+            schema=_schema("ordinary_legacy_context"),
+            handler=lambda args, **kwargs: seen.append(kwargs) or "ok",
+        )
+
+        assert registry.dispatch(
+            "ordinary_legacy_context",
+            {},
+            tool_context="legacy-host-context",
+        ) == "ok"
+        assert seen == [{"tool_context": "legacy-host-context"}]
+
+    def test_absent_forged_stale_and_model_supplied_context_do_not_enter_handler(self):
+        from tools.registry import ToolRegistry
+
+        registry = ToolRegistry()
+        seen = []
+        registry.register(
+            name="protected",
+            toolset="plugin-test",
+            schema=_schema("protected"),
+            handler=lambda args, **kwargs: seen.append((args, kwargs)) or json.dumps({"ok": True}),
+            requires_authenticated_gateway=True,
+        )
+
+        class Forged:
+            authorized = True
+
+        denied = json.loads(registry.dispatch("protected", {"value": "x"}))
+        assert denied["error_type"] == "authenticated_gateway_required"
+        denied = json.loads(
+            registry.dispatch(
+                "protected",
+                {"value": "x"},
+                authenticated_gateway_context=Forged(),
+            )
+        )
+        assert denied["error_type"] == "authenticated_gateway_required"
+        denied = json.loads(
+            registry.dispatch(
+                "protected",
+                {"value": "x", "platform": "telegram"},
+            )
+        )
+        assert denied["error_type"] == "authenticated_gateway_required"
+
+        with _lease() as live:
+            result = json.loads(
+                registry.dispatch(
+                    "protected",
+                    {"value": "x"},
+                    authenticated_gateway_context=live,
+                )
+            )
+            assert result == {"ok": True}
+            args, kwargs = seen[-1]
+            assert args == {"value": "x"}
+            assert kwargs == {"tool_context": live}
+
+        denied = json.loads(
+            registry.dispatch(
+                "protected",
+                {"value": "x"},
+                authenticated_gateway_context=live,
+            )
+        )
+        assert denied["error_type"] == "authenticated_gateway_required"
+        assert len(seen) == 1
+
+    def test_unprotected_tool_never_receives_internal_gateway_context(self):
+        from tools.registry import ToolRegistry
+
+        registry = ToolRegistry()
+        seen = []
+        registry.register(
+            name="legacy",
+            toolset="plugin-test",
+            schema=_schema("legacy"),
+            handler=lambda args, **kwargs: seen.append((args, kwargs)) or "ok",
+        )
+
+        with _lease() as live:
+            assert registry.dispatch(
+                "legacy", {"value": "x"}, authenticated_gateway_context=live
+            ) == "ok"
+        assert seen == [({"value": "x"}, {})]
+
+    def test_plugin_context_dispatch_cannot_forward_a_gateway_lease(self):
+        from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+        from tools.registry import registry
+
+        name = "test_plugin_context_protected_dispatch"
+        seen = []
+        registry.register(
+            name=name,
+            toolset="plugin-test",
+            schema=_schema(name),
+            handler=lambda args, **kwargs: seen.append((args, kwargs)) or "ok",
+            requires_authenticated_gateway=True,
+        )
+        try:
+            context = PluginContext(
+                PluginManifest(name="authenticated-test", source="user"),
+                PluginManager(),
+            )
+            with _lease() as live:
+                denied = json.loads(
+                    context.dispatch_tool(
+                        name,
+                        {"value": "x"},
+                        authenticated_gateway_context=live,
+                    )
+                )
+            assert denied["error_type"] == "authenticated_gateway_required"
+            assert seen == []
+        finally:
+            registry.deregister(name)
+
+
+def test_api_tool_surface_requires_live_tool_lease():
+    from types import SimpleNamespace
+
+    from agent.chat_completion_helpers import build_api_kwargs
+    from tools.registry import registry
+
+    protected = "test_surface_protected"
+    ordinary = "test_surface_ordinary"
+    registry.register(
+        name=protected,
+        toolset="plugin-test",
+        schema=_schema(protected),
+        handler=lambda args, **kwargs: "protected",
+        requires_authenticated_gateway=True,
+    )
+    registry.register(
+        name=ordinary,
+        toolset="plugin-test",
+        schema=_schema(ordinary),
+        handler=lambda args, **kwargs: "ordinary",
+    )
+    try:
+        definitions = [
+            {"type": "function", "function": _schema(protected)},
+            {"type": "function", "function": _schema(ordinary)},
+        ]
+
+        class CaptureTransport:
+            def build_kwargs(self, **kwargs):
+                return kwargs
+
+        agent = SimpleNamespace(
+            tools=definitions,
+            _authenticated_gateway_context=None,
+            api_mode="bedrock_converse",
+            model="test-model",
+            max_tokens=100,
+            _bedrock_region=None,
+            _bedrock_guardrail_config=None,
+            _get_transport=lambda: CaptureTransport(),
+        )
+
+        def exposed_names():
+            payload = build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+            return [item["function"]["name"] for item in payload["tools"]]
+
+        assert exposed_names() == [ordinary]
+        with _lease(dispatch_kind="command") as command_context:
+            agent._authenticated_gateway_context = command_context
+            assert exposed_names() == [ordinary]
+        with _lease() as tool_context:
+            agent._authenticated_gateway_context = tool_context
+            assert exposed_names() == [protected, ordinary]
+        assert exposed_names() == [ordinary]
+        assert agent.tools is definitions
+    finally:
+        registry.deregister(protected)
+        registry.deregister(ordinary)
+
+
+def test_tool_search_catalog_requires_live_tool_lease():
+    import model_tools
+    from tools.registry import registry
+
+    protected = "test_surface_catalog_protected"
+    registry.register(
+        name=protected,
+        toolset="plugin-test",
+        schema=_schema(protected),
+        handler=lambda args, **kwargs: "protected",
+        requires_authenticated_gateway=True,
+    )
+    try:
+        def search(context=None):
+            return json.loads(
+                model_tools.handle_function_call(
+                    "tool_search",
+                    {"query": protected},
+                    enabled_toolsets=["plugin-test"],
+                    skip_pre_tool_call_hook=True,
+                    skip_tool_request_middleware=True,
+                    authenticated_gateway_context=context,
+                )
+            )
+
+        assert search()["matches"] == []
+        with _lease(dispatch_kind="command") as command_context:
+            assert search(command_context)["matches"] == []
+        with _lease() as tool_context:
+            assert [hit["name"] for hit in search(tool_context)["matches"]] == [
+                protected
+            ]
+    finally:
+        registry.deregister(protected)
+
+
+def test_model_dispatch_denies_before_middleware_and_accepts_live_lease(monkeypatch):
+    import model_tools
+    from agent.agent_runtime_helpers import invoke_tool
+    from hermes_cli import middleware
+    from tools.registry import registry
+
+    name = "test_protected_model_dispatch"
+    seen = []
+
+    def handler(args, *, tool_context, **kwargs):
+        seen.append(tool_context)
+        return args["value"]
+
+    registry.register(
+        name=name,
+        toolset="plugin-test",
+        schema={
+            "name": name,
+            "description": "test",
+            "parameters": {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+            },
+        },
+        handler=handler,
+        requires_authenticated_gateway=True,
+    )
+    try:
+        def middleware_must_not_run(*args, **kwargs):
+            raise AssertionError("unauthorized protected call reached middleware")
+
+        monkeypatch.setattr(
+            middleware,
+            "apply_tool_request_middleware",
+            middleware_must_not_run,
+        )
+        denied = json.loads(model_tools.handle_function_call(name, {"value": "denied"}))
+        assert denied["error_type"] == "authenticated_gateway_required"
+        denied = json.loads(
+            invoke_tool(
+                object(),
+                name,
+                {"value": "denied"},
+                "task",
+            )
+        )
+        assert denied["error_type"] == "authenticated_gateway_required"
+        assert seen == []
+
+        from types import SimpleNamespace
+
+        with _lease() as live:
+            agent = SimpleNamespace(
+                _authenticated_gateway_context=live,
+                _memory_manager=None,
+                session_id="session",
+                valid_tool_names=None,
+                enabled_toolsets=None,
+                disabled_toolsets=None,
+            )
+            assert invoke_tool(
+                agent,
+                name,
+                {"value": "accepted"},
+                "task",
+                pre_tool_block_checked=True,
+                skip_tool_request_middleware=True,
+            ) == "accepted"
+            assert seen == [live]
+    finally:
+        registry.deregister(name)
+
+
+@pytest.mark.parametrize("mode", ["sequential", "concurrent"])
+def test_executor_denies_protected_tool_before_all_extension_observers(
+    monkeypatch,
+    mode,
+):
+    import threading
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from agent import tool_executor
+    from tools.registry import registry
+
+    name = f"test_executor_protected_{mode}"
+    observed = []
+    handler_calls = []
+    registry.register(
+        name=name,
+        toolset="plugin-test",
+        schema=_schema(name),
+        handler=lambda args, **kwargs: handler_calls.append((args, kwargs)) or "ok",
+        requires_authenticated_gateway=True,
+    )
+    try:
+        def request_middleware(_agent, **kwargs):
+            observed.append("request_middleware")
+            return kwargs["function_args"], []
+
+        monkeypatch.setattr(
+            tool_executor,
+            "_apply_tool_request_middleware_for_agent",
+            request_middleware,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: observed.append("pre_tool_hook"),
+        )
+        monkeypatch.setattr(
+            tool_executor,
+            "_emit_terminal_post_tool_call",
+            lambda *args, **kwargs: observed.append("post_tool_hook"),
+        )
+        monkeypatch.setattr(
+            tool_executor,
+            "maybe_persist_tool_result",
+            lambda *, content, **kwargs: observed.append("persist_result") or content,
+        )
+
+        agent = MagicMock()
+        agent._authenticated_gateway_context = None
+        agent._interrupt_requested = False
+        agent._tool_guardrails.before_call.side_effect = lambda *args: (
+            observed.append("guardrail")
+            or SimpleNamespace(allows_execution=True)
+        )
+        agent._checkpoint_mgr.enabled = False
+        agent.tool_delay = 0
+        agent.quiet_mode = True
+        agent.tool_progress_mode = "off"
+        agent.verbose_logging = False
+        agent.tool_progress_callback = lambda *args, **kwargs: observed.append(
+            "progress_callback"
+        )
+        agent.tool_start_callback = lambda *args, **kwargs: observed.append(
+            "start_callback"
+        )
+        agent.tool_complete_callback = lambda *args, **kwargs: observed.append(
+            "complete_callback"
+        )
+        agent._should_emit_quiet_tool_messages.return_value = False
+        agent._should_start_quiet_spinner.return_value = False
+        agent._tool_result_content_for_active_model.side_effect = (
+            lambda _name, result: result
+        )
+        agent._touch_activity.side_effect = lambda *args, **kwargs: observed.append(
+            "activity"
+        )
+        agent._append_guardrail_observation.side_effect = (
+            lambda *args, **kwargs: observed.append("guardrail_observation")
+            or args[2]
+        )
+        agent._subdirectory_hints.check_tool_call.side_effect = (
+            lambda *args, **kwargs: observed.append("subdirectory_hints")
+        )
+        agent._tool_worker_threads = set()
+        agent._tool_worker_threads_lock = threading.Lock()
+        agent._invoke_tool.side_effect = lambda tool_name, args, *rest, **kwargs: (
+            registry.dispatch(tool_name, args)
+        )
+
+        tool_call = SimpleNamespace(
+            id=f"call-{mode}",
+            function=SimpleNamespace(name=name, arguments='{"value": "denied"}'),
+        )
+        assistant_message = SimpleNamespace(tool_calls=[tool_call])
+        messages = []
+
+        if mode == "sequential":
+            tool_executor.execute_tool_calls_sequential(
+                agent,
+                assistant_message,
+                messages,
+                "task",
+                finalize=False,
+            )
+        else:
+            tool_executor.execute_tool_calls_concurrent(
+                agent,
+                assistant_message,
+                messages,
+                "task",
+                finalize=False,
+            )
+
+        assert observed == []
+        assert handler_calls == []
+        assert len(messages) == 1
+        denial = json.loads(messages[0]["content"])
+        assert denial["error_type"] == "authenticated_gateway_required"
+    finally:
+        registry.deregister(name)
+
+
+@pytest.mark.parametrize("mode", ["sequential", "concurrent"])
+def test_protected_executor_claims_lease_before_request_middleware(
+    monkeypatch,
+    mode,
+):
+    import threading
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from agent import tool_executor
+    from gateway.authenticated_dispatch import revoke_authenticated_gateway_dispatch
+    from tools.registry import registry
+
+    name = f"test_pipeline_claim_{mode}"
+    middleware_entered = threading.Event()
+    release_middleware = threading.Event()
+    revocation_finished = threading.Event()
+    handler_calls = []
+    registry.register(
+        name=name,
+        toolset="plugin-test",
+        schema=_schema(name),
+        handler=lambda args, **kwargs: handler_calls.append(args["value"]) or "ok",
+        requires_authenticated_gateway=True,
+    )
+    try:
+        def blocking_middleware(_agent, **kwargs):
+            middleware_entered.set()
+            assert release_middleware.wait(timeout=2)
+            return kwargs["function_args"], []
+
+        monkeypatch.setattr(
+            tool_executor,
+            "_apply_tool_request_middleware_for_agent",
+            blocking_middleware,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: None,
+        )
+
+        agent = MagicMock()
+        agent._interrupt_requested = False
+        agent._tool_guardrails.before_call.return_value = SimpleNamespace(
+            allows_execution=True
+        )
+        agent._checkpoint_mgr.enabled = False
+        agent._memory_manager = None
+        agent.tool_delay = 0
+        agent.quiet_mode = True
+        agent.tool_progress_mode = "off"
+        agent.verbose_logging = False
+        agent.tool_progress_callback = None
+        agent.tool_start_callback = None
+        agent.tool_complete_callback = None
+        agent._should_emit_quiet_tool_messages.return_value = False
+        agent._should_start_quiet_spinner.return_value = False
+        agent._tool_result_content_for_active_model.side_effect = (
+            lambda _name, result: result
+        )
+        agent._subdirectory_hints.check_tool_call.return_value = None
+        agent._append_guardrail_observation.side_effect = (
+            lambda _name, _args, result, failed=False: result
+        )
+        agent._invoke_tool.side_effect = lambda tool_name, args, *rest, **kwargs: (
+            registry.dispatch(
+                tool_name,
+                args,
+                authenticated_gateway_context=agent._authenticated_gateway_context,
+                authenticated_gateway_tool_call_id=rest[1],
+            )
+        )
+        agent._tool_worker_threads = set()
+        agent._tool_worker_threads_lock = threading.Lock()
+
+        tool_call = SimpleNamespace(
+            id=f"call-{mode}",
+            function=SimpleNamespace(name=name, arguments='{"value": "accepted"}'),
+        )
+        assistant_message = SimpleNamespace(tool_calls=[tool_call])
+        messages = []
+
+        with _lease() as live:
+            agent._authenticated_gateway_context = live
+            executor = (
+                tool_executor.execute_tool_calls_sequential
+                if mode == "sequential"
+                else tool_executor.execute_tool_calls_concurrent
+            )
+            execution_thread = threading.Thread(
+                target=executor,
+                args=(agent, assistant_message, messages, "task"),
+                kwargs={"finalize": False},
+            )
+            execution_thread.start()
+            assert middleware_entered.wait(timeout=2)
+
+            def revoke():
+                revoke_authenticated_gateway_dispatch(live)
+                revocation_finished.set()
+
+            revoker = threading.Thread(target=revoke)
+            revoker.start()
+            # Revocation closes admission immediately and must not block the
+            # gateway control path while an already-admitted handler drains.
+            assert revocation_finished.wait(timeout=1)
+            release_middleware.set()
+            execution_thread.join(timeout=3)
+            revoker.join(timeout=3)
+
+            assert not execution_thread.is_alive()
+            assert not revoker.is_alive()
+            assert revocation_finished.is_set()
+            assert handler_calls == ["accepted"], messages
+            assert messages[-1]["content"] == "ok"
+    finally:
+        release_middleware.set()
+        registry.deregister(name)
+
+
+def test_concurrent_partial_submission_failure_never_waits_for_started_worker(
+    monkeypatch,
+):
+    import concurrent.futures
+    import threading
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from agent import tool_executor
+    from tools.registry import registry
+
+    names = ["test-submit-failure-1", "test-submit-failure-2"]
+    for name in names:
+        registry.register(
+            name=name,
+            toolset="plugin-test",
+            schema=_schema(name),
+            handler=lambda args, **kwargs: "ok",
+            requires_authenticated_gateway=True,
+        )
+
+    shutdown_calls = []
+
+    class PartialFailureExecutor:
+        def __init__(self, *, max_workers):
+            self.submissions = 0
+
+        def submit(self, fn, *args, **kwargs):
+            self.submissions += 1
+            if self.submissions == 1:
+                return concurrent.futures.Future()
+            raise RuntimeError("synthetic partial submission failure")
+
+        def shutdown(self, *, wait, cancel_futures):
+            shutdown_calls.append((wait, cancel_futures))
+
+    try:
+        monkeypatch.setattr(
+            "tools.daemon_pool.DaemonThreadPoolExecutor",
+            PartialFailureExecutor,
+        )
+        monkeypatch.setattr(
+            tool_executor,
+            "_apply_tool_request_middleware_for_agent",
+            lambda _agent, **kwargs: (kwargs["function_args"], []),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: None,
+        )
+
+        agent = MagicMock()
+        agent._interrupt_requested = False
+        agent._tool_guardrails.before_call.return_value = SimpleNamespace(
+            allows_execution=True
+        )
+        agent._checkpoint_mgr.enabled = False
+        agent._memory_manager = None
+        agent.tool_delay = 0
+        agent.quiet_mode = True
+        agent.tool_progress_mode = "off"
+        agent.verbose_logging = False
+        agent.tool_progress_callback = None
+        agent.tool_start_callback = None
+        agent.tool_complete_callback = None
+        agent._should_emit_quiet_tool_messages.return_value = False
+        agent._should_start_quiet_spinner.return_value = False
+        agent._subdirectory_hints.check_tool_call.return_value = None
+        agent._tool_worker_threads = set()
+        agent._tool_worker_threads_lock = threading.Lock()
+
+        tool_calls = [
+            SimpleNamespace(
+                id=f"call-{index}",
+                function=SimpleNamespace(name=name, arguments="{}"),
+            )
+            for index, name in enumerate(names)
+        ]
+        assistant_message = SimpleNamespace(tool_calls=tool_calls)
+
+        with _lease() as live:
+            agent._authenticated_gateway_context = live
+            with pytest.raises(
+                RuntimeError,
+                match="synthetic partial submission failure",
+            ):
+                tool_executor.execute_tool_calls_concurrent(
+                    agent,
+                    assistant_message,
+                    [],
+                    "task",
+                    finalize=False,
+                )
+
+        assert shutdown_calls == [(False, True)]
+    finally:
+        for name in names:
+            registry.deregister(name)
+
+
+def test_sequential_policy_block_closes_claim_before_block_callback(monkeypatch):
+    import threading
+    from contextlib import contextmanager
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from agent import tool_executor
+    from gateway import authenticated_dispatch
+    from tools.registry import registry
+
+    name = "test-sequential-blocked-claim-cleanup"
+    registry.register(
+        name=name,
+        toolset="plugin-test",
+        schema=_schema(name),
+        handler=lambda args, **kwargs: "unexpected",
+        requires_authenticated_gateway=True,
+    )
+    claims = []
+    callback_active_states = []
+    original_use = authenticated_dispatch.use_authenticated_gateway_tool_dispatch
+
+    @contextmanager
+    def tracking_use(*args, **kwargs):
+        with original_use(*args, **kwargs) as claim:
+            claims.append(claim)
+            yield claim
+
+    try:
+        monkeypatch.setattr(
+            authenticated_dispatch,
+            "use_authenticated_gateway_tool_dispatch",
+            tracking_use,
+        )
+        monkeypatch.setattr(
+            tool_executor,
+            "_apply_tool_request_middleware_for_agent",
+            lambda _agent, **kwargs: (kwargs["function_args"], []),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: "blocked by policy",
+        )
+        monkeypatch.setattr(
+            tool_executor,
+            "_emit_terminal_post_tool_call",
+            lambda *args, **kwargs: callback_active_states.append(claims[-1].active),
+        )
+
+        agent = MagicMock()
+        agent._interrupt_requested = False
+        agent._tool_guardrails.before_call.return_value = SimpleNamespace(
+            allows_execution=True
+        )
+        agent._checkpoint_mgr.enabled = False
+        agent._memory_manager = None
+        agent.tool_delay = 0
+        agent.quiet_mode = True
+        agent.tool_progress_mode = "off"
+        agent.verbose_logging = False
+        agent.tool_progress_callback = None
+        agent.tool_start_callback = None
+        agent.tool_complete_callback = None
+        agent._should_emit_quiet_tool_messages.return_value = False
+        agent._should_start_quiet_spinner.return_value = False
+        agent._tool_result_content_for_active_model.side_effect = (
+            lambda _name, result: result
+        )
+        agent._append_guardrail_observation.side_effect = (
+            lambda _name, _args, result, failed=False: result
+        )
+        agent._subdirectory_hints.check_tool_call.return_value = None
+        agent._tool_worker_threads = set()
+        agent._tool_worker_threads_lock = threading.Lock()
+
+        tool_call = SimpleNamespace(
+            id="call-blocked",
+            function=SimpleNamespace(name=name, arguments="{}"),
+        )
+        with _lease() as live:
+            agent._authenticated_gateway_context = live
+            tool_executor.execute_tool_calls_sequential(
+                agent,
+                SimpleNamespace(tool_calls=[tool_call]),
+                [],
+                "task",
+                finalize=False,
+            )
+
+        assert callback_active_states == [False]
+        assert claims[0].active is False
+    finally:
+        registry.deregister(name)
+
+
+def test_agent_turn_binds_restores_rejects_stale_and_excludes_codex(monkeypatch):
+    from contextlib import contextmanager
+
+    import agent.aux_accounting as aux_accounting
+    import agent.auxiliary_client as auxiliary_client
+    import agent.conversation_loop as conversation_loop
+    import agent.portal_tags as portal_tags
+    from run_agent import AIAgent
+
+    observed = []
+
+    def fake_run(agent, *args, **kwargs):
+        observed.append(getattr(agent, "_authenticated_gateway_context", "missing"))
+        return {"final_response": "ok"}
+
+    @contextmanager
+    def fake_scope(value):
+        yield
+
+    monkeypatch.setattr(conversation_loop, "run_conversation", fake_run)
+    monkeypatch.setattr(aux_accounting, "set_accounting_context", lambda *a: object())
+    monkeypatch.setattr(aux_accounting, "reset_accounting_context", lambda token: None)
+    monkeypatch.setattr(portal_tags, "set_conversation_context", lambda value: object())
+    monkeypatch.setattr(portal_tags, "reset_conversation_context", lambda token: None)
+    monkeypatch.setattr(auxiliary_client, "scoped_runtime_main", fake_scope)
+
+    class DummyAgent:
+        api_mode = "openai"
+        _session_db = None
+        session_id = "session"
+        _authenticated_gateway_context = "prior"
+
+        @staticmethod
+        def _conversation_root_id():
+            return "root"
+
+    agent = DummyAgent()
+    with _lease() as live:
+        assert AIAgent.run_conversation(
+            agent,
+            "hello",
+            authenticated_gateway_context=live,
+        ) == {"final_response": "ok"}
+        assert observed[-1] is live
+        assert agent._authenticated_gateway_context == "prior"
+
+    with pytest.raises(PermissionError):
+        AIAgent.run_conversation(
+            agent,
+            "stale",
+            authenticated_gateway_context=live,
+        )
+    assert agent._authenticated_gateway_context == "prior"
+
+    def fail_turn_setup(value):
+        raise RuntimeError("setup failed")
+
+    monkeypatch.setattr(portal_tags, "set_conversation_context", fail_turn_setup)
+    with _lease() as setup_live:
+        with pytest.raises(RuntimeError, match="setup failed"):
+            AIAgent.run_conversation(
+                agent,
+                "setup failure",
+                authenticated_gateway_context=setup_live,
+            )
+    assert agent._authenticated_gateway_context == "prior"
+    monkeypatch.setattr(portal_tags, "set_conversation_context", lambda value: object())
+
+    agent.api_mode = "codex_app_server"
+    with _lease() as codex_live:
+        AIAgent.run_conversation(
+            agent,
+            "codex",
+            authenticated_gateway_context=codex_live,
+        )
+    assert observed[-1] is None
+    assert agent._authenticated_gateway_context == "prior"
+
+
+@pytest.mark.parametrize("mode", ["sequential", "concurrent"])
+def test_executor_forwards_live_context_after_middleware(monkeypatch, mode):
+    import threading
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from agent import tool_executor
+    from tools.registry import registry
+
+    name = f"test_executor_live_{mode}"
+    middleware_calls = []
+    handler_calls = []
+
+    def handler(args, *, tool_context, **kwargs):
+        handler_calls.append((args, tool_context))
+        return args["value"]
+
+    registry.register(
+        name=name,
+        toolset="plugin-test",
+        schema=_schema(name, {"value": {"type": "string"}}),
+        handler=handler,
+        requires_authenticated_gateway=True,
+    )
+    try:
+        def request_middleware(_agent, **kwargs):
+            middleware_calls.append((kwargs["function_name"], kwargs["function_args"]))
+            return {"value": "after-middleware"}, [
+                {"plugin": "test", "middleware": "rewrite"}
+            ]
+
+        monkeypatch.setattr(
+            tool_executor,
+            "_apply_tool_request_middleware_for_agent",
+            request_middleware,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: None,
+        )
+
+        agent = MagicMock()
+        agent._interrupt_requested = False
+        agent._tool_guardrails.before_call.return_value = SimpleNamespace(
+            allows_execution=True
+        )
+        agent._checkpoint_mgr.enabled = False
+        agent._memory_manager = None
+        agent.tool_delay = 0
+        agent.quiet_mode = True
+        agent.tool_progress_mode = "off"
+        agent.verbose_logging = False
+        agent.tool_progress_callback = None
+        agent.tool_start_callback = None
+        agent.tool_complete_callback = None
+        agent._should_emit_quiet_tool_messages.return_value = False
+        agent._should_start_quiet_spinner.return_value = False
+        agent._append_guardrail_observation.side_effect = (
+            lambda _name, _args, result, **kwargs: result
+        )
+        agent._tool_result_content_for_active_model.side_effect = (
+            lambda _name, result: result
+        )
+        agent._subdirectory_hints.check_tool_call.return_value = None
+        agent._context_engine_tool_names = []
+        agent._memory_manager = None
+        agent._tool_worker_threads = set()
+        agent._tool_worker_threads_lock = threading.Lock()
+        agent.session_id = "session"
+        agent.valid_tool_names = None
+        agent.enabled_toolsets = None
+        agent.disabled_toolsets = None
+
+        tool_call = SimpleNamespace(
+            id=f"call-{mode}",
+            function=SimpleNamespace(name=name, arguments='{"value": "before"}'),
+        )
+        assistant_message = SimpleNamespace(tool_calls=[tool_call])
+        messages = []
+
+        with _lease() as live:
+            agent._authenticated_gateway_context = live
+
+            def dispatch(tool_name, args, *rest, **kwargs):
+                tool_call_id = kwargs.get("tool_call_id")
+                if tool_call_id is None and len(rest) > 1:
+                    tool_call_id = rest[1]
+                return registry.dispatch(
+                    tool_name,
+                    args,
+                    authenticated_gateway_context=live,
+                    authenticated_gateway_tool_call_id=tool_call_id,
+                )
+
+            agent._invoke_tool.side_effect = dispatch
+            monkeypatch.setattr(
+                tool_executor,
+                "_ra",
+                lambda: SimpleNamespace(handle_function_call=dispatch),
+            )
+
+            if mode == "sequential":
+                tool_executor.execute_tool_calls_sequential(
+                    agent,
+                    assistant_message,
+                    messages,
+                    "task",
+                    finalize=False,
+                )
+            else:
+                tool_executor.execute_tool_calls_concurrent(
+                    agent,
+                    assistant_message,
+                    messages,
+                    "task",
+                    finalize=False,
+                )
+
+            assert handler_calls == [({"value": "after-middleware"}, live)]
+
+        assert middleware_calls == [(name, {"value": "before"})]
+        assert messages[0]["content"] == "after-middleware"
+    finally:
+        registry.deregister(name)
+
+
+def test_gateway_turn_requires_explicit_authenticated_decision():
+    from types import SimpleNamespace
+
+    from gateway.authenticated_dispatch import authenticated_gateway_turn
+
+    agent = SimpleNamespace(authenticated_gateway_tool_dispatch_version=1)
+    source = SimpleNamespace(
+        platform="telegram",
+        user_id="user",
+        chat_id="chat",
+        thread_id="thread",
+        message_id="message",
+    )
+
+    with authenticated_gateway_turn(agent, source) as context:
+        assert context is None
+
+
+def test_gateway_turn_rejects_missing_or_mismatched_trigger_message_id():
+    from types import SimpleNamespace
+
+    from gateway.authenticated_dispatch import authenticated_gateway_turn
+
+    agent = SimpleNamespace(authenticated_gateway_tool_dispatch_version=1)
+    source = SimpleNamespace(
+        platform="telegram",
+        user_id="user",
+        chat_id="chat",
+        thread_id=None,
+        message_id="source-message",
+    )
+
+    for event_message_id in (None, "different-message"):
+        with authenticated_gateway_turn(
+            agent,
+            source,
+            authenticated_gateway_request=True,
+            event_message_id=event_message_id,
+        ) as context:
+            assert context is None
+
+
+def test_gateway_turn_uses_event_message_id_when_source_has_none():
+    from types import SimpleNamespace
+
+    from gateway.authenticated_dispatch import authenticated_gateway_turn
+
+    agent = SimpleNamespace(authenticated_gateway_tool_dispatch_version=1)
+    source = SimpleNamespace(
+        platform="telegram",
+        user_id="user",
+        chat_id="chat",
+        thread_id=None,
+        message_id=None,
+    )
+
+    with authenticated_gateway_turn(
+        agent,
+        source,
+        authenticated_gateway_request=True,
+        event_message_id="event-message",
+    ) as context:
+        assert context is not None
+        assert context.message_id == "event-message"
+
+
+def test_gateway_turn_issues_only_for_exact_capability_and_complete_source():
+    from types import SimpleNamespace
+
+    from gateway.authenticated_dispatch import (
+        authenticated_gateway_turn,
+        validate_authenticated_gateway_dispatch,
+    )
+
+    source = SimpleNamespace(
+        platform=SimpleNamespace(value="telegram"),
+        user_id="user-1",
+        chat_id="chat-1",
+        thread_id="thread-1",
+        message_id="message-1",
+    )
+    capable_agent = SimpleNamespace(
+        authenticated_gateway_tool_dispatch_version=1,
+    )
+    with authenticated_gateway_turn(
+        capable_agent,
+        source,
+        authenticated_gateway_request=True,
+        event_message_id="message-1",
+    ) as live:
+        assert validate_authenticated_gateway_dispatch(live)
+        assert live.platform == "telegram"
+        assert live.user_id == "user-1"
+        assert live.chat_id == "chat-1"
+        assert live.thread_id == "thread-1"
+        assert live.message_id == "message-1"
+    assert not validate_authenticated_gateway_dispatch(live)
+
+    for unsupported in (
+        SimpleNamespace(),
+        SimpleNamespace(authenticated_gateway_tool_dispatch_version=True),
+        SimpleNamespace(authenticated_gateway_tool_dispatch_version="1"),
+        SimpleNamespace(authenticated_gateway_tool_dispatch_version=2),
+    ):
+        with authenticated_gateway_turn(
+            unsupported,
+            source,
+            authenticated_gateway_request=True,
+        ) as denied:
+            assert denied is None
+
+    incomplete_source = SimpleNamespace(
+        platform=SimpleNamespace(value="telegram"),
+        user_id=None,
+        chat_id="chat-1",
+        thread_id=None,
+        message_id="message-1",
+    )
+    with authenticated_gateway_turn(
+        capable_agent,
+        incomplete_source,
+        authenticated_gateway_request=True,
+    ) as denied:
+        assert denied is None

--- a/tests/test_dispatch_session_id.py
+++ b/tests/test_dispatch_session_id.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 def _make_registry(captured: dict):
     """Return a mock registry whose dispatch records the kwargs it receives."""
     registry = MagicMock()
+    registry.get_tool_entry.return_value = MagicMock()
+    registry.authenticated_gateway_dispatch_error.return_value = None
 
     def _dispatch(name, args, **kwargs):
         captured.update(kwargs)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -15,6 +15,7 @@ Import chain (circular-import safe):
 """
 
 import ast
+from contextlib import nullcontext
 import importlib
 import json
 import logging
@@ -25,6 +26,43 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
+
+
+_AUTHENTICATED_GATEWAY_RESERVED_FIELDS = frozenset({
+    "authenticated_gateway_context",
+    "tool_context",
+})
+
+
+def _schema_contains_authenticated_gateway_field(value) -> bool:
+    """Return whether any nested JSON-schema property claims host provenance."""
+    if isinstance(value, dict):
+        properties = value.get("properties")
+        if isinstance(properties, dict):
+            if _AUTHENTICATED_GATEWAY_RESERVED_FIELDS.intersection(properties):
+                return True
+        return any(_schema_contains_authenticated_gateway_field(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_schema_contains_authenticated_gateway_field(item) for item in value)
+    return False
+
+
+def _args_contain_authenticated_gateway_field(value) -> bool:
+    """Return whether model-controlled arguments contain reserved identity keys."""
+    if isinstance(value, dict):
+        if _AUTHENTICATED_GATEWAY_RESERVED_FIELDS.intersection(value):
+            return True
+        return any(_args_contain_authenticated_gateway_field(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_args_contain_authenticated_gateway_field(item) for item in value)
+    return False
+
+
+def _authenticated_gateway_error(message: str) -> str:
+    return json.dumps({
+        "error": message,
+        "error_type": "authenticated_gateway_required",
+    })
 
 
 def _is_registry_register_call(node: ast.AST) -> bool:
@@ -91,11 +129,13 @@ class ToolEntry:
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
         "max_result_size_chars", "dynamic_schema_overrides",
+        "requires_authenticated_gateway",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 requires_authenticated_gateway=False):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -114,6 +154,7 @@ class ToolEntry:
         # on every get_definitions() call; results are merged shallow on top
         # of the base schema before the {"type": "function", ...} wrap.
         self.dynamic_schema_overrides = dynamic_schema_overrides
+        self.requires_authenticated_gateway = requires_authenticated_gateway
 
 
 # ---------------------------------------------------------------------------
@@ -276,6 +317,44 @@ class ToolRegistry:
         with self._lock:
             return self._tools.get(name)
 
+    def authenticated_gateway_dispatch_error(
+        self,
+        name: str,
+        args: dict,
+        context: object,
+        *,
+        tool_call_id: Optional[str] = None,
+        allow_admitted_claim: bool = True,
+    ) -> Optional[str]:
+        """Return a fail-closed error for a denied protected tool call."""
+        entry = self.get_entry(name)
+        if not entry or not entry.requires_authenticated_gateway:
+            return None
+        if _args_contain_authenticated_gateway_field(args):
+            return _authenticated_gateway_error(
+                "Model arguments may not contain gateway provenance fields"
+            )
+        from gateway.authenticated_dispatch import (
+            current_authenticated_gateway_tool_claim_authorizes,
+            validate_authenticated_gateway_tool_dispatch,
+        )
+
+        if not (
+            (
+                allow_admitted_claim
+                and current_authenticated_gateway_tool_claim_authorizes(
+                    context,
+                    name,
+                    tool_call_id=tool_call_id,
+                )
+            )
+            or validate_authenticated_gateway_tool_dispatch(context)
+        ):
+            return _authenticated_gateway_error(
+                "Authenticated gateway tool dispatch required"
+            )
+        return None
+
     def get_registered_toolset_names(self) -> List[str]:
         """Return sorted unique toolset names present in the registry."""
         return sorted({entry.toolset for entry in self._snapshot_entries()})
@@ -376,6 +455,7 @@ class ToolRegistry:
         max_result_size_chars: int | float | None = None,
         dynamic_schema_overrides: Callable = None,
         override: bool = False,
+        requires_authenticated_gateway: bool = False,
     ):
         """Register a tool.  Called at module-import time by each tool file.
 
@@ -385,6 +465,15 @@ class ToolRegistry:
         registrations that would shadow an existing tool from a different
         toolset are rejected to prevent accidental overwrites.
         """
+        if type(requires_authenticated_gateway) is not bool:
+            raise TypeError("requires_authenticated_gateway must be a built-in bool")
+        if (
+            requires_authenticated_gateway
+            and _schema_contains_authenticated_gateway_field(schema)
+        ):
+            raise ValueError(
+                "Authenticated gateway provenance fields must not be model-visible"
+            )
         with self._lock:
             existing = self._tools.get(name)
             if existing and existing.toolset != toolset:
@@ -445,6 +534,7 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                requires_authenticated_gateway=requires_authenticated_gateway,
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by
@@ -573,6 +663,16 @@ class ToolRegistry:
                         "using static schema",
                         name, exc,
                     )
+            if (
+                entry.requires_authenticated_gateway
+                and _schema_contains_authenticated_gateway_field(schema_with_name)
+            ):
+                logger.error(
+                    "Protected tool %s dynamic schema contains reserved gateway fields; "
+                    "omitting it from the model surface",
+                    name,
+                )
+                continue
             result.append({"type": "function", "function": schema_with_name})
         return result
 
@@ -623,25 +723,72 @@ class ToolRegistry:
         entry = self.get_entry(name)
         if not entry:
             return json.dumps({"error": f"Unknown tool: {name}"})
-        try:
-            if entry.is_async:
-                from model_tools import _run_async
-                result = _run_async(entry.handler(args, **kwargs))
+
+        # The authenticated capability is always host transport.  Legacy
+        # ``tool_context`` kwargs remain part of the ordinary dispatch API, but
+        # protected tools must receive only the host-issued context below.
+        authenticated_context = kwargs.pop("authenticated_gateway_context", None)
+        authenticated_tool_call_id = kwargs.pop(
+            "authenticated_gateway_tool_call_id", None
+        )
+        lease_use = nullcontext(True)
+        if entry.requires_authenticated_gateway:
+            kwargs.pop("tool_context", None)
+            if _args_contain_authenticated_gateway_field(args):
+                return _authenticated_gateway_error(
+                    "Model arguments may not contain gateway provenance fields"
+                )
+            from gateway.authenticated_dispatch import (
+                current_authenticated_gateway_tool_claim_authorizes,
+                current_authenticated_gateway_tool_claim_is_bound,
+                use_authenticated_gateway_tool_dispatch,
+            )
+
+            if current_authenticated_gateway_tool_claim_authorizes(
+                authenticated_context,
+                name,
+                tool_call_id=authenticated_tool_call_id,
+                consume=True,
+            ):
+                lease_use = nullcontext(True)
+            elif current_authenticated_gateway_tool_claim_is_bound():
+                # A bound claim is invocation-specific. Mismatch or reuse must
+                # fail closed rather than minting replacement authority from the
+                # still-live turn lease.
+                lease_use = nullcontext(False)
             else:
-                result = entry.handler(args, **kwargs)
-            return self._normalize_handler_result(name, result)
-        except Exception as e:
-            logger.exception("Tool %s dispatch error: %s", name, e)
-            # Route through the sanitizer so framing tokens / CDATA / fences
-            # in exception strings don't reach the model as structural noise.
-            # See model_tools._sanitize_tool_error for rationale.
-            raw = f"Tool execution failed: {type(e).__name__}: {e}"
+                lease_use = use_authenticated_gateway_tool_dispatch(
+                    authenticated_context,
+                    name,
+                    tool_call_id=authenticated_tool_call_id,
+                )
+
+        with lease_use as authorized:
+            if entry.requires_authenticated_gateway:
+                if not authorized:
+                    return _authenticated_gateway_error(
+                        "Authenticated gateway tool dispatch required"
+                    )
+                kwargs["tool_context"] = authenticated_context
             try:
-                from model_tools import _sanitize_tool_error
-                sanitized = _sanitize_tool_error(raw)
-            except Exception:
-                sanitized = raw  # defensive: never let the sanitizer block error propagation
-            return json.dumps({"error": sanitized})
+                if entry.is_async:
+                    from model_tools import _run_async
+                    result = _run_async(entry.handler(args, **kwargs))
+                else:
+                    result = entry.handler(args, **kwargs)
+                return self._normalize_handler_result(name, result)
+            except Exception as e:
+                logger.exception("Tool %s dispatch error: %s", name, e)
+                # Route through the sanitizer so framing tokens / CDATA / fences
+                # in exception strings don't reach the model as structural noise.
+                # See model_tools._sanitize_tool_error for rationale.
+                raw = f"Tool execution failed: {type(e).__name__}: {e}"
+                try:
+                    from model_tools import _sanitize_tool_error
+                    sanitized = _sanitize_tool_error(raw)
+                except Exception:
+                    sanitized = raw  # defensive: never let the sanitizer block error propagation
+                return json.dumps({"error": sanitized})
 
     # ------------------------------------------------------------------
     # Query helpers  (replace redundant dicts in model_tools.py)
@@ -656,6 +803,47 @@ class ToolRegistry:
             return default
         from tools.budget_config import DEFAULT_RESULT_SIZE_CHARS
         return DEFAULT_RESULT_SIZE_CHARS
+
+    def filter_authenticated_gateway_tool_definitions(
+        self,
+        definitions: Optional[List[dict]],
+        authenticated_gateway_context: object = None,
+    ) -> List[dict]:
+        """Return the per-request model surface allowed by a live tool lease.
+
+        The registry snapshot and the caller's cached definition list remain
+        untouched. Command leases are deliberately ineligible.
+        """
+        definitions = list(definitions or [])
+        try:
+            from gateway.authenticated_dispatch import (
+                validate_authenticated_gateway_tool_dispatch,
+            )
+
+            if validate_authenticated_gateway_tool_dispatch(
+                authenticated_gateway_context
+            ):
+                return definitions
+        except Exception:
+            pass
+
+        protected_names = {
+            entry.name
+            for entry in self._snapshot_entries()
+            if entry.requires_authenticated_gateway
+        }
+        if not protected_names:
+            return definitions
+
+        filtered = []
+        for definition in definitions:
+            function = definition.get("function") if isinstance(definition, dict) else None
+            name = function.get("name") if isinstance(function, dict) else None
+            if name is None and isinstance(definition, dict):
+                name = definition.get("name")
+            if name not in protected_names:
+                filtered.append(definition)
+        return filtered
 
     def get_all_tool_names(self) -> List[str]:
         """Return sorted list of all registered tool names."""

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -298,6 +298,72 @@ def register(ctx):
 
 The dispatched tool goes through the normal approval, redaction, and budget pipelines — it's a real tool invocation, not a shortcut around them.
 
+### Require authenticated gateway dispatch for consequential surfaces
+
+Plugins that expose consequential actions can ask the host to admit them only
+from an independently authenticated gateway message. Check the exact capability
+version before registering the surface, then set
+`requires_authenticated_gateway=True`:
+
+```python
+SUPPORTED_AUTH_DISPATCH = 1
+
+
+def register(ctx):
+    tool_capability = ctx.authenticated_gateway_tool_dispatch_version
+    if type(tool_capability) is not int or tool_capability != SUPPORTED_AUTH_DISPATCH:
+        raise RuntimeError("Unsupported authenticated tool dispatch contract")
+    command_capability = ctx.authenticated_gateway_dispatch_version
+    if type(command_capability) is not int or command_capability != SUPPORTED_AUTH_DISPATCH:
+        raise RuntimeError("Unsupported authenticated command dispatch contract")
+
+    def protected_tool(args, *, tool_context):
+        # Frozen, host-issued fields; never accept these values from args.
+        actor = tool_context.user_id
+        message_id = tool_context.message_id
+        return json.dumps({"actor": actor, "message_id": message_id})
+
+    def protected_command(raw_args, *, command_context):
+        actor = command_context.user_id
+        return f"Accepted authenticated request from {actor}"
+
+    ctx.register_tool(
+        name="protected_action",
+        toolset="my-plugin",
+        schema=PROTECTED_ACTION_SCHEMA,
+        handler=protected_tool,
+        requires_authenticated_gateway=True,
+    )
+    ctx.register_command(
+        "protected-action",
+        protected_command,
+        requires_authenticated_gateway=True,
+    )
+```
+
+The host enforces these rules before handler entry:
+
+- Only the exact built-in integer capability version is supported. Treat an
+  absent, boolean, or different value as unsupported.
+- `tool_context` and `authenticated_gateway_context` are reserved host
+  provenance names and must not appear anywhere in a protected tool's model
+  schema or model-supplied arguments.
+- Protected tool handlers receive the live lease as keyword-only
+  `tool_context`; protected slash-command handlers receive `command_context`.
+- Tool and command contexts are not interchangeable. They are valid only for
+  the admitted request and are revoked when that dispatch completes.
+- CLI, TUI, internal/synthetic, direct registry, and plugin-initiated
+  `ctx.dispatch_tool()` calls do not gain authenticated gateway authority and
+  are denied for protected surfaces.
+- The host authentication decision is only the admission boundary. The plugin
+  must still apply its own domain policy, actor allowlist, approval,
+  idempotency, and audit rules before a consequential write.
+
+Ordinary tools remain backward compatible: `ctx.dispatch_tool(...,
+tool_context=value)` forwards that legacy keyword unchanged. For a protected
+tool, the registry discards any caller-supplied legacy value and uses only its
+live host-issued context.
+
 ## Step 6: Test it
 
 Start Hermes:


### PR DESCRIPTION
## Summary

Add a host-owned authenticated gateway dispatch contract for plugin commands and model tools that perform sensitive gateway-originated actions.

Plugins can mark individual slash commands or registry tools as requiring authenticated gateway provenance. Hermes then issues a short-lived, immutable authority object only for an authenticated external gateway message, validates it before extension observers or handler entry, and revokes it at the end of the applicable command or agent-turn scope.

## Concrete use case

Hermes plugins may expose actions that are safe only when invoked by an authenticated user through a messaging gateway—for example, an approval command or a model-selected tool that mutates an external service. Existing plugin hooks can expose the action, but they do not provide a host-verifiable guarantee that a particular invocation came from the authenticated inbound message currently driving the turn.

This change supplies that missing generic boundary without adding a new core model tool or a product-specific integration.

## Security contract

- Host-issued authority objects are immutable, non-copyable, non-serializable, identity-validated, and valid only inside their live scope.
- Command and tool capabilities are distinct and cannot authorize each other.
- Protected command authorization occurs before command hooks and handler entry.
- Protected tool authorization occurs before request middleware, plugin hooks, guardrails, approvals, and handler entry.
- Model tool calls receive call-specific claims bound to the exact tool name and tool-call ID and consumable only once.
- Atomic admission prevents new protected calls after revocation.
- Revocation is non-blocking: previously admitted calls may finish, while no new call may enter.
- Steer, redirect, interrupt, stop/new-session, and shutdown paths revoke authority before accepted causal prompt mutation.
- Inbound security provenance is separate from outbound reply/thread anchoring.
- Internal, synthetic, unsupported-agent, incomplete-identity, stale, forged, and mismatched requests fail closed.
- Native Hermes agents negotiate the exact capability version; Codex app-server and legacy/third-party agents receive no in-process authority.

## Compatibility and footprint

- Unprotected commands and tools retain their existing behavior.
- Unsupported agent implementations keep their previous call signatures.
- Protected tool definitions are omitted from model input when the current runtime is ineligible to execute them, preserving prompt-cache and schema footprint expectations.
- Ordinary tool schemas may continue using domain fields such as `message_id`, `user_id`, `chat_id`, and `platform`; these cannot forge the host-owned authority object.
- The implementation is generic and has no dependency on a downstream product or private integration.

## Change structure

1. Host authority, registry enforcement, agent propagation, and sequential/concurrent executor claims.
2. Gateway command authorization, message provenance, queue/turn integration, and deterministic regressions.
3. Security and plugin developer documentation.

## Validation

Post-commit validation on the pushed snapshot:

- `277 passed` — authenticated dispatch, model tools, registry, gateway command/queue/provenance, and related regressions
- `600 passed` — run-agent, steering, and plugin suites
- Ruff: passed
- Python compilation: passed
- `git diff --check`: passed
- Documentation build: passed with pre-existing warnings only

Independent fail-closed reviews initially identified and blocked races, observer ordering, provenance conflation, claim-reuse fallback, and shutdown/cleanup defects. Each was reproduced with a regression test, fixed, and re-reviewed. The final targeted and consolidated reviews passed.

## Documentation

- `docs/security/authenticated-gateway-dispatch.md`
- `website/docs/developer-guide/plugins/index.md`
