### PR TITLE
feat(kanban): add deterministic recovery gates

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -506,6 +506,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--reason", default=None,
         help="Human-readable reason (recorded on the reclaimed event)",
     )
+    p_classify_recovery = sub.add_parser(
+        "classify-recovery",
+        help="Record the causal classification required for another retry",
+    )
+    p_classify_recovery.add_argument("task_id")
+    p_classify_recovery.add_argument(
+        "classification",
+        help="Concrete cause discovered since the unchanged retry",
+    )
 
     p_reassign = sub.add_parser(
         "reassign",
@@ -1051,6 +1060,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "assign":   _cmd_assign,
             "set-model": _cmd_set_model,
             "reclaim":  _cmd_reclaim,
+            "classify-recovery": _cmd_classify_recovery,
             "reassign": _cmd_reassign,
             "diagnostics": _cmd_diagnostics,
             "diag":     _cmd_diagnostics,
@@ -1836,6 +1846,22 @@ def _cmd_reclaim(args: argparse.Namespace) -> int:
         )
         return 1
     print(f"Reclaimed {args.task_id}")
+    return 0
+
+
+def _cmd_classify_recovery(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        ok = kb.classify_recovery_cause(
+            conn, args.task_id, args.classification
+        )
+    if not ok:
+        print(
+            f"cannot classify recovery for {args.task_id} "
+            "(unknown or terminal task)",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Classified recovery cause for {args.task_id}")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -949,6 +949,9 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Operator-supplied causal classification after an unchanged recovery
+    # retry is exhausted. Folded into subsequent checkpoint fingerprints.
+    recovery_cause: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1037,6 +1040,9 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            recovery_cause=(
+                row["recovery_cause"] if "recovery_cause" in keys else None
             ),
         )
 
@@ -1220,7 +1226,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Recovery classifications are explicit operator/dispatcher state, not
+    -- inferred from heartbeats. They participate in semantic-progress gates.
+    recovery_cause       TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2403,6 +2412,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "tasks",
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
+        )
+
+    if "recovery_cause" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "recovery_cause", "recovery_cause TEXT"
         )
 
     # Indexes over additive ``tasks`` columns must be created after the
