### PR TITLE
fix(memory): honor global tool disable aliases (#49386)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -87,7 +87,7 @@ def memory_provider_tools_enabled(
     memory_tool_present: bool = False,
 ) -> bool:
     """Return whether external memory-provider tools should be exposed."""
-    if disabled_toolsets and "memory" in disabled_toolsets:
+    if disabled_toolsets and {"memory", "all", "*"}.intersection(disabled_toolsets):
         return False
     if memory_tool_present:
         return True

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -84,7 +84,7 @@ def normalize_tool_schema(schema: Any) -> Optional[Dict[str, Any]]:
 def memory_provider_tools_enabled(enabled_toolsets: Optional[List[str]], disabled_toolsets: Optional[List[str]] = None,
                                   *, memory_tool_present: bool = False) -> bool:
     """Return whether external memory-provider tools should be exposed."""
-    if disabled_toolsets and "memory" in disabled_toolsets:
+    if disabled_toolsets and {"memory", "all", "*"}.intersection(disabled_toolsets):
         return False
     if memory_tool_present or enabled_toolsets is None:
         return True

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1440,6 +1440,18 @@ class TestMemoryToolToolsetGate:
         assert tools == []
         assert names == set()
 
+    @pytest.mark.parametrize("disabled_toolset", ["all", "*"])
+    def test_global_disabled_toolset_blocks_injection(self, disabled_toolset):
+        """Global deny aliases must not be bypassed by provider injection."""
+        mgr = self._mgr_with_tools("fact_store")
+        tools, names = self._run_memory_injection(
+            None,
+            mgr,
+            disabled_toolsets=[disabled_toolset],
+        )
+        assert tools == []
+        assert names == set()
+
     def test_empty_toolsets_blocks_injection(self):
         """`platform_toolsets: telegram: []` must suppress memory tools. (#5544)"""
         mgr = self._mgr_with_tools("fact_store")

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1148,13 +1148,14 @@ class TestMemoryToolToolsetGate:
         assert any(t["function"]["name"] == "hindsight_recall" for t in tools)
 
     @pytest.mark.parametrize("enabled_toolsets", [None, ["memory"], ["all"], ["hermes-acp"]])
-    def test_disabled_memory_toolset_blocks_injection(self, enabled_toolsets):
+    @pytest.mark.parametrize("disabled_toolset", ["memory", "all", "*"])
+    def test_disabled_memory_toolset_blocks_injection(self, enabled_toolsets, disabled_toolset):
         """An explicit memory disable wins over default or composite enablement."""
         mgr = self._mgr_with_tools("hindsight_recall")
         tools, names = self._run_memory_injection(
             enabled_toolsets,
             mgr,
-            disabled_toolsets=["memory"],
+            disabled_toolsets=[disabled_toolset],
         )
         assert tools == []
         assert names == set()

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -142,17 +142,6 @@ def test_refresh_preserves_memory_provider_and_context_engine_tools(monkeypatch)
 
 def test_refresh_does_not_reinject_disabled_memory_provider_tools(monkeypatch):
     """A refresh removes stale provider tools when memory becomes disabled."""
-    agent = _agent(
-        ["read_file", "memory_search"],
-        enabled=["all"],
-        disabled=["memory"],
-    )
-    agent._memory_manager = types.SimpleNamespace(
-        get_all_tool_schemas=lambda: [
-            {"name": "memory_search", "description": "", "parameters": {}}
-        ]
-    )
-
     import model_tools
     monkeypatch.setattr(
         model_tools,
@@ -160,10 +149,22 @@ def test_refresh_does_not_reinject_disabled_memory_provider_tools(monkeypatch):
         lambda **kw: [_tool("read_file")],
     )
 
-    mcp_tool.refresh_agent_mcp_tools(agent)
+    for disabled_toolset in ("memory", "all", "*"):
+        agent = _agent(
+            ["read_file", "memory_search"],
+            enabled=["all"],
+            disabled=[disabled_toolset],
+        )
+        agent._memory_manager = types.SimpleNamespace(
+            get_all_tool_schemas=lambda: [
+                {"name": "memory_search", "description": "", "parameters": {}}
+            ]
+        )
 
-    assert "memory_search" not in agent.valid_tool_names
-    assert all(t["function"]["name"] != "memory_search" for t in agent.tools)
+        mcp_tool.refresh_agent_mcp_tools(agent)
+
+        assert "memory_search" not in agent.valid_tool_names
+        assert all(t["function"]["name"] != "memory_search" for t in agent.tools)
 
 
 def test_refresh_respects_context_engine_toolset_gate(monkeypatch):

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -89,12 +89,13 @@ def test_refresh_preserves_memory_provider_and_context_engine_tools(monkeypatch)
     assert added == {"mcp_new_server_tool"}
 
 
-def test_refresh_does_not_reinject_disabled_memory_provider_tools(monkeypatch):
+@pytest.mark.parametrize("disabled_toolset", ["memory", "all", "*"])
+def test_refresh_does_not_reinject_disabled_memory_provider_tools(monkeypatch, disabled_toolset):
     """A refresh removes stale provider tools when memory becomes disabled."""
     agent = _agent(
         ["read_file", "memory_search"],
         enabled=["all"],
-        disabled=["memory"],
+        disabled=[disabled_toolset],
     )
     agent._memory_manager = types.SimpleNamespace(
         get_all_tool_schemas=lambda: [


### PR DESCRIPTION
External memory providers can re-add tool schemas after `disabled_toolsets=["all"]` or `["*"]` removes registry tools. The shared injection predicate currently recognizes only literal `memory` denial.

Treat both global aliases as memory-provider denials. The same one-line predicate change covers initial injection, prompt exposure, and MCP refresh. Extend the existing injection and refresh tests with alias parameters; enabled-provider behavior stays covered. Snapshot dispatch and broader provider-policy changes remain in separate PRs.

Validation against current main `485aaf69b7f0930a5f6631752172d90a4a5575c6`:
- Before: 10 alias regression cases fail (8 initial injection, 2 refresh); literal-memory cases pass.
- After: `scripts/run_tests.sh tests/agent/test_memory_provider.py tests/tools/test_refresh_agent_mcp_tools.py -q`: 99 passed.
- Ruff and `git diff --check`: passed.

Not checked: full suite; CodeRabbit skipped for this author-side maintenance without P0/P1 priority.

Related #49386 and #46171. The literal-memory fix from #69221 is already upstream; this PR covers only the remaining global aliases.

Agent disclosure: original change by GPT-5.6-sol with xhigh reasoning in Codex Desktop. Maintenance by GPT-6 in Codex desktop (parent reasoning level unavailable). The account owner loosely reviews these actions and receives the usual GitHub notifications.
