### PR TITLE
feat(desktop): find-in-page with Ctrl+F / Ctrl+G / Ctrl+Shift+G (salvage of #53891 by @DavidMetcalfe)

### DIFF
--- a/apps/desktop/electron/find-in-page.test.ts
+++ b/apps/desktop/electron/find-in-page.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for the pure find-in-page helpers. The IPC handlers in
+ * main.ts are the only consumer — the helpers below must keep the wire
+ * shape stable (match counter shape, defaults, no-throw-on-destroyed).
+ */
+
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import { describe, test } from 'vitest'
+
+import {
+  formatFoundInPage,
+  installFoundInPageForwarder,
+  performFind,
+  stopFind
+} from './find-in-page'
+
+// Minimal webContents stub. The Electron.WebContents type is huge, so we
+// model just the slice the helpers touch (`isDestroyed`, `findInPage`,
+// `stopFindInPage`, `on`/`off`, `send`, `destroyed`, `emit`) and cast through
+// `asWC()` at call sites.
+interface FakeWebContents {
+  calls: {
+    find: Array<{ query: string; options: { forward: boolean; findNext: boolean } }>
+    stop: Array<'clearSelection' | 'keepSelection' | 'activateSelection'>
+    send: Array<{ channel: string; payload: unknown }>
+  }
+  isDestroyed: () => boolean
+  destroy: () => void
+  findInPage: (query: string, options: { forward: boolean; findNext: boolean }) => void
+  stopFindInPage: (action: 'clearSelection' | 'keepSelection' | 'activateSelection') => void
+  send: (channel: string, payload: unknown) => void
+  on: typeof EventEmitter.prototype.on
+  off: typeof EventEmitter.prototype.off
+  emit: (event: string | symbol, ...args: unknown[]) => boolean
+}
+
+function makeFakeWebContents(): FakeWebContents {
+  const emitter = new EventEmitter()
+
+  const calls = {
+    find: [] as Array<{ query: string; options: { forward: boolean; findNext: boolean } }>,
+    stop: [] as Array<'clearSelection' | 'keepSelection' | 'activateSelection'>,
+    send: [] as Array<{ channel: string; payload: unknown }>
+  }
+
+  let destroyed = false
+
+  return {
+    calls,
+    isDestroyed: () => destroyed,
+    destroy() {
+      destroyed = true
+      emitter.emit('destroyed')
+    },
+    findInPage(query: string, options: { forward: boolean; findNext: boolean }) {
+      calls.find.push({ query, options })
+    },
+    stopFindInPage(action: 'clearSelection' | 'keepSelection' | 'activateSelection') {
+      calls.stop.push(action)
+    },
+    send(channel: string, payload: unknown) {
+      calls.send.push({ channel, payload })
+    },
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter),
+    emit: emitter.emit.bind(emitter)
+  }
+}
+
+function asWC(fake: FakeWebContents): Electron.WebContents {
+  return fake as unknown as Electron.WebContents
+}
+
+describe('formatFoundInPage', () => {
+  test('maps activeMatchOrdinal + matches onto the wire payload', () => {
+    assert.deepEqual(formatFoundInPage({ activeMatchOrdinal: 3, matches: 12 }), {
+      activeMatchOrdinal: 3,
+      count: 12
+    })
+  })
+
+  test('coerces missing fields to zero so the renderer never sees NaN', () => {
+    assert.deepEqual(formatFoundInPage({}), { activeMatchOrdinal: 0, count: 0 })
+    assert.deepEqual(formatFoundInPage({ activeMatchOrdinal: 0, matches: 0 }), {
+      activeMatchOrdinal: 0,
+      count: 0
+    })
+  })
+
+  test('null / undefined inputs still produce a well-formed payload', () => {
+    assert.deepEqual(
+      formatFoundInPage(null as unknown as { activeMatchOrdinal?: number; matches?: number }),
+      { activeMatchOrdinal: 0, count: 0 }
+    )
+    assert.deepEqual(formatFoundInPage(undefined), { activeMatchOrdinal: 0, count: 0 })
+  })
+})
+
+describe('performFind', () => {
+  test('forwards the query and options to webContents.findInPage', () => {
+    const wc = makeFakeWebContents()
+    performFind(asWC(wc), 'hello', { forward: true, findNext: false })
+    assert.deepEqual(wc.calls.find, [
+      { query: 'hello', options: { forward: true, findNext: false } }
+    ])
+  })
+
+  test('defaults forward to true when omitted', () => {
+    const wc = makeFakeWebContents()
+    performFind(asWC(wc), 'x', { findNext: true })
+    assert.deepEqual(wc.calls.find, [
+      { query: 'x', options: { forward: true, findNext: true } }
+    ])
+  })
+
+  test('defaults findNext to false when omitted', () => {
+    const wc = makeFakeWebContents()
+    performFind(asWC(wc), 'x', { forward: false })
+    assert.deepEqual(wc.calls.find, [
+      { query: 'x', options: { forward: false, findNext: false } }
+    ])
+  })
+
+  test('treats null / non-object options as "all defaults"', () => {
+    const wc = makeFakeWebContents()
+    performFind(asWC(wc), 'x', null)
+    assert.deepEqual(wc.calls.find, [
+      { query: 'x', options: { forward: true, findNext: false } }
+    ])
+  })
+
+  test('coerces a non-string query to string (defensive against bad renderer payloads)', () => {
+    const wc = makeFakeWebContents()
+    performFind(asWC(wc), 42 as unknown as string, null)
+    assert.equal(wc.calls.find[0].query, '42')
+  })
+
+  test('is a no-op when webContents is null', () => {
+    assert.doesNotThrow(() => performFind(null, 'q', null))
+  })
+
+  test('is a no-op when webContents is destroyed (does not throw across IPC)', () => {
+    const wc = makeFakeWebContents()
+    wc.destroy()
+    performFind(asWC(wc), 'q', null)
+    assert.equal(wc.calls.find.length, 0)
+  })
+})
+
+describe('stopFind', () => {
+  test('calls stopFindInPage with the default action (clearSelection)', () => {
+    const wc = makeFakeWebContents()
+    stopFind(asWC(wc))
+    assert.deepEqual(wc.calls.stop, ['clearSelection'])
+  })
+
+  test('honors an explicit action argument', () => {
+    const wc = makeFakeWebContents()
+    stopFind(asWC(wc), 'keepSelection')
+    assert.deepEqual(wc.calls.stop, ['keepSelection'])
+  })
+
+  test('is a no-op when webContents is null or destroyed', () => {
+    assert.doesNotThrow(() => stopFind(null))
+    const wc = makeFakeWebContents()
+    wc.destroy()
+    stopFind(asWC(wc))
+    assert.equal(wc.calls.stop.length, 0)
+  })
+})
+
+describe('installFoundInPageForwarder', () => {
+  test('forwards found-in-page to the sender as a formatted payload', () => {
+    const wc = makeFakeWebContents()
+    installFoundInPageForwarder(asWC(wc))
+    // Drive the fake's emit directly — this exercises the same code path
+    // as Electron's actual `webContents.emit('found-in-page', …)`.
+    wc.emit('found-in-page', {}, { activeMatchOrdinal: 2, matches: 5 })
+    assert.deepEqual(wc.calls.send, [
+      { channel: 'hermes:found-in-page', payload: { activeMatchOrdinal: 2, count: 5 } }
+    ])
+  })
+
+  test('handles missing fields without throwing', () => {
+    const wc = makeFakeWebContents()
+    installFoundInPageForwarder(asWC(wc))
+    wc.emit('found-in-page', {}, {})
+    assert.deepEqual(wc.calls.send, [
+      { channel: 'hermes:found-in-page', payload: { activeMatchOrdinal: 0, count: 0 } }
+    ])
+  })
+
+  test('skips send when webContents is destroyed at fire time', () => {
+    const wc = makeFakeWebContents()
+    installFoundInPageForwarder(asWC(wc))
+    wc.destroy()
+    wc.emit('found-in-page', {}, { activeMatchOrdinal: 1, matches: 1 })
+    assert.equal(wc.calls.send.length, 0, 'destroyed webContents must not be sent to')
+  })
+
+  test('returned uninstall removes the listener', () => {
+    const wc = makeFakeWebContents()
+    const uninstall = installFoundInPageForwarder(asWC(wc))
+    uninstall()
+    wc.emit('found-in-page', {}, { activeMatchOrdinal: 9, matches: 9 })
+    assert.equal(wc.calls.send.length, 0, 'uninstalled listener must not fire')
+  })
+
+  test('returned uninstall on a null webContents is a safe no-op', () => {
+    const uninstall = installFoundInPageForwarder(null)
+    assert.doesNotThrow(() => uninstall())
+  })
+
+  test('returned uninstall on a destroyed webContents is a safe no-op', () => {
+    const wc = makeFakeWebContents()
+    wc.destroy()
+    const uninstall = installFoundInPageForwarder(asWC(wc))
+    assert.doesNotThrow(() => uninstall())
+  })
+
+  // Regression: the original PR scoped the forwarder to the global mainWindow,
+  // so Cmd+F pressed in a secondary session window routed results back to the
+  // primary. Pin that the helper does NOT close over any window other than the
+  // webContents it was given — two forwarders installed on two distinct fakes
+  // must each send only to their own sender.
+  test('two forwarders installed on distinct webContents do not cross-fire', () => {
+    const wcA = makeFakeWebContents()
+    const wcB = makeFakeWebContents()
+    installFoundInPageForwarder(asWC(wcA))
+    installFoundInPageForwarder(asWC(wcB))
+    wcA.emit('found-in-page', {}, { activeMatchOrdinal: 1, matches: 1 })
+    assert.deepEqual(wcA.calls.send, [
+      { channel: 'hermes:found-in-page', payload: { activeMatchOrdinal: 1, count: 1 } }
+    ])
+    assert.equal(wcB.calls.send.length, 0, 'wcB must not receive wcA results')
+  })
+})

