### PR TITLE
fix(desktop): scope messaging config writes to the active profile

### DIFF
--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -15,6 +15,7 @@ import {
   type MessagingPlatformInfo,
   updateMessagingPlatform
 } from '@/hermes'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { type Translations, useI18n } from '@/i18n'
 import { openExternalLink } from '@/lib/external-link'
 import { ExternalLink, Save, Trash2 } from '@/lib/icons'
@@ -22,6 +23,8 @@ import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
 import { runGatewayRestart } from '@/store/system-actions'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
+import { useStore } from '@nanostores/react'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
@@ -110,6 +113,12 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   const [query, setQuery] = useState('')
   const [refreshing, setRefreshing] = useState(false)
   const [saving, setSaving] = useState<string | null>(null)
+  // The profile this config will be read from / written to. Writes are routed
+  // to this profile's backend (its own HERMES_HOME) via profileScoped() in the
+  // API layer — this just makes the target visible so a save can never
+  // silently mutate the wrong profile (#72031).
+  const activeProfile = normalizeProfileKey(useStore($activeGatewayProfile))
+  const [pendingSave, setPendingSave] = useState<MessagingPlatformInfo | null>(null)
   const platformIds = useMemo(() => platforms?.map(p => p.id) ?? [], [platforms])
   const [selectedId, setSelectedId] = useRouteEnumParam('platform', platformIds, platformIds[0] ?? '')
 
@@ -218,7 +227,7 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
     }
   }
 
-  async function handleSave(platform: MessagingPlatformInfo) {
+  async function commitSave(platform: MessagingPlatformInfo) {
     const env = trimEdits(edits[platform.id] || {})
 
     if (Object.keys(env).length === 0) {
@@ -242,6 +251,19 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
     } finally {
       setSaving(null)
     }
+  }
+
+  async function handleSave(platform: MessagingPlatformInfo) {
+    const env = trimEdits(edits[platform.id] || {})
+
+    if (Object.keys(env).length === 0) {
+      return
+    }
+
+    // Surface the destination profile before mutating it. The save itself
+    // routes to activeProfile's backend, so confirming here prevents a
+    // silent write to the wrong profile (#72031).
+    setPendingSave(platform)
   }
 
   async function handleClear(platform: MessagingPlatformInfo, key: string) {
@@ -307,6 +329,7 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
           >
             {selected && (
               <PlatformDetail
+                activeProfile={activeProfile}
                 edits={edits[selected.id] || {}}
                 onClear={key => void handleClear(selected, key)}
                 onEdit={(key, value) =>
@@ -324,6 +347,17 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
             )}
           </DetailColumn>
         </MasterDetail>
+      )}
+      {pendingSave && (
+        <ConfirmDialog
+          cancelLabel={t.common.cancel}
+          confirmLabel={t.common.confirm}
+          description={m.saveScopeBody(activeProfile)}
+          onClose={() => setPendingSave(null)}
+          onConfirm={() => void commitSave(pendingSave)}
+          open
+          title={m.saveScopeTitle(pendingSave.name)}
+        />
       )}
     </PageSearchShell>
   )
