### PR TITLE
fix(kanban): avoid current venv shell shim

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10137,7 +10137,15 @@ def _module_hermes_argv() -> list[str]:
     # ``hermes_cli.main`` is the console-script target declared in
     # pyproject.toml, NOT a top-level ``hermes`` package — there is no
     # ``hermes`` package to import.
-    return [sys.executable, "-m", "hermes_cli.main"]
+    #
+    # ``-P`` (PYTHONSAFEPATH) keeps the worker's ``cwd=workspace`` (see
+    # ``_default_spawn``) out of ``sys.path[0]``. Without it, ``-m`` prepends
+    # the current directory to the module search path, so a task-controlled
+    # workspace file that collides with a real top-level module name (e.g.
+    # ``hermes_bootstrap.py``, imported first thing by ``hermes_cli.main``)
+    # would be imported instead of the installed one — arbitrary code
+    # execution at worker startup, before any task sandboxing applies.
+    return [sys.executable, "-P", "-m", "hermes_cli.main"]
 
 
 def _absolute_hermes_path(path: str) -> str:
@@ -10199,12 +10207,18 @@ def _hermes_path_argv(path: str) -> list[str]:
 
     Windows batch shims (`.cmd` / `.bat`) are not safe as argv[0] for
     worker launches because the argument vector includes task-derived
