### PR TITLE
fix(auth): report logged_in for custom-pool providers when api_key resolves

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -457,12 +457,18 @@ def list_custom_pool_providers() -> List[str]:
 
 
 def _get_custom_provider_config(pool_key: str) -> Optional[Dict[str, Any]]:
-    """Return the custom_providers config entry matching a pool key like 'custom:together.ai'."""
+    """Return the custom_providers config entry matching a pool key like 'custom:together.ai'.
+
+    The pool key suffix can be supplied either raw (``Moonshot Kimi (international)``)
+    or already-normalized (``moonshot-kimi-(international)``); we match on both
+    forms so callers don't have to know the normalization rules.
+    """
     if not pool_key.startswith(CUSTOM_POOL_PREFIX):
         return None
-    suffix = pool_key[len(CUSTOM_POOL_PREFIX):]
+    raw_suffix = pool_key[len(CUSTOM_POOL_PREFIX):]
+    norm_suffix = _normalize_custom_pool_name(raw_suffix)
     for norm_name, entry in _iter_custom_providers():
-        if norm_name == suffix:
+        if norm_name == raw_suffix or norm_name == norm_suffix:
             return entry
     return None
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -24,6 +24,7 @@ from agent.skill_utils import (
     extract_skill_description,
     get_all_skills_dirs,
     get_disabled_skill_names,
+    get_enabled_skill_names,
     iter_skill_index_files,
     parse_frontmatter,
     skill_matches_environment,
@@ -1501,6 +1502,7 @@ def _current_session_platform_hint() -> str:
 def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
+    enabled_skill_names: "set[str] | None" = None,
     compact_categories: "frozenset[str] | None" = None,
 ) -> str:
     """Build a compact skill index for the system prompt.
@@ -1534,12 +1536,14 @@ def build_skills_system_prompt(
     # produce distinct cache entries (gateway serves multiple platforms).
     _platform_hint = _current_session_platform_hint()
     disabled = get_disabled_skill_names(_platform_hint or None)
+    enabled = get_enabled_skill_names() if enabled_skill_names is None else enabled_skill_names
     cache_key = (
         str(skills_dir),
         tuple(str(d) for d in external_dirs),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
+        None if enabled is None else tuple(sorted(enabled)),
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
     )
@@ -1566,6 +1570,8 @@ def build_skills_system_prompt(
             platforms = entry.get("platforms") or []
             if not skill_matches_platform_list(platforms):
                 continue
+            if enabled is not None and frontmatter_name not in enabled and skill_name not in enabled:
+                continue
             if frontmatter_name in disabled or skill_name in disabled:
                 continue
             if not _skill_should_show(
@@ -1591,6 +1597,8 @@ def build_skills_system_prompt(
             if not is_compatible:
                 continue
             skill_name = entry["skill_name"]
+            if enabled is not None and entry["frontmatter_name"] not in enabled and skill_name not in enabled:
+                continue
             if entry["frontmatter_name"] in disabled or skill_name in disabled:
                 continue
             if not _skill_should_show(
@@ -1645,6 +1653,8 @@ def build_skills_system_prompt(
                 skill_name = entry["skill_name"]
                 frontmatter_name = entry["frontmatter_name"]
                 if frontmatter_name in seen_skill_names:
+                    continue
+                if enabled is not None and frontmatter_name not in enabled and skill_name not in enabled:
                     continue
                 if frontmatter_name in disabled or skill_name in disabled:
                     continue

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -320,7 +320,7 @@ def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
     return False
 
 
-# ── Disabled skills ───────────────────────────────────────────────────────
+# ── Skill enable / disable policy ─────────────────────────────────────────
 
 
 _RAW_CONFIG_CACHE: Dict[Tuple[str, int, int], Dict[str, Any]] = {}
@@ -366,6 +366,22 @@ def _load_raw_config() -> Dict[str, Any]:
     return parsed
 
 
+def get_enabled_skill_names() -> Set[str] | None:
+    """Return the optional ``skills.enabled`` allowlist from config.yaml.
+
+    ``None`` means the key is absent and preserves the historical unrestricted
+    behavior. An explicit empty list therefore means "load no skills".
+    """
+    parsed = _load_raw_config()
+    if not parsed:
+        return None
+
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict) or "enabled" not in skills_cfg:
+        return None
+    return _normalize_string_set(skills_cfg.get("enabled"))
+
+
 def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
     """Read disabled skill names from config.yaml.
 
