### PR TITLE
fix(gateway): isolate kanban notifier failures + cursor snap at creation (salvage #59278, #62712, #63001)

### DIFF
--- a/contributors/emails/robertsryan_21@icloud.com
+++ b/contributors/emails/robertsryan_21@icloud.com
@@ -1,0 +1,1 @@
+rhylryan21

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -78,6 +78,16 @@ class GatewayAuthorizationMixin:
             return None
         profile_name = (profile or "").strip() or None
         if profile_name and profile_name != "default":
+            active_profile = None
+            active_profile_fn = getattr(self, "_active_profile_name", None)
+            if callable(active_profile_fn):
+                try:
+                    active_profile = active_profile_fn()
+                except Exception:
+                    active_profile = None
+            if profile_name == active_profile:
+                adapters = getattr(self, "adapters", None) or {}
+                return adapters.get(platform)
             profile_adapters = getattr(self, "_profile_adapters", None) or {}
             if profile_name in profile_adapters:
                 return profile_adapters[profile_name].get(platform)

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -252,45 +252,54 @@ class GatewayKanbanWatchersMixin:
                             if not subs:
                                 logger.debug("kanban notifier: board %s has no subscriptions", slug)
                             for sub in subs:
-                                owner_profile = sub.get("notifier_profile") or None
-                                if owner_profile and owner_profile != notifier_profile:
-                                    _owner_adapters = getattr(self, "_profile_adapters", {}).get(owner_profile)
-                                    if not _owner_adapters:
+                                try:
+                                    owner_profile = sub.get("notifier_profile") or None
+                                    if owner_profile and owner_profile != notifier_profile:
+                                        _owner_adapters = getattr(self, "_profile_adapters", {}).get(owner_profile)
+                                        if not _owner_adapters:
+                                            logger.debug(
+                                                "kanban notifier: subscription for %s owned by profile %s; current profile %s has no adapter for it, skipping",
+                                                sub.get("task_id"), owner_profile, notifier_profile,
+                                            )
+                                            continue
+                                    platform = (sub.get("platform") or "").lower()
+                                    if platform not in active_platforms:
                                         logger.debug(
-                                            "kanban notifier: subscription for %s owned by profile %s; current profile %s has no adapter for it, skipping",
-                                            sub.get("task_id"), owner_profile, notifier_profile,
+                                            "kanban notifier: subscription for %s on %s skipped; adapter not connected",
+                                            sub.get("task_id"), platform or "<missing>",
                                         )
                                         continue
-                                platform = (sub.get("platform") or "").lower()
-                                if platform not in active_platforms:
-                                    logger.debug(
-                                        "kanban notifier: subscription for %s on %s skipped; adapter not connected",
-                                        sub.get("task_id"), platform or "<missing>",
+                                    old_cursor, cursor, events = _kb.claim_unseen_events_for_sub(
+                                        conn,
+                                        task_id=sub["task_id"],
+                                        platform=sub["platform"],
+                                        chat_id=sub["chat_id"],
+                                        thread_id=sub.get("thread_id") or "",
+                                        kinds=TERMINAL_KINDS,
                                     )
-                                    continue
-                                old_cursor, cursor, events = _kb.claim_unseen_events_for_sub(
-                                    conn,
-                                    task_id=sub["task_id"],
-                                    platform=sub["platform"],
-                                    chat_id=sub["chat_id"],
-                                    thread_id=sub.get("thread_id") or "",
-                                    kinds=TERMINAL_KINDS,
-                                )
-                                if not events:
-                                    continue
-                                task = _kb.get_task(conn, sub["task_id"])
-                                logger.debug(
-                                    "kanban notifier: claimed %d event(s) for %s on board %s cursor %s→%s",
-                                    len(events), sub["task_id"], slug, old_cursor, cursor,
-                                )
-                                deliveries.append({
-                                    "sub": sub,
-                                    "old_cursor": old_cursor,
-                                    "cursor": cursor,
-                                    "events": events,
-                                    "task": task,
-                                    "board": slug,
-                                })
+                                    if not events:
+                                        continue
+                                    task = _kb.get_task(conn, sub["task_id"])
+                                    logger.debug(
+                                        "kanban notifier: claimed %d event(s) for %s on board %s cursor %s→%s",
+                                        len(events), sub["task_id"], slug, old_cursor, cursor,
+                                    )
+                                    deliveries.append({
+                                        "sub": sub,
+                                        "old_cursor": old_cursor,
+                                        "cursor": cursor,
+                                        "events": events,
+                                        "task": task,
+                                        "board": slug,
+                                    })
+                                except Exception as sub_exc:
+                                    # Isolate per-subscription failures so one
+                                    # bad subscription cannot block delivery for
+                                    # all other subscriptions in this tick.
+                                    logger.warning(
+                                        "kanban notifier: subscription for %s on board %s failed: %s",
+                                        sub.get("task_id"), slug, sub_exc,
+                                    )
                         finally:
                             conn.close()
                     return deliveries

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -236,6 +236,26 @@ class GatewayKanbanWatchersMixin:
                             )
                             continue
                         seen_db_paths.add(resolved_db_path)
+                        # Zero-subscription early exit: probe the board with a
+                        # cheap read-only connection BEFORE the writable
+                        # `connect()`. A board with no subscriptions has
+                        # nothing to notify, and the writable open (schema
+                        # init/migration on first open, WAL/-shm sidecars,
+                        # checkpoint traffic) is exactly the per-tick cost
+                        # this skip avoids.
+                        try:
+                            if _kb.count_notify_subs(board=slug) == 0:
+                                logger.debug(
+                                    "kanban notifier: board %s has no subscriptions; skipping open",
+                                    slug,
+                                )
+                                continue
+                        except Exception as exc:
+                            logger.debug(
+                                "kanban notifier: read-only subscription probe failed "
+                                "for board %s (%s); falling back to writable open",
+                                slug, exc,
+                            )
                         try:
                             conn = _kb.connect(board=slug)
                         except Exception as exc:

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -164,7 +164,7 @@ class GatewayKanbanWatchersMixin:
 
         # "status" covers dashboard drag-drop and `_set_status_direct()`
         # writes — surface those transitions to subscribers too.
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked")
+        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "block_loop_detected")
         # Subscriptions are removed only when the task reaches a truly final
         # status (done / archived). We used to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
