### PR TITLE
fix(cron): enforce one scheduler owner per home

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1614,3 +1614,14 @@ updates:
 #     command: "cat /run/user/1000/hermes-secrets.env"
 #     helper_timeout_seconds: 3
 #     override_existing: false             # .env/shell win by default
+# Cron scheduler ownership and trigger provider.
+cron:
+  # Exactly one runtime may schedule jobs for each HERMES_HOME.
+  # auto: Gateway is preferred; standalone Desktop runs the built-in ticker
+  # when no same-home Gateway is active. Or pin "gateway" / "desktop".
+  scheduler_owner: auto
+
+  # Empty/builtin uses Hermes' in-process ticker. A configured external
+  # provider must be installed and available; automatic startup fails closed
+  # instead of silently falling back to the built-in ticker.
+  provider: ""

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -19,7 +19,8 @@ from typing import Any, Dict, Iterator, List, Optional
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
-EXECUTIONS_FILE = get_hermes_home().resolve() / "cron" / "executions.db"
+_DEFAULT_EXECUTIONS_FILE = get_hermes_home().resolve() / "cron" / "executions.db"
+EXECUTIONS_FILE = _DEFAULT_EXECUTIONS_FILE
 MAX_TERMINAL_EXECUTIONS = 1000
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
@@ -27,8 +28,13 @@ _PROCESS_ID = uuid.uuid4().hex
 
 
 def _connect() -> sqlite3.Connection:
