### PR TITLE
fix(gateway): guard faulthandler.enable() against sys.stderr=None on Windows

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7818,7 +7818,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Enable faulthandler at gateway start so that SIGUSR2 (or an
         # internal watchdog) can dump all thread and task stacks to stderr
         # for post-mortem diagnosis of event-loop freezes (#70344).
-        faulthandler.enable()
+        # Guard against sys.stderr being None on Windows when spawned
+        # as a subprocess without a TTY (avoids RuntimeError).
+        if sys.stderr is not None:
+            faulthandler.enable()
         # Also dump stacks to a rotating file for off-line analysis when
         # the gateway is running under a service manager that doesn't
         # capture stderr.


### PR DESCRIPTION
## Problem

`faulthandler.enable()` crashes with `RuntimeError: sys.stderr is None` when the gateway is spawned as a subprocess without a TTY on Windows. This happens because faulthandler defaults to writing to `sys.stderr`, which is `None` in that context.

This breaks two scenarios:
- `hermes gateway start` — spawns the gateway as a child process, crashes immediately with exit code 1
- Desktop app backend launch (`hermes serve` spawned by Electron) — same crash, producing "Could not connect to hermes gateway" in the UI

The crash happens at `gateway/run.py:7821`.

## Fix

Wrap `faulthandler.enable()` with a `if sys.stderr is not None:` guard. This preserves the faulthandler behavior on platforms where `sys.stderr` is available (Linux, macOS, Windows with TTY) while preventing the crash on headless child processes.

## Verification

- Windows 10, gateway spawned as child process: before fix, crashes <1s; after fix, runs indefinitely
- Desktop app connects and loads successfully after reboot
- Feishu messaging gateway stable for 30+ minutes and responding to messages
- `hermes gateway start` returns success and process stays running
- No impact on Linux/macOS (sys.stderr is always available there)
