### PR TITLE
fix(gateway): force .ogg output for Telegram auto-TTS voice bubbles

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5482,11 +5482,27 @@ class BasePlatformAdapter(ABC):
                         from tools.tts_tool import text_to_speech_tool, check_tts_requirements
                         if check_tts_requirements():
                             import json as _json
+                            import tempfile as _tf
+                            import uuid as _uuid
                             speech_text = self.prepare_tts_text(text_content)
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
+                            # Force .ogg output for Telegram (voice bubbles need
+                            # Opus).  TTS picks format from output_path extension,
+                            # bypassing the ContextVar lookup which is empty at this
+                            # point because _clear_session_env already ran.
+                            _tts_out = None
+                            if self.platform == Platform.TELEGRAM:
+                                _tts_out = os.path.join(
+                                    _tf.gettempdir(), "hermes_voice",
+                                    f"auto_tts_{_uuid.uuid4().hex[:12]}.ogg"
+                                )
+                                os.makedirs(os.path.dirname(_tts_out), exist_ok=True)
+                            tts_kwargs = {"text": speech_text}
+                            if _tts_out:
+                                tts_kwargs["output_path"] = _tts_out
                             tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
+                                text_to_speech_tool, **tts_kwargs
                             )
                             tts_data = _json.loads(tts_result_str)
                             _tts_path = tts_data.get("file_path")


### PR DESCRIPTION
## Problem

When replying to a Telegram voice message with auto_TTS enabled, the response arrived as a `.mp3` audio file (shown as an attachment with a music-note icon) instead of a native voice bubble.

### Root Cause

`_process_message_background` runs as a background task. Before it starts, `_clear_session_env` in the outer handler's finally block already ran, clearing the `HERMES_SESSION_PLATFORM` ContextVar to `""`.

`get_session_env()` checks the ContextVar first — if it was explicitly set (even to empty string), it **never** falls back to `os.environ`. So `text_to_speech_tool` saw an empty platform and defaulted to `.mp3` output.

Both `copy_context()` and `os.environ` workarounds failed because `clear_session_vars()` sets ContextVar to `""`, which the resolver treats as explicitly set and skips the env var fallback entirely.

## Solution

Explicitly pass `output_path` with `.ogg` extension for Telegram. The TTS tool reads the format from the path extension (`_tts_response_format_from_path`) and sends `response_format=opus` to the TTS server. Other platforms are unaffected — they continue using the default path (no `output_path` specified).

## Testing

- Live-tested on Telegram with Silero TTS server (OpenAI-compatible endpoint)
- Before fix: reply arrived as `tts_YYYYMMDD_HHMMSS.mp3` attachment
- After fix: reply arrives as native voice bubble (waveform, play button)

## Files Changed

- `gateway/platforms/base.py` — auto_TTS block in `_process_message_background`

Note: `gateway/run.py` `_send_voice_reply` path was already correct (it passes `audio_ext = "ogg"` via `output_path`), so no changes needed there.