### PR TITLE
fix(deps): converge huggingface-hub on one exact version across lock and lazy pin

### DIFF
--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -223,3 +223,70 @@ def test_nemo_relay_extra_uses_supported_official_distribution_range():
         spec == "hermes-agent[nemo-relay]"
         for spec in optional_dependencies["all"]
     )
+
+
+def _uv_lock_version(package: str) -> str:
+    """Resolved version of ``package`` in uv.lock, or fail loudly."""
+    import re
+
+    lock_path = Path(__file__).resolve().parents[1] / "uv.lock"
+    lock = lock_path.read_text(encoding="utf-8")
+    m = re.search(
+        rf'\[\[package\]\]\nname = "{re.escape(package)}"\nversion = "([^"]+)"',
+        lock,
+    )
+    assert m, f"{package} not found in uv.lock"
+    return m.group(1)
+
+
+def test_huggingface_hub_lazy_pin_matches_uv_lock():
+    """The whole tree must converge on ONE huggingface-hub version (#60783).
+
+    huggingface-hub is a shared dependency: the core lock resolves it (via
+    faster-whisper/tokenizers, and transformers/sentence-transformers when
+    local Hindsight embeddings are installed), and LAZY_DEPS
+    ['tool.trace_upload'] exact-pins it. Because active_features() activates
+    a feature from mere package presence, the `hermes update` lazy-refresh
+    pass re-asserts the LAZY_DEPS pin on every install where hub is present.
+    If that pin drifts from the lock's resolved version, every update churns
+    the shared package — and a pin below transformers' floor (>=1.5.0)
+    force-downgrades it and breaks the Hindsight local daemon on startup.
+    """
+    from tools.lazy_deps import LAZY_DEPS
+
+    lazy_pin = _exact_pins(LAZY_DEPS["tool.trace_upload"]).get("huggingface-hub")
+    assert lazy_pin, "tool.trace_upload must exact-pin huggingface-hub"
+
+    locked = _uv_lock_version("huggingface-hub")
+    assert lazy_pin == locked, (
+        "LAZY_DEPS['tool.trace_upload'] pins huggingface-hub=="
+        f"{lazy_pin} but uv.lock resolves {locked}. These must move in "
+        "lockstep (bump the pin AND run `uv lock --upgrade-package "
+        "huggingface-hub`), or `hermes update` will churn/downgrade the "
+        "shared package and break Hindsight local embeddings (#60783)."
+    )
+
+
+def test_huggingface_hub_lazy_pin_inside_transformers_window():
+    """The hub pin must stay in transformers' accepted range (#60783).
+
+    transformers (pulled by sentence-transformers for Hindsight
+    local/local_embedded embeddings) requires huggingface-hub>=1.5.0,<2.
+    An exact pin outside that window makes the lazy-refresh downgrade the
+    shared package below what the embedding stack imports, and the
+    Hindsight daemon fails on startup. Contract, not a snapshot: any
+    future exact pin is fine as long as it stays inside the window.
+    """
+    from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
+
+    from tools.lazy_deps import LAZY_DEPS
+
+    pin = _exact_pins(LAZY_DEPS["tool.trace_upload"]).get("huggingface-hub")
+    assert pin, "tool.trace_upload must exact-pin huggingface-hub"
+    transformers_window = SpecifierSet(">=1.5.0,<2")
+    assert Version(pin) in transformers_window, (
+        f"huggingface-hub=={pin} falls outside transformers' accepted "
+        "range (>=1.5.0,<2). The lazy refresh would downgrade the shared "
+        "package and break Hindsight local embeddings (#60783)."
+    )

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -293,6 +293,22 @@ class TestIsSatisfiedVersionAware:
         self._fake_version(monkeypatch, {"mautrix": "0.20.0"})
         assert ld._is_satisfied("mautrix[encryption]==0.21.0") is False
 
