### PR TITLE
fix(tools): strip degenerate anyOf so Kimi/Moonshot requests don't 400

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1109,6 +1109,29 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     _is_tokenhub = base_url_host_matches(agent._base_url_lower, "tokenhub.tencentmaas.com")
     _is_lmstudio = (agent.provider or "").strip().lower() == "lmstudio"
 
+    # Moonshot's endpoint (Kimi models, direct or routed through Nous /
+    # OpenRouter) rejects tool schemas containing anyOf lists made up of
+    # empty object branches (HTTP 400 "Check the model name and other
+    # parameters"), most commonly shipped by MCP-derived tools. The
+    # construct is a no-op, so strip it for any Kimi-bound request.
+    # Deep-copy first: the sanitizer mutates in place and ``tools_for_api``
+    # references the shared ``agent.tools`` registry (see #27907).
+    _model_l = (agent.model or "").lower()
+    if tools_for_api and (_is_kimi or "kimi" in _model_l):
+        try:
+            import copy as _copy
+            from tools.schema_sanitizer import strip_degenerate_anyof
+            _tools_copy, _n_stripped = strip_degenerate_anyof(
+                _copy.deepcopy(tools_for_api)
+            )
+            if _n_stripped:
+                tools_for_api = _tools_copy
+        except Exception as exc:
+            logger.warning(
+                "%s⚠️ Failed to sanitize tool schemas for Kimi/Moonshot: %s",
+                getattr(agent, "log_prefix", ""), exc,
+            )
+
     # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
     # sentinel (temperature omitted entirely), a numeric override, or None.
     try:

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -11,6 +11,7 @@ import copy
 
 from tools.schema_sanitizer import (
     sanitize_tool_schemas,
+    strip_degenerate_anyof,
     strip_pattern_and_format,
     strip_slash_enum,
 )
@@ -867,3 +868,130 @@ def test_unrename_passes_unknown_keys_through():
 def test_sanitize_property_key_empty_falls_back():
     assert sanitize_property_key("~~~") == "___"
     assert sanitize_property_key("") == "param"
