### PR TITLE
feat(webhook): update existing GitHub delivery comments

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1212,10 +1212,11 @@ class WebhookAdapter(BasePlatformAdapter):
     async def _deliver_github_comment(
         self, content: str, delivery: dict
     ) -> SendResult:
-        """Post agent response as a GitHub PR/issue comment via ``gh`` CLI."""
+        """Post or update a GitHub PR/issue comment via ``gh`` CLI."""
         extra = delivery.get("deliver_extra", {})
         repo = extra.get("repo", "")
         pr_number = extra.get("pr_number", "")
+        comment_id = extra.get("comment_id", "")
 
         if not repo or not pr_number:
             logger.error(
@@ -1246,9 +1247,36 @@ class WebhookAdapter(BasePlatformAdapter):
                 success=False, error="Invalid repo format"
             )
 
+        # comment_id is optional. When present, update that existing issue
+        # comment instead of creating another PR comment.
+        comment_int = None
+        if comment_id not in (None, ""):
+            try:
+                comment_int = int(comment_id)
+                if comment_int <= 0:
+                    raise ValueError("non-positive")
+            except (ValueError, TypeError):
+                logger.error(
+                    "[webhook] invalid comment_id: %r", comment_id
+                )
+                return SendResult(
+                    success=False, error="Invalid comment_id"
+                )
+
         try:
-            result = subprocess.run(
-                [
+            if comment_int is not None:
+                command = [
+                    "gh",
+                    "api",
+                    "--method",
+                    "PATCH",
+                    f"repos/{repo}/issues/comments/{comment_int}",
+                    "-f",
+                    f"body={content}",
+                    "--silent",
+                ]
+            else:
+                command = [
                     "gh",
                     "pr",
                     "comment",
@@ -1257,19 +1285,25 @@ class WebhookAdapter(BasePlatformAdapter):
                     repo,
                     "--body",
                     content,
-                ],
+                ]
+            result = subprocess.run(
+                command,
                 capture_output=True,
                 text=True, encoding='utf-8', errors='replace',
                 timeout=30,
             )
             if result.returncode == 0:
                 logger.info(
-                    "[webhook] Posted comment on %s#%s", repo, pr_number
+                    "[webhook] %s comment on %s#%s",
+                    "Updated" if comment_int is not None else "Posted",
+                    repo,
+                    pr_number,
                 )
                 return SendResult(success=True)
             else:
                 logger.error(
-                    "[webhook] gh pr comment failed: %s", result.stderr
+                    "[webhook] GitHub comment delivery failed: %s",
+                    result.stderr,
                 )
                 return SendResult(success=False, error=result.stderr)
         except FileNotFoundError:

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -338,3 +338,76 @@ class TestGitHubCommentDelivery:
         # Delivery info is retained after send() so interim status messages
         # don't strand the final response (TTL-based cleanup happens on POST).
         assert chat_id in adapter._delivery_info
+
+    @pytest.mark.asyncio
+    async def test_github_comment_delivery_updates_existing_comment(self):
+        routes = {
+            "pr-bot": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "Review: {pull_request.title}",
+                "deliver": "github_comment",
+                "deliver_extra": {
+                    "repo": "{repository.full_name}",
+                    "pr_number": "{number}",
+                    "comment_id": "{response_comment_id}",
+                },
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+        payload = {**GITHUB_PR_PAYLOAD, "response_comment_id": 12345}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/pr-bot",
+                json=payload,
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-GitHub-Delivery": "gh-comment-update-001",
+                },
+            )
+            assert resp.status == 202
+
+        chat_id = "webhook:pr-bot:gh-comment-update-001"
+        mock_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch(
+            "gateway.platforms.webhook.subprocess.run",
+            return_value=mock_result,
+        ) as mock_run:
+            result = await adapter.send(chat_id, "Updated review result.")
+
+        assert result.success is True
+        mock_run.assert_called_once_with(
+            [
+                "gh", "api", "--method", "PATCH",
+                "repos/org/repo/issues/comments/12345",
+                "-f", "body=Updated review result.",
+                "--silent",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+        )
+
+    @pytest.mark.asyncio
+    async def test_github_comment_delivery_rejects_invalid_comment_id(self):
+        adapter = _make_adapter({})
+        chat_id = "webhook:pr-bot:gh-comment-update-invalid"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "github_comment",
+            "deliver_extra": {
+                "repo": "org/repo",
+                "pr_number": "42",
+                "comment_id": "--delete",
+            },
+        }
+
+        with patch("gateway.platforms.webhook.subprocess.run") as mock_run:
+            result = await adapter.send(chat_id, "Must not execute.")
+
+        assert result.success is False
+        assert result.error == "Invalid comment_id"
+        mock_run.assert_not_called()

--- a/website/docs/guides/webhook-github-pr-review.md
+++ b/website/docs/guides/webhook-github-pr-review.md
@@ -74,6 +74,9 @@ platforms:
           deliver_extra:
             repo: "{repository.full_name}"
             pr_number: "{number}"
