### PR TITLE
feat(cli): hermes record — demonstrate browser workflows, /learn turns them into replayable skills

### DIFF
--- a/agent/learn_prompt.py
+++ b/agent/learn_prompt.py
@@ -24,6 +24,8 @@ gateway ``/learn``, the dashboard "Learn a skill" panel) calls
 
 from __future__ import annotations
 
+import re
+
 # The house-style rules, distilled from AGENTS.md "Skill authoring standards
 # (HARDLINE)" and the hermes-agent-dev new-skill salvage reference. Embedded in
 # the prompt so the agent authors skills the way a maintainer would by hand.
@@ -96,6 +98,47 @@ Quality bar:
   templates in `templates/`."""
 
 
+# Guidance appended when the /learn request points at a `hermes record`
+# recording (a .json under HERMES_HOME/recordings/, or the word "recording").
+# The recording JSON schema is documented in hermes_cli/record.py:
+# {version, started_at, url, steps: [{t, type, selector, text?, value?, url?}]}.
+_RECORDING_GUIDANCE = """\
+RECORDING SOURCE — the request references a `hermes record` browser workflow
+recording. Handle it like this:
+
+- Read the recording JSON with `read_file`. Its shape is
+  {version, started_at, url, steps: [{t, type, selector, text?, value?, url?}]}
+  where step types are: click (selector + text), input (selector + final
+  value), enter (selector), navigate (url), and manual (free-text narration).
+- Reconstruct the workflow in HUMAN terms first: what the user was doing and
+  why, not a selector-by-selector transcript. Collapse noise (stray clicks,
+  focus changes) into the meaningful steps.
+- SECRET PLACEHOLDERS: any step value like `{SECRET:name}` is a masked
+  password or credential — the real value was never recorded. Ask the user
+  which env var or secret reference should supply each placeholder (e.g.
+  `$MYAPP_PASSWORD` from .env or `hermes secrets`). NEVER ask them to paste
+  the secret inline, and NEVER write a literal secret into the skill.
+- Author the skill so its Procedure section REPLAYS the flow with the
+  existing browser tools: `browser_navigate` to the recorded URLs,
+  `browser_snapshot` to find elements, `browser_click` / `browser_type` for
+  the recorded clicks and inputs (using the recorded selectors and text as
+  hints for locating the right elements, since ref IDs change per session),
+  and `browser_press` for Enter submissions. Secret placeholders become
+  env/secret lookups at replay time.
+- Keep the recorded selectors in the skill as location hints, but tell the
+  agent to prefer the live `browser_snapshot` refs when replaying."""
+
+
+def _references_recording(req: str) -> bool:
+    """True when a /learn request points at a `hermes record` recording."""
+    low = (req or "").lower()
+    if "recording" in low:
+        return True
+    # A .json path under a recordings/ directory also counts, even without
+    # the keyword (e.g. "/learn ~/.hermes/recordings/checkout-....json").
+    return bool(re.search(r"recordings[/\\][^\s]+\.json", low))
+
+
 def build_learn_prompt(user_request: str) -> str:
     """Build the agent prompt for an open-ended ``/learn`` request.
 
@@ -115,6 +158,10 @@ def build_learn_prompt(user_request: str) -> str:
             "the steps taken and distill them into a reusable skill"
         )
 