@@ -4342,6 +4356,8 @@ def release_stale_claims(
         termination = _terminate_reclaimed_worker(
             row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
         )
+        if not termination.get("descendants_stopped", True):
+            continue
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.
         if _worker_survived_termination(termination):
@@ -4627,6 +4643,28 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+def _run_can_finalize_owner(
+    conn: sqlite3.Connection, task_id: str, expected_run_id: int
+) -> bool:
+    """Only the current, live owner run may complete or block its card."""
+    row = conn.execute(
+        "SELECT r.task_id, r.run_role, r.owner_task_id, r.ended_at, "
+        "       t.current_run_id, t.status "
+        "FROM task_runs r JOIN tasks t ON t.id=? "
+        "WHERE r.id=?",
+        (task_id, int(expected_run_id)),
+    ).fetchone()
+    return bool(
+        row
+        and row["task_id"] == task_id
+        and row["run_role"] == "owner"
+        and (row["owner_task_id"] is None or row["owner_task_id"] == task_id)
+        and row["ended_at"] is None
+        and row["current_run_id"] == int(expected_run_id)
+        and row["status"] not in ("done", "archived")
+    )
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4698,6 +4736,21 @@ def complete_task(
         conn, task_id, metadata, summary=summary, result=result,
     )
     with write_txn(conn):
+        if expected_run_id is not None and not _run_can_finalize_owner(
+            conn, task_id, int(expected_run_id)
+        ):
+            _append_event(
+                conn,
+                task_id,
+                "finalization_rejected",
+                {
+                    "action": "complete",
+                    "run_id": int(expected_run_id),
+                    "reason": "current_owner_run_required",
+                },
+                run_id=int(expected_run_id),
+            )
+            return False
         if expected_run_id is None:
             cur = conn.execute(
                 """
@@ -5451,6 +5504,21 @@ def block_task(
     routed_to = "blocked"
     recurrences = 0
     with write_txn(conn):
+        if expected_run_id is not None and not _run_can_finalize_owner(
+            conn, task_id, int(expected_run_id)
+        ):
+            _append_event(
+                conn,
+                task_id,
+                "finalization_rejected",
+                {
+                    "action": "block",
+                    "run_id": int(expected_run_id),
+                    "reason": "current_owner_run_required",
+                },
+                run_id=int(expected_run_id),
+            )
+            return False
         cur_row = conn.execute(
             "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
             (task_id,),
@@ -6810,11 +6878,89 @@ def _pid_alive(pid: Optional[int]) -> bool:
     return True
 
 
+def _descendant_pids(pid: int) -> Optional[list[int]]:
+    """Return descendants leaf-first so reclaim can stop children first."""
+    if pid <= 0:
+        return []
+    try:
+        import psutil  # type: ignore
+
+        descendants = psutil.Process(pid).children(recursive=True)
+        parent_of = {proc.pid: proc.ppid() for proc in descendants}
+
+        def _depth(child_pid: int) -> int:
+            depth = 0
+            seen: set[int] = set()
+            current = child_pid
+            while current in parent_of and current not in seen:
+                seen.add(current)
+                depth += 1
+                current = parent_of[current]
+            return depth
+
+        return sorted(
+            parent_of,
+            key=lambda child_pid: (-_depth(child_pid), child_pid),
+        )
+    except ImportError:
+        pass
+    except Exception as exc:
+        try:
+            import psutil  # type: ignore
+
+            if isinstance(exc, psutil.NoSuchProcess):
+                return []
+        except ImportError:
+            pass
+        if _IS_WINDOWS:
+            return None
+    if _IS_WINDOWS:
+        return None
+    try:
+        proc = subprocess.run(
+            ["ps", "-axo", "pid=,ppid="],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError, TimeoutError):
+        return None
+    if proc.returncode != 0:
+        return None
+    children: dict[int, list[int]] = {}
+    for line in (proc.stdout or "").splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        try:
+            child_pid, parent_pid = (int(fields[0]), int(fields[1]))
+        except ValueError:
+            continue
+        children.setdefault(parent_pid, []).append(child_pid)
+
+    ordered: list[int] = []
+    seen: set[int] = set()
+
+    def _walk(parent: int) -> None:
+        for child in sorted(children.get(parent, ())):
+            if child in seen:
+                continue
+            seen.add(child)
+            _walk(child)
+            ordered.append(child)
+
+    _walk(int(pid))
+    return ordered
+
+
 def _terminate_reclaimed_worker(
     pid: Optional[int],
     claim_lock: Optional[str],
     *,
     signal_fn=None,
+    signal_dead_owner: bool = True,
 ) -> dict[str, Any]:
     """Best-effort host-local worker termination for reclaim paths."""
     import signal
@@ -6825,6 +6971,8 @@ def _terminate_reclaimed_worker(
         "termination_attempted": False,
         "terminated": False,
         "sigkill": False,
+        "descendant_pids": [],
+        "descendants_stopped": True,
     }
     if not pid or pid <= 0 or not claim_lock:
         return info
@@ -6838,15 +6986,61 @@ def _terminate_reclaimed_worker(
         os.kill if hasattr(os, "kill") else None
     )
     if kill is None:
+        info["descendants_stopped"] = False
         return info
 
     info["termination_attempted"] = True
+    descendants = _descendant_pids(int(pid))
+    if descendants is None:
+        info["descendants_stopped"] = False
+        info["descendant_enumeration_failed"] = True
+        return info
+    info["descendant_pids"] = descendants
+    for child_pid in descendants:
+        if not _pid_alive(child_pid):
+            continue
+        try:
+            kill(child_pid, signal.SIGTERM)
+        except (ProcessLookupError, OSError):
+            pass
+
+    for _ in range(10):
+        if not any(_pid_alive(child_pid) for child_pid in descendants):
+            break
+        time.sleep(0.1)
+
+    survivors = [
+        child_pid for child_pid in descendants if _pid_alive(child_pid)
+    ]
+    if survivors:
+        _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
+        for child_pid in survivors:
+            try:
+                kill(child_pid, _sigkill)
+                info["sigkill"] = True
+            except (ProcessLookupError, OSError):
+                pass
+        for _ in range(10):
+            if not any(_pid_alive(child_pid) for child_pid in survivors):
+                break
+            time.sleep(0.1)
+    survivors = [
+        child_pid for child_pid in descendants if _pid_alive(child_pid)
+    ]
+    info["descendants_stopped"] = not survivors
+    if survivors:
+        info["descendant_survivors"] = survivors
+        # Never terminate/reclaim the owner while a descendant is still
+        # confirmed alive: doing so can orphan the real workload.
+        return info
+
+    if not signal_dead_owner and not _pid_alive(pid):
+        info["terminated"] = True
+        return info
+
     try:
         kill(int(pid), signal.SIGTERM)
     except ProcessLookupError:
-        # Process is already gone — that's a successful termination, not a
-        # survival. Leaving terminated=False here would make the reclaim guard
-        # misread a dead worker as still-alive and defer forever.
         info["terminated"] = True
         return info
     except OSError:
@@ -6856,7 +7050,7 @@ def _terminate_reclaimed_worker(
         if not _pid_alive(pid):
             info["terminated"] = True
             return info
-        time.sleep(0.5)
+        time.sleep(0.1)
 
     if _pid_alive(pid):
         try:
@@ -7167,6 +7361,8 @@ def detect_stale_running(
         termination = _terminate_reclaimed_worker(
             pid, lock, signal_fn=signal_fn,
         )
+        if not termination.get("descendants_stopped", True):
+            continue
 
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1074,6 +1074,11 @@ class Run:
     summary: Optional[str]
     metadata: Optional[dict]
     error: Optional[str]
+    canonical_worktree: Optional[str] = None
+    dispatch_key: Optional[str] = None
+    run_role: str = "owner"
+    owner_task_id: Optional[str] = None
+    checkpoint_id: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Run":
@@ -1098,6 +1103,11 @@ class Run:
             summary=row["summary"],
             metadata=meta,
             error=row["error"],
+            canonical_worktree=(row["canonical_worktree"] if "canonical_worktree" in row.keys() else None),
+            dispatch_key=(row["dispatch_key"] if "dispatch_key" in row.keys() else None),
+            run_role=(row["run_role"] if "run_role" in row.keys() and row["run_role"] else "owner"),
+            owner_task_id=(row["owner_task_id"] if "owner_task_id" in row.keys() else None),
+            checkpoint_id=(int(row["checkpoint_id"]) if "checkpoint_id" in row.keys() and row["checkpoint_id"] is not None else None),
         )
 
 
@@ -1281,8 +1291,24 @@ CREATE TABLE IF NOT EXISTS task_runs (
     --          gave_up | reclaimed | (null while still running)
     summary             TEXT,
     metadata            TEXT,
-    error               TEXT
+    error               TEXT,
+    canonical_worktree  TEXT,
+    dispatch_key        TEXT,
+    run_role            TEXT NOT NULL DEFAULT 'owner',
+    owner_task_id       TEXT,
+    checkpoint_id       INTEGER
 );
+
+CREATE TABLE IF NOT EXISTS recovery_checkpoints (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT NOT NULL, run_id INTEGER,
+    canonical_worktree TEXT NOT NULL, head_sha TEXT, porcelain_digest TEXT NOT NULL,
+    untracked_digest TEXT NOT NULL, remaining_defects TEXT NOT NULL,
+    remaining_defects_digest TEXT NOT NULL, causal_classification TEXT,
+    semantic_digest TEXT NOT NULL, owner_pid INTEGER, owner_run_id INTEGER,
+    owner_identity TEXT, reason TEXT NOT NULL, created_at INTEGER NOT NULL
+);
+CREATE TRIGGER IF NOT EXISTS recovery_checkpoints_no_update BEFORE UPDATE ON recovery_checkpoints BEGIN SELECT RAISE(ABORT, 'recovery checkpoints are immutable'); END;
+CREATE TRIGGER IF NOT EXISTS recovery_checkpoints_no_delete BEFORE DELETE ON recovery_checkpoints BEGIN SELECT RAISE(ABORT, 'recovery checkpoints are immutable'); END;
 
 -- Files attached to a task (PDFs, images, source documents). The blob
 -- lives on disk under ``attachments_root(board)/<task_id>/<stored_name>``;
@@ -2448,6 +2474,30 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         "ON task_events(run_id, id)"
     )
 
+    runs_exist = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_runs'"
+    ).fetchone() is not None
+    if runs_exist:
+        run_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")}
+        for column, ddl in (
+            ("canonical_worktree", "canonical_worktree TEXT"),
+            ("dispatch_key", "dispatch_key TEXT"),
+            ("run_role", "run_role TEXT NOT NULL DEFAULT 'owner'"),
+            ("owner_task_id", "owner_task_id TEXT"),
+            ("checkpoint_id", "checkpoint_id INTEGER"),
+        ):
+            if column not in run_cols:
+                _add_column_if_missing(conn, "task_runs", column, ddl)
+        final_run_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")}
+        if "ended_at" in final_run_cols:
+            conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_one_live_owner_worktree ON task_runs(canonical_worktree) WHERE ended_at IS NULL AND run_role='owner' AND canonical_worktree IS NOT NULL")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_runs_dispatch_key ON task_runs(dispatch_key, ended_at, outcome)")
+    conn.execute("CREATE TABLE IF NOT EXISTS recovery_checkpoints (id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT NOT NULL, run_id INTEGER, canonical_worktree TEXT NOT NULL, head_sha TEXT, porcelain_digest TEXT NOT NULL, untracked_digest TEXT NOT NULL, remaining_defects TEXT NOT NULL, remaining_defects_digest TEXT NOT NULL, causal_classification TEXT, semantic_digest TEXT NOT NULL, owner_pid INTEGER, owner_run_id INTEGER, owner_identity TEXT, reason TEXT NOT NULL, created_at INTEGER NOT NULL)")
+    conn.execute("CREATE TRIGGER IF NOT EXISTS recovery_checkpoints_no_update BEFORE UPDATE ON recovery_checkpoints BEGIN SELECT RAISE(ABORT, 'recovery checkpoints are immutable'); END")
+    conn.execute("CREATE TRIGGER IF NOT EXISTS recovery_checkpoints_no_delete BEFORE DELETE ON recovery_checkpoints BEGIN SELECT RAISE(ABORT, 'recovery checkpoints are immutable'); END")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_recovery_task ON recovery_checkpoints(task_id, created_at)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_recovery_semantic ON recovery_checkpoints(task_id, semantic_digest)")
+
     notify_table_exists = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_notify_subs'"
     ).fetchone() is not None
@@ -2572,10 +2622,13 @@ _REBUILD_SPECS = {
         " worker_pid INTEGER, max_runtime_seconds INTEGER,"
         " last_heartbeat_at INTEGER, started_at INTEGER NOT NULL,"
         " ended_at INTEGER, outcome TEXT, summary TEXT, metadata TEXT,"
-        " error TEXT)",
+        " error TEXT, canonical_worktree TEXT, dispatch_key TEXT,"
+        " run_role TEXT NOT NULL DEFAULT 'owner', owner_task_id TEXT, checkpoint_id INTEGER)",
         (
             "CREATE INDEX idx_runs_task ON task_runs(task_id, started_at)",
             "CREATE INDEX idx_runs_status ON task_runs(status)",
+            "CREATE UNIQUE INDEX idx_runs_one_live_owner_worktree ON task_runs(canonical_worktree) WHERE ended_at IS NULL AND run_role='owner' AND canonical_worktree IS NOT NULL",
+            "CREATE INDEX idx_runs_dispatch_key ON task_runs(dispatch_key, ended_at, outcome)",
         ),
     ),
     "kanban_notify_subs": (
@@ -4031,6 +4084,72 @@ def recompute_ready(
 # Claim / complete / block
 # ---------------------------------------------------------------------------
 
+def _canonical_worktree(task: Task, *, board: Optional[str] = None) -> str:
+    path = Path(task.workspace_path) if task.workspace_path else workspaces_root(board=board) / task.id
+    path = path.expanduser().resolve(strict=False)
+    try:
+        result = subprocess.run(["git", "-C", str(path), "rev-parse", "--show-toplevel"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False, timeout=5)
+        if result.returncode == 0 and result.stdout.strip():
+            path = Path(os.fsdecode(result.stdout.strip())).resolve(strict=False)
+    except (OSError, subprocess.SubprocessError, TimeoutError):
+        pass
+    return os.path.normcase(str(path))
+
+
+def dispatch_idempotency_key(outcome_key: str, canonical_worktree: str) -> str:
+    return hashlib.sha256(f"kanban-dispatch-v1\0{outcome_key}\0{canonical_worktree}".encode("utf-8", errors="surrogatepass")).hexdigest()
+
+
+def _uses_recovery_gates(task: Task) -> bool:
+    return task.workspace_kind == "worktree" or (task.workspace_kind == "dir" and bool(task.workspace_path))
+
+
+def _snapshot_worktree(path: str) -> tuple[Optional[str], str, str]:
+    def git(*args: str) -> bytes:
+        try:
+            p = subprocess.run(["git", "-C", path, *args], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False, timeout=10)
+            return p.stdout if p.returncode == 0 else b""
+        except (OSError, subprocess.SubprocessError, TimeoutError):
+            return b""
+    head = git("rev-parse", "--verify", "HEAD").strip() or None
+    return (os.fsdecode(head) if head else None, hashlib.sha256(git("status", "--porcelain=v1", "-z", "--untracked-files=no")).hexdigest(), hashlib.sha256(git("ls-files", "--others", "--exclude-standard", "-z")).hexdigest())
+
+
+def _defects(conn: sqlite3.Connection, task_id: str, fallback: str) -> list[str]:
+    row = conn.execute("SELECT metadata FROM task_runs WHERE task_id=? ORDER BY id DESC LIMIT 1", (task_id,)).fetchone()
+    try:
+        values = json.loads(row["metadata"] or "{}") .get("remaining_acceptance_defects", []) if row else []
+    except (TypeError, ValueError): values = []
+    return [str(v).strip() for v in values if str(v).strip()] or [fallback]
+
+
+def _checkpoint(conn: sqlite3.Connection, task: Task, reason: str, defects: Optional[Iterable[str]] = None) -> int:
+    canonical = _canonical_worktree(task)
+    head, porcelain, untracked = _snapshot_worktree(canonical)
+    values = list(dict.fromkeys(str(v).strip() for v in (defects or _defects(conn, task.id, reason)) if str(v).strip()))
+    encoded = json.dumps(values, ensure_ascii=False, separators=(",", ":"))
+    defects_digest = hashlib.sha256(encoded.encode()).hexdigest()
+    semantic = hashlib.sha256(json.dumps({"head": head, "porcelain": porcelain, "untracked": untracked, "defects": defects_digest, "cause": task.recovery_cause}, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    existing = conn.execute("SELECT id FROM recovery_checkpoints WHERE task_id=? AND semantic_digest=? ORDER BY id DESC LIMIT 1", (task.id, semantic)).fetchone()
+    if existing is not None:
+        return int(existing["id"])
+    cur = conn.execute("INSERT INTO recovery_checkpoints (task_id,run_id,canonical_worktree,head_sha,porcelain_digest,untracked_digest,remaining_defects,remaining_defects_digest,causal_classification,semantic_digest,owner_pid,owner_run_id,owner_identity,reason,created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", (task.id,task.current_run_id,canonical,head,porcelain,untracked,encoded,defects_digest,task.recovery_cause,semantic,task.worker_pid,task.current_run_id,task.claim_lock,reason,int(time.time())))
+    return int(cur.lastrowid)
+
+
+def classify_recovery_cause(conn: sqlite3.Connection, task_id: str, classification: str) -> bool:
+    value = str(classification).strip()
+    if not value: raise ValueError("causal classification is required")
+    with write_txn(conn):
+        cur = conn.execute("UPDATE tasks SET recovery_cause=? WHERE id=? AND status NOT IN ('done','archived')", (value, task_id))
+        if cur.rowcount: _append_event(conn, task_id, "recovery_cause_classified", {"classification": value})
+        return bool(cur.rowcount)
+
+
+# ---------------------------------------------------------------------------
+# Claim / complete / block
+# ---------------------------------------------------------------------------
+
 def claim_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4046,7 +4165,40 @@ def claim_task(
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
+    task = get_task(conn, task_id)
+    if task is None:
+        return None
+    canonical_worktree = _canonical_worktree(task)
     with write_txn(conn):
+        if _uses_recovery_gates(task):
+            outcome_key = task.idempotency_key or task.id
+            dispatch_key = dispatch_idempotency_key(outcome_key, canonical_worktree)
+            live = conn.execute("SELECT id, task_id FROM task_runs WHERE canonical_worktree=? AND ended_at IS NULL AND run_role='owner' LIMIT 1", (canonical_worktree,)).fetchone()
+            if live is None:
+                for legacy in conn.execute("SELECT id, task_id FROM task_runs WHERE canonical_worktree IS NULL AND ended_at IS NULL AND run_role='owner'").fetchall():
+                    other = get_task(conn, legacy["task_id"])
+                    if other and _uses_recovery_gates(other) and _canonical_worktree(other) == canonical_worktree:
+                        live = legacy; break
+            if live is not None:
+                _append_event(conn, task_id, "dispatch_deduplicated", {"reason":"live_owner_exists","owner_task_id":live["task_id"],"owner_run_id":live["id"]})
+                return None
+            terminal = conn.execute("SELECT id FROM task_runs WHERE dispatch_key=? AND outcome='completed' LIMIT 1", (dispatch_key,)).fetchone()
+            if terminal is not None:
+                _append_event(conn, task_id, "dispatch_deduplicated", {"reason":"terminal_outcome_exists","terminal_run_id":terminal["id"]})
+                return None
+            previous = conn.execute("SELECT checkpoint_id FROM task_runs WHERE task_id=? AND ended_at IS NOT NULL ORDER BY id DESC LIMIT 1", (task_id,)).fetchone()
+            checkpoint_id = None
+            if previous:
+                checkpoint_id = _checkpoint(conn, get_task(conn, task_id) or task, "redispatch")
+                digest = conn.execute("SELECT semantic_digest FROM recovery_checkpoints WHERE id=?", (checkpoint_id,)).fetchone()["semantic_digest"]
+                retries = conn.execute("SELECT COUNT(*) FROM task_runs r JOIN recovery_checkpoints c ON c.id=r.checkpoint_id WHERE r.dispatch_key=? AND c.semantic_digest=?", (dispatch_key, digest)).fetchone()[0]
+                if retries >= 1:
+                    already_blocked = conn.execute("SELECT 1 FROM task_events WHERE task_id=? AND kind='recovery_gate_blocked' AND payload LIKE '%causal_classification_required%' LIMIT 1", (task_id,)).fetchone()
+                    if already_blocked is None:
+                        _append_event(conn, task_id, "recovery_gate_blocked", {"reason":"causal_classification_required","checkpoint_id":checkpoint_id})
+                    return None
+        else:
+            dispatch_key, checkpoint_id = dispatch_idempotency_key(task.idempotency_key or task.id, canonical_worktree), None
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
@@ -4117,20 +4269,16 @@ def claim_task(
         run_cur = conn.execute(
             """
             INSERT INTO task_runs (
-                task_id, profile, step_key, status,
-                claim_lock, claim_expires, max_runtime_seconds,
-                started_at
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?)
+                task_id, profile, step_key, status, claim_lock, claim_expires,
+                max_runtime_seconds, started_at, canonical_worktree, dispatch_key,
+                run_role, owner_task_id, checkpoint_id
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, 'owner', ?, ?)
             """,
-            (
-                task_id,
-                trow["assignee"] if trow else None,
-                trow["current_step_key"] if trow else None,
-                lock,
-                expires,
-                trow["max_runtime_seconds"] if trow else None,
-                now,
-            ),
+            (task_id, trow["assignee"] if trow else None,
+             trow["current_step_key"] if trow else None, lock, expires,
+             trow["max_runtime_seconds"] if trow else None, now,
+             canonical_worktree if _uses_recovery_gates(task) else None,
+             dispatch_key, task_id, checkpoint_id),
         )
         run_id = run_cur.lastrowid
         conn.execute(
@@ -4197,22 +4345,8 @@ def claim_review_task(
             (task_id,),
         ).fetchone()
         run_cur = conn.execute(
-            """
-            INSERT INTO task_runs (
-                task_id, profile, step_key, status,
-                claim_lock, claim_expires, max_runtime_seconds,
-                started_at
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?)
-            """,
-            (
-                task_id,
-                trow["assignee"] if trow else None,
-                trow["current_step_key"] if trow else None,
-                lock,
-                expires,
-                trow["max_runtime_seconds"] if trow else None,
-                now,
-            ),
+            """INSERT INTO task_runs (task_id, profile, step_key, status, claim_lock, claim_expires, max_runtime_seconds, started_at, run_role, owner_task_id) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, 'reviewer', ?)""",
+            (task_id, trow["assignee"] if trow else None, trow["current_step_key"] if trow else None, lock, expires, trow["max_runtime_seconds"] if trow else None, now, task_id),
         )
         run_id = run_cur.lastrowid
         conn.execute(
@@ -4438,7 +4572,12 @@ def reclaim_task(
     termination = _terminate_reclaimed_worker(
         row["worker_pid"], prev_lock, signal_fn=signal_fn,
     )
+    if not termination.get("descendants_stopped", True) or _worker_survived_termination(termination):
+        return False
     with write_txn(conn):
+        task = get_task(conn, task_id)
+        if task is not None and _uses_recovery_gates(task):
+            _checkpoint(conn, task, "manual_reclaim")
         cur = conn.execute(
             "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
             "claim_expires = NULL, worker_pid = NULL "
@@ -7128,6 +7267,7 @@ def heartbeat_worker(
     task_id: str,
     *,
     note: Optional[str] = None,
+    remaining_defects: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
     """Record a ``heartbeat`` event + touch ``last_heartbeat_at``.
