### PR TITLE
fix(desktop): hide stale skill hub results

### DIFF
--- a/apps/desktop/src/app/skills/hub-query-state.ts
+++ b/apps/desktop/src/app/skills/hub-query-state.ts
@@ -1,0 +1,17 @@
+export interface SkillHubQueryState {
+  pending: boolean
+  showLanding: boolean
+  showResults: boolean
+}
+
+export function getSkillHubQueryState(query: string, term: string): SkillHubQueryState {
+  const normalizedQuery = query.trim()
+  const showLanding = normalizedQuery.length === 0
+  const showResults = !showLanding && normalizedQuery === term
+
+  return {
+    pending: !showLanding && !showResults,
+    showLanding,
+    showResults
+  }
+}

--- a/apps/desktop/src/app/skills/hub.test.ts
+++ b/apps/desktop/src/app/skills/hub.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { getSkillHubQueryState } from './hub-query-state'
+
+describe('getSkillHubQueryState', () => {
+  it('shows featured skills for an empty input', () => {
+    expect(getSkillHubQueryState('  ', 'previous')).toEqual({
+      pending: false,
+      showLanding: true,
+      showResults: false
+    })
+  })
+
+  it('shows results only after the debounced term matches the input', () => {
+    expect(getSkillHubQueryState('matrix', 'matrix')).toEqual({
+      pending: false,
+      showLanding: false,
+      showResults: true
+    })
+  })
+
+  it('hides stale results while a changed query is still debouncing', () => {
+    expect(getSkillHubQueryState('telegram', 'matrix')).toEqual({
+      pending: true,
+      showLanding: false,
+      showResults: false
+    })
+  })
+})

