### PR TITLE
fix(agent): parse model output cap errors

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4179,6 +4179,59 @@ def run_conversation(
                         agent.log_prefix,
                     )
 
+                # Output-cap errors are deterministic request-shape failures:
+                # retrying with the same oversized max_tokens only burns the
+                # generic retry budget. Clamp before retry bookkeeping so
+                # provider messages such as DeepSeek's "max_tokens (98304)
+                # exceeds model's maximum output tokens (65536)" recover on
+                # the next request instead of surfacing "failed after 3
+                # retries".
+                _output_cap_retry_budget = parse_available_output_tokens_from_error(
+                    str(api_error)
+                )
+                if _output_cap_retry_budget is not None:
+                    compressor = agent.context_compressor
+                    old_ctx = compressor.context_length
+                    request_input_estimate = estimate_request_tokens_rough(
+                        api_messages, tools=agent.tools or None,
+                    )
+                    local_available_out = old_ctx - request_input_estimate
+                    if local_available_out > 0:
+                        safe_out = max(
+                            1,
+                            min(_output_cap_retry_budget, local_available_out) - 64,
+                        )
+                    else:
+                        safe_out = max(1, _output_cap_retry_budget - 64)
+                    agent._ephemeral_max_output_tokens = safe_out
+                    agent._buffer_vprint(
+                        f"⚠️  Output cap too large for current prompt — "
+                        f"retrying with max_tokens={safe_out:,} "
+                        f"(provider_available={_output_cap_retry_budget:,}, "
+                        f"estimated_request_tokens={request_input_estimate:,}; "
+                        f"context_length unchanged at {old_ctx:,})"
+                    )
+                    compression_attempts += 1
+                    if compression_attempts > max_compression_attempts:
+                        agent._flush_status_buffer()
+                        agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
+                        agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
+                        logger.error(f"{agent.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
+                        agent._persist_session(messages, conversation_history)
+                        _final_response = f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached."
+                        return {
+                            "final_response": _final_response,
+                            "messages": messages,
+                            "completed": False,
+                            "api_calls": api_call_count,
+                            "error": _final_response,
+                            "partial": True,
+                            "failed": True,
+                            "compression_exhausted": True,
+                        }
+                    _retry.restart_with_compressed_messages = True
+                    break
+
                 retry_count += 1
                 elapsed_time = time.time() - api_start_time
                 agent._touch_activity(

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1616,9 +1616,27 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         # The input itself fits — this is purely an output-cap error, so reduce
         # max_tokens and retry; do NOT compress.
         "range of max_tokens should be" in error_lower
+    ) or (
+        # OpenAI-compatible relays may reject a request whose output cap exceeds
+        # the model's separate completion-token limit, e.g.
+        #   "max_tokens (98304) exceeds model's maximum output tokens (65536)"
+        # This is independent of the input context window.
+        "exceeds model" in error_lower
+        and "maximum output tokens" in error_lower
     )
     if not is_output_cap_error:
         return None
+
+    # Generic model-output-cap form:
+    #   "max_tokens (98304) exceeds model's maximum output tokens (65536)"
+    _m_max_output = re.search(
+        r'exceeds model(?:\'s)? maximum output tokens\s*\(?\s*(\d+)\s*\)?',
+        error_lower,
+    )
+    if _m_max_output:
+        _cap = int(_m_max_output.group(1))
+        if _cap >= 1:
+            return _cap
 
     # DashScope / Alibaba range form: "Range of max_tokens should be [1, 65536]".
     # The upper bound is the available output cap.
@@ -1739,6 +1757,8 @@ def is_output_cap_error(error_msg: str) -> bool:
         or "should be" in error_lower                       # generic "max_tokens should be <= N"
         or "less than or equal" in error_lower
         or "must be" in error_lower
+        or ("exceeds model" in error_lower
+            and "maximum output tokens" in error_lower)
     )
     if not output_cap_signal:
         return False

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4109,6 +4109,92 @@ class TestRunConversation:
         assert agent.context_compressor.context_length == 200_000
         mock_compress.assert_called_once()
 
