### PR TITLE
fix(delegation): size subagent summary budget by context occupancy, not cumulative spend

### DIFF
--- a/tests/tools/test_delegate_summary_budget.py
+++ b/tests/tools/test_delegate_summary_budget.py
@@ -124,3 +124,118 @@ def test_empty_results_is_noop():
         [{"task_index": 0, "status": "failed", "summary": None}],
         _FakeParent(131_000, 1_000, 8_000),
     )
+
+
+class _LiveParent:
+    """Parent whose compressor reports real occupancy, alongside the
+    session-CUMULATIVE billing counter that grows on every API call."""
+
+    def __init__(
+        self,
+        context_length,
+        session_prompt_tokens,
+        max_tokens,
+        last_prompt_tokens=0,
+        last_real_prompt_tokens=0,
+    ):
+        compressor = _FakeCompressor(context_length, max_tokens)
+        compressor.last_prompt_tokens = last_prompt_tokens
+        compressor.last_real_prompt_tokens = last_real_prompt_tokens
+        self.context_compressor = compressor
+        self.session_prompt_tokens = session_prompt_tokens
+
+
+def test_budget_tracks_occupancy_not_cumulative_spend():
+    """The budget must size against what is IN the context, not lifetime spend.
+
+    ``session_prompt_tokens`` accumulates on every API call and is never reset
+    by compaction, so on a long-but-small conversation it crosses
+    ``context_length`` after a handful of ordinary tool-loop iterations. Sizing
+    the budget off it collapses every subagent summary to the floor for the
+    rest of the session, even though the parent is nearly empty.
+    """
+    # Conversation occupies 20k of a 131k window (~15% full) and stays there,
+    # but 20 API calls have been billed.
+    parent = _LiveParent(
+        context_length=131_072,
+        session_prompt_tokens=400_000,
+        max_tokens=8_000,
+        last_prompt_tokens=20_000,
+    )
+    budget = dt._parent_summary_char_budget(parent, n_summaries=1)
+
+    assert budget is not None
+    # Real headroom is 131,072 - 20,000 - 8,000 = 103,072 tokens.
+    assert budget == (103_072 * 4) // 2
+    assert budget > dt._MIN_SUMMARY_CHARS
+
+    # The cumulative counter must not move the budget at all.
+    later = _LiveParent(
+        context_length=131_072,
+        session_prompt_tokens=4_000_000,
+        max_tokens=8_000,
+        last_prompt_tokens=20_000,
+    )
+    assert dt._parent_summary_char_budget(later, n_summaries=1) == budget
+
+
+def test_summary_survives_when_parent_has_headroom(monkeypatch):
+    """End-to-end: a report that fits must reach the parent untrimmed."""
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setenv("HERMES_HOME", os.path.join(td, ".hermes"))
+        report = "HEAD_MARKER\n" + ("SUBAGENT FINDINGS. " * 900) + "\nTAIL_MARKER"
+        parent = _LiveParent(
+            context_length=131_072,
+            session_prompt_tokens=400_000,   # 20 API calls billed
+            max_tokens=8_000,
+            last_prompt_tokens=20_000,       # but only 15% of the window in use
+        )
+        results = [{"task_index": 0, "summary": report, "status": "completed"}]
+        dt._apply_summary_budget(results, parent)
+
+        assert results[0]["summary"] == report
+        assert "summary_truncated" not in results[0]
+
+
+def test_floor_still_enforced_when_context_genuinely_full():
+    """The #9126 overflow guard must survive the occupancy fix."""
+    parent = _LiveParent(
+        context_length=131_072,
+        session_prompt_tokens=125_000,
+        max_tokens=8_000,
+        last_prompt_tokens=125_000,   # genuinely nearly full
+    )
+    assert dt._parent_summary_char_budget(parent, 3) == dt._MIN_SUMMARY_CHARS
+
+
+def test_post_compaction_sentinel_falls_back_to_last_real():
+    """Right after a compaction ``last_prompt_tokens`` is parked at -1.
+
+    The budget must fall through to ``last_real_prompt_tokens`` rather than
+    treating the sentinel as "empty context" (or reaching the cumulative
+    counter, which would report the parent as hopelessly over budget).
+    """
+    parent = _LiveParent(
+        context_length=131_072,
+        session_prompt_tokens=900_000,
+        max_tokens=8_000,
+        last_prompt_tokens=-1,
+        last_real_prompt_tokens=30_000,
+    )
+    budget = dt._parent_summary_char_budget(parent, n_summaries=1)
+    assert budget == ((131_072 - 30_000 - 8_000) * 4) // 2
+
+
+def test_cumulative_fallback_is_clamped_to_context_length():
+    """With no compressor telemetry the cumulative counter is the last resort,
+    but it must not drive headroom arbitrarily negative — clamped, the worst it
+    can say is "full"."""
+    parent = _LiveParent(
+        context_length=131_072,
+        session_prompt_tokens=10_000_000,
+        max_tokens=8_000,
+    )
+    assert dt._parent_used_tokens(
+        parent, parent.context_compressor, 131_072
+    ) == 131_072
+    assert dt._parent_summary_char_budget(parent, 1) == dt._MIN_SUMMARY_CHARS

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1696,6 +1696,42 @@ def _trim_summary_with_footer(
     return model_text, spill_path
 
 
+def _parent_used_tokens(parent_agent, compressor, context_length: int) -> int:
+    """Tokens currently OCCUPYING the parent's context window.
+
+    Must be occupancy, not lifetime spend.  ``agent.session_prompt_tokens`` is
+    a session-CUMULATIVE billing counter — ``+=`` on every API call
+    (conversation_loop.py, codex_runtime.py), reset only at explicit session
+    boundaries (``reset_session_state``), never by compaction.  It therefore
+    grows without bound while the conversation itself stays the same size, and
+    crosses ``context_length`` after a handful of ordinary tool-loop
+    iterations.  ``ContextCompressor.last_prompt_tokens`` is the prompt size
+    the provider actually reported for the most recent request — the real
+    occupancy signal, and what the compressor's own threshold checks use.
+
+    Resolution order mirrors ``hermes_cli/context_switch_guard._estimate_tokens``:
+
+    1. ``last_prompt_tokens`` — the last request's real prompt size.
+    2. ``last_real_prompt_tokens`` — covers the one-turn window right after a
+       compaction, where ``last_prompt_tokens`` is parked at the ``-1``
+       sentinel while ``awaiting_real_usage_after_compression`` is set.
+    3. ``session_prompt_tokens``, clamped to ``context_length`` — last-resort
+       fallback (no compressor telemetry yet, e.g. delegating before the first
+       API call).  Clamping keeps a cumulative counter from driving headroom
+       arbitrarily negative; at worst it reports "full", never "full ten times
+       over".
+    """
+    for source in ("last_prompt_tokens", "last_real_prompt_tokens"):
+        value = getattr(compressor, source, 0)
+        if isinstance(value, (int, float)) and value > 0:
+            return int(value)
+
+    session_tokens = getattr(parent_agent, "session_prompt_tokens", 0)
+    if not isinstance(session_tokens, (int, float)) or session_tokens < 0:
+        return 0
+    return min(int(session_tokens), context_length)
+
+
 def _parent_summary_char_budget(parent_agent, n_summaries: int) -> Optional[int]:
     """Per-summary character budget sized against the parent's *remaining*
     context headroom, split across the batch.
@@ -1703,8 +1739,9 @@ def _parent_summary_char_budget(parent_agent, n_summaries: int) -> Optional[int]
     The overflow this guards against is N summaries entering the parent
     context at once (batch fan-out), not any single summary being large.  We
     take a fraction of the headroom the parent has left (resolved context
-    length minus what's already in its prompt) and divide it across the batch,
-    converting tokens→chars at the standard ~4 chars/token estimate.
+    length minus what's already in its prompt, per :func:`_parent_used_tokens`)
+    and divide it across the batch, converting tokens→chars at the standard
+    ~4 chars/token estimate.
 
     Returns the per-summary char budget, or None when the parent's context
     state is unknown (no compressor / no token count) — in which case the
@@ -1716,9 +1753,7 @@ def _parent_summary_char_budget(parent_agent, n_summaries: int) -> Optional[int]
         if not isinstance(context_length, int) or context_length <= 0:
             return None
 
-        used_tokens = getattr(parent_agent, "session_prompt_tokens", 0)
-        if not isinstance(used_tokens, (int, float)) or used_tokens < 0:
-            used_tokens = 0
+        used_tokens = _parent_used_tokens(parent_agent, compressor, context_length)
 
         # Reserve the compressor's output budget so we measure INPUT headroom.
         reserved = getattr(compressor, "max_tokens", 0) or 0


### PR DESCRIPTION
## Summary

`delegate_task` sizes each subagent summary against the parent's remaining context headroom, but it measures "what's already in the parent's prompt" with `agent.session_prompt_tokens` — a session-**cumulative billing counter**, not context occupancy. The counter grows on every API call and is never reset by compaction, so it crosses the context window after a handful of ordinary tool-loop iterations. From that point on every subagent summary is truncated to the `_MIN_SUMMARY_CHARS` floor (2,000 chars, 12× below the configured `delegation.max_summary_chars` ceiling) for the rest of the session — while the parent's context is in fact nearly empty.

Fix: measure occupancy via `ContextCompressor.last_prompt_tokens`, mirroring the resolution order `hermes_cli/context_switch_guard._estimate_tokens` already uses.

## Problem

Two individually-correct mechanisms disagree about what a token count means.

**A — `session_prompt_tokens` is a lifetime accumulator.** It is initialised once (`agent/agent_init.py:2522`), incremented on *every* API call (`agent/conversation_loop.py:2916`, `agent/codex_runtime.py:132`) alongside `session_completion_tokens` / `session_total_tokens` / `session_api_calls`, and reset only by `reset_session_state()` (`run_agent.py:740`) at explicit session boundaries — `/new`, `/resume`, `/branch`. Compaction does not reset it. Every other consumer treats it as a billing total (`cli.py:10575` token report, `gateway/platforms/api_server.py:5789` `input_tokens`).

**B — `_parent_summary_char_budget()` wants current occupancy.** Its docstring defines the input as "resolved context length minus what's already in its prompt", and non-positive headroom is commented "Parent is already over budget".

`tools/delegate_tool.py:1719` wires A into B:

```python
used_tokens = getattr(parent_agent, "session_prompt_tokens", 0)
...
headroom_tokens = context_length - int(used_tokens) - int(reserved)
if headroom_tokens <= 0:
    return _MIN_SUMMARY_CHARS
```

A fixed window minus a monotonically growing lifetime total goes negative and never recovers, because the counter only ever increases.

**Measured** — 131,072-token model, 8,000 reserved, conversation pinned at 20,000 tokens (~15% full) for the whole run:

| API calls | `session_prompt_tokens` | budget (chars) | |
|---|---|---|---|
| 5 | 100,000 | 46,144 | ok |
| 6 | 120,000 | 6,144 | ok |
| **7** | **140,000** | **2,000** | **floor** |
| 25 | 500,000 | 2,000 | floor |
| 50 | 1,000,000 | 2,000 | floor |

End-to-end, one `delegate_task` after 10 API calls: a 17,124-char subagent report is delivered to the parent as 2,628 chars — **85% cut from context** — at a moment when the parent had 103,072 tokens (~412,288 chars) of genuinely free headroom, enough to accept that report 24 times over.

**Why it is silent and costly.** The only signal is a `logger.debug` line (`tools/delegate_tool.py:1785`) and a footer inside the tool result. The parent either answers from a gutted report, or pages the spill file back in with `read_file` round-trips — extra full-context API calls on the very turn delegation was supposed to make cheaper.

No second precondition: default config, single-task `delegate_task`, ordinary CLI/TUI session. The model normally explores with tools before deciding to delegate, so the counter has almost always crossed the window by the time delegation happens.

## Fix

New `_parent_used_tokens()` resolves occupancy in the same order as `hermes_cli/context_switch_guard._estimate_tokens`:

1. `compressor.last_prompt_tokens` — the prompt size the provider reported for the most recent request.
2. `compressor.last_real_prompt_tokens` — covers the one-turn window right after a compaction, where `last_prompt_tokens` is parked at the `-1` sentinel while `awaiting_real_usage_after_compression` is set (`agent/context_compressor.py:2186`, `:2205`).
3. `session_prompt_tokens`, **clamped to `context_length`** — last-resort fallback when there is no compressor telemetry yet (e.g. delegating before the first API call). Clamping keeps a cumulative counter from driving headroom arbitrarily negative; at worst it reports "full", never "full ten times over".

The `#9126` batch-overflow guard is unchanged — a parent whose context is genuinely full still gets the floor, and N children still split one headroom slice.

## Scope

- `tools/delegate_tool.py` — new `_parent_used_tokens()` helper; `_parent_summary_char_budget()` calls it instead of reading `session_prompt_tokens` directly; docstring updated.
- No change to the floor, the headroom fraction, the static ceiling, the spill-to-disk path, or any call site of `_apply_summary_budget`.
- `session_prompt_tokens` itself is untouched — it remains the billing counter every other consumer expects.

Related but distinct: #70204 reports the same cumulative-vs-occupancy confusion in `acp_adapter/server.py` (client-side usage display). It states the CLI's own context logic "correctly reads `context_compressor.last_prompt_tokens` directly, never `session_prompt_tokens`" — `tools/delegate_tool.py` was the exception.

## Testing

`tests/tools/test_delegate_summary_budget.py` — 5 new regression tests; all 4 behavioural ones fail on `main` and pass here:

- `test_budget_tracks_occupancy_not_cumulative_spend` — 15%-full parent with 400k lifetime tokens gets the full headroom budget, and raising the counter to 4M does not move it. On `main`: floor.
- `test_summary_survives_when_parent_has_headroom` — end-to-end through `_apply_summary_budget`; a report that fits arrives untrimmed. On `main`: truncated + spilled.
- `test_post_compaction_sentinel_falls_back_to_last_real` — `last_prompt_tokens == -1` falls through to `last_real_prompt_tokens` rather than the cumulative counter.
- `test_cumulative_fallback_is_clamped_to_context_length` — the last-resort fallback cannot exceed the window.
- `test_floor_still_enforced_when_context_genuinely_full` — the `#9126` guard still fires (passes before and after, by design).

```
python -m pytest tests/tools/test_delegate_summary_budget.py -o addopts= -q
12 passed

python -m pytest tests/tools/test_delegate_summary_budget.py tests/tools/test_delegate.py \
  tests/tools/test_delegate_toolset_scope.py tests/tools/test_delegate_composite_toolsets.py -o addopts= -q
185 passed
```

All 7 pre-existing tests in the file pass unmodified.