+    def test_trace_upload_hub_at_core_locked_version_is_current(self, monkeypatch):
+        """#60783 regression: refresh must not churn the shared hub install.
+
+        huggingface-hub arrives in the venv via the core lock (transformers /
+        sentence-transformers for local Hindsight, faster-whisper, tokenizers).
+        With the LAZY_DEPS pin held in lockstep with uv.lock, the version the
+        core installs satisfies the trace-upload spec, so the `hermes update`
+        lazy-refresh pass reports "current" instead of reinstalling — the
+        downgrade that used to break the Hindsight daemon can't happen.
+        """
+        spec = ld.LAZY_DEPS["tool.trace_upload"][0]
+        pinned = ld._specifier_from_spec(spec).lstrip("=")
+        self._fake_version(monkeypatch, {"huggingface-hub": pinned})
+        assert ld._is_satisfied(spec) is True
+        assert ld.feature_missing("tool.trace_upload") == ()
+
 
 # ---------------------------------------------------------------------------
 # active_features + refresh_active_features (Piece A — hermes update wiring)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -241,7 +241,20 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "starlette==1.0.1",  # CVE-2026-48710 — keep in sync with pyproject [computer-use]
     ),
     # HF Agent Trace Viewer upload (hermes trace upload / /upload-trace).
-    "tool.trace_upload": ("huggingface-hub==1.2.3",),
+    #
+    # huggingface-hub is a SHARED dependency: transformers (pulled by
+    # sentence-transformers for local Hindsight embeddings) requires
+    # >=1.5.0,<2, and faster-whisper/tokenizers depend on it transitively.
+    # Because active_features() marks a feature active from mere package
+    # presence, the `hermes update` lazy-refresh pass re-asserts THIS pin on
+    # every install where hub is present — so an exact pin below 1.5.0
+    # force-downgrades the shared package and breaks Hindsight startup
+    # (#60783). Policy: keep the exact pin (no ranges — security posture),
+    # but it MUST stay inside transformers' accepted window and MUST match
+    # uv.lock so the whole tree converges on ONE hub version
+    # (tests/test_project_metadata.py enforces both). When bumping: update
+    # here AND `uv lock --upgrade-package huggingface-hub` in lockstep.
+    "tool.trace_upload": ("huggingface-hub==1.24.0",),
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -675,14 +675,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -1859,26 +1859,18 @@ provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge
 
 [[package]]
 name = "hf-xet"
