### PR TITLE
feat(cli,desktop): persistent /goal indicator in status bar and above composer (salvage of #63527)

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/goal-indicator.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/goal-indicator.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { $goalsBySession, type SessionGoal } from '@/store/goals'
+
+import { ComposerStatusStack } from './index'
+
+// The stack measures itself into a surface var — jsdom has no ResizeObserver.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+
+const SID = 'sess-goal-1'
+
+const goal = (status: SessionGoal['status'], title = 'ship the feature', detail?: string): SessionGoal => ({
+  detail,
+  status,
+  title,
+  updatedAt: Date.now()
+})
+
+function renderStack(sessionId: null | string = SID) {
+  return render(
+    <MemoryRouter>
+      <I18nProvider configClient={null} initialLocale="en">
+        <ComposerStatusStack queue={null} sessionId={sessionId} />
+      </I18nProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('ComposerStatusStack goal indicator', () => {
+  beforeEach(() => {
+    $goalsBySession.set({})
+  })
+
+  afterEach(() => {
+    cleanup()
+    $goalsBySession.set({})
+  })
+
+  it('renders nothing when the session has no goal', () => {
+    const view = renderStack()
+
+    expect(view.container.firstChild).toBeNull()
+  })
+
+  it('shows an active goal with its title', () => {
+    $goalsBySession.set({ [SID]: goal('active') })
+
+    renderStack()
+
+    expect(screen.getByText('Goal active')).toBeTruthy()
+    expect(screen.getByText('ship the feature')).toBeTruthy()
+  })
+
+  it('labels a paused goal as paused', () => {
+    $goalsBySession.set({ [SID]: goal('paused') })
+
+    renderStack()
+
+    expect(screen.getByText('Goal paused')).toBeTruthy()
+    expect(screen.getByText('ship the feature')).toBeTruthy()
+  })
+
+  it('shows the continuation detail line for an active goal', () => {
+    $goalsBySession.set({ [SID]: goal('active', 'ship it', 'Continuing toward goal (3/20)') })
+
+    renderStack()
+
+    expect(screen.getByText('Continuing toward goal (3/20)')).toBeTruthy()
+  })
+
+  it('scopes the indicator to the goal-owning session', () => {
+    $goalsBySession.set({ 'other-session': goal('active') })
+
+    const view = renderStack()
+
+    expect(view.container.firstChild).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -23,6 +23,7 @@ import {
   type StatusGroup,
   stopBackgroundProcess
 } from '@/store/composer-status'
+import { refreshSessionGoal } from '@/store/goals'
 import { $previewStatusBySession, dismissPreviewArtifact } from '@/store/preview-status'
 import { $threadScrolledUp } from '@/store/thread-scroll'
 import { openSessionInNewWindow } from '@/store/windows'
@@ -42,12 +43,25 @@ const isLocalhostPreview = (target: string): boolean => /\b(?:localhost|127\.0\.
 // Real codicons per group (no sparkles): a checklist for todos, the agent glyph
 // for subagents, a background process glyph for background tasks.
 const GROUP_ICON: Record<StatusGroup['type'], string> = {
+  goal: 'target',
   todo: 'checklist',
   subagent: 'agent',
   background: 'server-process'
 }
 
 const groupLabel = (group: StatusGroup, s: Translations['statusStack']) => {
+  if (group.type === 'goal') {
+    const status = group.items[0]?.goalStatus
+
+    return status === 'paused'
+      ? s.goalPaused
+      : status === 'waiting'
+        ? s.goalWaiting
+        : status === 'done'
+          ? s.goalDone
+          : s.goalActive
+  }
+
   if (group.type === 'todo') {
     return s.todos(group.items.filter(i => i.todoStatus === 'completed').length, group.items.length)
   }
@@ -87,6 +101,7 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   useEffect(() => {
     if (sessionId) {
       void refreshBackgroundProcesses(sessionId)
+      void refreshSessionGoal(sessionId)
     }
   }, [sessionId])
 
@@ -154,7 +169,7 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
               </Tip>
             ) : undefined
           }
-          defaultCollapsed={group.type !== 'todo'}
+          defaultCollapsed={group.type !== 'todo' && group.type !== 'goal'}
           icon={<Codicon className="text-muted-foreground/70" name={GROUP_ICON[group.type]} size="0.8rem" />}
           label={groupLabel(group, t.statusStack)}
         >

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -25,6 +25,24 @@ const TODO_GLYPHS: Record<Exclude<TodoStatus, 'in_progress' | 'pending'>, { icon
 // Left slot: braille spinner while running, otherwise a small status dot
 // (green = done, red = failed) so the slot is always filled and rows align.
 function leadingGlyph(item: ComposerStatusItem, s: Translations['statusStack']): ReactNode {
+  if (item.type === 'goal') {
+    if (item.goalStatus === 'paused') {
+      return <Codicon className="text-muted-foreground/60" name="debug-pause" size="0.8rem" />
+    }
+
+    if (item.goalStatus === 'done') {
+      return <Codicon className="text-emerald-500/80" name="pass-filled" size="0.8rem" />
+    }
+
+    return (
+      <GlyphSpinner
+        ariaLabel={s.running}
+        className="text-[0.85rem] leading-none text-emerald-500/80"
+        spinner="braille"
+      />
+    )
+  }
+
   if (item.todoStatus === 'pending') {
     return (
       <span
@@ -135,6 +153,11 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
         {item.type === 'subagent' && item.currentTool && (
           <span className="shrink-0 truncate text-[0.62rem] leading-4 text-muted-foreground/70">
             {toolLabel(item.currentTool)}
+          </span>
+        )}
+        {item.type === 'goal' && item.currentTool && (
+          <span className="shrink-0 truncate text-[0.62rem] leading-4 text-muted-foreground/70">
+            {item.currentTool}
           </span>
         )}
         {failed && typeof item.exitCode === 'number' && item.exitCode !== 0 && (

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -22,6 +22,7 @@ import { clearClarifyRequest, normalizeChoices, setClarifyRequest, warnDroppedCh
 import { setSessionCompacting } from '@/store/compaction'
 import { refreshBackgroundProcesses } from '@/store/composer-status'
 import { $gateway } from '@/store/gateway'
+import { applyGoalStatusText } from '@/store/goals'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { notify } from '@/store/notifications'
 import { requestDesktopOnboarding, requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
@@ -909,6 +910,8 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           // The gateway's notification poller announces background process
           // completions / watch matches here — re-sync the status stack.
           void refreshBackgroundProcesses(sessionId)
+        } else if (sessionId && payload?.kind === 'goal') {
+          applyGoalStatusText(sessionId, coerceGatewayText(payload?.text))
         }
       } else if (event.type === 'review.summary') {
         // Self-improvement background review saved something to memory/skills

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -18,6 +18,7 @@ import { setSessionYolo } from '@/lib/yolo-session'
 import { openCommandPalettePage } from '@/store/command-palette'
 import { setComposerDraft } from '@/store/composer'
 import { enqueueQueuedPrompt } from '@/store/composer-queue'
+import { applyGoalStatusText } from '@/store/goals'
 import { dismissNotification, notify, notifyError } from '@/store/notifications'
 import { setPetScale } from '@/store/pet-gallery'
 import { $petGenInput, openPetGenerate } from '@/store/pet-generate'
@@ -232,6 +233,15 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           // `/goal <text>` looked like it did nothing.
           if ((dispatch.type === 'send' || dispatch.type === 'prefill') && dispatch.notice?.trim()) {
             renderSlashOutput(dispatch.notice.trim())
+
+            // `/goal <text>` returns its "⊙ Goal set …" notice here and kicks
+            // off the first turn immediately; the backend only emits a
+            // `status.update kind:"goal"` after that turn's post-turn judge
+            // runs. Seed the goal store from the notice so the indicator shows
+            // the active goal right away instead of after the first turn.
+            if (name === 'goal') {
+              applyGoalStatusText(sessionId, dispatch.notice.trim())
+            }
           }
 
           const message = ('message' in dispatch ? dispatch.message : '')?.trim() ?? ''
@@ -313,6 +323,15 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
           const output = result && typeof result === 'object' ? (result as SlashExecResponse) : null
           const body = output?.output || `/${name}: no output`
+
+          // `/goal status|pause|resume|clear` come back as plain exec output
+          // ("⊙ Goal (active, 3/20 turns): …", "⏸ Goal paused: …", "✓ Goal
+          // cleared." …). Mirror it into the goal store so the composer
+          // indicator tracks pause/resume/clear immediately.
+          if (name === 'goal' && output?.output) {
+            applyGoalStatusText(sessionId, output.output)
+          }
+
           renderSlashOutput(output?.warning ? `warning: ${output.warning}\n${body}` : body)
 
           return

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2013,6 +2013,10 @@ export const en: Translations = {
   statusStack: {
     agents: 'Agents',
     background: count => `${count} Background`,
+    goalActive: 'Goal active',
+    goalDone: 'Goal done',
+    goalPaused: 'Goal paused',
+    goalWaiting: 'Goal waiting',
     subagents: count => `${count} Subagent${count === 1 ? '' : 's'}`,
     todos: (done, total) => `Tasks ${done}/${total}`,
     running: 'Running',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1880,6 +1880,10 @@ export const ja = defineLocale({
   statusStack: {
     agents: 'エージェント',
     background: count => `バックグラウンド ${count} 件`,
+    goalActive: '目標進行中',
+    goalDone: '目標達成',
+    goalPaused: '目標一時停止中',
+    goalWaiting: '目標待機中',
     subagents: count => `サブエージェント ${count} 件`,
     todos: (done, total) => `タスク ${done}/${total}`,
     running: '実行中',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1669,6 +1669,10 @@ export interface Translations {
   statusStack: {
     agents: string
     background: (count: number) => string
+    goalActive: string
+    goalDone: string
+    goalPaused: string
+    goalWaiting: string
     subagents: (count: number) => string
     todos: (done: number, total: number) => string
     running: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1825,6 +1825,10 @@ export const zhHant = defineLocale({
   statusStack: {
     agents: '代理',
     background: count => `${count} 個背景任務`,
+    goalActive: '目標進行中',
+    goalDone: '目標已完成',
+    goalPaused: '目標已暫停',
+    goalWaiting: '目標等待中',
     subagents: count => `${count} 個子代理`,
     todos: (done, total) => `任務 ${done}/${total}`,
     running: '執行中',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2202,6 +2202,10 @@ export const zh: Translations = {
   statusStack: {
     agents: '代理',
     background: count => `${count} 个后台任务`,
+    goalActive: '目标进行中',
+    goalDone: '目标已完成',
+    goalPaused: '目标已暂停',
+    goalWaiting: '目标等待中',
     subagents: count => `${count} 个子代理`,
     todos: (done, total) => `任务 ${done}/${total}`,
     running: '运行中',

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -5,6 +5,7 @@ import { stableArray } from '@/lib/stable-array'
 import type { TodoItem, TodoStatus } from '@/lib/todos'
 
 import { $gateway } from './gateway'
+import { $goalsBySession, type GoalStatus } from './goals'
 import { dispatchNativeNotification } from './native-notifications'
 import { notifyError } from './notifications'
 import { $sessionStates } from './session-states'
@@ -13,13 +14,15 @@ import { $todosBySession } from './todos'
 
 /** Composer status stack feed — merged todos, subagents, background per session. */
 export type StatusItemState = 'done' | 'failed' | 'running'
-export type StatusItemType = 'background' | 'subagent' | 'todo'
+export type StatusItemType = 'background' | 'goal' | 'subagent' | 'todo'
 
 export interface ComposerStatusItem {
   /** background: non-zero exit shown inline when failed. */
   exitCode?: number
   /** subagent: active tool label shown on the right. */
   currentTool?: string
+  /** goal: active | paused | waiting | done. */
+  goalStatus?: GoalStatus
   id: string
   /** background process: captured stdout/stderr tail for the inline viewer. */
   output?: string
@@ -143,10 +146,19 @@ const todoToItem = (t: TodoItem): ComposerStatusItem => ({
   type: 'todo'
 })
 
+const goalToItem = (goal: { detail?: string; status: GoalStatus; title: string }): ComposerStatusItem => ({
+  currentTool: goal.detail,
+  goalStatus: goal.status,
+  id: 'goal:standing',
+  state: goal.status === 'active' || goal.status === 'waiting' ? 'running' : 'done',
+  title: goal.title,
+  type: 'goal'
+})
+
 // The single thing the stack reads: a typed, merged item list per session.
 export const $statusItemsBySession = computed(
-  [$subagentsBySession, $backgroundStatusBySession, $todosBySession],
-  (subs, background, todos) => {
+  [$goalsBySession, $subagentsBySession, $backgroundStatusBySession, $todosBySession],
+  (goals, subs, background, todos) => {
     const out: Record<string, ComposerStatusItem[]> = {}
 
     const push = (sid: string, items: ComposerStatusItem[]) => {
@@ -157,6 +169,10 @@ export const $statusItemsBySession = computed(
 
     for (const [sid, list] of Object.entries(todos)) {
       push(sid, list.map(todoToItem))
+    }
+
+    for (const [sid, goal] of Object.entries(goals)) {
+      push(sid, [goalToItem(goal)])
     }
 
     for (const [sid, list] of Object.entries(subs)) {
@@ -172,7 +188,7 @@ export const $statusItemsBySession = computed(
 )
 
 // Fixed render order for the groups in the stack (top → bottom, above queue).
-const TYPE_ORDER: readonly StatusItemType[] = ['todo', 'subagent', 'background']
+const TYPE_ORDER: readonly StatusItemType[] = ['goal', 'todo', 'subagent', 'background']
 
 export interface StatusGroup {
   items: ComposerStatusItem[]

--- a/apps/desktop/src/store/goals.test.ts
+++ b/apps/desktop/src/store/goals.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $goalsBySession, applyGoalStatusText, clearSessionGoal } from './goals'
+
+describe('goal store', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    $goalsBySession.set({})
+  })
+
+  it('stores active goals from /goal output', () => {
+    applyGoalStatusText('s1', '⊙ Goal set (20-turn budget): ship the feature')
+
+    expect($goalsBySession.get().s1).toMatchObject({
+      status: 'active',
+      title: 'ship the feature'
+    })
+  })
+
+  it('keeps the current title for continuation and pause messages', () => {
+    applyGoalStatusText('s1', '⊙ Goal set (20-turn budget): ship the feature')
+    applyGoalStatusText('s1', '↻ Continuing toward goal (1/20): next step is tests')
+
+    expect($goalsBySession.get().s1).toMatchObject({
+      detail: 'Continuing toward goal (1/20): next step is tests',
+      status: 'active',
+      title: 'ship the feature'
+    })
+
+    applyGoalStatusText('s1', '⏸ Goal paused — 20/20 turns used. Use /goal resume to keep going.')
+
+    expect($goalsBySession.get().s1).toMatchObject({
+      status: 'paused',
+      title: 'ship the feature'
+    })
+  })
+
+  it('lingers done goals before clearing them', () => {
+    vi.useFakeTimers()
+
+    applyGoalStatusText('s1', '⊙ Goal set (20-turn budget): ship the feature')
+    applyGoalStatusText('s1', '✓ Goal achieved: tests pass')
+
+    expect($goalsBySession.get().s1).toMatchObject({ status: 'done' })
+
+    vi.advanceTimersByTime(7_999)
+    expect($goalsBySession.get().s1).toBeTruthy()
+
+    vi.advanceTimersByTime(1)
+    expect($goalsBySession.get().s1).toBeUndefined()
+  })
+
+  it('clears on no-goal output', () => {
+    applyGoalStatusText('s1', '⊙ Goal set (20-turn budget): ship another feature')
+    applyGoalStatusText('s1', 'No active goal. Set one with /goal <text>.')
+
+    expect($goalsBySession.get().s1).toBeUndefined()
+  })
+
+  it('cancels pending done clears when replacing a goal', () => {
+    vi.useFakeTimers()
+
+    applyGoalStatusText('s1', '⊙ Goal set: first')
+    applyGoalStatusText('s1', '✓ Goal achieved: first done')
+    applyGoalStatusText('s1', '⊙ Goal set: second')
+
+    vi.advanceTimersByTime(8_000)
+
+    expect($goalsBySession.get().s1).toMatchObject({ status: 'active', title: 'second' })
+
+    clearSessionGoal('s1')
+  })
+})

--- a/apps/desktop/src/store/goals.ts
+++ b/apps/desktop/src/store/goals.ts
@@ -1,0 +1,177 @@
+import { atom } from 'nanostores'
+
+import { $gateway } from './gateway'
+
+export type GoalStatus = 'active' | 'done' | 'paused' | 'waiting'
+
+export interface SessionGoal {
+  detail?: string
+  status: GoalStatus
+  title: string
+  updatedAt: number
+}
+
+export const $goalsBySession = atom<Record<string, SessionGoal>>({})
+
+const DONE_LINGER_MS = 8_000
+const clearTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+function cancelScheduledClear(sid: string) {
+  const timer = clearTimers.get(sid)
+
+  if (timer !== undefined) {
+    clearTimeout(timer)
+    clearTimers.delete(sid)
+  }
+}
+
+export function setSessionGoal(sid: string, goal: SessionGoal) {
+  if (!sid) {
+    return
+  }
+
+  cancelScheduledClear(sid)
+  $goalsBySession.set({ ...$goalsBySession.get(), [sid]: goal })
+
+  if (goal.status === 'done') {
+    clearTimers.set(
+      sid,
+      setTimeout(() => {
+        clearTimers.delete(sid)
+        clearSessionGoal(sid)
+      }, DONE_LINGER_MS)
+    )
+  }
+}
+
+export function clearSessionGoal(sid: string) {
+  cancelScheduledClear(sid)
+
+  const map = $goalsBySession.get()
+
+  if (!(sid in map)) {
+    return
+  }
+
+  const { [sid]: _drop, ...rest } = map
+  $goalsBySession.set(rest)
+}
+
+const clean = (value: string): string => value.replace(/\r/g, '').trim()
+
+const firstLine = (value: string): string => clean(value).split('\n')[0]?.trim() ?? ''
+
+function goalTitleFromLine(line: string, pattern: RegExp): string {
+  return (line.match(pattern)?.[1] ?? '').trim()
+}
+
+function nextGoalFromText(text: string, previous?: SessionGoal): SessionGoal | null | undefined {
+  const body = clean(text)
+  const line = firstLine(body)
+
+  if (!line) {
+    return undefined
+  }
+
+  if (
+    /^No active goal\b/i.test(line) ||
+    /^No goal (?:set|to resume)\b/i.test(line) ||
+    /^✓ Goal cleared\b/i.test(line)
+  ) {
+    return null
+  }
+
+  const now = Date.now()
+  const fromSet = goalTitleFromLine(line, /^⊙ Goal set(?:\s*\([^)]*\))?:\s*(.+)$/)
+  const fromActive = goalTitleFromLine(line, /^⊙ Goal\s*\([^)]*active[^)]*\):\s*(.+)$/)
+  const fromResume = goalTitleFromLine(line, /^▶ Goal resumed:\s*(.+)$/)
+
+  if (fromSet || fromActive || fromResume) {
+    return { status: 'active', title: fromSet || fromActive || fromResume, updatedAt: now }
+  }
+
+  const fromWaiting = goalTitleFromLine(line, /^⏳ Goal\s*\([^)]*(?:parked|active)[^)]*\):\s*(.+)$/)
+
+  if (fromWaiting) {
+    return { status: 'waiting', title: fromWaiting, updatedAt: now }
+  }
+
+  const fromPaused = goalTitleFromLine(line, /^⏸ Goal(?:\s*\([^)]*\)| paused)?:\s*(.+)$/)
+
+  if (fromPaused) {
+    return { status: 'paused', title: fromPaused, updatedAt: now }
+  }
+
+  const fromDone = goalTitleFromLine(line, /^✓ Goal done\s*\([^)]*\):\s*(.+)$/)
+
+  if (fromDone) {
+    return { status: 'done', title: fromDone, updatedAt: now }
+  }
+
+  if (/^↻ Continuing toward goal\b/i.test(line)) {
+    return {
+      detail: line.replace(/^↻\s*/, ''),
+      status: 'active',
+      title: previous?.title || 'Standing goal',
+      updatedAt: now
+    }
+  }
+
+  if (/^⏳ Goal parked\b/i.test(line)) {
+    return {
+      detail: line.replace(/^⏳\s*/, ''),
+      status: 'waiting',
+      title: previous?.title || 'Standing goal',
+      updatedAt: now
+    }
+  }
+
+  if (/^⏸ Goal paused\b/i.test(line)) {
+    return {
+      detail: line.replace(/^⏸\s*/, ''),
+      status: 'paused',
+      title: previous?.title || 'Standing goal',
+      updatedAt: now
+    }
+  }
+
+  if (/^✓ Goal achieved\b/i.test(line)) {
+    return {
+      detail: line.replace(/^✓\s*/, ''),
+      status: 'done',
+      title: previous?.title || 'Standing goal',
+      updatedAt: now
+    }
+  }
+
+  return undefined
+}
+
+export function applyGoalStatusText(sid: string, text: string) {
+  if (!sid) {
+    return
+  }
+
+  const next = nextGoalFromText(text, $goalsBySession.get()[sid])
+
+  if (next === null) {
+    clearSessionGoal(sid)
+  } else if (next) {
+    setSessionGoal(sid, next)
+  }
+}
+
+export async function refreshSessionGoal(sid: string): Promise<void> {
+  const gateway = $gateway.get()
+
+  if (!sid || !gateway) {
+    return
+  }
+
+  try {
+    const result = await gateway.request<{ output?: string }>('slash.exec', { command: 'goal status', session_id: sid })
+    applyGoalStatusText(sid, result?.output ?? '')
+  } catch {
+    // Best-effort: older gateways or detached sessions simply won't hydrate it.
+  }
+}

--- a/cli.py
+++ b/cli.py
@@ -5121,6 +5121,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             pass
 
+        # Standing /goal state (Ralph loop). GoalManager is cached on self and
+        # keeps its state in memory, so this is a cheap attribute read — no DB
+        # hit per repaint. Only an *active* goal earns a segment; paused/done
+        # goals stay out of the bar (matching the desktop's active-first row).
+        snapshot["goal_active"] = False
+        snapshot["goal_turns_used"] = 0
+        snapshot["goal_max_turns"] = 0
+        try:
+            goal_mgr = self._get_goal_manager()
+            if goal_mgr is not None and goal_mgr.is_active():
+                goal_state = goal_mgr.state
+                snapshot["goal_active"] = True
+                snapshot["goal_turns_used"] = int(getattr(goal_state, "turns_used", 0) or 0)
+                snapshot["goal_max_turns"] = int(getattr(goal_state, "max_turns", 0) or 0)
+        except Exception:
+            pass
+
 
         if not agent:
             return snapshot
@@ -5563,6 +5580,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         cont = " | Continuous" if self._voice_continuous else ""
         return [("class:voice-status", f" 🎤 Voice mode{tts}{cont}  —  {label} to record ")]
 
+    @staticmethod
+    def _status_bar_goal_segment(snapshot: Dict[str, Any]) -> str:
+        """Return the ``⊙ goal 3/20`` segment, or ``""`` when no goal is active.
+
+        Active-goal-only by design: paused/done goals don't occupy status-bar
+        real estate (they already print their own glyph lines in the thread).
+        """
+        if not snapshot.get("goal_active"):
+            return ""
+        used = snapshot.get("goal_turns_used") or 0
+        max_turns = snapshot.get("goal_max_turns") or 0
+        if max_turns:
+            return f"⊙ goal {used}/{max_turns}"
+        return "⊙ goal"
+
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
         """Return a compact one-line session status string for the TUI footer."""
         try:
@@ -5576,8 +5608,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             battery_prefix = f"{battery_label} │ " if battery_label else ""
 
             yolo_active = self._is_session_yolo_active()
+            goal_segment = self._status_bar_goal_segment(snapshot)
             if width < 52:
                 text = f"{battery_prefix}⚕ {snapshot['model_short']} · {duration_label}"
+                if goal_segment:
+                    text += f" · {goal_segment}"
                 if yolo_active:
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
@@ -5597,6 +5632,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 bg_subagent_count = snapshot.get("active_background_subagents", 0)
                 if bg_subagent_count:
                     parts.append(f"⛓ {bg_subagent_count}")
+                if goal_segment:
+                    parts.append(goal_segment)
                 parts.append(duration_label)
                 if yolo_active:
                     parts.append("⚠ YOLO")
@@ -5624,6 +5661,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             bg_subagent_count = snapshot.get("active_background_subagents", 0)
             if bg_subagent_count:
                 parts.append(f"⛓ {bg_subagent_count}")
+            if goal_segment:
+                parts.append(goal_segment)
             parts.append(duration_label)
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
@@ -5650,6 +5689,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             width = self._get_tui_terminal_width()
             duration_label = snapshot["duration"]
             yolo_active = self._is_session_yolo_active()
+            goal_segment = self._status_bar_goal_segment(snapshot)
             battery_label = snapshot.get("battery_label") or ""
             battery_style = self._battery_status_style(snapshot.get("battery_category", "dim"))
 
@@ -5660,6 +5700,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
                 ]
+                if goal_segment:
+                    frags.append(("class:status-bar-dim", " · "))
+                    frags.append(("class:status-bar-strong", goal_segment))
                 if yolo_active:
                     frags.append(("class:status-bar-dim", " · "))
                     frags.append(("class:status-bar-yolo", "⚠ YOLO"))
@@ -5690,6 +5733,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     if bg_subagent_count:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append(("class:status-bar-strong", f"⛓ {bg_subagent_count}"))
+                    if goal_segment:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar-strong", goal_segment))
                     frags.extend([
                         ("class:status-bar-dim", " · "),
                         ("class:status-bar-dim", duration_label),
@@ -5733,6 +5779,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     if bg_subagent_count:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-strong", f"⛓ {bg_subagent_count}"))
+                    if goal_segment:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-strong", goal_segment))
                     frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),

--- a/tests/cli/test_cli_status_bar_goal.py
+++ b/tests/cli/test_cli_status_bar_goal.py
@@ -1,0 +1,96 @@
+"""Status-bar goal segment (⊙ goal N/M) — active-goal-only rendering.
+
+The segment mirrors the desktop composer goal indicator: it appears only
+while a /goal is ACTIVE, shows turns used vs the turn budget, and stays out
+of the bar entirely for paused/done/absent goals (those already print their
+own glyph lines in the conversation thread).
+"""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+from cli import HermesCLI
+
+
+def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.model = model
+    cli_obj.session_start = datetime.now() - timedelta(minutes=14, seconds=32)
+    cli_obj.conversation_history = [{"role": "user", "content": "hi"}]
+    cli_obj.agent = None
+    return cli_obj
+
+
+def _attach_goal(cli_obj, *, active: bool, turns_used: int = 3, max_turns: int = 20):
+    """Bind a fake GoalManager the way _get_goal_manager caches one."""
+    cli_obj.session_id = "sess-goal-test"
+    cli_obj._goal_manager = SimpleNamespace(
+        session_id="sess-goal-test",
+        is_active=lambda: active,
+        state=SimpleNamespace(turns_used=turns_used, max_turns=max_turns),
+    )
+    return cli_obj
+
+
+class TestStatusBarGoalSegment:
+    def test_goal_segment_composition(self):
+        cli_obj = _attach_goal(_make_cli(), active=True, turns_used=3, max_turns=20)
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["goal_active"] is True
+        assert snapshot["goal_turns_used"] == 3
+        assert snapshot["goal_max_turns"] == 20
+        assert cli_obj._status_bar_goal_segment(snapshot) == "⊙ goal 3/20"
+
+    def test_goal_segment_absent_without_goal(self):
+        cli_obj = _make_cli()  # no session_id → no goal manager
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["goal_active"] is False
+        assert cli_obj._status_bar_goal_segment(snapshot) == ""
+
+    def test_goal_segment_absent_when_paused(self):
+        # Paused goals must NOT occupy the status bar (active-only contract).
+        cli_obj = _attach_goal(_make_cli(), active=False)
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["goal_active"] is False
+        assert cli_obj._status_bar_goal_segment(snapshot) == ""
+
+    def test_goal_segment_without_budget_omits_counter(self):
+        segment = HermesCLI._status_bar_goal_segment(
+            {"goal_active": True, "goal_turns_used": 0, "goal_max_turns": 0}
+        )
+
+        assert segment == "⊙ goal"
+
+    def test_active_goal_rendered_in_wide_status_bar(self):
+        cli_obj = _attach_goal(_make_cli(), active=True, turns_used=5, max_turns=20)
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "⊙ goal 5/20" in text
+
+    def test_active_goal_rendered_in_medium_status_bar(self):
+        cli_obj = _attach_goal(_make_cli(), active=True, turns_used=1, max_turns=20)
+
+        text = cli_obj._build_status_bar_text(width=60)
+
+        assert "⊙ goal 1/20" in text
+
+    def test_active_goal_rendered_in_narrow_status_bar(self):
+        cli_obj = _attach_goal(_make_cli(), active=True, turns_used=2, max_turns=20)
+
+        text = cli_obj._build_status_bar_text(width=50)
+
+        assert "⊙ goal" in text
+
+    def test_no_goal_segment_in_status_bar_without_goal(self):
+        cli_obj = _make_cli()
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "⊙ goal" not in text


### PR DESCRIPTION
## Summary

An active `/goal` is now visible at a glance instead of only in the turn-by-turn scrollback: a `goal 3/20` segment in the CLI status bar, and a progress row above the Desktop composer showing active / paused / achieved state. Salvage of #63527 by @wjj1872744570-source, extended with the CLI half and locale coverage.

ChatGPT Work shows a persistent goal progress row above its composer; Codex CLI keeps goal state in its status line. Hermes had `/goal` but no persistent indicator on any surface — once the glyph line scrolled away, the only way to check was `/goal status`.

## How it works

Goal state stays backend-authoritative per `apps/desktop/AGENTS.md` — the renderer subscribes to it through the existing goal event path rather than polling, and the store treats it as a cache of backend truth. Display-only: no new gateway RPCs, no controls that don't already have a backend verb. The CLI segment renders inside the existing status-bar composer and honors `/statusbar`.

## Changes

- `apps/desktop/src/store/goals.ts` — goal state store + hydration on `/goal` set and controls
- `apps/desktop/src/store/composer-status.ts` — progress row above the composer
- `apps/desktop/src/i18n/{en,zh,zh-hant}.ts` — full locale copy
- `cli.py` — `goal N/M` status-bar segment, active-goal-only
- `tests/cli/test_cli_status_bar_goal.py` (8 tests) + `apps/desktop/src/store/goals.test.ts` (5 tests)

## Validation

| | Result |
|---|---|
| `scripts/run_tests.sh tests/cli/test_cli_status_bar_goal.py` | 8 passed, 0 failed |
| `npx vitest run src/store/goals.test.ts` | 5 passed, 0 failed |

Supersedes the 4-PR cluster: #63527 (base, credited), #55651, #48285, #43020 — to be closed with credit after merge.

## Infographic

![goal indicator](https://v3b.fal.media/files/b/0aa3d95b/A3mra406NIlMvfBtaMjEj_cgT2LZ4v.png)
