### PR TITLE
fix(skills): never change a skill's source registry on update (data loss)

### DIFF
--- a/contributors/emails/carnie-bot@openclaw.local
+++ b/contributors/emails/carnie-bot@openclaw.local
@@ -1,0 +1,2 @@
+menhguin
+# Carnie agent commits — PRs #59009 / #59010 / #72216

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -502,7 +502,8 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
 def do_install(identifier: str, category: str = "", force: bool = False,
                console: Optional[Console] = None, skip_confirm: bool = False,
                invalidate_cache: bool = True,
-               name_override: str = "") -> None:
+               name_override: str = "",
+               source_id: Optional[str] = None) -> None:
     """Fetch, quarantine, scan, confirm, and install a skill.
 
     ``name_override`` lets non-interactive callers (slash commands, gateway,
@@ -511,10 +512,18 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     triggers a prompt instead; ``skip_confirm=True`` means "non-interactive"
     (so pair it with ``name_override`` when installing from a URL that has
     no frontmatter).
+
+    ``source_id`` pins resolution to a single source adapter (e.g. ``clawhub``).
+    Callers that already know a skill's provenance -- notably ``do_update``,
+    which reads it from the lockfile -- should pass it so a bare, slash-less
+    identifier cannot be fuzzy-resolved to a same-named skill in a different
+    registry. Skill names are not namespaced across registries, so an
+    unconstrained resolve can silently change a skill's provenance.
     """
     from tools.skills_hub import (
         GitHubAuth, create_source_router, ensure_hub_dirs,
         quarantine_bundle, install_from_quarantine, HubLockFile,
+        _source_matches,
     )
     from tools.skills_guard import scan_skill_cached, should_allow_install, format_scan_report
 
@@ -524,6 +533,18 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     # Resolve which source adapter handles this identifier
     auth = GitHubAuth()
     sources = create_source_router(auth)
+
+    if source_id:
+        pinned = [src for src in sources if _source_matches(src, source_id)]
+        if pinned:
+            sources = pinned
+        else:
+            c.print(
+                f"[bold red]Error:[/] no source adapter for '{source_id}'. "
+                f"Refusing to resolve '{identifier}' against other registries "
+                f"(that would change the skill's provenance).\n"
+            )
+            return
 
     # If identifier looks like a short name (no slashes), resolve it via search
     if "/" not in identifier:
@@ -1058,7 +1079,20 @@ def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> 
         installed = lock.get_installed(entry["name"])
         category = _derive_category_from_install_path(installed.get("install_path", "")) if installed else ""
         c.print(f"[bold]Updating:[/] {entry['name']}")
