### PR TITLE
fix(tools): bind is_error before the concurrent batch's synthesized branches

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -854,6 +854,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     for i, (tc, name, args, middleware_trace, block_result, blocked_by_guardrail) in enumerate(parsed_calls):
         r = results[i]
         blocked = False
+        # The synthesized branches below (deadline timeout / user-interrupt
+        # cancel / thread-missing) have no tool output to classify, so they
+        # never bind ``is_error`` — but the activity-log suffix at the bottom of
+        # this loop reads it unconditionally. Without this reset the first entry
+        # of a batch that hits one of those branches raises NameError and the
+        # whole batch's results are discarded, and a later entry would inherit
+        # the previous tool's verdict. They are failures by construction; the
+        # real-result branch overwrites this with _detect_tool_failure's answer.
+        is_error = True
         # A worker can finish and write results[i] in the window between the
         # deadline snapshot (timed_out_indices, taken from not_done) and this
         # loop. Prefer that real result over a fabricated timeout message — the

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -118,6 +118,43 @@ def test_concurrent_preflight_interrupt_skips_all(monkeypatch):
     agent._invoke_tool.assert_not_called()
 
 
+def test_concurrent_batch_deadline_still_records_every_tool_result(monkeypatch):
+    """A tool still running at the batch deadline leaves ``results[i] is None``,
+    so the post-execution loop takes one of the synthesized branches. Those
+    branches bind no ``is_error`` — which the activity-log suffix at the bottom
+    of the same loop reads unconditionally. The resulting NameError escapes
+    before any tool_result is appended, so the whole batch is lost, including
+    the siblings that finished successfully.
+
+    The same shape fires on a mid-batch user interrupt; the deadline is the
+    deterministic way to reach it.
+    """
+    monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "0.2")
+    agent = _make_agent(monkeypatch)
+
+    def _invoke(function_name, *args, **kwargs):
+        if function_name == "tool_slow":
+            time.sleep(1.5)
+        return '{"ok": true}'
+
+    agent._invoke_tool = MagicMock(side_effect=_invoke)
+
+    msg = _FakeAssistantMsg(
+        [
+            _FakeToolCall("tool_slow", call_id="tc_slow"),
+            _FakeToolCall("tool_fast", call_id="tc_fast"),
+        ]
+    )
+    messages = []
+
+    agent._execute_tool_calls_concurrent(msg, messages, "test_task")
+
+    # One tool_result per tool_call, even when the first one hit the deadline:
+    # the fast tool's real output must not be discarded along with it.
+    assert len(messages) == 2
+    assert "timed out" in messages[0]["content"]
+
+
 
 
 def test_clear_interrupt_clears_worker_tids(monkeypatch):

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -2,6 +2,7 @@
 
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -31,7 +32,10 @@ def _make_agent(monkeypatch):
         verbose_logging = False
         log_prefix_chars = 200
         _checkpoint_mgr = MagicMock(enabled=False)
-        _subdirectory_hints = MagicMock()
+        # A bare MagicMock returns a mock from check_tool_call, which then gets
+        # concatenated onto the tool result and destroys the text a test wants
+        # to assert on. No hints is the honest default here.
+        _subdirectory_hints = MagicMock(**{"check_tool_call.return_value": ""})
         tool_progress_callback = None
         tool_start_callback = None
         tool_complete_callback = None
@@ -43,6 +47,16 @@ def _make_agent(monkeypatch):
         _current_tool = None
         _last_activity = 0
         _print_fn = print
+        # Every tool goes through the guardrail gate before dispatch. The
+        # pre-existing tests never reach it (they interrupt before any tool
+        # runs); a test that actually dispatches does, so allow everything —
+        # these tests exercise the batch's result loop, not guardrail policy.
+        _tool_guardrails = SimpleNamespace(
+            before_call=lambda name, args: SimpleNamespace(allows_execution=True),
+            after_call=lambda name, args, result, failed=False: SimpleNamespace(
+                action="allow", should_halt=False
+            ),
+        )
         # Worker-thread tracking state mirrored from AIAgent.__init__ so the
         # real interrupt() method can fan out to concurrent-tool workers.
         _active_children: list = []
@@ -76,6 +90,15 @@ def _make_agent(monkeypatch):
     stub._execute_tool_calls_concurrent = _ra.AIAgent._execute_tool_calls_concurrent.__get__(stub)
     stub.interrupt = _ra.AIAgent.interrupt.__get__(stub)
     stub.clear_interrupt = _ra.AIAgent.clear_interrupt.__get__(stub)
+    # Real method rather than a stub: it short-circuits to the result unchanged
+    # for the plain string results these tests produce, and only multimodal
+    # results would need agent state we don't have.
+    stub._tool_result_content_for_active_model = (
+        _ra.AIAgent._tool_result_content_for_active_model.__get__(stub)
+    )
+    stub._append_guardrail_observation = (
+        _ra.AIAgent._append_guardrail_observation.__get__(stub)
+    )
     # /steer injection (added in PR #12116) fires after every concurrent
     # tool batch. Stub it as a no-op — this test exercises interrupt
     # fanout, not steer injection.


