### PR TITLE
fix(tools): isolate search pagination from shell aliases

### DIFF
--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -248,7 +248,7 @@ class TestPaginationBounds:
         assert result.files == ["a.py"]
         rg_commands = [cmd for cmd in commands if "--files" in cmd]
         assert rg_commands
-        assert "| head -n 2" in rg_commands[0]
+        assert "| command head -n 2" in rg_commands[0]
 
 
 # =========================================================================

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -317,7 +317,7 @@ class TestPaginationBounds:
         assert result.files == ["a.py"]
         rg_commands = [cmd for cmd in commands if cmd.startswith("rg --files")]
         assert rg_commands
-        assert "| head -n 1" in rg_commands[0]
+        assert "| command head -n 1" in rg_commands[0]
 
 
 # =========================================================================

--- a/tests/tools/test_search_pagination_shell_isolation.py
+++ b/tests/tools/test_search_pagination_shell_isolation.py
@@ -1,0 +1,108 @@
+"""Regression coverage for search pagination in restored Bash sessions."""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+from tools.file_operations import ShellFileOperations
+
+
+@pytest.mark.skipif(
+    not shutil.which("bash"),
+    reason="requires bash",
+)
+class TestSearchPaginationShellIsolation:
+    """Search pagination must not inherit a user's ``head`` definition."""
+
+    class _HeadShadowingEnvironment:
+        def __init__(self, cwd):
+            self.cwd = str(cwd)
+
+        def execute(self, command, cwd=None, **kwargs):
+            completed = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    "head() { command head -n 1; }\n" + command,
+                ],
+                cwd=cwd or self.cwd,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+            return {"output": completed.stdout, "returncode": completed.returncode}
+
+    @staticmethod
+    def _write_notes(tmp_path):
+        for index in range(3):
+            (tmp_path / f"note-{index}.md").write_text(
+                "date: 2026-07\n",
+                encoding="utf-8",
+            )
+
+    @staticmethod
+    def _skip_if_path_unsearchable(result):
+        if result.error and result.error.startswith("Path not found:"):
+            pytest.skip("bash cannot search the absolute temporary path")
+
+    @pytest.mark.skipif(not shutil.which("rg"), reason="requires ripgrep")
+    def test_ripgrep_searches_ignore_shadowed_head(self, tmp_path):
+        self._write_notes(tmp_path)
+
+        ops = ShellFileOperations(self._HeadShadowingEnvironment(tmp_path))
+
+        files = ops.search("*.md", str(tmp_path), target="files", limit=50)
+        self._skip_if_path_unsearchable(files)
+        assert files.error is None
+        assert {Path(path).name for path in files.files} == {
+            "note-0.md",
+            "note-1.md",
+            "note-2.md",
+        }
+        assert files.total_count == 3
+
+        matches = ops.search("date: 2026-07", str(tmp_path), target="content", limit=50)
+        assert matches.error is None
+        assert len(matches.matches) == 3
+        assert matches.total_count == 3
+
+        invalid = ops.search("[", str(tmp_path), target="content", limit=50)
+        assert invalid.error is not None
+        assert invalid.error.startswith("Search failed:")
+
+    @pytest.mark.skipif(not shutil.which("find"), reason="requires find")
+    def test_find_fallback_ignores_shadowed_head(self, tmp_path, monkeypatch):
+        self._write_notes(tmp_path)
+
+        ops = ShellFileOperations(self._HeadShadowingEnvironment(tmp_path))
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+
+        files = ops.search("*.md", str(tmp_path), target="files", limit=50)
+        self._skip_if_path_unsearchable(files)
+
+        assert files.error is None
+        assert {Path(path).name for path in files.files} == {
+            "note-0.md",
+            "note-1.md",
+            "note-2.md",
+        }
+        assert files.total_count == 3
+
+    @pytest.mark.skipif(not shutil.which("grep"), reason="requires grep")
+    def test_grep_fallback_ignores_shadowed_head(self, tmp_path, monkeypatch):
+        self._write_notes(tmp_path)
+
+        ops = ShellFileOperations(self._HeadShadowingEnvironment(tmp_path))
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "grep")
+
+        matches = ops.search("date: 2026-07", str(tmp_path), target="content", limit=50)
+        self._skip_if_path_unsearchable(matches)
+
+        assert matches.error is None
+        assert len(matches.matches) == 3
+        assert matches.total_count == 3

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2150,7 +2150,7 @@ class ShellFileOperations(FileOperations):
         # explicit hidden-root searches.
         pagination_expr = ""
         if not has_hidden_path_ancestor:
-            pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
+            pagination_expr = f" | tail -n +{offset + 1} | command head -n {limit}"
 
         cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
               f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
@@ -2216,10 +2216,12 @@ class ShellFileOperations(FileOperations):
 
         fetch_limit = limit + offset
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
+        # ``command`` bypasses aliases and functions restored in terminal
+        # snapshots, which must not silently alter search pagination.
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
             f"{self._escape_shell_arg(path)} 2>/dev/null "
-            f"| head -n {fetch_limit}"
+            f"| command head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
@@ -2230,7 +2232,7 @@ class ShellFileOperations(FileOperations):
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
                 f"{self._escape_shell_arg(path)} 2>/dev/null "