-version = "1.3.1"
+version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/d0/73454ef7ca885598a3194d07d5c517d91a840753c5b35d272600d7907f64/hf_xet-1.3.1.tar.gz", hash = "sha256:513aa75f8dc39a63cc44dbc8d635ccf6b449e07cdbd8b2e2d006320d2e4be9bb", size = 641393, upload-time = "2026-02-25T00:57:56.701Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/39/67be8d71f900d9a55761b6022821d6679fb56c64f1b6063d5af2c2606727/hf_xet-1.5.2.tar.gz", hash = "sha256:73044bd31bae33c984af832d19c752a0dffb67518fee9ddbd91d616e1101cf47", size = 903674, upload-time = "2026-07-16T17:29:56.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/79/9b6a5614230d7a871442d8d8e1c270496821638ba3a9baac16a5b9166200/hf_xet-1.3.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:08b231260c68172c866f7aa7257c165d0c87887491aafc5efeee782731725366", size = 3759716, upload-time = "2026-02-25T00:57:41.052Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/de/72acb8d7702b3cf9b36a68e8380f3114bf04f9f21cf9e25317457fe31f00/hf_xet-1.3.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:0810b69c64e96dee849036193848007f665dca2311879c9ea8693f4fc37f1795", size = 3518075, upload-time = "2026-02-25T00:57:39.605Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/5c/ed728d8530fec28da88ee882b522fccf00dc98e9d7bae4cdb0493070cb17/hf_xet-1.3.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ecd38f98e7f0f41108e30fd4a9a5553ec30cf726df7473dd3e75a1b6d56728c2", size = 4174369, upload-time = "2026-02-25T00:57:32.697Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/db/785a0e20aa3086948a26573f1d4ff5c090e63564bf0a52d32eb5b4d82e8d/hf_xet-1.3.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:65411867d46700765018b1990eb1604c3bf0bf576d9e65fc57fdcc10797a2eb9", size = 3953249, upload-time = "2026-02-25T00:57:30.096Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/6a/51b669c1e3dbd9374b61356f554e8726b9e1c1d6a7bee5d727d3913b10ad/hf_xet-1.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:1684c840c60da12d76c2a031ba40e4b154fdbf9593836fcf5ff090d95a033c61", size = 4152989, upload-time = "2026-02-25T00:57:48.308Z" },
-    { url = "https://files.pythonhosted.org/packages/df/31/de07e26e396f46d13a09251df69df9444190e93e06a9d30d639e96c8a0ed/hf_xet-1.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b3012c0f2ce1f0863338491a2bc0fd3f84aded0e147ab25f230da1f5249547fd", size = 4390709, upload-time = "2026-02-25T00:57:49.845Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/c1/fcb010b54488c2c112224f55b71f80e44d1706d9b764a0966310b283f86e/hf_xet-1.3.1-cp313-cp313t-win_amd64.whl", hash = "sha256:4eb432e1aa707a65a7e1f8455e40c5b47431d44fe0fb1b0c5d53848c27469398", size = 3634142, upload-time = "2026-02-25T00:57:59.063Z" },
-    { url = "https://files.pythonhosted.org/packages/da/a6/9ef49cc601c68209979661b3e0b6659fc5a47bfb40f3ebf29eae9ee09e5c/hf_xet-1.3.1-cp313-cp313t-win_arm64.whl", hash = "sha256:e56104c84b2a88b9c7b23ba11a2d7ed0ccbe96886b3f985a50cedd2f0e99853f", size = 3494918, upload-time = "2026-02-25T00:57:57.654Z" },
-    { url = "https://files.pythonhosted.org/packages/75/f8/c2da4352c0335df6ae41750cf5bab09fdbfc30d3b4deeed9d621811aa835/hf_xet-1.3.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:581d1809a016f7881069d86a072168a8199a46c839cf394ff53970a47e4f1ca1", size = 3761755, upload-time = "2026-02-25T00:57:43.621Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/e5/a2f3eaae09da57deceb16a96ebe9ae1f6f7b9b94145a9cd3c3f994e7782a/hf_xet-1.3.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:329c80c86f2dda776bafd2e4813a46a3ee648dce3ac0c84625902c70d7a6ddba", size = 3523677, upload-time = "2026-02-25T00:57:42.3Z" },
-    { url = "https://files.pythonhosted.org/packages/61/cd/acbbf9e51f17d8cef2630e61741228e12d4050716619353efc1ac119f902/hf_xet-1.3.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2973c3ff594c3a8da890836308cae1444c8af113c6f10fe6824575ddbc37eca7", size = 4178557, upload-time = "2026-02-25T00:57:35.399Z" },
-    { url = "https://files.pythonhosted.org/packages/df/4f/014c14c4ae3461d9919008d0bed2f6f35ba1741e28b31e095746e8dac66f/hf_xet-1.3.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ed4bfd2e6d10cb86c9b0f3483df1d7dd2d0220f75f27166925253bacbc1c2dbe", size = 3958975, upload-time = "2026-02-25T00:57:34.004Z" },
-    { url = "https://files.pythonhosted.org/packages/86/50/043f5c5a26f3831c3fa2509c17fcd468fd02f1f24d363adc7745fbe661cb/hf_xet-1.3.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:713913387cc76e300116030705d843a9f15aee86158337eeffb9eb8d26f47fcd", size = 4158298, upload-time = "2026-02-25T00:57:51.14Z" },
-    { url = "https://files.pythonhosted.org/packages/08/9c/b667098a636a88358dbeb2caf90e3cb9e4b961f61f6c55bb312793424def/hf_xet-1.3.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e5063789c9d21f51e9ed4edbee8539655d3486e9cad37e96b7af967da20e8b16", size = 4395743, upload-time = "2026-02-25T00:57:52.783Z" },
-    { url = "https://files.pythonhosted.org/packages/70/37/4db0e4e1534270800cfffd5a7e0b338f2137f8ceb5768000147650d34ea9/hf_xet-1.3.1-cp37-abi3-win_amd64.whl", hash = "sha256:607d5bbc2730274516714e2e442a26e40e3330673ac0d0173004461409147dee", size = 3638145, upload-time = "2026-02-25T00:58:02.167Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/46/1ba8d36f8290a4b98f78898bdce2b0e8fe6d9a59df34a1399eb61a8d877f/hf_xet-1.3.1-cp37-abi3-win_arm64.whl", hash = "sha256:851b1be6597a87036fe7258ce7578d5df3c08176283b989c3b165f94125c5097", size = 3500490, upload-time = "2026-02-25T00:58:00.667Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ba/2b70603c7552db82baeb2623e2336898304a17328845151be4fe1f48d420/hf_xet-1.5.2-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f922b8f5fb84f1dd3d7ab7a1316354a1bca9b1c73ecfc19c76e51a2a49d29799", size = 4033760, upload-time = "2026-07-16T17:29:43.884Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ac/b097a86a1e4a6098f3a79382643ab09d5733d87ccc864877ad1e12b49b70/hf_xet-1.5.2-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:045f84440c55cdeb659cf1a1dd48c77bcd0d2e93632e2fea8f2c3bdee79f38ed", size = 3841438, upload-time = "2026-07-16T17:29:45.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/35/db860aa3a0780660324a506ad4b3d322ddc6ecbba4b9340aed0942cbf21c/hf_xet-1.5.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db78c39c83d6279daddc98e2238f373ab8980685556d42472b4ec51abcf03e8c", size = 4428006, upload-time = "2026-07-16T17:29:46.996Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6b/832dd980af4b0c3ae0660e309285f2ffcdff2faa38129390dbb47aa4a3f9/hf_xet-1.5.2-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7db73c810500c54c6760be8c39d4b2e476974de85424c50063efc22fdda13025", size = 4221099, upload-time = "2026-07-16T17:29:48.525Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/05/ae50f0d34e3254e6c3e208beb2519f6b8673016fc4b3643badaf6450d186/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6395cfe3c9cbead4f16b31808b0e67eac428b66c656f856e99636adaddea878f", size = 4420766, upload-time = "2026-07-16T17:29:50.092Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/c050bc2743a2bcd68928bfee157b08681667a164a24ec95fbfcfcd717e08/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cde8cd167126bb6109b2ceb19b844433a4988643e8f3e01dd9dd0e4a34535097", size = 4636716, upload-time = "2026-07-16T17:29:51.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/68b01c5c2edb56ac9a67b3d076ffddcb90867abaee923923eb34e7a14e76/hf_xet-1.5.2-cp38-abi3-win_amd64.whl", hash = "sha256:ecf63d1cb69a9a7319910f8f83fcf9b46e7a32dfcf4b8f8eeddb55f647306e65", size = 3988373, upload-time = "2026-07-16T17:29:53.395Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c6/988383e9dc17294d536fcbcd6fd16eed882e411ad16c954984a53e47b09c/hf_xet-1.5.2-cp38-abi3-win_arm64.whl", hash = "sha256:1da28519496eb7c8094c11e4d25509b4a468457a0302d58136099db2fd9a671d", size = 3816957, upload-time = "2026-07-16T17:29:54.991Z" },
 ]
 
 [[package]]
