### PR TITLE
fix(computer-use): preserve action verdict after capture

### DIFF
--- a/tests/tools/test_computer_use_delivery_ladder.py
+++ b/tests/tools/test_computer_use_delivery_ladder.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 from unittest.mock import patch
 
 import pytest
@@ -172,6 +172,117 @@ def test_text_response_surfaces_fields_additively():
     }
     for k in ("effect", "escalation", "code", "verified", "path", "degraded", "delivery_mode"):
         assert k not in payload2
+
+
+def test_capture_after_preserves_semantic_refusal_fields():
+    from tools.computer_use.backend import ActionResult, CaptureResult, ComputerUseBackend
+    from tools.computer_use.tool import _maybe_follow_capture
+
+    class Backend:
+        _last_target = {"pid": 4242, "window_id": 7}
+
+        def capture(self, **kwargs):
+            assert kwargs["pid"] == 4242
+            assert kwargs["window_id"] == 7
+            return CaptureResult(mode="ax", width=800, height=600)
+
+    result = ActionResult(
+        ok=True,
+        action="click",
+        message="background delivery was refused",
+        verified=False,
+        effect="suspected_noop",
+        escalation={"recommended": "foreground"},
+        path="ax",
+        degraded=True,
+        delivery_mode="background",
+        code="background_unavailable",
+        meta={"reason": "occluded renderer"},
+    )
+
+    backend = cast(ComputerUseBackend, Backend())
+    payload = json.loads(_maybe_follow_capture(backend, result, True))
+    assert payload["ok"] is True
+    assert payload["effect"] == "suspected_noop"
+    assert payload["verified"] is False
+    assert payload["escalation"] == {"recommended": "foreground"}
+    assert payload["code"] == "background_unavailable"
+    assert payload["path"] == "ax"
+    assert payload["degraded"] is True
+    assert payload["delivery_mode"] == "background"
+    assert payload["meta"] == {"reason": "occluded renderer"}
+    assert payload["verdict"] == {
+        "decision": "escalate",
+        "recommended": "foreground",
+    }
+    assert payload["mode"] == "ax"
+    assert payload["width"] == 800
+    assert payload["height"] == 600
+    assert payload["elements"] == []
+    assert payload["total_elements"] == 0
+    assert "capture mode=ax 800x600" in payload["summary"]
+
+
+def test_multimodal_capture_after_embeds_complete_action_result():
+    from tools.computer_use.backend import ActionResult, CaptureResult, ComputerUseBackend
+    from tools.computer_use.tool import _maybe_follow_capture
+
+    class Backend:
+        _last_target = {}
+        _last_app = "Fixture"
+
+        def capture(self, **kwargs):
+            assert kwargs["app"] == "Fixture"
+            return CaptureResult(mode="vision", width=800, height=600)
+
+    response = {
+        "_multimodal": True,
+        "content": [
+            {"type": "text", "text": "capture"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,fixture"}},
+        ],
+        "text_summary": "capture",
+        "meta": {"mode": "vision", "width": 800, "height": 600},
+    }
+    result = ActionResult(
+        ok=True,
+        action="drag",
+        message="background delivery could not be verified",
+        effect="unverifiable",
+        verified=False,
+        path="ax",
+        degraded=True,
+        delivery_mode="background",
+        code="background_unavailable",
+        escalation={"recommended": "foreground"},
+        meta={"reason": "unverifiable renderer"},
+    )
+
+    with patch("tools.computer_use.tool._capture_response", return_value=response):
+        backend = cast(ComputerUseBackend, Backend())
+        payload = _maybe_follow_capture(backend, result, True)
+
+    expected_action = {
+        "ok": True,
+        "action": "drag",
+        "message": "background delivery could not be verified",
+        "meta": {"reason": "unverifiable renderer"},
+        "verified": False,
+        "effect": "unverifiable",
+        "escalation": {"recommended": "foreground"},
+        "path": "ax",
+        "degraded": True,
+        "delivery_mode": "background",
+        "code": "background_unavailable",
+        "verdict": {"decision": "verify_fresh_state"},
+    }
+    assert payload["action_result"] == expected_action
+    for delivered_text in (payload["content"][0]["text"], payload["text_summary"]):
+        action_line = delivered_text.split("\n\n", 1)[0]
+        # main prefixes the capture with the full JSON action payload
+        assert json.loads(action_line) == expected_action
+    assert payload["content"][1] == response["content"][1]
+    assert payload["meta"] == {"mode": "vision", "width": 800, "height": 600}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Preserves the complete `computer_use` action verdict when `capture_after=true` appends a follow-up screenshot. Previously, a transport-successful action with a semantic refusal such as `effect="suspected_noop"` could be reduced to a normal-looking capture response, dropping `verified`, `effect`, `escalation`, `path`, `degraded`, `delivery_mode`, `code`, and `meta`.

The text path now merges the existing additive `_text_response()` payload into the capture, while the multimodal path carries the same payload in `action_result` and in both provider-delivered text surfaces. Screenshot content and capture metadata remain intact.

## Related Issue

N/A — no matching open or closed PR was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/computer_use/tool.py`: retain the complete action verdict across text and multimodal follow-up captures.
- `tests/tools/test_computer_use_delivery_ladder.py`: cover semantic refusals, capture-field preservation, and both multimodal delivery surfaces.

## How to Test

1. Return an `ActionResult` with `ok=true`, `effect="suspected_noop"`, `code="background_unavailable"`, and `escalation={"recommended":"foreground"}`.
2. Call `_maybe_follow_capture(..., do_capture=True)`.
3. Confirm the follow-up capture is present and all action-verdict fields remain available.
4. Run:
   - `python -m pytest -q -p no:cacheprovider tests/tools/test_computer_use*.py tests/run_agent/test_vision_tool_messages.py`
   - `python scripts/check-windows-footguns.py --all`
   - `python -m ruff check tools/computer_use/tool.py tests/tools/test_computer_use_delivery_ladder.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and covered by comments/tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no schema change

## Screenshots / Logs

- Computer Use plus multimodal adapter coverage: `321 passed in 63.81s`
- Windows footgun scan: `No Windows footguns found (818 files scanned)`
- Focused Ruff check and `git diff --check`: clean
