### PR TITLE
fix(slack): serialize status updates and isolate workspace state

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -975,12 +975,20 @@ class SlackAdapter(BasePlatformAdapter):
         self._agent_view_contexts: Dict[Tuple[str, str], Dict[str, str]] = {}
         self._AGENT_VIEW_CONTEXTS_MAX = 5000
         # Status-bubble dedup (issue #30045, extended to Slack): remember the
-        # message ts of the last status bubble per (channel, thread, status
-        # key) so repeated progress callbacks (compression retries, fallback
+        # message ts of the last status bubble per (workspace, channel, thread,
+        # status key) so repeated progress callbacks (compression retries, fallback
         # switches, ...) edit ONE message in place instead of appending a new
         # bubble per event — long retry loops used to spam threads with
         # dozens of out-of-order status messages.
-        self._status_message_ids: Dict[Tuple[str, str, str], str] = {}
+        self._status_message_ids: Dict[Tuple[str, str, str, str], str] = {}
+        # Status callbacks are scheduled independently from the agent worker.
+        # Serialize each workspace/thread/key so a retry burst cannot race
+        # several empty-cache reads into several visible Slack posts.
+        # Fixed lock striping bounds memory even when sends fail before an id
+        # can be cached. Hash collisions only serialize unrelated statuses.
+        self._status_message_locks: Tuple[asyncio.Lock, ...] = tuple(
+            asyncio.Lock() for _ in range(64)
+        )
         self._STATUS_MESSAGE_IDS_MAX = 2000
         # Cache for _fetch_thread_context results: cache_key → _ThreadContextCache
         self._thread_context_cache: Dict[str, _ThreadContextCache] = {}
@@ -2453,6 +2461,9 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
 
+        preserve_live_status = bool(
+            isinstance(metadata, dict) and metadata.get("non_conversational")
+        )
         chat_id = await self._ensure_dm_conversation(
             chat_id, team_id=self._metadata_team_id(metadata)
         )
@@ -2464,7 +2475,15 @@ class SlackAdapter(BasePlatformAdapter):
             # already showed an ephemeral "Running /cmd…" message.  If we have
             # a stashed response_url for this channel, replace that ack with
             # the actual command reply ephemerally instead of posting publicly.
-            slash_ctx = self._pop_slash_context(chat_id, team_id)
+            # Intermediate progress/status output must not consume the
+            # response_url reserved for the slash command's final private
+            # reply; doing so can make that final response fall through to a
+            # public channel post.
+            slash_ctx = (
+                None
+                if preserve_live_status
+                else self._pop_slash_context(chat_id, team_id)
+            )
             if slash_ctx:
                 ephemeral_result = await self._send_slash_ephemeral(
                     slash_ctx,
@@ -2475,7 +2494,8 @@ class SlackAdapter(BasePlatformAdapter):
                     # Slack never auto-clears the Assistant status for them.
                     # Clear it explicitly or a command run inside an
                     # assistant thread leaves "is thinking..." forever.
-                    await self._clear_thread_status_quietly(chat_id, metadata)
+                    if not preserve_live_status:
+                        await self._clear_thread_status_quietly(chat_id, metadata)
                     return ephemeral_result
                 # response_url delivery failed (#19688): fall back to
                 # chat.postEphemeral — an independent API path that keeps
@@ -2494,7 +2514,8 @@ class SlackAdapter(BasePlatformAdapter):
                     content,
                 )
                 if fallback_result.success:
-                    await self._clear_thread_status_quietly(chat_id, metadata)
+                    if not preserve_live_status:
+                        await self._clear_thread_status_quietly(chat_id, metadata)
                     return fallback_result
                 # Both ephemeral paths failed — surface the failure instead
                 # of leaking the reply publicly. The user still has the
@@ -2518,7 +2539,8 @@ class SlackAdapter(BasePlatformAdapter):
                 # produced no visible text (e.g. "(empty)" final responses
                 # are filtered upstream), the assistant thread status must
                 # not stay stuck on "is thinking..." (#24117).
-                await self._clear_thread_status_quietly(chat_id, metadata)
+                if not preserve_live_status:
+                    await self._clear_thread_status_quietly(chat_id, metadata)
                 return SendResult(success=True)
 
             # Split long messages, preserving code block boundaries
@@ -2571,7 +2593,7 @@ class SlackAdapter(BasePlatformAdapter):
                         raise
 
             # Clear Slack Assistant status as soon as the final message is posted.
