### PR TITLE
perf(dashboard): lazy-load routes + split vendors; polish session-list placeholders

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,6 @@
 import {
+  lazy,
+  Suspense,
   useCallback,
   useEffect,
   useMemo,
@@ -72,25 +74,27 @@ import { ProfileSwitcher } from "@/components/ProfileSwitcher";
 import { ProfileScopeBanner } from "@/components/ProfileScopeBanner";
 import { useSystemActions } from "@/contexts/useSystemActions";
 import type { SystemAction } from "@/contexts/system-actions-context";
-import ConfigPage from "@/pages/ConfigPage";
-import DocsPage from "@/pages/DocsPage";
-import EnvPage from "@/pages/EnvPage";
-import FilesPage from "@/pages/FilesPage";
-import SessionsPage from "@/pages/SessionsPage";
-import LogsPage from "@/pages/LogsPage";
-import AnalyticsPage from "@/pages/AnalyticsPage";
-import ModelsPage from "@/pages/ModelsPage";
-import CronPage from "@/pages/CronPage";
-import ProfilesPage from "@/pages/ProfilesPage";
-import ProfileBuilderPage from "@/pages/ProfileBuilderPage";
-import SkillsPage from "@/pages/SkillsPage";
-import PluginsPage from "@/pages/PluginsPage";
-import McpPage from "@/pages/McpPage";
-import PairingPage from "@/pages/PairingPage";
-import ChannelsPage from "@/pages/ChannelsPage";
-import WebhooksPage from "@/pages/WebhooksPage";
-import SystemPage from "@/pages/SystemPage";
-import ChatPage from "@/pages/ChatPage";
+// Route pages are lazy-loaded so the initial dashboard shell does not pay for
+// every admin surface (and heavy deps like xterm) up front.
+const ConfigPage = lazy(() => import("@/pages/ConfigPage"));
+const DocsPage = lazy(() => import("@/pages/DocsPage"));
+const EnvPage = lazy(() => import("@/pages/EnvPage"));
+const FilesPage = lazy(() => import("@/pages/FilesPage"));
+const SessionsPage = lazy(() => import("@/pages/SessionsPage"));
+const LogsPage = lazy(() => import("@/pages/LogsPage"));
+const AnalyticsPage = lazy(() => import("@/pages/AnalyticsPage"));
+const ModelsPage = lazy(() => import("@/pages/ModelsPage"));
+const CronPage = lazy(() => import("@/pages/CronPage"));
+const ProfilesPage = lazy(() => import("@/pages/ProfilesPage"));
+const ProfileBuilderPage = lazy(() => import("@/pages/ProfileBuilderPage"));
+const SkillsPage = lazy(() => import("@/pages/SkillsPage"));
+const PluginsPage = lazy(() => import("@/pages/PluginsPage"));
+const McpPage = lazy(() => import("@/pages/McpPage"));
+const PairingPage = lazy(() => import("@/pages/PairingPage"));
+const ChannelsPage = lazy(() => import("@/pages/ChannelsPage"));
+const WebhooksPage = lazy(() => import("@/pages/WebhooksPage"));
+const SystemPage = lazy(() => import("@/pages/SystemPage"));
+const ChatPage = lazy(() => import("@/pages/ChatPage"));
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
@@ -99,8 +103,24 @@ import { PluginPage, PluginSlot, usePlugins } from "@/plugins";
 import type { PluginManifest } from "@/plugins";
 import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
+import { latchChatActivation } from "@/lib/chat-activation";
 import { api } from "@/lib/api";
 import type { StatusResponse, UpdateCheckResponse } from "@/lib/api";
+
+function RouteFallback({ label = "Loading…" }: { label?: string }) {
+  return (
+    <div
+      className="flex min-h-[12rem] flex-1 items-center justify-center"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Spinner />
+        <span>{label}</span>
+      </div>
+    </div>
+  );
+}
 
 function RootRedirect() {
   return <Navigate to="/sessions" replace />;
@@ -127,8 +147,10 @@ const CHAT_NAV_ITEM: NavItem = {
  * inline near the bottom of this file — so the PTY child, WebSocket,
  * and xterm instance survive when the user visits another tab and comes
  * back.  A `display:none` toggle hides the terminal without unmounting.
- * Routing still owns the URL so /chat deep-links, browser back/forward,
- * and nav highlight keep working.
+ * The host itself is still deferred until the first /chat visit so the
+ * xterm chunk is not downloaded on unrelated pages.  Routing still owns
+ * the URL so /chat deep-links, browser back/forward, and nav highlight
+ * keep working.
  */
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
@@ -378,6 +400,13 @@ export default function App() {
   const normalizedPath = pathname.replace(/\/$/, "") || "/";
   const isChatRoute = normalizedPath === "/chat";
   const embeddedChat = isDashboardEmbeddedChatEnabled();
+  // Defer mounting the persistent chat host (and its xterm chunk) until the
+  // user has actually opened /chat at least once. Sticky after that so the
+  // PTY survives later tab switches.
+  const [chatHostMounted, setChatHostMounted] = useState(isChatRoute);
+  useEffect(() => {
+    setChatHostMounted((prev) => latchChatActivation(prev, isChatRoute));
+  }, [isChatRoute]);
 
   // `dashboard.show_token_analytics` gates the Analytics nav item.  The
   // page itself remains reachable by URL (it renders an explanation when
@@ -737,35 +766,28 @@ export default function App() {
                 )}
               >
                 <ProfileKeyedRoutes>
-                  <Routes>
-                    {routes.map(({ key, path, element }) => (
-                      <Route key={key} path={path} element={element} />
-                    ))}
-                    <Route
-                      path="*"
-                      element={
-                        <UnknownRouteFallback pluginsLoading={pluginsLoading} />
-                      }
-                    />
-                  </Routes>
+                  <Suspense fallback={<RouteFallback />}>
+                    <Routes>
+                      {routes.map(({ key, path, element }) => (
+                        <Route key={key} path={path} element={element} />
+                      ))}
+                      <Route
+                        path="*"
+                        element={
+                          <UnknownRouteFallback pluginsLoading={pluginsLoading} />
+                        }
+                      />
+                    </Routes>
+                  </Suspense>
                 </ProfileKeyedRoutes>
 
                 {embeddedChat &&
                   !chatOverriddenByPlugin &&
                   (pluginsLoading ? (
                     isChatRoute ? (
-                      <div
-                        className="flex min-h-0 min-w-0 flex-1 items-center justify-center"
-                        aria-busy="true"
-                        aria-live="polite"
-                      >
-                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                          <Spinner />
-                          <span>Loading chat…</span>
-                        </div>
-                      </div>
+                      <RouteFallback label="Loading chat…" />
                     ) : null
-                  ) : (
+                  ) : chatHostMounted ? (
                     <div
                       data-chat-active={isChatRoute ? "true" : "false"}
                       className={cn(
@@ -774,9 +796,19 @@ export default function App() {
                       )}
                       aria-hidden={!isChatRoute}
                     >
-                      <ChatPage isActive={isChatRoute} />
+                      <Suspense
+                        fallback={
+                          isChatRoute ? (
+                            <RouteFallback label="Loading chat…" />
+                          ) : null
+                        }
+                      >
+                        <ChatPage isActive={isChatRoute} />
+                      </Suspense>
                     </div>
-                  ))}
+                  ) : isChatRoute ? (
+                    <RouteFallback label="Loading chat…" />
+                  ) : null)}
               </div>
               <PluginSlot name="post-main" />
             </div>

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -614,10 +614,14 @@ function SessionRow({
                 )}
               </div>
               <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-muted-foreground">
-                <span className="max-w-[min(100%,12rem)] truncate sm:max-w-[180px]">
-                  {(session.model ?? t.common.unknown).split("/").pop()}
-                </span>
-                <span className="text-border">&#183;</span>
+                {session.model && (
+                  <>
+                    <span className="max-w-[min(100%,12rem)] truncate sm:max-w-[180px]">
+                      {session.model.split("/").pop()}
+                    </span>
+                    <span className="text-border">&#183;</span>
+                  </>
+                )}
                 <span className="shrink-0">
                   {session.message_count} {t.common.msgs}
                 </span>
@@ -1752,19 +1756,29 @@ export default function SessionsPage() {
                     className="flex min-w-0 max-w-full flex-col gap-2 border border-border p-3 sm:flex-row sm:items-center sm:justify-between"
                   >
                     <div className="flex min-w-0 flex-1 flex-col gap-1">
-                      <span className="font-mondwest normal-case min-w-0 truncate text-sm font-medium">
-                        {s.title ?? t.common.untitled}
+                      <span
+                        className={`font-mondwest normal-case min-w-0 truncate text-sm ${s.title ? "font-medium" : "text-muted-foreground italic"}`}
+                      >
+                        {s.title ??
+                          (s.preview
+                            ? s.preview.slice(0, 60)
+                            : t.common.untitled)}
                       </span>
 
                       <span className="min-w-0 break-words text-xs text-muted-foreground">
-                        <span className="font-mono-ui">
-                          {(s.model ?? t.common.unknown).split("/").pop()}
-                        </span>{" "}
-                        · {s.message_count} {t.common.msgs} ·{" "}
+                        {s.model && (
+                          <>
+                            <span className="font-mono-ui">
+                              {s.model.split("/").pop()}
+                            </span>{" "}
+                            ·{" "}
+                          </>
+                        )}
+                        {s.message_count} {t.common.msgs} ·{" "}
                         {timeAgo(s.last_active)}
                       </span>
 
-                      {s.preview && (
+                      {s.preview && s.title && (
                         <p className="font-mondwest normal-case min-w-0 max-w-full text-xs leading-snug text-text-tertiary [overflow-wrap:anywhere]">
                           {s.preview}
                         </p>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -86,6 +86,51 @@ export default defineConfig({
   build: {
     outDir: "../hermes_cli/web_dist",
     emptyOutDir: true,
+    // Shell stays a bit over Vite's 500 kB default after vendor splits;
+    // page/xterm chunks load on demand. Keep a modest ceiling so a true
+    // regression still warns.
+    chunkSizeWarningLimit: 600,
+    // Split heavy vendors so the first dashboard paint does not download
+    // xterm/three/plot/etc. until a route actually needs them. Lazy page
+    // imports in App.tsx create the route boundaries; these groups keep
+    // shared node_modules out of every page chunk.
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          minSize: 20_000,
+          groups: [
+            {
+              name: "react-vendor",
+              test: /node_modules[\\/](react|react-dom|scheduler|react-router|react-router-dom)([\\/]|$)/,
+            },
+            {
+              name: "xterm",
+              test: /node_modules[\\/]@xterm[\\/]/,
+            },
+            {
+              name: "three",
+              test: /node_modules[\\/](three|@react-three)([\\/]|$)/,
+            },
+            {
+              name: "plot",
+              test: /node_modules[\\/]@observablehq[\\/]plot([\\/]|$)/,
+            },
+            {
+              name: "motion",
+              test: /node_modules[\\/](motion|framer-motion)([\\/]|$)/,
+            },
+            {
+              name: "ui",
+              test: /node_modules[\\/]@nous-research[\\/]ui([\\/]|$)/,
+            },
+            {
+              name: "vendor",
+              test: /node_modules[\\/]/,
+            },
+          ],
+        },
+      },
+    },
   },
   server: {
     proxy: {


### PR DESCRIPTION
## Summary

Dashboard load-time and session-list polish — the two follow-ups deferred from the #72234 QA pass. First paint no longer downloads the entire 2 MB admin bundle (xterm/terminal included), and session lists stop rendering "Untitled · unknown" placeholder stacks.

Salvages #72119 by @erick713006 (route-level code splitting, fixes #25912), cherry-picked with authorship preserved.

## Changes

**perf: lazy-load routes + split heavy vendors** (salvaged from #72119, @erick713006)
- `web/src/App.tsx`: all page imports converted to `React.lazy`, `<Routes>` wrapped in `<Suspense>` with a shared spinner fallback; the persistent embedded-chat host (and its xterm chunk) is deferred until the first `/chat` visit, sticky afterward so the PTY still survives tab switches (`latchChatActivation`).
- `web/vite.config.ts`: rolldown `codeSplitting` groups for react/xterm/three/plot/motion/ui/vendor; `chunkSizeWarningLimit: 600` so true regressions still warn. Follow-up commit normalizes the CRLF line endings the cherry-pick introduced.

**fix: session lists render placeholders gracefully**
- Session rows omit the model segment entirely when the store has no model — no more `unknown` with a dangling separator.
- The Overview "Recent Sessions" card falls back to the message preview as the row label (italic, matching the History list) instead of bare "Untitled", and skips the duplicate preview paragraph when the preview is the label.

## Validation

| Check | Result |
|---|---|
| Bundle (before → after) | one 2,021 kB main chunk (577 kB gz) → 548 kB shell (160 kB gz) + on-demand chunks (xterm 496 kB loads only on /chat) |
| `web` npm run check (typecheck + vitest + eslint) | 106/106 tests, 0 errors |
| Live smoke (fresh build, isolated HERMES_HOME) | all routes render through Suspense; /chat terminal + PTY works; xterm chunk absent from network until /chat visited; #72234's header buttons still survive; sessions rows show preview labels and no "unknown" |
| ruff / footguns | clean (no Python changes) |

## Infographic

![Dashboard perf + polish infographic](https://v3b.fal.media/files/b/0aa3dba6/Res9_7Z_hzqjDvY7ENcvj_21qYUhT5.png)
