### PR TITLE
fix(tui): deliver kanban notify subscriptions to TUI/desktop sessions (salvage #66435)

### DIFF
--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -138,3 +138,102 @@ class TestFormatKanbanEventText:
         ev = SimpleNamespace(kind="timed_out", payload={"limit_seconds": "not-a-number"})
         text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
         assert "timed out" in text
+
+
+class TestNotificationPollerLoopKanbanWiring:
+    """Drive a real TUI subscription through ``_notification_poller_loop``.
+
+    Covers the wiring above ``_collect_kanban_notifications``: status.update
+    emission, agent-turn dispatch when the session is idle, and the
+    busy-session pending buffer that flushes once the session goes idle.
+    """
+
+    def _start_poller(self, session: dict, monkeypatch):
+        import threading
+        import tui_gateway.server as server
+
+        emits: list = []
+        submits: list = []
+        monkeypatch.setattr(server, "_KANBAN_POLL_SECONDS", 0.01)
+        monkeypatch.setattr(
+            server, "_emit", lambda event, sid, payload=None: emits.append((event, payload))
+        )
+        monkeypatch.setattr(
+            server,
+            "_run_prompt_submit",
+            lambda rid, sid, sess, text: submits.append(text),
+        )
+        stop = threading.Event()
+        thread = threading.Thread(
+            target=server._notification_poller_loop,
+            args=(stop, "sid-poller-test", session),
+            daemon=True,
+        )
+        thread.start()
+        return stop, thread, emits, submits
+
+    @staticmethod
+    def _wait_for(predicate, timeout: float = 5.0) -> bool:
+        import time as _time
+
+        deadline = _time.monotonic() + timeout
+        while _time.monotonic() < deadline:
+            if predicate():
+                return True
+            _time.sleep(0.02)
+        return False
+
+    def _poller_session(self, *, running: bool = False) -> dict:
+        import threading
+
+        return {
+            "session_key": SESSION_KEY,
+            "history_lock": threading.Lock(),
+            "running": running,
+        }
+
+    def test_idle_session_gets_status_update_and_agent_turn(self, monkeypatch):
+        tid = _create_subscribed_task()
+        _complete(tid, summary="poller e2e done")
+        session = self._poller_session(running=False)
+
+        stop, thread, emits, submits = self._start_poller(session, monkeypatch)
+        try:
+            assert self._wait_for(lambda: submits), "agent turn was never dispatched"
+        finally:
+            stop.set()
+            thread.join(timeout=5)
+
+        status_texts = [p["text"] for e, p in emits if e == "status.update" and p]
+        assert any(tid in t for t in status_texts), status_texts
+        assert any(e == "message.start" for e, _ in emits)
+        assert any(tid in text for text in submits), submits
+        assert session["running"] is True  # poller claimed the turn
+        assert not session.get("_kanban_pending")
+
+    def test_busy_session_buffers_then_flushes_when_idle(self, monkeypatch):
+        tid = _create_subscribed_task()
+        _complete(tid, summary="buffered while busy")
+        session = self._poller_session(running=True)
+
+        stop, thread, emits, submits = self._start_poller(session, monkeypatch)
+        try:
+            # Busy: the status line appears and the event is buffered, but no
+            # agent turn is dispatched while another turn is running.
+            assert self._wait_for(
+                lambda: any(e == "status.update" for e, _ in emits)
+                and session.get("_kanban_pending")
+            )
+            assert not submits
+
+            with session["history_lock"]:
+                session["running"] = False
+
+            assert self._wait_for(lambda: submits), "pending batch never flushed"
+        finally:
+            stop.set()
+            thread.join(timeout=5)
+
+        assert any(tid in text for text in submits), submits
+        assert session["_kanban_pending"] == []
+        assert session["running"] is True

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -1,0 +1,140 @@
+"""Tests for the TUI-side kanban notification poller (issue #59890).
+
+``kanban_create`` auto-subscribes TUI/desktop sessions with
+``platform="tui"`` / ``chat_id=HERMES_SESSION_KEY``, but no component ever
+read those rows back: the gateway notifier skips them (no "tui" messaging
+adapter) and the TUI notification poller only watched process completions.
+``last_event_id`` stayed 0 forever and no notification was ever delivered.
+
+These tests cover the delivery half that now lives in tui_gateway/server.py:
+``_collect_kanban_notifications`` (cursor claim + formatting + terminal
+unsubscribe) and ``_format_kanban_event_text``.
+"""
+
+from types import SimpleNamespace
+
+from hermes_cli import kanban_db as kb
+from tui_gateway.server import (
+    _collect_kanban_notifications,
+    _format_kanban_event_text,
+)
+
+SESSION_KEY = "tui-session-key-1"
+
+
+def _session(key: str = SESSION_KEY) -> dict:
+    return {"session_key": key}
+
+
+def _create_subscribed_task(*, chat_id: str = SESSION_KEY, platform: str = "tui"):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="notify tui", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform=platform, chat_id=chat_id)
+        return tid
+    finally:
+        conn.close()
+
+
+def _complete(tid: str, summary: str = "all done") -> None:
+    conn = kb.connect()
+    try:
+        kb.complete_task(conn, tid, summary=summary)
+    finally:
+        conn.close()
+
+
+def _sub_rows(tid: str) -> list:
+    conn = kb.connect()
+    try:
+        return kb.list_notify_subs(conn, task_id=tid)
+    finally:
+        conn.close()
+
+
+class TestCollectKanbanNotifications:
+    def test_delivers_completed_event_and_unsubscribes(self):
+        tid = _create_subscribed_task()
+        _complete(tid, summary="shipped the fix")
+
+        texts = _collect_kanban_notifications(_session())
+
+        assert len(texts) == 1
+        assert tid in texts[0]
+        assert "done" in texts[0]
+        assert "shipped the fix" in texts[0]
+        # Task is at a final status -> subscription removed.
+        assert _sub_rows(tid) == []
+
+    def test_claim_advances_cursor_so_second_poll_is_empty(self):
+        tid = _create_subscribed_task()
+        conn = kb.connect()
+        try:
+            kb.block_task(conn, tid, reason="waiting on review")
+        finally:
+            conn.close()
+
+        first = _collect_kanban_notifications(_session())
+        second = _collect_kanban_notifications(_session())
+
+        assert len(first) == 1
+        assert "blocked" in first[0]
+        assert "waiting on review" in first[0]
+        assert second == []
+        # Blocked is not a final status -> subscription stays alive so a
+        # respawned task's next terminal event still reaches the user.
+        assert len(_sub_rows(tid)) == 1
+
+    def test_ignores_other_sessions_and_platforms(self):
+        tid_other_session = _create_subscribed_task(chat_id="some-other-session")
+        tid_gateway = _create_subscribed_task(platform="telegram", chat_id="chat-1")
+        _complete(tid_other_session)
+        _complete(tid_gateway)
+
+        texts = _collect_kanban_notifications(_session())
+
+        assert texts == []
+        # Foreign subscriptions untouched: cursors still 0, rows still there.
+        for tid in (tid_other_session, tid_gateway):
+            rows = _sub_rows(tid)
+            assert len(rows) == 1
+            assert rows[0]["last_event_id"] == 0
+
+    def test_no_session_key_is_a_noop(self):
+        tid = _create_subscribed_task()
+        _complete(tid)
+
+        assert _collect_kanban_notifications({"session_key": ""}) == []
+        assert _collect_kanban_notifications({"session_key": None}) == []
+        assert len(_sub_rows(tid)) == 1
+
+
+class TestFormatKanbanEventText:
+    SUB = {"task_id": "t_abc123"}
+    TASK = SimpleNamespace(title="build the thing", assignee="worker", result=None)
+
+    def test_silent_kinds_return_none(self):
+        for kind in ("archived", "unblocked"):
+            ev = SimpleNamespace(kind=kind, payload={})
+            assert _format_kanban_event_text(self.SUB, self.TASK, ev, "main") is None
+
+    def test_blocked_includes_reason(self):
+        ev = SimpleNamespace(kind="blocked", payload={"reason": "needs creds"})
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "main")
+        assert "t_abc123" in text
+        assert "blocked" in text
+        assert "needs creds" in text
+        assert "[main]" in text
+        assert "@worker" in text
+
+    def test_completed_prefers_payload_summary(self):
+        ev = SimpleNamespace(kind="completed", payload={"summary": "first line\nsecond"})
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+        assert "done" in text
+        assert "first line" in text
+        assert "second" not in text
+
+    def test_timed_out_with_bad_payload_does_not_raise(self):
+        ev = SimpleNamespace(kind="timed_out", payload={"limit_seconds": "not-a-number"})
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+        assert "timed out" in text

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -108,6 +108,42 @@ class TestCollectKanbanNotifications:
         assert _collect_kanban_notifications({"session_key": None}) == []
         assert len(_sub_rows(tid)) == 1
 