-    EXECUTIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    return sqlite3.connect(EXECUTIONS_FILE, timeout=5)
+    path = (
+        get_hermes_home().resolve() / "cron" / "executions.db"
+        if EXECUTIONS_FILE == _DEFAULT_EXECUTIONS_FILE
+        else EXECUTIONS_FILE
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return sqlite3.connect(path, timeout=5)
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4024,8 +4024,12 @@ def _notify_provider_jobs_changed() -> None:
     Never raises into the caller.
     """
     try:
-        from cron.scheduler_provider import resolve_cron_scheduler
-        resolve_cron_scheduler().on_jobs_changed()
+        from cron.scheduler_runtime import borrow_scheduler_provider
+        from hermes_constants import get_hermes_home
+
+        with borrow_scheduler_provider(hermes_home=get_hermes_home()) as provider:
+            if provider is not None:
+                provider.on_jobs_changed()
     except Exception as e:
         logger.debug("on_jobs_changed notify failed: %s", e)
 

--- a/cron/scheduler_lease.py
+++ b/cron/scheduler_lease.py
@@ -1,0 +1,162 @@
+"""Cross-process ownership lease for one cron scheduler per HERMES_HOME."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import IO, Literal
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
+
+_WINDOWS_LOCK_OFFSET = 1024 * 1024
+_PROCESS_LEASES: set[str] = set()
+_PROCESS_LEASES_LOCK = threading.Lock()
+
+
+def _canonical_lock_path(hermes_home: Path) -> Path:
+    return hermes_home.expanduser().resolve() / "cron" / ".scheduler-owner.lock"
+
+
+def _try_lock(handle: IO[str]) -> bool:
+    try:
+        if sys.platform == "win32":
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write("\n")
+                handle.flush()
+            handle.seek(_WINDOWS_LOCK_OFFSET)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except (BlockingIOError, OSError):
+        return False
+
+
+def _unlock(handle: IO[str]) -> None:
+    try:
+        if sys.platform == "win32":
+            handle.seek(_WINDOWS_LOCK_OFFSET)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        pass
+
+
+def read_scheduler_owner_status(hermes_home: Path) -> dict | None:
+    """Return trustworthy live lease metadata, or ``None`` when unowned."""
+    path = _canonical_lock_path(hermes_home)
+    try:
+        handle = open(path, "a+", encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        if _try_lock(handle):
+            _unlock(handle)
+            return None
+        handle.seek(0)
+        try:
+            value = json.load(handle)
+        except (json.JSONDecodeError, OSError):
+            return None
+        return value if isinstance(value, dict) else None
+    finally:
+        try:
+            handle.close()
+        except OSError:
+            pass
+
+
+class SchedulerOwnershipLease:
+    """Kernel-authoritative, non-blocking scheduler ownership lease.
+
+    The lock file is never unlinked: unlinking a locked pathname can create a
+    second inode and allow two live owners.
+    """
+
+    def __init__(self, path: Path, handle: IO[str]) -> None:
+        self.path = path
+        self._key = str(path)
+        self._handle: IO[str] | None = handle
+        self._release_lock = threading.Lock()
+
+    @classmethod
+    def try_acquire(
+        cls,
+        *,
+        hermes_home: Path,
+        owner: Literal["gateway", "desktop"],
+        provider: str,
+    ) -> "SchedulerOwnershipLease | None":
+        path = _canonical_lock_path(hermes_home)
+        key = str(path)
+        with _PROCESS_LEASES_LOCK:
+            if key in _PROCESS_LEASES:
+                return None
+            _PROCESS_LEASES.add(key)
+
+        handle: IO[str] | None = None
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            handle = open(path, "a+", encoding="utf-8")
+            if not _try_lock(handle):
+                handle.close()
+                handle = None
+                return None
+            metadata = {
+                "version": 1,
+                "pid": os.getpid(),
+                "owner": owner,
+                "provider": provider,
+                "acquired_at": datetime.now(timezone.utc).isoformat(),
+            }
+            handle.seek(0)
+            handle.truncate()
+            json.dump(metadata, handle, sort_keys=True)
+            handle.flush()
+            try:
+                os.fsync(handle.fileno())
+            except OSError:
+                pass
+            return cls(path, handle)
+        except Exception:
+            if handle is not None:
+                try:
+                    handle.close()
+                except OSError:
+                    pass
+                handle = None
+            raise
+        finally:
+            if handle is None:
+                with _PROCESS_LEASES_LOCK:
+                    _PROCESS_LEASES.discard(key)
+
+    def release(self) -> None:
+        with self._release_lock:
+            handle = self._handle
+            if handle is None:
+                return
+            self._handle = None
+            _unlock(handle)
+            try:
+                handle.close()
+            except OSError:
+                pass
+            finally:
+                with _PROCESS_LEASES_LOCK:
+                    _PROCESS_LEASES.discard(self._key)
+
+    def __enter__(self) -> "SchedulerOwnershipLease":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.release()

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -17,11 +17,68 @@ ticker. Alternative providers (e.g. Chronos, a NAS-mediated managed-cron
 provider for scale-to-zero deployments) live under plugins/cron_providers/<name>/ and are
 selected via the `cron.provider` config key (empty = built-in).
 """
+
 from __future__ import annotations
 
 import threading
 from abc import ABC, abstractmethod
 from typing import Any
+
+import logging
+
+logger = logging.getLogger("cron.scheduler_provider")
+_CRON_SCHEDULER_RUNTIME_OWNERS = frozenset({"gateway", "desktop"})
+
+
+def resolve_cron_scheduler_owner(*, config: dict[str, Any] | None = None) -> str | None:
+    """Compatibility wrapper for the strict ownership policy reader."""
+    from cron.scheduler_runtime import read_scheduler_ownership_policy_strict
+
+    policy = read_scheduler_ownership_policy_strict(config)
+    return policy.mode if policy is not None else None
+
+
+def should_start_cron_scheduler(
+    runtime_owner: str, *, config: dict[str, Any] | None = None
+) -> bool:
+    """Compatibility policy probe; the ownership lease is authoritative."""
+    if runtime_owner not in _CRON_SCHEDULER_RUNTIME_OWNERS:
+        raise ValueError("Unknown cron scheduler runtime owner")
+    owner = resolve_cron_scheduler_owner(config=config)
+    return owner == runtime_owner or owner == "auto"
+
+
+def resolve_owned_cron_scheduler(
+    runtime_owner: str, *, config: dict[str, Any] | None = None
+) -> "CronScheduler | None":
+    """Legacy one-shot resolver. Automatic runtimes use OwnedSchedulerRuntime."""
+    _owner, provider = resolve_cron_scheduler_startup(runtime_owner, config=config)
+    return provider
+
+
+def resolve_cron_scheduler_startup(
+    runtime_owner: str, *, config: dict[str, Any] | None = None
+) -> "tuple[str | None, CronScheduler | None]":
+    """Legacy strict policy snapshot retained for public API compatibility."""
+    from cron.scheduler_runtime import (
+        read_scheduler_ownership_policy_strict,
+        scheduler_runtime_is_eligible,
+    )
+
+    if runtime_owner not in _CRON_SCHEDULER_RUNTIME_OWNERS:
+        raise ValueError("Unknown cron scheduler runtime owner")
+    policy = read_scheduler_ownership_policy_strict(config)
+    if policy is None:
+        return None, None
+    if not scheduler_runtime_is_eligible(
+        policy,
+        runtime=runtime_owner,  # type: ignore[arg-type]
+        same_home_gateway_running=False,
+    ):
+        return policy.mode, None
+    return policy.mode, resolve_cron_scheduler_runtime_strict(
+        policy.configured_provider
+    )
 
 
 class CronScheduler(ABC):
@@ -119,6 +176,38 @@ class CronScheduler(ABC):
         return None
 
 
+_BUILTIN_PROVIDER_NAMES = frozenset({"", "builtin", "in-process", "inprocess"})
+
+
+def resolve_cron_scheduler_runtime_strict(
+    configured_provider: str,
+) -> "CronScheduler | None":
+    """Resolve a configured provider without silently changing its trigger."""
+    if configured_provider in _BUILTIN_PROVIDER_NAMES:
+        return InProcessCronScheduler()
+    try:
+        from plugins.cron_providers import load_cron_scheduler
+
+        provider = load_cron_scheduler(configured_provider)
+        if provider is None:
+            logger.error(
+                "Configured cron provider %r is not installed", configured_provider
+            )
+            return None
+        if not provider.is_available():
+            logger.error(
+                "Configured cron provider %r is unavailable", configured_provider
+            )
+            return None
+        logger.info("Using cron scheduler provider: %s", provider.name)
+        return provider
+    except Exception:
+        logger.exception(
+            "Configured cron provider %r failed to load", configured_provider
+        )
+        return None
+
+
 def resolve_cron_scheduler() -> "CronScheduler":
     """Return the active cron scheduler provider.
 
@@ -127,13 +216,10 @@ def resolve_cron_scheduler() -> "CronScheduler":
     False`` falls back to the built-in with a warning — cron must never be left
     without a trigger.
     """
-    import logging
-
-    logger = logging.getLogger("cron.scheduler_provider")
-
     name = ""
     try:
         from hermes_cli.config import cfg_get, load_config
+
         name = (cfg_get(load_config(), "cron", "provider", default="") or "").strip()
     except Exception:
         pass
@@ -143,12 +229,15 @@ def resolve_cron_scheduler() -> "CronScheduler":
 
     try:
         from plugins.cron_providers import load_cron_scheduler
+
         provider = load_cron_scheduler(name)
         if provider is None:
             logger.warning("cron.provider '%s' not found; using built-in ticker", name)
             return InProcessCronScheduler()
         if not provider.is_available():
-            logger.warning("cron.provider '%s' not available; using built-in ticker", name)
+            logger.warning(
+                "cron.provider '%s' not available; using built-in ticker", name
+            )
             return InProcessCronScheduler()
         logger.info("Using cron scheduler provider: %s", provider.name)
         return provider
@@ -226,7 +315,9 @@ class InProcessCronScheduler(CronScheduler):
             ok = False
             try:
                 if can_dispatch is not None and not can_dispatch():
-                    logger.debug("Cron dispatch paused while gateway drains existing work")
+                    logger.debug(
+                        "Cron dispatch paused while gateway drains existing work"
+                    )
                 else:
                     cron_tick(
                         verbose=False,
@@ -286,7 +377,10 @@ class InProcessCronScheduler(CronScheduler):
             record_ticker_heartbeat,
             use_cron_store,
         )
-        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+        from hermes_constants import (
+            set_hermes_home_override,
+            reset_hermes_home_override,
+        )
 
         logger = logging.getLogger("cron.scheduler_provider")
         logger.info(
@@ -316,7 +410,9 @@ class InProcessCronScheduler(CronScheduler):
             ok = False
             try:
                 if can_dispatch is not None and not can_dispatch():
-                    logger.debug("Cron dispatch paused while gateway drains existing work")
+                    logger.debug(
+                        "Cron dispatch paused while gateway drains existing work"
+                    )
                 else:
                     for entry in profile_homes:
                         home = entry[1] if isinstance(entry, tuple) else entry

--- a/cron/scheduler_runtime.py
+++ b/cron/scheduler_runtime.py
@@ -1,0 +1,660 @@
+"""Strict policy, provider, lease, and drain lifecycle for cron runtimes."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import re
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Literal, cast
+
+from cron.scheduler_lease import SchedulerOwnershipLease
+
+logger = logging.getLogger("cron.scheduler_runtime")
+RuntimeOwner = Literal["gateway", "desktop"]
+OwnershipMode = Literal["auto", "gateway", "desktop"]
+_PROVIDER_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+_BUILTIN_NAMES = frozenset({"", "builtin", "in-process", "inprocess"})
+_ACTIVE_PROVIDERS: dict[str, "_ProviderAdmission"] = {}
+_ACTIVE_PROVIDERS_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class SchedulerOwnershipPolicy:
+    mode: OwnershipMode
+    configured_provider: str
+
+
+def _read_mapping(path: Path) -> dict[str, Any]:
+    from utils import fast_safe_load
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    meaningful = [
+        line.split("#", 1)[0].strip()
+        for line in raw.splitlines()
+        if line.split("#", 1)[0].strip() not in {"", "---", "..."}
+    ]
+    if not meaningful:
+        return {}
+    parsed = fast_safe_load(io.StringIO(raw))
+    if parsed is None:
+        raise ValueError("explicit null config root")
+    if not isinstance(parsed, dict):
+        raise ValueError("config root must be a mapping")
+    return parsed
+
+
+def _read_effective_cron_config_strict(home: Path) -> dict[str, Any] | None:
+    from hermes_cli import managed_scope
+    from hermes_cli.config import _expand_env_vars
+
+    try:
+        user = cast(
+            dict[str, Any], _expand_env_vars(_read_mapping(home / "config.yaml"))
+        )
+        managed_dir = managed_scope.get_managed_dir()
+        managed = (
+            cast(
+                dict[str, Any],
+                _expand_env_vars(_read_mapping(managed_dir / "config.yaml")),
+            )
+            if managed_dir is not None
+            else {}
+        )
+        user_cron = user.get("cron", {})
+        managed_cron = managed.get("cron", {})
+        if "cron" in user and not isinstance(user_cron, dict):
+            raise ValueError("cron section must be a mapping")
+        if "cron" in managed and not isinstance(managed_cron, dict):
+            raise ValueError("managed cron section must be a mapping")
+        effective = dict(user_cron)
+        effective.update(managed_cron)
+        return {"cron": effective}
+    except Exception:
+        logger.error(
+            "Unable to read valid cron scheduler policy for %s; scheduler startup disabled.",
+            home,
+        )
+        return None
+
+
+def read_scheduler_ownership_policy_strict(
+    config: dict[str, Any] | None = None,
+    *,
+    hermes_home: Path | None = None,
+) -> SchedulerOwnershipPolicy | None:
+    """Read owner and provider together, failing closed on malformed input."""
+    if config is None:
+        if hermes_home is None:
+            from hermes_constants import get_hermes_home
+
+            hermes_home = get_hermes_home()
+        config = _read_effective_cron_config_strict(
+            Path(hermes_home).expanduser().resolve()
+        )
+        if config is None:
+            return None
+    if not isinstance(config, dict):
+        logger.error("Invalid configuration root; scheduler startup disabled.")
+        return None
+    cron = config.get("cron", {})
+    if "cron" in config and not isinstance(cron, dict):
+        logger.error("Invalid cron configuration shape; scheduler startup disabled.")
+        return None
+
+    raw_mode = cron.get("scheduler_owner", "auto")
+    mode = raw_mode.strip().lower() if isinstance(raw_mode, str) else ""
+    if mode not in {"auto", "gateway", "desktop"}:
+        logger.error(
+            "Invalid cron.scheduler_owner; use auto, gateway, or desktop. "
+            "Scheduler startup disabled."
+        )
+        return None
+    raw_provider = cron.get("provider", "")
+    if raw_provider is None or not isinstance(raw_provider, str):
+        logger.error("Invalid cron.provider; scheduler startup disabled.")
+        return None
+    provider = raw_provider.strip()
+    if provider.lower() in _BUILTIN_NAMES:
+        provider = "builtin"
+    elif not _PROVIDER_RE.fullmatch(provider):
+        logger.error("Invalid cron.provider; scheduler startup disabled.")
+        return None
+    return SchedulerOwnershipPolicy(cast(OwnershipMode, mode), provider)
+
+
+def scheduler_runtime_is_eligible(
+    policy: SchedulerOwnershipPolicy,
+    *,
+    runtime: RuntimeOwner,
+    same_home_gateway_running: bool,
+) -> bool:
+    if policy.mode == "gateway":
+        return runtime == "gateway"
+    if policy.mode == "desktop":
+        return runtime == "desktop"
+    if runtime == "gateway":
+        return True
+    return policy.configured_provider == "builtin" and not same_home_gateway_running
+
+
+def _home_key(home: Path) -> str:
+    return str(home.expanduser().resolve())
+
+
+def _gateway_presence_path(home: Path) -> Path:
+    return home / "cron" / ".gateway-present.json"
+
+
+def exact_home_gateway_is_running(home: Path) -> bool:
+    """Check the per-served-profile Gateway presence record.
+
+    A bare live PID is insufficient because the OS may have recycled it after
+    the publishing Gateway exited.  Require the persisted Gateway identity,
+    exact home, and process start fingerprint to still match.
+    """
+    try:
+        from gateway.status import _pid_exists, get_process_start_time
+
+        record = json.loads(_gateway_presence_path(home).read_text(encoding="utf-8"))
+        pid = int(record["pid"])
+        start_time = record["start_time"]
+        if (
+            record.get("kind") != "gateway"
+            or Path(record["hermes_home"]).expanduser().resolve() != home.resolve()
+            or not isinstance(start_time, int)
+            or isinstance(start_time, bool)
+        ):
+            return False
+        return _pid_exists(pid) and get_process_start_time(pid) == start_time
+    except (
+        FileNotFoundError,
+        KeyError,
+        TypeError,
+        ValueError,
+        OSError,
+        json.JSONDecodeError,
+    ):
+        return False
+
+
+def _publish_gateway_presence(home: Path) -> None:
+    from gateway.status import get_process_start_time
+
+    start_time = get_process_start_time(os.getpid())
+    if start_time is None:
+        logger.warning(
+            "Cannot publish PID-reuse-safe Gateway presence for %s; "
+            "Desktop auto ownership will remain fail-open",
+            home,
+        )
+        return
+    path = _gateway_presence_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({
+            "pid": os.getpid(),
+            "start_time": start_time,
+            "kind": "gateway",
+            "hermes_home": str(home.resolve()),
+        }),
+        encoding="utf-8",
+    )
+
+
+def _clear_gateway_presence(home: Path) -> None:
+    from gateway.status import get_process_start_time
+
+    path = _gateway_presence_path(home)
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+        if (
+            int(record.get("pid", -1)) == os.getpid()
+            and record.get("start_time") == get_process_start_time(os.getpid())
+            and record.get("kind") == "gateway"
+        ):
+            path.unlink()
+    except (FileNotFoundError, OSError, ValueError, TypeError, json.JSONDecodeError):
+        pass
+
+
+class _ProviderAdmission:
+    """Closeable exact-home provider admission with in-flight accounting."""
+
+    def __init__(self, provider: Any) -> None:
+        self.provider = provider
+        self._condition = threading.Condition()
+        self._accepting = True
+        self._in_flight = 0
+
+    def borrow(self) -> Any | None:
+        with self._condition:
+            if not self._accepting:
+                return None
+            self._in_flight += 1
+            return self.provider
+
+    def release(self) -> None:
+        with self._condition:
+            self._in_flight -= 1
+            self._condition.notify_all()
+
+    def close(self) -> None:
+        with self._condition:
+            self._accepting = False
+
+    def wait_drained(self, timeout: float) -> bool:
+        deadline = time.monotonic() + max(0.0, timeout)
+        with self._condition:
+            while self._in_flight:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._condition.wait(remaining)
+            return True
+
+    @property
+    def in_flight(self) -> int:
+        with self._condition:
+            return self._in_flight
+
+
+def _active_admission(home: Path) -> _ProviderAdmission | None:
+    with _ACTIVE_PROVIDERS_LOCK:
+        return _ACTIVE_PROVIDERS.get(_home_key(home))
+
+
+def get_active_scheduler_provider(*, hermes_home: Path | None = None) -> Any | None:
+    """Compatibility snapshot; new callback paths must use borrow_scheduler_provider."""
+    if hermes_home is None:
+        from hermes_constants import get_hermes_home
+
+        hermes_home = get_hermes_home()
+    admission = _active_admission(Path(hermes_home))
+    return admission.provider if admission is not None else None
+
+
+def _set_active_provider(home: Path, admission: _ProviderAdmission | None) -> None:
+    with _ACTIVE_PROVIDERS_LOCK:
+        if admission is None:
+            _ACTIVE_PROVIDERS.pop(_home_key(home), None)
+        else:
+            _ACTIVE_PROVIDERS[_home_key(home)] = admission
+
+
+@contextmanager
+def borrow_scheduler_provider(*, hermes_home: Path | None = None):
+    """Borrow the exact-home owner provider, or yield ``None`` if admission closed."""
+    if hermes_home is None:
+        from hermes_constants import get_hermes_home
+
+        hermes_home = get_hermes_home()
+    admission = _active_admission(Path(hermes_home))
+    provider = admission.borrow() if admission is not None else None
+    try:
+        yield provider
+    finally:
+        if provider is not None:
+            admission.release()
+
+
+class OwnedSchedulerRuntime:
+    """Blocking policy supervisor intended to run in one daemon thread."""
+
+    def __init__(
+        self,
+        runtime_owner: RuntimeOwner,
+        *,
+        adapters: Any = None,
+        loop: Any = None,
+        can_dispatch: Callable[[], bool] | None = None,
+        gateway_is_running: Callable[[], bool] | None = None,
+        interval: int = 60,
+        poll_interval: float = 0.5,
+        drain_timeout: float = 65.0,
+        hermes_home: Path | None = None,
+    ) -> None:
+        if runtime_owner not in {"gateway", "desktop"}:
+            raise ValueError("Unknown cron scheduler runtime owner")
+        self.runtime_owner = runtime_owner
+        self.adapters = adapters
+        self.loop = loop
+        self.can_dispatch = can_dispatch
+        self.gateway_is_running = gateway_is_running or (lambda: False)
+        self.interval = interval
+        self.poll_interval = poll_interval
+        self.drain_timeout = drain_timeout
+        self.hermes_home = Path(hermes_home).resolve() if hermes_home else None
+        self._active_provider: Any | None = None
+        self._active_policy: SchedulerOwnershipPolicy | None = None
+        self._lease: SchedulerOwnershipLease | None = None
+        self._provider_thread: threading.Thread | None = None
+        self._provider_stop: threading.Event | None = None
+        self._provider_failed = threading.Event()
+        self._state_lock = threading.Lock()
+        self._admission: _ProviderAdmission | None = None
+        self._jobs_signature: tuple[int, int, int] | None = None
+        self._reconcile_retry_at = 0.0
+        self._reconcile_retry_delay = poll_interval
+        self._retry_delay = poll_interval
+        self._retry_at = 0.0
+
+    @property
+    def active_provider(self) -> Any | None:
+        with self._state_lock:
+            return self._active_provider
+
+    def _home(self) -> Path:
+        if self.hermes_home is not None:
+            return self.hermes_home
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home().expanduser().resolve()
+
+    def _eligible(self, policy: SchedulerOwnershipPolicy | None) -> bool:
+        if policy is None:
+            return False
+        gateway_running = False
+        if self.runtime_owner == "desktop":
+            try:
+                gateway_running = exact_home_gateway_is_running(self._home()) or bool(
+                    self.gateway_is_running()
+                )
+            except Exception:
+                logger.exception("Gateway presence probe failed; Desktop cron yields")
+                gateway_running = True
+        return scheduler_runtime_is_eligible(
+            policy,
+            runtime=self.runtime_owner,
+            same_home_gateway_running=gateway_running,
+        )
+
+    def _provider_target(
+        self, provider: Any, stop: threading.Event, home: Path
+    ) -> None:
+        from cron.scheduler_provider import InProcessCronScheduler
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        token = set_hermes_home_override(home)
+        kwargs = {
+            "adapters": self.adapters,
+            "loop": self.loop,
+            "interval": self.interval,
+        }
+        if isinstance(provider, InProcessCronScheduler) and self.can_dispatch:
+            kwargs["can_dispatch"] = self.can_dispatch
+        try:
+            provider.start(stop, **kwargs)
+        except BaseException:
+            self._provider_failed.set()
+            logger.exception("Cron scheduler provider failed for %s", home)
+        finally:
+            reset_hermes_home_override(token)
+
+    def _start_active(self, policy: SchedulerOwnershipPolicy, home: Path) -> bool:
+        lease = SchedulerOwnershipLease.try_acquire(
+            hermes_home=home,
+            owner=self.runtime_owner,
+            provider=policy.configured_provider,
+        )
+        if lease is None:
+            return False
+        fresh = read_scheduler_ownership_policy_strict(hermes_home=home)
+        if fresh != policy or not self._eligible(fresh):
+            lease.release()
+            return False
+
+        from cron.scheduler_provider import resolve_cron_scheduler_runtime_strict
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        token = set_hermes_home_override(home)
+        try:
+            provider = resolve_cron_scheduler_runtime_strict(policy.configured_provider)
+        finally:
+            reset_hermes_home_override(token)
+        if provider is None:
+            lease.release()
+            return False
+        provider_stop = threading.Event()
+        admission = _ProviderAdmission(provider)
+        self._provider_failed.clear()
+        thread = threading.Thread(
+            target=self._provider_target,
+            args=(provider, provider_stop, home),
+            daemon=True,
+            name=f"{self.runtime_owner}-cron-provider",
+        )
+        with self._state_lock:
+            self._lease = lease
+            self._active_provider = provider
+            self._active_policy = policy
+            self._provider_stop = provider_stop
+            self._provider_thread = thread
+            self._admission = admission
+        try:
+            self._jobs_signature = self._read_jobs_signature(home)
+        except OSError:
+            self._jobs_signature = None
+            self._reconcile_retry_at = time.monotonic() + self.poll_interval
+            logger.exception("Cannot read initial cron jobs signature for %s", home)
+        _set_active_provider(home, admission)
+        try:
+            thread.start()
+        except BaseException:
+            # Publication makes the provider borrowable before Thread.start().
+            # A concurrent callback may therefore already be executing.  Close
+            # admission first, wait for every such borrower, then unpublish and
+            # only after that release the single-owner lease.
+            admission.close()
+            warned = False
+            while not admission.wait_drained(self.poll_interval):
+                if not warned:
+                    logger.warning(
+                        "Cron provider startup failed for %s; retaining lease "
+                        "until published borrowers drain",
+                        home,
+                    )
+                    warned = True
+            _set_active_provider(home, None)
+            with self._state_lock:
+                self._lease = None
+                self._active_provider = None
+                self._active_policy = None
+                self._provider_stop = None
+                self._provider_thread = None
+                self._admission = None
+            lease.release()
+            raise
+        logger.info(
+            "%s owns cron for %s (provider=%s)",
+            self.runtime_owner.capitalize(),
+            home,
+            provider.name,
+        )
+        self._reconcile_retry_delay = self.poll_interval
+        self._reconcile_retry_at = 0.0
+        return True
+
+    @staticmethod
+    def _read_jobs_signature(home: Path) -> tuple[int, int, int] | None:
+        path = home / "cron" / "jobs.json"
+        try:
+            stat = path.stat()
+            return (stat.st_mtime_ns, stat.st_size, stat.st_ino)
+        except FileNotFoundError:
+            return None
+
+    def _reconcile_if_changed(self, home: Path) -> None:
+        try:
+            signature = self._read_jobs_signature(home)
+        except OSError:
+            now = time.monotonic()
+            if now >= self._reconcile_retry_at:
+                logger.exception("Cannot read cron jobs signature for %s", home)
+                self._reconcile_retry_delay = min(
+                    max(self.poll_interval, self._reconcile_retry_delay * 2),
+                    30.0,
+                )
+                self._reconcile_retry_at = now + self._reconcile_retry_delay
+            return
+        if signature == self._jobs_signature:
+            return
+        now = time.monotonic()
+        if now < self._reconcile_retry_at:
+            return
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        with borrow_scheduler_provider(hermes_home=home) as provider:
+            if provider is None:
+                return
+            token = set_hermes_home_override(home)
+            try:
+                provider.on_jobs_changed()
+            except BaseException:
+                logger.exception("Cron provider reconciliation failed for %s", home)
+                self._reconcile_retry_delay = min(
+                    max(
+                        self.poll_interval,
+                        self._reconcile_retry_delay * 2,
+                    ),
+                    30.0,
+                )
+                self._reconcile_retry_at = now + self._reconcile_retry_delay
+                return
+            finally:
+                reset_hermes_home_override(token)
+        self._jobs_signature = signature
+        self._reconcile_retry_delay = self.poll_interval
+        self._reconcile_retry_at = 0.0
+
+    @staticmethod
+    def _jobs_drained(home: Path) -> bool:
+        from cron.scheduler import get_running_job_ids
+
+        # Job IDs are process-global today. Conservatively holding every active
+        # home lease until all jobs drain prevents cross-profile overlap.
+        return not get_running_job_ids()
+
+    def _drain_active(self, supervisor_stop: threading.Event, home: Path) -> None:
+        with self._state_lock:
+            provider = self._active_provider
+            provider_stop = self._provider_stop
+            thread = self._provider_thread
+            lease = self._lease
+            admission = self._admission
+        if provider is None or lease is None:
+            return
+        # Close admission before unpublishing or signaling teardown. Every fire
+        # and reconcile that already borrowed the provider remains counted.
+        if admission is not None:
+            admission.close()
+        _set_active_provider(home, None)
+        if provider_stop:
+            provider_stop.set()
+        deadline = time.monotonic() + max(0.0, self.drain_timeout)
+        warned = False
+        while (
+            (thread is not None and thread.is_alive())
+            or (admission is not None and admission.in_flight)
+            or not self._jobs_drained(home)
+        ):
+            if not warned and time.monotonic() >= deadline:
+                warned = True
+                logger.warning(
+                    "Cron for %s did not drain within %.0fs; retaining lease",
+                    home,
+                    self.drain_timeout,
+                )
+            # The supervisor stop event is already set during shutdown; waiting
+            # on it would return immediately and busy-spin while providers/jobs
+            # finish draining. Sleep independently so lease retention remains
+            # fail-closed without burning a CPU core.
+            time.sleep(min(self.poll_interval, 0.1) if warned else self.poll_interval)
+        # Provider stop tears down resources that admitted callbacks and the
+        # provider thread may still be using. Run it only after every borrower,
+        # provider lifecycle, and in-flight job has crossed the drain barrier;
+        # the ownership lease remains held throughout.
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        token = set_hermes_home_override(home)
+        try:
+            provider.stop()
+        except BaseException:
+            logger.exception("Cron provider stop failed")
+        finally:
+            reset_hermes_home_override(token)
+        with self._state_lock:
+            self._active_provider = None
+            self._active_policy = None
+            self._provider_stop = None
+            self._provider_thread = None
+            self._lease = None
+            self._admission = None
+            self._jobs_signature = None
+            self._reconcile_retry_delay = self.poll_interval
+            self._reconcile_retry_at = 0.0
+        lease.release()
+
+    def run(self, stop_event: threading.Event) -> None:
+        home = self._home()
+        if self.runtime_owner == "gateway":
+            _publish_gateway_presence(home)
+        try:
+            while not stop_event.is_set():
+                policy = read_scheduler_ownership_policy_strict(hermes_home=home)
+                active = self.active_provider
+                provider_failed = self._provider_failed.is_set()
+                if active is not None and (
+                    not self._eligible(policy)
+                    or policy != self._active_policy
+                    or provider_failed
+                ):
+                    self._drain_active(stop_event, home)
+                    if provider_failed:
+                        self._retry_delay = min(
+                            max(self.poll_interval, self._retry_delay * 2), 30.0
+                        )
+                        self._retry_at = time.monotonic() + self._retry_delay
+                    continue
+                if active is None and self._eligible(policy):
+                    assert policy is not None
+                    now = time.monotonic()
+                    if now >= self._retry_at:
+                        if self._start_active(policy, home):
+                            self._retry_delay = self.poll_interval
+                        else:
+                            self._retry_delay = min(
+                                max(self.poll_interval, self._retry_delay * 2), 30.0
+                            )
+                            self._retry_at = now + self._retry_delay
+                elif active is not None:
+                    self._reconcile_if_changed(home)
+                    self._retry_delay = self.poll_interval
+                stop_event.wait(self.poll_interval)
+        finally:
+            # Any unexpected supervisor failure must fail closed: stop and
+            # drain the provider before releasing its exact-home lease.
+            self._drain_active(stop_event, home)
+            if self.runtime_owner == "gateway":
+                _clear_gateway_presence(home)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -40,6 +40,7 @@ Requires:
 """
 
 import asyncio
+import threading
 import errno
 import hashlib
 import hmac
@@ -5416,25 +5417,6 @@ class APIServerAdapter(BasePlatformAdapter):
         trips NAS's HTTP timeout. The store CAS claim inside fire_due guards
         against double-fire on a NAS/scheduler retry.
         """
-        from hermes_cli.config import cfg_get, load_config
-        from plugins.cron_providers.chronos.verify import get_fire_verifier
-
-        auth = request.headers.get("Authorization", "")
-        token = auth[7:].strip() if auth.startswith("Bearer ") else ""
-
-        cfg = load_config()
-        claims = get_fire_verifier()(
-            token=token,
-            expected_audience=cfg_get(cfg, "cron", "chronos", "expected_audience", default=""),
-            jwks_or_key=cfg_get(cfg, "cron", "chronos", "nas_jwks_url", default="") or None,
-            issuer=cfg_get(cfg, "cron", "chronos", "portal_url", default="") or None,
-        )
-        if claims is None:
-            logger.warning(
-                "cron fire: rejected invalid token: %s",
-                self._request_audit_log_suffix(request),
-            )
-            return web.json_response({"error": "invalid fire token"}, status=401)
         draining = self._draining_response()
         if draining is not None:
             return draining
@@ -5448,15 +5430,134 @@ class APIServerAdapter(BasePlatformAdapter):
             if not job_id:
                 return web.json_response({"error": "missing job_id"}, status=400)
 
-            from cron.scheduler_provider import resolve_cron_scheduler
-            provider = resolve_cron_scheduler()
+            from hermes_constants import get_hermes_home
+            from cron.jobs import load_jobs
+            from hermes_cli.profiles import profiles_to_serve
+
+            runner = getattr(self, "gateway_runner", None)
+            multiplex = bool(
+                getattr(getattr(runner, "config", None), "multiplex_profiles", False)
+            )
+            if multiplex:
+                from gateway.run import _profile_runtime_scope
+
+                exact_scope = _profile_runtime_scope
+            else:
+                exact_scope = lambda _home: nullcontext()
+            homes = (
+                list(profiles_to_serve(multiplex=True))
+                if multiplex
+                else [("active", get_hermes_home())]
+            )
+            owners = []
+            for profile_name, candidate_home in homes:
+                home = Path(candidate_home).expanduser().resolve()
+                try:
+                    with exact_scope(home):
+                        if any(job.get("id") == job_id for job in load_jobs()):
+                            owners.append((profile_name, home))
+                except Exception:
+                    logger.exception(
+                        "cron fire: failed to inspect job owner for %s", home
+                    )
+                    return web.json_response(
+                        {"error": "job ownership unavailable"}, status=503
+                    )
+            if len(owners) != 1:
+                logger.warning(
+                    "cron fire: rejected %s job id %r",
+                    "unknown" if not owners else "ambiguous",
+                    job_id,
+                )
+                return web.json_response({"error": "job not found"}, status=404)
+
+            _owner_profile, owner_home = owners[0]
+            with exact_scope(owner_home):
+                from hermes_cli.config import cfg_get, load_config
+                from plugins.cron_providers.chronos.verify import get_fire_verifier
+
+                auth = request.headers.get("Authorization", "")
+                token = auth[7:].strip() if auth.startswith("Bearer ") else ""
+                cfg = load_config()
+                claims = get_fire_verifier()(
+                    token=token,
+                    expected_audience=cfg_get(
+                        cfg, "cron", "chronos", "expected_audience", default=""
+                    ),
+                    jwks_or_key=cfg_get(
+                        cfg, "cron", "chronos", "nas_jwks_url", default=""
+                    ) or None,
+                    issuer=cfg_get(
+                        cfg, "cron", "chronos", "portal_url", default=""
+                    ) or None,
+                )
+            if claims is None:
+                logger.warning(
+                    "cron fire: rejected invalid token: %s",
+                    self._request_audit_log_suffix(request),
+                )
+                return web.json_response({"error": "invalid fire token"}, status=401)
+
+            from cron.scheduler_runtime import borrow_scheduler_provider
 
             loop = asyncio.get_running_loop()
+            admission_ready = loop.create_future()
+            completed = loop.create_future()
+
+            def _fire_in_worker():
+                try:
+                    with borrow_scheduler_provider(hermes_home=owner_home) as provider:
+                        loop.call_soon_threadsafe(
+                            lambda admitted=provider is not None: (
+                                None
+                                if admission_ready.done()
+                                else admission_ready.set_result(admitted)
+                            )
+                        )
+                        if provider is None:
+                            result = None
+                        else:
+                            result = provider.fire_due(
+                                job_id, adapters=None, loop=loop
+                            )
+                    loop.call_soon_threadsafe(
+                        lambda value=result: (
+                            None if completed.done() else completed.set_result(value)
+                        )
+                    )
+                except BaseException as exc:
+                    if not admission_ready.done():
+                        loop.call_soon_threadsafe(
+                            lambda: (
+                                None
+                                if admission_ready.done()
+                                else admission_ready.set_result(False)
+                            )
+                        )
+                    loop.call_soon_threadsafe(
+                        lambda error=exc: (
+                            None if completed.done() else completed.set_exception(error)
+                        )
+                    )
+
+            async def _fire_reserved():
+                try:
+                    await asyncio.shield(completed)
+                except asyncio.CancelledError:
+                    # The accepted worker owns provider admission and pending
+                    # API tracking until fire_due really returns. Caller/task
+                    # cancellation must not release either ledger early.
+                    await asyncio.shield(completed)
+
             # Fire in the background (202 immediately). fire_due claims via the
             # store CAS, so a retry while this is in flight is de-duped.
-            task = asyncio.create_task(
-                asyncio.to_thread(provider.fire_due, job_id, adapters=None, loop=loop)
+            task = asyncio.create_task(_fire_reserved())
+            worker = threading.Thread(
+                target=_fire_in_worker,
+                daemon=True,
+                name=f"cron-fire-{job_id}",
             )
+            worker.start()
             reservation["detached"] = True
             task.add_done_callback(
                 lambda _task: _release_pending_api_work(self, reservation)
@@ -5467,6 +5568,13 @@ class APIServerAdapter(BasePlatformAdapter):
             except (TypeError, AttributeError):
                 pass
 
+            # Do not acknowledge until the actual worker thread owns admission.
+            # Waiting only for this hand-off is bounded by executor scheduling;
+            # the long fire itself remains background work in both ledgers.
+            if not await asyncio.shield(admission_ready):
+                return web.json_response(
+                    {"error": "scheduler ownership unavailable"}, status=503
+                )
             return web.json_response({"status": "accepted", "job_id": job_id}, status=202)
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23721,6 +23721,46 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     InProcessCronScheduler().start(stop_event, adapters=adapters, loop=loop, interval=interval)
 
 
+def _start_gateway_cron_schedulers(runner, stop_event, loop):
+    """Start one exact-home ownership supervisor per served Gateway profile."""
+    from cron.scheduler_runtime import (
+        OwnedSchedulerRuntime,
+    )
+    from hermes_constants import get_hermes_home
+
+    homes = [("active", get_hermes_home())]
+    if getattr(runner.config, "multiplex_profiles", False):
+        try:
+            from hermes_cli.profiles import profiles_to_serve
+            homes = list(profiles_to_serve(multiplex=True))
+        except Exception as exc:
+            logger.error("Could not resolve multiplex cron profile homes: %s", exc)
+            homes = []
+
+    supervisors = []
+    for profile_name, profile_home in homes:
+        home = Path(profile_home).expanduser().resolve()
+        runtime = OwnedSchedulerRuntime(
+            "gateway",
+            adapters=runner.adapters,
+            loop=loop,
+            can_dispatch=lambda: not (
+                runner._draining or runner._external_drain_active
+            ),
+            drain_timeout=_CRON_SHUTDOWN_DRAIN_TIMEOUT,
+            hermes_home=home,
+        )
+        thread = threading.Thread(
+            target=runtime.run,
+            args=(stop_event,),
+            daemon=True,
+            name=f"gateway-cron-supervisor-{profile_name}",
+        )
+        thread.start()
+        supervisors.append((runtime, thread))
+    return supervisors
+
+
 # Upper bound for cooperatively draining the cron ticker on shutdown. The cron
 # thread delivers via ``safe_schedule_threadsafe`` and blocks on
 # ``future.result(timeout=60)`` (see cron/scheduler.py::_deliver_result), so a
@@ -24248,53 +24288,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # historical in-process 60s ticker; an external provider (e.g. chronos)
     # may arm a schedule and return. Pass the event loop so cron delivery can
     # use live adapters (E2EE support).
-    from cron.scheduler_provider import InProcessCronScheduler, resolve_cron_scheduler
     cron_stop = threading.Event()
-    cron_provider = resolve_cron_scheduler()
-    cron_start_kwargs: Dict[str, Any] = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
-
-    # Multiplex profiles: tell the built-in ticker which profile homes to
-    # tick so secondary-profile cron jobs actually fire (#69377).
-    # Without this, only the process-global HERMES_HOME (default profile)
-    # is iterated and every secondary profile's cron store is silently
-    # ignored — jobs show as "scheduled" with a valid next_run_at but
-    # never execute because no ticker owns that store.
-    if (
-        isinstance(cron_provider, InProcessCronScheduler)
-        and getattr(runner.config, "multiplex_profiles", False)
-    ):
-        try:
-            from hermes_cli.profiles import profiles_to_serve
-
-            profile_homes = list(profiles_to_serve(multiplex=True))
-            if profile_homes:
-                cron_start_kwargs["profile_homes"] = profile_homes
-                logger.info(
-                    "Cron scheduler will tick %d profile(s) under multiplex: %s",
-                    len(profile_homes),
-                    [p[0] if isinstance(p, tuple) else p for p in profile_homes],
-                )
-        except Exception as exc:
-            logger.warning(
-                "Could not resolve profile homes for multiplex cron: %s",
-                exc,
-            )
-
-    # External cron providers own their remote scheduling contract. Only the
-    # in-process ticker polls local due jobs, so only it receives the local
-    # external-drain dispatch gate.
-    if isinstance(cron_provider, InProcessCronScheduler):
-        cron_start_kwargs["can_dispatch"] = lambda: not (
-            runner._draining or runner._external_drain_active
-        )
-    cron_thread = threading.Thread(
-        target=cron_provider.start,
-        args=(cron_stop,),
-        kwargs=cron_start_kwargs,
-        daemon=True,
-        name="cron-scheduler",
+    cron_supervisors = _start_gateway_cron_schedulers(
+        runner, cron_stop, asyncio.get_running_loop()
     )
-    cron_thread.start()
 
     # Gateway-only periodic housekeeping (channel dir, cache cleanup, paste
     # sweep, curator) — runs independently of which cron provider is active.
@@ -24325,11 +24322,6 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     except Exception:
         pass
 
-    if runner.should_exit_with_failure:
-        if runner.exit_reason:
-            logger.error("Gateway exiting with failure: %s", runner.exit_reason)
-        return False
-    
     # Stop cron scheduler + housekeeping cleanly.
     #
     # These MUST be awaited cooperatively, not join()ed. A cron delivery in
@@ -24340,18 +24332,29 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # silently dropped (#58818). Awaiting keeps the loop alive so the in-flight
     # delivery finishes before we tear down.
     cron_stop.set()
-    try:
-        cron_provider.stop()
-    except Exception as e:
-        logger.debug("Cron provider stop() error: %s", e)
-    if not await _await_thread_exit(cron_thread, timeout=_CRON_SHUTDOWN_DRAIN_TIMEOUT):
-        logger.warning(
-            "Cron ticker did not exit within %.0fs of shutdown — an in-flight "
-            "delivery may have been dropped.", _CRON_SHUTDOWN_DRAIN_TIMEOUT,
+    cron_exit_results = await asyncio.gather(
+        *(
+            _await_thread_exit(
+                cron_thread, timeout=_CRON_SHUTDOWN_DRAIN_TIMEOUT
+            )
+            for _runtime, cron_thread in cron_supervisors
         )
+    )
+    for exited in cron_exit_results:
+        if not exited:
+            logger.warning(
+                "Cron supervisor did not exit within %.0fs; ownership remains "
+                "held until provider and in-flight jobs drain.",
+                _CRON_SHUTDOWN_DRAIN_TIMEOUT,
+            )
     await _await_thread_exit(
         housekeeping_thread, timeout=_HOUSEKEEPING_SHUTDOWN_DRAIN_TIMEOUT
     )
+
+    if runner.should_exit_with_failure:
+        if runner.exit_reason:
+            logger.error("Gateway exiting with failure: %s", runner.exit_reason)
+        return False
 
     # Stop the planned-stop watcher (daemon=True so this is belt-and-suspenders).
     _planned_stop_watcher_stop.set()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2845,13 +2845,17 @@ DEFAULT_CONFIG = {
     },
 
     "cron": {
+        # Exactly one long-running runtime owns automatic scheduling per
+        # HERMES_HOME. "auto" prefers Gateway while preserving standalone
+        # Desktop's built-in ticker when no same-home Gateway is running.
+        "scheduler_owner": "auto",
         # Active cron SCHEDULER provider (Axis B — the trigger that decides
         # WHEN a due job fires). Empty string = the built-in in-process 60s
         # ticker (default). Name an installed provider (plugins/cron_providers/<name>/ or
         # $HERMES_HOME/plugins/<name>/) to relocate the trigger — e.g. "chronos",
         # the NAS-mediated managed-cron provider for scale-to-zero deployments.
-        # An unknown or unavailable provider falls back to the built-in, so cron
-        # never loses its trigger.
+        # Automatic runtimes fail closed when a configured provider is missing
+        # or unavailable; they never silently change the configured trigger.
         "provider": "",
         # Chronos (NAS-mediated managed cron) settings. Only consulted when
         # provider == "chronos". All non-secret (URLs + the JWT audience): the

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -63,36 +63,61 @@ def _active_cron_provider_name() -> str:
         return "builtin"
 
 
-def _warn_if_gateway_not_running() -> None:
-    """Warn that scheduled jobs won't fire unless the gateway is running.
-
-    The cron ticker only runs inside the gateway (``_start_cron_ticker`` in
-    gateway/run.py); there is no standalone cron daemon. Without a running
-    gateway, ``next_run_at`` passes but jobs never fire and ``last_run_at``
-    stays null — the most common cron support report (#51038). Surfacing this
-    at create/list time, when the user is right there, prevents it.
-
-    An external provider (e.g. Chronos) fires jobs via a NAS-mediated webhook,
-    NOT the in-process ticker, so a momentarily-absent gateway process does not
-    mean jobs won't fire — the warning would be a false alarm. Stay quiet for
-    any non-builtin provider; the gateway-process heuristic only speaks to the
-    built-in ticker's trigger.
-    """
+def _scheduler_health():
+    """Strict exact-home policy plus kernel-authoritative live owner metadata."""
     try:
-        if _active_cron_provider_name() != "builtin":
-            return
+        from cron.scheduler_lease import read_scheduler_owner_status
+        from cron.scheduler_runtime import read_scheduler_ownership_policy_strict
+        from hermes_constants import get_hermes_home
 
-        from hermes_cli.gateway import find_gateway_pids
-
-        if find_gateway_pids():
-            return
+        home = get_hermes_home().expanduser().resolve()
+        policy = read_scheduler_ownership_policy_strict(hermes_home=home)
+        owner = read_scheduler_owner_status(home)
+        if owner is not None and (
+            owner.get("owner") not in {"gateway", "desktop"}
+            or not isinstance(owner.get("provider"), str)
+        ):
+            owner = None
+        return policy, owner
     except Exception:
-        # If we can't determine gateway state, stay quiet rather than nag.
+        return None, None
+
+
+def _scheduler_owner_matches_policy(policy, owner) -> bool:
+    """Return whether a live lease matches the configured provider and owner policy."""
+    if owner is None or owner.get("provider") != policy.configured_provider:
+        return False
+    owner_name = owner.get("owner")
+    if policy.mode == "gateway":
+        return owner_name == "gateway"
+    if policy.mode == "desktop":
+        return owner_name == "desktop"
+    if policy.configured_provider == "builtin":
+        return owner_name in {"gateway", "desktop"}
+    return owner_name == "gateway"
+
+
+def _warn_if_gateway_not_running() -> None:
+    """Warn when no exact-home runtime owns the configured scheduler.
+
+    The live kernel lease, rather than a process-name/PID heuristic, covers
+    Gateway- and Desktop-owned built-in schedulers as well as external
+    providers. A configured provider without a matching live lease fails
+    closed because jobs are not currently armed or ticked.
+    """
+    policy, owner = _scheduler_health()
+    if policy is None:
+        print(color("  ⚠  Cron policy is invalid — automatic firing is disabled.", Colors.YELLOW))
+        return
+    if _scheduler_owner_matches_policy(policy, owner):
         return
 
-    print(color("  ⚠  Gateway is not running — jobs won't fire automatically.", Colors.YELLOW))
-    print(color("     Start it with: hermes gateway install", Colors.DIM))
-    print(color("                    sudo hermes gateway install --system  # Linux servers", Colors.DIM))
+    if policy.mode == "gateway":
+        print(color("  ⚠  Gateway is not running — jobs won't fire automatically.", Colors.YELLOW))
+    else:
+        print(color("  ⚠  No live cron owner — jobs won't fire automatically.", Colors.YELLOW))
+    print(color("     Start an eligible Gateway or Desktop runtime.", Colors.DIM))
+    print(color("     Gateway setup: hermes gateway install", Colors.DIM))
     print(color("     Check status:  hermes cron status", Colors.DIM))
 
 
@@ -221,7 +246,31 @@ def cron_status():
 
     print()
 
-    provider = _active_cron_provider_name()
+    policy, owner = _scheduler_health()
+    if policy is None:
+        print(color("✗ Cron scheduler policy is invalid — automatic firing is disabled", Colors.RED))
+        print()
+        _print_active_jobs_summary(list_jobs(include_disabled=False))
+        print()
+        return
+    provider = policy.configured_provider
+    if not _scheduler_owner_matches_policy(policy, owner):
+        if policy.mode == "gateway" and provider == "builtin":
+            reason = "Gateway is not running — cron jobs will NOT fire automatically"
+        else:
+            reason = (
+                f"No live cron owner for configured provider {provider!r} — "
+                "jobs will NOT fire automatically"
+            )
+        print(color(
+            f"✗ {reason}",
+            Colors.RED,
+        ))
+        print()
+        _print_active_jobs_summary(list_jobs(include_disabled=False))
+        print()
+        return
+    owner_name = owner.get("owner", "unknown")
     if provider != "builtin":
         # An external provider (e.g. Chronos) does NOT run the in-process 60s
         # ticker — it arms one external one-shot per job and is fired by a
@@ -231,7 +280,7 @@ def cron_status():
         # healthy Chronos instance. Report the provider instead and skip the
         # ticker-liveness heuristics entirely.
         print(color(
-            f"✓ Cron provider: {provider} — jobs fire via the managed scheduler, "
+            f"✓ Cron owner: {owner_name}; provider: {provider} — jobs fire via the managed scheduler, "
             "not the in-process ticker.",
             Colors.GREEN,
         ))
@@ -245,8 +294,8 @@ def cron_status():
         print()
         return
 
-    pids = find_gateway_pids()
-    if pids:
+    pids = find_gateway_pids() if owner_name == "gateway" else []
+    if owner_name in {"gateway", "desktop"}:
         # The gateway PROCESS is alive — but the cron ticker THREAD inside it
         # can die silently, or stay alive while every tick fails. Check both
         # the liveness heartbeat and the last-successful-tick marker so we
@@ -300,8 +349,13 @@ def cron_status():
                     ))
             print("  Check the gateway log for 'Cron tick error'.")
         else:
-            print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
-            print(f"  PID: {', '.join(map(str, pids))}")
+            if owner_name == "gateway":
+                message = "✓ Gateway is running and owns cron — jobs will fire automatically"
+            else:
+                message = "✓ Desktop owns cron — jobs will fire automatically"
+            print(color(message, Colors.GREEN))
+            if pids:
+                print(f"  PID: {', '.join(map(str, pids))}")
             if hb_age is not None:
                 print(f"  Ticker heartbeat: {int(hb_age)}s ago")
     else:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13,6 +13,7 @@ import contextlib
 from contextlib import asynccontextmanager, contextmanager
 
 import asyncio
+import contextvars
 import atexit
 import base64
 import binascii
@@ -134,6 +135,8 @@ except ImportError:
 
 WEB_DIST = Path(os.environ["HERMES_WEB_DIST"]) if "HERMES_WEB_DIST" in os.environ else Path(__file__).parent / "web_dist"
 _log = logging.getLogger(__name__)
+_DESKTOP_CRON_SHUTDOWN_TIMEOUT = 65.0
+_HOSTED_CRON_FIRE = contextvars.ContextVar("hosted_cron_fire", default=False)
 
 # ---------------------------------------------------------------------------
 # Per-channel subscriber registry used by /api/pub (PTY-side gateway → dashboard)
@@ -166,6 +169,45 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     provider = resolve_cron_scheduler()
     _log.info("Desktop cron scheduler started (provider=%s, interval=%ds)", provider.name, interval)
     provider.start(stop_event, interval=interval)
+
+
+def _start_desktop_cron_scheduler_if_owned():
+    """Start Desktop's dynamically yielding exact-home scheduler supervisor."""
+    if os.getenv("HERMES_DESKTOP") != "1":
+        return None, None, None
+    from cron.scheduler_runtime import OwnedSchedulerRuntime
+    from gateway.status import is_gateway_runtime_lock_active
+
+    stop = threading.Event()
+    runtime = OwnedSchedulerRuntime(
+        "desktop",
+        gateway_is_running=is_gateway_runtime_lock_active,
+        drain_timeout=_DESKTOP_CRON_SHUTDOWN_TIMEOUT,
+    )
+    thread = threading.Thread(
+        target=runtime.run, args=(stop,), daemon=True, name="desktop-cron-supervisor"
+    )
+    thread.start()
+    return runtime, stop, thread
+
+
+async def _stop_desktop_cron_scheduler(
+    _runtime, stop, thread, *, timeout=_DESKTOP_CRON_SHUTDOWN_TIMEOUT
+):
+    """Signal shutdown and wait boundedly without blocking the event loop."""
+    stop.set()
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max(0.0, timeout)
+    while thread.is_alive() and loop.time() < deadline:
+        await asyncio.sleep(0.1)
+    if thread.is_alive():
+        _log.warning(
+            "Desktop cron did not drain within %.0fs; ownership remains held "
+            "until drain or process death.",
+            timeout,
+        )
+        return False
+    return True
 
 
 def _warm_gateway_module() -> None:
@@ -206,17 +248,7 @@ async def _lifespan(app: "FastAPI"):
     # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
     # since the app has no gateway running the scheduler. Server `hermes
     # dashboard` is unaffected — it relies on its own gateway.
-    cron_stop: "threading.Event | None" = None
-    cron_thread: "threading.Thread | None" = None
-    if os.getenv("HERMES_DESKTOP") == "1":
-        cron_stop = threading.Event()
-        cron_thread = threading.Thread(
-            target=_start_desktop_cron_ticker,
-            args=(cron_stop,),
-            daemon=True,
-            name="desktop-cron-ticker",
-        )
-        cron_thread.start()
+    cron_runtime, cron_stop, cron_thread = _start_desktop_cron_scheduler_if_owned()
 
     # Reap idle/dead keep-alive PTY sessions in the background (30-min TTL).
     pty_reaper_task = asyncio.create_task(run_reaper(PTY_REGISTRY))
@@ -236,8 +268,8 @@ async def _lifespan(app: "FastAPI"):
         selftest_task.cancel()
         auto_archive_task.cancel()
         await PTY_REGISTRY.close_all()
-        if cron_stop is not None:
-            cron_stop.set()
+        if cron_runtime is not None and cron_stop is not None and cron_thread is not None:
+            await _stop_desktop_cron_scheduler(cron_runtime, cron_stop, cron_thread)
 
 
 def _get_event_state(app: "FastAPI"):
@@ -3092,19 +3124,28 @@ async def get_status(profile: Optional[str] = None):
             up empty, so the timeout is paid at most once per request and only
             in the cross-container case that needs it.
             """
+            deadline = time.monotonic() + _GATEWAY_HEALTH_ROUTE_TIMEOUT
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                 future = pool.submit(_probe_gateway_health)
                 try:
-                    return future.result(timeout=_GATEWAY_HEALTH_ROUTE_TIMEOUT)
-                except concurrent.futures.TimeoutError:
-                    _log.warning(
-                        "/api/status gateway health probe exceeded %.2fs; "
-                        "using local status",
-                        _GATEWAY_HEALTH_ROUTE_TIMEOUT,
+                    result = future.result(
+                        timeout=max(0.0, deadline - time.monotonic())
                     )
-                    return False, None
+                    # Future.result(timeout=...) may return a completed result
+                    # after the deadline when the waiting thread was not
+                    # scheduled promptly. Never accept a late health result.
+                    if time.monotonic() <= deadline:
+                        return result
+                except concurrent.futures.TimeoutError:
+                    pass
                 except Exception:
                     return False, None
+                _log.warning(
+                    "/api/status gateway health probe exceeded %.2fs; "
+                    "using local status",
+                    _GATEWAY_HEALTH_ROUTE_TIMEOUT,
+                )
+                return False, None
 
         local_runtime = (
             read_runtime_status(path=profile_dir / "gateway_state.json")
@@ -12278,14 +12319,38 @@ def _call_cron_for_profile(target_profile: Optional[str], func_name: str, *args,
 
 
 def _find_cron_job_profile(job_id: str) -> Optional[str]:
+    matches: List[str] = []
     for profile in _cron_profile_dicts():
         name = str(profile.get("name") or "")
         if not name:
             continue
         jobs = _call_cron_for_profile(name, "list_jobs", True)
         if any(j.get("id") == job_id or j.get("name") == job_id for j in jobs):
-            return name
-    return None
+            matches.append(name)
+    if len(matches) > 1:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cron job reference is ambiguous across profiles: {job_id}",
+        )
+    return matches[0] if matches else None
+
+
+def _find_exact_cron_job_profile(job_id: str) -> Optional[str]:
+    """Resolve a hosted fire target by canonical ID, never by display name."""
+    matches: List[str] = []
+    for profile in _cron_profile_dicts():
+        name = str(profile.get("name") or "")
+        if not name:
+            continue
+        jobs = _call_cron_for_profile(name, "list_jobs", True)
+        if any(j.get("id") == job_id for j in jobs):
+            matches.append(name)
+    if len(matches) > 1:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cron job ID exists in multiple profiles: {job_id}",
+        )
+    return matches[0] if matches else None
 
 
 def _list_cron_jobs_sync(profile: str = "all"):
@@ -12569,7 +12634,11 @@ def _fire_cron_job_for_profile(profile: str, job_id: str) -> bool:
     """
     _profile_name, home = _cron_profile_home(profile)
     from cron import jobs as cron_jobs
-    from cron.scheduler_provider import resolve_cron_scheduler
+    from cron.scheduler_runtime import (
+        borrow_scheduler_provider,
+        read_scheduler_ownership_policy_strict,
+    )
+    from cron.scheduler_provider import resolve_cron_scheduler_runtime_strict
     from hermes_constants import (
         reset_hermes_home_override,
         set_hermes_home_override,
@@ -12578,10 +12647,41 @@ def _fire_cron_job_for_profile(profile: str, job_id: str) -> bool:
     token = set_hermes_home_override(str(home))
     try:
         with cron_jobs.use_cron_store(home):
-            provider = resolve_cron_scheduler()
+            with borrow_scheduler_provider(hermes_home=home) as provider:
+                if provider is not None:
+                    return bool(provider.fire_due(job_id, adapters=None, loop=None))
+            # Hosted dashboards are the scale-to-zero callback surface. They
+            # may strictly resolve only the configured external provider; the
+            # builtin ticker must always remain behind ownership admission.
+            policy = read_scheduler_ownership_policy_strict(hermes_home=home)
+            if policy is None or policy.configured_provider == "builtin":
+                if not _HOSTED_CRON_FIRE.get():
+                    # Backward-compatible direct-helper seam. The public
+                    # hosted callback always sets strict_external_only=True.
+                    from cron.scheduler_provider import resolve_cron_scheduler
+
+                    return bool(
+                        resolve_cron_scheduler().fire_due(
+                            job_id, adapters=None, loop=None
+                        )
+                    )
+                return None
+            provider = resolve_cron_scheduler_runtime_strict(
+                policy.configured_provider
+            )
+            if provider is None:
+                return None
             return bool(provider.fire_due(job_id, adapters=None, loop=None))
     finally:
         reset_hermes_home_override(token)
+
+
+def _fire_hosted_cron_job_for_profile(profile: str, job_id: str) -> bool:
+    token = _HOSTED_CRON_FIRE.set(True)
+    try:
+        return _fire_cron_job_for_profile(profile, job_id)
+    finally:
+        _HOSTED_CRON_FIRE.reset(token)
 
 
 @app.post("/api/cron/fire")
@@ -12600,24 +12700,11 @@ async def cron_fire_webhook(request: Request):
     dashboard is the agent's always-reachable public HTTP surface on hosted
     deployments; the gateway may be idle/scaled down.
 
-    Returns 202 immediately and runs the job in the background so a long agent
-    turn never trips NAS's HTTP timeout.
+    Returns 202 only after the exact-profile provider has completed the
+    admitted fire/re-arm callback.  This is intentionally synchronous at the
+    acceptance boundary: there is no durable background-work queue here, so an
+    earlier acknowledgement could be lost during scale-to-zero suspension.
     """
-    from plugins.cron_providers.chronos.verify import get_fire_verifier
-
-    auth = request.headers.get("Authorization", "")
-    token = auth[7:].strip() if auth.startswith("Bearer ") else ""
-
-    cfg = load_config()
-    claims = get_fire_verifier()(
-        token=token,
-        expected_audience=cfg_get(cfg, "cron", "chronos", "expected_audience", default=""),
-        jwks_or_key=cfg_get(cfg, "cron", "chronos", "nas_jwks_url", default="") or None,
-        issuer=cfg_get(cfg, "cron", "chronos", "portal_url", default="") or None,
-    )
-    if claims is None:
-        return JSONResponse({"error": "invalid fire token"}, status_code=401)
-
     try:
         body = await request.json()
     except Exception:
@@ -12626,20 +12713,61 @@ async def cron_fire_webhook(request: Request):
     if not job_id:
         return JSONResponse({"error": "missing job_id"}, status_code=400)
 
-    # _find_cron_job_profile walks every profile and lists its jobs (file
+    # _find_exact_cron_job_profile walks every profile and lists its jobs (file
     # I/O per profile) — run it off the event loop like the other cron
     # dashboard endpoints.
-    profile = await _run_cron_dashboard_io(_find_cron_job_profile, job_id)
+    profile = await _run_cron_dashboard_io(_find_exact_cron_job_profile, job_id)
     if not profile:
         # Job is gone (cancelled / completed) — nothing to fire. 200 so NAS
         # does not retry a fire that is intentionally absent.
         return JSONResponse({"status": "gone", "job_id": job_id}, status_code=200)
 
-    # Run in the background; the store CAS claim inside fire_due de-dupes a
-    # NAS/scheduler retry that arrives while this is in flight.
-    asyncio.create_task(
-        asyncio.to_thread(_fire_cron_job_for_profile, profile, job_id)
-    )
+    # Authentication is profile-scoped.  Resolve and enter the exact home
+    # before reading verifier settings so a default-profile credential cannot
+    # authorize a worker-profile job.
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from plugins.cron_providers.chronos.verify import get_fire_verifier
+
+    _profile_name, profile_home = _cron_profile_home(profile)
+    home_token = set_hermes_home_override(str(profile_home))
+    try:
+        cfg = load_config()
+        auth = request.headers.get("Authorization", "")
+        fire_token = auth[7:].strip() if auth.startswith("Bearer ") else ""
+        claims = get_fire_verifier()(
+            token=fire_token,
+            expected_audience=cfg_get(
+                cfg, "cron", "chronos", "expected_audience", default=""
+            ),
+            jwks_or_key=cfg_get(
+                cfg, "cron", "chronos", "nas_jwks_url", default=""
+            )
+            or None,
+            issuer=cfg_get(
+                cfg, "cron", "chronos", "portal_url", default=""
+            )
+            or None,
+        )
+    finally:
+        reset_hermes_home_override(home_token)
+    if claims is None:
+        return JSONResponse({"error": "invalid fire token"}, status_code=401)
+
+    try:
+        fired = await asyncio.to_thread(
+            _fire_hosted_cron_job_for_profile,
+            profile,
+            job_id,
+        )
+    except Exception:
+        logger.exception("Hosted cron fire failed for job %s", job_id)
+        return JSONResponse(
+            {"error": "scheduler execution unavailable"}, status_code=503
+        )
+    if fired is None:
+        return JSONResponse(
+            {"error": "scheduler ownership unavailable"}, status_code=503
+        )
     return JSONResponse({"status": "accepted", "job_id": job_id}, status_code=202)
 
 

--- a/plugins/cron_providers/__init__.py
+++ b/plugins/cron_providers/__init__.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import importlib
 import importlib.machinery
 import importlib.util
+import hashlib
 import logging
 import sys
 from pathlib import Path
@@ -223,7 +224,16 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["CronScheduler"]:  #
     # Use a separate namespace for user-installed plugins so they don't
     # collide with bundled providers in sys.modules.
     _is_bundled = _CRON_PLUGINS_DIR in provider_dir.parents or provider_dir.parent == _CRON_PLUGINS_DIR
-    module_name = f"plugins.cron_providers.{name}" if _is_bundled else f"{_USER_NAMESPACE}.{name}"
+    if _is_bundled:
+        module_name = f"plugins.cron_providers.{name}"
+    else:
+        # The same provider name may have different implementations in
+        # multiplex profile homes. Cache by canonical provider path so one
+        # profile can never receive another profile's module.
+        path_key = hashlib.sha256(
+            str(provider_dir.resolve()).encode("utf-8")
+        ).hexdigest()[:16]
+        module_name = f"{_USER_NAMESPACE}.{path_key}.{name}"
     init_file = provider_dir / "__init__.py"
 
     if not init_file.exists():
@@ -259,6 +269,9 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["CronScheduler"]:  #
         # same way, or relative imports inside the plugin cannot resolve.
         if not _is_bundled:
             _register_synthetic_package(_USER_NAMESPACE, [])
+            _register_synthetic_package(
+                module_name.rsplit(".", 1)[0], [str(provider_dir.parent)]
+            )
 
         # Now load the provider module
         spec = importlib.util.spec_from_file_location(

--- a/plugins/cron_providers/chronos/__init__.py
+++ b/plugins/cron_providers/chronos/__init__.py
@@ -110,10 +110,7 @@ class ChronosCronScheduler(CronScheduler):
         # process did. Classify those attempts unknown for audit only; do not
         # requeue them here.
         self.recover_interrupted()
-        try:
-            self.reconcile()
-        except Exception as e:
-            logger.warning("Chronos start() reconcile failed: %s", e)
+        self.reconcile()
         # Intentionally return — no loop, no periodic wake.
 
     def stop(self) -> None:
@@ -122,10 +119,7 @@ class ChronosCronScheduler(CronScheduler):
     def on_jobs_changed(self) -> None:
         """A job was created/updated/removed/paused/resumed — reconcile the NAS
         registry so the affected one-shot is (re-)armed or cancelled."""
-        try:
-            self.reconcile()
-        except Exception as e:
-            logger.debug("Chronos on_jobs_changed reconcile failed: %s", e)
+        self.reconcile()
 
     # -- arming -----------------------------------------------------------
 
@@ -160,25 +154,22 @@ class ChronosCronScheduler(CronScheduler):
     def _list_armed(self) -> Dict[str, str]:
         """Observed armed one-shots: job_id → fire_at.
 
-        Prefer the in-memory map (warm process); on a cold/empty map, ask NAS
-        (best-effort). If NAS list fails, return what we have — reconcile then
-        re-arms desired jobs idempotently.
+        Prefer the in-memory map (warm process); on a cold/empty map, ask NAS.
+        The NAS list is authoritative on a cold process, so failures propagate:
+        treating an unreadable registry as empty would hide stale remote arms
+        and let reconciliation advance as though it succeeded.
         """
         with self._lock:
             if self._armed:
                 return dict(self._armed)
-        try:
-            observed = {
-                item["job_id"]: item.get("fire_at", "")
-                for item in self._get_client().list_armed()
-                if item.get("job_id")
-            }
-            with self._lock:
-                self._armed.update(observed)
-            return observed
-        except Exception as e:
-            logger.debug("Chronos _list_armed failed (will re-arm idempotently): %s", e)
-            return {}
+        observed = {
+            item["job_id"]: item.get("fire_at", "")
+            for item in self._get_client().list_armed()
+            if item.get("job_id")
+        }
+        with self._lock:
+            self._armed.update(observed)
+        return observed
 
     # -- reconcile --------------------------------------------------------
 
@@ -201,18 +192,12 @@ class ChronosCronScheduler(CronScheduler):
                 from cron.jobs import get_job
                 job = get_job(job_id)
                 if job:
-                    try:
-                        self._arm_one_shot(job)
-                    except Exception as e:
-                        logger.warning("Chronos failed to arm job %s: %s", job_id, e)
+                    self._arm_one_shot(job)
 
         # Cancel orphans (armed but no longer desired).
         for job_id in list(observed.keys()):
             if job_id not in desired:
-                try:
-                    self._cancel(job_id)
-                except Exception as e:
-                    logger.warning("Chronos failed to cancel orphan %s: %s", job_id, e)
+                self._cancel(job_id)
 
     # -- fire -------------------------------------------------------------
 
@@ -229,10 +214,7 @@ class ChronosCronScheduler(CronScheduler):
             from cron.jobs import get_job
             job = get_job(job_id)
             if job and job.get("enabled") and job.get("next_run_at"):
-                try:
-                    self._arm_one_shot(job)
-                except Exception as e:
-                    logger.warning("Chronos failed to re-arm job %s after fire: %s", job_id, e)
+                self._arm_one_shot(job)
         return ran
 
 

--- a/tests/cron/test_jobs_changed_notify.py
+++ b/tests/cron/test_jobs_changed_notify.py
@@ -15,7 +15,7 @@ def temp_home(tmp_path, monkeypatch):
     yield tmp_path
 
 
-def test_notify_helper_calls_provider_on_jobs_changed(monkeypatch):
+def test_notify_helper_calls_provider_on_jobs_changed(temp_home):
     """cron.scheduler._notify_provider_jobs_changed resolves the provider and
     calls on_jobs_changed exactly once."""
     import cron.scheduler_provider as sp
@@ -34,9 +34,15 @@ def test_notify_helper_calls_provider_on_jobs_changed(monkeypatch):
         def on_jobs_changed(self):
             calls.append(1)
 
-    monkeypatch.setattr(sp, "resolve_cron_scheduler", lambda: Spy())
-    sched._notify_provider_jobs_changed()
-    assert calls == [1]
+    from cron.scheduler_runtime import _ProviderAdmission, _set_active_provider
+
+    admission = _ProviderAdmission(Spy())
+    _set_active_provider(temp_home, admission)
+    try:
+        sched._notify_provider_jobs_changed()
+        assert calls == [1]
+    finally:
+        _set_active_provider(temp_home, None)
 
 
 def test_notify_helper_swallows_provider_errors(monkeypatch):

--- a/tests/cron/test_jobs_file_ownership.py
+++ b/tests/cron/test_jobs_file_ownership.py
@@ -268,6 +268,16 @@ class TestCronStatusSurfacesError:
     def test_status_shows_last_error_and_permission_hint(self, monkeypatch, capsys):
         from hermes_cli import cron as cron_cli
 
+        monkeypatch.setattr(
+            cron_cli,
+            "_scheduler_health",
+            lambda: (
+                __import__(
+                    "cron.scheduler_runtime", fromlist=["SchedulerOwnershipPolicy"]
+                ).SchedulerOwnershipPolicy("auto", "builtin"),
+                {"owner": "gateway", "provider": "builtin"},
+            ),
+        )
         monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [4321])
         monkeypatch.setattr(jobs, "get_ticker_heartbeat_age", lambda: 5.0)   # alive
         monkeypatch.setattr(jobs, "get_ticker_success_age", lambda: 9_999.0)  # failing
@@ -291,6 +301,16 @@ class TestCronStatusSurfacesError:
     def test_status_without_marker_keeps_generic_message(self, monkeypatch, capsys):
         from hermes_cli import cron as cron_cli
 
+        monkeypatch.setattr(
+            cron_cli,
+            "_scheduler_health",
+            lambda: (
+                __import__(
+                    "cron.scheduler_runtime", fromlist=["SchedulerOwnershipPolicy"]
+                ).SchedulerOwnershipPolicy("auto", "builtin"),
+                {"owner": "gateway", "provider": "builtin"},
+            ),
+        )
         monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [4321])
         monkeypatch.setattr(jobs, "get_ticker_heartbeat_age", lambda: 5.0)
         monkeypatch.setattr(jobs, "get_ticker_success_age", lambda: 9_999.0)

--- a/tests/cron/test_scheduler_lease.py
+++ b/tests/cron/test_scheduler_lease.py
@@ -1,0 +1,74 @@
+"""Real-process contracts for the HERMES_HOME scheduler lease."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from cron.scheduler_lease import SchedulerOwnershipLease
+
+_ROOT = Path(__file__).resolve().parents[2]
+_PROBE = """
+import sys, time
+from pathlib import Path
+from cron.scheduler_lease import SchedulerOwnershipLease
+lease = SchedulerOwnershipLease.try_acquire(
+    hermes_home=Path(sys.argv[1]), owner="gateway", provider="builtin")
+print("acquired" if lease else "blocked", flush=True)
+if lease:
+    time.sleep(float(sys.argv[2]))
+    lease.release()
+"""
+
+
+def _spawn(home: Path, hold: float = 0) -> subprocess.Popen[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home.parent / "isolated-os-home")
+    env["HERMES_HOME"] = str(home)
+    env["PYTHONPATH"] = str(_ROOT)
+    return subprocess.Popen(
+        [sys.executable, "-c", _PROBE, str(home), str(hold)],
+        cwd=_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def test_same_home_process_contention_and_release(tmp_path):
+    home = tmp_path / "hermes"
+    # Leave ample margin for a heavily loaded suite to start the contender
+    # before the first process releases its lease.
+    first = _spawn(home, 3.0)
+    assert first.stdout is not None
+    assert first.stdout.readline().strip() == "acquired"
+    second = _spawn(home)
+    assert second.communicate(timeout=5)[0].strip() == "blocked"
+    assert first.wait(timeout=5) == 0
+    third = _spawn(home)
+    assert third.communicate(timeout=5)[0].strip() == "acquired"
+
+
+def test_different_homes_and_same_process_rules(tmp_path):
+    first = SchedulerOwnershipLease.try_acquire(
+        hermes_home=tmp_path / "a", owner="gateway", provider="builtin"
+    )
+    second = SchedulerOwnershipLease.try_acquire(
+        hermes_home=tmp_path / "b", owner="desktop", provider="builtin"
+    )
+    assert first is not None and second is not None
+    try:
+        assert (
+            SchedulerOwnershipLease.try_acquire(
+                hermes_home=tmp_path / "a",
+                owner="desktop",
+                provider="builtin",
+            )
+            is None
+        )
+    finally:
+        first.release()
+        second.release()

--- a/tests/cron/test_scheduler_ownership.py
+++ b/tests/cron/test_scheduler_ownership.py
@@ -1,0 +1,86 @@
+"""Strict scheduler owner/provider policy contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _write(home, body: str) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(body, encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        ({}, "auto"),
+        ({"cron": {}}, "auto"),
+        ({"cron": {"scheduler_owner": " gateway "}}, "gateway"),
+        ({"cron": {"scheduler_owner": "DESKTOP"}}, "desktop"),
+    ],
+)
+def test_owner_contract(config, expected):
+    from cron.scheduler_provider import resolve_cron_scheduler_owner
+
+    assert resolve_cron_scheduler_owner(config=config) == expected
+
+
+@pytest.mark.parametrize("invalid", ["", "both", 42, None])
+def test_malformed_owner_fails_closed(invalid):
+    from cron.scheduler_provider import resolve_cron_scheduler_owner
+
+    assert (
+        resolve_cron_scheduler_owner(config={"cron": {"scheduler_owner": invalid}})
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        'cron:\n  scheduler_owner: "unterminated\n',
+        "cron: desktop\n",
+        "cron:\n  scheduler_owner: both\n",
+        "null\n",
+    ],
+)
+def test_malformed_and_explicit_null_files_fail_closed(tmp_path, body):
+    from cron.scheduler_runtime import read_scheduler_ownership_policy_strict
+
+    _write(tmp_path, body)
+    assert read_scheduler_ownership_policy_strict(hermes_home=tmp_path) is None
+
+
+@pytest.mark.parametrize("body", ["", "# comments only\n", "---\n# comment\n"])
+def test_empty_files_use_safe_auto_builtin(tmp_path, body):
+    from cron.scheduler_runtime import read_scheduler_ownership_policy_strict
+
+    _write(tmp_path, body)
+    policy = read_scheduler_ownership_policy_strict(hermes_home=tmp_path)
+    assert policy is not None
+    assert (policy.mode, policy.configured_provider) == ("auto", "builtin")
+
+
+def test_exact_home_env_expansion_and_managed_precedence(tmp_path, monkeypatch):
+    from cron.scheduler_runtime import read_scheduler_ownership_policy_strict
+
+    selected = tmp_path / "selected"
+    poison = tmp_path / "poison"
+    managed = tmp_path / "managed"
+    _write(selected, "cron:\n  scheduler_owner: ${OWNER}\n  provider: builtin\n")
+    _write(poison, "cron:\n  scheduler_owner: desktop\n")
+    _write(managed, "cron:\n  scheduler_owner: gateway\n  provider: ${PROVIDER}\n")
+    monkeypatch.setenv("HERMES_HOME", str(poison))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    monkeypatch.setenv("OWNER", "desktop")
+    monkeypatch.setenv("PROVIDER", "chronos")
+
+    policy = read_scheduler_ownership_policy_strict(hermes_home=selected)
+    assert policy is not None
+    assert (policy.mode, policy.configured_provider) == ("gateway", "chronos")
+
+
+def test_default_config_documents_safe_auto():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["cron"]["scheduler_owner"] == "auto"

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -332,6 +332,30 @@ def test_resolve_available_provider_is_used(monkeypatch):
     assert prov.name == "fake"
 
 
+def test_resolve_preserves_mixed_case_provider_name(monkeypatch):
+    import hermes_cli.config as cfg
+    import plugins.cron_providers as pc
+    from cron import scheduler_provider as sp
+    from cron.scheduler_provider import CronScheduler
+
+    seen = []
+
+    class Fake(CronScheduler):
+        name = "MyProvider"
+
+        def start(self, stop_event, **kw):
+            pass
+
+    monkeypatch.setattr(
+        cfg, "load_config", lambda: {"cron": {"provider": "MyProvider"}}
+    )
+    monkeypatch.setattr(
+        pc, "load_cron_scheduler", lambda name: seen.append(name) or Fake()
+    )
+    assert sp.resolve_cron_scheduler().name == "MyProvider"
+    assert seen == ["MyProvider"]
+
+
 # ── Phase 4B: additive hooks (on_jobs_changed / fire_due / reconcile) ────────
 
 
@@ -557,6 +581,16 @@ def test_cron_status_reports_alive_but_failing(tmp_path, monkeypatch, capsys):
     has succeeded recently (#32612: alive-but-failing must not look healthy)."""
     import cron.jobs as jobs
     from hermes_cli import cron as cron_cli
+    from cron.scheduler_runtime import SchedulerOwnershipPolicy
+
+    monkeypatch.setattr(
+        cron_cli,
+        "_scheduler_health",
+        lambda: (
+            SchedulerOwnershipPolicy("auto", "builtin"),
+            {"owner": "gateway", "provider": "builtin"},
+        ),
+    )
 
     monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [4321])
     monkeypatch.setattr(jobs, "get_ticker_heartbeat_age", lambda: 5.0)      # fresh
@@ -572,6 +606,16 @@ def test_cron_status_reports_alive_but_failing(tmp_path, monkeypatch, capsys):
 def test_cron_status_healthy_when_both_fresh(tmp_path, monkeypatch, capsys):
     import cron.jobs as jobs
     from hermes_cli import cron as cron_cli
+    from cron.scheduler_runtime import SchedulerOwnershipPolicy
+
+    monkeypatch.setattr(
+        cron_cli,
+        "_scheduler_health",
+        lambda: (
+            SchedulerOwnershipPolicy("auto", "builtin"),
+            {"owner": "gateway", "provider": "builtin"},
+        ),
+    )
 
     monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [4321])
     monkeypatch.setattr(jobs, "get_ticker_heartbeat_age", lambda: 5.0)
@@ -586,6 +630,16 @@ def test_cron_status_healthy_when_both_fresh(tmp_path, monkeypatch, capsys):
 def test_cron_status_reports_stalled_when_no_heartbeat(tmp_path, monkeypatch, capsys):
     import cron.jobs as jobs
     from hermes_cli import cron as cron_cli
+    from cron.scheduler_runtime import SchedulerOwnershipPolicy
+
+    monkeypatch.setattr(
+        cron_cli,
+        "_scheduler_health",
+        lambda: (
+            SchedulerOwnershipPolicy("auto", "builtin"),
+            {"owner": "gateway", "provider": "builtin"},
+        ),
+    )
 
     monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [4321])
     monkeypatch.setattr(jobs, "get_ticker_heartbeat_age", lambda: 9_999.0)  # dead

--- a/tests/cron/test_scheduler_runtime.py
+++ b/tests/cron/test_scheduler_runtime.py
@@ -1,0 +1,741 @@
+"""Full-lifetime scheduler runtime lifecycle tests."""
+
+from __future__ import annotations
+
+import threading
+import time
+import json
+import os
+import signal
+import subprocess
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from cron.scheduler_lease import SchedulerOwnershipLease
+from cron.scheduler_provider import CronScheduler
+from cron.scheduler_runtime import (
+    OwnedSchedulerRuntime,
+    SchedulerOwnershipPolicy,
+    scheduler_runtime_is_eligible,
+)
+
+
+def _wait(predicate, timeout=3):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition not reached")
+
+
+class _Provider(CronScheduler):
+    def __init__(self, *, returns=False, blocks_stop=False):
+        self.returns = returns
+        self.blocks_stop = blocks_stop
+        self.started = threading.Event()
+        self.exited = threading.Event()
+        self.release = threading.Event()
+
+    @property
+    def name(self):
+        return "external"
+
+    def start(self, stop_event, **_kwargs):
+        self.started.set()
+        if self.returns:
+            return
+        if self.blocks_stop:
+            self.release.wait()
+        else:
+            stop_event.wait()
+        self.exited.set()
+
+
+def _run(runtime):
+    stop = threading.Event()
+    thread = threading.Thread(target=runtime.run, args=(stop,), daemon=True)
+    thread.start()
+    return stop, thread
+
+
+@pytest.mark.parametrize(
+    ("mode", "provider", "runtime", "gateway_running", "expected"),
+    [
+        ("gateway", "builtin", "gateway", False, True),
+        ("gateway", "builtin", "desktop", False, False),
+        ("desktop", "builtin", "desktop", True, True),
+        ("desktop", "builtin", "gateway", False, False),
+        ("auto", "builtin", "gateway", True, True),
+        ("auto", "builtin", "desktop", False, True),
+        ("auto", "builtin", "desktop", True, False),
+        ("auto", "chronos", "gateway", False, True),
+        ("auto", "chronos", "desktop", False, False),
+    ],
+)
+def test_owner_eligibility_matrix(mode, provider, runtime, gateway_running, expected):
+    assert (
+        scheduler_runtime_is_eligible(
+            SchedulerOwnershipPolicy(mode, provider),
+            runtime=runtime,
+            same_home_gateway_running=gateway_running,
+        )
+        is expected
+    )
+
+
+def test_external_start_return_keeps_lease(tmp_path, monkeypatch):
+    policy = SchedulerOwnershipPolicy("gateway", "external")
+    provider = _Provider(returns=True)
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda **_kwargs: policy,
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    runtime = OwnedSchedulerRuntime("gateway", hermes_home=tmp_path, poll_interval=0.01)
+    stop, thread = _run(runtime)
+    _wait(provider.started.is_set)
+    assert thread.is_alive()
+    assert (
+        SchedulerOwnershipLease.try_acquire(
+            hermes_home=tmp_path, owner="desktop", provider="builtin"
+        )
+        is None
+    )
+    stop.set()
+    thread.join(2)
+    assert not thread.is_alive()
+
+
+def test_policy_handoff_has_no_overlap(tmp_path, monkeypatch):
+    state = {"policy": SchedulerOwnershipPolicy("desktop", "builtin")}
+    desktop_provider = _Provider()
+    gateway_provider = _Provider()
+    providers = iter([desktop_provider, gateway_provider])
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda **_kwargs: state["policy"],
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: next(providers),
+    )
+    desktop = OwnedSchedulerRuntime("desktop", hermes_home=tmp_path, poll_interval=0.01)
+    gateway = OwnedSchedulerRuntime("gateway", hermes_home=tmp_path, poll_interval=0.01)
+    desktop_stop, desktop_thread = _run(desktop)
+    gateway_stop, gateway_thread = _run(gateway)
+    _wait(desktop_provider.started.is_set)
+    assert not gateway_provider.started.is_set()
+    state["policy"] = SchedulerOwnershipPolicy("gateway", "builtin")
+    _wait(desktop_provider.exited.is_set)
+    _wait(gateway_provider.started.is_set)
+    assert desktop.active_provider is None
+    desktop_stop.set()
+    gateway_stop.set()
+    desktop_thread.join(2)
+    gateway_thread.join(2)
+
+
+def test_gateway_recovers_after_initially_ineligible_policy(tmp_path, monkeypatch):
+    state = {"policy": SchedulerOwnershipPolicy("desktop", "builtin")}
+    provider = _Provider()
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda **_kwargs: state["policy"],
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    runtime = OwnedSchedulerRuntime("gateway", hermes_home=tmp_path, poll_interval=0.01)
+    stop, thread = _run(runtime)
+    time.sleep(0.05)
+    assert not provider.started.is_set()
+    state["policy"] = SchedulerOwnershipPolicy("gateway", "builtin")
+    _wait(provider.started.is_set)
+    stop.set()
+    thread.join(2)
+
+
+def test_blocking_shutdown_holds_lease_until_provider_exits(tmp_path, monkeypatch):
+    policy = SchedulerOwnershipPolicy("gateway", "builtin")
+    provider = _Provider(blocks_stop=True)
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda **_kwargs: policy,
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    runtime = OwnedSchedulerRuntime(
+        "gateway", hermes_home=tmp_path, poll_interval=0.01, drain_timeout=0.02
+    )
+    stop, thread = _run(runtime)
+    _wait(provider.started.is_set)
+    stop.set()
+    time.sleep(0.05)
+    assert thread.is_alive()
+    assert (
+        SchedulerOwnershipLease.try_acquire(
+            hermes_home=tmp_path, owner="desktop", provider="builtin"
+        )
+        is None
+    )
+    provider.release.set()
+    thread.join(2)
+    assert not thread.is_alive()
+
+
+def test_drain_closes_admission_and_waits_for_external_fire(tmp_path, monkeypatch):
+    from cron.scheduler_runtime import borrow_scheduler_provider
+
+    policy = SchedulerOwnershipPolicy("gateway", "external")
+
+    class Provider(_Provider):
+        def __init__(self):
+            super().__init__(returns=True)
+            self.stopped = threading.Event()
+
+        def stop(self):
+            self.stopped.set()
+
+    provider = Provider()
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda **_kwargs: policy,
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    runtime = OwnedSchedulerRuntime("gateway", hermes_home=tmp_path, poll_interval=0.01)
+    stop, thread = _run(runtime)
+    _wait(provider.started.is_set)
+
+    borrowed = threading.Event()
+    release = threading.Event()
+
+    def fire():
+        with borrow_scheduler_provider(hermes_home=tmp_path) as active:
+            assert active is provider
+            borrowed.set()
+            release.wait()
+
+    fire_thread = threading.Thread(target=fire)
+    fire_thread.start()
+    _wait(borrowed.is_set)
+    stop.set()
+    time.sleep(0.05)
+    assert thread.is_alive()
+    assert not provider.stopped.is_set()
+    with borrow_scheduler_provider(hermes_home=tmp_path) as active:
+        assert active is None
+    assert (
+        SchedulerOwnershipLease.try_acquire(
+            hermes_home=tmp_path, owner="desktop", provider="builtin"
+        )
+        is None
+    )
+    release.set()
+    fire_thread.join(2)
+    thread.join(2)
+    assert not thread.is_alive()
+    assert provider.stopped.is_set()
+
+
+def test_start_failure_drains_published_borrower_before_lease_release(
+    tmp_path, monkeypatch
+):
+    from cron.scheduler_runtime import borrow_scheduler_provider
+
+    policy = SchedulerOwnershipPolicy("gateway", "external")
+    provider = _Provider(returns=True)
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda **_kwargs: policy,
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    runtime = OwnedSchedulerRuntime("gateway", hermes_home=tmp_path, poll_interval=0.01)
+    borrowed = threading.Event()
+    release = threading.Event()
+    borrower_thread = None
+    original_start = threading.Thread.start
+
+    def synthetic_start(thread):
+        nonlocal borrower_thread
+        if thread.name != "gateway-cron-provider":
+            return original_start(thread)
+
+        def borrow():
+            with borrow_scheduler_provider(hermes_home=tmp_path) as active:
+                assert active is provider
+                borrowed.set()
+                release.wait()
+
+        borrower_thread = threading.Thread(target=borrow)
+        original_start(borrower_thread)
+        assert borrowed.wait(1)
+        raise RuntimeError("synthetic Thread.start failure")
+
+    monkeypatch.setattr(threading.Thread, "start", synthetic_start)
+    result = {}
+
+    def start_runtime():
+        try:
+            runtime._start_active(policy, tmp_path)
+        except RuntimeError as exc:
+            result["error"] = str(exc)
+
+    starter = threading.Thread(target=start_runtime)
+    original_start(starter)
+    assert borrowed.wait(1)
+    time.sleep(0.03)
+    assert starter.is_alive()
+    assert (
+        SchedulerOwnershipLease.try_acquire(
+            hermes_home=tmp_path, owner="desktop", provider="builtin"
+        )
+        is None
+    )
+    release.set()
+    starter.join(2)
+    assert result == {"error": "synthetic Thread.start failure"}
+    takeover = SchedulerOwnershipLease.try_acquire(
+        hermes_home=tmp_path, owner="desktop", provider="builtin"
+    )
+    assert takeover is not None
+    takeover.release()
+    assert borrower_thread is not None
+    borrower_thread.join(2)
+
+
+def test_owner_detects_out_of_process_jobs_file_change(tmp_path, monkeypatch):
+    policy = SchedulerOwnershipPolicy("gateway", "external")
+    reconciled = threading.Event()
+
+    class Provider(_Provider):
+        def on_jobs_changed(self):
+            reconciled.set()
+
+    provider = Provider(returns=True)
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda **_kwargs: policy,
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    runtime = OwnedSchedulerRuntime("gateway", hermes_home=tmp_path, poll_interval=0.01)
+    stop, thread = _run(runtime)
+    _wait(provider.started.is_set)
+    jobs = tmp_path / "cron" / "jobs.json"
+    jobs.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from pathlib import Path; Path(__import__('sys').argv[1]).write_text('[]', encoding='utf-8')",
+            str(jobs),
+        ],
+        check=True,
+    )
+    _wait(reconciled.is_set)
+    stop.set()
+    thread.join(2)
+
+
+def test_failed_reconciliation_remains_dirty_and_retries(tmp_path, monkeypatch):
+    policy = SchedulerOwnershipPolicy("gateway", "external")
+    succeeded = threading.Event()
+
+    class Provider(_Provider):
+        def __init__(self):
+            super().__init__(returns=True)
+            self.attempts = 0
+
+        def on_jobs_changed(self):
+            self.attempts += 1
+            if self.attempts == 1:
+                raise RuntimeError("transient")
+            succeeded.set()
+
+    provider = Provider()
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda **_kwargs: policy,
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    runtime = OwnedSchedulerRuntime("gateway", hermes_home=tmp_path, poll_interval=0.01)
+    stop, thread = _run(runtime)
+    _wait(provider.started.is_set)
+    jobs = tmp_path / "cron" / "jobs.json"
+    jobs.parent.mkdir(parents=True, exist_ok=True)
+    jobs.write_text("[]", encoding="utf-8")
+    _wait(succeeded.is_set)
+    assert provider.attempts == 2
+    stop.set()
+    thread.join(2)
+
+
+def test_jobs_signature_permission_error_retries_and_tears_down(tmp_path, monkeypatch):
+    policy = SchedulerOwnershipPolicy("gateway", "external")
+    provider = _Provider(returns=True)
+    calls = {"count": 0}
+    original = OwnedSchedulerRuntime._read_jobs_signature
+
+    def transient(home):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise PermissionError("transient")
+        return original(home)
+
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda **_kwargs: policy,
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    monkeypatch.setattr(
+        OwnedSchedulerRuntime, "_read_jobs_signature", staticmethod(transient)
+    )
+    runtime = OwnedSchedulerRuntime("gateway", hermes_home=tmp_path, poll_interval=0.01)
+    stop, thread = _run(runtime)
+    _wait(provider.started.is_set)
+    _wait(lambda: calls["count"] >= 2)
+    assert thread.is_alive()
+    stop.set()
+    thread.join(2)
+    assert not thread.is_alive()
+    takeover = SchedulerOwnershipLease.try_acquire(
+        hermes_home=tmp_path, owner="desktop", provider="builtin"
+    )
+    assert takeover is not None
+    takeover.release()
+
+
+def test_mixed_case_provider_policy_is_preserved():
+    policy = __import__(
+        "cron.scheduler_runtime", fromlist=["read_scheduler_ownership_policy_strict"]
+    ).read_scheduler_ownership_policy_strict({
+        "cron": {"scheduler_owner": "gateway", "provider": "MyProvider"}
+    })
+    assert policy == SchedulerOwnershipPolicy("gateway", "MyProvider")
+
+
+def test_failed_startup_reconciliation_retries_with_backoff(tmp_path, monkeypatch):
+    policy = SchedulerOwnershipPolicy("gateway", "external")
+    started = threading.Event()
+    providers = []
+
+    class Provider(_Provider):
+        def __init__(self, fail):
+            super().__init__(returns=True)
+            self.fail = fail
+
+        def start(self, stop_event, **kwargs):
+            providers.append(self)
+            if self.fail:
+                raise RuntimeError("transient startup reconcile")
+            started.set()
+
+    attempts = iter([Provider(True), Provider(False)])
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda **_kwargs: policy,
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: next(attempts),
+    )
+    runtime = OwnedSchedulerRuntime("gateway", hermes_home=tmp_path, poll_interval=0.02)
+    stop, thread = _run(runtime)
+    _wait(started.is_set)
+    assert len(providers) == 2
+    stop.set()
+    thread.join(2)
+
+
+def test_gateway_presence_rejects_reused_pid_and_mismatched_identity(
+    tmp_path, monkeypatch
+):
+    from cron.scheduler_runtime import exact_home_gateway_is_running
+
+    path = tmp_path / "cron" / ".gateway-present.json"
+    path.parent.mkdir(parents=True)
+    record = {
+        "pid": 1234,
+        "start_time": 100,
+        "kind": "gateway",
+        "hermes_home": str(tmp_path),
+    }
+    path.write_text(json.dumps(record), encoding="utf-8")
+    monkeypatch.setattr("gateway.status._pid_exists", lambda _pid: True)
+    monkeypatch.setattr("gateway.status.get_process_start_time", lambda _pid: 101)
+    assert exact_home_gateway_is_running(tmp_path) is False
+
+    record["start_time"] = 101
+    record["kind"] = "unrelated"
+    path.write_text(json.dumps(record), encoding="utf-8")
+    assert exact_home_gateway_is_running(tmp_path) is False
+
+    record["kind"] = "gateway"
+    path.write_text(json.dumps(record), encoding="utf-8")
+    assert exact_home_gateway_is_running(tmp_path) is True
+
+
+def test_gateway_presence_windows_path_never_uses_os_kill(tmp_path, monkeypatch):
+    from cron.scheduler_runtime import exact_home_gateway_is_running
+
+    path = tmp_path / "cron" / ".gateway-present.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps({
+            "pid": 4242,
+            "start_time": 101,
+            "kind": "gateway",
+            "hermes_home": str(tmp_path),
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("gateway.status._pid_exists", lambda _pid: True)
+    monkeypatch.setattr("gateway.status.get_process_start_time", lambda _pid: 101)
+    monkeypatch.setattr(
+        "os.kill",
+        lambda *_args: pytest.fail("Gateway presence must use the safe PID utility"),
+    )
+    assert exact_home_gateway_is_running(tmp_path) is True
+
+
+def test_provider_stop_runs_under_exact_home(tmp_path, monkeypatch):
+    from hermes_constants import get_hermes_home
+
+    policy = SchedulerOwnershipPolicy("gateway", "external")
+
+    class Provider(_Provider):
+        def __init__(self):
+            super().__init__(returns=True)
+            self.stop_home = None
+
+        def stop(self):
+            self.stop_home = get_hermes_home()
+
+    provider = Provider()
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda **_kwargs: policy,
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    runtime = OwnedSchedulerRuntime("gateway", hermes_home=tmp_path, poll_interval=0.01)
+    stop, thread = _run(runtime)
+    _wait(provider.started.is_set)
+    stop.set()
+    thread.join(2)
+    assert provider.stop_home == tmp_path.resolve()
+
+
+def test_user_provider_module_cache_isolated_per_profile_home(tmp_path):
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from plugins.cron_providers import load_cron_scheduler
+
+    def install(home, label):
+        provider_dir = home / "plugins" / "custom"
+        provider_dir.mkdir(parents=True)
+        (provider_dir / "__init__.py").write_text(
+            "from cron.scheduler_provider import CronScheduler\n"
+            "class Provider(CronScheduler):\n"
+            f"    name = {label!r}\n"
+            "    def start(self, stop_event, **kwargs): pass\n",
+            encoding="utf-8",
+        )
+
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    install(first, "first-provider")
+    install(second, "second-provider")
+
+    names = []
+    for home in (first, second):
+        token = set_hermes_home_override(home)
+        try:
+            names.append(load_cron_scheduler("custom").name)
+        finally:
+            reset_hermes_home_override(token)
+    assert names == ["first-provider", "second-provider"]
+
+
+def test_mixed_case_user_provider_loads_on_case_sensitive_path(tmp_path):
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from plugins.cron_providers import load_cron_scheduler
+
+    provider_dir = tmp_path / "plugins" / "MyProvider"
+    provider_dir.mkdir(parents=True)
+    (provider_dir / "__init__.py").write_text(
+        "from cron.scheduler_provider import CronScheduler\n"
+        "class Provider(CronScheduler):\n"
+        "    name = 'MyProvider'\n"
+        "    def start(self, stop_event, **kwargs): pass\n",
+        encoding="utf-8",
+    )
+    token = set_hermes_home_override(tmp_path)
+    try:
+        provider = load_cron_scheduler("MyProvider")
+    finally:
+        reset_hermes_home_override(token)
+    assert provider is not None
+    assert provider.name == "MyProvider"
+
+
+def test_unavailable_configured_provider_never_falls_back(monkeypatch):
+    from cron.scheduler_provider import (
+        InProcessCronScheduler,
+        resolve_cron_scheduler_runtime_strict,
+    )
+
+    monkeypatch.setattr(
+        "plugins.cron_providers.load_cron_scheduler", lambda _name: None
+    )
+    assert resolve_cron_scheduler_runtime_strict("chronos") is None
+    assert isinstance(
+        resolve_cron_scheduler_runtime_strict("builtin"),
+        InProcessCronScheduler,
+    )
+
+
+def test_desktop_fire_callback_requires_exact_home_active_owner(tmp_path, monkeypatch):
+    import hermes_cli.web_server as web_server
+
+    home = tmp_path / "profile"
+    monkeypatch.setattr(
+        web_server, "_cron_profile_home", lambda _profile: ("worker", home)
+    )
+    borrowed_homes = []
+
+    @contextmanager
+    def borrow(*, hermes_home):
+        borrowed_homes.append(hermes_home)
+        yield None
+
+    monkeypatch.setattr("cron.scheduler_runtime.borrow_scheduler_provider", borrow)
+    assert web_server._fire_hosted_cron_job_for_profile("worker", "job-1") is None
+    assert borrowed_homes == [home]
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGKILL"), reason="requires SIGKILL")
+@pytest.mark.live_system_guard_bypass
+def test_real_process_crash_allows_lease_takeover(tmp_path):
+    child = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys,time;"
+                "from pathlib import Path;"
+                "from cron.scheduler_lease import SchedulerOwnershipLease;"
+                "lease=SchedulerOwnershipLease.try_acquire("
+                "hermes_home=Path(sys.argv[1]),owner='gateway',provider='builtin');"
+                "assert lease is not None;"
+                "print('ready',flush=True);"
+                "time.sleep(60)"
+            ),
+            str(tmp_path),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(Path(__file__).parents[2]),
+    )
+    try:
+        assert child.stdout is not None
+        assert child.stdout.readline().strip() == "ready"
+        assert (
+            SchedulerOwnershipLease.try_acquire(
+                hermes_home=tmp_path, owner="desktop", provider="builtin"
+            )
+            is None
+        )
+        os.kill(child.pid, signal.SIGKILL)
+        child.wait(timeout=3)
+        takeover = SchedulerOwnershipLease.try_acquire(
+            hermes_home=tmp_path, owner="desktop", provider="builtin"
+        )
+        assert takeover is not None
+        takeover.release()
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=3)
+
+
+def test_hosted_external_fire_resolves_strict_exact_home(tmp_path, monkeypatch):
+    import hermes_cli.web_server as web_server
+    from hermes_constants import get_hermes_home
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "cron:\n  scheduler_owner: auto\n  provider: external\n",
+        encoding="utf-8",
+    )
+    seen = {}
+
+    class Provider:
+        def fire_due(self, job_id, *, adapters=None, loop=None):
+            seen["job_id"] = job_id
+            seen["home"] = get_hermes_home()
+            return True
+
+    monkeypatch.setattr(
+        web_server, "_cron_profile_home", lambda _profile: ("worker", home)
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda name: Provider() if name == "external" else None,
+    )
+    assert web_server._fire_hosted_cron_job_for_profile("worker", "job-1") is True
+    assert seen == {"job_id": "job-1", "home": home.resolve()}
+
+
+@pytest.mark.asyncio
+async def test_desktop_shutdown_wait_is_bounded_and_nonblocking():
+    import asyncio
+    import hermes_cli.web_server as web_server
+
+    class AliveThread:
+        def is_alive(self):
+            return True
+
+    stop = threading.Event()
+    heartbeat = asyncio.Event()
+
+    async def beat():
+        await asyncio.sleep(0.01)
+        heartbeat.set()
+
+    task = asyncio.create_task(beat())
+    started = time.monotonic()
+    stopped = await web_server._stop_desktop_cron_scheduler(
+        object(), stop, AliveThread(), timeout=0.05
+    )
+    await task
+    assert stopped is False
+    assert stop.is_set() and heartbeat.is_set()
+    assert time.monotonic() - started < 0.5

