### PR TITLE
fix(tui-gateway): install the selected profile's secret scope (Desktop/dashboard)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -661,6 +661,61 @@ def test_profile_scoped_agent_build_starts_mcp_discovery_in_profile_home(
     assert seen == [str(profile_home)]
 
 
+def test_profile_scoped_agent_build_installs_secret_scope(monkeypatch, tmp_path):
+    """Agent construction must install the selected profile's secret scope.
+
+    Without it, get_secret() falls through to process os.environ, so a session
+    "switched" to profile X resolves credentials from the LAUNCH profile's
+    .env (#67605 item 2).
+    """
+    import threading
+
+    from agent.secret_scope import current_secret_scope
+
+    profile_home = tmp_path / "profiles" / "grace"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text(
+        "PROXMOX_TOKEN=grace-secret\n", encoding="utf-8"
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default"))
+
+    scopes = []
+    built = threading.Event()
+
+    def _fake_make_agent(*args, **kwargs):
+        scope = current_secret_scope()
+        scopes.append(dict(scope) if scope else None)
+        built.set()
+        return type("Agent", (), {"model": "test"})()
+
+    monkeypatch.setattr(server, "_make_agent", _fake_make_agent)
+    monkeypatch.setattr(
+        "tui_gateway.entry.ensure_mcp_discovery_started", lambda: None
+    )
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_SlashWorker", lambda *args: None)
+    monkeypatch.setattr(server, "_attach_worker", lambda *args: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+
+    ready = threading.Event()
+    sid = "test-secret-sid"
+    session = {
+        "agent_ready": ready,
+        "session_key": "test-secret-key",
+        "profile_home": str(profile_home),
+    }
+
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert built.wait(timeout=2)
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert scopes == [{"PROXMOX_TOKEN": "grace-secret"}]
+
+
 def test_profile_configured_cwd_reads_target_profile(tmp_path):
     """A profile's own terminal.cwd is read from its config.yaml."""
     project = tmp_path / "proj"

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -436,12 +436,15 @@ class ComputeHost:
         profile_home = str(frame.get("profile_home") or "")
         session_db = None
         home_token = None
+        secret_token = None
         try:
             if profile_home:
                 from hermes_constants import set_hermes_home_override
+                from agent.secret_scope import build_profile_secret_scope, set_secret_scope
                 from hermes_state import SessionDB
 
                 home_token = set_hermes_home_override(profile_home)
+                secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
                 session_db = SessionDB(db_path=Path(profile_home) / "state.db")
             agent = server._make_agent(
                 sid,
@@ -457,8 +460,10 @@ class ComputeHost:
             if home_token is not None:
                 try:
                     from hermes_constants import reset_hermes_home_override
+                    from agent.secret_scope import reset_secret_scope
 
                     reset_hermes_home_override(home_token)
+                    reset_secret_scope(secret_token)
                 except Exception:
                     pass
         try:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -18,6 +18,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
+from agent.secret_scope import (
+    build_profile_secret_scope,
+    reset_secret_scope,
+    set_secret_scope,
+)
 from hermes_constants import (
     get_hermes_home,
     get_hermes_home_override,
@@ -1834,6 +1839,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
         worker = None
         notify_registered = False
         home_token = None
+        secret_token = None
         profile_home = current.get("profile_home")
         try:
             tokens = _set_session_context(key)
@@ -1843,6 +1849,12 @@ def _start_agent_build(sid: str, session: dict) -> None:
             session_db = None
             if profile_home:
                 home_token = set_hermes_home_override(profile_home)
+                try:
+                    from agent.secret_scope import build_profile_secret_scope, set_secret_scope
+
+                    secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+                except Exception:
+                    pass
                 try:
                     from hermes_state import SessionDB
 
@@ -1963,6 +1975,13 @@ def _start_agent_build(sid: str, session: dict) -> None:
         finally:
             if home_token is not None:
                 reset_hermes_home_override(home_token)
+            if secret_token is not None:
+                try:
+                    from agent.secret_scope import reset_secret_scope
+
+                    reset_secret_scope(secret_token)
+                except Exception:
+                    pass
             # _attach_worker already closed the worker if this session was
             # reaped mid-build; only the late notify registration can still
             # leak (session.close unregistered before _build registered it).
@@ -7474,6 +7493,11 @@ def _(rid, params: dict) -> dict:
     home_token = (
         set_hermes_home_override(str(profile_home)) if profile_home is not None else None
     )
+    secret_token = (
+        set_secret_scope(build_profile_secret_scope(Path(str(profile_home))))
+        if profile_home is not None
+        else None
+    )
     try:
         db.reopen_session(target)
         # One lineage SELECT feeds both projections (see the interactive resume
@@ -7515,6 +7539,8 @@ def _(rid, params: dict) -> dict:
     finally:
         if home_token is not None:
             reset_hermes_home_override(home_token)
+        if secret_token is not None:
+            reset_secret_scope(secret_token)
 
     # Double-checked locking: another concurrent resume may have created the
     # live session while we were building. Re-check under the lock; if it won,
@@ -7545,6 +7571,11 @@ def _(rid, params: dict) -> dict:
                 if profile_home is not None
                 else None
             )
+            init_secret_token = (
+                set_secret_scope(build_profile_secret_scope(Path(str(profile_home))))
+                if profile_home is not None
+                else None
+            )
             try:
                 _init_session(
                     sid,
@@ -7559,6 +7590,8 @@ def _(rid, params: dict) -> dict:
             finally:
                 if init_home_token is not None:
                     reset_hermes_home_override(init_home_token)
+                if init_secret_token is not None:
+                    reset_secret_scope(init_secret_token)
             if sid in _sessions:
                 if stored_runtime_overrides.get("model_override") is not None:
                     _sessions[sid]["model_override"] = stored_runtime_overrides[
@@ -11609,6 +11642,7 @@ def _run_prompt_submit(
         approval_token = None
         session_tokens = []
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
+        secret_token = None
         goal_followup = None  # set by the post-turn goal hook below
         tts_queue = None  # streaming-TTS feed for this turn (voice mode)
         one_turn_restore = session.pop("one_turn_model_restore", None)
@@ -11641,6 +11675,7 @@ def _run_prompt_submit(
             _profile_home_str = session.get("profile_home")
             if _profile_home_str:
                 home_token = set_hermes_home_override(_profile_home_str)
+                secret_token = set_secret_scope(build_profile_secret_scope(Path(_profile_home_str)))
             # The sudo password callback is thread-local (tools.terminal_tool
             # _callback_tls), so wiring it on the build thread doesn't reach this
             # turn thread — terminal sudo prompts would fall through to /dev/tty
@@ -12164,6 +12199,8 @@ def _run_prompt_submit(
                 pass
             if home_token is not None:
                 reset_hermes_home_override(home_token)
+            if secret_token is not None:
+                reset_secret_scope(secret_token)
             _clear_session_context(session_tokens)
             # Clear the per-turn interim callback so a stale closure from
             # this turn can't fire during a later turn on the same agent.


### PR DESCRIPTION
## Summary

Credentials in Desktop/dashboard sessions now resolve from the **selected** profile's `.env` instead of falling through to the launch profile's process environment. Fixes item 2 of #67605 (secret scope never installed on the tui_gateway path); salvage of #67623 by @kyssta-exe.

Root cause: `gateway/run.py` and `hermes_cli/web_server.py` install the profile secret scope around profile-bound work, but nothing in `tui_gateway/` did — so `get_secret()` fell through to `os.environ`, which holds the launch profile's `.env` (loaded with `override=True` at module import).

## Changes

- `tui_gateway/server.py`: install `set_secret_scope(build_profile_secret_scope(profile_home))` alongside the existing `HERMES_HOME` override at all three bind sites — agent build (`_start_agent_build`), session resume (`_reuse_live_payload`, both init paths), and per-turn prompt (`run`) — with paired resets in `finally` (contributor).
- `tui_gateway/compute_host.py`: same pairing in `_ensure_server_session` (contributor).
- `tests/test_tui_gateway_server.py`: regression test proving agent build installs the selected profile's scope (follow-up; the PR shipped without tests).

Dropped from the original branch: the `hermes_cli/mcp_startup.py` gate removal — superseded by #72219, which fixed the discovery gate properly by propagating the profile override into the discovery thread.

## Validation

| Check | Result |
|---|---|
| `tests/test_tui_gateway_server.py` (468) | pass |
| `tests/tui_gateway/` + `tests/agent/test_secret_scope.py` (988 total) | pass |
| Sabotage run (secret-scope install removed from `_start_agent_build`) | new test fails as expected |
| E2E (real imports, temp homes, poisoned process env) | 6/6: profile value wins over launch env; multiplex-off overlay fallthrough preserved; multiplex-on absent-key no-leak; reset restores env |

## Infographic

![Profile secret scope for tui_gateway](https://v3b.fal.media/files/b/0aa3db89/DGVrriCW3OHXX4OZ_VhPX_zu7jyEoB.png)
