### PR TITLE
fix(config): merge duplicate kanban block so auto_subscribe_on_create default survives (salvage #55778)

### DIFF
--- a/contributors/emails/MaxFreedomPollard@users.noreply.github.com
+++ b/contributors/emails/MaxFreedomPollard@users.noreply.github.com
@@ -1,0 +1,1 @@
+MaxFreedomPollard

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1562,21 +1562,6 @@ DEFAULT_CONFIG = {
                                       # Example: 1800 = compact after 30 min idle.
     },
 
-    # Kanban subsystem (orchestrator workers + dispatcher-driven child tasks).
-    # See tools/kanban_tools.py and hermes_cli/kanban_db.py for the actual
-    # implementations. Per-platform notification opt-out is handled by the
-    # kanban dashboard (see ``hermes dashboard`` -> Notifications).
-    "kanban": {
-        # Auto-subscribe the originating gateway/TUI session to task
-        # completion + block events when ``kanban_create`` is called from
-        # inside a session that has a persistent delivery channel. The
-        # agent that dispatched the task will get notified automatically
-        # instead of having to poll. Disable to mirror pre-feature
-        # behaviour — e.g. for a profile that prefers explicit
-        # ``kanban_notify-subscribe`` calls per task.
-        "auto_subscribe_on_create": True,
-    },
-
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
     # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
     "prompt_caching": {
@@ -2920,6 +2905,14 @@ DEFAULT_CONFIG = {
     # each claimable ready task. One dispatcher per profile is sufficient;
     # running more than one on the same kanban.db will race for claims.
     "kanban": {
+        # Auto-subscribe the originating gateway/TUI session to task
+        # completion + block events when ``kanban_create`` is called from
+        # inside a session that has a persistent delivery channel. The
+        # agent that dispatched the task will get notified automatically
+        # instead of having to poll. Disable to mirror pre-feature
+        # behaviour — e.g. for a profile that prefers explicit
+        # ``kanban_notify-subscribe`` calls per task.
+        "auto_subscribe_on_create": True,
         # Run the dispatcher inside the gateway process. On by default —
         # the cost is ~300µs every `dispatch_interval_seconds` when idle,
         # and gateway is the supervisor users already have. Set to false

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -2385,3 +2385,35 @@ class TestProviderEnabledRuntimeGate:
             assert "disabled" not in str(e).lower()
         except Exception:
             pass  # any non-ValueError is fine; we only gate the disabled path
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_CONFIG must not carry a duplicate "kanban" key
+# ---------------------------------------------------------------------------
+
+def test_default_config_kanban_block_not_dropped_by_duplicate_key():
+    """DEFAULT_CONFIG previously declared ``"kanban"`` twice, so Python kept
+    only the second literal and silently dropped the first — losing the
+    ``auto_subscribe_on_create`` default. Both sets of defaults must survive.
+    """
+    kanban = DEFAULT_CONFIG["kanban"]
+    # From the first (dropped) block:
+    assert kanban.get("auto_subscribe_on_create") is True
+    # From the second block:
+    assert "dispatch_in_gateway" in kanban
+    assert "auto_decompose" in kanban
+
+
+def test_default_config_has_no_duplicate_top_level_keys():
+    """Guard against any duplicate key silently shadowing a default."""
+    import ast
+    import hermes_cli.config as cfg_mod
+
+    src = open(cfg_mod.__file__, encoding="utf-8").read()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Dict):
+            keys = [k.value for k in node.keys if isinstance(k, ast.Constant)]
+            if "model" in keys and "kanban" in keys:  # the DEFAULT_CONFIG literal
+                dupes = {k for k in keys if keys.count(k) > 1}
+                assert not dupes, f"duplicate DEFAULT_CONFIG keys: {sorted(dupes)}"


### PR DESCRIPTION
## Summary

`DEFAULT_CONFIG` declared the top-level `"kanban"` key twice; Python dict literals keep only the last, so the earlier block's `auto_subscribe_on_create: True` default was silently dropped from the schema. Salvage of #55778 by @MaxFreedomPollard (authorship preserved).

The runtime consumer masked the defect (`cfg_get(..., default=True)` in `tools/kanban_tools.py`), but the documented default was absent from `DEFAULT_CONFIG` — so `hermes config get kanban.auto_subscribe_on_create`, the docs schema, and any consumer without a local fallback disagreed with the documented behavior.

Fixes #55779.

## Changes

- `hermes_cli/config.py`: merge the two `"kanban"` blocks into one (notification + dispatcher defaults together) — @MaxFreedomPollard
- `tests/hermes_cli/test_config.py`: regression tests — kanban defaults present, and an AST-based guard that `DEFAULT_CONFIG` has no duplicate top-level keys (catches the whole class)
- `contributors/emails/`: mapping file (came with the PR)

## Validation

| Check | Result |
|---|---|
| AST duplicate-key scan of `DEFAULT_CONFIG` | NONE |
| `tests/hermes_cli/test_config.py` + `tests/tools/test_kanban_tools.py` | 307/307 pass |
| E2E (temp HERMES_HOME): `load_config()` carries `auto_subscribe_on_create=True` AND `dispatch_in_gateway=True` + `failure_limit=2` from the merged block | pass |

## Infographic

![kanban-config-dup-key](https://v3b.fal.media/files/b/0aa3d73b/vXpunJAyRDwWvMjAZMpew_4IVMwWTe.png)
