### PR TITLE
refactor(agent): consolidate SOUL.md identity resolution and pin drift propagation

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2026,10 +2026,16 @@ def compress_context(
         # can predate mid-session memory writes the in-memory snapshot has
         # already absorbed. External providers can change their own prompt
         # block during on_pre_compress(), so they retain the rebuild path.
+        # AGENTS.md:19-23 carves out context compression as the one place
+        # the system prompt may change mid-conversation. That makes this
+        # gate the only correct spot to act on SOUL.md identity drift.
+        from agent.system_prompt import stored_identity_is_stale
+
         if (
             cached_system_prompt is not None
             and getattr(agent, "_memory_manager", None) is None
             and _cached_prompt_reflects_builtin_memory(agent, cached_system_prompt)
+            and not stored_identity_is_stale(agent, cached_system_prompt)
         ):
             new_system_prompt = cached_system_prompt
             agent._cached_system_prompt = cached_system_prompt

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3989,7 +3989,13 @@ def compress_context(
         # local KV prefixes survive on equality; when something changed,
         # the cache was stale by definition and propagation is the point.
         # Preserve OBJECT identity on byte-equality for backends that key
-        # on it.
+        # on it. This unconditional rebuild also folds in #72253's SOUL.md
+        # identity-drift fix for free: a drifted identity block makes
+        # rebuilt_system_prompt differ from cached_system_prompt, so the
+        # containment-based `stored_identity_is_stale` gate that #72253 added
+        # to the old keep-prompt branch has no branch left to attach to — the
+        # byte comparison below already forces a rebuild whenever identity
+        # (or anything else) drifted.
         rebuilt_system_prompt = agent._build_system_prompt(system_message)
         if cached_system_prompt is not None and rebuilt_system_prompt == cached_system_prompt:
             new_system_prompt = cached_system_prompt

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -467,21 +467,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 agent.session_id, exc,
             )
 
-    # ``_stored_prompt_matches_runtime`` only rejects Model/Provider/cwd/
-    # Platform drift, so identity CONTENT drift — SOUL.md edited, created or
-    # deleted since the prompt was persisted — was reused verbatim for the rest
-    # of the session (issue #68563). ``stored_identity_is_stale`` answers that
-    # question next to the resolver it compares against, and only runs once the
-    # runtime check has already passed. The rebuild it triggers is the same
-    # one-shot, user-initiated path the runtime-drift branch below takes.
-    from agent.system_prompt import stored_identity_is_stale
-
-    runtime_ok = bool(stored_prompt) and _stored_prompt_matches_runtime(
-        agent, stored_prompt
-    )
-    identity_stale = runtime_ok and stored_identity_is_stale(agent, stored_prompt)
-
-    if runtime_ok and not identity_stale:
+    if stored_prompt and _stored_prompt_matches_runtime(agent, stored_prompt):
         # Continuing session — reuse the exact system prompt from the
         # previous turn so the Anthropic cache prefix matches.
         agent._cached_system_prompt = stored_prompt
@@ -500,14 +486,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
 
         reconstruct_static_prefix(agent, system_message=system_message)
         return
-    if identity_stale:
-        stored_state = "stale_identity"
-        logger.info(
-            "Stored system prompt for session %s has a stale identity "
-            "block (SOUL.md changed since it was persisted); rebuilding.",
-            agent.session_id,
-        )
-    elif stored_prompt:
+    if stored_prompt:
         stored_state = "stale_runtime"
         logger.info(
             "Stored system prompt for session %s has stale runtime identity; "
@@ -537,20 +516,16 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # Plugin hook: on_session_start — fired once when a brand-new
     # session is created (not on continuation).  Plugins can use this
     # to initialise session-scoped state (e.g. warm a memory cache).
-    # A stale-prompt fallthrough (runtime identity or SOUL.md drift) is a
-    # CONTINUING session getting its prompt rebuilt — firing here again
-    # would duplicate session-scoped plugin work, so those states skip it.
-    if stored_state not in ("stale_runtime", "stale_identity"):
-        try:
-            from hermes_cli.lifecycle import invoke_hook as _invoke_hook
-            _invoke_hook(
-                "on_session_start",
-                session_id=agent.session_id,
-                model=agent.model,
-                platform=getattr(agent, "platform", None) or "",
-            )
-        except Exception as exc:
-            logger.warning("on_session_start hook failed: %s", exc)
+    try:
+        from hermes_cli.lifecycle import invoke_hook as _invoke_hook
+        _invoke_hook(
+            "on_session_start",
+            session_id=agent.session_id,
+            model=agent.model,
+            platform=getattr(agent, "platform", None) or "",
+        )
+    except Exception as exc:
+        logger.warning("on_session_start hook failed: %s", exc)
 
     # Cold-start credits seed (L3) — fallback for the first-turn path. The TUI/
     # desktop build seeds at session OPEN (see seed_credits_at_session_start in

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -467,7 +467,21 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 agent.session_id, exc,
             )
 
-    if stored_prompt and _stored_prompt_matches_runtime(agent, stored_prompt):
+    # ``_stored_prompt_matches_runtime`` only rejects Model/Provider/cwd/
+    # Platform drift, so identity CONTENT drift — SOUL.md edited, created or
+    # deleted since the prompt was persisted — was reused verbatim for the rest
+    # of the session (issue #68563). ``stored_identity_is_stale`` answers that
+    # question next to the resolver it compares against, and only runs once the
+    # runtime check has already passed. The rebuild it triggers is the same
+    # one-shot, user-initiated path the runtime-drift branch below takes.
+    from agent.system_prompt import stored_identity_is_stale
+
+    runtime_ok = bool(stored_prompt) and _stored_prompt_matches_runtime(
+        agent, stored_prompt
+    )
+    identity_stale = runtime_ok and stored_identity_is_stale(agent, stored_prompt)
+
+    if runtime_ok and not identity_stale:
         # Continuing session — reuse the exact system prompt from the
         # previous turn so the Anthropic cache prefix matches.
         agent._cached_system_prompt = stored_prompt
@@ -486,7 +500,14 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
 
         reconstruct_static_prefix(agent, system_message=system_message)
         return
-    if stored_prompt:
+    if identity_stale:
+        stored_state = "stale_identity"
+        logger.info(
+            "Stored system prompt for session %s has a stale identity "
+            "block (SOUL.md changed since it was persisted); rebuilding.",
+            agent.session_id,
+        )
+    elif stored_prompt:
         stored_state = "stale_runtime"
         logger.info(
             "Stored system prompt for session %s has stale runtime identity; "
@@ -516,16 +537,20 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # Plugin hook: on_session_start — fired once when a brand-new
     # session is created (not on continuation).  Plugins can use this
     # to initialise session-scoped state (e.g. warm a memory cache).
-    try:
-        from hermes_cli.lifecycle import invoke_hook as _invoke_hook
-        _invoke_hook(
-            "on_session_start",
-            session_id=agent.session_id,
-            model=agent.model,
-            platform=getattr(agent, "platform", None) or "",
-        )
-    except Exception as exc:
-        logger.warning("on_session_start hook failed: %s", exc)
+    # A stale-prompt fallthrough (runtime identity or SOUL.md drift) is a
+    # CONTINUING session getting its prompt rebuilt — firing here again
+    # would duplicate session-scoped plugin work, so those states skip it.
+    if stored_state not in ("stale_runtime", "stale_identity"):
+        try:
+            from hermes_cli.lifecycle import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "on_session_start",
+                session_id=agent.session_id,
+                model=agent.model,
+                platform=getattr(agent, "platform", None) or "",
+            )
+        except Exception as exc:
+            logger.warning("on_session_start hook failed: %s", exc)
 
     # Cold-start credits seed (L3) — fallback for the first-turn path. The TUI/
     # desktop build seeds at session OPEN (see seed_credits_at_session_start in

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -661,16 +661,25 @@ def stored_identity_is_stale(agent: Any, stored_prompt: str) -> bool:
     assembly.
 
     Fails open to reuse: ``checkable=False`` (SOUL.md exists but is
-    temporarily unreadable, or HERMES_HOME itself is absent/unmounted) or a
-    resolver crash is no basis to call the stored identity stale —
-    rebuilding then would persist a DEFAULT_AGENT_IDENTITY downgrade over a
-    healthy custom identity.
+    temporarily unreadable, or HERMES_HOME itself is absent/unmounted), a
+    resolver crash, or ``stored_prompt`` never carrying the help-guidance
+    anchor anywhere at all, is no basis to call the stored identity stale.
+    That last case is a stored prompt that was never built through the
+    normal stable-tier layout (a legacy shape, or a hand-built value in a
+    test fixture) — the detector's contract is to report True only when it
+    can confidently say slot #1 changed, and it cannot locate slot #1 at
+    all here, so this is undetermined rather than a confirmed mismatch.
+    Rebuilding on either kind of fail-open would persist a
+    DEFAULT_AGENT_IDENTITY downgrade over a healthy custom identity.
     """
     try:
         identity = resolve_identity_block(agent)
         if not (identity["checkable"] and identity["text"]):
             return False
-        anchored = identity["text"].strip() + "\n\n" + HERMES_AGENT_HELP_GUIDANCE.strip()
+        help_anchor = HERMES_AGENT_HELP_GUIDANCE.strip()
+        if help_anchor not in stored_prompt:
+            return False
+        anchored = identity["text"].strip() + "\n\n" + help_anchor
         return not stored_prompt.startswith(anchored)
     except Exception:
         logger.debug("identity staleness check failed", exc_info=True)

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -173,14 +173,16 @@ def resolve_identity_block(agent: Any) -> Dict[str, Any]:
     provenance, not text comparison — a user's SOUL.md that happens to equal
     ``DEFAULT_AGENT_IDENTITY`` still counts as loaded.
 
-    ``checkable`` is for staleness judgements on session restore (#68563):
+    ``checkable`` is for staleness judgements at the compaction keep-prompt
+    gate (#68563, see ``stored_identity_is_stale``):
     ``load_soul_md`` returns None for an absent SOUL.md, for a readable but
     empty one, AND for one that exists but cannot be read (it swallows
     IO/decoding errors). The first two are legitimate "use the default
     personality" states (emptying SOUL.md is the documented way to reset —
-    see default_soul.py); only a failed read is no basis to declare the
-    stored prompt stale, so exactly that case sets ``checkable`` False and
-    callers must fail open to reuse."""
+    see default_soul.py); a failed SOUL.md read, or HERMES_HOME itself being
+    absent/unmounted, is no basis to declare the stored prompt stale, so
+    those two cases set ``checkable`` False and callers must fail open to
+    reuse."""
     text = None
     from_soul = False
     checkable = True
@@ -191,12 +193,20 @@ def resolve_identity_block(agent: Any) -> Dict[str, Any]:
             from_soul = True
         else:
             try:
-                _soul_path = get_hermes_home() / "SOUL.md"
-                if _soul_path.exists():
-                    # Distinguish readable-empty from unreadable: a read
-                    # that succeeds here means the None above was the
-                    # deliberate empty-file state, which IS checkable.
-                    _soul_path.read_text(encoding="utf-8")
+                _hermes_home = get_hermes_home()
+                if not _hermes_home.exists():
+                    # HERMES_HOME itself is absent/unmounted: nothing here
+                    # can confirm what identity applies, so this is NOT
+                    # checkable (distinct from HERMES_HOME existing with no
+                    # SOUL.md inside it, handled in the branch below).
+                    checkable = False
+                else:
+                    _soul_path = _hermes_home / "SOUL.md"
+                    if _soul_path.exists():
+                        # Distinguish readable-empty from unreadable: a read
+                        # that succeeds here means the None above was the
+                        # deliberate empty-file state, which IS checkable.
+                        _soul_path.read_text(encoding="utf-8")
             except Exception:
                 checkable = False
     if text is None:
@@ -235,8 +245,9 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     stable_parts: List[str] = []
 
     # Identity (SOUL.md or the hardcoded fallback) via the shared resolver —
-    # the restore-time staleness check (#68563) uses the same function, so
-    # the two can never disagree about what identity a fresh build would use.
+    # the compaction keep-prompt gate's staleness check (#68563, see
+    # stored_identity_is_stale) uses the same function, so the two can never
+    # disagree about what identity a fresh build would use.
     _identity = resolve_identity_block(agent)
     stable_parts.append(_identity["text"])
     _soul_loaded = _identity["from_soul"]
@@ -630,11 +641,17 @@ def stored_identity_is_stale(agent: Any, stored_prompt: str) -> bool:
     """Return True when ``stored_prompt`` no longer opens with this agent's
     identity block.
 