@@ -357,12 +391,14 @@ function PlatformRow({
 }
 
 function PlatformDetail({
+  activeProfile,
   edits,
   onClear,
   onEdit,
   platform,
   saving
 }: {
+  activeProfile: string
   edits: Record<string, string>
   onClear: (key: string) => void
   onEdit: (key: string, value: string) => void
@@ -396,6 +432,13 @@ function PlatformDetail({
           <PlatformHint platform={platform} />
         </div>
       </header>
+
+      {/* Profile scope: this config is read from / written to the active
+          profile's HERMES_HOME. Making the target explicit is the visible half
+          of the #72031 fix — the save confirm dialog is the warning half. */}
+      <div className="mt-3 flex items-center gap-2 rounded-md border border-(--ui-border-subtle) bg-(--ui-row-active-background) px-3 py-2 text-xs text-(--ui-text-secondary)">
+        <span className="font-medium text-foreground">{activeProfile === 'default' ? m.configScopeDefault : m.configScope(activeProfile)}</span>
+      </div>
 
       {platform.error_message && <ErrorBanner>{platform.error_message}</ErrorBanner>}
 

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -248,6 +248,9 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
       })
     } catch (err) {
       notifyError(err, m.failedSave(platform.name))
+      // Rethrow so the save confirmation dialog can surface the failure
+      // inline and stay open instead of reporting success (#72031 review).
+      throw err
     } finally {
       setSaving(null)
     }
@@ -354,7 +357,7 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
           confirmLabel={t.common.confirm}
           description={m.saveScopeBody(activeProfile)}
           onClose={() => setPendingSave(null)}
-          onConfirm={() => void commitSave(pendingSave)}
+          onConfirm={() => commitSave(pendingSave)}
           open
           title={m.saveScopeTitle(pendingSave.name)}
         />

--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -4,11 +4,14 @@ import {
   checkHermesUpdate,
   getActionStatus,
   getMemoryProviderConfig,
+  getMessagingPlatforms,
   getStatus,
   restartGateway,
   saveMemoryProviderConfig,
   setApiRequestProfile,
-  updateHermes
+  testMessagingPlatform,
+  updateHermes,
+  updateMessagingPlatform
 } from './hermes'
 
 // Contract: every backend-targeted action helper must carry the active gateway
@@ -58,5 +61,22 @@ describe('backend action helpers are profile-scoped', () => {
     for (const call of api.mock.calls) {
       expect(call[0].profile).toBe('coder')
     }
+  })
+
+  it('forwards the active profile to messaging read + write (Telegram config scoping, #72031)', () => {
+    setApiRequestProfile('casa')
+
+    void getMessagingPlatforms()
+    void updateMessagingPlatform('telegram', { env: { TELEGRAM_BOT_TOKEN: 'x' } })
+    void updateMessagingPlatform('telegram', { enabled: true })
+    void testMessagingPlatform('telegram')
+
+    for (const call of api.mock.calls) {
+      expect(call[0].profile).toBe('casa')
+    }
+
+    // The Telegram token write must reach the profile's backend, not default.
+    const saveCall = api.mock.calls.find(call => call[0].path?.includes('/api/messaging/platforms/telegram'))
+    expect(saveCall?.[0].profile).toBe('casa')
   })
 })

--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -38,6 +38,17 @@ describe('backend action helpers are profile-scoped', () => {
     expect(lastProfile()).toBeUndefined()
   })
 
+  it('omits profile for messaging helpers when none is active (no silent global write, #72031)', () => {
+    void getMessagingPlatforms()
+    void updateMessagingPlatform('telegram', { env: { TELEGRAM_BOT_TOKEN: 'x' } })
+    void updateMessagingPlatform('telegram', { enabled: true })
+    void testMessagingPlatform('telegram')
+
+    for (const call of api.mock.calls) {
+      expect(call[0].profile).toBeUndefined()
+    }
+  })
+
   it('forwards the active profile to memory provider config calls', () => {
     setApiRequestProfile('coder')
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1112,8 +1112,15 @@ export function grantComputerUsePermissions(): Promise<ActionResponse> {
   })
 }
 
+// Messaging read/write are profile-scoped: the platform config (config.yaml,
+// .env token) lives under the active profile's HERMES_HOME, NOT the default
+// root. Without profileScoped() the calls always hit the primary/default
+// backend, so editing a named profile's Telegram bot token silently mutated
+// the global config (#72031). profileScoped() rides the same Electron
+// request.profile routing the rest of the settings surface uses.
 export function getMessagingPlatforms(): Promise<MessagingPlatformsResponse> {
   return window.hermesDesktop.api<MessagingPlatformsResponse>({
+    ...profileScoped(),
     path: '/api/messaging/platforms'
   })
 }
