### PR TITLE
fix(launchd): mark gateway process interactive

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4027,6 +4027,9 @@ def generate_launchd_plist() -> str:
         <string>Aqua</string>
         <string>Background</string>
     </array>
+
+    <key>ProcessType</key>
+    <string>Interactive</string>
     
     <key>RunAtLoad</key>
     <true/>

--- a/tests/hermes_cli/test_launchd_plist_process_type.py
+++ b/tests/hermes_cli/test_launchd_plist_process_type.py
@@ -1,0 +1,17 @@
+from hermes_cli import gateway as gateway_cli
+
+
+def test_launchd_plist_marks_gateway_interactive(tmp_path, monkeypatch):
+    """The long-lived gateway must not be throttled by macOS App Nap."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+    monkeypatch.setattr(gateway_cli, "_stable_service_working_dir", lambda: str(home))
+    monkeypatch.setattr(gateway_cli, "get_python_path", lambda: "/usr/bin/python3")
+    monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: None)
+    monkeypatch.setattr(gateway_cli, "_build_service_path_dirs", lambda: ["/usr/bin"])
+    monkeypatch.setattr(gateway_cli.shutil, "which", lambda _name: None)
+
+    plist = gateway_cli.generate_launchd_plist()
+
+    assert "<key>ProcessType</key>\n    <string>Interactive</string>" in plist


### PR DESCRIPTION
## Summary

- mark generated macOS LaunchAgent gateway jobs as `ProcessType=Interactive`
- prevent App Nap/background scheduling from delaying heartbeat and reconnect work
- add focused, cross-platform plist regression coverage

Fixes #72210

## Testing

- Before: `python -m pytest tests/hermes_cli/test_launchd_plist_process_type.py -q` failed because `ProcessType` was absent
- After: `python -m pytest tests/hermes_cli/test_launchd_plist_process_type.py -q` -> `1 passed`
- `python -m py_compile hermes_cli/gateway.py`
- `git diff --check`