### PR TITLE
fix(kanban): enforce worker task ownership on kanban_link

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1546,7 +1546,7 @@ def test_create_rejects_non_list_skills(worker_env):
     assert json.loads(out).get("error")
 
 
-def test_link_happy_path(worker_env):
+def test_link_happy_path(monkeypatch, worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()
     try:
@@ -1554,6 +1554,11 @@ def test_link_happy_path(worker_env):
         b = kb.create_task(conn, title="B", assignee="x")
     finally:
         conn.close()
+    # Wiring two unrelated tasks is an orchestrator operation: a task-scoped
+    # worker may only link its own task (see
+    # test_worker_link_rejects_foreign_child_task). The fixture is used here
+    # for its DB setup, so drop the worker scope it also sets.
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     from tools import kanban_tools as kt
     out = kt._handle_link({"parent_id": a, "child_id": b})
     d = json.loads(out)
@@ -1881,6 +1886,75 @@ def test_worker_heartbeat_rejects_foreign_task_id(worker_env):
     out = kt._handle_heartbeat({"task_id": other})
     d = json.loads(out)
     assert "refusing to mutate" in d.get("error", "")
+
+
+def test_worker_link_rejects_foreign_child_task(worker_env):
+    """A worker cannot pull a foreign task under its own parent (#19534).
+
+    ``link_tasks`` mutates the child: a ``ready`` child is demoted to ``todo``
+    (the dispatcher stops promoting it) and it inherits the parent's notify
+    subscriptions. Without an ownership gate a task-scoped worker can stall a
+    sibling/cross-tenant task and redirect its terminal notifications to the
+    parent's subscribers.
+    """
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        victim = kb.create_task(conn, title="sibling", assignee="peer")
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (victim,))
+        conn.commit()
+        kb.add_notify_sub(
+            conn, task_id=worker_env, platform="telegram", chat_id="attacker-chat",
+        )
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_link({"parent_id": worker_env, "child_id": victim})
+    d = json.loads(out)
+    assert d.get("ok") is not True
+    assert "refusing to mutate" in d.get("error", "")
+
+    conn = kb.connect()
+    try:
+        # Still schedulable, and it did not inherit the worker's subscribers.
+        assert kb.get_task(conn, victim).status == "ready"
+        assert kb.list_notify_subs(conn, victim) == []
+    finally:
+        conn.close()
+
+
+def test_worker_can_link_its_own_task_under_a_parent(worker_env):
+    """The gate is on the mutated (child) end — a worker may still attach
+    its own task to a parent, and orchestrators stay unrestricted."""
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        epic = kb.create_task(conn, title="epic", assignee="peer")
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_link({"parent_id": epic, "child_id": worker_env})
+    d = json.loads(out)
+    assert d.get("ok") is True, f"linking own task must succeed: {d}"
+
+
+def test_orchestrator_can_link_foreign_tasks(monkeypatch, worker_env):
+    """No HERMES_KANBAN_TASK => orchestrator context, graph edits allowed."""
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        a = kb.create_task(conn, title="a", assignee="peer")
+        b = kb.create_task(conn, title="b", assignee="peer")
+    finally:
+        conn.close()
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    from tools import kanban_tools as kt
+    out = kt._handle_link({"parent_id": a, "child_id": b})
+    d = json.loads(out)
+    assert d.get("ok") is True, f"orchestrator link must succeed: {d}"
 
 
 def test_worker_can_comment_on_foreign_task(worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1421,6 +1421,17 @@ def _handle_link(args: dict, **kw) -> str:
     child_id = args.get("child_id")
     if not parent_id or not child_id:
         return tool_error("both parent_id and child_id are required")
+    # link_tasks mutates the CHILD: a ``ready`` child is demoted back to
+    # ``todo`` (the dispatcher stops promoting it) and it inherits the
+    # parent's notify subscriptions. That is run-lifecycle state, so it falls
+    # under the same worker scope rule as complete / block / heartbeat /
+    # attach (#19534) — without it a task-scoped worker can stall a sibling
+    # or cross-tenant task and redirect its terminal notifications to its own
+    # parent's subscribers. Orchestrators (no HERMES_KANBAN_TASK) are
+    # unaffected, and a worker may still attach its own task to a parent.
+    ownership_err = _enforce_worker_task_ownership(str(child_id))
+    if ownership_err:
+        return ownership_err
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)


### PR DESCRIPTION
## What does this PR do?

