### PR TITLE
Fix NameError in _handle_message_with_agent on already-sent media delivery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14558,7 +14558,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _media_adapter:
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
-                            history_media_paths=_history_media_paths,
+                            history_media_paths=_collect_history_media_paths(history),
                         )
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).


### PR DESCRIPTION
## Summary
- `_history_media_paths` was only defined inside the unrelated `run_sync()` closure (~line 21981), not in `_handle_message_with_agent`, so any already-streamed response that also needed to deliver media raised a `NameError` at the `_deliver_media_from_response(...)` call.
- This surfaced on essentially every Telegram message as a second `"Sorry, I encountered an unexpected error."` reply following the normal streamed response.
- Fix computes the same set from `history`, the pre-turn transcript already loaded earlier in `_handle_message_with_agent`, mirroring how `run_sync` derives `agent_history` for the same dedup purpose (so already-delivered media isn't double-counted, and media generated in the current turn is still delivered).

## Traceback fixed
```
File "gateway/run.py", line 14561, in _handle_message_with_agent
    history_media_paths=_history_media_paths,
NameError: name '_history_media_paths' is not defined
```

## Test plan
- [x] Reproduced live on a Telegram adapter instance: every message triggered the streamed reply followed by the generic error.
- [x] Applied fix, restarted the gateway process, confirmed the traceback no longer appears in `gateway.log` on subsequent messages.
- [ ] Would appreciate a maintainer's eyes on whether `history` (vs. some other pre-turn history source) is the right dedup input in all call paths that reach this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)