@@ -181,7 +181,13 @@ class GatewayKanbanWatchersMixin:
         # means the chat is dead (deleted, bot kicked, etc.) — after N
         # consecutive send failures the sub is dropped so we don't spin
         # against a dead chat every 5 seconds forever.
-        MAX_SEND_FAILURES = 3
+        # Raised from 3 to 12 (~60s at the 5s tick cadence): now that a
+        # reported SendResult(success=False) also lands here (see the
+        # delivery loop below), a transient Telegram/API outage of a few
+        # ticks must NOT permanently unsubscribe a live review-gate channel.
+        # A genuinely dead chat still drops, just ~60s later — a fine trade
+        # for an unattended gate where a false drop means silent work pileup.
+        MAX_SEND_FAILURES = 12
         sub_fail_counts: dict[tuple, int] = getattr(
             self, "_kanban_sub_fail_counts", {}
         )
@@ -413,6 +419,25 @@ class GatewayKanbanWatchersMixin:
                             if ev.payload and ev.payload.get("status"):
                                 new_status = str(ev.payload["status"])
                             msg = f"🔄 {board_tag}{tag}Kanban {sub['task_id']} → {new_status}"
+                        elif kind == "block_loop_detected":
+                            # A task re-blocked for the same cause past the
+                            # recurrence limit and was routed to `triage` for a
+                            # human decision. This is the ONE transition that
+                            # exists to force human attention, yet it emits no
+                            # `blocked`/`status` event — so before adding it to
+                            # TERMINAL_KINDS it produced zero notification and
+                            # the task stalled in triage silently. Ping loudly.
+                            reason = ""
+                            recurrences = None
+                            if ev.payload:
+                                if ev.payload.get("reason"):
+                                    reason = f": {str(ev.payload['reason'])[:160]}"
+                                recurrences = ev.payload.get("recurrences")
+                            rc = f" (blocked {recurrences}x for the same cause)" if recurrences else ""
+                            msg = (
+                                f"🛑 {board_tag}{tag}Kanban {sub['task_id']} routed to TRIAGE"
+                                f" — needs a human decision{rc}{reason}"
+                            )
                         else:
                             # archived / unblocked are claimed by TERMINAL_KINDS
                             # (so the cursor advances past them and they can't

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9431,7 +9431,17 @@ def add_notify_sub(
     delivery_metadata: Optional[Mapping[str, Any]] = None,
 ) -> None:
     """Register a gateway source that wants terminal-state notifications
-    for ``task_id``. Idempotent on (task, platform, chat, thread)."""
+    for ``task_id``. Idempotent on (task, platform, chat, thread).
+
+    New subscriptions start "caught up": ``last_event_id`` snaps to the
+    task's current ``MAX(task_events.id)`` at creation instead of the
+    schema default 0. A cursor of 0 on an already-active task made the
+    gateway notifier replay every historical terminal event on its next
+    tick — and with many stale subs, a single boot-time burst of 100+
+    messages (issue #29905). Subscribers only want events that occur
+    AFTER they subscribe; the gateway/tool auto-subscribe paths run at
+    task creation, where the snapshot is 0 anyway.
+    """
     now = int(time.time())
     metadata_json = _encode_notify_delivery_metadata(delivery_metadata)
     with write_txn(conn):
@@ -9439,8 +9449,9 @@ def add_notify_sub(
             """
             INSERT OR IGNORE INTO kanban_notify_subs
                 (task_id, platform, chat_id, chat_type, thread_id, user_id,
-                 notifier_profile, delivery_metadata, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 notifier_profile, delivery_metadata, created_at, last_event_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    COALESCE((SELECT MAX(id) FROM task_events WHERE task_id = ?), 0))
             """,
             (
                 task_id,
@@ -9452,6 +9463,7 @@ def add_notify_sub(
                 notifier_profile,
                 metadata_json,
                 now,
+                task_id,
             ),
         )
         if chat_type:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9511,6 +9511,44 @@ def list_notify_subs(
     return out
 
 
+def count_notify_subs(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+) -> int:
+    """Count ``kanban_notify_subs`` rows via a read-only connection.
+
+    Cheap probe for the gateway notifier's zero-subscription early exit:
+    unlike :func:`connect`, this never creates the DB file, never runs
+    schema init/migration, and never opens the database writable (no
+    write locks, no checkpoints — though a read-only open of a WAL
+    database may still create the ``-shm``/``-wal`` sidecars, it cannot
+    write table content). Rows in a not-yet-checkpointed WAL are
+    visible, so a freshly added subscription is never missed. A missing
+    DB, or a legacy DB that predates the subscriptions table, counts as
+    zero. Path resolution matches :func:`connect` (explicit ``db_path``,
+    else ``board`` via :func:`kanban_db_path`). Raises
+    :class:`sqlite3.Error` when the DB exists but cannot be read
+    (locked, corrupt); callers choose their own fallback.
+    """
+    path = db_path if db_path is not None else kanban_db_path(board=board)
+    if not path.exists():
+        return 0
+    conn = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True)
+    try:
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM kanban_notify_subs"
+            ).fetchone()
+        except sqlite3.OperationalError as exc:
+            if "no such table" in str(exc).lower():
+                return 0
+            raise
+        return int(row[0]) if row else 0
+    finally:
+        conn.close()
+
+
 def remove_notify_sub(
     conn: sqlite3.Connection,
     *,

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -226,6 +226,45 @@ def test_kanban_notifier_rewinds_claim_on_send_exception(tmp_path, monkeypatch):
     assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
 
 
+class ReportedFailureAdapter:
+    """Adapter that REPORTS failure via SendResult(success=False) instead of
+    raising — the exact contract the Telegram adapter uses for 'Not connected'
+    and degraded-send paths."""
+
+    def __init__(self):
+        self.attempts = 0
+
+    async def send(self, chat_id, text, metadata=None):
+        self.attempts += 1
+        from gateway.platforms.base import SendResult
+        return SendResult(success=False, error="Not connected")
+
+
+def test_kanban_notifier_rewinds_claim_on_reported_send_failure(tmp_path, monkeypatch):
+    """A non-raising SendResult(success=False) must NOT advance the cursor.
+
+    Regression for the silent-drop bug: the notifier used to discard send()'s
+    return value, so a reported (not raised) failure — e.g. Telegram mid-
+    reconnect after a gateway restart — fell through to the success branch,
+    marked the event seen, and lost the notification forever. The event must
+    remain unseen for retry, exactly like the raised-exception path.
+    """
+    db_path = tmp_path / "reported-failure.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_completed_subscription()
+
+    adapter = ReportedFailureAdapter()
+    runner = _make_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.attempts >= 1, "send should have been attempted"
+    assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"], (
+        "a reported send failure must rewind the claim, not silently drop the event"
+    )
+
+
 def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
     """A retry cycle (crashed → reclaimed → crashed) notifies the user twice.
 
@@ -286,6 +325,36 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
     )
     assert "crashed" in adapter.sent[1]["text"].lower()