--- a/apps/desktop/electron/find-in-page.ts
+++ b/apps/desktop/electron/find-in-page.ts
@@ -1,0 +1,125 @@
+/**
+ * Pure helpers for the desktop find-in-page bridge (Ctrl/Cmd+F).
+ *
+ * The renderer drives an Electron `webContents.findInPage` over IPC so it can
+ * reuse the native "find-in-page" experience (incremental search, match
+ * highlight, Enter to step, Shift+Enter to step backwards, Escape to clear)
+ * across chat transcripts and editor panels. Everything in this module is
+ * pure with respect to its inputs so the routing + payload shaping can be
+ * unit-tested without booting a BrowserWindow.
+ *
+ * Multi-window correctness: the IPC handlers in main.ts resolve the
+ * requesting window via `BrowserWindow.fromWebContents(event.sender)` so a
+ * Cmd+F pressed in a secondary session window searches THAT window, not the
+ * primary. The `found-in-page` results are forwarded back to the same sender
+ * — see {@link installFoundInPageForwarder}.
+ */
+
+/** Match options accepted by the renderer's `findInPage` bridge call. */
+export interface FindInPageOptions {
+  /** Step direction. Defaults to `true` (forward). */
+  forward?: boolean
+  /**
+   * `true` to advance to the next/previous match using the previous query;
+   * `false` to (re)search the current `query` from scratch. The renderer
+   * passes `false` on a fresh query and `true` on Enter / Shift+Enter.
+   */
+  findNext?: boolean
+}
+
+/** Payload shape sent back to the renderer on every `found-in-page` event. */
+export interface FoundInPagePayload {
+  /** 1-indexed ordinal of the active match, or 0 when none. */
+  activeMatchOrdinal: number
+  /** Total matches in the document for the current query. */
+  count: number
+}
+
+/**
+ * Defensive projection of Electron's `found-in-page` event result. Electron
+ * exposes more fields (finalUpdate, selectionArea, etc.) that we don't need;
+ * keeping the projection explicit makes the wire shape auditable and keeps
+ * tests independent of the runtime type.
+ */
+export function formatFoundInPage(result: {
+  activeMatchOrdinal?: number
+  matches?: number
+}): FoundInPagePayload {
+  return {
+    activeMatchOrdinal: Number(result?.activeMatchOrdinal ?? 0),
+    count: Number(result?.matches ?? 0)
+  }
+}
+
+/**
+ * Issue a `findInPage` against the given `webContents`. No-op when the
+ * webContents is missing or destroyed — surfaces as a silent miss rather
+ * than throwing across the IPC boundary, matching Electron's own semantics
+ * for a destroyed renderer.
+ */
+export function performFind(
+  webContents: Electron.WebContents | null | undefined,
+  query: string,
+  options: FindInPageOptions | null | undefined
+): void {
+  if (!webContents || webContents.isDestroyed()) {
+    return
+  }
+
+  const opts = options && typeof options === 'object' ? options : {}
+
+  webContents.findInPage(String(query ?? ''), {
+    forward: opts.forward !== false,
+    findNext: Boolean(opts.findNext)
+  })
+}
+
+/**
+ * Stop the current find and clear highlights. The default `action` matches
+ * what the renderer sends on Escape / close.
+ */
+export function stopFind(
+  webContents: Electron.WebContents | null | undefined,
+  action: 'clearSelection' | 'keepSelection' | 'activateSelection' = 'clearSelection'
+): void {
+  if (!webContents || webContents.isDestroyed()) {
+    return
+  }
+
+  webContents.stopFindInPage(action)
+}
+
+/**
+ * Install a `found-in-page` listener on the given sender `webContents` and
+ * forward each result back to the SAME renderer (via `webContents.send`).
+ *
+ * Returns an uninstall function. Call it from `webContents.on('destroyed', …)`
+ * to avoid leaking the listener when the window goes away — Electron does
+ * not auto-detach webContents listeners on close.
+ *
+ * The forwarder is intentionally bound to a single sender rather than the
+ * primary window: a Cmd+F pressed in a secondary session window must
+ * highlight matches in THAT window, and the match counter must reflect
+ * THAT window's DOM, not the primary's.
+ */
+export function installFoundInPageForwarder(
+  webContents: Electron.WebContents | null | undefined
+): () => void {
+  if (!webContents || webContents.isDestroyed()) {
+    return () => {}
+  }
+
+  const handler = (_event: Electron.Event, result: Parameters<typeof formatFoundInPage>[0]) => {
+    if (webContents.isDestroyed()) {
+      return
+    }
+
+    webContents.send('hermes:found-in-page', formatFoundInPage(result))
+  }
+
+  webContents.on('found-in-page', handler)
+
+  return () => {
+    webContents.off('found-in-page', handler)
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -81,6 +81,7 @@ import {
 import { installEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
 import { findGitBash as _findGitBash } from './find-git-bash'
+import { installFoundInPageForwarder, performFind, stopFind } from './find-in-page'
 import { createFirstRunSetupGate } from './first-run-setup-gate'
 import { readDirForIpc } from './fs-read-dir'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
@@ -9957,6 +9958,61 @@ ipcMain.handle('hermes:openExternal', (_event, url) => {
   if (!openExternalUrl(url)) {
     throw new Error('Invalid external URL')
   }
+})
+
+// ── Find-in-page (Ctrl/Cmd+F) ─────────────────────────────────────────────
+// The desktop supports multiple BrowserWindows (one primary plus any
+// per-session secondary windows spawned via `hermes:window:openSession`).
+// Find must run against the requesting window, not a global — otherwise
+// Cmd+F pressed in a secondary session window would search the primary
+// and the match counter would report matches the user can't see. Resolve
+// the sender through `BrowserWindow.fromWebContents(event.sender)` and
+// forward `found-in-page` results back to that same sender.
+
+// Lazily-installed forwarder per sender webContents. We track one
+// uninstall fn per webContents id and prune entries when the sender goes
+// away — Electron does not auto-detach webContents listeners on close,
+// so the map is the cleanup path.
+const foundInPageForwarders = new Map<number, () => void>()
+
+function ensureFoundInPageForwarder(sender: Electron.WebContents): void {
+  if (foundInPageForwarders.has(sender.id)) {
+    return
+  }
+
+  const uninstall = installFoundInPageForwarder(sender)
+  foundInPageForwarders.set(sender.id, uninstall)
+
+  sender.once('destroyed', () => {
+    foundInPageForwarders.get(sender.id)?.()
+    foundInPageForwarders.delete(sender.id)
+  })
+}
+
+ipcMain.handle('hermes:find-in-page', (event, query, options) => {
+  const win = BrowserWindow.fromWebContents(event.sender)
+
+  if (!win || win.isDestroyed()) {
+    return { count: 0 }
+  }
+
+  ensureFoundInPageForwarder(event.sender)
+  performFind(win.webContents, query, options)
+
+  // The match count arrives asynchronously via `found-in-page`; the
+  // synchronous return value is intentionally `{ count: 0 }` to mirror
+  // Electron's own `findInPage` return semantics (an opaque request id).
+  return { count: 0 }
+})
+
+ipcMain.handle('hermes:stop-find-in-page', event => {
+  const win = BrowserWindow.fromWebContents(event.sender)
+
+  if (!win || win.isDestroyed()) {
+    return
+  }
+
+  stopFind(win.webContents)
 })
 
 ipcMain.handle('hermes:openPreviewInBrowser', async (_event, url) => {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -268,5 +268,19 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   themes: {
     fetchMarketplace: id => ipcRenderer.invoke('hermes:vscode-theme:fetch', id),
     searchMarketplace: query => ipcRenderer.invoke('hermes:vscode-theme:search', query)
+  },
+  // Find-in-page (Ctrl/Cmd+F): delegates to Electron's
+  // webContents.findInPage on the IPC sender's window so a Cmd+F pressed
+  // in a secondary session window searches THAT window, not the primary.
+  // `onFoundInPage` returns the unsubscribe fn; the renderer wires it via
+  // `initFindInPageListener` in store/find-in-page.ts and tears it down
+  // when the FindBar unmounts.
+  findInPage: (query, options) => ipcRenderer.invoke('hermes:find-in-page', query, options),
+  stopFindInPage: () => ipcRenderer.invoke('hermes:stop-find-in-page'),
+  onFoundInPage: callback => {
+    const listener = (_event, result) => callback(result)
+    ipcRenderer.on('hermes:found-in-page', listener)
+
+    return () => ipcRenderer.removeListener('hermes:found-in-page', listener)
   }
 })

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -16,6 +16,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { BootFailureOverlay } from '@/components/boot-failure-overlay'
 import { DesktopInstallOverlay } from '@/components/desktop-install-overlay'
+import { FindBar } from '@/components/find-bar'
 import { GatewayConnectingOverlay } from '@/components/gateway-connecting-overlay'
 import { NotificationStack } from '@/components/notifications'
 import { DesktopOnboardingOverlay } from '@/components/onboarding'
@@ -978,6 +979,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       <SessionSwitcher />
       <FileActionDialogs />
       <RemoteFolderPicker />
+      <FindBar />
 
       {settingsOpen && (
         <Suspense fallback={null}>

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -10,6 +10,7 @@ import { comboAllowedInInput, comboFromEvent, isEditableTarget } from '@/lib/key
 import { composerFocusKeysAllowed, isComposerFocusSoftCombo, typeToFocusChar } from '@/lib/keybinds/composer-focus-keys'
 import { $repoStatus } from '@/store/coding-status'
 import { toggleCommandPalette } from '@/store/command-palette'
+import { openFindBar } from '@/store/find-in-page'
 import { $capture, $comboIndex, endCapture, setBinding } from '@/store/keybinds'
 import {
   requestSessionSearchFocus,
@@ -188,6 +189,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     // the Win/Linux path where ⌘W reaches the renderer directly.
     'view.closeTab': () => void closeActiveTab(id => navigate(sessionRoute(id))),
     'view.reopenTab': reopenLastClosedTile,
+    'view.findInPage': openFindBar,
 
     'appearance.toggleMode': () => setMode(resolvedMode === 'dark' ? 'light' : 'dark'),
 

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -5,12 +5,18 @@ import { closeActiveTab } from '@/app/chat/close-tab'
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { closeActiveTerminal, createTerminal, cycleTerminal } from '@/app/right-sidebar/terminal/terminals'
 import { activateTreeTabSlot, cycleTreeTabInFocusedZone, layoutHasRootSide } from '@/components/pane-shell/tree/store'
+import { findBarClaimsCombo } from '@/lib/find-in-page'
 import { contributedKeybindHandler, PROFILE_SLOT_COUNT, SESSION_SLOT_COUNT } from '@/lib/keybinds/actions'
 import { comboAllowedInInput, comboFromEvent, isEditableTarget } from '@/lib/keybinds/combo'
 import { composerFocusKeysAllowed, isComposerFocusSoftCombo, typeToFocusChar } from '@/lib/keybinds/composer-focus-keys'
 import { $repoStatus } from '@/store/coding-status'
 import { toggleCommandPalette } from '@/store/command-palette'
-import { openFindBar } from '@/store/find-in-page'
+import {
+  $findInPage,
+  findNext as findNextMatch,
+  findPrevious as findPreviousMatch,
+  openFindBar
+} from '@/store/find-in-page'
 import { $capture, $comboIndex, endCapture, setBinding } from '@/store/keybinds'
 import {
   requestSessionSearchFocus,
@@ -190,6 +196,13 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     'view.closeTab': () => void closeActiveTab(id => navigate(sessionRoute(id))),
     'view.reopenTab': reopenLastClosedTile,
     'view.findInPage': openFindBar,
+    // ⌘G / ⌘⇧G are handled by the find bar's own capture-phase listener while
+    // it is open (so they don't collide with `view.toggleReview`). These
+    // registry handlers cover a user-assigned dedicated chord: stepping is a
+    // no-op unless the bar is open with a query, so a bound key can't search
+    // invisibly.
+    'view.findNext': findNextMatch,
+    'view.findPrevious': findPreviousMatch,
 
     'appearance.toggleMode': () => setMode(resolvedMode === 'dark' ? 'light' : 'dark'),
 
@@ -242,6 +255,16 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
       const combo = comboFromEvent(event)
 
       if (!combo) {
+        return
+      }
+
+      // The open find bar owns ⌘G / ⌘⇧G / Escape. Its own capture-phase
+      // listener runs those actions; bail here so the registry doesn't ALSO
+      // fire the action bound to the same combo (⌘G = view.toggleReview,
+      // Escape = composer.cancel, which would abort a live turn). Both
+      // listeners are on `window`, so stopPropagation in the bar can't
+      // suppress this one — the dispatcher has to yield explicitly.
+      if ($findInPage.get().active && findBarClaimsCombo(combo)) {
         return
       }
 

--- a/apps/desktop/src/components/find-bar.test.tsx
+++ b/apps/desktop/src/components/find-bar.test.tsx
@@ -1,0 +1,518 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FindBar } from '@/components/find-bar'
+import { I18nProvider } from '@/i18n'
+import { findBarClaimsCombo, findBarKeyAction, formatMatchLabel } from '@/lib/find-in-page'
+import {
+  $findInPage,
+  closeFindBar,
+  findInPageListenerCount,
+  findNext,
+  findPrevious,
+  initFindInPageListener,
+  openFindBar,
+  resetFindInPageListenerForTest,
+  setFindQuery,
+  updateFindResults
+} from '@/store/find-in-page'
+
+// ── Bridge double ───────────────────────────────────────────────────────────
+// Stands in for the preload `hermesDesktop` surface. `onFoundInPage` records
+// its subscribers so the tests can assert the listener refcount and drive
+// results back into the store the way the main process would.
+
+interface FoundResult {
+  activeMatchOrdinal: number
+  count: number
+}
+
+function installBridge() {
+  const findInPage = vi.fn().mockResolvedValue({ count: 0 })
+  const stopFindInPage = vi.fn().mockResolvedValue(undefined)
+  const subscribers = new Set<(result: FoundResult) => void>()
+
+  const onFoundInPage = vi.fn((callback: (result: FoundResult) => void) => {
+    subscribers.add(callback)
+
+    return () => subscribers.delete(callback)
+  })
+
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    findInPage,
+    stopFindInPage,
+    onFoundInPage
+  }
+
+  return {
+    findInPage,
+    stopFindInPage,
+    onFoundInPage,
+    subscribers,
+    emit(result: FoundResult) {
+      for (const callback of [...subscribers]) {
+        callback(result)
+      }
+    }
+  }
+}
+
+function resetStore() {
+  $findInPage.set({ active: false, query: '', matchOrdinal: 0, matchCount: 0 })
+}
+
+// Zero the bridge refcount so a leaked subscription can't bleed between tests.
+function drainListeners() {
+  resetFindInPageListenerForTest()
+}
+
+let bridge: ReturnType<typeof installBridge>
+
+beforeEach(() => {
+  bridge = installBridge()
+  resetStore()
+})
+
+afterEach(() => {
+  cleanup()
+  resetStore()
+  drainListeners()
+  vi.restoreAllMocks()
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+// ── Pure: match-count formatting ────────────────────────────────────────────
+
+describe('formatMatchLabel', () => {
+  it('hides the counter entirely when there is no query', () => {
+    expect(formatMatchLabel('', 0, 0)).toBe('')
+    // Even if stale counts linger from a previous search.
+    expect(formatMatchLabel('', 3, 12)).toBe('')
+  })
+
+  it('reports an explicit zero when a query matches nothing', () => {
+    expect(formatMatchLabel('nope', 0, 0)).toBe('0/0')
+  })
+
+  it('formats ordinal over count', () => {
+    expect(formatMatchLabel('hit', 3, 12)).toBe('3/12')
+    expect(formatMatchLabel('hit', 1, 1)).toBe('1/1')
+  })
+
+  it('shows 0 ordinal for the frame before the first match is selected', () => {
+    // Electron legitimately reports matches with activeMatchOrdinal 0 on the
+    // first (non-final) update of a fresh search.
+    expect(formatMatchLabel('hit', 0, 5)).toBe('0/5')
+  })
+
+  it('clamps an out-of-range ordinal into the count', () => {
+    expect(formatMatchLabel('hit', 99, 5)).toBe('5/5')
+    expect(formatMatchLabel('hit', -3, 5)).toBe('0/5')
+  })
+
+  it('never emits NaN for non-finite input', () => {
+    expect(formatMatchLabel('hit', Number.NaN, 4)).toBe('0/4')
+    expect(formatMatchLabel('hit', 2, Number.NaN)).toBe('0/0')
+    expect(formatMatchLabel('hit', 2, Number.POSITIVE_INFINITY)).toBe('0/0')
+  })
+
+  it('floors fractional counts rather than rendering decimals', () => {
+    expect(formatMatchLabel('hit', 2.7, 9.9)).toBe('2/9')
+  })
+})
+
+// ── Pure: keybinding matcher ────────────────────────────────────────────────
+
+describe('findBarKeyAction', () => {
+  it('maps Escape to close', () => {
+    expect(findBarKeyAction({ key: 'Escape' })).toBe('close')
+  })
+
+  it('maps Cmd+G / Ctrl+G to next from anywhere', () => {
+    expect(findBarKeyAction({ key: 'g', metaKey: true })).toBe('next')
+    expect(findBarKeyAction({ key: 'g', ctrlKey: true })).toBe('next')
+  })
+
+  it('maps Cmd+Shift+G / Ctrl+Shift+G to previous', () => {
+    // event.key is uppercase 'G' when Shift is held — matched case-insensitively.
+    expect(findBarKeyAction({ key: 'G', metaKey: true, shiftKey: true })).toBe('previous')
+    expect(findBarKeyAction({ key: 'g', ctrlKey: true, shiftKey: true })).toBe('previous')
+  })
+
+  it('steps with Enter / Shift+Enter only while focus is in the input', () => {
+    expect(findBarKeyAction({ key: 'Enter' }, { inInput: true })).toBe('next')
+    expect(findBarKeyAction({ key: 'Enter', shiftKey: true }, { inInput: true })).toBe('previous')
+    // Bare Enter outside the input belongs to the composer, not the find bar.
+    expect(findBarKeyAction({ key: 'Enter' })).toBeNull()
+  })
+
+  it('ignores a bare g so typing never triggers a step', () => {
+    expect(findBarKeyAction({ key: 'g' })).toBeNull()
+    expect(findBarKeyAction({ key: 'g' }, { inInput: true })).toBeNull()
+    expect(findBarKeyAction({ key: 'G', shiftKey: true }, { inInput: true })).toBeNull()
+  })
+
+  it('falls through when Alt is held so ⌥⌘G is not swallowed', () => {
+    expect(findBarKeyAction({ key: 'g', metaKey: true, altKey: true })).toBeNull()
+    expect(findBarKeyAction({ key: 'Escape', altKey: true })).toBeNull()
+  })
+
+  it('does not treat Cmd+Escape as close', () => {
+    expect(findBarKeyAction({ key: 'Escape', metaKey: true })).toBeNull()
+  })
+
+  it('ignores unrelated keys', () => {
+    expect(findBarKeyAction({ key: 'f', metaKey: true })).toBeNull()
+    expect(findBarKeyAction({ key: 'Tab' }, { inInput: true })).toBeNull()
+  })
+})
+
+describe('findBarClaimsCombo', () => {
+  it('claims the step accelerators and Escape', () => {
+    expect(findBarClaimsCombo('mod+g')).toBe(true)
+    expect(findBarClaimsCombo('mod+shift+g')).toBe(true)
+    expect(findBarClaimsCombo('escape')).toBe(true)
+  })
+
+  it('leaves every other combo to the keybind registry', () => {
+    // ⌘F must still reach view.findInPage even while the bar is open.
+    expect(findBarClaimsCombo('mod+f')).toBe(false)
+    expect(findBarClaimsCombo('mod+k')).toBe(false)
+    expect(findBarClaimsCombo('mod+b')).toBe(false)
+    expect(findBarClaimsCombo('enter')).toBe(false)
+  })
+})
+
+// ── Store: open/close state + dispatch ──────────────────────────────────────
+
+describe('find-in-page store', () => {
+  it('opens with a cleared query and counters', () => {
+    updateFindResults(3, 12)
+    openFindBar()
+
+    expect($findInPage.get()).toEqual({ active: true, query: '', matchOrdinal: 0, matchCount: 0 })
+  })
+
+  it('closing clears state and stops the native find (clears selection)', () => {
+    openFindBar()
+    setFindQuery('needle')
+    updateFindResults(2, 7)
+
+    closeFindBar()
+
+    expect($findInPage.get().active).toBe(false)
+    expect($findInPage.get().query).toBe('')
+    expect($findInPage.get().matchCount).toBe(0)
+    expect(bridge.stopFindInPage).toHaveBeenCalledTimes(1)
+  })
+
+  it('closing an already-closed bar does not re-issue stopFindInPage', () => {
+    openFindBar()
+    closeFindBar()
+    closeFindBar()
+
+    expect(bridge.stopFindInPage).toHaveBeenCalledTimes(1)
+  })
+
+  it('a fresh query searches from scratch (findNext false)', () => {
+    openFindBar()
+    setFindQuery('needle')
+
+    expect(bridge.findInPage).toHaveBeenCalledWith('needle', { forward: true, findNext: false })
+  })
+
+  it('clearing the query stops the find instead of searching for empty', () => {
+    openFindBar()
+    setFindQuery('needle')
+    bridge.findInPage.mockClear()
+
+    setFindQuery('')
+
+    expect(bridge.findInPage).not.toHaveBeenCalled()
+    expect(bridge.stopFindInPage).toHaveBeenCalled()
+    expect($findInPage.get().matchCount).toBe(0)
+  })
+
+  it('findNext steps forward and findPrevious steps backward on the same query', () => {
+    openFindBar()
+    setFindQuery('needle')
+    bridge.findInPage.mockClear()
+
+    findNext()
+    expect(bridge.findInPage).toHaveBeenLastCalledWith('needle', { forward: true, findNext: true })
+
+    findPrevious()
+    expect(bridge.findInPage).toHaveBeenLastCalledWith('needle', { forward: false, findNext: true })
+  })
+
+  it('stepping with no query is a no-op (never searches invisibly)', () => {
+    openFindBar()
+
+    findNext()
+    findPrevious()
+
+    expect(bridge.findInPage).not.toHaveBeenCalled()
+  })
+
+  it('setFindQuery on a closed bar never searches', () => {
+    // A debounce timer that already fired, or any late caller, must not
+    // re-highlight the page after the user dismissed the bar.
+    setFindQuery('needle')
+
+    expect(bridge.findInPage).not.toHaveBeenCalled()
+    expect($findInPage.get().query).toBe('')
+  })
+
+  it('found-in-page results land on the store', () => {
+    openFindBar()
+    setFindQuery('needle')
+    const release = initFindInPageListener()
+
+    bridge.emit({ activeMatchOrdinal: 4, count: 9 })
+
+    expect($findInPage.get().matchOrdinal).toBe(4)
+    expect($findInPage.get().matchCount).toBe(9)
+    release()
+  })
+
+  it('refcounts the bridge listener so remounts cannot stack subscriptions', () => {
+    const first = initFindInPageListener()
+    const second = initFindInPageListener()
+
+    // One real bridge subscription regardless of subscriber count.
+    expect(bridge.onFoundInPage).toHaveBeenCalledTimes(1)
+    expect(bridge.subscribers.size).toBe(1)
+    expect(findInPageListenerCount()).toBe(2)
+
+    first()
+    // Still one holder → the bridge listener stays installed.
+    expect(bridge.subscribers.size).toBe(1)
+
+    second()
+    // Last holder released → the listener is detached, nothing leaks.
+    expect(bridge.subscribers.size).toBe(0)
+    expect(findInPageListenerCount()).toBe(0)
+  })
+
+  it('releasing the same subscription twice cannot drive the refcount negative', () => {
+    const release = initFindInPageListener()
+    release()
+    release()
+
+    expect(findInPageListenerCount()).toBe(0)
+
+    // A fresh subscribe after a double-release still installs exactly one.
+    const next = initFindInPageListener()
+    expect(bridge.subscribers.size).toBe(1)
+    next()
+  })
+})
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+// Store mutations that a MOUNTED FindBar subscribes to must be act()-wrapped
+// so React flushes the resulting re-render inside the test.
+function actStore(mutate: () => void) {
+  act(() => {
+    mutate()
+  })
+}
+
+function renderFindBar() {
+  return render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <FindBar />
+    </I18nProvider>
+  )
+}
+
+describe('FindBar', () => {
+  it('renders nothing while closed', () => {
+    renderFindBar()
+
+    expect(screen.queryByRole('search')).toBeNull()
+  })
+
+  it('renders input, counter and close button when open with results', async () => {
+    openFindBar()
+    renderFindBar()
+
+    const input = await screen.findByRole('textbox', { name: /find in page/i })
+    expect(input).toBeTruthy()
+    expect(screen.getByRole('button', { name: /close/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /next match/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /previous match/i })).toBeTruthy()
+
+    // Counter appears once a query + results exist.
+    expect(screen.queryByText('3/12')).toBeNull()
+    actStore(() => $findInPage.set({ active: true, query: 'needle', matchOrdinal: 3, matchCount: 12 }))
+    await waitFor(() => expect(screen.getByText('3/12')).toBeTruthy())
+  })
+
+  it('focuses the input on open', async () => {
+    openFindBar()
+    renderFindBar()
+
+    const input = await screen.findByRole('textbox', { name: /find in page/i })
+    // eslint-disable-next-line no-restricted-globals -- asserting real focus requires the live document
+    await waitFor(() => expect(document.activeElement).toBe(input))
+  })
+
+  it('debounces typing into a single findInPage call', async () => {
+    vi.useFakeTimers()
+
+    try {
+      openFindBar()
+      renderFindBar()
+
+      const input = screen.getByRole('textbox', { name: /find in page/i })
+      fireEvent.change(input, { target: { value: 'n' } })
+      fireEvent.change(input, { target: { value: 'ne' } })
+      fireEvent.change(input, { target: { value: 'nee' } })
+
+      expect(bridge.findInPage).not.toHaveBeenCalled()
+
+      // Flushing the debounce updates the store, which re-renders the bar.
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+
+      expect(bridge.findInPage).toHaveBeenCalledTimes(1)
+      expect(bridge.findInPage).toHaveBeenCalledWith('nee', { forward: true, findNext: false })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not fire a pending search after the bar closes', async () => {
+    vi.useFakeTimers()
+
+    try {
+      openFindBar()
+      renderFindBar()
+
+      fireEvent.change(screen.getByRole('textbox', { name: /find in page/i }), {
+        target: { value: 'needle' }
+      })
+
+      actStore(closeFindBar)
+      vi.advanceTimersByTime(500)
+
+      expect(bridge.findInPage).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('Enter dispatches next and Shift+Enter dispatches previous', async () => {
+    $findInPage.set({ active: true, query: 'needle', matchOrdinal: 1, matchCount: 4 })
+    renderFindBar()
+
+    const input = screen.getByRole('textbox', { name: /find in page/i })
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(bridge.findInPage).toHaveBeenLastCalledWith('needle', { forward: true, findNext: true })
+
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
+    expect(bridge.findInPage).toHaveBeenLastCalledWith('needle', { forward: false, findNext: true })
+  })
+
+  it('Cmd+G / Cmd+Shift+G step from outside the input while the bar is open', async () => {
+    $findInPage.set({ active: true, query: 'needle', matchOrdinal: 1, matchCount: 4 })
+    renderFindBar()
+
+    // Fired on window (not the input) — the accelerator must not require focus.
+    fireEvent.keyDown(window, { key: 'g', metaKey: true })
+    expect(bridge.findInPage).toHaveBeenLastCalledWith('needle', { forward: true, findNext: true })
+
+    fireEvent.keyDown(window, { key: 'G', metaKey: true, shiftKey: true })
+    expect(bridge.findInPage).toHaveBeenLastCalledWith('needle', { forward: false, findNext: true })
+  })
+
+  it('Escape closes the bar and clears the native selection', async () => {
+    openFindBar()
+    renderFindBar()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect($findInPage.get().active).toBe(false)
+    expect(bridge.stopFindInPage).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(screen.queryByRole('search')).toBeNull())
+  })
+
+  it('the close button clears state and stops the find', async () => {
+    openFindBar()
+    renderFindBar()
+
+    fireEvent.click(screen.getByRole('button', { name: /close/i }))
+
+    expect($findInPage.get().active).toBe(false)
+    expect(bridge.stopFindInPage).toHaveBeenCalledTimes(1)
+  })
+
+  it('the next / previous buttons dispatch a step', () => {
+    $findInPage.set({ active: true, query: 'needle', matchOrdinal: 1, matchCount: 4 })
+    renderFindBar()
+
+    fireEvent.click(screen.getByRole('button', { name: /next match/i }))
+    expect(bridge.findInPage).toHaveBeenLastCalledWith('needle', { forward: true, findNext: true })
+
+    fireEvent.click(screen.getByRole('button', { name: /previous match/i }))
+    expect(bridge.findInPage).toHaveBeenLastCalledWith('needle', { forward: false, findNext: true })
+  })
+
+  it('keeps exactly one bridge subscription across an open/close cycle', async () => {
+    renderFindBar()
+
+    // Mounted-but-closed already holds the subscription: results for an
+    // in-flight search must still land after the bar hides.
+    expect(bridge.subscribers.size).toBe(1)
+
+    actStore(openFindBar)
+    await waitFor(() => expect(screen.getByRole('search')).toBeTruthy())
+    actStore(closeFindBar)
+    await waitFor(() => expect(screen.queryByRole('search')).toBeNull())
+    actStore(openFindBar)
+
+    // Toggling visibility must not stack listeners — the subscription is
+    // mount-scoped, not active-scoped.
+    expect(bridge.onFoundInPage).toHaveBeenCalledTimes(1)
+    expect(bridge.subscribers.size).toBe(1)
+  })
+
+  it('unmount releases the bridge subscription (no leak across route changes)', () => {
+    const { unmount } = renderFindBar()
+    expect(bridge.subscribers.size).toBe(1)
+
+    unmount()
+
+    expect(bridge.subscribers.size).toBe(0)
+    expect(findInPageListenerCount()).toBe(0)
+  })
+
+  it('a remount does not stack subscriptions', () => {
+    const first = renderFindBar()
+    first.unmount()
+
+    const second = renderFindBar()
+
+    expect(bridge.subscribers.size).toBe(1)
+    second.unmount()
+    expect(bridge.subscribers.size).toBe(0)
+  })
+
+  it('the window key listener is removed on unmount', () => {
+    openFindBar()
+    const { unmount } = renderFindBar()
+
+    unmount()
+    bridge.stopFindInPage.mockClear()
+
+    // Reopen the store WITHOUT a mounted bar; a leaked listener would still
+    // handle Escape and call into the bridge.
+    actStore(openFindBar)
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(bridge.stopFindInPage).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/components/find-bar.test.tsx
+++ b/apps/desktop/src/components/find-bar.test.tsx
@@ -1,9 +1,14 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, useNavigate } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { FindBar } from '@/components/find-bar'
 import { I18nProvider } from '@/i18n'
+import { en } from '@/i18n/en'
+import { zh } from '@/i18n/zh'
 import { findBarClaimsCombo, findBarKeyAction, formatMatchLabel } from '@/lib/find-in-page'
+import { KEYBIND_ACTIONS } from '@/lib/keybinds/actions'
+import { comboAllowedInInput } from '@/lib/keybinds/combo'
 import {
   $findInPage,
   closeFindBar,
@@ -183,6 +188,47 @@ describe('findBarClaimsCombo', () => {
   })
 })
 
+// ── Keybind registration ────────────────────────────────────────────────────
+
+describe('find-in-page keybind registration', () => {
+  const byId = new Map(KEYBIND_ACTIONS.map(action => [action.id, action]))
+
+  it('registers view.findInPage on mod+f in the view category', () => {
+    const action = byId.get('view.findInPage')
+
+    expect(action).toBeTruthy()
+    expect(action?.category).toBe('view')
+    expect(action?.defaults).toEqual(['mod+f'])
+  })
+
+  it('mod+f fires from inside a textarea (browser find behavior)', () => {
+    // The runtime consults comboAllowedInInput before dispatching a combo
+    // while an editable element owns focus; if mod combos ever stop
+    // qualifying, ⌘F from the composer would type 'f' instead of opening find.
+    expect(comboAllowedInInput('mod+f')).toBe(true)
+  })
+
+  it('registers the step pair unbound so it cannot conflict with view.toggleReview', () => {
+    const next = byId.get('view.findNext')
+    const previous = byId.get('view.findPrevious')
+
+    expect(next?.category).toBe('view')
+    expect(previous?.category).toBe('view')
+    // mod+g stays with view.toggleReview by default; the open find bar claims
+    // it at dispatch time instead (findBarClaimsCombo above).
+    expect(next?.defaults).toEqual([])
+    expect(previous?.defaults).toEqual([])
+    expect(byId.get('view.toggleReview')?.defaults).toEqual(['mod+g'])
+  })
+
+  it('every registered find action has an i18n label (keybinds panel row)', () => {
+    for (const id of ['view.findInPage', 'view.findNext', 'view.findPrevious']) {
+      expect(en.keybinds.actions[id], id).toBeTruthy()
+      expect(zh.keybinds.actions[id], id).toBeTruthy()
+    }
+  })
+})
+
 // ── Store: open/close state + dispatch ──────────────────────────────────────
 
 describe('find-in-page store', () => {
@@ -318,12 +364,36 @@ function actStore(mutate: () => void) {
   })
 }
 
-function renderFindBar() {
+function renderFindBar(initialPath = '/') {
   return render(
-    <I18nProvider configClient={null} initialLocale="en">
-      <FindBar />
-    </I18nProvider>
+    <MemoryRouter initialEntries={[initialPath]}>
+      <I18nProvider configClient={null} initialLocale="en">
+        <FindBar />
+      </I18nProvider>
+    </MemoryRouter>
   )
+}
+
+/** Harness that can navigate the route the mounted FindBar observes. */
+function renderFindBarWithNavigation(initialPath = '/session/a') {
+  let navigateRef: ReturnType<typeof useNavigate> | undefined
+
+  function CaptureNavigate() {
+    navigateRef = useNavigate()
+
+    return null
+  }
+
+  const view = render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <I18nProvider configClient={null} initialLocale="en">
+        <CaptureNavigate />
+        <FindBar />
+      </I18nProvider>
+    </MemoryRouter>
+  )
+
+  return { ...view, navigate: (to: string) => act(() => navigateRef?.(to)) }
 }
 
 describe('FindBar', () => {
@@ -513,6 +583,31 @@ describe('FindBar', () => {
     actStore(openFindBar)
     fireEvent.keyDown(window, { key: 'Escape' })
 
+    expect(bridge.stopFindInPage).not.toHaveBeenCalled()
+  })
+
+  it('navigating to another route closes the bar and clears the highlights', async () => {
+    const { navigate } = renderFindBarWithNavigation('/session/a')
+
+    actStore(openFindBar)
+    actStore(() => $findInPage.set({ active: true, query: 'needle', matchOrdinal: 2, matchCount: 7 }))
+    await waitFor(() => expect(screen.getByRole('search')).toBeTruthy())
+
+    navigate('/session/b')
+
+    // Bar gone, state reset, and the native selection cleared — stale
+    // highlights must not survive a session switch.
+    await waitFor(() => expect(screen.queryByRole('search')).toBeNull())
+    expect($findInPage.get()).toEqual({ active: false, query: '', matchOrdinal: 0, matchCount: 0 })
+    expect(bridge.stopFindInPage).toHaveBeenCalledTimes(1)
+  })
+
+  it('navigation while the bar is closed does not reach into the bridge', async () => {
+    const { navigate } = renderFindBarWithNavigation('/session/a')
+
+    navigate('/session/b')
+
+    await waitFor(() => expect(screen.queryByRole('search')).toBeNull())
     expect(bridge.stopFindInPage).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/components/find-bar.tsx
+++ b/apps/desktop/src/components/find-bar.tsx
@@ -1,0 +1,193 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useRef, useState } from 'react'
+
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+import {
+  $findInPage,
+  closeFindBar,
+  findNext,
+  findPrevious,
+  initFindInPageListener,
+  setFindQuery
+} from '@/store/find-in-page'
+
+/**
+ * Find-in-page overlay (Ctrl/Cmd+F).
+ *
+ * Drives Electron's `webContents.findInPage` via the preload bridge so the
+ * user gets the native browser-like incremental search (highlight, Enter to
+ * step, Shift+Enter to step backwards, Escape to close) over the rendered
+ * chat transcript + editor panels. Multi-window routing is handled in the
+ * main process — see apps/desktop/electron/find-in-page.ts.
+ */
+export function FindBar() {
+  const { t } = useI18n()
+  const { active, query, matchOrdinal, matchCount } = useStore($findInPage)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [localQuery, setLocalQuery] = useState('')
+
+  // Focus input when find bar opens.
+  useEffect(() => {
+    if (active) {
+      setLocalQuery('')
+      // Small delay so the DOM paints the input before we focus.
+      const id = requestAnimationFrame(() => inputRef.current?.focus())
+
+      return () => cancelAnimationFrame(id)
+    }
+
+    return undefined
+  }, [active])
+
+  // Subscribe to found-in-page results from the main process.
+  useEffect(() => {
+    const unsub = initFindInPageListener()
+
+    return unsub
+  }, [])
+
+  // Debounce search — fire findInPage 200ms after the user stops typing.
+  // The ref lets us cancel the pending timeout when the bar closes.
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!active || !localQuery) {
+      return undefined
+    }
+
+    const id = setTimeout(() => setFindQuery(localQuery), 200)
+    debounceRef.current = id
+
+    return () => {
+      clearTimeout(id)
+      debounceRef.current = null
+    }
+  }, [active, localQuery])
+
+  // Cancel pending debounce + close highlights when the bar closes.
+  useEffect(() => {
+    if (!active && debounceRef.current) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+  }, [active])
+
+  // Global Escape listener — works even when focus is outside the input.
+  // Captured so the find bar can always close regardless of which element
+  // inside the shell owns focus (composer textarea, side panel button, etc).
+  useEffect(() => {
+    if (!active) {
+      return undefined
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        closeFindBar()
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown, { capture: true })
+
+    return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
+  }, [active])
+
+  if (!active) {
+    return null
+  }
+
+  const onInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value
+    setLocalQuery(val)
+
+    // Empty query: clear highlights.
+    if (!val) {
+      setFindQuery('')
+    }
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      closeFindBar()
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+
+      if (e.shiftKey) {
+        findPrevious()
+      } else {
+        findNext()
+      }
+    }
+  }
+
+  const matchLabel =
+    query && matchCount > 0
+      ? `${matchOrdinal}/${matchCount}`
+      : query && matchCount === 0
+        ? '0/0'
+        : ''
+
+  return (
+    <div
+      className={cn(
+        'pointer-events-auto fixed right-4 top-[calc(var(--titlebar-height,0px)+0.5rem)] z-50',
+        'flex items-center gap-1 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-surface-background) px-2 py-1 shadow-md'
+      )}
+    >
+      <input
+        className="h-6 w-40 bg-transparent text-xs text-(--ui-text-primary) outline-none placeholder:text-(--ui-text-tertiary)"
+        onChange={onInput}
+        onKeyDown={onKeyDown}
+        placeholder={t.keybinds.actions['view.findInPage'] ?? 'Find'}
+        ref={inputRef}
+        type="text"
+        value={localQuery}
+      />
+
+      {matchLabel && (
+        <span className="min-w-[3rem] text-center text-[0.6875rem] text-(--ui-text-tertiary)">
+          {matchLabel}
+        </span>
+      )}
+
+      <Tip label="Previous">
+        <button
+          className="flex h-5 w-5 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
+          onClick={findPrevious}
+          type="button"
+        >
+          <svg height="12" viewBox="0 0 16 16" width="12">
+            <path d="M4 10l4-4 4 4" fill="none" stroke="currentColor" strokeWidth="1.5" />
+          </svg>
+        </button>
+      </Tip>
+
+      <Tip label="Next">
+        <button
+          className="flex h-5 w-5 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
+          onClick={findNext}
+          type="button"
+        >
+          <svg height="12" viewBox="0 0 16 16" width="12">
+            <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" strokeWidth="1.5" />
+          </svg>
+        </button>
+      </Tip>
+
+      <Tip label="Close">
+        <button
+          className="flex h-5 w-5 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
+          onClick={closeFindBar}
+          type="button"
+        >
+          <svg height="10" viewBox="0 0 12 12" width="10">
+            <path d="M1 1l10 10M11 1L1 11" stroke="currentColor" strokeWidth="1.5" />
+          </svg>
+        </button>
+      </Tip>
+    </div>
+  )
+}

--- a/apps/desktop/src/components/find-bar.tsx
+++ b/apps/desktop/src/components/find-bar.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
+import { findBarKeyAction, formatMatchLabel } from '@/lib/find-in-page'
 import { cn } from '@/lib/utils'
 import {
   $findInPage,
@@ -14,13 +15,21 @@ import {
 } from '@/store/find-in-page'
 
 /**
- * Find-in-page overlay (Ctrl/Cmd+F).
+ * Find-in-page overlay (⌘F).
  *
  * Drives Electron's `webContents.findInPage` via the preload bridge so the
- * user gets the native browser-like incremental search (highlight, Enter to
- * step, Shift+Enter to step backwards, Escape to close) over the rendered
- * chat transcript + editor panels. Multi-window routing is handled in the
- * main process — see apps/desktop/electron/find-in-page.ts.
+ * user gets the native browser-like incremental search (highlight, step,
+ * Escape to clear) over the rendered chat transcript + editor panels. Multi-
+ * window routing is handled in the main process — see
+ * apps/desktop/electron/find-in-page.ts.
+ *
+ * Accelerators, matching the platform convention (and Claude Desktop's set):
+ * ⌘F opens (via the `view.findInPage` keybind), ⌘G / ⌘⇧G step next/previous
+ * from anywhere while the bar is open, Enter / ⇧Enter step from the input,
+ * and Escape closes + clears the native selection.
+ *
+ * Key routing lives in `lib/find-in-page.ts` as a pure matcher so the
+ * accelerator set is testable without a DOM.
  */
 export function FindBar() {
   const { t } = useI18n()
@@ -41,51 +50,53 @@ export function FindBar() {
     return undefined
   }, [active])
 
-  // Subscribe to found-in-page results from the main process.
-  useEffect(() => {
-    const unsub = initFindInPageListener()
-
-    return unsub
-  }, [])
+  // Subscribe to found-in-page results from the main process. Refcounted in
+  // the store, so a remount (connection re-home) can't stack listeners; the
+  // subscription is deliberately mount-scoped and NOT tied to `active` —
+  // results for an in-flight search must still land if the bar just closed.
+  useEffect(() => initFindInPageListener(), [])
 
   // Debounce search — fire findInPage 200ms after the user stops typing.
-  // The ref lets us cancel the pending timeout when the bar closes.
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
   useEffect(() => {
     if (!active || !localQuery) {
       return undefined
     }
 
     const id = setTimeout(() => setFindQuery(localQuery), 200)
-    debounceRef.current = id
 
-    return () => {
-      clearTimeout(id)
-      debounceRef.current = null
-    }
+    // Cleanup covers every exit: another keystroke, the bar closing, and
+    // unmount. Nothing can fire a find after the bar is gone.
+    return () => clearTimeout(id)
   }, [active, localQuery])
 
-  // Cancel pending debounce + close highlights when the bar closes.
-  useEffect(() => {
-    if (!active && debounceRef.current) {
-      clearTimeout(debounceRef.current)
-      debounceRef.current = null
-    }
-  }, [active])
-
-  // Global Escape listener — works even when focus is outside the input.
-  // Captured so the find bar can always close regardless of which element
-  // inside the shell owns focus (composer textarea, side panel button, etc).
+  // Global accelerators while the bar is open: Escape closes, ⌘G / ⌘⇧G step.
+  // Capture-phase so they win regardless of which element inside the shell
+  // owns focus (composer textarea, side panel button, …). ⌘G is also bound to
+  // `view.toggleReview` in the keybinds registry — this listener runs in the
+  // capture phase and stops propagation, so while the find bar is open ⌘G
+  // means "find next" and the review toggle does not also fire. Closing the
+  // bar hands ⌘G straight back to the review pane.
   useEffect(() => {
     if (!active) {
       return undefined
     }
 
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault()
+    const onKeyDown = (event: KeyboardEvent) => {
+      const action = findBarKeyAction(event)
+
+      if (!action) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      if (action === 'close') {
         closeFindBar()
+      } else if (action === 'next') {
+        findNext()
+      } else {
+        findPrevious()
       }
     }
 
@@ -98,37 +109,36 @@ export function FindBar() {
     return null
   }
 
-  const onInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const val = e.target.value
-    setLocalQuery(val)
+  const onInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value
+    setLocalQuery(value)
 
-    // Empty query: clear highlights.
-    if (!val) {
+    // Empty query: clear highlights immediately rather than after the debounce.
+    if (!value) {
       setFindQuery('')
     }
   }
 
-  const onKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      e.preventDefault()
-      closeFindBar()
-    } else if (e.key === 'Enter') {
-      e.preventDefault()
+  // Enter / ⇧Enter step while focus is in the input. Escape and ⌘G are handled
+  // by the window listener above, so they are intentionally not duplicated
+  // here — `inInput` only unlocks the bare-Enter family.
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    const action = findBarKeyAction(event, { inInput: true })
 
-      if (e.shiftKey) {
-        findPrevious()
-      } else {
-        findNext()
-      }
+    if (action !== 'next' && action !== 'previous') {
+      return
+    }
+
+    event.preventDefault()
+
+    if (action === 'next') {
+      findNext()
+    } else {
+      findPrevious()
     }
   }
 
-  const matchLabel =
-    query && matchCount > 0
-      ? `${matchOrdinal}/${matchCount}`
-      : query && matchCount === 0
-        ? '0/0'
-        : ''
+  const matchLabel = formatMatchLabel(query, matchOrdinal, matchCount)
 
   return (
     <div
@@ -136,25 +146,31 @@ export function FindBar() {
         'pointer-events-auto fixed right-4 top-[calc(var(--titlebar-height,0px)+0.5rem)] z-50',
         'flex items-center gap-1 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-surface-background) px-2 py-1 shadow-md'
       )}
+      role="search"
     >
       <input
+        aria-label={t.keybinds.actions['view.findInPage'] ?? 'Find in page'}
         className="h-6 w-40 bg-transparent text-xs text-(--ui-text-primary) outline-none placeholder:text-(--ui-text-tertiary)"
         onChange={onInput}
         onKeyDown={onKeyDown}
-        placeholder={t.keybinds.actions['view.findInPage'] ?? 'Find'}
+        placeholder={t.keybinds.actions['view.findInPage'] ?? 'Find in page'}
         ref={inputRef}
         type="text"
         value={localQuery}
       />
 
       {matchLabel && (
-        <span className="min-w-[3rem] text-center text-[0.6875rem] text-(--ui-text-tertiary)">
+        <span
+          aria-live="polite"
+          className="min-w-[3rem] text-center text-[0.6875rem] text-(--ui-text-tertiary)"
+        >
           {matchLabel}
         </span>
       )}
 
-      <Tip label="Previous">
+      <Tip label={t.findInPage.previous}>
         <button
+          aria-label={t.findInPage.previous}
           className="flex h-5 w-5 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
           onClick={findPrevious}
           type="button"
@@ -165,8 +181,9 @@ export function FindBar() {
         </button>
       </Tip>
 
-      <Tip label="Next">
+      <Tip label={t.findInPage.next}>
         <button
+          aria-label={t.findInPage.next}
           className="flex h-5 w-5 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
           onClick={findNext}
           type="button"
@@ -177,8 +194,9 @@ export function FindBar() {
         </button>
       </Tip>
 
-      <Tip label="Close">
+      <Tip label={t.common.close}>
         <button
+          aria-label={t.common.close}
           className="flex h-5 w-5 items-center justify-center rounded text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)"
           onClick={closeFindBar}
           type="button"

--- a/apps/desktop/src/components/find-bar.tsx
+++ b/apps/desktop/src/components/find-bar.tsx
@@ -1,5 +1,6 @@
 import { useStore } from '@nanostores/react'
 import { useEffect, useRef, useState } from 'react'
+import { useLocation } from 'react-router-dom'
 
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
@@ -36,6 +37,21 @@ export function FindBar() {
   const { active, query, matchOrdinal, matchCount } = useStore($findInPage)
   const inputRef = useRef<HTMLInputElement>(null)
   const [localQuery, setLocalQuery] = useState('')
+  const { pathname } = useLocation()
+
+  // Navigating away (opening another session, a settings page, …) closes the
+  // bar and clears the native highlight. Electron's findInPage selection is
+  // per-webContents, not per-route: without this, highlights (and a stale
+  // match counter) from the previous chat would survive onto the next view.
+  // Implemented as effect cleanup so the first render never fires it, a
+  // pathname change tears down the previous route's search, and unmount
+  // (session/profile switches that remount the shell) gets the same teardown.
+  // closeFindBar is idempotent, so a closed bar never re-enters the bridge.
+  useEffect(() => {
+    void pathname
+
+    return () => closeFindBar()
+  }, [pathname])
 
   // Focus input when find bar opens.
   useEffect(() => {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -237,6 +237,19 @@ declare global {
         // returns the most-installed themes.
         searchMarketplace: (query: string) => Promise<DesktopMarketplaceSearchItem[]>
       }
+      // Find-in-page: delegates to Electron's webContents.findInPage on the
+      // IPC sender's window so Cmd+F from a secondary session window
+      // searches that window (not the primary). `onFoundInPage` returns the
+      // unsubscribe fn; the renderer wires it via `initFindInPageListener`
+      // in store/find-in-page.ts and tears it down when the FindBar unmounts.
+      findInPage: (
+        query: string,
+        options?: { forward?: boolean; findNext?: boolean }
+      ) => Promise<{ count: number }>
+      stopFindInPage: () => Promise<void>
+      onFoundInPage: (
+        callback: (result: { activeMatchOrdinal: number; count: number }) => void
+      ) => () => void
     }
   }
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -267,6 +267,7 @@ export const en: Translations = {
       'view.closeTab': 'Close tab',
       'view.reopenTab': 'Reopen closed tab',
       'view.flipPanes': 'Swap sidebar sides',
+      'view.findInPage': 'Find in page',
       'appearance.toggleMode': 'Toggle light / dark',
       'profile.default': 'Switch to default profile',
       'profile.switch.1': 'Switch to profile 1',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -268,6 +268,8 @@ export const en: Translations = {
       'view.reopenTab': 'Reopen closed tab',
       'view.flipPanes': 'Swap sidebar sides',
       'view.findInPage': 'Find in page',
+      'view.findNext': 'Find next match',
+      'view.findPrevious': 'Find previous match',
       'appearance.toggleMode': 'Toggle light / dark',
       'profile.default': 'Switch to default profile',
       'profile.switch.1': 'Switch to profile 1',
@@ -303,6 +305,11 @@ export const en: Translations = {
       'composer.history': 'Cycle popover / history',
       'composer.cancel': 'Close popover · cancel run'
     }
+  },
+
+  findInPage: {
+    next: 'Next match',
+    previous: 'Previous match'
   },
 
   language: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -262,6 +262,12 @@ export interface Translations {
     actions: Record<string, string>
   }
 
+  // Find-in-page bar (⌘F). `close` reuses common.close.
+  findInPage: {
+    next: string
+    previous: string
+  }
+
   language: {
     label: string
     description: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -259,6 +259,8 @@ export const zh: Translations = {
       'view.reopenTab': '重新打开已关闭的标签',
       'view.flipPanes': '交换侧边栏位置',
       'view.findInPage': '页面内查找',
+      'view.findNext': '查找下一个',
+      'view.findPrevious': '查找上一个',
       'appearance.toggleMode': '切换浅色/深色',
       'profile.default': '切换到默认配置',
       'profile.switch.1': '切换到配置 1',
@@ -294,6 +296,11 @@ export const zh: Translations = {
       'composer.history': '切换弹窗/历史',
       'composer.cancel': '关闭弹窗·取消运行'
     }
+  },
+
+  findInPage: {
+    next: '下一个匹配',
+    previous: '上一个匹配'
   },
 
   language: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -258,6 +258,7 @@ export const zh: Translations = {
       'view.closeTab': '关闭标签',
       'view.reopenTab': '重新打开已关闭的标签',
       'view.flipPanes': '交换侧边栏位置',
+      'view.findInPage': '页面内查找',
       'appearance.toggleMode': '切换浅色/深色',
       'profile.default': '切换到默认配置',
       'profile.switch.1': '切换到配置 1',

--- a/apps/desktop/src/lib/find-in-page.ts
+++ b/apps/desktop/src/lib/find-in-page.ts
@@ -1,0 +1,109 @@
+// Pure logic for the find-in-page bar (⌘F). Kept out of the component so the
+// match-counter projection and the in-bar key routing can be unit-tested
+// without jsdom, a BrowserWindow, or the preload bridge.
+//
+// The Electron side of the feature lives in electron/find-in-page.ts; this is
+// strictly renderer presentation logic.
+
+/**
+ * Counter shown next to the input, e.g. `"3/12"`.
+ *
+ * Three distinct states, and they are not the same thing:
+ * - No query → `''`. The counter hides entirely rather than claiming "0/0"
+ *   before the user has asked anything.
+ * - A query with no matches → `'0/0'`. An explicit, honest zero.
+ * - A query with matches → `'<ordinal>/<count>'`.
+ *
+ * `activeMatchOrdinal` is 1-indexed and can legitimately arrive as 0 from
+ * Electron for the frame between issuing a search and the first match being
+ * selected, so the ordinal is clamped into `[0, count]` rather than trusted.
+ */
+export function formatMatchLabel(query: string, activeMatchOrdinal: number, matchCount: number): string {
+  if (!query) {
+    return ''
+  }
+
+  const count = Number.isFinite(matchCount) && matchCount > 0 ? Math.floor(matchCount) : 0
+
+  if (count === 0) {
+    return '0/0'
+  }
+
+  const raw = Number.isFinite(activeMatchOrdinal) ? Math.floor(activeMatchOrdinal) : 0
+  const ordinal = Math.min(Math.max(raw, 0), count)
+
+  return `${ordinal}/${count}`
+}
+
+/** What a keypress means to an open find bar. `null` = not ours, let it through. */
+export type FindBarKeyAction = 'close' | 'next' | 'previous' | null
+
+/** The subset of a keyboard event the matcher needs — works for DOM and React events. */
+export interface FindBarKeyEvent {
+  key: string
+  shiftKey?: boolean
+  metaKey?: boolean
+  ctrlKey?: boolean
+  altKey?: boolean
+}
+
+/**
+ * Map a keypress to a find-bar action while the bar is open.
+ *
+ * Two families, matching the platform convention Chrome/Safari/VS Code (and
+ * Claude Desktop's `findInPage` accelerators) all share:
+ * - Bare `Enter` / `Shift+Enter` step forward / backward. Only valid while
+ *   focus is in the find input, so callers pass `inInput: true` there.
+ * - `⌘G` / `⌘⇧G` (Ctrl+G / Ctrl+Shift+G off macOS) step forward / backward
+ *   from anywhere while the bar is open — that is the accelerator pair, and it
+ *   must not require the input to hold focus.
+ * - `Escape` closes from anywhere.
+ *
+ * `Alt` is treated as disqualifying so ⌥⌘G and friends fall through to
+ * whatever else may want them instead of being silently swallowed.
+ */
+export function findBarKeyAction(event: FindBarKeyEvent, options: { inInput?: boolean } = {}): FindBarKeyAction {
+  if (event.altKey) {
+    return null
+  }
+
+  const mod = Boolean(event.metaKey || event.ctrlKey)
+
+  if (event.key === 'Escape') {
+    return mod ? null : 'close'
+  }
+
+  // `event.key` for the G key is 'g' unshifted and 'G' with Shift held, so
+  // compare case-insensitively and read direction from `shiftKey` alone.
+  if (mod && event.key.toLowerCase() === 'g') {
+    return event.shiftKey ? 'previous' : 'next'
+  }
+
+  if (event.key === 'Enter' && !mod && options.inInput) {
+    return event.shiftKey ? 'previous' : 'next'
+  }
+
+  return null
+}
+
+/**
+ * Combos the open find bar owns, in canonical `comboFromEvent` form.
+ *
+ * The global keybind dispatcher (app/hooks/use-keybinds.ts) consults this
+ * before routing a combo to the registry. Without it, three real collisions
+ * fire alongside the find bar:
+ * - `mod+g` → `view.toggleReview` (⌘G is the review pane's default).
+ * - `mod+shift+g` → whatever a user has bound there.
+ * - `escape` → `composer.cancel`, which would abort a running turn while the
+ *   user only meant to dismiss the find bar.
+ *
+ * `stopPropagation` cannot solve this: both listeners sit on `window` in the
+ * capture phase, and propagation control does not suppress sibling listeners
+ * on the same target. Ownership has to be decided by the dispatcher, which is
+ * the documented single owner of combo dispatch. This matches the
+ * "keyboard ownership follows focus / one cancel gesture does one thing"
+ * invariant in apps/desktop/AGENTS.md.
+ */
+export function findBarClaimsCombo(combo: string): boolean {
+  return combo === 'mod+g' || combo === 'mod+shift+g' || combo === 'escape'
+}

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -122,6 +122,10 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // is a no-op. ⌘⇧T reopens the last closed tab where it was.
   { id: 'view.closeTab', category: 'view', defaults: ['mod+w'] },
   { id: 'view.reopenTab', category: 'view', defaults: ['mod+shift+t'] },
+  // ⌘F — open the find-in-page bar. `comboAllowedInInput` lets the combo
+  // fire from inside a textarea / contenteditable (matches browser behavior
+  // so typing in the composer and pressing ⌘F focuses find, not 'f').
+  { id: 'view.findInPage', category: 'view', defaults: ['mod+f'] },
   { id: 'appearance.toggleMode', category: 'view', defaults: ['shift+x'] },
   { id: 'keybinds.openPanel', category: 'view', defaults: ['mod+/'] }
 ]

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -126,6 +126,17 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // fire from inside a textarea / contenteditable (matches browser behavior
   // so typing in the composer and pressing ⌘F focuses find, not 'f').
   { id: 'view.findInPage', category: 'view', defaults: ['mod+f'] },
+  // ⌘G / ⌘⇧G step matches — the platform-standard find-next/find-previous
+  // pair (Chrome, Safari, VS Code, and Claude Desktop all ship it). No
+  // `defaults` here on purpose: ⌘G already belongs to `view.toggleReview`,
+  // and shipping a duplicate default would flag a permanent conflict in the
+  // keybinds panel. While the find bar is OPEN, its capture-phase listener
+  // claims ⌘G/⌘⇧G and stops propagation (see components/find-bar.tsx), so
+  // stepping works out of the box and the review toggle keeps the key the
+  // rest of the time. These entries exist so the panel documents the pair
+  // and a user who prefers a dedicated chord can bind one.
+  { id: 'view.findNext', category: 'view', defaults: [] },
+  { id: 'view.findPrevious', category: 'view', defaults: [] },
   { id: 'appearance.toggleMode', category: 'view', defaults: ['shift+x'] },
   { id: 'keybinds.openPanel', category: 'view', defaults: ['mod+/'] }
 ]

--- a/apps/desktop/src/store/find-in-page.ts
+++ b/apps/desktop/src/store/find-in-page.ts
@@ -1,0 +1,66 @@
+import { atom } from 'nanostores'
+
+export interface FindInPageState {
+  active: boolean
+  query: string
+  matchOrdinal: number
+  matchCount: number
+}
+
+export const $findInPage = atom<FindInPageState>({
+  active: false,
+  query: '',
+  matchOrdinal: 0,
+  matchCount: 0
+})
+
+export function openFindBar(): void {
+  $findInPage.set({ active: true, query: '', matchOrdinal: 0, matchCount: 0 })
+}
+
+export function closeFindBar(): void {
+  $findInPage.set({ active: false, query: '', matchOrdinal: 0, matchCount: 0 })
+  void window.hermesDesktop?.stopFindInPage()
+}
+
+export function setFindQuery(query: string): void {
+  const prev = $findInPage.get()
+  $findInPage.set({ ...prev, query })
+
+  if (!query) {
+    void window.hermesDesktop?.stopFindInPage()
+    $findInPage.set({ ...prev, query: '', matchOrdinal: 0, matchCount: 0 })
+
+    return
+  }
+
+  void window.hermesDesktop?.findInPage(query, { forward: true, findNext: false })
+}
+
+export function findNext(): void {
+  const { query } = $findInPage.get()
+
+  if (query) {
+    void window.hermesDesktop?.findInPage(query, { forward: true, findNext: true })
+  }
+}
+
+export function findPrevious(): void {
+  const { query } = $findInPage.get()
+
+  if (query) {
+    void window.hermesDesktop?.findInPage(query, { forward: false, findNext: true })
+  }
+}
+
+/** Called by the preload bridge when `found-in-page` fires on webContents. */
+export function updateFindResults(activeMatch: number, count: number): void {
+  const prev = $findInPage.get()
+  $findInPage.set({ ...prev, matchOrdinal: activeMatch, matchCount: count })
+}
+
+export function initFindInPageListener(): (() => void) | undefined {
+  return window.hermesDesktop?.onFoundInPage?.((result: { activeMatchOrdinal: number; count: number }) => {
+    updateFindResults(result.activeMatchOrdinal, result.count)
+  })
+}

--- a/apps/desktop/src/store/find-in-page.ts
+++ b/apps/desktop/src/store/find-in-page.ts
@@ -7,33 +7,45 @@ export interface FindInPageState {
   matchCount: number
 }
 
-export const $findInPage = atom<FindInPageState>({
-  active: false,
-  query: '',
-  matchOrdinal: 0,
-  matchCount: 0
-})
+const EMPTY: FindInPageState = { active: false, query: '', matchOrdinal: 0, matchCount: 0 }
+
+export const $findInPage = atom<FindInPageState>({ ...EMPTY })
 
 export function openFindBar(): void {
-  $findInPage.set({ active: true, query: '', matchOrdinal: 0, matchCount: 0 })
+  $findInPage.set({ ...EMPTY, active: true })
 }
 
 export function closeFindBar(): void {
-  $findInPage.set({ active: false, query: '', matchOrdinal: 0, matchCount: 0 })
+  // Already closed: don't re-issue stopFindInPage. Escape is a shared gesture
+  // (the switcher and dialogs claim it too), so a stray second close must not
+  // reach into Electron again.
+  if (!$findInPage.get().active) {
+    return
+  }
+
+  $findInPage.set({ ...EMPTY })
+  // Clears both the search and the native highlight/selection in the page.
   void window.hermesDesktop?.stopFindInPage()
 }
 
 export function setFindQuery(query: string): void {
   const prev = $findInPage.get()
-  $findInPage.set({ ...prev, query })
+
+  // Never search for a closed bar. The component clears its debounce on
+  // close, but a timer that already fired (or any late caller) must not
+  // re-issue a find and re-highlight the page after the user pressed Escape.
+  if (!prev.active) {
+    return
+  }
 
   if (!query) {
-    void window.hermesDesktop?.stopFindInPage()
     $findInPage.set({ ...prev, query: '', matchOrdinal: 0, matchCount: 0 })
+    void window.hermesDesktop?.stopFindInPage()
 
     return
   }
 
+  $findInPage.set({ ...prev, query })
   void window.hermesDesktop?.findInPage(query, { forward: true, findNext: false })
 }
 
@@ -59,8 +71,60 @@ export function updateFindResults(activeMatch: number, count: number): void {
   $findInPage.set({ ...prev, matchOrdinal: activeMatch, matchCount: count })
 }
 
-export function initFindInPageListener(): (() => void) | undefined {
-  return window.hermesDesktop?.onFoundInPage?.((result: { activeMatchOrdinal: number; count: number }) => {
-    updateFindResults(result.activeMatchOrdinal, result.count)
-  })
+// The found-in-page subscription is process-wide, not per-mount: the FindBar
+// lives in the global overlay set and the shell remounts it on a connection
+// re-home (soft switch) while route changes keep it alive. Refcount the single
+// bridge listener so a remount cannot stack duplicate subscriptions — every
+// stacked listener would re-dispatch the same result and, worse, outlive its
+// component.
+let listenerRefs = 0
+let detachListener: (() => void) | undefined
+
+/**
+ * Subscribe to `found-in-page` results. Returns a release fn; the underlying
+ * bridge listener is installed on the first subscriber and removed when the
+ * last one releases. Safe to call from an effect with a `[]` dep list.
+ */
+export function initFindInPageListener(): () => void {
+  listenerRefs += 1
+
+  if (listenerRefs === 1) {
+    detachListener = window.hermesDesktop?.onFoundInPage?.(result => {
+      updateFindResults(result.activeMatchOrdinal, result.count)
+    })
+  }
+
+  let released = false
+
+  return () => {
+    // Guard double-release: React can invoke a cleanup once, but a caller
+    // holding the fn shouldn't be able to drive the refcount negative.
+    if (released) {
+      return
+    }
+
+    released = true
+    listenerRefs -= 1
+
+    if (listenerRefs === 0) {
+      detachListener?.()
+      detachListener = undefined
+    }
+  }
+}
+
+/** Test seam: number of live bridge subscriptions (0 or 1 in practice). */
+export function findInPageListenerCount(): number {
+  return listenerRefs
+}
+
+/**
+ * Test seam: force-detach the bridge listener and zero the refcount.
+ * Production code never calls this — tests use it so one case's leaked
+ * subscription can't bleed into the next.
+ */
+export function resetFindInPageListenerForTest(): void {
+  detachListener?.()
+  detachListener = undefined
+  listenerRefs = 0
 }


### PR DESCRIPTION
## Summary

Hermes Desktop gets find-in-page: `Ctrl/Cmd+F` opens a find bar with a live match counter, `Ctrl/Cmd+G` / `Ctrl/Cmd+Shift+G` step through matches, `Esc` closes and clears highlights. Salvage of #53891 by @DavidMetcalfe, completed to the full accelerator set.

Sourced from a hands-on UX audit of the competition: I extracted the official Claude Desktop 1.24012.9 `.deb` and unpacked its `app.asar` — Cowork ships a dedicated `findInPage.js` bundle, a `FIND_IN_PAGE: "find-in-page"` WebContentsType, and exactly this `CmdOrCtrl+F` / `+G` / `+Shift+G` accelerator table. Hermes Desktop had nothing.

## How it works

Uses Electron's native `webContents.findInPage` / `stopFindInPage` (no DOM scanning, no highlight reimplementation), bridged through the existing typed capability seam per `apps/desktop/AGENTS.md`. Match counts come from the native `found-in-page` result event. Renderer owns presentation (`find-bar.tsx` + a small `find-in-page` store); Electron owns the machine side. Multi-window routing covered.

## Changes

- `apps/desktop/electron/find-in-page.ts` — main-process bridge + per-window routing
- `apps/desktop/src/components/find-bar.tsx` — find bar UI (input, counter, next/prev, close)
- `apps/desktop/src/store/find-in-page.ts` — presentation state
- `apps/desktop/src/lib/keybinds/actions.ts` + `hooks/use-keybinds.ts` — accelerators
- `apps/desktop/src/i18n/en.ts` + `zh.ts` — locale parity
- `apps/desktop/electron/find-in-page.test.ts` — 20 tests

## Validation

| | Result |
|---|---|
| `npx vitest run electron/find-in-page.test.ts` | 20 passed, 0 failed |
| `tsc --noEmit` on touched files | clean (114 pre-existing errors on main, none in new files) |

Closes #53891 (salvaged — @DavidMetcalfe's three commits are the base of this branch, authorship preserved).

## Infographic

![find-in-page](https://v3b.fal.media/files/b/0aa3d919/wY38H_wwIP1vKSb7iB_uZ_OArQCnpd.png)
