### PR TITLE
fix(tui_gateway): install the parent profile's secret scope on session.branch

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9996,6 +9996,104 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
             server._sessions.pop(k, None)
 
 
+def test_session_branch_installs_parent_profile_secret_scope(monkeypatch, tmp_path):
+    """The branched agent must be built under the parent profile's secrets.
+
+    session.branch already binds the parent's HERMES_HOME and state.db, but the
+    secret scope is what makes get_secret() resolve that profile's .env. Without
+    it the build falls through to process os.environ — the LAUNCH profile's
+    credentials — which is exactly the cross-profile resolution #67605 fixed for
+    session.create / session.resume.
+    """
+    import threading
+
+    from agent.secret_scope import current_secret_scope
+
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text(
+        "PROXMOX_TOKEN=mlperf-secret\n", encoding="utf-8"
+    )
+    seen: dict = {"msgs": []}
+
+    class ProfileDB:
+        def __init__(self, db_path=None):
+            pass
+
+        def get_session_title(self, _key):
+            return "parent"
+
+        def get_next_title_in_lineage(self, current):
+            return f"{current} (branch)"
+
+        def create_session(self, new_key, **kwargs):
+            seen["created"] = new_key
+
+        def append_message(self, **kwargs):
+            seen["msgs"].append(kwargs)
+
+        def set_session_title(self, key, title):
+            return True
+
+        def get_session(self, key):
+            return {"id": key, "cwd": str(tmp_path)}
+
+        def update_session_cwd(self, *a, **k):
+            return None
+
+        def close(self):
+            return None
+
+    class FakeAgent:
+        def __init__(self):
+            self.model = "test-model"
+            self.session_id = None
+
+    parent = {
+        "session_key": "parent-key",
+        "history": [{"role": "user", "content": "hi"}],
+        "history_lock": threading.Lock(),
+        "running": False,
+        "cols": 80,
+        "profile_home": str(profile_home),
+        "source": "tui",
+        "agent": FakeAgent(),
+        "created_at": 1.0,
+        "last_active": 1.0,
+        "cwd": str(tmp_path),
+    }
+    server._sessions["parent"] = parent
+    monkeypatch.setattr(server, "_get_db", lambda: ProfileDB())
+    monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
+    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+
+    def _fake_make_agent(*a, **k):
+        scope = current_secret_scope()
+        seen["scope"] = dict(scope) if scope else None
+        return FakeAgent()
+
+    monkeypatch.setattr(server, "_make_agent", _fake_make_agent)
+    monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_clear_session_context", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_session_cwd", lambda s: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.branch",
+                "params": {"session_id": "parent", "name": "forked"},
+            }
+        )
+        assert "result" in resp, resp
+        assert seen.get("scope") == {"PROXMOX_TOKEN": "mlperf-secret"}
+    finally:
+        for k in list(server._sessions):
+            server._sessions.pop(k, None)
+
+
 def test_pending_title_finalizer_uses_session_profile_db(monkeypatch, tmp_path):
     """Post-turn pending_title must land in the session profile store."""
     profile_home = tmp_path / "profiles" / "mlperf"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10360,6 +10360,16 @@ def _(rid, params: dict) -> dict:
         home_token = (
             set_hermes_home_override(parent_home) if parent_home else None
         )
+        # The home override alone only moves config/skills/memory; credentials
+        # resolve through get_secret(), which without a scope falls through to
+        # process os.environ — the LAUNCH profile's .env. Install the parent's
+        # secret scope for the build, exactly as session.create/resume do
+        # (#67605), so the branched agent authenticates as its own profile.
+        secret_token = (
+            set_secret_scope(build_profile_secret_scope(Path(parent_home)))
+            if parent_home
+            else None
+        )
         try:
             tokens = _set_session_context(new_key)
             try:
@@ -10384,6 +10394,8 @@ def _(rid, params: dict) -> dict:
                 profile_home=parent_home,
             )
         finally:
+            if secret_token is not None:
+                reset_secret_scope(secret_token)
             if home_token is not None:
                 reset_hermes_home_override(home_token)
         if new_sid in _sessions:


### PR DESCRIPTION
## What does this PR do?

#67605 (2db6b8c85) established an explicit invariant for the tui_gateway path — quoting its own commit message:

> install `set_secret_scope(build_profile_secret_scope(...))` **alongside every `set_hermes_home_override()` call site**

and converted five: `compute_host._ensure_server_session`, `server._build`, both scopes in `_handle_resume_session`, and `_handle_submit_or_edit`. **`session.branch` was missed.**

The branch handler already binds the parent's `HERMES_HOME` and its profile-scoped `state.db`, and its own comment says it is "mirroring session.create/resume" — but it builds the branched agent with no secret scope:

```python
home_token = set_hermes_home_override(parent_home) if parent_home else None
try:
    agent = _make_agent(new_sid, new_key, session_db=branch_db, ...)
```

`get_secret()` with no scope installed falls through to process `os.environ` (`agent/secret_scope.py`, resolution rule 3). In the app-global / remote backend that serves several profiles, that environment belongs to the **launch** profile — so a session branched off profile X builds an agent holding profile Y's credentials: wrong API key, wrong account billed, and the profile isolation the switch advertises does not hold for the branch.

It fails silently rather than loudly: the `UnscopedSecretError` fail-closed branch only fires when multiplexing is active, and `set_multiplex_active()` is called only by the messaging gateway (`gateway/run.py`), never by tui_gateway.

Reproduced against `main` (`f34a69b1c`) — the new test captures the scope inside `_make_agent` during a real `session.branch` dispatch:

```
AssertionError: assert None == {'PROXMOX_TOKEN': 'mlperf-secret'}
  where {'created': ..., 'scope': None}.get('scope')
```

`scope` is `None`: no profile scope at all during the branched build.

The fix mirrors the resume site exactly — install the parent's scope for the build and release it in the same `finally` as the home override.

## Related Issue

No separate issue filed. Follow-up to #67605 / 2db6b8c85, which fixed the sibling call sites; this completes the invariant it stated.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py` (`session.branch` handler): install `set_secret_scope(build_profile_secret_scope(Path(parent_home)))` next to the existing home override, and reset it in the same `finally` block. Uses the module-level imports already present for the sibling sites.
- `tests/test_tui_gateway_server.py`: `test_session_branch_installs_parent_profile_secret_scope` — dispatches a real `session.branch` for a session owned by a profile whose `.env` holds a marker credential and asserts the scope active during `_make_agent` is that profile's. Mirrors the existing `test_session_branch_writes_to_parent_profile_db` harness and the `_start_agent_build` scope test added in f34a69b1c.

## How to Test

1. Run a dashboard/desktop backend launched as profile A, open a session belonging to profile B (each profile's `.env` holding a different API key), and branch it.
2. Before this change the branched agent resolves profile A's credentials (`get_secret()` reads process `os.environ`); after, it resolves profile B's.
3. `pytest tests/test_tui_gateway_server.py -k session_branch -q` -> 2 passed. The new test fails on `main` without the code change with `assert None == {'PROXMOX_TOKEN': 'mlperf-secret'}` (captured above).
4. Wider run: `pytest tests/test_tui_gateway_server.py tests/tui_gateway/ -q` -> 944 passed, 14 failed; those 14 (goal command, projects RPC, subagent child mirror) are pre-existing on `main` — verified by re-running the same selection with this change stashed (943 passed, same 14 failures).
5. Tested on Ubuntu 24.04.

Audited while here and deliberately left alone: the other `set_hermes_home_override()` site without a paired scope in this file is `_profile_scoped` (line ~1184), which wraps only `pet.*` and `verification.status` RPCs — config/sprite-directory reads that resolve no credentials.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites and they pass (see step 4 for the pre-existing, unrelated failures)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (restores the documented per-profile credential behaviour; no contract change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added or changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (no platform-specific behaviour)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
