### PR TITLE
feat(tui): add persistent agent dock

### DIFF
--- a/ui-tui/scripts/visual/render.tsx
+++ b/ui-tui/scripts/visual/render.tsx
@@ -21,10 +21,11 @@ import React, { type ReactElement } from 'react'
 import { GatewayProvider } from '../../src/app/gatewayContext.js'
 import { patchOverlayState, resetOverlayState } from '../../src/app/overlayStore.js'
 import { patchUiState, resetUiState } from '../../src/app/uiStore.js'
+import { AgentDockView } from '../../src/components/agentDock.js'
 import { FloatingOverlays } from '../../src/components/appOverlays.js'
 import { Banner, SessionPanel } from '../../src/components/branding.js'
 import { fromSkin, type Theme } from '../../src/theme.js'
-import type { SessionInfo } from '../../src/types.js'
+import type { SessionInfo, SubagentProgress } from '../../src/types.js'
 
 const noop = () => {}
 const pending = () => new Promise<never>(() => {})
@@ -80,6 +81,48 @@ const completions = [
   { display: '/clear', meta: 'Clear screen and start a new session', text: '/clear' },
   { display: '/redraw', meta: 'Force a full UI repaint', text: '/redraw' },
   { display: '/history', meta: 'Show conversation history', text: '/history' }
+]
+
+const dockNow = 1_750_000_000_000
+
+const dockAgent = (id: string, index: number, overrides: Partial<SubagentProgress> = {}): SubagentProgress => ({
+  depth: 0,
+  goal: id,
+  id,
+  index,
+  notes: [],
+  parentId: null,
+  startedAt: dockNow - 74_000,
+  status: 'running',
+  taskCount: 1,
+  thinking: [],
+  toolCount: 0,
+  tools: [],
+  ...overrides
+})
+
+// B3 fixture: one running, one failed, one result-ready in the three row
+// slots (a failure must earn a row), with completed work overflowing into
+// the aggregate line. Goals are word-shaped so callsign derivation shows its
+// real behavior, not the indexed fallback.
+const dockAgents: SubagentProgress[] = [
+  dockAgent('inspect gateway auth', 0, { startedAt: dockNow - 134_000, tools: ['Read("src/gateway/auth.ts")'] }),
+  dockAgent('review diff stability', 1, { status: 'failed', summary: 'blocked on stable diff' }),
+  dockAgent('regression sweep suite', 2, { durationSeconds: 44, status: 'completed', summary: '22 tests pass' }),
+  dockAgent('changelog draft', 3, { durationSeconds: 9, status: 'completed' }),
+  dockAgent('flaky quarantine triage', 4, { durationSeconds: 21, status: 'completed', summary: '2 quarantined' })
+]
+
+const dockNestedAgents: SubagentProgress[] = [
+  dockAgent('plan parent batch', 0, { id: 'nested-parent', status: 'queued' }),
+  dockAgent('inspect child task', 0, { depth: 1, id: 'nested-child', parentId: 'nested-parent' }),
+  dockAgent('verify grandchild task', 0, { depth: 2, id: 'nested-grandchild', parentId: 'nested-child' })
+]
+
+const dockTerminalAgents: SubagentProgress[] = [
+  dockAgent('review interrupted task', 0, { durationSeconds: 14, status: 'interrupted' }),
+  dockAgent('test timeout task', 1, { durationSeconds: 30, status: 'timeout' }),
+  dockAgent('audit error task', 2, { durationSeconds: 6, status: 'error' })
 ]
 
 function renderAnsi(node: ReactElement, columns: number): string {
@@ -243,10 +286,31 @@ const addScene = (name: string, bgHex: string, skin: Record<string, string>) => 
   scenes.push({ bg: bgHex, fg: theme.color.text, name, theme })
 }
 
+// Grayscale skin: proves dock statuses stay glyph-distinguishable when the
+// theme carries no hue at all.
+const MONO = {
+  banner_accent: '#bbbbbb',
+  banner_border: '#666666',
+  banner_dim: '#555555',
+  banner_text: '#c0c0c0',
+  banner_title: '#d0d0d0',
+  prompt: '#c0c0c0',
+  session_border: '#555555',
+  session_label: '#d0d0d0',
+  status_bar_bg: '#1a1a1a',
+  status_bar_text: '#c0c0c0',
+  ui_accent: '#e6e6e6',
+  ui_error: '#f2f2f2',
+  ui_label: '#a8a8a8',
+  ui_ok: '#cccccc',
+  ui_warn: '#dcdcdc'
+}
+
 addScene('default · dark terminal', '#101014', {})
 addScene('default · light terminal (Cursor)', '#ffffff', {})
 addScene('slate · dark terminal', '#101014', SLATE)
 addScene('slate · light terminal (raw palette + display shim)', '#ffffff', SLATE)
+addScene('mono · grayscale skin', '#101014', MONO)
 
 let page = `<!doctype html><meta charset="utf-8"><body style="margin:0;background:#666;font:13px/1.35 Menlo,monospace"><div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;padding:16px">`
 
@@ -298,11 +362,102 @@ for (const scene of scenes) {
     88
   )
 
+  const dockNormal = renderAnsi(
+    <Box flexDirection="column" width={88}>
+      <Text color={scene.theme.color.text}>assistant · implementation is moving; transcript remains visible above.</Text>
+      <AgentDockView cols={86} nowMs={dockNow} onOpen={noop} subagents={dockAgents} t={scene.theme} />
+      <Text color={scene.theme.color.muted}>──────────────────────────────────────────────────────────────────────────────</Text>
+      <Text color={scene.theme.color.prompt}>❯ </Text>
+    </Box>,
+    88
+  )
+
+  const dock80 = renderAnsi(
+    <Box flexDirection="column" width={80}>
+      <Text color={scene.theme.color.text}>assistant · transcript remains visible above.</Text>
+      <AgentDockView cols={80} nowMs={dockNow} onOpen={noop} subagents={dockAgents} t={scene.theme} />
+      <Text color={scene.theme.color.muted}>{'─'.repeat(80)}</Text>
+      <Text color={scene.theme.color.prompt}>❯ </Text>
+    </Box>,
+    80
+  )
+
+  const dock60 = renderAnsi(
+    <Box flexDirection="column" width={60}>
+      <Text color={scene.theme.color.text}>assistant · transcript above.</Text>
+      <AgentDockView cols={60} nowMs={dockNow} onOpen={noop} subagents={dockAgents} t={scene.theme} />
+      <Text color={scene.theme.color.muted}>{'─'.repeat(60)}</Text>
+      <Text color={scene.theme.color.prompt}>❯ </Text>
+    </Box>,
+    60
+  )
+
+  const dockNarrow = renderAnsi(
+    <Box flexDirection="column" width={50}>
+      <Text color={scene.theme.color.text}>assistant · transcript remains visible.</Text>
+      <AgentDockView cols={48} nowMs={dockNow} onOpen={noop} subagents={dockAgents} t={scene.theme} />
+      <Text color={scene.theme.color.muted}>────────────────────────────────────────────────</Text>
+      <Text color={scene.theme.color.prompt}>❯ </Text>
+    </Box>,
+    50
+  )
+
+  const dockShortHeight = renderAnsi(
+    <Box flexDirection="column" width={80}>
+      <Text color={scene.theme.color.text}>assistant · short viewport keeps transcript space.</Text>
+      <AgentDockView
+        cols={80}
+        nowMs={dockNow}
+        onOpen={noop}
+        subagents={dockAgents}
+        summaryOnly
+        t={scene.theme}
+      />
+      <Text color={scene.theme.color.muted}>{'─'.repeat(80)}</Text>
+      <Text color={scene.theme.color.prompt}>❯ </Text>
+    </Box>,
+    80
+  )
+
+  const dockNested = renderAnsi(
+    <Box flexDirection="column" width={80}>
+      <Text color={scene.theme.color.text}>assistant · nested delegation remains visible.</Text>
+      <AgentDockView cols={80} nowMs={dockNow} onOpen={noop} subagents={dockNestedAgents} t={scene.theme} />
+      <Text color={scene.theme.color.muted}>{'─'.repeat(80)}</Text>
+      <Text color={scene.theme.color.prompt}>❯ </Text>
+    </Box>,
+    80
+  )
+
+  const dockTerminal = renderAnsi(
+    <Box flexDirection="column" width={80}>
+      <Text color={scene.theme.color.text}>assistant · terminal outcomes remain distinguishable.</Text>
+      <AgentDockView cols={80} nowMs={dockNow} onOpen={noop} subagents={dockTerminalAgents} t={scene.theme} />
+      <Text color={scene.theme.color.muted}>{'─'.repeat(80)}</Text>
+      <Text color={scene.theme.color.prompt}>❯ </Text>
+    </Box>,
+    80
+  )
+
   page += `<div style="background:${scene.bg};color:${scene.fg};padding:14px;border-radius:6px">`
   page += `<div style="font:bold 12px sans-serif;opacity:.6;margin-bottom:8px;color:${scene.fg}">${scene.name}</div>`
   page += `<pre style="margin:0;white-space:pre">${ansiToHtml(intro, scene.fg, scene.bg)}</pre>`
   page += `<pre style="margin:8px 0 0;white-space:pre">${ansiToHtml(comps, scene.fg, scene.bg)}</pre>`
   page += `<pre style="margin:8px 0 0;white-space:pre">${ansiToHtml(statusLine, scene.fg, scene.bg)}</pre>`
+  page += `<div style="font:bold 11px sans-serif;opacity:.6;margin-top:12px;color:${scene.fg}">persistent agent dock · 88-col terminal (cols 86)</div>`
+  page += `<pre style="margin:4px 0 0;white-space:pre">${ansiToHtml(dockNormal, scene.fg, scene.bg)}</pre>`
+  page += `<div style="font:bold 11px sans-serif;opacity:.6;margin-top:12px;color:${scene.fg}">persistent agent dock · exact 80 cols</div>`
+  page += `<pre style="margin:4px 0 0;white-space:pre">${ansiToHtml(dock80, scene.fg, scene.bg)}</pre>`
+  page += `<div style="font:bold 11px sans-serif;opacity:.6;margin-top:12px;color:${scene.fg}">persistent agent dock · exact 60 cols (frame floor)</div>`
+  page += `<pre style="margin:4px 0 0;white-space:pre">${ansiToHtml(dock60, scene.fg, scene.bg)}</pre>`
+  page += `<div style="font:bold 11px sans-serif;opacity:.6;margin-top:12px;color:${scene.fg}">persistent agent dock · narrow summary (48 cols, no frame)</div>`
+  page += `<pre style="margin:4px 0 0;white-space:pre">${ansiToHtml(dockNarrow, scene.fg, scene.bg)}</pre>`
+  page += `<div style="font:bold 11px sans-serif;opacity:.6;margin-top:12px;color:${scene.fg}">persistent agent dock · short viewport summary (80 cols, 14 rows)</div>`
+  page += `<pre style="margin:4px 0 0;white-space:pre">${ansiToHtml(dockShortHeight, scene.fg, scene.bg)}</pre>`
+  page += `<div style="font:bold 11px sans-serif;opacity:.6;margin-top:12px;color:${scene.fg}">persistent agent dock · queued + nested running tree</div>`
+  page += `<pre style="margin:4px 0 0;white-space:pre">${ansiToHtml(dockNested, scene.fg, scene.bg)}</pre>`
+  page += `<div style="font:bold 11px sans-serif;opacity:.6;margin-top:12px;color:${scene.fg}">persistent agent dock · interrupted + timeout + error</div>`
+  page += `<pre style="margin:4px 0 0;white-space:pre">${ansiToHtml(dockTerminal, scene.fg, scene.bg)}</pre>`
   page += `</div>`
 }
 

