### PR TITLE
fix(agent): keep the compaction summary when the turn-end override rewrites the user row

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1762,8 +1762,23 @@ class AIAgent:
                 # blocks. A list override, however, is the original clean
                 # multimodal payload (for example before a queued /model note)
                 # and must replace the API-local list once the turn is final.
-                if override is not None and (
-                    not isinstance(msg.get("content"), list) or isinstance(override, list)
+                # Preflight compaction can re-anchor this index at a message
+                # whose content was MERGED with the compaction summary
+                # (merge-summary-into-tail).  That is not an accident:
+                # ``reanchor_current_turn_user_idx`` falls back to the last
+                # user row precisely BECAUSE the merge rewrote the content and
+                # the exact-match lookup misses.  Overwriting it with the clean
+                # text would drop the summary from the continuation history the
+                # next turn is built from — the same hazard the DB-write twin
+                # below already refuses (see the sibling guard in
+                # ``_flush_messages_to_session_db_unlocked``).
+                if (
+                    override is not None
+                    and not msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                    and (
+                        not isinstance(msg.get("content"), list)
+                        or isinstance(override, list)
+                    )
                 ):
                     msg["content"] = override
                 if timestamp is not None:

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -776,6 +776,67 @@ class TestFlushCompressedSummaryOverrideGuard:
         finally:
             db.close()
 
+    def test_live_override_skipped_for_compression_merged_row(self, tmp_path):
+        """Same invariant as the test above, for the in-memory path.
+
+        ``finalize_turn`` calls ``_apply_persist_user_message_override`` and
+        only then ``_persist_session``, so the live dict is rewritten BEFORE
+        the DB-write guard above ever sees it. A compaction-merged row must
+        survive: the summary is the whole pre-compaction history, and this
+        list is the continuation history the next turn is built from.
+        """
+        from agent.context_compressor import COMPRESSED_SUMMARY_METADATA_KEY
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        sid = "sess-merged-live"
+        db.create_session(session_id=sid, source="cli")
+        try:
+            agent = self._make_agent(db, sid)
+            merged = "[prior context]\ncompaction summary\n\nactual question"
+            messages = [
+                {
+                    "role": "user",
+                    "content": merged,
+                    COMPRESSED_SUMMARY_METADATA_KEY: True,
+                }
+            ]
+            agent._persist_user_message_idx = 0
+            agent._persist_user_message_override = "actual question"
+            agent._persist_user_message_timestamp = 1730000000
+
+            agent._apply_persist_user_message_override(messages)
+
+            assert messages[0]["content"] == merged, (
+                "the compaction summary was erased from the continuation history"
+            )
+            # The paired timestamp override is unrelated and still applies.
+            assert messages[0]["timestamp"] == 1730000000
+        finally:
+            db.close()
+
+    def test_live_override_still_applies_without_merge_marker(self, tmp_path):
+        """Negative control: an ordinary turn is still cleaned in place."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        sid = "sess-plain-live"
+        db.create_session(session_id=sid, source="cli")
+        try:
+            agent = self._make_agent(db, sid)
+            messages = [
+                {
+                    "role": "user",
+                    "content": "[gateway note] observed\n\nactual question",
+                }
+            ]
+            agent._persist_user_message_idx = 0
+            agent._persist_user_message_override = "actual question"
+            agent._persist_user_message_timestamp = None
+
+            agent._apply_persist_user_message_override(messages)
+
+            assert messages[0]["content"] == "actual question"
+        finally:
+            db.close()
+
 
 class TestFlushSanitizeDivergenceCapture:
     def _make_agent(self, db, sid):


### PR DESCRIPTION
## Summary

`_apply_persist_user_message_override` replaces the anchored user message's
content with the clean transcript text. Its DB-write twin already refuses to do
that for a compaction-merged row — the live path does not, and `finalize_turn`
runs the live path **first**.

On the turn a compaction fires, the `[MERGED PRIOR CONTEXT]` summary — the
entire pre-compaction conversation — is deleted from the history the session
continues from. Silently, with no error.

## Problem

Two mechanisms, each correct on its own.

**1. Compression merges the summary into the current turn's user row.**
`_merge_summary_into_tail` rewrites that row's `content` and stamps it:

```python
msg[COMPRESSED_SUMMARY_METADATA_KEY] = True
drop_stale_api_content(msg)
```

**2. The turn-end override replaces that row's content with the clean text.**
`agent/turn_finalizer.py`:

```python
_apply_override = getattr(agent, "_apply_persist_user_message_override", None)
if callable(_apply_override):
    _apply_override(messages)
agent._persist_session(messages, conversation_history)
```

The DB-write twin in `run_agent.py` refuses this, and its comment describes the
hazard exactly:

```python
# Preflight compaction can re-anchor the override index at a message
# whose content was MERGED with the compaction summary
# (merge-summary-into-tail). Overwriting that with the clean gateway text
# would silently drop the summary from the durable transcript.
if (
    _ov_content is not None
    and (not isinstance(content, list) or isinstance(_ov_content, list))
    and not msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
):
```

`_apply_persist_user_message_override` has the same condition **without** the
`COMPRESSED_SUMMARY_METADATA_KEY` clause. Because the finalizer mutates the
dict before `_persist_session`, the DB-side guard is looking at content that is
already gone — and the same mutated list is returned as the continuation
history.

### The anchor lands on the merged row by design

`reanchor_current_turn_user_idx` prefers the last user row whose content
matches this turn's text, and its docstring says:

> Fall back to the last user message when no exact match survives
> (merge-summary-into-tail rewrites the content but the trackers still need a
> live anchor).

After a merge the exact match *cannot* survive — the merge rewrote the content
— so the fallback selects precisely the merged row. The same docstring names
the `#48677` persist override two lines earlier.

### Measured against the shipped function

Running the real `_apply_persist_user_message_override` on a merged row
(`{"role": "user", "content": "[prior context]\ncompaction summary\n\nactual question", "_compressed_summary": True}`)
with the override `"actual question"`:

| | resulting content | summary survives |
|---|---|---|
| `main` | `'actual question'` | **no** |
| patched | `'[prior context]\ncompaction summary\n\nactual question'` | yes |

### Why this is not cosmetic

The summary *is* the pre-compaction history. Once it is dropped from the
continuation list, the next request carries a bare user message where the whole
earlier conversation used to be, and the archived turns have already been
rotated away. The durable child row still holds the summary, so the live
session and a later `/resume` now replay different bytes for the same row — a
permanent prefix-cache miss on top of a transcript that disagrees with itself.

It fires on the ordinary path: every gateway and ACP turn sets the override
unconditionally, and compaction fires in every long session, repeatedly.

## Fix

Add the twin's guard to the live mutation. The paired timestamp override is
unrelated and still applies.

## Scope

- `run_agent.py` — one condition in `_apply_persist_user_message_override`.
- `tests/agent/test_api_content_sidecar.py` — 2 regression tests.

## Testing

`TestFlushCompressedSummaryOverrideGuard` already asserts this invariant for
the DB write (`test_override_skipped_for_compression_merged_row`, whose
docstring reads "must not replace a compression-merged user message: that would
silently drop the compaction summary"). The new tests assert the same invariant
for the in-memory path that runs first:

- `test_live_override_skipped_for_compression_merged_row` — the merged content
  survives `_apply_persist_user_message_override`, and the timestamp override
  still lands.
- `test_live_override_still_applies_without_merge_marker` — negative control:
  an ordinary turn is still cleaned in place.

The first fails on `main` (`the compaction summary was erased from the
continuation history`) and passes with the fix; the second passes on both.

## Note — related, not fixed here

The todo-snapshot merge in `agent/conversation_compression.py` writes
`_tail["content"] = _append_text_to_content(_stripped, _snapshot_text)` without
stamping any marker, so `[Your active task list was preserved across context
compression]` is dropped by **both** override sites. Closing that needs a new
marker at the merge site rather than a guard here — happy to fold it in if
you'd prefer one PR.
