### PR TITLE
fix(openviking): register sessions before the first messages POST — memory silently never extracted on official OpenViking >=0.3

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -2207,6 +2207,15 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._deferred_commit_lock = threading.Lock()
         self._committed_session_ids: Set[str] = set()
         self._committed_session_lock = threading.Lock()
+        # One registration POST per sid even with overlapping writers:
+        # _spawn_writer allows several concurrent writers for one sid, so
+        # the registered-set check and the register POST must be
+        # single-flight. The state lock guards the set and the per-sid lock
+        # table; the per-sid lock spans the POST itself, so first turns of
+        # DIFFERENT sids never serialize each other. See the #72146 review.
+        self._registered_session_ids: Set[str] = set()
+        self._session_registration_locks: Dict[str, threading.Lock] = {}
+        self._session_registration_state_lock = threading.Lock()
         self._pending_marked_sids: Set[str] = set()
         # Connection settings and _client are one published state. Serialize
         # refreshes so callers never observe a new config with the old client.
@@ -3098,6 +3107,42 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 assistant_message,
             ]
         }
+
+    # Official OpenViking (>=0.3.x) no longer auto-creates a session on the
+    # first messages/batch POST: an unregistered sid answers 404, every turn
+    # degrades to the fallback (which 404s the same way), and the final
+    # session commit fails with "Session not found" — so memory extraction
+    # silently never runs. Register the sid once per provider lifetime; an
+    # ALREADY_EXISTS answer (racing writer / prior run) counts as registered.
+    def _ensure_ov_session(self, client: "_VikingClient", sid: str) -> None:
+        if not sid:
+            return
+        # Single-flight per sid: the naive check/post/add lets two
+        # overlapping first writers both pass the check and both POST.
+        with self._session_registration_state_lock:
+            if sid in self._registered_session_ids:
+                return
+            lock = self._session_registration_locks.setdefault(
+                sid, threading.Lock()
+            )
+        with lock:
+            with self._session_registration_state_lock:
+                if sid in self._registered_session_ids:
+                    return
+            try:
+                client.post("/api/v1/sessions", {"session_id": sid})
+            except Exception as exc:
+                msg = str(exc).upper()
+                if not ("EXIST" in msg or "ALREADY" in msg or "DUPLICATE" in msg):
+                    logger.warning(
+                        "OpenViking session register failed for %s: %s", sid, exc
+                    )
+                    return
+            with self._session_registration_state_lock:
+                self._registered_session_ids.add(sid)
+                # A loser blocked on `lock` re-checks the set and returns;
+                # dropping the table entry just keeps it from growing.
+                self._session_registration_locks.pop(sid, None)
 
     def _post_session_turn(
         self,
@@ -4523,6 +4568,10 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
             def _post_turn(client: _VikingClient) -> None:
                 nonlocal next_batch_index
+                # Register the sid before any message POST (see
+                # _ensure_ov_session) — covers the batch path and the
+                # per-message fallback alike.
+                self._ensure_ov_session(client, sid)
                 if batch_messages:
                     while next_batch_index < len(batch_messages):
                         batch_end = min(

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -991,14 +991,21 @@ def test_sync_turn_captures_session_id_before_worker_runs():
     finally:
         _mod._VikingClient = real_client_cls
 
-    # The whole turn must target the OLD session id as a single ordered batch.
-    assert captured_paths == ["/api/v1/sessions/old-sid/messages/batch"]
-    assert captured_payloads == [{
-        "messages": [
-            {"role": "user", "parts": [{"type": "text", "text": "u"}]},
-            {"role": "assistant", "parts": [{"type": "text", "text": "a"}], "peer_id": "hermes"},
-        ]
-    }]
+    # The whole turn must target the OLD session id: session registration
+    # first (see _ensure_ov_session), then the single ordered batch.
+    assert captured_paths == [
+        "/api/v1/sessions",
+        "/api/v1/sessions/old-sid/messages/batch",
+    ]
+    assert captured_payloads == [
+        {"session_id": "old-sid"},
+        {
+            "messages": [
+                {"role": "user", "parts": [{"type": "text", "text": "u"}]},
+                {"role": "assistant", "parts": [{"type": "text", "text": "a"}], "peer_id": "hermes"},
+            ]
+        },
+    ]
 
 
 def _long_structured_turn(assistant_count=204):
@@ -1609,3 +1616,124 @@ def test_is_available_false_without_any_endpoint(monkeypatch):
         openviking_module, "_load_hermes_openviking_config", lambda: {}
     )
     assert OpenVikingMemoryProvider().is_available() is False
+
+
+def _registration_provider(sid):
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._endpoint = "http://test"
+    provider._api_key = ""
+    provider._account = "acct"
+    provider._user = "usr"
+    provider._agent = "hermes"
+    provider._session_id = sid
+    return provider
+
+
+def test_sync_turn_registers_session_once_per_sid():
+    """The sid is registered with POST /api/v1/sessions before its first
+    batch and never re-registered on later turns."""
+    provider = _registration_provider("sid-reg")
+    captured = []
+
+    class StubClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def post(self, path, payload=None, **kwargs):
+            captured.append(path)
+            return {}
+
+    import plugins.memory.openviking as _mod
+    real_client_cls = _mod._VikingClient
+    _mod._VikingClient = StubClient
+    try:
+        provider.sync_turn("u1", "a1")
+        assert provider._drain_writers("sid-reg", timeout=2.0)
+        provider.sync_turn("u2", "a2")
+        assert provider._drain_writers("sid-reg", timeout=2.0)
+    finally:
+        _mod._VikingClient = real_client_cls
+
+    assert captured[0] == "/api/v1/sessions"
+    assert captured.count("/api/v1/sessions") == 1
+    assert captured.count("/api/v1/sessions/sid-reg/messages/batch") == 2
+
+
+def test_sync_turn_treats_already_exists_registration_as_registered():
+    """An ALREADY_EXISTS answer (racing writer / previous run) counts as
+    registered: the batch proceeds and the sid is not re-registered."""
+    provider = _registration_provider("sid-exists")
+    captured = []
+
+    class StubClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def post(self, path, payload=None, **kwargs):
+            captured.append(path)
+            if path == "/api/v1/sessions":
+                raise RuntimeError(
+                    "ALREADY_EXISTS: Session 'sid-exists' already exists"
+                )
+            return {}
+
+    import plugins.memory.openviking as _mod
+    real_client_cls = _mod._VikingClient
+    _mod._VikingClient = StubClient
+    try:
+        provider.sync_turn("u1", "a1")
+        assert provider._drain_writers("sid-exists", timeout=2.0)
+        provider.sync_turn("u2", "a2")
+        assert provider._drain_writers("sid-exists", timeout=2.0)
+    finally:
+        _mod._VikingClient = real_client_cls
+
+    assert captured.count("/api/v1/sessions") == 1
+    assert captured.count("/api/v1/sessions/sid-exists/messages/batch") == 2
+
+
+def test_overlapping_first_writers_register_session_once():
+    """Two writers for ONE sid in flight at the same time produce exactly one
+    POST /api/v1/sessions: registration is single-flight per sid (review
+    finding on #72146 — the unsynchronized check/post/add sequence let both
+    first turns register)."""
+    provider = _registration_provider("sid-race")
+    captured = []
+    cap_lock = threading.Lock()
+    reg_entered = threading.Event()
+    release_reg = threading.Event()
+
+    class StubClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def post(self, path, payload=None, **kwargs):
+            with cap_lock:
+                captured.append(path)
+            if path == "/api/v1/sessions":
+                reg_entered.set()
+                # Hold the first registration POST open: this is exactly the
+                # window in which an unsynchronized second writer would pass
+                # the registered-set check and POST again.
+                release_reg.wait(timeout=2.0)
+            return {}
+
+    import plugins.memory.openviking as _mod
+    real_client_cls = _mod._VikingClient
+    _mod._VikingClient = StubClient
+    try:
+        provider.sync_turn("u1", "a1")          # writer 1: enters registration
+        assert reg_entered.wait(timeout=2.0)
+        provider.sync_turn("u2", "a2")          # writer 2: spawned mid-POST
+        # Give writer 2 time to reach the registration seam while writer 1
+        # still holds the POST open.
+        time.sleep(0.3)
+        release_reg.set()
+        assert provider._drain_writers("sid-race", timeout=5.0)
+    finally:
+        _mod._VikingClient = real_client_cls
+
+    with cap_lock:
+        assert captured.count("/api/v1/sessions") == 1
+        assert captured.count("/api/v1/sessions/sid-race/messages/batch") == 2


### PR DESCRIPTION
Fixes #72130.

### Problem
Against official OpenViking (≥0.3.x) the memory provider silently never extracts long-term memories: sessions are never registered, so the first `POST /api/v1/sessions/{sid}/messages/batch` 404s, every turn degrades to the fallback (which 404s the same way), and the final `commit` dies with `Session not found`. Details and live verification in #72130.

### Fix
An idempotent `_ensure_ov_session` — `POST /api/v1/sessions {"session_id": sid}` before a sid's first message POST — called from `sync_turn`'s `_post_turn`, covering the batch path and the per-message fallback alike. `ALREADY_EXISTS` answers (racing writer / previous run) count as registered; registered sids are cached per provider instance.

### Tests
- Two new tests: registers once per sid across turns; `ALREADY_EXISTS` treated as registered (batch proceeds, no re-register).
- Existing sync_turn tests updated for the leading registration POST (stubs that captured/asserted every POST now account for it).
- `tests/plugins/memory/test_openviking_provider.py`: **175 passed**.

### Verified in production
Running on our self-hosted deployment since today against official `ghcr.io/volcengine/openviking` 0.3.x (trusted mode + root API key): structured syncs succeed, session commits go through, memory extraction runs.