-            if thread_ts:
+            if thread_ts and not preserve_live_status:
                 await self.stop_typing(chat_id, metadata=metadata)
 
             # Track the sent message ts so we can auto-respond to thread
@@ -2600,7 +2622,8 @@ class SlackAdapter(BasePlatformAdapter):
             # resolution): stop_typing falls back to metadata / the uniquely
             # tracked status for this channel, so a failed turn cannot leave
             # "is thinking..." visible (#24117).
-            await self._clear_thread_status_quietly(chat_id, metadata)
+            if not preserve_live_status:
+                await self._clear_thread_status_quietly(chat_id, metadata)
             logger.error("[Slack] Send error: %s", e, exc_info=True)
             _retryable = self._is_retryable_upload_error(e)
             _retry_after = None
@@ -2678,34 +2701,61 @@ class SlackAdapter(BasePlatformAdapter):
         (context-pressure, compression retries, model fallback, lifecycle)
         used to append a fresh bubble on every call, spamming threads during
         long retry loops. The first call posts and the message ts is
-        remembered; subsequent calls with the same (channel, thread,
-        status_key) edit that message in place via ``chat.update``. If the
-        edit fails (message deleted, too old, ...) the cached ts is dropped
-        and a fresh message is sent.
+        remembered; subsequent calls with the same (workspace, channel,
+        thread, status_key) edit that message in place via ``chat.update``.
+        If a permanent edit fails (message deleted, too old, ...) the cached
+        ts is dropped and a fresh message is sent.
         """
-        thread_ts = self._resolve_thread_ts(None, metadata) or ""
-        key = (str(chat_id), str(thread_ts), str(status_key))
-        cached_id = self._status_message_ids.get(key)
-        if cached_id is not None:
-            result = await self.edit_message(
-                chat_id, cached_id, content, finalize=False, metadata=metadata,
+        status_metadata = dict(metadata or {})
+        # A status bubble is intermediate output. Sending it must not clear the
+        # live Assistant status or reset its elapsed-time heartbeat.
+        status_metadata["non_conversational"] = True
+        thread_ts = self._resolve_thread_ts(None, status_metadata) or ""
+        team_id = self._metadata_team_id(status_metadata)
+        key = (str(team_id), str(chat_id), str(thread_ts), str(status_key))
+        lock = self._status_message_locks[
+            hash(key) % len(self._status_message_locks)
+        ]
+
+        async with lock:
+            cached_id = self._status_message_ids.get(key)
+            if cached_id is not None:
+                result = await self.edit_message(
+                    chat_id,
+                    cached_id,
+                    content,
+                    finalize=False,
+                    metadata=status_metadata,
+                )
+                if result.success:
+                    if result.message_id:
+                        self._status_message_ids[key] = str(result.message_id)
+                    return result
+                if result.retryable:
+                    # chat.update is idempotent but its timeout is ambiguous:
+                    # preserve the existing id so the next callback catches up
+                    # instead of posting a duplicate status bubble.
+                    return result
+                # Permanent edit failure (deleted/too old): replace the bubble.
+                self._status_message_ids.pop(key, None)
+
+            result = await self.send(
+                chat_id,
+                content,
+                metadata=status_metadata,
             )
-            if result.success:
-                if result.message_id:
-                    self._status_message_ids[key] = str(result.message_id)
-                return result
-            # Edit failed — clear the cached ts and fall through to a fresh send.
-            self._status_message_ids.pop(key, None)
-        result = await self.send(chat_id, content, metadata=metadata)
-        if result.success and result.message_id:
-            if len(self._status_message_ids) >= self._STATUS_MESSAGE_IDS_MAX:
-                # Simple FIFO trim: drop the oldest half to bound memory.
-                for stale in list(self._status_message_ids)[
-                    : self._STATUS_MESSAGE_IDS_MAX // 2
-                ]:
-                    self._status_message_ids.pop(stale, None)
-            self._status_message_ids[key] = str(result.message_id)
-        return result
+            if result.success and result.message_id:
+                if len(self._status_message_ids) >= self._STATUS_MESSAGE_IDS_MAX:
+                    # Same-key updates share a stripe; evicting another key's
+                    # cached id is safe because that task restores it after a
+                    # successful edit.
+                    candidates = [
+                        stale for stale in self._status_message_ids if stale != key
+                    ]
+                    for stale in candidates[: self._STATUS_MESSAGE_IDS_MAX // 2]:
+                        self._status_message_ids.pop(stale, None)
+                self._status_message_ids[key] = str(result.message_id)
+            return result
 
     async def edit_message(
         self,
@@ -5121,14 +5171,28 @@ class SlackAdapter(BasePlatformAdapter):
             return False
 
         def _cached_parent_matches() -> Optional[bool]:
-            # Cache keys are "{channel_id}:{thread_ts}:{team_id}"; team_id may
-            # be empty at some call sites, so match on the channel+thread
-            # prefix rather than guessing the exact key.
-            for cached_key, cached_entry in self._thread_context_cache.items():
-                if cached_key.startswith(f"{channel_id}:{thread_ts}:"):
+            # Cache keys are workspace-scoped. Slack Connect can expose the
+            # same channel/thread ids in two teams, so a prefix match can read
+            # another workspace's root author and wake (or silence) this one.
+            exact_key = f"{channel_id}:{thread_ts}:{team_id}"
+            cached_entry = self._thread_context_cache.get(exact_key)
+            if cached_entry is not None:
+                return bool(
+                    cached_entry.parent_user_id
+                    and cached_entry.parent_user_id == bot_uid
+                )
+            if not team_id:
+                # Legacy/team-less callers may use a uniquely identifiable
+                # workspace cache entry, but ambiguity must fail closed.
+                matches = [
+                    entry
+                    for key, entry in self._thread_context_cache.items()
+                    if key.startswith(f"{channel_id}:{thread_ts}:")
+                ]
+                if len(matches) == 1:
                     return bool(
-                        cached_entry.parent_user_id
-                        and cached_entry.parent_user_id == bot_uid
+                        matches[0].parent_user_id
+                        and matches[0].parent_user_id == bot_uid
                     )
             return None
 
@@ -5218,7 +5282,9 @@ class SlackAdapter(BasePlatformAdapter):
                 if parent_text and f"<@{bot_uid}>" in parent_text:
                     # Remember the thread so later replies skip the fetch.
                     if not self._slack_strict_mention():
-                        self._register_mentioned_thread(event_thread_ts)
+                        self._register_mentioned_thread(
+                            event_thread_ts, team_id=team_id
+                        )
                     return True
         return False
 
@@ -5254,9 +5320,13 @@ class SlackAdapter(BasePlatformAdapter):
                 return
 
             original_message_ts = str(updated_message.get("ts") or "")
+            edit_team_id = self._event_team_id(event, payload)
+            processed_marker = self._workspace_event_id(
+                edit_team_id, original_message_ts
+            )
             if (
                 original_message_ts
-                and original_message_ts in self._processed_message_ts
+                and processed_marker in self._processed_message_ts
             ):
                 return
             edited = updated_message.get("edited")
@@ -6330,7 +6400,9 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
         if ts:
-            self._processed_message_ts[ts] = time.time()
+            self._processed_message_ts[
+                self._workspace_event_id(team_id, ts)
+            ] = time.time()
             if len(self._processed_message_ts) > self._PROCESSED_MESSAGE_TS_MAX:
                 newest_items = sorted(
                     self._processed_message_ts.items(),

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3542,6 +3542,40 @@ class TestMessageRouting:
 
         adapter.handle_message.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_processed_edit_guard_is_scoped_per_workspace(self, adapter):
+        """The same Slack-local message ts in another team is independent."""
+        original = {
+            "text": "<@U_BOT> workspace one",
+            "user": "U_USER",
+            "channel": "C_SHARED",
+            "channel_type": "mpim",
+            "team": "T_ONE",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(original)
+        adapter.handle_message.assert_awaited_once()
+        adapter.handle_message.reset_mock()
+
+        edited_in_other_workspace = {
+            "subtype": "message_changed",
+            "channel": "C_SHARED",
+            "channel_type": "mpim",
+            "team": "T_TWO",
+            "message": {
+                "text": "<@U_BOT> workspace two edit",
+                "user": "U_USER",
+                "channel": "C_SHARED",
+                "ts": "1234567890.000001",
+                "edited": {"user": "U_USER", "ts": "1234567899.000002"},
+            },
+        }
+        await adapter._handle_slack_message(edited_in_other_workspace)
+
+        adapter.handle_message.assert_awaited_once()
+        delivered = adapter.handle_message.await_args.args[0]
+        assert delivered.source.scope_id == "T_TWO"
+
 
 # ---------------------------------------------------------------------------
 # TestSendTyping — assistant.threads.setStatus
@@ -5084,7 +5118,10 @@ class TestThreadReplyHandling:
         # Cold-start context carries the parent so the agent sees the ask.
         assert "check this and ask me for run" in msg_event.channel_context
         # Thread remembered so later replies skip the parent fetch.
-        assert "123.000" in adapter_with_session_store._mentioned_threads
+        assert (
+            "T_TEAM",
+            "123.000",
+        ) in adapter_with_session_store._mentioned_threads
 
     @pytest.mark.asyncio
     async def test_top_level_mention_registers_thread_for_replies(

--- a/tests/gateway/test_slack_status_update.py
+++ b/tests/gateway/test_slack_status_update.py
@@ -9,6 +9,7 @@ The status-update path must:
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from unittest.mock import AsyncMock, MagicMock
 
@@ -47,6 +48,7 @@ import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
 _slack_mod.SLACK_AVAILABLE = True
 
 from gateway.config import PlatformConfig  # noqa: E402
+from gateway.run import _send_or_update_status_coro  # noqa: E402
 from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
 
 
@@ -142,3 +144,116 @@ async def test_distinct_threads_do_not_crosstalk(adapter):
     client = adapter._get_client.return_value
     assert client.chat_postMessage.call_count == 2
     assert client.chat_update.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_updates_post_one_status_bubble(adapter):
+    """A retry burst must not race empty-cache reads into duplicate posts."""
+    client = adapter._get_client.return_value
+
+    async def delayed_post(**kwargs):
+        await asyncio.sleep(0.01)
+        return {"ok": True, "ts": "status_ts"}
+
+    client.chat_postMessage = AsyncMock(side_effect=delayed_post)
+
+    results = await asyncio.gather(
+        *(
+            _send_or_update_status_coro(
+                adapter,
+                "C_CHAN",
+                "provider_retry",
+                f"retry {attempt}",
+                METADATA,
+            )
+            for attempt in range(8)
+        )
+    )
+
+    assert all(result.success for result in results)
+    assert client.chat_postMessage.await_count == 1
+    assert client.chat_update.await_count == 7
+
+
+@pytest.mark.asyncio
+async def test_same_ids_in_two_workspaces_do_not_share_status(adapter):
+    """Slack-local channel/thread IDs need the workspace in the cache key."""
+    one = AsyncMock()
+    one.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "same_ts"})
+    one.chat_update = AsyncMock(return_value={"ok": True})
+    two = AsyncMock()
+    two.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "same_ts"})
+    two.chat_update = AsyncMock(return_value={"ok": True})
+    adapter._get_client = MagicMock(
+        side_effect=lambda _chat_id, team_id=None: {"T_ONE": one, "T_TWO": two}[
+            team_id
+        ]
+    )
+
+    await adapter.send_or_update_status(
+        "C_SHARED",
+        "provider_retry",
+        "workspace one",
+        metadata={"thread_id": "same_thread", "slack_team_id": "T_ONE"},
+    )
+    await adapter.send_or_update_status(
+        "C_SHARED",
+        "provider_retry",
+        "workspace two",
+        metadata={"thread_id": "same_thread", "slack_team_id": "T_TWO"},
+    )
+
+    one.chat_postMessage.assert_awaited_once()
+    two.chat_postMessage.assert_awaited_once()
+    one.chat_update.assert_not_awaited()
+    two.chat_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_transient_edit_failure_keeps_existing_status_id(adapter):
+    """An ambiguous chat.update timeout must not fall through to a new post."""
+    first = await adapter.send_or_update_status(
+        "C_CHAN", "provider_retry", "retry 1", metadata=METADATA
+    )
+    client = adapter._get_client.return_value
+    client.chat_update = AsyncMock(side_effect=TimeoutError("transport stalled"))
+
+    failed = await adapter.send_or_update_status(
+        "C_CHAN", "provider_retry", "retry 2", metadata=METADATA
+    )
+
+    assert failed.success is False
+    assert failed.retryable is True
+    assert client.chat_postMessage.await_count == 1
+    assert adapter._status_message_ids[
+        ("", "C_CHAN", METADATA["thread_id"], "provider_retry")
+    ] == first.message_id
+
+
+@pytest.mark.asyncio
+async def test_status_send_does_not_clear_live_assistant_status(adapter):
+    """A progress bubble is not a final response and must keep typing alive."""
+    original_metadata = dict(METADATA)
+
+    await adapter.send_or_update_status(
+        "C_CHAN", "provider_retry", "retrying", metadata=original_metadata
+    )
+
+    adapter.stop_typing.assert_not_awaited()
+    assert original_metadata == METADATA
+
+
+@pytest.mark.asyncio
+async def test_status_does_not_consume_private_slash_reply_context(adapter):
+    """Only the final slash-command reply may claim its response_url."""
+    adapter._pop_slash_context = MagicMock(
+        return_value={"response_url": "https://local.invalid/response"}
+    )
+
+    result = await adapter.send_or_update_status(
+        "C_CHAN", "provider_retry", "retrying", metadata=METADATA
+    )
+
+    assert result.success is True
+    adapter._pop_slash_context.assert_not_called()
+    adapter._get_client.return_value.chat_postMessage.assert_awaited_once()

--- a/tests/gateway/test_slack_wake_external_bot_messages.py
+++ b/tests/gateway/test_slack_wake_external_bot_messages.py
@@ -93,6 +93,7 @@ def _make_adapter(bot_authored_root: bool = False):
     adapter._team_bot_user_ids = {}
     adapter._bot_message_ts = set()
     adapter._mentioned_threads = set()
+    adapter._MENTIONED_THREADS_MAX = 5000
     adapter._thread_context_cache = {}
 
     adapter._has_active_session_for_thread = lambda **kw: False
@@ -327,3 +328,48 @@ async def test_bot_authored_thread_root_uses_per_team_bot_id():
         adapter, CHANNEL_ID, THREAD_TS, team_id="T2"
     )
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_bot_authored_root_cache_does_not_cross_workspaces():
+    """A warm cache entry from T1 must not decide T2's wake policy."""
+    adapter = _make_adapter()
+    adapter._team_bot_user_ids = {"T_ONE": "U_BOT_T1", "T_TWO": "U_BOT_T2"}
+    adapter._thread_context_cache = {
+        f"{CHANNEL_ID}:{THREAD_TS}:T_ONE": _ThreadContextCache(
+            content="ctx",
+            # Deliberately equals T_TWO's bot id. A prefix-only cache lookup
+            # will read this first and falsely classify T_TWO's human root.
+            parent_user_id="U_BOT_T2",
+        ),
+        f"{CHANNEL_ID}:{THREAD_TS}:T_TWO": _ThreadContextCache(
+            content="ctx",
+            parent_user_id="U_HUMAN_T2",
+        ),
+    }
+
+    assert await SlackAdapter._bot_authored_thread_root(
+        adapter, CHANNEL_ID, THREAD_TS, team_id="T_TWO"
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_parent_mention_rehydration_records_workspace_marker():
+    """Restart recovery must not create a globally shared bare thread marker."""
+    adapter = _make_adapter(bot_authored_root=False)
+    adapter._team_bot_user_ids = {"T_TWO": "U_BOT_T2"}
+    adapter._fetch_thread_parent_text = AsyncMock(
+        return_value="<@U_BOT_T2> continue after the restart"
+    )
+
+    wake = await adapter._should_wake_on_unmentioned_message(
+        event_thread_ts=THREAD_TS,
+        channel_id=CHANNEL_ID,
+        user_id=USER_ID,
+        is_thread_reply=True,
+        team_id="T_TWO",
+    )
+
+    assert wake is True
+    assert ("T_TWO", THREAD_TS) in adapter._mentioned_threads
+    assert THREAD_TS not in adapter._mentioned_threads


### PR DESCRIPTION
## Summary

Fix eight independently reproduced Slack transport defects around concurrent status updates and workspace-local identifiers:

- serialize status read/edit/post per logical key;
- include workspace identity in status, processed-edit, bot-root, and recovered mention state;
- preserve known status IDs after ambiguous retryable edit failures;
- keep progress output from clearing native Assistant typing state;
- prevent progress output from consuming a private slash-command response URL.

## Root-cause evidence

On the parent commit:

- eight synchronized callbacks posted eight status bubbles;
- T2 edited T1's cached status for identical Slack-local IDs;
- an ambiguous chat.update timeout discarded the cached ID and posted a duplicate;
- a status send cleared native typing and claimed pending private slash context;
- same message timestamps caused T2 edits to be dropped;
- bot-root and recovered mention state crossed workspace boundaries.

No live Slack credentials or calls were used. Replays ran through the real adapter/gateway callback seam with local async fake clients.

## Validation

- focused Slack/status files: 452 passed
- full Slack suite: 846 passed
- adjacent pending/interrupt/dedup paths: 35 passed
- git diff --check: clean
