### PR TITLE
fix(auxiliary): never release Codex client FDs from the timeout Timer

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1138,18 +1138,47 @@ class _CodexCompletionsAdapter:
         deadline = time.monotonic() + float(total_timeout) if total_timeout else None
         timed_out = threading.Event()
         timeout_timer: Optional[threading.Timer] = None
+        # The thread driving this request owns its transport's file
+        # descriptors — see the ownership note in _close_client_on_timeout.
+        owner_tid = threading.get_ident()
 
         def _timeout_message() -> str:
             return f"Codex auxiliary Responses stream exceeded {float(total_timeout):.1f}s total timeout"
 
         def _close_client_on_timeout() -> None:
             timed_out.set()
-            close = getattr(self._client, "close", None)
-            if callable(close):
+            # FD-ownership contract (#29507 / #67142 / #70773): only the thread
+            # driving the request may RELEASE this client's file descriptors.
+            # This callback has two callers — ``_check_cancelled()`` on the
+            # owning thread, and the daemon ``threading.Timer`` below, which is
+            # a stranger thread. From a stranger thread we may only
+            # ``shutdown()`` the pooled sockets: ``close()`` releases the raw
+            # TLS fd while the owner's OpenSSL BIO still caches that integer,
+            # the kernel recycles it into the next ``open()`` in this process
+            # (a SessionDB / kanban.db handle), and the owner's unwinding TLS
+            # flush writes an application-data record into that database file.
+            # ``shutdown()`` from any thread is FD-safe; ``close()`` is not.
+            # The owning thread performs the real close in the ``finally``
+            # below, which is where the FD release belongs.
+            if threading.get_ident() == owner_tid:
+                close = getattr(self._client, "close", None)
+                if callable(close):
+                    try:
+                        close()
+                    except Exception:
+                        logger.debug("Codex auxiliary: client close during timeout failed", exc_info=True)
+            else:
                 try:
-                    close()
+                    from agent.agent_runtime_helpers import force_close_tcp_sockets
+
+                    shutdown_count = force_close_tcp_sockets(self._client)
+                    logger.info(
+                        "Codex auxiliary client aborted (timeout, tcp_force_closed=%d, "
+                        "deferred_close=stranger_thread)",
+                        shutdown_count,
+                    )
                 except Exception:
-                    logger.debug("Codex auxiliary: client close during timeout failed", exc_info=True)
+                    logger.debug("Codex auxiliary: client abort during timeout failed", exc_info=True)
             # The cached auxiliary client wraps this same ``self._client``
             # (or *is* a ``CodexAuxiliaryClient`` whose ``_real_client`` is
             # this instance).  After we close the httpx transport above, the
@@ -1274,6 +1303,19 @@ class _CodexCompletionsAdapter:
         finally:
             if timeout_timer is not None:
                 timeout_timer.cancel()
+            # A stranger-thread timeout only shut the sockets down; the FDs are
+            # still open and this — the owning thread, now unwound — is the one
+            # context that may release them (#29507).
+            if timed_out.is_set():
+                close = getattr(self._client, "close", None)
+                if callable(close):
+                    try:
+                        close()
+                    except Exception:
+                        logger.debug(
+                            "Codex auxiliary: owner-thread close after timeout failed",
+                            exc_info=True,
+                        )
 
         content = "".join(text_parts).strip() or None
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3,6 +3,7 @@
 import base64
 import json
 import logging
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, AsyncMock
@@ -5277,6 +5278,119 @@ class TestCodexAuxiliaryAdapterTimeout:
             )
 
         assert time.monotonic() - started < 0.14
