### PR TITLE
feat(cli): let profiles disable side-effecting 'hermes send' (security.cli_send_enabled)

### DIFF
--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -94,6 +94,25 @@ def _resolve_target(arg_to: Optional[str]) -> Optional[str]:
     return None
 
 
+def _cli_send_allowed() -> tuple[bool, str]:
+    """Return whether the active profile permits side-effecting CLI sends.
+
+    ``hermes send --list`` remains read-only and bypasses this check.  The
+    setting is opt-out for backwards compatibility; worker profiles that must
+    never contact users set ``security.cli_send_enabled: false``.
+    """
+    try:
+        from .config import load_config_readonly
+
+        config = load_config_readonly()
+    except Exception:
+        return True, "security policy unavailable; legacy default enabled"
+    security = config.get("security") if isinstance(config, dict) else None
+    if isinstance(security, dict) and security.get("cli_send_enabled") is False:
+        return False, "security.cli_send_enabled=false"
+    return True, "security.cli_send_enabled not disabled"
+
+
 def _emit_result(
     result_json: str,
     *,
@@ -310,6 +329,15 @@ def cmd_send(args: argparse.Namespace) -> None:
         platform_filter = getattr(args, "message", None)
         exit_code = _list_targets(platform_filter, json_mode=getattr(args, "json", False))
         sys.exit(exit_code)
+
+    allowed, policy_reason = _cli_send_allowed()
+    if not allowed:
+        print(
+            "hermes send: disabled by profile security policy "
+            f"({policy_reason}); no delivery attempted.",
+            file=sys.stderr,
+        )
+        sys.exit(_FAILURE_EXIT)
 
     target = _resolve_target(getattr(args, "to", None))
     if not target:

--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -141,6 +141,21 @@ def test_quiet_suppresses_stdout(fake_tool, capsys):
 # ---------------------------------------------------------------------------
 
 
+def test_profile_security_can_disable_cli_send(fake_tool, capsys, monkeypatch):
+    monkeypatch.setattr(
+        send_cmd,
+        "_cli_send_allowed",
+        lambda: (False, "security.cli_send_enabled=false"),
+    )
+    args = _parse(["--to", "telegram:8300219302", "must not send"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 1
+    assert fake_tool.calls == []
+    err = capsys.readouterr().err
+    assert "disabled by profile security policy" in err
+
+
 def test_missing_target(fake_tool, capsys, monkeypatch):
     # Ensure stdin is a tty so the CLI does not try to consume it as a body.
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)


### PR DESCRIPTION
## Problem
`hermes send` can deliver messages to any connected platform from the CLI. Automation/worker profiles that must never contact users had no way to disable this at the profile level — any code path (or prompt-injected instruction) reaching the CLI could send.

## Fix
New opt-out setting `security.cli_send_enabled: false` makes `hermes send` refuse delivery at the CLI layer with a clear stderr message. `hermes send --list` stays read-only and always allowed. Default unchanged (enabled) for backwards compatibility.

## Testing
`tests/hermes_cli/test_send_cmd.py` extended; suite passes on this branch.

https://claude.ai/code/session_013ExjAw69PUYMGBfLUhgwnX
