### PR TITLE
fix(setup): stop the wizard persisting the superseded max_turns default

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1500,6 +1500,20 @@ def _apply_default_agent_settings(config: dict):
     print_info("  Run `hermes setup agent` later to customize.")
 
 
+def _default_max_turns() -> int:
+    """The canonical ``agent.max_turns`` default.
+
+    Read from ``DEFAULT_CONFIG`` rather than hardcoded here: the wizard
+    persists whatever it displays, so a stale literal silently pins the
+    user to a superseded limit (deep-merge then preserves that explicit
+    value across every future default change).
+    """
+    try:
+        return int(DEFAULT_CONFIG.get("agent", {}).get("max_turns"))
+    except (AttributeError, TypeError, ValueError):
+        return 500
+
+
 def setup_agent_settings(config: dict):
     """Configure agent behavior: iterations, progress display, compression, session reset."""
 
@@ -1511,11 +1525,12 @@ def setup_agent_settings(config: dict):
     # config.yaml is authoritative; read from there. If a legacy .env
     # entry is still around (from pre-PR#18413 setups), prefer the
     # config value so we don't surface a stale number to the user.
-    current_max = str(cfg_get(config, "agent", "max_turns", default=90))
+    current_max = str(cfg_get(config, "agent", "max_turns", default=_default_max_turns()))
     print_info("Maximum tool-calling iterations per conversation.")
     print_info("Higher = more complex tasks, but costs more tokens.")
     print_info(
-        f"Press Enter to keep {current_max}. Use 90 for most tasks or 150+ for open exploration."
+        f"Press Enter to keep {current_max}. Lower values cap token spend; "
+        "raise it for long, open-ended tasks."
     )
 
     max_iter_str = prompt("Max iterations", current_max)
@@ -2316,7 +2331,7 @@ def _get_section_config_summary(config: dict, section_key: str) -> Optional[str]
         return f"backend: {backend}"
 
     elif section_key == "agent":
-        max_turns = cfg_get(config, "agent", "max_turns", default=90)
+        max_turns = cfg_get(config, "agent", "max_turns", default=_default_max_turns())
         return f"max turns: {max_turns}"
 
     elif section_key == "gateway":

--- a/tests/hermes_cli/test_setup_agent_settings.py
+++ b/tests/hermes_cli/test_setup_agent_settings.py
@@ -76,3 +76,59 @@ def test_setup_agent_settings_prefers_config_over_stale_env(tmp_path, monkeypatc
     assert "Press Enter to keep 60." not in out
     # And the stale .env entry gets cleaned up
     assert "HERMES_MAX_ITERATIONS" in removed_keys
+
+
+def test_setup_agent_settings_offers_canonical_default_when_unset(
+    tmp_path, monkeypatch, capsys
+):
+    """A user who never set ``agent.max_turns`` must be offered the real default.
+
+    The wizard persists whatever it displays, so a stale literal here writes a
+    superseded limit into config.yaml — and because that value is then an
+    explicit user setting, deep-merge preserves it across every future change
+    to the shipped default. Sourced from DEFAULT_CONFIG so this test stays
+    correct the next time the default moves.
+    """
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    expected = int(DEFAULT_CONFIG["agent"]["max_turns"])
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    # No agent.max_turns — the user relies on the shipped default.
+    config = {
+        "display": {"tool_progress": "all"},
+        "compression": {"threshold": 0.50},
+        "session_reset": {"mode": "both", "idle_minutes": 1440, "at_hour": 4},
+    }
+
+    # Every prompt gets a bare Enter, which returns the offered default.
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt",
+        lambda question, default=None, **kwargs: default or "",
+    )
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 4)
+    monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.setup.remove_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.setup.save_config", lambda *args, **kwargs: None)
+
+    setup_agent_settings(config)
+
+    out = capsys.readouterr().out
+    assert f"Press Enter to keep {expected}." in out
+    # Accepting the prompt must not silently downgrade the iteration budget.
+    assert config["agent"]["max_turns"] == expected
+
+
+def test_section_summary_reports_canonical_default_when_unset():
+    """The setup menu's agent summary must not report a superseded default."""
+    from hermes_cli.config import DEFAULT_CONFIG
+    from hermes_cli.setup import _get_section_config_summary
+
+    expected = int(DEFAULT_CONFIG["agent"]["max_turns"])
+
+    assert _get_section_config_summary({}, "agent") == f"max turns: {expected}"
+    # An explicit user value still wins.
+    assert (
+        _get_section_config_summary({"agent": {"max_turns": 120}}, "agent")
+        == "max turns: 120"
+    )