@@ -2009,23 +2001,22 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.4.1"
+version = "1.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "click" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "shellingham" },
     { name = "tqdm" },
-    { name = "typer-slim" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/fc/eb9bc06130e8bbda6a616e1b80a7aa127681c448d6b49806f61db2670b61/huggingface_hub-1.4.1.tar.gz", hash = "sha256:b41131ec35e631e7383ab26d6146b8d8972abc8b6309b963b306fbcca87f5ed5", size = 642156, upload-time = "2026-02-06T09:20:03.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/9b/d3bb4e7d792835daf34dd7091bbc7d7b4e0437d9388f1ea7239cce49f478/huggingface_hub-1.24.0.tar.gz", hash = "sha256:18431ff4daae0749aa9ba102fc952e314c98e1d30ebdec5319d85ca0a83e1ae5", size = 921848, upload-time = "2026-07-17T09:54:01.022Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/ae/2f6d96b4e6c5478d87d606a1934b5d436c4a2bce6bb7c6fdece891c128e3/huggingface_hub-1.4.1-py3-none-any.whl", hash = "sha256:9931d075fb7a79af5abc487106414ec5fba2c0ae86104c0c62fd6cae38873d18", size = 553326, upload-time = "2026-02-06T09:20:00.728Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c3/aeaaf3911d2529614be18d1c8b5496afc185560e76568063d517283318af/huggingface_hub-1.24.0-py3-none-any.whl", hash = "sha256:6ed4120a84a6beec900640aa7e346bd766a6b7341e41526fef5dc8bd81fb7d59", size = 771904, upload-time = "2026-07-17T09:53:59.106Z" },
 ]
 
 [[package]]