+
+
+class TestCodexAuxiliaryTimeoutFdOwnership:
+    """Regression: the timeout Timer must not release the client's FDs.
+
+    ``close()`` from a thread that does not own the in-flight httpx connection
+    releases the raw TLS fd while the owner's OpenSSL BIO still caches that
+    integer. The kernel can hand the same integer to the next ``open()`` in the
+    process — a SessionDB or kanban.db handle — and the owner's unwinding TLS
+    flush then writes an application-data record into that database file
+    (#29507 / #67142 / #70773). ``shutdown()`` is FD-safe from any thread;
+    ``close()`` is not, so it belongs to the owning thread.
+    """
+
+    @staticmethod
+    def _adapter_with_recording_client(stream):
+        """Build an adapter whose client records (action, thread) events.
+
+        The nested ``_client._transport._pool._connections`` shape is what
+        ``force_close_tcp_sockets`` traverses.
+        """
+        events = []
+
+        class _Sock:
+            def shutdown(self, how):
+                events.append(("shutdown", threading.get_ident()))
+
+            def close(self):
+                events.append(("sock.close", threading.get_ident()))
+
+        sock = _Sock()
+
+        class _Conn:
+            def __init__(self):
+                self._connection = self
+                self._network_stream = self
+
+            def get_extra_info(self, name):
+                return sock if name == "socket" else None
+
+        class _Client:
+            def __init__(self):
+                self._transport = SimpleNamespace(
+                    _pool=SimpleNamespace(_connections=[_Conn()])
+                )
+
+        class _LeafClient:
+            def __init__(self):
+                self._client = _Client()
+                self.responses = SimpleNamespace(create=lambda **kw: stream)
+
+            def close(self):
+                events.append(("client.close", threading.get_ident()))
+
+        return _CodexCompletionsAdapter(_LeafClient(), "gpt-5.5"), events
+
+    def test_stalled_stream_timeout_does_not_release_fds_from_timer_thread(self):
+        """The Timer fires on a stalled stream — it may only shutdown()."""
+
+        class _StalledStream:
+            def __iter__(self):
+                # No event ever arrives, so the owner-thread ``_check_cancelled``
+                # hook never runs and the Timer is the only thing that can fire.
+                time.sleep(1.5)
+                return
+                yield  # pragma: no cover
+
+            def close(self):
+                pass
+
+        owner_tid = threading.get_ident()
+        adapter, events = self._adapter_with_recording_client(_StalledStream())
+
+        with pytest.raises(TimeoutError):
+            adapter.create(
+                messages=[{"role": "user", "content": "summarize this"}],
+                timeout=0.05,
+            )
+
+        stranger = [action for action, tid in events if tid != owner_tid]
+        assert stranger, "the timeout callback never ran on the Timer thread"
+        # The stranger thread may shut sockets down, but must never release a FD.
+        assert all(action == "shutdown" for action in stranger), events
+        assert "client.close" not in stranger
+        assert "sock.close" not in stranger
+
+    def test_owner_thread_releases_fds_after_a_stranger_thread_timeout(self):
+        """Deferring the close still has to actually happen — on the owner."""
+
+        class _StalledStream:
+            def __iter__(self):
+                time.sleep(1.5)
+                return
+                yield  # pragma: no cover
+
+            def close(self):
+                pass
+
+        owner_tid = threading.get_ident()
+        adapter, events = self._adapter_with_recording_client(_StalledStream())
+
+        with pytest.raises(TimeoutError):
+            adapter.create(
+                messages=[{"role": "user", "content": "summarize this"}],
+                timeout=0.05,
+            )
+
+        owner_actions = [action for action, tid in events if tid == owner_tid]
+        assert "client.close" in owner_actions, events
+        # Ordering matters: shutdown unblocks the owner, then the owner closes.
+        assert [a for a, _ in events].index("shutdown") < [
+            a for a, _ in events
+        ].index("client.close")
 
 
 class TestCodexAuxiliaryToolMessageConversion:


### PR DESCRIPTION
## Summary

`_CodexCompletionsAdapter.create` arms a daemon `threading.Timer` that calls `client.close()` when the auxiliary Responses stream exceeds its timeout. On a **stalled** stream — the exact failure the timeout exists for — the Timer is the only thing that fires, so `close()` runs on a thread that does not own the in-flight httpx connection.