-        do_install(entry["identifier"], category=category, force=True, console=c)
+        # Pin the update to the source registry recorded in the lockfile.
+        # Without this, a bare (slash-less) identifier such as "reddit" falls
+        # through to _resolve_short_name()'s fuzzy catalog search inside
+        # do_install, which can match a same-named skill in a DIFFERENT
+        # registry and install that instead -- overwriting the user's files
+        # and rewriting the lock's `source`. An update must never change a
+        # skill's provenance.
+        do_install(
+            entry["identifier"],
+            category=category,
+            force=True,
+            console=c,
+            source_id=entry.get("source", "") or None,
+        )
 
     c.print(f"[bold green]Updated {len(updates)} skill(s).[/]\n")
 

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -92,7 +92,7 @@ def _capture_update(monkeypatch, results) -> tuple[str, list[tuple[str, str, boo
     monkeypatch.setattr(hub, "HubLockFile", lambda: type("L", (), {
         "get_installed": lambda self, name: {"install_path": "category/" + name}
     })())
-    monkeypatch.setattr(cli_hub, "do_install", lambda identifier, category="", force=False, console=None: installs.append((identifier, category, force)))
+    monkeypatch.setattr(cli_hub, "do_install", lambda identifier, category="", force=False, console=None, source_id=None: installs.append((identifier, category, force)))
 
     do_update(console=console)
     return sink.getvalue(), installs
@@ -247,6 +247,123 @@ def test_do_update_reinstalls_outdated_skills(monkeypatch):
 
     assert installs == [("skills-sh/example/repo/hub-skill", "category", True)]
     assert "Updated 1 skill" in output
+
+
+# ---------------------------------------------------------------------------
+# Cross-registry hijack regression tests
+#
+# An update must never change a skill's source registry. Skill names are not
+# namespaced across registries, so an unconstrained name resolve can install a
+# different author's same-named skill over the user's files.
+# ---------------------------------------------------------------------------
+
+
+def test_do_update_pins_install_to_locked_source(monkeypatch):
+    """do_update must forward the lockfile's `source` to do_install.
+
+    Without the pin, a bare identifier like "reddit" reaches
+    _resolve_short_name()'s fuzzy catalog search inside do_install and can
+    resolve to a same-named skill in another registry.
+    """
+    import tools.skills_hub as hub
+    import hermes_cli.skills_hub as cli_hub
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    calls = []
+
+    monkeypatch.setattr(hub, "check_for_skill_updates", lambda **_kwargs: [
+        {"name": "reddit", "identifier": "reddit", "source": "clawhub",
+         "status": "update_available"},
+    ])
+    monkeypatch.setattr(hub, "HubLockFile", lambda: type("L", (), {
+        "get_installed": lambda self, name: {"install_path": "category/" + name}
+    })())
+    monkeypatch.setattr(
+        cli_hub, "do_install",
+        lambda identifier, category="", force=False, console=None, source_id=None:
+            calls.append({"identifier": identifier, "source_id": source_id}),
+    )
+
+    do_update(console=console)
+
+    assert calls == [{"identifier": "reddit", "source_id": "clawhub"}]
+
+
+def test_do_install_refuses_unknown_pinned_source(monkeypatch, hub_env):
+    """A pinned source with no matching adapter must abort, not fall back.
+
+    Falling back to the full source router is what allowed a foreign registry
+    to satisfy the install.
+    """
+    import tools.skills_hub as hub
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    resolved = []
+
+    monkeypatch.setattr(hub, "create_source_router", lambda auth=None: [])
+    monkeypatch.setattr(hub, "GitHubAuth", lambda: object())
+    monkeypatch.setattr(
+        "hermes_cli.skills_hub._resolve_short_name",
+        lambda name, sources, c: resolved.append(name) or "",
+    )
+
+    do_install("reddit", source_id="clawhub", console=console)
+
+    assert resolved == [], "must not attempt a fuzzy resolve when the pin is unsatisfiable"
+    assert "provenance" in sink.getvalue()
+
+
+def test_check_for_skill_updates_does_not_fall_back_across_registries():
+    """An entry whose source has no adapter reports `unavailable`.
+
+    Previously `candidate_sources ... or sources` fell back to every source, so
+    a same-named skill in another registry could satisfy the fetch and be
+    reported as this entry's update -- the step that preceded the overwrite.
+    The foreign source here returns a *valid* bundle with a different hash, so
+    the old code reports `update_available` (sourced from the wrong registry)
+    while the fixed code reports `unavailable`.
+    """
+    from tools.skills_hub import check_for_skill_updates
+
+    class _ForeignBundle:
+        name = "reddit"
+        files = {"SKILL.md": "# a different author's reddit skill"}
+        source = "skills.sh"
+        identifier = "skills-sh/someone-else/reddit"
+        trust_level = "community"
+        metadata: dict = {}
+
+    class _ForeignSource:
+        """skills-sh adapter; must NOT be consulted for a clawhub-locked entry."""
+
+        def source_id(self):
+            return "skills-sh"
+
+        def fetch(self, identifier):
+            return _ForeignBundle()
+
+        def inspect(self, identifier):
+            return _ForeignBundle()
+
+    lock = _DummyLockFile([
+        {"name": "reddit", "identifier": "reddit", "source": "clawhub",
+         "content_hash": "hash-of-the-clawhub-copy"},
+    ])
+
+    results = check_for_skill_updates(
+        lock=lock,  # type: ignore[arg-type]  # duck-typed double, matches _DummyLockFile usage above
+        sources=[_ForeignSource()],  # type: ignore[list-item]
+    )
+
+    assert len(results) == 1
+    assert results[0]["source"] == "clawhub", "provenance must be preserved"
+    assert results[0]["status"] == "unavailable", (
+        "a clawhub-locked skill must not be matched against a skills-sh bundle; "
+        "reporting update_available here is the cross-registry hijack"
+    )
+    assert "bundle" not in results[0], "must not carry a foreign registry's bundle"
 
 
 def test_handle_skills_slash_search_accepts_chatconsole_without_status_errors():

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3742,7 +3742,22 @@ def check_for_skill_updates(
     for entry in installed:
         identifier = entry.get("identifier", "")
         source_name = entry.get("source", "")
-        candidate_sources = [src for src in sources if _source_matches(src, source_name)] or sources
+        candidate_sources = [src for src in sources if _source_matches(src, source_name)]
+        if not candidate_sources:
+            # No adapter for the recorded source (e.g. a tap was removed, or the
+            # source was renamed upstream). Previously this fell back to *all*
+            # sources, which meant a same-named skill in a DIFFERENT registry
+            # could satisfy the fetch and be reported as an update for this
+            # entry -- silently reassigning provenance. Skill names are not
+            # namespaced across registries, so that fallback is unsafe by
+            # construction. Report unavailable instead and let the user decide.
+            results.append({
+                "name": entry.get("name", ""),
+                "identifier": identifier,
+                "source": source_name,
+                "status": "unavailable",
+            })
+            continue
 
         bundle = None
         for src in candidate_sources:


### PR DESCRIPTION
## What does this PR do?

Stops `hermes skills update` from silently replacing a skill with a **same-named skill from a different registry by a different author**, deleting the original's files while reporting `Updated N skill(s).`

Skill names are not namespaced across registries, so any name collision could silently reassign provenance. On the reporter's machine this deleted all 5 scripts from `stock-market-pro` (8 files → 1) and `reddit.mjs` from `reddit`, leaving `stock-market-pro`'s replacement `SKILL.md` instructing users to run scripts that no longer existed.

**The approach:** treat a registry change as a *provenance change*, not an update. Both defects below are fixed by refusing to resolve outside the source recorded in the lockfile, rather than by making the fuzzy search smarter — a smarter search would still be guessing at provenance.

## Related Issue

Fixes #72215

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

**`tools/skills_hub.py::check_for_skill_updates`**
- `candidate_sources = [...] or sources` fell back to **every** registry when the lockfile's recorded source had no matching adapter, so a foreign same-named skill satisfied `src.fetch(identifier)` and was reported as this entry's update. Now reports `unavailable` and leaves the decision to the user.

**`hermes_cli/skills_hub.py::do_install`**
- New optional `source_id` parameter pins resolution to a single source adapter. An unsatisfiable pin **aborts with a clear message** rather than falling back to the full router — falling back is precisely the bug.

**`hermes_cli/skills_hub.py::do_update`**
- Forwards the lockfile's `source` to `do_install`, so a bare (slash-less) identifier like `reddit` can no longer reach `_resolve_short_name`'s cross-registry fuzzy search.

**`tests/hermes_cli/test_skills_hub.py`**
- Three regression tests (below), plus the existing `_capture_update` helper's `do_install` stub updated for the new keyword.

## How to Test

**Reproduce (pre-fix):** with a `clawhub`-sourced skill that has a same-named twin on `skills.sh`, run bare `hermes skills update`. It reports success; `git diff` in `~/.hermes` shows the files replaced and `lock.json`'s `source` flipped to `skills.sh`. `hermes skills check` then reports `up_to_date`, tracking the *new* upstream — nothing surfaces the swap.

**Automated:**
```bash
pytest tests/hermes_cli/test_skills_hub.py -k "pins_install or refuses_unknown_pinned or fall_back_across" -q
```

Each test was verified to **fail against the unfixed code**, not just pass against the fix:

| Test | Failure without the fix |
|---|---|
| `test_do_update_pins_install_to_locked_source` | `source_id: None != 'clawhub'` |
| `test_check_for_skill_updates_does_not_fall_back_across_registries` | `'update_available' == 'unavailable'` — reproduces the hijack |
| `test_do_install_refuses_unknown_pinned_source` | attempts a fuzzy resolve instead of aborting |

**Suite:** `tests/hermes_cli/test_skills_hub.py` + `tests/hermes_cli/test_skills_skip_confirm.py` + `tests/tools/test_skills_hub.py` → **193 passed, 12 failed**. Those same **12 fail identically on unmodified `main`** in this environment (`AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'` from `tools/daemon_pool.py:58` — all in `TestUnifiedSearchDedup` / `TestParallelSearchSourcesTimeout`), so they're pre-existing and unrelated. Verified by `git stash` + re-run: 175 passed / 12 failed before, 193 passed / same 12 after.

## Notes for reviewers

- **Behaviour change worth a look:** an entry whose recorded source has no adapter now reports `unavailable` instead of opportunistically resolving elsewhere. That's intentional — the old fallback is the vulnerability — but it does mean a removed tap surfaces as `unavailable` rather than silently resolving to whatever else matches the name.
- **Not addressed here, but related and worth a separate fix:** the security scan runs *after* files are written, so a blocked install can leave a half-swapped tree (observed on `reddit`). Scanning before the write would make blocked installs atomic. Happy to do that as a follow-up if you'd like it separate.
- An owner-scoped identifier (`theglove44/reddit`) contains a slash and already dodges the fuzzy resolver, so re-keying lock entries to owner-scoped form is a complementary mitigation — but it depends on every existing lockfile being rewritten, which is why this PR fixes the resolution path instead.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] Searched open *and* merged PRs/issues for duplicates (`gh search issues/prs` on `cross-registry`, `skills update source registry`, `_resolve_short_name`, `skills update overwrites`) — nearest are #6866 and #37008, same resolver path but different symptoms (broken install / hang, not data loss)
- [x] Code follows existing patterns in the touched files
- [x] No new dependencies
- [x] Comments explain *why* at each change site, not just what

### Tests

- [x] New regression tests added
- [x] Each new test verified to fail without the fix
- [x] Confirmed the 12 remaining failures are pre-existing on `main`
