### PR TITLE
fix(desktop): settle pending gateway connects on close

### DIFF
--- a/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
@@ -20,6 +20,30 @@ class FakeSocket {
   send = vi.fn()
 }
 
+class PendingSocket {
+  static OPEN = 1
+  readyState = 0
+  private listeners = new Map<string, Set<() => void>>()
+
+  addEventListener = vi.fn((type: string, handler: () => void) => {
+    const handlers = this.listeners.get(type) ?? new Set()
+    handlers.add(handler)
+    this.listeners.set(type, handlers)
+  })
+
+  removeEventListener = vi.fn((type: string, handler: () => void) => {
+    this.listeners.get(type)?.delete(handler)
+  })
+
+  close = vi.fn(() => {
+    for (const handler of this.listeners.get('close') ?? []) {
+      handler()
+    }
+  })
+
+  send = vi.fn()
+}
+
 describe('JsonRpcGatewayClient connect() URL guard', () => {
   beforeEach(() => {
     vi.stubGlobal('WebSocket', FakeSocket) // jsdom has none; class reads WebSocket.OPEN
@@ -61,5 +85,22 @@ describe('JsonRpcGatewayClient connect() URL guard', () => {
       await client.connect(url)
       expect(client.connectionState).toBe('open')
     }
+  })
+
+  it('settles an in-flight connect immediately when closed', async () => {
+    vi.stubGlobal('WebSocket', PendingSocket)
+
+    const socket = new PendingSocket()
+
+    const client = new JsonRpcGatewayClient({
+      connectTimeoutMs: 15_000,
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const connecting = client.connect('ws://127.0.0.1:1234/api/ws')
+    client.close()
+
+    await expect(connecting).rejects.toThrow('WebSocket closed')
+    expect(client.connectionState).toBe('closed')
   })
 })

--- a/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
@@ -20,6 +20,32 @@ class FakeSocket {
   send = vi.fn()
 }
 
+class PendingSocket {
+  static OPEN = 1
+  readyState = 0
+  private listeners = new Map<string, Set<() => void>>()
+
+  addEventListener = vi.fn((type: string, handler: () => void) => {
+    const handlers = this.listeners.get(type) ?? new Set()
+    handlers.add(handler)
+    this.listeners.set(type, handlers)
+  })
+
+  removeEventListener = vi.fn((type: string, handler: () => void) => {
+    this.listeners.get(type)?.delete(handler)
+  })
+
+  emitClose = () => {
+    for (const handler of this.listeners.get('close') ?? []) {
+      handler()
+    }
+  }
+
+  close = vi.fn(() => this.emitClose())
+
+  send = vi.fn()
+}
+
 describe('JsonRpcGatewayClient connect() URL guard', () => {
   beforeEach(() => {
     vi.stubGlobal('WebSocket', FakeSocket) // jsdom has none; class reads WebSocket.OPEN
@@ -61,5 +87,29 @@ describe('JsonRpcGatewayClient connect() URL guard', () => {
       await client.connect(url)
       expect(client.connectionState).toBe('open')
     }
+  })
+
+  it.each([
+    ['the client closes', (client: JsonRpcGatewayClient, _socket: PendingSocket) => client.close()],
+    ['the peer closes', (_client: JsonRpcGatewayClient, socket: PendingSocket) => socket.emitClose()]
+  ])('settles an in-flight connect immediately when %s', async (_label, close) => {
+    vi.stubGlobal('WebSocket', PendingSocket)
+
+    const socket = new PendingSocket()
+
+    const client = new JsonRpcGatewayClient({
+      connectTimeoutMs: 15_000,
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const outcome = Promise.race([
+      client.connect('ws://127.0.0.1:1234/api/ws').catch(error => error),
+      new Promise(resolve => setTimeout(() => resolve('still pending'), 50))
+    ])
+
+    close(client, socket)
+
+    await expect(outcome).resolves.toEqual(new Error('WebSocket closed'))
+    expect(client.connectionState).toBe('closed')
   })
 })

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -72,6 +72,7 @@ export class JsonRpcGatewayClient {
   private pending = new Map<GatewayRequestId, PendingCall>()
   private socket: WebSocketLike | null = null
   private state: ConnectionState = 'idle'
+  private cancelConnect: (() => void) | null = null
   private readonly eventHandlers = new Map<string, Set<(event: GatewayEvent) => void>>()
   private readonly stateHandlers = new Set<(state: ConnectionState) => void>()
   private readonly options: Required<Omit<GatewayClientOptions, 'socketFactory'>> &
@@ -157,6 +158,11 @@ export class JsonRpcGatewayClient {
 
         socket.removeEventListener('open', onOpen)
         socket.removeEventListener('error', onError)
+        socket.removeEventListener('close', onClose)
+
+        if (this.cancelConnect === onClose) {
+          this.cancelConnect = null
+        }
       }
 
       const onOpen = () => {
@@ -181,8 +187,26 @@ export class JsonRpcGatewayClient {
         reject(new Error(this.options.connectErrorMessage))
       }
 
+      const onClose = () => {
+        if (settled) {
+          return
+        }
+
+        settled = true
+        cleanup()
+
+        if (this.socket === socket) {
+          this.socket = null
+        }
+
+        this.setState('closed')
+        reject(new Error(this.options.closedErrorMessage))
+      }
+
+      this.cancelConnect = onClose
       socket.addEventListener('open', onOpen, { once: true })
       socket.addEventListener('error', onError, { once: true })
+      socket.addEventListener('close', onClose, { once: true })
 
       if (this.options.connectTimeoutMs > 0) {
         timer = setTimeout(() => {
@@ -218,6 +242,8 @@ export class JsonRpcGatewayClient {
     if (!socket) {
       return
     }
+
+    this.cancelConnect?.()
 
     try {
       socket.close()

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -74,6 +74,7 @@ export class JsonRpcGatewayClient {
   private pending = new Map<GatewayRequestId, PendingCall>()
   private socket: WebSocketLike | null = null
   private state: ConnectionState = 'idle'
+  private cancelConnect: (() => void) | null = null
   private readonly eventHandlers = new Map<string, Set<(event: GatewayEvent) => void>>()
   private readonly stateHandlers = new Set<(state: ConnectionState) => void>()
   private readonly options: Required<Omit<GatewayClientOptions, 'socketFactory'>> &
@@ -164,6 +165,11 @@ export class JsonRpcGatewayClient {
 
         socket.removeEventListener('open', onOpen)
         socket.removeEventListener('error', onError)
+        socket.removeEventListener('close', onClose)
+
+        if (this.cancelConnect === onClose) {
+          this.cancelConnect = null
+        }
       }
 
       const onOpen = () => {
@@ -188,8 +194,20 @@ export class JsonRpcGatewayClient {
         reject(new Error(this.options.connectErrorMessage))
       }
 
+      const onClose = () => {
+        if (settled) {
+          return
+        }
+
+        settled = true
+        cleanup()
+        reject(new Error(this.options.closedErrorMessage))
+      }
+
+      this.cancelConnect = onClose
       socket.addEventListener('open', onOpen, { once: true })
       socket.addEventListener('error', onError, { once: true })
+      socket.addEventListener('close', onClose, { once: true })
 
       if (this.options.connectTimeoutMs > 0) {
         timer = setTimeout(() => {
@@ -225,6 +243,8 @@ export class JsonRpcGatewayClient {
     if (!socket) {
       return
     }
+
+    this.cancelConnect?.()
 
     try {
       socket.close()


### PR DESCRIPTION
## Summary
- settle an in-flight gateway `connect()` when the client is explicitly closed
- reject immediately when a WebSocket closes before its `open` event
- clear the connect timeout and temporary listeners on every settlement path

## Root cause
`JsonRpcGatewayClient.close()` closed the socket but did not settle the Promise created by an in-flight `connect()`. A deliberate close during the WebSocket handshake therefore remained pending until the 15-second connect timeout fired, which could surface a stale error during desktop reset or reconnect flows.

## Tests
- regression proof before the fix: the focused test timed out after 15 seconds
- `npm --prefix apps/desktop test -- --project ui src/lib/json-rpc-gateway-url-guard.test.ts` (6 passed)
- `npm --prefix apps/shared run typecheck`
- `npm --prefix apps/desktop run typecheck`
- targeted ESLint for both changed files
- structured Codex autoreview: clean, no actionable findings

Related to #71226. This is limited to client-side pending-connect settlement and does not claim to resolve every backend startup cause discussed there.