### PR TITLE
fix(cli): resolve_provider() multi-key warning, alias normalization, and config failure visibility

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2186,10 +2186,13 @@ def resolve_provider(
         _model_cfg = (load_config() or {}).get("model")
         if isinstance(_model_cfg, dict):
             _cfg_provider = _model_cfg.get("provider")
-            if isinstance(_cfg_provider, str) and _cfg_provider.strip().lower() in PROVIDER_REGISTRY:
-                return _cfg_provider.strip().lower()
+            if isinstance(_cfg_provider, str):
+                _cfg_provider = _cfg_provider.strip().lower()
+                _cfg_provider = _PROVIDER_ALIASES.get(_cfg_provider, _cfg_provider)
+                if _cfg_provider in PROVIDER_REGISTRY:
+                    return _cfg_provider
     except Exception as e:
-        logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)
+        logger.warning("Could not read config.yaml model.provider for auto-resolution: %s", e)
 
     # Scope-aware key reads: under multiplex a secondary profile's API keys
     # live only in its secret scope, not os.environ — a bare getenv here
@@ -2243,7 +2246,12 @@ def resolve_provider(
     except Exception as e:
         logger.debug("Could not pre-read active auth provider: %s", e)
 
-    # Auto-detect API-key providers by checking their env vars
+    # Auto-detect API-key providers by checking their env vars. Collect every
+    # match before selecting the first so ambiguous environments are visible.
+    # Providers may share an env var (for example, the two Alibaba entries
+    # accept DASHSCOPE_API_KEY), so each env var represents only one candidate.
+    _api_key_candidates: List[Tuple[str, str]] = []
+    _seen_api_key_env_vars: set[str] = set()
     for pid, pconfig in PROVIDER_REGISTRY.items():
         if pconfig.auth_type != "api_key":
             continue
@@ -2256,20 +2264,39 @@ def resolve_provider(
         if pid in {"copilot", "lmstudio"}:
             continue
         for env_var in pconfig.api_key_env_vars:
+            if env_var in _seen_api_key_env_vars:
+                continue
+            _seen_api_key_env_vars.add(env_var)
             if has_usable_secret(_scoped_key_env(env_var)):
-                # An exported API key now wins over a logged-in OAuth provider
-                # (the #29285 fix). Surface that so a user who deliberately uses
-                # OAuth but has a stale key in ~/.hermes/.env isn't silently
-                # switched without knowing why.
-                if _oauth_active and _oauth_active != pid:
-                    logger.warning(
-                        "Provider resolved to %r via %s, preempting your "
-                        "logged-in OAuth provider %r. If you meant to use the "
-                        "OAuth login, unset %s or set `model.provider` "
-                        "explicitly.",
-                        pid, env_var, _oauth_active, env_var,
-                    )
-                return pid
+                _api_key_candidates.append((pid, env_var))
+                break  # one candidate per provider, even with multiple env vars
+
+    if _api_key_candidates:
+        pid, env_var = _api_key_candidates[0]
+        if len(_api_key_candidates) >= 2:
+            logger.warning(
+                "Multiple provider API keys detected: %s. Selected %r based "
+                "on provider registry order. Set `model.provider` explicitly "
+                "to choose a different provider.",
+                ", ".join(
+                    f"{candidate_pid} ({candidate_env_var})"
+                    for candidate_pid, candidate_env_var in _api_key_candidates
+                ),
+                pid,
+            )
+        # An exported API key now wins over a logged-in OAuth provider
+        # (the #29285 fix). Surface that so a user who deliberately uses
+        # OAuth but has a stale key in ~/.hermes/.env isn't silently
+        # switched without knowing why.
+        if _oauth_active and _oauth_active != pid:
+            logger.warning(
+                "Provider resolved to %r via %s, preempting your "
+                "logged-in OAuth provider %r. If you meant to use the "
+                "OAuth login, unset %s or set `model.provider` "
+                "explicitly.",
+                pid, env_var, _oauth_active, env_var,
+            )
+        return pid
 
     # Logged-in OAuth provider (auth.json `active_provider`) — a LAST-RESORT
     # fallback, chosen only when the user expressed no other preference above.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2023,6 +2023,7 @@ def resolve_provider(
             _seen_api_key_env_vars.add(env_var)
             if has_usable_secret(os.getenv(env_var, "")):
                 _api_key_candidates.append((pid, env_var))
+                break  # one candidate per provider, even with multiple env vars
 
     if _api_key_candidates:
         pid, env_var = _api_key_candidates[0]

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1997,7 +1997,12 @@ def resolve_provider(
     except Exception as e:
         logger.debug("Could not pre-read active auth provider: %s", e)
 
-    # Auto-detect API-key providers by checking their env vars
+    # Auto-detect API-key providers by checking their env vars. Collect every
+    # match before selecting the first so ambiguous environments are visible.
+    # Providers may share an env var (for example, the two Alibaba entries
+    # accept DASHSCOPE_API_KEY), so each env var represents only one candidate.
+    _api_key_candidates: List[Tuple[str, str]] = []
+    _seen_api_key_env_vars: set[str] = set()
     for pid, pconfig in PROVIDER_REGISTRY.items():
         if pconfig.auth_type != "api_key":
             continue
@@ -2010,20 +2015,38 @@ def resolve_provider(
         if pid in {"copilot", "lmstudio"}:
             continue
         for env_var in pconfig.api_key_env_vars:
+            if env_var in _seen_api_key_env_vars:
+                continue
+            _seen_api_key_env_vars.add(env_var)
             if has_usable_secret(os.getenv(env_var, "")):
-                # An exported API key now wins over a logged-in OAuth provider
-                # (the #29285 fix). Surface that so a user who deliberately uses
-                # OAuth but has a stale key in ~/.hermes/.env isn't silently
-                # switched without knowing why.
-                if _oauth_active and _oauth_active != pid:
-                    logger.warning(
-                        "Provider resolved to %r via %s, preempting your "
-                        "logged-in OAuth provider %r. If you meant to use the "
-                        "OAuth login, unset %s or set `model.provider` "
-                        "explicitly.",
-                        pid, env_var, _oauth_active, env_var,
-                    )
-                return pid
+                _api_key_candidates.append((pid, env_var))
+
+    if _api_key_candidates:
+        pid, env_var = _api_key_candidates[0]
+        if len(_api_key_candidates) >= 2:
+            logger.warning(
+                "Multiple provider API keys detected: %s. Selected %r based "
+                "on provider registry order. Set `model.provider` explicitly "
+                "to choose a different provider.",
+                ", ".join(
+                    f"{candidate_pid} ({candidate_env_var})"
+                    for candidate_pid, candidate_env_var in _api_key_candidates
+                ),
+                pid,
+            )
+        # An exported API key now wins over a logged-in OAuth provider
+        # (the #29285 fix). Surface that so a user who deliberately uses
+        # OAuth but has a stale key in ~/.hermes/.env isn't silently
+        # switched without knowing why.
+        if _oauth_active and _oauth_active != pid:
+            logger.warning(
+                "Provider resolved to %r via %s, preempting your "
+                "logged-in OAuth provider %r. If you meant to use the "
+                "OAuth login, unset %s or set `model.provider` "
+                "explicitly.",
+                pid, env_var, _oauth_active, env_var,
+            )
+        return pid
 
     # Logged-in OAuth provider (auth.json `active_provider`) — a LAST-RESORT
     # fallback, chosen only when the user expressed no other preference above.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1962,10 +1962,13 @@ def resolve_provider(
         _model_cfg = (load_config() or {}).get("model")
         if isinstance(_model_cfg, dict):
             _cfg_provider = _model_cfg.get("provider")
-            if isinstance(_cfg_provider, str) and _cfg_provider.strip().lower() in PROVIDER_REGISTRY:
-                return _cfg_provider.strip().lower()
+            if isinstance(_cfg_provider, str):
+                _cfg_provider = _cfg_provider.strip().lower()
+                _cfg_provider = _PROVIDER_ALIASES.get(_cfg_provider, _cfg_provider)
+                if _cfg_provider in PROVIDER_REGISTRY:
+                    return _cfg_provider
     except Exception as e:
-        logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)
+        logger.warning("Could not read config.yaml model.provider for auto-resolution: %s", e)
 
     if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(os.getenv("OPENROUTER_API_KEY")):
         return "openrouter"

--- a/tests/hermes_cli/test_provider_precedence.py
+++ b/tests/hermes_cli/test_provider_precedence.py
@@ -6,9 +6,11 @@ over a stale logged-in OAuth `active_provider` in auth.json. Before the fix,
 explicit choice — e.g. a user OAuth-logged-into Anthropic but with
 OPENAI_API_KEY exported (or model.provider set) got routed to Anthropic.
 """
+import logging
+
 import pytest
 
-from hermes_cli.auth import resolve_provider, AuthError
+from hermes_cli.auth import PROVIDER_REGISTRY, resolve_provider, AuthError
 
 
 def _login(monkeypatch, provider_id):
@@ -29,8 +31,16 @@ def _no_aws(monkeypatch):
 
 
 def _clear_provider_env(monkeypatch):
-    for var in ("OPENAI_API_KEY", "OPENROUTER_API_KEY", "GLM_API_KEY", "ZAI_API_KEY",
-                "KIMI_API_KEY", "MINIMAX_API_KEY", "HERMES_INFERENCE_PROVIDER"):
+    provider_key_vars = {
+        env_var
+        for provider in PROVIDER_REGISTRY.values()
+        for env_var in provider.api_key_env_vars
+    }
+    for var in provider_key_vars | {
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "HERMES_INFERENCE_PROVIDER",
+    }:
         monkeypatch.delenv(var, raising=False)
 
 
@@ -42,6 +52,91 @@ class TestProviderPrecedence:
         _login(monkeypatch, "anthropic")           # stale OAuth login
         _config(monkeypatch, {"provider": "zai", "default": "glm-4.6"})
         assert resolve_provider("auto") == "zai"
+
+    def test_config_provider_alias_is_normalized(self, monkeypatch):
+        """config.yaml model.provider accepts the same aliases as explicit input."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _config(monkeypatch, {"provider": " GO "})
+        assert resolve_provider("auto") == "opencode-go"
+
+    def test_config_read_failure_is_warning(self, monkeypatch, caplog):
+        """A config read failure must be visible without debug logging enabled."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: (_ for _ in ()).throw(OSError("unreadable config")),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
+            try:
+                resolve_provider("auto")
+            except AuthError:
+                pass
+
+        assert any(
+            "Could not read config.yaml model.provider" in record.message
+            for record in caplog.records
+        )
+
+    def test_warns_when_multiple_provider_api_keys_are_detected(
+        self, monkeypatch, caplog
+    ):
+        """Multiple provider keys warn while registry order selects the provider."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _config(monkeypatch, {})
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
+            assert resolve_provider("auto") == "alibaba"
+
+        warning_messages = [
+            record.message
+            for record in caplog.records
+            if "Multiple provider API keys detected" in record.message
+        ]
+        assert len(warning_messages) == 1
+        assert "alibaba (DASHSCOPE_API_KEY)" in warning_messages[0]
+        assert "opencode-go (OPENCODE_GO_API_KEY)" in warning_messages[0]
+
+    def test_shared_provider_api_key_does_not_emit_multi_key_warning(
+        self, monkeypatch, caplog
+    ):
+        """A shared env var is one candidate even when two providers accept it."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _config(monkeypatch, {})
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
+            assert resolve_provider("auto") == "alibaba"
+
+        assert not any(
+            "Multiple provider API keys detected" in record.message
+            for record in caplog.records
+        )
+
+    def test_single_provider_dual_env_vars_not_multi_key(
+        self, monkeypatch, caplog
+    ):
+        """A provider with multiple env vars (e.g. GLM_API_KEY + ZAI_API_KEY)
+        counts as one candidate, not two."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _config(monkeypatch, {})
+        monkeypatch.setenv("GLM_API_KEY", "test-glm-key")
+        monkeypatch.setenv("ZAI_API_KEY", "test-zai-key")
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
+            assert resolve_provider("auto") == "zai"
+
+        assert not any(
+            "Multiple provider API keys detected" in record.message
+            for record in caplog.records
+        )
 
     def test_env_key_beats_stale_oauth(self, monkeypatch):
         """An exported provider API key wins over a logged-in OAuth active_provider."""
@@ -66,7 +161,6 @@ class TestProviderPrecedence:
     def test_warns_on_silent_oauth_fallthrough(self, monkeypatch, caplog):
         """A populated model dict lacking `provider` that falls through to OAuth
         emits a WARN so the silent override is visible (#29285)."""
-        import logging
         _clear_provider_env(monkeypatch)
         _no_aws(monkeypatch)
         _login(monkeypatch, "anthropic")

--- a/tests/hermes_cli/test_provider_precedence.py
+++ b/tests/hermes_cli/test_provider_precedence.py
@@ -6,9 +6,11 @@ over a stale logged-in OAuth `active_provider` in auth.json. Before the fix,
 explicit choice — e.g. a user OAuth-logged-into Anthropic but with
 OPENAI_API_KEY exported (or model.provider set) got routed to Anthropic.
 """
+import logging
+
 import pytest
 
-from hermes_cli.auth import resolve_provider, AuthError
+from hermes_cli.auth import PROVIDER_REGISTRY, resolve_provider, AuthError
 
 
 def _login(monkeypatch, provider_id):
@@ -29,8 +31,16 @@ def _no_aws(monkeypatch):
 
 
 def _clear_provider_env(monkeypatch):
-    for var in ("OPENAI_API_KEY", "OPENROUTER_API_KEY", "GLM_API_KEY", "ZAI_API_KEY",
-                "KIMI_API_KEY", "MINIMAX_API_KEY", "HERMES_INFERENCE_PROVIDER"):
+    provider_key_vars = {
+        env_var
+        for provider in PROVIDER_REGISTRY.values()
+        for env_var in provider.api_key_env_vars
+    }
+    for var in provider_key_vars | {
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "HERMES_INFERENCE_PROVIDER",
+    }:
         monkeypatch.delenv(var, raising=False)
 
 
@@ -52,8 +62,6 @@ class TestProviderPrecedence:
 
     def test_config_read_failure_is_warning(self, monkeypatch, caplog):
         """A config read failure must be visible without debug logging enabled."""
-        import logging
-
         _clear_provider_env(monkeypatch)
         _no_aws(monkeypatch)
         monkeypatch.setattr(
@@ -82,6 +90,45 @@ class TestProviderPrecedence:
         assert resolve_provider("auto") == "openrouter"
 
 
+    def test_warns_when_multiple_provider_api_keys_are_detected(
+        self, monkeypatch, caplog
+    ):
+        """Multiple provider keys warn while registry order selects the provider."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _config(monkeypatch, {})
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
+            assert resolve_provider("auto") == "alibaba"
+
+        warning_messages = [
+            record.message
+            for record in caplog.records
+            if "Multiple provider API keys detected" in record.message
+        ]
+        assert len(warning_messages) == 1
+        assert "alibaba (DASHSCOPE_API_KEY)" in warning_messages[0]
+        assert "opencode-go (OPENCODE_GO_API_KEY)" in warning_messages[0]
+
+    def test_shared_provider_api_key_does_not_emit_multi_key_warning(
+        self, monkeypatch, caplog
+    ):
+        """A shared env var is one candidate even when two providers accept it."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _config(monkeypatch, {})
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
+            assert resolve_provider("auto") == "alibaba"
+
+        assert not any(
+            "Multiple provider API keys detected" in record.message
+            for record in caplog.records
+        )
+
     def test_oauth_used_as_last_resort(self, monkeypatch):
         """With NO config provider and NO env keys, the logged-in OAuth provider
         is still used (it's the last-resort fallback, not removed)."""
@@ -95,7 +142,6 @@ class TestProviderPrecedence:
     def test_warns_on_silent_oauth_fallthrough(self, monkeypatch, caplog):
         """A populated model dict lacking `provider` that falls through to OAuth
         emits a WARN so the silent override is visible (#29285)."""
-        import logging
         _clear_provider_env(monkeypatch)
         _no_aws(monkeypatch)
         _login(monkeypatch, "anthropic")
@@ -103,7 +149,6 @@ class TestProviderPrecedence:
         with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
             assert resolve_provider("auto") == "anthropic"
         assert any("no `provider` key" in r.message for r in caplog.records)
-
 
     def test_openrouter_pool_beats_stale_oauth(self, monkeypatch):
         """An OpenRouter credential-pool entry (no env var) wins over a logged-in

--- a/tests/hermes_cli/test_provider_precedence.py
+++ b/tests/hermes_cli/test_provider_precedence.py
@@ -129,6 +129,25 @@ class TestProviderPrecedence:
             for record in caplog.records
         )
 
+    def test_single_provider_dual_env_vars_not_multi_key(
+        self, monkeypatch, caplog
+    ):
+        """A provider with multiple env vars (e.g. GLM_API_KEY + ZAI_API_KEY)
+        counts as one candidate, not two."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _config(monkeypatch, {})
+        monkeypatch.setenv("GLM_API_KEY", "test-glm-key")
+        monkeypatch.setenv("ZAI_API_KEY", "test-zai-key")
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
+            assert resolve_provider("auto") == "zai"
+
+        assert not any(
+            "Multiple provider API keys detected" in record.message
+            for record in caplog.records
+        )
+
     def test_oauth_used_as_last_resort(self, monkeypatch):
         """With NO config provider and NO env keys, the logged-in OAuth provider
         is still used (it's the last-resort fallback, not removed)."""

--- a/tests/hermes_cli/test_provider_precedence.py
+++ b/tests/hermes_cli/test_provider_precedence.py
@@ -43,6 +43,35 @@ class TestProviderPrecedence:
         _config(monkeypatch, {"provider": "zai", "default": "glm-4.6"})
         assert resolve_provider("auto") == "zai"
 
+    def test_config_provider_alias_is_normalized(self, monkeypatch):
+        """config.yaml model.provider accepts the same aliases as explicit input."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _config(monkeypatch, {"provider": " GO "})
+        assert resolve_provider("auto") == "opencode-go"
+
+    def test_config_read_failure_is_warning(self, monkeypatch, caplog):
+        """A config read failure must be visible without debug logging enabled."""
+        import logging
+
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: (_ for _ in ()).throw(OSError("unreadable config")),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
+            try:
+                resolve_provider("auto")
+            except AuthError:
+                pass
+
+        assert any(
+            "Could not read config.yaml model.provider" in record.message
+            for record in caplog.records
+        )
+
     def test_env_key_beats_stale_oauth(self, monkeypatch):
         """An exported provider API key wins over a logged-in OAuth active_provider."""
         _clear_provider_env(monkeypatch)


### PR DESCRIPTION
## What does this PR do?

Fixes three related issues in `resolve_provider()` (`hermes_cli/auth.py`) reported in #72088:

1. **Multi-key ambiguity (Primary):** When multiple API-key providers have keys set in the environment (e.g. `DASHSCOPE_API_KEY` + `OPENCODE_GO_API_KEY`), `resolve_provider()` silently picks the first match in `PROVIDER_REGISTRY` insertion order. This PR replaces the immediate-return loop with a two-pass approach: collect all candidates first (deduplicating by env var name for shared-key providers like `alibaba`/`alibaba-coding-plan`), then emit `logger.warning` when ≥2 distinct keys are detected.

2. **Alias normalization gap (Secondary):** The config path at line 1964 checked raw provider values against `PROVIDER_REGISTRY` without alias normalization, while the `requested` parameter path (line 1926) already used `_PROVIDER_ALIASES`. Apply the same normalization so documented aliases like `go` → `opencode-go` work from `config.yaml`.

3. **Silent config failures (Tertiary):** Upgrade `load_config()` failure from `logger.debug` to `logger.warning` so these failures surface in production logs.

Uses the same warning pattern as the #29285 fix (OAuth vs API-key conflict).

## Related Issue

Fixes #72088

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/auth.py`: Two-pass auto-detect with env-var dedup + multi-key `logger.warning`; alias normalization in config path; log level upgrade; `break` to avoid same-provider multi-env false positive
- `tests/hermes_cli/test_provider_precedence.py`: `test_warns_when_multiple_provider_api_keys_are_detected`, `test_shared_provider_api_key_does_not_emit_multi_key_warning`, `test_single_provider_dual_env_vars_not_multi_key`, `test_config_provider_alias_is_normalized`, `test_config_read_failure_is_warning`

## How to Test

1. Set `DASHSCOPE_API_KEY` and `OPENCODE_GO_API_KEY` in the environment, clear `OPENAI_API_KEY` and `OPENROUTER_API_KEY`, then call `resolve_provider("auto")` — verify a `logger.warning` lists both candidates
2. Set only `DASHSCOPE_API_KEY` — verify no warning is emitted (single key, silent as before)
3. Monkeypatch `load_config` with `{"model": {"provider": "go"}}` — verify `resolve_provider("auto")` returns `"opencode-go"` (alias resolved)
4. Run `pytest tests/hermes_cli/test_provider_precedence.py -v` — both new tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've run `pytest tests/ -q` and all tests pass (ran `tests/hermes_cli/test_provider_precedence.py` — 10 passed including 5 new)
- [x] I've tested on my platform: macOS 26.5.1 (Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
