### PR TITLE
fix(tools): match glob tool filters in the hermes tools MCP checklist

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -4658,17 +4658,31 @@ def _configure_mcp_tools_interactive(config: dict):
             else:
                 labels.append(tool_name)
 
-        # Determine which tools are currently enabled
+        # Determine which tools are currently enabled. Filter entries may be
+        # exact names or fnmatch globs, so match them the way runtime
+        # registration does (tools/mcp_tool.py::matches_name_filter) — the
+        # checklist writes its selection back as tools.include, so treating a
+        # glob as a literal here would show every glob-excluded tool as
+        # enabled and persist them on the user's next edit.
+        try:
+            from tools.mcp_tool import matches_name_filter
+        except ImportError:  # pragma: no cover — defensive fallback
+            def matches_name_filter(tool_name, patterns):
+                return tool_name in patterns
+
+        include_set = {str(p) for p in include_list}
+        exclude_set = {str(p) for p in exclude_list}
+
         pre_selected: Set[int] = set()
         tool_names = [t[0] for t in tools]
         for i, tool_name in enumerate(tool_names):
-            if include_list:
+            if include_set:
                 # Include mode: only included tools are selected
-                if tool_name in include_list:
+                if matches_name_filter(tool_name, include_set):
                     pre_selected.add(i)
-            elif exclude_list:
+            elif exclude_set:
                 # Exclude mode: everything except excluded
-                if tool_name not in exclude_list:
+                if not matches_name_filter(tool_name, exclude_set):
                     pre_selected.add(i)
             else:
                 # No filter: all enabled

--- a/tests/hermes_cli/test_mcp_tools_config.py
+++ b/tests/hermes_cli/test_mcp_tools_config.py
@@ -293,3 +293,107 @@ def test_empty_tools_server_skipped(capsys):
     assert len(checklist_calls) == 0
     captured = capsys.readouterr()
     assert "no tools found" in captured.out
+
+
+def test_pre_selection_respects_glob_exclude():
+    """A glob exclude must start its matching tools unchecked.
+
+    Runtime registration matches include/exclude with fnmatch globs
+    (``tools/mcp_tool.py::matches_name_filter``). Matching only exact names
+    here shows every glob-excluded tool as enabled, so the checklist
+    disagrees with the tool surface the agent actually gets.
+    """
+    config = {
+        "mcp_servers": {
+            "cloudflare": {
+                "command": "npx",
+                "tools": {"exclude": ["*_radar_*"]},
+            },
+        }
+    }
+    tools = [
+        ("purge_cache", "Purge"),
+        ("cf_radar_http", "Radar HTTP"),
+        ("dns_records", "DNS"),
+        ("cf_radar_bgp", "Radar BGP"),
+    ]
+    captured_pre_selected = {}
+
+    def fake_checklist(title, labels, pre_selected, **kwargs):
+        captured_pre_selected["value"] = set(pre_selected)
+        return pre_selected  # No changes
+
+    with patch(_PROBE, return_value={"cloudflare": tools}), \
+         patch(_CHECKLIST, side_effect=fake_checklist), \
+         patch(_SAVE):
+        _configure_mcp_tools_interactive(config)
+
+    # Only the two non-radar tools may start checked.
+    assert captured_pre_selected["value"] == {0, 2}
+
+
+def test_pre_selection_respects_glob_include():
+    """A glob include must start only its matching tools checked."""
+    config = {
+        "mcp_servers": {
+            "cloudflare": {
+                "command": "npx",
+                "tools": {"include": ["dns_*"]},
+            },
+        }
+    }
+    tools = [
+        ("purge_cache", "Purge"),
+        ("dns_records", "DNS"),
+        ("dns_zones", "Zones"),
+    ]
+    captured_pre_selected = {}
+
+    def fake_checklist(title, labels, pre_selected, **kwargs):
+        captured_pre_selected["value"] = set(pre_selected)
+        return pre_selected  # No changes
+
+    with patch(_PROBE, return_value={"cloudflare": tools}), \
+         patch(_CHECKLIST, side_effect=fake_checklist), \
+         patch(_SAVE):
+        _configure_mcp_tools_interactive(config)
+
+    assert captured_pre_selected["value"] == {1, 2}
+
+
+def test_glob_exclude_survives_an_unrelated_edit():
+    """Editing one tool must not silently re-enable glob-excluded tools.
+
+    The checklist writes its selection back as ``tools.include`` and drops
+    ``exclude``. When glob-excluded tools start (wrongly) checked, the user's
+    next edit persists them as enabled — the filter is gone and every
+    excluded tool floods back into the agent's tool surface.
+    """
+    config = {
+        "mcp_servers": {
+            "cloudflare": {
+                "command": "npx",
+                "tools": {"exclude": ["*_radar_*"]},
+            },
+        }
+    }
+    tools = [
+        ("purge_cache", "Purge"),
+        ("cf_radar_http", "Radar HTTP"),
+        ("dns_records", "DNS"),
+    ]
+
+    def fake_checklist(title, labels, pre_selected, **kwargs):
+        # User unchecks one unrelated tool (dns_records) and confirms.
+        return set(pre_selected) - {2}
+
+    with patch(_PROBE, return_value={"cloudflare": tools}), \
+         patch(_CHECKLIST, side_effect=fake_checklist), \
+         patch(_SAVE):
+        _configure_mcp_tools_interactive(config)
+
+    written = config["mcp_servers"]["cloudflare"]["tools"].get("include", [])
+    assert "cf_radar_http" not in written, (
+        "an unrelated edit re-enabled a glob-excluded tool"
+    )
+    assert written == ["purge_cache"]