-                f"| head -n {fetch_limit}"
+                f"| command head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
@@ -2291,7 +2293,8 @@ class ShellFileOperations(FileOperations):
         # For context mode, rg emits separator lines ("--") between groups,
         # so we grab generously and filter in Python.
         fetch_limit = limit + offset + 200 if context > 0 else limit + offset
-        cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])
+        # Bypass aliases and functions restored in terminal snapshots.
+        cmd_parts.extend(["|", "command", "head", "-n", str(fetch_limit)])
         
         # `set -o pipefail` so rg's exit status propagates through `| head`.
         # Without it the pipeline reports head's status (0), masking rg's
@@ -2419,7 +2422,8 @@ class ShellFileOperations(FileOperations):
         
         # Fetch generously so we can compute total before slicing
         fetch_limit = limit + offset + (200 if context > 0 else 0)
-        cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])
+        # Bypass aliases and functions restored in terminal snapshots.
+        cmd_parts.extend(["|", "command", "head", "-n", str(fetch_limit)])
         
         # `set -o pipefail` so grep's exit status propagates through `| head`
         # (without it the pipeline reports head's 0, masking grep's error 2).

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -394,7 +394,8 @@ class SearchMixin:
         if native_ok and self._native_read_enabled():
             return self._run_rg_native(words, fetch_limit, timeout, merge_stderr=merge_stderr)
         stderr = "" if merge_stderr else " 2>/dev/null"
-        return self._exec(f"{shell_prefix}{' '.join(words)}{stderr} | head -n {fetch_limit}", timeout=timeout)
+        return self._exec(
+            f"{shell_prefix}{' '.join(words)}{stderr} | command head -n {fetch_limit}", timeout=timeout)
 
     def _quote_executable(self, executable: str) -> str:
         """Quote an executable without leaking controller path semantics."""
@@ -693,9 +694,9 @@ class SearchMixin:
         base = (f"find {' '.join(q_roots)}{protected_prune}{hidden_prune} -type f "
                 f"! -name '.*' -name {self._escape_shell_arg(search_pattern)}")
         if order == "modified":
-            cmd = "set -o pipefail; " + base + f" -printf '%T@ %p\\n' 2>/dev/null | sort -rn | head -n {fetch_limit}"
+            cmd = "set -o pipefail; " + base + f" -printf '%T@ %p\\n' 2>/dev/null | sort -rn | command head -n {fetch_limit}"
         else:
-            cmd = "set -o pipefail; " + base + f" -print 2>/dev/null | head -n {fetch_limit}"
+            cmd = "set -o pipefail; " + base + f" -print 2>/dev/null | command head -n {fetch_limit}"
 
         keys = _filename_search_root_keys(self.env, roots, self.cwd)
         if not _acquire_filename_search_roots(keys):
@@ -835,7 +836,8 @@ class SearchMixin:
         files_only/count where lines are paths/counts."""
         fetch_limit = limit + offset + (200 if context > 0 else 0)
         if line_cap:  # grep/find pipelines: shell only, with the column cap
-            parts = cmd_parts + ["|", "head", "-n", str(fetch_limit)]
+            # Bypass aliases and functions restored in terminal snapshots.
+            parts = cmd_parts + ["|", "command", "head", "-n", str(fetch_limit)]
             if output_mode not in ("files_only", "count"):
                 parts += ["|", "cut", "-c1-2000"]
             result = self._exec("set -o pipefail; " + " ".join(parts), timeout=60)


### PR DESCRIPTION
## What does this PR do?

Makes `search_files` pagination independent of user-defined Bash `head` aliases and functions restored into terminal sessions. This prevents a shadowed `head` from truncating file and content searches while preserving ripgrep/grep error propagation.

## Related Issue

Fixes #72047

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/file_operations.py`: invoke pagination through `command head` for ripgrep, grep, and find search paths.
- `tests/tools/test_file_operations_edge_cases.py`: update the pagination contract assertion.
- `tests/tools/test_search_pagination_shell_isolation.py`: cover file, content, and invalid-regex searches with a shadowed `head` function.

## How to Test

1. Run `/opt/homebrew/bin/timeout -k 30 480 "$VIRTUAL_ENV/bin/pytest" tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py tests/tools/test_search_pagination_shell_isolation.py -q --timeout=60` (130 passed locally).
2. Run `"$VIRTUAL_ENV/bin/ruff" check tools/file_operations.py tests/tools/test_file_operations_edge_cases.py tests/tools/test_search_pagination_shell_isolation.py`.
3. Run `"$VIRTUAL_ENV/bin/python" scripts/check-windows-footguns.py tools/file_operations.py tests/tools/test_file_operations_edge_cases.py tests/tools/test_search_pagination_shell_isolation.py`.
4. The configured full suite was attempted, but this runner aborts while collecting unrelated dashboard tests because its system Python lacks FastAPI/uvicorn.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched the supplied open-PR overlap information; the listed PRs change session/terminal files rather than file-search pagination.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

<!-- autocontrib:worker-id=issue-new-119af588 kind=pr-open -->