@@ -4173,18 +4164,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
-]
-
-[[package]]
-name = "typer-slim"
-version = "0.24.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776, upload-time = "2026-02-16T22:08:51.2Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/24/5480c20380dfd18cf33d14784096dca45a24eae6102e91d49a718d3b6855/typer_slim-0.24.0-py3-none-any.whl", hash = "sha256:d5d7ee1ee2834d5020c7c616ed5e0d0f29b9a4b1dd283bdebae198ec09778d0e", size = 3394, upload-time = "2026-02-16T22:08:49.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
`hermes update` can no longer downgrade `huggingface-hub` and break local Hindsight — the whole dependency tree now converges on **one exact version (1.24.0)**, held in lockstep between `uv.lock` and `LAZY_DEPS`, keeping the exact-pin security posture intact (fixes #60783).

Root cause: `LAZY_DEPS["tool.trace_upload"]` exact-pinned `huggingface-hub==1.2.3` while transformers (pulled by sentence-transformers for Hindsight local embeddings) requires `>=1.5.0,<2`. `active_features()` activates a feature from mere package presence, so every `hermes update` lazy-refresh re-asserted the stale pin and force-downgraded the shared package out from under the embedding stack — the Hindsight daemon then failed on startup.

Direction per maintainer discussion in Discord: no ranges (breaks the security lines), no two versions for two features — **a single exact version >= 1.5.0 everywhere**, which the Hindsight side (@nicoloboschi) confirmed is the workable resolution.

## Changes
- `tools/lazy_deps.py`: `tool.trace_upload` pin `huggingface-hub==1.2.3` → `==1.24.0` (current release, inside transformers' window), with a comment documenting the shared-dep hazard and the lockstep-bump procedure
- `uv.lock`: `uv lock --upgrade-package huggingface-hub` — hub 1.4.1 → 1.24.0, hf-xet 1.3.1 → 1.5.2, click 8.3.1 → 8.4.2 (hub 1.22+ requires `click>=8.4.2`; in-tree consumers uvicorn `>=7.0`, typer `>=8.2.1`, modal `~=8.1` all accept it), typer-slim dropped (no longer a hub dep)
- `tests/test_project_metadata.py`: two invariant tests (contracts, not snapshots) — the lazy pin must **equal the uv.lock resolved version**, and must **sit inside transformers' `>=1.5.0,<2` window**; any future drift or bad re-pin fails CI with a message explaining the lockstep bump
- `tests/tools/test_lazy_deps.py`: regression test that the core-locked hub version satisfies the trace-upload spec, so the refresh path reports `current` (no reinstall)

## Validation
| | Before | After |
|---|---|---|
| `hermes update` with hub present | downgrades to 1.2.3, Hindsight daemon fails | `refresh_active_features()` → `current`, 0 pip invocations |
| hub versions in the tree | lock 1.4.1 vs lazy 1.2.3 (two, both < 1.5.0) | one: 1.24.0 |
| pin drifts from lock in future | silent churn every update | invariant test fails with bump instructions |

- `scripts/run_tests.sh tests/tools/test_lazy_deps.py tests/tools/test_lazy_deps_durable_target.py tests/test_project_metadata.py` — 92/92 green; sabotage run (pin reverted to 1.2.3) fails both new invariant tests
- E2E with real imports against a temp `HERMES_HOME`: hub at 1.24.0 → `feature_missing()` empty, full `refresh_active_features()` reports `current`, zero pip subprocesses spawned
- Live venv with real `huggingface-hub==1.24.0`: the `HfApi` surface trace upload uses (`whoami` / `create_repo` / `upload_file`) present with identical kwargs
- `uv lock --check` clean

The cryptography conflict reported in the same thread (hindsight-api-slim wants `cryptography>=48`, we pin 46.0.7) is out of scope — hindsight-client 0.6.1 (what we install) has no cryptography requirement, and Hindsight starts and recalls with our pin retained.

## Credit
The range-based fixes #60797 (@falkoro, earliest, with tests), #66261 (@stigrunar), #70125 (@dschnurbusch), and the no-downgrade guard #68008 (@spiky02plateau) all correctly identified the mechanism; the range direction was declined by maintainers as breaking the exact-pin security policy, and this PR implements the agreed single-exact-version resolution instead.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa3dcea/3VcQ2FfwlsSuEf832l4-X_sHu2QRyR.png)
