### PR TITLE
fix(desktop): refresh slash catalog after palette closes

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.ts
@@ -21,7 +21,7 @@ import {
 import { detectTrigger, textBeforeCaret, type TriggerState } from '../text-utils'
 
 interface CompletionSource {
-  adapter: Unstable_TriggerAdapter | null
+  adapter: (Unstable_TriggerAdapter & { reset?: () => void }) | null
   loading: boolean
 }
 
@@ -63,6 +63,15 @@ export function useComposerTrigger({
   // re-rendered and the handler closure sees the post-keydown state.
   const triggerKeyConsumedRef = useRef(false)
 
+  const resetCompletionSource = useCallback(
+    (kind: TriggerState['kind']) => {
+      const source = kind === '@' ? at : slash
+
+      source.adapter?.reset?.()
+    },
+    [at, slash]
+  )
+
   const refreshTrigger = useCallback(() => {
     const editor = editorRef.current
 
@@ -79,6 +88,7 @@ export function useComposerTrigger({
 
     if (!rawText.includes('@') && !rawText.includes('/')) {
       if (trigger) {
+        resetCompletionSource(trigger.kind)
         setTrigger(null)
         setTriggerActive(0)
       }
@@ -97,6 +107,10 @@ export function useComposerTrigger({
         ? null
         : found
 
+    if (trigger?.kind && trigger.kind !== detected?.kind) {
+      resetCompletionSource(trigger.kind)
+    }
+
     setTrigger(detected)
 
     // Only reset the highlight when the trigger actually changed (opened, or
@@ -106,7 +120,7 @@ export function useComposerTrigger({
     if (detected?.kind !== trigger?.kind || detected?.query !== trigger?.query) {
       setTriggerActive(0)
     }
-  }, [editorRef, trigger])
+  }, [editorRef, resetCompletionSource, trigger])
 
   const triggerAdapter: Unstable_TriggerAdapter | null =
     trigger?.kind === '@' ? at.adapter : trigger?.kind === '/' ? slash.adapter : null
@@ -135,6 +149,10 @@ export function useComposerTrigger({
   const argStageEmpty = trigger?.kind === '/' && slashArgStage(trigger.query) && !triggerLoading && !triggerItems.length
 
   const closeTrigger = () => {
+    if (trigger) {
+      resetCompletionSource(trigger.kind)
+    }
+
     setTrigger(null)
     setTriggerItems([])
     setTriggerActive(0)

--- a/apps/desktop/src/app/chat/composer/hooks/use-live-completion-adapter.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-live-completion-adapter.ts
@@ -19,6 +19,10 @@ export interface CompletionPayload {
   query: string
 }
 
+export type LiveCompletionAdapter = Unstable_TriggerAdapter & {
+  reset: () => void
+}
+
 const EMPTY_QUERY = '\u0000'
 
 export function useLiveCompletionAdapter(options: {
@@ -26,7 +30,7 @@ export function useLiveCompletionAdapter(options: {
   debounceMs?: number
   fetcher: (query: string) => Promise<CompletionPayload>
   toItem: (entry: CompletionEntry, index: number) => Unstable_TriggerItem
-}): { adapter: Unstable_TriggerAdapter; loading: boolean } {
+}): { adapter: LiveCompletionAdapter; loading: boolean } {
   const { enabled, debounceMs = 60, fetcher, toItem } = options
 
   const [state, setState] = useState<{ query: string; items: Unstable_TriggerItem[] }>({
@@ -108,7 +112,15 @@ export function useLiveCompletionAdapter(options: {
     [cancelTimer, debounceMs, enabled, fetcher, toItem]
   )
 
-  const adapter = useMemo<Unstable_TriggerAdapter>(
+  const reset = useCallback(() => {
+    cancelTimer()
+    pendingQueryRef.current = null
+    tokenRef.current += 1
+    setLoading(false)
+    setState({ query: EMPTY_QUERY, items: [] })
+  }, [cancelTimer])
+
+  const adapter = useMemo<LiveCompletionAdapter>(
     () => ({
       categories: () => [],
       categoryItems: () => [],
@@ -118,9 +130,10 @@ export function useLiveCompletionAdapter(options: {
         }
 
         return state.items
-      }
+      },
+      reset
     }),
-    [scheduleFetch, state]
+    [reset, scheduleFetch, state]
   )
 
   return { adapter, loading }

--- a/apps/desktop/src/app/chat/composer/slash-nav-dom-repro.test.tsx
+++ b/apps/desktop/src/app/chat/composer/slash-nav-dom-repro.test.tsx
@@ -1,10 +1,19 @@
-import type { Unstable_TriggerAdapter, Unstable_TriggerItem } from '@assistant-ui/core'
+import type { Unstable_TriggerItem } from '@assistant-ui/core'
 import { act, fireEvent, render } from '@testing-library/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
-import { useLiveCompletionAdapter } from './hooks/use-live-completion-adapter'
+import {
+  type CompletionPayload,
+  type LiveCompletionAdapter,
+  useLiveCompletionAdapter
+} from './hooks/use-live-completion-adapter'
 import { detectTrigger, type TriggerState } from './text-utils'
+
+const DEFAULT_FETCHER = async (query: string): Promise<CompletionPayload> => ({
+  query,
+  items: Array.from({ length: 5 }, (_, i) => ({ text: `/cmd${i}`, display: `/cmd${i}`, meta: '' }))
+})
 
 // Faithful mirror of index.tsx's trigger wiring, driven through REAL DOM
 // keydown+keyup events on a contentEditable. Exercises the parts a direct
@@ -12,8 +21,10 @@ import { detectTrigger, type TriggerState } from './text-utils'
 // keydown-set "consumed" ref that guards it, and per-press keydown+keyup
 // ordering (critical for Escape, whose keydown nulls `trigger` before keyup).
 function Harness({
+  fetcher = DEFAULT_FETCHER,
   onState
 }: {
+  fetcher?: (query: string) => Promise<CompletionPayload>
   onState: (s: { active: number; items: readonly Unstable_TriggerItem[]; open: boolean }) => void
 }) {
   const editorRef = useRef<HTMLDivElement>(null)
@@ -25,14 +36,11 @@ function Harness({
   const { adapter } = useLiveCompletionAdapter({
     enabled: true,
     debounceMs: 0,
-    fetcher: async (query: string) => ({
-      query,
-      items: Array.from({ length: 5 }, (_, i) => ({ text: `/cmd${i}`, display: `/cmd${i}`, meta: '' }))
-    }),
+    fetcher,
     toItem: (entry, index) => ({ id: `${entry.text}|${index}`, type: 'slash', label: entry.text.slice(1) })
   })
 
-  const triggerAdapter: Unstable_TriggerAdapter | null = trigger?.kind === '/' ? adapter : null
+  const triggerAdapter: LiveCompletionAdapter | null = trigger?.kind === '/' ? adapter : null
 
   const refreshTrigger = useCallback(() => {
     const editor = editorRef.current
@@ -77,6 +85,7 @@ function Harness({
   onState({ active: triggerActive, items: triggerItems, open: trigger !== null })
 
   const closeTrigger = () => {
+    adapter.reset()
     setTrigger(null)
     setTriggerItems([])
     setTriggerActive(0)
@@ -182,5 +191,49 @@ describe('slash menu navigation — real DOM keydown+keyup', () => {
     })
     await flush()
     expect(latest.open).toBe(false)
+  })
+
+  it('refreshes the empty-query catalog after the palette closes and reopens', async () => {
+    vi.useRealTimers()
+    let catalogFetches = 0
+    let latest = { active: 0, items: [] as readonly Unstable_TriggerItem[], open: false }
+
+    const fetcher = async (query: string): Promise<CompletionPayload> => {
+      catalogFetches += 1
+
+      const command = catalogFetches === 1 ? '/old-skill' : '/fresh-skill'
+
+      return { query, items: [{ text: command, display: command, meta: '' }] }
+    }
+
+    const { getByTestId } = render(<Harness fetcher={fetcher} onState={s => (latest = s)} />)
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      editor.textContent = '/'
+      fireEvent.input(editor)
+    })
+    await flush()
+
+    expect(catalogFetches).toBe(1)
+    expect(latest.items[0]?.label).toBe('old-skill')
+
+    await act(async () => {
+      fireEvent.keyDown(editor, { key: 'Escape' })
+      fireEvent.keyUp(editor, { key: 'Escape' })
+    })
+    await flush()
+    expect(latest.open).toBe(false)
+
+    await act(async () => {
+      editor.textContent = ''
+      fireEvent.input(editor)
+      editor.textContent = '/'
+      fireEvent.input(editor)
+    })
+    await flush()
+
+    expect(catalogFetches).toBe(2)
+    expect(latest.items[0]?.label).toBe('fresh-skill')
   })
 })


### PR DESCRIPTION
## Summary

Refresh the Desktop slash-completion catalog after its palette closes so a later `/` search fetches the current commands, skills, and plugins instead of reusing stale empty-query state.

This restores repeated slash lookup in one chat, including after using an earlier slash command such as `/new`.

## Root cause

The live completion adapter retained both its cached empty-query result and `pendingQueryRef`. When the palette closed and later reopened with the same empty query, the adapter treated that query as already fetched and did not request a fresh catalog.

## Fix

- Add a `reset()` method to the live completion adapter.
- Cancel pending completion work and invalidate stale responses during reset.
- Reset the active completion source when the trigger closes, disappears, or switches kind.
- Add a DOM regression test that closes and reopens the slash palette and verifies a fresh catalog fetch.

## Verification

- Focused regression: 1 file passed, 2 tests passed.
- Full Desktop UI suite: 270 files passed, 2,284 tests passed, 1 skipped.
- TypeScript: renderer, Electron, and E2E configurations passed.
- ESLint: all three changed files passed with `--max-warnings 0`.
- `git diff --check`: passed.
- Manual confirmation in Hermes Desktop: repeated slash lookup is working.

## Scope

Three Desktop composer files only. No dependency, backend, protocol, or packaging changes.

This PR is submitted for review and is not intended to be merged by the contributor without maintainer approval.