### PR TITLE
fix(update): say which commits a branch switch leaves behind

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7488,6 +7488,64 @@ def _update_via_zip(args):
         _kill_stale_dashboard_processes(restart_managed=True)
 
 
+_CARRIED_COMMIT_PREVIEW = 10
+
+
+def _warn_about_carried_commits(
+    git_cmd: list[str], cwd: Path, current_branch: str, target_branch: str
+) -> int:
+    """Warn when switching branches would leave committed work behind.
+
+    ``hermes update`` targets ``main`` by default and checks it out when the
+    install is on another branch. For a git install carrying local commits —
+    a fork branch, a patch series, a cherry-picked fix — the rebuilt install
+    then silently does NOT contain that work. Nothing is lost from git, but
+    the running install changes underneath the user with no indication, and
+    the omission usually surfaces much later as "the fix I made is gone".
+
+    This does not block the update: the switch is long-standing, intended
+    behaviour, and update paths run unattended. It just makes the omission
+    visible, and names the flag that preserves the work.
+
+    Returns the number of commits that would be left behind (0 when the
+    branch is already contained in the target, or when git can't tell).
+    """
+    if not current_branch or current_branch == "HEAD":
+        return 0
+
+    result = subprocess.run(
+        git_cmd + ["log", "--no-merges", "--oneline", f"{target_branch}..{current_branch}"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        # Target ref may not exist locally yet; nothing useful to say.
+        return 0
+
+    commits = [line for line in result.stdout.splitlines() if line.strip()]
+    if not commits:
+        return 0
+
+    plural = "commit" if len(commits) == 1 else "commits"
+    print(
+        f"  ⚠ '{current_branch}' has {len(commits)} {plural} not in "
+        f"'{target_branch}'. The updated install will NOT include them:"
+    )
+    for line in commits[:_CARRIED_COMMIT_PREVIEW]:
+        print(f"      {line}")
+    if len(commits) > _CARRIED_COMMIT_PREVIEW:
+        print(f"      … and {len(commits) - _CARRIED_COMMIT_PREVIEW} more")
+    print(
+        f"    They remain on '{current_branch}'. To update while keeping them, "
+        f"cancel and run: hermes update --branch {current_branch}"
+    )
+
+    return len(commits)
+
+
 def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
     status = subprocess.run(
         git_cmd + ["status", "--porcelain"],
@@ -11440,6 +11498,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 else f"branch '{current_branch}'"
             )
             print(f"  ⚠ Currently on {label} — switching to {branch} for update...")
+            _warn_about_carried_commits(git_cmd, PROJECT_ROOT, current_branch, branch)
             # Stash before checkout so uncommitted work isn't lost
             auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
             checkout_result = subprocess.run(

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -1162,3 +1162,88 @@ def test_update_autostash_survives_undeletable_untracked_dir(tmp_path):
         assert (pkg / "hermes-agent.rb").read_text() == "formula\n"
     finally:
         os.chmod(pkg, 0o755)
+
+
+# ----------------------------------------------------------------------
+# Warning when a branch switch would leave committed work behind.
+# ----------------------------------------------------------------------
+
+
+def _fake_git(stdout="", returncode=0):
+    """Capture the git argv and return a canned result."""
+    calls = []
+
+    def run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
+
+    return run, calls
+
+
+def test_warns_and_lists_commits_left_behind(monkeypatch, capsys):
+    from hermes_cli import main as hermes_main
+
+    log = "abc1234 fix(desktop): keep sessions alive\ndef5678 fix(desktop): restore embeds\n"
+    run, calls = _fake_git(stdout=log)
+    monkeypatch.setattr(hermes_main.subprocess, "run", run)
+
+    left = hermes_main._warn_about_carried_commits(
+        ["git"], Path("/repo"), "my-fork", "main"
+    )
+
+    assert left == 2
+    out = capsys.readouterr().out
+    assert "2 commits not in 'main'" in out
+    assert "will NOT include them" in out
+    assert "abc1234" in out and "def5678" in out
+    # Must name the escape hatch, with the branch pre-filled.
+    assert "hermes update --branch my-fork" in out
+    # Must ask git for the right range.
+    assert any("main..my-fork" in part for cmd in calls for part in cmd)
+
+
+def test_silent_when_branch_is_contained_in_target(monkeypatch, capsys):
+    from hermes_cli import main as hermes_main
+
+    run, _ = _fake_git(stdout="")
+    monkeypatch.setattr(hermes_main.subprocess, "run", run)
+
+    left = hermes_main._warn_about_carried_commits(
+        ["git"], Path("/repo"), "stale-branch", "main"
+    )
+
+    assert left == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_silent_on_detached_head_and_when_git_fails(monkeypatch, capsys):
+    from hermes_cli import main as hermes_main
+
+    # Detached HEAD: no branch name to reason about, and no git call needed.
+    run, calls = _fake_git(stdout="whatever")
+    monkeypatch.setattr(hermes_main.subprocess, "run", run)
+    assert hermes_main._warn_about_carried_commits(["git"], Path("/repo"), "HEAD", "main") == 0
+    assert calls == []
+
+    # Unknown target ref: stay quiet rather than guessing.
+    run2, _ = _fake_git(stdout="", returncode=128)
+    monkeypatch.setattr(hermes_main.subprocess, "run", run2)
+    assert hermes_main._warn_about_carried_commits(["git"], Path("/repo"), "f", "nope") == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_truncates_a_long_commit_list(monkeypatch, capsys):
+    from hermes_cli import main as hermes_main
+
+    log = "".join(f"c{i:06d} commit {i}\n" for i in range(25))
+    run, _ = _fake_git(stdout=log)
+    monkeypatch.setattr(hermes_main.subprocess, "run", run)
+
+    left = hermes_main._warn_about_carried_commits(
+        ["git"], Path("/repo"), "big", "main"
+    )
+
+    assert left == 25
+    out = capsys.readouterr().out
+    assert "25 commits not in 'main'" in out
+    assert "… and 15 more" in out


### PR DESCRIPTION
## Summary

`hermes update` targets `main` by default and checks it out when the install is on another branch. For a git install carrying local commits — a fork branch, a patch series, a cherry-picked fix — the rebuilt install then does not contain that work, and nothing says so.

Root cause: `_resolve_update_branch()` defaults the target to `"main"`, and the git-sync step then runs `git checkout <target>` whenever `current_branch != branch` (the long-standing "always update against main" behaviour). The only output is `⚠ Currently on branch 'X' — switching to main for update...`, which does not say that committed work is being left out of the build.

Nothing is lost from git. But the running install changes underneath the user with no indication, and the omission surfaces much later as "the fix I made is gone", by which point the cause is no longer obvious. I hit this on an install carrying 8 local desktop commits: the update would have rebuilt the app without fixes that machine depended on.

## Changes

- `hermes_cli/main.py`: `_warn_about_carried_commits()` (new) lists the non-merge commits in `<target>..<current>` and names the flag that preserves them; called from the git-sync branch-switch path immediately before the autostash and checkout.
- `tests/hermes_cli/test_update_autostash.py`: 4 new tests.

Output:

```
  ⚠ Currently on branch 'my-fork' — switching to main for update...
  ⚠ 'my-fork' has 2 commits not in 'main'. The updated install will NOT include them:
      abc1234 fix(desktop): keep sessions alive
      def5678 fix(desktop): restore embeds
    They remain on 'my-fork'. To update while keeping them, cancel and run:
    hermes update --branch my-fork
```

## Deliberately not a prompt or a block

The branch switch is intended behaviour, and update paths run unattended (`--gateway`, the desktop `/update` flow, cron) where a prompt would hang and a hard failure would be worse than today. Only the *silence* was the problem, so this is purely additive: same control flow, same exit codes, one extra warning.

## Validation

| Situation | Behaviour |
|---|---|
| branch has commits not in target | warn, list up to 10, then `… and N more`; proceed |
| branch contained in target | silent |
| detached HEAD | silent, and **no git call made** |
| target ref unresolvable (non-zero exit) | silent — no guessing |
| branch merely merged `main` | silent (merge commits excluded, so no noise) |

| Check | Result |
|---|---|
| `pytest tests/hermes_cli/test_update_autostash.py -q` | 44/44 pass (4 new) |
| `pytest tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_interrupted_recovery.py tests/test_install_diverged_update.py tests/hermes_cli/test_update_post_pull_syntax_guard.py -q` | 77/77 pass |

Tests cover the warning content and that it asks git for the right `target..current` range; silence when contained; silence on detached HEAD (asserting no git call); silence on an unresolvable target; and truncation of a 25-commit list.

## Relationship to #64614 — complementary, not overlapping

#64614 by @RamenFast fixes a **harder** failure in the same command: on divergence the sync falls back to `git reset --hard origin/<branch>`, which *destroys* local commits. This PR addresses a different step — the branch **switch**, which leaves committed work behind silently but intact — and is additive output only, so the two don't conflict. If #64614 lands first this still applies; the warning fires before the switch either way.

Also adjacent: #68677 (behind-count reporting on diverged branches) reports on divergence rather than acting on it.

**Duplicate check**: searched open and merged PRs for `hermes update` branch/local-commit handling — #64614, #68677 above; no PR warns about commits omitted by the switch.