#19534 / #19713 established that a dispatcher-spawned worker may only mutate run-lifecycle state on **its own** task, and wired `_enforce_worker_task_ownership` into `kanban_complete`, `kanban_block`, `kanban_heartbeat`, `kanban_attach`, `kanban_attach_url` and `kanban_unblock`. `kanban_link` was left ungated — and it mutates the child task:

```python
# hermes_cli/kanban_db.py :: link_tasks
if parent_status != "done":
    conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'", (child_id,))
...
_inherit_notify_subs(conn, child_id, (parent_id,))
```

So a task-scoped worker — or a prompt-injected one, which is the threat the guard's own docstring names — can pass any `child_id` and:

1. **stall another tenant's work**: a `ready` task is demoted to `todo`, so the dispatcher stops promoting it, for as long as the attacker's parent stays un-done;
2. **hijack its notifications**: the victim task inherits the attacker's parent's notify subscriptions, so that task's terminal notification is delivered to the attacker's chat.

Reproduced against `main` (`759f68bc2`) from a worker context (`HERMES_KANBAN_TASK` set to the attacker's own task):

```
victim BEFORE  status: ready | subs: []
kanban_link result: {"ok": true, "parent_id": "t_20172129", "child_id": "t_b41e2dbe"}
victim AFTER   status: todo  | subs: ['ATTACKER-CHAT']
```

After this change the same call returns the standard scope refusal and the victim is untouched (`status: ready | subs: []`).

The gate goes on the **child** end — the task whose state actually changes. That keeps every legitimate flow working:

- orchestrator profiles (no `HERMES_KANBAN_TASK`) still rewire the graph freely;
- a worker can still attach **its own** task under a parent;
- spawning follow-up work keeps its documented path, `kanban_create(parents=[...])`, which the guard's own error message already points workers at.

Note on related work: #68029 proposes `kanban.worker_graph_mutations` as an opt-in policy that hides `kanban_create`/`kanban_link` from workers entirely; by its own summary "existing installs are unchanged by default". This PR is the narrower, on-by-default fix — it restores the ownership invariant the other destructive kanban tools already enforce, and remains correct with that policy either way.

## Related Issue

No separate issue filed. Completes the invariant from #19534 (fixed for the sibling tools in #19713).

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/kanban_tools.py` (`_handle_link`): call `_enforce_worker_task_ownership(child_id)` before connecting, mirroring the sibling handlers, with a comment recording why the child end is the gated one.
- `tests/tools/test_kanban_tools.py`: three new tests — a worker cannot link a foreign `ready` child (asserting it stays `ready` **and** inherits no subscriptions), a worker may still link its own task under a parent, and an orchestrator context can still link two foreign tasks.
- `tests/tools/test_kanban_tools.py` (`test_link_happy_path`): this existing test used the `worker_env` fixture only for its DB setup but incidentally ran with `HERMES_KANBAN_TASK` set while linking two unrelated tasks, which is now an orchestrator operation — it drops the worker scope the fixture also sets. Flagging the edit explicitly: unlike `test_worker_can_comment_on_foreign_task`, which documents its permissive policy and asks to fail CI if gated, this test states no intent about worker scope.

## How to Test

1. From a dispatcher-spawned worker (`HERMES_KANBAN_TASK` = its own task), call `kanban_link(parent_id=<own task>, child_id=<another tenant's ready task>)`.
2. Before this change the call returns `ok: true`, the victim task drops from `ready` to `todo`, and `list_notify_subs(victim)` shows the attacker's chat. After, the call is refused and the victim is unchanged.
3. `pytest tests/tools/test_kanban_tools.py -q` -> 123 passed (3 new). The cross-tenant test fails on `main` without the code change (`assert True is not True` — the link succeeds).
4. Wider run: `pytest tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_core_functionality.py tests/gateway/test_kanban_notifier.py tests/hermes_cli/test_kanban_notify.py -q` -> 321 passed, 8 failed; those 8 (protocol-violation streaks, stale detection) are pre-existing on `main` — verified by re-running them with this change stashed (same 8).
5. Tested on Ubuntu 24.04.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate — see the #68029 note above; no open PR gates `kanban_link` by default
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites and they pass (see step 4 for the pre-existing, unrelated failures)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (restores the documented worker-scope rule; the refusal message already names the supported alternatives)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added or changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (no platform-specific behaviour)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — the `kanban_link` schema is unchanged; the refusal surfaces at call time like the sibling tools' does
