### PR TITLE
fix(desktop): release maintenance op buttons when the action tail stops

### DIFF
--- a/apps/desktop/src/app/command-center/maintenance.test.tsx
+++ b/apps/desktop/src/app/command-center/maintenance.test.tsx
@@ -1,0 +1,146 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import type { ActionResponse, ActionStatusResponse } from '@/types/hermes'
+
+import { MaintenancePanel } from './maintenance'
+
+// Mirrors the constants in maintenance.tsx — the poll cadence and the ceiling
+// after which the panel stops tailing a still-running action.
+const ACTION_POLL_MS = 1200
+const ACTION_POLL_LIMIT = 240
+
+// Every spawn-backed op button is gated on the last observed action status.
+const OP_BUTTONS = ['Run doctor', 'Security audit', 'Create backup', 'Run now']
+
+const getActionStatus = vi.fn<(name: string, lines?: number) => Promise<ActionStatusResponse>>()
+const getCuratorStatus = vi.fn()
+const getMemoryStatus = vi.fn()
+const startAction = vi.fn<() => Promise<ActionResponse>>()
+
+vi.mock('@/hermes', () => ({
+  getActionStatus: (name: string, lines?: number) => getActionStatus(name, lines),
+  getCuratorStatus: () => getCuratorStatus(),
+  getMemoryStatus: () => getMemoryStatus(),
+  resetMemory: () => Promise.resolve({ deleted: [] }),
+  runBackup: () => startAction(),
+  runCurator: () => startAction(),
+  runDebugShare: () => Promise.resolve({ urls: {} }),
+  runDoctor: () => startAction(),
+  runSecurityAudit: () => startAction(),
+  setCuratorPaused: () => Promise.resolve()
+}))
+
+vi.mock('@/store/activity', () => ({ upsertDesktopActionTask: () => {} }))
+vi.mock('@/store/notifications', () => ({ notify: () => {}, notifyError: () => {} }))
+
+const TAILED_LINE = 'doctor: checking providers'
+
+function actionStatus(overrides: Partial<ActionStatusResponse> = {}): ActionStatusResponse {
+  return { exit_code: null, lines: [TAILED_LINE], name: 'doctor', pid: 4242, running: true, ...overrides }
+}
+
+function opButton(name: string): HTMLButtonElement {
+  return screen.getByRole('button', { name }) as HTMLButtonElement
+}
+
+function opButtonsDisabled(): boolean[] {
+  return OP_BUTTONS.map(name => opButton(name).disabled)
+}
+
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
+}
+
+/** Render the panel and press "Run doctor", settling on the first polled status. */
+async function launchDoctor() {
+  render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <MaintenancePanel />
+    </I18nProvider>
+  )
+
+  await waitFor(() => expect(opButton('Run now')).toBeTruthy())
+
+  fireEvent.click(opButton('Run doctor'))
+
+  await waitFor(() => expect(opButtonsDisabled()).toEqual([true, true, true, true]))
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  startAction.mockResolvedValue({ name: 'doctor', ok: true, pid: 4242 })
+  getCuratorStatus.mockResolvedValue({
+    archive_after_days: null,
+    enabled: true,
+    interval_hours: 6,
+    last_run_at: null,
+    min_idle_hours: null,
+    paused: false,
+    stale_after_days: null
+  })
+  getMemoryStatus.mockResolvedValue({ active: '', builtin_files: { memory: 0, user: 0 }, providers: [] })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  vi.resetAllMocks()
+})
+
+describe('MaintenancePanel action gate', () => {
+  it('releases the op buttons when the status endpoint starts failing mid-tail', async () => {
+    getActionStatus.mockResolvedValueOnce(actionStatus()).mockRejectedValue(new Error('status endpoint unreachable'))
+
+    await launchDoctor()
+
+    await advance(ACTION_POLL_MS)
+
+    await waitFor(() => expect(opButtonsDisabled()).toEqual([false, false, false, false]))
+
+    // The tail we already collected must survive the settle — only `running`
+    // changes, so the user keeps the log they were reading.
+    expect(screen.getByText(TAILED_LINE)).toBeTruthy()
+    expect(screen.queryByText('Running...')).toBeNull()
+  })
+
+  it('releases the op buttons when the poll ceiling is reached on a long-running action', async () => {
+    getActionStatus.mockResolvedValue(actionStatus())
+
+    await launchDoctor()
+
+    // One poll short of the ceiling the action is still being tailed, so the
+    // gate must stay closed.
+    await advance((ACTION_POLL_LIMIT - 2) * ACTION_POLL_MS)
+
+    expect(opButtonsDisabled()).toEqual([true, true, true, true])
+
+    await advance(2 * ACTION_POLL_MS)
+
+    await waitFor(() => expect(opButtonsDisabled()).toEqual([false, false, false, false]))
+    expect(screen.getByText(TAILED_LINE)).toBeTruthy()
+  })
+
+  it('leaves the normal completion path untouched', async () => {
+    getActionStatus
+      .mockResolvedValueOnce(actionStatus())
+      .mockResolvedValue(actionStatus({ exit_code: 0, lines: [TAILED_LINE, 'doctor: ok'], running: false }))
+
+    await launchDoctor()
+
+    await advance(ACTION_POLL_MS)
+
+    await waitFor(() => expect(opButtonsDisabled()).toEqual([false, false, false, false]))
+    expect(screen.getByText(/doctor: ok/)).toBeTruthy()
+
+    // A finished action stops the tail: no further polls are scheduled.
+    expect(getActionStatus).toHaveBeenCalledTimes(2)
+
+    await advance(10 * ACTION_POLL_MS)
+
+    expect(getActionStatus).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/app/command-center/maintenance.test.tsx
+++ b/apps/desktop/src/app/command-center/maintenance.test.tsx
@@ -37,6 +37,10 @@ vi.mock('@/store/notifications', () => ({ notify: () => {}, notifyError: () => {
 
 const TAILED_LINE = 'doctor: checking providers'
 
+// The "we stopped following this action" notices, keyed off the en locale.
+const DEGRADED_NOTICE = /the status endpoint stopped responding/i
+const EXHAUSTED_NOTICE = /still running when the log tail timed out/i
+
 function actionStatus(overrides: Partial<ActionStatusResponse> = {}): ActionStatusResponse {
   return { exit_code: null, lines: [TAILED_LINE], name: 'doctor', pid: 4242, running: true, ...overrides }
 }
@@ -52,6 +56,13 @@ function opButtonsDisabled(): boolean[] {
 async function advance(ms: number) {
   await act(async () => {
     await vi.advanceTimersByTimeAsync(ms)
+  })
+}
+
+/** Press the explicit re-verify affordance offered alongside the stop notice. */
+async function clickRecheck() {
+  await act(async () => {
+    fireEvent.click(opButton('Check status'))
   })
 }
 
@@ -92,36 +103,66 @@ afterEach(() => {
 })
 
 describe('MaintenancePanel action gate', () => {
-  it('releases the op buttons when the status endpoint starts failing mid-tail', async () => {
-    getActionStatus.mockResolvedValueOnce(actionStatus()).mockRejectedValue(new Error('status endpoint unreachable'))
+  it('keeps the gate closed when the status endpoint starts failing mid-tail, and releases it only on a verified completion', async () => {
+    getActionStatus.mockResolvedValueOnce(actionStatus()).mockRejectedValueOnce(new Error('status endpoint unreachable'))
 
     await launchDoctor()
 
     await advance(ACTION_POLL_MS)
 
-    await waitFor(() => expect(opButtonsDisabled()).toEqual([false, false, false, false]))
-
-    // The tail we already collected must survive the settle — only `running`
-    // changes, so the user keeps the log they were reading.
+    // The tail stopped, but the backend never said the action finished, so the
+    // gate must stay closed and the stored status must still read `running`.
+    await waitFor(() => expect(screen.getByText(DEGRADED_NOTICE)).toBeTruthy())
+    expect(opButtonsDisabled()).toEqual([true, true, true, true])
     expect(screen.getByText(TAILED_LINE)).toBeTruthy()
-    expect(screen.queryByText('Running...')).toBeNull()
+    expect(screen.getByText('Running...')).toBeTruthy()
+
+    // Re-checking while the action is genuinely still running must NOT release
+    // the gate — the backend value stays authoritative.
+    getActionStatus.mockResolvedValueOnce(actionStatus())
+    await clickRecheck()
+
+    expect(opButtonsDisabled()).toEqual([true, true, true, true])
+    expect(screen.getByText(EXHAUSTED_NOTICE)).toBeTruthy()
+
+    // Only once the backend itself reports the action done does the gate open.
+    getActionStatus.mockResolvedValueOnce(actionStatus({ exit_code: 0, lines: [TAILED_LINE, 'doctor: ok'], running: false }))
+    await clickRecheck()
+
+    await waitFor(() => expect(opButtonsDisabled()).toEqual([false, false, false, false]))
+    expect(screen.queryByText(EXHAUSTED_NOTICE)).toBeNull()
+    expect(screen.queryByText(DEGRADED_NOTICE)).toBeNull()
+    expect(screen.getByText(/doctor: ok/)).toBeTruthy()
   })
 
-  it('releases the op buttons when the poll ceiling is reached on a long-running action', async () => {
+  it('keeps the gate closed when the poll ceiling is reached on a long-running action, and releases it only on a verified completion', async () => {
     getActionStatus.mockResolvedValue(actionStatus())
 
     await launchDoctor()
 
-    // One poll short of the ceiling the action is still being tailed, so the
-    // gate must stay closed.
+    // One poll short of the ceiling the action is still being tailed, so no
+    // notice is shown yet.
     await advance((ACTION_POLL_LIMIT - 2) * ACTION_POLL_MS)
 
     expect(opButtonsDisabled()).toEqual([true, true, true, true])
+    expect(screen.queryByText(EXHAUSTED_NOTICE)).toBeNull()
 
     await advance(2 * ACTION_POLL_MS)
 
-    await waitFor(() => expect(opButtonsDisabled()).toEqual([false, false, false, false]))
+    await waitFor(() => expect(screen.getByText(EXHAUSTED_NOTICE)).toBeTruthy())
+    expect(opButtonsDisabled()).toEqual([true, true, true, true])
     expect(screen.getByText(TAILED_LINE)).toBeTruthy()
+
+    // Exhausting the ceiling stops the tail — it must not keep polling.
+    const pollsAtCeiling = getActionStatus.mock.calls.length
+    await advance(10 * ACTION_POLL_MS)
+    expect(getActionStatus).toHaveBeenCalledTimes(pollsAtCeiling)
+
+    getActionStatus.mockResolvedValue(actionStatus({ exit_code: 0, lines: [TAILED_LINE, 'doctor: ok'], running: false }))
+    await clickRecheck()
+
+    await waitFor(() => expect(opButtonsDisabled()).toEqual([false, false, false, false]))
+    expect(screen.queryByText(EXHAUSTED_NOTICE)).toBeNull()
   })
 
   it('leaves the normal completion path untouched', async () => {

--- a/apps/desktop/src/app/command-center/maintenance.tsx
+++ b/apps/desktop/src/app/command-center/maintenance.tsx
@@ -94,15 +94,27 @@ export function MaintenancePanel() {
           return
         }
 
-        setActionStatus(status)
-        upsertDesktopActionTask(status)
         polls += 1
 
-        if (status.running && polls < ACTION_POLL_LIMIT) {
+        // Giving up on a still-running action: keep the log we tailed, but store
+        // it as settled. `actionStatus.running` gates every op button below and
+        // only `launch()` ever clears it, so a stored `running: true` we have
+        // stopped refreshing disables the very buttons needed to escape it.
+        const exhausted = status.running && polls >= ACTION_POLL_LIMIT
+
+        setActionStatus(exhausted ? { ...status, running: false } : status)
+        upsertDesktopActionTask(status)
+
+        if (status.running && !exhausted) {
           timer = window.setTimeout(() => void poll(), ACTION_POLL_MS)
         }
       } catch {
-        // Status endpoint hiccup — stop tailing; the activity rail still has the task.
+        // Status endpoint hiccup — stop tailing; the activity rail still has the
+        // task. Settle the last observation for the same reason as above: it is
+        // now stale, and leaving it `running` wedges the op buttons.
+        if (!cancelled) {
+          setActionStatus(prev => (prev === null || !prev.running ? prev : { ...prev, running: false }))
+        }
       }
     }
 

--- a/apps/desktop/src/app/command-center/maintenance.tsx
+++ b/apps/desktop/src/app/command-center/maintenance.tsx
@@ -29,6 +29,17 @@ import type { ActionStatusResponse } from '@/types/hermes'
 const ACTION_POLL_MS = 1200
 const ACTION_POLL_LIMIT = 240 // ~5 minutes of polling before giving up.
 
+/** Lifecycle of the inline log tail, tracked separately from the action's own
+ *  `running` flag. The backend is the only authority on whether the process is
+ *  alive (`/api/actions/{name}/status` polls the tracked `Popen`), so giving up
+ *  on the tail must never be recorded as the action having finished.
+ *
+ *  - `idle`      — nothing to follow, or the backend reported the action done.
+ *  - `tailing`   — actively polling.
+ *  - `exhausted` — hit ACTION_POLL_LIMIT while the action was still running.
+ *  - `degraded`  — the status endpoint stopped answering. */
+type TailState = 'degraded' | 'exhausted' | 'idle' | 'tailing'
+
 function formatBytes(size: number): string {
   if (size <= 0) {
     return ''
@@ -61,6 +72,8 @@ export function MaintenancePanel() {
   const [memoryBusy, setMemoryBusy] = useState(false)
   const [share, setShare] = useState<DebugShareResponse | null>(null)
   const [sharing, setSharing] = useState(false)
+  const [tailState, setTailState] = useState<TailState>('idle')
+  const [rechecking, setRechecking] = useState(false)
   const [error, setError] = useState('')
 
   useEffect(() => {
@@ -86,6 +99,8 @@ export function MaintenancePanel() {
     let polls = 0
     let timer: null | number = null
 
+    setTailState('tailing')
+
     const poll = async () => {
       try {
         const status = await getActionStatus(actionName, 200)
@@ -96,24 +111,32 @@ export function MaintenancePanel() {
 
         polls += 1
 
-        // Giving up on a still-running action: keep the log we tailed, but store
-        // it as settled. `actionStatus.running` gates every op button below and
-        // only `launch()` ever clears it, so a stored `running: true` we have
-        // stopped refreshing disables the very buttons needed to escape it.
-        const exhausted = status.running && polls >= ACTION_POLL_LIMIT
-
-        setActionStatus(exhausted ? { ...status, running: false } : status)
+        // The stored status stays exactly as the backend reported it — `running`
+        // is never synthesized here. Whether we are still *following* the action
+        // is a property of this panel, not of the process, so it is tracked in
+        // `tailState` instead.
+        setActionStatus(status)
         upsertDesktopActionTask(status)
 
-        if (status.running && !exhausted) {
-          timer = window.setTimeout(() => void poll(), ACTION_POLL_MS)
+        if (!status.running) {
+          setTailState('idle')
+
+          return
         }
+
+        if (polls >= ACTION_POLL_LIMIT) {
+          setTailState('exhausted')
+
+          return
+        }
+
+        timer = window.setTimeout(() => void poll(), ACTION_POLL_MS)
       } catch {
         // Status endpoint hiccup — stop tailing; the activity rail still has the
-        // task. Settle the last observation for the same reason as above: it is
-        // now stale, and leaving it `running` wedges the op buttons.
+        // task. The last observation stays untouched: it is stale, not falsified,
+        // and the notice below tells the user we stopped following.
         if (!cancelled) {
-          setActionStatus(prev => (prev === null || !prev.running ? prev : { ...prev, running: false }))
+          setTailState('degraded')
         }
       }
     }
@@ -136,6 +159,7 @@ export function MaintenancePanel() {
       try {
         const started = await start()
         setActionStatus(null)
+        setTailState('idle')
         setActionName(started.name)
         notify({ kind: 'success', title: mm.actionStarted(label), message: '' })
       } catch (err) {
@@ -145,6 +169,29 @@ export function MaintenancePanel() {
     },
     [mm]
   )
+
+  /** Explicit re-verify for a tail we gave up on. Asks the backend once — the
+   *  op buttons release only if it now reports the action finished. */
+  const recheckAction = useCallback(async () => {
+    if (!actionName) {
+      return
+    }
+
+    setRechecking(true)
+    setError('')
+
+    try {
+      const status = await getActionStatus(actionName, 200)
+      setActionStatus(status)
+      upsertDesktopActionTask(status)
+      setTailState(status.running ? 'exhausted' : 'idle')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setTailState('degraded')
+    } finally {
+      setRechecking(false)
+    }
+  }, [actionName])
 
   const shareDebug = useCallback(async () => {
     setSharing(true)
@@ -258,6 +305,22 @@ export function MaintenancePanel() {
                 </Button>
               </div>
             ))}
+          </div>
+        )}
+
+        {actionName !== null && (tailState === 'exhausted' || tailState === 'degraded') && (
+          <div className="mt-2 flex items-center justify-between gap-3 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) px-3 py-2">
+            <span className="min-w-0 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+              {tailState === 'degraded' ? mm.tailDegraded : mm.tailExhausted}
+            </span>
+            <Button
+              disabled={rechecking}
+              onClick={() => void recheckAction()}
+              size="xs"
+              variant="textStrong"
+            >
+              {rechecking ? mm.recheckStatusBusy : mm.recheckStatus}
+            </Button>
           </div>
         )}
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1287,7 +1287,11 @@ export const en: Translations = {
       actionStarted: name => `${name} started — tailing log...`,
       actionFailed: name => `${name} failed to start`,
       running: 'Running...',
-      viewLog: 'Action log'
+      viewLog: 'Action log',
+      tailExhausted: 'Stopped following this action — it was still running when the log tail timed out.',
+      tailDegraded: 'Stopped following this action — the status endpoint stopped responding.',
+      recheckStatus: 'Check status',
+      recheckStatusBusy: 'Checking...'
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1139,6 +1139,10 @@ export interface Translations {
       actionFailed: (name: string) => string
       running: string
       viewLog: string
+      tailExhausted: string
+      tailDegraded: string
+      recheckStatus: string
+      recheckStatusBusy: string
     }
   }
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1481,7 +1481,11 @@ export const zh: Translations = {
       actionStarted: name => `${name} 已启动 — 正在跟踪日志…`,
       actionFailed: name => `${name} 启动失败`,
       running: '运行中…',
-      viewLog: '操作日志'
+      viewLog: '操作日志',
+      tailExhausted: '已停止跟踪此操作 — 日志跟踪超时时它仍在运行。',
+      tailDegraded: '已停止跟踪此操作 — 状态接口已停止响应。',
+      recheckStatus: '检查状态',
+      recheckStatusBusy: '正在检查…'
     }
   },
 


### PR DESCRIPTION
## What does this PR do?

Fixes a stuck-state bug in the desktop command center's **Maintenance** panel: its four spawn-backed op buttons can latch permanently disabled, leaving the panel unusable.

`MaintenancePanel` gates **Run doctor**, **Security audit**, **Create backup**, and the curator's **Run now** on `actionStatus?.running === true` — the *last status the poll loop observed*. That stored observation has only one other writer: `setActionStatus(null)` inside `launch()`, which is reachable exclusively by pressing one of those same four buttons.

The tail loop has two exits that stop refreshing the observation without the backend ever reporting the action finished:

1. **`getActionStatus` rejects.** The bare `catch` stops tailing on a single transient status-endpoint/network blip. The stored status still says `running: true`.
2. **Poll ceiling.** `polls < ACTION_POLL_LIMIT` with `ACTION_POLL_MS = 1200` and `ACTION_POLL_LIMIT = 240` gives up after ~4.8 minutes. Any action that legitimately runs longer — a backup of a large workspace, a full security audit — stops being polled while the stored status still says `running: true`.

Either one disables all four buttons for the life of the panel. The only escape is to navigate out of the Maintenance tab and back, which remounts the panel and *also discards the log tail the user was reading*.

The fix settles the stored status on both abnormal exits: flip `running` to `false` while preserving `lines`, `exit_code`, `name` and `pid`, so the collected log stays rendered and only the gate is released. Releasing the gate when the backend action may still be running matches the file's own stated intent — the in-tree comment already says the tail is best-effort ("the activity rail still has the task") — and `upsertDesktopActionTask` deliberately still receives the **unmodified** status, so the activity rail's view of a genuinely-running task is unchanged by this PR.

This mirrors the pattern already used by the skills hub's equivalent tail loop (`src/store/hub-actions.ts`), which releases its own `running` gate in a `finally`.

### Sibling-site sweep

`getActionStatus` has six other poll loops in `apps/desktop`. I checked each for the same root cause — *a stale last-observation gating an interactive control* — and none of them share it, so this PR is deliberately scoped to the one site that does:

| Site | Shares the root cause? |
| --- | --- |
| `app/command-center/maintenance.tsx` | **Yes** — fixed here (4 gated buttons, no release path) |
| `app/command-center/index.tsx` (`runSystemAction`) | No — `systemAction` is render-only text, it gates nothing |
| `app/settings/computer-use-panel.tsx` | No — gates on `granting`, cleared in `finally` |
| `app/settings/toolset-config-panel.tsx` | No — `status` only decides whether the log block renders |
| `store/hub-actions.ts` | No — already releases `running` in a `finally` (the pattern followed here) |
| `store/updates.ts` | No — its `catch` transitions state explicitly and the apply is finished on exit |
| `app/skills/mcp-tab.tsx` | No — single non-looping status read |

`ACTION_POLL_LIMIT` and the `running === true` gate expression each appear only in `maintenance.tsx`.

## Related Issue

No filed issue — found while auditing action-status handling in the desktop command center.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/command-center/maintenance.tsx` — in the action tail loop:
  - compute `exhausted = status.running && polls >= ACTION_POLL_LIMIT` and store `{ ...status, running: false }` when the poll ceiling is hit, instead of storing a `running: true` status that will never be refreshed again;
  - in the `catch`, settle the last stored observation the same way (`prev.running → false`, everything else preserved) rather than leaving it stale;
  - guard that `catch` write with the existing `cancelled` flag, dropping a post-unmount `setState`.
- `apps/desktop/src/app/command-center/maintenance.test.tsx` — new co-located test file (vitest `ui` project, jsdom + `@testing-library/react`), 3 cases.

## How to Test

Reproduce by hand (before the fix):

1. Open the desktop app → command center → **Maintenance**.
2. Press **Run doctor**. All four op buttons correctly grey out while the action tails.
3. Interrupt the status endpoint once (stop/restart the gateway, or drop the network for a couple of seconds) so a single `/api/actions` status poll fails. Equivalently, start an action that runs longer than ~4.8 minutes and wait out the poll ceiling.
4. The action finishes, but **Run doctor / Security audit / Create backup / Run now** stay disabled indefinitely. Leaving the Maintenance tab and returning is the only way to get them back, and it throws away the log tail.

After the fix, step 4's buttons re-enable as soon as the tail stops, and the already-collected log stays on screen.

Automated (`apps/desktop`):

```
npm run test:ui
npx eslint src/app/command-center/maintenance.tsx src/app/command-center/maintenance.test.tsx
```

Bidirectional regression guard — with the production hunk reverted to `main` and the new test file kept:

```
Tests  2 failed | 1 passed (3)
  × releases the op buttons when the status endpoint starts failing mid-tail
  × releases the op buttons when the poll ceiling is reached on a long-running action
  ✓ leaves the normal completion path untouched
```

With the fix applied:

```
Tests  3 passed (3)
```

Full renderer suite on this branch: `Test Files 277 passed (277)` / `Tests 2335 passed | 1 skipped (2336)`.

The third case is the no-regression guard: a run that ends with `running: false` still enables the buttons and schedules no further polls (`getActionStatus` called exactly twice, and still twice after ten more poll intervals elapse).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is a renderer-only TypeScript change with no Python surface; `npm run test:ui` in `apps/desktop` is the equivalent gate and is green (2335 passed / 1 skipped)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only React state logic, no platform-specific paths or APIs; verified on macOS only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
