### PR TITLE
fix(approval): stop treating kanban workers as cron sessions

### DIFF
--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -7,6 +7,7 @@ from tools.approval import (
     _get_cron_approval_mode,
     check_all_command_guards,
     check_dangerous_command,
+    check_execute_code_guard,
     detect_dangerous_command,
 )
 
@@ -358,6 +359,26 @@ class TestCronModeInteractions:
 
         result = check_dangerous_command("rm -rf /tmp/stuff", "local")
         assert result["approved"]
+
+    def test_inherited_cron_marker_does_not_make_kanban_worker_cron(self, monkeypatch):
+        """Kanban workers ignore leaked HERMES_CRON_SESSION from the gateway.
+
+        The gateway hosts both cron and kanban. A process-global cron marker can
+        be inherited by a dispatcher-spawned worker, but HERMES_KANBAN_TASK is a
+        stronger signal that this process has a live task owner rather than a
+        detached cron approval surface.
+        """
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        from unittest.mock import patch as mock_patch
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+            assert check_dangerous_command("rm -rf /tmp/stuff", "local")["approved"]
+            assert check_execute_code_guard("print('ok')", "local")["approved"]
 
 
 class TestCronWithGatewayOrigin:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -224,6 +224,22 @@ def _get_session_platform() -> str:
         return os.getenv("HERMES_SESSION_PLATFORM", "") or ""
 
 
+def _is_cron_session_context() -> bool:
+    """True only for a real cron agent run, not an inherited env leak.
+
+    The gateway process hosts both cron and the embedded Kanban dispatcher.
+    ``cron.scheduler`` marks cron runs with process-global HERMES_CRON_SESSION
+    so approval guards can apply ``approvals.cron_mode``. A worker subprocess
+    spawned later from the same process may inherit that flag even though
+    HERMES_KANBAN_TASK identifies it as a Kanban worker; treating that worker as
+    cron blocks tools like execute_code with a misleading cron-only message.
+    Kanban's task marker is therefore an explicit non-cron boundary here.
+    """
+    return env_var_enabled("HERMES_CRON_SESSION") and not bool(
+        (os.getenv("HERMES_KANBAN_TASK") or "").strip()
+    )
+
+
 def _is_gateway_approval_context() -> bool:
     """True when this call is inside a gateway/API session.
 
@@ -238,7 +254,7 @@ def _is_gateway_approval_context() -> bool:
     fall through to the gateway branch would submit a pending approval
     with no listener and block the job indefinitely.
     """
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_session_context():
         return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
@@ -2714,7 +2730,7 @@ def _run_approval_gate(
 
     if not is_cli and not is_gateway:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_session_context():
             if _get_cron_approval_mode() == "deny":
                 return {
                     "approved": False,
@@ -3242,7 +3258,7 @@ def check_all_command_guards(command: str, env_type: str,
     # flows, we do not block on approvals and we skip external guard work.
     if not is_cli and not is_gateway and not is_ask:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_session_context():
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
@@ -3678,7 +3694,7 @@ def check_execute_code_guard(code: str, env_type: str,
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 
     # Cron: no user is present to approve arbitrary code.
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_session_context():
         if _get_cron_approval_mode() == "deny":
             return {
                 "approved": False,


### PR DESCRIPTION
## Problem
The gateway process hosts both the cron scheduler and the embedded kanban dispatcher. cron marks its runs with the process-global `HERMES_CRON_SESSION` env var — and dispatcher-spawned kanban worker subprocesses inherit it. Those workers were then classified as cron sessions: subjected to `approvals.cron_mode`, and e.g. blocked from `execute_code` with a misleading cron-only message.

## Fix
`HERMES_KANBAN_TASK` identifies a process with a live task owner, so treat it as an explicit non-cron boundary: new `_is_cron_session_context()` helper used by the approval context checks instead of raw `HERMES_CRON_SESSION` sniffing.

## Testing
Regression test added in `tests/tools/test_cron_approval_mode.py` (inherited cron marker + kanban task marker → not cron). Suite passes on this branch.

https://claude.ai/code/session_013ExjAw69PUYMGBfLUhgwnX