@@ -7166,9 +7306,18 @@ def heartbeat_worker(
                 "UPDATE task_runs SET last_heartbeat_at = ? WHERE id = ?",
                 (now, run_id),
             )
+            if remaining_defects is not None:
+                row = conn.execute("SELECT metadata FROM task_runs WHERE id=?", (run_id,)).fetchone()
+                try:
+                    metadata = json.loads(row["metadata"] or "{}") if row else {}
+                except (TypeError, ValueError):
+                    metadata = {}
+                if not isinstance(metadata, dict): metadata = {}
+                metadata["remaining_acceptance_defects"] = list(dict.fromkeys(str(v).strip() for v in remaining_defects if str(v).strip()))
+                conn.execute("UPDATE task_runs SET metadata=? WHERE id=?", (json.dumps(metadata, ensure_ascii=False), run_id))
         _append_event(
             conn, task_id, "heartbeat",
-            {"note": note} if note else None,
+            ({"note": note, "remaining_defects_count": len(remaining_defects or [])} if remaining_defects is not None else ({"note": note} if note else None)),
             run_id=run_id,
         )
     return True
@@ -7632,6 +7781,9 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
 
+            task = get_task(conn, row["id"])
+            if task is not None and _uses_recovery_gates(task):
+                _checkpoint(conn, task, "rate_limited" if rate_limited_exit else "crashed")
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -406,6 +406,26 @@ def test_run_slash_reclaim_running_task(kanban_home):
     assert "ready" in out2.lower()
 
 
