### PR TITLE
fix(webhook): honor [SILENT] when the agent explains its own silence

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -292,7 +292,9 @@ SILENT_MARKER = "[SILENT]"
 # a marker is the entire response OR appears as its own first/last line — but
 # NOT when a token merely appears mid-sentence in a genuine report (e.g.
 # "I considered staying [SILENT] but here is the summary…" must deliver).
-_CRON_SILENCE_TOKENS = frozenset({"[SILENT]", "SILENT", "NO_REPLY", "NO REPLY"})
+# The actual matcher is shared with the webhook lane —
+# gateway.response_filters.is_autonomous_silence_response — so the two
+# autonomous lanes cannot drift apart.
 
 
 def _is_cron_silence_response(text: str) -> bool:
@@ -303,31 +305,13 @@ def _is_cron_silence_response(text: str) -> bool:
     variants the model emits when it drops the brackets (#51438, #46917).
     Whitespace-trimmed and case-insensitive.  A token buried mid-sentence is
     treated as real content and delivered.
+
+    Delegates to the shared autonomous-lane matcher in
+    :mod:`gateway.response_filters` (also used by the webhook adapter).
     """
-    if not isinstance(text, str):
-        return False
-    stripped = text.strip()
-    if not stripped:
-        return False
+    from gateway.response_filters import is_autonomous_silence_response
 
-    def _is_token(line: str) -> bool:
-        return " ".join(line.strip().upper().split()) in _CRON_SILENCE_TOKENS
-
-    # Whole response is exactly a token.
-    if _is_token(stripped):
-        return True
-    # Marker on its own first or last line (trailing/leading note on a
-    # separate line — e.g. "2 deals filtered\n\n[SILENT]").
-    lines = [ln for ln in stripped.splitlines() if ln.strip()]
-    if lines and (_is_token(lines[0]) or _is_token(lines[-1])):
-        return True
-    # Bracketed sentinel used as a same-line prefix — the documented cron
-    # pattern "[SILENT] No changes detected".  Restricted to the bracketed
-    # form so a bare word like "Silent retry succeeded" is NOT swallowed.
-    upper = stripped.upper()
-    if upper.startswith("[SILENT]"):
-        return True
-    return False
+    return is_autonomous_silence_response(text)
 
 # ---------------------------------------------------------------------------
 # Persistent thread pool for parallel cron jobs.

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -63,6 +63,7 @@ from gateway.platforms.webhook_filters import (
     DEFAULT_SCRIPT_TIMEOUT_SECONDS,
     WebhookRouteProcessor,
 )
+from gateway.response_filters import is_autonomous_silence_response
 
 logger = logging.getLogger(__name__)
 
@@ -76,29 +77,24 @@ def _is_webhook_silence_response(content: Any) -> bool:
     already replied, a routine close).  Nobody is waiting on the other end, so
     there is no reader for whom a "nothing happened" message is useful.
 
-    The reason this is cron's looser rule rather than the live gateway's is what
-    the two lanes optimise for.  In an interactive chat, swallowing a real answer
-    because it happens to open with a marker is much worse than showing a stray
-    marker, so ``is_intentional_silence_response`` demands the response be
-    EXACTLY a marker.  A webhook run has the opposite payoff: the cost of a
-    leaked non-story is a pointless notification on every tick, and models
-    reliably add a sentence explaining why they stayed quiet — which under the
-    strict rule flips the whole thing back to "deliver".  That is not a
-    hypothetical: it is why a Helper support lane kept messaging its owner to
+    The reason this is the loose autonomous rule rather than the live gateway's
+    is what the two lanes optimise for.  In an interactive chat, swallowing a
+    real answer because it happens to open with a marker is much worse than
+    showing a stray marker, so ``is_intentional_silence_response`` demands the
+    response be EXACTLY a marker.  A webhook run has the opposite payoff: the
+    cost of a leaked non-story is a pointless notification on every tick, and
+    models reliably add a sentence explaining why they stayed quiet — which
+    under the strict rule flips the whole thing back to "deliver".  That is not
+    a hypothetical: it is why a Helper support lane kept messaging its owner to
     report that it had nothing to report.
 
-    So reuse cron's matcher, which already treats a marker on its own first or
-    last line as silence while still delivering prose that merely mentions one
-    mid-sentence.  Sharing the function keeps the two autonomous lanes from
-    drifting apart, and keeps the interactive path untouched.
+    So use the shared autonomous-lane matcher (also used by cron), which treats
+    a marker on its own first or last line as silence while still delivering
+    prose that merely mentions one mid-sentence.  Sharing the function keeps
+    the two autonomous lanes from drifting apart, and keeps the interactive
+    path untouched.
     """
-    if not isinstance(content, str):
-        return False
-    try:
-        from cron.scheduler import _is_cron_silence_response
-    except Exception:  # pragma: no cover - cron package always ships with the gateway
-        return False
-    return _is_cron_silence_response(content)
+    return is_autonomous_silence_response(content)
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -66,6 +66,40 @@ from gateway.platforms.webhook_filters import (
 
 logger = logging.getLogger(__name__)
 
+
+def _is_webhook_silence_response(content: Any) -> bool:
+    """Whether an agent response means "deliberately say nothing".
+
+    Webhook routes are autonomous background lanes: a subscription prompt tells
+    the agent to answer with ``[SILENT]`` when a tick produced nothing worth a
+    human's attention (a duplicate inbound, a stand-down because a sibling lane
+    already replied, a routine close).  Nobody is waiting on the other end, so
+    there is no reader for whom a "nothing happened" message is useful.
+
+    The reason this is cron's looser rule rather than the live gateway's is what
+    the two lanes optimise for.  In an interactive chat, swallowing a real answer
+    because it happens to open with a marker is much worse than showing a stray
+    marker, so ``is_intentional_silence_response`` demands the response be
+    EXACTLY a marker.  A webhook run has the opposite payoff: the cost of a
+    leaked non-story is a pointless notification on every tick, and models
+    reliably add a sentence explaining why they stayed quiet — which under the
+    strict rule flips the whole thing back to "deliver".  That is not a
+    hypothetical: it is why a Helper support lane kept messaging its owner to
+    report that it had nothing to report.
+
+    So reuse cron's matcher, which already treats a marker on its own first or
+    last line as silence while still delivering prose that merely mentions one
+    mid-sentence.  Sharing the function keeps the two autonomous lanes from
+    drifting apart, and keeps the interactive path untouched.
+    """
+    if not isinstance(content, str):
+        return False
+    try:
+        from cron.scheduler import _is_cron_silence_response
+    except Exception:  # pragma: no cover - cron package always ships with the gateway
+        return False
+    return _is_cron_silence_response(content)
+
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
 # (no prefix / multiplexing off → handle as the default profile).
@@ -336,6 +370,12 @@ class WebhookAdapter(BasePlatformAdapter):
         do not consume the entry and silently downgrade the final response
         to the ``log`` deliver type.  TTL cleanup happens on POST.
         """
+        if _is_webhook_silence_response(content):
+            logger.info(
+                "[webhook] Response for %s is a silence marker — not delivering", chat_id
+            )
+            return SendResult(success=True)
+
         delivery = self._delivery_info.get(chat_id, {})
         deliver_type = delivery.get("deliver", "log")
 

--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -70,6 +70,47 @@ def is_intentional_silence_response(response: Any) -> bool:
     return any(candidate in LIVE_GATEWAY_SILENT_MARKERS for candidate in _canonical_silence_candidates(stripped))
 
 
+def is_autonomous_silence_response(response: Any) -> bool:
+    """Loose silence matcher for autonomous lanes (cron, webhook).
+
+    Autonomous lanes instruct the agent to emit ``[SILENT]`` when a tick
+    produced nothing worth a human's attention, and models reliably bracket
+    the marker with a short note explaining why they stayed quiet.  Unlike
+    :func:`is_intentional_silence_response` (the interactive-chat rule, which
+    demands the response be EXACTLY a marker), this suppresses when a marker
+    is the whole response, sits on its own first or last line, or the
+    bracketed sentinel opens the response (the documented
+    ``[SILENT] No changes detected`` pattern).  A token buried mid-sentence
+    in a genuine report is still delivered.
+
+    Shares :data:`LIVE_GATEWAY_SILENT_MARKERS` so the interactive and
+    autonomous marker sets can never drift apart.
+    """
+    if not isinstance(response, str):
+        return False
+    stripped = response.strip()
+    if not stripped:
+        return False
+
+    def _is_token(line: str) -> bool:
+        return _canonical_silence_candidate(line) in LIVE_GATEWAY_SILENT_MARKERS
+
+    # Whole response is exactly a token.
+    if _is_token(stripped):
+        return True
+    # Marker on its own first or last line (leading/trailing note on a
+    # separate line — e.g. "2 deals filtered\n\n[SILENT]").
+    lines = [ln for ln in stripped.splitlines() if ln.strip()]
+    if lines and (_is_token(lines[0]) or _is_token(lines[-1])):
+        return True
+    # Bracketed sentinel used as a same-line prefix — the documented pattern
+    # "[SILENT] No changes detected".  Restricted to the bracketed form so a
+    # bare word like "Silent retry succeeded" is NOT swallowed.
+    if stripped.upper().startswith("[SILENT]"):
+        return True
+    return False
+
+
 def is_intentional_silence_agent_result(agent_result: dict | None, response: Any) -> bool:
     """Silence markers suppress delivery only for successful agent turns."""
     if not isinstance(agent_result, dict):

--- a/tests/gateway/test_response_filters.py
+++ b/tests/gateway/test_response_filters.py
@@ -1,4 +1,5 @@
 from gateway.response_filters import (
+    is_autonomous_silence_response,
     is_intentional_silence_agent_result,
     is_intentional_silence_response,
 )
@@ -25,3 +26,21 @@ def test_blank_and_prose_mentions_are_not_silence():
 def test_failed_agent_result_never_counts_as_intentional_silence():
     assert is_intentional_silence_agent_result({"failed": False}, "NO_REPLY")
     assert not is_intentional_silence_agent_result({"failed": True}, "NO_REPLY")
+
+
+def test_autonomous_silence_accepts_marker_with_own_line_note():
+    """The loose rule for cron/webhook lanes: marker + explanation suppresses."""
+    assert is_autonomous_silence_response("[SILENT]")
+    assert is_autonomous_silence_response("[SILENT]\n\nNothing new this tick.")
+    assert is_autonomous_silence_response("2 deals filtered\n\n[SILENT]")
+    assert is_autonomous_silence_response("no_reply\nduplicate inbound, already handled")
+    assert is_autonomous_silence_response("[SILENT] No changes detected")
+
+
+def test_autonomous_silence_still_delivers_mid_sentence_mentions():
+    assert not is_autonomous_silence_response(
+        "I considered staying [SILENT] but this one moved money, so: refunded $240."
+    )
+    assert not is_autonomous_silence_response("Silent retry succeeded; all good.")
+    assert not is_autonomous_silence_response("")
+    assert not is_autonomous_silence_response(None)

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -1297,6 +1297,117 @@ class TestSessionIsolation:
 
 
 # ===================================================================
+# Silence-marker suppression
+# ===================================================================
+
+
+class TestWebhookSilenceSuppression:
+    """A webhook route that answers ``[SILENT]`` must deliver nothing.
+
+    Webhook routes are autonomous lanes with nobody waiting on the other end,
+    so a subscription prompt tells the agent to reply ``[SILENT]`` on a tick
+    that produced no story.  Models routinely append a sentence saying WHY they
+    stayed quiet, and the live gateway's exact-whole-response rule then treats
+    that as a real report — which is how a Helper support lane ended up
+    repeatedly messaging its owner to say it had nothing to say.
+    """
+
+    def _adapter_with_mock_target(self):
+        adapter = _make_adapter()
+        mock_target = AsyncMock()
+        mock_target.send = AsyncMock(return_value=SendResult(success=True))
+        mock_runner = MagicMock()
+        mock_runner.adapters = {Platform("telegram"): mock_target}
+        mock_runner.config.get_home_channel.return_value = None
+        adapter.gateway_runner = mock_runner
+
+        chat_id = "webhook:helper-events:d-1"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "telegram",
+            "deliver_extra": {"chat_id": "-100123"},
+        }
+        adapter._delivery_info_created[chat_id] = time.time()
+        return adapter, mock_target, chat_id
+
+    @pytest.mark.asyncio
+    async def test_bare_marker_is_not_delivered(self):
+        adapter, target, chat_id = self._adapter_with_mock_target()
+
+        result = await adapter.send(chat_id, "[SILENT]")
+
+        assert result.success is True
+        target.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_marker_followed_by_prose_is_not_delivered(self):
+        """The regression this suppression exists for.
+
+        The agent explains its own silence on the lines after the marker.  The
+        strict interactive rule reads that as substantive prose and delivers the
+        whole thing, marker included.
+        """
+        adapter, target, chat_id = self._adapter_with_mock_target()
+
+        result = await adapter.send(
+            chat_id,
+            "[SILENT]\n\nThe new inbound was the same email quoted back a second "
+            "time, on a ticket we already answered. Nothing new to reply to, so I "
+            "closed it; it reopens by itself if they write back.",
+        )
+
+        assert result.success is True
+        target.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_marker_on_the_last_line_is_not_delivered(self):
+        adapter, target, chat_id = self._adapter_with_mock_target()
+
+        result = await adapter.send(chat_id, "Nothing to report this tick.\n\n[SILENT]")
+
+        assert result.success is True
+        target.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_real_report_is_still_delivered(self):
+        """Suppression must not swallow an actual story."""
+        adapter, target, chat_id = self._adapter_with_mock_target()
+
+        result = await adapter.send(
+            chat_id,
+            "Refunded $240 to the buyer and replied; the seller had already agreed.",
+        )
+
+        assert result.success is True
+        target.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_report_mentioning_the_marker_mid_sentence_is_delivered(self):
+        """A report that merely quotes a marker is not a silence request."""
+        adapter, target, chat_id = self._adapter_with_mock_target()
+
+        result = await adapter.send(
+            chat_id,
+            "I considered staying [SILENT] but this one moved money, so: refunded "
+            "$240 and replied to the buyer.",
+        )
+
+        assert result.success is True
+        target.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_suppression_precedes_log_delivery(self):
+        """A `log` route also suppresses, so the two lanes behave the same."""
+        adapter = _make_adapter()
+        chat_id = "webhook:helper-events:d-log"
+        adapter._delivery_info[chat_id] = {"deliver": "log", "deliver_extra": {}}
+        adapter._delivery_info_created[chat_id] = time.time()
+
+        result = await adapter.send(chat_id, "[SILENT]\n\nnothing happened")
+
+        assert result.success is True
+
+
+# ===================================================================
 # Delivery info cleanup
 # ===================================================================
 


### PR DESCRIPTION
## Summary

Webhook routes now suppress delivery when the agent answers `[SILENT]` — including the common shape where the model appends a sentence explaining why it stayed quiet. Salvage of #71756 by @gumclaw, plus a follow-up that promotes the loose autonomous-lane matcher into `gateway/response_filters.py` so cron and webhook share one public helper instead of webhook importing cron's private function.

Root cause: webhook delivery relied on the interactive gateway's exact-whole-response silence rule, so `[SILENT]\n\n<explanation>` was treated as a real report and delivered on every empty tick.

## Changes

- `gateway/response_filters.py`: new `is_autonomous_silence_response()` — marker as whole response, own first/last line, or bracketed `[SILENT]` prefix; shares `LIVE_GATEWAY_SILENT_MARKERS` with the interactive rule so the marker sets can't drift
- `gateway/platforms/webhook.py`: suppress in `WebhookAdapter.send` before the deliver-type switch (covers `log`, `github_comment`, and cross-platform routes) — @gumclaw's fix, rewired to the shared helper
- `cron/scheduler.py`: `_is_cron_silence_response` delegates to the shared helper (behavior unchanged)
- Tests: 6 webhook suppression cases (@gumclaw, red-first verified) + 2 direct cases for the shared helper

## What this does NOT change

- Interactive/gateway delivery keeps the strict exact-marker rule (contract: prose mentioning a marker mid-sentence always delivers)
- No new config

## Validation

| | Before | After |
|---|---|---|
| webhook `[SILENT]` + explanation | delivered every tick | suppressed |
| webhook real report quoting `[SILENT]` mid-sentence | delivered | delivered |
| interactive chat `[SILENT]` + prose | delivered | delivered (unchanged) |
| cron silence cases | suppressed | suppressed (same matcher, now shared) |

Targeted suites green: `test_response_filters.py`, `test_webhook_adapter.py`, `test_stream_consumer_silence.py`, `test_scheduler.py`, `test_webhook_deliver_only.py`, `test_webhook_integration.py`, `test_cron_no_agent.py`, `test_shutdown_interrupt.py` — 428 passed. E2E with real imports confirmed cron/webhook/shared agree on 10 cases and the interactive rule is untouched.

Salvages #71756 (@gumclaw, authorship preserved). Supersedes #32216 (@Arno-MA-73, earliest submitter — same leak, but anywhere-substring matching would swallow real reports that merely quote the marker).

## Infographic

![Webhook lanes honor SILENT](https://v3b.fal.media/files/b/0aa3dbe4/NSofRTXwMqF2at1REuh3v_HRYXMMub.png)