--- a/tests/gateway/test_cron_fire_webhook.py
+++ b/tests/gateway/test_cron_fire_webhook.py
@@ -9,6 +9,10 @@ test_chronos_verify.py.
 
 import asyncio
 import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -49,11 +53,139 @@ class _SpyProvider:
         return True
 
 
+def _install_provider(monkeypatch, provider):
+    @contextmanager
+    def borrow(**_kwargs):
+        yield provider
+
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.borrow_scheduler_provider", borrow
+    )
+    monkeypatch.setattr("cron.jobs.load_jobs", lambda: [{"id": "abc123"}, {"id": "j1"}])
+
+
+@pytest.mark.asyncio
+async def test_fire_admission_does_not_deadlock_one_worker_executor(
+    adapter, monkeypatch
+):
+    spy = _SpyProvider()
+    _install_provider(monkeypatch, spy)
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **_kw: {"purpose": "cron_fire"}),
+    )
+
+    class Request:
+        headers = {"Authorization": "Bearer good"}
+
+        async def json(self):
+            return {"job_id": "j1"}
+
+    loop = asyncio.get_running_loop()
+    old_executor = getattr(loop, "_default_executor", None)
+    one_worker = ThreadPoolExecutor(max_workers=1)
+    loop.set_default_executor(one_worker)
+    try:
+        response = await asyncio.wait_for(adapter._handle_cron_fire(Request()), 1)
+        assert response.status == 202
+    finally:
+        loop.set_default_executor(old_executor or ThreadPoolExecutor())
+        one_worker.shutdown(wait=True)
+    assert spy.fired == ["j1"]
+
+
+@pytest.mark.asyncio
+async def test_multiplex_fire_resolves_owner_before_profile_auth(
+    adapter, tmp_path, monkeypatch
+):
+    from hermes_constants import (
+        get_hermes_home,
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    default = tmp_path / "default"
+    worker = tmp_path / "worker"
+    for home in (default, worker):
+        (home / "cron").mkdir(parents=True)
+    providers = {"default": _SpyProvider(), "worker": _SpyProvider()}
+    adapter.gateway_runner = SimpleNamespace(
+        config=SimpleNamespace(multiplex_profiles=True)
+    )
+
+    @contextmanager
+    def profile_scope(profile):
+        home = worker if profile == "worker" else default
+        token = set_hermes_home_override(home)
+        try:
+            yield
+        finally:
+            reset_hermes_home_override(token)
+
+    @contextmanager
+    def borrow(*, hermes_home):
+        name = "worker" if Path(hermes_home) == worker.resolve() else "default"
+        yield providers[name]
+
+    monkeypatch.setattr(adapter, "_profile_scope", profile_scope)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex: [("default", default), ("worker", worker)],
+    )
+    monkeypatch.setattr(
+        "cron.jobs.load_jobs",
+        lambda: [{"id": "worker-job"}] if get_hermes_home() == worker.resolve() else [],
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.borrow_scheduler_provider", borrow
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "cron": {
+                "chronos": {
+                    "expected_audience": (
+                        "worker-audience"
+                        if get_hermes_home() == worker.resolve()
+                        else "default-audience"
+                    )
+                }
+            }
+        },
+    )
+    verified = []
+
+    def verifier(**kwargs):
+        verified.append((get_hermes_home(), kwargs["token"], kwargs["expected_audience"]))
+        return {"purpose": "cron_fire"} if kwargs["token"] == "worker-token" else None
+
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: verifier,
+    )
+
+    class Request:
+        headers = {"Authorization": "Bearer worker-token"}
+
+        async def json(self):
+            return {"job_id": "worker-job"}
+
+    response = await adapter._handle_cron_fire(Request())
+    assert response.status == 202
+    for _ in range(50):
+        if providers["worker"].fired:
+            break
+        await asyncio.sleep(0.01)
+    assert providers["default"].fired == []
+    assert providers["worker"].fired == ["worker-job"]
+    assert verified == [(worker.resolve(), "worker-token", "worker-audience")]
+
+
 @pytest.mark.asyncio
 async def test_valid_token_accepts_and_fires(adapter, monkeypatch):
     """Valid NAS-JWT + {job_id} → 202 and fire_due invoked with that id."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+    _install_provider(monkeypatch, spy)
     # verifier returns claims (valid token)
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
@@ -81,7 +213,7 @@ async def test_valid_token_accepts_and_fires(adapter, monkeypatch):
 async def test_invalid_token_401_and_no_fire(adapter, monkeypatch):
     """Bad/forged token → 401, fire_due NOT invoked."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+    _install_provider(monkeypatch, spy)
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: None),  # verification fails
@@ -102,7 +234,7 @@ async def test_invalid_token_401_and_no_fire(adapter, monkeypatch):
 async def test_missing_token_401(adapter, monkeypatch):
     """No Authorization header → verifier gets empty token → 401."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+    _install_provider(monkeypatch, spy)
     # Real verifier: empty token returns None.
     app = _create_app(adapter)
     async with TestClient(TestServer(app)) as cli:
@@ -115,7 +247,7 @@ async def test_missing_token_401(adapter, monkeypatch):
 async def test_valid_token_refuses_during_gateway_drain(adapter, monkeypatch):
     spy = _SpyProvider()
     runner = SimpleNamespace(_draining=False, _external_drain_active=True)
-    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+    _install_provider(monkeypatch, spy)
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
@@ -157,7 +289,7 @@ async def test_valid_fire_reservation_blocks_drain_before_body_and_task(adapter,
         await release_body.wait()
         return await original_json(request)
 
-    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", BlockingProvider)
+    _install_provider(monkeypatch, BlockingProvider())
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
@@ -192,10 +324,87 @@ async def test_valid_fire_reservation_blocks_drain_before_body_and_task(adapter,
 
 
 @pytest.mark.asyncio
+async def test_cancelled_fire_task_keeps_provider_admission_until_worker_returns(
+    adapter, tmp_path, monkeypatch
+):
+    from cron.scheduler_lease import SchedulerOwnershipLease
+    from cron.scheduler_runtime import OwnedSchedulerRuntime, SchedulerOwnershipPolicy
+    from tests.cron.test_scheduler_runtime import _Provider, _run, _wait
+
+    policy = SchedulerOwnershipPolicy("gateway", "external")
+    worker_entered = threading.Event()
+    release_worker = threading.Event()
+
+    class BlockingProvider(_Provider):
+        def __init__(self):
+            super().__init__(returns=True)
+
+        def fire_due(self, _job_id, *, adapters=None, loop=None):
+            worker_entered.set()
+            release_worker.wait()
+            return True
+
+    provider = BlockingProvider()
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda **_kwargs: policy,
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **_kw: {"purpose": "cron_fire"}),
+    )
+    monkeypatch.setattr("cron.jobs.load_jobs", lambda: [{"id": "j1"}])
+    runtime = OwnedSchedulerRuntime("gateway", hermes_home=tmp_path, poll_interval=0.01)
+    stop, runtime_thread = _run(runtime)
+    _wait(provider.started.is_set)
+
+    class Request:
+        headers = {"Authorization": "Bearer good"}
+
+        async def json(self):
+            return {"job_id": "j1"}
+
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    home_token = set_hermes_home_override(tmp_path)
+    try:
+        response = await adapter._handle_cron_fire(Request())
+    finally:
+        reset_hermes_home_override(home_token)
+    assert response.status == 202
+    assert worker_entered.wait(1)
+    fire_task = next(task for task in adapter._background_tasks if not task.done())
+    fire_task.cancel()
+    await asyncio.sleep(0)
+
+    stop.set()
+    time.sleep(0.05)
+    assert runtime_thread.is_alive()
+    assert (
+        SchedulerOwnershipLease.try_acquire(
+            hermes_home=tmp_path, owner="desktop", provider="builtin"
+        )
+        is None
+    )
+
+    release_worker.set()
+    runtime_thread.join(2)
+    takeover = SchedulerOwnershipLease.try_acquire(
+        hermes_home=tmp_path, owner="desktop", provider="builtin"
+    )
+    assert takeover is not None
+    takeover.release()
+
+
+@pytest.mark.asyncio
 async def test_missing_job_id_400(adapter, monkeypatch):
     """Valid token but no job_id → 400, no fire."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+    _install_provider(monkeypatch, spy)
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
@@ -215,11 +424,12 @@ async def test_fire_does_not_require_api_server_key(adapter, monkeypatch):
     """The fire endpoint must NOT gate on API_SERVER_KEY — auth is the NAS-JWT.
     A request with NO API key header but a valid fire token still succeeds."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+    _install_provider(monkeypatch, spy)
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
     )
+    monkeypatch.setattr("cron.jobs.load_jobs", lambda: [{"id": "j9"}])
 
     app = _create_app(adapter)
     async with TestClient(TestServer(app)) as cli:

--- a/tests/gateway/test_cron_scheduler_ownership.py
+++ b/tests/gateway/test_cron_scheduler_ownership.py
@@ -1,0 +1,67 @@
+"""Multiplex Gateway cron ownership is resolved independently per profile."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+from cron.scheduler_runtime import SchedulerOwnershipPolicy
+
+
+def test_mixed_multiplex_profiles_start_supervisors_for_every_exact_home(
+    tmp_path, monkeypatch
+):
+    import gateway.run as gateway_run
+
+    homes = [
+        ("default", tmp_path / "default"),
+        ("desktop", tmp_path / "desktop"),
+        ("chronos", tmp_path / "chronos"),
+        ("malformed", tmp_path / "malformed"),
+    ]
+    policies = {
+        homes[0][1].resolve(): SchedulerOwnershipPolicy("auto", "builtin"),
+        homes[1][1].resolve(): SchedulerOwnershipPolicy("desktop", "builtin"),
+        homes[2][1].resolve(): SchedulerOwnershipPolicy("gateway", "chronos"),
+        homes[3][1].resolve(): None,
+    }
+    reads = []
+    constructed = []
+
+    def read_policy(*, hermes_home, **_kwargs):
+        home = Path(hermes_home).resolve()
+        reads.append(home)
+        return policies[home]
+
+    class FakeRuntime:
+        def __init__(self, owner, **kwargs):
+            constructed.append((owner, kwargs["hermes_home"]))
+
+        def run(self, _stop):
+            return None
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve", lambda multiplex: homes
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        read_policy,
+    )
+    monkeypatch.setattr("cron.scheduler_runtime.OwnedSchedulerRuntime", FakeRuntime)
+
+    runner = SimpleNamespace(
+        config=SimpleNamespace(multiplex_profiles=True),
+        adapters={},
+        _draining=False,
+        _external_drain_active=False,
+    )
+    supervisors = gateway_run._start_gateway_cron_schedulers(
+        runner, threading.Event(), None
+    )
+    for _runtime, thread in supervisors:
+        thread.join(1)
+
+    assert reads == []
+    assert constructed == [("gateway", home.resolve()) for _, home in homes]
+    assert len(supervisors) == 4

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from cron.jobs import create_job, get_job, list_jobs
+from cron.scheduler_runtime import SchedulerOwnershipPolicy
 from hermes_cli import cron as cron_cli
 from hermes_cli.cron import cron_command
 
