### PR TITLE
fix(gateway): preserve media dedup after streamed replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14572,7 +14572,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _media_adapter:
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
-                            history_media_paths=_history_media_paths,
+                            history_media_paths=_collect_history_media_paths(history),
                         )
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -212,6 +212,54 @@ async def test_not_new_messages_skip_db_when_agent_has_session_db(
     )
 
 
+# ── Post-stream MEDIA delivery keeps prior-turn deduplication ──────────
+
+
+@pytest.mark.asyncio
+async def test_streamed_response_receives_prior_turn_media_paths(
+    monkeypatch, tmp_path
+):
+    """An ordinary streamed reply completes the post-stream delivery branch.
+
+    The history-derived dedup set is part of that branch's contract, rather
+    than an optional best-effort hint: passing an undefined local crashes the
+    entire reply, while passing an empty set reintroduces duplicate MEDIA
+    attachments on later streamed responses.
+    """
+    runner = _bootstrap(monkeypatch, tmp_path)
+    prior_path = "/tmp/already-delivered.png"
+    runner.session_store.load_transcript.return_value = [
+        {"role": "assistant", "content": f"MEDIA:{prior_path}"},
+    ]
+    runner.adapters = {Platform.TELEGRAM: MagicMock()}
+    runner._deliver_media_from_response = AsyncMock()
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "the streamed reply completed normally",
+            "messages": [
+                {"role": "assistant", "content": f"MEDIA:{prior_path}"},
+                {"role": "user", "content": "what is my status?"},
+                {"role": "assistant", "content": "the streamed reply completed normally"},
+            ],
+            "tools": [],
+            "history_offset": 1,
+            "last_prompt_tokens": 0,
+            "already_sent": True,
+            "failed": False,
+        }
+    )
+
+    response = await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert response is None
+    runner._deliver_media_from_response.assert_awaited_once()
+    assert runner._deliver_media_from_response.await_args.kwargs[
+        "history_media_paths"
+    ] == {prior_path}
+
+
 # ── Test 4: normal path (new_messages found) uses skip_db=True ────────
 
 


### PR DESCRIPTION
## what does this PR do?

Fixes a gateway crash in the post-stream delivery path. When a streamed agent result has `already_sent=True` and a non-empty final response, `_handle_message_with_agent` passed `_history_media_paths`, which is only bound inside `_run_agent_inner`'s nested `run_sync` function. The outer handler therefore raises `NameError` after the model request succeeds, turning an otherwise-complete reply into a generic platform error.

This happens for ordinary streamed text replies as well as responses containing `MEDIA:` directives, because the post-stream attachment-delivery helper is invoked for any non-empty response.

The fix derives the existing history-media dedup set from the handler's loaded transcript. This resolves the crash **without** disabling cross-turn MEDIA deduplication.

This is deliberately limited to the gateway fix and its regression coverage. The related open #72228 also modifies unrelated desktop performance/debug files; its fallback-to-empty-set guard avoids the exception but drops the existing dedup context.

## related issue

No filed issue. Related PR: #72228.

## type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## changes made

- `gateway/run.py`: derive prior delivered MEDIA paths from the transcript before post-stream delivery.
- `tests/gateway/test_42039_duplicate_user_message.py`: exercise the real `already_sent` branch with an ordinary text reply and assert prior MEDIA paths reach the delivery helper.

## how to test

1. On unpatched `main`, drive `_handle_message_with_agent` with `already_sent=True`, any non-empty response, and a platform adapter. It raises `NameError: name '_history_media_paths' is not defined` after the streamed response completes.
2. Apply this patch and repeat. The post-stream helper receives the prior assistant MEDIA path and the reply completes normally.
3. Run:
   ```bash
   scripts/run_tests.sh tests/gateway/test_42039_duplicate_user_message.py tests/gateway/test_post_stream_media_delivery.py tests/gateway/test_tts_media_routing.py
   ```
   Result: 17 passed.

## checklist

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs; #72228 is the only exact open overlap and this PR does not duplicate its unrelated desktop changes.
- [x] My PR contains only changes related to this bug fix.
- [ ] I've run `pytest tests/ -q` and all tests pass. Full hermetic `scripts/run_tests.sh` is running separately; the targeted canonical suite above passed.
- [x] I've added a regression test for this bug fix.
- [x] I've tested on Linux (Arch).
- [x] Documentation/config/tool-schema changes: N/A.
- [x] Cross-platform impact considered: pure in-memory history parsing, no platform-specific I/O or process behavior.
