### PR TITLE
fix(google-workspace): preserve Gmail message metadata

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -175,12 +175,12 @@ GAPI="python ${HERMES_HOME:-$HOME/.hermes}/skills/productivity/google-workspace/
 ### Gmail
 
 ```bash
-# Search (returns JSON array with id, from, subject, date, snippet)
+# Search (returns JSON array with headers, Gmail internal date, and snippet)
 $GAPI gmail search "is:unread" --max 10
 $GAPI gmail search "from:boss@company.com newer_than:1d"
 $GAPI gmail search "has:attachment filename:pdf newer_than:7d"
 
-# Read full message (returns JSON with body text)
+# Read full message (returns body text and attachment metadata)
 $GAPI gmail get MESSAGE_ID
 
 # Send
@@ -290,8 +290,8 @@ $GAPI docs append DOC_ID --text "Additional content to append"
 
 All commands return JSON. Parse with `jq` or read directly. Key fields:
 
-- **Gmail search**: `[{id, threadId, from, to, subject, date, snippet, labels}]`
-- **Gmail get**: `{id, threadId, from, to, subject, date, labels, body}`
+- **Gmail search**: `[{id, threadId, from, to, subject, date, internalDate, snippet, labels}]`
+- **Gmail get**: `{id, threadId, from, to, cc, subject, date, internalDate, labels, body, attachments: [{filename, mimeType, attachmentId, size}]}`
 - **Gmail send/reply**: `{status: "sent", id, threadId}`
 - **Calendar list**: `[{id, summary, start, end, location, description, htmlLink}]`
 - **Calendar create**: `{status: "created", id, summary, htmlLink}`

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -154,6 +154,33 @@ def _extract_message_body(msg: dict) -> str:
     return body
 
 
+def _extract_message_attachments(msg: dict) -> list[dict]:
+    """Return nested MIME attachment metadata without downloading bodies."""
+    attachments = []
+
+    def visit(part: dict) -> None:
+        filename = str(part.get("filename") or "").strip()
+        part_body = part.get("body", {}) or {}
+        attachment_id = str(part_body.get("attachmentId") or "").strip()
+        if filename or attachment_id:
+            attachments.append(
+                {
+                    "filename": filename,
+                    "mimeType": str(part.get("mimeType") or ""),
+                    "attachmentId": attachment_id,
+                    "size": int(part_body.get("size") or 0),
+                }
+            )
+        for child in part.get("parts", []) or []:
+            if isinstance(child, dict):
+                visit(child)
+
+    payload = msg.get("payload", {}) or {}
+    if isinstance(payload, dict):
+        visit(payload)
+    return attachments
+
+
 def _extract_doc_text(doc: dict) -> str:
     text_parts = []
     for element in doc.get("body", {}).get("content", []):
@@ -238,6 +265,7 @@ def gmail_search(args):
                     "to": headers.get("to", ""),
                     "subject": headers.get("subject", ""),
                     "date": headers.get("date", ""),
+                    "internalDate": str(msg.get("internalDate", "")),
                     "snippet": msg.get("snippet", ""),
                     "labels": msg.get("labelIds", []),
                 }
@@ -268,6 +296,7 @@ def gmail_search(args):
             "to": headers.get("to", ""),
             "subject": headers.get("subject", ""),
             "date": headers.get("date", ""),
+            "internalDate": str(msg.get("internalDate", "")),
             "snippet": msg.get("snippet", ""),
             "labels": msg.get("labelIds", []),
         })
@@ -287,10 +316,13 @@ def gmail_get(args):
             "threadId": msg["threadId"],
             "from": headers.get("from", ""),
             "to": headers.get("to", ""),
+            "cc": headers.get("cc", ""),
             "subject": headers.get("subject", ""),
             "date": headers.get("date", ""),
+            "internalDate": str(msg.get("internalDate", "")),
             "labels": msg.get("labelIds", []),
             "body": _extract_message_body(msg),
+            "attachments": _extract_message_attachments(msg),
         }
         print(json.dumps(result, indent=2, ensure_ascii=False))
         return
@@ -306,10 +338,13 @@ def gmail_get(args):
         "threadId": msg["threadId"],
         "from": headers.get("from", ""),
         "to": headers.get("to", ""),
+        "cc": headers.get("cc", ""),
         "subject": headers.get("subject", ""),
         "date": headers.get("date", ""),
+        "internalDate": str(msg.get("internalDate", "")),
         "labels": msg.get("labelIds", []),
         "body": _extract_message_body(msg),
+        "attachments": _extract_message_attachments(msg),
     }
     print(json.dumps(result, indent=2, ensure_ascii=False))
 

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -195,3 +195,103 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+def _gmail_message(api_module):
+    return {
+        "id": "msg-1",
+        "threadId": "thread-1",
+        "internalDate": "1780056000000",
+        "labelIds": ["INBOX"],
+        "snippet": "preview",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": "sender@example.com"},
+                {"name": "To", "value": "recipient@example.com"},
+                {"name": "Cc", "value": "copy@example.com"},
+                {"name": "Subject", "value": "metadata"},
+                {"name": "Date", "value": "Fri, 29 May 2026 12:00:00 +0000"},
+            ],
+            "mimeType": "multipart/mixed",
+            "body": {},
+            "parts": [
+                {
+                    "mimeType": "text/plain",
+                    "body": {
+                        "data": api_module.base64.urlsafe_b64encode(b"Plain body").decode()
+                    },
+                },
+                {
+                    "mimeType": "multipart/related",
+                    "body": {},
+                    "parts": [
+                        {
+                            "filename": "example.pdf",
+                            "mimeType": "application/pdf",
+                            "body": {
+                                "attachmentId": "attachment-1",
+                                "size": 1234,
+                            },
+                        }
+                    ],
+                },
+            ],
+        },
+    }
+
+
+def _use_gmail_backend(api_module, backend, message):
+    if backend == "gws":
+        def fake_run_gws(parts, *, params=None, body=None):
+            if parts[-1] == "list":
+                return {"messages": [{"id": message["id"]}]}
+            return message
+
+        api_module._run_gws = fake_run_gws
+        return
+
+    api_module._gws_binary = lambda: None
+    messages = MagicMock()
+    messages.list.return_value.execute.return_value = {
+        "messages": [{"id": message["id"]}]
+    }
+    messages.get.return_value.execute.return_value = message
+    service = MagicMock()
+    service.users.return_value.messages.return_value = messages
+    api_module.build_service = lambda *_args: service
+
+
+@pytest.mark.parametrize("backend", ["gws", "sdk"])
+def test_api_gmail_search_preserves_internal_date(api_module, capsys, backend):
+    message = _gmail_message(api_module)
+    _use_gmail_backend(api_module, backend, message)
+    args = api_module.argparse.Namespace(query="from:sender", max=5)
+
+    api_module.gmail_search(args)
+
+    result = json.loads(capsys.readouterr().out)
+    assert result[0]["internalDate"] == "1780056000000"
+
+
+@pytest.mark.parametrize("backend", ["gws", "sdk"])
+def test_api_gmail_get_preserves_metadata_and_nested_attachments(
+    api_module, capsys, backend
+):
+    message = _gmail_message(api_module)
+    _use_gmail_backend(api_module, backend, message)
+    args = api_module.argparse.Namespace(message_id="msg-1")
+
+    api_module.gmail_get(args)
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["cc"] == "copy@example.com"
+    assert result["internalDate"] == "1780056000000"
+    assert result["body"] == "Plain body"
+    assert result["attachments"] == [
+        {
+            "filename": "example.pdf",
+            "mimeType": "application/pdf",
+            "attachmentId": "attachment-1",
+            "size": 1234,
+        }
+    ]

--- a/website/docs/user-guide/skills/google-workspace.md
+++ b/website/docs/user-guide/skills/google-workspace.md
@@ -34,7 +34,7 @@ $GAPI gmail search "from:boss@company.com newer_than:1d"
 $GAPI gmail search "has:attachment filename:pdf newer_than:7d"
 ```
 
