### PR TITLE
fix(gateway): defer interactive restart recovery until real input

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -842,23 +842,15 @@ def build_resume_recovery_note(
     reason: Optional[str],
     message: str = "",
     *,
-    interactive: bool = True,
+    internal: bool,
 ) -> str:
     """Build the resume-pending recovery system note for an interrupted turn.
 
     ``reason`` is the session's ``resume_reason`` (``restart_timeout``,
     ``shutdown_timeout``, or anything else → generic interruption phrasing).
-    ``message`` is the user's NEW message text; empty means this is the
-    startup auto-resume turn synthesized by
-    ``_schedule_resume_pending_sessions`` with no human message attached.
-
-    ``interactive`` selects the empty-message guidance: on interactive
-    platforms a human is present, so "report the restore and ask what next"
-    is right.  On non-interactive event platforms (webhook, API server —
-    adapters with ``interactive_resume = False``) nobody can answer; the
-    resumed turn must instead complete the interrupted work, or the task is
-    silently abandoned behind a "restored" acknowledgement that goes
-    nowhere (#57056).
+    ``message`` is the rendered event text. ``internal`` is the source of
+    truth for whether the event was synthesized: real attachment events can
+    have empty text, while internal events can render nonempty text.
     """
     reason_phrase = (
         "a gateway restart"
@@ -867,19 +859,10 @@ def build_resume_recovery_note(
         if reason == "shutdown_timeout"
         else "a gateway interruption"
     )
-    if message:
+    if not internal:
         resume_guidance = (
             "Address the user's NEW message below FIRST and focus "
             "on what the user is asking now."
-        )
-        tail_guidance = (
-            "Do NOT re-execute old tool calls — skip any "
-            "unfinished work from the conversation history."
-        )
-    elif interactive:
-        resume_guidance = (
-            "Report to the user that the session was restored "
-            "successfully and ask what they would like to do next."
         )
         tail_guidance = (
             "Do NOT re-execute old tool calls — skip any "
@@ -7605,14 +7588,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return redelivered
 
     def _schedule_resume_pending_sessions(self, platform=None) -> int:
-        """Auto-continue fresh restart-interrupted sessions after startup.
+        """Auto-continue fresh non-interactive sessions after startup.
 
         ``resume_pending`` already preserves the transcript AND the existing
         ``_is_resume_pending`` branch in ``_handle_message_with_agent``
-        injects a reason-aware recovery system note on the next turn.  This
-        method closes the UX gap by synthesizing that next turn once
-        adapters are back online — the event text is empty so the existing
-        injection path owns the wording and we never double up.
+        injects a reason-aware recovery system note on the next turn.
+        Non-interactive adapters synthesize that next turn once they are back
+        online. Interactive adapters keep ``resume_pending`` intact and wait
+        for a real user event instead of scheduling an empty model turn.
 
         Adapters that are not yet ready (adapter missing from
         ``self.adapters``) are skipped silently; their sessions stay
@@ -7653,6 +7636,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # is now in the loop). Defenses 1-2 cover the cron/CLI/terminal paths;
         # this catches every other SIGTERM source (e.g. a raw `terminal(
         # "launchctl kickstart ai.hermes.gateway")`).
+        # Interactive adapters defer recovery until the next real user event.
+        # Filter them before restart-loop accounting so deferred sessions do
+        # not count as startup auto-resume attempts.
+        candidates = [
+            entry
+            for entry in candidates
+            if not bool(
+                getattr(
+                    self._adapter_for_source(entry.origin),
+                    "interactive_resume",
+                    True,
+                )
+            )
+        ]
         if candidates:
             try:
                 from gateway import restart_loop_guard as _rlg
@@ -12404,7 +12401,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             group_sessions_per_user=_group_sessions_per_user,
             thread_sessions_per_user=_thread_sessions_per_user,
         )
-        if _is_shared_multi_user and source.user_name:
+        if _is_shared_multi_user and source.user_name and not event.internal:
             # source.user_name is the platform display name — attacker-
             # influenceable on any platform that lets participants set their
             # own name. Neutralize embedded newlines/control chars before
@@ -22162,20 +22159,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _is_resume_pending:
                 _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
                 _persist_user_message_override = message
-                # The empty-message case is the auto-resume startup turn
-                # synthesized by _schedule_resume_pending_sessions — there is
-                # no NEW user message to address.  Guidance is adapter-aware:
-                # interactive platforms report the restore and ask what next;
-                # non-interactive event platforms (webhook, API server)
-                # continue the interrupted work instead, because nobody is
-                # present to answer and an acknowledgement would silently
-                # abandon the task (#57056).
-                _resume_adapter = self._adapter_for_source(source)
-                _interactive_resume = bool(
-                    getattr(_resume_adapter, "interactive_resume", True)
-                )
+                # MessageEvent.internal is the source of truth: a real
+                # attachment can render as empty text, while a synthetic event
+                # can render nonempty text.
                 message = build_resume_recovery_note(
-                    _reason, message, interactive=_interactive_resume,
+                    _reason,
+                    message,
+                    internal=event.internal,
                 )
             elif _has_fresh_tool_tail:
                 _persist_user_message_override = message
@@ -22216,13 +22206,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _sn_reason = (
                     getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
                 )
-                _sn_adapter = self._adapter_for_source(source)
                 message = build_resume_recovery_note(
                     _sn_reason,
                     "",
-                    interactive=bool(
-                        getattr(_sn_adapter, "interactive_resume", True)
-                    ),
+                    internal=event.internal,
                 )
 
             _approval_session_key = session_key or ""

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -10,8 +10,9 @@ from gateway.session import SessionSource
 
 
 class RestartTestAdapter(BasePlatformAdapter):
-    def __init__(self):
+    def __init__(self, *, interactive_resume: bool = True):
         super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self.interactive_resume = interactive_resume
         self.sent: list[str] = []
         self.sent_calls: list[tuple[str, str, object]] = []
 
@@ -49,7 +50,10 @@ def make_restart_source(
 
 def make_restart_runner(
     adapter: BasePlatformAdapter | None = None,
+    *,
+    interactive_resume: bool = True,
 ) -> tuple[GatewayRunner, BasePlatformAdapter]:
+    """Build a runner with the Telegram-like adapter's production default."""
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
         platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
@@ -151,7 +155,9 @@ def make_restart_runner(
     runner.session_store._entries = {}
     runner.delivery_router = MagicMock()
 
-    platform_adapter = adapter or RestartTestAdapter()
+    platform_adapter = adapter or RestartTestAdapter(
+        interactive_resume=interactive_resume
+    )
     platform_adapter.set_message_handler(AsyncMock(return_value=None))
     platform_adapter.set_busy_session_handler(runner._handle_active_session_busy_message)
     runner.adapters = {Platform.TELEGRAM: platform_adapter}

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -112,6 +112,7 @@ def _simulate_note_injection(
     *,
     agent_history: list | None = None,
     window_secs: float | None = None,
+    internal: bool = False,
 ) -> str:
     """Mirror the note-injection logic in gateway/run.py _run_agent().
 
@@ -155,7 +156,11 @@ def _simulate_note_injection(
         reason = getattr(resume_entry, "resume_reason", None) or "restart_timeout"
         # Real production note builder — extracted to module scope in
         # gateway/run.py so tests exercise the actual strings.
-        message = build_resume_recovery_note(reason, message)
+        message = build_resume_recovery_note(
+            reason,
+            message,
+            internal=internal,
+        )
     elif has_fresh_tool_tail:
         message = (
             "[System note: A new message has arrived. The conversation "
@@ -174,7 +179,11 @@ def _simulate_note_injection(
         and getattr(resume_entry, "resume_pending", False)
     ):
         sn_reason = getattr(resume_entry, "resume_reason", None) or "restart_timeout"
-        message = build_resume_recovery_note(sn_reason, "")
+        message = build_resume_recovery_note(
+            sn_reason,
+            "",
+            internal=internal,
+        )
     return message
 
 
@@ -483,19 +492,13 @@ class TestResumePendingSystemNote:
         )
         assert "gateway shutdown" in result
 
-    def test_empty_message_interactive_note_asks_what_next(self):
-        """Interactive platforms: the startup auto-resume turn reports the
-        restore and asks the (present) human what to do next."""
-        note = build_resume_recovery_note("restart_timeout", "", interactive=True)
-        assert "session was restored" in note
-        assert "ask what they would like to do next" in note
-        assert "skip any unfinished work" in note
-
-    def test_empty_message_noninteractive_note_continues_task(self):
-        """Non-interactive platforms (webhook, API server): nobody can answer
-        'what next?', so the resumed turn must complete the interrupted work
-        instead of acknowledging (#57056)."""
-        note = build_resume_recovery_note("restart_timeout", "", interactive=False)
+    def test_internal_empty_message_note_continues_task(self):
+        """The synthesized non-interactive startup turn continues old work."""
+        note = build_resume_recovery_note(
+            "restart_timeout",
+            "",
+            internal=True,
+        )
         assert "CONTINUE the interrupted task" in note
         assert "session was restored" not in note
         assert "ask what they would like to do next" not in note
@@ -504,12 +507,25 @@ class TestResumePendingSystemNote:
         # But still guards against re-running already-recorded tool calls.
         assert "already appear in the history" in note
 
-    def test_new_message_guidance_identical_regardless_of_interactivity(self):
-        """A real NEW user message always wins — same guidance either way."""
-        a = build_resume_recovery_note("restart_timeout", "do the thing", interactive=True)
-        b = build_resume_recovery_note("restart_timeout", "do the thing", interactive=False)
-        assert a == b
-        assert "NEW message" in a
+    def test_new_message_guidance_is_preserved(self):
+        """A real NEW user message still wins over interrupted work."""
+        note = build_resume_recovery_note(
+            "restart_timeout",
+            "do the thing",
+            internal=False,
+        )
+        assert "NEW message" in note
+        assert "do the thing" in note
+
+    def test_nonempty_internal_message_continues_interrupted_task(self):
+        """Rendered synthetic text does not turn an internal event human."""
+        note = build_resume_recovery_note(
+            "restart_timeout",
+            "scheduled wake text",
+            internal=True,
+        )
+        assert "CONTINUE the interrupted task" in note
+        assert "NEW message" not in note
 
     def test_resume_pending_fires_without_tool_tail(self):
         """Key improvement over PR #9934: the restart-resume note fires
@@ -624,6 +640,7 @@ class TestResumePendingSystemNote:
             user_message="",  # the empty auto-resume event text
             resume_entry=entry,
             window_secs=1800,
+            internal=True,
         )
         assert result.strip(), "blank turn must never reach the model"
         assert "[System note:" in result
@@ -641,6 +658,46 @@ class TestResumePendingSystemNote:
             resume_entry=None,
         )
         assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_uncaptioned_native_image_is_new_resume_input(self, tmp_path):
+        """A real attachment event is human input even when its text is empty."""
+        runner, _adapter = make_restart_runner()
+        source = make_restart_source(chat_id="image-chat")
+        image_path = str(tmp_path / "uncaptioned.png")
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.PHOTO,
+            source=source,
+            media_urls=[image_path],
+            media_types=["image/png"],
+            internal=False,
+        )
+        runner._decide_image_input_mode = MagicMock(return_value="native")
+
+        message = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+        session_key = runner._session_key_for_source(source)
+        assert message == ""
+        assert runner._pending_native_image_paths_by_session[session_key] == [
+            image_path
+        ]
+
+        entry = self._pending_entry(reason="restart_timeout")
+        note = _simulate_note_injection(
+            history=[
+                {"role": "assistant", "content": "in progress", "timestamp": time.time()},
+            ],
+            user_message=message,
+            resume_entry=entry,
+            internal=event.internal,
+        )
+        assert "NEW message" in note
+        assert "CONTINUE the interrupted task" not in note
 
     def test_fresh_tool_tail_preserves_auto_continue_note(self):
         history = [
@@ -791,11 +848,8 @@ class TestResumePendingSystemNote:
         assert "already" in result and "do NOT re-execute or verify" in result
         assert "restarted!" in result
 
-    def test_resume_pending_empty_message_reports_recovery(self):
-        """On the empty-message auto-resume startup turn there is no NEW user
-        message, so the note instructs the model to report recovery and ask
-        for instructions rather than 'address the user's NEW message'.
-        """
+    def test_resume_pending_internal_empty_message_continues_interrupted_task(self):
+        """An internal startup turn continues work without acknowledgement."""
         entry = self._pending_entry(reason="restart_timeout")
         result = _simulate_note_injection(
             history=[
@@ -803,11 +857,13 @@ class TestResumePendingSystemNote:
             ],
             user_message="",
             resume_entry=entry,
+            internal=True,
         )
         assert "[System note:" in result
         assert "gateway restart" in result
-        assert "restored successfully" in result
-        assert "ask what they would like to do next" in result
+        assert "CONTINUE the interrupted task" in result
+        assert "restored successfully" not in result
+        assert "ask what they would like to do next" not in result
         assert "do NOT re-execute or verify" in result
         # No phantom "NEW message" instruction when there is no new message.
         assert "NEW message" not in result
@@ -1028,13 +1084,38 @@ async def test_drain_timeout_skips_pending_sentinel_sessions():
 
 
 @pytest.mark.asyncio
-async def test_startup_auto_resume_schedules_fresh_pending_sessions():
-    """Fresh resume_pending sessions should continue automatically after startup.
+async def test_startup_auto_resume_defers_interactive_pending_session():
+    runner, adapter = make_restart_runner(interactive_resume=True)
+    source = make_restart_source(chat_id="interactive-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:interactive-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
 
-    This closes the UX gap where restart recovery only happened if the user sent
-    another message after the gateway came back.
-    """
-    runner, adapter = make_restart_runner()
+    with patch("gateway.restart_loop_guard.check_and_record") as loop_guard:
+        scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+    assert pending_entry.resume_pending is True
+    loop_guard.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_schedules_noninteractive_pending_session():
+    """Non-interactive adapters continue fresh pending sessions at startup."""
+    runner, adapter = make_restart_runner(interactive_resume=False)
     source = make_restart_source(chat_id="resume-chat", thread_id="topic-1")
     pending_entry = SessionEntry(
         session_key="agent:main:telegram:group:resume-chat:topic-1",
@@ -1076,7 +1157,7 @@ async def test_startup_auto_resume_includes_crash_recovery():
     (crash/SIGKILL/OOM).  These should get the same magic continuation as
     drain-timeout interruptions.
     """
-    runner, adapter = make_restart_runner()
+    runner, adapter = make_restart_runner(interactive_resume=False)
     source = make_restart_source(chat_id="crash-chat")
     pending_entry = SessionEntry(
         session_key="agent:main:telegram:dm:crash-chat",
@@ -1103,7 +1184,7 @@ async def test_startup_auto_resume_includes_crash_recovery():
 @pytest.mark.asyncio
 async def test_startup_auto_resume_skips_stale_entries():
     """Entries older than the freshness window must not be auto-resumed."""
-    runner, adapter = make_restart_runner()
+    runner, adapter = make_restart_runner(interactive_resume=False)
     source = make_restart_source(chat_id="stale-chat")
     stale_marker = datetime.now() - timedelta(
         seconds=_auto_continue_freshness_window() + 60
@@ -1132,7 +1213,7 @@ async def test_startup_auto_resume_skips_stale_entries():
 @pytest.mark.asyncio
 async def test_startup_auto_resume_skips_suspended_and_originless():
     """suspended entries and entries with no origin are excluded."""
-    runner, adapter = make_restart_runner()
+    runner, adapter = make_restart_runner(interactive_resume=False)
     source = make_restart_source(chat_id="ok")
     suspended_entry = SessionEntry(
         session_key="agent:main:telegram:dm:suspended",
@@ -1179,7 +1260,7 @@ async def test_startup_auto_resume_skips_disallowed_reasons():
     existing _is_resume_pending branch — we just don't synthesize a turn
     for them at startup.
     """
-    runner, adapter = make_restart_runner()
+    runner, adapter = make_restart_runner(interactive_resume=False)
     source = make_restart_source(chat_id="other")
     other_entry = SessionEntry(
         session_key="agent:main:telegram:dm:other",
@@ -1213,7 +1294,7 @@ async def test_startup_auto_resume_skips_unauthorized_owner():
     _running_agents slot or persisting one — the slot claim happens only
     after this gate passes.
     """
-    runner, adapter = make_restart_runner()
+    runner, adapter = make_restart_runner(interactive_resume=False)
     runner._is_user_authorized = lambda _source: False
     runner._persist_active_agents = MagicMock()
     source = make_restart_source(chat_id="revoked-chat")
@@ -1248,7 +1329,7 @@ async def test_startup_auto_resume_fails_closed_on_auth_error():
     (fail-closed) rather than resumed — a broken auth check must never
     default to granting a full agent turn.
     """
-    runner, adapter = make_restart_runner()
+    runner, adapter = make_restart_runner(interactive_resume=False)
 
     def _boom(_source):
         raise RuntimeError("allowlist backend down")
@@ -1282,7 +1363,7 @@ async def test_startup_auto_resume_fails_closed_on_auth_error():
 
 @pytest.mark.asyncio
 async def test_startup_auto_resume_skips_when_adapter_unavailable():
-    runner, adapter = make_restart_runner()
+    runner, adapter = make_restart_runner(interactive_resume=False)
     source = make_restart_source(chat_id="resume-chat")
     pending_entry = SessionEntry(
         session_key="agent:main:telegram:dm:resume-chat",
@@ -1317,7 +1398,7 @@ async def test_reconnect_reschedules_pending_after_late_platform_connect():
     user sent a fresh message — the documented startup auto-resume silently
     dropped. The reconnect watcher now retries the platform-scoped pass.
     """
-    runner, adapter = make_restart_runner()
+    runner, adapter = make_restart_runner(interactive_resume=False)
     source = make_restart_source(chat_id="late-chat")
     pending_entry = SessionEntry(
         session_key="agent:main:telegram:dm:late-chat",
@@ -1358,7 +1439,7 @@ async def test_reconnect_reschedules_pending_after_late_platform_connect():
 async def test_reconnect_reschedule_is_platform_scoped():
     """The platform filter limits the pass to that platform's sessions, so
     reconnecting one platform never resumes another's pending session."""
-    runner, adapter = make_restart_runner()
+    runner, adapter = make_restart_runner(interactive_resume=False)
     tg_source = make_restart_source(chat_id="tg-chat")
     discord_source = SessionSource(
         platform=Platform.DISCORD, chat_id="dc-chat", chat_type="dm", user_id="u1"
@@ -1410,7 +1491,7 @@ async def test_auto_resume_skips_sessions_with_running_agent():
     """A session already being resumed (agent in-flight) is not scheduled
     again — guards against a double resume when a platform reconnects while a
     startup-scheduled resume is still running."""
-    runner, adapter = make_restart_runner()
+    runner, adapter = make_restart_runner(interactive_resume=False)
     source = make_restart_source(chat_id="inflight-chat")
     pending_entry = SessionEntry(
         session_key="agent:main:telegram:dm:inflight-chat",
@@ -1456,7 +1537,7 @@ async def test_startup_restore_gate_queues_real_inbound_messages():
 @pytest.mark.asyncio
 async def test_startup_restore_waits_for_resume_before_draining_inbound():
     """Queued inbound turns replay only after startup resume tasks finish."""
-    runner, adapter = make_restart_runner()
+    runner, adapter = make_restart_runner(interactive_resume=False)
     runner._startup_restore_in_progress = True
     runner._startup_restore_queue = []
     runner._startup_restore_tasks = []
@@ -1758,7 +1839,7 @@ async def test_auto_resume_sets_sentinel_before_task_execution():
     AIAgent.  The fix pre-claims the slot so the inbound path sees it as
     occupied.
     """
-    runner, adapter = make_restart_runner()
+    runner, adapter = make_restart_runner(interactive_resume=False)
     source = make_restart_source(chat_id="race-chat")
     pending_entry = SessionEntry(
         session_key="agent:main:telegram:dm:race-chat",
@@ -1804,7 +1885,7 @@ async def test_auto_resume_sentinel_cleaned_on_task_failure():
     """If handle_message raises before _process_message_background, the
     sentinel must still be released so the session is not locked forever.
     """
-    runner, adapter = make_restart_runner()
+    runner, adapter = make_restart_runner(interactive_resume=False)
     source = make_restart_source(chat_id="fail-chat")
     pending_entry = SessionEntry(
         session_key="agent:main:telegram:dm:fail-chat",
@@ -1865,7 +1946,7 @@ async def test_auto_resume_runs_agent_exactly_once_through_full_path():
     must run once — never zero (regression) and never twice (the bug
     the fix targets).
     """
-    runner, adapter = make_restart_runner()
+    runner, adapter = make_restart_runner(interactive_resume=False)
     source = make_restart_source(chat_id="full-path-chat")
     session_key = runner._session_key_for_source(source)
     pending_entry = SessionEntry(

--- a/tests/gateway/test_shared_group_sender_prefix.py
+++ b/tests/gateway/test_shared_group_sender_prefix.py
@@ -44,6 +44,34 @@ async def test_preprocess_prefixes_sender_for_shared_non_thread_group_session():
 
 
 @pytest.mark.asyncio
+async def test_preprocess_does_not_prefix_internal_shared_group_event():
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake"),
+            },
+            group_sessions_per_user=False,
+        )
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1002285219667",
+        chat_name="Test Group",
+        chat_type="group",
+        user_name="Alice",
+    )
+    event = MessageEvent(text="", source=source, internal=True)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
 async def test_preprocess_keeps_plain_text_for_default_group_sessions():
     runner = _make_runner(
         GatewayConfig(


### PR DESCRIPTION
## Summary

Closes #72280.

- do not add shared-session sender attribution to synthetic internal events
- defer interactive restart recovery until the next real human event
- classify textless native attachments as real user input via `MessageEvent.internal`
- preserve automatic continuation for non-interactive adapters
- remove the obsolete synthetic interactive recovery turn

## Why

Interactive adapters can resume after restart by synthesizing an empty internal event. In shared sessions that event could acquire an empty sender prefix, and the model could be invoked before any real user input arrived. Text truthiness is also insufficient because genuine uncaptioned attachments may render as empty text.

The gateway now uses `MessageEvent.internal` as the source of truth: interactive sessions retain `resume_pending` until a real event arrives, while non-interactive adapters keep their existing startup continuation behavior.

## Testing

- [x] `scripts/run_tests.sh tests/gateway/test_shared_group_sender_prefix.py tests/gateway/test_restart_resume_pending.py -j 2` — 91 passed
- [x] `.venv/bin/python -m pytest -q tests/gateway/test_stuck_loop.py` — 9 passed
- [x] `uv run ruff check gateway/run.py tests/gateway/restart_test_helpers.py tests/gateway/test_restart_resume_pending.py tests/gateway/test_shared_group_sender_prefix.py`
- [x] `git diff --check`