+    def test_output_cap_retry_before_generic_retry_exhaustion(self, agent):
+        """Provider max-output-cap 400s should clamp immediately, not burn all
+        generic retries and surface "API call failed after 3 retries".
+        """
+        self._setup_agent(agent)
+        agent.api_mode = "chat_completions"
+        agent.provider = "deepseek"
+        agent.base_url = "https://api.deepseek.com/v1"
+        agent.model = "deepseek-v4-flash"
+        agent.max_tokens = 98_304
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.should_compress = MagicMock(return_value=False)
+
+        error_msg = (
+            "[400]: max_tokens (98304) exceeds model's maximum output tokens "
+            "(65536) for model deepseek-v4-flash "
+            "(ref: 7735422e-9cb4-4075-a779-dfecb3204a0e)"
+        )
+        exc = Exception(error_msg)
+        exc.status_code = 400
+        exc.code = 400
+
+        ok_resp = _mock_response(content="done", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [exc, ok_resp]
+
+        mock_compress = MagicMock()
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent.context_compressor, "update_model"),
+            patch.object(agent, "_compress_context", mock_compress),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert len(agent.client.chat.completions.create.call_args_list) == 2
+        second_call = agent.client.chat.completions.create.call_args_list[1].kwargs
+        assert result["completed"] is True
+        assert second_call["max_tokens"] <= 65_472
+        assert agent.context_compressor.context_length == 200_000
+        mock_compress.assert_not_called()
+
+    def test_output_cap_retry_when_gateway_wraps_error_as_rate_limit(self, agent):
+        """Some relays wrap the upstream max-output 400 as HTTP 429. The
+        parsed output cap should still win over generic rate-limit retrying.
+        """
+        self._setup_agent(agent)
+        agent.api_mode = "chat_completions"
+        agent.provider = "custom"
+        agent.base_url = "http://192.168.1.254:20128/v1"
+        agent.model = "deepseekv4flash"
+        agent.max_tokens = 98_304
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.should_compress = MagicMock(return_value=False)
+
+        error_msg = (
+            "Error code: 429 - {'error': {'message': \"[400]: max_tokens "
+            "(98304) exceeds model's maximum output tokens (65536) for model "
+            "deepseek-v4-flash (ref: 37bde60f-44e7-44e2-b995-4af17fba6d6b)\", "
+            "'type': 'rate_limit_error', 'code': 'rate_limit_exceeded'}}"
+        )
+        exc = Exception(error_msg)
+        exc.status_code = 429
+        exc.code = "rate_limit_exceeded"
+
+        ok_resp = _mock_response(content="done", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [exc, ok_resp]
+
+        mock_compress = MagicMock()
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent.context_compressor, "update_model"),
+            patch.object(agent, "_compress_context", mock_compress),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert len(agent.client.chat.completions.create.call_args_list) == 2
+        second_call = agent.client.chat.completions.create.call_args_list[1].kwargs
+        assert result["completed"] is True
+        assert second_call["max_tokens"] <= 65_472
+        mock_compress.assert_not_called()
+
     def test_output_cap_retry_with_large_api_only_content(self, agent):
         """When a large system prompt makes api_messages huge while persisted
         messages stay tiny, the retry cap must still respect provider

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -68,6 +68,22 @@ class TestParseDashScopeOutputCap:
         assert parse_available_output_tokens_from_error(msg) == 32768
 
 
+class TestParseMaximumOutputTokensCap:
+    """Some OpenAI-compatible relays report the model's separate output cap."""
+
+    def test_parenthesized_max_output_cap(self):
+        msg = (
+            "API call failed after 3 retries: [400]: max_tokens (98304) "
+            "exceeds model's maximum output tokens (65536)"
+        )
+        assert parse_available_output_tokens_from_error(msg) == 65536
+
+    def test_parenthesized_max_output_cap_is_output_cap(self):
+        assert is_output_cap_error(
+            "max_tokens (98304) exceeds model's maximum output tokens (65536)"
+        ) is True
+
+
 class TestIsOutputCapError:
     """`is_output_cap_error` is the broader yes/no gate that keeps an
     output-cap 400 out of the compression death-loop even when we can't parse


### PR DESCRIPTION
## What does this PR do?

This fixes deterministic output-cap failures from OpenAI-compatible relays, including errors of the form:

```text
max_tokens (98304) exceeds model's maximum output tokens (65536)
```

Hermes now parses the advertised model output cap and clamps the next request before generic retry accounting burns all retries. That keeps this provider-side max-output rejection on the existing one-shot retry path instead of surfacing `API call failed after 3 retries` or treating it like an input context overflow.

The retry path also handles relays that wrap the upstream max-output 400 as another error class, such as HTTP 429 / `rate_limit_error`, as long as the wrapped message still includes the output-cap boundary.

## Related Issue

Fixes #72281

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`: detect and parse `exceeds model's maximum output tokens (...)` provider errors.
- `agent/conversation_loop.py`: handle parsed output-cap errors before generic retry bookkeeping so the next call uses a one-shot clamped output cap, even when a relay classifies the wrapped error as rate-limit.
- `tests/test_output_cap_parsing.py`: add regression coverage for parsing the cap and classifying the error as output-cap-shaped.
- `tests/run_agent/test_run_agent.py`: add runtime coverage for the exact `deepseek-v4-flash` failure shape, including a gateway-wrapped HTTP 429 / `rate_limit_error`, to prove it retries once with a safe cap instead of exhausting three retries.

## How to Test

1. Run:
   ```bash
   scripts/run_tests.sh tests/test_output_cap_parsing.py tests/run_agent/test_run_agent.py::TestRunConversation::test_output_cap_retry_before_generic_retry_exhaustion tests/run_agent/test_run_agent.py::TestRunConversation::test_output_cap_retry_when_gateway_wraps_error_as_rate_limit tests/run_agent/test_run_agent.py::TestRunConversation::test_output_cap_retry_uses_provider_available_out tests/run_agent/test_run_agent.py::TestRunConversation::test_output_cap_retry_with_compression_disabled_vllm_format
   ```
2. Confirm the parser returns `65536` for `max_tokens (98304) exceeds model's maximum output tokens (65536)`.
3. Confirm the conversation loop retries immediately with `max_tokens <= 65472` for the `deepseek-v4-flash` provider error, including when the relay wraps it as 429/rate-limit, instead of returning `API call failed after 3 retries`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian/trixie Linux, Python 3.13.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/test_output_cap_parsing.py tests/run_agent/test_run_agent.py::TestRunConversation::test_output_cap_retry_before_generic_retry_exhaustion tests/run_agent/test_run_agent.py::TestRunConversation::test_output_cap_retry_when_gateway_wraps_error_as_rate_limit tests/run_agent/test_run_agent.py::TestRunConversation::test_output_cap_retry_uses_provider_available_out tests/run_agent/test_run_agent.py::TestRunConversation::test_output_cap_retry_with_compression_disabled_vllm_format
▶ running per-file parallel test suite via run_tests_parallel.py
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; clean env)
▶ pre-compiling bytecode cache
▶ launching test runner
note: 'tests/run_agent/test_run_agent.py::TestRunConversation::test_output_cap_retry_before_generic_retry_exhaustion' is a pytest node id; this runner is file-granular. Running the file with -k 'test_output_cap_retry_before_generic_retry_exhaustion'.
note: 'tests/run_agent/test_run_agent.py::TestRunConversation::test_output_cap_retry_when_gateway_wraps_error_as_rate_limit' is a pytest node id; this runner is file-granular. Running the file with -k 'test_output_cap_retry_when_gateway_wraps_error_as_rate_limit'.
note: 'tests/run_agent/test_run_agent.py::TestRunConversation::test_output_cap_retry_uses_provider_available_out' is a pytest node id; this runner is file-granular. Running the file with -k 'test_output_cap_retry_uses_provider_available_out'.
note: 'tests/run_agent/test_run_agent.py::TestRunConversation::test_output_cap_retry_with_compression_disabled_vllm_format' is a pytest node id; this runner is file-granular. Running the file with -k 'test_output_cap_retry_with_compression_disabled_vllm_format'.
Discovered 2 test files (~467 tests) under ['tests/test_output_cap_parsing.py', 'tests/run_agent/test_run_agent.py', 'tests/run_agent/test_run_agent.py', 'tests/run_agent/test_run_agent.py', 'tests/run_agent/test_run_agent.py']; running with -j 40
[  4.7% |    22/~467 | ✓0 | ✗0] ✓ tests/test_output_cap_parsing.py (22 tests, 0.4s)
[100.0% |   467/~467 | ✓4 | ✗0] ✓ tests/run_agent/test_run_agent.py (4✓, 1.8s)

=== Summary: 2 files, 4 tests passed, 0 failed (100% complete) in 1.8s (40 workers) ===
```
