### PR TITLE
fix(tui-gateway): scope MCP discovery to the selected profile (Desktop/dashboard)

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -58,7 +58,28 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
         if not _has_configured_mcp_servers():
             return
 
+        # Capture the caller's context-local HERMES_HOME override (profile
+        # scoping in multi-profile processes like the dashboard/desktop
+        # backend) and re-install it inside the discovery thread. ContextVars
+        # do not propagate into bare threads, so without this a session
+        # "switched" to profile X would discover the LAUNCH profile's
+        # mcp_servers instead (#67605). The config gate above already runs on
+        # the caller's thread, so it sees the same override.
+        try:
+            from hermes_constants import get_hermes_home_override
+
+            home_override = get_hermes_home_override()
+        except Exception:
+            home_override = None
+
         def _discover() -> None:
+            token = None
+            try:
+                from hermes_constants import set_hermes_home_override
+
+                token = set_hermes_home_override(home_override)
+            except Exception:
+                token = None
             try:
                 _discover_mcp_tools_without_interactive_oauth()
                 try:
@@ -73,6 +94,13 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
             except Exception:
                 logger.debug("Background MCP tool discovery failed", exc_info=True)
             finally:
+                if token is not None:
+                    try:
+                        from hermes_constants import reset_hermes_home_override
+
+                        reset_hermes_home_override(token)
+                    except Exception:
+                        pass
                 with _mcp_discovery_lock:
                     global _mcp_discovery_thread, _mcp_discovery_started
                     _mcp_discovery_thread = None

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -94,6 +94,7 @@ def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
     session_key = "cwd-key"
     project = tmp_path / "project"
     project.mkdir()
+    (project / ".git").mkdir()
     launcher = tmp_path / "apps" / "desktop"
     launcher.mkdir(parents=True)
 
@@ -10787,12 +10788,14 @@ def test_session_most_recent_handles_db_unavailable(monkeypatch):
 # ── verification.status ──────────────────────────────────────────────
 
 
-def test_verification_status_returns_recorded_evidence(tmp_path):
-    home = tmp_path / ".hermes"
-    home.mkdir()
-    token = set_hermes_home_override(home)
+def test_verification_status_returns_recorded_evidence(tmp_path, monkeypatch):
+    profile_home = tmp_path / "profiles" / "verify"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "verify" else None)
+    token = set_hermes_home_override(profile_home)
     project = tmp_path / "project"
     project.mkdir()
+    (project / ".git").mkdir()
     (project / "package.json").write_text(
         json.dumps({"scripts": {"test": "vitest"}}),
         encoding="utf-8",
@@ -10813,7 +10816,7 @@ def test_verification_status_returns_recorded_evidence(tmp_path):
             {
                 "id": "1",
                 "method": "verification.status",
-                "params": {"cwd": str(project), "session_id": "sid"},
+                "params": {"cwd": str(project), "session_id": "sid", "profile": "verify"},
             }
         )
     finally:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -569,6 +569,7 @@ def _write_profile_cfg(home: Path, cwd: str | None) -> Path:
 
 def test_profile_scoped_mcp_discovery_uses_target_home(monkeypatch, tmp_path):
     """MCP discovery must start under the selected profile's HERMES_HOME."""
+    from hermes_cli import mcp_startup
     from hermes_constants import get_hermes_home
     from tui_gateway import entry
 
@@ -587,20 +588,26 @@ def test_profile_scoped_mcp_discovery_uses_target_home(monkeypatch, tmp_path):
 
     seen = []
 
-    monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_started", False)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    # ensure_mcp_discovery_started flips this module global; monkeypatch it so
+    # the enablement doesn't leak into sibling tests in this file.
+    monkeypatch.setattr(entry, "_mcp_discovery_enabled", False)
     monkeypatch.setattr(
-        "tools.mcp_tool.discover_mcp_tools",
+        mcp_startup,
+        "_discover_mcp_tools_without_interactive_oauth",
         lambda: seen.append(str(get_hermes_home())),
     )
 
     try:
         entry.ensure_mcp_discovery_started()
