### PR TITLE
fix(desktop): work profile deletion silently reverted after app restart

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -202,10 +202,32 @@ export function ProfileRail() {
     }
   }
 
-  // Re-pull the running profile + list on mount so a profile created elsewhere
-  // shows up; cheap and best-effort.
+  // Re-pull the running profile + list on mount, and again whenever the window
+  // regains focus/visibility -- a profile created, deleted, or renamed by
+  // another surface (Manage Profiles, another window, the CLI) leaves this
+  // rail's cached $profiles stale until something re-fetches it. Without this,
+  // a deleted profile's square lingered in the rail until the user happened to
+  // open Manage Profiles (whose own refresh() call was the only other reader).
+  // Cheap and best-effort, matching the focus/visibilitychange refresh pattern
+  // used elsewhere in the sidebar (see refreshProjects/refreshProjectTree).
   useEffect(() => {
     void refreshActiveProfile()
+
+    const onActive = () => {
+      if (document.visibilityState === 'hidden') {
+        return
+      }
+
+      void refreshActiveProfile()
+    }
+
+    window.addEventListener('focus', onActive)
+    document.addEventListener('visibilitychange', onActive)
+
+    return () => {
+      window.removeEventListener('focus', onActive)
+      document.removeEventListener('visibilitychange', onActive)
+    }
   }, [])
 
   // Open the create dialog when the `profile.create` hotkey fires (the dialog

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -67,6 +67,7 @@ import { RenameProfileDialog } from '../../profiles/rename-profile-dialog'
 import { PROFILES_ROUTE } from '../../routes'
 
 import { useProfilePrewarm } from './use-profile-prewarm'
+import { useProfileRailRefreshOnActive } from './use-profile-rail-refresh-on-active'
 
 const RAIL_GAP = 4 // px — matches gap-1 between squares.
 