+    recording_block = ""
+    if _references_recording(req):
+        recording_block = f"{_RECORDING_GUIDANCE}\n\n"
+
     return (
         "[/learn] The user wants you to learn a reusable skill from the "
         "request below, and save it.\n\n"
@@ -130,6 +177,7 @@ def build_learn_prompt(user_request: str) -> str:
         "endpoints` means: gather the URL AND honor \"focus on auth, skip "
         "deprecated\" as authoring requirements. Never fetch the first source "
         "and ignore the rest.\n\n"
+        f"{recording_block}"
         "Do this:\n"
         "1. Gather every source the user named, using the tools you already "
         "have — `read_file`/`search_files` for local files or directories, "

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14492,6 +14492,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "model", "pairing", "pets", "plugins", "portal", "profile",
         "project", "proxy",
         "prompt-size",
+        "record",
         "send", "sessions", "setup",
         "skin", "skills", "slack", "status", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "whatsapp-cloud", "chat", "secrets", "security",
@@ -15510,6 +15511,28 @@ def main():
         _register_journey_cli(journey_parser)
     except Exception as _exc:
         logging.getLogger(__name__).debug("journey CLI wiring failed: %s", _exc)
+
+    # =========================================================================
+    # record command — demonstrate a browser workflow, save it as a recording
+    # =========================================================================
+    record_parser = subparsers.add_parser(
+        "record",
+        help="Record a browser workflow over CDP; /learn turns it into a skill",
+        description=(
+            "Attach to your live browser (same CDP endpoint as /browser "
+            "connect), capture clicks, typed values (passwords masked as "
+            "{SECRET:name} placeholders at capture time), Enter presses, and "
+            "navigations until Ctrl-C, then save a recording JSON under "
+            "HERMES_HOME/recordings/. Turn it into a replayable skill with: "
+            'hermes chat "/learn recording <path>".'
+        ),
+    )
+    try:
+        from hermes_cli.record import register_cli as _register_record_cli
+
+        _register_record_cli(record_parser)
+    except Exception as _exc:
+        logging.getLogger(__name__).debug("record CLI wiring failed: %s", _exc)
 
     # =========================================================================
     # memory command  (parser built in hermes_cli/subcommands/memory.py)

--- a/hermes_cli/record.py
+++ b/hermes_cli/record.py
@@ -1,0 +1,632 @@
+"""``hermes record`` — demonstrate a browser workflow, save it as a recording.
+
+Attaches to the user's live Chromium-family browser over CDP (the same
+endpoint resolution as ``/browser connect`` / the ``browser_cdp`` tool),
+injects a small JavaScript event recorder into the active tab, and buffers
+what the user does until Ctrl-C. The result is a recording JSON under
+``HERMES_HOME/recordings/`` that ``/learn`` recognizes as a skill source:
+
+    hermes record --slug checkout-flow
+    ... click around in your browser ...
+    Ctrl-C
+    hermes chat "/learn recording ~/.hermes/recordings/checkout-flow-....json"
+
+Captured event types (documented contract — see ``RECORDER_JS``):
+
+- ``click``     — mouse clicks: CSS selector path, tag name, trimmed text.
+- ``input``     — final value of a field, captured on ``change`` (NOT per
+                  keystroke). Password fields are masked AT CAPTURE TIME in
+                  the page: the value never leaves the browser — the recorder
+                  substitutes a ``{SECRET:<name>}`` placeholder.
+- ``enter``     — Enter-key submissions (selector of the focused element).
+- ``navigate``  — top-frame navigations, observed CDP-side via
+                  ``Page.frameNavigated`` (URL + timestamp).
+
+Recording JSON schema (``RECORDING_VERSION``)::
+
+    {
+      "version": 1,
+      "started_at": "2026-07-26T12:00:00+00:00",
+      "url": "https://example.com/start",
+      "steps": [
+        {"t": 0.0, "type": "click", "selector": "#login > button", "text": "Sign in"},
+        {"t": 1.2, "type": "input", "selector": "input[name=user]", "value": "alice"},
+        {"t": 2.0, "type": "input", "selector": "input[name=pw]", "value": "{SECRET:pw}"},
+        {"t": 2.5, "type": "enter", "selector": "input[name=pw]"},
+        {"t": 3.1, "type": "navigate", "url": "https://example.com/home"}
+      ]
+    }
+
+Secret handling is two-layered: the recorder JS masks ``type=password`` (and
+autocomplete=current-password/new-password) fields in-page, and the Python
+normalizer (:func:`normalize_event`) masks them AGAIN as defense-in-depth, so
+a raw password value can never reach disk even if a page mutates input types
+mid-flight.
+
+If no CDP endpoint is reachable (or the ``websockets`` package is missing),
+``hermes record --manual`` offers a fallback: the user performs the steps in
+any browser and types what they did, one step per line; the same JSON schema
+is written with ``type: "manual"`` steps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import re
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+RECORDING_VERSION = 1
+
+# Event types the recorder emits. Anything else coming over the binding is
+# dropped by normalize_event() — forward-compat with newer recorder JS.
+KNOWN_EVENT_TYPES = ("click", "input", "enter", "navigate", "manual")
+
+# Input types / autocomplete hints whose values must never be stored raw.
+SECRET_INPUT_TYPES = ("password",)
+SECRET_AUTOCOMPLETE = ("current-password", "new-password", "one-time-code", "cc-number", "cc-csc")
+
+_SECRET_PLACEHOLDER_RE = re.compile(r"^\{SECRET:[^{}]*\}$")
+
+
+# ---------------------------------------------------------------------------
+# Recorder JavaScript
+# ---------------------------------------------------------------------------
+# Injected via Page.addScriptToEvaluateOnNewDocument (survives navigations)
+# AND Runtime.evaluate (covers the already-loaded page). Events are shipped
+# to Python through the Runtime.addBinding channel `__hermesRecord`.
+#
+# Captured event types: click, input (on `change`), enter. Navigations are
+# observed CDP-side (Page.frameNavigated), not in-page.
+#
+# PASSWORD MASKING HAPPENS HERE, AT CAPTURE TIME: for type=password (or
+# secret-ish autocomplete) fields the recorder never reads a placeholder from
+# the real value — it emits `{SECRET:<field name>}` instead. The raw value
+# never crosses the CDP wire.
+RECORDER_JS = r"""
+(() => {
+  if (window.__hermesRecorderInstalled) return;
+  window.__hermesRecorderInstalled = true;
+
+  const SECRET_TYPES = ["password"];
+  const SECRET_AUTOCOMPLETE = ["current-password", "new-password", "one-time-code", "cc-number", "cc-csc"];
+
+  const send = (ev) => {
+    try {
+      if (typeof window.__hermesRecord === "function") {
+        window.__hermesRecord(JSON.stringify(ev));
+      }
+    } catch (e) { /* recorder must never break the page */ }
+  };
+
+  // Robust-ish CSS path: prefer id, then unique-enough attribute hooks,
+  // else nth-of-type chain up to the nearest id/body.
+  const cssPath = (el) => {
+    if (!(el instanceof Element)) return "";
+    const parts = [];
+    while (el && el.nodeType === Node.ELEMENT_NODE) {
+      let part = el.nodeName.toLowerCase();
+      if (el.id) {
+        parts.unshift(part + "#" + CSS.escape(el.id));
+        break;
+      }
+      const name = el.getAttribute("name");
+      const testId = el.getAttribute("data-testid") || el.getAttribute("data-test-id");
+      const aria = el.getAttribute("aria-label");
+      if (testId) part += `[data-testid="${testId}"]`;
+      else if (name) part += `[name="${name}"]`;
+      else if (aria) part += `[aria-label="${aria}"]`;
+      else {
+        let sib = el, nth = 1;
+        while ((sib = sib.previousElementSibling)) {
+          if (sib.nodeName === el.nodeName) nth++;
+        }
+        if (nth > 1 || el.nextElementSibling) part += `:nth-of-type(${nth})`;
+      }
+      parts.unshift(part);
+      el = el.parentElement;
+    }
+    return parts.join(" > ");
+  };
+
+  const isSecretField = (el) => {
+    const type = (el.type || "").toLowerCase();
+    const ac = (el.getAttribute && (el.getAttribute("autocomplete") || "") || "").toLowerCase();
+    return SECRET_TYPES.includes(type) || SECRET_AUTOCOMPLETE.includes(ac);
+  };
+
+  const fieldName = (el) =>
+    el.name || el.id || el.getAttribute("aria-label") || el.placeholder || el.type || "secret";
+
+  document.addEventListener("click", (e) => {
+    const el = e.target instanceof Element ? e.target : null;
+    if (!el) return;
+    send({
+      t: Date.now(),
+      type: "click",
+      selector: cssPath(el),
+      tag: el.nodeName.toLowerCase(),
+      text: (el.innerText || el.value || "").trim().slice(0, 120),
+    });
+  }, true);
+
+  // Final value on change — not per keystroke. Passwords masked HERE.
+  document.addEventListener("change", (e) => {
+    const el = e.target;
+    if (!el || typeof el.value === "undefined") return;
+    const secret = isSecretField(el);
+    send({
+      t: Date.now(),
+      type: "input",
+      selector: cssPath(el),
+      tag: (el.nodeName || "").toLowerCase(),
+      inputType: (el.type || "").toLowerCase(),
+      name: fieldName(el),
+      value: secret ? "{SECRET:" + fieldName(el) + "}" : String(el.value).slice(0, 500),
+    });
+  }, true);
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter") return;
+    const el = e.target instanceof Element ? e.target : null;
+    send({
+      t: Date.now(),
+      type: "enter",
+      selector: el ? cssPath(el) : "",
+    });
+  }, true);
+})();
+"""
+
+BINDING_NAME = "__hermesRecord"
+
+
+# ---------------------------------------------------------------------------
+# Pure event-processing functions (unit-tested with synthetic CDP events)
+# ---------------------------------------------------------------------------
+
+
+def is_secret_placeholder(value: Any) -> bool:
+    """True when ``value`` is already a ``{SECRET:name}`` placeholder."""
+    return isinstance(value, str) and bool(_SECRET_PLACEHOLDER_RE.match(value))
+
+
+def mask_value(value: Any, input_type: str = "", autocomplete: str = "", name: str = "") -> str:
+    """Return the storable form of an input value, masking secrets.
+
+    Defense-in-depth mirror of the in-page masking: even if the recorder JS
+    somehow shipped a raw password (page swapped ``type`` after capture,
+    older recorder build, hand-crafted event), the Python side masks again
+    before anything is buffered or written.
+    """
+    text = "" if value is None else str(value)
+    if is_secret_placeholder(text):
+        return text
+    itype = (input_type or "").strip().lower()
+    ac = (autocomplete or "").strip().lower()
+    if itype in SECRET_INPUT_TYPES or ac in SECRET_AUTOCOMPLETE:
+        label = (name or "").strip() or itype or "secret"
+        return "{SECRET:" + label + "}"
+    return text
+
+
+def selector_for(event: Dict[str, Any]) -> str:
+    """Selector with fallbacks: explicit selector → tag[+text hint] → '*'.
+
+    The recorder JS computes a css path, but events can arrive without one
+    (detached nodes, shadow-DOM edges, manual events). Never return ''.
+    """
+    selector = str(event.get("selector") or "").strip()
+    if selector:
+        return selector
+    tag = str(event.get("tag") or "").strip().lower()
+    text = str(event.get("text") or "").strip()
+    if tag and text:
+        return f"{tag}:contains({text[:40]!r})"
+    if tag:
+        return tag
+    return "*"
+
+
+def normalize_event(raw: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Normalize one recorder/CDP event into a recording step, or None to drop.
+
+    Accepts the JSON payloads the recorder JS ships over the CDP binding
+    (click/input/enter), synthesized ``navigate`` events from
+    ``Page.frameNavigated``, and ``manual`` steps. Unknown types and events
+    without a usable payload are dropped.
+    """
+    if not isinstance(raw, dict):
+        return None
+    etype = str(raw.get("type") or "").strip().lower()
+    if etype not in KNOWN_EVENT_TYPES:
+        return None
+
+    try:
+        t = float(raw.get("t") or 0.0)
+    except (TypeError, ValueError):
+        t = 0.0
+
+    step: Dict[str, Any] = {"t": t, "type": etype}
+
+    if etype == "navigate":
+        url = str(raw.get("url") or "").strip()
+        if not url:
+            return None
+        step["url"] = url
+        return step
+
+    if etype == "manual":
+        text = str(raw.get("text") or "").strip()
+        if not text:
+            return None
+        step["text"] = text
+        return step
+
+    step["selector"] = selector_for(raw)
+
+    if etype == "click":
+        text = str(raw.get("text") or "").strip()
+        if text:
+            step["text"] = text
+    elif etype == "input":
+        step["value"] = mask_value(
+            raw.get("value"),
+            input_type=str(raw.get("inputType") or ""),
+            autocomplete=str(raw.get("autocomplete") or ""),
+            name=str(raw.get("name") or ""),
+        )
+    # "enter" carries only t/type/selector.
+    return step
+
+
+def build_recording(
+    url: str,
+    started_at: str,
+    events: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Assemble the recording document: normalize, order, rebase timestamps.
+
+    Steps are sorted by capture time and their ``t`` values rebased so the
+    first step is ``t=0.0`` (seconds, wall-clock ms in → relative s out when
+    the inputs look like epoch-milliseconds).
+    """
+    steps = [s for s in (normalize_event(e) for e in events) if s is not None]
+    steps.sort(key=lambda s: s["t"])
+    if steps:
+        base = steps[0]["t"]
+        for s in steps:
+            rel = s["t"] - base
+            # Epoch-ms deltas → seconds; already-relative small values pass through.
+            s["t"] = round(rel / 1000.0, 3) if base > 1e10 else round(rel, 3)
+    return {
+        "version": RECORDING_VERSION,
+        "started_at": started_at,
+        "url": url,
+        "steps": steps,
+    }
+
+
+def default_recordings_dir() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "recordings"
+
+
+def save_recording(recording: Dict[str, Any], slug: str, recordings_dir: Optional[Path] = None) -> Path:
+    """Write the recording JSON to ``<dir>/<slug>-<ts>.json`` and return the path."""
+    rec_dir = recordings_dir or default_recordings_dir()
+    rec_dir.mkdir(parents=True, exist_ok=True)
+    safe_slug = re.sub(r"[^a-z0-9-]+", "-", (slug or "recording").strip().lower()).strip("-") or "recording"
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    path = rec_dir / f"{safe_slug}-{ts}.json"
+    path.write_text(json.dumps(recording, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return path
+
+
+def list_recordings(recordings_dir: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """List saved recordings (newest first) with step counts and start URLs."""
+    rec_dir = recordings_dir or default_recordings_dir()
+    if not rec_dir.is_dir():
+        return []
+    out: List[Dict[str, Any]] = []
+    for path in sorted(rec_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True):
+        entry: Dict[str, Any] = {"path": str(path), "name": path.name}
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+            entry["url"] = doc.get("url", "")
+            entry["started_at"] = doc.get("started_at", "")
+            entry["steps"] = len(doc.get("steps", []) or [])
+        except Exception:
+            entry["error"] = "unreadable"
+        out.append(entry)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CDP recording session
+# ---------------------------------------------------------------------------
+
+
+def _resolve_cdp_endpoint() -> str:
+    """Same endpoint resolution as the ``browser_cdp`` tool (/browser connect)."""
+    try:
+        from tools.browser_cdp_tool import _resolve_cdp_endpoint as _resolve
+
+        return _resolve()
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.debug("record: CDP endpoint resolution failed: %s", exc)
+        return ""
+
+
+async def _record_over_cdp(
+    ws_url: str,
+    events: List[Dict[str, Any]],
+    stop: "threading.Event",
+    state: Dict[str, Any],
+) -> None:
+    """Attach to the active page target, inject the recorder, buffer events.
+
+    Runs until ``stop`` is set (Ctrl-C in the foreground thread). All raw
+    payloads are appended to ``events``; normalization happens at save time
+    via :func:`build_recording`.
+    """
+    import websockets
+
+    async with websockets.connect(
+        ws_url, max_size=None, open_timeout=15, close_timeout=5, ping_interval=None
+    ) as ws:
+        next_id = [0]
+
+        async def send(method: str, params: Dict[str, Any] | None = None, session_id: str | None = None) -> int:
+            next_id[0] += 1
+            msg: Dict[str, Any] = {"id": next_id[0], "method": method, "params": params or {}}
+            if session_id:
+                msg["sessionId"] = session_id
+            await ws.send(json.dumps(msg))
+            return next_id[0]
+
+        async def wait_result(call_id: int, timeout: float = 15.0) -> Dict[str, Any]:
+            deadline = asyncio.get_running_loop().time() + timeout
+            while True:
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    raise TimeoutError(f"CDP call {call_id} timed out")
+                msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=remaining))
+                if msg.get("id") == call_id:
+                    if "error" in msg:
+                        raise RuntimeError(f"CDP error: {msg['error']}")
+                    return msg.get("result", {})
+                _handle_event(msg, events, state)
+
+        # 1. Find the active page target.
+        targets = (await wait_result(await send("Target.getTargets"))).get("targetInfos", [])
+        page = next(
+            (t for t in targets if t.get("type") == "page" and not str(t.get("url", "")).startswith("devtools://")),
+            None,
+        )
+        if page is None:
+            raise RuntimeError("No page target found — open a tab in the connected browser first.")
+        state["url"] = page.get("url", "")
+
+        # 2. Attach (flattened session).
+        attach = await wait_result(
+            await send("Target.attachToTarget", {"targetId": page["targetId"], "flatten": True})
+        )
+        sid = attach.get("sessionId")
+        if not sid:
+            raise RuntimeError("Target.attachToTarget did not return a sessionId")
+        state["session_id"] = sid
+
+        # 3. Enable domains, register the binding, inject the recorder.
+        await wait_result(await send("Runtime.enable", session_id=sid))
+        await wait_result(await send("Page.enable", session_id=sid))
+        await wait_result(await send("Runtime.addBinding", {"name": BINDING_NAME}, session_id=sid))
+        await wait_result(
+            await send("Page.addScriptToEvaluateOnNewDocument", {"source": RECORDER_JS}, session_id=sid)
+        )
+        await wait_result(await send("Runtime.evaluate", {"expression": RECORDER_JS}, session_id=sid))
+        state["ready"] = True
+
+        # 4. Buffer events until told to stop.
+        while not stop.is_set():
+            try:
+                msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=0.5))
+            except asyncio.TimeoutError:
+                continue
+            _handle_event(msg, events, state)
+
+
+def _handle_event(msg: Dict[str, Any], events: List[Dict[str, Any]], state: Dict[str, Any]) -> None:
+    """Route one CDP protocol message into the raw event buffer.
+
+    - ``Runtime.bindingCalled`` for our binding → parsed recorder payload.
+    - ``Page.frameNavigated`` (top frame only) → synthesized navigate event.
+    Anything else is ignored. Pure function of its inputs; unit-testable
+    with synthetic CDP messages.
+    """
+    method = msg.get("method")
+    params = msg.get("params") or {}
+    if method == "Runtime.bindingCalled" and params.get("name") == BINDING_NAME:
+        try:
+            payload = json.loads(params.get("payload") or "{}")
+        except (json.JSONDecodeError, TypeError):
+            return
+        if isinstance(payload, dict):
+            events.append(payload)
+    elif method == "Page.frameNavigated":
+        frame = params.get("frame") or {}
+        if frame.get("parentId"):
+            return  # subframe — only top-level navigations become steps
+        url = str(frame.get("url") or "").strip()
+        if not url or url.startswith(("about:", "chrome://", "devtools://")):
+            return
+        events.append({"t": time.time() * 1000.0, "type": "navigate", "url": url})
+
+
+# ---------------------------------------------------------------------------
+# CLI commands
+# ---------------------------------------------------------------------------
+
+
+def _cmd_record(args: argparse.Namespace) -> int:
+    if getattr(args, "list", False):
+        return _cmd_list(args)
+    if getattr(args, "manual", False):
+        return _run_manual(args)
+    return _run_cdp(args)
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    recs = list_recordings()
+    if not recs:
+        print("No recordings yet. Start one with: hermes record --slug my-flow")
+        return 0
+    print(f"Recordings in {default_recordings_dir()}:\n")
+    for r in recs:
+        if "error" in r:
+            print(f"  {r['name']}  (unreadable)")
+        else:
+            print(f"  {r['name']}  — {r['steps']} steps  {r.get('url', '')}")
+    print('\nTurn one into a skill:  hermes chat "/learn recording <path>"')
+    return 0
+
+
+def _run_manual(args: argparse.Namespace) -> int:
+    """Manual fallback: user narrates their steps, one per line."""
+    print("Manual recording mode — perform your workflow in any browser and")
+    print("describe each step here, one per line. Empty line or Ctrl-D to finish.\n")
+    started_at = datetime.now(timezone.utc).isoformat()
+    url = input("Start URL (optional): ").strip()
+    events: List[Dict[str, Any]] = []
+    step_no = 0
+    while True:
+        try:
+            line = input(f"step {step_no + 1}> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if not line:
+            break
+        step_no += 1
+        events.append({"t": float(step_no), "type": "manual", "text": line})
+
+    if not events:
+        print("Nothing recorded.")
+        return 1
+    recording = build_recording(url, started_at, events)
+    path = save_recording(recording, getattr(args, "slug", None) or "manual")
+    print(f"\nSaved {len(recording['steps'])} steps -> {path}")
+    print(f'Next: hermes chat "/learn recording {path}"')
+    return 0
+
+
+def _run_cdp(args: argparse.Namespace) -> int:
+    try:
+        import websockets  # noqa: F401
+    except ImportError:
+        print("The 'websockets' package is required for CDP recording.")
+        print("Install it (pip install websockets) or use: hermes record --manual")
+        return 1
+
+    ws_url = _resolve_cdp_endpoint()
+    if not ws_url:
+        print("No CDP endpoint available. Attach to your browser first:")
+        print("  hermes chat, then /browser connect   (or set browser.cdp_url in config.yaml)")
+        print("Or record without CDP:  hermes record --manual")
+        return 1
+    if not ws_url.startswith(("ws://", "wss://")):
+        print(f"CDP endpoint is not a WebSocket URL: {ws_url!r}")
+        return 1
+
+    events: List[Dict[str, Any]] = []
+    state: Dict[str, Any] = {"url": "", "ready": False}
+    stop = threading.Event()
+    error: List[BaseException] = []
+    started_at = datetime.now(timezone.utc).isoformat()
+
+    def _runner() -> None:
+        try:
+            asyncio.run(_record_over_cdp(ws_url, events, stop, state))
+        except BaseException as exc:  # noqa: BLE001 — surfaced below
+            error.append(exc)
+
+    thread = threading.Thread(target=_runner, daemon=True)
+    thread.start()
+
+    # Wait for the recorder to be injected (or fail fast).
+    for _ in range(100):
+        if state.get("ready") or error:
+            break
+        time.sleep(0.1)
+    if error:
+        print(f"Could not start CDP recorder: {error[0]}")
+        print("Fallback: hermes record --manual")
+        return 1
+    if not state.get("ready"):
+        print("Timed out attaching the recorder. Is the browser still running?")
+        return 1
+
+    print(f"● Recording {state.get('url') or 'the active tab'}")
+    print("  Clicks, typed values (passwords masked), Enter presses, and")
+    print("  navigations are being captured. Press Ctrl-C to stop and save.\n")
+
+    try:
+        while thread.is_alive():
+            time.sleep(0.25)
+            if error:
+                break
+    except KeyboardInterrupt:
+        pass
+    finally:
+        stop.set()
+        thread.join(timeout=5)
+
+    if error and not events:
+        print(f"\nRecorder stopped with an error and captured nothing: {error[0]}")
+        return 1
+
+    if not events:
+        print("\nNo events captured — nothing to save.")
+        return 1
+
+    recording = build_recording(state.get("url", ""), started_at, events)
+    path = save_recording(recording, getattr(args, "slug", None) or "recording")
+    print(f"\nSaved {len(recording['steps'])} steps -> {path}")
+    print(f'Next: hermes chat "/learn recording {path}"')
+    return 0
+
+
+def register_cli(parent: argparse.ArgumentParser) -> None:
+    parent.add_argument(
+        "--slug",
+        default=None,
+        help="Name stem for the recording file (default: 'recording').",
+    )
+    parent.add_argument(
+        "--manual",
+        action="store_true",
+        help="Skip CDP: perform the steps yourself and narrate them, one per line.",
+    )
+    parent.add_argument(
+        "--list",
+        action="store_true",
+        help="List saved recordings and exit.",
+    )
+    parent.set_defaults(func=_cmd_record)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _p = argparse.ArgumentParser(prog="hermes record")
+    register_cli(_p)
+    _a = _p.parse_args()
+    sys.exit(_a.func(_a))

--- a/tests/hermes_cli/test_record.py
+++ b/tests/hermes_cli/test_record.py
@@ -1,0 +1,398 @@
+"""Tests for ``hermes record`` — browser workflow recording.
+
+All CDP I/O is mocked or bypassed: these tests exercise the pure Python
+event-processing functions (normalize_event, mask_value, selector_for,
+build_recording, _handle_event) with synthetic CDP events, the recording
+JSON schema shape, save/list round-trips, argparse wiring, and the /learn
+recording-source recognition. No live browser anywhere.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+from hermes_cli.record import (
+    BINDING_NAME,
+    RECORDER_JS,
+    RECORDING_VERSION,
+    _handle_event,
+    build_recording,
+    is_secret_placeholder,
+    list_recordings,
+    mask_value,
+    normalize_event,
+    register_cli,
+    save_recording,
+    selector_for,
+)
+
+
+# ---------------------------------------------------------------------------
+# Secret masking — python-side defense in depth
+# ---------------------------------------------------------------------------
+
+
+class TestMaskValue:
+    def test_password_input_type_is_masked(self):
+        assert mask_value("hunter2", input_type="password", name="pw") == "{SECRET:pw}"
+
+    def test_password_masking_never_contains_the_raw_value(self):
+        masked = mask_value("hunter2", input_type="password", name="login-password")
+        assert "hunter2" not in masked
+
+    def test_secretish_autocomplete_is_masked(self):
+        for ac in ("current-password", "new-password", "one-time-code"):
+            assert mask_value("s3cr3t", autocomplete=ac, name="f") == "{SECRET:f}"
+
+    def test_plain_text_value_passes_through(self):
+        assert mask_value("alice@example.com", input_type="email", name="user") == "alice@example.com"
+
+    def test_already_masked_placeholder_is_preserved_verbatim(self):
+        # The recorder JS masks in-page; the python side must not double-wrap.
+        assert mask_value("{SECRET:pw}", input_type="password", name="pw") == "{SECRET:pw}"
+
+    def test_mask_falls_back_to_type_when_field_is_nameless(self):
+        assert mask_value("x", input_type="password", name="") == "{SECRET:password}"
+
+    def test_is_secret_placeholder(self):
+        assert is_secret_placeholder("{SECRET:pw}")
+        assert not is_secret_placeholder("hunter2")
+        assert not is_secret_placeholder(None)
+
+
+# ---------------------------------------------------------------------------
+# Selector fallback
+# ---------------------------------------------------------------------------
+
+
+class TestSelectorFallback:
+    def test_explicit_selector_wins(self):
+        assert selector_for({"selector": "#login > button", "tag": "button"}) == "#login > button"
+
+    def test_falls_back_to_tag_and_text(self):
+        sel = selector_for({"selector": "", "tag": "button", "text": "Sign in"})
+        assert "button" in sel and "Sign in" in sel
+
+    def test_falls_back_to_bare_tag(self):
+        assert selector_for({"tag": "input"}) == "input"
+
+    def test_never_returns_empty(self):
+        assert selector_for({}) == "*"
+
+
+# ---------------------------------------------------------------------------
+# Event normalization with synthetic CDP-shipped payloads
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeEvent:
+    def test_click_event(self):
+        step = normalize_event(
+            {"t": 1000, "type": "click", "selector": "#buy", "tag": "button", "text": "Buy now"}
+        )
+        assert step == {"t": 1000.0, "type": "click", "selector": "#buy", "text": "Buy now"}
+
+    def test_input_event_masks_password(self):
+        step = normalize_event(
+            {
+                "t": 2000,
+                "type": "input",
+                "selector": "input[name=pw]",
+                "inputType": "password",
+                "name": "pw",
+                "value": "hunter2",  # simulates a recorder that failed to mask
+            }
+        )
+        assert step["value"] == "{SECRET:pw}"
+        assert "hunter2" not in json.dumps(step)
+
+    def test_input_event_keeps_plain_value(self):
+        step = normalize_event(
+            {"t": 3, "type": "input", "selector": "#user", "inputType": "text", "value": "alice"}
+        )
+        assert step["value"] == "alice"
+
+    def test_enter_event(self):
+        step = normalize_event({"t": 5, "type": "enter", "selector": "#pw"})
+        assert step == {"t": 5.0, "type": "enter", "selector": "#pw"}
+
+    def test_navigate_event(self):
+        step = normalize_event({"t": 9, "type": "navigate", "url": "https://x.test/home"})
+        assert step == {"t": 9.0, "type": "navigate", "url": "https://x.test/home"}
+
+    def test_navigate_without_url_is_dropped(self):
+        assert normalize_event({"t": 9, "type": "navigate"}) is None
+
+    def test_manual_event(self):
+        step = normalize_event({"t": 1, "type": "manual", "text": "clicked the login button"})
+        assert step == {"t": 1.0, "type": "manual", "text": "clicked the login button"}
+
+    def test_unknown_type_is_dropped(self):
+        assert normalize_event({"t": 1, "type": "scroll"}) is None
+
+    def test_non_dict_is_dropped(self):
+        assert normalize_event("nope") is None
+        assert normalize_event(None) is None
+
+    def test_bad_timestamp_defaults_to_zero(self):
+        assert normalize_event({"t": "junk", "type": "enter", "selector": "#a"})["t"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Recording assembly — ordering, rebasing, schema shape
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRecording:
+    def _events(self):
+        # Deliberately out of order; epoch-ms timestamps like the recorder ships.
+        return [
+            {"t": 1753500002000, "type": "input", "selector": "#user", "inputType": "text", "value": "alice"},
+            {"t": 1753500001000, "type": "click", "selector": "#login", "text": "Login"},
+            {"t": 1753500003000, "type": "navigate", "url": "https://x.test/home"},
+            {"t": 1753500002500, "type": "bogus"},  # dropped
+        ]
+
+    def test_schema_shape(self):
+        rec = build_recording("https://x.test/", "2026-07-26T00:00:00+00:00", self._events())
+        assert set(rec.keys()) == {"version", "started_at", "url", "steps"}
+        assert rec["version"] == RECORDING_VERSION
+        assert rec["url"] == "https://x.test/"
+        assert rec["started_at"] == "2026-07-26T00:00:00+00:00"
+        assert isinstance(rec["steps"], list)
+        for step in rec["steps"]:
+            assert "t" in step and "type" in step
+
+    def test_steps_are_ordered_by_time_and_rebased(self):
+        rec = build_recording("https://x.test/", "now", self._events())
+        types = [s["type"] for s in rec["steps"]]
+        assert types == ["click", "input", "navigate"]
+        ts = [s["t"] for s in rec["steps"]]
+        assert ts[0] == 0.0
+        assert ts == sorted(ts)
+        # epoch-ms deltas rebased into seconds
+        assert ts[1] == pytest.approx(1.0)
+        assert ts[2] == pytest.approx(2.0)
+
+    def test_unknown_events_are_dropped_not_fatal(self):
+        rec = build_recording("u", "s", self._events())
+        assert len(rec["steps"]) == 3
+
+    def test_empty_events_yield_empty_steps(self):
+        rec = build_recording("u", "s", [])
+        assert rec["steps"] == []
+
+    def test_recording_json_never_contains_raw_password(self):
+        events = self._events() + [
+            {"t": 1753500004000, "type": "input", "selector": "#pw",
+             "inputType": "password", "name": "pw", "value": "raw-secret-value"},
+        ]
+        rec = build_recording("u", "s", events)
+        assert "raw-secret-value" not in json.dumps(rec)
+        assert any(s.get("value") == "{SECRET:pw}" for s in rec["steps"])
+
+
+# ---------------------------------------------------------------------------
+# CDP protocol message routing (synthetic CDP messages, no websocket)
+# ---------------------------------------------------------------------------
+
+
+class TestHandleEvent:
+    def test_binding_called_payload_is_buffered(self):
+        events, state = [], {}
+        payload = {"t": 1, "type": "click", "selector": "#a"}
+        _handle_event(
+            {"method": "Runtime.bindingCalled",
+             "params": {"name": BINDING_NAME, "payload": json.dumps(payload)}},
+            events, state,
+        )
+        assert events == [payload]
+
+    def test_other_bindings_are_ignored(self):
+        events = []
+        _handle_event(
+            {"method": "Runtime.bindingCalled",
+             "params": {"name": "someOtherBinding", "payload": "{}"}},
+            events, {},
+        )
+        assert events == []
+
+    def test_malformed_binding_payload_is_ignored(self):
+        events = []
+        _handle_event(
+            {"method": "Runtime.bindingCalled",
+             "params": {"name": BINDING_NAME, "payload": "{not json"}},
+            events, {},
+        )
+        assert events == []
+
+    def test_top_frame_navigation_becomes_navigate_event(self):
+        events = []
+        _handle_event(
+            {"method": "Page.frameNavigated",
+             "params": {"frame": {"url": "https://x.test/next"}}},
+            events, {},
+        )
+        assert len(events) == 1
+        assert events[0]["type"] == "navigate"
+        assert events[0]["url"] == "https://x.test/next"
+
+    def test_subframe_navigation_is_ignored(self):
+        events = []
+        _handle_event(
+            {"method": "Page.frameNavigated",
+             "params": {"frame": {"url": "https://ads.test/", "parentId": "F2"}}},
+            events, {},
+        )
+        assert events == []
+
+    def test_internal_urls_are_ignored(self):
+        events = []
+        for url in ("about:blank", "chrome://newtab", "devtools://x"):
+            _handle_event(
+                {"method": "Page.frameNavigated", "params": {"frame": {"url": url}}},
+                events, {},
+            )
+        assert events == []
+
+    def test_unrelated_methods_are_ignored(self):
+        events = []
+        _handle_event({"method": "Network.requestWillBeSent", "params": {}}, events, {})
+        assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Recorder JS contract — masking lives in the page too
+# ---------------------------------------------------------------------------
+
+
+class TestRecorderJS:
+    def test_masks_passwords_at_capture_time(self):
+        # The load-bearing property: the placeholder is built in-page and the
+        # raw value is never read for secret fields.
+        assert "password" in RECORDER_JS
+        assert "{SECRET:" in RECORDER_JS
+
+    def test_covers_secretish_autocomplete(self):
+        for ac in ("current-password", "new-password", "one-time-code"):
+            assert ac in RECORDER_JS
+
+    def test_documented_event_types_are_emitted(self):
+        for etype in ('"click"', '"input"', '"enter"'):
+            assert f"type: {etype}" in RECORDER_JS
+
+    def test_uses_the_cdp_binding_channel(self):
+        assert BINDING_NAME in RECORDER_JS
+
+    def test_captures_final_value_on_change_not_keystrokes(self):
+        assert '"change"' in RECORDER_JS
+        assert '"keypress"' not in RECORDER_JS
+
+
+# ---------------------------------------------------------------------------
+# Save / list round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSaveAndList:
+    def test_save_and_list_roundtrip(self, tmp_path):
+        rec = build_recording(
+            "https://x.test/", "2026-07-26T00:00:00+00:00",
+            [{"t": 1, "type": "click", "selector": "#a", "text": "Go"}],
+        )
+        path = save_recording(rec, "My Flow!!", recordings_dir=tmp_path)
+        assert path.exists()
+        assert path.name.startswith("my-flow-")
+        assert json.loads(path.read_text(encoding="utf-8")) == rec
+
+        listed = list_recordings(recordings_dir=tmp_path)
+        assert len(listed) == 1
+        assert listed[0]["steps"] == 1
+        assert listed[0]["url"] == "https://x.test/"
+
+    def test_list_empty_dir(self, tmp_path):
+        assert list_recordings(recordings_dir=tmp_path / "nope") == []
+
+    def test_slug_is_sanitized(self, tmp_path):
+        path = save_recording(build_recording("u", "s", []), "../../etc/passwd", recordings_dir=tmp_path)
+        assert path.parent == tmp_path
+        assert "/" not in path.name.replace(path.suffix, "").replace("-", "")
+
+
+# ---------------------------------------------------------------------------
+# argparse wiring
+# ---------------------------------------------------------------------------
+
+
+class TestArgparseWiring:
+    def _parser(self):
+        p = argparse.ArgumentParser(prog="hermes record")
+        register_cli(p)
+        return p
+
+    def test_defaults(self):
+        args = self._parser().parse_args([])
+        assert args.slug is None
+        assert args.manual is False
+        assert args.list is False
+        assert callable(args.func)
+
+    def test_flags_parse(self):
+        args = self._parser().parse_args(["--slug", "checkout", "--manual"])
+        assert args.slug == "checkout"
+        assert args.manual is True
+
+    def test_list_flag(self):
+        assert self._parser().parse_args(["--list"]).list is True
+
+    def test_record_is_a_known_builtin_subcommand(self):
+        from hermes_cli.main import _BUILTIN_SUBCOMMANDS
+
+        assert "record" in _BUILTIN_SUBCOMMANDS
+
+
+# ---------------------------------------------------------------------------
+# /learn recognizes recordings as a source
+# ---------------------------------------------------------------------------
+
+
+class TestLearnRecordingIntegration:
+    def test_recording_path_triggers_replay_guidance(self):
+        from agent.learn_prompt import build_learn_prompt
+
+        prompt = build_learn_prompt("recording ~/.hermes/recordings/checkout-20260726.json")
+        low = prompt.lower()
+        # Replay guidance names the browser tools that re-drive the flow.
+        for tool in ("browser_navigate", "browser_click", "browser_type", "browser_press"):
+            assert tool in prompt
+        # Secret placeholder guidance: ask for env/secret refs, never inline.
+        assert "{SECRET:" in prompt
+        assert "never" in low and "inline" in low
+        assert "replay" in low
+
+    def test_bare_recordings_json_path_is_recognized_without_keyword(self):
+        from agent.learn_prompt import build_learn_prompt, _RECORDING_GUIDANCE
+
+        prompt = build_learn_prompt("/home/me/.hermes/recordings/login-flow-20260726.json")
+        assert _RECORDING_GUIDANCE in prompt
+
+    def test_non_recording_requests_do_not_get_the_block(self):
+        from agent.learn_prompt import build_learn_prompt, _RECORDING_GUIDANCE
+
+        assert _RECORDING_GUIDANCE not in build_learn_prompt("https://api.example.com/docs")
+        assert _RECORDING_GUIDANCE not in build_learn_prompt("")
+
+    def test_recording_guidance_documents_the_schema(self):
+        from agent.learn_prompt import _RECORDING_GUIDANCE
+
+        for key in ("version", "started_at", "url", "steps"):
+            assert key in _RECORDING_GUIDANCE
+
+    def test_standards_still_travel_with_recording_prompts(self):
+        from agent.learn_prompt import build_learn_prompt, _AUTHORING_STANDARDS
+
+        prompt = build_learn_prompt("recording foo.json")
+        assert _AUTHORING_STANDARDS in prompt

--- a/website/docs/user-guide/features/workflow-recording.md
+++ b/website/docs/user-guide/features/workflow-recording.md
@@ -1,0 +1,94 @@
+---
+title: Workflow Recording
+description: Demonstrate a browser workflow once with hermes record, then turn the recording into a replayable skill with /learn.
+sidebar_label: Workflow Recording
+sidebar_position: 17
+---
+
+# Workflow Recording
+
+`hermes record` lets you *demonstrate* a browser workflow instead of describing it. It attaches to your own browser over CDP (the same live-attach as [`/browser connect`](./browser.md)), watches what you do — clicks, typed values, Enter presses, navigations — and saves the demonstration as a recording JSON. `/learn` then recognizes that recording as a source and authors a skill whose Procedure replays the flow with the standard browser tools.
+
+The loop is: **record → learn → replay**.
+
+## Record
+
+1. Make sure Hermes can reach your browser — run `/browser connect` in a chat once (or set `browser.cdp_url` in `config.yaml`).
+2. Start recording:
+
+```bash
+hermes record --slug checkout-flow
+```
+
+3. Perform the workflow in your browser.
+4. Press `Ctrl-C` to stop. The recording is written to `~/.hermes/recordings/checkout-flow-<timestamp>.json`.
+
+What gets captured:
+
+| Event | What is stored |
+|---|---|
+| `click` | CSS selector path, tag, trimmed visible text |
+| `input` | Selector and the **final** field value (on `change`, not per keystroke) |
+| `enter` | Selector of the focused element when Enter was pressed |
+| `navigate` | Top-frame URL changes |
+
+### Secret masking
+
+Password fields (`type=password`, plus `current-password` / `new-password` / `one-time-code` / credit-card autocomplete hints) are masked **at capture time, inside the page**: the recorder never reads the real value — it stores a `{SECRET:<field name>}` placeholder instead. The Python side masks again before writing to disk as defense-in-depth, so a raw credential can never end up in a recording file.
+
+### Recording format
+
+```json
+{
+  "version": 1,
+  "started_at": "2026-07-26T12:00:00+00:00",
+  "url": "https://shop.example.com/login",
+  "steps": [
+    {"t": 0.0, "type": "click", "selector": "button#login", "text": "Sign in"},
+    {"t": 1.2, "type": "input", "selector": "input[name=\"user\"]", "value": "alice"},
+    {"t": 2.0, "type": "input", "selector": "input[name=\"pw\"]", "value": "{SECRET:pw}"},
+    {"t": 2.5, "type": "enter", "selector": "input[name=\"pw\"]"},
+    {"t": 3.1, "type": "navigate", "url": "https://shop.example.com/home"}
+  ]
+}
+```
+
+`t` is seconds relative to the first step.
+
+### Other modes
+
+```bash
+hermes record --list      # list saved recordings
+hermes record --manual    # no CDP: narrate your steps one per line
+```
+
+`--manual` is the fallback when no CDP endpoint is available (or you performed the flow in a non-Chromium browser): you type what you did, one step per line, and the same recording format is written with `type: "manual"` steps.
+
+## Learn
+
+Point `/learn` at the recording:
+
+```bash
+hermes chat "/learn recording ~/.hermes/recordings/checkout-flow-20260726-120000.json"
+```
+
+`/learn` recognizes recording sources (a `.json` under `recordings/`, or the word "recording") and adds replay-specific guidance: the agent reads the JSON, reconstructs the workflow in human terms, and authors a skill whose Procedure replays the flow via `browser_navigate`, `browser_snapshot`, `browser_click`, `browser_type`, and `browser_press`.
+
+For every `{SECRET:*}` placeholder, the agent asks which env var or secret reference should supply the value at replay time (e.g. `$SHOP_PASSWORD` from `.env` or `hermes secrets`). Secrets are never asked for inline and never written into the skill.
+
+## Replay
+
+Once the skill is saved, replay is just using it:
+
+```
+you> log into the shop and check my order status
+```
+
+The agent loads the learned skill and re-drives the browser through the recorded flow — using the live page snapshot to locate elements, with the recorded selectors and text as hints, and pulling credentials from the secret references you configured.
+
+## Pitfalls
+
+- **Recording captures the active tab.** Switch to the tab you want to demonstrate *before* starting `hermes record`.
+- **Selectors are hints, not gospel.** Sites change their DOM; learned skills tell the agent to prefer live `browser_snapshot` refs over recorded selectors when replaying.
+- **Values are captured on field change.** If you never blur/commit a field before stopping, its value may be missing — press Tab or Enter before `Ctrl-C`.
+- **Non-password secrets aren't auto-masked.** API keys typed into plain text fields are stored as-is; review the recording JSON before sharing it, or use `--manual` for sensitive flows.


### PR DESCRIPTION
## Summary

`hermes record` lets a user demonstrate a browser workflow once — clicks, form fills, navigations — and `/learn` turns the recording into a replayable skill. Demonstrate→automation is shipped by both competitor products (Claude-in-Chrome "workflow recording", ChatGPT "Record & Replay"); Hermes' `/learn` was describe-only.

## How it works

- `hermes record [--slug s]` attaches to the user's live Chromium over CDP (same endpoint resolution as `/browser connect`), injects a small in-page event recorder, and buffers events until Ctrl-C. Saves `HERMES_HOME/recordings/<slug>-<ts>.json`.
- Captured: `click` (selector path + text), `input` (final value on change — **not** per keystroke), `enter`, `navigate`. 
- **Secret masking is two-layered and capture-time**: the in-page JS substitutes `{SECRET:<name>}` for `type=password` / sensitive-autocomplete fields (value never leaves the browser), and the Python normalizer masks again as defense-in-depth. Placeholders are resolved at replay time via the user's env/secret refs, never inlined.
- `/learn recording <path>` is a recognized source: the prompt builder instructs the agent to read the JSON, reconstruct the workflow, ask the user to wire `{SECRET:*}` placeholders, and author a skill that replays via the existing `browser_*` tools.
- `hermes record --manual` fallback (no CDP / no websockets): type what you did step-by-step, same schema.
- `hermes record --list` shows saved recordings.

## Changes

- `hermes_cli/record.py` (632 lines: recorder JS, CDP loop, pure normalize/mask/build functions, argparse)
- `agent/learn_prompt.py`: recording-source recognition (+48)
- `hermes_cli/main.py`: `record` subcommand wiring
- `website/docs/user-guide/features/workflow-recording.md`
- `tests/hermes_cli/test_record.py` (50 tests — synthetic CDP events against the pure normalizers: masking, selector fallback, ordering, schema, /learn recognition; no live browser)

## Validation

| | Result |
|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_record.py` | 50 passed, 0 failed |
| Password value never reaches disk (asserted both layers) | pass |

Part of the Claude Cowork / ChatGPT Work capability-parity wave.

## Infographic

![hermes record](https://v3b.fal.media/files/b/0aa3d7aa/OG_UqEgThmkAAVuJMMJLr_7Act7Imt.png)