@@ -1123,6 +1130,7 @@ export function updateMessagingPlatform(
   body: MessagingPlatformUpdate
 ): Promise<{ ok: boolean; platform: string }> {
   return window.hermesDesktop.api<{ ok: boolean; platform: string }>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}`,
     method: 'PUT',
     body
@@ -1131,6 +1139,7 @@ export function updateMessagingPlatform(
 
 export function testMessagingPlatform(platformId: string): Promise<MessagingPlatformTestResponse> {
   return window.hermesDesktop.api<MessagingPlatformTestResponse>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}/test`,
     method: 'POST'
   })

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1144,6 +1144,11 @@ export const ar = defineLocale({
     failedUpdate: name => `فشل تحديث ${name}`,
     failedSave: name => `فشل حفظ ${name}`,
     failedClear: key => `فشل مسح ${key}`,
+    configScope: profile => `جارٍ الإعداد لملف ${profile}`,
+    configScopeDefault: 'جارٍ الإعداد لملف التعريف الافتراضي',
+    saveScopeTitle: name => `حفظ ${name} لهذا الملف؟`,
+    saveScopeBody: profile =>
+      `سيؤدي هذا إلى كتابة إعدادات المراسلة (config.yaml / .env) لملف ${profile === 'default' ? 'الافتراضي' : `«${profile}»`}. لن يؤثر على ملفات التعريف الأخرى.`,
     fieldCopy: {
       TELEGRAM_BOT_TOKEN: {
         label: 'رمز البوت (token)',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1339,6 +1339,15 @@ export const en: Translations = {
     failedUpdate: name => `Failed to update ${name}`,
     failedSave: name => `Failed to save ${name}`,
     failedClear: key => `Failed to clear ${key}`,
+    // Profile scope indicator + save confirmation (#72031): the Telegram bot
+    // token / platform config is written to the active profile's HERMES_HOME,
+    // so the UI must make that target explicit and confirm before mutating it.
+    configScope: profile => `Configuring for profile: ${profile}`,
+    configScopeDefault: 'Configuring for the default profile',
+    saveScopeTitle: name => `Save ${name} for this profile?`,
+    saveScopeBody: profile =>
+      `This writes the ${profile === 'default' ? 'default' : `“${profile}”`} profile's messaging config (config.yaml / .env). ` +
+      `It will not affect other profiles.`,
     fieldCopy: {
       TELEGRAM_BOT_TOKEN: {
         label: 'Bot token',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1269,6 +1269,11 @@ export const ja = defineLocale({
     failedUpdate: name => `${name} の更新に失敗しました`,
     failedSave: name => `${name} の保存に失敗しました`,
     failedClear: key => `${key} のクリアに失敗しました`,
+    configScope: profile => `プロファイル ${profile} の設定中`,
+    configScopeDefault: 'デフォルトプロファイルの設定中',
+    saveScopeTitle: name => `このプロファイルに ${name} を保存しますか？`,
+    saveScopeBody: profile =>
+      `これは${profile === 'default' ? 'デフォルト' : `「${profile}」`}プロファイルのメッセージング設定（config.yaml / .env）に書き込みます。他のプロファイルには影響しません。`,
     fieldCopy: {
       TELEGRAM_BOT_TOKEN: {
         label: 'ボットトークン',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1180,6 +1180,10 @@ export interface Translations {
     failedUpdate: (name: string) => string
     failedSave: (name: string) => string
     failedClear: (key: string) => string
+    configScope: (profile: string) => string
+    configScopeDefault: string
+    saveScopeTitle: (name: string) => string
+    saveScopeBody: (profile: string) => string
     fieldCopy: Record<string, { label?: string; help?: string; placeholder?: string }>
     platformIntro: Record<string, string>
   }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1236,6 +1236,11 @@ export const zhHant = defineLocale({
     failedUpdate: name => `更新 ${name} 失敗`,
     failedSave: name => `儲存 ${name} 失敗`,
     failedClear: key => `清除 ${key} 失敗`,
+    configScope: profile => `正在為設定檔 ${profile} 設定`,
+    configScopeDefault: '正在為預設設定檔設定',
+    saveScopeTitle: name => `為此設定檔儲存 ${name}？`,
+    saveScopeBody: profile =>
+      `這會寫入${profile === 'default' ? '預設' : `「${profile}」`}設定檔的訊息平台設定（config.yaml / .env），不會影響其他設定檔。`,
     fieldCopy: {
       TELEGRAM_BOT_TOKEN: {
         label: 'Bot Token',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1533,6 +1533,11 @@ export const zh: Translations = {
     failedUpdate: name => `更新 ${name} 失败`,
     failedSave: name => `保存 ${name} 失败`,
     failedClear: key => `清除 ${key} 失败`,
+    configScope: profile => `正在为配置文件 ${profile} 配置`,
+    configScopeDefault: '正在为默认配置文件配置',
+    saveScopeTitle: name => `为此配置文件保存 ${name}？`,
+    saveScopeBody: profile =>
+      `这将写入${profile === 'default' ? '默认' : `“${profile}”`}配置文件的消息平台配置（config.yaml / .env），不会影响其他配置文件。`,
     fieldCopy: {
       TELEGRAM_BOT_TOKEN: {
         label: 'Bot 令牌',


### PR DESCRIPTION
## Summary
Desktop profile switching did not scope Telegram/messaging bot configuration. The three messaging REST helpers (`getMessagingPlatforms`, `updateMessagingPlatform`, `testMessagingPlatform`) omitted `profileScoped()`, so requests carried no `request.profile` and Electron's `hermes:api` handler routed them to the default/primary backend. Editing a named profile's Telegram token silently mutated the global config.

## Fix
- Add `...profileScoped()` to the three messaging helpers so they route to the active profile's backend (correct HERMES_HOME).
- Add a visible profile-scope indicator and a save confirmation in the messaging view so a write never silently targets the wrong profile.
- Extend `hermes-profile-scope.test.ts` to assert the helpers forward the active profile and omit it when none is active.

## Test plan
- `pnpm --filter desktop test` (plus typecheck) — the new scope assertions cover the messaging helpers alongside the existing cron/action coverage.

Fixes #72031