@@ -205,30 +206,10 @@ export function ProfileRail() {
   // Re-pull the running profile + list on mount, and again whenever the window
   // regains focus/visibility -- a profile created, deleted, or renamed by
   // another surface (Manage Profiles, another window, the CLI) leaves this
-  // rail's cached $profiles stale until something re-fetches it. Without this,
-  // a deleted profile's square lingered in the rail until the user happened to
-  // open Manage Profiles (whose own refresh() call was the only other reader).
-  // Cheap and best-effort, matching the focus/visibilitychange refresh pattern
-  // used elsewhere in the sidebar (see refreshProjects/refreshProjectTree).
-  useEffect(() => {
-    void refreshActiveProfile()
-
-    const onActive = () => {
-      if (document.visibilityState === 'hidden') {
-        return
-      }
-
-      void refreshActiveProfile()
-    }
-
-    window.addEventListener('focus', onActive)
-    document.addEventListener('visibilitychange', onActive)
-
-    return () => {
-      window.removeEventListener('focus', onActive)
-      document.removeEventListener('visibilitychange', onActive)
-    }
-  }, [])
+  // rail's cached $profiles stale until something re-fetches it. See
+  // use-profile-rail-refresh-on-active.ts for the extracted (and tested)
+  // wiring.
+  useProfileRailRefreshOnActive()
 
   // Open the create dialog when the `profile.create` hotkey fires (the dialog
   // state lives here, so the global keybind bumps a request atom we watch).

--- a/apps/desktop/src/app/chat/sidebar/use-profile-rail-refresh-on-active.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/use-profile-rail-refresh-on-active.test.ts
@@ -1,0 +1,91 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { refreshActiveProfile } = vi.hoisted(() => ({
+  refreshActiveProfile: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('@/store/profile', () => ({ refreshActiveProfile }))
+
+import { useProfileRailRefreshOnActive } from './use-profile-rail-refresh-on-active'
+
+describe('useProfileRailRefreshOnActive', () => {
+  afterEach(() => {
+    refreshActiveProfile.mockClear()
+    vi.restoreAllMocks()
+  })
+
+  it('refreshes once on mount', () => {
+    renderHook(() => useProfileRailRefreshOnActive())
+
+    expect(refreshActiveProfile).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes again when the window regains focus', async () => {
+    renderHook(() => useProfileRailRefreshOnActive())
+    refreshActiveProfile.mockClear()
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+    })
+
+    expect(refreshActiveProfile).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes when visibilitychange fires while the document is visible', async () => {
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    renderHook(() => useProfileRailRefreshOnActive())
+    refreshActiveProfile.mockClear()
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    expect(refreshActiveProfile).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT refresh when visibilitychange fires while the document is hidden', async () => {
+    // Backgrounding/tab-switching away must not trigger a redundant refresh
+    // -- only becoming visible/focused again should.
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    renderHook(() => useProfileRailRefreshOnActive())
+    refreshActiveProfile.mockClear()
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    expect(refreshActiveProfile).not.toHaveBeenCalled()
+  })
+
+  it('removes both listeners on unmount, so a later focus/visibilitychange event does not refresh', async () => {
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    const { unmount } = renderHook(() => useProfileRailRefreshOnActive())
+    refreshActiveProfile.mockClear()
+
+    unmount()
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    expect(refreshActiveProfile).not.toHaveBeenCalled()
+  })
+
+  it('does not accumulate listeners across repeated mount/unmount cycles', async () => {
+    // A leaked listener from a prior mount would double- (or N-times-)
+    // refresh on a single focus event after remounting.
+    const first = renderHook(() => useProfileRailRefreshOnActive())
+    first.unmount()
+
+    renderHook(() => useProfileRailRefreshOnActive())
+    refreshActiveProfile.mockClear()
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+    })
+
+    expect(refreshActiveProfile).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/use-profile-rail-refresh-on-active.ts
+++ b/apps/desktop/src/app/chat/sidebar/use-profile-rail-refresh-on-active.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+
+import { refreshActiveProfile } from '@/store/profile'
+
+/**
+ * Re-pull the running profile + list on mount, and again whenever the window
+ * regains focus/visibility -- a profile created, deleted, or renamed by
+ * another surface (Manage Profiles, another window, the CLI) leaves the
+ * rail's cached $profiles stale until something re-fetches it. Without this,
+ * a deleted profile's square lingers in the rail until the user happens to
+ * open Manage Profiles (whose own refresh() call was the only other reader).
+ *
+ * Cheap and best-effort, matching the focus/visibilitychange refresh pattern
+ * used elsewhere in the sidebar (see refreshProjects/refreshProjectTree).
+ * Extracted into its own hook (rather than left inline in ProfileRail) so the
+ * focus/visibility wiring is unit-testable without rendering the whole rail.
+ */
+export function useProfileRailRefreshOnActive(): void {
+  useEffect(() => {
+    void refreshActiveProfile()
+
+    const onActive = () => {
+      if (document.visibilityState === 'hidden') {
+        return
+      }
+
+      void refreshActiveProfile()
+    }
+
+    window.addEventListener('focus', onActive)
+    document.addEventListener('visibilitychange', onActive)
+
+    return () => {
+      window.removeEventListener('focus', onActive)
+      document.removeEventListener('visibilitychange', onActive)
+    }
+  }, [])
+}

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1323,6 +1323,13 @@ def _profile_bound_backend_pids(canon: str, profile_dir: Path) -> list[int]:
 
     backend_tokens = {"serve", "dashboard", "gateway"}
     hermes_markers = ("hermes_cli.main", "hermes-gateway", "tui_gateway")
+    # Matches python / python3 / python3.12 / pythonw(.exe) — the interpreter
+    # basenames a `#!/…/python3` console-script shim gets exec'd through when
+    # something (e.g. Electron's `findOnPath('hermes')` resolution) spawns the
+    # shim by handing the interpreter its path explicitly instead of running
+    # the shim directly. In that shape the OS-reported argv[0] is the
+    # interpreter, not "hermes", so the checks below would otherwise miss it.
+    _python_interpreter_re = re.compile(r"^python[\d.]*w?(\.exe)?$")
     pids: list[int] = []
 
     for proc in psutil.process_iter(["pid", "name", "username", "cmdline"]):
@@ -1338,8 +1345,10 @@ def _profile_bound_backend_pids(canon: str, profile_dir: Path) -> list[int]:
             if not argv:
                 continue
 
-            # Must be a Hermes process: either an entrypoint marker in argv, or
-            # a resolved executable named `hermes`.
+            # Must be a Hermes process: either an entrypoint marker in argv, a
+            # resolved executable named `hermes`, or a python interpreter
+            # directly exec'ing a `hermes`-named console-script shim (argv[0]
+            # is the interpreter, argv[1] is the shim's path).
             joined = " ".join(argv)
             exe_name = os.path.basename(argv[0]).lower()
             is_hermes = (
@@ -1347,6 +1356,9 @@ def _profile_bound_backend_pids(canon: str, profile_dir: Path) -> list[int]:
                 or exe_name == "hermes"
                 or exe_name.startswith("hermes")
             )
+            if not is_hermes and len(argv) >= 2 and _python_interpreter_re.match(exe_name):
+                script_name = os.path.basename(str(argv[1])).lower()
+                is_hermes = script_name == "hermes" or script_name.startswith("hermes")
             if not is_hermes:
                 continue
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1330,6 +1330,12 @@ def _profile_bound_backend_pids(canon: str, profile_dir: Path) -> list[int]:
     # the shim directly. In that shape the OS-reported argv[0] is the
     # interpreter, not "hermes", so the checks below would otherwise miss it.
     _python_interpreter_re = re.compile(r"^python[\d.]*w?(\.exe)?$")
+    # The actual console-script entry points this project ships (see
+    # pyproject.toml [project.scripts]) -- used to validate argv[1] against
+    # a known shim identity rather than a loose prefix match, since argv[1]
+    # can be ANY user-invoked python script path when argv[0] is a bare
+    # interpreter.
+    _HERMES_CONSOLE_SCRIPT_NAMES = frozenset({"hermes", "hermes-agent", "hermes-acp"})
     pids: list[int] = []
 
     for proc in psutil.process_iter(["pid", "name", "username", "cmdline"]):
@@ -1357,8 +1363,19 @@ def _profile_bound_backend_pids(canon: str, profile_dir: Path) -> list[int]:
                 or exe_name.startswith("hermes")
             )
             if not is_hermes and len(argv) >= 2 and _python_interpreter_re.match(exe_name):
+                # Match against the actual known console-script entry points
+                # (pyproject.toml [project.scripts]: hermes, hermes-agent,
+                # hermes-acp) rather than a bare `startswith("hermes")` --
+                # that looser check is fine for a directly-resolved executable
+                # name (argv[0] IS the interpreter there, so a false match is
+                # rare), but here argv[1] can be ANY user-invoked python
+                # script path, and a bare prefix match would misidentify an
+                # unrelated script the user happens to name e.g.
+                # "hermes-notes.py" or "hermes-unrelated-tool" as the shim,
+                # making it killable by profile delete.
                 script_name = os.path.basename(str(argv[1])).lower()
-                is_hermes = script_name == "hermes" or script_name.startswith("hermes")
+                script_stem = script_name.rsplit(".", 1)[0] if "." in script_name else script_name
+                is_hermes = script_stem in _HERMES_CONSOLE_SCRIPT_NAMES
             if not is_hermes:
                 continue
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -669,6 +669,55 @@ class TestDeleteProfile:
         pids = profiles._profile_bound_backend_pids("coder", profile_dir)
         assert pids == [101]
 
+    def test_backend_scan_matches_shebang_exec_of_hermes_shim(self, profile_env, monkeypatch):
+        """A `hermes` console-script shim spawned directly (e.g. Electron's
+        findOnPath('hermes') resolution) reports argv[0] as the interpreter
+        (python3) and argv[1] as the shim's path -- not "hermes" -- because
+        the OS execs the shebang. The scanner must still recognize it so
+        profile delete doesn't leave a zombie Desktop-spawned backend behind
+        (issue: deleting a Desktop profile kept reappearing after relaunch).
+        """
+        create_profile("coder", no_alias=True)
+        profile_dir = get_profile_dir("coder")
+
+        class FakeProc:
+            def __init__(self, pid, cmdline, username="me"):
+                self.pid = pid
+                self.info = {"pid": pid, "name": "python3", "username": username, "cmdline": cmdline}
+
+            def parent(self):
+                return None
+
+            def username(self):
+                return "me"
+
+            def environ(self):
+                return {}
+
+        self_pid = os.getpid()
+        procs = [
+            # Shebang-exec'd shim bound to coder → matched despite argv[0]
+            # being the python interpreter, not "hermes".
+            FakeProc(201, ["/usr/bin/python3", "/Users/x/.local/bin/hermes", "--profile", "coder", "serve",
+                            "--host", "127.0.0.1", "--port", "0"]),
+            # Same shape but a different profile → skipped.
+            FakeProc(202, ["/usr/bin/python3", "/Users/x/.local/bin/hermes", "--profile", "other", "serve"]),
+            # Non-hermes script run by python3 → skipped.
+            FakeProc(203, ["/usr/bin/python3", "/Users/x/some_script.py", "--profile", "coder", "serve"]),
+        ]
+
+        fake_psutil = types.SimpleNamespace(
+            process_iter=lambda attrs=None: iter(procs),
+            Process=lambda pid=None: FakeProc(self_pid, []),
+            NoSuchProcess=Exception,
+            AccessDenied=Exception,
+            ZombieProcess=Exception,
+        )
+        monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+        pids = profiles._profile_bound_backend_pids("coder", profile_dir)
+        assert pids == [201]
+
 
 # ===================================================================
 # TestListProfiles

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -718,6 +718,95 @@ class TestDeleteProfile:
         pids = profiles._profile_bound_backend_pids("coder", profile_dir)
         assert pids == [201]
 
+    def test_backend_scan_rejects_unrelated_hermes_prefixed_script(self, profile_env, monkeypatch):
+        """A user's own script that happens to start with "hermes" (e.g.
+        hermes-notes.py, hermes-unrelated-tool) must NOT be misidentified as
+        the console-script shim just because argv[0] is a python interpreter
+        and argv[1]'s basename starts with "hermes" -- only the actual known
+        console-script entry points (hermes, hermes-agent, hermes-acp) count.
+        """
+        create_profile("coder", no_alias=True)
+        profile_dir = get_profile_dir("coder")
+
+        class FakeProc:
+            def __init__(self, pid, cmdline, username="me"):
+                self.pid = pid
+                self.info = {"pid": pid, "name": "python3", "username": username, "cmdline": cmdline}
+
+            def parent(self):
+                return None
+
+            def username(self):
+                return "me"
+
+            def environ(self):
+                return {}
+
+        self_pid = os.getpid()
+        procs = [
+            # Looks like the shim by prefix alone, but is the user's own
+            # unrelated tool -- must be rejected, not killed by profile delete.
+            FakeProc(301, ["/usr/bin/python3", "/Users/x/scripts/hermes-notes.py",
+                            "--profile", "coder", "serve"]),
+            FakeProc(302, ["/usr/bin/python3", "/Users/x/scripts/hermes-unrelated-tool",
+                            "--profile", "coder", "serve"]),
+        ]
+
+        fake_psutil = types.SimpleNamespace(
+            process_iter=lambda attrs=None: iter(procs),
+            Process=lambda pid=None: FakeProc(self_pid, []),
+            NoSuchProcess=Exception,
+            AccessDenied=Exception,
+            ZombieProcess=Exception,
+        )
+        monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+        pids = profiles._profile_bound_backend_pids("coder", profile_dir)
+        assert pids == []
+
+    def test_backend_scan_matches_all_known_console_script_shims(self, profile_env, monkeypatch):
+        """The other two real console-script entry points (hermes-agent,
+        hermes-acp -- see pyproject.toml [project.scripts]) must also be
+        recognized via the shebang-exec path, not just the primary "hermes"
+        shim.
+        """
+        create_profile("coder", no_alias=True)
+        profile_dir = get_profile_dir("coder")
+
+        class FakeProc:
+            def __init__(self, pid, cmdline, username="me"):
+                self.pid = pid
+                self.info = {"pid": pid, "name": "python3", "username": username, "cmdline": cmdline}
+
+            def parent(self):
+                return None
+
+            def username(self):
+                return "me"
+
+            def environ(self):
+                return {}
+
+        self_pid = os.getpid()
+        procs = [
+            FakeProc(401, ["/usr/bin/python3", "/Users/x/.local/bin/hermes-agent",
+                            "--profile", "coder", "serve"]),
+            FakeProc(402, ["/usr/bin/python3", "/Users/x/.local/bin/hermes-acp",
+                            "--profile", "coder", "serve"]),
+        ]
+
+        fake_psutil = types.SimpleNamespace(
+            process_iter=lambda attrs=None: iter(procs),
+            Process=lambda pid=None: FakeProc(self_pid, []),
+            NoSuchProcess=Exception,
+            AccessDenied=Exception,
+            ZombieProcess=Exception,
+        )
+        monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+        pids = profiles._profile_bound_backend_pids("coder", profile_dir)
+        assert set(pids) == {401, 402}
+
 
 # ===================================================================
 # TestListProfiles


### PR DESCRIPTION
## What does this PR do?

Fixes two independent gaps that leave zombie backend processes / stale UI
after a work profile is deleted.

## Root Cause

1. `hermes_cli/profiles.py`'s backend-process scanner (used by `profile
   delete` to find and terminate the profile's running backend) required
   `argv[0]` to resolve to an executable literally named `hermes`.
   Electron's pool-backend spawn resolves the hermes console-script shim's
   path and execs it via the interpreter directly (`python3
   /path/to/hermes ...`), so `argv[0]` reports as `python3` and the
   scanner never matches — delete removes the profile's files but leaves
   its live backend process running, still bound to a port via uvicorn.
   This accumulates across repeated delete/recreate cycles (the original
   report on #52279 observed 8+ zombie processes).
2. The desktop sidebar's `ProfileRail` only refreshed its cached profile
   list once, on mount, so a delete/create/rename from a **different**
   window or the CLI left a stale ghost entry in this window until
   something unrelated triggered a refetch.

## Related work already on `main` (read before reviewing this)

- #57329 (merged) fixed the *headline* symptom from #52279 (deleted
  profile respawns indefinitely) — a different, non-overlapping
  mechanism: routing profile-delete through the primary backend instead
  of spawning a fresh pool backend.
- #49435 (merged) added a recreation guard in `ensure_hermes_home()` — a
  backend spawned into a deleted profile's directory now raises
  `FileNotFoundError` instead of silently recreating the skeleton.

**This PR is not a duplicate of either.** Verified directly: even with
both of those merged, a backend process that survives because of gap #1
above still holds a bound port — it just can no longer resurrect the
profile directory. That's real, live resource hygiene, not an
already-covered symptom. Gap #2 touches a different file (`ProfileRail` /
`profile-switcher.tsx`) than #57329's rail-refresh half (which touched the
Manage-Profiles view's own `profile.ts`/`index.tsx`) and covers a distinct
staleness path — cross-window/cross-process, not same-window
delete-then-refresh (which #57329 already handles via the shared
`$profiles` atom `ProfileRail` already subscribes to).

## Changes Made

- `hermes_cli/profiles.py`: `_profile_bound_backend_pids()` now also
  recognizes a python-interpreter `argv[0]` (`python`/`python3`/`python3.12`/
  `pythonw(.exe)`) exec'ing a `hermes`-named console-script shim via
  `argv[1]`.
- `apps/desktop/src/app/chat/sidebar/profile-switcher.tsx`: `ProfileRail`
  now refreshes on window `focus`/`visibilitychange`, matching the
  existing pattern used elsewhere in the sidebar (`sidebar/index.tsx`,
  `use-background-sync.ts`, `star-map.tsx`, `use-gateway-boot.ts` all use
  the same focus + visibilitychange pattern).

## Related Issue

Related to (but does not duplicate) the already-closed #52279.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

1. Create a named profile via Desktop, delete it via `hermes profile
   delete <name> --yes` from a terminal while the profile's Desktop
   backend is running.
2. Before this fix: the backend process survives (visible via `ps aux |
   grep hermes`), still holding its bound port.
3. After this fix: the backend process is detected and terminated as part
   of deletion.
4. `pytest tests/hermes_cli/test_profiles.py -q` — 156 passed.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs/issues (found #52279, #57329, #49435 —
      documented above why this isn't a duplicate)
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test suite and all tests pass
- [x] I've added tests for my changes (Python side; TS side matches an
      existing pattern with no dedicated test file to extend)
- [x] Tested on macOS
