### PR TITLE
fix(agent): re-assert tool availability on partial-stream continuation

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -651,9 +651,16 @@ def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List
     elif is_partial_stub:
         return (
             "[System: The previous response was cut off by a "
-            "network error mid-stream. Continue exactly where "
-            "you left off. Do not restart or repeat prior text. "
-            "Finish the answer directly.]"
+            "network error mid-stream — this was a transport "
+            "interruption, NOT a change in your capabilities. "
+            "Your tools (including the terminal, file, and any "
+            "other tools listed in this request) are still fully "
+            "available; call them as normal. Ignore and do not "
+            "repeat any earlier statement claiming you lack tool "
+            "access or are in a text-only/compatibility-layer "
+            "session — that was an artifact of the cut-off stream. "
+            "Continue the task from where you left off, invoking "
+            "tools as needed. Do not restart or repeat prior text.]"
         )
     else:
         return (

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -668,3 +668,14 @@ class TestSendTimePadMultimodalSafety:
         assert out[2]["content"] == ""
         # input list untouched (repair is copy-on-write)
         assert api_messages[1]["content"] == ""
+def test_partial_stub_prompt_reasserts_tool_availability():
+    """Regression: after a mid-stream transport cut, the continuation prompt
+    must reassert that the model's tools are still available and tell it to
+    ignore any earlier text-only / no-tools claim. Without this, the model
+    sometimes refuses to call tools on continuation, stalling the task."""
+    prompt = _get_continuation_prompt(is_partial_stub=True, dropped_tools=None)
+    low = prompt.lower()
+    assert "still" in low and "available" in low
+    assert "text-only" in low or "compatibility" in low
+    # must NOT collapse to the plain output-length continuation
+    assert "truncated by the output" not in low


### PR DESCRIPTION
## What does this PR do?

Hardens the mid-stream continuation prompt so the model doesn't silently lose its tools after a transport interruption.

When a streamed response is cut off mid-stream (network/transport error), `_get_continuation_prompt(is_partial_stub=True)` re-prompts the model to continue. In practice the model sometimes concludes it's now in a "text-only / compatibility-layer session" and **refuses to call tools on continuation** — stalling the task, even though nothing about its capabilities actually changed. The cut-off itself is the only thing that happened.

This tightens the partial-stub continuation prompt to explicitly (a) state the interruption was transport-only, not a capability change, (b) reassert that its tools remain fully available, and (c) tell it to ignore/not-repeat any earlier claim of lacking tools or being in a text-only session.

## Related Issue

Fixes #74990

## Type of Change

- [x] 🐛 Bug fix (non-breaking robustness fix)

## Changes Made

- `agent/conversation_loop.py` — `_get_continuation_prompt` partial-stub branch now reasserts tool availability and instructs the model to disregard any earlier text-only/no-tools claim.
- `tests/run_agent/test_partial_stream_finish_reason.py` — assert the partial-stub prompt reasserts tools and is not the plain output-length continuation.

## How to Test

1. `pytest tests/run_agent/test_partial_stream_finish_reason.py -q` → all pass, incl. the new assertion.
2. Manual: interrupt a streamed tool-using turn mid-stream. **Before:** the model may respond on continuation claiming it lacks tools / is in a text-only session and stop. **After:** it continues invoking tools normally.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs — no open/merged PR touches this continuation-prompt wording
- [x] Only related changes
- [x] Ran `pytest tests/run_agent/test_partial_stream_finish_reason.py -q` — all pass
- [x] Added a test
- [x] Tested on: macOS 15 / Linux (Python 3.12)

### Documentation & Housekeeping

- [x] N/A — prompt string only, no docs/config/architecture change
- [x] Cross-platform: pure prompt text, no platform-specific code