### PR TITLE
test(gateway): isolate runtime PID identity fallback

### DIFF
--- a/tests/hermes_cli/test_gateway_runtime_health.py
+++ b/tests/hermes_cli/test_gateway_runtime_health.py
@@ -76,8 +76,28 @@ def test_runtime_status_running_pid_validates_live_gateway_record(monkeypatch):
     }
     monkeypatch.setattr(status_mod, "_pid_exists", lambda pid: pid == 12345)
     monkeypatch.setattr(status_mod, "_get_process_start_time", lambda pid: None)
-    monkeypatch.setattr(status_mod, "_looks_like_gateway_process", lambda pid: False)
+    monkeypatch.setattr(status_mod, "_read_process_cmdline", lambda pid: None)
 
     assert status_mod.get_runtime_status_running_pid(runtime) == 12345
 
+
+def test_runtime_status_running_pid_rejects_unrelated_live_process(monkeypatch):
+    from gateway import status as status_mod
+
+    runtime = {
+        "pid": 12345,
+        "kind": "hermes-gateway",
+        "argv": ["/opt/hermes/hermes_cli/main.py", "gateway", "run", "--replace"],
+        "start_time": None,
+        "gateway_state": "running",
+    }
+    monkeypatch.setattr(status_mod, "_pid_exists", lambda pid: pid == 12345)
+    monkeypatch.setattr(status_mod, "_get_process_start_time", lambda pid: None)
+    monkeypatch.setattr(
+        status_mod,
+        "_read_process_cmdline",
+        lambda pid: "/usr/bin/python unrelated-worker.py",
+    )
+
+    assert status_mod.get_runtime_status_running_pid(runtime) is None
 


### PR DESCRIPTION
## Summary

- isolate the unreadable-PID fallback test from the host process table
- stub the command-line probe explicitly when exercising the missing-inspection path
- add a separate regression case for rejecting an unrelated live process

## Why

The fallback test previously supplied a live PID without controlling its
command line. A coincidental host process could therefore make the test depend
on external process state. This test-only change was discovered while
refocusing closed PR #70016 and is intentionally published separately from the
security implementation.

## Validation

- `tests/hermes_cli/test_gateway_runtime_health.py`: 8 passed
- Ruff passes for the changed test file
- current-`main` merge-tree and diff checks pass

The account owner loosely reviews Codex actions and receives the usual GitHub
notifications.

## Agent Disclosure

- Created by: GPT-5.6-sol with xhigh reasoning in Codex Desktop
- Human manually signed the commit