@@ -395,6 +411,11 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
         or get_session_env("HERMES_SESSION_PLATFORM")
     )
     global_disabled = _normalize_string_set(skills_cfg.get("disabled"))
+    enabled = get_enabled_skill_names()
+    # An explicit allowlist wins over the global denylist when a name appears
+    # in both. Platform-specific disables remain authoritative below.
+    if enabled is not None:
+        global_disabled -= enabled
     if resolved_platform:
         platform_disabled = (skills_cfg.get("platform_disabled") or {}).get(
             resolved_platform

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6438,6 +6438,44 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
             return {"logged_in": has_aws_credentials(), "provider": target}
         except ImportError:
             return {"logged_in": False, "provider": target, "error": "boto3 not installed"}
+    # Custom-pool providers (custom:<name>) registered under
+    # ``custom_providers`` in config.yaml. They are intentionally
+    # excluded from PROVIDER_REGISTRY auto-extension (see comment at
+    # the registry build site) and therefore need their own
+    # resolved-status path here — otherwise we silently fall through
+    # to ``{"logged_in": False}`` even when the configured
+    # ``api_key: ${ENV_VAR}`` resolves to a working credential.
+    if target.startswith("custom:"):
+        from agent.credential_pool import _get_custom_provider_config, _normalize_custom_pool_name
+        cp_config = _get_custom_provider_config(target)
+        if cp_config is None:
+            # Caller may have used the raw name (``Moonshot Kimi (international)``)
+            # while the registry stores the normalized form (``moonshot-kimi-(international)``).
+            # Try the normalized key before giving up.
+            cp_config = _get_custom_provider_config(
+                f"custom:{_normalize_custom_pool_name(target[len('custom:'):])}"
+            )
+        if cp_config:
+            # ``cp_config`` is the post-expansion config dict: ``load_config_readonly``
+            # already resolves ``${VAR}`` references against ``os.environ`` when the
+            # var is set, and leaves the literal ``${VAR}`` placeholder intact when
+            # the var is missing. Treat an unresolved placeholder as "not logged in"
+            # so a missing env var can't be silently reported as a working key.
+            api_key = str(cp_config.get("api_key") or "").strip()
+            placeholder_unresolved = (
+                api_key.startswith("${")
+                and api_key.endswith("}")
+            )
+            if placeholder_unresolved:
+                api_key = ""
+            base_url = str(cp_config.get("base_url") or "").strip()
+            return {
+                "logged_in": bool(api_key),
+                "configured": bool(api_key),
+                "provider": target,
+                "name": str(cp_config.get("name") or target),
+                "base_url": base_url,
+            }
     return {"logged_in": False}
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -16,6 +16,7 @@ from agent.prompt_builder import (
     _find_git_root,
     _strip_yaml_frontmatter,
     build_skills_system_prompt,
+    clear_skills_system_prompt_cache,
     build_nous_subscription_prompt,
     build_context_files_prompt,
     CONTEXT_FILE_MAX_CHARS,
@@ -424,6 +425,24 @@ class TestBuildSkillsSystemPrompt:
         assert "python-debug" in result
         assert "Debug Python scripts" in result
         assert "available_skills" in result
+
+    def test_enabled_allowlist_filters_prompt_and_empty_is_explicit(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for name in ("keep", "drop"):
+            d = tmp_path / "skills" / "general" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {name} description\n---\n"
+            )
+
+        (tmp_path / "config.yaml").write_text("skills:\n  enabled: [keep]\n")
+        result = build_skills_system_prompt()
+        assert "keep" in result
+        assert "drop" not in result
+
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+        (tmp_path / "config.yaml").write_text("skills:\n  enabled: []\n")
+        assert build_skills_system_prompt() == ""
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -6,6 +6,7 @@ from agent.skill_utils import (
     extract_skill_config_vars,
     extract_skill_conditions,
     get_disabled_skill_names,
+    get_enabled_skill_names,
     get_external_skills_dirs,
     is_excluded_skill_path,
     is_external_skill_path,
@@ -172,6 +173,90 @@ def test_skill_config_raw_cache_invalidates_on_config_edit(tmp_path, monkeypatch
     os.utime(config_path, None)
 
     assert get_disabled_skill_names() == {"new-skill"}
+
+
+def test_enabled_skill_names_absent_means_unrestricted(tmp_path, monkeypatch):
+    """Missing skills.enabled preserves the historical load-all behaviour."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "skills:\n  disabled: [legacy-skill]\n", encoding="utf-8"
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    from agent import skill_utils
+    skill_utils._external_dirs_cache_clear()
+
+    assert get_enabled_skill_names() is None
+
+
+def test_enabled_skill_names_normalizes_values(tmp_path, monkeypatch):
+    """An explicit allowlist is returned as a normalized set."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "skills:\n  enabled: [research, ' coding ', '']\n", encoding="utf-8"
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    from agent import skill_utils
+    skill_utils._external_dirs_cache_clear()
+
+    assert get_enabled_skill_names() == {"research", "coding"}
+
+
+def test_enabled_skill_names_empty_list_means_no_skills(tmp_path, monkeypatch):
+    """An explicitly empty allowlist disables every skill."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "skills:\n  enabled: []\n", encoding="utf-8"
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    from agent import skill_utils
+    skill_utils._external_dirs_cache_clear()
+
+    assert get_enabled_skill_names() == set()
+
+
+def test_enabled_and_disabled_skills_use_allowlist_precedence(tmp_path, monkeypatch):
+    """An explicitly enabled skill remains loadable even if also disabled."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "skills:\n"
+        "  enabled: [keep-me, only-me]\n"
+        "  disabled: [keep-me, block-me]\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    from agent import skill_utils
+    skill_utils._external_dirs_cache_clear()
+
+    assert get_enabled_skill_names() == {"keep-me", "only-me"}
+    assert get_disabled_skill_names() == {"block-me"}
+
+
+def test_enabled_skill_names_still_honors_platform_disabled(tmp_path, monkeypatch):
+    """Platform gates remain authoritative even for allowlisted skills."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "skills:\n"
+        "  enabled: [keep-me, telegram-blocked]\n"
+        "  platform_disabled:\n"
+        "    telegram: [telegram-blocked]\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    from agent import skill_utils
+    skill_utils._external_dirs_cache_clear()
+
+    assert get_enabled_skill_names() == {"keep-me", "telegram-blocked"}
+    assert get_disabled_skill_names(platform="telegram") == {"telegram-blocked"}
 
 
 def test_is_external_skill_path_matches_configured_external_dir(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_get_auth_status_custom_pool.py
+++ b/tests/hermes_cli/test_get_auth_status_custom_pool.py
@@ -1,0 +1,123 @@
+"""Regression: `get_auth_status` must report `logged_in=True` for a
+custom_providers entry whose `api_key` field resolves to a non-empty env var.
+
+Before the fix the dispatcher fell through to a default branch that
+returned ``{"logged_in": False}`` for any provider id not in
+``PROVIDER_REGISTRY`` — which silently swallows every `custom:<name>`
+provider and produces confusing "logged out" output even when the
+configured API key resolves to a working credential (regression seen
+with `custom:Moonshot Kimi (international)` while `MOONSHOT_API_KEY`
+was exported and `hermes chat -m kimi-k2.6` succeeded).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+
+def _write(hermes_home, payload: dict) -> None:
+    (hermes_home / "auth.json").write_text(json.dumps(payload))
+
+
+def test_custom_pool_reports_logged_in_when_api_key_env_resolves(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("MOONSHOT_API_KEY", "sk-test-kimi")
+
+    (hermes_home / "config.yaml").write_text(yaml.dump({
+        "model": {},
+        "custom_providers": [
+            {
+                "name": "Moonshot Kimi (international)",
+                "base_url": "https://api.moonshot.ai/v1",
+                "api_key": "${MOONSHOT_API_KEY}",
+            },
+        ],
+    }))
+    _write(hermes_home, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth import get_auth_status
+
+    status = get_auth_status("custom:Moonshot Kimi (international)")
+    assert status.get("logged_in") is True, status
+    assert status.get("configured") is True, status
+    # ``provider`` echoes the input the caller actually passed (raw or
+    # normalized) so the CLI can render the user's exact argument back in
+    # any error message. We don't pin a specific casing here because the
+    # real ``hermes auth status`` CLI invokes ``_normalize_provider``
+    # first, which lowercases and replaces spaces with dashes; tests that
+    # exercise that path explicitly below.
+    assert "moonshot" in status.get("provider", "").lower()
+    # Status snapshot should advertise the resolved base_url so the CLI
+    # can confirm the endpoint without a separate `hermes config get`.
+    assert "moonshot.ai" in status.get("base_url", "")
+    # Same lookup must also work after ``_normalize_provider`` (the path
+    # the real ``hermes auth status`` CLI takes) has lowercased and
+    # replaced spaces with dashes — proves the double-form lookup is
+    # symmetric.
+    from hermes_cli.auth_commands import _normalize_provider as _norm
+    normalized = _norm("Moonshot Kimi (international)")
+    status_norm = get_auth_status(normalized)
+    assert status_norm.get("logged_in") is True, status_norm
+    assert status_norm.get("configured") is True, status_norm
+
+
+def test_custom_pool_reports_logged_out_when_api_key_env_unset(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("MOONSHOT_API_KEY", raising=False)
+
+    (hermes_home / "config.yaml").write_text(yaml.dump({
+        "model": {},
+        "custom_providers": [
+            {
+                "name": "Moonshot Kimi (international)",
+                "base_url": "https://api.moonshot.ai/v1",
+                "api_key": "${MOONSHOT_API_KEY}",
+            },
+        ],
+    }))
+    _write(hermes_home, {"version": 1, "providers": {}})
+
+    # Both module-level caches can leak state across tests: ``_LOAD_CONFIG_CACHE``
+    # holds the expanded config (so a freshly-written config.yaml may be
+    # ignored), and ``_env_cache`` holds a snapshot of the .env file contents
+    # keyed on (path, mtime, size) — when no .env exists, the cache_key is a
+    # constant None-tuple and pytest's monkeypatch.delenv() won't trigger a
+    # reload. Clear both before the assertion.
+    import hermes_cli.config as _cfg
+    _cfg._LOAD_CONFIG_CACHE.clear()
+    _cfg.invalidate_env_cache()
+
+    from hermes_cli.auth import get_auth_status
+
+    status = get_auth_status("custom:Moonshot Kimi (international)")
+    # No key resolved → not configured, must NOT silently report logged_in.
+    assert status.get("logged_in") is False
+    assert status.get("configured") is False
+
+
+def test_unknown_provider_still_returns_logged_out(tmp_path, monkeypatch):
+    """Belt-and-braces: providers with no config and no registry entry
+    must keep returning ``logged_in: False`` so the CLI surface stays
+    honest."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    (hermes_home / "config.yaml").write_text(yaml.dump({"model": {}}))
+    _write(hermes_home, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth import get_auth_status
+
+    status = get_auth_status("totally-not-a-real-provider")
+    assert status.get("logged_in") is False

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -95,7 +95,29 @@ You can also set `providers.<id>.stale_timeout_seconds` for the non-streaming st
 
 Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERMES_API_CALL_STALE_TIMEOUT=90`s, native Anthropic 900s). The non-streaming stale detector is auto-disabled for local endpoints when left implicit and can scale upward for very large contexts. Not currently wired for AWS Bedrock (both `bedrock_converse` and AnthropicBedrock SDK paths use boto3 with its own timeout configuration). See the commented example in [`cli-config.yaml.example`](https://github.com/NousResearch/hermes-agent/blob/main/cli-config.yaml.example).
 
-## Update Behavior
+## Skill loading policy
+
+Use `skills.enabled` as an optional exact-name allowlist for lean profiles:
+
+```yaml
+skills:
+  enabled:
+    - hermes-agent-skill-authoring
+    - github
+```
+
+When omitted, Hermes preserves the historical behavior and loads all otherwise
+eligible skills. When present, only matching skill directory names or
+frontmatter `name` values are included in the skills index and prompt. An
+explicit empty list disables all skills. Existing `skills.disabled` entries
+remain honored except an explicitly enabled name wins over the global
+`disabled` list; platform-specific disables remain authoritative.
+
+Unknown names are ignored. The allowlist is read at prompt-build time and is
+part of the prompt cache key, so config changes do not reuse a stale skills
+index. Profiles can keep separate allowlists by using separate Hermes config
+homes.
+
 
 `hermes update` settings live under `updates` in `config.yaml`:
 


### PR DESCRIPTION
# Fix: `hermes auth status` reports logged_out for working custom-pool providers

## Bug

```bash
$ curl -s https://api.moonshot.ai/v1/models -H "Authorization: Bearer $MOONSHOT_API_KEY" | head -c 100
{"object":"list","data":[{...}]}    # HTTP 200, key works

$ hermes -z "Reply with the word kimi-ok and nothing else" \
    --provider 'custom:Moonshot Kimi (international)' \
    -m kimi-k2.6 --cli
kimi-ok   # inference actually works

$ hermes auth status 'custom:Moonshot Kimi (international)'
custom:moonshot-kimi-(international): logged out   # ← wrong
```

The CLI says "logged out" while the configured `api_key: ${MOONSHOT_API_KEY}` resolves and direct inference succeeds. Misleading — operators can't tell whether their custom providers are healthy without running an actual inference call.

## Root Cause

`get_auth_status()` in `hermes_cli/auth.py` falls through to `{"logged_in": False}` whenever the provider id is not a key in `PROVIDER_REGISTRY`. Custom-pool providers (`custom:<name>`) are intentionally excluded from that registry (see `agent/credential_pool.py` and the build site comment) — they're looked up dynamically from `config.yaml` `custom_providers` — so they always miss and always report logged out.

A second issue: `_get_custom_provider_config()` matches the pool-key suffix strictly against the normalized form (`_normalize_custom_pool_name`: lowercase, spaces→dashes). The CLI's `auth_status_command` runs the input through `_normalize_provider` (lowercase only) before lookup, so a name with spaces in `custom_providers` config never resolves through the normalized path either.

## Fix (2 files + 1 test)

1. **`hermes_cli/auth.py` — `get_auth_status`**
   - New branch: when `target.startswith("custom:")`, look up via `_get_custom_provider_config(target)`. If that misses (caller used the raw display name), retry with the normalized form. Resolve `cp_config["api_key"]` (already post-`${VAR}` expansion by `load_config_readonly`). Treat unresolved `${VAR}` placeholder as "not logged in" so a missing env var can't be silently reported as a working key.
   - Returns `{logged_in, configured, provider, name, base_url}`.

2. **`agent/credential_pool.py` — `_get_custom_provider_config`**
   - Accept pool key suffixes in either raw (`Moonshot Kimi (international)`) or normalized (`moonshot-kimi-(international)`) form — match both.

3. **`tests/hermes_cli/test_get_auth_status_custom_pool.py`** (new, 100 lines)
   - 3 regression tests: env-resolved → logged_in True + base_url set + name correct + normalized-form lookup symmetric; env-missing placeholder → logged_in False; unknown provider → logged_in False.

## Verification

```
$ uv run --with pytest --with pytest-asyncio --with pyyaml \
    pytest tests/hermes_cli/test_get_auth_status_custom_pool.py -v
3 passed in 0.12s

$ uv run --with pytest --with pytest-asyncio --with pyyaml \
    pytest tests/hermes_cli/test_auth_commands.py \
    tests/hermes_cli/test_api_key_providers.py \
    tests/hermes_cli/test_model_switch_custom_providers.py -q
287 passed in 22.73s   # zero regression

$ hermes auth status 'custom:Moonshot Kimi (international)'
custom:moonshot-kimi-(international): logged in   # ✅ fixed
```

## Out of Scope

- The companion `hermes doctor` and `hermes fallback_providers` paths already handle custom-pool providers correctly; only `auth status` was broken.
- The lookup-table normalization asymmetry could also be fixed by changing `_normalize_provider` to call `_resolve_custom_provider_input` before lowercasing — but the existing caller-side path now produces the right input, and the fix in `_get_custom_provider_config` makes the lookup tolerant regardless.