-        thread = entry._mcp_discovery_thread
+        thread = mcp_startup._mcp_discovery_thread
         assert thread is not None
         thread.join(timeout=2)
     finally:
         reset_hermes_home_override(token)
-        entry._mcp_discovery_thread = None
+        mcp_startup._mcp_discovery_thread = None
+        mcp_startup._mcp_discovery_started = False
 
     assert seen == [str(profile_home)]
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -566,6 +566,93 @@ def _write_profile_cfg(home: Path, cwd: str | None) -> Path:
     return home
 
 
+def test_profile_scoped_mcp_discovery_uses_target_home(monkeypatch, tmp_path):
+    """MCP discovery must start under the selected profile's HERMES_HOME."""
+    from hermes_constants import get_hermes_home
+    from tui_gateway import entry
+
+    profile_home = tmp_path / "profiles" / "sheepyr"
+    profile_home.mkdir(parents=True)
+
+    (profile_home / "config.yaml").write_text(
+        "mcp_servers:\n"
+        "  bluesky_sheepyr:\n"
+        "    command: test-command\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default"))
+    token = set_hermes_home_override(str(profile_home))
+
+    seen = []
+
+    monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(
+        "tools.mcp_tool.discover_mcp_tools",
+        lambda: seen.append(str(get_hermes_home())),
+    )
+
+    try:
+        entry.ensure_mcp_discovery_started()
+        thread = entry._mcp_discovery_thread
+        assert thread is not None
+        thread.join(timeout=2)
+    finally:
+        reset_hermes_home_override(token)
+        entry._mcp_discovery_thread = None
+
+    assert seen == [str(profile_home)]
+
+
+def test_profile_scoped_agent_build_starts_mcp_discovery_in_profile_home(
+    monkeypatch, tmp_path
+):
+    """Agent construction must start MCP discovery under the selected profile."""
+    import threading
+
+    from hermes_constants import get_hermes_home
+
+    profile_home = tmp_path / "profiles" / "sheepyr"
+    profile_home.mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default"))
+
+    seen = []
+    built = threading.Event()
+
+    monkeypatch.setattr(
+        server,
+        "_make_agent",
+        lambda *args, **kwargs: built.set()
+        or type("Agent", (), {"model": "test"})(),
+    )
+    monkeypatch.setattr(
+        "tui_gateway.entry.ensure_mcp_discovery_started",
+        lambda: seen.append(str(get_hermes_home())),
+    )
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_SlashWorker", lambda *args: None)
+    monkeypatch.setattr(server, "_attach_worker", lambda *args: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+
+    ready = threading.Event()
+    sid = "test-sid"
+    session = {
+        "agent_ready": ready,
+        "session_key": "test-key",
+        "profile_home": str(profile_home),
+    }
+
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert built.wait(timeout=2)
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert seen == [str(profile_home)]
+
+
 def test_profile_configured_cwd_reads_target_profile(tmp_path):
     """A profile's own terminal.cwd is read from its config.yaml."""
     project = tmp_path / "proj"

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -9,13 +9,14 @@ from tui_gateway import server
 from tui_gateway import ws as ws_mod
 
 
-def test_ws_startup_starts_background_mcp_discovery(monkeypatch):
-    """The desktop app and dashboard chat reach the agent through this WS
-    sidecar, not through tui_gateway.entry.main() (which spawns the discovery
-    thread for the stdio TUI). handle_ws must start discovery itself, otherwise
-    _make_agent's wait_for_mcp_discovery no-ops and the agent snapshots an
-    MCP-less tool list. Regression test for #38945."""
+def test_ws_does_not_own_mcp_discovery_startup(monkeypatch):
+    """WebSocket transport must not start MCP discovery itself.
+
+    MCP discovery ownership belongs to the profile-scoped agent build path.
+    The WS layer only establishes the transport and emits gateway readiness.
+    """
     calls = []
+
     monkeypatch.setattr(
         mcp_startup,
         "start_background_mcp_discovery",
@@ -41,7 +42,7 @@ def test_ws_startup_starts_background_mcp_discovery(monkeypatch):
     finally:
         server._sessions.clear()
 
-    assert calls == [{"logger": ws_mod._log, "thread_name": "tui-ws-mcp-discovery"}]
+    assert calls == []
 
 
 def _run_disconnect(monkeypatch, seed):

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -218,3 +218,121 @@ def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
     # should not start MCP discovery before a profile has been bound.
     assert calls == []
     assert events == ["accept", "ready_after_0"]
+
+
+def test_ws_transport_serializes_concurrent_sends():
+    active_sends = 0
+    max_active_sends = 0
+    sent = []
+
+    class FakeWS:
+        async def send_text(self, line):
+            nonlocal active_sends, max_active_sends
+            active_sends += 1
+            max_active_sends = max(max_active_sends, active_sends)
+            try:
+                await asyncio.sleep(0.05)
+                sent.append(line)
+            finally:
+                active_sends -= 1
+
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    try:
+        transport = ws_mod.WSTransport(FakeWS(), loop, peer="serialize-test")
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [
+                pool.submit(transport.write, {"idx": 1}),
+                pool.submit(transport.write, {"idx": 2}),
+            ]
+            assert [f.result(timeout=2) for f in futures] == [True, True]
+
+        assert len(sent) == 2
+        assert max_active_sends == 1
+        assert transport._closed is False
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=2)
+        loop.close()
+
+
+def test_ws_transport_preserves_cross_batch_order():
+    async def scenario():
+        entered = []
+        first_entered = asyncio.Event()
+        release_first = asyncio.Event()
+        second_started = asyncio.Event()
+
+        class FakeWS:
+            async def send_text(self, line):
+                entered.append(line)
+                if line == "A1":
+                    first_entered.set()
+                    await release_first.wait()
+
+        transport = ws_mod.WSTransport(
+            FakeWS(), asyncio.get_running_loop(), peer="batch-order-test"
+        )
+        first = asyncio.create_task(transport._safe_send_many(["A1", "A2"]))
+        await first_entered.wait()
+
+        async def send_second():
+            second_started.set()
+            await transport._safe_send_many(["B1", "B2"])
+
+        second = asyncio.create_task(send_second())
+        await second_started.wait()
+
+        # The second task has reached the transport. Without whole-batch
+        # serialization it runs B1/B2 before this task can resume.
+        assert entered == ["A1"]
+
+        release_first.set()
+        await asyncio.gather(first, second)
+        assert entered == ["A1", "A2", "B1", "B2"]
+
+    asyncio.run(scenario())
+
+
+def test_ws_write_async_keeps_drained_tokens_with_current_frame():
+    async def scenario():
+        entered = []
+        first_entered = asyncio.Event()
+        release_first = asyncio.Event()
+        current_started = asyncio.Event()
+
+        class FakeWS:
+            async def send_text(self, line):
+                entered.append(line)
+                if line == "A1":
+                    first_entered.set()
+                    await release_first.wait()
+
+        transport = ws_mod.WSTransport(
+            FakeWS(), asyncio.get_running_loop(), peer="async-order-test"
+        )
+        transport._pending_tokens.append("pending-token")
+
+        first = asyncio.create_task(transport._safe_send_many(["A1", "A2"]))
+        await first_entered.wait()
+
+        async def send_current():
+            current_started.set()
+            await transport.write_async({"id": "current"})
+
+        current = asyncio.create_task(send_current())
+        await current_started.wait()
+        later = asyncio.create_task(transport._safe_send_many(["later-batch"]))
+
+        release_first.set()
+        await asyncio.gather(first, current, later)
+        assert entered == [
+            "A1",
+            "A2",
+            "pending-token",
+            json.dumps({"id": "current"}),
+            "later-batch",
+        ]
+
+    asyncio.run(scenario())

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -213,5 +213,7 @@ def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
 
     asyncio.run(ws_mod.handle_ws(FakeWS()))
 
-    assert calls == ["mcp"]
-    assert events == ["accept", "ready_after_1"]
+    # Discovery moved to profile-aware agent construction. WebSocket transport
+    # should not start MCP discovery before a profile has been bound.
+    assert calls == []
+    assert events == ["accept", "ready_after_0"]

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -188,119 +188,30 @@ def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
         loop.close()
 
 
-def test_ws_transport_serializes_concurrent_sends():
-    active_sends = 0
-    max_active_sends = 0
-    sent = []
+def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
+    import tui_gateway.entry as entry
+
+    calls = []
+    events = []
+
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
+    monkeypatch.setattr(entry, "ensure_mcp_discovery_started", lambda: calls.append("mcp"))
 
     class FakeWS:
+        async def accept(self):
+            events.append("accept")
+
         async def send_text(self, line):
-            nonlocal active_sends, max_active_sends
-            active_sends += 1
-            max_active_sends = max(max_active_sends, active_sends)
-            try:
-                await asyncio.sleep(0.05)
-                sent.append(line)
-            finally:
-                active_sends -= 1
+            if '"gateway.ready"' in line:
+                events.append(f"ready_after_{len(calls)}")
 
-    loop = asyncio.new_event_loop()
-    thread = threading.Thread(target=loop.run_forever, daemon=True)
-    thread.start()
-    try:
-        transport = ws_mod.WSTransport(FakeWS(), loop, peer="serialize-test")
-        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
-            futures = [
-                pool.submit(transport.write, {"idx": 1}),
-                pool.submit(transport.write, {"idx": 2}),
-            ]
-            assert [f.result(timeout=2) for f in futures] == [True, True]
+        async def receive_text(self):
+            raise ws_mod._WebSocketDisconnect()
 
-        assert len(sent) == 2
-        assert max_active_sends == 1
-        assert transport._closed is False
-    finally:
-        loop.call_soon_threadsafe(loop.stop)
-        thread.join(timeout=2)
-        loop.close()
+        async def close(self):
+            pass
 
+    asyncio.run(ws_mod.handle_ws(FakeWS()))
 
-def test_ws_transport_preserves_cross_batch_order():
-    async def scenario():
-        entered = []
-        first_entered = asyncio.Event()
-        release_first = asyncio.Event()
-        second_started = asyncio.Event()
-
-        class FakeWS:
-            async def send_text(self, line):
-                entered.append(line)
-                if line == "A1":
-                    first_entered.set()
-                    await release_first.wait()
-
-        transport = ws_mod.WSTransport(
-            FakeWS(), asyncio.get_running_loop(), peer="batch-order-test"
-        )
-        first = asyncio.create_task(transport._safe_send_many(["A1", "A2"]))
-        await first_entered.wait()
-
-        async def send_second():
-            second_started.set()
-            await transport._safe_send_many(["B1", "B2"])
-
-        second = asyncio.create_task(send_second())
-        await second_started.wait()
-
-        # The second task has reached the transport. Without whole-batch
-        # serialization it runs B1/B2 before this task can resume.
-        assert entered == ["A1"]
-
-        release_first.set()
-        await asyncio.gather(first, second)
-        assert entered == ["A1", "A2", "B1", "B2"]
-
-    asyncio.run(scenario())
-
-
-def test_ws_write_async_keeps_drained_tokens_with_current_frame():
-    async def scenario():
-        entered = []
-        first_entered = asyncio.Event()
-        release_first = asyncio.Event()
-        current_started = asyncio.Event()
-
-        class FakeWS:
-            async def send_text(self, line):
-                entered.append(line)
-                if line == "A1":
-                    first_entered.set()
-                    await release_first.wait()
-
-        transport = ws_mod.WSTransport(
-            FakeWS(), asyncio.get_running_loop(), peer="async-order-test"
-        )
-        transport._pending_tokens.append("pending-token")
-
-        first = asyncio.create_task(transport._safe_send_many(["A1", "A2"]))
-        await first_entered.wait()
-
-        async def send_current():
-            current_started.set()
-            await transport.write_async({"id": "current"})
-
-        current = asyncio.create_task(send_current())
-        await current_started.wait()
-        later = asyncio.create_task(transport._safe_send_many(["later-batch"]))
-
-        release_first.set()
-        await asyncio.gather(first, current, later)
-        assert entered == [
-            "A1",
-            "A2",
-            "pending-token",
-            json.dumps({"id": "current"}),
-            "later-batch",
-        ]
-
-    asyncio.run(scenario())
+    assert calls == ["mcp"]
+    assert events == ["accept", "ready_after_1"]

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -338,57 +338,59 @@ def join_mcp_discovery(timeout: float | None = None) -> bool:
 _recovery_times: list[float] = []
 
 
+
+def _has_configured_mcp_servers() -> bool:
+    """Return whether startup should attempt MCP discovery.
+
+    Keep this cheap so non-MCP users do not pay the MCP SDK import cost.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+
+        mcp_servers = (read_raw_config() or {}).get("mcp_servers")
+        return isinstance(mcp_servers, dict) and len(mcp_servers) > 0
+    except Exception:
+        # Be conservative: if we can't decide, fall back to attempting
+        # discovery. The caller starts it in the background.
+        return True
+
+
+def ensure_mcp_discovery_started() -> None:
+    """Start background MCP discovery once for gateway entrypoints.
+
+    ``main()`` covers the stdio/TUI path. WebSocket/Desktop entrypoints can
+    accept sessions without running ``main()``, so they must call this helper
+    before the first agent snapshots its tool list.
+    """
+    global _mcp_discovery_thread
+
+    if _mcp_discovery_thread is not None:
+        return
+
+    if not _has_configured_mcp_servers():
+        return
+
+    def _discover_mcp_background() -> None:
+        try:
+            from tools.mcp_tool import discover_mcp_tools
+
+            discover_mcp_tools()
+        except Exception:
+            logger.warning("Background MCP tool discovery failed", exc_info=True)
+
+    import threading as _mcp_threading
+
+    _mcp_discovery_thread = _mcp_threading.Thread(
+        target=_discover_mcp_background,
+        name="tui-mcp-discovery",
+        daemon=True,
+    )
+    _mcp_discovery_thread.start()
+
+
 def main():
     _install_sidecar_publisher()
 
-    # MCP tool discovery — runs in a background daemon thread so a slow or
-    # unreachable MCP server can't freeze TUI startup.  Previously this ran
-    # inline before ``gateway.ready``, which meant any configured-but-down
-    # server stalled the whole shell on "summoning hermes…" for the full
-    # connect-retry backoff (e.g. a dead stdio/http server burns 1+2+4s of
-    # retries → ~7s of dead air before the composer appears).  Discovery is
-    # idempotent and registers tools into the shared registry as servers
-    # connect.  The agent isn't built until the first prompt, at which point
-    # ``_make_agent`` briefly joins this thread (``wait_for_mcp_discovery``,
-    # bounded) so already-spawning fast servers land in the tool snapshot —
-    # a dead server is simply not waited on past the bound.  ``/reload-mcp``
-    # rebuilds the snapshot for servers that connect later in the session.
-    #
-    # Cold-start guard: importing ``tools.mcp_tool`` transitively pulls the
-    # full MCP SDK (mcp, pydantic, httpx, jsonschema, starlette parsers —
-    # ~200ms on macOS).  The overwhelming majority of users have no
-    # ``mcp_servers`` configured, in which case every byte of that import is
-    # wasted.  Check the config first (cheap) and only spawn the discovery
-    # thread when there's actually MCP work to do, so the import cost stays
-    # off the path entirely for the common case.
-    try:
-        from hermes_cli.config import read_raw_config
-        _mcp_servers = (read_raw_config() or {}).get("mcp_servers")
-        _has_mcp_servers = isinstance(_mcp_servers, dict) and len(_mcp_servers) > 0
-    except Exception:
-        # Be conservative: if we can't decide, fall back to attempting
-        # discovery (still backgrounded, so it can't block startup).
-        _has_mcp_servers = True
-    if _has_mcp_servers:
-        # Spawn via the shared owner in hermes_cli.mcp_startup instead of
-        # a hand-rolled thread, so the stdio TUI gets the same restart
-        # semantics as every other surface: a discovery run that completed
-        # with zero connected servers may be retried by a later spawn call
-        # instead of latching the process into a no-MCP-tools state.
-        # wait_for_mcp_discovery/mcp_discovery_in_flight/
-        # join_mcp_discovery below already consult that owner.
-        global _mcp_discovery_enabled
-        _mcp_discovery_enabled = True
-        try:
-            from hermes_cli.mcp_startup import start_background_mcp_discovery
-
-            start_background_mcp_discovery(
-                logger=logger, thread_name="tui-mcp-discovery"
-            )
-        except Exception:
-            logger.warning(
-                "Background MCP tool discovery failed to start", exc_info=True
-            )
 
     if not write_json({
         "jsonrpc": "2.0",

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -24,20 +24,23 @@ from tui_gateway.transport import TeeTransport
 
 logger = logging.getLogger(__name__)
 
-# Handle for the background MCP tool-discovery thread (see main()).  The first
-# agent build briefly joins this so already-spawning fast servers land before
-# the agent snapshots its tool list (see wait_for_mcp_discovery).
+# Handle for the background MCP tool-discovery thread (see
+# ensure_mcp_discovery_started).  The first agent build briefly joins this so
+# already-spawning fast servers land before the agent snapshots its tool list
+# (see wait_for_mcp_discovery).  Stays None when discovery is delegated to the
+# shared owner in hermes_cli.mcp_startup — the wait/in-flight/join helpers
+# below consult both owners.
 _mcp_discovery_thread = None
 
-# True once main() decided this TUI process has MCP servers configured and
-# spawned discovery through the shared owner. Lets wait_for_mcp_discovery
-# re-invoke the (idempotent) spawn on later agent builds so the
-# retry-after-zero-connected allowance in
-# hermes_cli.mcp_startup.start_background_mcp_discovery can actually fire for
-# the stdio TUI — without this, main()'s single spawn is the only call and a
-# first run that connected nothing latches the process MCP-less. Kept as a
-# flag (rather than re-probing config) so non-MCP sessions never pay the
-# tools.mcp_tool import on the per-agent-build wait path.
+# True once ensure_mcp_discovery_started decided this process has MCP servers
+# configured and spawned discovery through the shared owner. Lets
+# wait_for_mcp_discovery re-invoke the (idempotent) spawn on later agent
+# builds so the retry-after-zero-connected allowance in
+# hermes_cli.mcp_startup.start_background_mcp_discovery can actually fire —
+# without this, the single spawn is the only call and a first run that
+# connected nothing latches the process MCP-less. Kept as a flag (rather than
+# re-probing config) so non-MCP sessions never pay the tools.mcp_tool import
+# on the per-agent-build wait path.
 _mcp_discovery_enabled = False
 
 
@@ -243,17 +246,18 @@ def wait_for_mcp_discovery(timeout: "float | None" = None) -> None:
             bound = timeout if timeout is not None else 0.75
         thread.join(timeout=bound)
         return
-    # The stdio TUI spawns discovery via the shared owner (see main()); wait
-    # on it so the first agent build still catches fast servers. Re-invoke
-    # the idempotent spawn first: if the previous run finished with zero
-    # connected servers, start_background_mcp_discovery's
-    # retry-after-zero-connected allowance kicks off a fresh discovery run
-    # here instead of leaving the TUI latched MCP-less for the session.
-    # Only the stdio TUI (which spawned discovery through the shared owner)
-    # should delegate to the startup wait here — for every other surface
-    # (dashboard /api/ws) _make_agent already calls
-    # hermes_cli.mcp_startup.wait_for_mcp_discovery directly, and delegating
-    # unconditionally would make that bounded wait run twice per agent build.
+    # Discovery is spawned via the shared owner (ensure_mcp_discovery_started
+    # → hermes_cli.mcp_startup); wait on it so the first agent build still
+    # catches fast servers. Re-invoke the idempotent spawn first: if the
+    # previous run finished with zero connected servers,
+    # start_background_mcp_discovery's retry-after-zero-connected allowance
+    # kicks off a fresh discovery run here instead of leaving the process
+    # latched MCP-less for the session. In multi-profile processes this
+    # retry runs under the CALLER's profile context (agent build binds the
+    # session profile's HERMES_HOME first), so a launch profile with no
+    # mcp_servers no longer starves selected profiles of discovery (#67605).
+    # Gated on _mcp_discovery_enabled so non-MCP sessions never pay the
+    # tools.mcp_tool import on the per-agent-build wait path.
     if not _mcp_discovery_enabled:
         return
     try:
@@ -356,48 +360,53 @@ def _has_configured_mcp_servers() -> bool:
 
 
 def ensure_mcp_discovery_started() -> None:
-    """Start background MCP discovery once for gateway entrypoints.
+    """Start background MCP discovery for the current profile context, once.
 
-    ``main()`` covers the stdio/TUI path. WebSocket/Desktop entrypoints can
-    accept sessions without running ``main()``, so they must call this helper
-    before the first agent snapshots its tool list.
+    ``main()`` calls this for the stdio/TUI path. WebSocket/Desktop
+    entrypoints can accept sessions without running ``main()``, so the
+    agent-build path (``server._start_agent_build``) also calls it AFTER
+    binding the session profile's HERMES_HOME override — the shared owner in
+    ``hermes_cli.mcp_startup`` captures the caller's context-local override
+    and propagates it into the discovery thread, so discovery reads the
+    SELECTED profile's ``mcp_servers``, not the launch profile's (#67605).
+
+    Delegating to the shared owner (instead of a hand-rolled thread) keeps
+    the process-wide start lock, the retry-after-zero-connected allowance,
+    and interactive-OAuth suppression.
+
+    Known limitation: MCP tool registration is process-global, so in a
+    multi-profile process the FIRST profile that builds an agent wins the
+    discovery slot. Full per-profile MCP registries are tracked in #67605.
     """
-    global _mcp_discovery_thread
-
-    from hermes_constants import get_hermes_home_override, reset_hermes_home_override, set_hermes_home_override
-
-    if _mcp_discovery_thread is not None:
-        return
+    global _mcp_discovery_enabled
 
     if not _has_configured_mcp_servers():
         return
+    _mcp_discovery_enabled = True
+    try:
+        from hermes_cli.mcp_startup import start_background_mcp_discovery
 
-    home_override = get_hermes_home_override()
-
-    def _discover_mcp_background() -> None:
-        token = set_hermes_home_override(home_override)
-        try:
-            from tools.mcp_tool import discover_mcp_tools
-
-            discover_mcp_tools()
-        except Exception:
-            logger.warning("Background MCP tool discovery failed", exc_info=True)
-        finally:
-            reset_hermes_home_override(token)
-
-    import threading as _mcp_threading
-
-    _mcp_discovery_thread = _mcp_threading.Thread(
-        target=_discover_mcp_background,
-        name="tui-mcp-discovery",
-        daemon=True,
-    )
-    _mcp_discovery_thread.start()
+        start_background_mcp_discovery(
+            logger=logger, thread_name="tui-mcp-discovery"
+        )
+    except Exception:
+        logger.warning(
+            "Background MCP tool discovery failed to start", exc_info=True
+        )
 
 
 def main():
     _install_sidecar_publisher()
 
+    # MCP tool discovery — backgrounded so a slow or unreachable MCP server
+    # can't freeze TUI startup (a dead stdio/http server burns 1+2+4s of
+    # connect retries → ~7s of dead air before the composer appears).  The
+    # agent isn't built until the first prompt, at which point _make_agent
+    # briefly joins the discovery thread (wait_for_mcp_discovery, bounded) so
+    # already-spawning fast servers land in the tool snapshot.  The config
+    # gate inside ensure_mcp_discovery_started keeps the ~200ms MCP SDK
+    # import cost entirely off the path for users with no mcp_servers.
+    ensure_mcp_discovery_started()
 
     if not write_json({
         "jsonrpc": "2.0",

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -364,19 +364,26 @@ def ensure_mcp_discovery_started() -> None:
     """
     global _mcp_discovery_thread
 
+    from hermes_constants import get_hermes_home_override, reset_hermes_home_override, set_hermes_home_override
+
     if _mcp_discovery_thread is not None:
         return
 
     if not _has_configured_mcp_servers():
         return
 
+    home_override = get_hermes_home_override()
+
     def _discover_mcp_background() -> None:
+        token = set_hermes_home_override(home_override)
         try:
             from tools.mcp_tool import discover_mcp_tools
 
             discover_mcp_tools()
         except Exception:
             logger.warning("Background MCP tool discovery failed", exc_info=True)
+        finally:
+            reset_hermes_home_override(token)
 
     import threading as _mcp_threading
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1849,6 +1849,14 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     session_db = SessionDB(db_path=Path(profile_home) / "state.db")
                 except Exception:
                     session_db = None
+
+            try:
+                from tui_gateway.entry import ensure_mcp_discovery_started
+
+                ensure_mcp_discovery_started()
+            except Exception:
+                logger.warning("MCP discovery startup failed", exc_info=True)
+
             try:
                 # Lazy-resumed (watch) sessions carry the stored conversation
                 # id — pass it through so the upgrade continues that session

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7057,6 +7057,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("verification.status")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Best known coding verification evidence for a cwd/session.
 

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -303,22 +303,6 @@ async def handle_ws(ws: Any) -> None:
 
         transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer)
 
-        # The desktop app and dashboard chat reach the agent through this WS
-        # sidecar, NOT through tui_gateway.entry.main() (the stdio TUI path that
-        # spawns the background MCP discovery thread). Without starting it here,
-        # discovery never runs in this process: _make_agent only *waits* on the
-        # thread (wait_for_mcp_discovery), which no-ops when it was never
-        # created, so the agent snapshots an MCP-less tool list and the only way
-        # to surface MCP tools is a manual /reload-mcp. Start it once per
-        # process here (idempotent, config-gated) before gateway.ready so the
-        # first agent build can pick up already-spawning servers. (#38945)
-        from hermes_cli.mcp_startup import start_background_mcp_discovery
-
-        start_background_mcp_discovery(
-            logger=_log,
-            thread_name="tui-ws-mcp-discovery",
-        )
-
         ready_ok = await transport.write_async(
             {
                 "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary

MCP tools now load for the **selected** profile in the Desktop app / dashboard chat, instead of silently discovering the launch profile's (often empty) `mcp_servers`. Fixes the MCP half of #67605; salvage of #72135 by @LionGateOS with follow-up hardening.

Root cause: the WS sidecar started one process-global discovery thread gated on the *process* home's config, and the ContextVar profile override (`set_hermes_home_override`) never propagated into the bare discovery thread — so a dashboard launched under a profile without `mcp_servers` served zero MCP tools to every profile.

## Changes

- `tui_gateway/ws.py`: WS transport no longer owns MCP discovery startup (contributor).
- `tui_gateway/server.py`: `_start_agent_build` starts discovery AFTER binding the session profile's `HERMES_HOME`; `verification.status` gains `@_profile_scoped` (contributor).
- `tui_gateway/entry.py`: `ensure_mcp_discovery_started()` routes through the shared owner in `hermes_cli.mcp_startup` (keeps start lock, retry-after-zero-connected, OAuth suppression); stdio TUI `main()` startup discovery and the `_mcp_discovery_enabled` retry gate are restored (follow-up).
- `hermes_cli/mcp_startup.py`: the shared owner captures the caller's context-local `HERMES_HOME` override and re-installs it inside the discovery thread (follow-up).
- Tests: contributor's profile-scoped regression tests adapted to the shared-owner path; 3 WSTransport regression tests the original branch deleted are restored.

Known limitation (documented in-code): MCP registration is process-global, so the first profile to build an agent wins the discovery slot. Full per-profile registries stay tracked in #67605, which remains open for the secrets/`${VAR}`/MoA halves.

## Validation

| Check | Result |
|---|---|
| `tests/test_tui_gateway_server.py` (466) | pass |
| `tests/test_tui_gateway_ws.py`, `tests/hermes_cli/test_mcp_startup.py`, `tests/tui_gateway/` (983 total) | pass |
| Sabotage run (fix reverted) | regression test fails as expected |
| E2E (real imports, temp HERMES_HOME, launch profile without / selected profile with `mcp_servers`) | 5/5 scenarios pass, incl. caller-resets-override race and no-override CLI path unchanged |

## Infographic

![Profile-scoped MCP discovery](https://v3b.fal.media/files/b/0aa3d899/LABZVPBs2AtNiIDjk4Vlj_te5PDA2j.png)
