### PR TITLE
fix(pairing): invalidate pending codes on revoke

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -385,7 +385,7 @@ class PairingStore:
         _sync_allowlist_add(platform, normalized_user_id)
 
     def revoke(self, platform: str, user_id: str) -> bool:
-        """Remove a user from the approved list. Returns True if found."""
+        """Remove a user and invalidate their pending codes. Returns True if found."""
         path = self._approved_path(platform)
         with self._lock:
             approved = self._load_json(path)
@@ -398,6 +398,18 @@ class PairingStore:
                 for approved_user_id in matching_ids:
                     del approved[approved_user_id]
                 self._save_json(path, approved)
+                pending_path = self._pending_path(platform)
+                pending = self._load_json(pending_path)
+                stale_entry_ids = [
+                    entry_id
+                    for entry_id, entry in pending.items()
+                    if isinstance(entry, dict)
+                    and self._user_ids_match(platform, entry.get("user_id", ""), user_id)
+                ]
+                for entry_id in stale_entry_ids:
+                    del pending[entry_id]
+                if stale_entry_ids:
+                    self._save_json(pending_path, pending)
                 # Keep the allowlist mirror in sync: revoking a paired user
                 # also removes the entry the approval added (option i). No-op if
                 # the user was added to the allowlist by other means.

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -650,6 +650,29 @@ class TestRevoke:
             store = PairingStore()
             assert store.revoke("telegram", "nobody") is False
 
+    def test_revoke_invalidates_same_user_pending_codes_only(self, tmp_path):
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+            store = PairingStore()
+            approved_code = store.generate_code("telegram", "user1", "Alice")
+
+            limits = store._load_json(store._rate_limit_path())
+            limits["telegram:user1"] = time.time() - RATE_LIMIT_SECONDS - 1
+            store._save_json(store._rate_limit_path(), limits)
+
+            stale_code = store.generate_code("telegram", "user1", "Alice")
+            other_code = store.generate_code("telegram", "user2", "Bob")
+            store.approve_code("telegram", approved_code)
+
+            assert store.revoke("telegram", "user1") is True
+            pending = store.list_pending("telegram")
+
+            assert [entry["user_id"] for entry in pending] == ["user2"]
+            assert store.approve_code("telegram", stale_code) is None
+            assert store.approve_code("telegram", other_code) == {
+                "user_id": "user2",
+                "user_name": "Bob",
+            }
+
 
 # ---------------------------------------------------------------------------
 # List & clear


### PR DESCRIPTION
## What does this PR do?

Invalidates a revoked user's remaining unexpired pairing codes so an old code cannot restore access after an operator revokes that user. Pending requests for other users on the same platform are preserved.

## Related Issue

Fixes #72172

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/pairing.py`: remove same-platform pending entries whose user id aliases match the revoked user.
- `tests/gateway/test_pairing.py`: cover stale-code invalidation and preservation of an unrelated user's request.

## How to Test

1. Run `python -m pytest tests/gateway/test_pairing.py -q`.
2. Generate two codes for one user, approve one, revoke the user, then try the remaining code.
3. Confirm the stale code fails while a different user's pending code remains valid.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] Documentation update: N/A; the method docstring now states the revocation invariant
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered: storage and matching logic are platform-independent
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Focused suite:

```text
52 passed, 1 skipped in 5.16s
```

Deterministic reproduction on current `main` before the fix:

```json
{pending_after_revoke:[user1,user2],stale_code_reapproved:true,user1_approved_again:true}
```

After the fix:

```json
{pending_after_revoke:[user2],stale_code_reapproved:false,user1_approved_again:false}
```