### PR DESCRIPTION
## What does this PR do?

The change that raised the default tool-calling budget from 90 to 500 (#72176) updated every runtime surface that hardcodes the fallback — but not the setup wizard.

`setup_agent_settings` still read `default=90`. Because the wizard **writes back whatever it displays**, a user who has never set `agent.max_turns` is offered 90 and, by pressing Enter, persists `agent.max_turns: 90` into `config.yaml`. That is then an *explicit* user value, which the config deep-merge preserves — so the user is silently pinned to the superseded limit and never receives this or any future default change. `hermes setup` is the primary onboarding flow, so this quietly undoes the raise for exactly the users who never customized it. The setup menu's section summary reported the same stale number.

Reproduced against `main` (`6d1e08b2b`), driving the real `setup_agent_settings` with every prompt answered by a bare Enter:

```
### BEFORE FIX
shipped default (DEFAULT_CONFIG): 500
wizard offered: Press Enter to keep 90. ...
PERSISTED into user config after pressing Enter: 90

### AFTER FIX
shipped default (DEFAULT_CONFIG): 500
wizard offered: Press Enter to keep 500. ...
PERSISTED into user config after pressing Enter: 500
```

Both sites now read the default from `DEFAULT_CONFIG` (the single source of truth) instead of a literal, so the wizard cannot drift from the shipped value again the next time it moves. This also matches `_normalize_max_turns_config`, which deliberately avoids materializing the schema default into a user's config when they never set it.

Out of scope (deliberately not touched): `_blank_slate_minimize_config` writes `max_turns = 90` as part of an intentionally minimal install. That may be a deliberate low cap rather than a stale copy of the old default — happy to align it too if you confirm the intent.

## Related Issue

Follow-up to #72176 (no separate issue filed).

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/setup.py`: added `_default_max_turns()`, which resolves `agent.max_turns` from `DEFAULT_CONFIG`.
- `hermes_cli/setup.py`: `setup_agent_settings` offers that canonical default instead of the literal `90`, so accepting the prompt can no longer downgrade the iteration budget.
- `hermes_cli/setup.py`: `_get_section_config_summary` reports the canonical default in the setup menu.
- `hermes_cli/setup.py`: replaced the now-contradictory "Use 90 for most tasks or 150+ for open exploration" guidance.
- `tests/hermes_cli/test_setup_agent_settings.py`: two regression tests, both deriving the expected value from `DEFAULT_CONFIG` so they stay correct the next time the default moves.

## How to Test

1. Start from a config with no `agent.max_turns` (a user relying on the shipped default).
2. Run `hermes setup agent` and press Enter at the "Max iterations" prompt.
3. Inspect `~/.hermes/config.yaml`: before this change it contains `max_turns: 90`; after it matches the shipped default (500).
4. `pytest tests/hermes_cli/test_setup_agent_settings.py -q` -> 4 passed.
5. Mutation check: restoring `default=90` at either site fails the new tests (`assert 'max turns: 90' == 'max turns: 500'`), so they genuinely pin the behavior.
6. Tested on Ubuntu 24.04.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites and they pass (`tests/hermes_cli/` setup suites + `tests/cli/test_cli_init.py`: 98 passed; the 2 failures in `test_setup.py` are pre-existing on `main` and systemctl/container-related, unrelated to this change)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the wizard's own guidance text is updated; docs already state the 500 default
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added or changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure config-resolution change, no platform-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
