### PR TITLE
fix(providers): resolve named custom provider keys to CustomProfile

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -69,8 +69,29 @@ def get_provider_profile(name: str) -> ProviderProfile | None:
     """
     if not _discovered:
         _discover_providers()
-    canonical = _ALIASES.get(name, name)
+    canonical = _normalize_for_lookup(name)
     return _REGISTRY.get(canonical)
+
+
+def _normalize_for_lookup(name: str) -> str:
+    """Resolve a caller-supplied provider name to its registry key.
+
+    Mirrors the alias table for the common case, and additionally collapses
+    a *named* custom provider key (``custom:<name>``) down to ``custom``.
+    Such a qualified key is what survives on ``agent.provider`` after a
+    fallback activation (the resolution path keeps the pool/provider key),
+    so without this normalization the profile lookup returns None and the
+    request falls into the legacy unknown-provider path — silently dropping
+    the ``CustomProfile`` hooks (notably top-level ``reasoning_effort``)
+    even though the same model works as a primary (issue #72202).
+
+    Only the ``custom:`` prefix is case-folded (config-defined names are
+    arbitrary user strings); every other lookup keeps the original
+    case-sensitive alias-table semantics.
+    """
+    if (name or "").lower().startswith("custom:"):
+        name = "custom"
+    return _ALIASES.get(name, name)
 
 
 def list_providers() -> list[ProviderProfile]:

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -22,6 +22,29 @@ class TestRegistry:
     def test_unknown_provider_returns_none(self):
         assert get_provider_profile("nonexistent-provider") is None
 
+    def test_named_custom_provider_resolves_to_custom_profile(self):
+        """A named custom provider key (``custom:<name>``) — e.g. one left
+        on ``agent.provider`` after fallback activation — must resolve to the
+        generic ``CustomProfile`` so its ``build_api_kwargs_extras`` hook
+        (which emits top-level ``reasoning_effort``) still runs. Without this,
+        the lookup returned None and the request fell into the legacy
+        unknown-provider path, silently dropping ``reasoning_effort`` on
+        fallback (issue #72202).
+        """
+        # Canonical name and alias resolve as before.
+        assert get_provider_profile("custom").name == "custom"
+        assert get_provider_profile("ollama").name == "custom"
+
+        # Named custom keys now resolve to the same CustomProfile regardless
+        # of case or the suffix after the colon.
+        for key in ("custom:cpa", "custom:CPA", "custom:my-endpoint"):
+            resolved = get_provider_profile(key)
+            assert resolved is not None, f"{key!r} should resolve, got None"
+            assert resolved.name == "custom", (
+                f"{key!r} should resolve to the custom profile, "
+                f"got {resolved.name!r}"
+            )
+
     def test_all_providers_have_name(self):
         get_provider_profile("nvidia")  # trigger discovery
         for name, profile in _REGISTRY.items():


### PR DESCRIPTION
## Summary

A named custom provider key (``custom:<name>``) — e.g. one left on ``agent.provider`` after fallback activation — was not resolved by the provider registry, which only contains ``custom``. ``get_provider_profile(\"custom:cpa\")`` returned ``None``, so the request fell into the legacy unknown-provider path and the ``CustomProfile`` hooks (notably top-level ``reasoning_effort`` via ``build_api_kwargs_extras``) were never invoked. The same model worked as a primary because initial resolution normalizes the qualified key away — only the fallback path left it intact.

This silently dropped ``reasoning_effort`` on any named-custom-provider fallback (controlled reproduction in #72202).

## Fix

Collapse any ``custom:<name>`` key to ``custom`` inside the registry lookup (``providers.get_provider_profile``), the single chokepoint every caller funnels through (``build_api_kwargs``, auxiliary client, model fetch, plugin discovery). Only the ``custom:`` prefix is case-folded (config-defined names are arbitrary user strings); every other lookup keeps the existing case-sensitive alias-table semantics.

This mirrors the reporter's \"one shared helper\" suggestion in #72202 and fixes both profile-lookup call sites at once (``chat_completion_helpers.py:1160`` and ``:2095``) rather than normalizing per call site.

## Root cause (per #72202)

- Initial resolution normalizes ``custom:CPA`` → ``custom`` → ``get_provider_profile(\"custom\")`` → ``CustomProfile`` ✓
- After fallback, ``agent.provider`` stays the qualified pool/provider key ``custom:cpa``
- ``get_provider_profile(\"custom:cpa\")`` → registry miss → ``None``
- → legacy unknown-provider path; ``is_custom_provider = (agent.provider == \"custom\")`` is also ``False`` for the qualified key
- → ``CustomProfile.build_api_kwargs_extras()`` (which emits top-level ``reasoning_effort``) never runs

Verified the legacy path's ``is_custom_provider`` check at ``agent/chat_completion_helpers.py`` also misclassified the qualified key — confirming the profile-path fix is the correct resolution.

## Test plan

- [x] New regression test ``test_named_custom_provider_resolves_to_custom_profile`` in ``tests/providers/test_provider_profiles.py`` — asserts ``custom``, ``ollama``, ``custom:cpa``, ``custom:CPA``, ``custom:my-endpoint`` all resolve to the ``custom`` profile. Fails on main (``'custom:cpa' should resolve, got None``), passes with the fix.
- [x] Full ``tests/providers/`` suite: **63 passed**.
- [x] Provider resolution + reasoning suites (``test_runtime_provider_resolution.py``, ``test_reasoning_effort_menu.py``): **279 passed** total, no regressions.
- [x] ``ruff check`` clean on changed files.
- [ ] CI green (no API keys in the new test; hermetic).

## Scope

Single 8-line helper + one registry test. No behavioral change for any existing provider name or alias (verified no registry/alias key contains uppercase, and lowering changes zero canonical resolutions for existing inputs).

Fixes #72202.