### PR TITLE
fix(desktop): invalidate slash cache after hub success

### DIFF
--- a/apps/desktop/src/store/hub-actions.ts
+++ b/apps/desktop/src/store/hub-actions.ts
@@ -105,9 +105,10 @@ async function runHubAction(key: string, kind: HubActionKind, spawn: () => Promi
     // (un)install adds/removes a skill, so its count/rows must update too.
     void queryClient.invalidateQueries({ queryKey: HUB_SOURCES_KEY })
     void queryClient.invalidateQueries({ queryKey: SKILLS_LIST_KEY })
-    // …and the composer's `/` list, which caches the command catalog for an
-    // hour and would otherwise keep offering the skill we just removed.
-    invalidateSlashCompletions()
+
+    if (exitCode === 0) {
+      invalidateSlashCompletions()
+    }
   } catch (err) {
     // A profile switch points the next poll at the new backend, which 404s the
     // old action name — that's an abandonment, not a failure, so swallow it


### PR DESCRIPTION
## Summary

Invalidate the desktop slash-completion cache only after a successful skills-hub action.

Current `main` already preserves the catalog cache when `/` closes and reopens, invalidates it at command-set mutation sources, and keeps the skill-only filter for inline slash references. This patch prevents failed hub actions from invalidating the catalog.

## Verification

- Desktop UI tests: 446 passed across 58 files
- Desktop TypeScript checks: passed
- ESLint on the touched file: passed
- Prettier: passed
- `git diff --check`: passed

## Scope

One Desktop store file. No composer behavior, cache policy, backend API, or generated files changed.