-    values. Prefer the interpreter-bound module form whenever the resolved
-    executable is only a shell shim.
+    values. The current interpreter's venv shim can also depend on commands
+    missing from a service's PATH. Prefer the interpreter-bound module form
+    for either shim.
     """
-    if _IS_WINDOWS and _is_windows_batch_shim(path):
+    resolved = _absolute_hermes_path(path)
+    current_bin = os.path.dirname(os.path.abspath(sys.executable))
+    if (_IS_WINDOWS and _is_windows_batch_shim(resolved)) or (
+        os.path.basename(resolved) == "hermes"
+        and os.path.dirname(resolved) == current_bin
+    ):
         return _module_hermes_argv()
-    return [_absolute_hermes_path(path)]
+    return [resolved]
 
 
 def _resolve_hermes_argv() -> list[str]:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -31,12 +31,12 @@ def kanban_home(tmp_path, monkeypatch):
 
 def _init_git_repo(repo: Path) -> None:
     repo.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True, text=True)
-    subprocess.run(["git", "-C", str(repo), "config", "user.email", "kanban@example.com"], check=True, capture_output=True, text=True)
-    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Kanban Test"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "kanban@example.com"], check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Kanban Test"], check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
     (repo / "README.md").write_text("hello\n", encoding="utf-8")
-    subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True, capture_output=True, text=True)
-    subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
 
 
 # ---------------------------------------------------------------------------
@@ -1157,7 +1157,52 @@ def test_resolve_hermes_argv_falls_back_to_module_form_when_no_path_shim(monkeyp
     monkeypatch.delenv("HERMES_BIN", raising=False)
     monkeypatch.setattr(shutil, "which", lambda name: None)
     argv = kb._resolve_hermes_argv()
-    assert argv == [sys.executable, "-m", "hermes_cli.main"]
+    assert argv == [sys.executable, "-P", "-m", "hermes_cli.main"]
+
+
+def test_resolve_hermes_argv_avoids_current_venv_shell_shim(monkeypatch, tmp_path):
+    """The current venv shim must not make worker startup depend on PATH."""
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    python = bin_dir / "python3"
+    python.touch()
+    shim = bin_dir / "hermes"
+    shim.write_text("#!/bin/sh\nrealpath -- $0\n", encoding="utf-8")
+    monkeypatch.setattr(sys, "executable", str(python))
+    monkeypatch.setenv("HERMES_BIN", str(shim))
+
+    assert kb._resolve_hermes_argv() == [str(python), "-P", "-m", "hermes_cli.main"]
+
+
+@pytest.mark.parametrize("suffix", [".cmd", ".bat"])
+def test_resolve_hermes_argv_uses_module_form_for_windows_batch_shims(
+    monkeypatch, tmp_path, suffix,
+):
+    shim = tmp_path / f"hermes{suffix}"
+    shim.touch()
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    monkeypatch.setenv("HERMES_BIN", str(shim))
+
+    assert kb._resolve_hermes_argv() == [
+        sys.executable, "-P", "-m", "hermes_cli.main",
+    ]
+
+
+def test_resolve_hermes_argv_preserves_explicit_path_outside_current_bin(
+    monkeypatch, tmp_path,
+):
+    current_bin = tmp_path / "current" / "bin"
+    current_bin.mkdir(parents=True)
+    python = current_bin / "python3"
+    python.touch()
+    external_bin = tmp_path / "external" / "bin"
+    external_bin.mkdir(parents=True)
+    shim = external_bin / "hermes"
+    shim.touch()
+    monkeypatch.setattr(sys, "executable", str(python))
+    monkeypatch.setenv("HERMES_BIN", str(shim))
+
+    assert kb._resolve_hermes_argv() == [str(shim)]
 
 
 def test_resolve_hermes_argv_module_actually_runs():
@@ -1178,12 +1223,41 @@ def test_resolve_hermes_argv_module_actually_runs():
         os.environ.pop("HERMES_BIN", None)
         with mock.patch.object(shutil, "which", return_value=None):
             argv = kb._resolve_hermes_argv()
-    r = subprocess.run(argv + ["--version"], capture_output=True, text=True, timeout=30)
+    r = subprocess.run(
+        argv + ["--version"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+    )
     assert r.returncode == 0, (
         f"`{' '.join(argv)} --version` failed (rc={r.returncode}); "
         f"stderr={r.stderr[:200]!r}"
     )
     assert "Hermes Agent" in r.stdout, f"unexpected output: {r.stdout[:200]!r}"
+
+
+def test_module_hermes_argv_ignores_workspace_shadow_modules(tmp_path):
+    """Workers must not import task-workspace files as top-level modules."""
+    sentinel = tmp_path / "pwned.txt"
+    (tmp_path / "hermes_bootstrap.py").write_text(
+        f"open({str(sentinel)!r}, 'w').write('pwned')\n",
+        encoding="utf-8",
+    )
+
+    r = subprocess.run(
+        kb._module_hermes_argv() + ["--version"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+    )
+
+    assert r.returncode == 0, f"stderr={r.stderr[:200]!r}"
+    assert not sentinel.exists(), "workspace hermes_bootstrap.py was imported"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Kanban dispatchers can inherit `HERMES_BIN` pointing at the current virtual environment's `hermes` shell shim. If service startup later replaces `PATH` with a restricted value, that shim can fail before Python starts because utilities such as `realpath` and `dirname` are unavailable.

When the resolved executable is the `hermes` sibling of `sys.executable`, this change reuses the interpreter-bound `python -P -m hermes_cli.main` fallback. Explicit executable paths from other installations remain unchanged.

The `-P`/PYTHONSAFEPATH flag also keeps the task workspace used as the worker's current directory out of `sys.path[0]`. This prevents a workspace-controlled top-level module such as `hermes_bootstrap.py` from shadowing the installed Hermes module during worker startup.

## Related Issue

No related issue found; reproduced on macOS with a restricted service `PATH`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- Make `_hermes_path_argv()` select the interpreter-bound module invocation for the current interpreter's sibling `hermes` shim.
- Add `-P`/PYTHONSAFEPATH to `_module_hermes_argv()` so task workspaces cannot shadow installed top-level Hermes modules.
- Preserve PATH-resolved and explicit `HERMES_BIN` paths from other bin directories.
- Add regression coverage for restricted-PATH and workspace module-shadowing behavior.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -q`.
2. Set `HERMES_BIN` to a `hermes` shim beside `sys.executable` and use a `PATH` without `realpath` or `dirname`.
3. Confirm `_resolve_hermes_argv()` returns `[sys.executable, "-P", "-m", "hermes_cli.main"]` and `--version` exits successfully.
4. Launch the module fallback from a workspace containing `hermes_bootstrap.py` and confirm the workspace module is not imported.

## Verification

- [x] Current `main` port applied cleanly.
- [x] macOS focused suite: 34 passed, 1 Windows-only skip.
- [x] Linux/amd64 focused suite: 34 passed, 1 Windows-only skip.
- [ ] Full suites are red on current `main`: macOS 16 failures; Linux 16 failures. Linux exact-base reproduction retained 13 deterministic failures; the three candidate-only failures passed isolated rerun (116 tests; one Honcho test was flaky on first attempt).

No deterministic PR-introduced failure was observed.
