### PR TITLE
fix(matrix): surface oversized inbound media

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2958,14 +2958,16 @@ class MatrixAdapter(BasePlatformAdapter):
             event_size_int = int(event_size) if event_size is not None else 0
         except (TypeError, ValueError):
             event_size_int = 0
-        if event_size_int and event_size_int > self._max_media_bytes:
+        media_size_limit_exceeded = bool(
+            event_size_int and event_size_int > self._max_media_bytes
+        )
+        if media_size_limit_exceeded:
             logger.warning(
                 "[Matrix] Rejecting oversized inbound media %s (%d > %d bytes)",
                 event_id,
                 event_size_int,
                 self._max_media_bytes,
             )
-            return
 
         # For encrypted media, the URL may be in file.url.
         file_content = source_content.get("file", {})
@@ -3009,7 +3011,7 @@ class MatrixAdapter(BasePlatformAdapter):
         should_cache_locally = msg_type in {
             MessageType.PHOTO, MessageType.AUDIO, MessageType.VIDEO, MessageType.DOCUMENT,
         } or is_voice_message or is_encrypted_media
-        if should_cache_locally and url:
+        if should_cache_locally and url and not media_size_limit_exceeded:
             try:
                 file_bytes = await self._client.download_media(ContentURI(url))
                 if file_bytes is not None:
@@ -3107,7 +3109,20 @@ class MatrixAdapter(BasePlatformAdapter):
         if msgtype == "m.image" and _looks_like_matrix_image_filename(body):
             body = ""
 
-        allow_http_fallback = bool(http_url) and not is_encrypted_media
+        if media_size_limit_exceeded:
+            media_kind = {
+                "m.image": "image",
+                "m.audio": "audio",
+                "m.video": "video",
+            }.get(msgtype, "file")
+            marker = f"[matrix {media_kind} attachment too large]"
+            body = f"{body}\n{marker}".strip()
+
+        allow_http_fallback = (
+            bool(http_url)
+            and not is_encrypted_media
+            and not media_size_limit_exceeded
+        )
         media_urls = (
             [cached_path]
             if cached_path

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3546,14 +3546,16 @@ class MatrixAdapter(BasePlatformAdapter):
             event_size_int = int(event_size) if event_size is not None else 0
         except (TypeError, ValueError):
             event_size_int = 0
-        if event_size_int and event_size_int > self._max_media_bytes:
+        media_size_limit_exceeded = bool(
+            event_size_int and event_size_int > self._max_media_bytes
+        )
+        if media_size_limit_exceeded:
             logger.warning(
                 "[Matrix] Rejecting oversized inbound media %s (%d > %d bytes)",
                 event_id,
                 event_size_int,
                 self._max_media_bytes,
             )
-            return
 
         # For encrypted media, the URL may be in file.url.
         file_content = source_content.get("file", {})
@@ -3597,7 +3599,7 @@ class MatrixAdapter(BasePlatformAdapter):
         should_cache_locally = msg_type in {
             MessageType.PHOTO, MessageType.AUDIO, MessageType.VIDEO, MessageType.DOCUMENT,
         } or is_voice_message or is_encrypted_media
-        if should_cache_locally and url:
+        if should_cache_locally and url and not media_size_limit_exceeded:
             try:
                 file_bytes = await self._client.download_media(ContentURI(url))
                 if file_bytes is not None:
@@ -3713,7 +3715,20 @@ class MatrixAdapter(BasePlatformAdapter):
         if msgtype == "m.image" and _looks_like_matrix_image_filename(body):
             body = ""
 
-        allow_http_fallback = bool(http_url) and not is_encrypted_media
+        if media_size_limit_exceeded:
+            media_kind = {
+                "m.image": "image",
+                "m.audio": "audio",
+                "m.video": "video",
+            }.get(msgtype, "file")
+            marker = f"[matrix {media_kind} attachment too large]"
+            body = f"{body}\n{marker}".strip()
+
+        allow_http_fallback = (
+            bool(http_url)
+            and not is_encrypted_media
+            and not media_size_limit_exceeded
+        )
         media_urls = (
             [cached_path]
             if cached_path

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3356,7 +3356,7 @@ class TestMatrixImageOnlyMediaNormalization:
         assert captured_event.text == "Please describe this chart"
 
     @pytest.mark.asyncio
-    async def test_inbound_oversized_media_is_rejected(self):
+    async def test_inbound_oversized_media_surfaces_marker_without_download(self):
         captured_event = None
 
         async def capture(msg_event):
@@ -3381,7 +3381,43 @@ class TestMatrixImageOnlyMediaNormalization:
             msgtype="m.image",
         )
 
-        assert captured_event is None
+        assert captured_event is not None
+        assert captured_event.text == "[matrix image attachment too large]"
+        assert captured_event.media_urls is None
+        self.adapter._client.download_media.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_inbound_oversized_media_preserves_caption(self):
+        captured_event = None
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        self.adapter._max_media_bytes = 10
+        self.adapter.handle_message = capture
+
+        await self.adapter._handle_media_message(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            event_id="$video-big",
+            event_ts=0.0,
+            source_content={
+                "msgtype": "m.video",
+                "body": "Please summarize this recording",
+                "url": "mxc://example/large.mp4",
+                "info": {"mimetype": "video/mp4", "size": 11},
+            },
+            relates_to={},
+            msgtype="m.video",
+        )
+
+        assert captured_event is not None
+        assert captured_event.text == (
+            "Please summarize this recording\n"
+            "[matrix video attachment too large]"
+        )
+        assert captured_event.media_urls is None
         self.adapter._client.download_media.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1983,7 +1983,7 @@ class TestMatrixImageOnlyMediaNormalization:
 
 
     @pytest.mark.asyncio
-    async def test_inbound_oversized_media_is_rejected(self):
+    async def test_inbound_oversized_media_surfaces_marker_without_download(self):
         captured_event = None
 
         async def capture(msg_event):
@@ -2008,7 +2008,49 @@ class TestMatrixImageOnlyMediaNormalization:
             msgtype="m.image",
         )
 