+    def test_profile_scoped_session_reads_the_shared_board(self, tmp_path):
+        """The kanban board is shared across profiles BY DESIGN (see the
+        hermes_cli/kanban_db.py module docstring): ``kanban_home()`` anchors on
+        ``get_default_hermes_root()``, which resolves the process env and
+        ignores context-local profile overrides. A Desktop session bound to a
+        non-launch profile (``session["profile_home"]``) must therefore still
+        have its subscription claimed from the one shared board — the poller
+        needs no per-profile home binding.
+        """
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        tid = _create_subscribed_task()
+        _complete(tid, summary="cross-profile delivery")
+
+        other_profile_home = tmp_path / "profiles" / "reviewer"
+        other_profile_home.mkdir(parents=True)
+        session = {
+            "session_key": SESSION_KEY,
+            "profile_home": str(other_profile_home),
+        }
+        # Simulate the strictest case: a context-local profile override is
+        # active while the poller collects (as a profile-bound RPC would set).
+        token = set_hermes_home_override(str(other_profile_home))
+        try:
+            texts = _collect_kanban_notifications(session)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert len(texts) == 1
+        assert tid in texts[0]
+        assert "cross-profile delivery" in texts[0]
+        assert _sub_rows(tid) == []
+
 
 class TestFormatKanbanEventText:
     SUB = {"task_id": "t_abc123"}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11033,6 +11033,158 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
     return (evt_sid, evt_type)
 
 
