### PR TITLE
fix(dashboard): preserve zero compute-host respawn limit

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -185,6 +185,57 @@ def test_dashboard_process_isolation_config_coerces_raw_values():
     }
 
 
+def test_compute_host_supervisor_preserves_zero_respawn_limit(monkeypatch):
+    captured = {}
+
+    class FakeHostSupervisor:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    from tui_gateway import host_supervisor
+
+    monkeypatch.setattr(host_supervisor, "HostSupervisor", FakeHostSupervisor)
+    monkeypatch.setattr(server, "_compute_host_supervisor", None)
+    isolation_cfg = server._load_dashboard_process_isolation_config({
+        "dashboard": {
+            "turn_isolation": True,
+            "compute_host_respawn_max": 0,
+        }
+    })
+
+    server._get_compute_host_supervisor(isolation_cfg)
+
+    assert isolation_cfg["compute_host_respawn_max"] == 0
+    assert captured["respawn_max"] == 0
+
+
+@pytest.mark.parametrize(
+    ("isolation_cfg", "expected_respawn_max"),
+    [
+        ({"compute_host_respawn_max": 7}, 7),
+        ({}, 3),
+        ({"compute_host_respawn_max": None}, 3),
+    ],
+)
+def test_compute_host_supervisor_respawn_limit_defaults_only_when_missing_or_none(
+    monkeypatch, isolation_cfg, expected_respawn_max,
+):
+    captured = {}
+
+    class FakeHostSupervisor:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    from tui_gateway import host_supervisor
+
+    monkeypatch.setattr(host_supervisor, "HostSupervisor", FakeHostSupervisor)
+    monkeypatch.setattr(server, "_compute_host_supervisor", None)
+
+    server._get_compute_host_supervisor(isolation_cfg)
+
+    assert captured["respawn_max"] == expected_respawn_max
+
+
 def test_default_config_seeds_dashboard_process_isolation_keys():
     from hermes_cli.config import DEFAULT_CONFIG
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1372,10 +1372,13 @@ def _get_compute_host_supervisor(cfg: dict | None = None):
         if _compute_host_supervisor is None:
             from tui_gateway.host_supervisor import HostSupervisor
 
+            respawn_max = isolation_cfg.get("compute_host_respawn_max")
+            if respawn_max is None:
+                respawn_max = 3
             _compute_host_supervisor = HostSupervisor(
                 rpc_sink=write_json,
                 heartbeat_secs=int(isolation_cfg.get("compute_host_heartbeat_secs") or 15),
-                respawn_max=int(isolation_cfg.get("compute_host_respawn_max") or 3),
+                respawn_max=int(respawn_max),
             )
         return _compute_host_supervisor
 


### PR DESCRIPTION
## Summary

- preserve an explicitly configured `dashboard.compute_host_respawn_max: 0` when constructing `HostSupervisor`
- default to `3` only when the setting is missing or `None`
- add regression coverage for zero, positive, missing, and `None` values

## Problem

The raw dashboard config loader correctly accepts zero (`min_value=0`), but `_get_compute_host_supervisor()` used a truthiness fallback. As a result, a valid no-respawn configuration reached the factory as `3` instead of `0`.

## Reproduction

With a temporary `HERMES_HOME` containing:

```yaml
dashboard:
  turn_isolation: true
  compute_host_respawn_max: 0
```

three production-path runs reported `loader=0 supervisor=3 host_zero=0` before this change.

## Validation

- `python scripts/run_tests_parallel.py tests/test_tui_gateway_server.py -q` - 471 passed
- Focused factory regression cases - 4 passed
- `python -m ruff check tui_gateway/server.py tests/test_tui_gateway_server.py` - passed
- `git diff --check` - passed

I also ran `tests/tui_gateway/test_compute_host_phase1.py`; it has an unrelated Windows failure in `test_append_log_record_single_write_lines` (concurrent append produced 29/32 lines) and an interrupted subprocess-restart test. Neither failure exercises the dashboard config factory changed here.