-        assert captured_event is None
+        assert captured_event is not None
+        assert captured_event.text == "[matrix image attachment too large]"
+        assert captured_event.media_urls is None
+        self.adapter._client.download_media.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_inbound_oversized_media_preserves_caption(self):
+        captured_event = None
+
+        async def capture(msg_event):
+            nonlocal captured_event
+            captured_event = msg_event
+
+        self.adapter._max_media_bytes = 10
+        self.adapter.handle_message = capture
+
+        await self.adapter._handle_media_message(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            event_id="$video-big",
+            event_ts=0.0,
+            source_content={
+                "msgtype": "m.video",
+                "body": (
+                    "> <@bob:example.org> Original message\n\n"
+                    "Please summarize this recording"
+                ),
+                "url": "mxc://example/large.mp4",
+                "info": {"mimetype": "video/mp4", "size": 11},
+            },
+            relates_to={"m.in_reply_to": {"event_id": "$parent-event"}},
+            msgtype="m.video",
+        )
+
+        assert captured_event is not None
+        assert captured_event.text == (
+            "Please summarize this recording\n"
+            "[matrix video attachment too large]"
+        )
+        assert captured_event.media_urls is None
+        assert captured_event.reply_to_message_id == "$parent-event"
+        assert captured_event.reply_to_text == "Original message"
+        assert captured_event.reply_to_author_id == "@bob:example.org"
         self.adapter._client.download_media.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- keep the existing Matrix inbound media size limit and skip the download when it is exceeded
- deliver a visible attachment-too-large marker instead of silently dropping the event
- preserve any user-provided caption alongside the marker

## Root cause
The oversized-media guard returned before the event reached the normal message pipeline. This prevented the download, but also discarded the entire message and its caption without telling the user or agent what happened.

## Tests
- `python -m pytest tests/gateway/test_matrix.py::TestMatrixImageOnlyMediaNormalization -q` (18 passed)
- `python -m ruff check plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py`
- Full Matrix test file: 250 passed; 2 unrelated Windows-only failures (POSIX mode assertion on NTFS and locale decoding of a UTF-8 docs file)

Fixes #72238