### PR TITLE
fix(anthropic): stop JSON-serializing text-only tool-result content parts

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2186,7 +2186,15 @@ def _convert_tool_message_to_result(
             ]
     elif isinstance(content, list):
         converted = _content_parts_to_anthropic_blocks(content)
-        if any(b.get("type") == "image" for b in converted):
+        # Keep the converted blocks whether or not an image survived. A
+        # text-only parts list is the normal shape after compaction prunes a
+        # screenshot (_strip_image_parts_from_parts swaps the image for a text
+        # placeholder and keeps the list), and Anthropic accepts a text-block
+        # list as tool_result content. Gating on an image dropped that list on
+        # the floor and fell through to json.dumps() below, so the model read
+        # its own tool output as a serialized array with the newlines escaped.
+        # An empty conversion still falls through to the existing fallback.
+        if converted:
             multimodal_blocks = converted
     # Back-compat: some callers stash blocks under a private key.
     if multimodal_blocks is None:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1190,6 +1190,80 @@ class TestConvertMessages:
         assert tool_use["id"] == "tc_1"
         assert tool_use["cache_control"] == {"type": "ephemeral"}
 
+    def test_tool_result_text_only_parts_are_not_json_serialized(self):
+        """After compaction prunes a screenshot, a tool result's content is a
+        text-only parts LIST (_strip_image_parts_from_parts swaps the image for
+        a text placeholder and keeps the list). Gating the converted blocks on
+        "did an image survive" threw that list away and fell through to
+        json.dumps(), so the model read its own tool output as a serialized
+        array with every newline escaped."""
+        tool_text = "$ pytest -q\n....F...\nFAILED tests/test_auth.py::test_login"
+        messages = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "run the tests"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc_1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "tc_1",
+                "content": [
+                    {"type": "text", "text": tool_text},
+                    {"type": "text", "text": "[screenshot removed to save context]"},
+                ],
+            },
+        ]
+
+        _system, converted = convert_messages_to_anthropic(messages)
+        result = next(
+            b
+            for m in converted
+            for b in (m.get("content") or [])
+            if isinstance(b, dict) and b.get("type") == "tool_result"
+        )
+        content = result["content"]
+        assert isinstance(content, list), (
+            "text-only tool-result parts were JSON-serialized onto the wire"
+        )
+        assert content[0]["type"] == "text"
+        # The real output must survive verbatim, newlines intact.
+        assert content[0]["text"] == tool_text
+
+    def test_tool_result_plain_string_content_is_unchanged(self):
+        """Negative control: an ordinary string tool result still goes out as a
+        plain string, and an empty one still gets the placeholder."""
+        messages = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc_1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": "plain output"},
+        ]
+        _system, converted = convert_messages_to_anthropic(messages)
+        result = next(
+            b
+            for m in converted
+            for b in (m.get("content") or [])
+            if isinstance(b, dict) and b.get("type") == "tool_result"
+        )
+        assert result["content"] == "plain output"
+
     def test_ordered_replay_tool_use_cache_control_is_preserved(self):
         messages = apply_anthropic_cache_control([
             {"role": "system", "content": "System prompt"},


### PR DESCRIPTION
## Summary

`_convert_tool_message_to_result` converts a tool message's content-parts list
into Anthropic blocks and then throws the result away unless an image survived.
For a text-only list the conversion is discarded and the tail falls through to
`json.dumps(content)` — so the model reads its own tool output as a serialized
array with every newline escaped.

The producer is ordinary compaction, not an error path, and the mangled shape
is persisted, so it repeats on every later request for the rest of the session.

## Problem

`agent/anthropic_adapter.py`:

```python
elif isinstance(content, list):
    converted = _content_parts_to_anthropic_blocks(content)
    if any(b.get("type") == "image" for b in converted):
        multimodal_blocks = converted
...
if multimodal_blocks:
    result_content = multimodal_blocks
elif isinstance(content, str):
    result_content = content
else:
    result_content = json.dumps(content) if content else "(no output)"
```

`converted` is already a valid list of Anthropic `text` blocks. With no image
the gate fails, `multimodal_blocks` stays `None`, and since `content` is a list
rather than a `str`, the final branch serializes it.

### How a tool result becomes a text-only list

This is the normal compaction path, not a corner case. A computer_use / browser
screenshot result arrives as `[text, image]`. Under context pressure the
compressor's "replace old tool results with informative summaries" pass calls
`_demote_tool_result_at`, and `_strip_image_parts_from_parts`:

```python
if ptype in {"image", "image_url", "input_image"}:
    had_image = True
    out.append({"type": "text", "text": "[screenshot removed to save context]"})
else:
    out.append(part)
return out if had_image else None
```

replaces the image with a text placeholder and **keeps the list**. That list is
written back into history, so it is re-sent on every subsequent turn. It never
converts back.

### Measured end to end, with the real compressor helper and the real adapter

| | `tool_result.content` | what the model reads |
|---|---|---|
| before compaction | `list` — `['text', 'image']` | the tool output |
| after compaction (`main`) | `str` | `[{"type": "text", "text": "$ pytest -q\n....F...\nFAILED …` |
| after compaction (patched) | `list` — `['text', 'text']` | `$ pytest -q` / `....F...` / `FAILED …` |

Every newline becomes a literal `\n` and the block scaffolding rides along, so
terminal, file and diff output lose their line structure. It also inflates the
payload — 1.56× on the sample above — on every turn.

Nothing errors, nothing is logged, the request succeeds. That is why it has
survived: the only symptom is the agent misreading and re-fetching things it
already had.

## Fix

Keep `converted` whenever it is non-empty. Anthropic accepts a text-block list
as `tool_result.content`, and an empty conversion still falls through to the
existing `"(no output)"` / `json.dumps` fallback, so no new failure mode is
introduced.

## Scope

- `agent/anthropic_adapter.py` — one condition in
  `_convert_tool_message_to_result`.
- `tests/agent/test_anthropic_adapter.py` — 2 regression tests.

## Testing

- `test_tool_result_text_only_parts_are_not_json_serialized` — the
  post-compaction shape (`[text, "[screenshot removed to save context]"]`)
  reaches the wire as a text-block list with the tool output verbatim,
  newlines intact.
- `test_tool_result_plain_string_content_is_unchanged` — negative control: an
  ordinary string result still goes out as a plain string.

Verified across all four content shapes; only the text-only-list case changes:

```
main     text_image=list(['text','image'])  text_only=str            plain_str=str  empty=str
patched  text_image=list(['text','image'])  text_only=list(['text','text'])  plain_str=str  empty=str
```

No test previously referenced `_convert_tool_message_to_result` or
`_content_parts_to_anthropic_blocks`; the existing multimodal test pins the
`_multimodal` envelope **with** an image, and the other tool-message tests use
string content, so the text-only-list case was unpinned.

## Notes

`agent/bedrock_adapter.py` has the same
`content if isinstance(content, str) else json.dumps(content)` shape and
deserves the same treatment — left out here to keep the change to one adapter.
Happy to fold it in.

This touches the same file as #72226; if that lands first this needs only a
trivial rebase (the two hunks are far apart).
