### PR TITLE
fix(file-tools): preserve home for repeated tilde slashes

### DIFF
--- a/tests/tools/test_file_tools_tilde_profile.py
+++ b/tests/tools/test_file_tools_tilde_profile.py
@@ -43,6 +43,13 @@ class TestExpandTilde:
             result = ft._expand_tilde("~")
         assert result == "/opt/data/profiles/coder/home"
 
+    def test_consecutive_slashes_stay_under_profile_home(self):
+        """Extra slashes after ~/ must not turn the rest into an absolute path."""
+        profile_home = "/opt/data/profiles/coder/home"
+        with patch("hermes_constants.get_subprocess_home", return_value=profile_home):
+            result = ft._expand_tilde("~//foo")
+        assert result == os.path.join(profile_home, "foo")
+
     def test_falls_back_when_no_profile_home(self):
         """When get_subprocess_home returns None, use os.path.expanduser."""
         with patch("hermes_constants.get_subprocess_home", return_value=None):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -44,7 +44,7 @@ def _expand_tilde(path: str) -> str:
     except Exception:
         home = None
     if home and (path == "~" or path.startswith("~/")):
-        return home if path == "~" else os.path.join(home, path[2:])
+        return home if path == "~" else os.path.join(home, path[2:].lstrip("/"))
     return os.path.expanduser(path)
 
 


### PR DESCRIPTION
## Summary

- Preserve the configured home directory when a tilde path contains repeated slashes.
- Add a regression test for `~//foo`.

Fixes #53432

## Verification

- `scripts/run_tests.sh tests/tools/test_file_tools_tilde_profile.py -q -k test_consecutive_slashes_stay_under_profile_home` — passed.
- `ruff check tools/file_tools.py tests/tools/test_file_tools_tilde_profile.py` — passed.
- `git diff --check` — passed.
- The full targeted test file has one pre-existing Windows path-separator failure in `test_tilde_expands_to_profile_home`; it is unrelated to this change.