### PR TITLE
fix(gateway): survive faulthandler.enable() when sys.stderr is None (#71671 salvage)

### DIFF
--- a/contributors/emails/hereicq@users.noreply.github.com
+++ b/contributors/emails/hereicq@users.noreply.github.com
@@ -1,0 +1,1 @@
+hereicq

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7823,10 +7823,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Returns True if at least one adapter connected successfully.
         """
         logger.info("Starting Hermes Gateway...")
-        # Enable faulthandler at gateway start so that SIGUSR2 (or an
-        # internal watchdog) can dump all thread and task stacks to stderr
-        # for post-mortem diagnosis of event-loop freezes (#70344).
-        faulthandler.enable()
+        # Enable faulthandler for stack dumps on freezes/crashes (#70344).
+        # Falls back to a log file when sys.stderr is None (Windows VBS /
+        # pythonw / detached service) — otherwise the gateway would die
+        # here and take every adapter offline. See #71671.
+        try:
+            faulthandler.enable()
+        except (RuntimeError, ValueError, OSError):
+            try:
+                _fh_log_dir = getattr(self.config, "log_dir", None) or os.path.join(
+                    os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")),
+                    "logs",
+                )
+                os.makedirs(_fh_log_dir, exist_ok=True)
+                _fh_enable_path = os.path.join(_fh_log_dir, "gateway_faulthandler.log")
+                _fh_enable_file = open(_fh_enable_path, "a", encoding="utf-8")
+                faulthandler.enable(file=_fh_enable_file, all_threads=True)
+            except Exception:
+                logger.debug("faulthandler.enable() unavailable", exc_info=True)
         # Also dump stacks to a rotating file for off-line analysis when
         # the gateway is running under a service manager that doesn't
         # capture stderr.

--- a/tests/gateway/test_71671_faulthandler_no_stderr.py
+++ b/tests/gateway/test_71671_faulthandler_no_stderr.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import faulthandler
-import os
 import sys
 
 import pytest
@@ -33,15 +32,3 @@ def test_faulthandler_enable_falls_back_when_stderr_is_none(tmp_path):
         sys.stderr = real_stderr
         if was_enabled:
             faulthandler.enable()
-
-
-def test_gateway_run_keeps_faulthandler_guard():
-    src = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
-        "gateway", "run.py",
-    )
-    with open(src, encoding="utf-8") as f:
-        text = f.read()
-    assert "try:\n            faulthandler.enable()\n        except (RuntimeError, ValueError, OSError):" in text, (
-        "gateway/run.py must keep the try/except guard around faulthandler.enable() (see #71671)"
-    )

--- a/tests/gateway/test_71671_faulthandler_no_stderr.py
+++ b/tests/gateway/test_71671_faulthandler_no_stderr.py
@@ -1,0 +1,47 @@
+"""Regression: #71671 — gateway must survive faulthandler.enable() with sys.stderr=None."""
+
+from __future__ import annotations
+
+import faulthandler
+import os
+import sys
+
+import pytest
+
+
+def test_faulthandler_enable_falls_back_when_stderr_is_none(tmp_path):
+    was_enabled = faulthandler.is_enabled()
+    if was_enabled:
+        faulthandler.disable()
+
+    real_stderr = sys.stderr
+    sys.stderr = None
+    try:
+        with pytest.raises(RuntimeError, match="sys.stderr is None"):
+            faulthandler.enable()
+
+        log_path = tmp_path / "gateway_faulthandler.log"
+        fh = open(log_path, "a", encoding="utf-8")
+        try:
+            faulthandler.enable(file=fh, all_threads=True)
+            assert faulthandler.is_enabled()
+            assert log_path.exists()
+        finally:
+            faulthandler.disable()
+            fh.close()
+    finally:
+        sys.stderr = real_stderr
+        if was_enabled:
+            faulthandler.enable()
+
+
+def test_gateway_run_keeps_faulthandler_guard():
+    src = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "gateway", "run.py",
+    )
+    with open(src, encoding="utf-8") as f:
+        text = f.read()
+    assert "try:\n            faulthandler.enable()\n        except (RuntimeError, ValueError, OSError):" in text, (
+        "gateway/run.py must keep the try/except guard around faulthandler.enable() (see #71671)"
+    )


### PR DESCRIPTION
## Summary
Headless Windows gateways no longer die at startup: `faulthandler.enable()` on the first line of `GatewayRunner.start()` raises `RuntimeError: sys.stderr is None` when the gateway is spawned without a stderr handle (legacy pythonw scheduled tasks, VBS shims, detached `stdio='ignore'` spawns), taking every platform adapter offline. Root cause: #70344 added the call unconditionally; `faulthandler.enable()` writes to `sys.stderr` by default.

Salvages #71671 by @hereicq with authorship preserved. Chosen over the duplicate #72158 (bare skip-guard) because the fallback keeps the #70344 freeze diagnostics working on exactly the headless installs that need them most.

## Changes
- `gateway/run.py`: wrap `faulthandler.enable()`; on `RuntimeError/ValueError/OSError` fall back to `enable(file=logs/gateway_faulthandler.log)`; if even that fails, log and continue (@hereicq)
- `tests/gateway/test_71671_faulthandler_no_stderr.py`: behavioral regression test (@hereicq)
- Follow-up (ours): dropped the PR's second test which regex-asserted `gateway/run.py` source text — banned antipattern per AGENTS.md "Never read source code in tests"
- `contributors/emails/`: mapping for @hereicq

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/gateway/test_71671_faulthandler_no_stderr.py` | 1/1 passed |
| E2E: real process with fd 2 closed (`sys.stderr is None`), isolated `HERMES_HOME` | unguarded `enable()` raises; guarded path enables via file fallback, dump lands in `logs/gateway_faulthandler.log`, exit 0 |
| `py_compile gateway/run.py` | ok |

Sibling audit: all other faulthandler/stderr sites (`gateway/shutdown_watchdog.py`, telegram adapter) already wrapped in try/except — run.py:7829 was the only unguarded one.

Closes #71671. Closes #72158 (duplicate, 18h later).

## Infographic

![PR infographic](https://v3b.fal.media/files/b/0aa3dc55/3RDcm_QJJWtunDvxecccZ_sT0dfbAZ.png)