+# Mirror gateway/kanban_watchers.py TERMINAL_KINDS: claim silent kinds too so
+# the cursor advances past them and they can't wedge a later completed/blocked
+# event behind an unclaimed row.
+_KANBAN_NOTIFY_KINDS = (
+    "completed", "blocked", "gave_up", "crashed", "timed_out",
+    "status", "archived", "unblocked",
+)
+_KANBAN_SILENT_KINDS = frozenset({"archived", "unblocked"})
+_KANBAN_POLL_SECONDS = 5.0
+
+
+def _format_kanban_event_text(sub: dict, task, ev, board_slug: str) -> Optional[str]:
+    """Single-line notification text for one kanban event.
+
+    Wording mirrors the gateway notifier (gateway/kanban_watchers.py) so a
+    task completion reads the same in the TUI as it does on Telegram.
+    Returns None for kinds that are claimed but intentionally silent.
+    """
+    kind = getattr(ev, "kind", "")
+    if not kind or kind in _KANBAN_SILENT_KINDS:
+        return None
+    task_id = sub.get("task_id", "")
+    title = (getattr(task, "title", None) or task_id)[:120]
+    board_tag = f"[{board_slug}] " if board_slug else ""
+    who = getattr(task, "assignee", None) or ""
+    tag = f"@{who} " if who else ""
+    payload = getattr(ev, "payload", None) or {}
+    if kind == "completed":
+        handoff = ""
+        summary = payload.get("summary")
+        if summary:
+            lines = str(summary).strip().splitlines()
+            handoff = f"\n{lines[0][:200]}" if lines else ""
+        elif getattr(task, "result", None):
+            lines = str(task.result).strip().splitlines()
+            handoff = f"\n{lines[0][:160]}" if lines else ""
+        return f"✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}"
+    if kind == "blocked":
+        reason = f": {str(payload.get('reason'))[:160]}" if payload.get("reason") else ""
+        return f"⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}"
+    if kind == "gave_up":
+        err = f"\n{str(payload.get('error'))[:200]}" if payload.get("error") else ""
+        return f"✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}"
+    if kind == "crashed":
+        return f"✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry"
+    if kind == "timed_out":
+        limit = 0
+        try:
+            limit = int(payload.get("limit_seconds") or 0)
+        except (TypeError, ValueError):
+            pass
+        return f"⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry"
+    if kind == "status":
+        return f"🔄 {board_tag}{tag}Kanban {task_id} → {payload.get('status') or ''}"
+    return None
+
+
+def _collect_kanban_notifications(session: dict) -> list:
+    """Claim unseen terminal kanban events for this TUI session's subscriptions.
+
+    ``kanban_create`` auto-subscribes TUI/desktop sessions with
+    ``platform="tui"`` and ``chat_id=HERMES_SESSION_KEY`` (see
+    tools/kanban_tools.py ``_maybe_auto_subscribe``). The gateway notifier
+    can't deliver those — there is no "tui" messaging adapter — so this
+    poller is the delivery path for them (issue #59890). Uses the same
+    atomic cursor-claim (``claim_unseen_events_for_sub``) as the gateway
+    notifier, so a subscription is delivered exactly once even if a gateway
+    and a TUI poll the same board DB.
+
+    Returns the list of formatted notification texts (may be empty).
+    """
+    session_key = str(session.get("session_key") or "")
+    if not session_key or session.get("_finalized"):
+        return []
+    try:
+        from hermes_cli import kanban_db as _kb
+    except Exception:
+        return []
+    texts: list = []
+    try:
+        boards = _kb.list_boards(include_archived=False)
+    except Exception:
+        try:
+            boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+        except Exception:
+            return []
+    # Poll each resolved DB path once — multiple slugs can point at the same
+    # DB when HERMES_KANBAN_DB pins the board path (same guard as the gateway
+    # notifier).
+    seen_db_paths: set = set()
+    for board_meta in boards:
+        slug = (board_meta or {}).get("slug") or _kb.DEFAULT_BOARD
+        db_path = (board_meta or {}).get("db_path")
+        try:
+            resolved = (
+                str(Path(db_path).expanduser().resolve())
+                if db_path else str(_kb.kanban_db_path(slug).resolve())
+            )
+        except Exception:
+            resolved = f"slug:{slug}"
+        if resolved in seen_db_paths:
+            continue
+        seen_db_paths.add(resolved)
+        try:
+            conn = _kb.connect(board=slug)
+        except Exception:
+            continue
+        try:
+            try:
+                subs = _kb.list_notify_subs(conn)
+            except Exception:
+                continue
+            for sub in subs:
+                if (sub.get("platform") or "").lower() != "tui":
+                    continue
+                if sub.get("chat_id") != session_key:
+                    continue
+                _old, _new, events = _kb.claim_unseen_events_for_sub(
+                    conn,
+                    task_id=sub["task_id"],
+                    platform=sub["platform"],
+                    chat_id=sub["chat_id"],
+                    thread_id=sub.get("thread_id") or "",
+                    kinds=_KANBAN_NOTIFY_KINDS,
+                )
+                if not events:
+                    continue
+                task = _kb.get_task(conn, sub["task_id"])
+                for ev in events:
+                    text = _format_kanban_event_text(sub, task, ev, slug)
+                    if text:
+                        texts.append(text)
+                # Unsubscribe only at a truly final status (done/archived);
+                # blocked/crashed subs stay live so a respawned task's next
+                # terminal event still reaches the user (same rule as the
+                # gateway notifier).
+                if task and getattr(task, "status", "") in {"done", "archived"}:
+                    try:
+                        _kb.remove_notify_sub(
+                            conn,
+                            task_id=sub["task_id"],
+                            platform=sub["platform"],
+                            chat_id=sub["chat_id"],
+                            thread_id=sub.get("thread_id") or "",
+                        )
+                    except Exception:
+                        pass
+        finally:
+            conn.close()
+    return texts
+
+
 def _notification_poller_loop(
     stop_event: threading.Event, sid: str, session: dict
 ) -> None:
