### PR TITLE
fix(docker): keep the venv on PATH in login shells

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -334,6 +334,27 @@ ENV HERMES_LAZY_INSTALL_TARGET=/opt/data/lazy-packages
 # binary by absolute path, so this PATH ordering is transparent to
 # every other consumer.
 ENV PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}"
+
+# ...but a LOGIN shell ignores the inherited PATH and rebuilds it from
+# /etc/profile, which drops everything above. That is not hypothetical: the
+# terminal tool starts its in-container sessions with one —
+# tools/environments/docker.py::_run_bash() runs `docker exec … bash -l -c`
+# whenever login=True, which is how init_session snapshots the environment.
+#
+# Measured in a container built from this image:
+#
+#   bash -c  → python3 -> /opt/hermes/.venv/bin/python3
+#   bash -lc → python3 -> /usr/bin/python3
+#
+# The system interpreter has none of Hermes' dependencies, so the failures that
+# follow look like missing packages rather than a PATH problem.
+#
+# The ordering here deliberately mirrors the ENV above, /opt/hermes/bin first:
+# that is the privilege-drop shim, and it must keep winning PATH resolution in
+# login shells too. Prepending only the venv would silently invert that.
+RUN echo 'export PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}"' \
+      > /etc/profile.d/hermes-venv.sh
+
 RUN mkdir -p /opt/data
 VOLUME [ "/opt/data" ]
 


### PR DESCRIPTION
## Summary

Split out of #33179 as the focused docker-lane change @benbarclay asked for. One `RUN` line; the other two concerns from that PR are addressed separately (see the bottom).

`ENV PATH` puts `/opt/hermes/bin` and the venv ahead of the system paths, and ordinary processes inherit it. A **login** shell does not — it rebuilds `PATH` from `/etc/profile` and drops all of it.

## Answering the question from #33179

> Can you describe the path that hits this? … What's hitting `bash -l` inside the container? (Terminal-tool sessions? `docker exec -it … bash -l`? Something else?)

**Terminal-tool sessions.** `tools/environments/docker.py::_run_bash()` — docstring *"Spawn a bash process inside the Docker container"* — does:

```python
cmd = [self._docker_exe, "exec"]
...
# Only inject -e env args during init_session (login=True).
if login:
    cmd.extend(self._init_env_args)
cmd.extend([self._container_id])
if login:
    cmd.extend(["bash", "-l", "-c", cmd_string])
else:
    cmd.extend(["bash", "-c", cmd_string])
```

`init_session` is the caller that passes `login=True`, so environment snapshotting runs under `bash -l` inside the container. Your read of `main-wrapper.sh` and the s6 `run` scripts was right — none of those are login shells. This is a different entry point.

## Measured, not assumed

In a container built from this image, with no env overrides:

```
$ bash -c  'command -v python3; echo $PATH'
/opt/hermes/.venv/bin/python3
/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:...

$ bash -lc 'command -v python3; echo $PATH'
/usr/bin/python3
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

The login shell loses the venv entirely and `python3` falls back to the system interpreter, which has none of Hermes' dependencies. The failures that follow read as missing packages rather than as a `PATH` problem, which is what makes this slow to diagnose rather than merely broken.

## One deviation from #33179

That PR's line prepended only `/opt/hermes/.venv/bin:/opt/data/.local/bin`, omitting `/opt/hermes/bin`. The `ENV PATH` comment right above explains why that comes first — it is the privilege-drop shim, and it must win resolution. Omitting it would leave login shells with the opposite precedence to every other process. This version mirrors the `ENV` ordering exactly.

## Scope

- `ENV S6_KEEP_ENV=1` from #33179 is **dropped**, as requested. It is a no-op now that #32412 has landed — I verified that separately and posted the measurement on #33148: on a current image the pod environment survives the s6 scrub without it.
- The Mattermost `reply_mode = "auto"` feature from #33179 is #33149, reworked against the current centralized resolver.
