### PR TITLE
fix(desktop): summarize code blocks for read aloud

### DIFF
--- a/apps/desktop/src/lib/speech-text.test.ts
+++ b/apps/desktop/src/lib/speech-text.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeTextForSpeech } from './speech-text'
+
+describe('sanitizeTextForSpeech', () => {
+  it('summarizes fenced code blocks instead of reading them literally', () => {
+    expect(sanitizeTextForSpeech('Here is code:\n```ts\nconst x = 1\n```\nDone.')).toBe(
+      'Here is code: code block omitted Done.'
+    )
+  })
+
+  it('still keeps normal prose and inline code readable', () => {
+    expect(sanitizeTextForSpeech('Use `git status` after the change.')).toBe(
+      'Use git status after the change.'
+    )
+  })
+})

--- a/apps/desktop/src/lib/speech-text.ts
+++ b/apps/desktop/src/lib/speech-text.ts
@@ -1,6 +1,7 @@
 const EMOJI_RE = /(?:[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}]|[\u{FE0F}\u{200D}]|[\u{E0020}-\u{E007F}])+/gu
 
 const FENCED_CODE_RE = /```[\s\S]*?(?:```|$)/g
+const CODE_BLOCK_SUMMARY = ' code block omitted '
 const INLINE_CODE_RE = /`([^`]+)`/g
 const MARKDOWN_LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g
 const PARAGRAPH_BREAK_RE = /[ \t]*\n{2,}[ \t]*/g
@@ -21,7 +22,7 @@ function normalizeLineBreaks(text: string): string {
 
 export function sanitizeTextForSpeech(text: string): string {
   return normalizeLineBreaks(text)
-    .replace(FENCED_CODE_RE, ' ')
+    .replace(FENCED_CODE_RE, CODE_BLOCK_SUMMARY)
     .replace(THINKING_PREFIX_RE, ' ')
     .replace(MARKDOWN_LINK_RE, '$1')
     .replace(INLINE_CODE_RE, '$1')


### PR DESCRIPTION
## Summary
- Replace fenced code blocks in desktop Read Aloud text with a short audible placeholder: "code block omitted"
- Add a focused sanitizer test covering fenced code and inline code behavior

## Test Plan
- [x] `./node_modules/.bin/vitest run apps/desktop/src/lib/speech-text.test.ts`
- [x] `npm run build --workspace apps/desktop`

## Notes
This keeps Read Aloud from silently dropping large code blocks or attempting to narrate raw code-heavy responses.