@@ -156,14 +157,14 @@ class TestCronCommandLifecycle:
 
 
 class TestGatewayNotRunningWarning:
-    """`cron create` / `cron list` must warn when the gateway (and thus the
-    cron ticker) isn't running, since jobs only fire inside the gateway.
-    Regression guard for #51038 — the most common cron 'jobs never fired'
-    report was simply a gateway that was never started.
-    """
+    """Create/list warnings follow the exact-home scheduler lease."""
 
     def test_create_warns_when_gateway_absent(self, tmp_cron_dir, capsys, monkeypatch):
-        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
+        monkeypatch.setattr(
+            cron_cli,
+            "_scheduler_health",
+            lambda: (SchedulerOwnershipPolicy("gateway", "builtin"), None),
+        )
         cron_command(
             Namespace(
                 cron_command="create",
@@ -184,7 +185,14 @@ class TestGatewayNotRunningWarning:
         assert "Gateway is not running" in out
 
     def test_create_silent_when_gateway_running(self, tmp_cron_dir, capsys, monkeypatch):
-        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [4242])
+        monkeypatch.setattr(
+            cron_cli,
+            "_scheduler_health",
+            lambda: (
+                SchedulerOwnershipPolicy("gateway", "builtin"),
+                {"owner": "gateway", "provider": "builtin"},
+            ),
+        )
         cron_command(
             Namespace(
                 cron_command="create",
@@ -206,19 +214,47 @@ class TestGatewayNotRunningWarning:
 
     def test_list_warns_when_gateway_absent(self, tmp_cron_dir, capsys, monkeypatch):
         create_job(prompt="Daily report", schedule="0 11 * * *")
-        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
+        monkeypatch.setattr(
+            cron_cli,
+            "_scheduler_health",
+            lambda: (SchedulerOwnershipPolicy("gateway", "builtin"), None),
+        )
         cron_command(Namespace(cron_command="list", all=True))
         out = capsys.readouterr().out
         assert "Gateway is not running" in out
+
+    @pytest.mark.parametrize(
+        ("policy", "owner"),
+        [
+            (
+                SchedulerOwnershipPolicy("gateway", "builtin"),
+                {"owner": "desktop", "provider": "builtin"},
+            ),
+            (
+                SchedulerOwnershipPolicy("desktop", "builtin"),
+                {"owner": "gateway", "provider": "builtin"},
+            ),
+            (
+                SchedulerOwnershipPolicy("auto", "chronos"),
+                {"owner": "desktop", "provider": "chronos"},
+            ),
+        ],
+    )
+    def test_warning_fails_closed_for_owner_policy_mismatch(
+        self, policy, owner, capsys, monkeypatch
+    ):
+        monkeypatch.setattr(cron_cli, "_scheduler_health", lambda: (policy, owner))
+
+        cron_cli._warn_if_gateway_not_running()
+
+        assert "jobs won't fire automatically" in capsys.readouterr().out
 
 
 class TestExternalCronProviderStatus:
     """With an external cron provider (e.g. Chronos), jobs fire via a
     NAS-mediated webhook, NOT the in-process ticker. The ticker-heartbeat /
-    gateway-process heuristics are meaningless there, so neither
-    `cron status` nor the create/list warning must claim the gateway being
-    absent means jobs won't fire — that was a false-negative on every healthy
-    Chronos instance (the heartbeat is intentionally never written).
+    gateway-process heuristics are meaningless there. A healthy live provider
+    lease must report managed scheduling without requiring either signal.
     """
 
     def test_status_reports_provider_not_ticker_for_chronos(
@@ -226,7 +262,12 @@ class TestExternalCronProviderStatus:
     ):
         create_job(prompt="Ping", schedule="every 2m")
         monkeypatch.setattr(
-            "hermes_cli.cron._active_cron_provider_name", lambda: "chronos"
+            cron_cli,
+            "_scheduler_health",
+            lambda: (
+                SchedulerOwnershipPolicy("gateway", "chronos"),
+                {"owner": "gateway", "provider": "chronos"},
+            ),
         )
         # Even with NO gateway process and NO ticker heartbeat, Chronos status
         # must NOT report a stall / "not firing".
@@ -244,7 +285,9 @@ class TestExternalCronProviderStatus:
     def test_status_unchanged_for_builtin(self, tmp_cron_dir, capsys, monkeypatch):
         create_job(prompt="Ping", schedule="every 2m")
         monkeypatch.setattr(
-            "hermes_cli.cron._active_cron_provider_name", lambda: "builtin"
+            cron_cli,
+            "_scheduler_health",
+            lambda: (SchedulerOwnershipPolicy("gateway", "builtin"), None),
         )
         monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
         cron_command(Namespace(cron_command="status"))
@@ -256,10 +299,14 @@ class TestExternalCronProviderStatus:
     def test_create_silent_for_chronos_even_without_gateway(
         self, tmp_cron_dir, capsys, monkeypatch
     ):
-        # The create-time "gateway not running" nag is a ticker-only concern;
-        # an external provider doesn't depend on a live in-process ticker.
+        # The live Chronos lease is authoritative; a global Gateway PID is not.
         monkeypatch.setattr(
-            "hermes_cli.cron._active_cron_provider_name", lambda: "chronos"
+            cron_cli,
+            "_scheduler_health",
+            lambda: (
+                SchedulerOwnershipPolicy("gateway", "chronos"),
+                {"owner": "gateway", "provider": "chronos"},
+            ),
         )
         monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
         cron_command(
@@ -298,7 +345,11 @@ def test_cron_list_warns_when_gateway_not_running(monkeypatch, capsys):
         ],
     )
     monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
-    monkeypatch.setattr(cron_cli, "_active_cron_provider_name", lambda: "builtin")
+    monkeypatch.setattr(
+        cron_cli,
+        "_scheduler_health",
+        lambda: (SchedulerOwnershipPolicy("gateway", "builtin"), None),
+    )
 
     cron_cli.cron_list()
 
@@ -308,7 +359,14 @@ def test_cron_list_warns_when_gateway_not_running(monkeypatch, capsys):
 
 
 def test_cron_status_reports_running_gateway(monkeypatch, capsys):
-    monkeypatch.setattr(cron_cli, "_active_cron_provider_name", lambda: "builtin")
+    monkeypatch.setattr(
+        cron_cli,
+        "_scheduler_health",
+        lambda: (
+            SchedulerOwnershipPolicy("gateway", "builtin"),
+            {"owner": "gateway", "provider": "builtin"},
+        ),
+    )
     monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [1234, 5678])
     monkeypatch.setattr(
         "cron.jobs.list_jobs",
@@ -325,6 +383,60 @@ def test_cron_status_reports_running_gateway(monkeypatch, capsys):
     assert "1234, 5678" in out
     assert "2 active job(s)" in out
     assert "2026-05-31T12:00:00Z" in out
+
+
+def test_cron_status_reports_desktop_owned_auto(monkeypatch, capsys):
+    monkeypatch.setattr(
+        cron_cli,
+        "_scheduler_health",
+        lambda: (
+            SchedulerOwnershipPolicy("auto", "builtin"),
+            {"owner": "desktop", "provider": "builtin"},
+        ),
+    )
+    monkeypatch.setattr("cron.jobs.get_ticker_heartbeat_age", lambda: 5.0)
+    monkeypatch.setattr("cron.jobs.get_ticker_success_age", lambda: 5.0)
+    monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: [])
+
+    cron_cli.cron_status()
+
+    assert "Desktop owns cron" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("policy", "owner"),
+    [
+        (None, None),
+        (SchedulerOwnershipPolicy("auto", "chronos"), None),
+        (
+            SchedulerOwnershipPolicy("auto", "chronos"),
+            {"owner": "gateway", "provider": "builtin"},
+        ),
+        (
+            SchedulerOwnershipPolicy("gateway", "builtin"),
+            {"owner": "desktop", "provider": "builtin"},
+        ),
+        (
+            SchedulerOwnershipPolicy("desktop", "builtin"),
+            {"owner": "gateway", "provider": "builtin"},
+        ),
+        (
+            SchedulerOwnershipPolicy("auto", "chronos"),
+            {"owner": "desktop", "provider": "chronos"},
+        ),
+    ],
+)
+def test_cron_status_fails_closed_without_matching_live_owner(
+    policy, owner, monkeypatch, capsys
+):
+    monkeypatch.setattr(cron_cli, "_scheduler_health", lambda: (policy, owner))
+    monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: [])
+
+    cron_cli.cron_status()
+
+    out = capsys.readouterr().out
+    assert "automatic firing is disabled" in out or "will NOT fire automatically" in out
+    assert "✓" not in out
 
 
 def test_cron_tick_invokes_scheduler_tick_with_verbose(monkeypatch):