--- a/ui-tui/scripts/visual/shot.mjs
+++ b/ui-tui/scripts/visual/shot.mjs
@@ -20,7 +20,18 @@ app.whenReady().then(async () => {
   await win.loadFile(join(outDir, 'tui-visual.html'))
   await new Promise(r => setTimeout(r, 700))
 
-  const image = await win.webContents.capturePage()
+  // The scene grid can grow when new skins are added. Size the offscreen
+  // surface from the rendered document instead of silently clipping rows at
+  // the old fixed 2100px viewport (which hid the fifth mono scene).
+  const pageSize = await win.webContents.executeJavaScript(`({
+    height: Math.ceil(document.documentElement.scrollHeight),
+    width: Math.ceil(document.documentElement.scrollWidth)
+  })`)
+
+  win.setContentSize(pageSize.width, pageSize.height)
+  await new Promise(r => setTimeout(r, 100))
+
+  const image = await win.webContents.capturePage({ height: pageSize.height, width: pageSize.width, x: 0, y: 0 })
   const outFile = join(outDir, 'tui-visual.png')
 
   writeFileSync(outFile, image.toPNG())

--- a/ui-tui/src/__tests__/agentDock.test.ts
+++ b/ui-tui/src/__tests__/agentDock.test.ts
@@ -1,0 +1,445 @@
+import { describe, expect, it } from 'vitest'
+
+import { DOCK_MAX_ROWS, DOCK_NARROW_WIDTH, projectAgentDock } from '../lib/agentDock.js'
+import { formatToolCall } from '../lib/text.js'
+import type { SubagentProgress } from '../types.js'
+
+const NOW = 1_750_000_000_000
+
+const makeItem = (overrides: Partial<SubagentProgress> & Pick<SubagentProgress, 'id' | 'index'>): SubagentProgress => ({
+  depth: 0,
+  goal: overrides.id,
+  notes: [],
+  parentId: null,
+  status: 'running',
+  taskCount: 1,
+  thinking: [],
+  toolCount: 0,
+  tools: [],
+  ...overrides
+})
+
+const project = (items: SubagentProgress[], opts: Partial<Parameters<typeof projectAgentDock>[1]> = {}) =>
+  projectAgentDock(items, { nowMs: NOW, width: 100, ...opts })
+
+describe('projectAgentDock: visibility', () => {
+  it('hides for an empty subagent list', () => {
+    const view = project([])
+
+    expect(view.hidden).toBe(true)
+    expect(view.rows).toEqual([])
+    expect(view.totalCount).toBe(0)
+  })
+
+  it('shows a single running row with a safe callsign, plain activity, and live elapsed time', () => {
+    const view = project([makeItem({ id: 'a', index: 0, goal: 'scan repo', startedAt: NOW - 5000 })])
+
+    expect(view.hidden).toBe(false)
+    expect(view.activeCount).toBe(1)
+    expect(view.totalCount).toBe(1)
+    expect(view.rows).toHaveLength(1)
+
+    const row = view.rows[0]
+    expect(row.callsign).toBe('scan')
+    expect(row.activity).toBe('working')
+    expect(row.glyph).toBe('●')
+    expect(row.tone).toBe('accent')
+    expect(row.elapsed).toBe('5s')
+    expect(row.live).toBe(true)
+  })
+})
+
+describe('projectAgentDock: status metadata', () => {
+  it('distinguishes every status with glyph + tone, never color alone', () => {
+    const view = project(
+      [
+        makeItem({ id: 'run', index: 0, status: 'running' }),
+        makeItem({ id: 'que', index: 1, status: 'queued' }),
+        makeItem({ id: 'com', index: 2, status: 'completed' }),
+        makeItem({ id: 'int', index: 3, status: 'interrupted' }),
+        makeItem({ id: 'fai', index: 4, status: 'failed' }),
+        makeItem({ id: 'tim', index: 5, status: 'timeout' }),
+        makeItem({ id: 'err', index: 6, status: 'error' })
+      ],
+      { maxRows: 7 }
+    )
+
+    const meta = Object.fromEntries(view.rows.map(r => [r.id, { glyph: r.glyph, tone: r.tone }]))
+
+    expect(meta.run).toEqual({ glyph: '●', tone: 'accent' })
+    expect(meta.que).toEqual({ glyph: '○', tone: 'muted' })
+    expect(meta.com).toEqual({ glyph: '✓', tone: 'statusGood' })
+    expect(meta.int).toEqual({ glyph: '■', tone: 'warn' })
+    expect(meta.fai).toEqual({ glyph: '✗', tone: 'error' })
+    expect(meta.tim).toEqual({ glyph: 'T', tone: 'warn' })
+    expect(meta.err).toEqual({ glyph: '!', tone: 'error' })
+
+    // Glyphs are pairwise distinct so color is never the only signal.
+    const glyphs = view.rows.map(r => r.glyph)
+    expect(new Set(glyphs).size).toBe(glyphs.length)
+  })
+
+  it('counts running + queued as active', () => {
+    const view = project([
+      makeItem({ id: 'a', index: 0, status: 'running' }),
+      makeItem({ id: 'b', index: 1, status: 'queued' }),
+      makeItem({ id: 'c', index: 2, status: 'completed' })
+    ])
+
+    expect(view.activeCount).toBe(2)
+    expect(view.totalCount).toBe(3)
+  })
+})
+
+describe('projectAgentDock: ordering', () => {
+  it('preserves spawn/tree order with children after their parent', () => {
+    const view = project([
+      makeItem({ id: 'q', index: 1 }),
+      makeItem({ depth: 1, id: 'c1', index: 0, parentId: 'p' }),
+      makeItem({ id: 'p', index: 0 })
+    ])
+
+    expect(view.rows.map(r => r.id)).toEqual(['p', 'c1', 'q'])
+    expect(view.rows.map(r => r.depth)).toEqual([0, 1, 0])
+  })
+})
+
+describe('projectAgentDock: durations', () => {
+  it('prefers terminal durationSeconds over live elapsed', () => {
+    const view = project([
+      makeItem({ durationSeconds: 90, id: 'a', index: 0, startedAt: NOW - 5000, status: 'completed' })
+    ])
+
+    expect(view.rows[0].elapsed).toBe('1m 30s')
+    expect(view.rows[0].live).toBe(false)
+  })
+
+  it('preserves an explicit zero-second terminal duration', () => {
+    const view = project([
+      makeItem({ durationSeconds: 0, id: 'a', index: 0, startedAt: NOW - 5000, status: 'completed' })
+    ])
+
+    expect(view.rows[0].elapsed).toBe('0s')
+    expect(view.rows[0].live).toBe(false)
+  })
+
+  it('reports no duration when nothing is known', () => {
+    const view = project([makeItem({ id: 'a', index: 0, status: 'queued' })])
+
+    expect(view.rows[0].elapsed).toBe('')
+    expect(view.rows[0].live).toBe(false)
+  })
+})
+
+describe('projectAgentDock: labels', () => {
+  it('derives a bounded ASCII callsign and falls back truthfully for non-ASCII goals', () => {
+    const view = project(
+      [
+        makeItem({ goal: 'Patch token-bucket refill race', id: 'a', index: 0 }),
+        makeItem({ goal: '分析レポート 🔎', id: 'b', index: 2 }),
+        makeItem({ goal: '/Users/person/private/file.txt', id: 'c', index: 4 }),
+        makeItem({ goal: './private/file.ts', id: 'd', index: 5 }),
+        makeItem({ goal: '../private/file.ts', id: 'e', index: 6 }),
+        makeItem({ goal: 'src/private/file.ts', id: 'f', index: 7 }),
+        makeItem({ goal: 'file:///private/file.ts', id: 'g', index: 8 }),
+        makeItem({ goal: 'ssh://private.example/repo', id: 'h', index: 9 }),
+        makeItem({ goal: 'C:\\private\\file.ts', id: 'i', index: 10 }),
+        makeItem({ goal: '', id: 'j', index: 11 }),
+        makeItem({ goal: 'abcdefghijklmnop', id: 'k', index: 12 })
+      ],
+      { maxRows: 11 }
+    )
+
+    expect(view.rows[0].callsign).toBe('patch')
+    expect(view.rows[1].callsign).toBe('agent 3')
+    expect(view.rows[2].callsign).toBe('agent 5')
+    expect(view.rows.slice(3, 9).map(row => row.callsign)).toEqual([
+      'agent 6',
+      'agent 7',
+      'agent 8',
+      'agent 9',
+      'agent 10',
+      'agent 11'
+    ])
+    expect(view.rows[9].callsign).toBe('agent 12')
+    expect(view.rows[10].callsign).toBe('agent 13')
+    expect(view.rows.every(row => /^[\x20-\x7e]{1,12}$/.test(row.callsign))).toBe(true)
+  })
+
+  it('never exposes arbitrary names, projects, medical topics, emails, or token-like goal words', () => {
+    const view = project(
+      [
+        makeItem({ goal: 'Acme client handoff', id: 'a', index: 0 }),
+        makeItem({ goal: 'dana.reyes@example.com followup', id: 'b', index: 1 }),
+        makeItem({ goal: 'oncology review for patient', id: 'c', index: 2 }),
+        makeItem({ goal: 'sk_live_ABC123 rotate credentials', id: 'd', index: 3 })
+      ],
+      { maxRows: 4 }
+    )
+
+    expect(view.rows.map(row => row.callsign)).toEqual(['agent 1', 'agent 2', 'review', 'agent 4'])
+    expect(JSON.stringify(view)).not.toMatch(/Acme|reyes|oncology|patient|sk_live|ABC123/i)
+  })
+
+  it('maps the latest tool to a plain-language activity without its raw preview', () => {
+    const view = project([
+      makeItem({ id: 'a', index: 0, tools: ['Read', 'Terminal("npm test -- --run private/path")'] })
+    ])
+
+    expect(view.rows[0].activity).toBe('running commands')
+    expect(view.rows[0].activity).not.toContain('private/path')
+  })
+
+  it.each([
+    ['Read File("private/path")', 'reading files'],
+    ['Search Files("private/query")', 'searching'],
+    ['Web Search("private/query")', 'searching web'],
+    ['Write File("private/path")', 'writing files']
+  ])('maps real gateway label %s without exposing its private preview', (tool, activity) => {
+    const view = project([makeItem({ id: 'a', index: 0, tools: [tool] })])
+
+    expect(view.rows[0].activity).toBe(activity)
+    expect(view.rows[0].activity).not.toContain('private')
+  })
+
+  it.each([
+    ['terminal', 'running commands'],
+    ['read_file', 'reading files'],
+    ['write_file', 'writing files'],
+    ['patch', 'editing files'],
+    ['search_files', 'searching'],
+    ['web_search', 'searching web'],
+    ['web_extract', 'reading web'],
+    ['execute_code', 'running code'],
+    ['delegate_task', 'delegating'],
+    ['browser_navigate', 'browsing'],
+    ['browser_click', 'browsing'],
+    ['memory', 'updating memory'],
+    ['todo', 'updating todos'],
+    ['process', 'managing process'],
+    ['session_search', 'searching sessions'],
+    ['computer_use', 'using computer'],
+    ['skill_view', 'reading skills'],
+    ['kanban_show', 'reading task'],
+    ['ha_get_state', 'checking home']
+  ])('maps formatToolCall(%s) into a specific plain activity without leaking the preview', (name, activity) => {
+    const line = formatToolCall(name, 'private/value')
+    const view = project([makeItem({ id: 'a', index: 0, tools: [line] })])
+
+    expect(line).toContain('private/value')
+    expect(view.rows[0].activity).toBe(activity)
+    expect(view.rows[0].activity).not.toContain('private')
+    expect(view.rows[0].activity).not.toBe('working')
+  })
+
+  it('keeps unknown tool names generic without leaking preview text', () => {
+    const line = formatToolCall('totally_unknown_tool', 'private/secret')
+    const view = project([makeItem({ id: 'a', index: 0, tools: [line] })])
+
+    expect(view.rows[0].activity).toBe('working')
+    expect(view.rows[0].activity).not.toContain('private')
+    expect(view.rows[0].activity).not.toContain('secret')
+  })
+
+  it('uses truthful terminal activity labels rather than stale tool details', () => {
+    const view = project([
+      makeItem({
+        id: 'failed',
+        index: 0,
+        status: 'failed',
+        tools: ['Terminal("npm test -- --run private/path")']
+      })
+    ])
+
+    expect(view.rows[0].activity).toBe('failed')
+    expect(view.rows[0].activity).not.toContain('private/path')
+  })
+
+  it('marks completed output as result-ready without rendering its summary', () => {
+    const view = project([makeItem({ id: 'a', index: 0, status: 'completed', summary: 'wrote 3 tests' })])
+
+    expect(view.rows[0].activity).toBe('result ready')
+    expect(JSON.stringify(view)).not.toContain('wrote 3 tests')
+  })
+
+  it('labels every terminal and queued branch truthfully', () => {
+    const view = project(
+      [
+        makeItem({ id: 'done', index: 0, status: 'completed' }),
+        makeItem({ id: 'queued', index: 1, status: 'queued' }),
+        makeItem({ id: 'error', index: 2, status: 'error' }),
+        makeItem({ id: 'interrupted', index: 3, status: 'interrupted' }),
+        makeItem({ id: 'timeout', index: 4, status: 'timeout' })
+      ],
+      { maxRows: 5 }
+    )
+
+    expect(Object.fromEntries(view.rows.map(row => [row.id, row.activity]))).toEqual({
+      done: 'done',
+      error: 'failed',
+      interrupted: 'interrupted',
+      queued: 'queued',
+      timeout: 'timed out'
+    })
+  })
+})
+
+describe('projectAgentDock: header counts', () => {
+  it('separates running, queued, ready, and blocked counts', () => {
+    const view = project([
+      makeItem({ id: 'run', index: 0, status: 'running' }),
+      makeItem({ id: 'queue', index: 1, status: 'queued' }),
+      makeItem({ id: 'ready', index: 2, status: 'completed', summary: 'result' }),
+      makeItem({ id: 'failed', index: 3, status: 'failed' })
+    ])
+
+    expect(view.header).toBe('1 running · 1 queued · 1 ready · 1 blocked')
+  })
+
+  it('uses terminal counts instead of zero-running language when all work is done', () => {
+    const view = project([
+      makeItem({ id: 'done-0', index: 0, status: 'completed' }),
+      makeItem({ id: 'done-1', index: 1, status: 'completed', summary: 'result' }),
+      makeItem({ id: 'done-2', index: 2, status: 'completed' }),
+      makeItem({ id: 'done-3', index: 3, status: 'completed' }),
+      makeItem({ id: 'failed', index: 4, status: 'failed' })
+    ])
+
+    expect(view.header).toBe('4 done · 1 blocked')
+    expect(view.header).not.toContain('0 running')
+  })
+})
+
+describe('projectAgentDock: bounds', () => {
+  it('caps visible rows at three and reports overflow', () => {
+    const items = Array.from({ length: 8 }, (_, i) =>
+      makeItem({ id: `a${i}`, index: i, status: i >= 6 ? 'running' : 'completed' })
+    )
+
+    const view = project(items)
+
+    expect(DOCK_MAX_ROWS).toBe(3)
+    expect(view.rows).toHaveLength(3)
+    expect(view.rows.map(row => row.id)).toEqual(['a0', 'a6', 'a7'])
+    expect(view.overflow).toBe(5)
+    expect(view.overflowActive).toBe(0)
+    expect(view.overflowSummary).toBe('5 more · 5 done')
+  })
+
+  it('reports active overflow when more than three agents are live', () => {
+    const view = project(Array.from({ length: 6 }, (_, index) => makeItem({ id: `live-${index}`, index })))
+
+    expect(view.overflow).toBe(3)
+    expect(view.overflowActive).toBe(3)
+    expect(view.overflowSummary).toBe('3 more · 3 running')
+  })
+
+  it('honors a smaller maxRows override', () => {
+    const items = Array.from({ length: 4 }, (_, i) => makeItem({ id: `a${i}`, index: i }))
+    const view = project(items, { maxRows: 2 })
+
+    expect(view.rows).toHaveLength(2)
+    expect(view.overflow).toBe(2)
+  })
+
+  it('keeps later active and failed work visible ahead of completed rows', () => {
+    const view = project(
+      [
+        makeItem({ id: 'done-0', index: 0, status: 'completed' }),
+        makeItem({ id: 'done-1', index: 1, status: 'completed' }),
+        makeItem({ id: 'done-2', index: 2, status: 'completed' }),
+        makeItem({ id: 'done-3', index: 3, status: 'completed' }),
+        makeItem({ id: 'done-4', index: 4, status: 'completed' }),
+        makeItem({ id: 'live', index: 5, status: 'running' }),
+        makeItem({ id: 'failed', index: 6, status: 'failed' })
+      ],
+      { maxRows: 3 }
+    )
+
+    expect(view.rows.map(row => row.id)).toEqual(['done-0', 'live', 'failed'])
+    expect(view.overflowActive).toBe(0)
+  })
+
+  it('keeps queued work and every blocked status ahead of completed rows under pressure', () => {
+    const view = project(
+      [
+        makeItem({ id: 'done-0', index: 0, status: 'completed' }),
+        makeItem({ id: 'queued', index: 1, status: 'queued' }),
+        makeItem({ id: 'error', index: 2, status: 'error' }),
+        makeItem({ id: 'interrupted', index: 3, status: 'interrupted' }),
+        makeItem({ id: 'timeout', index: 4, status: 'timeout' }),
+        makeItem({ id: 'failed', index: 5, status: 'failed' }),
+        makeItem({ id: 'done-1', index: 6, status: 'completed' })
+      ],
+      { maxRows: 5 }
+    )
+
+    expect(view.rows.map(row => row.id)).toEqual(['queued', 'error', 'interrupted', 'timeout', 'failed'])
+  })
+
+  it('keeps a selected completed parent above its live child', () => {
+    const view = project([
+      makeItem({ id: 'parent', index: 0, status: 'completed' }),
+      makeItem({ depth: 1, id: 'child', index: 0, parentId: 'parent', status: 'running' })
+    ])
+
+    expect(view.rows.map(row => row.id)).toEqual(['parent', 'child'])
+    expect(view.rows.map(row => row.depth)).toEqual([0, 1])
+  })
+
+  it('rebases a live child to depth zero when its parent is overflowed', () => {
+    const view = project(
+      [
+        makeItem({ id: 'parent', index: 0, status: 'completed' }),
+        makeItem({ depth: 1, id: 'child', index: 0, parentId: 'parent', status: 'running' })
+      ],
+      { maxRows: 1 }
+    )
+
+    expect(view.rows.map(row => row.id)).toEqual(['child'])
+    expect(view.rows[0].depth).toBe(0)
+  })
+})
+
+describe('projectAgentDock: narrow terminals', () => {
+  it('collapses to a one-line summary below the narrow threshold', () => {
+    const items = [
+      makeItem({ id: 'a', index: 0, startedAt: NOW - 65_000 }),
+      makeItem({ id: 'b', index: 1, status: 'completed' }),
+      makeItem({ id: 'c', index: 2, status: 'failed' })
+    ]
+
+    const view = project(items, { width: DOCK_NARROW_WIDTH - 1 })
+
+    expect(view.summaryOnly).toBe(true)
+    expect(view.rows).toEqual([])
+    expect(view.summary).toContain('1/3 active')
+    expect(view.summary).toContain('1 issue')
+  })
+
+  it('stays expanded at 80 columns', () => {
+    const view = project([makeItem({ id: 'a', index: 0 })], { width: 80 })
+
+    expect(view.summaryOnly).toBe(false)
+    expect(view.rows).toHaveLength(1)
+  })
+
+  it('stays expanded at the exact 60-column boundary', () => {
+    const view = project([makeItem({ id: 'a', index: 0 })], { width: DOCK_NARROW_WIDTH })
+
+    expect(view.summaryOnly).toBe(false)
+    expect(view.rows).toHaveLength(1)
+  })
+})
+
+describe('projectAgentDock: purity', () => {
+  it('does not mutate its input', () => {
+    const item = Object.freeze(makeItem({ id: 'a', index: 0, startedAt: NOW - 1000 }))
+    const items = Object.freeze([item]) as unknown as SubagentProgress[]
+
+    expect(() => project(items)).not.toThrow()
+
+    const view = project(items)
+    expect(view.rows[0].id).toBe('a')
+  })
+})

--- a/ui-tui/src/__tests__/agentDockComponent.test.tsx
+++ b/ui-tui/src/__tests__/agentDockComponent.test.tsx
@@ -1,0 +1,960 @@
+import { PassThrough } from 'stream'
+
+import { Box, renderSync, stringWidth } from '@hermes/ink'
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
+import { getOverlayState, patchOverlayState, resetOverlayState } from '../app/overlayStore.js'
+import { clearSpawnHistory, getSpawnHistory } from '../app/spawnHistoryStore.js'
+import { markSubmitting } from '../app/submissionCore.js'
+import { turnController } from '../app/turnController.js'
+import { getTurnState, patchTurnState, resetTurnState } from '../app/turnStore.js'
+import { AgentDock, AgentDockView } from '../components/agentDock.js'
+import { AgentsOverlay } from '../components/agentsOverlay.js'
+import { projectAgentDock } from '../lib/agentDock.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+import type { Msg, SubagentProgress } from '../types.js'
+
+const NOW = 1_750_000_000_000
+
+const makeItem = (overrides: Partial<SubagentProgress> & Pick<SubagentProgress, 'id' | 'index'>): SubagentProgress => ({
+  depth: 0,
+  goal: overrides.id,
+  notes: [],
+  parentId: null,
+  status: 'running',
+  taskCount: 1,
+  thinking: [],
+  toolCount: 0,
+  tools: [],
+  ...overrides
+})
+
+const makeStreams = (columns = 100, rows = 24) => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns, isTTY: false, rows })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  // Ink's non-TTY path can emit more than one full frame into the stream.
+  // Prefer the final complete frame so width/line assertions are independent
+  // of NODE_ENV-driven render scheduling (test vs production).
+  const getOutput = () => {
+    const text = stripAnsi(output)
+    const frames = text.split(/\n(?=╭)/).filter(frame => frame.includes('╭') && frame.includes('╰'))
+
+    return frames.at(-1) ?? text
+  }
+
+  return { getOutput, stderr, stdin, stdout }
+}
+
+const ref = <T,>(current: T) => ({ current })
+
+const buildFlowCtx = (appended: Msg[]) =>
+  ({
+    composer: {
+      dequeue: () => undefined,
+      queueEditRef: ref<null | number>(null),
+      sendQueued: vi.fn(),
+      setInput: vi.fn()
+    },
+    gateway: {
+      gw: { request: vi.fn() },
+      rpc: vi.fn(async () => null)
+    },
+    session: {
+      STARTUP_RESUME_ID: '',
+      colsRef: ref(80),
+      newSession: vi.fn(),
+      resetSession: vi.fn(),
+      resumeById: vi.fn(),
+      setCatalog: vi.fn()
+    },
+    submission: { submitRef: ref(vi.fn()) },
+    system: { bellOnComplete: false, sys: vi.fn() },
+    transcript: {
+      appendMessage: (msg: Msg) => appended.push(msg),
+      panel: vi.fn(),
+      setHistoryItems: vi.fn()
+    },
+    voice: {
+      setProcessing: vi.fn(),
+      setRecording: vi.fn(),
+      setVoiceEnabled: vi.fn()
+    }
+  }) as any
+
+const renderView = (subagents: SubagentProgress[], cols = 100) => {
+  const streams = makeStreams(cols)
+
+  const instance = renderSync(
+    <Box flexDirection="column" width={cols}>
+      <AgentDockView cols={cols} nowMs={NOW} onOpen={() => {}} subagents={subagents} t={DEFAULT_THEME} />
+    </Box>,
+    {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    }
+  )
+
+  instance.unmount()
+  instance.cleanup()
+
+  return streams.getOutput()
+}
+
+afterEach(() => {
+  clearSpawnHistory()
+  resetOverlayState()
+  resetTurnState()
+  turnController.fullReset()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('AgentDockView', () => {
+  it('renders nothing without subagents', () => {
+    expect(renderView([]).trim()).toBe('')
+  })
+
+  it('renders semantic rows with bounded, sanitized activity', () => {
+    const output = renderView([
+      makeItem({
+        goal: 'inspect the layout',
+        id: 'a',
+        index: 0,
+        notes: ['private progress note'],
+        startedAt: NOW - 5000,
+        tools: ['Read("private/path")']
+      }),
+      makeItem({ durationSeconds: 12, goal: 'write tests', id: 'b', index: 1, status: 'completed', summary: 'tests pass' }),
+      makeItem({ goal: 'verify build', id: 'c', index: 2, status: 'failed' })
+    ])
+
+    expect(output).toContain('agents · 1 running · 1 ready · 1 blocked · /agents ↗')
+    expect(output).not.toContain('1/3 active')
+    expect(output).toContain('● inspect')
+    expect(output).toContain('reading files')
+    expect(output).toContain('5s')
+    expect(output).toContain('✓ write')
+    expect(output).toContain('result ready')
+    expect(output).toContain('12s')
+    expect(output).toContain('✗ verify')
+    expect(output).toContain('failed')
+    expect(output).not.toContain('tests pass')
+    expect(output).not.toContain('private/path')
+    expect(output).not.toContain('private progress note')
+  })
+
+  it('shows only a one-line summary on narrow terminals', () => {
+    const output = renderView(
+      [
+        makeItem({ goal: 'must not render', id: 'a', index: 0, startedAt: NOW - 5000 }),
+        makeItem({ goal: 'also hidden', id: 'b', index: 1, status: 'completed' })
+      ],
+      50
+    )
+
+    expect(output).toContain('agents · /agents ↗ · 1/2 active · 5s')
+    expect(output).not.toContain('must not render')
+    expect(output).not.toContain('also hidden')
+  })
+
+  it('preserves the drill-down cue before truncating a very narrow summary', () => {
+    const output = renderView([makeItem({ id: 'a', index: 0, startedAt: NOW - 5000 })], 32)
+
+    expect(output).toContain('agents · /agents ↗')
+    expect(output.trim().split('\n')).toHaveLength(1)
+  })
+
+  it('caps rows at three and reports overflow activity', () => {
+    const names = ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'golf']
+
+    const output = renderView(
+      Array.from({ length: 7 }, (_, index) =>
+        makeItem({ goal: names[index], id: `agent-${index}`, index, status: index === 6 ? 'running' : 'completed' })
+      )
+    )
+
+    expect(output).toContain('… 4 more · 4 done')
+    expect(output).not.toContain('+4 more')
+    expect(output).toContain('agent 1')
+    expect(output).toContain('agent 2')
+    expect(output).toContain('agent 7')
+    expect(output).not.toContain('agent 3')
+    expect(output).not.toContain('agent 4')
+  })
+
+  it('renders a positive active-overflow count', () => {
+    const output = renderView(Array.from({ length: 6 }, (_, index) => makeItem({ id: `live-${index}`, index })))
+
+    expect(output).toContain('… 3 more · 3 running')
+    expect(output).not.toContain('3 active')
+  })
+
+  it('uses truthful terminal counts instead of zero-running language', () => {
+    const output = renderView([
+      makeItem({ id: 'done-a', index: 0, status: 'completed', summary: 'ready' }),
+      makeItem({ id: 'done-b', index: 1, status: 'completed' }),
+      makeItem({ id: 'done-c', index: 2, status: 'completed', summary: 'ready' }),
+      makeItem({ id: 'blocked', index: 3, status: 'timeout' })
+    ])
+
+    expect(output).toContain('agents · 3 done · 1 blocked · /agents ↗')
+    expect(output).not.toContain('0 running')
+  })
+
+  it.each([60, 80, 86])('keeps every framed line exactly %i terminal cells wide', cols => {
+    const output = renderView(
+      [
+        makeItem({ id: 'inspect', index: 0, startedAt: NOW - 5000, tools: ['Read("private/path")'] }),
+        makeItem({ id: 'review', index: 1, status: 'timeout' }),
+        makeItem({ id: 'regression', index: 2, status: 'completed', summary: 'ready' }),
+        makeItem({ id: 'overflow', index: 3, status: 'queued' })
+      ],
+      cols
+    )
+
+    const lines = output.split('\n').filter(line => /^[╭│╰]/.test(line))
+
+    expect(lines).toHaveLength(6)
+    expect(lines[0]).toMatch(/^╭.*╮$/)
+    expect(lines.at(-1)).toMatch(/^╰.*╯$/)
+    expect(lines.every(line => stringWidth(line) === cols)).toBe(true)
+  })
+
+  it('marks omitted header counts explicitly at the exact 60-column frame floor', () => {
+    const output = renderView(
+      [
+        makeItem({ id: 'run', index: 0, status: 'running' }),
+        makeItem({ id: 'queue', index: 1, status: 'queued' }),
+        makeItem({ id: 'ready', index: 2, status: 'completed', summary: 'ready' }),
+        makeItem({ id: 'blocked', index: 3, status: 'failed' })
+      ],
+      60
+    )
+
+    const header = output.split('\n').find(line => line.startsWith('╭')) ?? ''
+
+    expect(header).toContain(' · … · /agents ↗')
+    expect(stringWidth(header)).toBe(60)
+  })
+
+  it('opens the existing overlay route on click without bubbling', () => {
+    const onOpen = vi.fn()
+    const stopImmediatePropagation = vi.fn()
+
+    const element = AgentDockView({
+      cols: 100,
+      nowMs: NOW,
+      onOpen,
+      subagents: [makeItem({ id: 'a', index: 0 })],
+      t: DEFAULT_THEME
+    }) as React.ReactElement<{ onClick: (event: { stopImmediatePropagation: () => void }) => void }>
+
+    element.props.onClick({ stopImmediatePropagation })
+
+    expect(stopImmediatePropagation).toHaveBeenCalledOnce()
+    expect(onOpen).toHaveBeenCalledOnce()
+  })
+
+  it('flows gateway lifecycle through the live dock, overlay route, and history archive', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const appended: Msg[] = []
+    const handler = createGatewayEventHandler(buildFlowCtx(appended))
+    const openAgents = () => patchOverlayState({ agents: true, agentsInitialHistoryIndex: 0 })
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({
+      payload: { goal: 'inspect runtime flow', subagent_id: 'flow-agent', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'flow-agent', status: 'running' }])
+    let output = renderView(getTurnState().subagents, 80)
+    expect(output).toContain('agents · 1 running · /agents ↗')
+    expect(output).toContain('● inspect')
+
+    handler({
+      payload: {
+        goal: 'inspect runtime flow',
+        subagent_id: 'flow-agent',
+        task_index: 0,
+        tool_name: 'Read',
+        tool_preview: 'private/runtime/path'
+      },
+      type: 'subagent.tool'
+    } as any)
+    handler({
+      payload: { goal: 'inspect runtime flow', subagent_id: 'flow-agent', task_index: 0, text: 'private progress note' },
+      type: 'subagent.progress'
+    } as any)
+
+    output = renderView(getTurnState().subagents, 80)
+    expect(output).toContain('reading files')
+    expect(output).not.toContain('private/runtime/path')
+    expect(output).not.toContain('private progress note')
+
+    const clickable = AgentDockView({
+      cols: 80,
+      nowMs: NOW,
+      onOpen: openAgents,
+      subagents: getTurnState().subagents,
+      t: DEFAULT_THEME
+    }) as React.ReactElement<{ onClick: (event: { stopImmediatePropagation: () => void }) => void }>
+
+    clickable.props.onClick({ stopImmediatePropagation: vi.fn() })
+    expect(getOverlayState()).toMatchObject({ agents: true, agentsInitialHistoryIndex: 0 })
+
+    handler({
+      payload: {
+        duration_seconds: 9,
+        goal: 'inspect runtime flow',
+        status: 'completed',
+        subagent_id: 'flow-agent',
+        summary: 'private completion summary',
+        task_index: 0
+      },
+      type: 'subagent.complete'
+    } as any)
+    handler({
+      payload: { goal: 'inspect runtime flow', subagent_id: 'flow-agent', task_index: 0, text: 'late private note' },
+      type: 'subagent.progress'
+    } as any)
+
+    expect(getTurnState().subagents).toMatchObject([
+      { durationSeconds: 9, id: 'flow-agent', status: 'completed', summary: 'private completion summary' }
+    ])
+    expect(projectAgentDock(getTurnState().subagents, { nowMs: NOW, width: 80 }).hidden).toBe(false)
+    expect(getSpawnHistory()).toEqual([])
+
+    handler({ payload: { text: 'parent synthesis complete' }, type: 'message.complete' } as any)
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()).toHaveLength(1)
+    expect(getSpawnHistory()[0]?.subagents).toMatchObject([
+      { durationSeconds: 9, id: 'flow-agent', status: 'completed', summary: 'private completion summary' }
+    ])
+    expect(appended).toContainEqual(expect.objectContaining({ role: 'assistant', text: 'parent synthesis complete' }))
+
+    const overlayStreams = makeStreams(100)
+    Object.assign(overlayStreams.stdin, {
+      isTTY: true,
+      ref: vi.fn(),
+      setRawMode: vi.fn(),
+      unref: vi.fn()
+    })
+
+    const overlay = renderSync(
+      <AgentsOverlay
+        gw={{ request: vi.fn(async () => ({})) } as any}
+        initialHistoryIndex={0}
+        onClose={() => patchOverlayState({ agents: false })}
+        t={DEFAULT_THEME}
+      />,
+      {
+        patchConsole: false,
+        stderr: overlayStreams.stderr as unknown as NodeJS.WriteStream,
+        stdin: overlayStreams.stdin as unknown as NodeJS.ReadStream,
+        stdout: overlayStreams.stdout as unknown as NodeJS.WriteStream
+      }
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(overlayStreams.getOutput()).toContain('Last turn · finished')
+    expect(overlayStreams.getOutput()).toContain('inspect runtime flow')
+    expect(overlayStreams.getOutput()).toContain('controls locked')
+    expect(overlayStreams.getOutput()).not.toContain('No subagents this turn')
+
+    overlay.unmount()
+    overlay.cleanup()
+  })
+
+  it('preserves background subagents across parent turns and archives terminal wake-up results', () => {
+    const appended: Msg[] = []
+    const handler = createGatewayEventHandler(buildFlowCtx(appended))
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({
+      payload: { goal: 'inspect background flow', subagent_id: 'background-agent', task_index: 0 },
+      type: 'subagent.spawn_requested'
+    } as any)
+    handler({ payload: { text: 'delegation dispatched' }, type: 'message.complete' } as any)
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'background-agent', status: 'queued' }])
+    expect(getSpawnHistory()).toEqual([])
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    expect(getTurnState().subagents).toMatchObject([{ id: 'background-agent', status: 'queued' }])
+
+    handler({
+      payload: { goal: 'inspect background flow', subagent_id: 'background-agent', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+    expect(getTurnState().subagents).toMatchObject([{ id: 'background-agent', status: 'running' }])
+
+    handler({
+      payload: {
+        duration_seconds: 12,
+        goal: 'inspect background flow',
+        status: 'completed',
+        subagent_id: 'background-agent',
+        summary: 'verified background result',
+        task_index: 0
+      },
+      type: 'subagent.complete'
+    } as any)
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'background-agent', status: 'completed' }])
+    expect(getSpawnHistory()).toEqual([])
+    handler({ payload: { text: 'background result synthesized' }, type: 'message.complete' } as any)
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()).toHaveLength(1)
+    expect(getSpawnHistory()[0]?.subagents).toMatchObject([
+      { durationSeconds: 12, id: 'background-agent', status: 'completed', summary: 'verified background result' }
+    ])
+  })
+
+  it('preserves a detached child across gateway recovery until its terminal event archives it', () => {
+    const handler = createGatewayEventHandler(buildFlowCtx([]))
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({
+      payload: { goal: 'survive gateway recovery', subagent_id: 'recovery-agent', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+    handler({ payload: { text: 'delegation dispatched' }, type: 'message.complete' } as any)
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'recovery-agent', status: 'running' }])
+    expect(getSpawnHistory()).toEqual([])
+
+    turnController.reset()
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'recovery-agent', status: 'running' }])
+    expect(getSpawnHistory()).toEqual([])
+
+    handler({
+      payload: {
+        duration_seconds: 17,
+        goal: 'survive gateway recovery',
+        status: 'completed',
+        subagent_id: 'recovery-agent',
+        summary: 'completed after gateway recovery',
+        task_index: 0
+      },
+      type: 'subagent.complete'
+    } as any)
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()).toHaveLength(1)
+    expect(getSpawnHistory()[0]?.subagents).toMatchObject([
+      { durationSeconds: 17, id: 'recovery-agent', status: 'completed', summary: 'completed after gateway recovery' }
+    ])
+  })
+
+  it('keeps sequential delegations in one live tree and archives one snapshot at parent turn end', () => {
+    const handler = createGatewayEventHandler(buildFlowCtx([]))
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({
+      payload: { goal: 'inspect first', subagent_id: 'sequential-a', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+    handler({
+      payload: { goal: 'inspect first', status: 'completed', subagent_id: 'sequential-a', task_index: 0 },
+      type: 'subagent.complete'
+    } as any)
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'sequential-a', status: 'completed' }])
+    expect(getSpawnHistory()).toEqual([])
+
+    handler({
+      payload: { goal: 'review second', subagent_id: 'sequential-b', task_index: 1 },
+      type: 'subagent.start'
+    } as any)
+    handler({
+      payload: { goal: 'review second', status: 'completed', subagent_id: 'sequential-b', task_index: 1 },
+      type: 'subagent.complete'
+    } as any)
+
+    expect(getTurnState().subagents).toMatchObject([
+      { id: 'sequential-a', status: 'completed' },
+      { id: 'sequential-b', status: 'completed' }
+    ])
+    expect(getSpawnHistory()).toEqual([])
+
+    handler({ payload: { text: 'sequential delegation complete' }, type: 'message.complete' } as any)
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()).toHaveLength(1)
+    expect(getSpawnHistory()[0]?.subagents).toMatchObject([
+      { id: 'sequential-a', status: 'completed' },
+      { id: 'sequential-b', status: 'completed' }
+    ])
+  })
+
+  it('archives a detached completion that lands after submit but before message.start', () => {
+    const handler = createGatewayEventHandler(buildFlowCtx([]))
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({
+      payload: { goal: 'finish before next start', subagent_id: 'prestart-agent', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+    handler({ payload: { text: 'delegation dispatched' }, type: 'message.complete' } as any)
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'prestart-agent', status: 'running' }])
+    expect(getSpawnHistory()).toEqual([])
+
+    markSubmitting()
+    handler({
+      payload: {
+        duration_seconds: 7,
+        goal: 'finish before next start',
+        status: 'completed',
+        subagent_id: 'prestart-agent',
+        summary: 'completed during submit round-trip',
+        task_index: 0
+      },
+      type: 'subagent.complete'
+    } as any)
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'prestart-agent', status: 'completed' }])
+    expect(getSpawnHistory()).toEqual([])
+
+    handler({ payload: {}, type: 'message.start' } as any)
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()).toHaveLength(1)
+    expect(getSpawnHistory()[0]?.subagents).toMatchObject([
+      { durationSeconds: 7, id: 'prestart-agent', status: 'completed', summary: 'completed during submit round-trip' }
+    ])
+  })
+
+  it('archives a detached child immediately when it completes after a real parent turn ends', () => {
+    const handler = createGatewayEventHandler(buildFlowCtx([]))
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({
+      payload: { goal: 'finish while parent idle', subagent_id: 'idle-agent', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+    handler({ payload: { text: 'delegation dispatched' }, type: 'message.complete' } as any)
+    handler({
+      payload: {
+        duration_seconds: 13,
+        goal: 'finish while parent idle',
+        status: 'completed',
+        subagent_id: 'idle-agent',
+        summary: 'completed while parent idle',
+        task_index: 0
+      },
+      type: 'subagent.complete'
+    } as any)
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()).toHaveLength(1)
+    expect(getSpawnHistory()[0]?.subagents).toMatchObject([
+      { durationSeconds: 13, id: 'idle-agent', status: 'completed', summary: 'completed while parent idle' }
+    ])
+  })
+
+  it('keeps terminal tombstones across recovery reset and clears them at fullReset', () => {
+    const handler = createGatewayEventHandler(buildFlowCtx([]))
+
+    const event = {
+      payload: { goal: 'reject stale replay', subagent_id: 'tombstone-agent', task_index: 0 },
+      type: 'subagent.start'
+    } as any
+
+    handler(event)
+    handler({
+      payload: { goal: 'reject stale replay', status: 'completed', subagent_id: 'tombstone-agent', task_index: 0 },
+      type: 'subagent.complete'
+    } as any)
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()).toHaveLength(1)
+
+    turnController.reset()
+    handler(event)
+    expect(getTurnState().subagents).toEqual([])
+
+    turnController.fullReset()
+    handler(event)
+    expect(getTurnState().subagents).toMatchObject([{ id: 'tombstone-agent', status: 'running' }])
+  })
+
+  it('allows a later turn to reuse the same fallback subagent identity', () => {
+    const handler = createGatewayEventHandler(buildFlowCtx([]))
+
+    const start = {
+      payload: { goal: 'repeat fallback delegation', task_index: 0 },
+      type: 'subagent.start'
+    } as any
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler(start)
+    handler({
+      payload: { goal: 'repeat fallback delegation', status: 'completed', task_index: 0 },
+      type: 'subagent.complete'
+    } as any)
+    handler({ payload: { text: 'first turn done' }, type: 'message.complete' } as any)
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()).toHaveLength(1)
+
+    handler(start)
+    expect(getTurnState().subagents).toEqual([])
+
+    markSubmitting()
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler(start)
+
+    expect(getTurnState().subagents).toMatchObject([
+      { id: 'sa:0:repeat fallback delegation', status: 'running' }
+    ])
+    expect(getSpawnHistory()).toHaveLength(1)
+  })
+
+  it('archives an all-terminal outgoing tree when fullReset abandons its active turn', () => {
+    const handler = createGatewayEventHandler(buildFlowCtx([]))
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({
+      payload: { goal: 'archive outgoing session', subagent_id: 'outgoing-agent', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+    handler({
+      payload: { goal: 'archive outgoing session', status: 'completed', subagent_id: 'outgoing-agent', task_index: 0 },
+      type: 'subagent.complete'
+    } as any)
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'outgoing-agent', status: 'completed' }])
+    expect(getSpawnHistory()).toEqual([])
+
+    turnController.fullReset()
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()).toHaveLength(1)
+    expect(getSpawnHistory()[0]?.subagents).toMatchObject([{ id: 'outgoing-agent', status: 'completed' }])
+  })
+
+  it('makes bare idle preserve pending background work and archive it once terminal', () => {
+    const handler = createGatewayEventHandler(buildFlowCtx([]))
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({
+      payload: { goal: 'survive visible history reset', subagent_id: 'visible-reset-agent', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+    handler({ payload: { text: 'delegation dispatched' }, type: 'message.complete' } as any)
+
+    turnController.idle()
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'visible-reset-agent', status: 'running' }])
+    expect(getSpawnHistory()).toEqual([])
+
+    markSubmitting()
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({
+      payload: {
+        goal: 'survive visible history reset',
+        status: 'completed',
+        subagent_id: 'visible-reset-agent',
+        task_index: 0
+      },
+      type: 'subagent.complete'
+    } as any)
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'visible-reset-agent', status: 'completed' }])
+
+    turnController.idle()
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()).toHaveLength(1)
+    expect(getSpawnHistory()[0]?.subagents).toMatchObject([{ id: 'visible-reset-agent', status: 'completed' }])
+  })
+
+  it('waits for every child to become terminal before archiving the live tree', () => {
+    const handler = createGatewayEventHandler(buildFlowCtx([]))
+
+    handler({ payload: { goal: 'inspect first', subagent_id: 'first-agent', task_index: 0 }, type: 'subagent.start' } as any)
+    handler({ payload: { goal: 'review second', subagent_id: 'second-agent', task_index: 1 }, type: 'subagent.start' } as any)
+    handler({
+      payload: { goal: 'inspect first', status: 'completed', subagent_id: 'first-agent', task_index: 0 },
+      type: 'subagent.complete'
+    } as any)
+
+    expect(getTurnState().subagents).toMatchObject([
+      { id: 'first-agent', status: 'completed' },
+      { id: 'second-agent', status: 'running' }
+    ])
+    expect(getSpawnHistory()).toEqual([])
+
+    handler({
+      payload: { goal: 'review second', status: 'failed', subagent_id: 'second-agent', task_index: 1 },
+      type: 'subagent.complete'
+    } as any)
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()).toHaveLength(1)
+    expect(getSpawnHistory()[0]?.subagents).toMatchObject([
+      { id: 'first-agent', status: 'completed' },
+      { id: 'second-agent', status: 'failed' }
+    ])
+  })
+
+  it('keeps a background tree visible when its wake-up turn is interrupted', () => {
+    const appended: Msg[] = []
+    const handler = createGatewayEventHandler(buildFlowCtx(appended))
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({
+      payload: { goal: 'survive parent interrupt', subagent_id: 'interrupt-agent', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+    handler({ payload: { text: 'delegation dispatched' }, type: 'message.complete' } as any)
+    handler({ payload: {}, type: 'message.start' } as any)
+
+    turnController.interruptTurn({
+      appendMessage: (msg: Msg) => appended.push(msg),
+      gw: { request: vi.fn(async () => ({})) } as any,
+      sid: 'session-1',
+      sys: vi.fn()
+    })
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'interrupt-agent', status: 'running' }])
+    expect(getSpawnHistory()).toEqual([])
+  })
+
+  it('preserves a running child when its spawn turn is interrupted before message.complete', () => {
+    const appended: Msg[] = []
+    const handler = createGatewayEventHandler(buildFlowCtx(appended))
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({
+      payload: { goal: 'survive spawn interrupt', subagent_id: 'spawn-interrupt-agent', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+
+    turnController.interruptTurn({
+      appendMessage: (msg: Msg) => appended.push(msg),
+      gw: { request: vi.fn(async () => ({})) } as any,
+      sid: 'session-1',
+      sys: vi.fn()
+    })
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'spawn-interrupt-agent', status: 'running' }])
+
+    handler({
+      payload: {
+        duration_seconds: 8,
+        goal: 'survive spawn interrupt',
+        status: 'completed',
+        subagent_id: 'spawn-interrupt-agent',
+        summary: 'completed after interrupt',
+        task_index: 0
+      },
+      type: 'subagent.complete'
+    } as any)
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()[0]?.subagents).toMatchObject([
+      { durationSeconds: 8, id: 'spawn-interrupt-agent', status: 'completed' }
+    ])
+  })
+
+  it('preserves a running child when its spawn turn errors before message.complete', () => {
+    const appended: Msg[] = []
+    const handler = createGatewayEventHandler(buildFlowCtx(appended))
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({
+      payload: { goal: 'survive spawn error', subagent_id: 'spawn-error-agent', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+
+    turnController.recordError()
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'spawn-error-agent', status: 'running' }])
+
+    handler({
+      payload: {
+        duration_seconds: 9,
+        goal: 'survive spawn error',
+        status: 'failed',
+        subagent_id: 'spawn-error-agent',
+        summary: 'failed after parent error',
+        task_index: 0
+      },
+      type: 'subagent.complete'
+    } as any)
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()[0]?.subagents).toMatchObject([
+      { durationSeconds: 9, id: 'spawn-error-agent', status: 'failed' }
+    ])
+  })
+
+  it('preserves a late background start across the next turn and archives it at wake-up completion', () => {
+    const appended: Msg[] = []
+    const handler = createGatewayEventHandler(buildFlowCtx(appended))
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({ payload: { text: 'delegation dispatched' }, type: 'message.complete' } as any)
+    handler({
+      payload: { goal: 'inspect late lifecycle', subagent_id: 'late-agent', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'late-agent', status: 'running' }])
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({
+      payload: { goal: 'inspect late lifecycle', subagent_id: 'late-agent', task_index: 0, text: 'still running' },
+      type: 'subagent.progress'
+    } as any)
+
+    expect(getTurnState().subagents).toMatchObject([{ id: 'late-agent', status: 'running' }])
+
+    handler({
+      payload: {
+        duration_seconds: 11,
+        goal: 'inspect late lifecycle',
+        status: 'completed',
+        subagent_id: 'late-agent',
+        summary: 'late result',
+        task_index: 0
+      },
+      type: 'subagent.complete'
+    } as any)
+
+    expect(getTurnState().subagents).toMatchObject([
+      { durationSeconds: 11, id: 'late-agent', status: 'completed', summary: 'late result' }
+    ])
+    expect(getSpawnHistory()).toEqual([])
+
+    handler({ payload: { text: 'late result synthesized' }, type: 'message.complete' } as any)
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()).toHaveLength(1)
+    expect(getSpawnHistory()[0]?.subagents).toMatchObject([
+      { durationSeconds: 11, id: 'late-agent', status: 'completed', summary: 'late result' }
+    ])
+
+    handler({ payload: {}, type: 'message.start' } as any)
+    handler({
+      payload: { goal: 'review new tree', subagent_id: 'new-agent', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+
+    expect(getTurnState().subagents.map(item => item.id)).toEqual(['new-agent'])
+    expect(getSpawnHistory()).toHaveLength(1)
+  })
+
+})
+
+describe('AgentDock live wrapper', () => {
+  it('reacts to height-only resizes and restores the one-line short-terminal summary safely', async () => {
+    patchTurnState({
+      subagents: [
+        makeItem({ id: 'run', index: 0, status: 'running' }),
+        makeItem({ id: 'queue', index: 1, status: 'queued' }),
+        makeItem({ id: 'done', index: 2, status: 'completed' })
+      ]
+    })
+
+    const streams = makeStreams(80, 14)
+    const previousRows = process.stdout.rows
+    const resizeListenersBefore = process.stdout.listenerCount('resize')
+    let instance: ReturnType<typeof renderSync> | null = null
+
+    try {
+      process.stdout.rows = 14
+
+      instance = renderSync(<AgentDock cols={80} onOpen={() => {}} t={DEFAULT_THEME} />, {
+        patchConsole: false,
+        stderr: streams.stderr as unknown as NodeJS.WriteStream,
+        stdin: streams.stdin as unknown as NodeJS.ReadStream,
+        stdout: streams.stdout as unknown as NodeJS.WriteStream
+      })
+
+      await vi.waitFor(() => expect(streams.getOutput()).toContain('agents · /agents ↗ · 2/3 active'))
+      expect(streams.getOutput()).not.toContain('╭')
+
+      process.stdout.rows = 16
+      process.stdout.emit('resize')
+
+      await vi.waitFor(() => expect(streams.getOutput()).toContain('╭'))
+      const outputBeforeReturnToShort = streams.getOutput().length
+
+      process.stdout.rows = 15
+      process.stdout.emit('resize')
+
+      await vi.waitFor(() =>
+        expect(streams.getOutput().slice(outputBeforeReturnToShort)).toContain('agents · /agents ↗ · 2/3 active')
+      )
+    } finally {
+      instance?.unmount()
+      instance?.cleanup()
+      process.stdout.rows = previousRows
+    }
+
+    expect(process.stdout.listenerCount('resize')).toBe(resizeListenersBefore)
+  })
+
+  it('subscribes without mutation, advances elapsed time, and stops its clock when work finishes', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+    const subagents = [makeItem({ id: 'a', index: 0, startedAt: NOW - 5000 })]
+    patchTurnState({ subagents })
+    const before = getTurnState()
+    const streams = makeStreams()
+
+    const instance = renderSync(<AgentDock cols={100} onOpen={() => {}} t={DEFAULT_THEME} />, {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(getTurnState()).toBe(before)
+    expect(getTurnState().subagents).toBe(subagents)
+    expect(streams.getOutput()).toContain('5s')
+    const dockTimerIndex = setIntervalSpy.mock.calls.findIndex(call => call[1] === 1000)
+    expect(dockTimerIndex).toBeGreaterThanOrEqual(0)
+    const dockTimer = setIntervalSpy.mock.results[dockTimerIndex]!.value
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(streams.getOutput()).toContain('6s')
+
+    patchTurnState({
+      subagents: [makeItem({ durationSeconds: 6, id: 'a', index: 0, startedAt: NOW - 5000, status: 'completed' })]
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(clearIntervalSpy).toHaveBeenCalledWith(dockTimer)
+
+    instance.unmount()
+    instance.cleanup()
+  })
+})

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
 import { getOverlayState, patchOverlayState, resetOverlayState } from '../app/overlayStore.js'
+import { clearSpawnHistory, getSpawnHistory } from '../app/spawnHistoryStore.js'
 import { turnController } from '../app/turnController.js'
 import { getTurnState, resetTurnState } from '../app/turnStore.js'
 import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
@@ -60,6 +61,7 @@ const buildCtx = (appended: Msg[]) =>
 describe('createGatewayEventHandler', () => {
   beforeEach(() => {
     resetOverlayState()
+    clearSpawnHistory()
     resetUiState()
     resetTurnState()
     turnController.fullReset()
@@ -1116,9 +1118,10 @@ describe('createGatewayEventHandler', () => {
       type: 'subagent.complete'
     } as any)
 
-    expect(getTurnState().subagents.find(s => s.id === 'sa-timeout')?.status).toBe('timeout')
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()[0]?.subagents).toMatchObject([{ id: 'sa-timeout', status: 'timeout' }])
 
-    // Late start/spawn updates must not clobber terminal timeout/error states.
+    // Late start/spawn updates must not resurrect archived terminal ids.
     onEvent({
       payload: { goal: 'timeout child', subagent_id: 'sa-timeout', task_index: 0 },
       type: 'subagent.start'
@@ -1128,7 +1131,7 @@ describe('createGatewayEventHandler', () => {
       type: 'subagent.spawn_requested'
     } as any)
 
-    expect(getTurnState().subagents.find(s => s.id === 'sa-timeout')?.status).toBe('timeout')
+    expect(getTurnState().subagents).toEqual([])
 
     onEvent({
       payload: { goal: 'error child', subagent_id: 'sa-error', task_index: 1 },
@@ -1139,7 +1142,13 @@ describe('createGatewayEventHandler', () => {
       type: 'subagent.complete'
     } as any)
 
-    expect(getTurnState().subagents.find(s => s.id === 'sa-error')?.status).toBe('error')
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory().flatMap(snapshot => snapshot.subagents)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'sa-timeout', status: 'timeout' }),
+        expect.objectContaining({ id: 'sa-error', status: 'error' })
+      ])
+    )
   })
 
   it('normalizes unknown subagent.complete statuses to completed', () => {
@@ -1155,7 +1164,22 @@ describe('createGatewayEventHandler', () => {
       type: 'subagent.complete'
     } as any)
 
-    expect(getTurnState().subagents.find(s => s.id === 'sa-weird')?.status).toBe('completed')
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()[0]?.subagents).toMatchObject([{ id: 'sa-weird', status: 'completed' }])
+  })
+
+  it('rejects late old-session subagent events while no session is active', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    patchUiState({ sid: null })
+    onEvent({
+      payload: { goal: 'inspect old session', subagent_id: 'old-agent', task_index: 0 },
+      session_id: 'old-session',
+      type: 'subagent.start'
+    } as any)
+
+    expect(getTurnState().subagents).toEqual([])
+    expect(getSpawnHistory()).toEqual([])
   })
 
   it('nudges toward /agents on the first spawn_requested of a turn', () => {

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -706,6 +706,13 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
   return (ev: GatewayEvent) => {
     const sid = getUiState().sid
 
+    // Subagent events are always session-owned. During a reset/switch `sid` is
+    // deliberately null; reject late events from the old session instead of
+    // allowing them to repopulate the new composer's automatic dock.
+    if (ev.type.startsWith('subagent.') && ev.session_id && ev.session_id !== sid) {
+      return
+    }
+
     if (ev.session_id && sid && ev.session_id !== sid && !ev.type.startsWith('gateway.')) {
       return
     }
@@ -1260,6 +1267,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           }),
           { createIfMissing: false }
         )
+        turnController.settleSubagentTerminalEvent()
 
         return
 

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -28,6 +28,14 @@ import { getUiState, patchUiState } from './uiStore.js'
 const INTERRUPT_COOLDOWN_MS = 1500
 const ACTIVITY_LIMIT = 8
 const TRAIL_LIMIT = 8
+const MAX_TERMINAL_SUBAGENT_TOMBSTONES = 512
+
+const isTerminalSubagentStatus = (status: SubagentProgress['status']) =>
+  status === 'completed' ||
+  status === 'error' ||
+  status === 'failed' ||
+  status === 'interrupted' ||
+  status === 'timeout'
 
 // Extracts the raw patch from a diff-only segment produced by
 // pushInlineDiffSegment. Used at message.complete to dedupe against final
@@ -127,6 +135,8 @@ class TurnController {
   private activeReasoningText = ''
   private reasoningSegmentIndex: null | number = null
   private interimBoundaryIndex: null | number = null
+  private terminalFallbackSubagentIds = new Set<string>()
+  private terminalSubagentIds = new Set<string>()
   private activityId = 0
   private reasoningStreamingTimer: Timer = null
   private reasoningTimer: Timer = null
@@ -269,7 +279,9 @@ class TurnController {
     patchTurnState({ reasoningActive: false, reasoningStreaming: false })
   }
 
-  idle() {
+  idle(opts: { preserveSubagents?: boolean } = {}) {
+    const preserveSubagents = opts.preserveSubagents ?? this.prepareSubagentsForIdle()
+
     this.endReasoningPhase()
     this.activeTools = []
     this.streamTimer = clear(this.streamTimer)
@@ -277,14 +289,15 @@ class TurnController {
     this.pendingSegmentTools = []
     this.segmentMessages = []
 
-    patchTurnState({
+    patchTurnState(state => ({
+      ...state,
       streamPendingTools: [],
       streamSegments: [],
       streaming: '',
-      subagents: [],
+      subagents: preserveSubagents ? state.subagents : [],
       tools: [],
       turnTrail: []
-    })
+    }))
     patchUiState({ busy: false })
     resetFlowOverlays()
   }
@@ -307,7 +320,11 @@ class TurnController {
     // Drain streaming/segment state off the nanostore before writing the
     // preserved snapshot to the transcript — otherwise each flushed segment
     // appears in both `turn.streamSegments` and the transcript for one frame.
-    this.idle()
+    // Detached background children outlive this parent-turn interrupt, so keep
+    // their rows available for the real terminal events. Inspect the live tree
+    // here: an interrupt can arrive before message.complete reaches the ordinary
+    // idle boundary.
+    this.idle({ preserveSubagents: this.prepareSubagentsForIdle() })
     this.clearReasoning()
     this.turnTools = []
     patchTurnState({ activity: [], outcome: '' })
@@ -543,7 +560,9 @@ class TurnController {
   }
 
   recordError() {
-    this.idle()
+    // Parent failure does not imply detached child failure. Recompute from the
+    // live tree because the error can precede message.complete.
+    this.idle({ preserveSubagents: this.prepareSubagentsForIdle() })
     this.clearReasoning()
     this.clearStatusTimer()
     this.pendingSegmentTools = []
@@ -553,6 +572,74 @@ class TurnController {
 
     // Real turn end: surface any notice held back while busy.
     this.flushPendingNotice()
+  }
+
+  private archiveSubagents(subagents: SubagentProgress[]) {
+    if (!subagents.length) {
+      return
+    }
+
+    const sessionId = getUiState().sid
+
+    for (const item of subagents) {
+      const tombstones = item.idSource === 'fallback' ? this.terminalFallbackSubagentIds : this.terminalSubagentIds
+
+      tombstones.add(item.id)
+    }
+
+    while (this.terminalSubagentIds.size > MAX_TERMINAL_SUBAGENT_TOMBSTONES) {
+      const oldest = this.terminalSubagentIds.values().next().value
+
+      if (oldest === undefined) {
+        break
+      }
+
+      this.terminalSubagentIds.delete(oldest)
+    }
+
+    while (this.terminalFallbackSubagentIds.size > MAX_TERMINAL_SUBAGENT_TOMBSTONES) {
+      const oldest = this.terminalFallbackSubagentIds.values().next().value
+
+      if (oldest === undefined) {
+        break
+      }
+
+      this.terminalFallbackSubagentIds.delete(oldest)
+    }
+
+    pushSnapshot(subagents, { sessionId, startedAt: null })
+    void this.persistSpawnTree?.(subagents, sessionId)
+  }
+
+  private prepareSubagentsForIdle() {
+    const subagents = getTurnState().subagents
+    const pendingSubagents = subagents.some(item => !isTerminalSubagentStatus(item.status))
+
+    if (subagents.length > 0 && !pendingSubagents) {
+      this.archiveSubagents(subagents)
+    }
+
+    return pendingSubagents
+  }
+
+  settleSubagentTerminalEvent() {
+    const subagents = getTurnState().subagents
+
+    if (subagents.length === 0 || subagents.some(item => !isTerminalSubagentStatus(item.status))) {
+      return
+    }
+
+    // A parent turn may delegate sequentially: A can finish before B is even
+    // spawned. Keep the terminal rows attached to the active turn so a later
+    // spawn extends the same tree, then archive the complete tree once at
+    // message.complete. Background completions still archive immediately
+    // because their parent turn is already idle.
+    if (getUiState().busy) {
+      return
+    }
+
+    this.archiveSubagents(subagents)
+    patchTurnState(state => ({ ...state, subagents: [] }))
   }
 
   recordMessageComplete(payload: {
@@ -637,21 +724,13 @@ class TurnController {
 
     const wasInterrupted = this.interrupted
 
-    // Archive the turn's spawn tree to history BEFORE idle() drops subagents
-    // from turnState.  Lets /replay and the overlay's history nav pull up
-    // finished fan-outs without a round-trip to disk.
-    const finishedSubagents = getTurnState().subagents
-    const sessionId = getUiState().sid
+    // Background delegations can outlive the parent turn. Preserve a tree with
+    // any nonterminal node so late tool/complete events update the existing
+    // rows and the dock remains truthful across the async wake-up turn. Archive
+    // only terminal trees after their real completion events arrive.
+    const pendingSubagents = this.prepareSubagentsForIdle()
 
-    if (finishedSubagents.length > 0) {
-      pushSnapshot(finishedSubagents, { sessionId, startedAt: null })
-      // Fire-and-forget disk persistence so /replay survives process restarts.
-      // The same snapshot lives in memory via spawnHistoryStore for immediate
-      // recall — disk is the long-term archive.
-      void this.persistSpawnTree?.(finishedSubagents, sessionId)
-    }
-
-    this.idle()
+    this.idle({ preserveSubagents: pendingSubagents })
     this.clearReasoning()
     this.turnTools = []
     this.persistedToolLabels.clear()
@@ -918,7 +997,12 @@ class TurnController {
   reset() {
     this.clearReasoning()
     this.clearStatusTimer()
-    this.idle()
+    // Gateway recovery is not a session boundary. Preserve any detached work
+    // exactly as the normal turn-end paths do so its eventual terminal event
+    // can still update and archive the existing row after reconnect.
+    const pendingSubagents = this.prepareSubagentsForIdle()
+
+    this.idle({ preserveSubagents: pendingSubagents })
     this.bufRef = ''
     this.interrupted = false
     this.lastStatusNote = ''
@@ -931,14 +1015,17 @@ class TurnController {
     this.turnTools = []
     this.toolTokenAcc = 0
     this.persistedToolLabels.clear()
-    // Session boundary: drop notice state so session A's sticky can't bleed
-    // into session B (R3-H5). reset()/fullReset() CLEAR — they never flush.
+    // Recovery/reset boundaries drop notice state rather than flushing a
+    // sticky notice into a later turn. A full session reset also clears the
+    // terminal tombstones below.
     this.clearNoticeState()
     patchTurnState({ activity: [], outcome: '' })
   }
 
   fullReset() {
     this.reset()
+    this.terminalFallbackSubagentIds.clear()
+    this.terminalSubagentIds.clear()
     resetTurnState()
   }
 
@@ -978,6 +1065,16 @@ class TurnController {
   }
 
   startMessage() {
+    // Submission marks the UI busy before the Gateway emits message.start. A
+    // detached child can finish in that gap, leaving an all-terminal tree that
+    // must be archived rather than cleared as the new turn initializes.
+    const pendingSubagents = this.prepareSubagentsForIdle()
+
+    // Older gateways omit subagent_id, so their composite fallback identity is
+    // only unique within one parent turn. Preserve stale-event suppression until
+    // the next real turn begins, then allow an identical legitimate delegation.
+    this.terminalFallbackSubagentIds.clear()
+
     this.endReasoningPhase()
     this.clearReasoning()
     this.activeTools = []
@@ -1002,7 +1099,15 @@ class TurnController {
     }
 
     patchUiState({ busy: true })
-    patchTurnState({ activity: [], outcome: '', subagents: [], toolTokens: 0, tools: [], turnTrail: [] })
+    patchTurnState(state => ({
+      ...state,
+      activity: [],
+      outcome: '',
+      subagents: pendingSubagents ? state.subagents : [],
+      toolTokens: 0,
+      tools: [],
+      turnTrail: []
+    }))
   }
 
   upsertSubagent(
@@ -1018,6 +1123,15 @@ class TurnController {
     patchTurnState(state => {
       const existing = state.subagents.find(item => item.id === id)
 
+      // Once an explicit terminal event archives a tree, stale start/spawn
+      // events must not resurrect it into the live dock. Server-issued ids stay
+      // tombstoned for the session; composite fallback ids expire next turn.
+      const tombstones = p.subagent_id ? this.terminalSubagentIds : this.terminalFallbackSubagentIds
+
+      if (!existing && tombstones.has(id)) {
+        return state
+      }
+
       // Late events (subagent.complete/tool/progress arriving after message.complete
       // has already fired idle()) would otherwise resurrect a finished
       // subagent into turn.subagents and block the "finished" title on the
@@ -1030,6 +1144,7 @@ class TurnController {
         depth: p.depth ?? 0,
         goal: p.goal,
         id,
+        idSource: p.subagent_id ? 'server' : 'fallback',
         index: p.task_index,
         model: p.model,
         notes: [],
@@ -1084,6 +1199,7 @@ class TurnController {
 
       return { ...state, subagents }
     })
+
   }
 }
 

--- a/ui-tui/src/components/agentDock.tsx
+++ b/ui-tui/src/components/agentDock.tsx
@@ -1,0 +1,291 @@
+import { Box, stringWidth, Text, useStdout } from '@hermes/ink'
+import React, { memo, useEffect, useState } from 'react'
+
+import { useTurnSelector } from '../app/turnStore.js'
+import { type DockRow, type DockTone, type DockView, projectAgentDock } from '../lib/agentDock.js'
+import { isRunning } from '../lib/subagentTree.js'
+import type { Theme } from '../theme.js'
+import type { SubagentProgress } from '../types.js'
+
+/**
+ * B3 "Framed Simple Ledger" — the approved resting dock. One continuous
+ * muted single-line perimeter around the agent region; the `agents` label,
+ * truthful header counts, and the `/agents ↗` affordance are integrated into
+ * the top edge. At most three projection rows plus one truthful aggregate line
+ * render inside. Below `DOCK_NARROW_WIDTH` the frame is omitted entirely and
+ * the tested one-line summary renders instead.
+ *
+ * All layout math uses `stringWidth` (terminal cells), never `.length`, so
+ * status glyphs and bounded labels cannot shear the right border. Colored ink
+ * frame is bounded: one status glyph per row; header label and affordance
+ * keep their established accent/label tones; everything else is muted.
+ */
+
+export interface AgentDockProps {
+  cols: number
+  onOpen: () => void
+  t: Theme
+}
+
+export interface AgentDockViewProps extends AgentDockProps {
+  nowMs: number
+  subagents: readonly SubagentProgress[]
+  summaryOnly?: boolean
+}
+
+interface Seg {
+  bold?: boolean
+  color?: string
+  text: string
+}
+
+const CALLSIGN_CELL = 12
+/** Minimum run of `─` before the top-right corner. */
+const MIN_TOP_FILL = 1
+/** Preserve transcript/composer room on unusually short terminals. */
+const MIN_FULL_DOCK_ROWS = 16
+
+function useTerminalRows(): number {
+  const { stdout } = useStdout()
+  const stream = stdout ?? process.stdout
+  const [rows, setRows] = useState(() => stream.rows ?? 24)
+
+  useEffect(() => {
+    const syncRows = () => setRows(stream.rows ?? 24)
+
+    syncRows()
+    stream.on('resize', syncRows)
+
+    return () => {
+      stream.off('resize', syncRows)
+    }
+  }, [stream])
+
+  return rows
+}
+
+const toneColor = (tone: DockTone, t: Theme): string => {
+  switch (tone) {
+    case 'accent':
+      return t.color.accent
+
+    case 'error':
+      return t.color.error
+
+    case 'statusGood':
+      return t.color.statusGood
+
+    case 'warn':
+      return t.color.warn
+
+    case 'muted':
+      return t.color.muted
+  }
+}
+
+const segsWidth = (segs: readonly Seg[]): number => segs.reduce((total, item) => total + stringWidth(item.text), 0)
+
+/** Truncate to a cell budget with a terminal-cell walk, ellipsis included. */
+const clipToWidth = (text: string, maxWidth: number): string => {
+  if (stringWidth(text) <= maxWidth) {
+    return text
+  }
+
+  let out = ''
+  let used = 0
+
+  for (const char of text) {
+    const charWidth = stringWidth(char)
+
+    if (used + charWidth > maxWidth - 1) {
+      break
+    }
+
+    out += char
+    used += charWidth
+  }
+
+  return `${out}…`
+}
+
+const padToWidth = (text: string, width: number): string => {
+  const remaining = width - stringWidth(text)
+
+  return remaining > 0 ? text + ' '.repeat(remaining) : text
+}
+
+function FrameLine({ segs }: { segs: readonly Seg[] }) {
+  return (
+    <Text wrap="truncate-end">
+      {segs.map((item, index) => (
+        <Text bold={item.bold} color={item.color} key={index}>
+          {item.text}
+        </Text>
+      ))}
+    </Text>
+  )
+}
+
+/** `╭─ agents · {header} · /agents ↗ ──…──╮`, exactly `cols` cells. When the
+ * header counts cannot fit, their trailing segments drop one by one before
+ * the corners or the `/agents ↗` affordance are ever clipped. */
+function topEdge(view: DockView, t: Theme, cols: number): Seg[] {
+  const inner = cols - 2
+  const affordance = '/agents ↗'
+  const fixedWidth = stringWidth('─ ') + stringWidth('agents') + stringWidth(' · ') + stringWidth(affordance) + stringWidth(' ')
+
+  const allParts = view.header.length > 0 ? view.header.split(' · ') : []
+  let parts = allParts
+  let omitted = false
+
+  const partsWidth = (items: readonly string[]): number =>
+    items.reduce((total, item) => total + stringWidth(' · ') + stringWidth(item), 0)
+
+  const omissionWidth = () => (omitted ? stringWidth(' · …') : 0)
+
+  while (parts.length > 0 && fixedWidth + partsWidth(parts) + omissionWidth() > inner - MIN_TOP_FILL) {
+    parts = parts.slice(0, -1)
+    omitted = true
+  }
+
+  const fill = Math.max(MIN_TOP_FILL, inner - fixedWidth - partsWidth(parts) - omissionWidth())
+
+  return [
+    { color: t.color.border, text: '╭─ ' },
+    { bold: true, color: t.color.accent, text: 'agents' },
+    ...parts.flatMap((part): Seg[] => [
+      { color: t.color.muted, text: ' · ' },
+      { color: t.color.muted, text: part }
+    ]),
+    ...(omitted
+      ? [
+          { color: t.color.muted, text: ' · ' },
+          { color: t.color.muted, text: '…' }
+        ]
+      : []),
+    { color: t.color.muted, text: ' · ' },
+    { color: t.color.label, text: affordance },
+    { color: t.color.border, text: ` ${'─'.repeat(fill)}╮` }
+  ]
+}
+
+function bottomEdge(t: Theme, cols: number): Seg[] {
+  return [{ color: t.color.border, text: `╰${'─'.repeat(Math.max(0, cols - 2))}╯` }]
+}
+
+/** Wrap interior content with `│ … │`, padded to exactly `cols` cells. */
+function interior(content: readonly Seg[], t: Theme, cols: number): Seg[] {
+  const inner = cols - 2
+  const pad = Math.max(0, inner - segsWidth(content))
+
+  return [
+    { color: t.color.border, text: '│' },
+    ...content,
+    { text: ' '.repeat(pad) },
+    { color: t.color.border, text: '│' }
+  ]
+}
+
+function rowContent(row: DockRow, t: Theme, cols: number): Seg[] {
+  const indent = '  '.repeat(Math.min(Math.max(row.depth, 0), 2))
+
+  const lead: Seg[] = [
+    { text: ` ${indent}` },
+    { color: toneColor(row.tone, t), text: row.glyph },
+    { text: ' ' },
+    { color: t.color.text, text: padToWidth(row.callsign, CALLSIGN_CELL) },
+    { text: '  ' }
+  ]
+
+  const trail = row.elapsed ? `${row.activity} · ${row.elapsed}` : row.activity
+  const budget = cols - 2 - segsWidth(lead)
+
+  return [...lead, { color: t.color.muted, text: clipToWidth(trail, Math.max(0, budget)) }]
+}
+
+/** Projection-owned truthful aggregate, ellipsis-indented and clipped so the
+ * framed line stays exact even for long summaries. */
+function aggregateContent(view: DockView, t: Theme, cols: number): Seg[] {
+  return [{ color: t.color.muted, text: clipToWidth(` … ${view.overflowSummary}`, Math.max(0, cols - 2)) }]
+}
+
+/**
+ * Render-only half of the dock. Keeping projection inputs explicit makes
+ * hidden, narrow, framed, overflow, and click behavior deterministic in
+ * tests without a live store or terminal.
+ */
+export function AgentDockView({ cols, nowMs, onOpen, subagents, summaryOnly = false, t }: AgentDockViewProps) {
+  const view = projectAgentDock(subagents, { forceSummary: summaryOnly, nowMs, width: cols })
+
+  if (view.hidden) {
+    return null
+  }
+
+  const open = (event?: { stopImmediatePropagation?: () => void }) => {
+    event?.stopImmediatePropagation?.()
+    onOpen()
+  }
+
+  if (view.summaryOnly) {
+    // No marginTop here: a narrow terminal cannot spare a blank row, and the
+    // one-line summary must stay exactly one line.
+    return (
+      <Box flexDirection="column" flexShrink={0} onClick={open}>
+        <Text wrap="truncate-end">
+          <Text bold color={t.color.accent}>
+            agents
+          </Text>
+          <Text color={t.color.label}> · /agents ↗</Text>
+          <Text color={t.color.muted}> · {view.summary}</Text>
+        </Text>
+      </Box>
+    )
+  }
+
+  return (
+    <Box flexDirection="column" flexShrink={0} marginTop={1} onClick={open}>
+      <FrameLine segs={topEdge(view, t, cols)} />
+
+      {view.rows.map(row => (
+        <FrameLine key={row.id} segs={interior(rowContent(row, t, cols), t, cols)} />
+      ))}
+
+      {view.overflowSummary !== '' ? <FrameLine segs={interior(aggregateContent(view, t, cols), t, cols)} /> : null}
+
+      <FrameLine segs={bottomEdge(t, cols)} />
+    </Box>
+  )
+}
+
+/**
+ * Live store wrapper. A one-second clock is active only while at least one
+ * row has a running/queued start time without a terminal duration.
+ */
+export const AgentDock = memo(function AgentDock({ cols, onOpen, t }: AgentDockProps) {
+  const subagents = useTurnSelector(state => state.subagents)
+  const terminalRows = useTerminalRows()
+  const [nowMs, setNowMs] = useState(() => Date.now())
+  const needsClock = subagents.some(item => item.startedAt != null && item.durationSeconds == null && isRunning(item))
+
+  useEffect(() => {
+    if (!needsClock) {
+      return
+    }
+
+    setNowMs(Date.now())
+    const timer = setInterval(() => setNowMs(Date.now()), 1000)
+
+    return () => clearInterval(timer)
+  }, [needsClock])
+
+  return (
+    <AgentDockView
+      cols={cols}
+      nowMs={nowMs}
+      onOpen={onOpen}
+      subagents={subagents}
+      summaryOnly={terminalRows < MIN_FULL_DOCK_ROWS}
+      t={t}
+    />
+  )
+})

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -24,6 +24,7 @@ import { PerfPane } from '../lib/perfPane.js'
 import { composerPromptText } from '../lib/prompt.js'
 import { ActiveWidgetSlot, AmbientDock, AmbientRail, useAmbientRailWidth } from '../sdk/host.js'
 
+import { AgentDock } from './agentDock.js'
 import { AgentsOverlay } from './agentsOverlay.js'
 import { GoodVibesHeart, StatusRule, StickyPromptTracker, TranscriptScrollbar } from './appChrome.js'
 import { FloatingOverlays, PromptZone } from './appOverlays.js'
@@ -351,6 +352,12 @@ const ComposerPane = memo(function ComposerPane({
           {ui.bgTasks.size} background {ui.bgTasks.size === 1 ? 'task' : 'tasks'} running
         </Text>
       )}
+
+      <AgentDock
+        cols={Math.max(1, composer.cols - 2)}
+        onOpen={() => patchOverlayState({ agents: true, agentsInitialHistoryIndex: 0 })}
+        t={ui.theme}
+      />
 
       {status.showStickyPrompt ? (
         <Text color={ui.theme.color.muted} wrap="truncate-end">

--- a/ui-tui/src/lib/agentDock.ts
+++ b/ui-tui/src/lib/agentDock.ts
@@ -1,0 +1,474 @@
+import type { SubagentProgress } from '../types.js'
+
+import { buildSubagentTree, flattenTree, fmtDuration, isRunning } from './subagentTree.js'
+
+/**
+ * Pure projection for the persistent agent dock — the compact live panel
+ * between transcript and composer. Converts the turn's `SubagentProgress[]`
+ * into a bounded, truthful view model so the Ink component stays a dumb
+ * renderer and every behavior is testable without a terminal.
+ *
+ * Tones are theme *keys*, not colors: the component resolves them against the
+ * active theme, and glyphs stay pairwise distinct so color is never the only
+ * status signal. Ordering reuses `buildSubagentTree`/`flattenTree`, the same
+ * spawn-order contract as the full `/agents` overlay.
+ */
+
+export const DOCK_MAX_ROWS = 3
+/** Below this many columns the dock degrades to a one-line summary. */
+export const DOCK_NARROW_WIDTH = 60
+
+export type DockTone = 'accent' | 'error' | 'muted' | 'statusGood' | 'warn'
+
+export interface DockRow {
+  /** Plain-language current activity or terminal state; never raw arguments. */
+  activity: string
+  /** Bounded ASCII-safe name derived from the goal, with an indexed fallback. */
+  callsign: string
+  depth: number
+  /** @deprecated Transitional alias for the pre-B3 renderer. */
+  detail: string
+  /** Formatted duration label, '' when nothing truthful is known. */
+  elapsed: string
+  glyph: string
+  /** @deprecated Transitional alias for the pre-B3 renderer. */
+  goal: string
+  id: string
+  /** True when `elapsed` derives from `nowMs` and needs periodic re-projection. */
+  live: boolean
+  status: SubagentProgress['status']
+  tone: DockTone
+}
+
+export interface DockView {
+  activeCount: number
+  /** Truthful framed header counts, without the `agents` label. */
+  header: string
+  hidden: boolean
+  overflow: number
+  /** How many of the overflowed rows are still running/queued. */
+  overflowActive: number
+  /** Truthful aggregate for rows outside the three-row budget. */
+  overflowSummary: string
+  rows: DockRow[]
+  summary: string
+  summaryOnly: boolean
+  totalCount: number
+}
+
+export interface DockOptions {
+  forceSummary?: boolean
+  maxRows?: number
+  nowMs: number
+  width: number
+}
+
+// Same glyph/tone semantics as the agents overlay, expressed as theme keys so
+// this module needs no Theme import and stays render-free.
+const STATUS_META: Record<SubagentProgress['status'], { glyph: string; tone: DockTone }> = {
+  completed: { glyph: '✓', tone: 'statusGood' },
+  error: { glyph: '!', tone: 'error' },
+  failed: { glyph: '✗', tone: 'error' },
+  interrupted: { glyph: '■', tone: 'warn' },
+  queued: { glyph: '○', tone: 'muted' },
+  running: { glyph: '●', tone: 'accent' },
+  timeout: { glyph: 'T', tone: 'warn' }
+}
+
+const CALLSIGN_MAX = 12
+
+const CALLSIGN_SAFE_WORDS = new Set([
+  'analyze',
+  'audit',
+  'benchmark',
+  'build',
+  'check',
+  'debug',
+  'design',
+  'document',
+  'fix',
+  'implement',
+  'inspect',
+  'investigate',
+  'monitor',
+  'patch',
+  'plan',
+  'profile',
+  'read',
+  'regression',
+  'research',
+  'review',
+  'scan',
+  'summarize',
+  'test',
+  'trace',
+  'validate',
+  'verify',
+  'write'
+])
+
+interface DockCounts {
+  blocked: number
+  completed: number
+  done: number
+  queued: number
+  ready: number
+  running: number
+}
+
+const isFailed = (s: SubagentProgress): boolean =>
+  s.status === 'error' || s.status === 'failed' || s.status === 'interrupted' || s.status === 'timeout'
+
+const elapsedFor = (item: SubagentProgress, nowMs: number): { elapsed: string; live: boolean } => {
+  if (item.durationSeconds != null) {
+    return { elapsed: fmtDuration(item.durationSeconds), live: false }
+  }
+
+  if (item.startedAt != null && isRunning(item)) {
+    return { elapsed: fmtDuration(Math.max(0, (nowMs - item.startedAt) / 1000)), live: true }
+  }
+
+  return { elapsed: '', live: false }
+}
+
+const callsignFor = (item: SubagentProgress): string => {
+  const fallback = `agent ${Math.max(0, item.index) + 1}`.slice(0, CALLSIGN_MAX)
+  const goal = item.goal.trim()
+  const pathOrUrlShaped = goal.includes('/') || goal.includes('\\') || /^[a-z][a-z0-9+.-]*:(?!\s)/i.test(goal)
+
+  if (pathOrUrlShaped) {
+    return fallback
+  }
+
+  const asciiGoal = Array.from(goal.normalize('NFKD'), char =>
+    (char.codePointAt(0) ?? Number.POSITIVE_INFINITY) <= 0x7f ? char : ' '
+  ).join('')
+
+  const tokens = asciiGoal
+    .toLowerCase()
+    .match(/[a-z0-9]+/g)
+
+  const chosen = tokens?.find(token => CALLSIGN_SAFE_WORDS.has(token))
+
+  if (chosen) {
+    return chosen.slice(0, CALLSIGN_MAX)
+  }
+
+  return fallback
+}
+
+// Keys are formatToolCall()/toolTrailLabel() output lowercased, then
+// stripped of any ("preview") suffix by activityFor. Keep this map keyed
+// to the real Hermes tool vocabulary so dock activity never silently
+// degrades to "working" for common tools.
+const PLAIN_ACTIVITY: Record<string, string> = {
+  // File + shell
+  'close terminal': 'closing terminal',
+  read: 'reading files',
+  'read file': 'reading files',
+  'read terminal': 'reading terminal',
+  'search files': 'searching',
+  write: 'writing files',
+  'write file': 'writing files',
+  patch: 'editing files',
+  terminal: 'running commands',
+
+  // Web + browser
+  'browser back': 'browsing',
+  'browser cdp': 'browsing',
+  'browser click': 'browsing',
+  'browser console': 'browsing',
+  'browser dialog': 'browsing',
+  'browser get images': 'browsing',
+  'browser navigate': 'browsing',
+  'browser press': 'browsing',
+  'browser scroll': 'browsing',
+  'browser snapshot': 'browsing',
+  'browser type': 'browsing',
+  'browser vision': 'browsing',
+  'web extract': 'reading web',
+  'web search': 'searching web',
+
+  // Agent core
+  clarify: 'asking',
+  'computer use': 'using computer',
+  cronjob: 'scheduling',
+  'delegate task': 'delegating',
+  'execute code': 'running code',
+  memory: 'updating memory',
+  process: 'managing process',
+  'session search': 'searching sessions',
+  'skill manage': 'managing skills',
+  'skill view': 'reading skills',
+  'skills list': 'listing skills',
+  todo: 'updating todos',
+  'text to speech': 'speaking',
+  'vision analyze': 'analyzing image',
+  'image generate': 'generating image',
+
+  // Home Assistant
+  'ha call service': 'controlling home',
+  'ha get state': 'checking home',
+  'ha list entities': 'listing home',
+  'ha list services': 'listing home',
+
+  // Kanban
+  'kanban attach': 'attaching files',
+  'kanban attach url': 'attaching files',
+  'kanban attachments': 'listing attachments',
+  'kanban block': 'blocking task',
+  'kanban comment': 'commenting',
+  'kanban complete': 'completing task',
+  'kanban create': 'creating task',
+  'kanban heartbeat': 'heartbeating',
+  'kanban link': 'linking tasks',
+  'kanban list': 'listing tasks',
+  'kanban show': 'reading task',
+  'kanban unblock': 'unblocking task',
+
+  // Desktop / TUI panes
+  'focus pane': 'focusing pane',
+  'open preview': 'opening preview'
+}
+
+const TERMINAL_ACTIVITY: Partial<Record<SubagentProgress['status'], string>> = {
+  error: 'failed',
+  failed: 'failed',
+  interrupted: 'interrupted',
+  queued: 'queued',
+  timeout: 'timed out'
+}
+
+const activityFor = (item: SubagentProgress): string => {
+  if (item.status === 'completed') {
+    return item.summary ? 'result ready' : 'done'
+  }
+
+  if (item.status !== 'running') {
+    return TERMINAL_ACTIVITY[item.status] ?? 'blocked'
+  }
+
+  const raw = item.tools.at(-1)
+
+  if (!raw) {
+    return 'working'
+  }
+
+  const label = (raw.includes('("') ? raw.slice(0, raw.indexOf('("')) : raw).trim().toLowerCase()
+
+  return PLAIN_ACTIVITY[label] ?? 'working'
+}
+
+const countsFor = (items: readonly SubagentProgress[]): DockCounts => {
+  let blocked = 0
+  let completed = 0
+  let queued = 0
+  let ready = 0
+  let running = 0
+
+  for (const item of items) {
+    if (item.status === 'running') {
+      running += 1
+    } else if (item.status === 'queued') {
+      queued += 1
+    } else if (item.status === 'completed') {
+      completed += 1
+
+      if (item.summary) {
+        ready += 1
+      }
+    } else {
+      blocked += 1
+    }
+  }
+
+  return { blocked, completed, done: completed - ready, queued, ready, running }
+}
+
+const plural = (count: number, singular: string): string => `${count} ${singular}`
+
+const activeCountLabels = (counts: DockCounts): string[] => {
+  const labels: string[] = []
+
+  if (counts.running > 0) {
+    labels.push(plural(counts.running, 'running'))
+  }
+
+  if (counts.queued > 0) {
+    labels.push(plural(counts.queued, 'queued'))
+  }
+
+  if (counts.ready > 0) {
+    labels.push(plural(counts.ready, 'ready'))
+  }
+
+  if (counts.done > 0) {
+    labels.push(plural(counts.done, 'done'))
+  }
+
+  if (counts.blocked > 0) {
+    labels.push(plural(counts.blocked, 'blocked'))
+  }
+
+  return labels
+}
+
+const headerFor = (items: readonly SubagentProgress[]): string => {
+  const counts = countsFor(items)
+
+  if (counts.running > 0 || counts.queued > 0) {
+    return activeCountLabels(counts).join(' · ')
+  }
+
+  const labels: string[] = []
+
+  if (counts.completed > 0) {
+    labels.push(plural(counts.completed, 'done'))
+  }
+
+  if (counts.blocked > 0) {
+    labels.push(plural(counts.blocked, 'blocked'))
+  }
+
+  return labels.join(' · ')
+}
+
+const overflowSummaryFor = (items: readonly SubagentProgress[]): string => {
+  if (items.length === 0) {
+    return ''
+  }
+
+  return [`${items.length} more`, ...activeCountLabels(countsFor(items))].join(' · ')
+}
+
+const buildSummary = (items: readonly SubagentProgress[], activeCount: number, nowMs: number): string => {
+  const total = items.length
+  const issues = items.filter(isFailed).length
+  const pieces = [activeCount > 0 ? `${activeCount}/${total} active` : `${total} agent${total === 1 ? '' : 's'}`]
+
+  if (issues > 0) {
+    pieces.push(`${issues} issue${issues === 1 ? '' : 's'}`)
+  }
+
+  let longest = 0
+
+  for (const item of items) {
+    if (item.startedAt != null && isRunning(item)) {
+      longest = Math.max(longest, (nowMs - item.startedAt) / 1000)
+    }
+  }
+
+  if (longest > 0) {
+    pieces.push(fmtDuration(longest))
+  }
+
+  return pieces.join(' · ')
+}
+
+export function projectAgentDock(subagents: readonly SubagentProgress[], opts: DockOptions): DockView {
+  const { forceSummary = false, maxRows = DOCK_MAX_ROWS, nowMs, width } = opts
+  const totalCount = subagents.length
+
+  if (totalCount === 0) {
+    return {
+      activeCount: 0,
+      header: '',
+      hidden: true,
+      overflow: 0,
+      overflowActive: 0,
+      overflowSummary: '',
+      rows: [],
+      summary: '',
+      summaryOnly: false,
+      totalCount: 0
+    }
+  }
+
+  const activeCount = subagents.filter(isRunning).length
+  const header = headerFor(subagents)
+  const summary = buildSummary(subagents, activeCount, nowMs)
+
+  if (forceSummary || width < DOCK_NARROW_WIDTH) {
+    return {
+      activeCount,
+      header,
+      hidden: false,
+      overflow: totalCount,
+      overflowActive: activeCount,
+      overflowSummary: `${totalCount} more`,
+      rows: [],
+      summary,
+      summaryOnly: true,
+      totalCount
+    }
+  }
+
+  const ordered = flattenTree(buildSubagentTree(subagents))
+
+  // Preserve spawn/tree order within each class, but never bury live work
+  // behind old completed rows when the three-row budget is full.
+  const prioritized = [
+    ...ordered.filter(node => isRunning(node.item)),
+    ...ordered.filter(node => !isRunning(node.item) && isFailed(node.item)),
+    ...ordered.filter(node => !isRunning(node.item) && !isFailed(node.item))
+  ]
+
+  const selectedIds = new Set(prioritized.slice(0, maxRows).map(node => node.item.id))
+  // Priority decides which rows earn the bounded slots. Tree order decides
+  // how those selected rows render, so a live child never jumps above a
+  // selected completed parent.
+  const visible = ordered.filter(node => selectedIds.has(node.item.id))
+  const overflowNodes = prioritized.slice(maxRows)
+  const overflowItems = overflowNodes.map(node => node.item)
+  const visibleItems = new Map(visible.map(node => [node.item.id, node.item]))
+
+  const visibleDepth = (item: SubagentProgress): number => {
+    let depth = 0
+    let parentId = item.parentId
+    const seen = new Set<string>()
+
+    while (parentId && visibleItems.has(parentId) && !seen.has(parentId)) {
+      seen.add(parentId)
+      depth += 1
+      parentId = visibleItems.get(parentId)?.parentId ?? null
+    }
+
+    return depth
+  }
+
+  const rows: DockRow[] = visible.map(node => {
+    const item = node.item
+    // Defensive fallback for cross-version snapshots with unknown statuses.
+    const meta = STATUS_META[item.status] ?? STATUS_META.error
+    const { elapsed, live } = elapsedFor(item, nowMs)
+    const activity = activityFor(item)
+    const callsign = callsignFor(item)
+
+    return {
+      activity,
+      callsign,
+      depth: visibleDepth(item),
+      detail: activity,
+      elapsed,
+      glyph: meta.glyph,
+      goal: callsign,
+      id: item.id,
+      live,
+      status: item.status,
+      tone: meta.tone
+    }
+  })
+
+  return {
+    activeCount,
+    header,
+    hidden: false,
+    overflow: overflowNodes.length,
+    overflowActive: overflowNodes.filter(n => isRunning(n.item)).length,
+    overflowSummary: overflowSummaryFor(overflowItems),
+    rows,
+    summary,
+    summaryOnly: false,
+    totalCount
+  }
+}

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -29,6 +29,7 @@ export interface SubagentProgress {
   filesWritten?: string[]
   goal: string
   id: string
+  idSource?: 'fallback' | 'server'
   index: number
   inputTokens?: number
   iteration?: number


### PR DESCRIPTION
## What does this PR do?

Adds a compact Agent Dock between the transcript and composer so delegated background work remains visible after the parent turn ends.

The dock projects the existing `SubagentProgress[]` tree into at most three privacy-safe rows plus a truthful aggregate. It preserves detached work across turn boundaries and gateway recovery, archives fully terminal trees, rejects stale events, and opens the existing `/agents` overlay for full detail.

At narrow widths or short terminal heights it degrades to a one-line summary, preserving transcript and composer space. Tool labels describe the latest observed activity using fixed language; goals, arguments, paths, queries, emails, and token-like strings are not rendered.

## Related Issue

N/A — standalone TUI usability improvement.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a pure Agent Dock projection with bounded, sanitized labels and terminal-cell-aware widths.
- Added the dock renderer and mounted it between transcript and composer.
- Preserved live detached delegations across idle boundaries and gateway recovery while preventing stale-event resurrection.
- Added projection, lifecycle, producer-to-consumer, privacy, responsive-width, and rendered-frame coverage.
- Extended the visual harness with wide, narrow, short-viewport, nested-tree, and terminal-state scenes across multiple skins.

## How to Test

1. `cd ui-tui`
2. `env -u NODE_ENV npm run check`
3. `env -u NODE_ENV npm run visual`
4. Inspect the generated dock scenes at 88, 80, 60, and 48 columns and the short-viewport case.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: this is a TypeScript-only TUI change; the complete TUI check passed
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A: the feature is self-contained TUI behavior with no user configuration
- [x] I've updated `cli-config.yaml.example` — N/A: no configuration keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A: no architecture or workflow contract changed
- [x] I've considered cross-platform impact: layout uses terminal-cell measurement and introduces no OS-specific APIs
- [x] I've updated tool descriptions/schemas — N/A: no tool behavior changed

## Screenshots / Logs

Automated verification completed successfully:

- `npm run check`: 131 test files passed; 1,468 tests passed and 4 skipped; build, typecheck, and lint passed
- `npm run visual`: generated and inspected the multi-theme, multi-width Agent Dock scene sheet
