### PR TITLE
fix(computer-use): clean up CUA backend at task completion

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2212,7 +2212,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
 
 def cleanup_task_resources(agent, task_id: str) -> None:
-    """Clean up VM and browser resources for a given task.
+    """Clean up VM, browser, and computer-use resources for a given task.
 
     Skips ``cleanup_vm`` when the active terminal environment is marked
     persistent (``persistent_filesystem=True``) so that long-lived sandbox
@@ -2257,6 +2257,11 @@ def cleanup_task_resources(agent, task_id: str) -> None:
     except Exception as e:
         if agent.verbose_logging:
             logger.warning(f"Failed to cleanup browser for task {task_id}: {e}")
+    try:
+        from tools.computer_use.tool import cleanup_computer_use
+        cleanup_computer_use(task_id)
+    except Exception as e:
+        logger.warning("Failed to cleanup computer_use for task %s: %s", task_id, e)
 
 
 def _build_partial_stream_stub(

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -8,6 +8,9 @@ for must still be returned.  Previously any of those raised straight out of
 traceback and lost the whole turn.
 """
 
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import pytest
 
 from agent.turn_finalizer import finalize_turn
@@ -41,6 +44,7 @@ class _StubAgent:
         self._interrupt_message = None
         self._tool_guardrail_halt_decision = None
         self._response_was_previewed = False
+        self.cleaned_task_ids = []
         self._skill_nudge_interval = 0
         self._iters_since_skill = 0
         for attr in (
@@ -63,7 +67,8 @@ class _StubAgent:
         if "save_trajectory" in self._raise_in:
             raise RuntimeError("trajectory disk full")
 
-    def _cleanup_task_resources(self, *a, **k):
+    def _cleanup_task_resources(self, task_id, *a, **k):
+        self.cleaned_task_ids.append(task_id)
         if "cleanup_task_resources" in self._raise_in:
             raise RuntimeError("docker teardown EOF")
 
@@ -106,6 +111,7 @@ def _run(
     final_response=None,
     api_call_count=3,
     turn_exit_reason="unknown",
+    interrupted=False,
 ):
     messages = [
         {"role": "user", "content": "do a thing"},
@@ -122,7 +128,7 @@ def _run(
         agent,
         final_response=final_response,
         api_call_count=api_call_count,
-        interrupted=False,
+        interrupted=interrupted,
         failed=False,
         messages=messages,
         conversation_history=None,
@@ -162,6 +168,34 @@ def test_single_cleanup_step_raises_does_not_skip_others(step):
         )
     ]
     assert len(result["cleanup_errors"]) == 1
+
+
+def test_computer_use_cleanup_failure_does_not_block_vm_or_browser_cleanup(caplog):
+    from agent import chat_completion_helpers as helpers
+
+    calls = []
+    runtime = SimpleNamespace(
+        cleanup_vm=lambda task_id: calls.append(("vm", task_id)),
+        cleanup_browser=lambda task_id: calls.append(("browser", task_id)),
+    )
+    agent = SimpleNamespace(verbose_logging=False)
+
+    with patch.object(helpers, "_ra", return_value=runtime), patch(
+        "tools.computer_use.tool.cleanup_computer_use",
+        side_effect=RuntimeError("MCP bridge close failed"),
+    ):
+        helpers.cleanup_task_resources(agent, "task-1")
+
+    assert calls == [("vm", "task-1"), ("browser", "task-1")]
+    assert "Failed to cleanup computer_use for task task-1" in caplog.text
+
+
+def test_user_interrupt_reaches_task_resource_cleanup():
+    agent = _StubAgent(raise_in=())
+    result = _run(agent, interrupted=True)
+
+    assert result["interrupted"] is True
+    assert agent.cleaned_task_ids == ["task-1"]
 
 
 def test_clean_turn_has_no_cleanup_errors_key():

--- a/tests/computer_use/test_cua_atexit_teardown.py
+++ b/tests/computer_use/test_cua_atexit_teardown.py
@@ -1,20 +1,4 @@
-"""Tests for cua-driver subprocess teardown on interpreter exit.
-
-``CuaDriverBackend`` spawns a long-lived ``cua-driver`` child process and
-caches it for the life of the Hermes process. Nothing ever tore it down, so
-the driver outlived the session that started it (#28152 item 3 — "Hermes does
-not keep the driver alive after tool completion"). #69903 fixed the *overlay*
-redraw loop that made the lingering process burn CPU, but not the lingering
-process itself.
-
-``tools/computer_use/tool.py`` registers an ``atexit`` hook that stops the
-cached backend, mirroring ``browser_tool``'s
-``atexit.register(_emergency_cleanup_all_sessions)``.
-
-These assert the behavior contract — the hook is registered, it stops a live
-backend, it is a no-op when nothing was ever started, and it never raises out
-of ``atexit`` — not a snapshot of the module's source.
-"""
+"""Tests for cua-driver subprocess teardown on interpreter exit."""
 
 import atexit
 from unittest.mock import MagicMock, patch
@@ -23,50 +7,42 @@ from tools.computer_use import tool as cu_tool
 
 
 class TestAtexitTeardown:
-    def test_shutdown_stops_a_live_backend(self):
-        """A cached backend is stopped when the interpreter exits."""
-        fake = MagicMock()
-        with patch.object(cu_tool, "_backend", fake):
+    def test_shutdown_stops_each_live_task_backend(self):
+        """Every still-owned backend is stopped when the interpreter exits."""
+        first = MagicMock()
+        second = MagicMock()
+        with patch.object(cu_tool, "_backends", {"task-a": first, "task-b": second}):
             cu_tool._shutdown_backend_atexit()
-            fake.stop.assert_called_once()
+            first.stop.assert_called_once()
+            second.stop.assert_called_once()
 
-    def test_shutdown_clears_the_cached_backend(self):
-        """After teardown the module cache is empty, so a later call re-spawns."""
+    def test_shutdown_clears_the_task_backend_registry(self):
+        """After teardown no task backend remains cached."""
         fake = MagicMock()
-        with patch.object(cu_tool, "_backend", fake):
+        with patch.object(cu_tool, "_backends", {"task-a": fake}):
             cu_tool._shutdown_backend_atexit()
-            assert cu_tool._backend is None
+            assert cu_tool._backends == {}
 
     def test_shutdown_is_a_noop_when_never_started(self):
         """No backend was ever created => nothing to stop, no error."""
-        with patch.object(cu_tool, "_backend", None):
+        with patch.object(cu_tool, "_backends", {}):
             cu_tool._shutdown_backend_atexit()  # must not raise
-            assert cu_tool._backend is None
+            assert cu_tool._backends == {}
 
     def test_shutdown_swallows_backend_errors(self):
-        """A failing stop() must not raise out of an atexit hook.
-
-        Exceptions escaping atexit print a traceback on every exit and can
-        mask the real exit status.
-        """
+        """A failing stop() must not raise out of an atexit hook."""
         fake = MagicMock()
         fake.stop.side_effect = RuntimeError("driver already dead")
-        with patch.object(cu_tool, "_backend", fake):
+        with patch.object(cu_tool, "_backends", {"task-a": fake}):
             cu_tool._shutdown_backend_atexit()  # must not raise
-            assert cu_tool._backend is None
+            assert cu_tool._backends == {}
 
     def test_hook_is_registered_with_atexit(self):
-        """Importing the tool module registers the teardown hook.
-
-        Verified by unregistering and re-registering: atexit.unregister only
-        removes a function that was actually registered, so a successful
-        round-trip proves the import-time registration happened.
-        """
+        """Importing the tool module registers the teardown hook."""
         atexit.unregister(cu_tool._shutdown_backend_atexit)
         try:
-            with patch.object(cu_tool, "_backend", MagicMock()) as fake:
-                # Re-register and fire the full atexit chain the way the
-                # interpreter would, then confirm our hook ran.
+            fake = MagicMock()
+            with patch.object(cu_tool, "_backends", {"task-a": fake}):
                 atexit.register(cu_tool._shutdown_backend_atexit)
                 atexit._run_exitfuncs()
                 fake.stop.assert_called_once()

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -6,6 +6,8 @@ import base64
 import json
 import os
 import sys
+import threading
+from types import SimpleNamespace
 from typing import Any, Dict, List, cast
 from unittest.mock import MagicMock, patch
 
@@ -360,6 +362,146 @@ class TestDispatch:
         # Noop backend returns ok=True, so capture should have been called.
         capture_calls = [c for c in noop_backend.calls if c[0] == "capture"]
         assert len(capture_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Task-owned backend lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestTaskOwnedBackendLifecycle:
+    class _Backend:
+        def __init__(self, *, fail_start=False, fail_stop=False):
+            self.fail_start = fail_start
+            self.fail_stop = fail_stop
+            self.started = 0
+            self.stopped = 0
+            self.calls = []
+
+        def start(self):
+            self.started += 1
+            if self.fail_start:
+                raise RuntimeError("start failed")
+
+        def stop(self):
+            self.stopped += 1
+            if self.fail_stop:
+                raise RuntimeError("stop failed")
+
+        def is_available(self):
+            return True
+
+        def list_apps(self):
+            self.calls.append("list_apps")
+            return []
+
+        def list_windows(self):
+            self.calls.append("list_windows")
+            return []
+
+    def test_actions_in_one_task_reuse_one_backend(self, monkeypatch):
+        from tools.computer_use import tool as cu_tool
+
+        monkeypatch.setenv("HERMES_COMPUTER_USE_BACKEND", "cua")
+        backend = self._Backend()
+        with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend) as factory:
+            cu_tool.handle_computer_use({"action": "list_apps"}, task_id="task-a")
+            cu_tool.handle_computer_use({"action": "list_apps"}, task_id="task-a")
+
+        assert factory.call_count == 1
+        assert backend.started == 1
+        assert backend.calls == ["list_apps", "list_apps"]
+
+    def test_concurrent_task_ids_receive_distinct_backends(self, monkeypatch):
+        from tools.computer_use import tool as cu_tool
+
+        monkeypatch.setenv("HERMES_COMPUTER_USE_BACKEND", "cua")
+        first = self._Backend()
+        second = self._Backend()
+        barrier = threading.Barrier(3)
+        results = []
+
+        def run(task_id):
+            barrier.wait()
+            results.append(cu_tool.handle_computer_use({"action": "list_apps"}, task_id=task_id))
+
+        with patch("tools.computer_use.cua_backend.CuaDriverBackend", side_effect=[first, second]) as factory:
+            threads = [threading.Thread(target=run, args=(task_id,)) for task_id in ("task-a", "task-b")]
+            for thread in threads:
+                thread.start()
+            barrier.wait()
+            for thread in threads:
+                thread.join()
+
+        assert factory.call_count == 2
+        assert len(results) == 2
+        assert all("error" not in json.loads(result) for result in results)
+        assert first is not second
+
+    def test_cleanup_detaches_only_its_task_backend_and_is_idempotent(self, monkeypatch):
+        from tools.computer_use import tool as cu_tool
+
+        monkeypatch.setenv("HERMES_COMPUTER_USE_BACKEND", "cua")
+        first = self._Backend()
+        second = self._Backend()
+        with patch("tools.computer_use.cua_backend.CuaDriverBackend", side_effect=[first, second]):
+            cu_tool.handle_computer_use({"action": "list_apps"}, task_id="task-a")
+            cu_tool.handle_computer_use({"action": "list_apps"}, task_id="task-b")
+            cu_tool.cleanup_computer_use("task-a")
+            cu_tool.cleanup_computer_use("task-a")
+
+            assert "task-a" not in cu_tool._backends
+            assert cu_tool._backends["task-b"] is second
+            assert first.stopped == 1
+            assert second.stopped == 0
+
+    def test_task_finalizer_closes_only_its_task_backend(self, monkeypatch):
+        from agent import chat_completion_helpers as helpers
+        from tools.computer_use import tool as cu_tool
+
+        monkeypatch.setenv("HERMES_COMPUTER_USE_BACKEND", "cua")
+        first = self._Backend()
+        second = self._Backend()
+        runtime = SimpleNamespace(cleanup_vm=lambda task_id: None, cleanup_browser=lambda task_id: None)
+        agent = SimpleNamespace(verbose_logging=False)
+        with patch("tools.computer_use.cua_backend.CuaDriverBackend", side_effect=[first, second]), patch.object(
+            helpers, "_ra", return_value=runtime
+        ):
+            cu_tool.handle_computer_use({"action": "list_apps"}, task_id="task-a")
+            cu_tool.handle_computer_use({"action": "list_apps"}, task_id="task-b")
+            helpers.cleanup_task_resources(agent, "task-a")
+
+        assert first.stopped == 1
+        assert second.stopped == 0
+        assert "task-a" not in cu_tool._backends
+        assert cu_tool._backends["task-b"] is second
+
+    def test_start_failure_does_not_cache_backend(self, monkeypatch):
+        from tools.computer_use import tool as cu_tool
+
+        monkeypatch.setenv("HERMES_COMPUTER_USE_BACKEND", "cua")
+        failed = self._Backend(fail_start=True)
+        with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=failed):
+            result = json.loads(cu_tool.handle_computer_use({"action": "list_apps"}, task_id="task-a"))
+
+        assert "backend unavailable" in result["error"]
+        assert failed.stopped == 1
+        assert "task-a" not in cu_tool._backends
+
+    def test_atexit_stops_all_task_backends_without_raising(self, monkeypatch):
+        from tools.computer_use import tool as cu_tool
+
+        monkeypatch.setenv("HERMES_COMPUTER_USE_BACKEND", "cua")
+        healthy = self._Backend()
+        failing = self._Backend(fail_stop=True)
+        with patch("tools.computer_use.cua_backend.CuaDriverBackend", side_effect=[healthy, failing]):
+            cu_tool.handle_computer_use({"action": "list_apps"}, task_id="task-a")
+            cu_tool.handle_computer_use({"action": "list_apps"}, task_id="task-b")
+            cu_tool._shutdown_backend_atexit()
+
+        assert healthy.stopped == 1
+        assert failing.stopped == 1
+        assert cu_tool._backends == {}
 
 
 # ---------------------------------------------------------------------------
@@ -1397,7 +1539,7 @@ class TestCaptureAfterAppContext:
 
         backend = TrackingBackend()
         cu_tool.reset_backend_for_tests()
-        cu_tool._backend = backend
+        cu_tool._backends[""] = cast(Any, backend)
 
         cu_tool.handle_computer_use({"action": "click", "element": 14, "capture_after": True})
 
@@ -1463,7 +1605,7 @@ class TestCaptureAfterAppContext:
 
         backend = NoContextBackend()
         cu_tool.reset_backend_for_tests()
-        cu_tool._backend = backend
+        cu_tool._backends[""] = cast(Any, backend)
 
         cu_tool.handle_computer_use({"action": "click", "element": 5, "capture_after": True})
 
@@ -2377,7 +2519,7 @@ class TestCaptureAfterExactTarget:
             return original_call_tool(name, args)
 
         session.call_tool.side_effect = _call_tool
-        monkeypatch.setattr(computer_use_tool, "_backend", backend)
+        monkeypatch.setattr(computer_use_tool, "_backends", {"": backend})
 
         capture_out = computer_use_tool.handle_computer_use({
             "action": "capture", "mode": "ax", "app": "org.freecad.FreeCAD",

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -137,11 +137,13 @@ def _is_blocked_type(text: str) -> Optional[str]:
 # Backend selection — env-swappable for tests
 # ---------------------------------------------------------------------------
 
-# Per-process cached backend; lazily instantiated on first call.
+# Task-owned backends, lazily instantiated on the first action for that task.
+# The runtime dispatcher always supplies ``task_id``.  The empty key preserves
+# direct-call/test compatibility for legacy callers outside that dispatcher.
 _backend_lock = threading.Lock()
 # Process-scoped aux-vision routing cache: (provider, model) → bool.
 _AUX_VISION_ROUTE_CACHE: Dict[Tuple[str, str], bool] = {}
-_backend: Optional[ComputerUseBackend] = None
+_backends: Dict[str, ComputerUseBackend] = {}
 # Approval state, scoped per conversation/run (keyed by session_id) so a
 # gateway serving concurrent sessions can't leak one run's "always approve"
 # unlock into another. Falls back to a shared "" bucket for callers that
@@ -154,55 +156,63 @@ _session_auto_approve: Dict[str, bool] = {}
 _always_allow: Dict[str, set] = {}
 
 
-def _get_backend() -> ComputerUseBackend:
-    global _backend
+def _get_backend(task_id: str = "") -> ComputerUseBackend:
+    """Return the backend owned by ``task_id``, starting it once if needed."""
     with _backend_lock:
-        if _backend is None:
-            backend_name = os.environ.get("HERMES_COMPUTER_USE_BACKEND", "cua").lower()
-            if backend_name in {"cua", "cua-driver", ""}:
-                from tools.computer_use.cua_backend import CuaDriverBackend
-                _backend = CuaDriverBackend()
-            elif backend_name == "noop":  # pragma: no cover
-                _backend = _NoopBackend()
-            else:
-                raise RuntimeError(f"Unknown HERMES_COMPUTER_USE_BACKEND={backend_name!r}")
+        backend = _backends.get(task_id)
+        if backend is not None:
+            return backend
+
+        backend_name = os.environ.get("HERMES_COMPUTER_USE_BACKEND", "cua").lower()
+        if backend_name in {"cua", "cua-driver", ""}:
+            from tools.computer_use.cua_backend import CuaDriverBackend
+            backend = CuaDriverBackend()
+        elif backend_name == "noop":  # pragma: no cover
+            backend = _NoopBackend()
+        else:
+            raise RuntimeError(f"Unknown HERMES_COMPUTER_USE_BACKEND={backend_name!r}")
+        try:
+            backend.start()
+        except Exception:
+            # start() can allocate the async bridge before failing.  It is not
+            # registered yet, so task cleanup and atexit cannot reach it.
+            # Best-effort stop preserves the original startup failure.
             try:
-                _backend.start()
+                backend.stop()
             except Exception:
-                # Don't cache a backend whose start() failed (e.g. a lazy
-                # dependency install was declined / failed). The next call
-                # retries cleanly instead of returning a half-initialised
-                # backend.
-                _backend = None
-                raise
-        return _backend
+                logger.debug("computer_use backend stop after failed start failed", exc_info=True)
+            raise
+        _backends[task_id] = backend
+        return backend
+
+
+def cleanup_computer_use(task_id: str) -> None:
+    """Stop and forget only the CUA backend owned by ``task_id``.
+
+    Detaching while holding the registry lock makes repeated cleanup harmless
+    and prevents another task's backend from being selected for teardown.
+    ``stop()`` runs outside the lock because its bounded MCP shutdown can wait.
+    """
+    with _backend_lock:
+        backend = _backends.pop(task_id, None)
+    if backend is not None:
+        backend.stop()
 
 
 def _shutdown_backend_atexit() -> None:
-    """Stop the cached backend so the cua-driver child doesn't outlive us.
+    """Emergency process-exit fallback for every still-owned CUA backend.
 
-    The backend is cached per-process and holds a long-lived ``cua-driver``
-    subprocess, so without this the driver survives the Hermes process that
-    spawned it (#28152 item 3). #69903 kept the orphan from burning a core by
-    disabling the cursor overlay; the process itself still lingered.
-
-    Mirrors ``browser_tool``'s ``atexit.register(_emergency_cleanup_all_sessions)``
-    — same spawn-and-drive-a-subprocess shape. atexit only, no signal handlers:
-    a ``SystemExit`` raised from a prompt_toolkit key binding corrupts its
-    coroutine state and makes the process unkillable. Never raises, since an
-    exception escaping atexit prints a traceback on every exit.
+    Normal task completion uses :func:`cleanup_computer_use`.  This hook only
+    protects abrupt interpreter exit and must never let a teardown error escape.
     """
-    global _backend
-    # Drop the lock before stop() — teardown budgets 5s and shouldn't block
-    # an unrelated caller waiting to spawn.
     with _backend_lock:
-        backend, _backend = _backend, None
-    if backend is None:
-        return
-    try:
-        backend.stop()
-    except Exception as e:
-        logger.debug("cua-driver atexit teardown failed: %s", e)
+        backends = list(_backends.values())
+        _backends.clear()
+    for backend in backends:
+        try:
+            backend.stop()
+        except Exception as e:
+            logger.debug("cua-driver atexit teardown failed: %s", e)
 
 
 atexit.register(_shutdown_backend_atexit)
@@ -292,8 +302,9 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
     action = (args.get("action") or "").strip().lower()
     if not action:
         return json.dumps({"error": "missing `action`"})
-    # Per-run key for approval-state isolation across concurrent sessions.
+    # Per-run keys isolate approvals and backend ownership across concurrent tasks.
     session_id = str(kwargs.get("session_id") or "")
+    task_id = str(kwargs.get("task_id") or "")
 
     # Safety: validate actions before approval prompt.
     if action == "type":
@@ -323,7 +334,7 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
 
     # Dispatch to backend.
     try:
-        backend = _get_backend()
+        backend = _get_backend(task_id)
     except Exception as e:
         return json.dumps({
             "error": f"computer_use backend unavailable: {e}",


### PR DESCRIPTION
CUA backends were cached for the lifetime of the Hermes process. A completed task could therefore retain its MCP session, cua-driver child, and async bridge until process exit.

## Fix
- Own each CUA backend by `task_id` in a lock-protected registry.
- Reuse only the backend for the active task.
- Run `cleanup_computer_use(task_id)` from task finalization; detach the task entry atomically, then call the existing `stop()`.
- Stop a partially initialized backend when `start()` fails before registration.
- Keep `atexit` as an emergency fallback for still-owned backends.

## Non-goals
- No changes to `CuaDriverBackend.stop()`.
- No process-name/PID killing, browser changes, provider/config changes, or gateway restart.

## Tests
- `228 passed, 1 deselected` — `tests/tools/test_computer_use.py` (the deselected Linux GNOME-shell test fails identically on the clean upstream baseline).
- `30 passed` — CUA atexit, turn-finalizer cleanup guard, and delivery-ladder tests.
- `git diff --check` and `py_compile` pass.

The open provider-ABC proposal (#61311) has a broader, separate provider-routing scope; this PR only closes the lifecycle leak in the current CUA backend path.