@@ -11045,11 +11197,56 @@ def _notification_poller_loop(
     The completion_queue is process-global. In multi-session Desktop each
     poller requeues events owned by another live session and drops addressed
     events whose owner is gone; ownerless legacy notifications remain global.
+
+    Also polls ``kanban_notify_subs`` every ``_KANBAN_POLL_SECONDS`` for this
+    session's TUI kanban subscriptions and delivers terminal task events the
+    same way (status.update + agent turn) — the delivery path
+    tools/kanban_tools.py documents for platform="tui" rows (issue #59890).
     """
     from tools.process_registry import process_registry, format_process_notification
 
     _emitted = set()  # dedup re-queued events so same completion isn't emitted 50 times while session is busy
+    _last_kanban_poll = 0.0
     while not stop_event.is_set() and not session.get("_finalized"):
+        _now = time.monotonic()
+        if _now - _last_kanban_poll >= _KANBAN_POLL_SECONDS:
+            _last_kanban_poll = _now
+            try:
+                _kanban_texts = _collect_kanban_notifications(session)
+            except Exception as _kb_exc:
+                print(
+                    f"[tui_gateway] kanban notification poll failed: "
+                    f"{type(_kb_exc).__name__}: {_kb_exc}",
+                    file=sys.stderr,
+                )
+                _kanban_texts = []
+            if _kanban_texts:
+                for _kb_text in _kanban_texts:
+                    _emit("status.update", sid, {"kind": "process", "text": _kb_text})
+                # Events are cursor-claimed (never re-queued), so buffer them
+                # until the session is idle instead of dropping the agent turn.
+                session.setdefault("_kanban_pending", []).extend(_kanban_texts)
+            _pending = session.get("_kanban_pending") or []
+            if _pending:
+                _batch: list = []
+                with session["history_lock"]:
+                    if not session.get("running"):
+                        session["running"] = True
+                        _batch = list(_pending)
+                        session["_kanban_pending"] = []
+                if _batch:
+                    rid = f"__notif__{int(time.time() * 1000)}"
+                    try:
+                        _emit("message.start", sid)
+                        _run_prompt_submit(rid, sid, session, "\n".join(_batch))
+                    except Exception as exc:
+                        print(
+                            f"[tui_gateway] kanban notification dispatch failed: "
+                            f"{type(exc).__name__}: {exc}",
+                            file=sys.stderr,
+                        )
+                        with session["history_lock"]:
+                            session["running"] = False
         try:
             evt = process_registry.completion_queue.get(timeout=0.5)
         except Exception:


### PR DESCRIPTION
## Summary

TUI/Desktop sessions now receive Kanban task notifications. `kanban_create` auto-subscribes the calling session with `platform="tui"` / `chat_id=HERMES_SESSION_KEY`, but no consumer ever read those rows back: the gateway notifier skips them (no "tui" messaging adapter) and the TUI notification poller only watched process completions — every subscription sat at `last_event_id=0` forever.

Salvage of #66435 (@cucurigoo's current-main cherry-pick of @falkoro's #60085) with authorship preserved, plus a follow-up regression test resolving the sweeper's profile-routing concern.

Fixes #59890 (TUI half; also covers duplicates #59960, #70791).

## Changes

- `tui_gateway/server.py`: `_collect_kanban_notifications()` claims unseen terminal events for this session's `platform="tui"` subscriptions via the same atomic `claim_unseen_events_for_sub` cursor-claim the gateway notifier uses (no double delivery when a gateway polls the same board DB); `_format_kanban_event_text()` mirrors gateway wording; `_notification_poller_loop` polls every 5s, emits `status.update`, buffers while busy, chains an agent turn when idle; unsubscribe only at done/archived — cherry-picked from #66435, authored by @falkoro
- `tests/tui_gateway/test_kanban_notify_poller.py`: 10 tests from the original PR (collector, formatting, poller wiring incl. busy→idle buffer) + 1 new test proving the collector reads the shared board correctly while a foreign-profile `set_hermes_home_override()` is active

## On the sweeper's profile_home concern (#66435 review)

The flagged binding is intentionally unnecessary: the kanban board is **shared across profiles by design** — `kanban_home()` anchors on `get_default_hermes_root()`, which resolves the process env and deliberately ignores context-local profile overrides (see the `hermes_cli/kanban_db.py` module docstring: "Profiles intentionally collapse onto a shared board: it IS the cross-profile coordination primitive"). Verified empirically: `kanban_db_path()` returns the same path with and without a profile override active. The new regression test pins this behavior.

## Validation

| Check | Result |
|---|---|
| `tests/tui_gateway/test_kanban_notify_poller.py` | 11/11 pass |
| `tests/tui_gateway/` + gateway notifier + kanban notify/tools suites (49 files) | 642/642 pass |
| E2E (real temp HERMES_HOME): `_maybe_auto_subscribe` → `block_task` → collector delivers ⏸ → `complete_task` → collector delivers ✔ + unsubscribes → second poll empty | pass |
| ruff check on both files | clean |