+def test_run_slash_classify_recovery_cause(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="classify retry",
+            assignee="worker",
+            workspace_kind="worktree",
+            workspace_path="/tmp/hermes-classify-recovery",
+        )
+
+    out = kc.run_slash(
+        f"classify-recovery {tid} dependency_state_was_stale"
+    )
+    assert "Classified recovery cause" in out
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).recovery_cause == (
+            "dependency_state_was_stale"
+        )
+
+
 def test_run_slash_reassign_with_reclaim_flag(kanban_home):
     import re
     import time

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -20,6 +20,9 @@ def _make_legacy_db(path: Path) -> None:
         DROP TABLE task_comments;
         DROP TABLE task_runs;
         DROP TABLE kanban_notify_subs;
+        DROP TRIGGER recovery_checkpoints_no_update;
+        DROP TRIGGER recovery_checkpoints_no_delete;
+        DROP TABLE recovery_checkpoints;
         CREATE TABLE task_comments (id TEXT PRIMARY KEY, task_id TEXT NOT NULL,
             author TEXT NOT NULL, body TEXT NOT NULL, created_at INTEGER NOT NULL);
         CREATE TABLE task_events (id TEXT PRIMARY KEY, task_id TEXT NOT NULL,
@@ -128,6 +131,21 @@ def test_legacy_text_pk_tables_rebuilt_to_integer_autoincrement(tmp_path, monkey
         for name in ("idx_events_task", "idx_events_run", "idx_comments_task",
                      "idx_runs_task", "idx_runs_status", "idx_notify_task"):
             assert name in indexes
+
+        run_columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
+        }
+        assert {
+            "canonical_worktree",
+            "dispatch_key",
+            "run_role",
+            "owner_task_id",
+            "checkpoint_id",
+        } <= run_columns
+        assert conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type='table' AND name='recovery_checkpoints'"
+        ).fetchone()
 
         # AUTOINCREMENT actually works after the rebuild.
         conn.execute("INSERT INTO task_events (task_id, kind, created_at) VALUES ('task-1', 'completed', 3000)")

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -519,6 +519,10 @@ async def test_notifier_uploads_artifacts_on_completion(kanban_home, tmp_path, m
     try:
         tid = kb.create_task(conn, title="render q3 chart", assignee="worker1")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
+        assert kb.claim_task(conn, tid)
+        run = kb.latest_run(conn, tid)
+        assert run is not None
+        run_id = run.id
     finally:
         conn.close()
 
@@ -526,6 +530,7 @@ async def test_notifier_uploads_artifacts_on_completion(kanban_home, tmp_path, m
     # → metadata.artifacts → event payload promotion.
     import os
     os.environ["HERMES_KANBAN_TASK"] = tid
+    os.environ["HERMES_KANBAN_RUN_ID"] = str(run_id)
     try:
         out = kt._handle_complete({
             "summary": "rendered the chart",
@@ -533,6 +538,7 @@ async def test_notifier_uploads_artifacts_on_completion(kanban_home, tmp_path, m
         })
     finally:
         os.environ.pop("HERMES_KANBAN_TASK", None)
+        os.environ.pop("HERMES_KANBAN_RUN_ID", None)
     import json as _json
     assert _json.loads(out)["ok"] is True
 
@@ -607,11 +613,16 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
     try:
         tid = kb.create_task(conn, title="t", assignee="worker1")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
+        assert kb.claim_task(conn, tid)
+        run = kb.latest_run(conn, tid)
+        assert run is not None
+        run_id = run.id
     finally:
         conn.close()
 
     import os
     os.environ["HERMES_KANBAN_TASK"] = tid
+    os.environ["HERMES_KANBAN_RUN_ID"] = str(run_id)
     try:
         kt._handle_complete({
             "summary": "one real, one ghost",
@@ -619,6 +630,7 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
         })
     finally:
         os.environ.pop("HERMES_KANBAN_TASK", None)
+        os.environ.pop("HERMES_KANBAN_RUN_ID", None)
 
     runner = object.__new__(GatewayRunner)
     runner._running = True

--- a/tests/hermes_cli/test_kanban_recovery_gates.py
+++ b/tests/hermes_cli/test_kanban_recovery_gates.py
@@ -1,0 +1,474 @@
+"""Deterministic recovery gates for shared Kanban worktrees."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import signal
+import socket
+import sqlite3
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def _git_worktree(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "recovery@example.invalid"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "Recovery Test"],
+        check=True,
+    )
+    tracked = repo / "tracked.txt"
+    tracked.write_text("baseline\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "tracked.txt"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "baseline"], check=True)
+    return repo
+
+
+def _ready_task(
+    conn,
+    *,
+    title: str,
+    workspace: Path,
+    idempotency_key: str | None = None,
+) -> str:
+    return kb.create_task(
+        conn,
+        title=title,
+        assignee="worker",
+        workspace_kind="worktree",
+        workspace_path=str(workspace),
+        idempotency_key=idempotency_key,
+        max_retries=10,
+    )
+
+
+def _host_claimer(suffix: str = "worker") -> str:
+    return f"{socket.gethostname()}:{suffix}"
+
+
+def _crash_current_run(conn, task_id: str, monkeypatch) -> None:
+    kb._set_worker_pid(conn, task_id, 98765)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    assert kb.detect_crashed_workers(conn) == [task_id]
+
+
+def test_schema_migrates_recovery_ledger_and_run_ownership(kanban_home):
+    with kb.connect() as conn:
+        tables = {
+            row["name"]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        run_columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
+        }
+        task_columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
+        }
+
+    assert "recovery_checkpoints" in tables
+    assert {
+        "canonical_worktree",
+        "dispatch_key",
+        "run_role",
+        "owner_task_id",
+        "checkpoint_id",
+    } <= run_columns
+    assert "recovery_cause" in task_columns
+
+
+def test_aliases_and_shared_paths_have_exactly_one_live_owner(
+    kanban_home, tmp_path, monkeypatch
+):
+    repo = _git_worktree(tmp_path)
+    alias = tmp_path / "repo-alias"
+    alias.symlink_to(repo, target_is_directory=True)
+    nested = repo / "nested"
+    nested.mkdir()
+
+    with kb.connect() as conn:
+        first = _ready_task(conn, title="first", workspace=alias)
+        second = _ready_task(conn, title="second", workspace=nested)
+
+        claimed = kb.claim_task(conn, first, claimer=_host_claimer("first"))
+        assert claimed is not None
+        kb._set_worker_pid(conn, first, os.getpid())
+        monkeypatch.setattr(kb, "_pid_alive", lambda pid: pid == os.getpid())
+
+        assert kb.claim_task(
+            conn, second, claimer=_host_claimer("second")
+        ) is None
+        live = conn.execute(
+            "SELECT canonical_worktree, dispatch_key FROM task_runs "
+            "WHERE ended_at IS NULL AND run_role='owner'"
+        ).fetchall()
+        assert len(live) == 1
+        assert live[0]["canonical_worktree"] == str(repo.resolve())
+        assert live[0]["dispatch_key"] == kb.dispatch_idempotency_key(
+            first, str(repo.resolve())
+        )
+
+
+def test_dispatcher_spawns_one_owner_and_deduplicates_shared_worktree(
+    kanban_home, tmp_path, monkeypatch, all_assignees_spawnable
+):
+    repo = _git_worktree(tmp_path)
+    alias = tmp_path / "repo-alias"
+    alias.symlink_to(repo, target_is_directory=True)
+    spawned: list[str] = []
+
+    def spawn(task, _workspace):
+        spawned.append(task.id)
+        return os.getpid()
+
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: pid == os.getpid())
+    with kb.connect() as conn:
+        first = _ready_task(conn, title="first", workspace=repo)
+        second = _ready_task(conn, title="second", workspace=alias)
+        conn.execute("UPDATE tasks SET priority=10 WHERE id=?", (first,))
+        conn.commit()
+
+        result = kb.dispatch_once(conn, spawn_fn=spawn, max_spawn=2)
+        assert spawned == [first]
+        assert [task_id for task_id, _profile, _path in result.spawned] == [
+            first
+        ]
+        assert kb.get_task(conn, first).status == "running"
+        assert kb.get_task(conn, second).status == "ready"
+        dedup = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id=? AND kind='dispatch_deduplicated'",
+            (second,),
+        ).fetchone()
+        assert "live_owner_exists" in dedup["payload"]
+
+
+def test_dead_owner_is_checkpointed_before_an_alias_can_claim(
+    kanban_home, tmp_path, monkeypatch
+):
+    repo = _git_worktree(tmp_path)
+    alias = tmp_path / "repo-alias"
+    alias.symlink_to(repo, target_is_directory=True)
+
+    with kb.connect() as conn:
+        first = _ready_task(conn, title="first", workspace=repo)
+        second = _ready_task(conn, title="second", workspace=alias)
+        assert kb.claim_task(conn, first, claimer=_host_claimer()) is not None
+        _crash_current_run(conn, first, monkeypatch)
+
+        checkpoint = conn.execute(
+            "SELECT * FROM recovery_checkpoints WHERE task_id=? ORDER BY id DESC",
+            (first,),
+        ).fetchone()
+        assert checkpoint is not None
+        assert checkpoint["owner_run_id"] is not None
+        assert checkpoint["owner_pid"] == 98765
+        assert checkpoint["canonical_worktree"] == str(repo.resolve())
+
+        assert kb.claim_task(conn, second, claimer=_host_claimer("next")) is not None
+
+
+def test_migrated_live_run_without_identity_still_blocks_alias(
+    kanban_home, tmp_path
+):
+    repo = _git_worktree(tmp_path)
+    alias = tmp_path / "repo-alias"
+    alias.symlink_to(repo, target_is_directory=True)
+    with kb.connect() as conn:
+        first = _ready_task(conn, title="legacy owner", workspace=repo)
+        second = _ready_task(conn, title="alias", workspace=alias)
+        assert kb.claim_task(conn, first, claimer=_host_claimer("legacy"))
+        run = kb.latest_run(conn, first)
+        conn.execute(
+            "UPDATE task_runs SET canonical_worktree=NULL, dispatch_key=NULL "
+            "WHERE id=?",
+            (run.id,),
+        )
+        conn.commit()
+
+        assert kb.claim_task(conn, second, claimer=_host_claimer("alias")) is None
+
+
+def test_checkpoint_is_immutable_and_contains_digests_not_private_contents(
+    kanban_home, tmp_path, monkeypatch
+):
+    repo = _git_worktree(tmp_path)
+    private = repo / "private-token.txt"
+    private.write_text("TOP-SECRET-CONTENTS\n", encoding="utf-8")
+    (repo / "tracked.txt").write_text("changed\n", encoding="utf-8")
+
+    with kb.connect() as conn:
+        task_id = _ready_task(conn, title="privacy", workspace=repo)
+        assert kb.claim_task(conn, task_id, claimer=_host_claimer()) is not None
+        assert kb.heartbeat_worker(
+            conn,
+            task_id,
+            remaining_defects=[
+                "acceptance test for retry policy is still failing"
+            ],
+        )
+        _crash_current_run(conn, task_id, monkeypatch)
+
+        row = conn.execute(
+            "SELECT * FROM recovery_checkpoints WHERE task_id=?", (task_id,)
+        ).fetchone()
+        assert row["head_sha"]
+        assert len(row["porcelain_digest"]) == 64
+        assert len(row["untracked_digest"]) == 64
+        assert len(row["remaining_defects_digest"]) == 64
+        assert json.loads(row["remaining_defects"]) == [
+            "acceptance test for retry policy is still failing"
+        ]
+        assert "TOP-SECRET-CONTENTS" not in json.dumps(dict(row))
+        assert "private-token.txt" not in json.dumps(dict(row))
+
+        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+            conn.execute(
+                "UPDATE recovery_checkpoints SET owner_pid=1 WHERE id=?",
+                (row["id"],),
+            )
+
+
+def test_one_unchanged_retry_then_causal_classification_is_required(
+    kanban_home, tmp_path, monkeypatch
+):
+    repo = _git_worktree(tmp_path)
+    with kb.connect() as conn:
+        task_id = _ready_task(conn, title="retry", workspace=repo)
+        assert kb.claim_task(conn, task_id, claimer=_host_claimer("initial"))
+        _crash_current_run(conn, task_id, monkeypatch)
+
+        assert kb.claim_task(conn, task_id, claimer=_host_claimer("retry-1"))
+        _crash_current_run(conn, task_id, monkeypatch)
+
+        assert kb.claim_task(
+            conn, task_id, claimer=_host_claimer("retry-2")
+        ) is None
+        event = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id=? AND kind='recovery_gate_blocked' ORDER BY id DESC",
+            (task_id,),
+        ).fetchone()
+        assert "causal_classification_required" in event["payload"]
+        checkpoint_count = conn.execute(
+            "SELECT COUNT(*) FROM recovery_checkpoints WHERE task_id=?",
+            (task_id,),
+        ).fetchone()[0]
+        blocked_event_count = conn.execute(
+            "SELECT COUNT(*) FROM task_events "
+            "WHERE task_id=? AND kind='recovery_gate_blocked'",
+            (task_id,),
+        ).fetchone()[0]
+        assert kb.claim_task(
+            conn, task_id, claimer=_host_claimer("same-held-retry")
+        ) is None
+        assert conn.execute(
+            "SELECT COUNT(*) FROM recovery_checkpoints WHERE task_id=?",
+            (task_id,),
+        ).fetchone()[0] == checkpoint_count
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events "
+            "WHERE task_id=? AND kind='recovery_gate_blocked'",
+            (task_id,),
+        ).fetchone()[0] == blocked_event_count
+
+        assert kb.classify_recovery_cause(
+            conn, task_id, "dependency_state_was_not_refreshed"
+        )
+        assert kb.claim_task(conn, task_id, claimer=_host_claimer("classified"))
+
+
+def test_changed_checkpoint_is_semantic_progress_but_heartbeat_is_not(
+    kanban_home, tmp_path, monkeypatch
+):
+    repo = _git_worktree(tmp_path)
+    with kb.connect() as conn:
+        task_id = _ready_task(conn, title="progress", workspace=repo)
+        assert kb.claim_task(conn, task_id, claimer=_host_claimer("initial"))
+        assert kb.heartbeat_worker(conn, task_id, note="still alive")
+        _crash_current_run(conn, task_id, monkeypatch)
+
+        assert kb.claim_task(conn, task_id, claimer=_host_claimer("retry-1"))
+        assert kb.heartbeat_worker(conn, task_id, note="still alive again")
+        _crash_current_run(conn, task_id, monkeypatch)
+
+        assert kb.claim_task(
+            conn, task_id, claimer=_host_claimer("heartbeat-only")
+        ) is None
+
+        (repo / "tracked.txt").write_text("measurable progress\n", encoding="utf-8")
+        assert kb.claim_task(conn, task_id, claimer=_host_claimer("progressed"))
+
+
+def test_reclaim_stops_and_confirms_descendants_before_owner(
+    kanban_home, tmp_path, monkeypatch
+):
+    repo = _git_worktree(tmp_path)
+    alive = {100, 101, 102}
+    signals: list[tuple[int, int]] = []
+
+    def fake_signal(pid: int, sig: int) -> None:
+        signals.append((pid, sig))
+        alive.discard(pid)
+
+    monkeypatch.setattr(kb, "_descendant_pids", lambda _pid: [102, 101])
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: pid in alive)
+
+    with kb.connect() as conn:
+        task_id = _ready_task(conn, title="tree", workspace=repo)
+        assert kb.claim_task(conn, task_id, claimer=_host_claimer())
+        kb._set_worker_pid(conn, task_id, 100)
+
+        assert kb.reclaim_task(conn, task_id, signal_fn=fake_signal)
+        assert signals == [
+            (102, signal.SIGTERM),
+            (101, signal.SIGTERM),
+            (100, signal.SIGTERM),
+        ]
+        assert kb.get_task(conn, task_id).status == "ready"
+
+
+def test_reclaim_refuses_to_orphan_a_confirmed_live_descendant(
+    kanban_home, tmp_path, monkeypatch
+):
+    repo = _git_worktree(tmp_path)
+    signals: list[tuple[int, int]] = []
+    monkeypatch.setattr(kb, "_descendant_pids", lambda _pid: [201])
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: pid in {200, 201})
+    monkeypatch.setattr(kb.time, "sleep", lambda _seconds: None)
+
+    with kb.connect() as conn:
+        task_id = _ready_task(conn, title="tree", workspace=repo)
+        assert kb.claim_task(conn, task_id, claimer=_host_claimer())
+        kb._set_worker_pid(conn, task_id, 200)
+
+        assert not kb.reclaim_task(
+            conn,
+            task_id,
+            signal_fn=lambda pid, sig: signals.append((pid, sig)),
+        )
+        assert all(pid == 201 for pid, _sig in signals)
+        assert kb.get_task(conn, task_id).status == "running"
+
+
+def test_terminal_dispatch_key_deduplicates_same_outcome_and_worktree(
+    kanban_home, tmp_path
+):
+    repo = _git_worktree(tmp_path)
+    outcome_key = "ship-auth-fix"
+    with kb.connect() as conn:
+        first = _ready_task(
+            conn,
+            title="first",
+            workspace=repo,
+            idempotency_key=outcome_key,
+        )
+        assert kb.claim_task(conn, first, claimer=_host_claimer("first"))
+        first_run = kb.latest_run(conn, first)
+        assert kb.complete_task(
+            conn, first, summary="done", expected_run_id=first_run.id
+        )
+        assert kb.archive_task(conn, first)
+
+        second = _ready_task(
+            conn,
+            title="duplicate",
+            workspace=repo,
+            idempotency_key=outcome_key,
+        )
+        assert kb.claim_task(
+            conn, second, claimer=_host_claimer("duplicate")
+        ) is None
+
+        keys = conn.execute(
+            "SELECT DISTINCT dispatch_key FROM task_runs "
+            "WHERE canonical_worktree=?",
+            (str(repo.resolve()),),
+        ).fetchall()
+        expected = hashlib.sha256(
+            f"kanban-dispatch-v1\0{outcome_key}\0{repo.resolve()}".encode()
+        ).hexdigest()
+        assert [row["dispatch_key"] for row in keys] == [expected]
+
+
+def test_non_owner_runs_and_cards_cannot_finalize_owning_task(
+    kanban_home, tmp_path
+):
+    repo = _git_worktree(tmp_path)
+    with kb.connect() as conn:
+        owner = _ready_task(conn, title="owner", workspace=repo)
+        child = kb.create_task(
+            conn,
+            title="child",
+            assignee="worker",
+            parents=(owner,),
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+        )
+        assert kb.claim_task(conn, owner, claimer=_host_claimer("owner"))
+        owner_run = kb.latest_run(conn, owner)
+
+        conn.execute(
+            "UPDATE task_runs SET run_role='helper' WHERE id=?", (owner_run.id,)
+        )
+        conn.commit()
+        assert not kb.complete_task(
+            conn, owner, summary="helper says done", expected_run_id=owner_run.id
+        )
+        assert not kb.block_task(
+            conn, owner, reason="helper says blocked", expected_run_id=owner_run.id
+        )
+
+        conn.execute(
+            "UPDATE task_runs SET run_role='owner' WHERE id=?", (owner_run.id,)
+        )
+        conn.commit()
+        assert kb.complete_task(
+            conn, owner, summary="owner done", expected_run_id=owner_run.id
+        )
+        assert kb.claim_task(conn, child, claimer=_host_claimer("child"))
+        child_run = kb.latest_run(conn, child)
+        assert not kb.complete_task(
+            conn, owner, summary="child says parent done", expected_run_id=child_run.id
+        )
+
+        review = _ready_task(conn, title="review", workspace=tmp_path / "review")
+        conn.execute("UPDATE tasks SET status='review' WHERE id=?", (review,))
+        conn.commit()
+        assert kb.claim_review_task(conn, review, claimer=_host_claimer("review"))
+        review_run = kb.latest_run(conn, review)
+        assert review_run.run_role == "reviewer"
+        assert not kb.complete_task(
+            conn, review, summary="reviewer says done", expected_run_id=review_run.id
+        )
+        assert not kb.block_task(
+            conn, review, reason="reviewer blocks", expected_run_id=review_run.id
+        )
+
+        assert kb.archive_task(conn, child)
+        assert not kb.complete_task(conn, child, summary="archived child")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -168,9 +168,11 @@ def worker_env(monkeypatch, tmp_path):
     try:
         tid = kb.create_task(conn, title="worker-test", assignee="test-worker")
         kb.claim_task(conn, tid)
+        run_id = kb.latest_run(conn, tid).id
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
     return tid
 
 
@@ -870,6 +872,21 @@ def test_heartbeat_without_note(worker_env):
     out = kt._handle_heartbeat({})
     d = json.loads(out)
     assert d["ok"] is True
+
+
+def test_heartbeat_records_remaining_acceptance_defects(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    out = kt._handle_heartbeat({
+        "remaining_defects": ["alias ownership regression still fails"],
+    })
+    assert json.loads(out)["ok"] is True
+    with kb.connect() as conn:
+        run = kb.latest_run(conn, worker_env)
+        assert run.metadata["remaining_acceptance_defects"] == [
+            "alias ownership regression still fails"
+        ]
 
 
 def test_heartbeat_extends_claim_expires(worker_env):
@@ -1959,6 +1976,17 @@ def test_worker_complete_own_task_still_works(worker_env):
     assert d.get("ok") is True and d.get("task_id") == worker_env
 
 
+def test_worker_finalization_requires_dispatcher_run_identity(
+    worker_env, monkeypatch
+):
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID")
+    out = kt._handle_block({"reason": "must not use an anonymous run"})
+    error = json.loads(out).get("error", "")
+    assert "worker run identity is missing" in error
+
+
 def test_worker_complete_rejects_stale_run_id(worker_env, monkeypatch):
     """A retried worker cannot complete the task using an old run token."""
     from hermes_cli import kanban_db as kb
@@ -2281,7 +2309,9 @@ def test_board_param_routes_heartbeat_to_alt_board(monkeypatch, tmp_path):
     with kb.connect(board="alt") as conn:
         tid = kb.create_task(conn, title="alt hb", assignee="alt-worker")
         kb.claim_task(conn, tid)
+        run_id = kb.latest_run(conn, tid).id
     monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
 
     from tools import kanban_tools as kt
     out = kt._handle_heartbeat({"note": "alive on alt", "board": "alt"})

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -151,6 +151,19 @@ def _worker_run_id(task_id: str) -> Optional[int]:
         return None
 
 
+def _worker_run_identity_error(task_id: str) -> Optional[str]:
+    """A task-scoped worker must carry the dispatcher-issued run token."""
+    if (
+        os.environ.get("HERMES_KANBAN_TASK") == task_id
+        and _worker_run_id(task_id) is None
+    ):
+        return tool_error(
+            "worker run identity is missing or invalid; refusing lifecycle "
+            "mutation without HERMES_KANBAN_RUN_ID"
+        )
+    return None
+
+
 def _stamp_worker_session_metadata(
     task_id: str, metadata: Optional[dict]
 ) -> Optional[dict]:
@@ -549,6 +562,9 @@ def _handle_complete(args: dict, **kw) -> str:
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
+    identity_err = _worker_run_identity_error(tid)
+    if identity_err:
+        return identity_err
     summary = args.get("summary")
     metadata = args.get("metadata")
     result = args.get("result")
@@ -728,6 +744,9 @@ def _handle_block(args: dict, **kw) -> str:
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
+    identity_err = _worker_run_identity_error(tid)
+    if identity_err:
+        return identity_err
     reason = args.get("reason")
     if not reason or not str(reason).strip():
         return tool_error("reason is required — explain what input you need")
@@ -817,7 +836,15 @@ def _handle_heartbeat(args: dict, **kw) -> str:
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
+    identity_err = _worker_run_identity_error(tid)
+    if identity_err:
+        return identity_err
     note = args.get("note")
+    remaining_defects = args.get("remaining_defects")
+    if remaining_defects is not None and not isinstance(
+        remaining_defects, (list, tuple)
+    ):
+        return tool_error("remaining_defects must be a list of strings")
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -834,6 +861,7 @@ def _handle_heartbeat(args: dict, **kw) -> str:
                 conn,
                 tid,
                 note=note,
+                remaining_defects=remaining_defects,
                 expected_run_id=_worker_run_id(tid),
             )
             if not ok:
@@ -1651,8 +1679,9 @@ KANBAN_HEARTBEAT_SCHEMA = {
     "description": (
         "Signal that you're still alive during a long operation "
         "(training, encoding, large crawls). Call every few minutes so "
-        "humans see liveness separately from PID checks. Pure side "
-        "effect — no work changes."
+        "humans see liveness separately from PID checks. A heartbeat alone "
+        "is not semantic progress; report changed remaining defects when "
+        "the acceptance state actually changes."
     ),
     "parameters": {
         "type": "object",
@@ -1666,6 +1695,16 @@ KANBAN_HEARTBEAT_SCHEMA = {
                 "description": (
                     "Optional short note describing current progress. "
                     "Shown in the event log."
+                ),
+            },
+            "remaining_defects": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional current list of unmet acceptance defects. "
+                    "Stored as structured recovery state so a later "
+                    "checkpoint can distinguish semantic progress from "
+                    "heartbeat-only liveness."
                 ),
             },
             "board": _board_schema_prop(),

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -144,7 +144,18 @@ def _worker_run_id(task_id: str) -> Optional[int]:
         return None
     raw = os.environ.get("HERMES_KANBAN_RUN_ID")
     if not raw:
-        return None
+        # Backwards-compatible local/CLI invocation. Dispatcher workers always
+        # receive a token; resolving the live task run here preserves the
+        # ownership check without breaking direct tool callers.
+        try:
+            from hermes_cli import kanban_db as _kb
+            with _kb.connect() as conn:
+                task = _kb.get_task(conn, task_id)
+                # Legacy direct goal-loop callers predate dispatcher run tokens;
+                # all normal worker lifecycle mutations remain token-bound.
+                return (task.current_run_id if task and task.goal_mode and task.current_run_id is not None else None)
+        except Exception:
+            return None
     try:
         return int(raw)
     except ValueError:


### PR DESCRIPTION
## Summary
- port deterministic Kanban recovery gates to current upstream
- enforce current owner/run identity for task-scoped complete/block paths while preserving legacy goal compatibility
- add recovery/migration/tenant and PID/termination/idempotency contract coverage
- update notifier completion tests to claim and supply the active owner run

## Verification
- `pytest -q tests/hermes_cli/test_kanban_recovery_gates.py tests/hermes_cli/test_kanban_db_init.py tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_notify.py` (198 passed)
- Broad Kanban suite was compared against an exact `origin/main` baseline: both candidate and baseline have the same 16 known order-dependent failures caused by `test_kanban_cli_dispatch_passthrough.py` deleting `hermes_cli` modules from `sys.modules`; targeted suites pass in isolation.
- `python -m py_compile hermes_cli/kanban.py hermes_cli/kanban_db.py tools/kanban_tools.py`
- `git diff --check`

Lint/type runners are not installed in this worktree environment; CI is authoritative.