-Returns JSON with `id`, `from`, `subject`, `date`, `snippet`, and `labels` for each message.
+Returns JSON with message IDs, sender and recipient headers, the RFC 5322 `date`, Gmail's `internalDate`, `snippet`, and `labels` for each message.
 
 ### Reading
 
@@ -42,7 +42,7 @@ Returns JSON with `id`, `from`, `subject`, `date`, `snippet`, and `labels` for e
 $GAPI gmail get MESSAGE_ID
 ```
 
-Returns the full message body as text (prefers plain text, falls back to HTML).
+Returns the full message body as text (prefers plain text, falls back to HTML), CC recipients, Gmail's internal date, and nested attachment metadata. Attachment bodies are not downloaded.
 
 ### Sending
 
@@ -171,8 +171,8 @@ All commands return JSON. Key fields per service:
 
 | Command | Fields |
 |---------|--------|
-| `gmail search` | `id`, `threadId`, `from`, `to`, `subject`, `date`, `snippet`, `labels` |
-| `gmail get` | `id`, `threadId`, `from`, `to`, `subject`, `date`, `labels`, `body` |
+| `gmail search` | `id`, `threadId`, `from`, `to`, `subject`, `date`, `internalDate`, `snippet`, `labels` |
+| `gmail get` | `id`, `threadId`, `from`, `to`, `cc`, `subject`, `date`, `internalDate`, `labels`, `body`, `attachments` (`filename`, `mimeType`, `attachmentId`, `size`) |
 | `gmail send/reply` | `status`, `id`, `threadId` |
 | `calendar list` | `id`, `summary`, `start`, `end`, `location`, `description`, `htmlLink` |
 | `calendar create` | `status`, `id`, `summary`, `htmlLink` |


### PR DESCRIPTION
## What does this PR do?

Preserves Gmail message metadata that the Google Workspace helper currently discards.

`gmail search` now retains Gmail's authoritative `internalDate`. `gmail get` now returns `cc`, `internalDate`, and attachment metadata without downloading attachment contents. Attachment discovery recursively traverses nested MIME parts.

The change covers both supported backends: the Google Workspace CLI (`gws`) and the Python SDK fallback.

## Related Issue

No related issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [x] 📚 Documentation

## Changes Made

- Preserve string-valued `internalDate` in Gmail search results for both backends.
- Return case-insensitive `cc` and string-valued `internalDate` from Gmail get.
- Recursively collect attachment filename, MIME type, attachment ID, and size without downloading attachment bodies.
- Add compact regression tests that exercise both mocked `gws` and Python-SDK paths, including nested attachment metadata.
- Document the additive output fields in the bundled skill and handwritten Google Workspace guide.

## How to Test

```bash
scripts/run_tests.sh tests/skills/test_google_workspace_api.py \
  tests/skills/test_google_workspace_credential_files.py -q
```

Expected result: 10 tests passed, 0 failed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing open and closed PRs. Closed PR #23465 adds attachment download commands and does not duplicate this metadata-preservation fix.
- [x] My PR contains only changes related to this fix.
- [x] Focused canonical tests pass (10/10).
- [x] Ruff, Python compilation, and `git diff --check` pass.
- [x] I've added tests for my changes.
- [x] I've tested on macOS.

### Documentation & Housekeeping

- [x] Updated `skills/productivity/google-workspace/SKILL.md`.
- [x] Updated `website/docs/user-guide/skills/google-workspace.md`.
- [x] `cli-config.yaml.example`: N/A; no config changes.
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A; no architecture changes.
- [x] Cross-platform impact considered; implementation uses Python data traversal only.
- [x] Tool descriptions/schemas: N/A; no core tool schema changes.

## Test Output

```text
=== Summary: 2 files, 10 tests passed, 0 failed (100% complete)
```