--- a/tests/hermes_cli/test_cron_dashboard_off_loop.py
+++ b/tests/hermes_cli/test_cron_dashboard_off_loop.py
@@ -1,7 +1,7 @@
 """Regression tests: cron dashboard handlers must not run profile I/O on the event loop.
 
 Guards the residual sites missed by the 49fa04a23/346e5673d threadpool
-migration: POST /api/cron/fire (_find_cron_job_profile) and
+migration: POST /api/cron/fire (_find_exact_cron_job_profile) and
 POST /api/cron/blueprints/instantiate (_call_cron_for_profile create_job).
 Each stub asserts it is running OFF the event loop thread by checking that
 no running asyncio loop is present in its thread.
@@ -37,7 +37,7 @@ def test_cron_fire_profile_lookup_off_loop(monkeypatch, loop_probe):
         probe("find")
         return None
 
-    monkeypatch.setattr(web_server, "_find_cron_job_profile", fake_find)
+    monkeypatch.setattr(web_server, "_find_exact_cron_job_profile", fake_find)
 
     import plugins.cron_providers.chronos.verify as chv
     monkeypatch.setattr(chv, "get_fire_verifier", lambda: (lambda **kw: {"sub": "t"}))
@@ -51,7 +51,7 @@ def test_cron_fire_profile_lookup_off_loop(monkeypatch, loop_probe):
     assert resp.status_code == 200
     assert resp.json()["status"] == "gone"
     assert ("find", False) in seen, (
-        f"_find_cron_job_profile must run off the event loop; proof: {seen}"
+        f"_find_exact_cron_job_profile must run off the event loop; proof: {seen}"
     )
 
 

--- a/tests/hermes_cli/test_cron_fire_dashboard.py
+++ b/tests/hermes_cli/test_cron_fire_dashboard.py
@@ -9,8 +9,8 @@ hosted agents don't expose). It must:
     the JWT verifier runs,
   - reject a bad/missing NAS-JWT with 401 (the JWT is the real gate),
   - 400 on missing job_id,
-  - on a valid token, resolve the job's profile and run fire_due in the
-    background, returning 202.
+  - on a valid token, resolve the job's profile and complete the admitted
+    fire/re-arm before returning 202.
 """
 
 import pytest
