### PR TITLE
Fix gateway tests terminating pytest early

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -360,7 +360,15 @@ def _run_one_file_once(
 
         output +=  "\n"
 
-    if rc == 5:
+    summary = _parse_pytest_summary(output)
+    if rc == 0 and not summary:
+        rc = 1
+        output = (
+            "ERROR: pytest exited 0 without a pytest summary; the process "
+            "terminated before reporting its collected outcomes (for example, "
+            "via os._exit(0)).\n" + output
+        )
+    elif rc == 5:
         # No tests collected in THIS file — legitimate per-file: a
         # platform-gated or fully-marker-filtered file (e.g. a win32-only
         # suite on Linux) collects nothing and must not fail the suite.
@@ -368,7 +376,6 @@ def _run_one_file_once(
         # NOTHING was collected across every file, so a broken invocation
         # (venv without pytest, -k that matches nothing) can't report green.
         rc = 0
-    summary = _parse_pytest_summary(output)
     subproc_wall = time.monotonic() - subproc_start
     return file, rc, output, summary, subproc_wall
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -238,6 +238,7 @@ class TestSystemdServiceRefresh:
             return True
 
         monkeypatch.setattr("gateway.run.start_gateway", fake_start_gateway)
+        monkeypatch.setattr("gateway.run._exit_after_graceful_shutdown", lambda code: None)
 
         gateway_cli.run_gateway()
 
@@ -1557,6 +1558,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(
@@ -1602,6 +1604,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 10.0)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
@@ -1661,6 +1664,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
         monkeypatch.setattr(gateway_cli, "_recover_pending_systemd_restart", lambda system=False, previous_pid=None: False)
@@ -1691,6 +1695,7 @@ class TestGatewaySystemServiceRouting:
     def test_systemd_restart_recovers_failed_planned_restart(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(
             "gateway.status.read_runtime_status",

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -379,6 +379,22 @@ def test_zero_collected_across_run_fails_and_says_so(tmp_path: Path) -> None:
     assert "NOT a pass" in proc.stdout
 
 
+def test_file_that_hard_exits_zero_without_a_summary_fails(tmp_path: Path) -> None:
+    """A test process cannot hide the rest of its file behind ``os._exit(0)``."""
+    probe_dir = tmp_path / "hardexit"
+    probe_dir.mkdir()
+    (probe_dir / "test_hardexit.py").write_text(
+        "import os\n\n"
+        "def test_exits_process():\n    os._exit(0)\n\n"
+        "def test_never_reached():\n    assert False\n"
+    )
+
+    proc = _run_runner(probe_dir)
+
+    assert proc.returncode == 1, proc.stdout
+    assert "exited 0 without a pytest summary" in proc.stdout
+
+
 def test_all_skipped_file_is_still_a_pass(tmp_path: Path) -> None:
     """Per-file zero-collection stays tolerated.
 


### PR DESCRIPTION
## Summary

- prevent the gateway service test from invoking the production hard-exit hook
- isolate systemd restart tests from the host's user-systemd preflight
- fail the parallel test runner when pytest exits successfully without emitting a summary

## Why

The gateway service file could terminate pytest with `os._exit(0)` partway through collection. The canonical runner therefore reported a green file with 0 tests passed and no pytest summary, hiding the remaining tests.

## Verification

- before: `scripts/run_tests.sh -j 1 tests/hermes_cli/test_gateway_service.py -q` reported 0 passed / 0 failed from a file containing 189 tests
- after: gateway service and runner regression suites report 201 passed / 0 failed
- `ruff check` passed for all changed Python files

Related downstream diagnosis: https://github.com/nadicodeai/nadia-core/issues/199