-    The restore path's runtime check only rejects Model/Provider/cwd/Platform
+    Session restore's runtime check only rejects Model/Provider/cwd/Platform
     drift, so identity CONTENT drift — SOUL.md edited, created or deleted
-    since the prompt was persisted — kept being reused verbatim for the rest
-    of the session (issue #68563). This lives next to ``resolve_identity_block``
-    so the comparison and the resolver it compares against stay in step.
+    since the prompt was persisted — used to keep being reused verbatim for
+    the rest of the session (issue #68563). Restore itself never rebuilds on
+    identity drift (AGENTS.md:19-23 only exempts context compression from
+    the "no mid-conversation system-prompt rewrite" rule), so this function's
+    only caller is the Hermes-native compaction keep-prompt gate in
+    agent/conversation_compression.py — the boundary where a rebuild is
+    actually allowed to happen and to persist. This lives next to
+    ``resolve_identity_block`` so the comparison and the resolver it
+    compares against stay in step.
 
     The comparison is anchored: identity is slot #1 and
     ``HERMES_AGENT_HELP_GUIDANCE`` always follows it in the stable tier, so
@@ -644,9 +661,10 @@ def stored_identity_is_stale(agent: Any, stored_prompt: str) -> bool:
     assembly.
 
     Fails open to reuse: ``checkable=False`` (SOUL.md exists but is
-    temporarily unreadable) or a resolver crash is no basis to call the stored
-    identity stale — rebuilding then would persist a DEFAULT_AGENT_IDENTITY
-    downgrade over a healthy custom identity.
+    temporarily unreadable, or HERMES_HOME itself is absent/unmounted) or a
+    resolver crash is no basis to call the stored identity stale —
+    rebuilding then would persist a DEFAULT_AGENT_IDENTITY downgrade over a
+    healthy custom identity.
     """
     try:
         identity = resolve_identity_block(agent)
@@ -655,7 +673,7 @@ def stored_identity_is_stale(agent: Any, stored_prompt: str) -> bool:
         anchored = identity["text"].strip() + "\n\n" + HERMES_AGENT_HELP_GUIDANCE.strip()
         return not stored_prompt.startswith(anchored)
     except Exception:
-        logger.debug("identity staleness check failed on restore", exc_info=True)
+        logger.debug("identity staleness check failed", exc_info=True)
         return False
 
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -149,6 +149,61 @@ def _tui_embedded_pane_clarifier(hint: str) -> str:
     return hint + _TUI_EMBEDDED_PANE_CLARIFIER
 
 
+def _resolve_context_length(agent: Any) -> Optional[int]:
+    """Resolve the model context window used for context-file caps.
+
+    Stable for the life of the conversation (see the caller's note), so it
+    does not threaten prompt caching. None falls back to the historical flat
+    default inside the loaders."""
+    _cc = getattr(agent, "context_compressor", None)
+    if _cc is not None:
+        _cc_len = getattr(_cc, "context_length", None)
+        if isinstance(_cc_len, int) and _cc_len > 0:
+            return _cc_len
+    return None
+
+
+def resolve_identity_block(agent: Any) -> Dict[str, Any]:
+    """Resolve the identity block (slot #1) exactly as the prompt builder does.
+
+    Returns ``{"text": str, "from_soul": bool, "checkable": bool}``.
+
+    ``from_soul`` preserves the builder's ``_soul_loaded`` semantics (it
+    controls whether SOUL.md is injected again as project context), and it is
+    provenance, not text comparison — a user's SOUL.md that happens to equal
+    ``DEFAULT_AGENT_IDENTITY`` still counts as loaded.
+
+    ``checkable`` is for staleness judgements on session restore (#68563):
+    ``load_soul_md`` returns None for an absent SOUL.md, for a readable but
+    empty one, AND for one that exists but cannot be read (it swallows
+    IO/decoding errors). The first two are legitimate "use the default
+    personality" states (emptying SOUL.md is the documented way to reset —
+    see default_soul.py); only a failed read is no basis to declare the
+    stored prompt stale, so exactly that case sets ``checkable`` False and
+    callers must fail open to reuse."""
+    text = None
+    from_soul = False
+    checkable = True
+    if agent.load_soul_identity or not agent.skip_context_files:
+        _soul_content = _ra().load_soul_md(_resolve_context_length(agent))
+        if _soul_content:
+            text = _soul_content
+            from_soul = True
+        else:
+            try:
+                _soul_path = get_hermes_home() / "SOUL.md"
+                if _soul_path.exists():
+                    # Distinguish readable-empty from unreadable: a read
+                    # that succeeds here means the None above was the
+                    # deliberate empty-file state, which IS checkable.
+                    _soul_path.read_text(encoding="utf-8")
+            except Exception:
+                checkable = False
+    if text is None:
+        text = DEFAULT_AGENT_IDENTITY
+    return {"text": text, "from_soul": from_soul, "checkable": checkable}
+
+
 def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
     """Assemble the system prompt as three ordered cache tiers.
 
@@ -174,31 +229,17 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
     # Resolve the model's context window once so context-file caps can scale
     # to it (dynamic cap — see prompt_builder._dynamic_context_file_max_chars).
-    # None falls back to the historical flat default. This value is stable for
-    # the life of the conversation, so it does not threaten prompt caching.
-    _ctx_len: Optional[int] = None
-    _cc = getattr(agent, "context_compressor", None)
-    if _cc is not None:
-        _cc_len = getattr(_cc, "context_length", None)
-        if isinstance(_cc_len, int) and _cc_len > 0:
-            _ctx_len = _cc_len
+    _ctx_len: Optional[int] = _resolve_context_length(agent)
 
     # ── Stable tier ────────────────────────────────────────────────
     stable_parts: List[str] = []
 
-    # Try SOUL.md as primary identity unless the caller explicitly skipped it.
-    # Some execution modes (cron) still want HERMES_HOME persona while keeping
-    # cwd project instructions disabled.
-    _soul_loaded = False
-    if agent.load_soul_identity or not agent.skip_context_files:
-        _soul_content = _r.load_soul_md(_ctx_len)
-        if _soul_content:
-            stable_parts.append(_soul_content)
-            _soul_loaded = True
-
-    if not _soul_loaded:
-        # Fallback to hardcoded identity
-        stable_parts.append(DEFAULT_AGENT_IDENTITY)
+    # Identity (SOUL.md or the hardcoded fallback) via the shared resolver —
+    # the restore-time staleness check (#68563) uses the same function, so
+    # the two can never disagree about what identity a fresh build would use.
+    _identity = resolve_identity_block(agent)
+    stable_parts.append(_identity["text"])
+    _soul_loaded = _identity["from_soul"]
 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
     stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
@@ -583,6 +624,39 @@ def invalidate_system_prompt(agent: Any) -> None:
     agent._cached_system_prompt_static = None
     if agent._memory_store:
         agent._memory_store.load_from_disk()
+
+
+def stored_identity_is_stale(agent: Any, stored_prompt: str) -> bool:
+    """Return True when ``stored_prompt`` no longer opens with this agent's
+    identity block.
+
+    The restore path's runtime check only rejects Model/Provider/cwd/Platform
+    drift, so identity CONTENT drift — SOUL.md edited, created or deleted
+    since the prompt was persisted — kept being reused verbatim for the rest
+    of the session (issue #68563). This lives next to ``resolve_identity_block``
+    so the comparison and the resolver it compares against stay in step.
+
+    The comparison is anchored: identity is slot #1 and
+    ``HERMES_AGENT_HELP_GUIDANCE`` always follows it in the stable tier, so
+    requiring the pair as the prompt prefix supplies the boundary a bare
+    substring check lacks (deleting the TAIL of SOUL.md would otherwise still
+    "match"). Cost is one file read plus a truncation — no probes, no tier
+    assembly.
+
+    Fails open to reuse: ``checkable=False`` (SOUL.md exists but is
+    temporarily unreadable) or a resolver crash is no basis to call the stored
+    identity stale — rebuilding then would persist a DEFAULT_AGENT_IDENTITY
+    downgrade over a healthy custom identity.
+    """
+    try:
+        identity = resolve_identity_block(agent)
+        if not (identity["checkable"] and identity["text"]):
+            return False
+        anchored = identity["text"].strip() + "\n\n" + HERMES_AGENT_HELP_GUIDANCE.strip()
+        return not stored_prompt.startswith(anchored)
+    except Exception:
+        logger.debug("identity staleness check failed on restore", exc_info=True)
+        return False
 
 
 def reconstruct_static_prefix(

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -283,6 +283,81 @@ def _plugin_section_blocks(sections: tuple, position: str) -> List[str]:
     block = format_system_prompt_sections(selected)
     return [block] if block else []
 
+def _resolve_context_length(agent: Any) -> Optional[int]:
+    """Resolve the model context window used for context-file caps.
+
+    Stable for the life of the conversation (see the caller's note), so it
+    does not threaten prompt caching. None falls back to the historical flat
+    default inside the loaders."""
+    _cc = getattr(agent, "context_compressor", None)
+    if _cc is not None:
+        _cc_len = getattr(_cc, "context_length", None)
+        if isinstance(_cc_len, int) and _cc_len > 0:
+            return _cc_len
+    return None
+
+
+def resolve_identity_block(agent: Any) -> Dict[str, Any]:
+    """Resolve the identity block (slot #1) exactly as the prompt builder does.
+
+    Returns ``{"text": str, "from_soul": bool, "checkable": bool}``.
+
+    ``from_soul`` preserves the builder's ``_soul_loaded`` semantics (it
+    controls whether SOUL.md is injected again as project context), and it is
+    provenance, not text comparison — a user's SOUL.md that happens to equal
+    ``DEFAULT_AGENT_IDENTITY`` still counts as loaded.
+
+    ``checkable`` is for staleness judgements made by ``stored_identity_is_stale``
+    (#68563). That helper has no production caller today — #98426's
+    unconditional rebuild at the compaction boundary already propagates
+    SOUL.md drift on its own (a drifted identity makes the fresh build differ
+    from the cached prompt, which routes to the rebuild branch by itself) —
+    but it is kept and regression-tested as a standalone identity-staleness
+    check in case a future caller needs one:
+    ``load_soul_md`` returns None for an absent SOUL.md, for a readable but
+    empty one, AND for one that exists but cannot be read (it swallows
+    IO/decoding errors). The first two are legitimate "use the default
+    personality" states (emptying SOUL.md is the documented way to reset —
+    see default_soul.py); a failed SOUL.md read, or HERMES_HOME itself being
+    absent/unmounted, is no basis to declare the stored prompt stale, so
+    those two cases set ``checkable`` False and callers must fail open to
+    reuse."""
+    text = None
+    from_soul = False
+    checkable = True
+    if agent.load_soul_identity or not agent.skip_context_files:
+        # Scope the SOUL.md read to the agent's OWN home (see _agent_home) —
+        # ambient resolution on a thread that lost the HERMES_HOME ContextVar
+        # reads the launch profile's SOUL.md instead (#50233).
+        _home = _agent_home(agent)
+        _soul_content = _ra().load_soul_md(
+            _resolve_context_length(agent), home_override=_home
+        )
+        if _soul_content:
+            text = _soul_content
+            from_soul = True
+        else:
+            try:
+                _probe_home = _home or get_hermes_home()
+                if not _probe_home.exists():
+                    # The agent's home itself is absent/unmounted: nothing
+                    # here can confirm what identity applies, so this is NOT
+                    # checkable (distinct from the home existing with no
+                    # SOUL.md inside it, handled in the branch below).
+                    checkable = False
+                else:
+                    _soul_path = _probe_home / "SOUL.md"
+                    if _soul_path.exists():
+                        # Distinguish readable-empty from unreadable: a read
+                        # that succeeds here means the None above was the
+                        # deliberate empty-file state, which IS checkable.
+                        _soul_path.read_text(encoding="utf-8")
+            except Exception:
+                checkable = False
+    if text is None:
+        text = DEFAULT_AGENT_IDENTITY
+    return {"text": text, "from_soul": from_soul, "checkable": checkable}
+
 
 def _session_start_like(agent: Any, now: Any) -> Any:
     """Best-known conversation start time, or ``now`` as a fallback.
@@ -457,34 +532,22 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
     # Resolve the model's context window once so context-file caps can scale
     # to it (dynamic cap — see prompt_builder._dynamic_context_file_max_chars).
-    # None falls back to the historical flat default. This value is stable for
-    # the life of the conversation, so it does not threaten prompt caching.
-    _ctx_len: Optional[int] = None
-    _cc = getattr(agent, "context_compressor", None)
-    if _cc is not None:
-        _cc_len = getattr(_cc, "context_length", None)
-        if isinstance(_cc_len, int) and _cc_len > 0:
-            _ctx_len = _cc_len
+    _ctx_len: Optional[int] = _resolve_context_length(agent)
 
     # ── Stable tier ────────────────────────────────────────────────
     stable_parts: List[str] = []
 
-    # Try SOUL.md as primary identity unless the caller explicitly skipped it.
-    # Some execution modes (cron) still want HERMES_HOME persona while keeping
-    # cwd project instructions disabled.
-    _soul_loaded = False
-    if agent.load_soul_identity or not agent.skip_context_files:
-        # Scope the SOUL.md read to the agent's OWN home (see _agent_home) —
-        # ambient resolution on a thread that lost the HERMES_HOME ContextVar
-        # reads the launch profile's SOUL.md instead (#50233).
-        _soul_content = _r.load_soul_md(_ctx_len, home_override=_agent_home(agent))
-        if _soul_content:
-            stable_parts.append(_soul_content)
-            _soul_loaded = True
-
-    if not _soul_loaded:
-        # Fallback to hardcoded identity
-        stable_parts.append(DEFAULT_AGENT_IDENTITY)
+    # Identity (SOUL.md or the hardcoded fallback) via the shared resolver.
+    # stored_identity_is_stale (#68563) is built on this same function, so a
+    # future caller of that helper can never disagree with the builder about
+    # what identity a fresh build would use — but stored_identity_is_stale
+    # itself has no production caller today: #98426's unconditional rebuild
+    # at the compaction boundary already carries SOUL.md drift into a fresh
+    # prompt on its own, so the helper is kept as a tested, standalone
+    # identity-staleness check rather than as an active gate condition.
+    _identity = resolve_identity_block(agent)
+    stable_parts.append(_identity["text"])
+    _soul_loaded = _identity["from_soul"]
 
     # Pointer to the docs (and, when it exists, the hermes-agent skill) for
     # user questions about Hermes itself. The skill_view() pointer is a
@@ -1075,6 +1138,56 @@ def invalidate_system_prompt(agent: Any) -> None:
         delattr(agent, _snapshot_attr)
     if agent._memory_store:
         agent._memory_store.load_from_disk()
+
+
+def stored_identity_is_stale(agent: Any, stored_prompt: str) -> bool:
+    """Return True when ``stored_prompt`` no longer opens with this agent's
+    identity block.
+
+    Session restore's runtime check only rejects Model/Provider/cwd/Platform
+    drift, so identity CONTENT drift — SOUL.md edited, created or deleted
+    since the prompt was persisted — used to keep being reused verbatim for
+    the rest of the session (issue #68563). Restore itself never rebuilds on
+    identity drift (AGENTS.md:19-23 only exempts context compression from
+    the "no mid-conversation system-prompt rewrite" rule). The compaction
+    keep-prompt gate that used to call this function was replaced by the
+    unconditional rebuild in #98426, so it currently has no production
+    caller: a drifted identity simply makes the fresh build differ from the
+    cached bytes. It stays as a tested helper next to
+    ``resolve_identity_block`` so the comparison and the resolver it
+    compares against stay in step.
+
+    The comparison is anchored: identity is slot #1 and
+    ``HERMES_AGENT_HELP_GUIDANCE`` always follows it in the stable tier, so
+    requiring the pair as the prompt prefix supplies the boundary a bare
+    substring check lacks (deleting the TAIL of SOUL.md would otherwise still
+    "match"). Cost is one file read plus a truncation — no probes, no tier
+    assembly.
+
+    Fails open to reuse: ``checkable=False`` (SOUL.md exists but is
+    temporarily unreadable, or HERMES_HOME itself is absent/unmounted), a
+    resolver crash, or ``stored_prompt`` never carrying the help-guidance
+    anchor anywhere at all, is no basis to call the stored identity stale.
+    That last case is a stored prompt that was never built through the
+    normal stable-tier layout (a legacy shape, or a hand-built value in a
+    test fixture) — the detector's contract is to report True only when it
+    can confidently say slot #1 changed, and it cannot locate slot #1 at
+    all here, so this is undetermined rather than a confirmed mismatch.
+    Rebuilding on either kind of fail-open would persist a
+    DEFAULT_AGENT_IDENTITY downgrade over a healthy custom identity.
+    """
+    try:
+        identity = resolve_identity_block(agent)
+        if not (identity["checkable"] and identity["text"]):
+            return False
+        help_anchor = HERMES_AGENT_HELP_GUIDANCE.strip()
+        if help_anchor not in stored_prompt:
+            return False
+        anchored = identity["text"].strip() + "\n\n" + help_anchor
+        return not stored_prompt.startswith(anchored)
+    except Exception:
+        logger.debug("identity staleness check failed", exc_info=True)
+        return False
 
 
 def reconstruct_static_prefix(

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from agent.conversation_loop import _restore_or_build_system_prompt
+from agent.system_prompt import stored_identity_is_stale
 
 
 def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
@@ -223,6 +224,78 @@ class TestPromptStabilityInvariant:
 
 
 # ---------------------------------------------------------------------------
+# PR #72253 redesign (v6) — restore-path contract pins (§6-C). Restore never
+# rewrites the stored prompt on identity drift: AGENTS.md:19-23 forbids
+# mid-conversation system-prompt rewrites outside the explicit compression
+# exception, and restore is not that exception. agent/conversation_loop.py
+# was reverted to main's behavior, so _restore_or_build_system_prompt no
+# longer calls stored_identity_is_stale at all; identity drift is instead
+# handled at the compaction keep-prompt gate (TestCompactionIdentityDriftGate).
+# See .claude/archive/72253-redesign-v6.md §6-C for the design rationale.
+# ---------------------------------------------------------------------------
+
+
+class TestV6RedesignFailBeforePins:
+    def test_soul_drift_does_not_rewrite_stored_prompt(self, monkeypatch, caplog):
+        """v6 §1/§6-C-1: SOUL.md drift on restore must NOT rebuild or persist —
+        AGENTS.md:19-23 forbids mid-conversation system-prompt rewrites outside
+        the explicit compression exception. Restore is not that exception.
+
+        _restore_or_build_system_prompt no longer imports or calls
+        stored_identity_is_stale at all (agent/conversation_loop.py was fully
+        reverted to main's behavior), so this reuse holds unconditionally.
+        """
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        _patch_identity(monkeypatch, "NEW SOUL IDENTITY")
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        db.update_system_prompt.assert_not_called()
+
+    def test_restore_does_not_read_soul_md(self, monkeypatch):
+        """v6 §6-A point 2: the restore hot path must not re-read SOUL.md on
+        every reuse turn (no memoization exists for it, unlike
+        reconstruct_static_prefix's retry-loop guard at system_prompt.py:610-614).
+
+        Holds because _restore_or_build_system_prompt no longer calls
+        stored_identity_is_stale (which is what previously chained into
+        resolve_identity_block -> run_agent.load_soul_md on every turn); the
+        real resolver is wired in below to prove that chain is genuinely
+        unreached, not just mocked away.
+        """
+        identity = "CURRENT SOUL IDENTITY"
+        stored = _stored_with_identity(identity)
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        agent.load_soul_identity = True
+        agent.skip_context_files = False
+
+        # Undo the file's autouse neutral-resolver patch for this test only,
+        # so the real resolver (and therefore the real load_soul_md call) is
+        # actually exercised — a fully-mocked resolver would make this pin
+        # vacuous (it would pass regardless of what the restore path does).
+        monkeypatch.setattr(
+            "agent.system_prompt.resolve_identity_block", _REAL_RESOLVE_IDENTITY
+        )
+        soul_reader = MagicMock(return_value=identity)
+        monkeypatch.setattr("run_agent.load_soul_md", soul_reader)
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        soul_reader.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Cross-session static prefix reconstruction (issue #68191 follow-up)
 # ---------------------------------------------------------------------------
 
@@ -413,15 +486,16 @@ def _patch_identity(monkeypatch, text, checkable=True, from_soul=True):
 
 
 class TestIdentityStalenessRebuild:
-    """SOUL.md edits must reach continuing sessions (issue #68563).
+    """SOUL.md edits do NOT rebuild the restored prompt (PR #72253 v6
+    redesign). ``AGENTS.md:19-23`` only exempts context compression from the
+    "never rebuild mid-conversation" rule, and restore is not that
+    exception, so drift here must fall through to verbatim reuse — even
+    though ``_stored_prompt_matches_runtime`` already rejects Model/
+    Provider/cwd/Platform drift on its own, unrelated axis. Identity drift
+    reaching a running session is handled at the Hermes-native compaction
+    keep-prompt gate instead (see ``TestCompactionIdentityDriftGate``)."""
 
-    ``_stored_prompt_matches_runtime`` only rejects Model/Provider/cwd/
-    Platform drift; identity content drift previously left the stale prompt
-    reused verbatim forever. The check is anchored on the identity block
-    plus ``HERMES_AGENT_HELP_GUIDANCE`` (the always-present next stable
-    component), which supplies the boundary a bare substring lacks."""
-
-    def test_edited_soul_rebuilds_and_persists(self, monkeypatch, caplog):
+    def test_edited_soul_reuses_verbatim(self, monkeypatch, caplog):
         stored = _stored_with_identity("OLD SOUL IDENTITY")
         db = MagicMock()
         db.get_session.return_value = {"system_prompt": stored}
@@ -433,17 +507,14 @@ class TestIdentityStalenessRebuild:
                 agent, None, [{"role": "user", "content": "hi"}]
             )
 
-        assert agent._cached_system_prompt == "BUILT_PROMPT"
-        agent._build_system_prompt.assert_called_once()
-        db.update_system_prompt.assert_called_once_with(
-            "test-session-id", "BUILT_PROMPT"
-        )
-        assert any("stale identity" in r.getMessage() for r in caplog.records)
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        db.update_system_prompt.assert_not_called()
 
-    def test_trailing_deletion_from_soul_is_detected(self, monkeypatch):
+    def test_trailing_deletion_from_soul_reuses_verbatim(self, monkeypatch):
         """Deleting the TAIL of SOUL.md leaves the new block a prefix of the
-        old one — a bare containment check would still "match". The anchor
-        (help guidance immediately after the identity) catches it."""
+        old one — restore doesn't compare them at all anymore, so the
+        stored prompt is kept regardless."""
         stored = _stored_with_identity("You are concise.\nNever disclose secrets.")
         db = MagicMock()
         db.get_session.return_value = {"system_prompt": stored}
@@ -454,12 +525,13 @@ class TestIdentityStalenessRebuild:
             agent, None, [{"role": "user", "content": "hi"}]
         )
 
-        assert agent._cached_system_prompt == "BUILT_PROMPT"
-        agent._build_system_prompt.assert_called_once()
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
 
-    def test_deleted_soul_falls_back_to_default_and_rebuilds(self, monkeypatch):
-        """SOUL.md removed → the resolver returns the hardcoded default,
-        which a SOUL-built stored prompt does not start with → rebuild."""
+    def test_deleted_soul_reuses_verbatim(self, monkeypatch):
+        """SOUL.md removed → the resolver would return the hardcoded
+        default, but restore never consults it, so the stored (SOUL-built)
+        prompt is kept as-is."""
         stored = _stored_with_identity("CUSTOM SOUL IDENTITY")
         db = MagicMock()
         db.get_session.return_value = {"system_prompt": stored}
@@ -472,8 +544,8 @@ class TestIdentityStalenessRebuild:
             agent, None, [{"role": "user", "content": "hi"}]
         )
 
-        assert agent._cached_system_prompt == "BUILT_PROMPT"
-        agent._build_system_prompt.assert_called_once()
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
 
     def test_matching_identity_reuses_verbatim(self, monkeypatch):
         identity = "CURRENT SOUL IDENTITY"
@@ -530,58 +602,53 @@ class TestIdentityStalenessRebuild:
         agent._build_system_prompt.assert_not_called()
 
 
-class TestSessionStartHookGuard:
-    """on_session_start is documented "not on continuation": a stale-prompt
-    fallthrough is a CONTINUING session getting its prompt rebuilt, so the
-    hook must not re-fire there (it would duplicate session-scoped plugin
-    work). Fresh builds keep firing it."""
+class TestStoredIdentityIsStale:
+    """Direct unit tests of ``stored_identity_is_stale()`` itself (v6 §6-F).
 
-    def test_stale_identity_fallthrough_does_not_fire_hook(self, monkeypatch):
-        stored = _stored_with_identity("OLD SOUL IDENTITY")
-        db = MagicMock()
-        db.get_session.return_value = {"system_prompt": stored}
-        agent = _make_agent(session_db=db)
-        _patch_identity(monkeypatch, "NEW SOUL IDENTITY")
-        hook = MagicMock()
-        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", hook)
+    Its only caller is now the compaction keep-prompt gate
+    (``TestCompactionIdentityDriftGate``), not restore — the indirect
+    coverage above (via ``_restore_or_build_system_prompt``) no longer
+    exercises this function at all, since restore was reverted to main's
+    behavior and never calls it. These pins keep the anchored-detection and
+    fail-open properties covered independent of any caller."""
 
-        _restore_or_build_system_prompt(
-            agent, None, [{"role": "user", "content": "hi"}]
+    def test_trailing_deletion_is_detected_as_stale(self, monkeypatch):
+        """Deleting the TAIL of SOUL.md leaves the new block a prefix of the
+        old one — a bare containment check would still "match". The anchor
+        (help guidance immediately after the identity) catches it."""
+        stored = _stored_with_identity("You are concise.\nNever disclose secrets.")
+        _patch_identity(monkeypatch, "You are concise.")
+
+        assert stored_identity_is_stale(MagicMock(), stored) is True
+
+    def test_undetermined_identity_fails_open(self, monkeypatch):
+        """checkable=True but text="" (no basis to judge, e.g. the file's
+        own autouse neutral-resolver default) must not be called stale."""
+        stored = _stored_with_identity("CUSTOM SOUL IDENTITY")
+        _patch_identity(monkeypatch, "", checkable=True, from_soul=False)
+
+        assert stored_identity_is_stale(MagicMock(), stored) is False
+
+    def test_unreadable_soul_fails_open(self, monkeypatch):
+        """checkable=False = SOUL.md exists but could not be read. Declaring
+        staleness on unreadable input is not safe, so this must fail open."""
+        stored = _stored_with_identity("CUSTOM SOUL IDENTITY")
+        _patch_identity(
+            monkeypatch, "DEFAULT HARDCODED IDENTITY",
+            checkable=False, from_soul=False,
         )
 
-        assert agent._cached_system_prompt == "BUILT_PROMPT"
-        assert not any(
-            c.args and c.args[0] == "on_session_start" for c in hook.call_args_list
-        )
+        assert stored_identity_is_stale(MagicMock(), stored) is False
 
-    def test_fresh_build_still_fires_hook(self, monkeypatch):
-        agent = _make_agent(session_db=None)
-        hook = MagicMock()
-        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", hook)
+    def test_resolver_exception_fails_open(self, monkeypatch):
+        stored = _stored_with_identity("CUSTOM SOUL IDENTITY")
 
-        _restore_or_build_system_prompt(agent, None, [])
+        def _boom(agent):
+            raise RuntimeError("resolver crashed")
 
-        assert any(
-            c.args and c.args[0] == "on_session_start" for c in hook.call_args_list
-        )
+        monkeypatch.setattr("agent.system_prompt.resolve_identity_block", _boom)
 
-    def test_preview_restart_with_parent_history_still_fires_hook(self, monkeypatch):
-        """The preview-restart shape: a brand-new session that deliberately
-        receives nonempty PARENT history but has no session DB. Its start
-        hook is legitimate — a guard keyed on history truthiness (instead of
-        the stale states) would wrongly suppress it."""
-        agent = _make_agent(session_db=None)
-        hook = MagicMock()
-        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", hook)
-
-        _restore_or_build_system_prompt(
-            agent, None, [{"role": "user", "content": "from parent session"}]
-        )
-
-        assert agent._cached_system_prompt == "BUILT_PROMPT"
-        assert any(
-            c.args and c.args[0] == "on_session_start" for c in hook.call_args_list
-        )
+        assert stored_identity_is_stale(MagicMock(), stored) is False
 
 
 class TestResolveIdentityBlockClassification:
@@ -648,6 +715,350 @@ class TestResolveIdentityBlockClassification:
         assert ident["checkable"] is True
         assert ident["from_soul"] is False
         assert ident["text"] == DEFAULT_AGENT_IDENTITY
+
+    def test_absent_hermes_home_is_not_checkable(self, monkeypatch, tmp_path):
+        """v6 class 12: HERMES_HOME itself missing/unmounted is a different
+        failure mode than an existing HERMES_HOME with no SOUL.md inside it
+        (the case above). Nothing here can confirm what identity applies, so
+        this must NOT be checkable — fail open to reuse on restore, rather
+        than confidently reporting "default identity"."""
+        missing_home = tmp_path / "does_not_exist"
+        assert not missing_home.exists()
+        monkeypatch.setenv("HERMES_HOME", str(missing_home))
+
+        ident = _REAL_RESOLVE_IDENTITY(self._resolver_agent())
+
+        assert ident["checkable"] is False
+        assert ident["from_soul"] is False
+
+
+# ---------------------------------------------------------------------------
+# PR #72253 redesign (v6) — pins for the compaction keep-prompt gate
+# (agent/conversation_compression.py). §5 applies identity drift detection
+# ONLY at this gate (the one place AGENTS.md:19-23 already carves out as the
+# explicit exception), not on the restore hot path above. The gate now adds
+# `and not stored_identity_is_stale(...)` to its keep condition (implemented
+# in this diff); the tests below exercise the real, non-xfail behavior.
+# See 72253-redesign-v6.md §6-D.
+# ---------------------------------------------------------------------------
+
+
+class TestCompactionIdentityDriftGate:
+    """Real AIAgent + real SessionDB, mirroring
+    tests/run_agent/test_in_place_compaction.py's harness, so compress_context
+    runs its real locking/persistence path instead of a mocked stand-in."""
+
+    def _make_agent(self, session_db, session_id, cached_prompt):
+        import os
+        from unittest.mock import patch as _patch
+
+        with _patch.dict(os.environ, {"OPENROUTER_API_KEY": "tk"}):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="tk",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=session_db,
+                session_id=session_id,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        agent.compression_in_place = True
+        agent._cached_system_prompt = cached_prompt
+
+        def _fake_compress(messages, current_tokens=None, focus_topic=None, force=False):
+            return [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary of prior turns"},
+                {"role": "assistant", "content": "recent reply"},
+            ]
+
+        agent.context_compressor.compress = _fake_compress
+        agent.context_compressor._last_compress_aborted = False
+        agent.context_compressor._last_summary_error = None
+        agent.context_compressor.compression_count = 1
+        return agent
+
+    def _seed(self, db, sid, n=8):
+        db.create_session(sid, "cli", model="test/model")
+        for i in range(n):
+            db.append_message(
+                session_id=sid,
+                role="user" if i % 2 == 0 else "assistant",
+                content=f"msg {i}",
+            )
+
+    def test_compaction_keeps_prompt_when_identity_unchanged(self, monkeypatch):
+        """Existing keep-prompt optimization (KV-cache retention) must survive
+        the redesign untouched — regression pin, expected to PASS today."""
+        import tempfile
+        from pathlib import Path
+
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        identity = "CURRENT SOUL IDENTITY"
+        stored = _stored_with_identity(identity)
+        monkeypatch.setattr(
+            "agent.system_prompt.resolve_identity_block",
+            lambda agent: {"text": identity, "from_soul": True, "checkable": True},
+        )
+        rebuild = MagicMock(return_value="SHOULD_NOT_BE_USED")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260804_120000_keep01"
+            self._seed(db, sid)
+            agent = self._make_agent(db, sid, stored)
+            agent._build_system_prompt = rebuild
+
+            _compressed, new_sp = compress_context(
+                agent, [{"role": "user", "content": "x"}] * 8,
+                approx_tokens=100_000, system_message="sys",
+            )
+
+            assert new_sp == stored
+            rebuild.assert_not_called()
+            assert db.get_session(sid)["system_prompt"] == stored
+            db.close()
+
+    def test_compaction_rebuilds_prompt_when_soul_changed(self, monkeypatch):
+        """v6 §5: identity drift suppresses the keep optimization so the
+        rebuilt (new-identity) prompt is what gets persisted at the
+        compaction boundary — this is the one place AGENTS.md:19-23 already
+        allows the system prompt to change mid-conversation.
+
+        The keep gate in agent/conversation_compression.py now adds
+        `and not stored_identity_is_stale(agent, cached_system_prompt)` to
+        its existing (cached_system_prompt is not None, _memory_manager is
+        None, _cached_prompt_reflects_builtin_memory) condition, so drift
+        falls through to the rebuild branch instead of keeping stale bytes.
+        """
+        import tempfile
+        from pathlib import Path
+
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        new_prompt = _stored_with_identity("NEW SOUL IDENTITY")
+        monkeypatch.setattr(
+            "agent.system_prompt.resolve_identity_block",
+            lambda agent: {
+                "text": "NEW SOUL IDENTITY", "from_soul": True, "checkable": True
+            },
+        )
+        rebuild = MagicMock(return_value=new_prompt)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260804_120100_drift01"
+            self._seed(db, sid)
+            agent = self._make_agent(db, sid, stored)
+            agent._build_system_prompt = rebuild
+
+            _compressed, new_sp = compress_context(
+                agent, [{"role": "user", "content": "x"}] * 8,
+                approx_tokens=100_000, system_message="sys",
+            )
+
+            assert new_sp == new_prompt, (
+                "expected the keep gate to be suppressed by identity drift "
+                f"and rebuild to reflect it; got stale kept bytes: {new_sp!r}"
+            )
+            rebuild.assert_called_once()
+            assert db.get_session(sid)["system_prompt"] == new_prompt
+            db.close()
+
+    def test_adopted_child_path_passes_through_on_drift(self, monkeypatch):
+        """v6 §4.2 (F6): when another process has already rotated this
+        session via its own compression, the adopting call returns the
+        CHILD's own already-persisted prompt unchanged — never a rebuild,
+        even if that prompt would be judged stale by the current resolver.
+        ``_adopt_live_compression_child`` sets ``agent._cached_system_prompt``
+        to the child's value before this call site reads it, so identity
+        drift on top of that must not trigger a rebuild here. This documents
+        the intentional pass-through rather than relying on it silently."""
+        import tempfile
+        from pathlib import Path
+
+        from hermes_state import SessionDB
+        import agent.conversation_compression as cc_module
+
+        child_prompt = _stored_with_identity("CHILD PERSISTED IDENTITY")
+        _patch_identity(monkeypatch, "SOME OTHER NEW IDENTITY")
+        rebuild = MagicMock(return_value="SHOULD_NOT_BE_USED")
+
+        def _fake_rotated(db, sid):
+            return True
+
+        def _fake_adopt(agent, db, sid):
+            agent._cached_system_prompt = child_prompt
+            return [{"role": "user", "content": "recovered from child"}]
+
+        monkeypatch.setattr(
+            cc_module, "_session_was_rotated_by_compression", _fake_rotated
+        )
+        monkeypatch.setattr(
+            cc_module, "_adopt_live_compression_child", _fake_adopt
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260804_120200_adopt01"
+            self._seed(db, sid)
+            agent = self._make_agent(db, sid, "PARENT STALE PROMPT")
+            agent._build_system_prompt = rebuild
+
+            _compressed, new_sp = cc_module.compress_context(
+                agent, [{"role": "user", "content": "x"}] * 8,
+                approx_tokens=100_000, system_message="sys",
+            )
+
+            assert new_sp == child_prompt, (
+                "adoption path must pass through the child's persisted "
+                f"prompt unchanged despite drift; got {new_sp!r}"
+            )
+            rebuild.assert_not_called()
+            db.close()
+
+
+# ---------------------------------------------------------------------------
+# PR #72253 redesign (v6) — pass-through pins for the CAS (codex_app_server)
+# compression path, which this PR intentionally leaves untouched (v6 §3.2).
+# That path has no system-prompt write-back on `main` or here, so adding
+# drift detection to it would change the in-flight prompt for one turn and
+# then lose it on the next restore. These pins document that limitation
+# rather than relying on it silently. See 72253-redesign-v6.md §6-D item 5.
+# ---------------------------------------------------------------------------
+
+
+class TestCasPassThroughOnDrift:
+    """Mirrors tests/run_agent/test_codex_app_server_compaction.py's
+    DummyAgent/FakeCodexSession pattern — the CAS dispatch in
+    compress_context never acquires the compression lock or touches
+    session_db, so a lightweight fake agent (rather than the real
+    AIAgent+SessionDB harness above) is enough to reach every return form."""
+
+    class _FakeCodexSession:
+        def __init__(self, result):
+            self.result = result
+            self.calls = 0
+
+        def compact_thread(self):
+            self.calls += 1
+            return self.result
+
+        def close(self):
+            pass
+
+    @staticmethod
+    def _cas_agent(cached_prompt, *, auto_compaction, codex_session):
+        from types import SimpleNamespace
+
+        agent = MagicMock()
+        agent.api_mode = "codex_app_server"
+        agent.codex_app_server_auto_compaction = auto_compaction
+        agent.session_id = "cas-drift-session"
+        agent.platform = "cli"
+        agent._cached_system_prompt = cached_prompt
+        agent._codex_session = codex_session
+        agent._build_system_prompt = MagicMock(return_value="SHOULD_NOT_BE_BUILT")
+        agent.context_compressor = SimpleNamespace(
+            compression_count=0,
+            last_compression_rough_tokens=0,
+            last_prompt_tokens=0,
+            last_completion_tokens=0,
+            awaiting_real_usage_after_compression=False,
+        )
+        return agent
+
+    @staticmethod
+    def _run(agent, force):
+        from agent.conversation_compression import compress_context
+
+        return compress_context(
+            agent, [{"role": "user", "content": "hi"}], "sys",
+            approx_tokens=100_000, force=force,
+        )
+
+    def test_skip_native_mode_passes_through_on_drift(self, monkeypatch):
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        _patch_identity(monkeypatch, "NEW SOUL IDENTITY")
+        agent = self._cas_agent(
+            stored, auto_compaction="native", codex_session=None
+        )
+
+        _messages, prompt = self._run(agent, force=False)
+
+        assert prompt == stored
+        agent._build_system_prompt.assert_not_called()
+
+    def test_thread_absent_passes_through_on_drift(self, monkeypatch):
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        _patch_identity(monkeypatch, "NEW SOUL IDENTITY")
+        agent = self._cas_agent(
+            stored, auto_compaction="hermes", codex_session=None
+        )
+
+        _messages, prompt = self._run(agent, force=True)
+
+        assert prompt == stored
+        agent._build_system_prompt.assert_not_called()
+
+    def test_failure_passes_through_on_drift(self, monkeypatch):
+        from agent.transports.codex_app_server_session import TurnResult
+
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        _patch_identity(monkeypatch, "NEW SOUL IDENTITY")
+        session = self._FakeCodexSession(TurnResult(interrupted=True))
+        agent = self._cas_agent(
+            stored, auto_compaction="hermes", codex_session=session
+        )
+
+        _messages, prompt = self._run(agent, force=True)
+
+        assert prompt == stored
+        assert session.calls == 1
+        agent._build_system_prompt.assert_not_called()
+
+    def test_success_passes_through_on_drift(self, monkeypatch):
+        from agent.transports.codex_app_server_session import TurnResult
+
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        _patch_identity(monkeypatch, "NEW SOUL IDENTITY")
+        session = self._FakeCodexSession(TurnResult(compacted=True))
+        agent = self._cas_agent(
+            stored, auto_compaction="hermes", codex_session=session
+        )
+
+        _messages, prompt = self._run(agent, force=True)
+
+        assert prompt == stored, (
+            "CAS success has no system-prompt write-back (v6 F1 residual) "
+            "— identity drift must not reach the returned prompt even on a "
+            f"successful compaction; got {prompt!r}"
+        )
+        assert session.calls == 1
+        agent._build_system_prompt.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestSessionStartHookGuard was removed from this file (v6 §6-B). It pinned
+# on_session_start firing/not-firing across the identity-stale, fresh-build,
+# and preview-restart restore states. This PR only touches the compaction
+# keep-prompt gate, not restore, so the identity-stale restore state it was
+# guarding no longer exists here — it belongs to a follow-up PR that fixes
+# the pre-existing on_session_start double-fire bug for the stale_runtime
+# and null/empty stored-prompt classes in
+# agent/conversation_loop.py's restore path (unrelated to SOUL.md identity).
+# That follow-up PR must carry forward the preview-restart boundary case
+# this class used to pin (a brand-new session that legitimately receives
+# nonempty PARENT history but has no session DB): a guard keyed on history
+# truthiness instead of the specific stale states would wrongly suppress
+# that session's on_session_start hook.
+# ---------------------------------------------------------------------------
 
 
 if __name__ == "__main__":

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from agent.conversation_loop import _restore_or_build_system_prompt
+from agent.system_prompt import stored_identity_is_stale
 
 
 def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
@@ -223,6 +224,78 @@ class TestPromptStabilityInvariant:
 
 
 # ---------------------------------------------------------------------------
+# PR #72253 redesign (v6) — restore-path contract pins (§6-C). Restore never
+# rewrites the stored prompt on identity drift: AGENTS.md:19-23 forbids
+# mid-conversation system-prompt rewrites outside the explicit compression
+# exception, and restore is not that exception. agent/conversation_loop.py
+# was reverted to main's behavior, so _restore_or_build_system_prompt no
+# longer calls stored_identity_is_stale at all; identity drift is instead
+# handled at the compaction keep-prompt gate (TestCompactionIdentityDriftGate).
+# See .claude/archive/72253-redesign-v6.md §6-C for the design rationale.
+# ---------------------------------------------------------------------------
+
+
+class TestV6RedesignFailBeforePins:
+    def test_soul_drift_does_not_rewrite_stored_prompt(self, monkeypatch, caplog):
+        """v6 §1/§6-C-1: SOUL.md drift on restore must NOT rebuild or persist —
+        AGENTS.md:19-23 forbids mid-conversation system-prompt rewrites outside
+        the explicit compression exception. Restore is not that exception.
+
+        _restore_or_build_system_prompt no longer imports or calls
+        stored_identity_is_stale at all (agent/conversation_loop.py was fully
+        reverted to main's behavior), so this reuse holds unconditionally.
+        """
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        _patch_identity(monkeypatch, "NEW SOUL IDENTITY")
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        db.update_system_prompt.assert_not_called()
+
+    def test_restore_does_not_read_soul_md(self, monkeypatch):
+        """v6 §6-A point 2: the restore hot path must not re-read SOUL.md on
+        every reuse turn (no memoization exists for it, unlike
+        reconstruct_static_prefix's retry-loop guard at system_prompt.py:610-614).
+
+        Holds because _restore_or_build_system_prompt no longer calls
+        stored_identity_is_stale (which is what previously chained into
+        resolve_identity_block -> run_agent.load_soul_md on every turn); the
+        real resolver is wired in below to prove that chain is genuinely
+        unreached, not just mocked away.
+        """
+        identity = "CURRENT SOUL IDENTITY"
+        stored = _stored_with_identity(identity)
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        agent.load_soul_identity = True
+        agent.skip_context_files = False
+
+        # Undo the file's autouse neutral-resolver patch for this test only,
+        # so the real resolver (and therefore the real load_soul_md call) is
+        # actually exercised — a fully-mocked resolver would make this pin
+        # vacuous (it would pass regardless of what the restore path does).
+        monkeypatch.setattr(
+            "agent.system_prompt.resolve_identity_block", _REAL_RESOLVE_IDENTITY
+        )
+        soul_reader = MagicMock(return_value=identity)
+        monkeypatch.setattr("run_agent.load_soul_md", soul_reader)
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        soul_reader.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Cross-session static prefix reconstruction (issue #68191 follow-up)
 # ---------------------------------------------------------------------------
 
@@ -377,6 +450,654 @@ class TestReconstructStaticPrefixMemoization:
         assert build.call_count == 1
         assert agent._cached_system_prompt_static == stable
         assert getattr(agent, "_static_rebuild_failed_for", None) is None
+# ---------------------------------------------------------------------------
+# Identity (SOUL.md) staleness on restore — issue #68563
+# ---------------------------------------------------------------------------
+
+from agent.prompt_builder import HERMES_AGENT_HELP_GUIDANCE as _HELP
+# Captured at import time, BEFORE the neutral autouse fixture patches the
+# module attribute — the classification tests exercise the real function.
+from agent.system_prompt import resolve_identity_block as _REAL_RESOLVE_IDENTITY
+
+
+@pytest.fixture(autouse=True)
+def _neutral_identity_resolver(monkeypatch):
+    """Neutralize ``resolve_identity_block`` (#68563) for every test below.
+
+    Restore itself never calls this resolver — it reuses the stored prompt
+    verbatim (see TestV6RedesignFailBeforePins). But the prompt builder and
+    ``stored_identity_is_stale`` (a tested standalone helper with no
+    production caller since #98426's unconditional rebuild absorbed drift
+    propagation) both call it, and several tests below build a real
+    ``AIAgent`` or invoke that helper directly. Running the real resolver
+    against these MagicMock agents would read the test HERMES_HOME and
+    randomly flip the decision, so default it to "no basis to judge" (empty
+    text -> check skipped); the staleness tests below override it with
+    explicit values."""
+    monkeypatch.setattr(
+        "agent.system_prompt.resolve_identity_block",
+        lambda agent: {"text": "", "from_soul": False, "checkable": True},
+    )
+
+
+def _stored_with_identity(identity: str, tail: str = "per-session context") -> str:
+    """Assemble a stored prompt the way the builder joins the stable tier."""
+    return identity.strip() + "\n\n" + _HELP.strip() + "\n\n" + tail
+
+
+def _patch_identity(monkeypatch, text, checkable=True, from_soul=True):
+    monkeypatch.setattr(
+        "agent.system_prompt.resolve_identity_block",
+        lambda agent: {"text": text, "from_soul": from_soul, "checkable": checkable},
+    )
+
+
+class TestIdentityStalenessRebuild:
+    """SOUL.md edits do NOT rebuild the restored prompt (PR #72253 v6
+    redesign). ``AGENTS.md:19-23`` only exempts context compression from the
+    "never rebuild mid-conversation" rule, and restore is not that
+    exception, so drift here must fall through to verbatim reuse — even
+    though ``_stored_prompt_matches_runtime`` already rejects Model/
+    Provider/cwd/Platform drift on its own, unrelated axis. Identity drift
+    reaching a running session is handled at the Hermes-native compaction
+    keep-prompt gate instead (see ``TestCompactionIdentityDriftGate``)."""
+
+    def test_edited_soul_reuses_verbatim(self, monkeypatch, caplog):
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        _patch_identity(monkeypatch, "NEW SOUL IDENTITY")
+
+        with caplog.at_level(logging.INFO, logger="agent.conversation_loop"):
+            _restore_or_build_system_prompt(
+                agent, None, [{"role": "user", "content": "hi"}]
+            )
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        db.update_system_prompt.assert_not_called()
+
+    def test_trailing_deletion_from_soul_reuses_verbatim(self, monkeypatch):
+        """Deleting the TAIL of SOUL.md leaves the new block a prefix of the
+        old one — restore doesn't compare them at all anymore, so the
+        stored prompt is kept regardless."""
+        stored = _stored_with_identity("You are concise.\nNever disclose secrets.")
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        _patch_identity(monkeypatch, "You are concise.")
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+
+    def test_deleted_soul_reuses_verbatim(self, monkeypatch):
+        """SOUL.md removed → the resolver would return the hardcoded
+        default, but restore never consults it, so the stored (SOUL-built)
+        prompt is kept as-is."""
+        stored = _stored_with_identity("CUSTOM SOUL IDENTITY")
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        _patch_identity(
+            monkeypatch, "DEFAULT HARDCODED IDENTITY", from_soul=False
+        )
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+
+    def test_matching_identity_reuses_verbatim(self, monkeypatch):
+        identity = "CURRENT SOUL IDENTITY"
+        stored = _stored_with_identity(identity)
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        _patch_identity(monkeypatch, identity)
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        db.update_system_prompt.assert_not_called()
+
+    def test_unreadable_soul_fails_open_to_reuse(self, monkeypatch):
+        """checkable=False = SOUL.md exists but could not be read. Declaring
+        staleness would persist a default-identity downgrade over a healthy
+        custom identity, so the check must fail open to reuse."""
+        stored = _stored_with_identity("CUSTOM SOUL IDENTITY")
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        _patch_identity(
+            monkeypatch, "DEFAULT HARDCODED IDENTITY",
+            checkable=False, from_soul=False,
+        )
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+
+    def test_resolver_exception_fails_open_to_reuse(self, monkeypatch):
+        stored = _stored_with_identity("CUSTOM SOUL IDENTITY")
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+
+        def _boom(agent):
+            raise RuntimeError("resolver crashed")
+
+        monkeypatch.setattr("agent.system_prompt.resolve_identity_block", _boom)
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+
+
+class TestStoredIdentityIsStale:
+    """Direct unit tests of ``stored_identity_is_stale()`` itself (v6 §6-F).
+
+    It has no production caller. It was originally wired into the
+    compaction keep-prompt gate, but #98426's unconditional rebuild at that
+    boundary replaced the containment-based gate this function attached to
+    — a drifted identity now simply makes the fresh build differ from the
+    cached prompt, which already routes to the rebuild branch on its own,
+    so the gate stopped calling this helper (see
+    ``TestCompactionIdentityDriftGate``). Restore never called it either —
+    it reuses the stored prompt verbatim (see
+    ``TestV6RedesignFailBeforePins``). These pins keep the anchored-detection
+    and fail-open properties covered as a standalone, tested library
+    function in case a future caller needs one."""
+
+    def test_trailing_deletion_is_detected_as_stale(self, monkeypatch):
+        """Deleting the TAIL of SOUL.md leaves the new block a prefix of the
+        old one — a bare containment check would still "match". The anchor
+        (help guidance immediately after the identity) catches it."""
+        stored = _stored_with_identity("You are concise.\nNever disclose secrets.")
+        _patch_identity(monkeypatch, "You are concise.")
+
+        assert stored_identity_is_stale(MagicMock(), stored) is True
+
+    def test_undetermined_identity_fails_open(self, monkeypatch):
+        """checkable=True but text="" (no basis to judge, e.g. the file's
+        own autouse neutral-resolver default) must not be called stale."""
+        stored = _stored_with_identity("CUSTOM SOUL IDENTITY")
+        _patch_identity(monkeypatch, "", checkable=True, from_soul=False)
+
+        assert stored_identity_is_stale(MagicMock(), stored) is False
+
+    def test_unreadable_soul_fails_open(self, monkeypatch):
+        """checkable=False = SOUL.md exists but could not be read. Declaring
+        staleness on unreadable input is not safe, so this must fail open."""
+        stored = _stored_with_identity("CUSTOM SOUL IDENTITY")
+        _patch_identity(
+            monkeypatch, "DEFAULT HARDCODED IDENTITY",
+            checkable=False, from_soul=False,
+        )
+
+        assert stored_identity_is_stale(MagicMock(), stored) is False
+
+    def test_resolver_exception_fails_open(self, monkeypatch):
+        stored = _stored_with_identity("CUSTOM SOUL IDENTITY")
+
+        def _boom(agent):
+            raise RuntimeError("resolver crashed")
+
+        monkeypatch.setattr("agent.system_prompt.resolve_identity_block", _boom)
+
+        assert stored_identity_is_stale(MagicMock(), stored) is False
+
+
+class TestResolveIdentityBlockClassification:
+    """Real-resolver pins for the absent/empty/unreadable provenance split
+    (#68563 review): a readable-but-empty SOUL.md is the documented way to
+    reset to the default personality, so it must stay checkable; only a
+    failed read makes staleness unjudgeable."""
+
+    @staticmethod
+    def _resolver_agent():
+        agent = MagicMock()
+        agent.load_soul_identity = True
+        agent.skip_context_files = False
+        agent.context_compressor = None
+        # No profile-scoped home: _agent_home must resolve to None so the
+        # resolver falls back to the ambient home these tests configure
+        # (a bare MagicMock would fabricate a nonexistent db-derived home
+        # and flip `checkable` — see #50233 home scoping).
+        agent._session_db = None
+        return agent
+
+    @pytest.fixture(autouse=True)
+    def _no_seeding(self, monkeypatch):
+        # ensure_hermes_home may seed a default SOUL.md on first run; these
+        # tests pin the classification of a state the USER created, so the
+        # first-run seeding is out of scope and disabled.
+        monkeypatch.setattr(
+            "hermes_cli.config.ensure_hermes_home", lambda: None
+        )
+
+    def test_readable_empty_soul_is_checkable_default(self):
+        from hermes_constants import get_hermes_home
+
+        from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+
+        soul = get_hermes_home() / "SOUL.md"
+        soul.parent.mkdir(parents=True, exist_ok=True)
+        soul.write_text("   \n\n  ", encoding="utf-8")
+
+        ident = _REAL_RESOLVE_IDENTITY(self._resolver_agent())
+
+        assert ident["checkable"] is True
+        assert ident["from_soul"] is False
+        assert ident["text"] == DEFAULT_AGENT_IDENTITY
+
+    def test_undecodable_soul_is_not_checkable(self):
+        from hermes_constants import get_hermes_home
+
+
+        soul = get_hermes_home() / "SOUL.md"
+        soul.parent.mkdir(parents=True, exist_ok=True)
+        soul.write_bytes(b"\xff\xfe\x9c invalid utf-8 \x80")
+
+        ident = _REAL_RESOLVE_IDENTITY(self._resolver_agent())
+
+        assert ident["checkable"] is False
+        assert ident["from_soul"] is False
+
+    def test_absent_soul_is_checkable_default(self):
+        from hermes_constants import get_hermes_home
+
+        from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+
+        soul = get_hermes_home() / "SOUL.md"
+        assert not soul.exists()
+
+        ident = _REAL_RESOLVE_IDENTITY(self._resolver_agent())
+
+        assert ident["checkable"] is True
+        assert ident["from_soul"] is False
+        assert ident["text"] == DEFAULT_AGENT_IDENTITY
+
+    def test_absent_hermes_home_is_not_checkable(self, monkeypatch, tmp_path):
+        """v6 class 12: HERMES_HOME itself missing/unmounted is a different
+        failure mode than an existing HERMES_HOME with no SOUL.md inside it
+        (the case above). Nothing here can confirm what identity applies, so
+        this must NOT be checkable — fail open to reuse on restore, rather
+        than confidently reporting "default identity"."""
+        missing_home = tmp_path / "does_not_exist"
+        assert not missing_home.exists()
+        monkeypatch.setenv("HERMES_HOME", str(missing_home))
+
+        ident = _REAL_RESOLVE_IDENTITY(self._resolver_agent())
+
+        assert ident["checkable"] is False
+        assert ident["from_soul"] is False
+
+
+# ---------------------------------------------------------------------------
+# PR #72253 redesign (v6) — pins for the compaction keep-prompt gate
+# (agent/conversation_compression.py). §5 applies identity drift detection
+# ONLY at this gate (the one place AGENTS.md:19-23 already carves out as the
+# explicit exception), not on the restore hot path above.
+#
+# Absorbed onto #98426's always-rebuild redesign (rb-72253 rebase, 2026-08):
+# the gate no longer calls `stored_identity_is_stale` at all — #98426 made
+# the prompt rebuild unconditional at every compaction, so a drifted
+# identity now always surfaces as a byte mismatch between the fresh build
+# and the cached prompt, which already routes to the rebuild branch on its
+# own. `stored_identity_is_stale` survives as a standalone resolver (used
+# and unit-tested above), not as a compaction-gate condition. The tests
+# below pin the resulting behavior.
+# See 72253-redesign-v6.md §6-D.
+# ---------------------------------------------------------------------------
+
+
+class TestCompactionIdentityDriftGate:
+    """Real AIAgent + real SessionDB, mirroring
+    tests/run_agent/test_in_place_compaction.py's harness, so compress_context
+    runs its real locking/persistence path instead of a mocked stand-in."""
+
+    def _make_agent(self, session_db, session_id, cached_prompt):
+        import os
+        from unittest.mock import patch as _patch
+
+        with _patch.dict(os.environ, {"OPENROUTER_API_KEY": "tk"}):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="tk",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=session_db,
+                session_id=session_id,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        agent.compression_in_place = True
+        agent._cached_system_prompt = cached_prompt
+
+        def _fake_compress(messages, current_tokens=None, focus_topic=None, force=False):
+            return [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary of prior turns"},
+                {"role": "assistant", "content": "recent reply"},
+            ]
+
+        agent.context_compressor.compress = _fake_compress
+        agent.context_compressor._last_compress_aborted = False
+        agent.context_compressor._last_summary_error = None
+        agent.context_compressor.compression_count = 1
+        return agent
+
+    def _seed(self, db, sid, n=8):
+        db.create_session(sid, "cli", model="test/model")
+        for i in range(n):
+            db.append_message(
+                session_id=sid,
+                role="user" if i % 2 == 0 else "assistant",
+                content=f"msg {i}",
+            )
+
+    def test_compaction_keeps_prompt_when_identity_unchanged(self, monkeypatch):
+        """Object-identity preservation on a byte-equal rebuild (the
+        surviving form of the old keep-prompt KV-cache optimization) must
+        hold — regression pin, expected to PASS today.
+
+        #98426 replaced the containment-based keep-prompt branch with an
+        unconditional rebuild at every compaction (agent/conversation_
+        compression.py, always-rebuild arc #95681): ``_build_system_prompt``
+        is now called on every compaction regardless of drift, and only
+        object identity — not invocation — is what survives when the fresh
+        build is byte-equal to the cached prompt. Asserting non-invocation
+        (the pre-rebase form of this pin) is no longer meaningful; see
+        test_compaction_rebuilds_prompt_when_soul_changed for the drift case.
+        """
+        import tempfile
+        from pathlib import Path
+
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        identity = "CURRENT SOUL IDENTITY"
+        stored = _stored_with_identity(identity)
+        monkeypatch.setattr(
+            "agent.system_prompt.resolve_identity_block",
+            lambda agent: {"text": identity, "from_soul": True, "checkable": True},
+        )
+        rebuild = MagicMock(return_value=stored)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260804_120000_keep01"
+            self._seed(db, sid)
+            agent = self._make_agent(db, sid, stored)
+            agent._build_system_prompt = rebuild
+
+            _compressed, new_sp = compress_context(
+                agent, [{"role": "user", "content": "x"}] * 8,
+                approx_tokens=100_000, system_message="sys",
+            )
+
+            assert new_sp == stored
+            assert new_sp is stored, (
+                "byte-equal rebuild must preserve the cached object identity"
+            )
+            rebuild.assert_called_once()
+            assert db.get_session(sid)["system_prompt"] == stored
+            db.close()
+
+    def test_compaction_rebuilds_prompt_when_soul_changed(self, monkeypatch):
+        """v6 §5: identity drift reaches the persisted prompt at the
+        compaction boundary — this is the one place AGENTS.md:19-23 already
+        allows the system prompt to change mid-conversation.
+
+        Post-#98426 the compaction gate rebuilds unconditionally and only
+        keeps the cached object when the fresh build is byte-equal to it
+        (see agent/conversation_compression.py); it no longer calls
+        `stored_identity_is_stale` at all. Drift falls through to the
+        rebuild branch simply because a drifted identity makes the fresh
+        build differ from the cached bytes — the byte comparison alone is
+        enough, with no separate staleness check required.
+        """
+        import tempfile
+        from pathlib import Path
+
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        new_prompt = _stored_with_identity("NEW SOUL IDENTITY")
+        monkeypatch.setattr(
+            "agent.system_prompt.resolve_identity_block",
+            lambda agent: {
+                "text": "NEW SOUL IDENTITY", "from_soul": True, "checkable": True
+            },
+        )
+        rebuild = MagicMock(return_value=new_prompt)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260804_120100_drift01"
+            self._seed(db, sid)
+            agent = self._make_agent(db, sid, stored)
+            agent._build_system_prompt = rebuild
+
+            _compressed, new_sp = compress_context(
+                agent, [{"role": "user", "content": "x"}] * 8,
+                approx_tokens=100_000, system_message="sys",
+            )
+
+            assert new_sp == new_prompt, (
+                "expected the keep gate to be suppressed by identity drift "
+                f"and rebuild to reflect it; got stale kept bytes: {new_sp!r}"
+            )
+            rebuild.assert_called_once()
+            assert db.get_session(sid)["system_prompt"] == new_prompt
+            db.close()
+
+    def test_adopted_child_path_passes_through_on_drift(self, monkeypatch):
+        """v6 §4.2 (F6): when another process has already rotated this
+        session via its own compression, the adopting call returns the
+        CHILD's own already-persisted prompt unchanged — never a rebuild,
+        even if that prompt would be judged stale by the current resolver.
+        ``_adopt_live_compression_child`` sets ``agent._cached_system_prompt``
+        to the child's value before this call site reads it, so identity
+        drift on top of that must not trigger a rebuild here. This documents
+        the intentional pass-through rather than relying on it silently."""
+        import tempfile
+        from pathlib import Path
+
+        from hermes_state import SessionDB
+        import agent.conversation_compression as cc_module
+
+        child_prompt = _stored_with_identity("CHILD PERSISTED IDENTITY")
+        _patch_identity(monkeypatch, "SOME OTHER NEW IDENTITY")
+        rebuild = MagicMock(return_value="SHOULD_NOT_BE_USED")
+
+        def _fake_rotated(db, sid):
+            return True
+
+        def _fake_adopt(agent, db, sid):
+            agent._cached_system_prompt = child_prompt
+            return [{"role": "user", "content": "recovered from child"}]
+
+        monkeypatch.setattr(
+            cc_module, "_session_was_rotated_by_compression", _fake_rotated
+        )
+        monkeypatch.setattr(
+            cc_module, "_adopt_live_compression_child", _fake_adopt
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260804_120200_adopt01"
+            self._seed(db, sid)
+            agent = self._make_agent(db, sid, "PARENT STALE PROMPT")
+            agent._build_system_prompt = rebuild
+
+            _compressed, new_sp = cc_module.compress_context(
+                agent, [{"role": "user", "content": "x"}] * 8,
+                approx_tokens=100_000, system_message="sys",
+            )
+
+            assert new_sp == child_prompt, (
+                "adoption path must pass through the child's persisted "
+                f"prompt unchanged despite drift; got {new_sp!r}"
+            )
+            rebuild.assert_not_called()
+            db.close()
+
+
+# ---------------------------------------------------------------------------
+# PR #72253 redesign (v6) — pass-through pins for the CAS (codex_app_server)
+# compression path, which this PR intentionally leaves untouched (v6 §3.2).
+# That path has no system-prompt write-back on `main` or here, so adding
+# drift detection to it would change the in-flight prompt for one turn and
+# then lose it on the next restore. These pins document that limitation
+# rather than relying on it silently. See 72253-redesign-v6.md §6-D item 5.
+# ---------------------------------------------------------------------------
+
+
+class TestCasPassThroughOnDrift:
+    """Mirrors tests/run_agent/test_codex_app_server_compaction.py's
+    DummyAgent/FakeCodexSession pattern — the CAS dispatch in
+    compress_context never acquires the compression lock or touches
+    session_db, so a lightweight fake agent (rather than the real
+    AIAgent+SessionDB harness above) is enough to reach every return form."""
+
+    class _FakeCodexSession:
+        def __init__(self, result):
+            self.result = result
+            self.calls = 0
+
+        def compact_thread(self):
+            self.calls += 1
+            return self.result
+
+        def close(self):
+            pass
+
+    @staticmethod
+    def _cas_agent(cached_prompt, *, auto_compaction, codex_session):
+        from types import SimpleNamespace
+
+        agent = MagicMock()
+        agent.api_mode = "codex_app_server"
+        agent.codex_app_server_auto_compaction = auto_compaction
+        agent.session_id = "cas-drift-session"
+        agent.platform = "cli"
+        agent._cached_system_prompt = cached_prompt
+        agent._codex_session = codex_session
+        agent._build_system_prompt = MagicMock(return_value="SHOULD_NOT_BE_BUILT")
+        agent.context_compressor = SimpleNamespace(
+            compression_count=0,
+            last_compression_rough_tokens=0,
+            last_prompt_tokens=0,
+            last_completion_tokens=0,
+            awaiting_real_usage_after_compression=False,
+        )
+        return agent
+
+    @staticmethod
+    def _run(agent, force):
+        from agent.conversation_compression import compress_context
+
+        return compress_context(
+            agent, [{"role": "user", "content": "hi"}], "sys",
+            approx_tokens=100_000, force=force,
+        )
+
+    def test_skip_native_mode_passes_through_on_drift(self, monkeypatch):
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        _patch_identity(monkeypatch, "NEW SOUL IDENTITY")
+        agent = self._cas_agent(
+            stored, auto_compaction="native", codex_session=None
+        )
+
+        _messages, prompt = self._run(agent, force=False)
+
+        assert prompt == stored
+        agent._build_system_prompt.assert_not_called()
+
+    def test_thread_absent_passes_through_on_drift(self, monkeypatch):
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        _patch_identity(monkeypatch, "NEW SOUL IDENTITY")
+        agent = self._cas_agent(
+            stored, auto_compaction="hermes", codex_session=None
+        )
+
+        _messages, prompt = self._run(agent, force=True)
+
+        assert prompt == stored
+        agent._build_system_prompt.assert_not_called()
+
+    def test_failure_passes_through_on_drift(self, monkeypatch):
+        from agent.transports.codex_app_server_session import TurnResult
+
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        _patch_identity(monkeypatch, "NEW SOUL IDENTITY")
+        session = self._FakeCodexSession(TurnResult(interrupted=True))
+        agent = self._cas_agent(
+            stored, auto_compaction="hermes", codex_session=session
+        )
+
+        _messages, prompt = self._run(agent, force=True)
+
+        assert prompt == stored
+        assert session.calls == 1
+        agent._build_system_prompt.assert_not_called()
+
+    def test_success_passes_through_on_drift(self, monkeypatch):
+        from agent.transports.codex_app_server_session import TurnResult
+
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        _patch_identity(monkeypatch, "NEW SOUL IDENTITY")
+        session = self._FakeCodexSession(TurnResult(compacted=True))
+        agent = self._cas_agent(
+            stored, auto_compaction="hermes", codex_session=session
+        )
+
+        _messages, prompt = self._run(agent, force=True)
+
+        assert prompt == stored, (
+            "CAS success has no system-prompt write-back (v6 F1 residual) "
+            "— identity drift must not reach the returned prompt even on a "
+            f"successful compaction; got {prompt!r}"
+        )
+        assert session.calls == 1
+        agent._build_system_prompt.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestSessionStartHookGuard was removed from this file (v6 §6-B). It pinned
+# on_session_start firing/not-firing across the identity-stale, fresh-build,
+# and preview-restart restore states. This PR only touches the compaction
+# keep-prompt gate, not restore, so the identity-stale restore state it was
+# guarding no longer exists here — it belongs to a follow-up PR that fixes
+# the pre-existing on_session_start double-fire bug for the stale_runtime
+# and null/empty stored-prompt classes in
+# agent/conversation_loop.py's restore path (unrelated to SOUL.md identity).
+# That follow-up PR must carry forward the preview-restart boundary case
+# this class used to pin (a brand-new session that legitimately receives
+# nonempty PARENT history but has no session DB): a guard keyed on history
+# truthiness instead of the specific stale states would wrongly suppress
+# that session's on_session_start hook.
+# ---------------------------------------------------------------------------
 
 
 class TestPerResponseSessionWritePath:

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -377,6 +377,277 @@ class TestReconstructStaticPrefixMemoization:
         assert build.call_count == 1
         assert agent._cached_system_prompt_static == stable
         assert getattr(agent, "_static_rebuild_failed_for", None) is None
+# ---------------------------------------------------------------------------
+# Identity (SOUL.md) staleness on restore — issue #68563
+# ---------------------------------------------------------------------------
+
+from agent.prompt_builder import HERMES_AGENT_HELP_GUIDANCE as _HELP
+# Captured at import time, BEFORE the neutral autouse fixture patches the
+# module attribute — the classification tests exercise the real function.
+from agent.system_prompt import resolve_identity_block as _REAL_RESOLVE_IDENTITY
+
+
+@pytest.fixture(autouse=True)
+def _neutral_identity_resolver(monkeypatch):
+    """Restore now consults the identity resolver on every reuse (#68563);
+    running the real one against these MagicMock agents would read the test
+    HERMES_HOME and randomly flip the decision. Default it to "no basis to
+    judge" (empty text -> check skipped, reuse); the staleness tests below
+    override it with explicit values."""
+    monkeypatch.setattr(
+        "agent.system_prompt.resolve_identity_block",
+        lambda agent: {"text": "", "from_soul": False, "checkable": True},
+    )
+
+
+def _stored_with_identity(identity: str, tail: str = "per-session context") -> str:
+    """Assemble a stored prompt the way the builder joins the stable tier."""
+    return identity.strip() + "\n\n" + _HELP.strip() + "\n\n" + tail
+
+
+def _patch_identity(monkeypatch, text, checkable=True, from_soul=True):
+    monkeypatch.setattr(
+        "agent.system_prompt.resolve_identity_block",
+        lambda agent: {"text": text, "from_soul": from_soul, "checkable": checkable},
+    )
+
+
+class TestIdentityStalenessRebuild:
+    """SOUL.md edits must reach continuing sessions (issue #68563).
+
+    ``_stored_prompt_matches_runtime`` only rejects Model/Provider/cwd/
+    Platform drift; identity content drift previously left the stale prompt
+    reused verbatim forever. The check is anchored on the identity block
+    plus ``HERMES_AGENT_HELP_GUIDANCE`` (the always-present next stable
+    component), which supplies the boundary a bare substring lacks."""
+
+    def test_edited_soul_rebuilds_and_persists(self, monkeypatch, caplog):
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        _patch_identity(monkeypatch, "NEW SOUL IDENTITY")
+
+        with caplog.at_level(logging.INFO, logger="agent.conversation_loop"):
+            _restore_or_build_system_prompt(
+                agent, None, [{"role": "user", "content": "hi"}]
+            )
+
+        assert agent._cached_system_prompt == "BUILT_PROMPT"
+        agent._build_system_prompt.assert_called_once()
+        db.update_system_prompt.assert_called_once_with(
+            "test-session-id", "BUILT_PROMPT"
+        )
+        assert any("stale identity" in r.getMessage() for r in caplog.records)
+
+    def test_trailing_deletion_from_soul_is_detected(self, monkeypatch):
+        """Deleting the TAIL of SOUL.md leaves the new block a prefix of the
+        old one — a bare containment check would still "match". The anchor
+        (help guidance immediately after the identity) catches it."""
+        stored = _stored_with_identity("You are concise.\nNever disclose secrets.")
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        _patch_identity(monkeypatch, "You are concise.")
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == "BUILT_PROMPT"
+        agent._build_system_prompt.assert_called_once()
+
+    def test_deleted_soul_falls_back_to_default_and_rebuilds(self, monkeypatch):
+        """SOUL.md removed → the resolver returns the hardcoded default,
+        which a SOUL-built stored prompt does not start with → rebuild."""
+        stored = _stored_with_identity("CUSTOM SOUL IDENTITY")
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        _patch_identity(
+            monkeypatch, "DEFAULT HARDCODED IDENTITY", from_soul=False
+        )
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == "BUILT_PROMPT"
+        agent._build_system_prompt.assert_called_once()
+
+    def test_matching_identity_reuses_verbatim(self, monkeypatch):
+        identity = "CURRENT SOUL IDENTITY"
+        stored = _stored_with_identity(identity)
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        _patch_identity(monkeypatch, identity)
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        db.update_system_prompt.assert_not_called()
+
+    def test_unreadable_soul_fails_open_to_reuse(self, monkeypatch):
+        """checkable=False = SOUL.md exists but could not be read. Declaring
+        staleness would persist a default-identity downgrade over a healthy
+        custom identity, so the check must fail open to reuse."""
+        stored = _stored_with_identity("CUSTOM SOUL IDENTITY")
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        _patch_identity(
+            monkeypatch, "DEFAULT HARDCODED IDENTITY",
+            checkable=False, from_soul=False,
+        )
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+
+    def test_resolver_exception_fails_open_to_reuse(self, monkeypatch):
+        stored = _stored_with_identity("CUSTOM SOUL IDENTITY")
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+
+        def _boom(agent):
+            raise RuntimeError("resolver crashed")
+
+        monkeypatch.setattr("agent.system_prompt.resolve_identity_block", _boom)
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+
+
+class TestSessionStartHookGuard:
+    """on_session_start is documented "not on continuation": a stale-prompt
+    fallthrough is a CONTINUING session getting its prompt rebuilt, so the
+    hook must not re-fire there (it would duplicate session-scoped plugin
+    work). Fresh builds keep firing it."""
+
+    def test_stale_identity_fallthrough_does_not_fire_hook(self, monkeypatch):
+        stored = _stored_with_identity("OLD SOUL IDENTITY")
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        _patch_identity(monkeypatch, "NEW SOUL IDENTITY")
+        hook = MagicMock()
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", hook)
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        assert agent._cached_system_prompt == "BUILT_PROMPT"
+        assert not any(
+            c.args and c.args[0] == "on_session_start" for c in hook.call_args_list
+        )
+
+    def test_fresh_build_still_fires_hook(self, monkeypatch):
+        agent = _make_agent(session_db=None)
+        hook = MagicMock()
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", hook)
+
+        _restore_or_build_system_prompt(agent, None, [])
+
+        assert any(
+            c.args and c.args[0] == "on_session_start" for c in hook.call_args_list
+        )
+
+    def test_preview_restart_with_parent_history_still_fires_hook(self, monkeypatch):
+        """The preview-restart shape: a brand-new session that deliberately
+        receives nonempty PARENT history but has no session DB. Its start
+        hook is legitimate — a guard keyed on history truthiness (instead of
+        the stale states) would wrongly suppress it."""
+        agent = _make_agent(session_db=None)
+        hook = MagicMock()
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", hook)
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "from parent session"}]
+        )
+
+        assert agent._cached_system_prompt == "BUILT_PROMPT"
+        assert any(
+            c.args and c.args[0] == "on_session_start" for c in hook.call_args_list
+        )
+
+
+class TestResolveIdentityBlockClassification:
+    """Real-resolver pins for the absent/empty/unreadable provenance split
+    (#68563 review): a readable-but-empty SOUL.md is the documented way to
+    reset to the default personality, so it must stay checkable; only a
+    failed read makes staleness unjudgeable."""
+
+    @staticmethod
+    def _resolver_agent():
+        agent = MagicMock()
+        agent.load_soul_identity = True
+        agent.skip_context_files = False
+        agent.context_compressor = None
+        return agent
+
+    @pytest.fixture(autouse=True)
+    def _no_seeding(self, monkeypatch):
+        # ensure_hermes_home may seed a default SOUL.md on first run; these
+        # tests pin the classification of a state the USER created, so the
+        # first-run seeding is out of scope and disabled.
+        monkeypatch.setattr(
+            "hermes_cli.config.ensure_hermes_home", lambda: None
+        )
+
+    def test_readable_empty_soul_is_checkable_default(self):
+        from hermes_constants import get_hermes_home
+
+        from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+
+        soul = get_hermes_home() / "SOUL.md"
+        soul.parent.mkdir(parents=True, exist_ok=True)
+        soul.write_text("   \n\n  ", encoding="utf-8")
+
+        ident = _REAL_RESOLVE_IDENTITY(self._resolver_agent())
+
+        assert ident["checkable"] is True
+        assert ident["from_soul"] is False
+        assert ident["text"] == DEFAULT_AGENT_IDENTITY
+
+    def test_undecodable_soul_is_not_checkable(self):
+        from hermes_constants import get_hermes_home
+
+
+        soul = get_hermes_home() / "SOUL.md"
+        soul.parent.mkdir(parents=True, exist_ok=True)
+        soul.write_bytes(b"\xff\xfe\x9c invalid utf-8 \x80")
+
+        ident = _REAL_RESOLVE_IDENTITY(self._resolver_agent())
+
+        assert ident["checkable"] is False
+        assert ident["from_soul"] is False
+
+    def test_absent_soul_is_checkable_default(self):
+        from hermes_constants import get_hermes_home
+
+        from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+
+        soul = get_hermes_home() / "SOUL.md"
+        assert not soul.exists()
+
+        ident = _REAL_RESOLVE_IDENTITY(self._resolver_agent())
+
+        assert ident["checkable"] is True
+        assert ident["from_soul"] is False
+        assert ident["text"] == DEFAULT_AGENT_IDENTITY
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Editing SOUL.md never reached a continuing session: the restore path reuses the persisted system prompt verbatim, and `_stored_prompt_matches_runtime` only rejects Model/Provider/cwd/Platform drift, not identity content drift (#68563).

This PR consolidates identity resolution into `resolve_identity_block()`, now the single source that the prompt builder uses, and pins SOUL.md drift propagation with regression tests. The compaction-gate staleness check earlier versions of this PR added was superseded by #98426's unconditional rebuild at the compaction boundary: a drifted identity now simply makes the fresh build differ from the cached bytes, and the tests here pin that propagation. `stored_identity_is_stale` stays as a tested helper with no production caller today. Restore-path I/O is unchanged (AGENTS.md only exempts context compression from the no-mid-conversation-rewrite rule).