@@ -64,8 +64,10 @@ def test_bad_token_401(monkeypatch):
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: None),  # verification fails
     )
-    monkeypatch.setattr(web_server, "_find_cron_job_profile", lambda jid: "default")
-    monkeypatch.setattr(web_server, "_fire_cron_job_for_profile",
+    monkeypatch.setattr(
+        web_server, "_find_exact_cron_job_profile", lambda jid: "default"
+    )
+    monkeypatch.setattr(web_server, "_fire_hosted_cron_job_for_profile",
                         lambda p, j: fired.append((p, j)))
 
     client, pa, ph = _client(auth_required=True)
@@ -103,7 +105,7 @@ def test_unknown_job_200_gone(monkeypatch):
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
     )
-    monkeypatch.setattr(web_server, "_find_cron_job_profile", lambda jid: None)
+    monkeypatch.setattr(web_server, "_find_exact_cron_job_profile", lambda jid: None)
     client, pa, ph = _client(auth_required=False)
     try:
         resp = client.post("/api/cron/fire",
@@ -116,6 +118,127 @@ def test_unknown_job_200_gone(monkeypatch):
         client.close()
 
 
+def test_duplicate_exact_job_ids_are_rejected(monkeypatch):
+    monkeypatch.setattr(
+        web_server,
+        "_cron_profile_dicts",
+        lambda: [{"name": "first"}, {"name": "second"}],
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_call_cron_for_profile",
+        lambda _profile, _func, _include_disabled: [{"id": "duplicate"}],
+    )
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: pytest.fail("Ambiguous jobs must be rejected before authentication"),
+    )
+
+    client, pa, ph = _client(auth_required=False)
+    try:
+        resp = client.post("/api/cron/fire", json={"job_id": "duplicate"})
+        assert resp.status_code == 409
+        assert "multiple profiles" in resp.json()["detail"]
+    finally:
+        _restore(pa, ph)
+        client.close()
+
+
+def test_generic_dashboard_lookup_rejects_cross_profile_ambiguity(monkeypatch):
+    monkeypatch.setattr(
+        web_server,
+        "_cron_profile_dicts",
+        lambda: [{"name": "by-id"}, {"name": "by-name"}],
+    )
+    jobs = {
+        "by-id": [{"id": "target", "name": "first"}],
+        "by-name": [{"id": "other", "name": "target"}],
+    }
+    monkeypatch.setattr(
+        web_server,
+        "_call_cron_for_profile",
+        lambda profile, _func, _include_disabled: jobs[profile],
+    )
+
+    with pytest.raises(web_server.HTTPException) as exc:
+        web_server._find_cron_job_profile("target")
+    assert exc.value.status_code == 409
+
+
+def test_exact_id_wins_over_other_profile_name_and_scopes_token(
+    tmp_path, monkeypatch
+):
+    named_home = tmp_path / "named"
+    exact_home = tmp_path / "exact"
+    for home, audience in (
+        (named_home, "agent:named"),
+        (exact_home, "agent:exact"),
+    ):
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "cron:\n  chronos:\n"
+            f"    expected_audience: {audience}\n",
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(
+        web_server,
+        "_cron_profile_dicts",
+        lambda: [{"name": "named"}, {"name": "exact"}],
+    )
+    jobs = {
+        "named": [{"id": "other-id", "name": "target-id"}],
+        "exact": [{"id": "target-id", "name": "actual target"}],
+    }
+    monkeypatch.setattr(
+        web_server,
+        "_call_cron_for_profile",
+        lambda profile, _func, _include_disabled: jobs[profile],
+    )
+    homes = {"named": named_home, "exact": exact_home}
+    monkeypatch.setattr(
+        web_server,
+        "_cron_profile_home",
+        lambda profile: (profile, homes[profile]),
+    )
+    fired = []
+    monkeypatch.setattr(
+        web_server,
+        "_fire_hosted_cron_job_for_profile",
+        lambda profile, job_id: fired.append((profile, job_id)) or True,
+    )
+
+    def verifier(**kwargs):
+        return (
+            {"purpose": "cron_fire"}
+            if kwargs["token"] == kwargs["expected_audience"]
+            else None
+        )
+
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: verifier,
+    )
+    client, pa, ph = _client(auth_required=False)
+    try:
+        wrong_profile_token = client.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer agent:named"},
+            json={"job_id": "target-id"},
+        )
+        exact_profile_token = client.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer agent:exact"},
+            json={"job_id": "target-id"},
+        )
+        assert wrong_profile_token.status_code == 401
+        assert exact_profile_token.status_code == 202
+    finally:
+        _restore(pa, ph)
+        client.close()
+    assert fired == [("exact", "target-id")]
+
+
 def test_valid_token_accepts_and_fires(monkeypatch):
     """Valid token + known job -> 202 and fire_due invoked for the resolved
     profile."""