--- a/apps/desktop/src/app/skills/hub.test.ts
+++ b/apps/desktop/src/app/skills/hub.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { createElement } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type * as HermesApi from '@/hermes'
+import { HUB_SOURCES_KEY } from '@/store/hub-actions'
+
+import { SkillsHub } from './hub'
+import { getSkillHubQueryState } from './hub-query-state'
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<typeof HermesApi>()),
+  getSkillHubSources: vi.fn(),
+  searchSkillsHub: vi.fn()
+}))
+
+vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('getSkillHubQueryState', () => {
+  it('shows featured skills for an empty input', () => {
+    expect(getSkillHubQueryState('  ', 'previous')).toEqual({
+      pending: false,
+      showLanding: true,
+      showResults: false
+    })
+  })
+
+  it('shows results only after the debounced term matches the input', () => {
+    expect(getSkillHubQueryState('matrix', 'matrix')).toEqual({
+      pending: false,
+      showLanding: false,
+      showResults: true
+    })
+  })
+
+  it('hides stale rows and actions until the changed query settles', async () => {
+    vi.useFakeTimers()
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    const result = (name: string, identifier: string) => ({
+      name,
+      identifier,
+      description: `${name} description`,
+      installed: {},
+      repo: null,
+      results: [],
+      source: 'official',
+      source_counts: {},
+      tags: [],
+      timed_out: [],
+      trust_level: 'trusted'
+    })
+
+    const matrix = result('Matrix Skill', 'matrix-skill')
+    const telegram = result('Telegram Skill', 'telegram-skill')
+
+    client.setQueryData(HUB_SOURCES_KEY, {
+      featured: [],
+      index_available: true,
+      installed: {},
+      sources: [{ id: 'official', label: 'Official', searchable: true }]
+    })
+    client.setQueryData(['skill-hub-search', 'matrix', 'official'], { ...matrix, results: [matrix] })
+    client.setQueryData(['skill-hub-search', 'telegram', 'official'], { ...telegram, results: [telegram] })
+
+    const view = (query: string) => createElement(QueryClientProvider, { client }, createElement(SkillsHub, { query }))
+
+    const rendered = render(view('matrix'))
+
+    await act(async () => {})
+    expect(screen.getByText('Matrix Skill')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Preview' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Install' })).toBeTruthy()
+
+    rendered.rerender(view('telegram'))
+
+    expect(screen.queryByText('Matrix Skill')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Preview' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Install' })).toBeNull()
+
+    await act(() => vi.advanceTimersByTimeAsync(350))
+    expect(screen.getByText('Telegram Skill')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/skills/hub.tsx
+++ b/apps/desktop/src/app/skills/hub.tsx
@@ -42,6 +42,8 @@ import {
 } from '@/store/hub-actions'
 import { notify, notifyError } from '@/store/notifications'
 
+import { getSkillHubQueryState } from './hub-query-state'
+
 // Dedup rank when the same skill surfaces from multiple sources — higher trust
 // wins. Mirrors the backend's unified_search `_TRUST_RANK`.
 const TRUST_RANK: Record<string, number> = { builtin: 2, trusted: 1, community: 0 }
@@ -155,6 +157,7 @@ export function SkillsHub({ query }: SkillsHubProps) {
   // Debounced hub search, keyed on the settled query so RQ dedupes/caches per
   // term and abandons stale terms for us (no hand-rolled sequence guard).
   const term = useDebounced(query.trim(), 350)
+  const queryState = getSkillHubQueryState(query, term)
 
   // Progressive per-source search: one query per source the backend says is
   // worth hitting individually (it marks index-covered API sources unsearchable
@@ -232,7 +235,10 @@ export function SkillsHub({ query }: SkillsHubProps) {
   const searchStateById = new Map<string, { failed: boolean; fetching: boolean }>()
   searchableSources.forEach((source, i) => {
     const q = sourceSearches[i]
-    searchStateById.set(source.id, { failed: q.isError, fetching: term.length > 0 && q.isFetching })
+    searchStateById.set(source.id, {
+      failed: q.isError,
+      fetching: queryState.showResults && q.isFetching
+    })
   })
 
   // Merge every source's results, deduped by identifier preferring higher trust
@@ -271,13 +277,16 @@ export function SkillsHub({ query }: SkillsHubProps) {
 
   // Still fetching from at least one source; "done" only once every source has
   // settled (so "No results" doesn't flash while slower sources are still in).
-  const anyFetching = term.length > 0 && sourceSearches.some(q => q.isFetching)
-  const searched = term.length > 0 && sourceSearches.length > 0 && sourceSearches.every(q => !q.isFetching)
-  const showLanding = term.length === 0
-  const listed = showLanding ? featured : results
+  const anyFetching = queryState.showResults && sourceSearches.some(q => q.isFetching)
+
+  const searched =
+    queryState.showResults && sourceSearches.length > 0 && sourceSearches.every(q => !q.isFetching)
+
+  const listed = queryState.showLanding ? featured : queryState.showResults ? results : []
+
   // Only block the whole pane on the first sources landing; after that results
   // stream in progressively while a subtle footer shows more are coming.
-  const searching = anyFetching && results.length === 0
+  const searching = queryState.pending || (anyFetching && results.length === 0)
   const hasInstalled = Object.keys(installed).length > 0
 
   return (
@@ -299,7 +308,7 @@ export function SkillsHub({ query }: SkillsHubProps) {
                       'relative rounded px-1.5 py-0.5 text-[0.6rem] transition-opacity',
                       degraded ? 'bg-amber-500/15 text-amber-400' : 'bg-(--ui-bg-tertiary) text-(--ui-text-secondary)',
                       // While searching, un-hit sources dim so the active ones read clearly.
-                      term.length > 0 && !fetching && !state?.failed && 'opacity-55'
+                      queryState.showResults && !fetching && !state?.failed && 'opacity-55'
                     )}
                     key={source.id}
                   >
@@ -322,7 +331,7 @@ export function SkillsHub({ query }: SkillsHubProps) {
       {listed.length > 0 && (
         <div className="flex shrink-0 items-center justify-between gap-3 px-4 pb-1.5 text-[0.68rem] text-(--ui-text-tertiary)">
           <span className="min-w-0 truncate">
-            {term.length > 0 ? h.resultCount(results.length, null) : h.featured}
+            {queryState.showResults ? h.resultCount(results.length, null) : h.featured}
             {anyFetching && results.length > 0 && (
               <span className="ml-2 text-(--ui-text-quaternary)">{h.searching}</span>
             )}


### PR DESCRIPTION
## Summary
- distinguish immediate input state from the debounced Skills Hub search term
- hide prior-query rows while the next query is settling, so stale skills cannot be previewed or installed
- keep network requests debounced and restore featured skills immediately when the input is cleared

## Root cause
The Desktop Skills Hub keyed requests by the debounced term but also used that term to decide which rows remained visible. During the 350 ms debounce window, the input showed the new query while rows from the previous term stayed interactive.

## Tests
- `npm exec --workspace apps/desktop -- vitest run --project ui src/app/skills/hub.test.ts` (3 passed)
- `npm exec --workspace apps/desktop -- vitest run --project ui src/app/skills/index.test.tsx` (4 passed)
- `npm run typecheck --workspace apps/desktop`
- targeted ESLint on all three changed files
- structured Codex autoreview: clean, no actionable findings

Fixes #72266