+# ─────────────────────────────────────────────────────────────────────────
+# strip_degenerate_anyof — Moonshot/Kimi strict-validation recovery.
+# Moonshot's chat-completions endpoint (Kimi K2.x/K3, direct or routed via
+# Nous/OpenRouter) 400s the whole request when a tool schema contains an
+# anyOf/oneOf made up solely of empty object branches (e.g. Apollo MCP's
+# tasks_bulk_create array items).
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_strip_degenerate_anyof_all_empty_branches_removed():
+    """The Apollo MCP shape: anyOf of empty object schemas inside array items."""
+    tools = [_tool("bulk_create", {
+        "type": "object",
+        "required": ["tasks_attributes"],
+        "properties": {
+            "tasks_attributes": {
+                "type": "array",
+                "items": {
+                    "required": ["user_id", "type"],
+                    "anyOf": [
+                        {"type": "object", "properties": {}, "required": []},
+                        {"type": "object", "properties": {}, "required": []},
+                        {"type": "object", "properties": {}, "required": []},
+                    ],
+                    "properties": {
+                        "user_id": {"type": "string"},
+                        "type": {"type": "string"},
+                    },
+                },
+            },
+        },
+    })]
+    _, stripped = strip_degenerate_anyof(tools)
+    assert stripped == 1
+    items = tools[0]["function"]["parameters"]["properties"]["tasks_attributes"]["items"]
+    assert "anyOf" not in items
+    # Sibling keys survive intact
+    assert items["required"] == ["user_id", "type"]
+    assert items["properties"]["user_id"]["type"] == "string"
+
+
+def test_strip_degenerate_anyof_mixed_branches_untouched():
+    """A real constrained branch alongside an empty one → leave the anyOf alone."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "value": {
+                "anyOf": [
+                    {"type": "object", "properties": {}, "required": []},
+                    {"type": "string", "enum": ["a", "b"]},
+                ],
+            },
+        },
+    })]
+    _, stripped = strip_degenerate_anyof(tools)
+    assert stripped == 0
+    assert len(tools[0]["function"]["parameters"]["properties"]["value"]["anyOf"]) == 2
+
+
+def test_strip_degenerate_oneof_all_empty_branches_removed():
+    """Same treatment for oneOf."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "value": {
+                "oneOf": [{}, {"type": "object"}],
+            },
+        },
+    })]
+    _, stripped = strip_degenerate_anyof(tools)
+    assert stripped == 1
+    assert "oneOf" not in tools[0]["function"]["parameters"]["properties"]["value"]
+
+
+def test_strip_degenerate_anyof_real_union_untouched():
+    """Legitimate type unions (string | integer) must survive."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "id": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+        },
+    })]
+    _, stripped = strip_degenerate_anyof(tools)
+    assert stripped == 0
+    assert len(tools[0]["function"]["parameters"]["properties"]["id"]["anyOf"]) == 2
+
+
+def test_strip_degenerate_anyof_responses_format_tool():
+    """Responses-format tools ({"name", "parameters"}) are also walked."""
+    tools = [{
+        "type": "function",
+        "name": "t",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "x": {"anyOf": [{"type": "object", "properties": {}, "required": []}]},
+            },
+        },
+    }]
+    _, stripped = strip_degenerate_anyof(tools)
+    assert stripped == 1
+    assert "anyOf" not in tools[0]["parameters"]["properties"]["x"]
+
+
+def test_strip_degenerate_anyof_is_idempotent():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "x": {"anyOf": [{"type": "object", "properties": {}, "required": []}]},
+        },
+    })]
+    _, first = strip_degenerate_anyof(tools)
+    _, second = strip_degenerate_anyof(tools)
+    assert first == 1
+    assert second == 0
+
+
+def test_strip_degenerate_anyof_empty_returns_zero():
+    tools, stripped = strip_degenerate_anyof([])
+    assert tools == []
+    assert stripped == 0
+
+
+def test_strip_degenerate_anyof_none_returns_zero():
+    tools, stripped = strip_degenerate_anyof(None)
+    assert tools is None
+    assert stripped == 0

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -587,3 +587,95 @@ def strip_slash_enum(tools: list[dict]) -> tuple[list[dict], int]:
             stripped,
         )
     return tools, stripped
+
+
+def _is_degenerate_object_branch(branch: Any) -> bool:
+    """True when an anyOf/oneOf branch carries no constraints at all.
+
+    Matches ``{}``, ``{"type": "object"}``, and the MCP-generated
+    ``{"type": "object", "properties": {}, "required": []}`` shape — an
+    empty object schema that accepts everything and constrains nothing.
+    """
+    if not isinstance(branch, dict):
+        return False
+    for key, value in branch.items():
+        if key == "type" and value == "object":
+            continue
+        if key == "properties" and value == {}:
+            continue
+        if key == "required" and value == []:
+            continue
+        return False
+    return True
+
+
+def strip_degenerate_anyof(tools: list[dict]) -> tuple[list[dict], int]:
+    """Strip ``anyOf``/``oneOf`` keywords whose branches are ALL empty
+    object schemas.
+
+    Moonshot AI's chat-completions endpoint (Kimi K2.x/K3, reached directly
+    or via routers like Nous/OpenRouter) rejects tool schemas containing an
+    ``anyOf`` made up of empty object branches — e.g. the Apollo MCP
+    ``tasks_bulk_create`` tool ships
+    ``anyOf: [{"type":"object","properties":{},"required":[]}, ...]`` inside
+    its array ``items`` — failing the whole request with an opaque HTTP 400
+    ("Check the model name and other parameters"). Every other provider
+    tolerates the construct.
+
+    An empty object branch accepts everything, so an ``anyOf`` composed
+    solely of such branches is a no-op — dropping the keyword preserves
+    semantics exactly. Mixed ``anyOf`` lists (any branch with real
+    constraints) are left untouched.
+
+    Args:
+        tools: OpenAI-format or Responses-format tool list, mutated in
+            place. Callers that need to preserve the original should
+            deep-copy first.
+
+    Returns:
+        ``(tools, stripped_count)`` — same list reference plus a count of
+        how many ``anyOf``/``oneOf`` keywords were removed.
+    """
+    if not tools:
+        return tools, 0
+
+    stripped = 0
+
+    def _walk(node: Any) -> None:
+        nonlocal stripped
+        if isinstance(node, dict):
+            for combinator in ("anyOf", "oneOf"):
+                branches = node.get(combinator)
+                if (
+                    isinstance(branches, list)
+                    and branches
+                    and all(_is_degenerate_object_branch(b) for b in branches)
+                ):
+                    node.pop(combinator, None)
+                    stripped += 1
+            for v in node.values():
+                _walk(v)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function")
+        if isinstance(fn, dict):
+            params = fn.get("parameters")
+            if isinstance(params, dict):
+                _walk(params)
+                continue
+        params = tool.get("parameters")
+        if isinstance(params, dict):
+            _walk(params)
+
+    if stripped:
+        logger.info(
+            "schema_sanitizer: stripped %d degenerate anyOf/oneOf keyword(s) "
+            "from tool schemas (Moonshot/Kimi strict-validation recovery)",
+            stripped,
+        )
+    return tools, stripped


### PR DESCRIPTION
## What

Adds `strip_degenerate_anyof()` to `tools/schema_sanitizer.py` and applies it in `build_api_kwargs` for Kimi-bound chat-completions requests. It removes `anyOf`/`oneOf` keywords whose branches are **all** empty object schemas (`{}`, `{"type":"object"}`, or `{"type":"object","properties":{},"required":[]}`). Mixed lists with any real branch are left untouched.

## Why

Moonshot's chat-completions endpoint (Kimi K2.x/K3 — reached directly via api.kimi.com/moonshot.ai, or routed through Nous Portal / OpenRouter) rejects any request whose tool schemas contain an `anyOf` made up solely of empty object branches. The whole request fails with an opaque:

```
HTTP 400: This request is not valid. Check the model name and other parameters. Additional info: Provider returned error
```

The Apollo MCP server ships exactly that shape in `apollo_tasks_bulk_create` — `anyOf: [{"type":"object","properties":{},"required":[]}, ...]` × 3 inside its array `items`. Any Hermes session with Apollo attached bricks **every** Kimi turn, while all other models (GLM, Claude, GPT, DeepSeek…) tolerate the construct, which makes this very hard for users to diagnose.

Since an empty object branch accepts everything, an `anyOf` composed only of such branches constrains nothing — dropping the keyword is semantically a no-op.

Implementation mirrors the existing recovery sanitizers (`strip_pattern_and_format` / `strip_slash_enum`): mutate-in-place contract with `(tools, count)` return, and the call site deep-copies first so the shared `agent.tools` registry is never mutated (same rationale as the xAI sanitizer call, see #27907).

## How to test

- `scripts/run_tests.sh tests/tools/test_schema_sanitizer.py` — 8 new unit tests cover the Apollo shape (nested in array `items`, siblings preserved), mixed/legit `anyOf` unions left untouched, `oneOf`, Responses-format tools, idempotency, and empty/None inputs.
- Reproduction: connect the Apollo MCP server (https://mcp.apollo.io), select `moonshotai/kimi-k3` via Nous, send any message → 400 before this patch, normal response after. Verified by replaying the captured request dump (`~/.hermes/sessions/request_dump_*.json`) against `inference-api.nousresearch.com`: unsanitized payload 400s, sanitized payload returns 200 from Moonshot AI with all 73 tools attached.

## Platforms tested

macOS (Apple Silicon, Python 3.11 venv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)