### PR TITLE
fix(desktop): retire recovery marker on stop

### DIFF
--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -122,6 +122,75 @@ def test_marker_clear_is_noop_without_entry(tmp_path):
     assert read_turn_marker(tmp_path, "missing") is None
 
 
+def test_interrupt_ack_retires_marker_before_run_thread_exits(monkeypatch, marker_home):
+    """A confirmed Stop must not auto-continue if the backend dies afterward."""
+
+    class _AliveThread:
+        def is_alive(self):
+            return True
+
+    interrupted = []
+    agent = types.SimpleNamespace(interrupt=lambda: interrupted.append(True))
+    session = _session(
+        agent=agent,
+        running=True,
+        _run_thread=_AliveThread(),
+        _active_turn_marker_key="original-key",
+    )
+    session["session_key"] = "rotated-key"
+    session_home = marker_home / "remote-profile"
+    session["profile_home"] = str(session_home)
+    record_turn_start(session_home, "original-key", "do not resume me")
+
+    monkeypatch.setattr(server, "_sess_nowait", lambda params, rid: (session, None))
+    monkeypatch.setattr(server, "_sess", lambda params, rid: (session, None))
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda current: False)
+    monkeypatch.setattr(server, "_clear_pending", lambda sid=None: None)
+
+    response = server._methods["session.interrupt"]("request-1", {"session_id": "runtime-1"})
+
+    assert response["result"]["status"] == "interrupted"
+    assert interrupted == [True]
+    assert read_turn_marker(session_home, "original-key") is None
+    assert read_turn_marker(session_home, "rotated-key") is None
+    assert "_active_turn_marker_key" not in session
+
+
+def test_interrupt_racing_marker_write_cannot_leave_recovery_state(
+    monkeypatch, emits, turn_env, marker_home
+):
+    """Stop before the disk write must still prevent later auto-continue."""
+
+    interrupted = []
+    agent = types.SimpleNamespace(
+        session_id="session-key",
+        clear_interrupt=lambda: None,
+        interrupt=lambda: interrupted.append(True),
+        run_conversation=lambda message, **kwargs: {"final_response": "stopped"},
+    )
+    session = _session(agent=agent, running=True)
+
+    monkeypatch.setattr(server, "_sess_nowait", lambda params, rid: (session, None))
+    monkeypatch.setattr(server, "_sess", lambda params, rid: (session, None))
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda current: False)
+    monkeypatch.setattr(server, "_clear_pending", lambda sid=None: None)
+
+    def write_after_stop(home, key, prompt, *, attempts=0):
+        response = server._methods["session.interrupt"](
+            "stop-during-write", {"session_id": "runtime-race"}
+        )
+        assert response["result"]["status"] == "interrupted"
+        record_turn_start(home, key, prompt, attempts=attempts)
+
+    monkeypatch.setattr(server, "record_turn_start", write_after_stop)
+
+    server._run_prompt_submit("request-race", "runtime-race", session, "race me")
+
+    assert interrupted == [True]
+    assert read_turn_marker(marker_home, "session-key") is None
+    assert "_active_turn_marker_key" not in session
+
+
 def test_marker_write_prunes_expired_entries(tmp_path):
     import json
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10370,6 +10370,8 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    assert session is not None
+
     if _session_uses_compute_host(session):
         sid = str(params.get("session_id") or "")
         if session.get("running"):
@@ -10391,6 +10393,7 @@ def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
         return err
+    assert session is not None
     # Safety net: if the turn's run thread is already gone but `running` stayed
     # stuck (a crash/desync that skipped the run loop's `finally`), force-clear it
     # so the session can't be permanently bricked at 4009 "session busy" — every
@@ -10404,6 +10407,7 @@ def _(rid, params: dict) -> dict:
     if should_interrupt and hasattr(session["agent"], "interrupt"):
         session["agent"].interrupt()
     with session["history_lock"]:
+        active_marker_key = str(session.pop("_active_turn_marker_key", "") or "")
         session["_turn_cancel_requested"] = True
         session["queued_prompt"] = None
     if not run_thread_alive:
@@ -10427,6 +10431,9 @@ def _(rid, params: dict) -> dict:
         resolve_gateway_approval(session["session_key"], "deny", resolve_all=True)
     except Exception:
         pass
+    # The local agent accepted the cooperative interrupt. Retire the recovery
+    # marker before ACK rather than waiting for the run thread's finally block.
+    _retire_turn_marker(session, active_marker_key)
     return _ok(rid, {"status": "interrupted"})
 
 
@@ -11626,7 +11633,17 @@ def _run_prompt_submit(
         marker_attempt = int(session.pop("_auto_continue_attempt", 0) or 0)
         marker_text = session.pop("_auto_continue_prompt", None) or text
         if isinstance(marker_text, str) and marker_text.strip():
+            # Publish the original key before the disk write so an interrupt
+            # racing startup can retire it even if compression rotates the
+            # session key later. The post-write cancel check closes the inverse
+            # race where Stop lands first and therefore clears no file yet.
+            with session["history_lock"]:
+                session["_active_turn_marker_key"] = marker_key
             record_turn_start(marker_home, marker_key, marker_text, attempts=marker_attempt)
+            with session["history_lock"]:
+                marker_cancelled = bool(session.get("_turn_cancel_requested"))
+            if marker_cancelled:
+                clear_turn_marker(marker_home, marker_key)
         try:
             from tools.approval import (
                 reset_current_session_key,
@@ -12176,6 +12193,9 @@ def _run_prompt_submit(
             # Backstop for turns that never reached a terminal frame (the
             # frame paths retire the marker as they emit).
             _retire_turn_marker(session, marker_key)
+            with session["history_lock"]:
+                if session.get("_active_turn_marker_key") == marker_key:
+                    session.pop("_active_turn_marker_key", None)
             session.pop("_auto_continue_scheduled", None)
             _emit_settled_session_info(sid, session, agent)
 


### PR DESCRIPTION
## Summary

- retire the durable interrupted-turn marker before returning a successful **local Desktop** `session.interrupt` response
- close the Stop-vs-marker-write race and preserve the original marker key across session-key rotation
- cover local Stop, profile-specific marker homes, marker-write races, and stale-running reconciliation
- prevent an explicitly stopped local turn from auto-continuing and appearing to be running after Desktop/backend restart

## Root cause

The normal local turn thread retires its crash-recovery marker in its terminal path. There is a race after a user Stop is accepted but before that thread finishes unwinding: if the Desktop backend exits in that window, the marker survives. The next `session.resume` interprets it as an unhandled process crash and schedules auto-continue, resurrecting a turn the user deliberately interrupted.

Two local boundary races are handled:

1. Stop can arrive just before the run thread writes its marker. The turn now publishes its active marker key first and re-checks cancellation immediately after the write.
2. Compression can rotate `session_key` mid-turn. The local interrupt path now retires both the original active marker key and the current key.

Compute-host interrupt acknowledgment has separate cross-process semantics and is intentionally unchanged by this narrow fix.

## Test plan

- `uv run --with pytest pytest -q tests/tui_gateway/test_auto_continue.py` — 21 passed
- `uv run --with ruff ruff check tui_gateway/server.py tests/tui_gateway/test_auto_continue.py` — passed
- `uv run python -m py_compile tui_gateway/server.py tests/tui_gateway/test_auto_continue.py` — passed
- clean temporary `HERMES_HOME`, delegation flags removed: `uv run --with pytest pytest -q tests/tui_gateway` — 502 passed, 1 order-sensitive failure
- the aggregate-only failure, `test_prompt_submit_rejected_while_child_run_active`, passes in isolation (1 passed)

The branch was rebased onto the current `main` after its history was replaced. Upstream Actions currently reports `action_required` with zero jobs because this fork workflow run requires maintainer approval; no CI job has executed yet.

Introduced follow-up to #71184.