That is the file-descriptor ownership violation this repo has already fixed twice on the main transport (#29507, #67142, #70773). `agent/auxiliary_client.py` never received the same treatment: it contains no thread-ownership machinery at all.

## Problem

The rule is stated in the repo's own guard, `agent/agent_runtime_helpers.py:3505` `force_close_tcp_sockets`:

> `shutdown()` from any thread is FD-safe; `close()` is not.

and its docstring spells out the consequence: the `ssl.SSLSocket`'s OpenSSL `BIO` caches the raw integer fd, so once `os.close(fd)` runs the kernel may immediately recycle that integer to the next `open()` — "e.g. the kanban dispatcher opening `kanban.db`" — and the owning thread's unwinding TLS flush writes the encrypted bytes into the wrong file (#29507: a 24-byte TLS application-data record clobbering SQLite header bytes 5..28).

**The guarded twins** enforce exactly this, and their comments name the hazard:

- `run_agent.py:4393` `_retire_shared_openai_client` — *"Only an owner may release FDs … So nobody calls close(): we shutdown() the pooled sockets … and defer the actual FD release to garbage collection."*
- `run_agent.py:4553` `_abort_request_openai_client` — *"Calling `client.close()` from a thread that does not own the active httpx connection raced the still-live SSL BIO and corrupted unrelated file descriptors when the kernel recycled the just-freed TCP FD (#29507)."*
- Dispatched at `agent/chat_completion_helpers.py:2594-2620` via `stranger_thread = ... owner_tid != threading.get_ident()`.

**The unguarded path.** `agent/auxiliary_client.py:1150`, inside `_close_client_on_timeout`:

```python
close = getattr(self._client, "close", None)
if callable(close):
    close()          # <- runs on the threading.Timer thread
```

`grep -n "get_ident|force_close_tcp_sockets|SHUT_RDWR|shutdown(" agent/auxiliary_client.py` returns **zero hits**. The guarded twins live in `run_agent.py` and are unreachable here — `_CodexCompletionsAdapter` holds no `AIAgent` reference.

The same callback is invoked from two threads with no dispatch between them: `_check_cancelled()` runs it on the **owning** thread (safe), and the `threading.Timer` armed at line 1186 runs it on a **stranger** thread (unsafe). Once the Timer sets `timed_out`, line 1166's `if not timed_out.is_set()` means the stranger-thread close is the *only* close.

**Why the Timer wins.** `_check_cancelled` is reachable only from `_on_each_event`, i.e. only when an SSE event actually arrives. The Timer fires at the deadline unconditionally. On a stalled body no event ever arrives, so the owner-thread path cannot run at all.

**Trigger.** Main or auxiliary provider on a Responses-only backend (`openai-codex` ChatGPT OAuth, or `xai-oauth`) — `_resolve_auto` Step 1 routes aux tasks to the user's main provider, so this needs no extra config. Then any ordinary long session where compression, `flush_memories`, MoA aggregation or title generation exceeds its timeout while still streaming. `_effective_aux_timeout` always returns a positive value (`_DEFAULT_AUX_TIMEOUT = 30.0`; compression floored at 300s), so the Timer is always armed.

**Blast radius.** The leaf client is process-global (`_client_cache`, keyed per provider/model) and shared across compression, memory flush, MoA, title generation, session_search and web_tools — and `AsyncCodexAuxiliaryClient` runs the same sync adapter on `asyncio.to_thread` workers, so the Timer's `close()` can also kill a connection owned by an unrelated worker thread.

### Reproduced

Both legs of the causal chain, in-process, driving the real `_CodexCompletionsAdapter`:

```
=== leg 1: which thread calls close() ? ===
owner (calling) thread : 4344
close() ran on thread  : 14440
STRANGER-THREAD CLOSE  : True

=== leg 2: is that fd recycled into the database ? ===
fd released by Timer   : 3
fd handed to open(db)  : 3
SAME FD NUMBER         : True
state.db header now    : b'\x17\x03\x03\x00\x13^W^Q]H-\xca\xff\xb1\xc3'
still 'SQLite format 3': False
```

The 24-byte TLS application-data record lands on the SQLite header — the documented #29507 signature. Corruption there sends `SessionDB` down the quarantine path, which opens a **fresh empty database**: every session in the old file is gone from the running product. There is no spill file, no `active=0` twin (the damaged bytes *are* the storage), no content-bearing log, and `create_quick_snapshot` is not continuous — it runs on `hermes update` and deliberately skips a large `state.db`.

## Fix

Dispatch on ownership, mirroring `agent/chat_completion_helpers.py`:

- Capture `owner_tid = threading.get_ident()` at the top of `create()`.
- In `_close_client_on_timeout`, the **owning** thread keeps closing directly; a **stranger** thread only calls `force_close_tcp_sockets()` (`shutdown(SHUT_RDWR)`), which unblocks the owner's pending `recv` without releasing any fd.
- The owning thread then performs the real `close()` in the `finally` once it has unwound — where the FD release belongs.

Cache eviction on timeout (#23432) is unchanged.

## Scope

- `agent/auxiliary_client.py` — ownership dispatch in `_close_client_on_timeout`; owner-side close in the existing `finally`. No change to timeout values, retry behaviour, cache eviction, or the Responses streaming logic.
- Not addressed here: #46390 (open) touches auxiliary client lifecycle but explicitly lists *"no timeout timer / ownership redesign"* as a non-goal, so the two do not overlap. #25064 previously edited this same callback for cache-eviction reasons and reasoned only that "close() is safe to call twice" — it did not consider FD ownership.

## Testing

New `TestCodexAuxiliaryTimeoutFdOwnership` in `tests/agent/test_auxiliary_client.py`, built on the nested `_client._transport._pool._connections` shape that `force_close_tcp_sockets` traverses, recording `(action, thread)` for every socket operation:

- `test_stalled_stream_timeout_does_not_release_fds_from_timer_thread` — on a stalled stream the stranger thread performs `shutdown` and **never** `client.close` / `sock.close`.
- `test_owner_thread_releases_fds_after_a_stranger_thread_timeout` — the deferred close still happens, on the owner, and strictly after the `shutdown`.

Both **fail on `main`** and pass here:

```
2 failed, 2 passed    <- on main (the 2 passing are the pre-existing timeout tests)
4 passed              <- with this change
```

```bash
python -m pytest tests/agent/test_auxiliary_client.py -o addopts= -q
364 passed
```

```bash
python -m pytest tests/run_agent/test_70773_shared_client_fd_corruption.py \
  tests/run_agent/test_tls_fd_recycle_corruption.py \
  tests/agent/test_auxiliary_compression_timeout_floor.py \
  tests/agent/test_auxiliary_transient_retry.py -o addopts= -q
27 passed
```

The two pre-existing tests in `TestCodexAuxiliaryAdapterTimeout` pass unmodified, so timeout forwarding and timing behaviour are unchanged.