+            # Optional: when a route script returns response_comment_id,
+            # update that existing PR issue comment instead of creating one.
+            # comment_id: "{response_comment_id}"
 ```
 
 **Key fields:**
@@ -86,6 +89,7 @@ platforms:
 | `deliver` | `github_comment` posts via `gh pr comment`. `log` just writes to the gateway log. |
 | `deliver_extra.repo` | Resolves to e.g. `org/repo` from the payload. |
 | `deliver_extra.pr_number` | Resolves to the PR number from the payload. |
+| `deliver_extra.comment_id` | Optional positive issue-comment ID, often rendered from route-script output. When set, Hermes updates that comment via `gh api` instead of creating another one. |
 
 :::note The payload does not contain code
 The GitHub webhook payload includes PR metadata (title, description, branch names, URLs) but **not the diff**. The prompt above instructs the agent to run `gh pr diff` to fetch the actual changes. The `terminal` tool is included in the default `hermes-webhook` toolset, so no extra configuration is needed.
@@ -232,6 +236,9 @@ platforms:
           deliver_extra:
             repo: "{repository.full_name}"
             pr_number: "{number}"
+            # Optional: when a route script returns response_comment_id,
+            # update that existing PR issue comment instead of creating one.
+            # comment_id: "{response_comment_id}"
 ```
 
 > **Note:** Only the first skill in the list that is found is loaded. Hermes does not stack multiple skills — subsequent entries are ignored.

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -300,7 +300,7 @@ The `deliver` field controls where the agent's response goes after processing th
 | Deliver Type | Description |
 |-------------|-------------|
 | `log` | Logs the response to the gateway log output. This is the default and is useful for testing. |
-| `github_comment` | Posts the response as a PR/issue comment via the `gh` CLI. Requires `deliver_extra.repo` and `deliver_extra.pr_number`. The `gh` CLI must be installed and authenticated on the gateway host (`gh auth login`). |
+| `github_comment` | Posts the response as a PR/issue comment via the `gh` CLI. Requires `deliver_extra.repo` and `deliver_extra.pr_number`. Optional `deliver_extra.comment_id` updates that existing issue comment instead of creating another one. The `gh` CLI must be installed and authenticated on the gateway host (`gh auth login`). |
 | `telegram` | Routes the response to Telegram. Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 | `discord` | Routes the response to Discord. Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 | `slack` | Routes the response to Slack. Uses the home channel, or specify `chat_id` in `deliver_extra`. |


### PR DESCRIPTION
## What does this PR do?

Adds an optional `deliver_extra.comment_id` contract to webhook routes that deliver with `github_comment`.

Today every delivery runs `gh pr comment`, so acknowledgement, progress, and final output become separate PR comments. When a route or preprocessing script already has a bot-owned issue comment ID, Hermes can now update that comment in place via GitHub's issue-comment API. Routes without `comment_id` keep the existing create-comment behavior unchanged.

The ID is validated as a positive integer before it is interpolated into the API path. Repository and PR-number validation remain unchanged.

## Related Issue

No tracked issue.

This is complementary to, rather than a replacement for:

- #13048 (GitHub App authentication and webhook fan-out)
- #36165 (non-blocking `gh` subprocess execution)
- #57125 (GitHub webhook self-loop protection)

This PR intentionally does not add App credentials, executable overrides, or loop-detection policy.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/webhook.py`
  - Accept optional `deliver_extra.comment_id`.
  - Reject non-positive or non-numeric comment IDs before invoking `gh`.
  - Use `gh api --method PATCH repos/{repo}/issues/comments/{id}` when an ID is supplied.
  - Preserve the existing `gh pr comment` path when it is omitted.
- `tests/gateway/test_webhook_integration.py`
  - Cover rendered comment IDs end to end through webhook route delivery.
  - Cover invalid-ID rejection and the unchanged create path.
- `website/docs/guides/webhook-github-pr-review.md`
  - Document the optional field and update-in-place behavior.
- `website/docs/user-guide/messaging/webhooks.md`
  - Update the canonical delivery-options reference with the optional field.

## How to Test

1. Run the focused webhook regression suite:
   ```bash
   scripts/run_tests.sh tests/gateway/test_webhook_integration.py tests/gateway/test_webhook_deliver_only.py tests/gateway/test_webhook_adapter.py -q
   ```
   Result: **115 passed**.
2. Run the full gateway suite:
   ```bash
   scripts/run_tests.sh tests/gateway -q
   ```
   Result: **11,282 passed**.
3. Run lint and cross-platform checks:
   ```bash
   ruff check gateway/platforms/webhook.py tests/gateway/test_webhook_integration.py
   python scripts/check-windows-footguns.py gateway/platforms/webhook.py tests/gateway/test_webhook_integration.py website/docs/guides/webhook-github-pr-review.md
   git diff --check
   ```
   Result: clean.
4. Real API smoke test: created a temporary comment on a private test PR, delivered through `WebhookAdapter._deliver_github_comment()` with `comment_id`, fetched the comment to verify the updated body, then deleted it. Result: passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (x86_64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (route `deliver_extra` is schemaless and the guide is the authoritative example)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; behavior is covered by integration tests and a real GitHub API smoke test.