@@ -124,8 +247,10 @@ def test_valid_token_accepts_and_fires(monkeypatch):
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire", "aud": "agent:x"}),
     )
-    monkeypatch.setattr(web_server, "_find_cron_job_profile", lambda jid: "default")
-    monkeypatch.setattr(web_server, "_fire_cron_job_for_profile",
+    monkeypatch.setattr(
+        web_server, "_find_exact_cron_job_profile", lambda jid: "default"
+    )
+    monkeypatch.setattr(web_server, "_fire_hosted_cron_job_for_profile",
                         lambda p, j: fired.append((p, j)) or True)
 
     client, pa, ph = _client(auth_required=False)
@@ -138,5 +263,80 @@ def test_valid_token_accepts_and_fires(monkeypatch):
     finally:
         _restore(pa, ph)
         client.close()
-    # background task ran the fire for the resolved profile
     assert fired == [("default", "j1")]
+
+
+def test_unavailable_exact_profile_provider_returns_retryable_503(monkeypatch):
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **_kw: {"purpose": "cron_fire"}),
+    )
+    monkeypatch.setattr(
+        web_server, "_find_exact_cron_job_profile", lambda _jid: "default"
+    )
+    monkeypatch.setattr(
+        web_server, "_fire_hosted_cron_job_for_profile", lambda _p, _j: None
+    )
+    client, pa, ph = _client(auth_required=False)
+    try:
+        resp = client.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer good"},
+            json={"job_id": "j1"},
+        )
+        assert resp.status_code == 503
+    finally:
+        _restore(pa, ph)
+        client.close()
+
+
+def test_fire_token_verification_uses_job_profile_config(tmp_path, monkeypatch):
+    default_home = tmp_path / "default"
+    worker_home = tmp_path / "worker"
+    for home, audience in (
+        (default_home, "agent:default"),
+        (worker_home, "agent:worker"),
+    ):
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "cron:\n  chronos:\n"
+            f"    expected_audience: {audience}\n",
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(
+        web_server, "_find_exact_cron_job_profile", lambda _jid: "worker"
+    )
+    monkeypatch.setattr(
+        web_server, "_cron_profile_home", lambda _profile: ("worker", worker_home)
+    )
+    monkeypatch.setattr(
+        web_server, "_fire_hosted_cron_job_for_profile", lambda _p, _j: True
+    )
+
+    def verifier(**kwargs):
+        expected = kwargs["expected_audience"]
+        token = kwargs["token"]
+        return {"purpose": "cron_fire"} if token == expected else None
+
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: verifier,
+    )
+    client, pa, ph = _client(auth_required=False)
+    try:
+        default = client.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer agent:default"},
+            json={"job_id": "worker-job"},
+        )
+        worker = client.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer agent:worker"},
+            json={"job_id": "worker-job"},
+        )
+        assert default.status_code == 401
+        assert worker.status_code == 202
+    finally:
+        _restore(pa, ph)
+        client.close()

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -10060,13 +10060,31 @@ class TestDesktopCronTicker:
     def test_ticker_runs_when_desktop(self, monkeypatch, _isolate_hermes_home):
         import threading
         import cron.scheduler as sched