+
+
+def test_notifier_delivers_subscription_owned_by_active_profile(tmp_path, monkeypatch):
+    """A single-profile gateway stamps active profile but keeps adapters primary."""
+    db_path = tmp_path / "active-profile-owner.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="owned by active profile", assignee="worker")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-1",
+            notifier_profile="dev",
+        )
+        kb.complete_task(conn, tid, summary="done")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner._active_profile_name = lambda: "dev"
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert tid in adapter.sent[0]["text"]
 
 
 def test_notifier_owning_profile_adapter_no_default_fallback(tmp_path, monkeypatch):

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -562,16 +562,22 @@ def test_kanban_notifier_isolates_per_subscription_failure(tmp_path, monkeypatch
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
     kb.init_db()
 
-    # Create two tasks with subscriptions and complete both.
+    # Create two tasks with subscriptions and complete both. The BAD task is
+    # created first: list_notify_subs() has no ORDER BY, so SQLite's natural
+    # scan returns insertion order — the failing subscription must be
+    # processed BEFORE the good one or this test passes even without the
+    # per-subscription isolation (the good delivery happens before the tick
+    # aborts). A deterministic-order shim below removes the reliance on the
+    # scan order entirely.
     conn = kb.connect()
     try:
-        tid_good = kb.create_task(conn, title="good task", assignee="worker")
-        kb.add_notify_sub(conn, task_id=tid_good, platform="telegram", chat_id="chat-good")
-        kb.complete_task(conn, tid_good, summary="done")
-
         tid_bad = kb.create_task(conn, title="bad task", assignee="worker")
         kb.add_notify_sub(conn, task_id=tid_bad, platform="telegram", chat_id="chat-bad")
         kb.complete_task(conn, tid_bad, summary="done")
+
+        tid_good = kb.create_task(conn, title="good task", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid_good, platform="telegram", chat_id="chat-good")
+        kb.complete_task(conn, tid_good, summary="done")
     finally:
         conn.close()
 
@@ -584,6 +590,16 @@ def test_kanban_notifier_isolates_per_subscription_failure(tmp_path, monkeypatch
 
     monkeypatch.setattr(kb, "claim_unseen_events_for_sub", selective_claim)
 
+    # Force the failing subscription to be iterated FIRST regardless of the
+    # unordered SELECT's scan order.
+    original_list = kb.list_notify_subs
+
+    def bad_first(conn, task_id=None):
+        subs = original_list(conn, task_id)
+        return sorted(subs, key=lambda s: 0 if s["task_id"] == tid_bad else 1)
+
+    monkeypatch.setattr(kb, "list_notify_subs", bad_first)
+
     adapter = RecordingAdapter()
     runner = _make_runner(adapter)
 
@@ -592,3 +608,52 @@ def test_kanban_notifier_isolates_per_subscription_failure(tmp_path, monkeypatch
     # The good task must still be delivered despite the bad task failing.
     assert len(adapter.sent) == 1
     assert tid_good in adapter.sent[0]["text"]
+
+
+def test_notifier_delivers_block_loop_detected_triage_ping(tmp_path, monkeypatch):
+    """A `block_loop_detected` event must reach the subscriber as a triage ping.
+
+    Regression for the silent-triage gap (PR #62712): kanban_db routes a task
+    to `triage` after BLOCK_RECURRENCE_LIMIT re-blocks for the same cause and
+    emits ONLY a `block_loop_detected` event — no `blocked`/`status` event.
+    Before `block_loop_detected` joined TERMINAL_KINDS with its own message
+    branch, that one transition (the whole point of which is to force human
+    attention) produced zero notification and the task stalled in triage
+    silently.
+    """
+    db_path = tmp_path / "block-loop.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="loops forever", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb._append_event(
+            conn, tid, "block_loop_detected",
+            {"reason": "needs credentials", "kind": "needs_input",
+             "recurrences": 2, "limit": kb.BLOCK_RECURRENCE_LIMIT},
+        )
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1, "block_loop_detected must produce a notification"
+    text = adapter.sent[0]["text"]
+    assert "TRIAGE" in text
+    assert tid in text
+    assert "needs credentials" in text
+    # Cursor advanced: the event is claimed and not re-delivered.
+    conn = kb.connect()
+    try:
+        _, remaining = kb.unseen_events_for_sub(
+            conn, task_id=tid, platform="telegram", chat_id="chat-1",
+            kinds=["block_loop_detected"],
+        )
+    finally:
+        conn.close()
+    assert remaining == []

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -480,3 +480,46 @@ def _unseen_terminal_events_for(tid, chat_id):
         return events
     finally:
         conn.close()
+
+
+def test_kanban_notifier_isolates_per_subscription_failure(tmp_path, monkeypatch):
+    """One bad subscription must not block delivery for all others.
+
+    Regression for #59269: when claim_unseen_events_for_sub raises for one
+    subscription, the entire notifier tick used to abort — silently blocking
+    delivery for every other subscription.
+    """
+    db_path = tmp_path / "isolation.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    # Create two tasks with subscriptions and complete both.
+    conn = kb.connect()
+    try:
+        tid_good = kb.create_task(conn, title="good task", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid_good, platform="telegram", chat_id="chat-good")
+        kb.complete_task(conn, tid_good, summary="done")
+
+        tid_bad = kb.create_task(conn, title="bad task", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid_bad, platform="telegram", chat_id="chat-bad")
+        kb.complete_task(conn, tid_bad, summary="done")
+    finally:
+        conn.close()
+
+    original_claim = kb.claim_unseen_events_for_sub
+
+    def selective_claim(conn, task_id, **kwargs):
+        if task_id == tid_bad:
+            raise RuntimeError("simulated DB corruption for bad task")
+        return original_claim(conn, task_id=task_id, **kwargs)
+
+    monkeypatch.setattr(kb, "claim_unseen_events_for_sub", selective_claim)
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    # The good task must still be delivered despite the bad task failing.
+    assert len(adapter.sent) == 1
+    assert tid_good in adapter.sent[0]["text"]

--- a/tests/gateway/test_kanban_notifier_zero_sub_gate.py
+++ b/tests/gateway/test_kanban_notifier_zero_sub_gate.py
@@ -1,0 +1,120 @@
+"""Tests for the kanban notifier zero-subscription early exit.
+
+The notifier used to writable-open EVERY board DB on every tick even when a
+board had zero subscriptions — paying schema init/migration on first open,
+WAL/-shm sidecar creation, and checkpoint traffic for boards with nothing to
+notify. Per-board work is now gated by a read-only subscription probe
+(``kanban_db.count_notify_subs``), so boards with zero subscriptions are
+never opened writable.
+
+(The companion machine-global ``.notifier.lock`` singleton gate from PR
+#63001 was deliberately NOT salvaged: a lock-winning default-profile gateway
+cannot deliver a secondary profile's subscriptions in standalone-profile
+deployments — profile routing fails closed in
+``gateway/authz_mixin.py::_authorization_adapter`` — so the lock could
+suppress delivery entirely. The read-only probe captures the per-tick cost
+win without that risk.)
+"""
+
+import asyncio
+
+from unittest.mock import patch
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+
+
+class RecordingAdapter:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+
+def _make_runner(adapter):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._kanban_sub_fail_counts = {}
+    return runner
+
+
+async def _run_one_notifier_tick(monkeypatch, runner):
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await runner._kanban_notifier_watcher(interval=1)
+
+
+def _create_completed_task(*, subscribe: bool) -> str:
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="owner gate", assignee="worker")
+        if subscribe:
+            kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.complete_task(conn, tid, summary="done")
+        return tid
+    finally:
+        conn.close()
+
+
+def test_zero_sub_board_is_never_opened_writable(tmp_path, monkeypatch):
+    """A board with zero subscriptions must be skipped BEFORE `_kb.connect`."""
+    db_path = tmp_path / "zero-subs.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    _create_completed_task(subscribe=False)
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+
+    with patch.object(kb, "connect", wraps=kb.connect) as spy_connect:
+        asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    spy_connect.assert_not_called()
+    assert adapter.sent == []
+
+
+def test_subscribed_board_still_delivers_through_the_gate(tmp_path, monkeypatch):
+    """Regression: the zero-sub probe must not change delivery for live subs."""
+    db_path = tmp_path / "subscribed.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_completed_task(subscribe=True)
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert tid in adapter.sent[0]["text"]
+
+
+def test_probe_failure_falls_back_to_writable_open(tmp_path, monkeypatch):
+    """If the read-only probe raises (locked/corrupt DB), the notifier must
+    fall back to the writable open — a broken probe must never silently
+    disable notifications for a board with live subscriptions."""
+    db_path = tmp_path / "probe-broken.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_completed_task(subscribe=True)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr(kb, "count_notify_subs", _boom)
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert tid in adapter.sent[0]["text"]

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -101,6 +101,14 @@ def test_secondary_allowlist_still_authorized(monkeypatch):
     assert runner._is_user_authorized(source) is True
 
 
+def test_active_profile_stamp_resolves_primary_adapter(monkeypatch):
+    """A single-profile gateway stamps its active profile but stores adapters as primary."""
+    runner, default_adapter, _secondary_adapter = _make_multiplex_runner(monkeypatch)
+    runner._active_profile_name = lambda: "dev"
+
+    assert runner._authorization_adapter(Platform.WECOM, profile="dev") is default_adapter
+
+
 def test_adapter_for_source_resolves_secondary_profile_adapter(monkeypatch):
     """Ingress adapter lookup must use the stamped profile's adapter map."""
     runner, default_adapter, secondary_adapter = _make_multiplex_runner(monkeypatch)

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -602,6 +602,9 @@ def test_notify_claim_is_single_owner_and_rewindable(kanban_home):
     try:
         tid = kb.create_task(conn1, title="x", assignee="w")
         kb.add_notify_sub(conn1, task_id=tid, platform="telegram", chat_id="123")
+        # New subs start caught up at the task's current MAX(task_events.id)
+        # (the `created` event) — issue #29905.
+        initial_cursor = int(kb.list_notify_subs(conn1, tid)[0]["last_event_id"])
         kb.complete_task(conn1, tid, result="ok")
 
         old_cursor, claimed_cursor, events = kb.claim_unseen_events_for_sub(
@@ -611,7 +614,7 @@ def test_notify_claim_is_single_owner_and_rewindable(kanban_home):
             chat_id="123",
             kinds=["completed", "blocked"],
         )
-        assert old_cursor == 0
+        assert old_cursor == initial_cursor
         assert claimed_cursor > old_cursor
         assert [ev.kind for ev in events] == ["completed"]
 
@@ -4801,3 +4804,49 @@ def test_dispatch_once_stale_disabled_when_timeout_zero(kanban_home, monkeypatch
         )
         assert res.stale == [], "stale_timeout_seconds=0 should disable detection"
         assert kb.get_task(conn, t).status == "running"
+
+
+def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
+    """A new subscription must NOT replay historical terminal events.
+
+    Regression for issue #29905: `kanban_notify_subs.last_event_id` defaulted
+    to 0, so subscribing to a task that already had terminal events in
+    `task_events` replayed the entire backlog on the next notifier tick — 27
+    stale subs produced a 100+ message burst at gateway boot. The cursor now
+    snaps to the task's MAX(task_events.id) at creation: only events that
+    occur AFTER subscribing are delivered.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="old task", assignee="w")
+        # Historical terminal activity BEFORE anyone subscribes.
+        kb.complete_task(conn, tid, result="done long ago")
+
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="123")
+        sub = kb.list_notify_subs(conn, tid)[0]
+        assert int(sub["last_event_id"]) > 0, (
+            "cursor must snap to MAX(task_events.id) at subscription time"
+        )
+        _, events = kb.unseen_events_for_sub(
+            conn, task_id=tid, platform="telegram", chat_id="123",
+            kinds=["completed", "blocked", "gave_up", "crashed", "timed_out"],
+        )
+        assert events == [], "historical events must not replay to a new sub"
+    finally:
+        conn.close()
+
+
+def test_notify_sub_on_fresh_task_still_gets_future_events(kanban_home):
+    """The caught-up snap must not lose events that happen AFTER subscribing."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="fresh", assignee="w")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="123")
+        kb.complete_task(conn, tid, result="ok")
+        _, events = kb.unseen_events_for_sub(
+            conn, task_id=tid, platform="telegram", chat_id="123",
+            kinds=["completed"],
+        )
+        assert [ev.kind for ev in events] == ["completed"]
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_kanban_count_notify_subs.py
+++ b/tests/hermes_cli/test_kanban_count_notify_subs.py
@@ -1,0 +1,98 @@
+"""Tests for ``kanban_db.count_notify_subs`` — the read-only subscription probe.
+
+The gateway notifier uses it to skip boards with zero subscriptions BEFORE
+any writable ``connect()``: the probe must never create the DB file, never
+run schema init/migration, and never write — that first-open cost on every
+tick is exactly what the zero-sub early exit avoids. It must also never
+UNDER-count: rows sitting in a not-yet-checkpointed WAL still count, or the
+notifier would skip a board that has a live subscription.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return home
+
+
+def test_missing_db_counts_zero_and_creates_nothing(kanban_home):
+    db_path = kb.kanban_db_path(board="default")
+    assert not db_path.exists()
+    assert kb.count_notify_subs(board="default") == 0
+    assert not db_path.exists(), "read-only probe must not create the DB"
+
+
+def test_counts_rows_via_board_resolution(kanban_home):
+    conn = kb.connect(board="default")
+    try:
+        tid = kb.create_task(conn, title="t", assignee="w")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="c1")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="c2")
+    finally:
+        conn.close()
+    assert kb.count_notify_subs(board="default") == 2
+
+
+def test_probe_is_read_only_and_sees_uncheckpointed_wal_rows(kanban_home):
+    """A sub committed by a still-open writer (rows only in the WAL, not yet
+    checkpointed into the main DB file) must be counted — under-counting
+    would make the notifier skip a board that has a live subscription. And
+    the probe itself must be read-only: the writer's connection stays the
+    only writer."""
+    conn = kb.connect(board="default")
+    try:
+        tid = kb.create_task(conn, title="t", assignee="w")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="c1")
+        # Writer still open: the row lives in the -wal, not the main file.
+        assert kb.count_notify_subs(board="default") == 1
+    finally:
+        conn.close()
+
+
+def test_legacy_db_without_subs_table_counts_zero_and_stays_unmigrated(tmp_path):
+    legacy = tmp_path / "legacy.db"
+    conn = sqlite3.connect(legacy)
+    try:
+        conn.execute("CREATE TABLE something_else (id INTEGER)")
+        conn.commit()
+    finally:
+        conn.close()
+    assert kb.count_notify_subs(db_path=legacy) == 0
+    # The probe must not have run schema init on the foreign/legacy DB.
+    conn = sqlite3.connect(legacy)
+    try:
+        tables = {
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    finally:
+        conn.close()
+    assert "kanban_notify_subs" not in tables, (
+        "read-only probe must never create schema"
+    )
+
+
+def test_explicit_db_path_overrides_board(kanban_home, tmp_path):
+    pinned = tmp_path / "pinned.db"
+    conn = kb.connect(db_path=pinned)
+    try:
+        tid = kb.create_task(conn, title="t", assignee="w")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="c1")
+    finally:
+        conn.close()
+    assert kb.count_notify_subs(pinned) == 1
+    assert kb.count_notify_subs(board="default") == 0

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -451,6 +451,9 @@ async def test_notifier_skips_subscription_owned_by_other_profile(kanban_home):
             notifier_profile="default",
         )
         kb.complete_task(conn, tid, result="done")
+        # New subs start caught up at the creation-time MAX(task_events.id)
+        # (issue #29905); claiming the completion would advance past this.
+        pre_claim_cursor = int(kb.list_notify_subs(conn, tid)[0]["last_event_id"])
     finally:
         conn.close()
 
@@ -486,7 +489,9 @@ async def test_notifier_skips_subscription_owned_by_other_profile(kanban_home):
     finally:
         conn.close()
     assert len(subs) == 1
-    assert int(subs[0]["last_event_id"]) == 0, "wrong profile must not claim the event"
+    assert int(subs[0]["last_event_id"]) == pre_claim_cursor, (
+        "wrong profile must not claim the event"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -88,17 +88,23 @@ class TestCollectKanbanNotifications:
     def test_ignores_other_sessions_and_platforms(self):
         tid_other_session = _create_subscribed_task(chat_id="some-other-session")
         tid_gateway = _create_subscribed_task(platform="telegram", chat_id="chat-1")
+        # New subs start caught up at creation time (issue #29905); record the
+        # pre-completion cursors so we can assert they were never claimed.
+        pre_cursors = {
+            tid: _sub_rows(tid)[0]["last_event_id"]
+            for tid in (tid_other_session, tid_gateway)
+        }
         _complete(tid_other_session)
         _complete(tid_gateway)
 
         texts = _collect_kanban_notifications(_session())
 
         assert texts == []
-        # Foreign subscriptions untouched: cursors still 0, rows still there.
+        # Foreign subscriptions untouched: cursors unclaimed, rows still there.
         for tid in (tid_other_session, tid_gateway):
             rows = _sub_rows(tid)
             assert len(rows) == 1
-            assert rows[0]["last_event_id"] == 0
+            assert rows[0]["last_event_id"] == pre_cursors[tid]
 
     def test_no_session_key_is_a_noop(self):
         tid = _create_subscribed_task()


### PR DESCRIPTION
## Summary

One bad kanban subscription can no longer jam every notification. In `_kanban_notifier_watcher._collect()`, an exception from a single subscription's cursor claim aborted the entire collect pass (caught only by the outer tick-level except) — zero deliveries for ALL subscriptions on that board, every tick, forever. Consolidated salvage of the notifier-robustness cluster.

Fixes #59269. Also covers the boot-storm half of #29905 (cursor snap at creation).

## Changes

- `fix(gateway): isolate per-subscription failures in kanban notifier` — @AlexFucuson9 (#59278): per-subscription try/except in the collect loop; one sub's failure logs and continues, others deliver
- `fix(gateway): kanban notifier delivery reliability` — @rhylryan21 (#62712, live halves): notify on `block_loop_detected`, tolerate transient outages (the SendResult(success=False) half was already fixed on main and dropped)
- `fix(gateway): zero-sub early exit for kanban notifier board polling` — @David Beyer (#63001): skip opening board DBs that have no subscriptions
- `fix(kanban): snap notify-sub cursor to MAX(task_events.id) at creation` (mine): new subscriptions start at the current event head instead of 0, eliminating the boot storm of stale-event replays (#29905)
- Hardened isolation regression + block_loop_detected e2e coverage (mine)
- Contributor mappings for all three salvaged authors

Deferred (needs-decision, not salvage): #69064's dead-letter tables (heavy new infrastructure per the speculative-infrastructure bar), #63515's Telegram-durability rewrite, #45940 (both halves covered — SendResult on main, CLI auto-subscribe belongs to #50972's scope).

## Validation

| Check | Result |
|---|---|
| 10 kanban/gateway suites after rebase onto current main | 392/392 pass |
| Builder's full run (12 files incl. cursor-snap adjacents) | 473/473 pass |
| Sabotage checks (revert isolation → test fails; revert cursor snap → test fails) | both verified |
| AST duplicate-kwarg scan after train rebase | clean |

## Infographic

![kanban-notifier-robustness](https://v3b.fal.media/files/b/0aa3d919/NltUB7PLPFjPl0BSP--P5_5ox8cUX0.png)
