### PR TITLE
fix(desktop): flush transcript synchronously when switching onto a busy session

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -493,3 +493,85 @@ describe('useSessionStateCache — cross-thread error isolation', () => {
     expect(cache.getRuntimeIdForStoredSession('stored-A')).toBeNull()
   })
 })
+
+describe('useSessionStateCache — first paint on a still-busy session is never RAF-throttled', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    $messages.set([])
+  })
+
+  it('flushes synchronously when switching onto a session that differs from the on-screen one, even when rAF never fires', () => {
+    // Simulate a throttled/backgrounded window: requestAnimationFrame is
+    // scheduled but its callback never runs (Chromium clamps rAF while the
+    // window is backgrounded/occluded). If the first paint after a session
+    // switch relied on this callback, the transcript would stay blank
+    // forever even though the cached state already has the answer.
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1 as unknown as number)
+
+    $messages.set([])
+    let cache!: Cache
+    const { rerender } = render(<ViewHarness activeSessionId="thread-A" onReady={c => (cache = c)} />)
+
+    act(() => {
+      cache.updateSessionState(
+        'thread-A',
+        state => ({ ...state, busy: false, messages: [userMessage('user-a', 'first session')] }),
+        'stored-A'
+      )
+    })
+    expect($messages.get().map(m => m.id)).toEqual(['user-a'])
+
+    // Switch onto thread B, which is still busy (a live, in-flight turn).
+    // This is the FIRST paint after the switch and must not depend on rAF
+    // ever firing — the cached transcript must appear immediately.
+    rerender(<ViewHarness activeSessionId="thread-B" onReady={c => (cache = c)} />)
+    act(() => {
+      cache.updateSessionState(
+        'thread-B',
+        state => ({
+          ...state,
+          busy: true,
+          messages: [userMessage('user-b', 'second session'), assistantText('assistant-b-partial', 'streaming...')]
+        }),
+        'stored-B'
+      )
+    })
+
+    expect($messages.get().map(m => m.id)).toEqual(['user-b', 'assistant-b-partial'])
+  })
+
+  it('still RAF-coalesces a repeat busy heartbeat to the session already on screen', () => {
+    // A session already on screen should keep the RAF-batched path for
+    // routine busy heartbeats -- only the first paint after a SWITCH must
+    // bypass it. Stub rAF to never fire and confirm a same-session busy
+    // update is NOT forced through synchronously.
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1 as unknown as number)
+
+    $messages.set([])
+    let cache!: Cache
+    render(<ViewHarness activeSessionId="thread-A" onReady={c => (cache = c)} />)
+
+    act(() => {
+      cache.updateSessionState(
+        'thread-A',
+        state => ({ ...state, busy: false, messages: [userMessage('user-a', 'first message')] }),
+        'stored-A'
+      )
+    })
+    expect($messages.get().map(m => m.id)).toEqual(['user-a'])
+
+    // A routine busy heartbeat on the SAME (already-on-screen) session.
+    act(() => {
+      cache.updateSessionState('thread-A', state => ({
+        ...state,
+        busy: true,
+        messages: [userMessage('user-a', 'first message'), assistantText('assistant-a-partial', 'thinking...')]
+      }))
+    })
+
+    // Since rAF never fires and this isn't a session switch, the coalesced
+    // update should NOT have reached $messages yet.
+    expect($messages.get().map(m => m.id)).toEqual(['user-a'])
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -219,7 +219,21 @@ export function useSessionStateCache({
       // state anyway). The plain busy heartbeat stays RAF-batched: that
       // coalescing exists only to keep periodic `session.info` updates from
       // churning `$messages` and jerking the scroll position while reading.
-      const isCriticalTransition = !state.busy || state.needsInput
+      //
+      // A session SWITCH is a third case, distinct from a same-session
+      // heartbeat: `viewSessionIdRef` names whichever session's transcript is
+      // currently painted into `$messages`, so `sessionId !== viewSessionIdRef`
+      // means this is the FIRST paint after switching onto a still-busy
+      // session (clicking back into a running session, resuming a warm-cached
+      // busy session, etc.). That first paint must not be RAF-batched with the
+      // rest — if it lands on a throttled tick, the transcript stays blank
+      // indefinitely even though the backend keeps streaming, because nothing
+      // else forces a flush until the turn finishes ("clicked back into a
+      // running session and it looks blank" bug). Only a repeat update to a
+      // session that's already on screen should get the scroll-jank-avoiding
+      // RAF coalescing.
+      const isSessionSwitch = sessionId !== viewSessionIdRef.current
+      const isCriticalTransition = !state.busy || state.needsInput || isSessionSwitch
 
       if (isCriticalTransition) {
         if (viewSyncRafRef.current !== null && typeof window !== 'undefined') {


### PR DESCRIPTION
## What does this PR do?

Fixes a blank-transcript bug: clicking back into a still-running (busy)
session shows nothing until the turn finishes, even though the backend
keeps streaming.

## Root Cause

`useSessionStateCache`'s `syncSessionStateToView()` RAF-batches the first
paint after switching onto a still-running session the same as a routine
busy heartbeat. If that RAF tick lands on a throttled frame (window
backgrounded/occluded — Chromium clamps `requestAnimationFrame` in that
state), the transcript stays permanently blank because nothing else forces
a flush until the turn finishes.

## Changes Made

`apps/desktop/src/app/session/hooks/use-session-state-cache.ts`: force a
synchronous flush whenever the session being synced differs from
`viewSessionIdRef` (the session currently painted into `$messages`) — not
just on `busy -> idle`/`needsInput` transitions. A repeat update to a
session already on screen still gets RAF coalescing to avoid scroll jank.

## Related Issue

No existing issue found (searched `gh search issues` for "session switch
blank transcript", "clicked back into running session blank",
"backgrounded window transcript stall", "RAF throttle desktop transcript" —
no hits).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

1. Start a long-running turn in session A.
2. Switch to session B, then switch back to session A while it's still
   busy, with the window backgrounded/occluded.
3. Before this fix: the transcript can stay blank until the turn ends.
4. After this fix: the cached transcript appears immediately on switch.
5. `vitest run src/app/session/hooks/use-session-state-cache.test.tsx` —
   14 passed (12 pre-existing + 2 new).
6. Full `src/app/session` suite: 320 passed, 0 failed.

Added 2 regression tests: one stubs `requestAnimationFrame` to never
invoke its callback (simulating a throttled/backgrounded window) and
confirms a session switch onto a busy session still flushes synchronously;
the other confirms a repeat heartbeat to a session already on screen still
gets RAF-coalesced (unaffected). The first test fails against the pre-fix
code (verified via a scripted revert).

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs/issues (none found)
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test suite and all tests pass
- [x] I've added tests for my changes
- [x] Tested on macOS
