### PR TITLE
feat(mcp): add Korean fire regulations catalog entry

### DIFF
--- a/optional-mcps/fire-regulations/manifest.yaml
+++ b/optional-mcps/fire-regulations/manifest.yaml
@@ -1,0 +1,55 @@
+# Nous-approved MCP catalog entry proposal.
+# Inclusion requires maintainer review and PR merge into NousResearch/hermes-agent.
+manifest_version: 1
+
+name: fire-regulations
+description: Search versioned Korean fire-safety laws and administrative rules from official-source local snapshots.
+source: https://github.com/119gpt333-sys/fire-regulations-mcp
+
+transport:
+  type: stdio
+  command: uv
+  args:
+    - run
+    - --project
+    - "${INSTALL_DIR}"
+    - --no-sync
+    - fire-mcp
+  version: "0.1.0"
+
+install:
+  type: git
+  url: https://github.com/119gpt333-sys/fire-regulations-mcp.git
+  # Full commit SHA: catalog installs must not float with a branch head.
+  ref: 245a916fc5b793caccec4040e46088123a87fdf7
+  bootstrap:
+    - "uv sync --locked --no-dev"
+
+auth:
+  type: none
+
+tools:
+  # All tools are read-only. Sync and review operations remain separate local CLIs.
+  default_enabled:
+    - search_current_rules
+    - get_rule_as_of
+    - trace_exception_path
+    - get_source_status
+    - list_pending_changes
+
+post_install: |
+  This MCP keeps official-source snapshots and its SQLite index on the user's machine.
+  The catalog install intentionally contains no pre-synced legal text or credentials.
+
+  Populate a small sample with the National Law Information Center's public test credential:
+    uv run --project "${HERMES_HOME:-$HOME/.hermes}/mcp-installs/fire-regulations" fire-mcp-sync --max-per-entry 3
+
+  For operational synchronization, obtain an OC credential through the official
+  National Law Information Center data-sharing process and pass it only at runtime:
+    LAW_API_OC='<issued value>' uv run --project "${HERMES_HOME:-$HOME/.hermes}/mcp-installs/fire-regulations" fire-mcp-sync
+
+  Newly collected or hash-changed versions remain pending until a responsible reviewer
+  compares them with the official source and approves them through fire-mcp-review.
+  The MCP does not automatically determine legal compliance for an individual facility.
+
+  Start a new Hermes session after synchronization to use the tools.


### PR DESCRIPTION
## What does this PR do?

Adds `fire-regulations` to the curated MCP catalog as a pinned, stdio-based server.

The MCP provides read-only tools for searching versioned Korean fire-safety laws and administrative rules from local official-source snapshots. It keeps legal-source data and the generated SQLite index on the user's machine and does not automatically determine facility compliance.

Upstream source:
https://github.com/119gpt333-sys/fire-regulations-mcp

Pinned source commit:
`245a916fc5b793caccec4040e46088123a87fdf7`

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Added `optional-mcps/fire-regulations/manifest.yaml`
- Uses `uv` with a locked dependency graph and a full commit SHA
- Enables five read-only MCP tools by default
- Keeps synchronization and human review as separate local CLI operations
- Does not bundle credentials, official-source snapshots, or generated indexes

## Security / Supply-chain Notes

- Transport: local stdio
- Runtime command: `uv run --project ${INSTALL_DIR} --no-sync fire-mcp`
- Bootstrap: `uv sync --locked --no-dev`
- Authentication: none for MCP runtime
- Optional National Law Information Center OC credential is used only when the user manually runs the synchronization CLI
- Repository `.gitignore` excludes `.env`, local snapshots, SQLite indexes, virtual environments, and caches
- Source is licensed under MIT; synchronized external legal text remains subject to the official provider's terms

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py`
2. Parse the catalog with `HERMES_OPTIONAL_MCPS=<repo>/optional-mcps` and confirm the entry's transport, auth, pinned ref, and five default tools.
3. In an isolated `HERMES_HOME`, run `hermes mcp install fire-regulations` and `hermes mcp test fire-regulations`.
4. Confirm the installed checkout equals `245a916fc5b793caccec4040e46088123a87fdf7`.
5. Run the upstream sample sync with `LAW_API_OC=test ... fire-mcp-sync --max-per-entry 1` and verify the MCP reads the resulting local index.

Local verification completed:

- Catalog tests: 39 passed
- Upstream tests: 17 passed
- Ruff: passed
- MCP protocol verification: 5 tools, 1 resource, 1 prompt
- Public catalog installation: passed
- Public URL connection test: passed
- Sample official-source sync: 23 documents saved, 0 errors
- Post-sync MCP status: 23 documents, 8,653 provisions

## Checklist

- [x] I searched the current catalog for an existing entry
- [x] The change is limited to one MCP catalog manifest
- [x] The install source is public and pinned to a full commit SHA
- [x] Bootstrap commands are minimal and reproducible
- [x] No credential is committed or required for MCP startup
- [x] Relevant catalog tests pass locally
- [x] Tested on Windows 11 with WSL
