### PR TITLE
docs(config): align max_turns example with the real default (salvage #55673)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -778,10 +778,10 @@ skills:
 # Agent Behavior
 # =============================================================================
 agent:
-  # Maximum tool-calling iterations per conversation
+  # Maximum tool-calling iterations per conversation (default: 90)
   # Higher = more room for complex tasks, but costs more tokens
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
-  max_turns: 60
+  max_turns: 90
 
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -778,10 +778,10 @@ skills:
 # Agent Behavior
 # =============================================================================
 agent:
-  # Maximum tool-calling iterations per conversation (default: 90)
+  # Maximum tool-calling iterations per conversation (default: 500)
   # Higher = more room for complex tasks, but costs more tokens
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
-  max_turns: 90
+  max_turns: 500
 
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving


### PR DESCRIPTION
## Summary
`cli-config.yaml.example` now shows the real `agent.max_turns` default (500) — it previously shipped a stale `max_turns: 60` that matched nothing.

Salvages #55673 by @waroffchange, who caught the example/default drift (example said 60, default was then 90). Their commit is cherry-picked with authorship preserved; a follow-up commit updates the value to 500 since #72176 raised the actual default after their PR was opened.

## Changes
- `cli-config.yaml.example`: `max_turns` example 60 → 500, comment states the current default

## Validation
| | Before | After |
|---|---|---|
| Example `max_turns` | 60 | 500 |
| Real default (`DEFAULT_CONFIG["agent"]["max_turns"]`) | 500 | 500 (matches) |

Credit: @waroffchange (#55673) for spotting the drift.
