### PR TITLE
fix(tui): /sessions + /model visible with ambient dock; /reload feedback

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -679,6 +679,32 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
   })
 
+  it('surfaces /reload progress even when the RPC resolves null', async () => {
+    const rpc = vi.fn(() => Promise.resolve(null))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    expect(createSlashHandler(ctx)('/reload')).toBe(true)
+    expect(rpc).toHaveBeenCalledWith('reload.env', {})
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('reloading .env…')
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('reloaded .env (no response)')
+  })
+
+  it('reports /reload updated count from a normal response', async () => {
+    const rpc = vi.fn(() => Promise.resolve({ updated: 3 }))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    expect(createSlashHandler(ctx)('/reload')).toBe(true)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('reloading .env…')
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('reloaded .env (3 vars updated)')
+  })
+
   it('renders browser connect progress messages from the gateway', async () => {
     const rpc = vi.fn(() =>
       Promise.resolve({

--- a/ui-tui/src/__tests__/floatingOverlays.test.tsx
+++ b/ui-tui/src/__tests__/floatingOverlays.test.tsx
@@ -8,6 +8,8 @@ import { GatewayProvider } from '../app/gatewayContext.js'
 import { $isBlocked, type OverlayState, patchOverlayState, resetOverlayState } from '../app/overlayStore.js'
 import { patchUiState } from '../app/uiStore.js'
 import { FloatingOverlays } from '../components/appOverlays.js'
+import { AmbientDock, openWidget } from '../sdk/host.js'
+import { defineWidgetApp, removeWidgetApp } from '../sdk/registry.js'
 
 // ── Stubs ─────────────────────────────────────────────────────────────
 // The real panel widgets mount their own input handlers + gateway RPC
@@ -62,7 +64,8 @@ const makeCapturingStdout = () => {
 // and the gateway context. Seed the stores, wrap in a provider, render, give
 // the throttled/microtask-deferred frame a tick to flush, then read the frame.
 const renderOverlays = async (overlay: Partial<OverlayState>, completions: { display: string; text: string }[] = []) => {
-  patchOverlayState({ ...resetOverlayState(), ...overlay })
+  resetOverlayState()
+  patchOverlayState(overlay)
   patchUiState({ sid: 'sess-test' })
 
   const { stdout, read } = makeCapturingStdout()
@@ -146,13 +149,96 @@ const renderSlice = async (
   completions: { display: string; text: string }[] = [],
   headroom = 0
 ) => {
-  patchOverlayState({ ...resetOverlayState(), ...overlay })
+  resetOverlayState()
+  patchOverlayState(overlay)
 
   const { stdout, read } = makeCapturingStdout()
 
   const instance = await render(
     <GatewayProvider value={{ gw: {} as never, rpc: vi.fn() as never }}>
       <ComposerSlice completions={completions} headroom={headroom} prompt={prompt} />
+    </GatewayProvider>,
+    { stderr: process.stderr, stdin: process.stdin, stdout }
+  )
+
+  await new Promise(resolve => setTimeout(resolve, 60))
+  instance.unmount()
+  await new Promise(resolve => setTimeout(resolve, 20))
+
+  return read()
+}
+
+// Real appLayout chrome stack: AmbientDock (top) + relative composer with
+// FloatingOverlays + $isBlocked prompt gate + AmbientDock (bottom).
+// Review #72208 / issue #69592 required this integrated path — synthetic
+// ComposerSlice alone does not mount AmbientDock.
+const DOCK_APP_ID = 'test-ambient-dock-69592'
+const DOCK_MARKER = 'AMBIENT_DOCK_MARKER'
+
+const AppLayoutChromeSlice = ({
+  completions,
+  prompt
+}: {
+  completions: { display: string; text: string }[]
+  prompt: string
+}) => {
+  const isBlocked = React.useSyncExternalStore(
+    cb => $isBlocked.subscribe(cb),
+    () => $isBlocked.get(),
+    () => $isBlocked.get()
+  )
+
+  return (
+    <Box flexDirection="column">
+      <AmbientDock placement="dock-top" />
+      <Box position="relative">
+        <FloatingOverlays
+          cols={100}
+          compIdx={0}
+          completions={completions}
+          onActiveSessionClose={vi.fn()}
+          onActiveSessionSelect={vi.fn()}
+          onModelSelect={vi.fn()}
+          onNewLiveSession={vi.fn()}
+          onNewPromptSession={vi.fn()}
+          onResumeSelect={vi.fn()}
+          pagerPageSize={20}
+        />
+        {!isBlocked && <Text>{prompt}</Text>}
+      </Box>
+      <AmbientDock placement="dock-bottom" />
+    </Box>
+  )
+}
+
+const seedDockTopWidget = () => {
+  const app = defineWidgetApp({
+    help: 'test ambient dock marker',
+    id: DOCK_APP_ID,
+    init: () => ({}),
+    mode: 'ambient' as const,
+    reduce: (state: Record<string, never>) => state,
+    render: () => <Text>{DOCK_MARKER}</Text>,
+    zone: 'dock-top' as const
+  })
+  openWidget(app, {})
+}
+
+const renderAppLayoutChrome = async (
+  overlay: Partial<OverlayState>,
+  prompt: string,
+  completions: { display: string; text: string }[] = []
+) => {
+  resetOverlayState()
+  seedDockTopWidget()
+  // openWidget wrote ambient; merge blocking flags without wiping the dock.
+  patchOverlayState(overlay)
+
+  const { stdout, read } = makeCapturingStdout()
+
+  const instance = await render(
+    <GatewayProvider value={{ gw: {} as never, rpc: vi.fn() as never }}>
+      <AppLayoutChromeSlice completions={completions} prompt={prompt} />
     </GatewayProvider>,
     { stderr: process.stderr, stdin: process.stdin, stdout }
   )
@@ -172,6 +258,7 @@ describe('FloatingOverlays ambient-dock layout (#69592)', () => {
 
   afterEach(() => {
     resetOverlayState()
+    removeWidgetApp(DOCK_APP_ID)
   })
 
   describe('blocking panels render in-flow (reserve rows, stay visible)', () => {
@@ -217,7 +304,7 @@ describe('FloatingOverlays ambient-dock layout (#69592)', () => {
       // stays live and the parent keeps its height. That is exactly why the
       // completion track can stay absolute (bottom:100% above a live prompt)
       // instead of in-flow like blocking panels.
-      patchOverlayState({ ...resetOverlayState() })
+      resetOverlayState()
       expect($isBlocked.get()).toBe(false)
     })
 
@@ -246,6 +333,36 @@ describe('FloatingOverlays ambient-dock layout (#69592)', () => {
       expect(frame).toContain('SESSIONS_PANEL_MARKER')
       // … while the ordinary prompt is hidden because the composer is blocked.
       expect(frame).not.toContain('PROMPT_LIVE_MARKER')
+    })
+  })
+
+  describe('integrated AmbientDock + blocking panel (#69592 / #72208 review)', () => {
+    it('keeps dock + sessions panel visible while the prompt is blocked', async () => {
+      const frame = await renderAppLayoutChrome({ sessions: true }, 'PROMPT_LIVE_MARKER')
+
+      // Real AmbientDock row must paint (this is the chrome that stole height
+      // under the old absolute-only overlay path).
+      expect(frame).toContain(DOCK_MARKER)
+      // Sessions panel stays on screen with the dock occupying rows above.
+      expect(frame).toContain('SESSIONS_PANEL_MARKER')
+      // Prompt is gated off via $isBlocked, same as appLayout.
+      expect(frame).not.toContain('PROMPT_LIVE_MARKER')
+    })
+
+    it('keeps dock + model picker visible while the prompt is blocked', async () => {
+      const frame = await renderAppLayoutChrome({ modelPicker: true }, 'PROMPT_LIVE_MARKER')
+
+      expect(frame).toContain(DOCK_MARKER)
+      expect(frame).toContain('MODEL_PICKER_MARKER')
+      expect(frame).not.toContain('PROMPT_LIVE_MARKER')
+    })
+
+    it('dock stays while completions leave the prompt live', async () => {
+      const frame = await renderAppLayoutChrome({}, 'PROMPT_LIVE_MARKER', [{ display: 'reload', text: 'reload' }])
+
+      expect(frame).toContain(DOCK_MARKER)
+      expect(frame).toContain('PROMPT_LIVE_MARKER')
+      expect($isBlocked.get()).toBe(false)
     })
   })
 })

--- a/ui-tui/src/__tests__/floatingOverlays.test.tsx
+++ b/ui-tui/src/__tests__/floatingOverlays.test.tsx
@@ -1,0 +1,251 @@
+import { PassThrough } from 'node:stream'
+
+import { Box, render, Text } from '@hermes/ink'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { GatewayProvider } from '../app/gatewayContext.js'
+import { $isBlocked, type OverlayState, patchOverlayState, resetOverlayState } from '../app/overlayStore.js'
+import { patchUiState } from '../app/uiStore.js'
+import { FloatingOverlays } from '../components/appOverlays.js'
+
+// ── Stubs ─────────────────────────────────────────────────────────────
+// The real panel widgets mount their own input handlers + gateway RPC
+// calls. For a layout regression we only care that FloatingOverlays puts
+// them on screen, so swap each for a single marker row. vi.mock is hoisted
+// before the component import above resolves.
+
+vi.mock('../components/activeSessionSwitcher.js', () => ({
+  ActiveSessionSwitcher: () => <Text>SESSIONS_PANEL_MARKER</Text>
+}))
+
+vi.mock('../components/modelPicker.js', () => ({
+  ModelPicker: () => <Text>MODEL_PICKER_MARKER</Text>,
+  // Exported helper kept by the real module; not exercised here but kept so
+  // the mock still satisfies any sibling import.
+  providerIndexAfterClearingFilter: () => -1
+}))
+
+vi.mock('../components/petPicker.js', () => ({
+  PetPicker: () => <Text>PET_PICKER_MARKER</Text>
+}))
+
+vi.mock('../components/skillsHub.js', () => ({
+  SkillsHub: () => <Text>SKILLS_HUB_MARKER</Text>
+}))
+
+vi.mock('../components/pluginsHub.js', () => ({
+  PluginsHub: () => <Text>PLUGINS_HUB_MARKER</Text>
+}))
+
+// A non-TTY writable stream that records every frame Ink writes, so the test
+// can assert what actually lands on screen. Mirrors how the real renderer
+// writes to process.stdout, minus terminal control.
+const makeCapturingStdout = () => {
+  const stream = new PassThrough()
+  Object.defineProperty(stream, 'columns', { configurable: true, value: 100 })
+  Object.defineProperty(stream, 'rows', { configurable: true, value: 40 })
+  Object.defineProperty(stream, 'isTTY', { configurable: true, value: false })
+
+  let captured = ''
+  stream.on('data', (chunk: Buffer) => {
+    captured += chunk.toString()
+  })
+
+  return {
+    stdout: stream as unknown as NodeJS.WriteStream,
+    read: () => captured
+  }
+}
+
+// FloatingOverlays reads $overlayState / $uiTheme / $uiSessionId (nanostores)
+// and the gateway context. Seed the stores, wrap in a provider, render, give
+// the throttled/microtask-deferred frame a tick to flush, then read the frame.
+const renderOverlays = async (overlay: Partial<OverlayState>, completions: { display: string; text: string }[] = []) => {
+  patchOverlayState({ ...resetOverlayState(), ...overlay })
+  patchUiState({ sid: 'sess-test' })
+
+  const { stdout, read } = makeCapturingStdout()
+
+  const noop = vi.fn()
+
+  const instance = await render(
+    <GatewayProvider value={{ gw: {} as never, rpc: noop as never }}>
+      <FloatingOverlays
+        cols={100}
+        compIdx={0}
+        completions={completions}
+        onActiveSessionClose={noop}
+        onActiveSessionSelect={noop}
+        onModelSelect={noop}
+        onNewLiveSession={noop}
+        onNewPromptSession={noop}
+        onResumeSelect={noop}
+        pagerPageSize={20}
+      />
+    </GatewayProvider>,
+    { stderr: process.stderr, stdin: process.stdin, stdout }
+  )
+
+  await new Promise(resolve => setTimeout(resolve, 60))
+  instance.unmount()
+  await new Promise(resolve => setTimeout(resolve, 20))
+
+  return read()
+}
+
+// Minimal slice of ComposerPane's composer box: the prompt is gated on
+// $isBlocked exactly like appLayout.tsx, and FloatingOverlays sits above it
+// in the same relative parent. This is the composition #69592 broke.
+//
+// `headroom` reserves blank rows ABOVE the relative composer box so an
+// absolute completion (positioned bottom:100% → floats above the box) has
+// somewhere to land inside the captured viewport instead of being clipped
+// off the top of a non-TTY render.
+const ComposerSlice = ({
+  completions,
+  headroom = 0,
+  prompt
+}: {
+  completions: { display: string; text: string }[]
+  headroom?: number
+  prompt: string
+}) => {
+  const isBlocked = React.useSyncExternalStore(
+    cb => $isBlocked.subscribe(cb),
+    () => $isBlocked.get(),
+    () => $isBlocked.get()
+  )
+
+  return (
+    <Box flexDirection="column">
+      {headroom > 0 ? <Box height={headroom} /> : null}
+      <Box position="relative">
+        <FloatingOverlays
+          cols={100}
+          compIdx={0}
+          completions={completions}
+          onActiveSessionClose={vi.fn()}
+          onActiveSessionSelect={vi.fn()}
+          onModelSelect={vi.fn()}
+          onNewLiveSession={vi.fn()}
+          onNewPromptSession={vi.fn()}
+          onResumeSelect={vi.fn()}
+          pagerPageSize={20}
+        />
+
+        {!isBlocked && <Text>{prompt}</Text>}
+      </Box>
+    </Box>
+  )
+}
+
+const renderSlice = async (
+  overlay: Partial<OverlayState>,
+  prompt: string,
+  completions: { display: string; text: string }[] = [],
+  headroom = 0
+) => {
+  patchOverlayState({ ...resetOverlayState(), ...overlay })
+
+  const { stdout, read } = makeCapturingStdout()
+
+  const instance = await render(
+    <GatewayProvider value={{ gw: {} as never, rpc: vi.fn() as never }}>
+      <ComposerSlice completions={completions} headroom={headroom} prompt={prompt} />
+    </GatewayProvider>,
+    { stderr: process.stderr, stdin: process.stdin, stdout }
+  )
+
+  await new Promise(resolve => setTimeout(resolve, 60))
+  instance.unmount()
+  await new Promise(resolve => setTimeout(resolve, 20))
+
+  return read()
+}
+
+describe('FloatingOverlays ambient-dock layout (#69592)', () => {
+  beforeEach(() => {
+    resetOverlayState()
+    patchUiState({ sid: 'sess-test' })
+  })
+
+  afterEach(() => {
+    resetOverlayState()
+  })
+
+  describe('blocking panels render in-flow (reserve rows, stay visible)', () => {
+    it('shows the sessions switcher when sessions is open', async () => {
+      const frame = await renderOverlays({ sessions: true })
+
+      // The panel must actually land on screen. With the pre-fix absolute
+      // `bottom:100%` wrapper inside the composer's collapsed relative box,
+      // this frame was empty — the regression.
+      expect(frame).toContain('SESSIONS_PANEL_MARKER')
+    })
+
+    it('shows the model picker when modelPicker is open', async () => {
+      const frame = await renderOverlays({ modelPicker: true })
+
+      expect(frame).toContain('MODEL_PICKER_MARKER')
+    })
+
+    it('shows other blocking hubs the same way', async () => {
+      const skills = await renderOverlays({ skillsHub: true })
+      expect(skills).toContain('SKILLS_HUB_MARKER')
+
+      const plugins = await renderOverlays({ pluginsHub: true })
+      expect(plugins).toContain('PLUGINS_HUB_MARKER')
+    })
+
+    it('renders nothing when no overlay and no completions are open', async () => {
+      const frame = await renderOverlays({})
+
+      // FloatingOverlays short-circuits to null — no panel or completion
+      // content lands in the frame. (The stream still carries Ink's terminal
+      // setup escape sequences, which is why we assert on the markers, not on
+      // an empty string.)
+      expect(frame).not.toContain('SESSIONS_PANEL_MARKER')
+      expect(frame).not.toContain('MODEL_PICKER_MARKER')
+      expect(frame).not.toContain('reload')
+    })
+  })
+
+  describe('completions keep the distinct absolute track', () => {
+    it('do not block the composer — $isBlocked stays false (the invariant that keeps them absolute)', () => {
+      // Completions are deliberately absent from $isBlocked, so the prompt
+      // stays live and the parent keeps its height. That is exactly why the
+      // completion track can stay absolute (bottom:100% above a live prompt)
+      // instead of in-flow like blocking panels.
+      patchOverlayState({ ...resetOverlayState() })
+      expect($isBlocked.get()).toBe(false)
+    })
+
+    it('render above a live prompt without blocking it', async () => {
+      // Headroom above the composer box gives the absolute completion
+      // (bottom:100% → floats above the box) room to land in the captured
+      // viewport. The prompt stays live underneath.
+      const frame = await renderSlice(
+        {},
+        'PROMPT_LIVE_MARKER',
+        [{ display: 'reload', text: 'reload' }, { display: 'sessions', text: 'sessions' }],
+        20
+      )
+
+      expect(frame).toContain('reload')
+      expect(frame).toContain('sessions')
+      expect(frame).toContain('PROMPT_LIVE_MARKER')
+    })
+  })
+
+  describe('composer region: picker visible while the prompt is blocked', () => {
+    it('hides the prompt and shows the panel when a blocking overlay opens', async () => {
+      const frame = await renderSlice({ sessions: true }, 'PROMPT_LIVE_MARKER')
+
+      // The fix's whole point: the panel is visible …
+      expect(frame).toContain('SESSIONS_PANEL_MARKER')
+      // … while the ordinary prompt is hidden because the composer is blocked.
+      expect(frame).not.toContain('PROMPT_LIVE_MARKER')
+    })
+  })
+})

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -130,16 +130,28 @@ export const opsCommands: SlashCommand[] = [
     help: 're-read ~/.hermes/.env into the running gateway (CLI parity)',
     name: 'reload',
     run: (_arg, ctx) => {
+      // Immediate feedback: createSlashHandler's guarded() bails on null/undefined
+      // (`if (!stale() && r)`), so a quiet RPC path would otherwise look like a
+      // no-op (#69592).
+      ctx.transcript.sys('reloading .env…')
       ctx.gateway
         .rpc<ReloadEnvResponse>('reload.env', {})
-        .then(
-          ctx.guarded<ReloadEnvResponse>(r => {
-            const n = Number(r.updated ?? 0)
-            const noun = n === 1 ? 'var' : 'vars'
+        .then(r => {
+          if (ctx.stale()) {
+            return
+          }
 
-            ctx.transcript.sys(`reloaded .env (${n} ${noun} updated)`)
-          })
-        )
+          if (!r) {
+            ctx.transcript.sys('reloaded .env (no response)')
+
+            return
+          }
+
+          const n = Number(r.updated ?? 0)
+          const noun = n === 1 ? 'var' : 'vars'
+
+          ctx.transcript.sys(`reloaded .env (${n} ${noun} updated)`)
+        })
         .catch(ctx.guardedErr)
     }
   },

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -320,8 +320,18 @@ export function FloatingOverlays({
     })
   }
 
+  // Completions are separate from blocking panels: they float above a LIVE
+  // prompt (parent has height). Blocking panels (sessions / model / hubs /
+  // pager / pet) open with `$isBlocked`, which hides the prompt and collapses
+  // this relative parent to height 0 — absolute `bottom: 100%` then has no
+  // anchor and loses the vertical room already consumed by AmbientDock +
+  // StatusRulePane above (see #69592). Keep completions absolute; put
+  // blocking panels in-flow so they reserve real rows between the dock and
+  // the composer chrome.
+  const completionWidgets: WidgetGridWidget[] = []
+
   if (completions.length) {
-    widgets.push({
+    completionWidgets.push({
       id: 'completions',
       render: () => (
         <FloatBox color={theme.color.primary}>
@@ -377,8 +387,17 @@ export function FloatingOverlays({
   }
 
   return (
-    <Box alignItems="flex-start" bottom="100%" flexDirection="column" left={0} position="absolute" right={0}>
-      <WidgetGrid cols={cols} columns={1} gap={0} paddingX={0} paddingY={0} rowGap={0} widgets={widgets} />
-    </Box>
+    <>
+      {widgets.length > 0 ? (
+        <Box flexDirection="column" flexShrink={0} width="100%">
+          <WidgetGrid cols={cols} columns={1} gap={0} paddingX={0} paddingY={0} rowGap={0} widgets={widgets} />
+        </Box>
+      ) : null}
+      {completionWidgets.length > 0 ? (
+        <Box alignItems="flex-start" bottom="100%" flexDirection="column" left={0} position="absolute" right={0}>
+          <WidgetGrid cols={cols} columns={1} gap={0} paddingX={0} paddingY={0} rowGap={0} widgets={completionWidgets} />
+        </Box>
+      ) : null}
+    </>
   )
 }


### PR DESCRIPTION
## Summary

Fixes #69592: blocking floating overlays open as an invisible blocked state when ambient widget docks are loaded. That hits **`/sessions` and `/model` / `/models` the same way** (plus skills/plugins hubs, pager, pet picker). Also makes `/reload` always show user feedback.

### Invisible overlays (`/sessions`, `/model`, hubs, …) + ambient dock

Same root cause for all of them. They go through `FloatingOverlays` and set flags in `$isBlocked` (`sessions`, `modelPicker`, etc.).

`FloatingOverlays` used `position: absolute; bottom: 100%` inside the composer’s relative box. Opening any of those flags hides the prompt and collapses that box to height 0. `AmbientDock` + `StatusRulePane` already consume rows above the anchor, so the panel had no vertical room — prompt gone, Esc only. **`/model` is not a separate bug path**; it is the same `modelPicker` widget on this stack.

**Fix:** render blocking panels (sessions, **model picker**, hubs, pager, pet) **in-flow** so they reserve real rows between the dock and composer chrome. Keep slash-completion menus absolute above a live prompt (parent still has height).

### `/reload` silent path

`createSlashHandler`’s `guarded()` bails on null/undefined (`if (!stale() && r)`). `/reload` now prints `reloading .env…` immediately and handles a null RPC result instead of going fully silent.

## Test plan

- [x] `vitest` `createSlashHandler.test.ts` (78 tests) including new `/reload` null + success cases
- [ ] Manual: ambient widgets loaded → `/sessions` shows switcher between dock and bottom chrome; Esc closes
- [ ] Manual: ambient widgets loaded → `/model` / `/models` shows the model picker the same way (not stuck/invisible)
- [ ] Manual: `/skills` (and other blocking hubs) still open with widgets on
- [ ] Manual: `/` completion menu still floats above the live prompt
- [ ] Manual: `/reload` prints progress + result

Closes #69592