### PR DESCRIPTION
## Summary

`execute_tool_calls_concurrent`'s post-execution loop reads `is_error`
unconditionally, but binds it in only one branch. A parallel tool batch whose
**first** entry has no recorded result raises `NameError` before a single
`tool_result` is appended — so the whole batch is discarded, including the
sibling tools that finished successfully, and the failure is reported to the
user as a provider error.

## Problem

In `agent/tool_executor.py`, the loop over `parsed_calls`:

```python
r = results[i]
blocked = False
...
if i in timed_out_indices and r is None:
    ...                       # deadline timeout — binds no is_error
elif r is None:
    ...                       # interrupt cancel / "thread did not return" — binds no is_error
else:
    function_name, function_args, function_result, tool_duration, is_error, blocked, middleware_trace = r
...
_status_suffix = " (error)" if is_error else ""      # read unconditionally
```

An AST scan of that function's own scope confirms it: `is_error` has exactly
**one** `Store` (the `else:` unpack) and is `Load`ed at the suffix line, which
sits at loop-body indentation, outside the `if/elif/else`. (The other
`is_error` in the file belongs to the nested `_run_tool` worker — a different
scope.)

So:

- **First entry synthesized → `NameError: cannot access local variable
  'is_error' where it is not associated with a value`.**
- A synthesized entry that *follows* a real one silently inherits the previous
  tool's verdict, mislabelling the activity log.

The sequential twin, `execute_tool_calls`, is unaffected: its
`_is_error_result` is bound unconditionally via `_detect_tool_failure` before
it is read.

### Reachable two ways, neither exotic

1. **User interrupt while the first call of a parallel batch is still
   running.** This is the common case — the batch launches together and the
   user interrupts *because* it is slow.
2. **The 420s batch deadline** (`_DEFAULT_CONCURRENT_TOOL_TIMEOUT_S`) with the
   first call hung. No user action at all.

Reproducing the loop's exact control flow with the first entry unresolved:

```
main    : NameError: cannot access local variable 'is_error' ...
          -> tool results appended: 0 (both discarded)
patched : OK -> tool results appended: 2 ['tool_a', 'tool_b']
```

### Fallout

The exception escapes `_execute_tool_calls` into the outer handler in
`agent/conversation_loop.py`. `tool_executor` is in neither
`_LOCAL_PROCESSING_MODULES` nor `_API_CALL_MODULES`, so it is classified as a
**provider** failure:

- The user sees `❌ Error during OpenAI-compatible API call #N: local variable
  'is_error' referenced before assignment` — blaming the API for a local bug.
- **Completed tool output is lost.** The crash is upstream of
  `messages.append(tool_message)`, so siblings that already returned never
  reach `messages`; the backfill then records
  `Error executing tool: Error during OpenAI-compatible API call #N: …` for
  every call id.
- **Side effects are re-run.** Those siblings' effects already landed
  (`write_file`, `patch`, `terminal` and `send_message` are all
  parallel-eligible), but the model is told the batch failed with an internal
  error, so it repeats them.
- `/stop` on a parallel batch never produces the intended
  `[Tool execution cancelled — X was skipped due to user interrupt]` markers.

There is no workaround: the concurrent path cannot be disabled, and setting
`HERMES_CONCURRENT_TOOL_TIMEOUT_S=0` removes only the deadline trigger, not the
interrupt one.

## Fix

Bind `is_error = True` at the top of the loop body, alongside
`blocked = False`. The synthesized branches are failures by construction; the
real-result branch overwrites it with `_detect_tool_failure`'s verdict. This
also removes the stale-verdict case, since the flag no longer survives an
iteration.

## Scope

- `agent/tool_executor.py` — one initialization in the post-execution loop.
- `tests/run_agent/test_concurrent_interrupt.py` — regression test.

## Testing

`test_concurrent_batch_deadline_still_records_every_tool_result` drives the
real `_execute_tool_calls_concurrent` with `HERMES_CONCURRENT_TOOL_TIMEOUT_S`
lowered so the first tool is still running at the deadline (the deterministic
way to reach the same branch a mid-batch interrupt reaches), and asserts one
`tool_result` per `tool_call` — i.e. the fast tool's real output is not
discarded with the slow one.

The existing `test_concurrent_preflight_interrupt_skips_all` sets
`_interrupt_requested` *before* the call, which returns at the pre-flight block
and never enters this loop — which is why the regression slipped through. A
repo-wide grep shows no test exercising `timed_out_indices`,
`HERMES_CONCURRENT_TOOL_TIMEOUT_S`, `thread did not return`, or
`_status_suffix`.