### PR TITLE
fix(anthropic): keep the assistant cache breakpoint on the ordered-replay path

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2060,6 +2060,28 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
             _apply_assistant_cache_control_to_last_cacheable_block(
                 replayed, m.get("cache_control")
             )
+            # apply_anthropic_cache_control marks an assistant turn with
+            # non-empty text by writing cache_control INTO ``content`` (see
+            # _apply_cache_marker's list branch), not at the top level. This
+            # branch rebuilds the message from ordered_blocks and never reads
+            # ``content``, so that marker would be dropped -- and because
+            # _can_carry_marker already counted this message as a carrier, the
+            # breakpoint is burned rather than relocated. #56195 covered the
+            # complementary shape (blank content -> top-level marker); this is
+            # the interleaved thinking + preamble-text + tool_use shape.
+            _inline_cc = None
+            _msg_content = m.get("content")
+            if isinstance(_msg_content, list):
+                for _blk in _msg_content:
+                    if isinstance(_blk, dict) and isinstance(
+                        _blk.get("cache_control"), dict
+                    ):
+                        _inline_cc = _blk["cache_control"]
+                        break
+            if _inline_cc is not None:
+                _apply_assistant_cache_control_to_last_cacheable_block(
+                    replayed, _inline_cc
+                )
             return {"role": "assistant", "content": replayed}
 
     blocks = _extract_preserved_thinking_blocks(m)

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1190,6 +1190,54 @@ class TestConvertMessages:
         assert tool_use["id"] == "tc_1"
         assert tool_use["cache_control"] == {"type": "ephemeral"}
 
+    def test_ordered_replay_keeps_cache_control_from_nonempty_content(self):
+        """An assistant turn that interleaves signed thinking with a tool_use
+        AND has preamble text carries its cache_control INSIDE ``content``
+        (apply_anthropic_cache_control marks the last content block, not the
+        top level). The ordered-replay branch rebuilds the message from
+        ``anthropic_content_blocks`` alone, so without harvesting that marker
+        the breakpoint is dropped -- and it is *burned*, because
+        _can_carry_marker already spent a budget slot on this message.
+
+        #56195 covers the blank-content shape; this is the non-empty one, which
+        is what a Claude thinking+tools turn normally looks like.
+        """
+        preamble = "I will read a.py now."
+        messages = apply_anthropic_cache_control([
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "Read a.py"},
+            {
+                "role": "assistant",
+                "content": preamble,
+                "anthropic_content_blocks": [
+                    {"type": "thinking", "thinking": "Need a tool.", "signature": "sig_1"},
+                    {"type": "text", "text": preamble},
+                    {"type": "tool_use", "id": "tc_1", "name": "test_tool", "input": {}},
+                ],
+                "tool_calls": [
+                    {
+                        "id": "tc_1",
+                        "type": "function",
+                        "function": {"name": "test_tool", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": "contents"},
+        ])
+
+        _system, converted = convert_messages_to_anthropic(messages)
+        assistant = next(m for m in converted if m.get("role") == "assistant")
+        marked = [
+            b for b in assistant["content"]
+            if isinstance(b, dict) and b.get("cache_control")
+        ]
+        assert marked, (
+            "the assistant cache breakpoint was dropped by the ordered-replay "
+            "path and the budget slot is burned"
+        )
+        # The signed thinking block must still lead the replayed message.
+        assert assistant["content"][0]["type"] == "thinking"
+
     def test_ordered_replay_tool_use_cache_control_is_preserved(self):
         messages = apply_anthropic_cache_control([
             {"role": "system", "content": "System prompt"},


### PR DESCRIPTION
## Summary

`apply_anthropic_cache_control` marks an assistant turn with non-empty text by
writing `cache_control` **into** `content`. The ordered-replay branch of
`_convert_assistant_message` rebuilds the message from
`anthropic_content_blocks` and never reads `content`, so that breakpoint is
dropped — and because `_can_carry_marker` already counted the message as a
carrier, the budget slot is **burned**, not relocated.

Every request in a Claude thinking-plus-tools session ships one fewer cache
breakpoint than it paid for. No error, no warning, identical model output.

## Problem

`agent/prompt_caching.py`, `_apply_cache_marker` — for an assistant message
with non-empty content the marker goes on a content block, not top level:

```python
if isinstance(content, str):
    msg["content"] = [
        {"type": "text", "text": content, "cache_control": cache_marker}
    ]
    return
```

`agent/anthropic_adapter.py`, the ordered-replay branch of
`_convert_assistant_message`, builds `replayed` from `anthropic_content_blocks`
and returns early. Its only cache sources are:

```python
if _relocated_replay_cache_control is not None:
    _apply_assistant_cache_control_to_last_cacheable_block(
        replayed, _relocated_replay_cache_control
    )
_apply_assistant_cache_control_to_last_cacheable_block(
    replayed, m.get("cache_control")
)
return {"role": "assistant", "content": replayed}
```

`_relocated_replay_cache_control` only rescues markers from blocks the replay
sanitizer dropped; `m.get("cache_control")` is the top level. Neither is where
the marker actually is.

`anthropic_content_blocks` is set whenever a Claude turn interleaves signed
thinking with a `tool_use`, and it rides the message in `agent.messages` for
the rest of the session.

### Measured with the real functions

Same history, native layout, only `anthropic_content_blocks` differing:

| | wire breakpoints | assistant blocks carrying `cache_control` |
|---|---|---|
| normal path | **4** (system 2 + messages 2) | `['text']` |
| ordered-replay path | **3** (system 2 + messages 1) | none |

`_can_carry_marker(msg, native_anthropic=True)` returns `True` for this shape,
so the breakpoint budget was already spent on it.

Under the static-prefix layout there are only two conversation-tier
breakpoints, so losing one halves them.

### Why it survived

The request succeeds, the model output is identical, and Hermes' own
accounting believes the marker landed. There is nothing to notice — the only
symptom is a cache-read rate that is quietly worse than it should be, on every
turn of every extended-thinking tool session.

### Prior art — this is the other half of #56195

#56195 ("preserve tool_use cache_control markers") fixed the complementary
shape: assistant `content == ""`, where the marker lands top-level and is
therefore visible to the existing lookup. Its regression test,
`test_ordered_replay_tool_use_cache_control_is_preserved`, pins
`"content": ""`.

The non-empty case is what a Claude 4.5/4.6 tool turn normally looks like — a
sentence of preamble before the call — and was never covered.
`test_assistant_cache_control_blocks_are_preserved` covers non-empty content
but *without* `anthropic_content_blocks`. Nothing tests the intersection.

## Fix

Harvest an in-`content` marker alongside the existing top-level lookup and hand
it to the same `_apply_assistant_cache_control_to_last_cacheable_block` helper.

## Scope

- `agent/anthropic_adapter.py` — the ordered-replay branch of
  `_convert_assistant_message`.
- `tests/agent/test_anthropic_adapter.py` — regression test, placed next to its
  #56195 sibling.

## Testing

`test_ordered_replay_keeps_cache_control_from_nonempty_content` builds the
interleaved thinking + preamble-text + `tool_use` shape, runs the real
`apply_anthropic_cache_control` → `convert_messages_to_anthropic`, and asserts
the assistant message still carries a breakpoint (and that the signed thinking
block still leads).

Verified against both paths:

```
main     non-empty text: marker=NONE          | blank content (#56195): marker=['tool_use']
patched  non-empty text: marker=['tool_use']  | blank content (#56195): marker=['tool_use']
```

So the fix restores the missing breakpoint and leaves the #56195 shape
unchanged; the signed thinking block leads the replayed message in every case.
