### PR TITLE
fix(dashboard): poll for new messages in active sessions

### DIFF
--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -399,21 +399,51 @@ function SessionRow({
   const { t } = useI18n();
   const navigate = useNavigate();
 
+  // Initial load + live polling for active sessions
   useEffect(() => {
-    if (!isExpanded || messages !== null) return;
+    if (!isExpanded) return;
+
     let cancelled = false;
-    api
-      .getSessionMessages(session.id)
-      .then((resp) => {
-        if (!cancelled) setMessages(resp.messages);
-      })
-      .catch((err) => {
-        if (!cancelled) setError(String(err));
-      });
+    let lastCount = messages?.length ?? 0;
+
+    // Initial full load
+    if (messages === null) {
+      api
+        .getSessionMessages(session.id)
+        .then((resp) => {
+          if (!cancelled) {
+            setMessages(resp.messages);
+            lastCount = resp.messages.length;
+          }
+        })
+        .catch((err) => {
+          if (!cancelled) setError(String(err));
+        });
+    }
+
+    // Poll for new messages every 3s if session is active (running)
+    if (!session.is_active) return;
+
+    const interval = setInterval(() => {
+      if (cancelled) return;
+      api
+        .getSessionMessages(session.id)
+        .then((resp) => {
+          if (cancelled) return;
+          if (resp.messages.length !== lastCount) {
+            setMessages(resp.messages);
+            lastCount = resp.messages.length;
+          }
+        })
+        .catch(() => {});
+    }, 3000);
+
     return () => {
       cancelled = true;
+      clearInterval(interval);
     };
-  }, [isExpanded, session.id, messages]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isExpanded, session.id, session.is_active]);
 
   const sourceInfo = (session.source
     ? SOURCE_CONFIG[session.source]


### PR DESCRIPTION
## What this does

Fixes #42962
Fixes #70346

The `SessionRow` component in `SessionsPage.tsx` loaded messages once (`messages !== null` guard) and never refreshed. When a session was running — e.g. a CLI-dispatched subagent or a Telegram gateway continuation — users had to manually refresh the page to see new messages.

## Change

When `session.is_active` is true, the component now polls `GET /api/sessions/{id}/messages` every 3 seconds. If the message count changed, it replaces the local message array. Non-active sessions are unaffected — no extra requests are made for idle or ended sessions.

The polling interval is cleaned up on unmount or when the session is collapsed.

## How to reproduce the bug

1. Open the Sessions page in the dashboard.
2. Start a session from the CLI (or have a Codex-dispatched subagent running).
3. Expand the session row in the Sessions page.
4. New messages written by the external process are **not shown** until you collapse and re-expand.

After this fix, new messages appear automatically every 3 seconds while the session is active.

## File changed

- `web/src/pages/SessionsPage.tsx` (+40, -10)