### PR TITLE
fix(gateway): preserve lifecycle status invariants

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -47,6 +47,7 @@ _WINDOWS_LOCK_OFFSET = 1024 * 1024
 _GATEWAY_RUNNING_PID_CACHE_TTL_SECONDS = 1.0
 _gateway_running_pid_cache_lock = threading.Lock()
 _gateway_running_pid_cache: dict[tuple[str, bool, bool], tuple[float, tuple[Any, ...], Optional[int]]] = {}
+_runtime_status_write_lock = threading.RLock()
 
 logger = logging.getLogger(__name__)
 
@@ -987,41 +988,49 @@ def write_runtime_status(
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
-    payload = _read_json_file(path) or _build_runtime_status_record()
-    current_record = _build_pid_record()
-    payload.setdefault("platforms", {})
-    payload["kind"] = current_record["kind"]
-    payload["pid"] = current_record["pid"]
-    payload["argv"] = current_record["argv"]
-    payload["start_time"] = current_record["start_time"]
-    payload["updated_at"] = _utc_now_iso()
+    # Platform adapters and active-turn accounting update this shared document
+    # from different gateway threads.  The atomic replace below protects
+    # readers from partial JSON, but without a lock the read-modify-write
+    # sequence can still lose a sibling update entirely.
+    with _runtime_status_write_lock:
+        payload = _read_json_file(path) or _build_runtime_status_record()
+        current_record = _build_pid_record()
+        if not isinstance(payload.get("platforms"), dict):
+            payload["platforms"] = {}
+        payload["kind"] = current_record["kind"]
+        payload["pid"] = current_record["pid"]
+        payload["argv"] = current_record["argv"]
+        payload["start_time"] = current_record["start_time"]
+        payload["updated_at"] = _utc_now_iso()
 
-    if gateway_state is not _UNSET:
-        payload["gateway_state"] = gateway_state
-    if exit_reason is not _UNSET:
-        payload["exit_reason"] = exit_reason
-    if restart_requested is not _UNSET:
-        payload["restart_requested"] = bool(restart_requested)
-    if active_agents is not _UNSET:
-        payload["active_agents"] = parse_active_agents(active_agents)
-    if served_profiles is not _UNSET:
-        # Profiles this gateway multiplexes (multi-profile mode). Absent/empty
-        # for a single-profile gateway. Lets `hermes status` show per-profile
-        # coverage without a second probe.
-        payload["served_profiles"] = list(served_profiles or [])
+        if gateway_state is not _UNSET:
+            payload["gateway_state"] = gateway_state
+        if exit_reason is not _UNSET:
+            payload["exit_reason"] = exit_reason
+        if restart_requested is not _UNSET:
+            payload["restart_requested"] = bool(restart_requested)
+        if active_agents is not _UNSET:
+            payload["active_agents"] = parse_active_agents(active_agents)
+        if served_profiles is not _UNSET:
+            # Profiles this gateway multiplexes (multi-profile mode). Absent/empty
+            # for a single-profile gateway. Lets `hermes status` show per-profile
+            # coverage without a second probe.
+            payload["served_profiles"] = list(served_profiles or [])
 
-    if platform is not _UNSET:
-        platform_payload = payload["platforms"].get(platform, {})
-        if platform_state is not _UNSET:
-            platform_payload["state"] = platform_state
-        if error_code is not _UNSET:
-            platform_payload["error_code"] = error_code
-        if error_message is not _UNSET:
-            platform_payload["error_message"] = error_message
-        platform_payload["updated_at"] = _utc_now_iso()
-        payload["platforms"][platform] = platform_payload
+        if platform is not _UNSET:
+            platform_payload = payload["platforms"].get(platform)
+            if not isinstance(platform_payload, dict):
+                platform_payload = {}
+            if platform_state is not _UNSET:
+                platform_payload["state"] = platform_state
+            if error_code is not _UNSET:
+                platform_payload["error_code"] = error_code
+            if error_message is not _UNSET:
+                platform_payload["error_message"] = error_message
+            platform_payload["updated_at"] = _utc_now_iso()
+            payload["platforms"][platform] = platform_payload
 
-    _write_json_file(path, payload)
+        _write_json_file(path, payload)
 
 
 def read_runtime_status(path: Optional[Path] = None) -> Optional[dict[str, Any]]:
@@ -2185,7 +2194,10 @@ def get_running_pid(
         if _record_matches_live_gateway_pid(record, pid):
             return pid
 
-    _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+    # The held OS lock is authoritative even when both identity records are
+    # malformed.  Unlinking an actively locked pathname would let another
+    # process create and lock a replacement inode while the live gateway still
+    # owns the original, defeating the singleton guard.
     if pid_path is None:
         runtime_pid = get_runtime_status_running_pid()
         if runtime_pid is not None:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -359,6 +359,32 @@ class TestGatewayPidState:
         finally:
             status.release_gateway_runtime_lock()
 
+    def test_get_running_pid_never_unlinks_an_actively_locked_identity_file(
+        self, tmp_path, monkeypatch
+    ):
+        """A live OS lock is authoritative even when its JSON is damaged.
+
+        Unlinking an actively locked file creates a new unlocked pathname while
+        the live process still owns the old inode, allowing a second gateway to
+        claim the replacement lock and run concurrently.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        lock_path = tmp_path / "gateway.lock"
+
+        assert status.acquire_gateway_runtime_lock() is True
+        try:
+            status.write_pid_file()
+            pid_path.write_text("damaged", encoding="utf-8")
+            lock_path.write_text("damaged", encoding="utf-8")
+
+            assert status.is_gateway_runtime_lock_active(lock_path) is True
+            assert status.get_running_pid(pid_path) is None
+            assert pid_path.exists()
+            assert lock_path.exists()
+        finally:
+            status.release_gateway_runtime_lock()
+
     def test_gateway_identity_files_use_process_home_not_context_override(
         self, tmp_path, monkeypatch
     ):
@@ -396,6 +422,68 @@ class TestGatewayPidState:
 
 
 class TestGatewayRuntimeStatus:
+    def test_concurrent_platform_updates_preserve_both_records(
+        self, tmp_path, monkeypatch
+    ):
+        """Concurrent read-modify-write updates must not drop sibling state."""
+        import threading
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        worker_count = 24
+        barrier = threading.Barrier(worker_count)
+        errors = []
+
+        def update(platform):
+            try:
+                barrier.wait(timeout=5)
+                status.write_runtime_status(
+                    platform=platform, platform_state="connected"
+                )
+            except Exception as exc:  # pragma: no cover - asserted below
+                errors.append(exc)
+
+        workers = [
+            threading.Thread(target=update, args=(f"platform-{index}",))
+            for index in range(worker_count)
+        ]
+        for worker in workers:
+            worker.start()
+        for worker in workers:
+            worker.join(timeout=5)
+
+        assert not errors
+        assert all(not worker.is_alive() for worker in workers)
+        payload = status.read_runtime_status()
+        assert set(payload["platforms"]) == {
+            f"platform-{index}" for index in range(worker_count)
+        }
+
+    def test_platform_update_recovers_malformed_platform_container(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({"platforms": []}), encoding="utf-8")
+
+        status.write_runtime_status(platform="slack", platform_state="connected")
+
+        payload = status.read_runtime_status()
+        assert payload["platforms"]["slack"]["state"] == "connected"
+
+    def test_platform_update_recovers_malformed_platform_record(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(
+            json.dumps({"platforms": {"slack": "damaged"}}), encoding="utf-8"
+        )
+
+        status.write_runtime_status(platform="slack", platform_state="connected")
+
+        payload = status.read_runtime_status()
+        assert payload["platforms"]["slack"]["state"] == "connected"
+
     def test_write_json_file_uses_atomic_json_write(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         calls = []


### PR DESCRIPTION
## Summary

Fix three independently reproduced gateway lifecycle defects in runtime identity and status persistence:

- preserve actively locked gateway identity paths even when their JSON metadata is damaged;
- serialize the full runtime-status read/modify/write transaction so concurrent adapter updates cannot overwrite one another;
- recover malformed persisted platform containers and records before applying a new update.

## Root-cause evidence

On the parent commit:

- a held OS lock plus damaged PID/lock JSON caused both pathnames to be unlinked while the old inode remained locked, allowing a replacement pathname to be claimed;
- 24 synchronized writers retained only 1 of 24 platform records in 20 independent runs;
- malformed platform state raised AttributeError or TypeError instead of recovering diagnostics.

The OS lock remains authoritative; the change does not weaken singleton enforcement or change external gateway contracts.

## Validation

- scripts/run_tests.sh tests/gateway/test_status.py -q — 138 passed
- broader lifecycle selection — 169 passed
- isolated gateway v0.19.0 restart on port 18701 — health 200
- 20 concurrent duplicate starts — all rejected; owner PID remained unchanged
- git diff --check — clean