### PR DESCRIPTION
## What does this PR do?

`hermes tools` -> MCP tool checklist decided which tools start checked using **exact membership**:

```python
if tool_name in include_list: ...      # include mode
if tool_name not in exclude_list: ...  # exclude mode
```

Runtime registration, however, has matched `tools.include` / `tools.exclude` with **fnmatch globs** since e7172ab1b (`matches_name_filter` in `tools/mcp_tool.py`), and the `hermes mcp configure` picker was converted in that same commit specifically "so the UI agrees with runtime registration". This checklist was not.

So with a glob filter — e.g. the Cloudflare case that motivated glob support, `exclude: ["*_radar_*"]` trimming 3,320 tools to ~1,905 — nothing matches here and **every glob-excluded tool is displayed as enabled**.

That is not just a display mismatch. This checklist **writes its selection back**: it sets `tools.include = <checked names>` and drops `exclude`. So the moment the user edits any single unrelated tool, the wrongly-checked ones are persisted as enabled: the glob filter is silently replaced by a literal include list that re-enables everything it had excluded, and the full tool surface floods back into the agent's context — the exact blowup glob support was added to prevent. (If all tools end up checked, both `include` and `exclude` are removed outright.)

Reproduced against `main` (`6d1e08b2b`) — the three new tests fail before this change:

```
FAILED test_pre_selection_respects_glob_exclude
FAILED test_pre_selection_respects_glob_include
FAILED test_glob_exclude_survives_an_unrelated_edit
E   AssertionError: an unrelated edit re-enabled a glob-excluded tool
E   assert 'cf_radar_http' not in ['purge_cache', 'cf_radar_http']
```

The fix routes this surface through the same `matches_name_filter` the runtime and the other picker already use, so all three agree. Behaviour for literal (non-glob) filter entries is unchanged — `matches_name_filter` checks exact membership first, and entries without metacharacters stay strictly literal.

## Related Issue

No separate issue filed — found while auditing the surfaces touched by e7172ab1b.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/tools_config.py` (`_configure_mcp_tools_interactive`): pre-selection now matches `tools.include` / `tools.exclude` with `matches_name_filter` (exact names or fnmatch globs) instead of literal membership, mirroring `hermes_cli/mcp_config.py::cmd_mcp_configure`. Same defensive `ImportError` fallback as that call site.
- `tests/hermes_cli/test_mcp_tools_config.py`: three regression tests — glob exclude leaves matching tools unchecked, glob include checks only matching tools, and an unrelated edit no longer re-enables glob-excluded tools (the config-clobbering path).

## How to Test

1. Configure an MCP server with a glob filter, e.g. `mcp_servers.<name>.tools.exclude: ["*_radar_*"]`.
2. Run `hermes tools` and open the MCP tool checklist for that server: before this change every `*_radar_*` tool starts checked; after it they start unchecked, matching what the agent actually registers.
3. Toggle one unrelated tool and confirm. Before this change `config.yaml` loses `exclude` and gains an `include` list containing the radar tools (they are now live); after, they stay out.
4. `pytest tests/hermes_cli/test_mcp_tools_config.py -q` -> 17 passed (3 new). All three new tests fail on `main` without the code change.
5. Wider run: `pytest tests/hermes_cli/test_mcp_tools_config.py tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_catalog.py tests/hermes_cli/test_aux_picker_inventory.py tests/tools/test_mcp_tool.py -q` -> 342 passed, 1 failed; that failure (`TestBuildSafeEnv::test_windows_location_vars_passed_without_secrets`) is pre-existing on `main` and environment-specific, confirmed by re-running it with this change stashed.
6. Tested on Ubuntu 24.04.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites and they pass (see step 5 for the one pre-existing, unrelated failure)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no user-facing config shape or behaviour contract changed; this aligns a UI with the documented runtime semantics)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added or changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure string-matching change, no platform-specific behaviour)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (tool schemas unchanged; only which MCP tools the checklist shows as enabled)