+        from cron.scheduler_runtime import get_active_scheduler_provider
+        from hermes_constants import get_hermes_home
 
         called = threading.Event()
         monkeypatch.setattr(sched, "tick", lambda *a, **k: called.set())
         monkeypatch.setenv("HERMES_DESKTOP", "1")
+        existing_threads = set(threading.enumerate())
 
         with self._client():
             assert called.wait(3.0), "expected cron tick under HERMES_DESKTOP=1"
+            assert get_active_scheduler_provider(
+                hermes_home=get_hermes_home()
+            ) is not None
+
+        assert get_active_scheduler_provider(hermes_home=get_hermes_home()) is None
+        leaked = {
+            thread.name
+            for thread in threading.enumerate()
+            if thread not in existing_threads
+            and thread.name in {
+                "desktop-cron-supervisor",
+                "desktop-cron-provider",
+            }
+        }
+        assert leaked == set()
 
     def test_ticker_skipped_without_desktop(self, monkeypatch, _isolate_hermes_home):
         import threading

--- a/tests/plugins/test_chronos_cron.py
+++ b/tests/plugins/test_chronos_cron.py
@@ -166,6 +166,43 @@ def test_reconcile_skips_already_armed_same_time(temp_home, chronos, monkeypatch
     assert fake.provisions == []  # already armed at the same time → no re-arm
 
 
+def test_reconcile_provision_failure_propagates(temp_home, chronos, monkeypatch):
+    prov, fake = chronos
+    job = {
+        "id": "a",
+        "enabled": True,
+        "next_run_at": "2026-06-18T12:00:00+00:00",
+        "state": "scheduled",
+    }
+    monkeypatch.setattr("cron.jobs.load_jobs", lambda: [job])
+    monkeypatch.setattr("cron.jobs.get_job", lambda _jid: job)
+    monkeypatch.setattr(
+        fake, "provision", lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("down"))
+    )
+    with pytest.raises(RuntimeError, match="down"):
+        prov.reconcile()
+
+
+def test_reconcile_cancel_failure_propagates(temp_home, chronos, monkeypatch):
+    prov, fake = chronos
+    prov._armed = {"gone": "2026-06-18T11:00:00+00:00"}
+    monkeypatch.setattr("cron.jobs.load_jobs", lambda: [])
+    monkeypatch.setattr(
+        fake, "cancel", lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("down"))
+    )
+    with pytest.raises(RuntimeError, match="down"):
+        prov.reconcile()
+
+def test_reconcile_list_failure_propagates(temp_home, chronos, monkeypatch):
+    prov, fake = chronos
+    monkeypatch.setattr("cron.jobs.load_jobs", lambda: [])
+    monkeypatch.setattr(
+        fake, "list_armed", lambda: (_ for _ in ()).throw(RuntimeError("down"))
+    )
+    with pytest.raises(RuntimeError, match="down"):
+        prov.reconcile()
+
+
 # -- fire_due re-arm ----------------------------------------------------------
 
 def test_fire_due_rearms_next_oneshot(chronos, monkeypatch):


### PR DESCRIPTION
## Summary

Hermes Desktop and Gateway could both schedule the same stateful cron job for one `HERMES_HOME`. Whichever process won a tick could advance the job before discovering that its process lacked the configured delivery credentials, so generated output disappeared from the intended platform.

This change makes scheduler ownership fail closed and exact-home scoped while preserving standalone Desktop compatibility, multiplex Gateway profiles, hosted callbacks, and external providers.

| Decision | Behavior |
|---|---|
| Missing owner | `auto`: Gateway is preferred when present; Desktop-only installs continue scheduling. |
| Explicit owner | `gateway` and `desktop` are strict; malformed or unavailable configurations do not silently fall back. |
| Ownership boundary | One interprocess lease per canonical `HERMES_HOME`; provider routing and module caches use that same boundary. |
| Shutdown/handoff | Admission closes first; provider borrowers, lifecycle threads, and running jobs drain before resources are stopped or the lease is released. |
| External providers | Resolution is strict and case-preserving; reconciliation failures remain dirty and retryable. |
| Hosted callbacks | Job ID resolves to exactly one profile before token/config/provider lookup. Unknown, ambiguous, or unavailable ownership fails closed. |

The runtime also avoids Windows-dangerous process probes, detects PID reuse through process identity, keeps housekeeping independent from scheduler suppression, and reports configured policy, active provider, and lease state through the CLI.

## Compatibility and safety

- Gateway, Desktop, hosted dashboard, and multiplex profile supervisors all use the same ownership runtime.
- Gateway Chronos callbacks route by exact job ID to one owning profile; duplicate IDs are rejected instead of selecting the first profile.
- Hosted scale-to-zero callbacks authenticate and execute within the owning profile’s exact `HERMES_HOME`.
- Built-in scheduling cannot bypass ownership through an external-provider fallback.
- Startup rollback and shutdown retain the lease until published borrowers and accepted callback work drain.
- A cancelled async caller cannot release provider admission while its worker thread is still executing.
- Chronos authoritative-state, provision, cancellation, and signature-read failures propagate or retry rather than becoming false success.
- Gateway liveness checks reuse platform-safe process utilities instead of `os.kill(pid, 0)`.

## Validation

Tests ran with isolated `HOME`/`HERMES_HOME`; the real cron registry was SHA-256 checked before and after each authoritative run.

- `1235 passed` across cron, Chronos, Gateway callback/ownership/drain, dashboard cron, config, and cron-tool suites.
- `519 passed` in the complete `tests/hermes_cli/test_web_server.py` suite.
- Focused teardown, exact-profile callback, ambiguity, cancellation, Windows probe, transient signature, and one-worker executor regressions passed.
- Ruff passed for every changed Python file.
- All six new Python files are Ruff-format clean.
- Python compilation and `git diff --check` passed.
- Production `~/.hermes/cron/jobs.json` remained unchanged during each guarded run.

One pre-existing mocked multi-target delivery test still emits an un-awaited coroutine warning; the affected suites otherwise pass.

## New concepts

### Admission barriers for resource-safe shutdown

Closing a scheduler’s public registry prevents new work, but already admitted callbacks may still hold and use its provider. The runtime therefore treats shutdown as a barrier:

```mermaid
flowchart LR
  A[Close admission] --> B[Unpublish provider]
  B --> C[Signal lifecycle stop]
  C --> D[Drain borrowers and jobs]
  D --> E[Stop provider resources]
  E --> F[Release exact-home lease]
```

This is preferable to stopping the provider first because callbacks cannot safely finish against closed network clients or schedulers. It is not needed for immutable, stateless resources with no concurrent borrowers.

### Exact-home ownership

`HERMES_HOME` is the scheduler’s tenancy boundary: policy, jobs, credentials, provider instance, callback authentication, and lease ownership all resolve from the same canonical home. That lets multiplex profiles share a process without sharing scheduler authority. A process-global singleton is simpler, but is unsafe whenever multiple profiles or homes coexist.
