### PR TITLE
fix(security): extend secret redaction to GitLab token families

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -111,6 +111,23 @@ _PREFIX_PATTERNS = [
     r"fw-[A-Za-z0-9]{30,}",             # Fireworks AI API key
     r"fw_[A-Za-z0-9]{30,}",             # Fireworks AI API key
     r"fpk_[A-Za-z0-9]{30,}",            # Fireworks AI project key
+    # GitLab token families (each pattern keeps a full literal prefix so the
+    # _PREFIX_SUBSTRINGS pre-screen stays false-negative-free). Ported from
+    # openclaw/openclaw#112954; follow-up invited in #4541.
+    r"glpat-[A-Za-z0-9_\-]{10,}",       # GitLab personal access token
+    r"gloas-[A-Za-z0-9_\-]{10,}",       # GitLab OAuth application secret
+    r"gldt-[A-Za-z0-9_\-]{10,}",        # GitLab deploy token
+    r"glrt-[A-Za-z0-9_.\-]{10,}",       # GitLab runner authentication token (routable tokens are dotted)
+    r"glrtr-[A-Za-z0-9_.\-]{10,}",      # GitLab runner registration token (routable)
+    r"glcbt-[A-Za-z0-9_\-]{10,}",       # GitLab CI/CD job token
+    r"glptt-[A-Za-z0-9_\-]{10,}",       # GitLab pipeline trigger token
+    r"glft-[A-Za-z0-9_\-]{10,}",        # GitLab feed token
+    r"glimt-[A-Za-z0-9_\-]{10,}",       # GitLab incoming mail token
+    r"glagent-[A-Za-z0-9_\-]{10,}",     # GitLab agent (KAS) token
+    r"glsoat-[A-Za-z0-9_\-]{10,}",      # GitLab service-account access token
+    r"glffct-[A-Za-z0-9_\-]{10,}",      # GitLab feature-flags client token
+    r"glwt-[A-Za-z0-9_\-]{10,}",        # GitLab workspace token
+    r"GR1348941[A-Za-z0-9_\-]{10,}",    # GitLab legacy runner registration token
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name.

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -20,6 +20,45 @@ class TestKnownPrefixes:
 
 
 
+    def test_gitlab_token_prefixes(self):
+        """GitLab token families redact via their literal prefixes.
+
+        Ported from openclaw/openclaw#112954; follow-up invited in #4541.
+        """
+        tokens = [
+            # NOTE: every token is prefix + suffix CONCATENATION so no
+            # contiguous token literal exists in this file — GitHub push
+            # protection blocks realistic GitLab-token-shaped literals.
+            "glpat-" + "Zx9AbCdEfGhIjKlMnOpQ",       # personal access token
+            "gloas-" + "a" * 64,                     # OAuth application secret
+            "gldt-" + "AbCdEfGhIjKlMnOpQrSt",        # deploy token
+            "glrt-" + "t1_AbCdEfGhIjKlMnOpQrSt",     # runner auth token
+            "glrt-" + "A" * 27 + ".01." + "a" * 9,   # routable (dotted) runner token
+            "glrtr-" + "B" * 27 + ".01." + "b" * 9,  # routable runner registration
+            "glcbt-" + "a1B2_AbCdEfGhIjKlMnOpQ",     # CI/CD job token
+            "glptt-" + "c" * 40,                     # pipeline trigger token
+            "glft-" + "AbCdEfGhIjKlMnOp",            # feed token
+            "glimt-" + "AbCdEfGhIjKlMnOpQrStUvWxY",  # incoming mail token
+            "glagent-" + "d" * 50,                   # agent (KAS) token
+            "glsoat-" + "AbCdEfGhIjKlMnOpQrSt",      # service-account token
+            "glffct-" + "AbCdEfGhIjKlMnOpQrSt",      # feature-flags client token
+            "glwt-" + "AbCdEfGhIjKlMnOpQrSt",        # workspace token
+            "GR1348941" + "E" * 20,                  # legacy runner registration
+        ]
+        for token in tokens:
+            result = redact_sensitive_text(f"leaked {token} in output")
+            secret_body = token.split("-", 1)[-1] if "-" in token else token[9:]
+            assert secret_body not in result, f"{token!r} survived redaction: {result!r}"
+
+    def test_gitlab_prefix_requires_word_boundary_and_length(self):
+        """Prose and embedded identifiers must not false-positive."""
+        for benign in [
+            "the glossary explains gitlab tokens",   # no prefix at all
+            "glpat-short",                            # suffix under 10 chars
+            "myglpat-AbCdEfGhIjKlMnOpQrSt",           # embedded — lookbehind blocks
+        ]:
+            assert redact_sensitive_text(benign) == benign
+
     def test_slack_token(self):
         token = "xoxb-" + "0" * 12 + "-" + "a" * 14
         result = redact_sensitive_text(token)

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -169,6 +169,15 @@ class TestScanFile:
         assert findings == []
 
 
+    def test_detect_gitlab_pat(self, tmp_path):
+        f = tmp_path / "leak.md"
+        # Concatenated so no contiguous token literal exists in this file
+        # (GitHub push protection blocks GitLab-PAT-shaped literals).
+        fake_token = "glpat-" + "Zx9AbCdEfGhIjKlMnOpQ"
+        f.write_text(f"Use {fake_token} to authenticate.\n")
+        findings = scan_file(f, "leak.md")
+        assert any(fi.pattern_id == "gitlab_token_leaked" for fi in findings)
+
     def test_detect_markdown_injection(self, tmp_path):
         f = tmp_path / "bad.md"
         f.write_text(

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -487,6 +487,9 @@ THREAT_PATTERNS = [
     (r'AKIA[0-9A-Z]{16}',
      "aws_access_key_leaked", "critical", "credential_exposure",
      "AWS access key ID in skill content"),
+    (r'glpat-[A-Za-z0-9_\-]{20,}',
+     "gitlab_token_leaked", "critical", "credential_exposure",
+     "GitLab personal access token in skill content"),
 
     # ── Additional prompt injection: jailbreak patterns ──
     (r'\bDAN\s+mode\b|Do\s+Anything\s+Now',


### PR DESCRIPTION
## Summary
Secret redaction now recognizes GitLab tokens — 14 token families (`glpat-`, `gloas-`, `gldt-`, `glrt-`, `glrtr-`, `glcbt-`, `glptt-`, `glft-`, `glimt-`, `glagent-`, `glsoat-`, `glffct-`, `glwt-`, legacy `GR1348941`) previously passed through display and log surfaces verbatim.

Port of [openclaw/openclaw#112954](https://github.com/openclaw/openclaw/pull/112954) (weekly OpenClaw PR scout). This is the focused follow-up explicitly invited when #4541 was closed ("The GitLab/Deepgram/Linear additions bundled here weren't included; feel free to open a focused follow-up").

## Changes
- `agent/redact.py`: 14 GitLab prefix patterns added to `_PREFIX_PATTERNS`. Each pattern keeps a full literal prefix (no shared `gl(?:...)` alternation) so the auto-derived `_PREFIX_SUBSTRINGS` pre-screen stays false-negative-free — a combined pattern would degrade the screen literal to `"gl"`. Routable runner tokens (`glrt-`/`glrtr-`) allow dotted segments per GitLab's routable token format.
- `tools/skills_guard.py` (sibling site): credential-exposure scan gains a `gitlab_token_leaked` pattern so skill installs flag embedded GitLab PATs, matching the existing GitHub/OpenAI/Anthropic/AWS entries.
- Tests: all 14 families redact; false-positive guards (prose, sub-10-char suffixes, embedded identifiers blocked by the word-boundary lookbehind); skills_guard finding test. Fake tokens are built by concatenation because GitHub push protection (correctly) blocks GitLab-PAT-shaped literals.

## Adaptation notes
OpenClaw also redacts the `_gitlab_session` cookie value; hermes's context-keyed assignment/JSON/cookie-header patterns already handle key=value shapes, so only the bare prefix-token families were ported. The AWS *secret access key* sibling PR (openclaw#112947) was deliberately NOT ported — its bare 40-char base64 heuristic needed 12 rounds of false-positive fixes upstream (commit hashes, JWT segments, Fly tokens) and hermes's context-keyed patterns already cover realistic assignment shapes for prefix-less secrets.

## Validation
| Check | Result |
|---|---|
| `tests/agent/test_redact.py` + `tests/tools/test_skills_guard.py` | 239/239 pass |
| Sabotage run (patterns reverted) | both new detection tests fail; FP-guard test passes on both, as designed |
| False-positive guards | prose / short suffix / embedded identifier untouched |

## Infographic

![gitlab-token-redaction](https://v3b.fal.media/files/b/0aa3dd3b/PNbcnFX4OCooTDkuiTvF0_vtqtM9xX.png)
